### PR TITLE
48 investigate and add video support

### DIFF
--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1,7 +1,6 @@
 """Base class for LibreYOLO inference backends."""
 
 import logging
-import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
@@ -17,7 +16,7 @@ from ..utils.drawing import draw_boxes
 from ..utils.general import COCO_CLASSES, get_safe_stem
 from ..utils.image_loader import ImageLoader
 from ..utils.results import Boxes, Masks, Results
-from ..utils.video import VideoSource, is_video_file, run_video_inference
+from ..utils.video import collect_video_results, is_video_file, run_video_inference
 
 logger = logging.getLogger(__name__)
 
@@ -533,17 +532,7 @@ class BaseBackend(ABC):
             )
             if stream:
                 return gen
-            vs = VideoSource(source, vid_stride=vid_stride)
-            est_frames = vs.total_frames // max(1, vid_stride)
-            vs.release()
-            if est_frames > 500:
-                warnings.warn(
-                    f"Video has ~{est_frames} frames to process. "
-                    f"Consider using stream=True to avoid high memory usage. "
-                    f"Example: backend('{source}', stream=True)",
-                    stacklevel=2,
-                )
-            return list(gen)
+            return collect_video_results(gen, source, vid_stride)
 
         if isinstance(source, (str, Path)) and Path(source).is_dir():
             image_paths = ImageLoader.collect_images(source)

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Tuple, Union
@@ -21,7 +20,7 @@ from ...utils.drawing import draw_boxes, draw_masks, draw_tile_grid
 from ...utils.general import get_safe_stem, get_slice_bboxes, nms, resolve_save_path
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.results import Boxes, Masks, Results
-from ...utils.video import VideoSource, is_video_file, run_video_inference
+from ...utils.video import collect_video_results, is_video_file, run_video_inference
 
 logger = logging.getLogger(__name__)
 
@@ -109,18 +108,7 @@ class InferenceRunner:
             )
             if stream:
                 return gen
-            # Collect all results into a list (with warning for large videos)
-            vs = VideoSource(source, vid_stride=vid_stride)
-            est_frames = vs.total_frames // max(1, vid_stride)
-            vs.release()
-            if est_frames > 500:
-                warnings.warn(
-                    f"Video has ~{est_frames} frames to process. "
-                    f"Consider using stream=True to avoid high memory usage. "
-                    f"Example: model('{source}', stream=True)",
-                    stacklevel=2,
-                )
-            return list(gen)
+            return collect_video_results(gen, source, vid_stride)
 
         # Handle directory input
         if isinstance(source, (str, Path)) and Path(source).is_dir():

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -305,11 +305,18 @@ def run_video_inference(
                     if annotate_fn is not None:
                         annotated_pil = annotate_fn(pil_img, result)
                     elif len(result) > 0:
+                        names = result.names
+                        class_names = (
+                            [names[i] for i in range(max(names) + 1)]
+                            if names
+                            else None
+                        )
                         annotated_pil = draw_boxes(
                             pil_img,
                             result.boxes.xyxy.tolist(),
                             result.boxes.conf.tolist(),
                             result.boxes.cls.tolist(),
+                            class_names=class_names,
                         )
                     else:
                         annotated_pil = pil_img

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -1,6 +1,7 @@
 """Video source utilities for LibreYOLO."""
 
 import logging
+import warnings
 from pathlib import Path
 from typing import Callable, Generator, Iterator, Tuple, Union
 
@@ -223,8 +224,29 @@ class VideoWriter:
 
 
 # ---------------------------------------------------------------------------
-# Shared video inference loop
+# Shared video inference helpers
 # ---------------------------------------------------------------------------
+
+_LARGE_VIDEO_THRESHOLD = 500
+
+
+def collect_video_results(
+    gen: Generator,
+    source: Union[str, Path],
+    vid_stride: int = 1,
+) -> list:
+    """Collect all video results into a list, warning for large videos."""
+    vs = VideoSource(source, vid_stride=vid_stride)
+    est_frames = vs.total_frames // max(1, vid_stride)
+    vs.release()
+
+    if est_frames > _LARGE_VIDEO_THRESHOLD:
+        warnings.warn(
+            f"Video has ~{est_frames} frames to process. "
+            f"Consider using stream=True to avoid high memory usage.",
+            stacklevel=3,
+        )
+    return list(gen)
 
 
 def run_video_inference(

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -7,6 +7,8 @@ from typing import Callable, Generator, Iterator, Tuple, Union
 
 import numpy as np
 
+from .general import increment_path
+
 logger = logging.getLogger(__name__)
 
 # Video extensions supported via OpenCV's VideoCapture
@@ -45,8 +47,6 @@ def resolve_video_save_path(
         out = Path(output_path)
         out.parent.mkdir(parents=True, exist_ok=True)
         return str(out)
-
-    from .general import increment_path
 
     save_dir = Path("runs/detect") / "predict"
     save_dir = increment_path(save_dir, exist_ok=False, mkdir=True)

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -299,18 +299,12 @@ def run_video_inference(
                     if annotate_fn is not None:
                         annotated_pil = annotate_fn(pil_img, result)
                     elif len(result) > 0:
-                        names = result.names
-                        class_names = (
-                            [names[i] for i in range(max(names) + 1)]
-                            if names
-                            else None
-                        )
                         annotated_pil = draw_boxes(
                             pil_img,
                             result.boxes.xyxy.tolist(),
                             result.boxes.conf.tolist(),
                             result.boxes.cls.tolist(),
-                            class_names=class_names,
+                            class_names=result.names,
                         )
                     else:
                         annotated_pil = pil_img

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -147,9 +147,6 @@ class VideoSource:
             finally:
                 self._cap = None
 
-    def __del__(self):
-        self.release()
-
     def __repr__(self) -> str:
         return (
             f"VideoSource(path='{self._path}', "
@@ -215,9 +212,6 @@ class VideoWriter:
                 self._writer.release()
             finally:
                 self._writer = None
-
-    def __del__(self):
-        self.release()
 
     def __repr__(self) -> str:
         return f"VideoWriter(path='{self._path}')"


### PR DESCRIPTION
Adds video inference support across all model families (YOLOX, YOLO9, RF-DETR). Users can pass a video file path (e.g. .mp4) directly to model() just like they would an image.

Usage                                                                                                                                                                       
 ```
from libreyolo import LibreYOLO
                                                                                                                           
model = LibreYOLO("LibreYOLOXn.pt")                                                                                      
                                                                                                                           
# Stream mode (recommended for large videos — low memory)                                                                
for result in model("video.mp4", stream=True, conf=0.25):       
    print(f"Frame {result.frame_idx}: {len(result)} detections")                                                         
                                                                                                                       
# List mode (collects all results — warns if >500 frames)                                                                
results = model("video.mp4", conf=0.25)                                                                                  
                                                                                                                       
# Save annotated video                                          
for r in model("video.mp4", stream=True, save=True, output_path="out.mp4"):                                              
    pass                                                                                                                 

# Process every 5th frame                                                                                                
for r in model("video.mp4", stream=True, vid_stride=5):         
    pass                           
```                                                                                      
                                                                  
What's included                                                                                                                                                                
  - VideoSource / VideoWriter utilities with context manager support                                                       
  - run_video_inference shared loop used by both ONNX and PyTorch backends
  - stream=True returns a generator; stream=False returns a list                                                           
  - vid_stride parameter for frame skipping (efficient grab-without-decode)                                                
  - save=True writes annotated output video with auto-incrementing path                                                    
  - show=True displays frames in a cv2 window (press q to quit)                                                            
  - frame_idx added to Results for frame tracking                                                                          
  - Unit tests with synthetic video + E2E tests across all 3 model families                                                
  - Requires opencv-python (imported lazily, clear error message if missing)  