### PR TITLE
Fix up tensor type conversion

### DIFF
--- a/libreyolo/models/yolox/loss.py
+++ b/libreyolo/models/yolox/loss.py
@@ -50,7 +50,7 @@ class IoULoss(nn.Module):
         area_p = torch.prod(pred[:, 2:], 1)
         area_g = torch.prod(target[:, 2:], 1)
 
-        en = (tl < br).type(tl.type()).prod(dim=1)
+        en = (tl < br).to(dtype=tl.dtype).prod(dim=1)
         area_i = torch.prod(br - tl, 1) * en
         area_u = area_p + area_g - area_i
         iou = (area_i) / (area_u + 1e-16)


### PR DESCRIPTION
Closes #87

`type()` returns a backend-specific tensor class name string like `torch.FloatTensor` or `torch.cuda.FloatTensor` and subsequently can take another backend-specific tensor class name and convert to it. However, MPS doesn't seem to support this API. Doing a specific `dtype` conversion seems to work.

I've confirmed the fix by training YOLOX on mps and it worked whereas it previously failed.