### PR TITLE
Add native YOLO-NAS detection support

### DIFF
--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import version, PackageNotFoundError
 from pathlib import Path as _Path
 
 # Core API — always available
-from .models import LibreYOLO, LibreYOLOX, LibreYOLO9
+from .models import LibreYOLO, LibreYOLOX, LibreYOLO9, LibreYOLONAS
 from .utils.results import Results, Boxes, Masks
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
@@ -51,6 +51,7 @@ __all__ = [
     # Main API
     "LibreYOLO",
     "LibreYOLO9",
+    "LibreYOLONAS",
     "LibreYOLOX",
     "LibreYOLORFDETR",
     # Results

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -12,6 +12,7 @@ import torch.nn.functional as F
 from PIL import Image
 
 from ..models.yolo9.utils import preprocess_image
+from ..models.yolonas.utils import preprocess_image as yolonas_preprocess_image
 from ..models.yolox.utils import preprocess_image as yolox_preprocess_image
 from ..utils.drawing import draw_boxes, draw_masks
 from ..utils.general import COCO_CLASSES, get_safe_stem
@@ -107,6 +108,10 @@ class BaseBackend(ABC):
             return yolox_preprocess_image(
                 image, input_size=effective_imgsz, color_format=color_format
             )
+        elif self.model_family == "yolonas":
+            return yolonas_preprocess_image(
+                image, input_size=effective_imgsz, color_format=color_format
+            )
         elif self.model_family == "rfdetr":
             tensor, img, size = self._preprocess_rfdetr(
                 image, effective_imgsz, color_format
@@ -149,6 +154,11 @@ class BaseBackend(ABC):
         if self.model_family == "yolox":
             boxes, scores, cls = self._parse_yolox(
                 all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio
+            )
+            return boxes, scores, cls, None
+        elif self.model_family == "yolonas":
+            boxes, scores, cls = self._parse_yolonas(
+                all_outputs, orig_w, orig_h, conf, ratio=ratio
             )
             return boxes, scores, cls, None
         elif self.model_family == "rfdetr":
@@ -215,6 +225,26 @@ class BaseBackend(ABC):
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
 
+        return boxes, max_scores, class_ids
+
+    def _parse_yolonas(self, all_outputs, orig_w, orig_h, conf, ratio=1.0):
+        """Parse YOLO-NAS output: [boxes(B,N,4), scores(B,N,nc)] in input pixels."""
+        boxes = all_outputs[0][0]  # (N, 4) xyxy in input image coordinates
+        scores = all_outputs[1][0]  # (N, nc)
+
+        max_scores = np.max(scores, axis=1)
+        class_ids = np.argmax(scores, axis=1)
+
+        mask = max_scores > conf
+        boxes, max_scores, class_ids = boxes[mask], max_scores[mask], class_ids[mask]
+
+        if len(boxes) == 0:
+            return boxes, max_scores, class_ids
+
+        boxes = boxes.astype(np.float32, copy=True)
+        boxes /= ratio
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
         return boxes, max_scores, class_ids
 
     def _parse_rfdetr(self, all_outputs, orig_w, orig_h, conf):

--- a/libreyolo/backends/ncnn.py
+++ b/libreyolo/backends/ncnn.py
@@ -75,7 +75,13 @@ class NcnnBackend(BaseBackend):
         self.net.load_param(str(param_path))
         self.net.load_model(str(bin_path))
 
-        self._input_names, self._output_names = self._discover_blob_names(param_path)
+        input_names_fn = getattr(self.net, "input_names", None)
+        output_names_fn = getattr(self.net, "output_names", None)
+        if callable(input_names_fn) and callable(output_names_fn):
+            self._input_names = list(input_names_fn())
+            self._output_names = list(output_names_fn())
+        else:
+            self._input_names, self._output_names = self._discover_blob_names(param_path)
 
         super().__init__(
             model_path=str(model_dir),
@@ -169,4 +175,13 @@ class NcnnBackend(BaseBackend):
                         f"Failed to extract output '{out_name}' from ncnn model"
                     )
             all_outputs.append(np.array(mat_out).reshape(1, *np.array(mat_out).shape))
+
+        # YOLO-NAS exports two outputs (scores, boxes) from pnnx as out1/out0.
+        # Reorder them to [boxes, scores] so the shared backend parser can stay
+        # aligned with the ONNX/TorchScript/OpenVINO conventions.
+        if self.model_family == "yolonas" and len(all_outputs) == 2:
+            first, second = all_outputs
+            if first.shape[-1] != 4 and second.shape[-1] == 4:
+                all_outputs = [second, first]
+
         return all_outputs

--- a/libreyolo/backends/torchscript.py
+++ b/libreyolo/backends/torchscript.py
@@ -1,0 +1,97 @@
+"""TorchScript inference backend for LibreYOLO."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from ..utils.general import COCO_CLASSES
+from .base import BaseBackend
+
+
+class TorchScriptBackend(BaseBackend):
+    """TorchScript inference backend for LibreYOLO models."""
+
+    def __init__(
+        self, model_path: str, nb_classes: int | None = None, device: str = "auto"
+    ):
+        if not Path(model_path).exists():
+            raise FileNotFoundError(f"TorchScript model not found: {model_path}")
+
+        if device == "auto":
+            if torch.cuda.is_available():
+                resolved_device = "cuda"
+            elif torch.backends.mps.is_available():
+                resolved_device = "mps"
+            else:
+                resolved_device = "cpu"
+        else:
+            resolved_device = device
+
+        map_location = torch.device(resolved_device)
+        extra_files = {"libreyolo_metadata.json": ""}
+        self.model = torch.jit.load(
+            model_path, map_location=map_location, _extra_files=extra_files
+        )
+        self.model.eval()
+
+        metadata = {}
+        raw_meta = extra_files.get("libreyolo_metadata.json", "")
+        if raw_meta:
+            metadata = json.loads(raw_meta)
+
+        input_size = 640
+        model_family = metadata.get("model_family")
+        if "imgsz" in metadata:
+            input_size = int(metadata["imgsz"])
+
+        if nb_classes is not None:
+            resolved_nb_classes = nb_classes
+        elif "nb_classes" in metadata:
+            resolved_nb_classes = int(metadata["nb_classes"])
+        else:
+            resolved_nb_classes = 80
+
+        if "names" in metadata:
+            names_raw = metadata["names"]
+            if isinstance(names_raw, str):
+                names_raw = json.loads(names_raw)
+            names = {int(k): v for k, v in names_raw.items()}
+        elif resolved_nb_classes == 80:
+            names = {i: n for i, n in enumerate(COCO_CLASSES)}
+        else:
+            names = self.build_names(resolved_nb_classes)
+
+        super().__init__(
+            model_path=model_path,
+            nb_classes=resolved_nb_classes,
+            device=resolved_device,
+            imgsz=input_size,
+            model_family=model_family,
+            names=names,
+        )
+
+    def _run_inference(self, blob: np.ndarray) -> list:
+        tensor = torch.from_numpy(blob).to(self.device)
+        with torch.no_grad():
+            outputs = self.model(tensor)
+
+        if isinstance(outputs, torch.Tensor):
+            return [outputs.detach().cpu().numpy()]
+
+        if isinstance(outputs, (tuple, list)):
+            out_list = []
+            for out in outputs:
+                if isinstance(out, torch.Tensor):
+                    out_list.append(out.detach().cpu().numpy())
+                else:
+                    raise TypeError(
+                        "Unsupported TorchScript output element type: "
+                        f"{type(out)!r}"
+                    )
+            return out_list
+
+        raise TypeError(f"Unsupported TorchScript output type: {type(outputs)!r}")

--- a/libreyolo/data/yolo_coco_api.py
+++ b/libreyolo/data/yolo_coco_api.py
@@ -383,19 +383,12 @@ def create_yolo_coco_api(data_yaml_path: str, split: str = "val") -> YOLOCocoAPI
         >>> coco_api = create_yolo_coco_api("path/to/data.yaml", split="val")
         >>> # Use with COCOeval
     """
-    import yaml
+    from .utils import load_data_config
 
-    with open(data_yaml_path, "r") as f:
-        data = yaml.safe_load(f)
-
-    # Get root directory
-    root = Path(data_yaml_path).parent
-    if "path" in data:
-        root_override = Path(data["path"])
-        if not root_override.is_absolute():
-            root = root / root_override
-        else:
-            root = root_override
+    # Reuse the same YAML alias and dataset-root resolution logic as the main
+    # loader so COCO evaluation works for dataset names like "coco128.yaml".
+    data = load_data_config(data_yaml_path, autodownload=False)
+    root = Path(data["path"])
 
     # Get class names
     names = data.get("names", [])
@@ -410,9 +403,9 @@ def create_yolo_coco_api(data_yaml_path: str, split: str = "val") -> YOLOCocoAPI
     # Get split paths
     split_key = split.split("_")[0]  # Handle 'val_speed' etc.
     images_subpath = data.get(split_key, f"images/{split_key}")
-
-    # Resolve images directory
-    images_dir = root / images_subpath
+    images_dir = Path(images_subpath)
+    if not images_dir.is_absolute():
+        images_dir = root / images_subpath
     if not images_dir.exists():
         # Try with 'images/' prefix
         images_dir = root / "images" / split_key

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -438,8 +438,10 @@ class TorchScriptExporter(BaseExporter):
     supports_int8 = False
     apply_model_half = True
 
-    def _export(self, nn_model, dummy, *, output_path, **kwargs):
-        return export_torchscript(nn_model, dummy, output_path=output_path)
+    def _export(self, nn_model, dummy, *, output_path, metadata, **kwargs):
+        return export_torchscript(
+            nn_model, dummy, output_path=output_path, metadata=metadata
+        )
 
 
 class TensorRTExporter(BaseExporter):

--- a/libreyolo/export/torchscript.py
+++ b/libreyolo/export/torchscript.py
@@ -4,20 +4,28 @@ TorchScript export implementation.
 Exports PyTorch models to TorchScript format via tracing.
 """
 
+import json
+
 import torch
 
 
-def export_torchscript(nn_model, dummy, *, output_path: str) -> str:
+def export_torchscript(
+    nn_model, dummy, *, output_path: str, metadata: dict | None = None
+) -> str:
     """Export a PyTorch model to TorchScript format.
 
     Args:
         nn_model: The PyTorch nn.Module to export.
         dummy: Dummy input tensor for tracing.
         output_path: Destination file path for the .torchscript file.
+        metadata: Optional metadata dict to embed as an extra file.
 
     Returns:
         The output_path string.
     """
     traced = torch.jit.trace(nn_model, dummy)
-    traced.save(output_path)
+    extra_files = {}
+    if metadata:
+        extra_files["libreyolo_metadata.json"] = json.dumps(metadata)
+    torch.jit.save(traced, output_path, _extra_files=extra_files)
     return output_path

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -22,6 +22,7 @@ from ..utils.download import download_weights
 # Always-available models (importing triggers __init_subclass__ registration)
 from .yolox.model import LibreYOLOX  # noqa: E402
 from .yolo9.model import LibreYOLO9  # noqa: E402
+from .yolonas.model import LibreYOLONAS  # noqa: E402
 
 
 def _ensure_rfdetr():
@@ -57,12 +58,25 @@ def _resolve_weights_path(model_path: str) -> str:
 
 
 def _unwrap_state_dict(state_dict: dict) -> dict:
-    """Extract weights from nested checkpoint formats (EMA, model wrappers)."""
+    """Extract weights from nested checkpoint formats.
+
+    Supports:
+    - LibreYOLO trainer checkpoints (``model``)
+    - legacy EMA wrappers (``ema``)
+    - SuperGradients checkpoints (``ema_net`` / ``net``)
+    - generic wrappers (``state_dict``)
+    """
     if "ema" in state_dict and isinstance(state_dict.get("ema"), dict):
         ema_data = state_dict["ema"]
         return ema_data.get("module", ema_data)
+    if "ema_net" in state_dict and isinstance(state_dict.get("ema_net"), dict):
+        return state_dict["ema_net"]
+    if "net" in state_dict and isinstance(state_dict.get("net"), dict):
+        return state_dict["net"]
     if "model" in state_dict and isinstance(state_dict.get("model"), dict):
         return state_dict["model"]
+    if "state_dict" in state_dict and isinstance(state_dict.get("state_dict"), dict):
+        return state_dict["state_dict"]
     return state_dict
 
 
@@ -102,6 +116,11 @@ def LibreYOLO(
         from ..backends.onnx import OnnxBackend
 
         return OnnxBackend(model_path, nb_classes=nb_classes or 80, device=device)
+
+    if model_path.endswith(".torchscript"):
+        from ..backends.torchscript import TorchScriptBackend
+
+        return TorchScriptBackend(model_path, nb_classes=nb_classes, device=device)
 
     if model_path.endswith((".engine", ".tensorrt")):
         from ..backends.tensorrt import TensorRTBackend
@@ -194,7 +213,7 @@ def LibreYOLO(
     if matched_cls is None:
         raise ValueError(
             "Could not detect model architecture from state dict keys.\n"
-            "Supported architectures: YOLOX, YOLOv9, RF-DETR."
+            "Supported architectures: YOLOX, YOLOv9, YOLO-NAS, RF-DETR."
         )
 
     # Auto-detect size

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -300,6 +300,7 @@ class LibreYOLO9(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreYOLO9('path/to/last.pt', size='t'); model.train(data=..., resume=True)"
                 )
+            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()

--- a/libreyolo/models/yolonas/__init__.py
+++ b/libreyolo/models/yolonas/__init__.py
@@ -1,0 +1,5 @@
+"""YOLO-NAS model package."""
+
+from .model import LibreYOLONAS
+
+__all__ = ["LibreYOLONAS"]

--- a/libreyolo/models/yolonas/loss.py
+++ b/libreyolo/models/yolonas/loss.py
@@ -1,0 +1,731 @@
+"""YOLO-NAS loss functions for native LibreYOLO training.
+
+Ported and adapted from SuperGradients PP-YOLOE / YOLO-NAS training code.
+The implementation here stays self-contained and uses LibreYOLO tensor
+conventions plus a small target adapter for the shared dataloader output.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+from ...utils.general import cxcywh_to_xyxy
+from .nn import batch_distance2bbox
+
+
+def flatten_yolonas_targets(targets: Tensor) -> Tensor:
+    """Convert padded `(B, max_labels, 5)` targets to flat `(N, 6)`.
+
+    Input rows are expected in `[class, cx, cy, w, h]` pixel coordinates.
+    Empty rows are identified by non-positive width/height.
+    """
+    if targets.ndim != 3 or targets.shape[-1] != 5:
+        raise ValueError(
+            "YOLO-NAS training expects targets shaped (B, max_labels, 5), "
+            f"got {tuple(targets.shape)}"
+        )
+
+    valid = (targets[..., 3] > 0) & (targets[..., 4] > 0)
+    if not valid.any():
+        return targets.new_zeros((0, 6))
+
+    batch_idx = torch.arange(
+        targets.shape[0], dtype=targets.dtype, device=targets.device
+    ).view(-1, 1, 1)
+    batch_idx = batch_idx.expand(-1, targets.shape[1], 1)
+    flat = torch.cat([batch_idx, targets], dim=-1)
+    return flat[valid]
+
+
+def batch_iou_similarity(box1: Tensor, box2: Tensor, eps: float = 1e-9) -> Tensor:
+    box1 = box1.unsqueeze(2)
+    box2 = box2.unsqueeze(1)
+    px1y1, px2y2 = box1[..., 0:2], box1[..., 2:4]
+    gx1y1, gx2y2 = box2[..., 0:2], box2[..., 2:4]
+    x1y1 = torch.maximum(px1y1, gx1y1)
+    x2y2 = torch.minimum(px2y2, gx2y2)
+    overlap = (x2y2 - x1y1).clamp_min(0).prod(-1)
+    area1 = (px2y2 - px1y1).clamp_min(0).prod(-1)
+    area2 = (gx2y2 - gx1y1).clamp_min(0).prod(-1)
+    union = area1 + area2 - overlap + eps
+    return overlap / union
+
+
+def iou_similarity(box1: Tensor, box2: Tensor, eps: float = 1e-9) -> Tensor:
+    box1 = box1.unsqueeze(1)
+    box2 = box2.unsqueeze(0)
+    px1y1, px2y2 = box1[..., 0:2], box1[..., 2:4]
+    gx1y1, gx2y2 = box2[..., 0:2], box2[..., 2:4]
+    x1y1 = torch.maximum(px1y1, gx1y1)
+    x2y2 = torch.minimum(px2y2, gx2y2)
+    overlap = (x2y2 - x1y1).clamp_min(0).prod(-1)
+    area1 = (px2y2 - px1y1).clamp_min(0).prod(-1)
+    area2 = (gx2y2 - gx1y1).clamp_min(0).prod(-1)
+    union = area1 + area2 - overlap + eps
+    return overlap / union
+
+
+def compute_max_iou_anchor(ious: Tensor) -> Tensor:
+    num_max_boxes = ious.shape[-2]
+    max_iou_index = ious.argmax(dim=-2)
+    is_max_iou = F.one_hot(max_iou_index, num_max_boxes).permute(0, 2, 1)
+    return is_max_iou.type_as(ious)
+
+
+def compute_max_iou_gt(ious: Tensor) -> Tensor:
+    num_anchors = ious.shape[-1]
+    max_iou_index = ious.argmax(dim=-1)
+    is_max_iou = F.one_hot(max_iou_index, num_anchors)
+    return is_max_iou.type_as(ious)
+
+
+def bbox_center(boxes: Tensor) -> Tensor:
+    boxes_cx = (boxes[..., 0] + boxes[..., 2]) / 2
+    boxes_cy = (boxes[..., 1] + boxes[..., 3]) / 2
+    return torch.stack([boxes_cx, boxes_cy], dim=-1)
+
+
+def check_points_inside_bboxes(
+    points: Tensor,
+    bboxes: Tensor,
+    center_radius_tensor: Optional[Tensor] = None,
+    eps: float = 1e-9,
+):
+    points = points.unsqueeze(0).unsqueeze(0)
+    x, y = points.chunk(2, dim=-1)
+    xmin, ymin, xmax, ymax = bboxes.unsqueeze(2).chunk(4, dim=-1)
+
+    left = x - xmin
+    top = y - ymin
+    right = xmax - x
+    bottom = ymax - y
+    delta_ltrb = torch.cat([left, top, right, bottom], dim=-1)
+    is_in_bboxes = delta_ltrb.min(dim=-1).values > eps
+
+    if center_radius_tensor is not None:
+        center_radius_tensor = center_radius_tensor.unsqueeze(0).unsqueeze(0)
+        cx = (xmin + xmax) * 0.5
+        cy = (ymin + ymax) * 0.5
+        left = x - (cx - center_radius_tensor)
+        top = y - (cy - center_radius_tensor)
+        right = (cx + center_radius_tensor) - x
+        bottom = (cy + center_radius_tensor) - y
+        delta_ltrb_c = torch.cat([left, top, right, bottom], dim=-1)
+        is_in_center = delta_ltrb_c.min(dim=-1).values > eps
+        return (
+            torch.logical_and(is_in_bboxes, is_in_center),
+            torch.logical_or(is_in_bboxes, is_in_center),
+        )
+
+    return is_in_bboxes.type_as(bboxes)
+
+
+def gather_topk_anchors(
+    metrics: Tensor,
+    topk: int,
+    largest: bool = True,
+    topk_mask: Optional[Tensor] = None,
+    eps: float = 1e-9,
+) -> Tensor:
+    num_anchors = metrics.shape[-1]
+    topk_metrics, topk_idxs = torch.topk(metrics, topk, dim=-1, largest=largest)
+    if topk_mask is None:
+        topk_mask = (
+            topk_metrics.max(dim=-1, keepdim=True).values > eps
+        ).type_as(metrics)
+    is_in_topk = F.one_hot(topk_idxs, num_anchors).sum(dim=-2).type_as(metrics)
+    return is_in_topk * topk_mask
+
+
+class ATSSAssigner(nn.Module):
+    def __init__(
+        self,
+        topk: int = 9,
+        num_classes: int = 80,
+        force_gt_matching: bool = False,
+        eps: float = 1e-9,
+    ):
+        super().__init__()
+        self.topk = topk
+        self.num_classes = num_classes
+        self.force_gt_matching = force_gt_matching
+        self.eps = eps
+
+    def _gather_topk_pyramid(
+        self,
+        gt2anchor_distances: Tensor,
+        num_anchors_list: list[int],
+        pad_gt_mask: Optional[Tensor],
+    ):
+        gt2anchor_distances_list = torch.split(
+            gt2anchor_distances, num_anchors_list, dim=-1
+        )
+        num_anchors_index = [0]
+        for n in num_anchors_list[:-1]:
+            num_anchors_index.append(num_anchors_index[-1] + n)
+
+        is_in_topk_list = []
+        topk_idxs_list = []
+        for distances, anchors_index in zip(gt2anchor_distances_list, num_anchors_index):
+            num_anchors = distances.shape[-1]
+            _, topk_idxs = torch.topk(distances, self.topk, dim=-1, largest=False)
+            topk_idxs_list.append(topk_idxs + anchors_index)
+            is_in_topk = F.one_hot(topk_idxs, num_anchors).sum(dim=-2).type_as(
+                gt2anchor_distances
+            )
+            if pad_gt_mask is not None:
+                is_in_topk = is_in_topk * pad_gt_mask
+            is_in_topk_list.append(is_in_topk)
+        return torch.cat(is_in_topk_list, dim=-1), torch.cat(topk_idxs_list, dim=-1)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        anchor_bboxes: Tensor,
+        num_anchors_list: list[int],
+        gt_labels: Tensor,
+        gt_bboxes: Tensor,
+        pad_gt_mask: Optional[Tensor],
+        bg_index: int,
+        gt_scores: Optional[Tensor] = None,
+        pred_bboxes: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        num_anchors, _ = anchor_bboxes.shape
+        batch_size, num_max_boxes, _ = gt_bboxes.shape
+
+        if num_max_boxes == 0:
+            assigned_labels = torch.full(
+                [batch_size, num_anchors],
+                bg_index,
+                dtype=torch.long,
+                device=anchor_bboxes.device,
+            )
+            assigned_bboxes = torch.zeros(
+                [batch_size, num_anchors, 4], device=anchor_bboxes.device
+            )
+            assigned_scores = torch.zeros(
+                [batch_size, num_anchors, self.num_classes], device=anchor_bboxes.device
+            )
+            return assigned_labels, assigned_bboxes, assigned_scores
+
+        ious = iou_similarity(gt_bboxes.reshape([-1, 4]), anchor_bboxes)
+        ious = ious.reshape([batch_size, -1, num_anchors])
+
+        gt_centers = bbox_center(gt_bboxes.reshape([-1, 4])).unsqueeze(1)
+        anchor_centers = bbox_center(anchor_bboxes)
+        gt2anchor_distances = torch.norm(
+            gt_centers - anchor_centers.unsqueeze(0), p=2, dim=-1
+        ).reshape([batch_size, -1, num_anchors])
+
+        is_in_topk, topk_idxs = self._gather_topk_pyramid(
+            gt2anchor_distances, num_anchors_list, pad_gt_mask
+        )
+
+        iou_candidates = ious * is_in_topk
+        iou_threshold = torch.gather(
+            iou_candidates.flatten(end_dim=-2),
+            dim=1,
+            index=topk_idxs.flatten(end_dim=-2),
+        )
+        iou_threshold = iou_threshold.reshape([batch_size, num_max_boxes, -1])
+        iou_threshold = iou_threshold.mean(dim=-1, keepdim=True) + iou_threshold.std(
+            dim=-1, keepdim=True
+        )
+        is_in_topk = torch.where(
+            iou_candidates > iou_threshold, is_in_topk, torch.zeros_like(is_in_topk)
+        )
+
+        is_in_gts = check_points_inside_bboxes(anchor_centers, gt_bboxes)
+        mask_positive = is_in_topk * is_in_gts
+        if pad_gt_mask is not None:
+            mask_positive = mask_positive * pad_gt_mask
+
+        mask_positive_sum = mask_positive.sum(dim=-2)
+        if mask_positive_sum.max() > 1:
+            mask_multiple_gts = (mask_positive_sum.unsqueeze(1) > 1).tile(
+                [1, num_max_boxes, 1]
+            )
+            is_max_iou = compute_max_iou_anchor(ious)
+            mask_positive = torch.where(mask_multiple_gts, is_max_iou, mask_positive)
+            mask_positive_sum = mask_positive.sum(dim=-2)
+
+        if self.force_gt_matching:
+            is_max_iou = compute_max_iou_gt(ious)
+            if pad_gt_mask is not None:
+                is_max_iou = is_max_iou * pad_gt_mask
+            mask_max_iou = (is_max_iou.sum(-2, keepdim=True) == 1).tile(
+                [1, num_max_boxes, 1]
+            )
+            mask_positive = torch.where(mask_max_iou, is_max_iou, mask_positive)
+            mask_positive_sum = mask_positive.sum(dim=-2)
+
+        assigned_gt_index = mask_positive.argmax(dim=-2)
+        batch_ind = torch.arange(
+            end=batch_size, dtype=gt_labels.dtype, device=gt_labels.device
+        ).unsqueeze(-1)
+        assigned_gt_index = assigned_gt_index + batch_ind * num_max_boxes
+
+        assigned_labels = torch.gather(
+            gt_labels.flatten(), index=assigned_gt_index.flatten(), dim=0
+        )
+        assigned_labels = assigned_labels.reshape([batch_size, num_anchors])
+        assigned_labels = torch.where(
+            mask_positive_sum > 0,
+            assigned_labels,
+            torch.full_like(assigned_labels, bg_index),
+        )
+
+        assigned_bboxes = gt_bboxes.reshape([-1, 4])[assigned_gt_index.flatten(), :]
+        assigned_bboxes = assigned_bboxes.reshape([batch_size, num_anchors, 4])
+
+        assigned_scores = F.one_hot(assigned_labels, self.num_classes + 1).float()
+        indices = [i for i in range(self.num_classes + 1) if i != bg_index]
+        assigned_scores = torch.index_select(
+            assigned_scores,
+            index=torch.tensor(indices, device=assigned_scores.device),
+            dim=-1,
+        )
+
+        if pred_bboxes is not None:
+            ious = batch_iou_similarity(gt_bboxes, pred_bboxes) * mask_positive
+            ious = ious.max(dim=-2).values.unsqueeze(-1)
+            assigned_scores = assigned_scores * ious
+        elif gt_scores is not None:
+            gather_scores = torch.gather(
+                gt_scores.flatten(), assigned_gt_index.flatten(), dim=0
+            )
+            gather_scores = gather_scores.reshape([batch_size, num_anchors])
+            gather_scores = torch.where(
+                mask_positive_sum > 0, gather_scores, torch.zeros_like(gather_scores)
+            )
+            assigned_scores = assigned_scores * gather_scores.unsqueeze(-1)
+
+        return assigned_labels, assigned_bboxes, assigned_scores
+
+
+class TaskAlignedAssigner(nn.Module):
+    def __init__(
+        self, topk: int = 13, alpha: float = 1.0, beta: float = 6.0, eps: float = 1e-9
+    ):
+        super().__init__()
+        self.topk = topk
+        self.alpha = alpha
+        self.beta = beta
+        self.eps = eps
+
+    @torch.no_grad()
+    def forward(
+        self,
+        pred_scores: Tensor,
+        pred_bboxes: Tensor,
+        anchor_points: Tensor,
+        num_anchors_list: list[int],
+        gt_labels: Tensor,
+        gt_bboxes: Tensor,
+        pad_gt_mask: Optional[Tensor],
+        bg_index: int,
+        gt_scores: Optional[Tensor] = None,
+    ):
+        del num_anchors_list, gt_scores
+
+        batch_size, num_anchors, num_classes = pred_scores.shape
+        _, num_max_boxes, _ = gt_bboxes.shape
+
+        if num_max_boxes == 0:
+            assigned_labels = torch.full(
+                [batch_size, num_anchors],
+                bg_index,
+                dtype=torch.long,
+                device=gt_labels.device,
+            )
+            assigned_bboxes = torch.zeros(
+                [batch_size, num_anchors, 4], device=gt_labels.device
+            )
+            assigned_scores = torch.zeros(
+                [batch_size, num_anchors, num_classes], device=gt_labels.device
+            )
+            return assigned_labels, assigned_bboxes, assigned_scores
+
+        ious = batch_iou_similarity(gt_bboxes, pred_bboxes)
+        pred_scores = torch.permute(pred_scores, [0, 2, 1])
+        batch_ind = torch.arange(
+            end=batch_size, dtype=gt_labels.dtype, device=gt_labels.device
+        ).unsqueeze(-1)
+        gt_labels_ind = torch.stack(
+            [batch_ind.tile([1, num_max_boxes]), gt_labels.squeeze(-1)], dim=-1
+        )
+        bbox_cls_scores = pred_scores[gt_labels_ind[..., 0], gt_labels_ind[..., 1]]
+        alignment_metrics = bbox_cls_scores.pow(self.alpha) * ious.pow(self.beta)
+
+        is_in_gts = check_points_inside_bboxes(anchor_points, gt_bboxes)
+        is_in_topk = gather_topk_anchors(
+            alignment_metrics * is_in_gts, self.topk, topk_mask=pad_gt_mask
+        )
+
+        mask_positive = is_in_topk * is_in_gts
+        if pad_gt_mask is not None:
+            mask_positive *= pad_gt_mask
+
+        mask_positive_sum = mask_positive.sum(dim=-2)
+        if mask_positive_sum.max() > 1:
+            mask_multiple_gts = (mask_positive_sum.unsqueeze(1) > 1).tile(
+                [1, num_max_boxes, 1]
+            )
+            is_max_iou = compute_max_iou_anchor(ious)
+            mask_positive = torch.where(mask_multiple_gts, is_max_iou, mask_positive)
+            mask_positive_sum = mask_positive.sum(dim=-2)
+
+        assigned_gt_index = mask_positive.argmax(dim=-2)
+        assigned_gt_index = assigned_gt_index + batch_ind * num_max_boxes
+        assigned_labels = torch.gather(
+            gt_labels.flatten(), index=assigned_gt_index.flatten(), dim=0
+        )
+        assigned_labels = assigned_labels.reshape([batch_size, num_anchors])
+        assigned_labels = torch.where(
+            mask_positive_sum > 0,
+            assigned_labels,
+            torch.full_like(assigned_labels, bg_index),
+        )
+
+        assigned_bboxes = gt_bboxes.reshape([-1, 4])[assigned_gt_index.flatten(), :]
+        assigned_bboxes = assigned_bboxes.reshape([batch_size, num_anchors, 4])
+
+        assigned_scores = F.one_hot(assigned_labels, num_classes + 1)
+        indices = [i for i in range(num_classes + 1) if i != bg_index]
+        assigned_scores = torch.index_select(
+            assigned_scores,
+            index=torch.tensor(indices, device=assigned_scores.device, dtype=torch.long),
+            dim=-1,
+        )
+
+        alignment_metrics *= mask_positive
+        max_metrics_per_instance = alignment_metrics.max(dim=-1, keepdim=True).values
+        max_ious_per_instance = (ious * mask_positive).max(dim=-1, keepdim=True).values
+        alignment_metrics = alignment_metrics / (
+            max_metrics_per_instance + self.eps
+        ) * max_ious_per_instance
+        alignment_metrics = alignment_metrics.max(dim=-2).values.unsqueeze(-1)
+        assigned_scores = assigned_scores * alignment_metrics
+
+        return assigned_labels, assigned_bboxes, assigned_scores
+
+
+class GIoULoss:
+    def __init__(
+        self, loss_weight: float = 1.0, eps: float = 1e-10, reduction: str = "none"
+    ):
+        self.loss_weight = loss_weight
+        self.eps = eps
+        if reduction not in ("none", "mean", "sum"):
+            raise ValueError(f"Unsupported reduction: {reduction}")
+        self.reduction = reduction
+
+    def bbox_overlap(
+        self, box1: Tensor, box2: Tensor, eps: float = 1e-10
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        x1, y1, x2, y2 = box1
+        x1g, y1g, x2g, y2g = box2
+        xkis1 = torch.maximum(x1, x1g)
+        ykis1 = torch.maximum(y1, y1g)
+        xkis2 = torch.minimum(x2, x2g)
+        ykis2 = torch.minimum(y2, y2g)
+        w_inter = (xkis2 - xkis1).clamp_min(0)
+        h_inter = (ykis2 - ykis1).clamp_min(0)
+        overlap = w_inter * h_inter
+
+        area1 = (x2 - x1) * (y2 - y1)
+        area2 = (x2g - x1g) * (y2g - y1g)
+        union = area1 + area2 - overlap + eps
+        iou = overlap / union
+        return iou, overlap, union
+
+    def __call__(self, pbox: Tensor, gbox: Tensor, iou_weight=1.0, loc_reweight=None):
+        x1, y1, x2, y2 = pbox.chunk(4, dim=-1)
+        x1g, y1g, x2g, y2g = gbox.chunk(4, dim=-1)
+
+        iou, _, union = self.bbox_overlap(
+            [x1, y1, x2, y2], [x1g, y1g, x2g, y2g], self.eps
+        )
+        xc1 = torch.minimum(x1, x1g)
+        yc1 = torch.minimum(y1, y1g)
+        xc2 = torch.maximum(x2, x2g)
+        yc2 = torch.maximum(y2, y2g)
+
+        area_c = (xc2 - xc1) * (yc2 - yc1) + self.eps
+        miou = iou - ((area_c - union) / area_c)
+        if loc_reweight is not None:
+            loc_reweight = torch.reshape(loc_reweight, shape=(-1, 1))
+            loc_thresh = 0.9
+            giou = 1 - (1 - loc_thresh) * miou - loc_thresh * miou * loc_reweight
+        else:
+            giou = 1 - miou
+
+        if self.reduction == "none":
+            loss = giou
+        elif self.reduction == "sum":
+            loss = torch.sum(giou * iou_weight)
+        else:
+            loss = torch.mean(giou * iou_weight)
+        return loss * self.loss_weight
+
+
+class PPYoloELoss(nn.Module):
+    """Native YOLO-NAS / PP-YOLOE loss for LibreYOLO."""
+
+    def __init__(
+        self,
+        num_classes: int,
+        use_varifocal_loss: bool = True,
+        use_static_assigner: bool = False,
+        classification_loss_weight: float = 1.0,
+        iou_loss_weight: float = 2.5,
+        dfl_loss_weight: float = 0.5,
+    ):
+        super().__init__()
+        self.use_varifocal_loss = use_varifocal_loss
+        self.classification_loss_weight = classification_loss_weight
+        self.iou_loss_weight = iou_loss_weight
+        self.dfl_loss_weight = dfl_loss_weight
+        self.num_classes = num_classes
+
+        self.iou_loss = GIoULoss()
+        self.static_assigner = ATSSAssigner(topk=9, num_classes=num_classes)
+        self.assigner = TaskAlignedAssigner(topk=13, alpha=1.0, beta=6.0)
+        self.use_static_assigner = use_static_assigner
+
+    def get_proj_conv_for_reg_max(self, reg_max: int, device: torch.device) -> Tensor:
+        return torch.linspace(0, reg_max, reg_max + 1, device=device).reshape(
+            [1, reg_max + 1, 1, 1]
+        )
+
+    @torch.no_grad()
+    def _get_targets_for_batched_assigner(
+        self, targets: Tensor, batch_size: int
+    ) -> dict[str, Tensor]:
+        image_index = targets[:, 0]
+        gt_class = targets[:, 1:2].long()
+        gt_bbox = cxcywh_to_xyxy(targets[:, 2:6])
+
+        per_image_class = []
+        per_image_bbox = []
+        per_image_pad_mask = []
+
+        max_boxes = 0
+        for i in range(batch_size):
+            mask = image_index == i
+            image_labels = gt_class[mask]
+            image_bboxes = gt_bbox[mask, :]
+            valid_bboxes = image_bboxes.sum(dim=1, keepdims=True) > 0
+
+            per_image_class.append(image_labels)
+            per_image_bbox.append(image_bboxes)
+            per_image_pad_mask.append(valid_bboxes)
+
+            max_boxes = max(max_boxes, int(mask.sum().item()))
+
+        for i in range(batch_size):
+            elements_to_pad = max_boxes - len(per_image_class[i])
+            pad = (0, 0, 0, elements_to_pad)
+            per_image_class[i] = F.pad(per_image_class[i], pad, mode="constant", value=0)
+            per_image_bbox[i] = F.pad(per_image_bbox[i], pad, mode="constant", value=0)
+            per_image_pad_mask[i] = F.pad(
+                per_image_pad_mask[i], pad, mode="constant", value=0
+            )
+
+        return {
+            "gt_class": torch.stack(per_image_class, dim=0),
+            "gt_bbox": torch.stack(per_image_bbox, dim=0),
+            "pad_gt_mask": torch.stack(per_image_pad_mask, dim=0),
+        }
+
+    def _forward_batched(
+        self,
+        predictions: Tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor],
+        targets: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        (
+            pred_scores,
+            pred_distri,
+            anchors,
+            anchor_points,
+            num_anchors_list,
+            stride_tensor,
+        ) = predictions
+
+        targets = self._get_targets_for_batched_assigner(
+            targets, batch_size=pred_scores.size(0)
+        )
+        anchor_points_s = anchor_points / stride_tensor
+        pred_bboxes, reg_max, _ = self._bbox_decode(anchor_points_s, pred_distri)
+
+        gt_labels = targets["gt_class"]
+        gt_bboxes = targets["gt_bbox"]
+        pad_gt_mask = targets["pad_gt_mask"]
+
+        if self.use_static_assigner:
+            assigned_labels, assigned_bboxes, assigned_scores = self.static_assigner(
+                anchor_bboxes=anchors,
+                num_anchors_list=num_anchors_list,
+                gt_labels=gt_labels,
+                gt_bboxes=gt_bboxes,
+                pad_gt_mask=pad_gt_mask,
+                bg_index=self.num_classes,
+                pred_bboxes=pred_bboxes.detach() * stride_tensor,
+            )
+            alpha_l = 0.25
+        else:
+            assigned_labels, assigned_bboxes, assigned_scores = self.assigner(
+                pred_scores=pred_scores.detach().sigmoid(),
+                pred_bboxes=pred_bboxes.detach() * stride_tensor,
+                anchor_points=anchor_points,
+                num_anchors_list=num_anchors_list,
+                gt_labels=gt_labels,
+                gt_bboxes=gt_bboxes,
+                pad_gt_mask=pad_gt_mask,
+                bg_index=self.num_classes,
+            )
+            alpha_l = -1
+
+        if self.use_varifocal_loss:
+            one_hot_label = F.one_hot(
+                assigned_labels, self.num_classes + 1
+            )[..., :-1]
+            cls_loss_sum = self._varifocal_loss(
+                pred_scores, assigned_scores, one_hot_label
+            )
+        else:
+            cls_loss_sum = self._focal_loss(pred_scores, assigned_scores, alpha_l)
+
+        assigned_scores_sum = assigned_scores.sum()
+        iou_loss_sum, dfl_loss_sum = self._bbox_loss(
+            pred_distri,
+            pred_bboxes,
+            anchor_points_s,
+            assigned_labels,
+            assigned_bboxes / stride_tensor,
+            assigned_scores,
+            reg_max,
+        )
+        return cls_loss_sum, iou_loss_sum, dfl_loss_sum, assigned_scores_sum
+
+    def forward(self, outputs, targets: Tensor):
+        if targets.ndim == 3:
+            targets = flatten_yolonas_targets(targets)
+
+        if isinstance(outputs, tuple) and len(outputs) == 2:
+            _, predictions = outputs
+        else:
+            predictions = outputs
+
+        cls_loss_sum, iou_loss_sum, dfl_loss_sum, assigned_scores_sum = (
+            self._forward_batched(predictions, targets)
+        )
+
+        assigned_scores_sum = torch.clamp(assigned_scores_sum, min=1.0)
+        cls_loss = self.classification_loss_weight * cls_loss_sum / assigned_scores_sum
+        iou_loss = self.iou_loss_weight * iou_loss_sum / assigned_scores_sum
+        dfl_loss = self.dfl_loss_weight * dfl_loss_sum / assigned_scores_sum
+        loss = cls_loss + iou_loss + dfl_loss
+        log_losses = torch.stack(
+            [cls_loss.detach(), iou_loss.detach(), dfl_loss.detach(), loss.detach()]
+        )
+        return loss, log_losses
+
+    def _df_loss(self, pred_dist: Tensor, target: Tensor) -> Tensor:
+        target_left = target.long()
+        target_right = target_left + 1
+        weight_left = target_right.float() - target
+        weight_right = 1 - weight_left
+
+        pred_dist = torch.moveaxis(pred_dist, -1, 1)
+        loss_left = (
+            F.cross_entropy(pred_dist, target_left, reduction="none") * weight_left
+        )
+        loss_right = (
+            F.cross_entropy(pred_dist, target_right, reduction="none") * weight_right
+        )
+        return (loss_left + loss_right).mean(dim=-1, keepdim=True)
+
+    def _bbox_loss(
+        self,
+        pred_dist: Tensor,
+        pred_bboxes: Tensor,
+        anchor_points: Tensor,
+        assigned_labels: Tensor,
+        assigned_bboxes: Tensor,
+        assigned_scores: Tensor,
+        reg_max: int,
+    ) -> Tuple[Tensor, Tensor]:
+        mask_positive = assigned_labels != self.num_classes
+        num_pos = mask_positive.sum()
+        if num_pos > 0:
+            bbox_mask = mask_positive.unsqueeze(-1).tile([1, 1, 4])
+            pred_bboxes_pos = torch.masked_select(pred_bboxes, bbox_mask).reshape(
+                [-1, 4]
+            )
+            assigned_bboxes_pos = torch.masked_select(
+                assigned_bboxes, bbox_mask
+            ).reshape([-1, 4])
+            bbox_weight = torch.masked_select(
+                assigned_scores.sum(-1), mask_positive
+            ).unsqueeze(-1)
+
+            loss_iou = self.iou_loss(pred_bboxes_pos, assigned_bboxes_pos) * bbox_weight
+            loss_iou = loss_iou.sum()
+
+            dist_mask = mask_positive.unsqueeze(-1).tile([1, 1, (reg_max + 1) * 4])
+            pred_dist_pos = torch.masked_select(pred_dist, dist_mask).reshape(
+                [-1, 4, reg_max + 1]
+            )
+            assigned_ltrb = self._bbox2distance(anchor_points, assigned_bboxes, reg_max)
+            assigned_ltrb_pos = torch.masked_select(assigned_ltrb, bbox_mask).reshape(
+                [-1, 4]
+            )
+            loss_dfl = self._df_loss(pred_dist_pos, assigned_ltrb_pos) * bbox_weight
+            loss_dfl = loss_dfl.sum()
+        else:
+            loss_iou = torch.zeros([], device=pred_bboxes.device)
+            loss_dfl = pred_dist.sum() * 0.0
+        return loss_iou, loss_dfl
+
+    def _bbox_decode(self, anchor_points: Tensor, pred_dist: Tensor):
+        b, l, *_ = pred_dist.size()
+        pred_dist = pred_dist.reshape([b, l, 4, -1])
+        reg_max = pred_dist.size(-1) - 1
+        proj_conv = self.get_proj_conv_for_reg_max(reg_max, device=pred_dist.device)
+        pred_dist = torch.softmax(pred_dist, dim=-1)
+        pred_dist = F.conv2d(pred_dist.permute(0, 3, 1, 2), proj_conv).squeeze(1)
+        return batch_distance2bbox(anchor_points, pred_dist), reg_max, proj_conv
+
+    def _bbox2distance(self, points: Tensor, bbox: Tensor, reg_max: int):
+        x1y1, x2y2 = torch.split(bbox, 2, -1)
+        lt = points - x1y1
+        rb = x2y2 - points
+        return torch.cat([lt, rb], dim=-1).clip(0, reg_max - 0.01)
+
+    @staticmethod
+    def _focal_loss(pred_logits: Tensor, label: Tensor, alpha=0.25, gamma=2.0) -> Tensor:
+        pred_score = pred_logits.sigmoid()
+        weight = (pred_score - label).pow(gamma)
+        if alpha > 0:
+            alpha_t = alpha * label + (1 - alpha) * (1 - label)
+            weight *= alpha_t
+        loss = weight * F.binary_cross_entropy_with_logits(
+            pred_logits, label, reduction="none"
+        )
+        return loss.sum()
+
+    @staticmethod
+    def _varifocal_loss(
+        pred_logits: Tensor, gt_score: Tensor, label: Tensor, alpha=0.75, gamma=2.0
+    ) -> Tensor:
+        pred_score = pred_logits.sigmoid()
+        weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
+        loss = weight * F.binary_cross_entropy_with_logits(
+            pred_logits, gt_score, reduction="none"
+        )
+        return loss.sum()

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -1,0 +1,283 @@
+"""LibreYOLO YOLO-NAS wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from ..base import BaseModel
+from ...utils.image_loader import ImageInput
+from ...validation.preprocessors import YOLONASValPreprocessor
+from .nn import LibreYOLONASModel
+from .utils import (
+    postprocess,
+    preprocess_image,
+    unwrap_yolonas_checkpoint,
+)
+
+
+class LibreYOLONAS(BaseModel):
+    FAMILY = "yolonas"
+    FILENAME_PREFIX = "LibreYOLONAS"
+    INPUT_SIZES = {"s": 640, "m": 640, "l": 640}
+    val_preprocessor_class = YOLONASValPreprocessor
+
+    _REQUIRED_SIGNATURE_KEYS = (
+        "backbone.stem.conv.branch_3x3.conv.weight",
+        "backbone.stem.conv.branch_1x1.weight",
+        "backbone.stem.conv.rbr_reparam.weight",
+        "heads.head1.cls_pred.weight",
+        "heads.head1.reg_pred.weight",
+    )
+    _SIZE_FROM_HEAD_WIDTH = {64: "s", 96: "m", 128: "l"}
+    _NUM_CLASSES_KEY = "heads.head1.cls_pred.weight"
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        return all(key in weights_dict for key in cls._REQUIRED_SIGNATURE_KEYS)
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        tensor = weights_dict.get(cls._NUM_CLASSES_KEY)
+        if tensor is None or tensor.ndim < 2:
+            return None
+        return cls._SIZE_FROM_HEAD_WIDTH.get(tensor.shape[1])
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        tensor = weights_dict.get(cls._NUM_CLASSES_KEY)
+        if tensor is None or tensor.ndim == 0:
+            return None
+        return int(tensor.shape[0])
+
+    def __init__(
+        self,
+        model_path,
+        size: str,
+        nb_classes: int = 80,
+        device: str = "auto",
+        reg_max: int = 16,
+        **kwargs,
+    ):
+        self.reg_max = reg_max
+        if isinstance(model_path, dict):
+            model_path = unwrap_yolonas_checkpoint(model_path)
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=nb_classes,
+            device=device,
+            **kwargs,
+        )
+        if isinstance(model_path, str):
+            self._load_weights(model_path)
+
+    def _init_model(self) -> nn.Module:
+        return LibreYOLONASModel(
+            config=self.size,
+            nb_classes=self.nb_classes,
+            reg_max=self.reg_max,
+        )
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {
+            "backbone_stem": self.model.backbone.stem,
+            "backbone_stage1": self.model.backbone.stage1,
+            "backbone_stage2": self.model.backbone.stage2,
+            "backbone_stage3": self.model.backbone.stage3,
+            "backbone_stage4": self.model.backbone.stage4,
+            "backbone_context_module": self.model.backbone.context_module,
+            "neck1": self.model.neck.neck1,
+            "neck2": self.model.neck.neck2,
+            "neck3": self.model.neck.neck3,
+            "neck4": self.model.neck.neck4,
+            "heads": self.model.heads,
+        }
+
+    def _rebuild_for_new_classes(self, new_nb_classes: int):
+        self.nb_classes = new_nb_classes
+        self.model.nc = new_nb_classes
+        self.model.heads.replace_num_classes(new_nb_classes)
+        self.model.to(self.device)
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        from .utils import preprocess_numpy
+
+        return preprocess_numpy
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, Any, Tuple[int, int], float]:
+        effective_size = input_size if input_size is not None else self.input_size
+        return preprocess_image(
+            image,
+            input_size=effective_size,
+            color_format=color_format,
+        )
+
+    def _forward(self, input_tensor: torch.Tensor) -> Any:
+        output = self.model(input_tensor)
+        if isinstance(output, tuple):
+            if len(output) == 2 and isinstance(output[0], tuple):
+                boxes, scores = output[0]
+                return {
+                    "boxes": boxes,
+                    "scores": scores,
+                    "raw_predictions": output[1],
+                }
+            if len(output) == 2 and all(isinstance(x, torch.Tensor) for x in output):
+                boxes, scores = output
+                return {"boxes": boxes, "scores": scores}
+        return output
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        **kwargs,
+    ) -> Dict:
+        actual_input_size = kwargs.get("input_size", self.input_size)
+        return postprocess(
+            output,
+            conf_thres=conf_thres,
+            iou_thres=iou_thres,
+            input_size=actual_input_size,
+            original_size=original_size,
+            max_det=max_det,
+            letterbox=kwargs.get("letterbox", True),
+        )
+
+    def _strict_loading(self) -> bool:
+        return False
+
+    def _load_weights(self, model_path: str):
+        if not Path(model_path).exists():
+            raise FileNotFoundError(f"Model weights file not found: {model_path}")
+
+        try:
+            loaded = torch.load(model_path, map_location="cpu", weights_only=False)
+            state_dict = unwrap_yolonas_checkpoint(loaded)
+            state_dict = self._strip_ddp_prefix(dict(state_dict))
+            state_dict = self._prepare_state_dict(state_dict)
+
+            if isinstance(loaded, dict):
+                ckpt_family = loaded.get("model_family", "")
+                own_family = self._get_model_name()
+                if ckpt_family and ckpt_family != own_family:
+                    raise RuntimeError(
+                        f"Checkpoint was trained with model_family='{ckpt_family}' "
+                        f"but is being loaded into '{own_family}'. "
+                        f"Use the correct model class for this checkpoint."
+                    )
+
+                ckpt_nc = loaded.get("nc")
+                if ckpt_nc is not None and ckpt_nc != self.nb_classes:
+                    self._rebuild_for_new_classes(int(ckpt_nc))
+
+                ckpt_names = loaded.get("names")
+                effective_nc = int(ckpt_nc) if ckpt_nc is not None else self.nb_classes
+                if ckpt_names is not None:
+                    self.names = self._sanitize_names(ckpt_names, effective_nc)
+
+            self.model.load_state_dict(state_dict, strict=self._strict_loading())
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load YOLO-NAS weights from {model_path}: {e}"
+            ) from e
+
+    def train(
+        self,
+        data: str,
+        *,
+        epochs: int = 300,
+        batch: int = 16,
+        imgsz: int = 640,
+        lr0: float = 5e-4,
+        optimizer: str = "AdamW",
+        device: str = "",
+        workers: int = 8,
+        seed: int = 0,
+        project: str = "runs/train",
+        name: str = "yolonas_exp",
+        exist_ok: bool = False,
+        resume: bool = False,
+        amp: bool = False,
+        patience: int = 50,
+        **kwargs,
+    ) -> dict:
+        from libreyolo.data import load_data_config
+
+        from .trainer import YOLONASTrainer
+
+        try:
+            data_config = load_data_config(data, autodownload=True)
+            data = data_config.get("yaml_file", data)
+        except Exception as e:
+            raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")
+
+        yaml_nc = data_config.get("nc")
+        if yaml_nc is not None and yaml_nc != self.nb_classes:
+            self._rebuild_for_new_classes(yaml_nc)
+
+        if seed > 0:
+            import random
+
+            import numpy as np
+
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(seed)
+
+        trainer = YOLONASTrainer(
+            model=self.model,
+            wrapper_model=self,
+            size=self.size,
+            num_classes=self.nb_classes,
+            data=data,
+            epochs=epochs,
+            batch=batch,
+            imgsz=imgsz,
+            lr0=lr0,
+            optimizer=optimizer.lower(),
+            device=device if device else "auto",
+            workers=workers,
+            seed=seed,
+            project=project,
+            name=name,
+            exist_ok=exist_ok,
+            resume=resume,
+            amp=amp,
+            patience=patience,
+            **kwargs,
+        )
+
+        if resume:
+            if not self.model_path:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreYOLONAS('path/to/last.pt'); model.train(data=..., resume=True)"
+                )
+            trainer.setup()
+            trainer.resume(str(self.model_path))
+            return trainer.train()
+
+        results = trainer.train()
+
+        best_ckpt = results.get("best_checkpoint")
+        if best_ckpt and Path(best_ckpt).exists():
+            self.model_path = best_ckpt
+            self._load_weights(best_ckpt)
+
+        return results

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -35,9 +35,20 @@ class LibreYOLONAS(BaseModel):
     _SIZE_FROM_HEAD_WIDTH = {64: "s", 96: "m", 128: "l"}
     _NUM_CLASSES_KEY = "heads.head1.cls_pred.weight"
 
+    _DECI_CDN_BASE = "https://d2gjn4b69gu75n.cloudfront.net/models"
+
     @classmethod
     def can_load(cls, weights_dict: dict) -> bool:
         return all(key in weights_dict for key in cls._REQUIRED_SIGNATURE_KEYS)
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        # YOLO-NAS weights are under Deci's proprietary license — LibreYOLO
+        # links to Deci's public CDN instead of mirroring on its own HF org.
+        size = cls.detect_size_from_filename(filename)
+        if size is None:
+            return None
+        return f"{cls._DECI_CDN_BASE}/yolo_nas_{size}_coco.pth"
 
     @classmethod
     def detect_size(cls, weights_dict: dict) -> Optional[str]:

--- a/libreyolo/models/yolonas/nn.py
+++ b/libreyolo/models/yolonas/nn.py
@@ -1,0 +1,1094 @@
+"""Native YOLO-NAS architecture port.
+
+This file keeps the module tree close to SuperGradients so official
+``yolo_nas_{s,m,l}_coco.pth`` checkpoints load with minimal or no remapping.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import partial
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+
+def autopad(kernel, padding=None):
+    if padding is None:
+        return kernel // 2 if isinstance(kernel, int) else [x // 2 for x in kernel]
+    return padding
+
+
+def width_multiplier(original: int, factor: float, divisor: int | None = None) -> int:
+    scaled = int(original * factor)
+    if divisor is None:
+        return scaled
+    return math.ceil(scaled / divisor) * divisor
+
+
+class Residual(nn.Module):
+    def forward(self, x: Tensor) -> Tensor:
+        return x
+
+
+class DropPath(nn.Module):
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = float(drop_prob)
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.drop_prob == 0.0 or not self.training:
+            return x
+        keep_prob = 1.0 - self.drop_prob
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
+        random_tensor.floor_()
+        return x.div(keep_prob) * random_tensor
+
+
+class ConvBNAct(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int | Tuple[int, int],
+        padding: int | Tuple[int, int],
+        activation_type: type[nn.Module],
+        stride: int | Tuple[int, int] = 1,
+        dilation: int | Tuple[int, int] = 1,
+        groups: int = 1,
+        bias: bool = True,
+        use_normalization: bool = True,
+        activation_kwargs: Optional[dict] = None,
+    ):
+        super().__init__()
+        activation_kwargs = activation_kwargs or {}
+        self.seq = nn.Sequential()
+        self.seq.add_module(
+            "conv",
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                dilation=dilation,
+                groups=groups,
+                bias=bias,
+            ),
+        )
+        if use_normalization:
+            self.seq.add_module("bn", nn.BatchNorm2d(out_channels))
+        if activation_type is not None:
+            self.seq.add_module("act", activation_type(**activation_kwargs))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.seq(x)
+
+
+class Conv(nn.Module):
+    def __init__(
+        self,
+        input_channels: int,
+        output_channels: int,
+        kernel: int,
+        stride: int,
+        activation_type: type[nn.Module],
+        padding: Optional[int] = None,
+        groups: Optional[int] = None,
+    ):
+        super().__init__()
+        self.conv = nn.Conv2d(
+            input_channels,
+            output_channels,
+            kernel,
+            stride,
+            autopad(kernel, padding),
+            groups=groups or 1,
+            bias=False,
+        )
+        self.bn = nn.BatchNorm2d(output_channels)
+        self.act = activation_type()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.act(self.bn(self.conv(x)))
+
+
+class ConvBNReLU(ConvBNAct):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int | Tuple[int, int],
+        stride: int | Tuple[int, int] = 1,
+        padding: int | Tuple[int, int] = 0,
+        dilation: int | Tuple[int, int] = 1,
+        groups: int = 1,
+        bias: bool = True,
+        use_normalization: bool = True,
+        use_activation: bool = True,
+        inplace: bool = False,
+    ):
+        super().__init__(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            padding=padding,
+            activation_type=nn.ReLU if use_activation else None,
+            activation_kwargs={"inplace": True} if inplace else None,
+            stride=stride,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+            use_normalization=use_normalization,
+        )
+
+
+class QARepVGGBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        stride: int = 1,
+        dilation: int = 1,
+        groups: int = 1,
+        activation_type: type[nn.Module] = nn.ReLU,
+        activation_kwargs: Optional[dict] = None,
+        build_residual_branches: bool = True,
+        use_residual_connection: bool = True,
+        use_alpha: bool = False,
+        use_1x1_bias: bool = True,
+        use_post_bn: bool = True,
+    ):
+        super().__init__()
+        activation_kwargs = activation_kwargs or {}
+
+        self.groups = groups
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.stride = stride
+        self.dilation = dilation
+        self.use_residual_connection = use_residual_connection
+        self.use_alpha = use_alpha
+        self.use_1x1_bias = use_1x1_bias
+        self.use_post_bn = use_post_bn
+
+        self.nonlinearity = activation_type(**activation_kwargs)
+        self.se = nn.Identity()
+
+        self.branch_3x3 = nn.Sequential()
+        self.branch_3x3.add_module(
+            "conv",
+            nn.Conv2d(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_size=3,
+                stride=stride,
+                padding=dilation,
+                groups=groups,
+                bias=False,
+                dilation=dilation,
+            ),
+        )
+        self.branch_3x3.add_module("bn", nn.BatchNorm2d(out_channels))
+
+        self.branch_1x1 = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=1,
+            stride=stride,
+            padding=0,
+            groups=groups,
+            bias=use_1x1_bias,
+        )
+
+        if use_residual_connection:
+            assert out_channels == in_channels and stride == 1
+            self.identity = Residual()
+            input_dim = self.in_channels // self.groups
+            id_tensor = torch.zeros((self.in_channels, input_dim, 3, 3))
+            for i in range(self.in_channels):
+                id_tensor[i, i % input_dim, 1, 1] = 1.0
+            self.register_buffer("id_tensor", id_tensor, persistent=False)
+        else:
+            self.identity = None
+
+        if use_alpha:
+            noise = torch.randn((1,)) * 0.01
+            self.alpha = nn.Parameter(torch.tensor([1.0]) + noise, requires_grad=True)
+        else:
+            self.alpha = 1.0
+
+        self.post_bn = nn.BatchNorm2d(out_channels) if use_post_bn else nn.Identity()
+        self.rbr_reparam = nn.Conv2d(
+            in_channels=self.branch_3x3.conv.in_channels,
+            out_channels=self.branch_3x3.conv.out_channels,
+            kernel_size=self.branch_3x3.conv.kernel_size,
+            stride=self.branch_3x3.conv.stride,
+            padding=self.branch_3x3.conv.padding,
+            dilation=self.branch_3x3.conv.dilation,
+            groups=self.branch_3x3.conv.groups,
+            bias=True,
+        )
+        self.partially_fused = False
+        self.fully_fused = False
+
+        if not build_residual_branches:
+            self.fuse_block_residual_branches()
+
+    def forward(self, inputs: Tensor) -> Tensor:
+        if self.fully_fused:
+            return self.se(self.nonlinearity(self.rbr_reparam(inputs)))
+        if self.partially_fused:
+            return self.se(self.nonlinearity(self.post_bn(self.rbr_reparam(inputs))))
+
+        id_out = 0.0 if self.identity is None else self.identity(inputs)
+        x_3x3 = self.branch_3x3(inputs)
+        x_1x1 = self.alpha * self.branch_1x1(inputs)
+        branches = x_3x3 + x_1x1 + id_out
+        out = self.nonlinearity(self.post_bn(branches))
+        return self.se(out)
+
+    def _pad_1x1_to_3x3_tensor(self, kernel1x1):
+        if kernel1x1 is None:
+            return 0
+        return F.pad(kernel1x1, [1, 1, 1, 1])
+
+    def _fuse_bn_tensor(self, kernel, bias, running_mean, running_var, gamma, beta, eps):
+        std = torch.sqrt(running_var + eps)
+        fused_bias = beta - gamma * running_mean / std
+        scale = (gamma / std).expand_as(kernel.transpose(0, -1)).transpose(0, -1)
+        return kernel * scale, bias * (gamma / std) + fused_bias
+
+    def _get_equivalent_kernel_bias_for_branches(self):
+        kernel3x3, bias3x3 = self._fuse_bn_tensor(
+            self.branch_3x3.conv.weight,
+            0,
+            self.branch_3x3.bn.running_mean,
+            self.branch_3x3.bn.running_var,
+            self.branch_3x3.bn.weight,
+            self.branch_3x3.bn.bias,
+            self.branch_3x3.bn.eps,
+        )
+        kernel1x1 = self._pad_1x1_to_3x3_tensor(self.branch_1x1.weight)
+        bias1x1 = self.branch_1x1.bias if self.branch_1x1.bias is not None else 0
+        kernelid = self.id_tensor if self.identity is not None else 0
+        biasid = 0
+        eq_kernel = kernel3x3 + self.alpha * kernel1x1 + kernelid
+        eq_bias = bias3x3 + self.alpha * bias1x1 + biasid
+        return eq_kernel, eq_bias
+
+    def partial_fusion(self):
+        if self.partially_fused:
+            return
+        if self.fully_fused:
+            raise NotImplementedError(
+                "QARepVGGBlock can't be converted to partially fused from fully fused"
+            )
+
+        kernel, bias = self._get_equivalent_kernel_bias_for_branches()
+        self.rbr_reparam.weight.data = kernel
+        self.rbr_reparam.bias.data = bias
+
+        del self.branch_3x3
+        del self.branch_1x1
+        if hasattr(self, "identity"):
+            del self.identity
+        if hasattr(self, "alpha"):
+            del self.alpha
+        if hasattr(self, "id_tensor"):
+            del self.id_tensor
+
+        self.partially_fused = True
+        self.fully_fused = False
+
+    def full_fusion(self):
+        if self.fully_fused:
+            return
+        if not self.partially_fused:
+            self.partial_fusion()
+
+        if self.use_post_bn:
+            eq_kernel, eq_bias = self._fuse_bn_tensor(
+                self.rbr_reparam.weight,
+                self.rbr_reparam.bias,
+                self.post_bn.running_mean,
+                self.post_bn.running_var,
+                self.post_bn.weight,
+                self.post_bn.bias,
+                self.post_bn.eps,
+            )
+            self.rbr_reparam.weight.data = eq_kernel
+            self.rbr_reparam.bias.data = eq_bias
+
+        for para in self.parameters():
+            para.detach_()
+
+        if hasattr(self, "post_bn"):
+            del self.post_bn
+
+        self.partially_fused = False
+        self.fully_fused = True
+
+    def fuse_block_residual_branches(self):
+        self.partial_fusion()
+
+    def prep_model_for_conversion(self, input_size=None, full_fusion: bool = False, **kwargs):
+        if full_fusion:
+            self.full_fusion()
+        else:
+            self.partial_fusion()
+
+
+class YoloNASBottleneck(nn.Module):
+    def __init__(
+        self,
+        input_channels: int,
+        output_channels: int,
+        block_type,
+        activation_type: type[nn.Module],
+        shortcut: bool,
+        use_alpha: bool,
+        drop_path_rate: float = 0.0,
+    ):
+        super().__init__()
+        self.cv1 = block_type(input_channels, output_channels, activation_type=activation_type)
+        self.cv2 = block_type(output_channels, output_channels, activation_type=activation_type)
+        self.add = shortcut and input_channels == output_channels
+        self.shortcut = Residual() if self.add else None
+        self.drop_path = DropPath(drop_path_rate) if drop_path_rate > 0.0 else nn.Identity()
+        self.alpha = nn.Parameter(torch.tensor([1.0]), requires_grad=True) if use_alpha else 1.0
+
+    def forward(self, x: Tensor) -> Tensor:
+        y = self.drop_path(self.cv2(self.cv1(x)))
+        return self.alpha * self.shortcut(x) + y if self.add else y
+
+
+class SequentialWithIntermediates(nn.Sequential):
+    def __init__(self, output_intermediates: bool, *args):
+        super().__init__(*args)
+        self.output_intermediates = output_intermediates
+
+    def forward(self, input: Tensor) -> List[Tensor]:
+        if self.output_intermediates:
+            output = [input]
+            for module in self:
+                output.append(module(output[-1]))
+            return output
+        return [super().forward(input)]
+
+
+class YoloNASCSPLayer(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        num_bottlenecks: int,
+        block_type,
+        activation_type: type[nn.Module],
+        shortcut: bool = True,
+        use_alpha: bool = True,
+        expansion: float = 0.5,
+        hidden_channels: Optional[int] = None,
+        concat_intermediates: bool = False,
+        drop_path_rates: Optional[Iterable[float]] = None,
+        dropout_rate: float = 0.0,
+    ):
+        super().__init__()
+        if drop_path_rates is None:
+            drop_path_rates = [0.0] * num_bottlenecks
+        else:
+            drop_path_rates = tuple(drop_path_rates)
+        if len(drop_path_rates) != num_bottlenecks:
+            raise ValueError("drop_path_rates length must equal num_bottlenecks")
+
+        if hidden_channels is None:
+            hidden_channels = int(out_channels * expansion)
+
+        self.conv1 = Conv(in_channels, hidden_channels, 1, 1, activation_type)
+        self.conv2 = Conv(in_channels, hidden_channels, 1, 1, activation_type)
+        self.conv3 = Conv(
+            hidden_channels * (2 + int(concat_intermediates) * num_bottlenecks),
+            out_channels,
+            1,
+            1,
+            activation_type,
+        )
+        self.bottlenecks = SequentialWithIntermediates(
+            concat_intermediates,
+            *[
+                YoloNASBottleneck(
+                    hidden_channels,
+                    hidden_channels,
+                    block_type,
+                    activation_type,
+                    shortcut,
+                    use_alpha,
+                    drop_path_rate=drop_path_rates[i],
+                )
+                for i in range(num_bottlenecks)
+            ],
+        )
+        self.dropout = nn.Dropout2d(dropout_rate, inplace=True) if dropout_rate > 0.0 else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        x_1 = self.conv1(x)
+        x_1 = self.bottlenecks(x_1)
+        x_2 = self.conv2(x)
+        x = torch.cat((*x_1, x_2), dim=1)
+        x = self.dropout(x)
+        return self.conv3(x)
+
+
+class YoloNASStem(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 2):
+        super().__init__()
+        self._out_channels = out_channels
+        self.conv = QARepVGGBlock(
+            in_channels,
+            out_channels,
+            stride=stride,
+            use_residual_connection=False,
+        )
+
+    @property
+    def out_channels(self):
+        return self._out_channels
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.conv(x)
+
+
+class YoloNASStage(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        num_blocks: int,
+        activation_type: type[nn.Module],
+        hidden_channels: Optional[int] = None,
+        concat_intermediates: bool = False,
+        drop_path_rates: Optional[Iterable[float]] = None,
+        dropout_rate: float = 0.0,
+        stride: int = 2,
+    ):
+        super().__init__()
+        self._out_channels = out_channels
+        self.downsample = QARepVGGBlock(
+            in_channels,
+            out_channels,
+            stride=stride,
+            activation_type=activation_type,
+            use_residual_connection=False,
+        )
+        self.blocks = YoloNASCSPLayer(
+            out_channels,
+            out_channels,
+            num_blocks,
+            QARepVGGBlock,
+            activation_type,
+            shortcut=True,
+            hidden_channels=hidden_channels,
+            concat_intermediates=concat_intermediates,
+            drop_path_rates=drop_path_rates,
+            dropout_rate=dropout_rate,
+        )
+
+    @property
+    def out_channels(self):
+        return self._out_channels
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.blocks(self.downsample(x))
+
+
+class YoloNASUpStage(nn.Module):
+    def __init__(
+        self,
+        in_channels: List[int],
+        out_channels: int,
+        width_mult: float,
+        num_blocks: int,
+        depth_mult: float,
+        activation_type: type[nn.Module],
+        hidden_channels: Optional[int] = None,
+        concat_intermediates: bool = False,
+        reduce_channels: bool = False,
+        drop_path_rates: Optional[Iterable[float]] = None,
+        dropout_rate: float = 0.0,
+    ):
+        super().__init__()
+        num_inputs = len(in_channels)
+        if num_inputs == 2:
+            in_channels, skip_in_channels = in_channels
+        else:
+            in_channels, skip_in_channels1, skip_in_channels2 = in_channels
+            skip_in_channels = skip_in_channels1 + out_channels
+
+        out_channels = width_multiplier(out_channels, width_mult, 8)
+        num_blocks = max(round(num_blocks * depth_mult), 1) if num_blocks > 1 else num_blocks
+
+        if num_inputs == 2:
+            self.reduce_skip = Conv(skip_in_channels, out_channels, 1, 1, activation_type) if reduce_channels else nn.Identity()
+        else:
+            self.reduce_skip1 = Conv(skip_in_channels1, out_channels, 1, 1, activation_type) if reduce_channels else nn.Identity()
+            self.reduce_skip2 = Conv(skip_in_channels2, out_channels, 1, 1, activation_type) if reduce_channels else nn.Identity()
+
+        self.conv = Conv(in_channels, out_channels, 1, 1, activation_type)
+        self.upsample = nn.ConvTranspose2d(out_channels, out_channels, kernel_size=2, stride=2)
+        if num_inputs == 3:
+            ds_in = out_channels if reduce_channels else skip_in_channels2
+            self.downsample = Conv(ds_in, out_channels, 3, 2, activation_type)
+
+        self.reduce_after_concat = Conv(num_inputs * out_channels, out_channels, 1, 1, activation_type) if reduce_channels else nn.Identity()
+        after_concat_channels = out_channels if reduce_channels else out_channels + skip_in_channels
+        self.blocks = YoloNASCSPLayer(
+            after_concat_channels,
+            out_channels,
+            num_blocks,
+            QARepVGGBlock,
+            activation_type,
+            hidden_channels=hidden_channels,
+            concat_intermediates=concat_intermediates,
+            drop_path_rates=drop_path_rates,
+            dropout_rate=dropout_rate,
+        )
+        self._out_channels = [out_channels, out_channels]
+
+    @property
+    def out_channels(self):
+        return self._out_channels
+
+    def forward(self, inputs):
+        if len(inputs) == 2:
+            x, skip_x = inputs
+            skip_x = [self.reduce_skip(skip_x)]
+        else:
+            x, skip_x1, skip_x2 = inputs
+            skip_x1 = self.reduce_skip1(skip_x1)
+            skip_x2 = self.reduce_skip2(skip_x2)
+            skip_x = [skip_x1, self.downsample(skip_x2)]
+        x_inter = self.conv(x)
+        x = self.upsample(x_inter)
+        x = torch.cat([x, *skip_x], 1)
+        x = self.reduce_after_concat(x)
+        x = self.blocks(x)
+        return x_inter, x
+
+
+class YoloNASDownStage(nn.Module):
+    def __init__(
+        self,
+        in_channels: List[int],
+        out_channels: int,
+        width_mult: float,
+        num_blocks: int,
+        depth_mult: float,
+        activation_type: type[nn.Module],
+        hidden_channels: Optional[int] = None,
+        concat_intermediates: bool = False,
+        drop_path_rates: Optional[Iterable[float]] = None,
+        dropout_rate: float = 0.0,
+    ):
+        super().__init__()
+        in_channels, skip_in_channels = in_channels
+        out_channels = width_multiplier(out_channels, width_mult, 8)
+        num_blocks = max(round(num_blocks * depth_mult), 1) if num_blocks > 1 else num_blocks
+
+        self.conv = Conv(in_channels, out_channels // 2, 3, 2, activation_type)
+        after_concat_channels = out_channels // 2 + skip_in_channels
+        self.blocks = YoloNASCSPLayer(
+            in_channels=after_concat_channels,
+            out_channels=out_channels,
+            num_bottlenecks=num_blocks,
+            block_type=partial(Conv, kernel=3, stride=1),
+            activation_type=activation_type,
+            hidden_channels=hidden_channels,
+            concat_intermediates=concat_intermediates,
+            drop_path_rates=drop_path_rates,
+            dropout_rate=dropout_rate,
+        )
+        self._out_channels = out_channels
+
+    @property
+    def out_channels(self):
+        return self._out_channels
+
+    def forward(self, inputs):
+        x, skip_x = inputs
+        x = self.conv(x)
+        x = torch.cat([x, skip_x], 1)
+        return self.blocks(x)
+
+
+class SPP(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        output_channels: int,
+        k: Tuple[int, ...],
+        activation_type: type[nn.Module],
+    ):
+        super().__init__()
+        self._output_channels = output_channels
+        hidden_channels = in_channels // 2
+        self.cv1 = Conv(in_channels, hidden_channels, 1, 1, activation_type)
+        self.cv2 = Conv(hidden_channels * (len(k) + 1), output_channels, 1, 1, activation_type)
+        self.m = nn.ModuleList([nn.MaxPool2d(kernel_size=x, stride=1, padding=x // 2) for x in k])
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.cv1(x)
+        return self.cv2(torch.cat([x] + [m(x) for m in self.m], 1))
+
+    @property
+    def out_channels(self):
+        return self._output_channels
+
+
+class YoloNASBackbone(nn.Module):
+    def __init__(self, config: dict, in_channels: int = 3):
+        super().__init__()
+        activation_type = nn.ReLU
+        self.stem = YoloNASStem(in_channels, 48)
+        stage_out = [96, 192, 384, 768]
+        stage_blocks = [2, 3, 5, 2]
+        stage_hidden = config["stage_hidden"]
+        stage_concat = config["stage_concat"]
+
+        self.stage1 = YoloNASStage(48, stage_out[0], stage_blocks[0], activation_type, hidden_channels=stage_hidden[0], concat_intermediates=stage_concat[0])
+        self.stage2 = YoloNASStage(stage_out[0], stage_out[1], stage_blocks[1], activation_type, hidden_channels=stage_hidden[1], concat_intermediates=stage_concat[1])
+        self.stage3 = YoloNASStage(stage_out[1], stage_out[2], stage_blocks[2], activation_type, hidden_channels=stage_hidden[2], concat_intermediates=stage_concat[2])
+        self.stage4 = YoloNASStage(stage_out[2], stage_out[3], stage_blocks[3], activation_type, hidden_channels=stage_hidden[3], concat_intermediates=stage_concat[3])
+        self.context_module = SPP(stage_out[3], stage_out[3], (5, 9, 13), activation_type)
+        self._out_channels = (stage_out[0], stage_out[1], stage_out[2], stage_out[3])
+
+    @property
+    def out_channels(self):
+        return self._out_channels
+
+    def forward(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        x = self.stem(x)
+        c2 = self.stage1(x)
+        c3 = self.stage2(c2)
+        c4 = self.stage3(c3)
+        c5 = self.stage4(c4)
+        c5 = self.context_module(c5)
+        return c2, c3, c4, c5
+
+
+class YoloNASPANNeckWithC2(nn.Module):
+    def __init__(self, in_channels: List[int], config: dict):
+        super().__init__()
+        c2_out, c3_out, c4_out, c5_out = in_channels
+        activation_type = nn.ReLU
+
+        self.neck1 = YoloNASUpStage(
+            [c5_out, c4_out, c3_out],
+            out_channels=192,
+            num_blocks=config["up_blocks"][0],
+            hidden_channels=config["up_hidden"][0],
+            width_mult=1.0,
+            depth_mult=1.0,
+            activation_type=activation_type,
+            reduce_channels=True,
+        )
+        self.neck2 = YoloNASUpStage(
+            [self.neck1.out_channels[1], c3_out, c2_out],
+            out_channels=96,
+            num_blocks=config["up_blocks"][1],
+            hidden_channels=config["up_hidden"][1],
+            width_mult=1.0,
+            depth_mult=1.0,
+            activation_type=activation_type,
+            reduce_channels=True,
+        )
+        self.neck3 = YoloNASDownStage(
+            [self.neck2.out_channels[1], self.neck2.out_channels[0]],
+            out_channels=192,
+            num_blocks=config["down_blocks"][0],
+            hidden_channels=config["down_hidden"][0],
+            width_mult=1.0,
+            depth_mult=1.0,
+            activation_type=activation_type,
+        )
+        self.neck4 = YoloNASDownStage(
+            [self.neck3.out_channels, self.neck1.out_channels[0]],
+            out_channels=384,
+            num_blocks=config["down_blocks"][1],
+            hidden_channels=config["down_hidden"][1],
+            width_mult=1.0,
+            depth_mult=1.0,
+            activation_type=activation_type,
+        )
+
+        self._out_channels = [
+            self.neck2.out_channels[1],
+            self.neck3.out_channels,
+            self.neck4.out_channels,
+        ]
+
+    @property
+    def out_channels(self):
+        return self._out_channels
+
+    def forward(self, inputs: Tuple[Tensor, Tensor, Tensor, Tensor]) -> Tuple[Tensor, Tensor, Tensor]:
+        c2, c3, c4, c5 = inputs
+        x_n1_inter, x = self.neck1([c5, c4, c3])
+        x_n2_inter, p3 = self.neck2([x, c3, c2])
+        p4 = self.neck3([p3, x_n2_inter])
+        p5 = self.neck4([p4, x_n1_inter])
+        return p3, p4, p5
+
+
+@torch.no_grad()
+def generate_anchors_for_grid_cell(
+    feats: Tuple[Tensor, ...],
+    fpn_strides: Tuple[int, ...],
+    grid_cell_size: float = 5.0,
+    grid_cell_offset: float = 0.5,
+    dtype: torch.dtype = torch.float,
+) -> Tuple[Tensor, Tensor, List[int], Tensor]:
+    anchors = []
+    anchor_points = []
+    num_anchors_list = []
+    stride_tensor = []
+    device = feats[0].device
+
+    for feat, stride in zip(feats, fpn_strides):
+        _, _, h, w = feat.shape
+        cell_half_size = grid_cell_size * stride * 0.5
+        shift_x = (torch.arange(end=w, device=device) + grid_cell_offset) * stride
+        shift_y = (torch.arange(end=h, device=device) + grid_cell_offset) * stride
+        if torch.__version__ >= "1.10":
+            shift_y, shift_x = torch.meshgrid(shift_y, shift_x, indexing="ij")
+        else:
+            shift_y, shift_x = torch.meshgrid(shift_y, shift_x)
+
+        anchor = torch.stack(
+            [
+                shift_x - cell_half_size,
+                shift_y - cell_half_size,
+                shift_x + cell_half_size,
+                shift_y + cell_half_size,
+            ],
+            dim=-1,
+        ).to(dtype=dtype)
+        anchor_point = torch.stack([shift_x, shift_y], dim=-1).to(dtype=dtype)
+
+        anchors.append(anchor.reshape([-1, 4]))
+        anchor_points.append(anchor_point.reshape([-1, 2]))
+        num_anchors_list.append(len(anchors[-1]))
+        stride_tensor.append(torch.full([num_anchors_list[-1], 1], stride, dtype=dtype, device=device))
+
+    anchors = torch.cat(anchors).to(device)
+    anchor_points = torch.cat(anchor_points).to(device)
+    stride_tensor = torch.cat(stride_tensor).to(device)
+    return anchors, anchor_points, num_anchors_list, stride_tensor
+
+
+def batch_distance2bbox(points: Tensor, distance: Tensor, max_shapes: Optional[Tensor] = None) -> Tensor:
+    lt, rb = torch.split(distance, 2, dim=-1)
+    x1y1 = points - lt
+    x2y2 = rb + points
+    out_bbox = torch.cat([x1y1, x2y2], dim=-1)
+    if max_shapes is not None:
+        max_shapes = max_shapes.flip(-1).tile([1, 2])
+        delta_dim = out_bbox.ndim - max_shapes.ndim
+        for _ in range(delta_dim):
+            max_shapes.unsqueeze_(1)
+        out_bbox = torch.where(out_bbox < max_shapes, out_bbox, max_shapes)
+        out_bbox = torch.where(out_bbox > 0, out_bbox, torch.zeros_like(out_bbox))
+    return out_bbox
+
+
+class YoloNASDFLHead(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        inter_channels: int,
+        width_mult: float,
+        first_conv_group_size: int,
+        num_classes: int,
+        stride: int,
+        reg_max: int,
+        cls_dropout_rate: float = 0.0,
+        reg_dropout_rate: float = 0.0,
+    ):
+        super().__init__()
+        inter_channels = width_multiplier(inter_channels, width_mult, 8)
+        if first_conv_group_size == 0:
+            groups = 0
+        elif first_conv_group_size == -1:
+            groups = 1
+        else:
+            groups = inter_channels // first_conv_group_size
+
+        self.num_classes = num_classes
+        self.stem = ConvBNReLU(in_channels, inter_channels, kernel_size=1, stride=1, padding=0, bias=False)
+
+        first_cls_conv = [ConvBNReLU(inter_channels, inter_channels, kernel_size=3, stride=1, padding=1, groups=groups, bias=False)] if groups else []
+        self.cls_convs = nn.Sequential(*first_cls_conv, ConvBNReLU(inter_channels, inter_channels, kernel_size=3, stride=1, padding=1, bias=False))
+
+        first_reg_conv = [ConvBNReLU(inter_channels, inter_channels, kernel_size=3, stride=1, padding=1, groups=groups, bias=False)] if groups else []
+        self.reg_convs = nn.Sequential(*first_reg_conv, ConvBNReLU(inter_channels, inter_channels, kernel_size=3, stride=1, padding=1, bias=False))
+
+        self.cls_pred = nn.Conv2d(inter_channels, self.num_classes, 1, 1, 0)
+        self.reg_pred = nn.Conv2d(inter_channels, 4 * (reg_max + 1), 1, 1, 0)
+        self.cls_dropout_rate = nn.Dropout2d(cls_dropout_rate) if cls_dropout_rate > 0 else nn.Identity()
+        self.reg_dropout_rate = nn.Dropout2d(reg_dropout_rate) if reg_dropout_rate > 0 else nn.Identity()
+
+        self.grid = torch.zeros(1)
+        self.stride = stride
+        self.prior_prob = 1e-2
+        self._initialize_biases()
+
+    def _initialize_biases(self):
+        prior_bias = -math.log((1 - self.prior_prob) / self.prior_prob)
+        torch.nn.init.constant_(self.cls_pred.bias, prior_bias)
+
+    def replace_num_classes(self, num_classes: int):
+        self.cls_pred = nn.Conv2d(self.cls_pred.in_channels, num_classes, 1, 1, 0)
+        self.num_classes = num_classes
+        self._initialize_biases()
+
+    @property
+    def out_channels(self):
+        return None
+
+    def forward(self, x: Tensor):
+        x = self.stem(x)
+        cls_feat = self.cls_dropout_rate(self.cls_convs(x))
+        reg_feat = self.reg_dropout_rate(self.reg_convs(x))
+        cls_output = self.cls_pred(cls_feat)
+        reg_output = self.reg_pred(reg_feat)
+        return reg_output, cls_output
+
+
+class NDFLHeads(nn.Module):
+    def __init__(
+        self,
+        num_classes: int,
+        in_channels: Tuple[int, int, int],
+        width_mult: float,
+        grid_cell_scale: float = 5.0,
+        grid_cell_offset: float = 0.5,
+        reg_max: int = 16,
+        eval_size: Optional[Tuple[int, int]] = None,
+    ):
+        super().__init__()
+        self.in_channels = tuple(in_channels)
+        self.num_classes = num_classes
+        self.grid_cell_scale = grid_cell_scale
+        self.grid_cell_offset = grid_cell_offset
+        self.reg_max = reg_max
+        self.eval_size = eval_size
+        proj = torch.linspace(0, self.reg_max, self.reg_max + 1).reshape([1, self.reg_max + 1, 1, 1])
+        self.register_buffer("proj_conv", proj, persistent=False)
+
+        self.head1 = YoloNASDFLHead(in_channels[0], 128, width_mult, 0, num_classes, 8, reg_max)
+        self.head2 = YoloNASDFLHead(in_channels[1], 256, width_mult, 0, num_classes, 16, reg_max)
+        self.head3 = YoloNASDFLHead(in_channels[2], 512, width_mult, 0, num_classes, 32, reg_max)
+        self.num_heads = 3
+        self.fpn_strides = (8, 16, 32)
+        self._init_weights()
+
+    def replace_num_classes(self, num_classes: int):
+        self.head1.replace_num_classes(num_classes)
+        self.head2.replace_num_classes(num_classes)
+        self.head3.replace_num_classes(num_classes)
+        self.num_classes = num_classes
+
+    @torch.jit.ignore
+    def cache_anchors(self, input_size: Tuple[int, int]):
+        self.eval_size = input_size
+        device = next(self.parameters()).device
+        dtype = next(self.parameters()).dtype
+        anchor_points, stride_tensor = self._generate_anchors(dtype=dtype, device=device)
+        self.register_buffer("anchor_points", anchor_points, persistent=False)
+        self.register_buffer("stride_tensor", stride_tensor, persistent=False)
+
+    @torch.jit.ignore
+    def _init_weights(self):
+        if self.eval_size:
+            device = next(self.parameters()).device
+            dtype = next(self.parameters()).dtype
+            anchor_points, stride_tensor = self._generate_anchors(dtype=dtype, device=device)
+            self.anchor_points = anchor_points
+            self.stride_tensor = stride_tensor
+
+    def _generate_anchors(self, feats=None, dtype=None, device=None):
+        anchor_points = []
+        stride_tensor = []
+        dtype = dtype or feats[0].dtype
+        device = device or feats[0].device
+
+        for i, stride in enumerate(self.fpn_strides):
+            if feats is not None:
+                _, _, h, w = feats[i].shape
+            else:
+                h = int(self.eval_size[0] / stride)
+                w = int(self.eval_size[1] / stride)
+
+            shift_x = torch.arange(end=w, dtype=torch.float32, device=device) + self.grid_cell_offset
+            shift_y = torch.arange(end=h, dtype=torch.float32, device=device) + self.grid_cell_offset
+            if torch.__version__ >= "1.10":
+                shift_y, shift_x = torch.meshgrid(shift_y, shift_x, indexing="ij")
+            else:
+                shift_y, shift_x = torch.meshgrid(shift_y, shift_x)
+
+            anchor_point = torch.stack([shift_x, shift_y], dim=-1).to(dtype=dtype)
+            anchor_points.append(anchor_point.reshape([-1, 2]))
+            stride_tensor.append(torch.full([h * w, 1], stride, dtype=dtype, device=device))
+
+        return torch.cat(anchor_points), torch.cat(stride_tensor)
+
+    @property
+    def out_channels(self):
+        return None
+
+    def forward(self, feats: Tuple[Tensor, ...]):
+        feats = feats[: self.num_heads]
+        cls_score_list = []
+        reg_distri_list = []
+        reg_dist_reduced_list = []
+
+        for i, feat in enumerate(feats):
+            b, _, h, w = feat.shape
+            hw = h * w
+            reg_distri, cls_logit = getattr(self, f"head{i + 1}")(feat)
+            reg_distri_list.append(torch.permute(reg_distri.flatten(2), [0, 2, 1]))
+
+            reg_dist_reduced = torch.permute(
+                reg_distri.reshape([-1, 4, self.reg_max + 1, hw]),
+                [0, 2, 3, 1],
+            )
+            reg_dist_reduced = torch.softmax(reg_dist_reduced, dim=1) * self.proj_conv
+            reg_dist_reduced = reg_dist_reduced.sum(dim=1, keepdim=False)
+
+            cls_score_list.append(cls_logit.reshape([b, self.num_classes, hw]))
+            reg_dist_reduced_list.append(reg_dist_reduced)
+
+        cls_score_list = torch.cat(cls_score_list, dim=-1)
+        cls_score_list = torch.permute(cls_score_list, [0, 2, 1])
+        reg_distri_list = torch.cat(reg_distri_list, dim=1)
+        reg_dist_reduced_list = torch.cat(reg_dist_reduced_list, dim=1)
+
+        if self.eval_size:
+            anchor_points_inference, stride_tensor = self.anchor_points, self.stride_tensor
+        else:
+            anchor_points_inference, stride_tensor = self._generate_anchors(feats)
+
+        pred_scores = cls_score_list.sigmoid()
+        pred_bboxes = batch_distance2bbox(anchor_points_inference, reg_dist_reduced_list) * stride_tensor
+        decoded_predictions = pred_bboxes, pred_scores
+
+        if torch.jit.is_tracing():
+            return decoded_predictions
+
+        anchors, anchor_points, num_anchors_list, raw_stride_tensor = generate_anchors_for_grid_cell(
+            feats,
+            self.fpn_strides,
+            self.grid_cell_scale,
+            self.grid_cell_offset,
+        )
+        raw_predictions = (
+            cls_score_list,
+            reg_distri_list,
+            anchors,
+            anchor_points,
+            num_anchors_list,
+            raw_stride_tensor,
+        )
+        return decoded_predictions, raw_predictions
+
+
+_VARIANT_CONFIGS = {
+    "s": {
+        "stage_hidden": [32, 64, 96, 192],
+        "stage_concat": [False, False, False, False],
+        "up_blocks": [2, 2],
+        "up_hidden": [64, 48],
+        "down_blocks": [2, 2],
+        "down_hidden": [64, 64],
+        "head_width_mult": 0.5,
+    },
+    "m": {
+        "stage_hidden": [64, 128, 256, 384],
+        "stage_concat": [True, True, True, False],
+        "up_blocks": [2, 3],
+        "up_hidden": [192, 64],
+        "down_blocks": [2, 3],
+        "down_hidden": [192, 256],
+        "head_width_mult": 0.75,
+    },
+    "l": {
+        "stage_hidden": [96, 128, 256, 512],
+        "stage_concat": [True, True, True, True],
+        "up_blocks": [4, 4],
+        "up_hidden": [128, 128],
+        "down_blocks": [4, 4],
+        "down_hidden": [128, 256],
+        "head_width_mult": 1.0,
+    },
+}
+
+
+class LibreYOLONASModel(nn.Module):
+    def __init__(
+        self,
+        config: str = "s",
+        nb_classes: int = 80,
+        in_channels: int = 3,
+        reg_max: int = 16,
+        eval_size: Optional[Tuple[int, int]] = None,
+        bn_eps: float = 1e-3,
+        bn_momentum: float = 0.03,
+        inplace_act: bool = True,
+    ):
+        super().__init__()
+        if config not in _VARIANT_CONFIGS:
+            raise ValueError(f"Unknown YOLO-NAS config '{config}'")
+
+        variant = _VARIANT_CONFIGS[config]
+        self.config = config
+        self.nc = nb_classes
+        self.reg_max = reg_max
+
+        self.backbone = YoloNASBackbone(variant, in_channels=in_channels)
+        self.neck = YoloNASPANNeckWithC2(list(self.backbone.out_channels), variant)
+        self.heads = NDFLHeads(
+            num_classes=nb_classes,
+            in_channels=tuple(self.neck.out_channels),
+            width_mult=variant["head_width_mult"],
+            reg_max=reg_max,
+            eval_size=eval_size,
+        )
+        self._initialize_weights(bn_eps, bn_momentum, inplace_act)
+
+    @property
+    def head(self):
+        return self.heads
+
+    def _initialize_weights(self, bn_eps: float, bn_momentum: float, inplace_act: bool):
+        for m in self.modules():
+            if isinstance(m, nn.BatchNorm2d):
+                m.eps = bn_eps
+                m.momentum = bn_momentum
+            elif inplace_act and isinstance(m, (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, nn.Mish)):
+                m.inplace = True
+
+    def prep_model_for_conversion(self, input_size=None, full_fusion: bool = False, **kwargs):
+        for module in self.modules():
+            if module is not self and hasattr(module, "prep_model_for_conversion"):
+                module.prep_model_for_conversion(input_size=input_size, full_fusion=full_fusion, **kwargs)
+
+    def fuse_reparam(self, full_fusion: bool = False):
+        self.prep_model_for_conversion(full_fusion=full_fusion)
+        return self
+
+    def forward(self, x: Tensor):
+        x = self.backbone(x)
+        x = self.neck(x)
+        return self.heads(x)

--- a/libreyolo/models/yolonas/trainer.py
+++ b/libreyolo/models/yolonas/trainer.py
@@ -1,0 +1,70 @@
+"""YOLO-NAS trainer for native LibreYOLO training."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+import torch
+
+from ...training.config import TrainConfig, YOLONASConfig
+from ...training.scheduler import CosineAnnealingScheduler
+from ...training.trainer import BaseTrainer
+from .loss import PPYoloELoss
+from .transforms import YOLONASAffineMixupDataset, YOLONASTrainTransform
+
+
+class YOLONASTrainer(BaseTrainer):
+    @classmethod
+    def _config_class(cls) -> Type[TrainConfig]:
+        return YOLONASConfig
+
+    def get_model_family(self) -> str:
+        return "yolonas"
+
+    def get_model_tag(self) -> str:
+        return f"YOLO-NAS-{self.config.size}"
+
+    def create_transforms(self):
+        preproc = YOLONASTrainTransform(
+            max_labels=100,
+            flip_prob=self.config.flip_prob,
+            hsv_prob=self.config.hsv_prob,
+        )
+        return preproc, YOLONASAffineMixupDataset
+
+    def create_scheduler(self, iters_per_epoch: int):
+        return CosineAnnealingScheduler(
+            lr=self.effective_lr,
+            iters_per_epoch=iters_per_epoch,
+            total_epochs=self.config.epochs,
+            warmup_epochs=self.config.warmup_epochs,
+            warmup_lr_start=self.config.warmup_lr_start,
+            min_lr_ratio=self.config.min_lr_ratio,
+        )
+
+    def on_setup(self):
+        self.loss_fn = PPYoloELoss(
+            num_classes=self.config.num_classes,
+            use_static_assigner=False,
+            use_varifocal_loss=True,
+        ).to(self.device)
+
+    def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
+        def _scalar(v):
+            return v.item() if isinstance(v, torch.Tensor) else v
+
+        return {
+            "cls": _scalar(outputs.get("cls", 0)),
+            "iou": _scalar(outputs.get("iou", 0)),
+            "dfl": _scalar(outputs.get("dfl", 0)),
+        }
+
+    def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor) -> Dict:
+        model_outputs = self.model(imgs)
+        total_loss, log_losses = self.loss_fn(model_outputs, targets)
+        return {
+            "total_loss": total_loss,
+            "cls": log_losses[0],
+            "iou": log_losses[1],
+            "dfl": log_losses[2],
+        }

--- a/libreyolo/models/yolonas/transforms.py
+++ b/libreyolo/models/yolonas/transforms.py
@@ -1,0 +1,228 @@
+"""YOLO-NAS training transforms and dataset wrapper."""
+
+from __future__ import annotations
+
+import random
+
+import cv2
+import numpy as np
+
+from ...training.augment import (
+    adjust_box_anns,
+    augment_hsv,
+    mirror,
+    random_affine,
+    xyxy2cxcywh,
+)
+
+
+def preproc(img, input_size, swap=(2, 0, 1)):
+    """Letterbox to RGB float32/0-1, matching the native inference path."""
+    if len(img.shape) == 3:
+        padded_img = np.ones((input_size[0], input_size[1], 3), dtype=np.uint8) * 114
+    else:
+        padded_img = np.ones(input_size, dtype=np.uint8) * 114
+
+    r = min(input_size[0] / img.shape[0], input_size[1] / img.shape[1])
+    resized_img = cv2.resize(
+        img,
+        (int(img.shape[1] * r), int(img.shape[0] * r)),
+        interpolation=cv2.INTER_LINEAR,
+    ).astype(np.uint8)
+    padded_img[: int(img.shape[0] * r), : int(img.shape[1] * r)] = resized_img
+
+    padded_img = padded_img[:, :, ::-1]  # BGR -> RGB
+    padded_img = padded_img.transpose(swap)
+    padded_img = np.ascontiguousarray(padded_img, dtype=np.float32) / 255.0
+    return padded_img, r
+
+
+class YOLONASTrainTransform:
+    """Train transform emitting `[class, cx, cy, w, h]` pixel targets."""
+
+    def __init__(self, max_labels=100, flip_prob=0.5, hsv_prob=0.5):
+        self.max_labels = max_labels
+        self.flip_prob = flip_prob
+        self.hsv_prob = hsv_prob
+
+    def __call__(self, image, targets, input_dim):
+        boxes = targets[:, :4].copy()
+        labels = targets[:, 4].copy()
+
+        if len(boxes) == 0:
+            padded_labels = np.zeros((self.max_labels, 5), dtype=np.float32)
+            image, _ = preproc(image, input_dim)
+            return image, padded_labels
+
+        image_o = image.copy()
+        boxes_o = boxes.copy()
+        labels_o = labels.copy()
+        boxes_o = xyxy2cxcywh(boxes_o)
+
+        if random.random() < self.hsv_prob:
+            augment_hsv(image)
+
+        image_t, boxes = mirror(image, boxes, self.flip_prob)
+        image_t, r = preproc(image_t, input_dim)
+        boxes = xyxy2cxcywh(boxes)
+        boxes *= r
+
+        mask_b = np.minimum(boxes[:, 2], boxes[:, 3]) > 1
+        boxes_t = boxes[mask_b]
+        labels_t = labels[mask_b]
+
+        if len(boxes_t) == 0:
+            image_t, r_o = preproc(image_o, input_dim)
+            boxes_o *= r_o
+            boxes_t = boxes_o
+            labels_t = labels_o
+
+        labels_t = np.expand_dims(labels_t, 1)
+        targets_t = np.hstack((labels_t, boxes_t))
+        padded_labels = np.zeros((self.max_labels, 5), dtype=np.float32)
+        padded_labels[range(len(targets_t))[: self.max_labels]] = targets_t[
+            : self.max_labels
+        ]
+        padded_labels = np.ascontiguousarray(padded_labels, dtype=np.float32)
+        return image_t, padded_labels
+
+
+class YOLONASAffineMixupDataset:
+    """Small YOLO-NAS-specific wrapper with affine + optional mixup.
+
+    The constructor matches BaseTrainer's existing dataset-wrapper contract so
+    the family can plug into shared training infrastructure without widening
+    that interface first.
+    """
+
+    def __init__(
+        self,
+        dataset,
+        img_size,
+        mosaic=True,
+        preproc=None,
+        degrees=0.0,
+        translate=0.25,
+        mosaic_scale=(0.5, 1.5),
+        mixup_scale=(0.5, 1.5),
+        shear=0.0,
+        enable_mixup=False,
+        mosaic_prob=0.0,
+        mixup_prob=0.0,
+    ):
+        del mosaic, mosaic_prob
+        self.dataset = dataset
+        self.img_size = img_size
+        self.preproc = preproc or YOLONASTrainTransform()
+        self.degrees = degrees
+        self.translate = translate
+        self.scale = mosaic_scale
+        self.shear = shear
+        self.mixup_scale = mixup_scale
+        self.enable_affine = True
+        self.enable_mixup = enable_mixup
+        self.mixup_prob = mixup_prob
+
+    def __len__(self):
+        return len(self.dataset)
+
+    @property
+    def input_dim(self):
+        return self.img_size
+
+    def close_mosaic(self):
+        self.enable_affine = False
+        self.enable_mixup = False
+
+    def __getitem__(self, idx):
+        img, label, img_info, img_id = self.dataset.pull_item(idx)
+
+        if self.enable_affine:
+            input_h, input_w = self.input_dim
+            img, label = random_affine(
+                img,
+                label,
+                target_size=(input_w, input_h),
+                degrees=self.degrees,
+                translate=self.translate,
+                scales=self.scale,
+                shear=self.shear,
+            )
+
+        if self.enable_mixup and len(label) > 0 and random.random() < self.mixup_prob:
+            img, label = self._mixup(img, label)
+
+        img, label = self.preproc(img, label, self.input_dim)
+        return img, label, img_info, img_id
+
+    def _mixup(self, origin_img, origin_labels):
+        jit_factor = random.uniform(*self.mixup_scale)
+        flip = random.uniform(0, 1) > 0.5
+
+        cp_labels = []
+        while len(cp_labels) == 0:
+            cp_index = random.randint(0, len(self.dataset) - 1)
+            cp_labels = self.dataset.load_anno(cp_index)
+
+        img, cp_labels, _, _ = self.dataset.pull_item(cp_index)
+        input_dim = self.input_dim
+        cp_img = np.ones((input_dim[0], input_dim[1], 3), dtype=np.uint8) * 114
+
+        cp_scale_ratio = min(input_dim[0] / img.shape[0], input_dim[1] / img.shape[1])
+        resized_img = cv2.resize(
+            img,
+            (int(img.shape[1] * cp_scale_ratio), int(img.shape[0] * cp_scale_ratio)),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        cp_img[
+            : int(img.shape[0] * cp_scale_ratio), : int(img.shape[1] * cp_scale_ratio)
+        ] = resized_img
+
+        cp_img = cv2.resize(
+            cp_img,
+            (int(cp_img.shape[1] * jit_factor), int(cp_img.shape[0] * jit_factor)),
+        )
+        cp_scale_ratio *= jit_factor
+
+        if flip:
+            cp_img = cp_img[:, ::-1, :]
+
+        origin_h, origin_w = cp_img.shape[:2]
+        target_h, target_w = origin_img.shape[:2]
+        padded_img = np.zeros(
+            (max(origin_h, target_h), max(origin_w, target_w), 3), dtype=np.uint8
+        )
+        padded_img[:origin_h, :origin_w] = cp_img
+
+        x_offset, y_offset = 0, 0
+        if padded_img.shape[0] > target_h:
+            y_offset = random.randint(0, padded_img.shape[0] - target_h - 1)
+        if padded_img.shape[1] > target_w:
+            x_offset = random.randint(0, padded_img.shape[1] - target_w - 1)
+
+        padded_cropped_img = padded_img[
+            y_offset : y_offset + target_h, x_offset : x_offset + target_w
+        ]
+
+        cp_bboxes_origin_np = adjust_box_anns(
+            cp_labels[:, :4].copy(), cp_scale_ratio, 0, 0, origin_w, origin_h
+        )
+        if flip:
+            cp_bboxes_origin_np[:, 0::2] = (
+                origin_w - cp_bboxes_origin_np[:, 0::2][:, ::-1]
+            )
+        cp_bboxes_transformed_np = cp_bboxes_origin_np.copy()
+        cp_bboxes_transformed_np[:, 0::2] = np.clip(
+            cp_bboxes_transformed_np[:, 0::2] - x_offset, 0, target_w
+        )
+        cp_bboxes_transformed_np[:, 1::2] = np.clip(
+            cp_bboxes_transformed_np[:, 1::2] - y_offset, 0, target_h
+        )
+
+        cls_labels = cp_labels[:, 4:5].copy()
+        labels = np.hstack((cp_bboxes_transformed_np, cls_labels))
+        merged_labels = np.vstack((origin_labels, labels))
+
+        origin_img = origin_img.astype(np.float32)
+        origin_img = 0.5 * origin_img + 0.5 * padded_cropped_img.astype(np.float32)
+        return origin_img.astype(np.uint8), merged_labels

--- a/libreyolo/models/yolonas/utils.py
+++ b/libreyolo/models/yolonas/utils.py
@@ -1,0 +1,124 @@
+"""YOLO-NAS preprocessing, postprocessing, and checkpoint helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping, MutableMapping, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+
+from ...utils.general import postprocess_detections
+from ...utils.image_loader import ImageInput, ImageLoader
+
+
+def unwrap_yolonas_checkpoint(
+    checkpoint: Mapping | MutableMapping,
+):
+    """Extract the actual state dict from common YOLO-NAS checkpoint layouts.
+
+    Official SuperGradients checkpoints typically store weights under ``net``,
+    while training checkpoints may also contain ``ema_net``. Prefer EMA weights
+    when present so downstream loading mirrors SG's own behavior.
+    """
+    if not isinstance(checkpoint, Mapping):
+        return checkpoint
+
+    for key in ("ema_net", "net", "model", "state_dict"):
+        value = checkpoint.get(key)
+        if isinstance(value, Mapping):
+            return value
+
+    return checkpoint
+
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray,
+    input_size: int = 640,
+    pad_value: int = 114,
+) -> Tuple[np.ndarray, float]:
+    """Preprocess RGB HWC uint8 image for YOLO-NAS inference.
+
+    This currently follows LibreYOLO's shared letterbox convention so validation
+    and single-image inference scale boxes back consistently. A later parity
+    pass can tighten this toward the exact SG processing pipeline.
+    """
+    orig_h, orig_w = img_rgb_hwc.shape[:2]
+    ratio = min(input_size / orig_h, input_size / orig_w)
+    new_w, new_h = int(orig_w * ratio), int(orig_h * ratio)
+
+    img_resized = Image.fromarray(img_rgb_hwc).resize(
+        (new_w, new_h), Image.Resampling.BILINEAR
+    )
+
+    padded = Image.new("RGB", (input_size, input_size), (pad_value, pad_value, pad_value))
+    padded.paste(img_resized, (0, 0))
+
+    arr = np.array(padded, dtype=np.float32) / 255.0
+    return arr.transpose(2, 0, 1), ratio
+
+
+def preprocess_image(
+    image: ImageInput,
+    input_size: int = 640,
+    color_format: str = "auto",
+) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
+    img = ImageLoader.load(image, color_format=color_format)
+    original_size = img.size
+    original_img = img.copy()
+
+    img_chw, ratio = preprocess_numpy(np.array(img), input_size=input_size)
+    img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
+    return img_tensor, original_img, original_size, ratio
+
+
+def _extract_decoded_predictions(output):
+    if isinstance(output, dict):
+        boxes = output["boxes"]
+        scores = output["scores"]
+        return boxes, scores
+
+    if isinstance(output, tuple):
+        if len(output) == 2 and isinstance(output[0], tuple):
+            return output[0]
+        if len(output) == 2 and all(isinstance(x, torch.Tensor) for x in output):
+            return output
+
+    raise TypeError(
+        "Unsupported YOLO-NAS output format for postprocess: "
+        f"{type(output)!r}"
+    )
+
+
+def postprocess(
+    output,
+    conf_thres: float = 0.25,
+    iou_thres: float = 0.45,
+    input_size: int = 640,
+    original_size: Tuple[int, int] | None = None,
+    max_det: int = 300,
+    letterbox: bool = True,
+):
+    boxes, scores = _extract_decoded_predictions(output)
+
+    if boxes.dim() == 3:
+        boxes = boxes[0]
+    if scores.dim() == 3:
+        scores = scores[0]
+
+    max_scores, class_ids = torch.max(scores, dim=1)
+    mask = max_scores > conf_thres
+    if not mask.any():
+        return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
+
+    return postprocess_detections(
+        boxes=boxes[mask].clone(),
+        scores=max_scores[mask],
+        class_ids=class_ids[mask],
+        conf_thres=conf_thres,
+        iou_thres=iou_thres,
+        input_size=input_size,
+        original_size=original_size,
+        max_det=max_det,
+        letterbox=letterbox,
+    )

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -259,6 +259,7 @@ class LibreYOLOX(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreYOLOX('path/to/last.pt'); model.train(data=..., resume=True)"
                 )
+            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -136,3 +136,30 @@ class YOLO9Config(TrainConfig):
     ema_decay: float = 0.9999
     name: str = "yolo9_exp"
     workers: int = 8
+
+
+@dataclass(kw_only=True)
+class YOLONASConfig(TrainConfig):
+    """YOLO-NAS-specific training defaults."""
+
+    optimizer: str = "adamw"
+    lr0: float = 5e-4
+    momentum: float = 0.9
+    weight_decay: float = 1e-5
+    scheduler: str = "cos"
+    warmup_epochs: int = 1
+    warmup_lr_start: float = 1e-6
+    no_aug_epochs: int = 0
+    min_lr_ratio: float = 0.1
+    mosaic_prob: float = 0.0
+    mixup_prob: float = 0.5
+    hsv_prob: float = 0.5
+    flip_prob: float = 0.5
+    degrees: float = 0.0
+    translate: float = 0.25
+    mosaic_scale: Tuple[float, float] = (0.5, 1.5)
+    mixup_scale: Tuple[float, float] = (0.5, 1.5)
+    shear: float = 0.0
+    ema_decay: float = 0.9997
+    amp: bool = False
+    name: str = "yolonas_exp"

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -63,6 +63,7 @@ class BaseTrainer(ABC):
         self.ema_model = None
         self.train_loader = None
         self.tensorboard_writer = None
+        self._is_setup = False
 
     # =========================================================================
     # Config
@@ -302,6 +303,9 @@ class BaseTrainer(ABC):
     # =========================================================================
 
     def setup(self):
+        if self._is_setup:
+            return
+
         logger.info("Setting up training...")
         self.model.to(self.device)
 
@@ -337,6 +341,7 @@ class BaseTrainer(ABC):
             logger.info("Training will continue without TensorBoard logging")
 
         logger.info(f"Saving to: {self.save_dir}")
+        self._is_setup = True
 
     def train(self) -> Dict:
         self.setup()
@@ -499,6 +504,7 @@ class BaseTrainer(ABC):
                 device=str(self.device),
                 half=self.config.amp and self.device.type == "cuda",
                 verbose=False,
+                num_workers=self.config.workers,
             )
 
             if self.wrapper_model is None:

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -4,8 +4,11 @@ import os
 import re
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 
 import requests
+
+_YOLONAS_LICENSE_NOTICE_SHOWN = False
 
 
 def _get_hf_token() -> Optional[str]:
@@ -17,6 +20,24 @@ def _get_hf_token() -> Optional[str]:
     if token_path.exists():
         return token_path.read_text().strip()
     return None
+
+
+def _notify_yolonas_license_once() -> None:
+    """Print Deci's YOLO-NAS license terms once per process before download."""
+    global _YOLONAS_LICENSE_NOTICE_SHOWN
+    if _YOLONAS_LICENSE_NOTICE_SHOWN:
+        return
+    _YOLONAS_LICENSE_NOTICE_SHOWN = True
+    print(
+        "\n"
+        "─────────────────────────────────────────────────────────────────────\n"
+        "YOLO-NAS weights are distributed by Deci.AI under a proprietary\n"
+        "license (non-commercial, no redistribution, no production use\n"
+        "without a separate agreement). By downloading, you accept those\n"
+        "terms. Full license text:\n"
+        "  https://github.com/Deci-AI/super-gradients/blob/master/LICENSE.YOLONAS.md\n"
+        "─────────────────────────────────────────────────────────────────────\n"
+    )
 
 
 def _detect_family_from_filename(filename: str) -> Optional[str]:
@@ -64,11 +85,18 @@ def download_weights(model_path: str, size: str):
     print(f"Model weights not found at {model_path}. Attempting download from {url}...")
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    host = urlparse(url).netloc
+    is_hf = host.endswith("huggingface.co")
+
+    if "cloudfront.net" in host or host.endswith("deci.ai"):
+        _notify_yolonas_license_once()
+
     headers = {}
     token = _get_hf_token()
-    if token:
+    if token and is_hf:
+        # Only attach the HF token to HF URLs — never leak it to third parties.
         headers["Authorization"] = f"Bearer {token}"
-    else:
+    elif is_hf and not token:
         print("Tip: Run `huggingface-cli login` or set HF_TOKEN for faster downloads.")
 
     try:

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -48,6 +48,7 @@ class DetectionValidator(BaseValidator):
         self.iou_thresholds = torch.tensor(self.config.iou_thresholds)
         self.nc = model.nb_classes
         self.val_preproc = None  # set in _setup_dataloader
+        self.data_cfg = None
 
     # =========================================================================
     # Setup
@@ -84,6 +85,7 @@ class DetectionValidator(BaseValidator):
 
         if self.config.data:
             data_cfg = load_data_config(self.config.data)
+            self.data_cfg = data_cfg
             data_dir = data_cfg["root"]
             self.nc = data_cfg.get("nc", self.nc)
 
@@ -202,7 +204,11 @@ class DetectionValidator(BaseValidator):
                 if self.config.verbose:
                     print("Initializing COCO evaluator...")
 
-                coco_api = create_yolo_coco_api(self.config.data, self.config.split)
+                data_yaml = self.config.data
+                if self.data_cfg is not None:
+                    data_yaml = self.data_cfg.get("yaml_file", data_yaml)
+
+                coco_api = create_yolo_coco_api(data_yaml, self.config.split)
                 self.coco_evaluator = COCOEvaluator(coco_api, iou_type="bbox")
 
                 if self.config.verbose:

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -230,3 +230,12 @@ class YOLO9ValPreprocessor(BaseValPreprocessor):
             padded_targets[:n] = targets[:n]
 
         return padded_img, padded_targets
+
+
+class YOLONASValPreprocessor(YOLO9ValPreprocessor):
+    """YOLO-NAS preprocessor.
+
+    The current native port uses LibreYOLO's shared RGB 0-1 letterbox path for
+    consistency across inference and validation. A later parity pass can tighten
+    this toward the exact SG preprocessing contract if needed.
+    """

--- a/tests/e2e/configs/yolonas.yaml
+++ b/tests/e2e/configs/yolonas.yaml
@@ -1,0 +1,43 @@
+# RF5 - YOLO-NAS family
+model_type: yolonas
+
+# Size-specific defaults
+sizes:
+  s: {imgsz: 640, lr0: 0.0005, weights: downloads/yolonas/yolo_nas_s_coco.pth}
+  m: {imgsz: 640, lr0: 0.0005, weights: downloads/yolonas/yolo_nas_m_coco.pth}
+  l: {imgsz: 640, lr0: 0.0005, weights: downloads/yolonas/yolo_nas_l_coco.pth}
+
+# Training
+epochs: 100
+batch_size: 16
+optimizer: adamw
+momentum: 0.9
+weight_decay: 0.00001
+nesterov: true
+
+# Scheduler
+scheduler: cos
+warmup_epochs: 1
+warmup_lr_start: 0.000001
+no_aug_epochs: 0
+min_lr_ratio: 0.1
+
+# Augmentation
+mosaic_prob: 0.0
+mixup_prob: 0.5
+hsv_prob: 0.5
+flip_prob: 0.5
+degrees: 0.0
+translate: 0.25
+mosaic_scale: [0.5, 1.5]
+mixup_scale: [0.5, 1.5]
+shear: 0.0
+
+# Training options
+ema: true
+ema_decay: 0.9997
+amp: false
+patience: 50
+eval_interval: 10
+save_period: 10
+workers: 4

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,6 +2,7 @@
 
 import gc
 import multiprocessing
+from pathlib import Path
 
 import pytest
 import torch
@@ -333,6 +334,9 @@ MODEL_CATALOG = [
     ("yolo9", "s", "LibreYOLO9s.pt"),
     ("yolo9", "m", "LibreYOLO9m.pt"),
     ("yolo9", "c", "LibreYOLO9c.pt"),
+    ("yolonas", "s", "downloads/yolonas/yolo_nas_s_coco.pth"),
+    ("yolonas", "m", "downloads/yolonas/yolo_nas_m_coco.pth"),
+    ("yolonas", "l", "downloads/yolonas/yolo_nas_l_coco.pth"),
     ("rfdetr", "n", "LibreRFDETRn.pt"),
     ("rfdetr", "s", "LibreRFDETRs.pt"),
     ("rfdetr", "m", "LibreRFDETRm.pt"),
@@ -342,17 +346,18 @@ MODEL_CATALOG = [
 # Derived lists (no manual maintenance)
 YOLOX_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "yolox"]
 YOLO9_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "yolo9"]
+YOLONAS_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "yolonas"]
 RFDETR_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "rfdetr"]
 
 ALL_MODELS = [(f, s) for f, s, _ in MODEL_CATALOG]
 ALL_MODELS_WITH_WEIGHTS = MODEL_CATALOG
-YOLOX_YOLO9_MODELS = [(f, s) for f, s, _ in MODEL_CATALOG if f != "rfdetr"]
+NON_RFDETR_MODELS = [(f, s) for f, s, _ in MODEL_CATALOG if f != "rfdetr"]
 
-# Quick test set (for CI — smallest models only)
+# Quick test set (for CI — smallest auto-available models only)
 QUICK_TEST_MODELS = [("yolox", "n"), ("yolo9", "t")]
 
-# Full test set (YOLOX + YOLO9, no RF-DETR)
-FULL_TEST_MODELS = YOLOX_YOLO9_MODELS
+# Full test set (all non-RF-DETR models)
+FULL_TEST_MODELS = NON_RFDETR_MODELS
 
 # RF-DETR test set (separate due to dependency)
 RFDETR_TEST_MODELS = [(f, s) for f, s, _ in MODEL_CATALOG if f == "rfdetr"]
@@ -364,6 +369,14 @@ def get_model_weights(family: str, size: str) -> str:
         if f == family and s == size:
             return w
     raise ValueError(f"Unknown model: {family}-{size}")
+
+
+def require_test_weights(weights: str) -> str:
+    """Skip cleanly if a test depends on a missing local checkpoint path."""
+    path = Path(weights)
+    if path.parent != Path(".") and not path.exists():
+        pytest.skip(f"Required local weights not found: {weights}")
+    return weights
 
 
 def make_ids(models):
@@ -433,7 +446,7 @@ def load_model(model_type: str, size: str, device: str = "cuda"):
     """Load a model by type and size."""
     from libreyolo import LibreYOLO
 
-    weights = get_model_weights(model_type, size)
+    weights = require_test_weights(get_model_weights(model_type, size))
     return LibreYOLO(weights, device=device)
 
 

--- a/tests/e2e/test_ncnn.py
+++ b/tests/e2e/test_ncnn.py
@@ -35,6 +35,12 @@ from .conftest import (
 )
 
 pytestmark = [pytest.mark.e2e, pytest.mark.ncnn]
+OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
+OFFICIAL_YOLONAS_WEIGHTS = {
+    "s": Path("downloads/yolonas/yolo_nas_s_coco.pth"),
+    "m": Path("downloads/yolonas/yolo_nas_m_coco.pth"),
+    "l": Path("downloads/yolonas/yolo_nas_l_coco.pth"),
+}
 
 # ---------------------------------------------------------------------------
 # xfail markers for ncnn op limitations
@@ -97,6 +103,51 @@ class TestNCNNExportFP32:
             "model.ncnn.param not found"
         )
         assert (exported_dir / "model.ncnn.bin").exists(), "model.ncnn.bin not found"
+
+
+class TestNCNNYOLONAS:
+    """Test ncnn export for the official YOLO-NAS-S checkpoint."""
+
+    @requires_ncnn
+    @pytest.mark.skipif(
+        not OFFICIAL_YOLONAS_S.exists(),
+        reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+    )
+    def test_ncnn_export_yolonas_s(self, sample_image, tmp_path):
+        """Export YOLO-NAS-S to ncnn, reload it, and compare inference results."""
+        from libreyolo import LibreYOLO
+
+        pt_model = LibreYOLO(str(OFFICIAL_YOLONAS_S), device="cpu")
+        pt_results = pt_model(sample_image, conf=0.25)
+
+        ncnn_path = str(tmp_path / "yolonas_s_ncnn")
+        exported_path = pt_model.export(
+            format="ncnn",
+            output_path=ncnn_path,
+            half=False,
+            simplify=False,
+        )
+        assert Path(exported_path).is_dir(), "ncnn output directory not created"
+        assert (Path(exported_path) / "model.ncnn.param").exists()
+        assert (Path(exported_path) / "model.ncnn.bin").exists()
+
+        loaded_model = LibreYOLO(exported_path, device="cpu")
+        assert loaded_model.model_family == "yolonas"
+        assert loaded_model.nb_classes == pt_model.nb_classes
+        assert loaded_model.names == pt_model.names
+
+        ncnn_results = loaded_model(sample_image, conf=0.25)
+
+        match_rate, matched, total = match_detections(pt_results, ncnn_results)
+        assert results_are_acceptable(
+            match_rate,
+            len(pt_results),
+            len(ncnn_results),
+            threshold=0.8,
+        ), (
+            f"Results mismatch: PT={len(pt_results)}, NCNN={len(ncnn_results)}, "
+            f"matched={matched}/{total}, rate={match_rate:.2%}"
+        )
 
 
 class TestNCNNExportFP16:
@@ -395,6 +446,37 @@ class TestNCNNModelCoverage:
             assert Path(exported_path).is_dir(), f"Failed to export RF-DETR-{size}"
 
             # Verify inference works via backend
+            ncnn_model = LibreYOLO(exported_path)
+            result = ncnn_model(sample_image, conf=0.25)
+            assert result is not None
+
+            del pt_model
+
+    @requires_ncnn
+    @pytest.mark.slow
+    def test_all_yolonas_sizes_exportable(self, sample_image, tmp_path):
+        """Test that all local official YOLO-NAS detection sizes export and run."""
+        from libreyolo import LibreYOLO
+
+        missing = [size for size, path in OFFICIAL_YOLONAS_WEIGHTS.items() if not path.exists()]
+        if missing:
+            pytest.skip(
+                "Official YOLO-NAS checkpoints not present for sizes: "
+                + ", ".join(sorted(missing))
+            )
+
+        for size, weights in OFFICIAL_YOLONAS_WEIGHTS.items():
+            pt_model = LibreYOLO(str(weights), device="cpu")
+            ncnn_path = str(tmp_path / f"yolonas_{size}_ncnn")
+
+            exported_path = pt_model.export(
+                format="ncnn",
+                output_path=ncnn_path,
+                half=False,
+                simplify=False,
+            )
+            assert Path(exported_path).is_dir(), f"Failed to export YOLO-NAS-{size}"
+
             ncnn_model = LibreYOLO(exported_path)
             result = ncnn_model(sample_image, conf=0.25)
             assert result is not None

--- a/tests/e2e/test_onnx.py
+++ b/tests/e2e/test_onnx.py
@@ -22,13 +22,21 @@ from .conftest import (
     QUICK_TEST_MODELS,
     RFDETR_TEST_MODELS,
     load_model,
+    match_detections,
     requires_rfdetr,
+    results_are_acceptable,
     run_consistency_test,
     run_export_compare_test,
     run_metadata_round_trip_test,
 )
 
 pytestmark = pytest.mark.e2e
+OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
+OFFICIAL_YOLONAS_WEIGHTS = {
+    "s": Path("downloads/yolonas/yolo_nas_s_coco.pth"),
+    "m": Path("downloads/yolonas/yolo_nas_m_coco.pth"),
+    "l": Path("downloads/yolonas/yolo_nas_l_coco.pth"),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +83,53 @@ class TestONNXExport:
         # ONNX-specific: verify model validity
         onnx_model = onnx.load(exported_path)
         onnx.checker.check_model(onnx_model)
+
+
+class TestONNXYOLONAS:
+    """Test ONNX export for the official YOLO-NAS-S checkpoint."""
+
+    @pytest.mark.skipif(
+        not OFFICIAL_YOLONAS_S.exists(),
+        reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+    )
+    def test_onnx_export_yolonas_s(self, sample_image, tmp_path):
+        """Export YOLO-NAS-S to ONNX, reload it, and compare inference results."""
+        from libreyolo import LibreYOLO
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        pt_model = LibreYOLO(str(OFFICIAL_YOLONAS_S), device=device)
+        pt_results = pt_model(sample_image, conf=0.25)
+
+        onnx_path = str(tmp_path / "yolonas_s.onnx")
+        exported_path = pt_model.export(
+            format="onnx",
+            output_path=onnx_path,
+            simplify=True,
+            dynamic=True,
+        )
+        assert Path(exported_path).exists(), "ONNX file not created"
+
+        onnx_model = onnx.load(exported_path)
+        onnx.checker.check_model(onnx_model)
+
+        loaded_model = LibreYOLO(exported_path, device=device)
+        assert loaded_model.model_family == "yolonas"
+        assert loaded_model.nb_classes == pt_model.nb_classes
+        assert loaded_model.names == pt_model.names
+
+        onnx_results = loaded_model(sample_image, conf=0.25)
+
+        match_rate, matched, total = match_detections(pt_results, onnx_results)
+        assert results_are_acceptable(
+            match_rate,
+            len(pt_results),
+            len(onnx_results),
+            threshold=0.8,
+        ), (
+            f"Results mismatch: PT={len(pt_results)}, ONNX={len(onnx_results)}, "
+            f"matched={matched}/{total}, rate={match_rate:.2%}"
+        )
 
 
 class TestONNXExportHalf:
@@ -298,6 +353,33 @@ class TestONNXModelCoverage:
             # Verify model is valid
             onnx_model = onnx.load(onnx_path)
             onnx.checker.check_model(onnx_model)
+
+    def test_all_yolonas_sizes_exportable(self, tmp_path):
+        """Test that all local official YOLO-NAS detection sizes export."""
+        from libreyolo import LibreYOLO
+
+        missing = [size for size, path in OFFICIAL_YOLONAS_WEIGHTS.items() if not path.exists()]
+        if missing:
+            pytest.skip(
+                "Official YOLO-NAS checkpoints not present for sizes: "
+                + ", ".join(sorted(missing))
+            )
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        for size, weights in OFFICIAL_YOLONAS_WEIGHTS.items():
+            pt_model = LibreYOLO(str(weights), device=device)
+            onnx_path = str(tmp_path / f"yolonas_{size}.onnx")
+
+            pt_model.export(format="onnx", output_path=onnx_path, simplify=False)
+            assert Path(onnx_path).exists(), f"Failed to export YOLO-NAS-{size}"
+
+            onnx_model = onnx.load(onnx_path)
+            onnx.checker.check_model(onnx_model)
+
+            loaded = LibreYOLO(onnx_path, device=device)
+            assert loaded.model_family == "yolonas"
+            assert loaded.nb_classes == pt_model.nb_classes
 
 
 class TestONNXOpset:

--- a/tests/e2e/test_rf1_training.py
+++ b/tests/e2e/test_rf1_training.py
@@ -1,5 +1,5 @@
 """
-RF1: Training test for all 15 models.
+RF1: Training test for all catalog models.
 
 Trains each model for 2 epochs on LibreYOLO/marbles (HuggingFace, public,
 56 train / 20 valid / 36 test images, 2 classes), then validates on the test
@@ -21,7 +21,13 @@ import yaml
 from PIL import Image
 
 from libreyolo import LibreYOLO
-from .conftest import ALL_MODELS_WITH_WEIGHTS, cuda_cleanup, make_ids, run_in_subprocess
+from .conftest import (
+    ALL_MODELS_WITH_WEIGHTS,
+    cuda_cleanup,
+    make_ids,
+    require_test_weights,
+    run_in_subprocess,
+)
 
 pytestmark = [pytest.mark.e2e, pytest.mark.rf1]
 
@@ -171,6 +177,8 @@ MIN_MAP = 0.05
 )
 def test_rf1_training(family, size, weights, dataset_coco, dataset_data_yaml, tmp_path):
     """Train 10 epochs on marbles, verify loss decreases and mAP improves."""
+    weights = require_test_weights(weights)
+
     # RF-DETR: run in a fresh subprocess to avoid CUDA driver state corruption
     # that causes SIGSEGV when export tests have run beforehand in the same process.
     if family == "rfdetr":

--- a/tests/e2e/test_rf5_training.py
+++ b/tests/e2e/test_rf5_training.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional
 import pytest
 import yaml
 
-from .conftest import cuda_cleanup
+from .conftest import cuda_cleanup, require_test_weights
 
 pytestmark = [pytest.mark.e2e, pytest.mark.rf5]
 
@@ -258,7 +258,7 @@ def test_rf5_training(config_path, size, dataset_name, rf5_datasets, tmp_path):
     assert data_yaml.exists(), f"data.yaml not found in {dataset_path}"
 
     # Create model
-    weights = config.get("model_weights")
+    weights = require_test_weights(config.get("model_weights"))
     model = LibreYOLO(weights, size=size)
 
     # Build train kwargs

--- a/tests/e2e/test_torchscript.py
+++ b/tests/e2e/test_torchscript.py
@@ -18,10 +18,18 @@ from .conftest import (
     QUICK_TEST_MODELS,
     RFDETR_TEST_MODELS,
     load_model,
+    match_detections,
     requires_rfdetr,
+    results_are_acceptable,
 )
 
 pytestmark = pytest.mark.e2e
+OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
+OFFICIAL_YOLONAS_WEIGHTS = {
+    "s": Path("downloads/yolonas/yolo_nas_s_coco.pth"),
+    "m": Path("downloads/yolonas/yolo_nas_m_coco.pth"),
+    "l": Path("downloads/yolonas/yolo_nas_l_coco.pth"),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +86,50 @@ class TestTorchScriptExport:
 
         # Output should be a tensor or tuple
         assert output is not None
+
+
+class TestTorchScriptYOLONAS:
+    """Test TorchScript export for the official YOLO-NAS-S checkpoint."""
+
+    @pytest.mark.skipif(
+        not OFFICIAL_YOLONAS_S.exists(),
+        reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+    )
+    def test_torchscript_export_yolonas_s(self, sample_image, tmp_path):
+        """Export YOLO-NAS-S to TorchScript, reload it, and compare results."""
+        from libreyolo import LibreYOLO
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        pt_model = LibreYOLO(str(OFFICIAL_YOLONAS_S), device=device)
+        pt_results = pt_model(sample_image, conf=0.25)
+
+        ts_path = str(tmp_path / "yolonas_s.torchscript")
+        exported_path = pt_model.export(
+            format="torchscript",
+            output_path=ts_path,
+        )
+        assert Path(exported_path).exists(), "TorchScript file not created"
+        assert Path(exported_path).stat().st_size > 0, "TorchScript file is empty"
+
+        loaded_model = LibreYOLO(exported_path, device=device)
+        assert loaded_model.model_family == "yolonas"
+        assert loaded_model.nb_classes == pt_model.nb_classes
+        assert loaded_model.names == pt_model.names
+        assert loaded_model.imgsz == pt_model._get_input_size()
+
+        ts_results = loaded_model(sample_image, conf=0.25)
+
+        match_rate, matched, total = match_detections(pt_results, ts_results)
+        assert results_are_acceptable(
+            match_rate,
+            len(pt_results),
+            len(ts_results),
+            threshold=0.8,
+        ), (
+            f"Results mismatch: PT={len(pt_results)}, TorchScript={len(ts_results)}, "
+            f"matched={matched}/{total}, rate={match_rate:.2%}"
+        )
 
 
 class TestTorchScriptLoadAndInference:
@@ -244,6 +296,31 @@ class TestTorchScriptModelCoverage:
             except Exception as e:
                 # RF-DETR may have tracing issues due to dynamic shapes
                 pytest.skip(f"RF-DETR-{size} TorchScript export not supported: {e}")
+
+    def test_all_yolonas_sizes_exportable(self, tmp_path):
+        """Test that all local official YOLO-NAS detection sizes export."""
+        from libreyolo import LibreYOLO
+
+        missing = [size for size, path in OFFICIAL_YOLONAS_WEIGHTS.items() if not path.exists()]
+        if missing:
+            pytest.skip(
+                "Official YOLO-NAS checkpoints not present for sizes: "
+                + ", ".join(sorted(missing))
+            )
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        for size, weights in OFFICIAL_YOLONAS_WEIGHTS.items():
+            pt_model = LibreYOLO(str(weights), device=device)
+            ts_path = str(tmp_path / f"yolonas_{size}.torchscript")
+
+            pt_model.export(format="torchscript", output_path=ts_path)
+            assert Path(ts_path).exists(), f"Failed to export YOLO-NAS-{size}"
+
+            loaded = LibreYOLO(ts_path, device=device)
+            assert loaded.model_family == "yolonas"
+            assert loaded.nb_classes == pt_model.nb_classes
+            assert loaded.imgsz == pt_model._get_input_size()
 
 
 class TestTorchScriptBatchSize:

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -6,7 +6,7 @@ runs ByteTrack through several LibreYOLO detectors, checking that:
   - track IDs are assigned and consistent across frames
   - the same person keeps the same ID across consecutive frames
   - no duplicate IDs within a single frame
-  - the tracker works with every supported model family (YOLOX, YOLO9, RF-DETR)
+  - the tracker works with every supported model family (YOLOX, YOLO9, RF-DETR, YOLO-NAS)
 
 The video auto-downloads and is cached at ~/.cache/libreyolo/tracking/ — no
 manual setup needed.
@@ -36,6 +36,8 @@ pytestmark = [pytest.mark.e2e, requires_cuda]
 VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/people-walking.mp4"
 VIDEO_CACHE = Path.home() / ".cache" / "libreyolo" / "tracking"
 VIDEO_PATH = VIDEO_CACHE / "people-walking.mp4"
+
+OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
 
 
 def download_tracking_video():
@@ -185,6 +187,50 @@ class TestTrackingYOLO9:
 
     def test_track_produces_results(self, model, video_path):
         """YOLO9 tracker should produce tracked results."""
+        frames = _run_tracker(model, video_path, n_frames=5)
+        assert len(frames) == 5
+        for f in frames:
+            assert f.track_id is not None
+            assert len(f) > 0
+
+    def test_id_consistency(self, model, video_path):
+        """IDs should persist across consecutive frames."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        stable = sum(
+            1
+            for i in range(1, len(frames))
+            if len(_ids(frames[i - 1]) & _ids(frames[i]))
+            >= len(_ids(frames[i - 1])) * 0.5
+        )
+        assert stable >= len(frames) // 2
+
+    def test_no_duplicate_ids_in_frame(self, model, video_path):
+        """Within a single frame, each ID should be unique."""
+        frames = _run_tracker(model, video_path, n_frames=10)
+        for i, f in enumerate(frames):
+            ids = f.track_id.tolist() if f.track_id is not None else []
+            assert len(ids) == len(set(ids)), f"Frame {i}: duplicate IDs: {ids}"
+
+
+# ── YOLO-NAS ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not OFFICIAL_YOLONAS_S.exists(),
+    reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+)
+class TestTrackingYOLONAS:
+    """Tracking e2e with the smallest YOLO-NAS model."""
+
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = LibreYOLO(str(OFFICIAL_YOLONAS_S))
+        yield m
+        del m
+        cuda_cleanup()
+
+    def test_track_produces_results(self, model, video_path):
+        """YOLO-NAS tracker should produce tracked results."""
         frames = _run_tracker(model, video_path, n_frames=5)
         assert len(frames) == 5
         for f in frames:

--- a/tests/e2e/test_val_coco128.py
+++ b/tests/e2e/test_val_coco128.py
@@ -1,5 +1,5 @@
 """
-val_128: Validation sanity check for all 15 pretrained models.
+val_128: Validation sanity check for all catalog pretrained models.
 
 Runs model.val() on coco128.yaml (128 images) and checks mAP50-95 >= 0.18.
 Purpose: catch catastrophic regressions (broken preprocessing, wrong class
@@ -14,7 +14,12 @@ Usage:
 import pytest
 
 from libreyolo import LibreYOLO
-from .conftest import ALL_MODELS_WITH_WEIGHTS, cuda_cleanup, make_ids
+from .conftest import (
+    ALL_MODELS_WITH_WEIGHTS,
+    cuda_cleanup,
+    make_ids,
+    require_test_weights,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -28,6 +33,7 @@ MIN_MAP = 0.18  # Uniform threshold for all models
 )
 def test_val_coco128(family, size, weights):
     """Validate a pretrained model on coco128 and check mAP >= 0.18."""
+    weights = require_test_weights(weights)
     model = LibreYOLO(weights, size=size)
 
     results = model.val(data="coco128.yaml", batch=16, conf=0.001, iou=0.6)

--- a/tests/e2e/test_video.py
+++ b/tests/e2e/test_video.py
@@ -2,7 +2,7 @@
 E2E video inference: validate model() on a real video with pedestrians.
 
 Downloads a short test video (7.3 MB, 13.6s) from the LibreYOLO HF repo and
-runs video inference through one model per family (YOLOX, YOLO9, RF-DETR),
+runs video inference through one model per family (YOLOX, YOLO9, RF-DETR, YOLO-NAS),
 checking that:
   - stream=True yields a generator of Results
   - stream=False collects Results into a list
@@ -36,6 +36,8 @@ pytestmark = pytest.mark.e2e
 VIDEO_URL = "https://huggingface.co/datasets/LibreYOLO/test-assets/resolve/main/videos/people-walking.mp4"
 VIDEO_CACHE = Path.home() / ".cache" / "libreyolo" / "tracking"
 VIDEO_PATH = VIDEO_CACHE / "people-walking.mp4"
+
+OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
 
 
 def download_video():
@@ -91,6 +93,14 @@ def yolo9_model():
 @pytest.fixture(scope="module")
 def rfdetr_model():
     m = LibreYOLO("LibreRFDETRn.pt")
+    yield m
+    del m
+    cuda_cleanup()
+
+
+@pytest.fixture(scope="module")
+def yolonas_model():
+    m = LibreYOLO(str(OFFICIAL_YOLONAS_S))
     yield m
     del m
     cuda_cleanup()
@@ -328,4 +338,58 @@ class TestVideoRFDETR:
 
     def test_orig_shape(self, rfdetr_model, video_path):
         result = next(iter(rfdetr_model(video_path, stream=True, conf=0.25)))
+        assert result.orig_shape == (1080, 1920)
+
+
+# ---------------------------------------------------------------------------
+# YOLO-NAS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not OFFICIAL_YOLONAS_S.exists(),
+    reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+)
+class TestVideoYOLONAS:
+    """Video inference with YOLO-NAS."""
+
+    def test_stream_returns_generator(self, yolonas_model, video_path):
+        gen = yolonas_model(video_path, stream=True, conf=0.25)
+        assert hasattr(gen, "__next__")
+        result = next(gen)
+        assert result is not None
+        assert result.frame_idx == 0
+        gen.close()
+
+    def test_detects_people(self, yolonas_model, video_path):
+        frames = _collect_n_frames(yolonas_model, video_path, n=30, conf=0.25)
+        total_dets = sum(len(r) for r in frames)
+        assert total_dets > 100, f"Only {total_dets} detections in 30 frames"
+
+    def test_vid_stride(self, yolonas_model, video_path):
+        frames = _collect_n_frames(
+            yolonas_model, video_path, n=1000, conf=0.25, vid_stride=5
+        )
+        indices = [r.frame_idx for r in frames[:5]]
+        assert indices == [0, 5, 10, 15, 20]
+
+    def test_save(self, yolonas_model, video_path, tmp_path):
+        output = str(tmp_path / "yolonas_output.mp4")
+        n = 0
+        for r in yolonas_model(
+            video_path,
+            stream=True,
+            save=True,
+            output_path=output,
+            conf=0.25,
+            vid_stride=10,
+        ):
+            n += 1
+        assert Path(output).exists()
+        cap = cv2.VideoCapture(output)
+        assert int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) == n
+        cap.release()
+
+    def test_orig_shape(self, yolonas_model, video_path):
+        result = next(iter(yolonas_model(video_path, stream=True, conf=0.25)))
         assert result.orig_shape == (1080, 1920)

--- a/tests/e2e/test_yolonas.py
+++ b/tests/e2e/test_yolonas.py
@@ -1,0 +1,155 @@
+"""
+YOLO-NAS end-to-end smoke tests.
+
+These tests cover the native LibreYOLO YOLO-NAS path using the official
+small checkpoint downloaded locally under downloads/yolonas/.
+
+Scope:
+- validation sanity check on coco128
+- training/checkpoint/resume lifecycle smoke
+
+This is intentionally not an exact SuperGradients parity benchmark.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo import LibreYOLO
+
+from .conftest import cuda_cleanup
+
+pytestmark = pytest.mark.e2e
+
+OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
+MIN_MAP = 0.25
+
+
+@pytest.mark.skipif(
+    not OFFICIAL_YOLONAS_S.exists(),
+    reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+)
+def test_yolonas_s_val_coco128():
+    """Validate the official YOLO-NAS-S checkpoint on coco128."""
+    model = LibreYOLO(str(OFFICIAL_YOLONAS_S), device="cpu")
+
+    results = model.val(
+        data="coco128.yaml",
+        batch=8,
+        imgsz=320,
+        conf=0.001,
+        iou=0.6,
+        verbose=False,
+        num_workers=0,
+    )
+
+    map50_95 = results["metrics/mAP50-95"]
+    map50 = results["metrics/mAP50"]
+    print(
+        f"\n  YOLO-NAS-S coco128: mAP50-95={map50_95:.4f}, mAP50={map50:.4f}"
+    )
+
+    assert map50_95 >= MIN_MAP, (
+        f"mAP50-95={map50_95:.4f} below threshold {MIN_MAP} — "
+        "YOLO-NAS validation path may be broken"
+    )
+
+    cuda_cleanup()
+
+
+@pytest.mark.skipif(
+    not OFFICIAL_YOLONAS_S.exists(),
+    reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+)
+def test_yolonas_s_train_resume_smoke(tmp_path):
+    """Train for 1 epoch, reload checkpoint, resume to epoch 2."""
+    model = LibreYOLO(str(OFFICIAL_YOLONAS_S), device="cpu")
+
+    train_results = model.train(
+        data="coco128.yaml",
+        epochs=1,
+        batch=8,
+        imgsz=320,
+        workers=0,
+        device="cpu",
+        amp=False,
+        eval_interval=1,
+        save_period=1,
+        project=str(tmp_path),
+        name="yolonas_s_train",
+        exist_ok=True,
+    )
+
+    first_last_ckpt = Path(train_results["last_checkpoint"])
+    assert first_last_ckpt.exists(), "Initial training run did not save last.pt"
+
+    resumed = LibreYOLO(str(first_last_ckpt), device="cpu")
+    resume_results = resumed.train(
+        data="coco128.yaml",
+        epochs=2,
+        batch=8,
+        imgsz=320,
+        workers=0,
+        device="cpu",
+        amp=False,
+        eval_interval=1,
+        save_period=1,
+        project=str(tmp_path),
+        name="yolonas_s_resume",
+        exist_ok=True,
+        resume=True,
+    )
+
+    resumed_last_ckpt = Path(resume_results["last_checkpoint"])
+    assert resumed_last_ckpt.exists(), "Resume run did not save last.pt"
+    assert resume_results["final_loss"] > 0, "Resume run returned invalid final loss"
+
+    checkpoint = torch.load(resumed_last_ckpt, map_location="cpu", weights_only=False)
+    assert checkpoint["model_family"] == "yolonas"
+    assert checkpoint["size"] == "s"
+    assert checkpoint["nc"] == 80
+    assert checkpoint["epoch"] == 1, "Resume run should finish at epoch index 1"
+
+    reloaded = LibreYOLO(str(resumed_last_ckpt), device="cpu")
+    assert reloaded.size == "s"
+    assert reloaded.nb_classes == 80
+
+    cuda_cleanup()
+
+
+@pytest.mark.skipif(
+    not OFFICIAL_YOLONAS_S.exists(),
+    reason="Official YOLO-NAS-S checkpoint not present in downloads/yolonas/",
+)
+def test_yolonas_s_torchscript_roundtrip(sample_image, tmp_path):
+    """Export YOLO-NAS-S to TorchScript and reload it through LibreYOLO."""
+    model = LibreYOLO(str(OFFICIAL_YOLONAS_S), device="cpu")
+
+    export_path = tmp_path / "yolonas_s.torchscript"
+    exported = model.export(format="torchscript", output_path=str(export_path))
+
+    assert Path(exported).exists(), "TorchScript export did not create a file"
+    assert Path(exported).stat().st_size > 0, "TorchScript export is empty"
+
+    reloaded = LibreYOLO(str(exported), device="cpu")
+    assert reloaded.__class__.__name__ == "TorchScriptBackend"
+    assert reloaded.model_family == "yolonas"
+    assert reloaded.nb_classes == 80
+    assert reloaded.imgsz == 640
+
+    output_image = tmp_path / "yolonas_s_roundtrip.jpg"
+    result = reloaded(
+        sample_image,
+        conf=0.25,
+        iou=0.45,
+        imgsz=640,
+        save=True,
+        output_path=str(output_image),
+    )
+
+    assert len(result.boxes) > 0, "Round-tripped TorchScript model returned no boxes"
+    assert output_image.exists(), "Round-tripped TorchScript inference did not save output"
+    assert result.saved_path == str(output_image)
+
+    cuda_cleanup()

--- a/tests/unit/test_yolonas_heuristics.py
+++ b/tests/unit/test_yolonas_heuristics.py
@@ -1,0 +1,169 @@
+"""Unit tests for YOLO-NAS checkpoint heuristics and native model smoke paths."""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo.models import LibreYOLO, _unwrap_state_dict
+from libreyolo.models.yolonas.loss import PPYoloELoss
+from libreyolo.models.yolonas.model import LibreYOLONAS
+from libreyolo.models.yolonas.nn import LibreYOLONASModel
+from libreyolo.models.yolox.model import LibreYOLOX
+from libreyolo.models.yolo9.model import LibreYOLO9
+from libreyolo.models.yolonas.utils import unwrap_yolonas_checkpoint
+
+pytestmark = pytest.mark.unit
+
+OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
+
+
+def _make_yolonas_state_dict(width: int, num_classes: int = 80):
+    return {
+        "backbone.stem.conv.branch_3x3.conv.weight": torch.zeros(48, 3, 3, 3),
+        "backbone.stem.conv.branch_1x1.weight": torch.zeros(48, 3, 1, 1),
+        "backbone.stem.conv.rbr_reparam.weight": torch.zeros(48, 3, 3, 3),
+        "heads.head1.cls_pred.weight": torch.zeros(num_classes, width, 1, 1),
+        "heads.head1.reg_pred.weight": torch.zeros(68, width, 1, 1),
+    }
+
+
+class TestCheckpointUnwrap:
+    def test_global_unwrap_supports_sg_net(self):
+        state = {"net": {"foo": torch.tensor(1.0)}}
+        assert _unwrap_state_dict(state) == state["net"]
+
+    def test_global_unwrap_prefers_sg_ema_net(self):
+        state = {
+            "net": {"foo": torch.tensor(1.0)},
+            "ema_net": {"bar": torch.tensor(2.0)},
+        }
+        assert _unwrap_state_dict(state) == state["ema_net"]
+
+    def test_local_yolonas_unwrap_prefers_ema_net(self):
+        state = {
+            "net": {"foo": torch.tensor(1.0)},
+            "ema_net": {"bar": torch.tensor(2.0)},
+        }
+        assert unwrap_yolonas_checkpoint(state) == state["ema_net"]
+
+
+class TestYOLONASHeuristics:
+    def test_can_load_positive(self):
+        assert LibreYOLONAS.can_load(_make_yolonas_state_dict(width=64))
+
+    def test_can_load_negative_yolox(self):
+        yolox_state = {
+            "backbone.backbone.stem.conv.conv.weight": torch.zeros(32, 3, 3, 3),
+            "head.cls_preds.0.weight": torch.zeros(80, 32, 1, 1),
+        }
+        assert LibreYOLOX.can_load(yolox_state)
+        assert not LibreYOLONAS.can_load(yolox_state)
+
+    def test_can_load_negative_yolo9(self):
+        yolo9_state = {
+            "backbone.conv0.conv.weight": torch.zeros(32, 3, 3, 3),
+            "backbone.elan1.cv1.conv.weight": torch.zeros(64, 32, 1, 1),
+            "head.cv3.0.2.weight": torch.zeros(80, 64, 1, 1),
+        }
+        assert LibreYOLO9.can_load(yolo9_state)
+        assert not LibreYOLONAS.can_load(yolo9_state)
+
+    @pytest.mark.parametrize(
+        ("width", "expected_size"),
+        [(64, "s"), (96, "m"), (128, "l")],
+    )
+    def test_detect_size_from_head_width(self, width, expected_size):
+        assert (
+            LibreYOLONAS.detect_size(_make_yolonas_state_dict(width=width))
+            == expected_size
+        )
+
+    def test_detect_size_missing_key(self):
+        assert LibreYOLONAS.detect_size({}) is None
+
+    def test_detect_nb_classes(self):
+        assert LibreYOLONAS.detect_nb_classes(_make_yolonas_state_dict(64, 17)) == 17
+
+
+class TestYOLONASNativeModel:
+    def test_native_model_forward_shapes(self):
+        model = LibreYOLONASModel("s")
+        model.eval()
+
+        with torch.no_grad():
+            output = model(torch.randn(1, 3, 640, 640))
+
+        decoded_boxes, decoded_scores = output[0]
+        assert tuple(decoded_boxes.shape) == (1, 8400, 4)
+        assert tuple(decoded_scores.shape) == (1, 8400, 80)
+
+    @pytest.mark.skipif(
+        not OFFICIAL_YOLONAS_S.exists(),
+        reason="Official YOLO-NAS checkpoint not present in local downloads/",
+    )
+    def test_official_checkpoint_loads_cleanly(self):
+        model = LibreYOLONASModel("s")
+        ckpt = torch.load(OFFICIAL_YOLONAS_S, map_location="cpu", weights_only=False)[
+            "net"
+        ]
+        missing, unexpected = model.load_state_dict(ckpt, strict=False)
+        assert missing == []
+        assert unexpected == []
+
+    @pytest.mark.skipif(
+        not OFFICIAL_YOLONAS_S.exists(),
+        reason="Official YOLO-NAS checkpoint not present in local downloads/",
+    )
+    def test_factory_detects_official_checkpoint(self):
+        model = LibreYOLO(str(OFFICIAL_YOLONAS_S), device="cpu")
+        assert isinstance(model, LibreYOLONAS)
+        assert model.size == "s"
+        assert model.nb_classes == 80
+
+    def test_rebuild_for_new_classes_replaces_class_heads(self):
+        model = LibreYOLONAS(model_path=None, size="s", nb_classes=80, device="cpu")
+        assert model.model.heads.head1.cls_pred.weight.shape[0] == 80
+
+        model._rebuild_for_new_classes(5)
+
+        assert model.nb_classes == 5
+        assert model.model.heads.head1.cls_pred.weight.shape[0] == 5
+        assert model.model.heads.head2.cls_pred.weight.shape[0] == 5
+        assert model.model.heads.head3.cls_pred.weight.shape[0] == 5
+
+    def test_loss_backward_with_synthetic_targets(self):
+        model = LibreYOLONASModel("s", nb_classes=80)
+        model.train()
+        loss_fn = PPYoloELoss(num_classes=80)
+
+        imgs = torch.randn(1, 3, 64, 64)
+        targets = torch.zeros(1, 10, 5)
+        targets[0, 0] = torch.tensor([0.0, 32.0, 32.0, 16.0, 20.0])
+
+        outputs = model(imgs)
+        loss, logs = loss_fn(outputs, targets)
+        loss.backward()
+
+        assert torch.isfinite(loss)
+        assert tuple(logs.shape) == (4,)
+        assert model.heads.head1.cls_pred.weight.grad is not None
+
+    def test_factory_detects_local_training_checkpoint(self, tmp_path):
+        wrapper = LibreYOLONAS(model_path=None, size="s", nb_classes=80, device="cpu")
+        ckpt_path = tmp_path / "yolonas_train.pt"
+        torch.save(
+            {
+                "model": wrapper.model.state_dict(),
+                "nc": 80,
+                "size": "s",
+                "model_family": "yolonas",
+                "names": {i: f"class_{i}" for i in range(80)},
+            },
+            ckpt_path,
+        )
+
+        loaded = LibreYOLO(str(ckpt_path), device="cpu")
+        assert isinstance(loaded, LibreYOLONAS)
+        assert loaded.size == "s"
+        assert loaded.nb_classes == 80

--- a/tests/unit/test_yolonas_heuristics.py
+++ b/tests/unit/test_yolonas_heuristics.py
@@ -85,6 +85,30 @@ class TestYOLONASHeuristics:
     def test_detect_nb_classes(self):
         assert LibreYOLONAS.detect_nb_classes(_make_yolonas_state_dict(64, 17)) == 17
 
+    @pytest.mark.parametrize(
+        ("filename", "expected_url"),
+        [
+            (
+                "LibreYOLONASs.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_s_coco.pth",
+            ),
+            (
+                "LibreYOLONASm.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_m_coco.pth",
+            ),
+            (
+                "LibreYOLONASl.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_l_coco.pth",
+            ),
+        ],
+    )
+    def test_get_download_url_points_to_deci_cdn(self, filename, expected_url):
+        # Overrides the HF default because Deci's weights license forbids mirroring.
+        assert LibreYOLONAS.get_download_url(filename) == expected_url
+
+    def test_get_download_url_returns_none_for_unknown_filename(self):
+        assert LibreYOLONAS.get_download_url("unrelated.pt") is None
+
 
 class TestYOLONASNativeModel:
     def test_native_model_forward_shapes(self):


### PR DESCRIPTION
Adds YOLO-NAS ( S / M / L ) detection to LibreYOLO including training,validation,inference, export to ONNX / torchscript / ncnn / OpenVINO / TensorRT, video / tracking, tests

LIMITATIONS:
- The DECI AI license does not allow redistribution, so currently weights autodownload from their CDN instead of LibreYOLO's HF. In the future, we plan to train YOLO-NAS from scratch in order to put our own license.

TESTS:
We have run the e2e test "RF1" for the three model sizes, proving that it can train with new objects. 