### PR TITLE
fix(yolo9-seg): make mask target resolution imgsz-agnostic

### DIFF
--- a/libreyolo/models/yolo9/transforms.py
+++ b/libreyolo/models/yolo9/transforms.py
@@ -11,6 +11,11 @@ import cv2
 import numpy as np
 
 
+# Seg mask target resolution = input_dim // MASK_STRIDE.
+# YOLOv9 proto head output stride is 4 (imgsz 640 → 160x160, imgsz 128 → 32x32).
+MASK_STRIDE = 4
+
+
 def augment_hsv(img, hgain=5, sgain=30, vgain=30):
     """Apply HSV augmentation to an image."""
     hsv_augs = np.random.uniform(-1, 1, 3) * [hgain, sgain, vgain]
@@ -102,13 +107,18 @@ class YOLO9TrainTransform:
         boxes = targets[:, :4].copy()
         labels = targets[:, 4].copy()
 
+        # Mask targets are rasterized at proto resolution (input / MASK_STRIDE).
+        # YOLOv9 proto stride is 4, so imgsz=640 → masks 160x160, imgsz=128 → 32x32.
+        mask_h = input_dim[0] // MASK_STRIDE
+        mask_w = input_dim[1] // MASK_STRIDE
+
         if len(boxes) == 0:
             padded_labels = np.zeros((self.max_labels, 5), dtype=np.float32)
             padded_labels[:, 0] = -1
             image, _ = preproc(image, input_dim)
             if has_polys:
                 from libreyolo.data.dataset import polygons_to_masks
-                masks = polygons_to_masks([], 160, 160, self.max_labels)
+                masks = polygons_to_masks([], mask_h, mask_w, self.max_labels)
                 return image, padded_labels, masks
             return image, padded_labels
 
@@ -188,7 +198,7 @@ class YOLO9TrainTransform:
                 else:
                     polys_norm.append(None)
             from libreyolo.data.dataset import polygons_to_masks
-            masks = polygons_to_masks(polys_norm, 160, 160, self.max_labels)
+            masks = polygons_to_masks(polys_norm, mask_h, mask_w, self.max_labels)
             return image_t, padded_labels, masks
 
         return image_t, padded_labels
@@ -299,7 +309,8 @@ class YOLO9MosaicMixupDataset:
                 img, label = preproc_result
                 from libreyolo.data.dataset import polygons_to_masks
                 max_labels = self.preproc.max_labels if hasattr(self.preproc, 'max_labels') else 100
-                masks = polygons_to_masks([], 160, 160, max_labels)
+                mh, mw = self.input_dim[0] // MASK_STRIDE, self.input_dim[1] // MASK_STRIDE
+                masks = polygons_to_masks([], mh, mw, max_labels)
             return img, label, img_info, img_id, masks
         else:
             img, label, img_info, img_id = result
@@ -425,7 +436,8 @@ class YOLO9MosaicMixupDataset:
                 # Seg dataset but this mosaic had no polygons — return empty masks
                 from libreyolo.data.dataset import polygons_to_masks
                 max_labels = self.preproc.max_labels if hasattr(self.preproc, 'max_labels') else 100
-                masks = polygons_to_masks([], 160, 160, max_labels)
+                mh, mw = self.input_dim[0] // MASK_STRIDE, self.input_dim[1] // MASK_STRIDE
+                masks = polygons_to_masks([], mh, mw, max_labels)
             else:
                 masks = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ testpaths = ["tests"]
 markers = [
     "unit: fast tests that avoid external weights or large files",
     "e2e: end-to-end tests requiring full model loading and inference",
+    "smoke: fast end-to-end pipeline checks on tiny synthetic data (CPU, <60s)",
     "tensorrt: tests requiring TensorRT",
     "openvino: tests requiring OpenVINO",
     "ncnn: tests requiring ncnn",

--- a/tests/smoke/test_yolo9_seg_smoke.py
+++ b/tests/smoke/test_yolo9_seg_smoke.py
@@ -1,0 +1,148 @@
+"""Offline smoke test for YOLOv9 instance segmentation.
+
+Validates that the full training pipeline runs end-to-end on CPU with tiny
+synthetic data: model construction, polygon label parsing, mask target
+generation, forward/backward, loss computation, optimizer step, checkpoint
+writing. Deliberately does NOT download weights or datasets.
+
+Run: `pytest tests/smoke/test_yolo9_seg_smoke.py -v -m smoke`
+
+Target: <60 seconds wall-clock on a MacBook (CPU).
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from PIL import Image
+
+from libreyolo.models.yolo9.model import LibreYOLO9
+from libreyolo.models.yolo9.nn import LibreYOLO9Model
+
+
+pytestmark = pytest.mark.smoke
+
+
+def _make_tiny_seg_dataset(root: Path, imgsz: int = 128, num_imgs: int = 2) -> Path:
+    """Create a tiny YOLO-seg dataset with 1 polygon per image (2 classes).
+
+    Layout:
+        root/
+            images/train/0.jpg, 1.jpg
+            images/val/0.jpg
+            labels/train/0.txt, 1.txt   (class cx cy w h  or  class x1 y1 x2 y2 ... polygon)
+            labels/val/0.txt
+            data.yaml
+    """
+    (root / "images" / "train").mkdir(parents=True, exist_ok=True)
+    (root / "images" / "val").mkdir(parents=True, exist_ok=True)
+    (root / "labels" / "train").mkdir(parents=True, exist_ok=True)
+    (root / "labels" / "val").mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(0)
+
+    def _write_sample(split: str, idx: int, cls: int):
+        # Synthetic image: solid base + a bright square
+        img = rng.integers(60, 100, size=(imgsz, imgsz, 3), dtype=np.uint8)
+        x0, y0 = 24 + 12 * idx, 24 + 12 * idx
+        x1, y1 = x0 + 40, y0 + 40
+        img[y0:y1, x0:x1] = 220
+        Image.fromarray(img).save(root / "images" / split / f"{idx}.jpg", quality=85)
+
+        # Polygon label: rectangle as 4 points, normalized to [0, 1]
+        xs = [x0, x1, x1, x0]
+        ys = [y0, y0, y1, y1]
+        coords = []
+        for x, y in zip(xs, ys):
+            coords.append(f"{x / imgsz:.6f}")
+            coords.append(f"{y / imgsz:.6f}")
+        line = f"{cls} " + " ".join(coords)
+        (root / "labels" / split / f"{idx}.txt").write_text(line + "\n")
+
+    for i in range(num_imgs):
+        _write_sample("train", i, cls=i % 2)
+    _write_sample("val", 0, cls=0)
+
+    data_yaml = {
+        "path": str(root),
+        "train": "images/train",
+        "val": "images/val",
+        "nc": 2,
+        "names": ["classA", "classB"],
+    }
+    (root / "data.yaml").write_text(yaml.dump(data_yaml))
+    return root / "data.yaml"
+
+
+def _make_seg_checkpoint(path: Path, size: str = "t", nb_classes: int = 2) -> Path:
+    """Build a fresh YOLOv9 seg model and save its state_dict as a libreyolo checkpoint."""
+    net = LibreYOLO9Model(config=size, nb_classes=nb_classes, segmentation=True)
+    torch.save({"model": net.state_dict()}, path)
+    return path
+
+
+def test_yolo9_seg_training_runs_end_to_end(tmp_path):
+    """Smoke: instantiate seg model, train 1 epoch on tiny data, verify finite loss + checkpoint."""
+    # 1. Build dataset
+    data_yaml = _make_tiny_seg_dataset(tmp_path / "data", imgsz=128, num_imgs=2)
+
+    # 2. Build fresh seg checkpoint (no network)
+    ckpt = _make_seg_checkpoint(tmp_path / "seg-init.pt", size="t", nb_classes=2)
+
+    # 3. Load via wrapper with explicit segmentation=True
+    model = LibreYOLO9(model_path=str(ckpt), size="t", nb_classes=2, segmentation=True, device="cpu")
+    assert model._is_segmentation, "Model should be in segmentation mode"
+
+    # 4. Train briefly (CPU, tiny batch, small imgsz)
+    out = tmp_path / "runs"
+    results = model.train(
+        data=str(data_yaml),
+        epochs=1,
+        batch=2,
+        imgsz=128,
+        lr0=0.01,
+        optimizer="SGD",
+        device="cpu",
+        workers=0,
+        project=str(out),
+        name="smoke",
+        amp=False,
+        patience=1,
+    )
+
+    # 5. Verify outputs
+    assert "final_loss" in results
+    assert math.isfinite(results["final_loss"]), f"loss not finite: {results['final_loss']}"
+    assert Path(results["last_checkpoint"]).exists(), "last checkpoint missing"
+
+    # 6. Verify checkpoint has seg head keys
+    saved = torch.load(results["last_checkpoint"], map_location="cpu", weights_only=False)
+    state = saved.get("model", saved)
+    seg_keys = [k for k in state if k.startswith("head.proto") or k.startswith("head.cv4")]
+    assert seg_keys, "Seg head keys missing from saved checkpoint"
+
+
+def test_yolo9_seg_inference_returns_masks(tmp_path):
+    """Smoke: run inference with a fresh seg model, confirm Results.masks is populated shape-wise."""
+    ckpt = _make_seg_checkpoint(tmp_path / "seg-init.pt", size="t", nb_classes=2)
+    model = LibreYOLO9(model_path=str(ckpt), size="t", nb_classes=2, segmentation=True, device="cpu")
+
+    # Synthetic RGB image
+    rng = np.random.default_rng(0)
+    img = rng.integers(0, 255, size=(160, 160, 3), dtype=np.uint8)
+    pil = Image.fromarray(img)
+
+    # Run with a very low confidence threshold so we're likely to get at least one detection
+    results = model(pil, conf=0.0001, iou=0.5)
+    assert results is not None
+    # Results may be a list or a single object depending on input type — normalize
+    res = results[0] if isinstance(results, list) else results
+
+    # If there are any detections, masks must be present and shape-consistent
+    if len(res.boxes) > 0:
+        assert res.masks is not None, "seg model returned boxes but no masks"
+        assert res.masks.data.shape[0] == len(res.boxes), "mask count != box count"


### PR DESCRIPTION
## Summary

`libreyolo/models/yolo9/transforms.py` hardcodes the YOLO-seg mask-target resolution at `160×160` in five call sites. Since YOLOv9's proto head is at stride 4, this only matches `imgsz=640` (640/4 = 160). Any other imgsz — including a small CPU smoke test at `imgsz=128` — blows up inside the training loop with:

```
ValueError: Target size (torch.Size([N, 160, 160]))
            must be the same as input size (torch.Size([N, 32, 32]))
```

## Fix

- Introduce a named `MASK_STRIDE = 4` constant at the top of `transforms.py`.
- Compute `mask_h, mask_w = input_dim // MASK_STRIDE` at each call site.
- Five edits across `YOLO9TrainTransform.__call__` and `YOLO9MosaicMixupDataset._get_{normal,mosaic}_item`.

## Evidence

New offline smoke test (`tests/smoke/test_yolo9_seg_smoke.py`, pytest marker `smoke`) that builds a fresh seg model, synthesizes 2 images + polygon labels, and runs 1 epoch at `imgsz=128`, `batch=2`, `device="cpu"`. Pre-fix: immediate BCE shape mismatch. Post-fix: 2/2 tests pass in ~2 seconds.

Existing 163-test unit suite stays green — no regressions.

## Test plan

- [x] \`pytest tests/smoke/test_yolo9_seg_smoke.py -m smoke\` → 2 passed
- [x] \`pytest tests/unit -q\` → 163 passed, 0 failed
- [x] \`pytest tests/unit/test_segmentation.py -q\` → 39 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)