### PR TITLE
add ByteTrack tracking and video inference support

### DIFF
--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -27,6 +27,8 @@ def __getattr__(name):
         "DetectionValidator": (".validation", "DetectionValidator"),
         "ValidationConfig": (".validation", "ValidationConfig"),
         "DetMetrics": (".validation", "DetMetrics"),
+        "ByteTracker": (".tracking", "ByteTracker"),
+        "TrackConfig": (".tracking", "TrackConfig"),
         "DATASETS_DIR": (".data", "DATASETS_DIR"),
         "load_data_config": (".data", "load_data_config"),
         "check_dataset": (".data", "check_dataset"),
@@ -57,6 +59,9 @@ __all__ = [
     "Masks",
     # Assets
     "SAMPLE_IMAGE",
+    # Tracking
+    "ByteTracker",
+    "TrackConfig",
     # Lazy-loaded
     "OnnxBackend",
     "OpenVINOBackend",

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -17,7 +17,7 @@ from ..utils.drawing import draw_boxes
 from ..utils.general import COCO_CLASSES, get_safe_stem
 from ..utils.image_loader import ImageLoader
 from ..utils.results import Boxes, Masks, Results
-from ..utils.video import VideoSource, VideoWriter, is_video_file
+from ..utils.video import VideoSource, is_video_file, run_video_inference
 
 logger = logging.getLogger(__name__)
 
@@ -583,7 +583,7 @@ class BaseBackend(ABC):
 
     def _predict_video(
         self,
-        source: str | Path,
+        source: Union[str, Path],
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -593,99 +593,33 @@ class BaseBackend(ABC):
         save: bool = False,
         show: bool = False,
         vid_stride: int = 1,
-        output_path: str | None = None,
-        color_format: str = "auto",
+        output_path: Optional[str] = None,
     ) -> Generator[Results, None, None]:
         """Run inference on a video file, yielding per-frame Results."""
-        import cv2
-
-        video_src = VideoSource(source, vid_stride=vid_stride)
         effective_imgsz = imgsz if imgsz is not None else self.imgsz
 
-        writer = None
-        if save:
-            out_path = self._resolve_video_save_path(source, output_path)
-            effective_fps = video_src.fps / max(1, vid_stride)
-            writer = VideoWriter(
-                out_path, effective_fps, video_src.width, video_src.height
+        def predict_frame(pil_img):
+            input_tensor, original_img, original_size, ratio = self._preprocess(
+                pil_img, effective_imgsz, "rgb"
+            )
+            blob = input_tensor.numpy()
+            all_outputs = self._run_inference(blob)
+            boxes, max_scores, class_ids = self._parse_outputs(
+                all_outputs, effective_imgsz, original_size, conf, ratio=ratio
+            )
+            orig_w, orig_h = original_size
+            return self._build_result(
+                boxes, max_scores, class_ids,
+                orig_shape=(orig_h, orig_w),
+                image_path=str(source),
+                iou=iou, classes=classes, max_det=max_det,
             )
 
-        try:
-            for frame_bgr, frame_idx in video_src:
-                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
-                pil_img = Image.fromarray(frame_rgb)
-
-                input_tensor, original_img, original_size, ratio = self._preprocess(
-                    pil_img, effective_imgsz, "rgb"
-                )
-
-                blob = input_tensor.numpy()
-                all_outputs = self._run_inference(blob)
-
-                boxes, max_scores, class_ids = self._parse_outputs(
-                    all_outputs, effective_imgsz, original_size, conf, ratio=ratio
-                )
-
-                orig_w, orig_h = original_size
-                orig_shape = (orig_h, orig_w)
-                result = self._build_result(
-                    boxes,
-                    max_scores,
-                    class_ids,
-                    orig_shape=orig_shape,
-                    image_path=str(source),
-                    iou=iou,
-                    classes=classes,
-                    max_det=max_det,
-                )
-                result.frame_idx = frame_idx
-
-                if save or show:
-                    if len(result) > 0:
-                        annotated_pil = draw_boxes(
-                            original_img,
-                            result.boxes.xyxy.tolist(),
-                            result.boxes.conf.tolist(),
-                            result.boxes.cls.tolist(),
-                        )
-                    else:
-                        annotated_pil = original_img
-
-                    annotated_bgr = cv2.cvtColor(
-                        np.array(annotated_pil), cv2.COLOR_RGB2BGR
-                    )
-
-                    if save and writer is not None:
-                        writer.write_frame(annotated_bgr)
-
-                    if show:
-                        cv2.imshow("LibreYOLO", annotated_bgr)
-                        if cv2.waitKey(1) & 0xFF == ord("q"):
-                            break
-
-                yield result
-
-        finally:
-            video_src.release()
-            if writer is not None:
-                writer.release()
-                logger.info(f"Video saved to {out_path}")
-            if show:
-                cv2.destroyAllWindows()
-
-    @staticmethod
-    def _resolve_video_save_path(
-        source: str | Path, output_path: str | None
-    ) -> str:
-        """Determine the output path for a saved video."""
-        if output_path is not None:
-            out = Path(output_path)
-            out.parent.mkdir(parents=True, exist_ok=True)
-            return str(out)
-
-        from ..utils.general import increment_path
-
-        save_dir = Path("runs/detect") / "predict"
-        save_dir = increment_path(save_dir, exist_ok=False, mkdir=True)
-        stem = Path(source).stem
-        return str(save_dir / f"{stem}.mp4")
+        yield from run_video_inference(
+            source,
+            predict_frame,
+            vid_stride=vid_stride,
+            save=save,
+            show=show,
+            output_path=output_path,
+        )

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1,9 +1,11 @@
 """Base class for LibreYOLO inference backends."""
 
+import logging
+import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -15,6 +17,9 @@ from ..utils.drawing import draw_boxes
 from ..utils.general import COCO_CLASSES, get_safe_stem
 from ..utils.image_loader import ImageLoader
 from ..utils.results import Boxes, Masks, Results
+from ..utils.video import VideoSource, VideoWriter, is_video_file
+
+logger = logging.getLogger(__name__)
 
 
 def _nms_numpy(
@@ -504,10 +509,43 @@ class BaseBackend(ABC):
         max_det: int = 300,
         save: bool = False,
         batch: int = 1,
+        # video parameters
+        stream: bool = False,
+        vid_stride: int = 1,
+        show: bool = False,
         output_path: str | None = None,
         color_format: str = "auto",
-    ) -> Union[Results, List[Results]]:
-        """Run inference on an image or directory of images."""
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
+        """Run inference on an image, directory, or video."""
+        # Handle video input
+        if is_video_file(source):
+            gen = self._predict_video(
+                source,
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                save=save,
+                show=show,
+                vid_stride=vid_stride,
+                output_path=output_path,
+                color_format=color_format,
+            )
+            if stream:
+                return gen
+            vs = VideoSource(source, vid_stride=vid_stride)
+            est_frames = vs.total_frames // max(1, vid_stride)
+            vs.release()
+            if est_frames > 500:
+                warnings.warn(
+                    f"Video has ~{est_frames} frames to process. "
+                    f"Consider using stream=True to avoid high memory usage. "
+                    f"Example: backend('{source}', stream=True)",
+                    stacklevel=2,
+                )
+            return list(gen)
+
         if isinstance(source, (str, Path)) and Path(source).is_dir():
             image_paths = ImageLoader.collect_images(source)
             if not image_paths:
@@ -537,6 +575,117 @@ class BaseBackend(ABC):
             color_format=color_format,
         )
 
-    def predict(self, *args, **kwargs) -> Union[Results, List[Results]]:
+    def predict(
+        self, *args, **kwargs
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """Alias for __call__ method."""
         return self(*args, **kwargs)
+
+    def _predict_video(
+        self,
+        source: str | Path,
+        *,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[int] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        save: bool = False,
+        show: bool = False,
+        vid_stride: int = 1,
+        output_path: str | None = None,
+        color_format: str = "auto",
+    ) -> Generator[Results, None, None]:
+        """Run inference on a video file, yielding per-frame Results."""
+        import cv2
+
+        video_src = VideoSource(source, vid_stride=vid_stride)
+        effective_imgsz = imgsz if imgsz is not None else self.imgsz
+
+        writer = None
+        if save:
+            out_path = self._resolve_video_save_path(source, output_path)
+            effective_fps = video_src.fps / max(1, vid_stride)
+            writer = VideoWriter(
+                out_path, effective_fps, video_src.width, video_src.height
+            )
+
+        try:
+            for frame_bgr, frame_idx in video_src:
+                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+                pil_img = Image.fromarray(frame_rgb)
+
+                input_tensor, original_img, original_size, ratio = self._preprocess(
+                    pil_img, effective_imgsz, "rgb"
+                )
+
+                blob = input_tensor.numpy()
+                all_outputs = self._run_inference(blob)
+
+                boxes, max_scores, class_ids = self._parse_outputs(
+                    all_outputs, effective_imgsz, original_size, conf, ratio=ratio
+                )
+
+                orig_w, orig_h = original_size
+                orig_shape = (orig_h, orig_w)
+                result = self._build_result(
+                    boxes,
+                    max_scores,
+                    class_ids,
+                    orig_shape=orig_shape,
+                    image_path=str(source),
+                    iou=iou,
+                    classes=classes,
+                    max_det=max_det,
+                )
+                result.frame_idx = frame_idx
+
+                if save or show:
+                    if len(result) > 0:
+                        annotated_pil = draw_boxes(
+                            original_img,
+                            result.boxes.xyxy.tolist(),
+                            result.boxes.conf.tolist(),
+                            result.boxes.cls.tolist(),
+                        )
+                    else:
+                        annotated_pil = original_img
+
+                    annotated_bgr = cv2.cvtColor(
+                        np.array(annotated_pil), cv2.COLOR_RGB2BGR
+                    )
+
+                    if save and writer is not None:
+                        writer.write_frame(annotated_bgr)
+
+                    if show:
+                        cv2.imshow("LibreYOLO", annotated_bgr)
+                        if cv2.waitKey(1) & 0xFF == ord("q"):
+                            break
+
+                yield result
+
+        finally:
+            video_src.release()
+            if writer is not None:
+                writer.release()
+                logger.info(f"Video saved to {out_path}")
+            if show:
+                cv2.destroyAllWindows()
+
+    @staticmethod
+    def _resolve_video_save_path(
+        source: str | Path, output_path: str | None
+    ) -> str:
+        """Determine the output path for a saved video."""
+        if output_path is not None:
+            out = Path(output_path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            return str(out)
+
+        from ..utils.general import increment_path
+
+        save_dir = Path("runs/detect") / "predict"
+        save_dir = increment_path(save_dir, exist_ok=False, mkdir=True)
+        stem = Path(source).stem
+        return str(save_dir / f"{stem}.mp4")

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -530,7 +530,6 @@ class BaseBackend(ABC):
                 show=show,
                 vid_stride=vid_stride,
                 output_path=output_path,
-                color_format=color_format,
             )
             if stream:
                 return gen

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -21,7 +21,7 @@ from ...utils.drawing import draw_boxes, draw_masks, draw_tile_grid
 from ...utils.general import get_safe_stem, get_slice_bboxes, nms, resolve_save_path
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.results import Boxes, Masks, Results
-from ...utils.video import VideoSource, VideoWriter, is_video_file
+from ...utils.video import VideoSource, is_video_file, run_video_inference
 
 logger = logging.getLogger(__name__)
 
@@ -392,7 +392,7 @@ class InferenceRunner:
 
     def _predict_video(
         self,
-        source: str | Path,
+        source: Union[str, Path],
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -402,114 +402,32 @@ class InferenceRunner:
         save: bool = False,
         show: bool = False,
         vid_stride: int = 1,
-        output_path: str | None = None,
+        output_path: Optional[str] = None,
         **kwargs,
     ) -> Generator[Results, None, None]:
-        """Run inference on a video file, yielding per-frame Results.
-
-        Args:
-            source: Path to a video file.
-            conf: Confidence threshold.
-            iou: IoU threshold for NMS.
-            imgsz: Input size override.
-            classes: Filter to specific class IDs.
-            max_det: Maximum detections per frame.
-            save: Write annotated video to disk.
-            show: Display annotated frames in a window.
-            vid_stride: Process every N-th frame.
-            output_path: Optional output path for saved video.
-            **kwargs: Additional postprocessing arguments.
-
-        Yields:
-            Results for each processed frame.
-        """
-        import cv2
-        from PIL import Image
-
-        video_src = VideoSource(source, vid_stride=vid_stride)
+        """Run inference on a video file, yielding per-frame Results."""
         effective_imgsz = imgsz if imgsz is not None else self.model._get_input_size()
 
-        writer = None
-        if save:
-            out_path = self._resolve_video_save_path(source, output_path)
-            effective_fps = video_src.fps / max(1, vid_stride)
-            writer = VideoWriter(out_path, effective_fps, video_src.width, video_src.height)
+        def predict_frame(pil_img):
+            input_tensor, original_img, original_size, ratio = (
+                self.model._preprocess(pil_img, "rgb", input_size=effective_imgsz)
+            )
+            with torch.no_grad():
+                output = self.model._forward(input_tensor.to(self.model.device))
+            detections = self.model._postprocess(
+                output, conf, iou, original_size, max_det=max_det, ratio=ratio,
+                **kwargs,
+            )
+            return self._wrap_results(detections, original_size, str(source), classes)
 
-        try:
-            for frame_bgr, frame_idx in video_src:
-                # Convert BGR frame to PIL RGB for the existing pipeline
-                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
-                pil_img = Image.fromarray(frame_rgb)
-
-                # Preprocess
-                input_tensor, original_img, original_size, ratio = (
-                    self.model._preprocess(pil_img, "rgb", input_size=effective_imgsz)
-                )
-
-                # Forward
-                with torch.no_grad():
-                    output = self.model._forward(input_tensor.to(self.model.device))
-
-                # Postprocess
-                detections = self.model._postprocess(
-                    output, conf, iou, original_size, max_det=max_det, ratio=ratio,
-                    **kwargs,
-                )
-
-                # Wrap results
-                result = self._wrap_results(detections, original_size, str(source), classes)
-                result.frame_idx = frame_idx
-
-                # Annotate frame for save/show
-                if save or show:
-                    if len(result) > 0:
-                        annotated_pil = draw_boxes(
-                            original_img,
-                            result.boxes.xyxy.tolist(),
-                            result.boxes.conf.tolist(),
-                            result.boxes.cls.tolist(),
-                        )
-                    else:
-                        annotated_pil = original_img
-
-                    annotated_bgr = cv2.cvtColor(
-                        np.array(annotated_pil), cv2.COLOR_RGB2BGR
-                    )
-
-                    if save and writer is not None:
-                        writer.write_frame(annotated_bgr)
-
-                    if show:
-                        cv2.imshow("LibreYOLO", annotated_bgr)
-                        if cv2.waitKey(1) & 0xFF == ord("q"):
-                            break
-
-                yield result
-
-        finally:
-            video_src.release()
-            if writer is not None:
-                writer.release()
-                logger.info(f"Video saved to {out_path}")
-            if show:
-                cv2.destroyAllWindows()
-
-    @staticmethod
-    def _resolve_video_save_path(
-        source: str | Path, output_path: str | None
-    ) -> str:
-        """Determine the output path for a saved video."""
-        if output_path is not None:
-            out = Path(output_path)
-            out.parent.mkdir(parents=True, exist_ok=True)
-            return str(out)
-
-        save_dir = Path("runs/detect") / "predict"
-        from ...utils.general import increment_path
-
-        save_dir = increment_path(save_dir, exist_ok=False, mkdir=True)
-        stem = Path(source).stem
-        return str(save_dir / f"{stem}.mp4")
+        yield from run_video_inference(
+            source,
+            predict_frame,
+            vid_stride=vid_stride,
+            save=save,
+            show=show,
+            output_path=output_path,
+        )
 
     def _merge_tile_detections(
         self,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -2,22 +2,28 @@
 Inference runner for LibreYOLO models.
 
 Encapsulates all inference-related logic: single-image prediction,
-tiled inference, batch processing, and result wrapping.
+tiled inference, batch processing, video inference, and result wrapping.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import warnings
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
 
 from ...utils.drawing import draw_boxes, draw_masks, draw_tile_grid
 from ...utils.general import get_safe_stem, get_slice_bboxes, nms, resolve_save_path
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.results import Boxes, Masks, Results
+from ...utils.video import VideoSource, VideoWriter, is_video_file
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .model import BaseModel
@@ -40,6 +46,10 @@ class InferenceRunner:
         max_det: int = 300,
         save: bool = False,
         batch: int = 1,
+        # video parameters
+        stream: bool = False,
+        vid_stride: int = 1,
+        show: bool = False,
         # libreyolo-specific
         output_path: str | None = None,
         color_format: str = "auto",
@@ -47,19 +57,23 @@ class InferenceRunner:
         overlap_ratio: float = 0.2,
         output_file_format: Optional[str] = None,
         **kwargs,
-    ) -> Union[Results, List[Results]]:
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """
-        Run inference on an image or directory.
+        Run inference on an image, directory, or video.
 
         Args:
-            source: Input image or directory path.
+            source: Input image, directory path, or video file path.
             conf: Confidence threshold.
             iou: IoU threshold for NMS.
             imgsz: Input size override (None = model default).
             classes: Filter to specific class IDs.
             max_det: Maximum detections per image.
-            save: If True, saves annotated image.
+            save: If True, saves annotated image or video.
             batch: Batch size for directory processing.
+            stream: If True, return a generator yielding per-frame Results.
+                Recommended for video to avoid high memory usage.
+            vid_stride: Process every N-th video frame (default: 1).
+            show: If True, display annotated frames in a window (video only).
             output_path: Optional output path.
             color_format: Color format hint.
             tiling: Enable tiled inference for large images.
@@ -68,7 +82,7 @@ class InferenceRunner:
             **kwargs: Additional arguments for postprocessing.
 
         Returns:
-            Results instance or list of Results.
+            Results, list of Results, or generator of Results (video + stream).
         """
         if output_file_format is not None:
             output_file_format = output_file_format.lower().lstrip(".")
@@ -77,6 +91,36 @@ class InferenceRunner:
                     f"Invalid output_file_format: {output_file_format}. "
                     "Must be one of: 'jpg', 'png', 'webp'"
                 )
+
+        # Handle video input
+        if is_video_file(source):
+            gen = self._predict_video(
+                source,
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                save=save,
+                show=show,
+                vid_stride=vid_stride,
+                output_path=output_path,
+                **kwargs,
+            )
+            if stream:
+                return gen
+            # Collect all results into a list (with warning for large videos)
+            vs = VideoSource(source, vid_stride=vid_stride)
+            est_frames = vs.total_frames // max(1, vid_stride)
+            vs.release()
+            if est_frames > 500:
+                warnings.warn(
+                    f"Video has ~{est_frames} frames to process. "
+                    f"Consider using stream=True to avoid high memory usage. "
+                    f"Example: model('{source}', stream=True)",
+                    stacklevel=2,
+                )
+            return list(gen)
 
         # Handle directory input
         if isinstance(source, (str, Path)) and Path(source).is_dir():
@@ -345,6 +389,127 @@ class InferenceRunner:
             result.saved_path = str(save_path)
 
         return result
+
+    def _predict_video(
+        self,
+        source: str | Path,
+        *,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[int] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        save: bool = False,
+        show: bool = False,
+        vid_stride: int = 1,
+        output_path: str | None = None,
+        **kwargs,
+    ) -> Generator[Results, None, None]:
+        """Run inference on a video file, yielding per-frame Results.
+
+        Args:
+            source: Path to a video file.
+            conf: Confidence threshold.
+            iou: IoU threshold for NMS.
+            imgsz: Input size override.
+            classes: Filter to specific class IDs.
+            max_det: Maximum detections per frame.
+            save: Write annotated video to disk.
+            show: Display annotated frames in a window.
+            vid_stride: Process every N-th frame.
+            output_path: Optional output path for saved video.
+            **kwargs: Additional postprocessing arguments.
+
+        Yields:
+            Results for each processed frame.
+        """
+        import cv2
+        from PIL import Image
+
+        video_src = VideoSource(source, vid_stride=vid_stride)
+        effective_imgsz = imgsz if imgsz is not None else self.model._get_input_size()
+
+        writer = None
+        if save:
+            out_path = self._resolve_video_save_path(source, output_path)
+            effective_fps = video_src.fps / max(1, vid_stride)
+            writer = VideoWriter(out_path, effective_fps, video_src.width, video_src.height)
+
+        try:
+            for frame_bgr, frame_idx in video_src:
+                # Convert BGR frame to PIL RGB for the existing pipeline
+                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+                pil_img = Image.fromarray(frame_rgb)
+
+                # Preprocess
+                input_tensor, original_img, original_size, ratio = (
+                    self.model._preprocess(pil_img, "rgb", input_size=effective_imgsz)
+                )
+
+                # Forward
+                with torch.no_grad():
+                    output = self.model._forward(input_tensor.to(self.model.device))
+
+                # Postprocess
+                detections = self.model._postprocess(
+                    output, conf, iou, original_size, max_det=max_det, ratio=ratio,
+                    **kwargs,
+                )
+
+                # Wrap results
+                result = self._wrap_results(detections, original_size, str(source), classes)
+                result.frame_idx = frame_idx
+
+                # Annotate frame for save/show
+                if save or show:
+                    if len(result) > 0:
+                        annotated_pil = draw_boxes(
+                            original_img,
+                            result.boxes.xyxy.tolist(),
+                            result.boxes.conf.tolist(),
+                            result.boxes.cls.tolist(),
+                        )
+                    else:
+                        annotated_pil = original_img
+
+                    annotated_bgr = cv2.cvtColor(
+                        np.array(annotated_pil), cv2.COLOR_RGB2BGR
+                    )
+
+                    if save and writer is not None:
+                        writer.write_frame(annotated_bgr)
+
+                    if show:
+                        cv2.imshow("LibreYOLO", annotated_bgr)
+                        if cv2.waitKey(1) & 0xFF == ord("q"):
+                            break
+
+                yield result
+
+        finally:
+            video_src.release()
+            if writer is not None:
+                writer.release()
+                logger.info(f"Video saved to {out_path}")
+            if show:
+                cv2.destroyAllWindows()
+
+    @staticmethod
+    def _resolve_video_save_path(
+        source: str | Path, output_path: str | None
+    ) -> str:
+        """Determine the output path for a saved video."""
+        if output_path is not None:
+            out = Path(output_path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            return str(out)
+
+        save_dir = Path("runs/detect") / "predict"
+        from ...utils.general import increment_path
+
+        save_dir = increment_path(save_dir, exist_ok=False, mkdir=True)
+        stem = Path(source).stem
+        return str(save_dir / f"{stem}.mp4")
 
     def _merge_tile_detections(
         self,

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -394,6 +394,10 @@ class BaseModel(ABC):
         if tracker_config is None:
             tracker_config = TrackConfig.from_kwargs(**tracker_kwargs)
 
+        source = Path(source)
+        if not source.exists():
+            raise FileNotFoundError(f"Video file not found: {source}")
+
         # ByteTrack needs to see low-confidence detections.
         effective_conf = tracker_config.track_low_thresh
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -18,6 +18,8 @@ from PIL import Image
 from ...utils.general import COCO_CLASSES
 from ...utils.image_loader import ImageInput
 from ...utils.results import Results
+
+from typing import Generator
 from ...validation.preprocessors import StandardValPreprocessor
 
 
@@ -338,10 +340,14 @@ class BaseModel(ABC):
             self._runner_instance = InferenceRunner(self)
         return self._runner_instance
 
-    def __call__(self, source=None, **kwargs):
+    def __call__(
+        self, source=None, **kwargs
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         return self._runner(source, **kwargs)
 
-    def predict(self, *args, **kwargs) -> Union[Results, List[Results]]:
+    def predict(
+        self, *args, **kwargs
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """Alias for __call__ method."""
         return self(*args, **kwargs)
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -349,13 +349,13 @@ class BaseModel(ABC):
         self,
         source: str | Path,
         *,
-        conf: float = 0.25,
+        track_conf: float = 0.25,
         iou: float = 0.45,
         imgsz: Optional[int] = None,
         classes: Optional[List[int]] = None,
         max_det: int = 300,
         save: bool = False,
-        save_dir: Optional[str] = None,
+        output_path: Optional[str] = None,
         tracker_config=None,
         **tracker_kwargs,
     ) -> Generator[Results, None, None]:
@@ -367,16 +367,17 @@ class BaseModel(ABC):
 
         Args:
             source: Path to a video file.
-            conf: Confidence threshold passed to the tracker as
-                ``track_high_thresh``. The detector runs at a lower threshold
-                internally so ByteTrack can use low-confidence detections.
+            track_conf: Confidence threshold for the tracker's first
+                association stage (``track_high_thresh``). The detector
+                runs at the lower ``track_low_thresh`` internally so
+                ByteTrack can use low-confidence detections for recovery.
             iou: IoU threshold for NMS during detection.
             imgsz: Override input image size.
             classes: Filter to specific class IDs.
             max_det: Maximum detections per frame.
             save: If True, save annotated frames (with bounding boxes and
-                track IDs) as images to *save_dir*.
-            save_dir: Directory to save annotated frames. Defaults to
+                track IDs) as images to *output_path*.
+            output_path: Directory to save annotated frames. Defaults to
                 ``runs/track/<video_stem>/``.
             tracker_config: A ``TrackConfig`` instance, or None to build
                 one from **tracker_kwargs.
@@ -404,8 +405,8 @@ class BaseModel(ABC):
         # Resolve save directory.
         output_dir = None
         if save:
-            if save_dir is not None:
-                output_dir = Path(save_dir)
+            if output_path is not None:
+                output_dir = Path(output_path)
             else:
                 video_stem = Path(source).stem
                 from ...utils.general import increment_path

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -361,6 +361,8 @@ class BaseModel(ABC):
         classes: Optional[List[int]] = None,
         max_det: int = 300,
         save: bool = False,
+        show: bool = False,
+        vid_stride: int = 1,
         output_path: Optional[str] = None,
         tracker_config=None,
         **tracker_kwargs,
@@ -381,10 +383,11 @@ class BaseModel(ABC):
             imgsz: Override input image size.
             classes: Filter to specific class IDs.
             max_det: Maximum detections per frame.
-            save: If True, save annotated frames (with bounding boxes and
-                track IDs) as images to *output_path*.
-            output_path: Directory to save annotated frames. Defaults to
-                ``runs/track/<video_stem>/``.
+            save: If True, save annotated video to *output_path*.
+            show: Display tracked frames in a window.
+            vid_stride: Process every N-th frame.
+            output_path: Path for saved video. Defaults to
+                ``runs/track/<video_stem>.mp4``.
             tracker_config: A ``TrackConfig`` instance, or None to build
                 one from **tracker_kwargs.
             **tracker_kwargs: Forwarded to ``TrackConfig.from_kwargs``.
@@ -392,11 +395,9 @@ class BaseModel(ABC):
         Yields:
             Results with ``track_id`` attribute set as an (N,) int tensor.
         """
-        import cv2
-        import numpy as np
-
         from ...tracking import ByteTracker, TrackConfig
         from ...utils.drawing import draw_boxes
+        from ...utils.video import run_video_inference
 
         if tracker_config is None:
             tracker_config = TrackConfig.from_kwargs(**tracker_kwargs)
@@ -407,71 +408,59 @@ class BaseModel(ABC):
 
         # ByteTrack needs to see low-confidence detections.
         effective_conf = tracker_config.track_low_thresh
-
-        # Resolve save directory.
-        output_dir = None
-        if save:
-            if output_path is not None:
-                output_dir = Path(output_path)
-            else:
-                video_stem = Path(source).stem
-                from ...utils.general import increment_path
-
-                output_dir = increment_path(
-                    Path("runs") / "track" / video_stem, exist_ok=False
-                )
-            output_dir.mkdir(parents=True, exist_ok=True)
-            print(f"Saving tracked frames to {output_dir}/")
-
         tracker = ByteTracker(config=tracker_config)
-        cap = cv2.VideoCapture(str(source))
-        frame_idx = 0
+        model_names = self.names
 
-        try:
-            while cap.isOpened():
-                ret, frame_bgr = cap.read()
-                if not ret:
-                    break
+        def predict_and_track(pil_img):
+            result = self._runner(
+                pil_img,
+                conf=effective_conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                color_format="rgb",
+            )
+            return tracker.update(result)
 
-                # Convert BGR → RGB numpy array for the detector.
-                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+        def annotate_tracked(pil_img, result):
+            if len(result) == 0:
+                return pil_img
+            tid_list = (
+                result.track_id.tolist()
+                if result.track_id is not None
+                else None
+            )
+            return draw_boxes(
+                pil_img,
+                result.boxes.xyxy.tolist(),
+                result.boxes.conf.tolist(),
+                result.boxes.cls.tolist(),
+                class_names=model_names,
+                track_ids=tid_list,
+            )
 
-                result = self._runner(
-                    frame_rgb,
-                    conf=effective_conf,
-                    iou=iou,
-                    imgsz=imgsz,
-                    classes=classes,
-                    max_det=max_det,
-                    color_format="rgb",
+        # Use runs/track/ prefix instead of runs/detect/
+        track_output = output_path
+        if save and output_path is None:
+            from ...utils.general import increment_path
+
+            track_output = str(
+                increment_path(
+                    Path("runs") / "track" / f"{source.stem}.mp4",
+                    exist_ok=False,
                 )
+            )
 
-                tracked = tracker.update(result)
-
-                if save and output_dir is not None:
-                    img_pil = Image.fromarray(frame_rgb)
-                    tid_list = (
-                        tracked.track_id.tolist()
-                        if tracked.track_id is not None and len(tracked) > 0
-                        else None
-                    )
-                    if len(tracked) > 0:
-                        annotated = draw_boxes(
-                            img_pil,
-                            tracked.boxes.xyxy.tolist(),
-                            tracked.boxes.conf.tolist(),
-                            tracked.boxes.cls.tolist(),
-                            class_names=self.names,
-                            track_ids=tid_list,
-                        )
-                    else:
-                        annotated = img_pil
-                    annotated.save(output_dir / f"frame_{frame_idx:06d}.jpg")
-
-                frame_idx += 1
-                yield tracked
-        finally:
-            cap.release()
+        yield from run_video_inference(
+            source,
+            predict_and_track,
+            vid_stride=vid_stride,
+            save=save,
+            show=show,
+            output_path=track_output,
+            annotate_fn=annotate_tracked,
+        )
 
     def export(self, format: str = "onnx", **kwargs) -> str:
         """Export model to deployment format.

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -354,6 +354,8 @@ class BaseModel(ABC):
         imgsz: Optional[int] = None,
         classes: Optional[List[int]] = None,
         max_det: int = 300,
+        save: bool = False,
+        save_dir: Optional[str] = None,
         tracker_config=None,
         **tracker_kwargs,
     ) -> Generator[Results, None, None]:
@@ -372,6 +374,10 @@ class BaseModel(ABC):
             imgsz: Override input image size.
             classes: Filter to specific class IDs.
             max_det: Maximum detections per frame.
+            save: If True, save annotated frames (with bounding boxes and
+                track IDs) as images to *save_dir*.
+            save_dir: Directory to save annotated frames. Defaults to
+                ``runs/track/<video_stem>/``.
             tracker_config: A ``TrackConfig`` instance, or None to build
                 one from **tracker_kwargs.
             **tracker_kwargs: Forwarded to ``TrackConfig.from_kwargs``.
@@ -383,6 +389,7 @@ class BaseModel(ABC):
         import numpy as np
 
         from ...tracking import ByteTracker, TrackConfig
+        from ...utils.drawing import draw_boxes
 
         if tracker_config is None:
             tracker_config = TrackConfig.from_kwargs(**tracker_kwargs)
@@ -390,8 +397,23 @@ class BaseModel(ABC):
         # ByteTrack needs to see low-confidence detections.
         effective_conf = tracker_config.track_low_thresh
 
+        # Resolve save directory.
+        output_dir = None
+        if save:
+            if save_dir is not None:
+                output_dir = Path(save_dir)
+            else:
+                video_stem = Path(source).stem
+                from ...utils.general import increment_path
+
+                output_dir = increment_path(
+                    Path("runs") / "track" / video_stem, exist_ok=False
+                )
+            output_dir.mkdir(parents=True, exist_ok=True)
+
         tracker = ByteTracker(config=tracker_config)
         cap = cv2.VideoCapture(str(source))
+        frame_idx = 0
 
         try:
             while cap.isOpened():
@@ -413,6 +435,28 @@ class BaseModel(ABC):
                 )
 
                 tracked = tracker.update(result)
+
+                if save and output_dir is not None:
+                    img_pil = Image.fromarray(frame_rgb)
+                    tid_list = (
+                        tracked.track_id.tolist()
+                        if tracked.track_id is not None and len(tracked) > 0
+                        else None
+                    )
+                    if len(tracked) > 0:
+                        annotated = draw_boxes(
+                            img_pil,
+                            tracked.boxes.xyxy.tolist(),
+                            tracked.boxes.conf.tolist(),
+                            tracked.boxes.cls.tolist(),
+                            class_names=self.names,
+                            track_ids=tid_list,
+                        )
+                    else:
+                        annotated = img_pil
+                    annotated.save(output_dir / f"frame_{frame_idx:06d}.jpg")
+
+                frame_idx += 1
                 yield tracked
         finally:
             cap.release()

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
@@ -344,6 +344,78 @@ class BaseModel(ABC):
     def predict(self, *args, **kwargs) -> Union[Results, List[Results]]:
         """Alias for __call__ method."""
         return self(*args, **kwargs)
+
+    def track(
+        self,
+        source: str | Path,
+        *,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[int] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        tracker_config=None,
+        **tracker_kwargs,
+    ) -> Generator[Results, None, None]:
+        """Track objects across video frames.
+
+        Runs detection on each frame and associates detections across time
+        using the ByteTrack algorithm. Yields one Results per frame with
+        ``track_id`` set.
+
+        Args:
+            source: Path to a video file.
+            conf: Confidence threshold passed to the tracker as
+                ``track_high_thresh``. The detector runs at a lower threshold
+                internally so ByteTrack can use low-confidence detections.
+            iou: IoU threshold for NMS during detection.
+            imgsz: Override input image size.
+            classes: Filter to specific class IDs.
+            max_det: Maximum detections per frame.
+            tracker_config: A ``TrackConfig`` instance, or None to build
+                one from **tracker_kwargs.
+            **tracker_kwargs: Forwarded to ``TrackConfig.from_kwargs``.
+
+        Yields:
+            Results with ``track_id`` attribute set as an (N,) int tensor.
+        """
+        import cv2
+        import numpy as np
+
+        from ...tracking import ByteTracker, TrackConfig
+
+        if tracker_config is None:
+            tracker_config = TrackConfig.from_kwargs(**tracker_kwargs)
+
+        # ByteTrack needs to see low-confidence detections.
+        effective_conf = tracker_config.track_low_thresh
+
+        tracker = ByteTracker(config=tracker_config)
+        cap = cv2.VideoCapture(str(source))
+
+        try:
+            while cap.isOpened():
+                ret, frame_bgr = cap.read()
+                if not ret:
+                    break
+
+                # Convert BGR → RGB numpy array for the detector.
+                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+
+                result = self._runner(
+                    frame_rgb,
+                    conf=effective_conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    classes=classes,
+                    max_det=max_det,
+                    color_format="rgb",
+                )
+
+                tracked = tracker.update(result)
+                yield tracked
+        finally:
+            cap.release()
 
     def export(self, format: str = "onnx", **kwargs) -> str:
         """Export model to deployment format.

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -415,6 +415,7 @@ class BaseModel(ABC):
                     Path("runs") / "track" / video_stem, exist_ok=False
                 )
             output_dir.mkdir(parents=True, exist_ok=True)
+            print(f"Saving tracked frames to {output_dir}/")
 
         tracker = ByteTracker(config=tracker_config)
         cap = cv2.VideoCapture(str(source))

--- a/libreyolo/tracking/__init__.py
+++ b/libreyolo/tracking/__init__.py
@@ -1,0 +1,6 @@
+"""Multi-object tracking for LibreYOLO."""
+
+from .config import TrackConfig
+from .tracker import ByteTracker
+
+__all__ = ["ByteTracker", "TrackConfig"]

--- a/libreyolo/tracking/config.py
+++ b/libreyolo/tracking/config.py
@@ -1,0 +1,42 @@
+"""Tracking configuration for ByteTrack."""
+
+import warnings
+from dataclasses import dataclass, fields
+
+
+@dataclass(kw_only=True)
+class TrackConfig:
+    """Configuration for the ByteTrack multi-object tracker.
+
+    Args:
+        track_high_thresh: Minimum confidence for first association stage.
+        track_low_thresh: Minimum confidence for second association (low-conf recovery).
+        new_track_thresh: Minimum confidence to initialize a new track.
+        match_thresh: IoU cost threshold for first association.
+        track_buffer: Frames to keep lost tracks before removal.
+        frame_rate: Video frame rate (used to scale track_buffer).
+        fuse_score: Fuse detection score with IoU for first association.
+        minimum_consecutive_frames: Frames a track must be matched before it is confirmed.
+    """
+
+    track_high_thresh: float = 0.25
+    track_low_thresh: float = 0.1
+    new_track_thresh: float = 0.25
+    match_thresh: float = 0.8
+    track_buffer: int = 30
+    frame_rate: int = 30
+    fuse_score: bool = True
+    minimum_consecutive_frames: int = 1
+
+    @classmethod
+    def from_kwargs(cls, **kwargs) -> "TrackConfig":
+        """Construct config, warning on unknown keys."""
+        valid = {f.name for f in fields(cls)}
+        unknown = set(kwargs) - valid
+        if unknown:
+            warnings.warn(
+                f"Unknown tracking config keys (ignored): {sorted(unknown)}",
+                stacklevel=2,
+            )
+        filtered = {k: v for k, v in kwargs.items() if k in valid}
+        return cls(**filtered)

--- a/libreyolo/tracking/config.py
+++ b/libreyolo/tracking/config.py
@@ -43,6 +43,11 @@ class TrackConfig:
             raise ValueError(f"track_buffer must be >= 0, got {self.track_buffer}")
         if self.minimum_consecutive_frames < 1:
             raise ValueError(f"minimum_consecutive_frames must be >= 1, got {self.minimum_consecutive_frames}")
+        if self.track_high_thresh < self.track_low_thresh:
+            raise ValueError(
+                f"track_high_thresh ({self.track_high_thresh}) must be >= "
+                f"track_low_thresh ({self.track_low_thresh})"
+            )
 
     @classmethod
     def from_kwargs(cls, **kwargs) -> "TrackConfig":

--- a/libreyolo/tracking/config.py
+++ b/libreyolo/tracking/config.py
@@ -28,6 +28,22 @@ class TrackConfig:
     fuse_score: bool = True
     minimum_consecutive_frames: int = 1
 
+    def __post_init__(self):
+        if self.frame_rate <= 0:
+            raise ValueError(f"frame_rate must be > 0, got {self.frame_rate}")
+        if not (0 <= self.track_high_thresh <= 1):
+            raise ValueError(f"track_high_thresh must be in [0, 1], got {self.track_high_thresh}")
+        if not (0 <= self.track_low_thresh <= 1):
+            raise ValueError(f"track_low_thresh must be in [0, 1], got {self.track_low_thresh}")
+        if not (0 <= self.new_track_thresh <= 1):
+            raise ValueError(f"new_track_thresh must be in [0, 1], got {self.new_track_thresh}")
+        if not (0 <= self.match_thresh <= 1):
+            raise ValueError(f"match_thresh must be in [0, 1], got {self.match_thresh}")
+        if self.track_buffer < 0:
+            raise ValueError(f"track_buffer must be >= 0, got {self.track_buffer}")
+        if self.minimum_consecutive_frames < 1:
+            raise ValueError(f"minimum_consecutive_frames must be >= 1, got {self.minimum_consecutive_frames}")
+
     @classmethod
     def from_kwargs(cls, **kwargs) -> "TrackConfig":
         """Construct config, warning on unknown keys."""

--- a/libreyolo/tracking/kalman_filter.py
+++ b/libreyolo/tracking/kalman_filter.py
@@ -5,7 +5,14 @@ Measurement: (cx, cy, aspect_ratio, height)
 """
 
 import numpy as np
-import scipy.linalg
+
+try:
+    import scipy.linalg
+except ImportError as e:
+    raise ImportError(
+        "scipy is required for tracking. "
+        "Install with: pip install libreyolo[tracking]"
+    ) from e
 
 
 class KalmanFilterXYAH:

--- a/libreyolo/tracking/kalman_filter.py
+++ b/libreyolo/tracking/kalman_filter.py
@@ -1,0 +1,174 @@
+"""Kalman filter with constant-velocity model for bounding box tracking.
+
+State space: (cx, cy, aspect_ratio, height, v_cx, v_cy, v_a, v_h)
+Measurement: (cx, cy, aspect_ratio, height)
+"""
+
+import numpy as np
+import scipy.linalg
+
+
+class KalmanFilterXYAH:
+    """8-dimensional Kalman filter for bounding box tracking.
+
+    Uses a constant-velocity model with adaptive noise proportional
+    to the bounding box height.
+    """
+
+    _std_weight_position = 1.0 / 20
+    _std_weight_velocity = 1.0 / 160
+
+    def __init__(self):
+        ndim = 4
+        dt = 1.0
+
+        # State transition matrix (constant velocity).
+        self._motion_mat = np.eye(2 * ndim, dtype=np.float64)
+        for i in range(ndim):
+            self._motion_mat[i, ndim + i] = dt
+
+        # Observation matrix (we only observe position components).
+        self._update_mat = np.eye(ndim, 2 * ndim, dtype=np.float64)
+
+    def initiate(self, measurement: np.ndarray):
+        """Initialize track state from an unassociated measurement.
+
+        Args:
+            measurement: (cx, cy, a, h) bounding box center, aspect ratio, height.
+
+        Returns:
+            (mean, covariance) tuple with shapes (8,) and (8, 8).
+        """
+        mean_pos = measurement
+        mean_vel = np.zeros_like(mean_pos)
+        mean = np.concatenate([mean_pos, mean_vel])
+
+        h = measurement[3]
+        std = [
+            2 * self._std_weight_position * h,
+            2 * self._std_weight_position * h,
+            1e-2,
+            2 * self._std_weight_position * h,
+            10 * self._std_weight_velocity * h,
+            10 * self._std_weight_velocity * h,
+            1e-5,
+            10 * self._std_weight_velocity * h,
+        ]
+        covariance = np.diag(np.square(std))
+        return mean, covariance
+
+    def predict(self, mean: np.ndarray, covariance: np.ndarray):
+        """Run Kalman filter prediction step.
+
+        Args:
+            mean: (8,) state vector.
+            covariance: (8, 8) state covariance.
+
+        Returns:
+            (predicted_mean, predicted_covariance).
+        """
+        h = max(mean[3], 1e-2)
+        std_pos = [
+            self._std_weight_position * h,
+            self._std_weight_position * h,
+            1e-2,
+            self._std_weight_position * h,
+        ]
+        std_vel = [
+            self._std_weight_velocity * h,
+            self._std_weight_velocity * h,
+            1e-5,
+            self._std_weight_velocity * h,
+        ]
+        motion_cov = np.diag(np.square(np.concatenate([std_pos, std_vel])))
+
+        mean = self._motion_mat @ mean
+        # Clamp covariance to prevent overflow from repeated prediction
+        # without updates (e.g., lost tracks). The near-zero aspect-ratio
+        # velocity variance can trigger spurious numpy matmul warnings.
+        covariance = np.clip(covariance, -1e10, 1e10)
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            covariance = (
+                self._motion_mat @ covariance @ self._motion_mat.T + motion_cov
+            )
+        return mean, covariance
+
+    def multi_predict(self, mean: np.ndarray, covariance: np.ndarray):
+        """Vectorized prediction for multiple tracks.
+
+        Args:
+            mean: (N, 8) state vectors.
+            covariance: (N, 8, 8) state covariances.
+
+        Returns:
+            (predicted_means, predicted_covariances) with same shapes.
+        """
+        h = np.maximum(mean[:, 3], 1e-2)
+        std_pos = [
+            self._std_weight_position * h,
+            self._std_weight_position * h,
+            1e-2 * np.ones_like(h),
+            self._std_weight_position * h,
+        ]
+        std_vel = [
+            self._std_weight_velocity * h,
+            self._std_weight_velocity * h,
+            1e-5 * np.ones_like(h),
+            self._std_weight_velocity * h,
+        ]
+        sqr = np.square(np.column_stack(std_pos + std_vel))
+        motion_cov = np.array([np.diag(s) for s in sqr])
+
+        mean = np.einsum("ij,nj->ni", self._motion_mat, mean)
+        covariance = np.clip(covariance, -1e10, 1e10)
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            covariance = (
+                np.einsum(
+                    "ij,njk,lk->nil",
+                    self._motion_mat,
+                    covariance,
+                    self._motion_mat,
+                )
+                + motion_cov
+            )
+        return mean, covariance
+
+    def update(self, mean: np.ndarray, covariance: np.ndarray, measurement: np.ndarray):
+        """Run Kalman filter correction step.
+
+        Args:
+            mean: (8,) predicted state vector.
+            covariance: (8, 8) predicted state covariance.
+            measurement: (4,) observed (cx, cy, a, h).
+
+        Returns:
+            (corrected_mean, corrected_covariance).
+        """
+        h = mean[3]
+        std = [
+            self._std_weight_position * h,
+            self._std_weight_position * h,
+            1e-1,
+            self._std_weight_position * h,
+        ]
+        innovation_cov = np.diag(np.square(std))
+
+        projected_mean = self._update_mat @ mean
+        projected_cov = (
+            self._update_mat @ covariance @ self._update_mat.T + innovation_cov
+        )
+
+        # Solve via Cholesky decomposition for numerical stability.
+        chol_factor, lower = scipy.linalg.cho_factor(
+            projected_cov, lower=True, check_finite=False
+        )
+        kalman_gain = scipy.linalg.cho_solve(
+            (chol_factor, lower),
+            (covariance @ self._update_mat.T).T,
+            check_finite=False,
+        ).T
+
+        innovation = measurement - projected_mean
+        new_mean = mean + innovation @ kalman_gain.T
+        new_covariance = covariance - kalman_gain @ projected_cov @ kalman_gain.T
+        return new_mean, new_covariance

--- a/libreyolo/tracking/matching.py
+++ b/libreyolo/tracking/matching.py
@@ -8,7 +8,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.optimize import linear_sum_assignment as scipy_lsa
+
+try:
+    from scipy.optimize import linear_sum_assignment as scipy_lsa
+except ImportError as e:
+    raise ImportError(
+        "scipy is required for tracking. "
+        "Install with: pip install libreyolo[tracking]"
+    ) from e
 
 if TYPE_CHECKING:
     from .strack import STrack

--- a/libreyolo/tracking/matching.py
+++ b/libreyolo/tracking/matching.py
@@ -1,0 +1,115 @@
+"""Association utilities for multi-object tracking.
+
+All functions operate on numpy arrays — the tracker runs in numpy-land.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment as scipy_lsa
+
+if TYPE_CHECKING:
+    from .strack import STrack
+
+
+def bbox_iou_batch(bboxes_a: np.ndarray, bboxes_b: np.ndarray) -> np.ndarray:
+    """Compute pairwise IoU between two sets of bounding boxes.
+
+    Args:
+        bboxes_a: (N, 4) array in xyxy format.
+        bboxes_b: (M, 4) array in xyxy format.
+
+    Returns:
+        (N, M) IoU matrix.
+    """
+    x1 = np.maximum(bboxes_a[:, 0:1], bboxes_b[:, 0])
+    y1 = np.maximum(bboxes_a[:, 1:2], bboxes_b[:, 1])
+    x2 = np.minimum(bboxes_a[:, 2:3], bboxes_b[:, 2])
+    y2 = np.minimum(bboxes_a[:, 3:4], bboxes_b[:, 3])
+
+    intersection = np.maximum(0.0, x2 - x1) * np.maximum(0.0, y2 - y1)
+
+    area_a = (bboxes_a[:, 2] - bboxes_a[:, 0]) * (bboxes_a[:, 3] - bboxes_a[:, 1])
+    area_b = (bboxes_b[:, 2] - bboxes_b[:, 0]) * (bboxes_b[:, 3] - bboxes_b[:, 1])
+
+    union = area_a[:, None] + area_b[None, :] - intersection
+    return intersection / np.maximum(union, 1e-6)
+
+
+def iou_distance(tracks: list[STrack], detections: np.ndarray) -> np.ndarray:
+    """Compute cost matrix as 1 - IoU between tracks and detections.
+
+    Args:
+        tracks: List of STrack instances.
+        detections: (M, 4) array of detection bboxes in xyxy format.
+
+    Returns:
+        (N, M) cost matrix where N = len(tracks).
+    """
+    if len(tracks) == 0 or len(detections) == 0:
+        return np.empty((len(tracks), len(detections)), dtype=np.float64)
+
+    track_bboxes = np.array([t.xyxy for t in tracks], dtype=np.float64)
+    return 1.0 - bbox_iou_batch(track_bboxes, detections)
+
+
+def fuse_score(cost_matrix: np.ndarray, scores: np.ndarray) -> np.ndarray:
+    """Fuse detection confidence scores into the IoU cost matrix.
+
+    Formula: fused = 1 - (iou_similarity * detection_score)
+
+    Args:
+        cost_matrix: (N, M) IoU-based cost matrix.
+        scores: (M,) detection confidence scores.
+
+    Returns:
+        (N, M) fused cost matrix.
+    """
+    iou_sim = 1.0 - cost_matrix
+    fused_sim = iou_sim * scores[None, :]
+    return 1.0 - fused_sim
+
+
+def linear_assignment(
+    cost_matrix: np.ndarray,
+    thresh: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Solve the linear assignment problem and filter by threshold.
+
+    Args:
+        cost_matrix: (N, M) cost matrix.
+        thresh: Maximum cost for a valid assignment.
+
+    Returns:
+        matches: (K, 2) array of (row, col) index pairs.
+        unmatched_a: (P,) array of unmatched row indices.
+        unmatched_b: (Q,) array of unmatched col indices.
+    """
+    if cost_matrix.size == 0:
+        return (
+            np.empty((0, 2), dtype=int),
+            np.arange(cost_matrix.shape[0], dtype=int),
+            np.arange(cost_matrix.shape[1], dtype=int),
+        )
+
+    row_indices, col_indices = scipy_lsa(cost_matrix)
+
+    matches = []
+    unmatched_a = set(range(cost_matrix.shape[0]))
+    unmatched_b = set(range(cost_matrix.shape[1]))
+
+    for r, c in zip(row_indices, col_indices):
+        if cost_matrix[r, c] > thresh:
+            continue
+        matches.append([r, c])
+        unmatched_a.discard(r)
+        unmatched_b.discard(c)
+
+    matches_arr = np.array(matches, dtype=int) if matches else np.empty((0, 2), dtype=int)
+    return (
+        matches_arr,
+        np.array(sorted(unmatched_a), dtype=int),
+        np.array(sorted(unmatched_b), dtype=int),
+    )

--- a/libreyolo/tracking/strack.py
+++ b/libreyolo/tracking/strack.py
@@ -1,0 +1,153 @@
+"""Single track representation for ByteTrack."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+import numpy as np
+
+from .kalman_filter import KalmanFilterXYAH
+
+
+class TrackState(IntEnum):
+    """Track lifecycle states."""
+
+    New = 0
+    Tracked = 1
+    Lost = 2
+    Removed = 3
+
+
+class STrack:
+    """A single tracked object managed by a Kalman filter.
+
+    Stores the Kalman state, track metadata, and provides coordinate
+    conversions between xyxy, xyah, and tlwh formats.
+    """
+
+    def __init__(self, xyxy: np.ndarray, score: float, cls: int, detection_index: int):
+        self.mean: np.ndarray = np.zeros(8, dtype=np.float64)
+        self.covariance: np.ndarray = np.eye(8, dtype=np.float64)
+
+        self._xyxy = xyxy.astype(np.float64)
+        self.score = score
+        self.cls = int(cls)
+        self.detection_index = detection_index
+
+        self.track_id: int = 0
+        self.state: TrackState = TrackState.New
+        self.is_activated: bool = False
+
+        self.frame_id: int = 0
+        self.start_frame: int = 0
+        self._hits: int = 0
+
+    # ------------------------------------------------------------------
+    # Coordinate conversions
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def xyxy_to_xyah(xyxy: np.ndarray) -> np.ndarray:
+        """Convert (x1, y1, x2, y2) to (cx, cy, aspect_ratio, height)."""
+        w = xyxy[2] - xyxy[0]
+        h = xyxy[3] - xyxy[1]
+        cx = xyxy[0] + w / 2
+        cy = xyxy[1] + h / 2
+        a = w / max(h, 1e-6)
+        return np.array([cx, cy, a, h], dtype=np.float64)
+
+    @property
+    def xyah(self) -> np.ndarray:
+        """Current (cx, cy, aspect_ratio, height) from Kalman state."""
+        return self.mean[:4].copy()
+
+    @property
+    def tlwh(self) -> np.ndarray:
+        """Current (top, left, width, height) from Kalman state."""
+        ret = self.mean[:4].copy()
+        ret[2] *= ret[3]  # width = aspect * height
+        ret[:2] -= ret[2:] / 2  # center to top-left
+        return ret
+
+    @property
+    def xyxy(self) -> np.ndarray:
+        """Current (x1, y1, x2, y2) from Kalman state."""
+        tlwh = self.tlwh
+        return np.array(
+            [tlwh[0], tlwh[1], tlwh[0] + tlwh[2], tlwh[1] + tlwh[3]],
+            dtype=np.float64,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle methods
+    # ------------------------------------------------------------------
+
+    def activate(self, kf: KalmanFilterXYAH, frame_id: int, track_id: int):
+        """Initialize this track from its first detection."""
+        self.track_id = track_id
+        measurement = self.xyxy_to_xyah(self._xyxy)
+        self.mean, self.covariance = kf.initiate(measurement)
+
+        self.state = TrackState.Tracked
+        self.is_activated = True
+        self.frame_id = frame_id
+        self.start_frame = frame_id
+        self._hits = 1
+
+    def re_activate(
+        self,
+        kf: KalmanFilterXYAH,
+        new_detection: STrack,
+        frame_id: int,
+        new_id: bool = False,
+        new_track_id: int = 0,
+    ):
+        """Re-activate a lost track with a new detection."""
+        measurement = self.xyxy_to_xyah(new_detection._xyxy)
+        # If covariance has degenerated (NaN/Inf from repeated prediction
+        # without updates), reinitialize from the new measurement.
+        if np.any(np.isnan(self.covariance)) or np.any(np.isinf(self.covariance)):
+            self.mean, self.covariance = kf.initiate(measurement)
+        else:
+            self.mean, self.covariance = kf.update(
+                self.mean, self.covariance, measurement
+            )
+
+        self.state = TrackState.Tracked
+        self.is_activated = True
+        self.frame_id = frame_id
+        self.score = new_detection.score
+        self.cls = new_detection.cls
+        self.detection_index = new_detection.detection_index
+        self._hits += 1
+
+        if new_id:
+            self.track_id = new_track_id
+
+    def update(self, kf: KalmanFilterXYAH, new_detection: STrack, frame_id: int):
+        """Update a matched track with a new detection."""
+        measurement = self.xyxy_to_xyah(new_detection._xyxy)
+        self.mean, self.covariance = kf.update(self.mean, self.covariance, measurement)
+
+        self.state = TrackState.Tracked
+        self.is_activated = True
+        self.frame_id = frame_id
+        self.score = new_detection.score
+        self.cls = new_detection.cls
+        self.detection_index = new_detection.detection_index
+        self._hits += 1
+
+    def predict(self, kf: KalmanFilterXYAH):
+        """Predict the next state using the Kalman filter."""
+        # Zero velocity for lost tracks to prevent unbounded drift.
+        if self.state != TrackState.Tracked:
+            self.mean[7] = 0  # zero height velocity
+        self.mean, self.covariance = kf.predict(self.mean, self.covariance)
+
+    def mark_lost(self):
+        """Transition to Lost state."""
+        self.state = TrackState.Lost
+
+    def mark_removed(self):
+        """Transition to Removed state."""
+        self.state = TrackState.Removed

--- a/libreyolo/tracking/tracker.py
+++ b/libreyolo/tracking/tracker.py
@@ -179,11 +179,9 @@ class ByteTracker:
         for i in u_det_final:
             det = remaining_high_dets[i]
             if det.score >= cfg.new_track_thresh:
-                if cfg.minimum_consecutive_frames <= 1:
-                    det.activate(self.kalman_filter, self._frame_id, self._next_id())
-                else:
-                    # Start as unconfirmed — don't assign a visible ID yet.
-                    det.activate(self.kalman_filter, self._frame_id, self._next_id())
+                det.activate(self.kalman_filter, self._frame_id, self._next_id())
+                if cfg.minimum_consecutive_frames > 1:
+                    # Start as unconfirmed — needs more consecutive matches.
                     det.is_activated = False
 
         # ------------------------------------------------------------------

--- a/libreyolo/tracking/tracker.py
+++ b/libreyolo/tracking/tracker.py
@@ -1,0 +1,331 @@
+"""ByteTrack multi-object tracker.
+
+Implements the BYTE association method from:
+    ByteTrack: Multi-Object Tracking by Associating Every Detection Box
+    (Zhang et al., ECCV 2022)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from ..utils.results import Boxes, Results
+from .config import TrackConfig
+from .kalman_filter import KalmanFilterXYAH
+from .matching import fuse_score, iou_distance, linear_assignment
+from .strack import STrack, TrackState
+
+
+class ByteTracker:
+    """Multi-object tracker using the ByteTrack algorithm.
+
+    Args:
+        config: Tracking configuration. If None, uses default TrackConfig.
+        **kwargs: Forwarded to TrackConfig.from_kwargs when config is None.
+
+    Example::
+
+        tracker = ByteTracker()
+        for frame in frames:
+            result = model(frame, conf=0.1)
+            tracked = tracker.update(result)
+            print(tracked.track_id)
+    """
+
+    def __init__(self, config: TrackConfig | None = None, **kwargs):
+        self.config = config or TrackConfig.from_kwargs(**kwargs)
+        self._id_count: int = 0
+        self._frame_id: int = 0
+        self.tracked_stracks: list[STrack] = []
+        self.lost_stracks: list[STrack] = []
+        self.removed_stracks: list[STrack] = []
+        self.kalman_filter = KalmanFilterXYAH()
+
+    def _next_id(self) -> int:
+        self._id_count += 1
+        return self._id_count
+
+    def reset(self):
+        """Clear all tracks and reset the ID counter."""
+        self._id_count = 0
+        self._frame_id = 0
+        self.tracked_stracks.clear()
+        self.lost_stracks.clear()
+        self.removed_stracks.clear()
+
+    def update(self, results: Results) -> Results:
+        """Run one frame of tracking.
+
+        Takes detection results and returns new Results with track IDs
+        assigned. Only confirmed, currently tracked objects are returned.
+
+        Args:
+            results: Detection results from any detector.
+
+        Returns:
+            New Results with ``track_id`` attribute set as an (N,) int tensor.
+        """
+        self._frame_id += 1
+        cfg = self.config
+
+        # ------------------------------------------------------------------
+        # 1. Extract detections (torch → numpy boundary)
+        # ------------------------------------------------------------------
+        boxes_np = results.boxes.xyxy.cpu().numpy().astype(np.float64)
+        scores_np = results.boxes.conf.cpu().numpy().astype(np.float64)
+        classes_np = results.boxes.cls.cpu().numpy().astype(np.float64)
+
+        # Filter below track_low_thresh and build STrack candidates.
+        keep = scores_np >= cfg.track_low_thresh
+        boxes_np = boxes_np[keep]
+        scores_np = scores_np[keep]
+        classes_np = classes_np[keep]
+        # Map back to original detection indices for result slicing.
+        original_indices = np.where(keep)[0]
+
+        # Split into high / low confidence.
+        high_mask = scores_np >= cfg.track_high_thresh
+        low_mask = ~high_mask
+
+        high_dets = [
+            STrack(boxes_np[i], scores_np[i], classes_np[i], int(original_indices[i]))
+            for i in np.where(high_mask)[0]
+        ]
+        low_dets = [
+            STrack(boxes_np[i], scores_np[i], classes_np[i], int(original_indices[i]))
+            for i in np.where(low_mask)[0]
+        ]
+
+        high_bboxes = boxes_np[high_mask] if len(high_dets) > 0 else np.empty((0, 4))
+        low_bboxes = boxes_np[low_mask] if len(low_dets) > 0 else np.empty((0, 4))
+        high_scores = scores_np[high_mask] if len(high_dets) > 0 else np.empty(0)
+
+        # ------------------------------------------------------------------
+        # 2. Predict existing tracks
+        # ------------------------------------------------------------------
+        for t in self.tracked_stracks:
+            t.predict(self.kalman_filter)
+        for t in self.lost_stracks:
+            t.predict(self.kalman_filter)
+
+        # Split tracked into confirmed and unconfirmed.
+        unconfirmed = [t for t in self.tracked_stracks if not t.is_activated]
+        tracked_stracks = [t for t in self.tracked_stracks if t.is_activated]
+
+        # Pool for first association: confirmed tracked + lost.
+        strack_pool = _joint_stracks(tracked_stracks, self.lost_stracks)
+
+        # ------------------------------------------------------------------
+        # 3. Stage 1: high-confidence detections ↔ track pool
+        # ------------------------------------------------------------------
+        cost = iou_distance(strack_pool, high_bboxes)
+        if cfg.fuse_score and len(high_scores) > 0:
+            cost = fuse_score(cost, high_scores)
+        matches, u_track, u_det_high = linear_assignment(cost, cfg.match_thresh)
+
+        for m in matches:
+            track = strack_pool[m[0]]
+            det = high_dets[m[1]]
+            if track.state == TrackState.Tracked:
+                track.update(self.kalman_filter, det, self._frame_id)
+            else:
+                track.re_activate(self.kalman_filter, det, self._frame_id)
+
+        # ------------------------------------------------------------------
+        # 4. Stage 2: low-confidence detections ↔ remaining tracked (NOT lost)
+        # ------------------------------------------------------------------
+        remaining_tracked = [
+            strack_pool[i] for i in u_track if strack_pool[i].state == TrackState.Tracked
+        ]
+        cost2 = iou_distance(remaining_tracked, low_bboxes)
+        matches2, u_track2, _ = linear_assignment(cost2, 0.5)
+
+        for m in matches2:
+            track = remaining_tracked[m[0]]
+            det = low_dets[m[1]]
+            track.update(self.kalman_filter, det, self._frame_id)
+
+        # Mark unmatched tracked as lost.
+        for i in u_track2:
+            t = remaining_tracked[i]
+            if t.state != TrackState.Lost:
+                t.mark_lost()
+
+        # ------------------------------------------------------------------
+        # 5. Stage 3: remaining high-conf ↔ unconfirmed tracks
+        # ------------------------------------------------------------------
+        remaining_high_dets = [high_dets[i] for i in u_det_high]
+        remaining_high_bboxes = (
+            np.array([d._xyxy for d in remaining_high_dets])
+            if remaining_high_dets
+            else np.empty((0, 4))
+        )
+        cost3 = iou_distance(unconfirmed, remaining_high_bboxes)
+        matches3, u_unconf, u_det_final = linear_assignment(cost3, 0.7)
+
+        for m in matches3:
+            track = unconfirmed[m[0]]
+            det = remaining_high_dets[m[1]]
+            track.update(self.kalman_filter, det, self._frame_id)
+
+        # Remove unmatched unconfirmed tracks.
+        for i in u_unconf:
+            unconfirmed[i].mark_removed()
+
+        # ------------------------------------------------------------------
+        # 6. Initialize new tracks from remaining unmatched high-conf detections
+        # ------------------------------------------------------------------
+        for i in u_det_final:
+            det = remaining_high_dets[i]
+            if det.score >= cfg.new_track_thresh:
+                if cfg.minimum_consecutive_frames <= 1:
+                    det.activate(self.kalman_filter, self._frame_id, self._next_id())
+                else:
+                    # Start as unconfirmed — don't assign a visible ID yet.
+                    det.activate(self.kalman_filter, self._frame_id, self._next_id())
+                    det.is_activated = False
+
+        # ------------------------------------------------------------------
+        # 7. Handle lost tracks: mark expired as removed
+        # ------------------------------------------------------------------
+        max_time_lost = int(cfg.track_buffer * cfg.frame_rate / 30)
+        for t in self.lost_stracks:
+            if self._frame_id - t.frame_id > max_time_lost:
+                t.mark_removed()
+
+        # ------------------------------------------------------------------
+        # 8. Update track lists
+        # ------------------------------------------------------------------
+        # Collect all tracks that are now Tracked (from any source).
+        all_candidates = strack_pool + unconfirmed + high_dets + low_dets
+        new_tracked = [t for t in all_candidates if t.state == TrackState.Tracked]
+        # Deduplicate by track_id (keep first seen = the updated one).
+        seen_ids: set[int] = set()
+        deduped_tracked: list[STrack] = []
+        for t in new_tracked:
+            if t.track_id not in seen_ids:
+                seen_ids.add(t.track_id)
+                deduped_tracked.append(t)
+        self.tracked_stracks = deduped_tracked
+
+        # Lost: anything from strack_pool or old lost list that is still Lost.
+        tracked_ids = {t.track_id for t in self.tracked_stracks}
+        self.lost_stracks = [
+            t
+            for t in strack_pool + self.lost_stracks
+            if t.state == TrackState.Lost and t.track_id not in tracked_ids
+        ]
+        # Deduplicate lost list.
+        seen_lost: set[int] = set()
+        deduped_lost: list[STrack] = []
+        for t in self.lost_stracks:
+            if t.track_id not in seen_lost:
+                seen_lost.add(t.track_id)
+                deduped_lost.append(t)
+        self.lost_stracks = deduped_lost
+
+        # Remove duplicates between tracked and lost.
+        self.tracked_stracks, self.lost_stracks = _remove_duplicate_stracks(
+            self.tracked_stracks, self.lost_stracks
+        )
+
+        # Prune removed list.
+        self.removed_stracks = [
+            t for t in self.removed_stracks if t.state == TrackState.Removed
+        ]
+        if len(self.removed_stracks) > 1000:
+            self.removed_stracks = self.removed_stracks[-500:]
+
+        # ------------------------------------------------------------------
+        # 9. Build output Results
+        # ------------------------------------------------------------------
+        output_stracks = [
+            t
+            for t in self.tracked_stracks
+            if t.is_activated and t._hits >= cfg.minimum_consecutive_frames
+        ]
+
+        if len(output_stracks) == 0:
+            empty_boxes = Boxes(
+                torch.zeros((0, 4), dtype=torch.float32),
+                torch.zeros((0,), dtype=torch.float32),
+                torch.zeros((0,), dtype=torch.float32),
+            )
+            return Results(
+                boxes=empty_boxes,
+                orig_shape=results.orig_shape,
+                path=results.path,
+                names=results.names,
+                track_id=torch.zeros((0,), dtype=torch.int64),
+            )
+
+        # Slice original detections by detection_index.
+        indices = [t.detection_index for t in output_stracks]
+        out_boxes = results.boxes.xyxy[indices]
+        out_conf = results.boxes.conf[indices]
+        out_cls = results.boxes.cls[indices]
+        track_ids = torch.tensor(
+            [t.track_id for t in output_stracks], dtype=torch.int64
+        )
+
+        return Results(
+            boxes=Boxes(out_boxes, out_conf, out_cls),
+            orig_shape=results.orig_shape,
+            path=results.path,
+            names=results.names,
+            track_id=track_ids,
+        )
+
+
+# --------------------------------------------------------------------------
+# Module-level helpers
+# --------------------------------------------------------------------------
+
+
+def _joint_stracks(a: list[STrack], b: list[STrack]) -> list[STrack]:
+    """Merge two track lists, deduplicating by track_id."""
+    seen = {}
+    for t in a:
+        seen[t.track_id] = t
+    for t in b:
+        if t.track_id not in seen:
+            seen[t.track_id] = t
+    return list(seen.values())
+
+
+def _sub_stracks(a: list[STrack], b: list[STrack]) -> list[STrack]:
+    """Return tracks in a whose track_id is not in b."""
+    b_ids = {t.track_id for t in b}
+    return [t for t in a if t.track_id not in b_ids]
+
+
+def _remove_duplicate_stracks(
+    tracked: list[STrack], lost: list[STrack]
+) -> tuple[list[STrack], list[STrack]]:
+    """Remove duplicates between tracked and lost lists.
+
+    When two tracks overlap (IoU > 0.85), keep the one with more frames.
+    """
+    if not tracked or not lost:
+        return tracked, lost
+
+    from .matching import bbox_iou_batch
+
+    t_bboxes = np.array([t.xyxy for t in tracked], dtype=np.float64)
+    l_bboxes = np.array([t.xyxy for t in lost], dtype=np.float64)
+    iou = bbox_iou_batch(t_bboxes, l_bboxes)
+
+    remove_tracked = set()
+    remove_lost = set()
+    for ti, li in zip(*np.where(iou > 0.85)):
+        t_age = tracked[ti].frame_id - tracked[ti].start_frame
+        l_age = lost[li].frame_id - lost[li].start_frame
+        if t_age >= l_age:
+            remove_lost.add(li)
+        else:
+            remove_tracked.add(ti)
+
+    kept_tracked = [t for i, t in enumerate(tracked) if i not in remove_tracked]
+    kept_lost = [t for i, t in enumerate(lost) if i not in remove_lost]
+    return kept_tracked, kept_lost

--- a/libreyolo/tracking/tracker.py
+++ b/libreyolo/tracking/tracker.py
@@ -292,12 +292,6 @@ def _joint_stracks(a: list[STrack], b: list[STrack]) -> list[STrack]:
     return list(seen.values())
 
 
-def _sub_stracks(a: list[STrack], b: list[STrack]) -> list[STrack]:
-    """Return tracks in a whose track_id is not in b."""
-    b_ids = {t.track_id for t in b}
-    return [t for t in a if t.track_id not in b_ids]
-
-
 def _remove_duplicate_stracks(
     tracked: list[STrack], lost: list[STrack]
 ) -> tuple[list[STrack], list[STrack]]:

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -1,12 +1,27 @@
 """Drawing utility functions for visualization."""
 
 import colorsys
+from functools import lru_cache
 from typing import Dict, List, Tuple
 
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 from .general import COCO_CLASSES
+
+
+@lru_cache(maxsize=16)
+def _get_font(font_size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    """Load and cache a font at the given size."""
+    try:
+        return ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", font_size)
+    except OSError:
+        try:
+            return ImageFont.truetype(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", font_size
+            )
+        except OSError:
+            return ImageFont.load_default()
 
 
 def _get_class_color_rgb(class_id: int) -> Tuple[int, int, int]:
@@ -64,16 +79,7 @@ def draw_boxes(
     box_thickness = max(2, int(2 * scale_factor))
     font_size = max(12, int(12 * scale_factor))
 
-    try:
-        font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", font_size)
-    except OSError:
-        try:
-            # Linux fallback
-            font = ImageFont.truetype(
-                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", font_size
-            )
-        except OSError:
-            font = ImageFont.load_default()
+    font = _get_font(font_size)
 
     label_padding = max(2, int(2 * scale_factor))
 

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -30,6 +30,7 @@ def draw_boxes(
     scores: List,
     classes: List,
     class_names: List[str] | Dict[int, str] | None = None,
+    track_ids: List | None = None,
 ) -> Image.Image:
     """
     Draw bounding boxes on image with class-specific colors.
@@ -44,6 +45,8 @@ def draw_boxes(
         classes: List of class IDs
         class_names: Optional class-name container, either a list indexed by class
             ID or a dict mapping class ID to class name (default: COCO_CLASSES)
+        track_ids: Optional list of track IDs. When provided, each box is
+            colored by its track ID and the label includes ``ID:<n>``.
 
     Returns:
         Annotated PIL Image
@@ -74,27 +77,43 @@ def draw_boxes(
 
     label_padding = max(2, int(2 * scale_factor))
 
-    for box, score, cls_id in zip(boxes, scores, classes):
+    _track_ids = track_ids or [None] * len(boxes)
+
+    for box, score, cls_id, tid in zip(boxes, scores, classes, _track_ids):
         x1, y1, x2, y2 = box
         cls_id_int = int(cls_id)
-        color = get_class_color(cls_id_int)
+
+        # Color by track ID when tracking, otherwise by class ID.
+        color = get_class_color(int(tid)) if tid is not None else get_class_color(cls_id_int)
 
         draw.rectangle([x1, y1, x2, y2], outline=color, width=box_thickness)
 
-        class_name = None
-        if isinstance(class_names, dict):
-            class_name = class_names.get(cls_id_int)
-        elif class_names and cls_id_int < len(class_names):
-            class_name = class_names[cls_id_int]
-
-        if class_name is not None:
-            label = f"{class_name}: {score:.2f}"
+        # Tracking mode: short two-tone label  "#23 0.87"
+        # Detection mode: full label           "person: 0.87"
+        if tid is not None:
+            id_text = f"#{int(tid)}"
+            conf_text = f" {score:.2f}"
+            # Measure both parts separately for two-tone rendering.
+            id_bbox = draw.textbbox((0, 0), id_text, font=font)
+            full_label = id_text + conf_text
+            full_bbox = draw.textbbox((0, 0), full_label, font=font)
+            text_width = full_bbox[2] - full_bbox[0]
+            text_height = full_bbox[3] - full_bbox[1]
+            id_width = id_bbox[2] - id_bbox[0]
         else:
-            label = f"Class {cls_id_int}: {score:.2f}"
+            class_name = None
+            if isinstance(class_names, dict):
+                class_name = class_names.get(cls_id_int)
+            elif class_names and cls_id_int < len(class_names):
+                class_name = class_names[cls_id_int]
 
-        bbox = draw.textbbox((0, 0), label, font=font)
-        text_width = bbox[2] - bbox[0]
-        text_height = bbox[3] - bbox[1]
+            if class_name is not None:
+                full_label = f"{class_name}: {score:.2f}"
+            else:
+                full_label = f"Class {cls_id_int}: {score:.2f}"
+            full_bbox = draw.textbbox((0, 0), full_label, font=font)
+            text_width = full_bbox[2] - full_bbox[0]
+            text_height = full_bbox[3] - full_bbox[1]
 
         # Check if label fits above box; if not, draw inside
         outside = y1 >= text_height + label_padding * 2
@@ -104,34 +123,37 @@ def draw_boxes(
         label_x = max(0, label_x)
 
         if outside:
-            draw.rectangle(
-                [
-                    label_x,
-                    y1 - text_height - label_padding * 2,
-                    label_x + text_width + label_padding * 2,
-                    y1,
-                ],
-                fill=color,
+            bg_y0 = y1 - text_height - label_padding * 2
+            bg_y1 = y1
+            text_y = y1 - text_height - label_padding
+        else:
+            bg_y0 = y1
+            bg_y1 = y1 + text_height + label_padding * 2
+            text_y = y1 + label_padding
+
+        draw.rectangle(
+            [label_x, bg_y0, label_x + text_width + label_padding * 2, bg_y1],
+            fill=color,
+        )
+
+        if tid is not None:
+            # Two-tone: track ID in yellow, confidence in white
+            draw.text(
+                (label_x + label_padding, text_y),
+                id_text,
+                fill="#FFFF00",
+                font=font,
             )
             draw.text(
-                (label_x + label_padding, y1 - text_height - label_padding),
-                label,
-                fill="white",
+                (label_x + label_padding + id_width, text_y),
+                conf_text,
+                fill="#DDDDDD",
                 font=font,
             )
         else:
-            draw.rectangle(
-                [
-                    label_x,
-                    y1,
-                    label_x + text_width + label_padding * 2,
-                    y1 + text_height + label_padding * 2,
-                ],
-                fill=color,
-            )
             draw.text(
-                (label_x + label_padding, y1 + label_padding),
-                label,
+                (label_x + label_padding, text_y),
+                full_label,
                 fill="white",
                 font=font,
             )

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -188,6 +188,7 @@ class Results:
         path: Source image path (or None).
         names: Dict mapping class ID -> class name.
         masks: Optional Masks instance for segmentation results.
+        track_id: Optional (N,) tensor of integer track IDs from a tracker.
     """
 
     def __init__(
@@ -197,12 +198,14 @@ class Results:
         path: Optional[str] = None,
         names: Optional[Dict[int, str]] = None,
         masks: Optional[Masks] = None,
+        track_id: Optional[torch.Tensor] = None,
     ):
         self.boxes = boxes
         self.orig_shape = orig_shape
         self.path = path
         self.names = names or {}
         self.masks = masks
+        self.track_id = track_id
 
     def cpu(self) -> "Results":
         """Return a copy with all tensors on CPU."""
@@ -212,6 +215,7 @@ class Results:
             path=self.path,
             names=self.names,
             masks=self.masks.cpu() if self.masks is not None else None,
+            track_id=self.track_id.cpu() if self.track_id is not None else None,
         )
 
     def __len__(self) -> int:
@@ -225,4 +229,6 @@ class Results:
         ]
         if self.masks is not None:
             parts.append(f"masks={self.masks}")
+        if self.track_id is not None:
+            parts.append(f"track_ids={len(self.track_id)}")
         return f"Results({', '.join(parts)})"

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -199,6 +199,7 @@ class Results:
         names: Optional[Dict[int, str]] = None,
         masks: Optional[Masks] = None,
         track_id: Optional[torch.Tensor] = None,
+        frame_idx: Optional[int] = None,
     ):
         self.boxes = boxes
         self.orig_shape = orig_shape
@@ -206,6 +207,7 @@ class Results:
         self.names = names or {}
         self.masks = masks
         self.track_id = track_id
+        self.frame_idx = frame_idx
 
     def cpu(self) -> "Results":
         """Return a copy with all tensors on CPU."""
@@ -216,6 +218,7 @@ class Results:
             names=self.names,
             masks=self.masks.cpu() if self.masks is not None else None,
             track_id=self.track_id.cpu() if self.track_id is not None else None,
+            frame_idx=self.frame_idx,
         )
 
     def __len__(self) -> int:
@@ -231,4 +234,6 @@ class Results:
             parts.append(f"masks={self.masks}")
         if self.track_id is not None:
             parts.append(f"track_ids={len(self.track_id)}")
+        if self.frame_idx is not None:
+            parts.append(f"frame_idx={self.frame_idx}")
         return f"Results({', '.join(parts)})"

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -235,6 +235,7 @@ def run_video_inference(
     save: bool = False,
     show: bool = False,
     output_path: Union[str, None] = None,
+    annotate_fn: Union[Callable, None] = None,
 ) -> Generator:
     """Generic video inference loop shared by all backends.
 
@@ -246,6 +247,9 @@ def run_video_inference(
         save: Write annotated output video.
         show: Display frames in a cv2 window.
         output_path: Output path for saved video.
+        annotate_fn: Optional callable ``(pil_img, result) -> pil_img`` for
+            custom annotation (e.g. tracking labels). When *None*, the default
+            ``draw_boxes()`` annotation is used.
 
     Yields:
         ``Results`` for each processed frame.
@@ -276,7 +280,9 @@ def run_video_inference(
 
                 # Annotate frame for save/show
                 if save or show:
-                    if len(result) > 0:
+                    if annotate_fn is not None:
+                        annotated_pil = annotate_fn(pil_img, result)
+                    elif len(result) > 0:
                         annotated_pil = draw_boxes(
                             pil_img,
                             result.boxes.xyxy.tolist(),

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -1,0 +1,147 @@
+"""Video source utilities for LibreYOLO."""
+
+from pathlib import Path
+from typing import Iterator, Optional, Tuple
+
+import numpy as np
+
+# Video extensions supported via OpenCV's VideoCapture
+VIDEO_EXTENSIONS = {
+    ".asf",
+    ".avi",
+    ".gif",
+    ".m4v",
+    ".mkv",
+    ".mov",
+    ".mp4",
+    ".mpeg",
+    ".mpg",
+    ".ts",
+    ".wmv",
+    ".webm",
+}
+
+
+def is_video_file(source) -> bool:
+    """Check whether *source* looks like a path to a video file."""
+    if not isinstance(source, (str, Path)):
+        return False
+    return Path(source).suffix.lower() in VIDEO_EXTENSIONS
+
+
+class VideoSource:
+    """Iterate over video frames using OpenCV.
+
+    Args:
+        path: Path to a video file.
+        vid_stride: Process every N-th frame (default ``1`` = every frame).
+
+    Yields:
+        ``(frame_bgr, frame_idx)`` tuples where *frame_bgr* is a
+        ``np.ndarray`` in BGR/uint8 format and *frame_idx* is the
+        zero-based index of the frame in the original video.
+    """
+
+    def __init__(self, path: str | Path, vid_stride: int = 1):
+        try:
+            import cv2
+        except ImportError:
+            raise ImportError(
+                "Video support requires 'opencv-python'. "
+                "Install it with: pip install opencv-python"
+            )
+
+        self._path = str(path)
+        self._vid_stride = max(1, int(vid_stride))
+
+        self._cap = cv2.VideoCapture(self._path)
+        if not self._cap.isOpened():
+            raise ValueError(f"Cannot open video file: {self._path}")
+
+        self.fps: float = self._cap.get(cv2.CAP_PROP_FPS) or 30.0
+        self.total_frames: int = int(self._cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        self.width: int = int(self._cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        self.height: int = int(self._cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    # ------------------------------------------------------------------
+    # Iteration
+    # ------------------------------------------------------------------
+
+    def __iter__(self) -> Iterator[Tuple[np.ndarray, int]]:
+        frame_idx = 0
+        while self._cap.isOpened():
+            grabbed = self._cap.grab()
+            if not grabbed:
+                break
+
+            # Only decode on the stride boundary
+            if frame_idx % self._vid_stride == 0:
+                ok, frame = self._cap.retrieve()
+                if ok:
+                    yield frame, frame_idx
+
+            frame_idx += 1
+
+        self.release()
+
+    def release(self):
+        """Release the underlying VideoCapture."""
+        if self._cap is not None:
+            self._cap.release()
+            self._cap = None
+
+    def __del__(self):
+        self.release()
+
+    def __repr__(self) -> str:
+        return (
+            f"VideoSource(path='{self._path}', "
+            f"fps={self.fps:.1f}, "
+            f"frames={self.total_frames}, "
+            f"size={self.width}x{self.height}, "
+            f"vid_stride={self._vid_stride})"
+        )
+
+
+class VideoWriter:
+    """Write annotated frames to a video file using OpenCV.
+
+    Args:
+        path: Output video file path (should end in ``.mp4``).
+        fps: Frames per second.
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+    """
+
+    def __init__(self, path: str | Path, fps: float, width: int, height: int):
+        try:
+            import cv2
+        except ImportError:
+            raise ImportError(
+                "Video writing requires 'opencv-python'. "
+                "Install it with: pip install opencv-python"
+            )
+
+        self._path = str(path)
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        self._writer = cv2.VideoWriter(self._path, fourcc, fps, (width, height))
+        if not self._writer.isOpened():
+            raise ValueError(f"Cannot open video writer for: {self._path}")
+
+    def write_frame(self, frame_bgr: np.ndarray):
+        """Write a single BGR frame."""
+        self._writer.write(frame_bgr)
+
+    def release(self):
+        """Flush and close the writer."""
+        if self._writer is not None:
+            self._writer.release()
+            self._writer = None
+
+    def __del__(self):
+        self.release()
+
+    def __repr__(self) -> str:
+        return f"VideoWriter(path='{self._path}')"

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -1,9 +1,12 @@
 """Video source utilities for LibreYOLO."""
 
+import logging
 from pathlib import Path
-from typing import Iterator, Optional, Tuple
+from typing import Callable, Generator, Iterator, Tuple, Union
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # Video extensions supported via OpenCV's VideoCapture
 VIDEO_EXTENSIONS = {
@@ -29,20 +32,47 @@ def is_video_file(source) -> bool:
     return Path(source).suffix.lower() in VIDEO_EXTENSIONS
 
 
+def resolve_video_save_path(
+    source: Union[str, Path], output_path: Union[str, None]
+) -> str:
+    """Determine the output path for a saved video.
+
+    If *output_path* is provided, uses it directly. Otherwise creates an
+    auto-incrementing directory under ``runs/detect/predict*/``.
+    """
+    if output_path is not None:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        return str(out)
+
+    from .general import increment_path
+
+    save_dir = Path("runs/detect") / "predict"
+    save_dir = increment_path(save_dir, exist_ok=False, mkdir=True)
+    stem = Path(source).stem
+    return str(save_dir / f"{stem}.mp4")
+
+
 class VideoSource:
     """Iterate over video frames using OpenCV.
+
+    Supports use as a context manager::
+
+        with VideoSource("clip.mp4", vid_stride=2) as src:
+            for frame_bgr, frame_idx in src:
+                ...
 
     Args:
         path: Path to a video file.
         vid_stride: Process every N-th frame (default ``1`` = every frame).
 
-    Yields:
-        ``(frame_bgr, frame_idx)`` tuples where *frame_bgr* is a
-        ``np.ndarray`` in BGR/uint8 format and *frame_idx* is the
-        zero-based index of the frame in the original video.
+    Note:
+        A ``VideoSource`` instance can only be iterated **once**. After
+        iteration completes (or the source is released), create a new
+        instance to iterate again.
     """
 
-    def __init__(self, path: str | Path, vid_stride: int = 1):
+    def __init__(self, path: Union[str, Path], vid_stride: int = 1):
         try:
             import cv2
         except ImportError:
@@ -56,7 +86,10 @@ class VideoSource:
 
         self._cap = cv2.VideoCapture(self._path)
         if not self._cap.isOpened():
+            self._cap.release()
             raise ValueError(f"Cannot open video file: {self._path}")
+
+        self._iterated = False
 
         self.fps: float = self._cap.get(cv2.CAP_PROP_FPS) or 30.0
         self.total_frames: int = int(self._cap.get(cv2.CAP_PROP_FRAME_COUNT))
@@ -64,10 +97,27 @@ class VideoSource:
         self.height: int = int(self._cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
     # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "VideoSource":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.release()
+
+    # ------------------------------------------------------------------
     # Iteration
     # ------------------------------------------------------------------
 
     def __iter__(self) -> Iterator[Tuple[np.ndarray, int]]:
+        if self._cap is None or self._iterated:
+            raise RuntimeError(
+                "VideoSource has been consumed or released. "
+                "Create a new instance to iterate again."
+            )
+        self._iterated = True
+
         frame_idx = 0
         while self._cap.isOpened():
             grabbed = self._cap.grab()
@@ -79,16 +129,22 @@ class VideoSource:
                 ok, frame = self._cap.retrieve()
                 if ok:
                     yield frame, frame_idx
+                else:
+                    logger.warning(
+                        "Failed to decode frame %d in %s, skipping",
+                        frame_idx,
+                        self._path,
+                    )
 
             frame_idx += 1
 
-        self.release()
-
     def release(self):
-        """Release the underlying VideoCapture."""
+        """Release the underlying VideoCapture. Safe to call multiple times."""
         if self._cap is not None:
-            self._cap.release()
-            self._cap = None
+            try:
+                self._cap.release()
+            finally:
+                self._cap = None
 
     def __del__(self):
         self.release()
@@ -106,6 +162,11 @@ class VideoSource:
 class VideoWriter:
     """Write annotated frames to a video file using OpenCV.
 
+    Supports use as a context manager::
+
+        with VideoWriter("out.mp4", fps=25, width=1920, height=1080) as w:
+            w.write_frame(frame_bgr)
+
     Args:
         path: Output video file path (should end in ``.mp4``).
         fps: Frames per second.
@@ -113,7 +174,7 @@ class VideoWriter:
         height: Frame height in pixels.
     """
 
-    def __init__(self, path: str | Path, fps: float, width: int, height: int):
+    def __init__(self, path: Union[str, Path], fps: float, width: int, height: int):
         try:
             import cv2
         except ImportError:
@@ -130,18 +191,118 @@ class VideoWriter:
         if not self._writer.isOpened():
             raise ValueError(f"Cannot open video writer for: {self._path}")
 
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "VideoWriter":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.release()
+
+    # ------------------------------------------------------------------
+
     def write_frame(self, frame_bgr: np.ndarray):
         """Write a single BGR frame."""
         self._writer.write(frame_bgr)
 
     def release(self):
-        """Flush and close the writer."""
+        """Flush and close the writer. Safe to call multiple times."""
         if self._writer is not None:
-            self._writer.release()
-            self._writer = None
+            try:
+                self._writer.release()
+            finally:
+                self._writer = None
 
     def __del__(self):
         self.release()
 
     def __repr__(self) -> str:
         return f"VideoWriter(path='{self._path}')"
+
+
+# ---------------------------------------------------------------------------
+# Shared video inference loop
+# ---------------------------------------------------------------------------
+
+
+def run_video_inference(
+    source: Union[str, Path],
+    predict_frame_fn: Callable,
+    *,
+    vid_stride: int = 1,
+    save: bool = False,
+    show: bool = False,
+    output_path: Union[str, None] = None,
+) -> Generator:
+    """Generic video inference loop shared by all backends.
+
+    Args:
+        source: Path to video file.
+        predict_frame_fn: Callable that takes a PIL RGB image and returns
+            a ``Results`` object.
+        vid_stride: Process every N-th frame.
+        save: Write annotated output video.
+        show: Display frames in a cv2 window.
+        output_path: Output path for saved video.
+
+    Yields:
+        ``Results`` for each processed frame.
+    """
+    import cv2
+    from PIL import Image
+
+    from .drawing import draw_boxes
+
+    with VideoSource(source, vid_stride=vid_stride) as video_src:
+        writer = None
+        if save:
+            out_path = resolve_video_save_path(source, output_path)
+            effective_fps = video_src.fps / max(1, vid_stride)
+            writer = VideoWriter(
+                out_path, effective_fps, video_src.width, video_src.height
+            )
+
+        try:
+            for frame_bgr, frame_idx in video_src:
+                # Convert BGR frame to PIL RGB for the model pipeline
+                frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+                pil_img = Image.fromarray(frame_rgb)
+
+                # Run model-specific inference
+                result = predict_frame_fn(pil_img)
+                result.frame_idx = frame_idx
+
+                # Annotate frame for save/show
+                if save or show:
+                    if len(result) > 0:
+                        annotated_pil = draw_boxes(
+                            pil_img,
+                            result.boxes.xyxy.tolist(),
+                            result.boxes.conf.tolist(),
+                            result.boxes.cls.tolist(),
+                        )
+                    else:
+                        annotated_pil = pil_img
+
+                    annotated_bgr = cv2.cvtColor(
+                        np.array(annotated_pil), cv2.COLOR_RGB2BGR
+                    )
+
+                    if save and writer is not None:
+                        writer.write_frame(annotated_bgr)
+
+                    if show:
+                        cv2.imshow("LibreYOLO", annotated_bgr)
+                        if cv2.waitKey(1) & 0xFF == ord("q"):
+                            break
+
+                yield result
+
+        finally:
+            if writer is not None:
+                writer.release()
+                logger.info("Video saved to %s", out_path)
+            if show:
+                cv2.destroyAllWindows()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,16 @@ ncnn = [
     "pnnx",
     "ncnn",
 ]
+tracking = [
+    "scipy>=1.7.0",
+]
 all = [
     "libreyolo[onnx]",
     "libreyolo[rfdetr]",
     "libreyolo[tensorrt]",
     "libreyolo[openvino]",
     "libreyolo[ncnn]",
+    "libreyolo[tracking]",
 ]
 
 [project.urls]

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -147,23 +147,24 @@ class TestTrackingYOLOX:
             f"Only {len(all_ids)} unique IDs across 10 frames"
         )
 
-    def test_save_creates_annotated_frames(self, model, video_path, tmp_path):
-        """save=True should write annotated JPEG frames to output_path."""
-        out = tmp_path / "track_output"
+    def test_save_creates_annotated_video(self, model, video_path, tmp_path):
+        """save=True should write an annotated video to output_path."""
+        import cv2
+
+        out = tmp_path / "track_output.mp4"
         frames = []
         for i, r in enumerate(model.track(video_path, save=True, output_path=str(out))):
             frames.append(r)
             if i >= 4:
                 break
 
-        assert out.exists(), "Output directory was not created"
-        saved = sorted(out.glob("frame_*.jpg"))
-        assert len(saved) == 5, f"Expected 5 saved frames, got {len(saved)}"
-        assert saved[0].name == "frame_000000.jpg"
-        assert saved[-1].name == "frame_000004.jpg"
-        # Verify files are non-empty JPEGs
-        for f in saved:
-            assert f.stat().st_size > 1000, f"{f.name} is suspiciously small"
+        assert out.exists(), "Output video was not created"
+        assert out.stat().st_size > 1000, "Output video is suspiciously small"
+        cap = cv2.VideoCapture(str(out))
+        assert cap.isOpened(), "Output video is not a valid video file"
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        cap.release()
+        assert frame_count == 5, f"Expected 5 frames, got {frame_count}"
 
     def test_track_raises_on_missing_video(self, model):
         """track() should raise FileNotFoundError for non-existent video."""

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -165,6 +165,11 @@ class TestTrackingYOLOX:
         for f in saved:
             assert f.stat().st_size > 1000, f"{f.name} is suspiciously small"
 
+    def test_track_raises_on_missing_video(self, model):
+        """track() should raise FileNotFoundError for non-existent video."""
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
+            next(model.track("/tmp/nonexistent_video_12345.mp4"))
+
 
 # ── YOLO9 ────────────────────────────────────────────────────────────────────
 

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -1,0 +1,229 @@
+"""
+E2E tracking: validate model.track() on a real video with multiple pedestrians.
+
+Downloads a short test video (7.3 MB, 13.6s) from Roboflow's public CDN and
+runs ByteTrack through several LibreYOLO detectors, checking that:
+  - track IDs are assigned and consistent across frames
+  - the same person keeps the same ID across consecutive frames
+  - no duplicate IDs within a single frame
+  - the tracker works with every supported model family (YOLOX, YOLO9, RF-DETR)
+
+The video auto-downloads and is cached at ~/.cache/libreyolo/tracking/ — no
+manual setup needed.
+
+Usage:
+    pytest tests/e2e/test_tracking.py -v -m e2e
+    pytest tests/e2e/test_tracking.py::TestTrackingYOLOX -v
+    pytest tests/e2e/test_tracking.py -k "rfdetr" -v
+"""
+
+import urllib.request
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo import LibreYOLO
+
+from .conftest import (
+    cuda_cleanup,
+    requires_cuda,
+    requires_rfdetr,
+)
+
+pytestmark = [pytest.mark.e2e, requires_cuda]
+
+VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/people-walking.mp4"
+VIDEO_CACHE = Path.home() / ".cache" / "libreyolo" / "tracking"
+VIDEO_PATH = VIDEO_CACHE / "people-walking.mp4"
+
+
+def download_tracking_video():
+    """Download the test video from Roboflow if not already cached."""
+    if VIDEO_PATH.exists():
+        return
+    print(f"\nDownloading tracking test video from {VIDEO_URL} ...")
+    VIDEO_CACHE.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(VIDEO_URL, str(VIDEO_PATH))
+    print(f"Video cached at {VIDEO_PATH}")
+
+
+@pytest.fixture(scope="module")
+def video_path():
+    """Download the test video once per module, skip if network unavailable."""
+    try:
+        download_tracking_video()
+    except Exception as exc:
+        pytest.skip(f"Cannot download test video: {exc}")
+    return VIDEO_PATH
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _run_tracker(model, video, n_frames=30):
+    """Run model.track() and collect first *n_frames* results."""
+    frames = []
+    for i, result in enumerate(model.track(video)):
+        frames.append(result)
+        if i + 1 >= n_frames:
+            break
+    return frames
+
+
+def _ids(result):
+    """Extract track IDs as a Python set."""
+    if result.track_id is None:
+        return set()
+    return set(result.track_id.tolist())
+
+
+# ── YOLOX ────────────────────────────────────────────────────────────────────
+
+
+class TestTrackingYOLOX:
+    """Tracking e2e with the smallest YOLOX model."""
+
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = LibreYOLO("LibreYOLOXn.pt")
+        yield m
+        del m
+        cuda_cleanup()
+
+    def test_track_ids_assigned(self, model, video_path):
+        """Every frame should have at least one tracked object with an ID."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        assert len(frames) == 10
+        for i, f in enumerate(frames):
+            assert f.track_id is not None, f"Frame {i}: track_id is None"
+            assert isinstance(f.track_id, torch.Tensor)
+            assert len(f.track_id) == len(f), f"Frame {i}: track_id length mismatch"
+            assert len(f) > 0, f"Frame {i}: no detections"
+
+    def test_id_consistency_across_frames(self, model, video_path):
+        """Core IDs should persist across consecutive frames."""
+        frames = _run_tracker(model, video_path, n_frames=20)
+
+        stable_count = 0
+        for i in range(1, len(frames)):
+            prev_ids = _ids(frames[i - 1])
+            curr_ids = _ids(frames[i])
+            if not prev_ids or not curr_ids:
+                continue
+            overlap = prev_ids & curr_ids
+            survival_rate = len(overlap) / len(prev_ids)
+            if survival_rate >= 0.5:
+                stable_count += 1
+
+        assert stable_count >= len(frames) // 2, (
+            f"Only {stable_count}/{len(frames)-1} frame-pairs had >=50% ID overlap"
+        )
+
+    def test_ids_are_positive_integers(self, model, video_path):
+        """All track IDs should be positive integers."""
+        frames = _run_tracker(model, video_path, n_frames=5)
+        for i, f in enumerate(frames):
+            if f.track_id is not None and len(f.track_id) > 0:
+                assert (f.track_id > 0).all(), (
+                    f"Frame {i}: non-positive IDs: {f.track_id.tolist()}"
+                )
+                assert f.track_id.dtype == torch.int64
+
+    def test_no_duplicate_ids_in_frame(self, model, video_path):
+        """Within a single frame, each ID should be unique."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        for i, f in enumerate(frames):
+            ids = f.track_id.tolist() if f.track_id is not None else []
+            assert len(ids) == len(set(ids)), f"Frame {i}: duplicate IDs: {ids}"
+
+    def test_multiple_objects_tracked(self, model, video_path):
+        """Video has many pedestrians — should track many distinct objects."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        all_ids = set()
+        for f in frames:
+            all_ids |= _ids(f)
+        assert len(all_ids) >= 10, (
+            f"Only {len(all_ids)} unique IDs across 10 frames"
+        )
+
+
+# ── YOLO9 ────────────────────────────────────────────────────────────────────
+
+
+class TestTrackingYOLO9:
+    """Tracking e2e with the smallest YOLO9 model."""
+
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = LibreYOLO("LibreYOLO9t.pt")
+        yield m
+        del m
+        cuda_cleanup()
+
+    def test_track_produces_results(self, model, video_path):
+        """YOLO9 tracker should produce tracked results."""
+        frames = _run_tracker(model, video_path, n_frames=5)
+        assert len(frames) == 5
+        for f in frames:
+            assert f.track_id is not None
+            assert len(f) > 0
+
+    def test_id_consistency(self, model, video_path):
+        """IDs should persist across consecutive frames."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        stable = sum(
+            1
+            for i in range(1, len(frames))
+            if len(_ids(frames[i - 1]) & _ids(frames[i]))
+            >= len(_ids(frames[i - 1])) * 0.5
+        )
+        assert stable >= len(frames) // 2
+
+    def test_no_duplicate_ids_in_frame(self, model, video_path):
+        """Within a single frame, each ID should be unique."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        for i, f in enumerate(frames):
+            ids = f.track_id.tolist() if f.track_id is not None else []
+            assert len(ids) == len(set(ids)), f"Frame {i}: duplicate IDs: {ids}"
+
+
+# ── RF-DETR ──────────────────────────────────────────────────────────────────
+
+
+@requires_rfdetr
+class TestTrackingRFDETR:
+    """Tracking e2e with the smallest RF-DETR model."""
+
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = LibreYOLO("LibreRFDETRn.pt")
+        yield m
+        del m
+        cuda_cleanup()
+
+    def test_track_produces_results(self, model, video_path):
+        """RF-DETR tracker should produce tracked results."""
+        frames = _run_tracker(model, video_path, n_frames=5)
+        assert len(frames) == 5
+        for f in frames:
+            assert f.track_id is not None
+            assert len(f) > 0
+
+    def test_id_consistency(self, model, video_path):
+        """IDs should persist across consecutive frames."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        stable = sum(
+            1
+            for i in range(1, len(frames))
+            if len(_ids(frames[i - 1]) & _ids(frames[i]))
+            >= len(_ids(frames[i - 1])) * 0.5
+        )
+        assert stable >= len(frames) // 2
+
+    def test_no_duplicate_ids_in_frame(self, model, video_path):
+        """Within a single frame, each ID should be unique."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        for i, f in enumerate(frames):
+            ids = f.track_id.tolist() if f.track_id is not None else []
+            assert len(ids) == len(set(ids)), f"Frame {i}: duplicate IDs: {ids}"

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -147,6 +147,24 @@ class TestTrackingYOLOX:
             f"Only {len(all_ids)} unique IDs across 10 frames"
         )
 
+    def test_save_creates_annotated_frames(self, model, video_path, tmp_path):
+        """save=True should write annotated JPEG frames to output_path."""
+        out = tmp_path / "track_output"
+        frames = []
+        for i, r in enumerate(model.track(video_path, save=True, output_path=str(out))):
+            frames.append(r)
+            if i >= 4:
+                break
+
+        assert out.exists(), "Output directory was not created"
+        saved = sorted(out.glob("frame_*.jpg"))
+        assert len(saved) == 5, f"Expected 5 saved frames, got {len(saved)}"
+        assert saved[0].name == "frame_000000.jpg"
+        assert saved[-1].name == "frame_000004.jpg"
+        # Verify files are non-empty JPEGs
+        for f in saved:
+            assert f.stat().st_size > 1000, f"{f.name} is suspiciously small"
+
 
 # ── YOLO9 ────────────────────────────────────────────────────────────────────
 

--- a/tests/e2e/test_video.py
+++ b/tests/e2e/test_video.py
@@ -1,7 +1,7 @@
 """
 E2E video inference: validate model() on a real video with pedestrians.
 
-Downloads a short test video (7.3 MB, 13.6s) from Roboflow's public CDN and
+Downloads a short test video (7.3 MB, 13.6s) from the LibreYOLO HF repo and
 runs video inference through LibreYOLO detectors, checking that:
   - stream=True yields a generator of Results
   - stream=False collects Results into a list
@@ -31,7 +31,7 @@ from .conftest import cuda_cleanup
 
 pytestmark = pytest.mark.e2e
 
-VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/people-walking.mp4"
+VIDEO_URL = "https://huggingface.co/datasets/LibreYOLO/test-assets/resolve/main/videos/people-walking.mp4"
 VIDEO_CACHE = Path.home() / ".cache" / "libreyolo" / "tracking"
 VIDEO_PATH = VIDEO_CACHE / "people-walking.mp4"
 

--- a/tests/e2e/test_video.py
+++ b/tests/e2e/test_video.py
@@ -2,14 +2,15 @@
 E2E video inference: validate model() on a real video with pedestrians.
 
 Downloads a short test video (7.3 MB, 13.6s) from the LibreYOLO HF repo and
-runs video inference through LibreYOLO detectors, checking that:
+runs video inference through one model per family (YOLOX, YOLO9, RF-DETR),
+checking that:
   - stream=True yields a generator of Results
   - stream=False collects Results into a list
   - vid_stride skips frames correctly
   - save=True writes a valid output video
-  - show=False does not crash (show=True requires a display)
   - frame_idx is set correctly on each result
   - detections are found (the video contains many pedestrians)
+  - conf and classes filters work
 
 The video auto-downloads and is cached at ~/.cache/libreyolo/tracking/ — no
 manual setup needed.
@@ -17,6 +18,7 @@ manual setup needed.
 Usage:
     pytest tests/e2e/test_video.py -v -m e2e
     pytest tests/e2e/test_video.py -k "yolo9" -v
+    pytest tests/e2e/test_video.py -k "rfdetr" -v
 """
 
 import urllib.request
@@ -27,7 +29,7 @@ import pytest
 
 from libreyolo import LibreYOLO
 
-from .conftest import cuda_cleanup
+from .conftest import cuda_cleanup, requires_rfdetr
 
 pytestmark = pytest.mark.e2e
 
@@ -37,7 +39,7 @@ VIDEO_PATH = VIDEO_CACHE / "people-walking.mp4"
 
 
 def download_video():
-    """Download the test video from Roboflow if not already cached."""
+    """Download the test video from HF if not already cached."""
     if VIDEO_PATH.exists():
         return
     print(f"\nDownloading test video from {VIDEO_URL} ...")
@@ -56,147 +58,156 @@ def video_path():
     return str(VIDEO_PATH)
 
 
+# ---------------------------------------------------------------------------
+# Model fixtures — one per family, smallest variant
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture(scope="module")
-def model():
-    """Load the smallest YOLO9 model once per module."""
+def yolox_model():
+    m = LibreYOLO("LibreYOLOXn.pt")
+    yield m
+    del m
+    cuda_cleanup()
+
+
+@pytest.fixture(scope="module")
+def yolo9_model():
     m = LibreYOLO("LibreYOLO9t.pt")
     yield m
     del m
     cuda_cleanup()
 
 
+@pytest.fixture(scope="module")
+def rfdetr_model():
+    m = LibreYOLO("LibreRFDETRn.pt")
+    yield m
+    del m
+    cuda_cleanup()
+
+
 # ---------------------------------------------------------------------------
-# stream=True (generator)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-class TestVideoStream:
-    """Tests for generator-based video inference."""
+def _collect_n_frames(model, video_path, n=30, **kwargs):
+    """Run inference and collect first n frames."""
+    results = []
+    for i, r in enumerate(model(video_path, stream=True, **kwargs)):
+        results.append(r)
+        if i + 1 >= n:
+            break
+    return results
 
-    def test_stream_returns_generator(self, model, video_path):
-        gen = model(video_path, stream=True, conf=0.25)
-        assert hasattr(gen, "__next__"), "stream=True should return a generator"
-        # Consume just one frame to verify it works
+
+# ---------------------------------------------------------------------------
+# YOLOX
+# ---------------------------------------------------------------------------
+
+
+class TestVideoYOLOX:
+    """Video inference with YOLOX."""
+
+    def test_stream_returns_generator(self, yolox_model, video_path):
+        gen = yolox_model(video_path, stream=True, conf=0.25)
+        assert hasattr(gen, "__next__")
         result = next(gen)
         assert result is not None
-        # Clean up generator
+        assert result.frame_idx == 0
         gen.close()
 
-    def test_stream_yields_all_frames(self, model, video_path):
-        results = list(model(video_path, stream=True, conf=0.25))
-        # Video has 341 frames
-        assert len(results) == 341
-
-    def test_stream_results_have_frame_idx(self, model, video_path):
-        indices = []
-        for i, result in enumerate(model(video_path, stream=True, conf=0.25)):
-            indices.append(result.frame_idx)
-            if i >= 9:
-                break
-        assert indices == list(range(10))
-
-    def test_stream_results_have_path(self, model, video_path):
-        result = next(iter(model(video_path, stream=True, conf=0.25)))
-        assert result.path == video_path
-
-    def test_stream_detects_people(self, model, video_path):
-        """The video has many pedestrians — we should detect objects."""
-        total_dets = 0
-        for i, result in enumerate(model(video_path, stream=True, conf=0.25)):
-            total_dets += len(result)
-            if i >= 29:
-                break
-        # 30 frames of people walking — should find plenty of detections
+    def test_detects_people(self, yolox_model, video_path):
+        frames = _collect_n_frames(yolox_model, video_path, n=30, conf=0.25)
+        total_dets = sum(len(r) for r in frames)
         assert total_dets > 100, f"Only {total_dets} detections in 30 frames"
 
+    def test_vid_stride(self, yolox_model, video_path):
+        frames = _collect_n_frames(yolox_model, video_path, n=1000, conf=0.25, vid_stride=5)
+        indices = [r.frame_idx for r in frames[:5]]
+        assert indices == [0, 5, 10, 15, 20]
+
+    def test_save(self, yolox_model, video_path, tmp_path):
+        output = str(tmp_path / "yolox_output.mp4")
+        n = 0
+        for r in yolox_model(video_path, stream=True, save=True, output_path=output,
+                              conf=0.25, vid_stride=10):
+            n += 1
+        assert Path(output).exists()
+        cap = cv2.VideoCapture(output)
+        assert int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) == n
+        cap.release()
+
+    def test_orig_shape(self, yolox_model, video_path):
+        result = next(iter(yolox_model(video_path, stream=True, conf=0.25)))
+        assert result.orig_shape == (1080, 1920)
+
 
 # ---------------------------------------------------------------------------
-# stream=False (list)
+# YOLO9
 # ---------------------------------------------------------------------------
 
 
-class TestVideoList:
-    """Tests for list-based video inference (stream=False)."""
+class TestVideoYOLO9:
+    """Video inference with YOLO9."""
 
-    def test_list_mode_returns_list(self, model, video_path):
-        # Use vid_stride=10 to keep it fast
-        results = model(video_path, conf=0.25, vid_stride=10)
-        assert isinstance(results, list)
-        assert len(results) > 0
+    def test_stream_returns_generator(self, yolo9_model, video_path):
+        gen = yolo9_model(video_path, stream=True, conf=0.25)
+        assert hasattr(gen, "__next__")
+        result = next(gen)
+        assert result is not None
+        assert result.frame_idx == 0
+        gen.close()
 
-    def test_list_mode_results_have_frame_idx(self, model, video_path):
-        results = model(video_path, conf=0.25, vid_stride=10)
-        for result in results:
-            assert result.frame_idx is not None
+    def test_detects_people(self, yolo9_model, video_path):
+        frames = _collect_n_frames(yolo9_model, video_path, n=30, conf=0.25)
+        total_dets = sum(len(r) for r in frames)
+        assert total_dets > 100, f"Only {total_dets} detections in 30 frames"
 
-
-# ---------------------------------------------------------------------------
-# vid_stride
-# ---------------------------------------------------------------------------
-
-
-class TestVidStride:
-    """Tests for frame skipping."""
-
-    def test_vid_stride_1(self, model, video_path):
-        results = list(model(video_path, stream=True, conf=0.25))
+    def test_stream_yields_all_frames(self, yolo9_model, video_path):
+        results = list(yolo9_model(video_path, stream=True, conf=0.25))
         assert len(results) == 341
 
-    def test_vid_stride_2(self, model, video_path):
-        results = list(model(video_path, stream=True, conf=0.25, vid_stride=2))
-        assert len(results) == 171  # ceil(341/2)
+    def test_list_mode(self, yolo9_model, video_path):
+        results = yolo9_model(video_path, conf=0.25, vid_stride=10)
+        assert isinstance(results, list)
+        assert len(results) > 0
+        for r in results:
+            assert r.frame_idx is not None
 
-    def test_vid_stride_5(self, model, video_path):
-        results = list(model(video_path, stream=True, conf=0.25, vid_stride=5))
-        assert len(results) == 69  # ceil(341/5)
+    def test_vid_stride_2(self, yolo9_model, video_path):
+        results = list(yolo9_model(video_path, stream=True, conf=0.25, vid_stride=2))
+        assert len(results) == 171
 
-    def test_vid_stride_frame_indices(self, model, video_path):
-        results = list(model(video_path, stream=True, conf=0.25, vid_stride=5))
+    def test_vid_stride_5(self, yolo9_model, video_path):
+        results = list(yolo9_model(video_path, stream=True, conf=0.25, vid_stride=5))
+        assert len(results) == 69
+
+    def test_vid_stride_frame_indices(self, yolo9_model, video_path):
+        results = list(yolo9_model(video_path, stream=True, conf=0.25, vid_stride=5))
         indices = [r.frame_idx for r in results[:5]]
         assert indices == [0, 5, 10, 15, 20]
 
-
-# ---------------------------------------------------------------------------
-# save=True
-# ---------------------------------------------------------------------------
-
-
-class TestVideoSave:
-    """Tests for saving annotated output video."""
-
-    def test_save_creates_video(self, model, video_path, tmp_path):
-        output = str(tmp_path / "output.mp4")
-        # Use vid_stride=10 to keep it fast
-        for _ in model(video_path, stream=True, save=True, output_path=output,
-                       conf=0.25, vid_stride=10):
-            pass
+    def test_save_creates_valid_video(self, yolo9_model, video_path, tmp_path):
+        output = str(tmp_path / "yolo9_output.mp4")
+        n_input = 0
+        for _ in yolo9_model(video_path, stream=True, save=True, output_path=output,
+                              conf=0.25, vid_stride=10):
+            n_input += 1
 
         assert Path(output).exists()
         assert Path(output).stat().st_size > 1000
-
-    def test_saved_video_is_valid(self, model, video_path, tmp_path):
-        output = str(tmp_path / "output.mp4")
-        n_input = 0
-        for _ in model(video_path, stream=True, save=True, output_path=output,
-                       conf=0.25, vid_stride=10):
-            n_input += 1
-
         cap = cv2.VideoCapture(output)
         assert cap.isOpened()
-        n_output = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        assert int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) == n_input
+        assert int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) == 1920
+        assert int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) == 1080
         cap.release()
 
-        assert n_output == n_input
-        assert width == 1920
-        assert height == 1080
-
-    def test_save_auto_path(self, model, video_path):
-        """save=True without output_path should create runs/detect/predict*."""
-        for _ in model(video_path, stream=True, save=True, conf=0.25, vid_stride=50):
+    def test_save_auto_path(self, yolo9_model, video_path):
+        for _ in yolo9_model(video_path, stream=True, save=True, conf=0.25, vid_stride=50):
             pass
-        # Check that some predict directory was created
         predict_dirs = list(Path("runs/detect").glob("predict*"))
         assert len(predict_dirs) > 0
         mp4s = []
@@ -204,53 +215,70 @@ class TestVideoSave:
             mp4s.extend(d.glob("*.mp4"))
         assert len(mp4s) > 0
 
+    def test_high_conf_fewer_detections(self, yolo9_model, video_path):
+        low = sum(len(r) for r in _collect_n_frames(
+            yolo9_model, video_path, n=10, conf=0.1, vid_stride=10))
+        high = sum(len(r) for r in _collect_n_frames(
+            yolo9_model, video_path, n=10, conf=0.7, vid_stride=10))
+        assert high < low
 
-# ---------------------------------------------------------------------------
-# conf / classes filters
-# ---------------------------------------------------------------------------
-
-
-class TestVideoFilters:
-    """Tests for conf/classes filtering during video inference."""
-
-    def test_high_conf_fewer_detections(self, model, video_path):
-        low_conf_dets = 0
-        high_conf_dets = 0
-        for i, r in enumerate(model(video_path, stream=True, conf=0.1, vid_stride=10)):
-            low_conf_dets += len(r)
-            if i >= 9:
-                break
-
-        for i, r in enumerate(model(video_path, stream=True, conf=0.7, vid_stride=10)):
-            high_conf_dets += len(r)
-            if i >= 9:
-                break
-
-        assert high_conf_dets < low_conf_dets
-
-    def test_classes_filter(self, model, video_path):
-        """Filter to class 0 (person) should still find detections."""
+    def test_classes_filter(self, yolo9_model, video_path):
         total = 0
-        for i, r in enumerate(model(video_path, stream=True, conf=0.25,
-                                     classes=[0], vid_stride=10)):
+        for r in _collect_n_frames(yolo9_model, video_path, n=10,
+                                    conf=0.25, classes=[0], vid_stride=10):
             total += len(r)
-            if r.boxes is not None and len(r) > 0:
-                # All detections should be class 0
+            if len(r) > 0:
                 assert (r.boxes.cls == 0).all()
-            if i >= 9:
-                break
         assert total > 0
 
+    def test_orig_shape(self, yolo9_model, video_path):
+        result = next(iter(yolo9_model(video_path, stream=True, conf=0.25)))
+        assert result.orig_shape == (1080, 1920)
+
+    def test_path_on_results(self, yolo9_model, video_path):
+        result = next(iter(yolo9_model(video_path, stream=True, conf=0.25)))
+        assert result.path == video_path
+
 
 # ---------------------------------------------------------------------------
-# orig_shape
+# RF-DETR
 # ---------------------------------------------------------------------------
 
 
-class TestVideoResultShape:
-    """Tests for result metadata correctness."""
+@requires_rfdetr
+class TestVideoRFDETR:
+    """Video inference with RF-DETR."""
 
-    def test_orig_shape_matches_video(self, model, video_path):
-        result = next(iter(model(video_path, stream=True, conf=0.25)))
-        # Video is 1920x1080, orig_shape is (H, W)
+    def test_stream_returns_generator(self, rfdetr_model, video_path):
+        gen = rfdetr_model(video_path, stream=True, conf=0.25)
+        assert hasattr(gen, "__next__")
+        result = next(gen)
+        assert result is not None
+        assert result.frame_idx == 0
+        gen.close()
+
+    def test_detects_people(self, rfdetr_model, video_path):
+        frames = _collect_n_frames(rfdetr_model, video_path, n=30, conf=0.25)
+        total_dets = sum(len(r) for r in frames)
+        assert total_dets > 100, f"Only {total_dets} detections in 30 frames"
+
+    def test_vid_stride(self, rfdetr_model, video_path):
+        frames = _collect_n_frames(rfdetr_model, video_path, n=1000,
+                                    conf=0.25, vid_stride=5)
+        indices = [r.frame_idx for r in frames[:5]]
+        assert indices == [0, 5, 10, 15, 20]
+
+    def test_save(self, rfdetr_model, video_path, tmp_path):
+        output = str(tmp_path / "rfdetr_output.mp4")
+        n = 0
+        for r in rfdetr_model(video_path, stream=True, save=True, output_path=output,
+                               conf=0.25, vid_stride=10):
+            n += 1
+        assert Path(output).exists()
+        cap = cv2.VideoCapture(output)
+        assert int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) == n
+        cap.release()
+
+    def test_orig_shape(self, rfdetr_model, video_path):
+        result = next(iter(rfdetr_model(video_path, stream=True, conf=0.25)))
         assert result.orig_shape == (1080, 1920)

--- a/tests/e2e/test_video.py
+++ b/tests/e2e/test_video.py
@@ -58,6 +58,15 @@ def video_path():
     return str(VIDEO_PATH)
 
 
+@pytest.fixture(scope="module")
+def video_total_frames(video_path):
+    """Query the actual frame count from the video (avoids hardcoding)."""
+    cap = cv2.VideoCapture(video_path)
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    cap.release()
+    return total
+
+
 # ---------------------------------------------------------------------------
 # Model fixtures — one per family, smallest variant
 # ---------------------------------------------------------------------------
@@ -165,9 +174,9 @@ class TestVideoYOLO9:
         total_dets = sum(len(r) for r in frames)
         assert total_dets > 100, f"Only {total_dets} detections in 30 frames"
 
-    def test_stream_yields_all_frames(self, yolo9_model, video_path):
+    def test_stream_yields_all_frames(self, yolo9_model, video_path, video_total_frames):
         results = list(yolo9_model(video_path, stream=True, conf=0.25))
-        assert len(results) == 341
+        assert len(results) == video_total_frames
 
     def test_list_mode(self, yolo9_model, video_path):
         results = yolo9_model(video_path, conf=0.25, vid_stride=10)
@@ -176,13 +185,15 @@ class TestVideoYOLO9:
         for r in results:
             assert r.frame_idx is not None
 
-    def test_vid_stride_2(self, yolo9_model, video_path):
+    def test_vid_stride_2(self, yolo9_model, video_path, video_total_frames):
         results = list(yolo9_model(video_path, stream=True, conf=0.25, vid_stride=2))
-        assert len(results) == 171
+        expected = len(range(0, video_total_frames, 2))
+        assert len(results) == expected
 
-    def test_vid_stride_5(self, yolo9_model, video_path):
+    def test_vid_stride_5(self, yolo9_model, video_path, video_total_frames):
         results = list(yolo9_model(video_path, stream=True, conf=0.25, vid_stride=5))
-        assert len(results) == 69
+        expected = len(range(0, video_total_frames, 5))
+        assert len(results) == expected
 
     def test_vid_stride_frame_indices(self, yolo9_model, video_path):
         results = list(yolo9_model(video_path, stream=True, conf=0.25, vid_stride=5))
@@ -205,10 +216,12 @@ class TestVideoYOLO9:
         assert int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) == 1080
         cap.release()
 
-    def test_save_auto_path(self, yolo9_model, video_path):
+    def test_save_auto_path(self, yolo9_model, video_path, tmp_path, monkeypatch):
+        # Run from tmp_path so runs/detect/ is created there, not in the repo
+        monkeypatch.chdir(tmp_path)
         for _ in yolo9_model(video_path, stream=True, save=True, conf=0.25, vid_stride=50):
             pass
-        predict_dirs = list(Path("runs/detect").glob("predict*"))
+        predict_dirs = list((tmp_path / "runs" / "detect").glob("predict*"))
         assert len(predict_dirs) > 0
         mp4s = []
         for d in predict_dirs:

--- a/tests/e2e/test_video.py
+++ b/tests/e2e/test_video.py
@@ -1,0 +1,256 @@
+"""
+E2E video inference: validate model() on a real video with pedestrians.
+
+Downloads a short test video (7.3 MB, 13.6s) from Roboflow's public CDN and
+runs video inference through LibreYOLO detectors, checking that:
+  - stream=True yields a generator of Results
+  - stream=False collects Results into a list
+  - vid_stride skips frames correctly
+  - save=True writes a valid output video
+  - show=False does not crash (show=True requires a display)
+  - frame_idx is set correctly on each result
+  - detections are found (the video contains many pedestrians)
+
+The video auto-downloads and is cached at ~/.cache/libreyolo/tracking/ — no
+manual setup needed.
+
+Usage:
+    pytest tests/e2e/test_video.py -v -m e2e
+    pytest tests/e2e/test_video.py -k "yolo9" -v
+"""
+
+import urllib.request
+from pathlib import Path
+
+import cv2
+import pytest
+
+from libreyolo import LibreYOLO
+
+from .conftest import cuda_cleanup
+
+pytestmark = pytest.mark.e2e
+
+VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/people-walking.mp4"
+VIDEO_CACHE = Path.home() / ".cache" / "libreyolo" / "tracking"
+VIDEO_PATH = VIDEO_CACHE / "people-walking.mp4"
+
+
+def download_video():
+    """Download the test video from Roboflow if not already cached."""
+    if VIDEO_PATH.exists():
+        return
+    print(f"\nDownloading test video from {VIDEO_URL} ...")
+    VIDEO_CACHE.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(VIDEO_URL, str(VIDEO_PATH))
+    print(f"Video cached at {VIDEO_PATH}")
+
+
+@pytest.fixture(scope="module")
+def video_path():
+    """Download the test video once per module, skip if network unavailable."""
+    try:
+        download_video()
+    except Exception as exc:
+        pytest.skip(f"Cannot download test video: {exc}")
+    return str(VIDEO_PATH)
+
+
+@pytest.fixture(scope="module")
+def model():
+    """Load the smallest YOLO9 model once per module."""
+    m = LibreYOLO("LibreYOLO9t.pt")
+    yield m
+    del m
+    cuda_cleanup()
+
+
+# ---------------------------------------------------------------------------
+# stream=True (generator)
+# ---------------------------------------------------------------------------
+
+
+class TestVideoStream:
+    """Tests for generator-based video inference."""
+
+    def test_stream_returns_generator(self, model, video_path):
+        gen = model(video_path, stream=True, conf=0.25)
+        assert hasattr(gen, "__next__"), "stream=True should return a generator"
+        # Consume just one frame to verify it works
+        result = next(gen)
+        assert result is not None
+        # Clean up generator
+        gen.close()
+
+    def test_stream_yields_all_frames(self, model, video_path):
+        results = list(model(video_path, stream=True, conf=0.25))
+        # Video has 341 frames
+        assert len(results) == 341
+
+    def test_stream_results_have_frame_idx(self, model, video_path):
+        indices = []
+        for i, result in enumerate(model(video_path, stream=True, conf=0.25)):
+            indices.append(result.frame_idx)
+            if i >= 9:
+                break
+        assert indices == list(range(10))
+
+    def test_stream_results_have_path(self, model, video_path):
+        result = next(iter(model(video_path, stream=True, conf=0.25)))
+        assert result.path == video_path
+
+    def test_stream_detects_people(self, model, video_path):
+        """The video has many pedestrians — we should detect objects."""
+        total_dets = 0
+        for i, result in enumerate(model(video_path, stream=True, conf=0.25)):
+            total_dets += len(result)
+            if i >= 29:
+                break
+        # 30 frames of people walking — should find plenty of detections
+        assert total_dets > 100, f"Only {total_dets} detections in 30 frames"
+
+
+# ---------------------------------------------------------------------------
+# stream=False (list)
+# ---------------------------------------------------------------------------
+
+
+class TestVideoList:
+    """Tests for list-based video inference (stream=False)."""
+
+    def test_list_mode_returns_list(self, model, video_path):
+        # Use vid_stride=10 to keep it fast
+        results = model(video_path, conf=0.25, vid_stride=10)
+        assert isinstance(results, list)
+        assert len(results) > 0
+
+    def test_list_mode_results_have_frame_idx(self, model, video_path):
+        results = model(video_path, conf=0.25, vid_stride=10)
+        for result in results:
+            assert result.frame_idx is not None
+
+
+# ---------------------------------------------------------------------------
+# vid_stride
+# ---------------------------------------------------------------------------
+
+
+class TestVidStride:
+    """Tests for frame skipping."""
+
+    def test_vid_stride_1(self, model, video_path):
+        results = list(model(video_path, stream=True, conf=0.25))
+        assert len(results) == 341
+
+    def test_vid_stride_2(self, model, video_path):
+        results = list(model(video_path, stream=True, conf=0.25, vid_stride=2))
+        assert len(results) == 171  # ceil(341/2)
+
+    def test_vid_stride_5(self, model, video_path):
+        results = list(model(video_path, stream=True, conf=0.25, vid_stride=5))
+        assert len(results) == 69  # ceil(341/5)
+
+    def test_vid_stride_frame_indices(self, model, video_path):
+        results = list(model(video_path, stream=True, conf=0.25, vid_stride=5))
+        indices = [r.frame_idx for r in results[:5]]
+        assert indices == [0, 5, 10, 15, 20]
+
+
+# ---------------------------------------------------------------------------
+# save=True
+# ---------------------------------------------------------------------------
+
+
+class TestVideoSave:
+    """Tests for saving annotated output video."""
+
+    def test_save_creates_video(self, model, video_path, tmp_path):
+        output = str(tmp_path / "output.mp4")
+        # Use vid_stride=10 to keep it fast
+        for _ in model(video_path, stream=True, save=True, output_path=output,
+                       conf=0.25, vid_stride=10):
+            pass
+
+        assert Path(output).exists()
+        assert Path(output).stat().st_size > 1000
+
+    def test_saved_video_is_valid(self, model, video_path, tmp_path):
+        output = str(tmp_path / "output.mp4")
+        n_input = 0
+        for _ in model(video_path, stream=True, save=True, output_path=output,
+                       conf=0.25, vid_stride=10):
+            n_input += 1
+
+        cap = cv2.VideoCapture(output)
+        assert cap.isOpened()
+        n_output = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        cap.release()
+
+        assert n_output == n_input
+        assert width == 1920
+        assert height == 1080
+
+    def test_save_auto_path(self, model, video_path):
+        """save=True without output_path should create runs/detect/predict*."""
+        for _ in model(video_path, stream=True, save=True, conf=0.25, vid_stride=50):
+            pass
+        # Check that some predict directory was created
+        predict_dirs = list(Path("runs/detect").glob("predict*"))
+        assert len(predict_dirs) > 0
+        mp4s = []
+        for d in predict_dirs:
+            mp4s.extend(d.glob("*.mp4"))
+        assert len(mp4s) > 0
+
+
+# ---------------------------------------------------------------------------
+# conf / classes filters
+# ---------------------------------------------------------------------------
+
+
+class TestVideoFilters:
+    """Tests for conf/classes filtering during video inference."""
+
+    def test_high_conf_fewer_detections(self, model, video_path):
+        low_conf_dets = 0
+        high_conf_dets = 0
+        for i, r in enumerate(model(video_path, stream=True, conf=0.1, vid_stride=10)):
+            low_conf_dets += len(r)
+            if i >= 9:
+                break
+
+        for i, r in enumerate(model(video_path, stream=True, conf=0.7, vid_stride=10)):
+            high_conf_dets += len(r)
+            if i >= 9:
+                break
+
+        assert high_conf_dets < low_conf_dets
+
+    def test_classes_filter(self, model, video_path):
+        """Filter to class 0 (person) should still find detections."""
+        total = 0
+        for i, r in enumerate(model(video_path, stream=True, conf=0.25,
+                                     classes=[0], vid_stride=10)):
+            total += len(r)
+            if r.boxes is not None and len(r) > 0:
+                # All detections should be class 0
+                assert (r.boxes.cls == 0).all()
+            if i >= 9:
+                break
+        assert total > 0
+
+
+# ---------------------------------------------------------------------------
+# orig_shape
+# ---------------------------------------------------------------------------
+
+
+class TestVideoResultShape:
+    """Tests for result metadata correctness."""
+
+    def test_orig_shape_matches_video(self, model, video_path):
+        result = next(iter(model(video_path, stream=True, conf=0.25)))
+        # Video is 1920x1080, orig_shape is (H, W)
+        assert result.orig_shape == (1080, 1920)

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -65,6 +65,30 @@ class TestTrackConfig:
         with pytest.warns(UserWarning, match="Unknown tracking config"):
             TrackConfig.from_kwargs(bogus=True)
 
+    def test_rejects_zero_frame_rate(self):
+        with pytest.raises(ValueError, match="frame_rate must be > 0"):
+            TrackConfig(frame_rate=0)
+
+    def test_rejects_negative_threshold(self):
+        with pytest.raises(ValueError, match="track_high_thresh must be in"):
+            TrackConfig(track_high_thresh=-0.5)
+
+    def test_rejects_threshold_over_one(self):
+        with pytest.raises(ValueError, match="track_low_thresh must be in"):
+            TrackConfig(track_low_thresh=1.5)
+
+    def test_rejects_high_below_low(self):
+        with pytest.raises(ValueError, match="track_high_thresh .* must be >= track_low_thresh"):
+            TrackConfig(track_high_thresh=0.1, track_low_thresh=0.5)
+
+    def test_rejects_negative_track_buffer(self):
+        with pytest.raises(ValueError, match="track_buffer must be >= 0"):
+            TrackConfig(track_buffer=-1)
+
+    def test_rejects_zero_minimum_consecutive_frames(self):
+        with pytest.raises(ValueError, match="minimum_consecutive_frames must be >= 1"):
+            TrackConfig(minimum_consecutive_frames=0)
+
 
 # --------------------------------------------------------------------------
 # KalmanFilter

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -1,0 +1,362 @@
+"""Unit tests for the ByteTrack tracking module."""
+
+import pytest
+import numpy as np
+import torch
+
+from libreyolo.tracking.config import TrackConfig
+from libreyolo.tracking.kalman_filter import KalmanFilterXYAH
+from libreyolo.tracking.matching import (
+    bbox_iou_batch,
+    fuse_score,
+    iou_distance,
+    linear_assignment,
+)
+from libreyolo.tracking.strack import STrack, TrackState
+from libreyolo.tracking.tracker import ByteTracker
+from libreyolo.utils.results import Boxes, Results
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _make_results(boxes_list, confs, classes, orig_shape=(480, 640)):
+    """Build a Results object from raw lists for testing."""
+    boxes = torch.tensor(boxes_list, dtype=torch.float32)
+    conf = torch.tensor(confs, dtype=torch.float32)
+    cls = torch.tensor(classes, dtype=torch.float32)
+    return Results(
+        boxes=Boxes(boxes, conf, cls),
+        orig_shape=orig_shape,
+    )
+
+
+# --------------------------------------------------------------------------
+# TrackConfig
+# --------------------------------------------------------------------------
+
+
+class TestTrackConfig:
+    def test_defaults(self):
+        cfg = TrackConfig()
+        assert cfg.track_high_thresh == 0.25
+        assert cfg.track_low_thresh == 0.1
+        assert cfg.new_track_thresh == 0.25
+        assert cfg.match_thresh == 0.8
+        assert cfg.track_buffer == 30
+        assert cfg.frame_rate == 30
+        assert cfg.fuse_score is True
+        assert cfg.minimum_consecutive_frames == 1
+
+    def test_custom_values(self):
+        cfg = TrackConfig(track_high_thresh=0.5, track_buffer=60)
+        assert cfg.track_high_thresh == 0.5
+        assert cfg.track_buffer == 60
+
+    def test_from_kwargs(self):
+        cfg = TrackConfig.from_kwargs(track_high_thresh=0.3, unknown_key=42)
+        assert cfg.track_high_thresh == 0.3
+
+    def test_from_kwargs_warns_on_unknown(self):
+        with pytest.warns(UserWarning, match="Unknown tracking config"):
+            TrackConfig.from_kwargs(bogus=True)
+
+
+# --------------------------------------------------------------------------
+# KalmanFilter
+# --------------------------------------------------------------------------
+
+
+class TestKalmanFilter:
+    def test_initiate_shapes(self):
+        kf = KalmanFilterXYAH()
+        measurement = np.array([100.0, 200.0, 0.5, 80.0])
+        mean, cov = kf.initiate(measurement)
+        assert mean.shape == (8,)
+        assert cov.shape == (8, 8)
+        np.testing.assert_array_almost_equal(mean[:4], measurement)
+        np.testing.assert_array_almost_equal(mean[4:], 0.0)
+
+    def test_predict_advances_position(self):
+        kf = KalmanFilterXYAH()
+        mean = np.array([100.0, 200.0, 0.5, 80.0, 5.0, 10.0, 0.0, 2.0])
+        cov = np.eye(8) * 1.0
+        pred_mean, pred_cov = kf.predict(mean, cov)
+        # Position should advance by velocity (dt=1).
+        assert pred_mean[0] == pytest.approx(105.0)
+        assert pred_mean[1] == pytest.approx(210.0)
+        assert pred_mean[3] == pytest.approx(82.0)
+
+    def test_update_corrects_state(self):
+        kf = KalmanFilterXYAH()
+        measurement = np.array([100.0, 200.0, 0.5, 80.0])
+        mean, cov = kf.initiate(measurement)
+        mean, cov = kf.predict(mean, cov)
+
+        # Measurement slightly different from prediction.
+        new_meas = np.array([102.0, 198.0, 0.5, 81.0])
+        updated_mean, updated_cov = kf.update(mean, cov, new_meas)
+
+        # Updated state should be between prediction and measurement.
+        assert 100.0 < updated_mean[0] < 103.0
+        assert 197.0 < updated_mean[1] < 201.0
+
+    def test_multi_predict_matches_single(self):
+        kf = KalmanFilterXYAH()
+        m1 = np.array([100.0, 200.0, 0.5, 80.0])
+        m2 = np.array([300.0, 400.0, 0.8, 120.0])
+        mean1, cov1 = kf.initiate(m1)
+        mean2, cov2 = kf.initiate(m2)
+
+        # Single predictions.
+        sp1, sc1 = kf.predict(mean1.copy(), cov1.copy())
+        sp2, sc2 = kf.predict(mean2.copy(), cov2.copy())
+
+        # Batch prediction.
+        means = np.stack([mean1, mean2])
+        covs = np.stack([cov1, cov2])
+        bp, bc = kf.multi_predict(means, covs)
+
+        np.testing.assert_array_almost_equal(bp[0], sp1)
+        np.testing.assert_array_almost_equal(bp[1], sp2)
+        np.testing.assert_array_almost_equal(bc[0], sc1)
+        np.testing.assert_array_almost_equal(bc[1], sc2)
+
+
+# --------------------------------------------------------------------------
+# Matching
+# --------------------------------------------------------------------------
+
+
+class TestMatching:
+    def test_iou_identical_boxes(self):
+        a = np.array([[10, 20, 50, 60]], dtype=np.float64)
+        iou = bbox_iou_batch(a, a)
+        assert iou[0, 0] == pytest.approx(1.0)
+
+    def test_iou_no_overlap(self):
+        a = np.array([[0, 0, 10, 10]], dtype=np.float64)
+        b = np.array([[20, 20, 30, 30]], dtype=np.float64)
+        iou = bbox_iou_batch(a, b)
+        assert iou[0, 0] == pytest.approx(0.0)
+
+    def test_iou_partial_overlap(self):
+        a = np.array([[0, 0, 10, 10]], dtype=np.float64)
+        b = np.array([[5, 5, 15, 15]], dtype=np.float64)
+        iou = bbox_iou_batch(a, b)
+        # Intersection = 5*5=25, union = 100+100-25=175.
+        assert iou[0, 0] == pytest.approx(25.0 / 175.0)
+
+    def test_iou_distance_is_complement(self):
+        tracks = [STrack(np.array([0, 0, 10, 10]), 0.9, 0, 0)]
+        tracks[0].mean = np.array([5, 5, 1.0, 10, 0, 0, 0, 0], dtype=np.float64)
+        dets = np.array([[0, 0, 10, 10]], dtype=np.float64)
+        cost = iou_distance(tracks, dets)
+        assert cost[0, 0] == pytest.approx(1.0 - 1.0)  # identical = IoU 1
+
+    def test_fuse_score_formula(self):
+        cost = np.array([[0.3]], dtype=np.float64)  # IoU sim = 0.7
+        scores = np.array([0.9], dtype=np.float64)
+        fused = fuse_score(cost, scores)
+        expected = 1.0 - (0.7 * 0.9)
+        assert fused[0, 0] == pytest.approx(expected)
+
+    def test_linear_assignment_perfect_match(self):
+        cost = np.array([[0.1, 0.9], [0.9, 0.1]], dtype=np.float64)
+        matches, ua, ub = linear_assignment(cost, 0.5)
+        assert len(matches) == 2
+        assert len(ua) == 0
+        assert len(ub) == 0
+
+    def test_linear_assignment_threshold(self):
+        cost = np.array([[0.8]], dtype=np.float64)
+        matches, ua, ub = linear_assignment(cost, 0.5)
+        assert len(matches) == 0
+        assert len(ua) == 1
+        assert len(ub) == 1
+
+    def test_linear_assignment_empty(self):
+        cost = np.empty((0, 0), dtype=np.float64)
+        matches, ua, ub = linear_assignment(cost, 0.5)
+        assert matches.shape == (0, 2)
+        assert len(ua) == 0
+        assert len(ub) == 0
+
+
+# --------------------------------------------------------------------------
+# STrack
+# --------------------------------------------------------------------------
+
+
+class TestSTrack:
+    def test_activate_sets_tracked(self):
+        kf = KalmanFilterXYAH()
+        st = STrack(np.array([10, 20, 50, 60]), 0.9, 0, 0)
+        st.activate(kf, frame_id=1, track_id=1)
+        assert st.state == TrackState.Tracked
+        assert st.is_activated is True
+        assert st.track_id == 1
+
+    def test_xyxy_to_xyah_and_back(self):
+        xyxy = np.array([10.0, 20.0, 50.0, 80.0])
+        xyah = STrack.xyxy_to_xyah(xyxy)
+        # cx=30, cy=50, a=40/60, h=60
+        assert xyah[0] == pytest.approx(30.0)
+        assert xyah[1] == pytest.approx(50.0)
+        assert xyah[2] == pytest.approx(40.0 / 60.0)
+        assert xyah[3] == pytest.approx(60.0)
+
+    def test_mark_lost_and_removed(self):
+        st = STrack(np.array([0, 0, 10, 10]), 0.9, 0, 0)
+        st.state = TrackState.Tracked
+        st.mark_lost()
+        assert st.state == TrackState.Lost
+        st.mark_removed()
+        assert st.state == TrackState.Removed
+
+
+# --------------------------------------------------------------------------
+# ByteTracker
+# --------------------------------------------------------------------------
+
+
+class TestByteTracker:
+    def test_empty_results(self):
+        tracker = ByteTracker()
+        result = _make_results([], [], [])
+        tracked = tracker.update(result)
+        assert len(tracked) == 0
+        assert tracked.track_id is not None
+        assert len(tracked.track_id) == 0
+
+    def test_single_detection_gets_id(self):
+        tracker = ByteTracker()
+        r1 = _make_results([[100, 100, 200, 200]], [0.9], [0])
+        t1 = tracker.update(r1)
+        assert len(t1) == 1
+        assert t1.track_id is not None
+        id1 = t1.track_id[0].item()
+
+        # Same object, slightly moved.
+        r2 = _make_results([[105, 105, 205, 205]], [0.9], [0])
+        t2 = tracker.update(r2)
+        assert len(t2) == 1
+        assert t2.track_id[0].item() == id1
+
+    def test_two_detections_different_ids(self):
+        tracker = ByteTracker()
+        r = _make_results(
+            [[100, 100, 200, 200], [400, 400, 500, 500]],
+            [0.9, 0.8],
+            [0, 0],
+        )
+        t = tracker.update(r)
+        assert len(t) == 2
+        assert t.track_id[0].item() != t.track_id[1].item()
+
+    def test_lost_track_recovery(self):
+        tracker = ByteTracker(track_buffer=10)
+
+        # Frame 1: object appears.
+        r1 = _make_results([[100, 100, 200, 200]], [0.9], [0])
+        t1 = tracker.update(r1)
+        id1 = t1.track_id[0].item()
+
+        # Frames 2-4: object disappears.
+        for _ in range(3):
+            tracker.update(_make_results([], [], []))
+
+        # Frame 5: object reappears at similar position.
+        r5 = _make_results([[105, 105, 205, 205]], [0.9], [0])
+        t5 = tracker.update(r5)
+        assert len(t5) == 1
+        assert t5.track_id[0].item() == id1
+
+    def test_low_confidence_recovery(self):
+        tracker = ByteTracker(track_high_thresh=0.5, track_low_thresh=0.1)
+
+        # Frame 1: high confidence.
+        r1 = _make_results([[100, 100, 200, 200]], [0.9], [0])
+        t1 = tracker.update(r1)
+        id1 = t1.track_id[0].item()
+
+        # Frame 2: same object, but low confidence (occluded).
+        r2 = _make_results([[103, 103, 203, 203]], [0.3], [0])
+        t2 = tracker.update(r2)
+        assert len(t2) == 1
+        assert t2.track_id[0].item() == id1
+
+    def test_minimum_consecutive_frames(self):
+        tracker = ByteTracker(minimum_consecutive_frames=3)
+
+        # Frame 1: new detection — should NOT be output yet.
+        r1 = _make_results([[100, 100, 200, 200]], [0.9], [0])
+        t1 = tracker.update(r1)
+        assert len(t1) == 0
+
+        # Frame 2: matched — still not enough frames.
+        r2 = _make_results([[102, 102, 202, 202]], [0.9], [0])
+        t2 = tracker.update(r2)
+        assert len(t2) == 0
+
+        # Frame 3: third consecutive match — now confirmed.
+        r3 = _make_results([[104, 104, 204, 204]], [0.9], [0])
+        t3 = tracker.update(r3)
+        assert len(t3) == 1
+
+    def test_reset_clears_state(self):
+        tracker = ByteTracker()
+        r = _make_results([[100, 100, 200, 200]], [0.9], [0])
+        t1 = tracker.update(r)
+        id1 = t1.track_id[0].item()
+
+        tracker.reset()
+
+        t2 = tracker.update(r)
+        id2 = t2.track_id[0].item()
+        # After reset, IDs start from 1 again.
+        assert id2 == 1
+
+    def test_track_id_tensor_on_results(self):
+        tracker = ByteTracker()
+        r = _make_results([[100, 100, 200, 200]], [0.9], [0])
+        t = tracker.update(r)
+        assert isinstance(t.track_id, torch.Tensor)
+        assert t.track_id.dtype == torch.int64
+        assert t.track_id.shape == (1,)
+
+    def test_per_instance_id_counter(self):
+        t1 = ByteTracker()
+        t2 = ByteTracker()
+
+        r = _make_results([[100, 100, 200, 200]], [0.9], [0])
+        res1 = t1.update(r)
+        res2 = t2.update(r)
+
+        # Both should start from 1 independently.
+        assert res1.track_id[0].item() == 1
+        assert res2.track_id[0].item() == 1
+
+    def test_results_backward_compatible(self):
+        """Results without track_id should still work."""
+        r = Results(
+            boxes=Boxes(torch.rand(2, 4), torch.rand(2), torch.rand(2)),
+            orig_shape=(480, 640),
+        )
+        assert r.track_id is None
+        assert "track_ids" not in repr(r)
+
+    def test_results_cpu_with_track_id(self):
+        r = Results(
+            boxes=Boxes(torch.rand(2, 4), torch.rand(2), torch.rand(2)),
+            orig_shape=(480, 640),
+            track_id=torch.tensor([1, 2]),
+        )
+        cpu_r = r.cpu()
+        assert cpu_r.track_id is not None
+        assert cpu_r.track_id.device.type == "cpu"
+        assert torch.equal(cpu_r.track_id, torch.tensor([1, 2]))

--- a/tests/unit/test_video.py
+++ b/tests/unit/test_video.py
@@ -99,9 +99,34 @@ class TestVideoSource:
         indices = [idx for _, idx in frames]
         assert indices == [0, 2, 4, 6, 8]
 
+    def test_vid_stride_larger_than_total(self, sample_video):
+        vs = VideoSource(sample_video, vid_stride=100)
+        frames = list(vs)
+        # Only frame 0 matches (0 % 100 == 0), all others are skipped
+        assert len(frames) == 1
+        assert frames[0][1] == 0
+
     def test_invalid_path(self):
         with pytest.raises(ValueError, match="Cannot open video"):
             VideoSource("/nonexistent/video.mp4")
+
+    def test_re_iteration_raises(self, sample_video):
+        vs = VideoSource(sample_video)
+        list(vs)  # consume once
+        with pytest.raises(RuntimeError, match="consumed or released"):
+            list(vs)
+
+    def test_context_manager(self, sample_video):
+        with VideoSource(sample_video) as vs:
+            frames = list(vs)
+        assert len(frames) == 10
+        # After exiting context, cap should be released
+        assert vs._cap is None
+
+    def test_double_release_safe(self, sample_video):
+        vs = VideoSource(sample_video)
+        vs.release()
+        vs.release()  # should not raise
 
     def test_repr(self, sample_video):
         vs = VideoSource(sample_video)
@@ -145,6 +170,14 @@ class TestVideoWriter:
         writer.write_frame(frame)
         writer.release()
         assert Path(out_path).exists()
+
+    def test_context_manager(self, tmp_path):
+        out_path = str(tmp_path / "ctx_output.mp4")
+        with VideoWriter(out_path, fps=10.0, width=32, height=32) as writer:
+            frame = np.zeros((32, 32, 3), dtype=np.uint8)
+            writer.write_frame(frame)
+        assert Path(out_path).exists()
+        assert writer._writer is None  # released
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_video.py
+++ b/tests/unit/test_video.py
@@ -1,0 +1,200 @@
+"""Unit tests for video support utilities."""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from libreyolo.utils.video import VIDEO_EXTENSIONS, VideoSource, VideoWriter, is_video_file
+
+pytestmark = pytest.mark.unit
+
+cv2 = pytest.importorskip("cv2", reason="opencv-python required for video tests")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_video(tmp_path):
+    """Create a tiny 10-frame 64x64 video for testing."""
+    path = str(tmp_path / "test_video.mp4")
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, 10.0, (64, 64))
+    for i in range(10):
+        # Each frame has a different shade so they're distinguishable
+        frame = np.full((64, 64, 3), fill_value=i * 25, dtype=np.uint8)
+        writer.write(frame)
+    writer.release()
+    return path
+
+
+# ---------------------------------------------------------------------------
+# is_video_file
+# ---------------------------------------------------------------------------
+
+
+class TestIsVideoFile:
+    def test_video_extensions(self):
+        assert is_video_file("clip.mp4")
+        assert is_video_file("clip.avi")
+        assert is_video_file("clip.mkv")
+        assert is_video_file(Path("clip.mov"))
+
+    def test_image_extensions(self):
+        assert not is_video_file("photo.jpg")
+        assert not is_video_file("photo.png")
+
+    def test_non_string(self):
+        assert not is_video_file(42)
+        assert not is_video_file(None)
+        assert not is_video_file(np.zeros((3, 3, 3)))
+
+    def test_case_insensitive(self):
+        assert is_video_file("CLIP.MP4")
+        assert is_video_file("Clip.Avi")
+
+
+# ---------------------------------------------------------------------------
+# VideoSource
+# ---------------------------------------------------------------------------
+
+
+class TestVideoSource:
+    def test_metadata(self, sample_video):
+        vs = VideoSource(sample_video)
+        assert vs.width == 64
+        assert vs.height == 64
+        assert vs.total_frames == 10
+        assert vs.fps == pytest.approx(10.0, abs=1.0)
+        vs.release()
+
+    def test_iterate_all_frames(self, sample_video):
+        vs = VideoSource(sample_video)
+        frames = list(vs)
+        assert len(frames) == 10
+        # Each element is (frame_bgr, frame_idx)
+        for frame, idx in frames:
+            assert frame.shape == (64, 64, 3)
+            assert frame.dtype == np.uint8
+
+    def test_frame_indices_sequential(self, sample_video):
+        vs = VideoSource(sample_video)
+        indices = [idx for _, idx in vs]
+        assert indices == list(range(10))
+
+    def test_vid_stride(self, sample_video):
+        vs = VideoSource(sample_video, vid_stride=3)
+        frames = list(vs)
+        indices = [idx for _, idx in frames]
+        # With stride 3 and 10 frames (0-9): should get frames 0, 3, 6, 9
+        assert indices == [0, 3, 6, 9]
+
+    def test_vid_stride_2(self, sample_video):
+        vs = VideoSource(sample_video, vid_stride=2)
+        frames = list(vs)
+        indices = [idx for _, idx in frames]
+        assert indices == [0, 2, 4, 6, 8]
+
+    def test_invalid_path(self):
+        with pytest.raises(ValueError, match="Cannot open video"):
+            VideoSource("/nonexistent/video.mp4")
+
+    def test_repr(self, sample_video):
+        vs = VideoSource(sample_video)
+        r = repr(vs)
+        assert "VideoSource" in r
+        assert "64x64" in r
+        vs.release()
+
+
+# ---------------------------------------------------------------------------
+# VideoWriter
+# ---------------------------------------------------------------------------
+
+
+class TestVideoWriter:
+    def test_write_and_read_back(self, tmp_path):
+        out_path = str(tmp_path / "output.mp4")
+        writer = VideoWriter(out_path, fps=10.0, width=32, height=32)
+
+        for i in range(5):
+            frame = np.full((32, 32, 3), fill_value=i * 50, dtype=np.uint8)
+            writer.write_frame(frame)
+        writer.release()
+
+        # Read back and verify
+        cap = cv2.VideoCapture(out_path)
+        assert cap.isOpened()
+        count = 0
+        while True:
+            ok, _ = cap.read()
+            if not ok:
+                break
+            count += 1
+        cap.release()
+        assert count == 5
+
+    def test_creates_parent_dirs(self, tmp_path):
+        out_path = str(tmp_path / "sub" / "dir" / "output.mp4")
+        writer = VideoWriter(out_path, fps=10.0, width=32, height=32)
+        frame = np.zeros((32, 32, 3), dtype=np.uint8)
+        writer.write_frame(frame)
+        writer.release()
+        assert Path(out_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# Results.frame_idx
+# ---------------------------------------------------------------------------
+
+
+class TestResultsFrameIdx:
+    def test_default_none(self):
+        import torch
+
+        from libreyolo.utils.results import Boxes, Results
+
+        boxes = Boxes(torch.zeros((0, 4)), torch.zeros((0,)), torch.zeros((0,)))
+        result = Results(boxes=boxes, orig_shape=(480, 640))
+        assert result.frame_idx is None
+
+    def test_set_frame_idx(self):
+        import torch
+
+        from libreyolo.utils.results import Boxes, Results
+
+        boxes = Boxes(torch.zeros((0, 4)), torch.zeros((0,)), torch.zeros((0,)))
+        result = Results(boxes=boxes, orig_shape=(480, 640), frame_idx=42)
+        assert result.frame_idx == 42
+
+    def test_cpu_preserves_frame_idx(self):
+        import torch
+
+        from libreyolo.utils.results import Boxes, Results
+
+        boxes = Boxes(torch.zeros((1, 4)), torch.zeros((1,)), torch.zeros((1,)))
+        result = Results(boxes=boxes, orig_shape=(480, 640), frame_idx=7)
+        cpu_result = result.cpu()
+        assert cpu_result.frame_idx == 7
+
+    def test_repr_includes_frame_idx(self):
+        import torch
+
+        from libreyolo.utils.results import Boxes, Results
+
+        boxes = Boxes(torch.zeros((0, 4)), torch.zeros((0,)), torch.zeros((0,)))
+        result = Results(boxes=boxes, orig_shape=(480, 640), frame_idx=3)
+        assert "frame_idx=3" in repr(result)
+
+    def test_repr_omits_frame_idx_when_none(self):
+        import torch
+
+        from libreyolo.utils.results import Boxes, Results
+
+        boxes = Boxes(torch.zeros((0, 4)), torch.zeros((0,)), torch.zeros((0,)))
+        result = Results(boxes=boxes, orig_shape=(480, 640))
+        assert "frame_idx" not in repr(result)


### PR DESCRIPTION
## Summary
- **ByteTrack multi-object tracking** via `model.track()` — 3-stage association with Kalman filtering
- **Video inference** via `model.predict(video.mp4)` — streaming, frame striding, save to MP4
- Tracking reuses video infrastructure (`VideoSource`, `VideoWriter`, `run_video_inference()`)
- Track ID visualization with per-ID colors and two-tone labels

## Key APIs
```python
# Video inference
results = model.predict("video.mp4", stream=True, save=True)

# Tracking
for result in model.track("video.mp4", save=True):
    print(result.track_id)  # persistent IDs across frames
```

## Test plan
- [x] 183 unit tests passing (tracking, video, all existing)
- [x] E2e tracking tests across YOLOX, YOLOv9, RF-DETR
- [x] E2e video tests across all model families
- [x] Manual verification: tracking demo video with persistent IDs