### PR TITLE
39 add instance segmentation to rf detr and yolo9

### DIFF
--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path as _Path
 
 # Core API — always available
 from .models import LibreYOLO, LibreYOLOX, LibreYOLO9
-from .utils.results import Results, Boxes
+from .utils.results import Results, Boxes, Masks
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
 
@@ -54,6 +54,7 @@ __all__ = [
     # Results
     "Results",
     "Boxes",
+    "Masks",
     # Assets
     "SAMPLE_IMAGE",
     # Lazy-loaded

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -14,7 +14,7 @@ from ..models.yolox.utils import preprocess_image as yolox_preprocess_image
 from ..utils.drawing import draw_boxes
 from ..utils.general import COCO_CLASSES, get_safe_stem
 from ..utils.image_loader import ImageLoader
-from ..utils.results import Boxes, Results
+from ..utils.results import Boxes, Masks, Results
 
 
 def _nms_numpy(
@@ -138,17 +138,21 @@ class BaseBackend(ABC):
         conf: float,
         ratio: float = 1.0,
     ):
-        """Parse raw outputs into (boxes_xyxy, scores, class_ids)."""
+        """Parse raw outputs into (boxes_xyxy, scores, class_ids, masks_or_None)."""
         orig_w, orig_h = original_size
 
         if self.model_family == "yolox":
-            return self._parse_yolox(
+            boxes, scores, cls = self._parse_yolox(
                 all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio
             )
+            return boxes, scores, cls, None
         elif self.model_family == "rfdetr":
             return self._parse_rfdetr(all_outputs, orig_w, orig_h, conf)
         else:
-            return self._parse_yolo9(all_outputs, effective_imgsz, orig_w, orig_h, conf)
+            boxes, scores, cls = self._parse_yolo9(
+                all_outputs, effective_imgsz, orig_w, orig_h, conf
+            )
+            return boxes, scores, cls, None
 
     def _parse_yolox(
         self, all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=1.0
@@ -209,9 +213,14 @@ class BaseBackend(ABC):
         return boxes, max_scores, class_ids
 
     def _parse_rfdetr(self, all_outputs, orig_w, orig_h, conf):
-        """Parse RF-DETR output: boxes (B,300,4) cxcywh [0,1] + logits (B,300,nc)."""
+        """Parse RF-DETR output: boxes (B,300,4) cxcywh [0,1] + logits (B,300,nc).
+
+        For segmentation models a third output is present:
+        masks (B,300,Hm,Wm) raw mask logits at model resolution.
+        """
         boxes_raw = all_outputs[0][0]  # (300, 4) normalized cxcywh
         logits = all_outputs[1][0]  # (300, nc) raw logits
+        raw_masks = all_outputs[2][0] if len(all_outputs) >= 3 else None
 
         scores = 1.0 / (1.0 + np.exp(-logits.astype(np.float64))).astype(np.float32)
 
@@ -221,9 +230,11 @@ class BaseBackend(ABC):
         mask = max_scores > conf
         boxes_raw = boxes_raw[mask]
         max_scores, class_ids = max_scores[mask], class_ids[mask]
+        if raw_masks is not None:
+            raw_masks = raw_masks[mask]
 
         if len(boxes_raw) == 0:
-            return boxes_raw, max_scores, class_ids
+            return boxes_raw, max_scores, class_ids, None
 
         # COCO 91→80 class mapping
         if logits.shape[1] == 91 and self.nb_classes == 80:
@@ -234,9 +245,11 @@ class BaseBackend(ABC):
             boxes_raw = boxes_raw[valid]
             max_scores = max_scores[valid]
             class_ids = mapped[valid]
+            if raw_masks is not None:
+                raw_masks = raw_masks[valid]
 
         if len(boxes_raw) == 0:
-            return boxes_raw, max_scores, class_ids
+            return boxes_raw, max_scores, class_ids, None
 
         cx, cy, w, h = (
             boxes_raw[:, 0],
@@ -253,7 +266,22 @@ class BaseBackend(ABC):
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
 
-        return boxes, max_scores, class_ids
+        # Resize and threshold masks to original image resolution
+        masks_out = None
+        if raw_masks is not None and len(raw_masks) > 0:
+            import torch
+            import torch.nn.functional as F
+
+            masks_t = torch.from_numpy(raw_masks).unsqueeze(1).float()
+            masks_t = F.interpolate(
+                masks_t,
+                size=(int(orig_h), int(orig_w)),
+                mode="bilinear",
+                align_corners=False,
+            )
+            masks_out = (masks_t[:, 0] > 0.0).numpy()  # (N, H, W)
+
+        return boxes, max_scores, class_ids, masks_out
 
     # =========================================================================
     # Result building
@@ -265,6 +293,7 @@ class BaseBackend(ABC):
         max_scores: np.ndarray,
         class_ids: np.ndarray,
         *,
+        masks: "np.ndarray | None" = None,
         orig_shape: Tuple[int, int],
         image_path,
         iou: float,
@@ -290,12 +319,16 @@ class BaseBackend(ABC):
             max_scores[keep],
             class_ids[keep],
         )
+        if masks is not None:
+            masks = masks[keep]
 
         if len(boxes) > max_det:
             top_indices = np.argsort(max_scores)[::-1][:max_det]
             boxes = boxes[top_indices]
             max_scores = max_scores[top_indices]
             class_ids = class_ids[top_indices]
+            if masks is not None:
+                masks = masks[top_indices]
 
         boxes_t = torch.tensor(boxes, dtype=torch.float32)
         conf_t = torch.tensor(max_scores, dtype=torch.float32)
@@ -308,9 +341,16 @@ class BaseBackend(ABC):
             boxes_t = boxes_t[cls_mask]
             conf_t = conf_t[cls_mask]
             cls_t = cls_t[cls_mask]
+            if masks is not None:
+                masks = masks[cls_mask.numpy()]
+
+        masks_obj = None
+        if masks is not None and len(masks) > 0:
+            masks_obj = Masks(torch.from_numpy(masks).bool(), orig_shape=orig_shape)
 
         return Results(
             boxes=Boxes(boxes_t, conf_t, cls_t),
+            masks=masks_obj,
             orig_shape=orig_shape,
             path=str(image_path) if image_path else None,
             names=self.names,
@@ -322,15 +362,22 @@ class BaseBackend(ABC):
 
     def _save_annotated(self, result, original_img, image_path, output_path):
         """Save annotated image to disk."""
+        annotated_img = original_img
         if len(result) > 0:
+            if result.masks is not None:
+                from ..utils.drawing import draw_masks
+
+                annotated_img = draw_masks(
+                    annotated_img,
+                    result.masks.data.numpy(),
+                    result.boxes.cls.tolist(),
+                )
             annotated_img = draw_boxes(
-                original_img,
+                annotated_img,
                 result.boxes.xyxy.tolist(),
                 result.boxes.conf.tolist(),
                 result.boxes.cls.tolist(),
             )
-        else:
-            annotated_img = original_img
 
         if output_path:
             final_path = Path(output_path)
@@ -386,7 +433,7 @@ class BaseBackend(ABC):
 
         all_outputs = self._run_inference(blob)
 
-        boxes, max_scores, class_ids = self._parse_outputs(
+        boxes, max_scores, class_ids, masks = self._parse_outputs(
             all_outputs, effective_imgsz, original_size, conf, ratio=ratio
         )
 
@@ -396,6 +443,7 @@ class BaseBackend(ABC):
             boxes,
             max_scores,
             class_ids,
+            masks=masks,
             orig_shape=orig_shape,
             image_path=image_path,
             iou=iou,

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -127,7 +127,18 @@ class YOLODataset(Dataset):
                     parts = line.strip().split()
                     if len(parts) >= 5:
                         cls_id = int(parts[0])
-                        cx, cy, w, h = map(float, parts[1:5])
+
+                        if len(parts) > 5:
+                            # Segmentation format: derive bbox from polygon vertices
+                            coords = [float(p) for p in parts[1:]]
+                            xs = coords[0::2]
+                            ys = coords[1::2]
+                            cx = (min(xs) + max(xs)) / 2
+                            cy = (min(ys) + max(ys)) / 2
+                            w = max(xs) - min(xs)
+                            h = max(ys) - min(ys)
+                        else:
+                            cx, cy, w, h = map(float, parts[1:5])
 
                         # Convert normalized xywh to pixel xyxy
                         x1 = (cx - w / 2) * width

--- a/libreyolo/data/yolo_coco_api.py
+++ b/libreyolo/data/yolo_coco_api.py
@@ -47,21 +47,26 @@ def parse_yolo_label_line(
     if len(parts) < 5:
         return None
 
-    # Warn about segmentation format (more than 5 columns)
-    if len(parts) > 5:
-        warnings.warn(
-            f"Label line has {len(parts)} columns (expected 5 for detection). "
-            f"This may be a segmentation dataset which is not supported. "
-            f"File: {label_path}, Line: '{line[:50]}...'"
-        )
-
     # Parse values with error handling
     try:
         class_id = int(parts[0])
-        cx = float(parts[1])
-        cy = float(parts[2])
-        bw = float(parts[3])
-        bh = float(parts[4])
+
+        if len(parts) > 5:
+            # Segmentation format: class_id x1 y1 x2 y2 x3 y3 ...
+            # Derive bounding box from polygon vertices.
+            coords = [float(p) for p in parts[1:]]
+            xs = coords[0::2]
+            ys = coords[1::2]
+            cx = (min(xs) + max(xs)) / 2
+            cy = (min(ys) + max(ys)) / 2
+            bw = max(xs) - min(xs)
+            bh = max(ys) - min(ys)
+        else:
+            # Detection format: class_id cx cy w h
+            cx = float(parts[1])
+            cy = float(parts[2])
+            bw = float(parts[3])
+            bh = float(parts[4])
     except ValueError as e:
         if label_path:
             warnings.warn(

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -60,6 +60,15 @@ def _postprocess_onnx(
     onnx.save(model_proto, path)
 
 
+def _detect_num_outputs(nn_model, dummy):
+    """Run a forward pass to detect how many outputs the model produces."""
+    with torch.no_grad():
+        out = nn_model(dummy)
+    if isinstance(out, tuple):
+        return len(out)
+    return 1
+
+
 def export_onnx(
     nn_model,
     dummy,
@@ -93,19 +102,35 @@ def export_onnx(
             "Install with: uv sync --extra onnx  or  pip install onnx"
         )
 
-    dynamic_axes = None
-    if dynamic:
-        dynamic_axes = {
-            "images": {0: "batch"},
-            "output": {0: "batch"},
-        }
+    # Detect segmentation models (3 outputs: boxes, logits, masks)
+    num_outputs = _detect_num_outputs(nn_model, dummy)
+    is_seg = num_outputs >= 3
+
+    if is_seg:
+        output_names = ["boxes", "scores", "masks"]
+        dynamic_axes = (
+            {
+                "images": {0: "batch"},
+                "boxes": {0: "batch"},
+                "scores": {0: "batch"},
+                "masks": {0: "batch"},
+            }
+            if dynamic
+            else None
+        )
+        metadata["segmentation"] = "true"
+    else:
+        output_names = ["output"]
+        dynamic_axes = (
+            {"images": {0: "batch"}, "output": {0: "batch"}} if dynamic else None
+        )
 
     export_kwargs = {
         "export_params": True,
         "opset_version": opset,
         "do_constant_folding": True,
         "input_names": ["images"],
-        "output_names": ["output"],
+        "output_names": output_names,
         "dynamic_axes": dynamic_axes,
     }
 

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -230,8 +230,14 @@ def LibreYOLO(
 
     if matched_cls.FAMILY == "rfdetr":
         # RF-DETR always needs the path (handles its own loading internally)
+        # Detect segmentation from filename (supplements auto-detection from weights)
+        task = matched_cls.detect_task_from_filename(Path(model_path).name)
         model = matched_cls(
-            model_path=model_path, size=size, nb_classes=nb_classes, device=device
+            model_path=model_path,
+            size=size,
+            nb_classes=nb_classes,
+            device=device,
+            segmentation=(task == "seg"),
         )
     elif has_metadata:
         # Our trainer checkpoint — pass path for metadata handling

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -317,7 +317,7 @@ class InferenceRunner:
                 # Draw masks first (underneath boxes)
                 if result.masks is not None:
                     masks_np = result.masks.data
-                    if hasattr(masks_np, "numpy"):
+                    if isinstance(masks_np, torch.Tensor):
                         masks_np = masks_np.cpu().numpy()
                     annotated_img = draw_masks(
                         annotated_img,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -17,7 +17,7 @@ import torch
 from ...utils.drawing import draw_boxes, draw_tile_grid
 from ...utils.general import get_safe_stem, get_slice_bboxes, nms, resolve_save_path
 from ...utils.image_loader import ImageInput, ImageLoader
-from ...utils.results import Boxes, Results
+from ...utils.results import Boxes, Masks, Results
 
 if TYPE_CHECKING:
     from .model import BaseModel
@@ -194,12 +194,14 @@ class InferenceRunner:
         conf_t: torch.Tensor,
         cls_t: torch.Tensor,
         classes: List[int],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        masks_t: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         """Filter detections to keep only the requested class IDs."""
         mask = torch.zeros(len(cls_t), dtype=torch.bool, device=cls_t.device)
         for cid in classes:
             mask |= cls_t == cid
-        return boxes_t[mask], conf_t[mask], cls_t[mask]
+        filtered_masks = masks_t[mask] if masks_t is not None else None
+        return boxes_t[mask], conf_t[mask], cls_t[mask], filtered_masks
 
     def _wrap_results(
         self,
@@ -211,11 +213,14 @@ class InferenceRunner:
         """Convert raw detection dict to a Results object.
 
         Args:
-            detections: Dict with 'boxes', 'scores', 'classes', 'num_detections'.
+            detections: Dict with 'boxes', 'scores', 'classes', 'num_detections',
+                and optionally 'masks'.
             original_size: (width, height) from preprocessing.
             image_path: Source path or None.
             classes: Optional class filter list.
         """
+        masks_t = None
+
         if detections["num_detections"] == 0:
             boxes_t = torch.zeros((0, 4), dtype=torch.float32)
             conf_t = torch.zeros((0,), dtype=torch.float32)
@@ -239,21 +244,33 @@ class InferenceRunner:
             else:
                 cls_t = torch.tensor(raw_cls, dtype=torch.float32)
 
+            raw_masks = detections.get("masks")
+            if raw_masks is not None:
+                if isinstance(raw_masks, torch.Tensor):
+                    masks_t = raw_masks
+                else:
+                    masks_t = torch.tensor(raw_masks)
+
         # Apply class filter
         if classes is not None and len(boxes_t) > 0:
-            boxes_t, conf_t, cls_t = self._apply_classes_filter(
-                boxes_t, conf_t, cls_t, classes
+            boxes_t, conf_t, cls_t, masks_t = self._apply_classes_filter(
+                boxes_t, conf_t, cls_t, classes, masks_t
             )
 
-        # original_size from preprocess is (W, H); orig_shape follows Ultralytics (H, W)
+        # original_size from preprocess is (W, H); orig_shape is (H, W)
         orig_w, orig_h = original_size
         orig_shape = (orig_h, orig_w)
+
+        masks_obj = None
+        if masks_t is not None:
+            masks_obj = Masks(masks_t, orig_shape)
 
         return Results(
             boxes=Boxes(boxes_t, conf_t, cls_t),
             orig_shape=orig_shape,
             path=str(image_path) if image_path else None,
             names=self.model.names,
+            masks=masks_obj,
         )
 
     def _predict_single(

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import torch
 
-from ...utils.drawing import draw_boxes, draw_tile_grid
+from ...utils.drawing import draw_boxes, draw_masks, draw_tile_grid
 from ...utils.general import get_safe_stem, get_slice_bboxes, nms, resolve_save_path
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.results import Boxes, Masks, Results
@@ -313,8 +313,19 @@ class InferenceRunner:
         # Save annotated image
         if save:
             if len(result) > 0:
+                annotated_img = original_img
+                # Draw masks first (underneath boxes)
+                if result.masks is not None:
+                    masks_np = result.masks.data
+                    if hasattr(masks_np, "numpy"):
+                        masks_np = masks_np.cpu().numpy()
+                    annotated_img = draw_masks(
+                        annotated_img,
+                        masks_np,
+                        result.boxes.cls.tolist(),
+                    )
                 annotated_img = draw_boxes(
-                    original_img,
+                    annotated_img,
                     result.boxes.xyxy.tolist(),
                     result.boxes.conf.tolist(),
                     result.boxes.cls.tolist(),

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -390,6 +390,16 @@ class InferenceRunner:
         **kwargs,
     ) -> Results:
         """Run tiled inference on large images."""
+        import warnings
+
+        if getattr(self.model, "_is_segmentation", False):
+            warnings.warn(
+                "Tiled inference does not support segmentation masks. "
+                "Masks will be None in the results. Use non-tiled inference "
+                "for instance segmentation.",
+                stacklevel=2,
+            )
+
         input_size = imgsz if imgsz is not None else self.model._get_input_size()
         img_pil = ImageLoader.load(image, color_format=color_format)
         orig_width, orig_height = img_pil.size

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -200,15 +200,34 @@ class BaseModel(ABC):
         self.model.to(self.device)
 
     @classmethod
-    def detect_size_from_filename(cls, filename: str) -> Optional[str]:
-        """Extract model size from a weight filename."""
+    def _filename_regex(cls) -> Optional[re.Pattern]:
+        """Compile regex for matching weight filenames with optional task suffix."""
         if not cls.INPUT_SIZES or not cls.FILENAME_PREFIX:
             return None
         sizes_pattern = "".join(cls.INPUT_SIZES.keys())
         prefix = cls.FILENAME_PREFIX.lower()
         ext = re.escape(cls.WEIGHT_EXT)
-        m = re.search(rf"{prefix}([{sizes_pattern}]){ext}", filename.lower())
+        return re.compile(rf"{prefix}([{sizes_pattern}])(-seg)?{ext}")
+
+    @classmethod
+    def detect_size_from_filename(cls, filename: str) -> Optional[str]:
+        """Extract model size from a weight filename."""
+        pattern = cls._filename_regex()
+        if pattern is None:
+            return None
+        m = pattern.search(filename.lower())
         return m.group(1) if m else None
+
+    @classmethod
+    def detect_task_from_filename(cls, filename: str) -> Optional[str]:
+        """Extract task suffix from a weight filename (e.g. 'seg')."""
+        pattern = cls._filename_regex()
+        if pattern is None:
+            return None
+        m = pattern.search(filename.lower())
+        if m and m.group(2):
+            return m.group(2).lstrip("-")
+        return None
 
     @classmethod
     def get_download_url(cls, filename: str) -> Optional[str]:
@@ -216,9 +235,10 @@ class BaseModel(ABC):
         size = cls.detect_size_from_filename(filename)
         if size is None:
             return None
-        repo = f"LibreYOLO/{cls.FILENAME_PREFIX}{size}"
-        actual = f"{cls.FILENAME_PREFIX}{size}{cls.WEIGHT_EXT}"
-        return f"https://huggingface.co/{repo}/resolve/main/{actual}"
+        task = cls.detect_task_from_filename(filename)
+        suffix = f"-{task}" if task else ""
+        name = f"{cls.FILENAME_PREFIX}{size}{suffix}"
+        return f"https://huggingface.co/LibreYOLO/{name}/resolve/main/{name}{cls.WEIGHT_EXT}"
 
     def _get_val_preprocessor(self, img_size: int | None = None):
         """Return the validation preprocessor for this model."""

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -208,9 +208,15 @@ class LibreYOLORFDETR(BaseModel):
 
         self._is_segmentation = segmentation
 
-        # Auto-detect segmentation from weights
+        # Auto-detect segmentation from filename first (avoids loading weights twice)
         if not segmentation and self._pretrain_weights is not None:
-            self._is_segmentation = self._detect_segmentation(self._pretrain_weights)
+            task = self.detect_task_from_filename(str(self._pretrain_weights))
+            if task == "seg":
+                self._is_segmentation = True
+            else:
+                self._is_segmentation = self._detect_segmentation(
+                    self._pretrain_weights
+                )
 
         if self._is_segmentation:
             self.INPUT_SIZES = self.SEG_INPUT_SIZES

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -103,10 +103,11 @@ _COCO91_TO_COCO80 = {
 
 
 class LibreYOLORFDETR(BaseModel):
-    """RF-DETR model for object detection.
+    """RF-DETR model for object detection and instance segmentation.
 
     RF-DETR is a Detection Transformer using DINOv2 backbone with
-    multi-scale deformable attention.
+    multi-scale deformable attention. Segmentation variants add a
+    lightweight mask head for instance segmentation.
 
     Args:
         model_path: Path to weights, pre-loaded state_dict, or None for pretrained.
@@ -124,6 +125,7 @@ class LibreYOLORFDETR(BaseModel):
     FAMILY = "rfdetr"
     FILENAME_PREFIX = "LibreRFDETR"
     INPUT_SIZES = {"n": 384, "s": 512, "m": 576, "l": 704}
+    SEG_INPUT_SIZES = {"n": 312, "s": 384, "m": 432, "l": 504}
     val_preprocessor_class = RFDETRValPreprocessor
 
     # =========================================================================
@@ -149,7 +151,11 @@ class LibreYOLORFDETR(BaseModel):
         cls, weights_dict: dict, state_dict: dict | None = None
     ) -> Optional[str]:
         full_ckpt = state_dict if state_dict is not None else weights_dict
+        is_seg = any(k.startswith("segmentation_head") for k in weights_dict)
+
         RESOLUTION_TO_SIZE = {384: "n", 512: "s", 576: "m", 704: "l"}
+        SEG_RESOLUTION_TO_SIZE = {312: "n", 384: "s", 432: "m", 504: "l"}
+        res_map = SEG_RESOLUTION_TO_SIZE if is_seg else RESOLUTION_TO_SIZE
 
         args = full_ckpt.get("args")
         if args is not None:
@@ -160,8 +166,8 @@ class LibreYOLORFDETR(BaseModel):
                 if isinstance(args, dict)
                 else None
             )
-            if resolution in RESOLUTION_TO_SIZE:
-                return RESOLUTION_TO_SIZE[resolution]
+            if resolution in res_map:
+                return res_map[resolution]
 
         # Fallback: infer from backbone position_embeddings shape
         pos_key = "backbone.0.encoder.encoder.embeddings.position_embeddings"
@@ -191,6 +197,7 @@ class LibreYOLORFDETR(BaseModel):
         size: str = "s",
         nb_classes: int = 80,
         device: str = "auto",
+        segmentation: bool = False,
         **kwargs,
     ):
         # Convert empty dict (from factory) to None for RF-DETR config compatibility
@@ -198,6 +205,15 @@ class LibreYOLORFDETR(BaseModel):
             self._pretrain_weights = None
         else:
             self._pretrain_weights = model_path
+
+        self._is_segmentation = segmentation
+
+        # Auto-detect segmentation from weights
+        if not segmentation and self._pretrain_weights is not None:
+            self._is_segmentation = self._detect_segmentation(self._pretrain_weights)
+
+        if self._is_segmentation:
+            self.INPUT_SIZES = self.SEG_INPUT_SIZES
 
         super().__init__(
             model_path=None,
@@ -211,6 +227,18 @@ class LibreYOLORFDETR(BaseModel):
         if self._pretrain_weights is not None:
             self.model.eval()
 
+    @staticmethod
+    def _detect_segmentation(model_path) -> bool:
+        """Check if weights contain a segmentation head."""
+        if not isinstance(model_path, str):
+            return False
+        try:
+            ckpt = torch.load(model_path, map_location="cpu", weights_only=False)
+            state = ckpt.get("model", ckpt)
+            return any(k.startswith("segmentation_head") for k in state)
+        except Exception:
+            return False
+
     # =========================================================================
     # Model lifecycle
     # =========================================================================
@@ -221,6 +249,7 @@ class LibreYOLORFDETR(BaseModel):
             nb_classes=self.nb_classes,
             pretrain_weights=self._pretrain_weights,
             device=str(self.device),
+            segmentation=self._is_segmentation,
         )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:
@@ -292,11 +321,14 @@ class LibreYOLORFDETR(BaseModel):
         scores = result["scores"]
         labels = result["labels"]
         boxes = result["boxes"]
+        masks = result.get("masks")  # (K, H, W) bool or None
 
         keep = scores > conf_thres
         scores = scores[keep]
         labels = labels[keep]
         boxes = boxes[keep]
+        if masks is not None:
+            masks = masks[keep]
 
         # Map COCO 91-class IDs to YOLO 80-class indices if needed
         num_output_classes = output["pred_logits"].shape[-1]
@@ -309,13 +341,18 @@ class LibreYOLORFDETR(BaseModel):
             boxes = boxes[valid]
             scores = scores[valid]
             labels = mapped[valid]
+            if masks is not None:
+                masks = masks[valid]
 
-        return {
+        det = {
             "boxes": boxes.cpu().tolist(),
             "scores": scores.cpu().tolist(),
             "classes": labels.cpu().tolist(),
             "num_detections": len(boxes),
         }
+        if masks is not None:
+            det["masks"] = masks.cpu()
+        return det
 
     # =========================================================================
     # Public API

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -395,6 +395,7 @@ class LibreYOLORFDETR(BaseModel):
             output_dir=output_dir,
             resume=resume,
             pretrain_weights=self._pretrain_weights,
+            segmentation=self._is_segmentation,
             **kwargs,
         )
 

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -8,8 +8,9 @@ rfdetr package to ensure 100% weight compatibility.
 import torch
 import torch.nn as nn
 
-from rfdetr.main import Model as RFDETRMainModel
-from rfdetr.models.lwdetr import LWDETR, MLP, PostProcess
+from rfdetr.detr import _build_model_context
+from rfdetr.models import PostProcess
+from rfdetr.models.lwdetr import LWDETR, MLP
 from rfdetr.config import (
     RFDETRLargeConfig,
     RFDETRNanoConfig,
@@ -86,9 +87,8 @@ class LibreRFDETRModel(nn.Module):
         self.hidden_dim = model_config.hidden_dim
         self.num_queries = getattr(model_config, "num_queries", 300)
 
-        config_dict = model_config.dict()
-        config_dict["device"] = device  # Override device
-        self._rfdetr = RFDETRMainModel(**config_dict)
+        model_config.device = device
+        self._rfdetr = _build_model_context(model_config)
 
         self.model = self._rfdetr.model
         self.postprocess = self._rfdetr.postprocess

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -15,6 +15,10 @@ from rfdetr.config import (
     RFDETRNanoConfig,
     RFDETRSmallConfig,
     RFDETRMediumConfig,
+    RFDETRSegLargeConfig,
+    RFDETRSegNanoConfig,
+    RFDETRSegSmallConfig,
+    RFDETRSegMediumConfig,
 )
 
 
@@ -25,13 +29,21 @@ RFDETR_CONFIGS = {
     "l": RFDETRLargeConfig,
 }
 
+RFDETR_SEG_CONFIGS = {
+    "n": RFDETRSegNanoConfig,
+    "s": RFDETRSegSmallConfig,
+    "m": RFDETRSegMediumConfig,
+    "l": RFDETRSegLargeConfig,
+}
+
 
 class LibreRFDETRModel(nn.Module):
     """
     RF-DETR Detection Transformer model wrapper.
 
     This wraps the original RF-DETR model to provide a consistent interface
-    while maintaining 100% weight compatibility.
+    while maintaining 100% weight compatibility. Supports both detection and
+    instance segmentation variants.
     """
 
     def __init__(
@@ -40,6 +52,7 @@ class LibreRFDETRModel(nn.Module):
         nb_classes: int = 80,
         pretrain_weights: str | None = None,
         device: str = "cpu",
+        segmentation: bool = False,
     ):
         """
         Initialize RF-DETR model.
@@ -49,18 +62,21 @@ class LibreRFDETRModel(nn.Module):
             nb_classes: Number of object classes (use 80 for COCO)
             pretrain_weights: Path to pretrained weights (optional)
             device: Device to use ('cpu', 'cuda', 'mps')
+            segmentation: If True, use segmentation config with mask head
         """
         super().__init__()
 
-        if config not in RFDETR_CONFIGS:
+        configs = RFDETR_SEG_CONFIGS if segmentation else RFDETR_CONFIGS
+        if config not in configs:
             raise ValueError(
-                f"Invalid config: {config}. Must be one of: {list(RFDETR_CONFIGS.keys())}"
+                f"Invalid config: {config}. Must be one of: {list(configs.keys())}"
             )
 
         self.config_name = config
         self.nb_classes = nb_classes
+        self.segmentation = segmentation
 
-        config_cls = RFDETR_CONFIGS[config]
+        config_cls = configs[config]
         model_config = config_cls(
             num_classes=nb_classes,
             pretrain_weights=pretrain_weights,
@@ -85,14 +101,16 @@ class LibreRFDETRModel(nn.Module):
             x: Input tensor of shape (B, 3, H, W)
 
         Returns:
-            Dictionary with 'pred_logits' and 'pred_boxes' (inference mode),
-            or tuple of (pred_boxes, pred_logits) when in export mode.
+            Dictionary with 'pred_logits', 'pred_boxes', and optionally
+            'pred_masks' (inference mode), or tuple of tensors in export mode.
         """
         out = self.model(x)
-        # In export mode, forward_export returns (coord, class, masks)
-        # where masks may be None (not traceable). Return only tensors.
+        # In export mode, forward_export returns (coord, class, masks).
+        # Pass through all available tensors.
         if isinstance(out, tuple):
             coord, cls = out[0], out[1]
+            if len(out) >= 3 and out[2] is not None:
+                return coord, cls, out[2]
             return coord, cls
         return out
 
@@ -122,6 +140,7 @@ def create_rfdetr_model(
     nb_classes: int = 80,
     pretrain_weights: str | None = None,
     device: str = "cpu",
+    segmentation: bool = False,
 ) -> LibreRFDETRModel:
     """
     Create an RF-DETR model.
@@ -131,6 +150,7 @@ def create_rfdetr_model(
         nb_classes: Number of object classes
         pretrain_weights: Path to pretrained weights
         device: Device to use
+        segmentation: If True, create segmentation variant with mask head
 
     Returns:
         LibreRFDETRModel instance
@@ -140,6 +160,7 @@ def create_rfdetr_model(
         nb_classes=nb_classes,
         pretrain_weights=pretrain_weights,
         device=device,
+        segmentation=segmentation,
     )
 
 

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -6,12 +6,20 @@ Wraps the original rfdetr training API with Ultralytics-compatible interface.
 from typing import Dict
 
 from rfdetr import RFDETRLarge, RFDETRNano, RFDETRSmall, RFDETRMedium
+from rfdetr import RFDETRSegLarge, RFDETRSegNano, RFDETRSegSmall, RFDETRSegMedium
 
 RFDETR_TRAINERS = {
     "n": RFDETRNano,
     "s": RFDETRSmall,
     "m": RFDETRMedium,
     "l": RFDETRLarge,
+}
+
+RFDETR_SEG_TRAINERS = {
+    "n": RFDETRSegNano,
+    "s": RFDETRSegSmall,
+    "m": RFDETRSegMedium,
+    "l": RFDETRSegLarge,
 }
 
 
@@ -24,6 +32,7 @@ def train_rfdetr(
     output_dir: str = "runs/train",
     resume: str | None = None,
     pretrain_weights: str | None = None,
+    segmentation: bool = False,
     **kwargs,
 ) -> Dict:
     """
@@ -55,12 +64,13 @@ def train_rfdetr(
         >>> from libreyolo.rfdetr import train_rfdetr
         >>> train_rfdetr(data="path/to/dataset", size="s", epochs=50)
     """
-    if size not in RFDETR_TRAINERS:
+    trainers = RFDETR_SEG_TRAINERS if segmentation else RFDETR_TRAINERS
+    if size not in trainers:
         raise ValueError(
-            f"Invalid size: {size}. Must be one of {list(RFDETR_TRAINERS.keys())}"
+            f"Invalid size: {size}. Must be one of {list(trainers.keys())}"
         )
 
-    trainer_cls = RFDETR_TRAINERS[size]
+    trainer_cls = trainers[size]
     init_kwargs = {}
     if pretrain_weights is not None:
         init_kwargs["pretrain_weights"] = pretrain_weights

--- a/libreyolo/models/rfdetr/utils.py
+++ b/libreyolo/models/rfdetr/utils.py
@@ -6,7 +6,7 @@ Postprocessing matches the original rfdetr implementation exactly.
 
 import numpy as np
 import torch
-import torch.nn.functional as TF
+import torch.nn.functional as F
 from typing import List, Dict, Tuple
 from PIL import Image
 
@@ -113,7 +113,7 @@ def postprocess(
 
             # Resize to original image size
             h, w = target_sizes[i].tolist()
-            masks_i = TF.interpolate(
+            masks_i = F.interpolate(
                 masks_i.unsqueeze(1),
                 size=(int(h), int(w)),
                 mode="bilinear",

--- a/libreyolo/models/rfdetr/utils.py
+++ b/libreyolo/models/rfdetr/utils.py
@@ -6,6 +6,7 @@ Postprocessing matches the original rfdetr implementation exactly.
 
 import numpy as np
 import torch
+import torch.nn.functional as TF
 from typing import List, Dict, Tuple
 from PIL import Image
 
@@ -68,6 +69,7 @@ def postprocess(
     """
     out_logits = outputs["pred_logits"]  # (B, num_queries, num_classes)
     out_bbox = outputs["pred_boxes"]  # (B, num_queries, 4) in cxcywh [0, 1]
+    out_masks = outputs.get("pred_masks")  # (B, num_queries, Hm, Wm) or None
 
     assert len(out_logits) == len(target_sizes)
     assert target_sizes.shape[1] == 2
@@ -94,9 +96,33 @@ def postprocess(
     scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1)
     boxes = boxes * scale_fct[:, None, :]
 
-    results = [
-        {"scores": s, "labels": lab, "boxes": b}
-        for s, lab, b in zip(scores, labels, boxes)
-    ]
+    results = []
+    for i in range(batch_size):
+        res_i = {"scores": scores[i], "labels": labels[i], "boxes": boxes[i]}
+
+        if out_masks is not None:
+            # Gather masks for top-K queries
+            k_idx = topk_boxes[i]
+            masks_i = torch.gather(
+                out_masks[i],
+                0,
+                k_idx.unsqueeze(-1)
+                .unsqueeze(-1)
+                .repeat(1, out_masks.shape[-2], out_masks.shape[-1]),
+            )  # (K, Hm, Wm)
+
+            # Resize to original image size
+            h, w = target_sizes[i].tolist()
+            masks_i = TF.interpolate(
+                masks_i.unsqueeze(1),
+                size=(int(h), int(w)),
+                mode="bilinear",
+                align_corners=False,
+            )  # (K, 1, H, W)
+
+            # Threshold at 0.0 in logit space (= 0.5 probability)
+            res_i["masks"] = (masks_i[:, 0] > 0.0).bool()  # (K, H, W)
+
+        results.append(res_i)
 
     return results

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -3,6 +3,7 @@
 import colorsys
 from typing import List, Tuple
 
+import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 from .general import COCO_CLASSES
@@ -15,6 +16,15 @@ def get_class_color(class_id: int) -> str:
     value = 0.8 + (class_id % 2) * 0.15
     rgb = colorsys.hsv_to_rgb(hue, saturation, value)
     return f"#{int(rgb[0] * 255):02x}{int(rgb[1] * 255):02x}{int(rgb[2] * 255):02x}"
+
+
+def _get_class_color_rgb(class_id: int) -> Tuple[int, int, int]:
+    """Get class color as (R, G, B) ints."""
+    hue = (class_id * 137.508) % 360 / 360.0
+    saturation = 0.7 + (class_id % 3) * 0.1
+    value = 0.8 + (class_id % 2) * 0.15
+    r, g, b = colorsys.hsv_to_rgb(hue, saturation, value)
+    return int(r * 255), int(g * 255), int(b * 255)
 
 
 def draw_boxes(
@@ -123,6 +133,43 @@ def draw_boxes(
             )
 
     return img_draw
+
+
+def draw_masks(
+    img: Image.Image,
+    masks: np.ndarray,
+    classes: List,
+    alpha: float = 0.45,
+) -> Image.Image:
+    """
+    Draw semi-transparent instance segmentation masks on image.
+
+    Args:
+        img: PIL Image to draw on.
+        masks: (N, H, W) boolean numpy array of instance masks.
+        classes: List of class IDs (one per mask).
+        alpha: Mask opacity (0 = transparent, 1 = opaque).
+
+    Returns:
+        Annotated PIL Image with mask overlays.
+    """
+    img_draw = img.copy().convert("RGBA")
+    overlay = Image.new("RGBA", img_draw.size, (0, 0, 0, 0))
+
+    alpha_int = int(alpha * 255)
+
+    for mask, cls_id in zip(masks, classes):
+        r, g, b = _get_class_color_rgb(int(cls_id))
+
+        # Create colored mask layer
+        mask_rgba = np.zeros((*mask.shape, 4), dtype=np.uint8)
+        mask_rgba[mask > 0] = (r, g, b, alpha_int)
+
+        mask_img = Image.fromarray(mask_rgba, mode="RGBA")
+        overlay = Image.alpha_composite(overlay, mask_img)
+
+    result = Image.alpha_composite(img_draw, overlay)
+    return result.convert("RGB")
 
 
 def draw_tile_grid(

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -9,22 +9,19 @@ from PIL import Image, ImageDraw, ImageFont
 from .general import COCO_CLASSES
 
 
-def get_class_color(class_id: int) -> str:
-    """Get a unique, consistent color for a class ID using HSV distribution."""
-    hue = (class_id * 137.508) % 360 / 360.0  # golden angle approximation
-    saturation = 0.7 + (class_id % 3) * 0.1
-    value = 0.8 + (class_id % 2) * 0.15
-    rgb = colorsys.hsv_to_rgb(hue, saturation, value)
-    return f"#{int(rgb[0] * 255):02x}{int(rgb[1] * 255):02x}{int(rgb[2] * 255):02x}"
-
-
 def _get_class_color_rgb(class_id: int) -> Tuple[int, int, int]:
-    """Get class color as (R, G, B) ints."""
-    hue = (class_id * 137.508) % 360 / 360.0
+    """Get a unique, consistent color for a class ID as (R, G, B) ints."""
+    hue = (class_id * 137.508) % 360 / 360.0  # golden angle approximation
     saturation = 0.7 + (class_id % 3) * 0.1
     value = 0.8 + (class_id % 2) * 0.15
     r, g, b = colorsys.hsv_to_rgb(hue, saturation, value)
     return int(r * 255), int(g * 255), int(b * 255)
+
+
+def get_class_color(class_id: int) -> str:
+    """Get a unique, consistent color for a class ID as hex string."""
+    r, g, b = _get_class_color_rgb(class_id)
+    return f"#{r:02x}{g:02x}{b:02x}"
 
 
 def draw_boxes(

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -1,16 +1,18 @@
 """
-Ultralytics-compatible Results and Boxes classes for LibreYOLO.
+Results, Boxes, and Masks classes for LibreYOLO.
 
-Provides structured access to detection results via attribute-style API:
+Provides structured access to detection and segmentation results:
     result.boxes.xyxy   # (N, 4) tensor of boxes
     result.boxes.conf   # (N,) tensor of confidences
     result.boxes.cls    # (N,) tensor of class IDs
     result.boxes.xywh   # (N, 4) center-x, center-y, width, height
     result.boxes.data   # (N, 6) combined [xyxy, conf, cls]
+    result.masks.data   # (N, H, W) tensor of instance masks
 """
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
 
 
@@ -97,15 +99,95 @@ class Boxes:
         )
 
 
+class Masks:
+    """
+    Wraps instance segmentation mask tensors for a single image.
+
+    Args:
+        masks: (N, H, W) tensor of binary instance masks at original image resolution.
+        orig_shape: (height, width) of the original image.
+    """
+
+    def __init__(
+        self,
+        masks: Union[torch.Tensor, np.ndarray],
+        orig_shape: Tuple[int, int],
+    ):
+        self._masks = masks
+        self.orig_shape = orig_shape
+
+    @property
+    def data(self) -> Union[torch.Tensor, np.ndarray]:
+        """(N, H, W) instance masks."""
+        return self._masks
+
+    @property
+    def xy(self) -> List[np.ndarray]:
+        """List of (M_i, 2) contour arrays in pixel coordinates, one per mask."""
+        return self._masks_to_contours(normalize=False)
+
+    @property
+    def xyn(self) -> List[np.ndarray]:
+        """List of (M_i, 2) contour arrays in normalized [0, 1] coordinates."""
+        return self._masks_to_contours(normalize=True)
+
+    def _masks_to_contours(self, normalize: bool) -> List[np.ndarray]:
+        """Extract contour polygons from binary masks."""
+        import cv2
+
+        masks_np = self._masks
+        if isinstance(masks_np, torch.Tensor):
+            masks_np = masks_np.cpu().numpy()
+        masks_np = masks_np.astype(np.uint8)
+
+        h, w = self.orig_shape
+        contours_list = []
+        for mask in masks_np:
+            contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            if contours:
+                # take the largest contour
+                c = max(contours, key=cv2.contourArea).squeeze(1).astype(np.float64)
+                if normalize:
+                    c[:, 0] /= w
+                    c[:, 1] /= h
+                contours_list.append(c)
+            else:
+                contours_list.append(np.empty((0, 2), dtype=np.float64))
+        return contours_list
+
+    def cpu(self) -> "Masks":
+        """Return a copy with all tensors on CPU."""
+        if isinstance(self._masks, torch.Tensor):
+            return Masks(self._masks.cpu(), self.orig_shape)
+        return self
+
+    def numpy(self) -> "Masks":
+        """Return a copy backed by numpy arrays."""
+        if isinstance(self._masks, torch.Tensor):
+            return Masks(self._masks.cpu().numpy(), self.orig_shape)
+        return self
+
+    def __len__(self) -> int:
+        return self._masks.shape[0]
+
+    def __repr__(self) -> str:
+        return (
+            f"Masks(n={len(self)}, "
+            f"shape={tuple(self._masks.shape)}, "
+            f"orig_shape={self.orig_shape})"
+        )
+
+
 class Results:
     """
-    Single-image detection result, matching the Ultralytics Results API.
+    Single-image result for detection and/or instance segmentation.
 
     Args:
         boxes: Boxes instance containing detections.
         orig_shape: (height, width) of the original image.
         path: Source image path (or None).
         names: Dict mapping class ID -> class name.
+        masks: Optional Masks instance for segmentation results.
     """
 
     def __init__(
@@ -114,11 +196,13 @@ class Results:
         orig_shape: Tuple[int, int],
         path: Optional[str] = None,
         names: Optional[Dict[int, str]] = None,
+        masks: Optional[Masks] = None,
     ):
         self.boxes = boxes
         self.orig_shape = orig_shape
         self.path = path
         self.names = names or {}
+        self.masks = masks
 
     def cpu(self) -> "Results":
         """Return a copy with all tensors on CPU."""
@@ -127,15 +211,18 @@ class Results:
             orig_shape=self.orig_shape,
             path=self.path,
             names=self.names,
+            masks=self.masks.cpu() if self.masks is not None else None,
         )
 
     def __len__(self) -> int:
         return len(self.boxes)
 
     def __repr__(self) -> str:
-        return (
-            f"Results("
-            f"path='{self.path}', "
-            f"orig_shape={self.orig_shape}, "
-            f"boxes={self.boxes})"
-        )
+        parts = [
+            f"path='{self.path}'",
+            f"orig_shape={self.orig_shape}",
+            f"boxes={self.boxes}",
+        ]
+        if self.masks is not None:
+            parts.append(f"masks={self.masks}")
+        return f"Results({', '.join(parts)})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ onnx = [
     "onnxruntime>=1.16.0",
 ]
 rfdetr = [
-    "rfdetr>=1.6.0",
+    "rfdetr[train]>=1.6.0",
 ]
 tensorrt = [
     "tensorrt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ onnx = [
     "onnxruntime>=1.16.0",
 ]
 rfdetr = [
-    "rfdetr>=1.4.1",
+    "rfdetr>=1.6.0",
 ]
 tensorrt = [
     "tensorrt",

--- a/tests/e2e/test_rfdetr_seg_training.py
+++ b/tests/e2e/test_rfdetr_seg_training.py
@@ -185,3 +185,85 @@ def test_rfdetr_seg_inference_only(dataset):
         """,
         timeout=300,
     )
+
+
+@requires_cuda
+def test_rfdetr_seg_resume_training(dataset, tmp_path):
+    """Train 3 epochs, stop, resume from checkpoint, train to 5 epochs."""
+    output_dir = str(tmp_path / "rfdetr_seg_resume")
+    dataset_dir = str(dataset)
+
+    run_in_subprocess(
+        f"""
+        import gc
+        import torch
+        from pathlib import Path
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        output_dir = "{output_dir}"
+        dataset_dir = "{dataset_dir}"
+
+        # Phase 1: Train 3 epochs
+        print("Phase 1: Training 3 epochs...")
+        model = LibreYOLORFDETR(
+            model_path="LibreRFDETRn-seg.pt",
+            size="n",
+            segmentation=True,
+        )
+        model.train(
+            data=dataset_dir,
+            epochs=3,
+            batch_size=2,
+            output_dir=output_dir,
+        )
+
+        # Find checkpoint
+        ckpt_path = Path(output_dir) / "checkpoint_best_total.pth"
+        if not ckpt_path.exists():
+            ckpts = sorted(Path(output_dir).glob("checkpoint*.pth"))
+            assert ckpts, f"No checkpoint found in {{output_dir}}"
+            ckpt_path = ckpts[-1]
+        print(f"Checkpoint: {{ckpt_path}}")
+
+        # Verify checkpoint has seg keys
+        ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        seg_keys = [k for k in ckpt["model"] if k.startswith("segmentation_head")]
+        assert len(seg_keys) > 0, "Checkpoint missing segmentation_head keys"
+
+        # Cleanup
+        del model, ckpt
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # Phase 2: Resume from checkpoint, train to 5 epochs
+        print("Phase 2: Resuming training to 5 epochs...")
+        model2 = LibreYOLORFDETR(
+            model_path="LibreRFDETRn-seg.pt",
+            size="n",
+            segmentation=True,
+        )
+        model2.train(
+            data=dataset_dir,
+            epochs=5,
+            batch_size=2,
+            output_dir=output_dir,
+            resume=str(ckpt_path),
+        )
+
+        # Verify resumed checkpoint still has seg keys
+        ckpt2_path = Path(output_dir) / "checkpoint_best_total.pth"
+        ckpt2 = torch.load(ckpt2_path, map_location="cpu", weights_only=False)
+        seg_keys2 = [k for k in ckpt2["model"] if k.startswith("segmentation_head")]
+        assert len(seg_keys2) > 0, "Resumed checkpoint missing segmentation_head keys"
+        print(f"Resumed checkpoint has {{len(seg_keys2)}} segmentation_head keys")
+
+        # Verify model still produces masks after resume
+        from libreyolo import SAMPLE_IMAGE
+        result = model2.predict(SAMPLE_IMAGE, conf=0.3)
+        print(f"Post-resume inference: {{len(result)}} dets, "
+              f"masks={{result.masks is not None}}")
+
+        print("PASSED")
+        """,
+        timeout=600,
+    )

--- a/tests/e2e/test_rfdetr_seg_training.py
+++ b/tests/e2e/test_rfdetr_seg_training.py
@@ -1,14 +1,19 @@
 """
-E2E: RF-DETR segmentation training test.
+E2E: RF-DETR segmentation training and inference tests.
 
-Trains RF-DETR-Seg-Nano for a few epochs on LibreYOLO/fire-smoke-seg
+Training test: trains RF-DETR-Seg-Nano for 5 epochs on LibreYOLO/fire-smoke-seg
 (HuggingFace, public, 141 train / 40 valid / 20 test images, 2 classes:
 fire & smoke, YOLO segmentation format with polygon annotations).
+
+NOTE: Seg training requires CUDA — the upstream rfdetr mask loss uses
+F.grid_sample(padding_mode='border') which MPS does not support.
+Seg inference works on all devices (CPU, MPS, CUDA).
 
 The dataset auto-downloads from HuggingFace — no API keys needed.
 
 Usage:
     pytest tests/e2e/test_rfdetr_seg_training.py -v -m e2e
+    pytest tests/e2e/test_rfdetr_seg_training.py::test_rfdetr_seg_inference_only -v
 """
 
 import subprocess
@@ -17,7 +22,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from .conftest import run_in_subprocess
+from .conftest import requires_cuda, run_in_subprocess
 
 pytestmark = [pytest.mark.e2e, pytest.mark.rfdetr, pytest.mark.slow]
 
@@ -62,6 +67,7 @@ def dataset():
     return DATASET_ROOT
 
 
+@requires_cuda
 def test_rfdetr_seg_training(dataset, tmp_path):
     """Train RF-DETR-Seg-Nano on fire-smoke-seg, verify masks are produced."""
     output_dir = str(tmp_path / "rfdetr_seg_n")

--- a/tests/e2e/test_rfdetr_seg_training.py
+++ b/tests/e2e/test_rfdetr_seg_training.py
@@ -1,0 +1,166 @@
+"""
+E2E: RF-DETR segmentation training test.
+
+Trains RF-DETR-Seg-Nano for a few epochs on LibreYOLO/fire-smoke-seg
+(HuggingFace, public, 141 train / 40 valid / 20 test images, 2 classes:
+fire & smoke, YOLO segmentation format with polygon annotations).
+
+The dataset auto-downloads from HuggingFace — no API keys needed.
+
+Usage:
+    pytest tests/e2e/test_rfdetr_seg_training.py -v -m e2e
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from .conftest import run_in_subprocess
+
+pytestmark = [pytest.mark.e2e, pytest.mark.rfdetr, pytest.mark.slow]
+
+DATASET_ROOT = Path.home() / ".cache" / "libreyolo" / "fire-smoke-seg"
+HF_REPO = "LibreYOLO/fire-smoke-seg"
+
+
+def download_fire_smoke_dataset():
+    """Download the fire-smoke-seg dataset from HuggingFace if not cached."""
+    if DATASET_ROOT.exists() and (DATASET_ROOT / "data.yaml").exists():
+        return
+
+    print(f"\nDownloading dataset {HF_REPO} from HuggingFace ...")
+    DATASET_ROOT.parent.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            f"https://huggingface.co/datasets/{HF_REPO}",
+            str(DATASET_ROOT),
+        ],
+        check=True,
+    )
+    print(f"Dataset downloaded to {DATASET_ROOT}")
+
+
+def patch_data_yaml():
+    """Ensure data.yaml has an absolute path so training resolves splits."""
+    data_yaml = DATASET_ROOT / "data.yaml"
+    data = yaml.safe_load(data_yaml.read_text())
+    if data.get("path") != str(DATASET_ROOT):
+        data["path"] = str(DATASET_ROOT)
+        data_yaml.write_text(yaml.dump(data, default_flow_style=False))
+
+
+@pytest.fixture(scope="module")
+def dataset():
+    """Download fire-smoke-seg dataset and patch data.yaml."""
+    download_fire_smoke_dataset()
+    patch_data_yaml()
+    return DATASET_ROOT
+
+
+def test_rfdetr_seg_training(dataset, tmp_path):
+    """Train RF-DETR-Seg-Nano on fire-smoke-seg, verify masks are produced."""
+    output_dir = str(tmp_path / "rfdetr_seg_n")
+    dataset_dir = str(dataset)
+
+    run_in_subprocess(
+        f"""
+        from pathlib import Path
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+        from libreyolo import SAMPLE_IMAGE
+
+        # 1. Load segmentation model
+        model = LibreYOLORFDETR(
+            model_path="LibreRFDETRn-seg.pt",
+            size="n",
+            segmentation=True,
+        )
+        assert model._is_segmentation, "Model should be in segmentation mode"
+
+        # 2. Verify pre-training inference produces masks
+        pre_result = model.predict(SAMPLE_IMAGE, conf=0.3)
+        print(f"Pre-training: {{len(pre_result)}} detections, "
+              f"masks={{pre_result.masks is not None}}")
+
+        # 3. Train on fire-smoke-seg dataset
+        model.train(
+            data="{dataset_dir}",
+            epochs=5,
+            batch_size=2,
+            output_dir="{output_dir}",
+        )
+
+        # 4. Verify checkpoint was produced
+        ckpt_path = Path("{output_dir}") / "checkpoint_best_total.pth"
+        if not ckpt_path.exists():
+            ckpts = sorted(Path("{output_dir}").glob("checkpoint*.pth"))
+            assert ckpts, f"No checkpoint found in {output_dir}"
+            ckpt_path = ckpts[-1]
+        print(f"Checkpoint: {{ckpt_path}}")
+
+        # 5. Verify checkpoint has segmentation_head keys
+        import torch
+        ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        state = ckpt["model"]
+        seg_keys = [k for k in state if k.startswith("segmentation_head")]
+        assert len(seg_keys) > 0, "Checkpoint missing segmentation_head keys"
+        print(f"Checkpoint has {{len(seg_keys)}} segmentation_head keys")
+
+        # 6. Post-training inference still produces masks
+        post_result = model.predict(SAMPLE_IMAGE, conf=0.3)
+        print(f"Post-training: {{len(post_result)}} detections, "
+              f"masks={{post_result.masks is not None}}")
+        if post_result.masks is not None:
+            print(f"Mask shape: {{post_result.masks.data.shape}}")
+
+        print("PASSED")
+        """,
+        timeout=600,
+    )
+
+
+def test_rfdetr_seg_inference_only(dataset):
+    """Verify seg model inference produces valid masks on dataset images."""
+    run_in_subprocess(
+        f"""
+        from pathlib import Path
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        model = LibreYOLORFDETR(
+            model_path="LibreRFDETRn-seg.pt",
+            size="n",
+            segmentation=True,
+        )
+
+        # Run inference on a few test images
+        test_images = sorted(Path("{dataset}") / "test" / "images")
+        test_images = list(test_images.glob("*.jpg"))[:5]
+        assert len(test_images) > 0, "No test images found"
+
+        for img_path in test_images:
+            result = model.predict(str(img_path), conf=0.25)
+            print(f"{{img_path.name}}: {{len(result)}} dets, "
+                  f"masks={{result.masks is not None}}")
+
+            # If detections exist, masks must exist too (seg model)
+            if len(result) > 0:
+                assert result.masks is not None, (
+                    f"Seg model produced detections but no masks for {{img_path.name}}"
+                )
+                assert result.masks.data.shape[0] == len(result), (
+                    f"Mask count ({{result.masks.data.shape[0]}}) != "
+                    f"detection count ({{len(result)}})"
+                )
+                # Masks should be at original image resolution
+                h, w = result.orig_shape
+                assert result.masks.data.shape[1] == h, "Mask height mismatch"
+                assert result.masks.data.shape[2] == w, "Mask width mismatch"
+
+        print("PASSED")
+        """,
+        timeout=300,
+    )

--- a/tests/e2e/test_rfdetr_seg_training.py
+++ b/tests/e2e/test_rfdetr_seg_training.py
@@ -69,9 +69,10 @@ def dataset():
 
 @requires_cuda
 def test_rfdetr_seg_training(dataset, tmp_path):
-    """Train RF-DETR-Seg-Nano on fire-smoke-seg, verify masks are produced."""
+    """Train RF-DETR-Seg-Nano on fire-smoke-seg, verify mAP improves and masks are produced."""
     output_dir = str(tmp_path / "rfdetr_seg_n")
     dataset_dir = str(dataset)
+    data_yaml = str(dataset / "data.yaml")
 
     run_in_subprocess(
         f"""
@@ -87,10 +88,12 @@ def test_rfdetr_seg_training(dataset, tmp_path):
         )
         assert model._is_segmentation, "Model should be in segmentation mode"
 
-        # 2. Verify pre-training inference produces masks
-        pre_result = model.predict(SAMPLE_IMAGE, conf=0.3)
-        print(f"Pre-training: {{len(pre_result)}} detections, "
-              f"masks={{pre_result.masks is not None}}")
+        # 2. Baseline mAP BEFORE training (box mAP on fire-smoke-seg)
+        pre = model.val(
+            data="{data_yaml}", split="test", batch=8, conf=0.001, iou=0.6
+        )
+        pre_map = pre["metrics/mAP50-95"]
+        print(f"Pre-training box mAP50-95: {{pre_map:.4f}}")
 
         # 3. Train on fire-smoke-seg dataset
         model.train(
@@ -116,7 +119,19 @@ def test_rfdetr_seg_training(dataset, tmp_path):
         assert len(seg_keys) > 0, "Checkpoint missing segmentation_head keys"
         print(f"Checkpoint has {{len(seg_keys)}} segmentation_head keys")
 
-        # 6. Post-training inference still produces masks
+        # 6. Post-training mAP (box mAP — seg mAP requires SegmentationValidator)
+        post = model.val(
+            data="{data_yaml}", split="test", batch=8, conf=0.001, iou=0.6
+        )
+        post_map = post["metrics/mAP50-95"]
+        print(f"Post-training box mAP50-95: {{post_map:.4f}}")
+
+        assert post_map >= 0.05, f"mAP50-95={{post_map:.4f}} below 0.05"
+        assert post_map > pre_map, (
+            f"No improvement: pre={{pre_map:.4f}} -> post={{post_map:.4f}}"
+        )
+
+        # 7. Post-training inference still produces masks
         post_result = model.predict(SAMPLE_IMAGE, conf=0.3)
         print(f"Post-training: {{len(post_result)}} detections, "
               f"masks={{post_result.masks is not None}}")
@@ -143,8 +158,8 @@ def test_rfdetr_seg_inference_only(dataset):
         )
 
         # Run inference on a few test images
-        test_images = sorted(Path("{dataset}") / "test" / "images")
-        test_images = list(test_images.glob("*.jpg"))[:5]
+        test_dir = Path("{dataset}") / "test" / "images"
+        test_images = sorted(test_dir.glob("*.jpg"))[:5]
         assert len(test_images) > 0, "No test images found"
 
         for img_path in test_images:

--- a/tests/unit/test_segmentation.py
+++ b/tests/unit/test_segmentation.py
@@ -219,3 +219,114 @@ class TestFactorySegDetection:
         assert LibreYOLOX.detect_task_from_filename("LibreYOLOXs.pt") is None
         assert LibreYOLO9.detect_size_from_filename("LibreYOLO9s.pt") == "s"
         assert LibreYOLO9.detect_task_from_filename("LibreYOLO9s.pt") is None
+
+
+class TestPolygonLabelParsing:
+    """Tests for polygon→bbox derivation in label parsers."""
+
+    def test_parse_yolo_label_polygon_format(self):
+        """parse_yolo_label_line derives bbox from polygon vertices."""
+        from libreyolo.data.yolo_coco_api import parse_yolo_label_line
+
+        # Triangle polygon: (0.2,0.3) (0.8,0.3) (0.5,0.9)
+        line = "0 0.2 0.3 0.8 0.3 0.5 0.9"
+        result = parse_yolo_label_line(line, img_w=100, img_h=100, num_classes=2)
+        assert result is not None
+        cls_id, x1, y1, x2, y2, area = result
+        assert cls_id == 0
+        # bbox of polygon: cx=0.5, cy=0.6, w=0.6, h=0.6
+        # pixel: x1=20, y1=30, x2=80, y2=90
+        assert abs(x1 - 20) < 1
+        assert abs(y1 - 30) < 1
+        assert abs(x2 - 80) < 1
+        assert abs(y2 - 90) < 1
+
+    def test_parse_yolo_label_detection_format(self):
+        """parse_yolo_label_line still works for standard 5-column detection."""
+        from libreyolo.data.yolo_coco_api import parse_yolo_label_line
+
+        line = "1 0.5 0.5 0.4 0.6"
+        result = parse_yolo_label_line(line, img_w=200, img_h=200, num_classes=2)
+        assert result is not None
+        cls_id, x1, y1, x2, y2, area = result
+        assert cls_id == 1
+        # cx=0.5, cy=0.5, w=0.4, h=0.6 → pixel: x1=60, y1=40, x2=140, y2=160
+        assert abs(x1 - 60) < 1
+        assert abs(y1 - 40) < 1
+        assert abs(x2 - 140) < 1
+        assert abs(y2 - 160) < 1
+
+    def test_yolo_dataset_polygon_format(self):
+        """YOLODataset._load_label derives bbox from polygon vertices."""
+        import tempfile
+        from pathlib import Path
+
+        from PIL import Image
+
+        # Create a minimal dataset with a polygon label
+        with tempfile.TemporaryDirectory() as tmpdir:
+            img_dir = Path(tmpdir) / "images" / "train"
+            lbl_dir = Path(tmpdir) / "labels" / "train"
+            img_dir.mkdir(parents=True)
+            lbl_dir.mkdir(parents=True)
+
+            # 100x100 dummy image
+            Image.new("RGB", (100, 100)).save(img_dir / "test.jpg")
+            # Polygon label: square from (0.2,0.2) to (0.8,0.8)
+            (lbl_dir / "test.txt").write_text(
+                "0 0.2 0.2 0.8 0.2 0.8 0.8 0.2 0.8\n"
+            )
+
+            from libreyolo.data.dataset import YOLODataset
+
+            ds = YOLODataset(data_dir=tmpdir, split="train", img_size=(100, 100))
+            _, target, _, _ = ds[0]
+            # target shape: (N, 5) with [x1, y1, x2, y2, cls]
+            assert len(target) == 1
+            x1, y1, x2, y2, cls = target[0]
+            assert cls == 0
+            assert abs(x1 - 20) < 1
+            assert abs(y1 - 20) < 1
+            assert abs(x2 - 80) < 1
+            assert abs(y2 - 80) < 1
+
+
+class TestDetectSegmentation:
+    """Tests for auto-detection of segmentation from weights."""
+
+    def test_detect_seg_from_checkpoint(self):
+        """_detect_segmentation returns True for checkpoints with seg keys."""
+        import tempfile
+        from pathlib import Path
+
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / "seg_model.pt")
+            torch.save(
+                {"model": {"segmentation_head.weight": torch.zeros(1)}},
+                path,
+            )
+            assert LibreYOLORFDETR._detect_segmentation(path) is True
+
+    def test_detect_det_from_checkpoint(self):
+        """_detect_segmentation returns False for detection-only checkpoints."""
+        import tempfile
+        from pathlib import Path
+
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / "det_model.pt")
+            torch.save(
+                {"model": {"class_embed.weight": torch.zeros(1)}},
+                path,
+            )
+            assert LibreYOLORFDETR._detect_segmentation(path) is False
+
+    def test_detect_seg_from_filename(self):
+        """Filename-based detection avoids loading weights."""
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        assert LibreYOLORFDETR.detect_task_from_filename("LibreRFDETRn-seg.pt") == "seg"
+        assert LibreYOLORFDETR.detect_task_from_filename("LibreRFDETRn.pt") is None

--- a/tests/unit/test_segmentation.py
+++ b/tests/unit/test_segmentation.py
@@ -3,7 +3,9 @@
 import pytest
 import torch
 import numpy as np
+from PIL import Image
 
+from libreyolo.utils.drawing import draw_masks
 from libreyolo.utils.results import Boxes, Masks, Results
 
 pytestmark = pytest.mark.unit
@@ -289,6 +291,106 @@ class TestPolygonLabelParsing:
             assert abs(y1 - 20) < 1
             assert abs(x2 - 80) < 1
             assert abs(y2 - 80) < 1
+
+
+class TestDrawMasks:
+    """Tests for draw_masks visualization function."""
+
+    def _make_img(self, w=200, h=100):
+        return Image.new("RGB", (w, h), color=(128, 128, 128))
+
+    def test_single_mask(self):
+        img = self._make_img()
+        masks = np.zeros((1, 100, 200), dtype=bool)
+        masks[0, 20:80, 40:160] = True
+        result = draw_masks(img, masks, classes=[0])
+        assert isinstance(result, Image.Image)
+        assert result.size == (200, 100)
+        assert result.mode == "RGB"
+
+    def test_multiple_masks_different_classes(self):
+        img = self._make_img()
+        masks = np.zeros((3, 100, 200), dtype=bool)
+        masks[0, 10:30, 10:50] = True
+        masks[1, 40:60, 60:120] = True
+        masks[2, 70:90, 130:190] = True
+        result = draw_masks(img, masks, classes=[0, 1, 2])
+        assert result.size == (200, 100)
+        # Masked regions should differ from uniform gray background
+        arr = np.array(result)
+        assert not np.all(arr == 128)
+
+    def test_empty_masks(self):
+        img = self._make_img()
+        masks = np.zeros((0, 100, 200), dtype=bool)
+        result = draw_masks(img, masks, classes=[])
+        assert result.size == img.size
+        # No masks → image should be unchanged
+        assert np.array_equal(np.array(result), np.array(img))
+
+    def test_all_false_mask(self):
+        img = self._make_img()
+        masks = np.zeros((1, 100, 200), dtype=bool)  # all False
+        result = draw_masks(img, masks, classes=[0])
+        assert result.size == img.size
+
+    def test_alpha_zero_transparent(self):
+        img = self._make_img()
+        masks = np.ones((1, 100, 200), dtype=bool)
+        result = draw_masks(img, masks, classes=[0], alpha=0.0)
+        # Alpha 0 = fully transparent, image should be unchanged
+        assert np.array_equal(np.array(result), np.array(img))
+
+    def test_alpha_one_opaque(self):
+        img = self._make_img()
+        masks = np.ones((1, 100, 200), dtype=bool)
+        result = draw_masks(img, masks, classes=[0], alpha=1.0)
+        # Alpha 1 = fully opaque, masked pixels should NOT match original
+        assert not np.array_equal(np.array(result), np.array(img))
+
+    def test_does_not_modify_original(self):
+        img = self._make_img()
+        original_arr = np.array(img).copy()
+        masks = np.ones((1, 100, 200), dtype=bool)
+        draw_masks(img, masks, classes=[0])
+        assert np.array_equal(np.array(img), original_arr)
+
+
+class TestDetectNumOutputs:
+    """Tests for ONNX segmentation output detection."""
+
+    def test_detection_model_two_outputs(self):
+        from libreyolo.export.onnx import _detect_num_outputs
+
+        class DetModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.zeros(1, 4), torch.zeros(1, 80)
+
+        model = DetModel()
+        dummy = torch.zeros(1, 3, 64, 64)
+        assert _detect_num_outputs(model, dummy) == 2
+
+    def test_segmentation_model_three_outputs(self):
+        from libreyolo.export.onnx import _detect_num_outputs
+
+        class SegModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.zeros(1, 4), torch.zeros(1, 80), torch.zeros(1, 1, 64, 64)
+
+        model = SegModel()
+        dummy = torch.zeros(1, 3, 64, 64)
+        assert _detect_num_outputs(model, dummy) == 3
+
+    def test_single_output_model(self):
+        from libreyolo.export.onnx import _detect_num_outputs
+
+        class SingleModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.zeros(1, 85, 100)
+
+        model = SingleModel()
+        dummy = torch.zeros(1, 3, 64, 64)
+        assert _detect_num_outputs(model, dummy) == 1
 
 
 class TestDetectSegmentation:

--- a/tests/unit/test_segmentation.py
+++ b/tests/unit/test_segmentation.py
@@ -1,0 +1,221 @@
+"""Unit tests for segmentation support: Masks class, Results with masks, factory detection."""
+
+import pytest
+import torch
+import numpy as np
+
+from libreyolo.utils.results import Boxes, Masks, Results
+
+pytestmark = pytest.mark.unit
+
+
+class TestMasks:
+    """Tests for the Masks wrapper class."""
+
+    def test_empty_masks(self):
+        masks = Masks(torch.zeros((0, 100, 100), dtype=torch.bool), (100, 100))
+        assert len(masks) == 0
+        assert masks.data.shape == (0, 100, 100)
+        assert masks.orig_shape == (100, 100)
+
+    def test_populated_masks(self):
+        m = torch.randint(0, 2, (3, 64, 64), dtype=torch.bool)
+        masks = Masks(m, (64, 64))
+        assert len(masks) == 3
+        assert masks.data.shape == (3, 64, 64)
+        assert torch.equal(masks.data, m)
+
+    def test_cpu(self):
+        m = torch.ones((2, 32, 32), dtype=torch.bool)
+        masks = Masks(m, (32, 32))
+        cpu_masks = masks.cpu()
+        assert cpu_masks.data.device.type == "cpu"
+        assert len(cpu_masks) == 2
+
+    def test_numpy(self):
+        m = torch.ones((2, 32, 32), dtype=torch.bool)
+        masks = Masks(m, (32, 32))
+        np_masks = masks.numpy()
+        assert isinstance(np_masks.data, np.ndarray)
+        assert np_masks.data.shape == (2, 32, 32)
+
+    def test_numpy_already_numpy(self):
+        m = np.ones((2, 32, 32), dtype=np.uint8)
+        masks = Masks(m, (32, 32))
+        np_masks = masks.numpy()
+        assert np_masks is masks  # should return self
+
+    def test_cpu_already_numpy(self):
+        m = np.ones((2, 32, 32), dtype=np.uint8)
+        masks = Masks(m, (32, 32))
+        cpu_masks = masks.cpu()
+        assert cpu_masks is masks  # should return self
+
+    def test_repr(self):
+        m = torch.ones((3, 100, 200), dtype=torch.bool)
+        masks = Masks(m, (100, 200))
+        r = repr(masks)
+        assert "Masks" in r
+        assert "n=3" in r
+        assert "(3, 100, 200)" in r
+
+    def test_xy_contours(self):
+        # Create a simple square mask
+        m = torch.zeros((1, 100, 100), dtype=torch.bool)
+        m[0, 20:80, 20:80] = True
+        masks = Masks(m, (100, 100))
+        contours = masks.xy
+        assert len(contours) == 1
+        assert contours[0].shape[1] == 2  # (M, 2) points
+        assert len(contours[0]) > 0  # has points
+
+    def test_xyn_normalized(self):
+        m = torch.zeros((1, 100, 200), dtype=torch.bool)
+        m[0, 20:80, 40:160] = True
+        masks = Masks(m, (100, 200))
+        contours = masks.xyn
+        assert len(contours) == 1
+        # All coordinates should be in [0, 1]
+        assert contours[0][:, 0].max() <= 1.0
+        assert contours[0][:, 1].max() <= 1.0
+        assert contours[0][:, 0].min() >= 0.0
+        assert contours[0][:, 1].min() >= 0.0
+
+    def test_xy_empty_mask(self):
+        m = torch.zeros((1, 50, 50), dtype=torch.bool)  # all zeros
+        masks = Masks(m, (50, 50))
+        contours = masks.xy
+        assert len(contours) == 1
+        assert contours[0].shape == (0, 2)  # empty contour
+
+
+class TestResultsWithMasks:
+    """Tests for Results class with segmentation masks."""
+
+    def _make_results_with_masks(self, n=3, h=100, w=200):
+        boxes = Boxes(
+            torch.rand(n, 4) * 100,
+            torch.rand(n),
+            torch.randint(0, 2, (n,)).float(),
+        )
+        masks = Masks(
+            torch.randint(0, 2, (n, h, w), dtype=torch.bool),
+            (h, w),
+        )
+        return Results(
+            boxes=boxes,
+            orig_shape=(h, w),
+            path="/tmp/test.jpg",
+            names={0: "fire", 1: "smoke"},
+            masks=masks,
+        )
+
+    def test_results_with_masks(self):
+        result = self._make_results_with_masks(5)
+        assert len(result) == 5
+        assert result.masks is not None
+        assert len(result.masks) == 5
+
+    def test_results_without_masks(self):
+        boxes = Boxes(torch.rand(3, 4), torch.rand(3), torch.zeros(3))
+        result = Results(boxes=boxes, orig_shape=(100, 100))
+        assert result.masks is None
+
+    def test_cpu_with_masks(self):
+        result = self._make_results_with_masks(2)
+        cpu_result = result.cpu()
+        assert cpu_result.masks is not None
+        assert cpu_result.masks.data.device.type == "cpu"
+        assert cpu_result.boxes.xyxy.device.type == "cpu"
+
+    def test_repr_with_masks(self):
+        result = self._make_results_with_masks(2)
+        r = repr(result)
+        assert "Results" in r
+        assert "masks=" in r
+        assert "Masks" in r
+
+    def test_repr_without_masks(self):
+        boxes = Boxes(torch.rand(2, 4), torch.rand(2), torch.zeros(2))
+        result = Results(boxes=boxes, orig_shape=(100, 100))
+        r = repr(result)
+        assert "masks=" not in r
+
+
+class TestClassesFilterWithMasks:
+    """Tests for class filtering when masks are present."""
+
+    def test_filter_with_masks(self):
+        from libreyolo.models.base.inference import InferenceRunner
+
+        boxes = torch.tensor([[0, 0, 10, 10], [20, 20, 30, 30], [40, 40, 50, 50]],
+                             dtype=torch.float32)
+        conf = torch.tensor([0.9, 0.8, 0.7])
+        cls = torch.tensor([0.0, 1.0, 0.0])
+        masks = torch.randint(0, 2, (3, 64, 64), dtype=torch.bool)
+
+        filtered_boxes, filtered_conf, filtered_cls, filtered_masks = (
+            InferenceRunner._apply_classes_filter(boxes, conf, cls, [0], masks)
+        )
+
+        assert len(filtered_boxes) == 2
+        assert len(filtered_masks) == 2
+
+    def test_filter_without_masks(self):
+        from libreyolo.models.base.inference import InferenceRunner
+
+        boxes = torch.tensor([[0, 0, 10, 10], [20, 20, 30, 30]], dtype=torch.float32)
+        conf = torch.tensor([0.9, 0.8])
+        cls = torch.tensor([0.0, 1.0])
+
+        filtered_boxes, filtered_conf, filtered_cls, filtered_masks = (
+            InferenceRunner._apply_classes_filter(boxes, conf, cls, [0])
+        )
+
+        assert len(filtered_boxes) == 1
+        assert filtered_masks is None
+
+
+class TestFactorySegDetection:
+    """Tests for -seg suffix detection in filenames."""
+
+    def test_detect_size_from_seg_filename(self):
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        assert LibreYOLORFDETR.detect_size_from_filename("LibreRFDETRs-seg.pt") == "s"
+        assert LibreYOLORFDETR.detect_size_from_filename("LibreRFDETRn-seg.pt") == "n"
+        assert LibreYOLORFDETR.detect_size_from_filename("LibreRFDETRm-seg.pt") == "m"
+        assert LibreYOLORFDETR.detect_size_from_filename("LibreRFDETRl-seg.pt") == "l"
+
+    def test_detect_task_from_seg_filename(self):
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        assert LibreYOLORFDETR.detect_task_from_filename("LibreRFDETRs-seg.pt") == "seg"
+        assert LibreYOLORFDETR.detect_task_from_filename("LibreRFDETRs.pt") is None
+
+    def test_det_filename_still_works(self):
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        assert LibreYOLORFDETR.detect_size_from_filename("LibreRFDETRs.pt") == "s"
+        assert LibreYOLORFDETR.detect_task_from_filename("LibreRFDETRs.pt") is None
+
+    def test_download_url_seg(self):
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        url = LibreYOLORFDETR.get_download_url("LibreRFDETRs-seg.pt")
+        assert url == "https://huggingface.co/LibreYOLO/LibreRFDETRs-seg/resolve/main/LibreRFDETRs-seg.pt"
+
+    def test_download_url_det(self):
+        from libreyolo.models.rfdetr.model import LibreYOLORFDETR
+
+        url = LibreYOLORFDETR.get_download_url("LibreRFDETRs.pt")
+        assert url == "https://huggingface.co/LibreYOLO/LibreRFDETRs/resolve/main/LibreRFDETRs.pt"
+
+    def test_other_families_unaffected(self):
+        from libreyolo.models.yolox.model import LibreYOLOX
+        from libreyolo.models.yolo9.model import LibreYOLO9
+
+        assert LibreYOLOX.detect_size_from_filename("LibreYOLOXs.pt") == "s"
+        assert LibreYOLOX.detect_task_from_filename("LibreYOLOXs.pt") is None
+        assert LibreYOLO9.detect_size_from_filename("LibreYOLO9s.pt") == "s"
+        assert LibreYOLO9.detect_task_from_filename("LibreYOLO9s.pt") is None


### PR DESCRIPTION
Adds instance segmentation support for RF-DETR models across inference, training, ONNX export, and validation.           
  - New Masks class with data, xy/xyn contour properties, and cpu()/numpy() methods                                        
  - RF-DETR seg variants auto-detected from -seg filename suffix or segmentation_head keys in weights
  - Seg mask output at original image resolution, drawn as semi-transparent overlays under bounding boxes                  
  - ONNX export auto-detects seg models and exports 3 outputs (boxes, scores, masks)                                       
  - Polygon-format YOLO labels (segmentation datasets) auto-derive bounding boxes for training/validation                  
  - Tiled inference warns that masks are unsupported in tiled mode                                                         
  - rfdetr dependency bumped to >=1.6.0 (with [train] extra) for upstream seg config support                               
                                                                                                                           
Usage                                                                                                                                                                                                                                               
```
from libreyolo import LibreYOLO                                 
                                                                                                                           
model = LibreYOLO("LibreRFDETRn-seg.pt")                                                                                 
result = model("image.jpg", conf=0.3, save=True)                                                                         
                                                                                                                         
result.masks.data   # (N, H, W) bool tensor                                                                              
result.masks.xy     # list of (M, 2) pixel contour arrays                                                                
result.masks.xyn    # list of (M, 2) normalized contour arrays           
```                                                
                                                                                                                           
Test plan                                                                                                                                                                                                                            
  - Unit tests pass: pytest tests/unit/test_segmentation.py -v                                                             
  - E2E seg inference: pytest tests/e2e/test_rfdetr_seg_training.py::test_rfdetr_seg_inference_only -v
  - E2E seg training (CUDA): pytest tests/e2e/test_rfdetr_seg_training.py::test_rfdetr_seg_training -v                     
  - E2E resume from checkpoint (CUDA): pytest tests/e2e/test_rfdetr_seg_training.py::test_rfdetr_seg_resume_training -v    
  - Existing detection tests still pass (no regressions)                                                                   
  - ONNX export with seg model produces 3 outputs  