### PR TITLE
feat(yoloworld): add open-vocabulary detection family (YOLO-World)

### DIFF
--- a/libreyolo/models/yoloworld/__init__.py
+++ b/libreyolo/models/yoloworld/__init__.py
@@ -1,0 +1,27 @@
+"""LibreYOLOWorld — open-vocabulary YOLO (text-prompted detection)."""
+
+from .model import LibreYOLOWorld
+from .nn import (
+    LibreYOLOWorldModel,
+    TextEncoder,
+    YOLOv8CSPDarknet,
+    YOLOWorldPAFPN,
+    YOLOWorldHeadModule,
+    MaxSigmoidAttnBlock,
+    MaxSigmoidCSPLayerWithTwoConv,
+    BNContrastiveHead,
+    CLIP_EMBED_DIM,
+)
+
+__all__ = [
+    "LibreYOLOWorld",
+    "LibreYOLOWorldModel",
+    "TextEncoder",
+    "YOLOv8CSPDarknet",
+    "YOLOWorldPAFPN",
+    "YOLOWorldHeadModule",
+    "MaxSigmoidAttnBlock",
+    "MaxSigmoidCSPLayerWithTwoConv",
+    "BNContrastiveHead",
+    "CLIP_EMBED_DIM",
+]

--- a/libreyolo/models/yoloworld/model.py
+++ b/libreyolo/models/yoloworld/model.py
@@ -1,0 +1,277 @@
+"""LibreYOLOWorld — user-facing wrapper (real YOLOv8-CSPDarknet + RepVL-PAN + BNContrastive)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ..base import BaseModel
+from .nn import LibreYOLOWorldModel, CLIP_EMBED_DIM
+
+
+class LibreYOLOWorld(BaseModel):
+    """Open-vocabulary YOLO. Text-prompted detection.
+
+    Architecture: YOLOv8-CSPDarknet backbone + frozen CLIP ViT-B/32 text encoder
+    + RepVL-PAN neck (MaxSigmoid fusion) + BNContrastive head. Structurally
+    compatible with `wondervictor/YOLO-World-V2.1` checkpoints.
+
+    Args:
+        model_path: Path to weights. None = random-init (for smoke tests).
+        size: YOLOv8 size "s"/"m"/"l"/"x" (default "l" — matches Tencent's default).
+        prompts: Initial list of class-name strings.
+        imgsz: Input image size (default 640, must be divisible by 32).
+        device: Inference device.
+
+    Example::
+
+        >>> model = LibreYOLOWorld(prompts=["person", "dog", "traffic cone"])
+        >>> result = model("photo.jpg")
+        >>> # result.boxes.cls are indices into the prompts list
+    """
+
+    FAMILY = "yoloworld"
+    FILENAME_PREFIX = "LibreYOLOWorld"
+    INPUT_SIZES = {"s": 640, "m": 640, "l": 640, "x": 640}
+    WEIGHT_EXT = ".pt"
+
+    # -----------------------------------------------------------------
+    # Registry classmethods
+    # -----------------------------------------------------------------
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        return any(
+            k.startswith("backbone.stem") or k.startswith("backbone.stage1")
+            or k.startswith("neck.top_down_layer") or k.startswith("head.cls_contrasts")
+            for k in weights_dict
+        )
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        # Look at backbone.stem.conv.weight (c1=3, c2 varies with size)
+        key = "backbone.stem.conv.weight"
+        if key not in weights_dict:
+            return None
+        out_ch = weights_dict[key].shape[0]
+        # stem channels = _make_divisible(64 * widen). s=32, m=48, l=64, x=80
+        for size, ch in (("s", 32), ("m", 48), ("l", 64), ("x", 80)):
+            if out_ch == ch:
+                return size
+        return None
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        # Open-vocab: class count is driven by runtime prompts.
+        return None
+
+    # -----------------------------------------------------------------
+    # Init
+    # -----------------------------------------------------------------
+
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        *,
+        size: str = "l",
+        prompts: Optional[List[str]] = None,
+        imgsz: int = 640,
+        reg_max: int = 16,
+        device: str = "auto",
+        **kwargs,
+    ):
+        self._imgsz = imgsz
+        self._reg_max = reg_max
+        self._size_override = size
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=len(prompts) if prompts else 1,
+            device=device,
+            **kwargs,
+        )
+        if model_path is not None and isinstance(model_path, str) and Path(model_path).exists():
+            self._load_weights(model_path)
+        self.set_prompts(prompts or ["object"])
+
+    # -----------------------------------------------------------------
+    # Build
+    # -----------------------------------------------------------------
+
+    def _init_model(self) -> nn.Module:
+        return LibreYOLOWorldModel(size=self._size_override, imgsz=self._imgsz, reg_max=self._reg_max)
+
+    def _get_available_layers(self):
+        return {
+            "backbone": self.model.backbone,
+            "text_encoder": self.model.text_encoder,
+            "neck": self.model.neck,
+            "head": self.model.head,
+        }
+
+    # -----------------------------------------------------------------
+    # Public API
+    # -----------------------------------------------------------------
+
+    def set_prompts(self, prompts: Sequence[str]) -> None:
+        self.model.set_prompts(prompts)
+        self.nb_classes = len(prompts)
+
+    @property
+    def prompts(self) -> List[str]:
+        return self.model.prompts
+
+    # -----------------------------------------------------------------
+    # Inference plumbing
+    # -----------------------------------------------------------------
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        import numpy as np
+
+        def _preprocess_numpy(arr: "np.ndarray", input_size: int = 640):
+            import cv2
+            img = cv2.resize(arr, (input_size, input_size), interpolation=cv2.INTER_LINEAR)
+            img = img[:, :, ::-1]
+            img = img.astype(np.float32) / 255.0
+            img = img.transpose(2, 0, 1)
+            return np.ascontiguousarray(img), 1.0
+
+        return _preprocess_numpy
+
+    def _preprocess(self, image, color_format: str = "auto", input_size: Optional[int] = None):
+        from PIL import Image
+        import numpy as np
+
+        if isinstance(image, (str, Path)):
+            image = Image.open(image).convert("RGB")
+        elif isinstance(image, np.ndarray):
+            image = Image.fromarray(image)
+        assert isinstance(image, Image.Image)
+        size = self._imgsz if input_size is None else input_size
+        img = image.resize((size, size))
+        arr = np.asarray(img).astype("float32") / 255.0
+        tensor = torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0).to(self.device)
+        return tensor, image, image.size, 1.0
+
+    def _forward(self, input_tensor: torch.Tensor):
+        return self.model(input_tensor)
+
+    def _postprocess(
+        self,
+        output,
+        conf_thres: float,
+        iou_thres: float,
+        original_size,
+        max_det: int = 300,
+        **kwargs,
+    ):
+        """Decode DFL bbox_dists + contrastive logits to per-image detections."""
+        bbox_dists = output["bbox_dists"]  # list of 3: (B, 4*reg_max, H, W)
+        cls_logits = output["cls_logits"]  # list of 3: (B, N_cls, H, W)
+        strides = output["strides"]
+        B = bbox_dists[0].shape[0]
+        assert B == 1, "MVP postprocess assumes batch=1"
+
+        reg_max = self._reg_max
+        all_boxes: List[torch.Tensor] = []
+        all_conf: List[torch.Tensor] = []
+        all_cls: List[torch.Tensor] = []
+
+        for dist, logits, stride in zip(bbox_dists, cls_logits, strides):
+            _, _, H, W = dist.shape
+            N = logits.shape[1]
+
+            # DFL: softmax over reg_max bins, expected value via integration
+            d = dist[0].reshape(4, reg_max, H, W)  # (4, reg_max, H, W)
+            d = F.softmax(d, dim=1)
+            bins = torch.arange(reg_max, dtype=d.dtype, device=d.device).view(1, reg_max, 1, 1)
+            ltrb = (d * bins).sum(dim=1)  # (4, H, W) — distances in grid units
+
+            # Grid cells (cx, cy) in input-image coordinates
+            ys, xs = torch.meshgrid(
+                torch.arange(H, dtype=d.dtype, device=d.device),
+                torch.arange(W, dtype=d.dtype, device=d.device),
+                indexing="ij",
+            )
+            cx = (xs + 0.5) * stride
+            cy = (ys + 0.5) * stride
+
+            # Convert ltrb distances (in grid units) to absolute xyxy
+            l, t, r, b = ltrb[0], ltrb[1], ltrb[2], ltrb[3]
+            x1 = cx - l * stride
+            y1 = cy - t * stride
+            x2 = cx + r * stride
+            y2 = cy + b * stride
+
+            # Class scores: sigmoid of contrastive logits
+            scores = torch.sigmoid(logits[0])  # (N, H, W)
+
+            # Per-location max over classes
+            max_scores, max_cls = scores.max(dim=0)  # (H, W)
+            mask = max_scores > conf_thres
+            if mask.any():
+                boxes = torch.stack(
+                    [x1[mask], y1[mask], x2[mask], y2[mask]], dim=-1
+                )  # (K, 4)
+                all_boxes.append(boxes)
+                all_conf.append(max_scores[mask])
+                all_cls.append(max_cls[mask].float())
+
+        if not all_boxes:
+            return {"boxes": torch.zeros((0, 4)), "scores": torch.zeros((0,)),
+                    "classes": torch.zeros((0,)), "num_detections": 0}
+
+        boxes_t = torch.cat(all_boxes, dim=0)
+        conf_t = torch.cat(all_conf, dim=0)
+        cls_t = torch.cat(all_cls, dim=0)
+
+        # Simple class-agnostic NMS
+        keep = _nms(boxes_t, conf_t, iou_thres)[:max_det]
+        boxes_t = boxes_t[keep]
+        conf_t = conf_t[keep]
+        cls_t = cls_t[keep]
+
+        # Rescale from imgsz coords to original image size
+        ow, oh = original_size
+        scale_x = ow / self._imgsz
+        scale_y = oh / self._imgsz
+        boxes_t = boxes_t.clone()
+        boxes_t[:, [0, 2]] *= scale_x
+        boxes_t[:, [1, 3]] *= scale_y
+
+        return {
+            "boxes": boxes_t.detach().cpu().float(),
+            "scores": conf_t.detach().cpu().float(),
+            "classes": cls_t.detach().cpu().float(),
+            "num_detections": int(conf_t.numel()),
+        }
+
+
+def _nms(boxes: torch.Tensor, scores: torch.Tensor, iou_thres: float) -> torch.Tensor:
+    """Class-agnostic NMS. Uses torchvision if available, else a simple fallback."""
+    try:
+        from torchvision.ops import nms
+        return nms(boxes, scores, iou_thres)
+    except Exception:
+        # Greedy NMS fallback
+        order = scores.argsort(descending=True)
+        keep: List[int] = []
+        while order.numel() > 0:
+            i = int(order[0])
+            keep.append(i)
+            if order.numel() == 1:
+                break
+            xx1 = boxes[order[1:], 0].clamp(min=float(boxes[i, 0]))
+            yy1 = boxes[order[1:], 1].clamp(min=float(boxes[i, 1]))
+            xx2 = boxes[order[1:], 2].clamp(max=float(boxes[i, 2]))
+            yy2 = boxes[order[1:], 3].clamp(max=float(boxes[i, 3]))
+            inter = (xx2 - xx1).clamp(min=0) * (yy2 - yy1).clamp(min=0)
+            area_i = (boxes[i, 2] - boxes[i, 0]) * (boxes[i, 3] - boxes[i, 1])
+            area_o = (boxes[order[1:], 2] - boxes[order[1:], 0]) * (boxes[order[1:], 3] - boxes[order[1:], 1])
+            iou = inter / (area_i + area_o - inter + 1e-9)
+            order = order[1:][iou <= iou_thres]
+        return torch.tensor(keep, dtype=torch.long, device=boxes.device)

--- a/libreyolo/models/yoloworld/nn.py
+++ b/libreyolo/models/yoloworld/nn.py
@@ -1,0 +1,568 @@
+"""LibreYOLOWorld — open-vocabulary YOLO architecture (real).
+
+Text-prompted detection with a YOLOv8-CSPDarknet backbone, a frozen CLIP text
+encoder, a RepVL-PAN neck (MaxSigmoidCSPLayerWithTwoConv fusion), and a
+BNContrastiveHead classifier. Structurally compatible with the Tencent/
+YOLO-World-V2.1 release — a separate state-dict remapper (see
+`weight_porting.py`) loads their `.pth` checkpoints into this module.
+
+License note: the official YOLO-World weights (`wondervictor/YOLO-World-V2.1`
+on HF) are **GPL-3.0**. LibreYOLO itself is MIT, so we never bundle weights.
+Users who opt in to the GPL weights at runtime are bound by GPL for their
+downstream code — document this clearly in the README.
+
+Architectural reference: https://github.com/AILab-CVC/YOLO-World (`yolo_world/`).
+"""
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# CLIP ViT-B/32 text embedding dimension (what YOLO-World-V2.1 uses by default).
+CLIP_EMBED_DIM = 512
+
+# YOLOv8 scaling factors per size. (deepen, widen, last_stage_out_channels).
+# Channel counts per stage (P3/P4/P5) = (256 * widen, 512 * widen, last_stage_out * widen).
+YOLO8_SCALES = {
+    "s": (0.33, 0.50, 1024),
+    "m": (0.67, 0.75, 768),
+    "l": (1.00, 1.00, 512),
+    "x": (1.00, 1.25, 512),
+}
+
+
+# ---------------------------------------------------------------------------
+# Basic building blocks — match mmyolo / Ultralytics YOLOv8 for weight portability.
+# ---------------------------------------------------------------------------
+
+
+def _autopad(k: int, p: Optional[int] = None) -> int:
+    return k // 2 if p is None else p
+
+
+class ConvModule(nn.Module):
+    """Conv -> BN -> SiLU, with sub-module names `conv`/`bn` matching mmyolo's ConvModule."""
+
+    def __init__(self, c1: int, c2: int, k: int = 1, s: int = 1, p: Optional[int] = None,
+                 g: int = 1, act: bool = True):
+        super().__init__()
+        self.conv = nn.Conv2d(c1, c2, k, s, _autopad(k, p), groups=g, bias=False)
+        self.bn = nn.BatchNorm2d(c2)
+        self.act = nn.SiLU(inplace=True) if act else nn.Identity()
+
+    def forward(self, x):
+        return self.act(self.bn(self.conv(x)))
+
+
+class DarknetBottleneck(nn.Module):
+    """Standard YOLOv8 bottleneck (2x ConvModule, optional residual)."""
+
+    def __init__(self, c1: int, c2: int, shortcut: bool = True, e: float = 0.5,
+                 k: Tuple[int, int] = (3, 3)):
+        super().__init__()
+        c_ = int(c2 * e)
+        self.conv1 = ConvModule(c1, c_, k[0], 1)
+        self.conv2 = ConvModule(c_, c2, k[1], 1, g=1)
+        self.add = shortcut and c1 == c2
+
+    def forward(self, x):
+        return x + self.conv2(self.conv1(x)) if self.add else self.conv2(self.conv1(x))
+
+
+class CSPLayerWithTwoConv(nn.Module):
+    """YOLOv8 C2f block — mmyolo's name for this: `CSPLayerWithTwoConv`.
+
+    Split-in-half cross-stage with N bottleneck blocks, concat-then-fuse.
+    Sub-module names chosen to match mmyolo state dicts:
+        main_conv, final_conv, blocks.{0..n-1}
+    """
+
+    def __init__(self, c1: int, c2: int, n: int = 1, shortcut: bool = False, e: float = 0.5):
+        super().__init__()
+        self.mid_channels = int(c2 * e)
+        self.main_conv = ConvModule(c1, 2 * self.mid_channels, 1, 1)
+        self.final_conv = ConvModule((2 + n) * self.mid_channels, c2, 1, 1)
+        self.blocks = nn.ModuleList(
+            DarknetBottleneck(self.mid_channels, self.mid_channels, shortcut=shortcut, e=1.0,
+                              k=(3, 3))
+            for _ in range(n)
+        )
+
+    def forward(self, x):
+        y = self.main_conv(x)
+        y1, y2 = y.split(self.mid_channels, dim=1)
+        outs = [y1, y2]
+        for blk in self.blocks:
+            outs.append(blk(outs[-1]))
+        return self.final_conv(torch.cat(outs, dim=1))
+
+
+class SPPFBottleneck(nn.Module):
+    """YOLOv8 SPPF: three chained maxpools, concat with input, 1x1 fuse."""
+
+    def __init__(self, c1: int, c2: int, k: int = 5):
+        super().__init__()
+        c_ = c1 // 2
+        self.conv1 = ConvModule(c1, c_, 1, 1)
+        self.conv2 = ConvModule(c_ * 4, c2, 1, 1)
+        self.m = nn.MaxPool2d(kernel_size=k, stride=1, padding=k // 2)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        y1 = self.m(x)
+        y2 = self.m(y1)
+        y3 = self.m(y2)
+        return self.conv2(torch.cat([x, y1, y2, y3], dim=1))
+
+
+# ---------------------------------------------------------------------------
+# Backbone — YOLOv8CSPDarknet.
+# ---------------------------------------------------------------------------
+
+
+def _make_divisible(x: float, divisor: int = 8) -> int:
+    return max(divisor, int(x + divisor / 2) // divisor * divisor)
+
+
+class YOLOv8CSPDarknet(nn.Module):
+    """YOLOv8 CSP-Darknet backbone. Outputs P3 / P4 / P5 feature maps.
+
+    Layer naming chosen to match mmyolo's `YOLOv8CSPDarknet` so state_dict
+    keys remap cleanly.
+    """
+
+    def __init__(self, size: str = "l"):
+        super().__init__()
+        if size not in YOLO8_SCALES:
+            raise ValueError(f"unknown size {size!r}; supported: {list(YOLO8_SCALES)}")
+        deepen, widen, last_out = YOLO8_SCALES[size]
+
+        self.size = size
+        self.widen = widen
+        self.deepen = deepen
+
+        # Stage channel counts (P3/P4/P5)
+        ch_p3 = _make_divisible(256 * widen)
+        ch_p4 = _make_divisible(512 * widen)
+        ch_p5 = _make_divisible(last_out * widen)
+
+        # Depths (C2f num_blocks) per stage — YOLOv8: [3, 6, 6, 3] scaled by deepen
+        d1 = max(1, round(3 * deepen))
+        d2 = max(1, round(6 * deepen))
+        d3 = max(1, round(6 * deepen))
+        d4 = max(1, round(3 * deepen))
+
+        ch_stem = _make_divisible(64 * widen)
+        ch_s1 = _make_divisible(128 * widen)
+
+        self.stem = ConvModule(3, ch_stem, k=3, s=2)
+
+        # stage{i} = Sequential(down_conv, C2f)
+        self.stage1 = nn.Sequential(
+            ConvModule(ch_stem, ch_s1, k=3, s=2),
+            CSPLayerWithTwoConv(ch_s1, ch_s1, n=d1, shortcut=True),
+        )
+        self.stage2 = nn.Sequential(
+            ConvModule(ch_s1, ch_p3, k=3, s=2),
+            CSPLayerWithTwoConv(ch_p3, ch_p3, n=d2, shortcut=True),
+        )
+        self.stage3 = nn.Sequential(
+            ConvModule(ch_p3, ch_p4, k=3, s=2),
+            CSPLayerWithTwoConv(ch_p4, ch_p4, n=d3, shortcut=True),
+        )
+        self.stage4 = nn.Sequential(
+            ConvModule(ch_p4, ch_p5, k=3, s=2),
+            CSPLayerWithTwoConv(ch_p5, ch_p5, n=d4, shortcut=True),
+            SPPFBottleneck(ch_p5, ch_p5, k=5),
+        )
+
+        self.out_channels = (ch_p3, ch_p4, ch_p5)
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        x = self.stem(x)
+        x = self.stage1(x)
+        p3 = self.stage2(x)
+        p4 = self.stage3(p3)
+        p5 = self.stage4(p4)
+        return p3, p4, p5
+
+
+# ---------------------------------------------------------------------------
+# CLIP text encoder (frozen).
+# ---------------------------------------------------------------------------
+
+
+class TextEncoder(nn.Module):
+    """Frozen HuggingFace CLIP text encoder with a projection head.
+
+    Matches YOLO-World-V2.1's `HuggingCLIPLanguageBackbone` (frozen, using
+    the `CLIPTextModelWithProjection` variant with `text_projection.weight`).
+    Outputs L2-normalized 512-D text embeddings.
+    """
+
+    _HF_MODEL = "openai/clip-vit-base-patch32"
+
+    def __init__(self, embed_dim: int = CLIP_EMBED_DIM):
+        super().__init__()
+        from transformers import CLIPTextModelWithProjection, CLIPTokenizer
+
+        self.tokenizer = CLIPTokenizer.from_pretrained(self._HF_MODEL)
+        self.text_model = CLIPTextModelWithProjection.from_pretrained(self._HF_MODEL)
+        for p in self.text_model.parameters():
+            p.requires_grad_(False)
+        self.text_model.eval()
+
+        proj_dim = self.text_model.config.projection_dim
+        self.proj = nn.Identity() if proj_dim == embed_dim else nn.Linear(proj_dim, embed_dim, bias=False)
+
+    @torch.no_grad()
+    def encode(self, prompts: Sequence[str], device: Optional[torch.device] = None) -> torch.Tensor:
+        if device is None:
+            device = next(self.text_model.parameters()).device
+        tokens = self.tokenizer(list(prompts), padding=True, return_tensors="pt").to(device)
+        out = self.text_model(**tokens)
+        # CLIPTextModelWithProjection returns a ModelOutput with .text_embeds (already projected).
+        x = self.proj(out.text_embeds)
+        return F.normalize(x, dim=-1)
+
+
+# ---------------------------------------------------------------------------
+# RepVL-PAN fusion — the core YOLO-World innovation.
+# ---------------------------------------------------------------------------
+
+
+class MaxSigmoidAttnBlock(nn.Module):
+    """Per-scale text-visual fusion: max-over-class sigmoid gating.
+
+    Given image feature `x` [B, C, H, W] and text embeddings
+    `guide` [B, N_cls, D_txt], compute a [B, H, W] per-pixel attention
+    (max over classes, per head, softmax-free), sigmoid it, and gate the
+    projected visual features.
+
+    Implementation matches `MaxSigmoidAttnBlock` from
+    yolo_world/models/layers/yolo_bricks.py.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, guide_channels: int,
+                 embed_channels: int, num_heads: int = 8):
+        super().__init__()
+        if embed_channels % num_heads != 0:
+            raise ValueError(f"embed_channels ({embed_channels}) must be divisible by num_heads ({num_heads})")
+        if out_channels % num_heads != 0:
+            raise ValueError(f"out_channels ({out_channels}) must be divisible by num_heads ({num_heads})")
+        self.num_heads = num_heads
+        self.attn_head_channels = embed_channels // num_heads   # Ch for attention dot-product
+        self.proj_head_channels = out_channels // num_heads     # Ch for output projection
+
+        self.embed_conv = (
+            ConvModule(in_channels, embed_channels, k=1, act=False)
+            if in_channels != embed_channels else nn.Identity()
+        )
+        self.guide_fc = nn.Linear(guide_channels, embed_channels)
+        self.bias = nn.Parameter(torch.zeros(num_heads))
+        self.project_conv = ConvModule(in_channels, out_channels, k=3)
+
+    def forward(self, x: torch.Tensor, guide: torch.Tensor) -> torch.Tensor:
+        B, _, H, W = x.shape
+        N = guide.shape[1]
+        M = self.num_heads
+
+        # Text embeddings projected and reshaped to (B, N, M, attn_Ch)
+        g = self.guide_fc(guide).view(B, N, M, self.attn_head_channels)
+
+        # Image embeddings for attention: (B, M, attn_Ch, H, W)
+        e = self.embed_conv(x).view(B, M, self.attn_head_channels, H, W)
+
+        # Attention scores: einsum -> (B, M, H, W, N)
+        attn = torch.einsum("bmchw,bnmc->bmhwn", e, g)
+        attn = attn.max(dim=-1)[0]  # max over classes -> (B, M, H, W)
+        attn = attn / math.sqrt(self.attn_head_channels)
+        attn = (attn + self.bias.view(1, M, 1, 1)).sigmoid()
+
+        # Image features for output, gated per-head
+        out = self.project_conv(x).view(B, M, self.proj_head_channels, H, W)
+        out = out * attn.unsqueeze(2)
+        return out.view(B, -1, H, W)
+
+
+class MaxSigmoidCSPLayerWithTwoConv(nn.Module):
+    """C2f block with text-visual fusion via MaxSigmoidAttnBlock (RepVL-PAN).
+
+    The attn_block is applied **in-place on the last block's output** (it
+    replaces the last block's output in the concat list, not adds a new
+    stream). This matches upstream's `(2 + n) * mid` final_conv input shape.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, guide_channels: int,
+                 embed_channels: int, num_heads: int, n: int = 1, shortcut: bool = False,
+                 e: float = 0.5):
+        super().__init__()
+        self.mid = int(out_channels * e)
+        self.main_conv = ConvModule(in_channels, 2 * self.mid, 1, 1)
+        self.blocks = nn.ModuleList(
+            DarknetBottleneck(self.mid, self.mid, shortcut=shortcut, e=1.0, k=(3, 3))
+            for _ in range(n)
+        )
+        self.attn_block = MaxSigmoidAttnBlock(
+            in_channels=self.mid, out_channels=self.mid,
+            guide_channels=guide_channels, embed_channels=embed_channels,
+            num_heads=num_heads,
+        )
+        self.final_conv = ConvModule((2 + n) * self.mid, out_channels, 1, 1)
+
+    def forward(self, x: torch.Tensor, guide: torch.Tensor) -> torch.Tensor:
+        y = self.main_conv(x)
+        y1, y2 = y.split(self.mid, dim=1)
+        outs = [y1, y2]
+        for blk in self.blocks:
+            outs.append(blk(outs[-1]))
+        # Attn applied IN-PLACE on the last block output (replaces, not appends)
+        outs[-1] = self.attn_block(outs[-1], guide)
+        return self.final_conv(torch.cat(outs, dim=1))
+
+
+# ---------------------------------------------------------------------------
+# Neck — YOLO-World PAFPN with MaxSigmoid fusion at each merge.
+# ---------------------------------------------------------------------------
+
+
+class YOLOWorldPAFPN(nn.Module):
+    """PAFPN (top-down + bottom-up) with text-visual fusion via RepVL-PAN blocks."""
+
+    # YOLO-World-V2.1 neck conventions (verified against the S checkpoint):
+    #   - n_blocks=2 across all 4 neck CSP layers (size-independent)
+    #   - num_heads = mid_channels // 32 per scale (so heads grow with channels)
+    #   - embed_channels = mid_channels (=out_channels // 2)
+    #   - num_heads is per-scale (P3, P4, P5) since deeper layers have wider features
+    DEFAULT_N_BLOCKS = 2
+
+    def __init__(self, in_channels: Tuple[int, int, int], out_channels: Tuple[int, int, int],
+                 guide_channels: int = CLIP_EMBED_DIM,
+                 embed_channels: Optional[Sequence[int]] = None,
+                 num_heads: Optional[Sequence[int]] = None,
+                 n_blocks: int = DEFAULT_N_BLOCKS):
+        super().__init__()
+        c3, c4, c5 = in_channels
+        o3, o4, o5 = out_channels
+
+        # Default embed_channels = mid (out_channels // 2). Matches the V2.1 conv shapes.
+        if embed_channels is None:
+            embed_channels = (o3 // 2, o4 // 2, o5 // 2)
+        # Default num_heads = mid // 32 (V2.1 rule: each head sees 32 channels).
+        if num_heads is None:
+            num_heads = tuple(max(1, ec // 32) for ec in embed_channels)
+
+        # Top-down path: P5 -> P4 -> P3
+        self.top_down_layer_1 = MaxSigmoidCSPLayerWithTwoConv(
+            in_channels=c5 + c4, out_channels=o4,
+            guide_channels=guide_channels,
+            embed_channels=embed_channels[1], num_heads=num_heads[1],
+            n=n_blocks,
+        )
+        self.top_down_layer_2 = MaxSigmoidCSPLayerWithTwoConv(
+            in_channels=o4 + c3, out_channels=o3,
+            guide_channels=guide_channels,
+            embed_channels=embed_channels[0], num_heads=num_heads[0],
+            n=n_blocks,
+        )
+
+        # Bottom-up path
+        self.downsample_1 = ConvModule(o3, o3, k=3, s=2)
+        self.bottom_up_layer_1 = MaxSigmoidCSPLayerWithTwoConv(
+            in_channels=o3 + o4, out_channels=o4,
+            guide_channels=guide_channels,
+            embed_channels=embed_channels[1], num_heads=num_heads[1],
+            n=n_blocks,
+        )
+        self.downsample_2 = ConvModule(o4, o4, k=3, s=2)
+        self.bottom_up_layer_2 = MaxSigmoidCSPLayerWithTwoConv(
+            in_channels=o4 + c5, out_channels=o5,
+            guide_channels=guide_channels,
+            embed_channels=embed_channels[2], num_heads=num_heads[2],
+            n=n_blocks,
+        )
+
+    def forward(self, feats: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+                text_embeds: torch.Tensor
+                ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        p3, p4, p5 = feats
+
+        # Top-down
+        p5_up = F.interpolate(p5, scale_factor=2.0, mode="nearest")
+        m4 = self.top_down_layer_1(torch.cat([p5_up, p4], dim=1), text_embeds)
+        m4_up = F.interpolate(m4, scale_factor=2.0, mode="nearest")
+        m3 = self.top_down_layer_2(torch.cat([m4_up, p3], dim=1), text_embeds)
+
+        # Bottom-up
+        m3_d = self.downsample_1(m3)
+        m4_out = self.bottom_up_layer_1(torch.cat([m3_d, m4], dim=1), text_embeds)
+        m4_d = self.downsample_2(m4_out)
+        m5_out = self.bottom_up_layer_2(torch.cat([m4_d, p5], dim=1), text_embeds)
+
+        return m3, m4_out, m5_out
+
+
+# ---------------------------------------------------------------------------
+# Head — YOLOv8 reg head + BNContrastiveHead classifier.
+# ---------------------------------------------------------------------------
+
+
+class BNContrastiveHead(nn.Module):
+    """YOLO-World's BNContrastiveHead: BN over image-side embed, L2 norm text side.
+
+    cls_logit = (BN(cls_embed) · L2Norm(text_embeds)) * exp(logit_scale) + bias
+    """
+
+    def __init__(self, embed_dim: int = CLIP_EMBED_DIM):
+        super().__init__()
+        self.norm = nn.BatchNorm2d(embed_dim)
+        # Both bias and logit_scale are scalars (shape ()) to match V2.1 checkpoints.
+        self.logit_scale = nn.Parameter(torch.tensor(2.6593))  # exp -> ~14.3
+        self.bias = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, cls_embed: torch.Tensor, text_embeds: torch.Tensor) -> torch.Tensor:
+        """
+        cls_embed: (B, embed_dim, H, W)
+        text_embeds: (B, N_cls, embed_dim)   L2-normalized
+        returns: (B, N_cls, H, W) logits
+        """
+        x = self.norm(cls_embed)
+        logits = torch.einsum("bdhw,bnd->bnhw", x, text_embeds)
+        return logits * self.logit_scale.exp() + self.bias
+
+
+class YOLOWorldHeadModule(nn.Module):
+    """Three-scale detection head. Regression via DFL; classification via contrastive."""
+
+    def __init__(self, in_channels: Tuple[int, int, int], embed_dim: int = CLIP_EMBED_DIM,
+                 reg_max: int = 16):
+        super().__init__()
+        self.reg_max = reg_max
+        self.num_levels = 3
+
+        # V2.1 head conventions:
+        #   reg intermediate channels = 4 * reg_max  (= 64 for reg_max=16)
+        #   cls intermediate channels = embed_dim // 4  (= 128 for embed_dim=512)
+        c_reg = 4 * reg_max
+        c_cls = embed_dim // 4
+
+        self.reg_preds = nn.ModuleList()
+        self.cls_preds = nn.ModuleList()
+        self.cls_contrasts = nn.ModuleList()
+
+        for c in in_channels:
+            self.reg_preds.append(nn.Sequential(
+                ConvModule(c, c_reg, k=3),
+                ConvModule(c_reg, c_reg, k=3),
+                nn.Conv2d(c_reg, 4 * reg_max, kernel_size=1),
+            ))
+            self.cls_preds.append(nn.Sequential(
+                ConvModule(c, c_cls, k=3),
+                ConvModule(c_cls, c_cls, k=3),
+                nn.Conv2d(c_cls, embed_dim, kernel_size=1),
+            ))
+            self.cls_contrasts.append(BNContrastiveHead(embed_dim))
+
+    def forward(self, feats: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+                text_embeds: torch.Tensor):
+        bbox_dists = []
+        cls_logits = []
+        for i, f in enumerate(feats):
+            bbox_dists.append(self.reg_preds[i](f))       # (B, 4*reg_max, H, W)
+            emb = self.cls_preds[i](f)                    # (B, embed_dim, H, W)
+            logits = self.cls_contrasts[i](emb, text_embeds)  # (B, N_cls, H, W)
+            cls_logits.append(logits)
+        return bbox_dists, cls_logits
+
+
+# ---------------------------------------------------------------------------
+# Full model
+# ---------------------------------------------------------------------------
+
+
+class LibreYOLOWorldModel(nn.Module):
+    """Open-vocabulary YOLO detector: YOLOv8 backbone + CLIP text + RepVL-PAN + BNContrastive head.
+
+    Structure follows YOLO-World-V2.1 so `weight_porting.py` can remap Tencent
+    state_dicts directly into this module.
+    """
+
+    def __init__(self, size: str = "l", imgsz: int = 640, reg_max: int = 16):
+        super().__init__()
+        self.size = size
+        self.imgsz = imgsz
+        self.reg_max = reg_max
+
+        self.backbone = YOLOv8CSPDarknet(size=size)
+        self.text_encoder = TextEncoder(embed_dim=CLIP_EMBED_DIM)
+
+        # Neck in/out channels = backbone's P3/P4/P5.
+        self.neck = YOLOWorldPAFPN(
+            in_channels=self.backbone.out_channels,
+            out_channels=self.backbone.out_channels,
+            guide_channels=CLIP_EMBED_DIM,
+        )
+
+        self.head = YOLOWorldHeadModule(
+            in_channels=self.backbone.out_channels,
+            embed_dim=CLIP_EMBED_DIM,
+            reg_max=reg_max,
+        )
+
+        # Strides at each scale (YOLOv8 default: 8, 16, 32)
+        self.register_buffer("strides", torch.tensor([8.0, 16.0, 32.0]), persistent=False)
+
+        # Cached prompts
+        self.register_buffer("_text_embeds", torch.zeros(0, CLIP_EMBED_DIM), persistent=False)
+        self._current_prompts: List[str] = []
+
+    # ------------------------------------------------------------------
+    # Prompt API
+    # ------------------------------------------------------------------
+
+    def set_prompts(self, prompts: Sequence[str]) -> None:
+        if not isinstance(prompts, (list, tuple)) or not all(isinstance(p, str) for p in prompts):
+            raise ValueError("prompts must be a list of strings")
+        if len(prompts) == 0:
+            raise ValueError("prompts list must be non-empty")
+        device = next(self.parameters()).device
+        embeds = self.text_encoder.encode(list(prompts), device=device)
+        self._text_embeds = embeds
+        self._current_prompts = list(prompts)
+
+    @property
+    def prompts(self) -> List[str]:
+        return list(self._current_prompts)
+
+    @property
+    def num_prompts(self) -> int:
+        return len(self._current_prompts)
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+
+    def forward(self, images: torch.Tensor) -> dict:
+        if self._text_embeds.shape[0] == 0:
+            raise RuntimeError("No text prompts set. Call model.set_prompts([...]) first.")
+        B = images.shape[0]
+
+        feats = self.backbone(images)  # (P3, P4, P5)
+
+        # Broadcast text to batch: (N, D) -> (B, N, D)
+        text = self._text_embeds.unsqueeze(0).expand(B, -1, -1).contiguous()
+
+        neck_feats = self.neck(feats, text)
+        bbox_dists, cls_logits = self.head(neck_feats, text)
+
+        return {
+            "bbox_dists": bbox_dists,   # list of 3 tensors (B, 4*reg_max, H, W)
+            "cls_logits": cls_logits,   # list of 3 tensors (B, N_cls, H, W)
+            "strides": self.strides.tolist(),
+            "feature_shapes": [tuple(f.shape[-2:]) for f in neck_feats],
+        }

--- a/libreyolo/models/yoloworld/weight_porting.py
+++ b/libreyolo/models/yoloworld/weight_porting.py
@@ -1,0 +1,161 @@
+"""Weight porting from wondervictor/YOLO-World-V2.1 (mmyolo/mmengine format).
+
+**GPL-3.0 WEIGHTS:** the upstream YOLO-World-V2.1 checkpoints are GPL-3.0
+licensed. LibreYOLO itself is MIT and does not bundle these weights. Users
+who download them via this module inherit GPL-3.0 obligations for any code
+that links against the loaded module instance.
+
+Usage (separate script, not auto-run):
+
+    from libreyolo.models.yoloworld.weight_porting import port_from_hf
+
+    model = LibreYOLOWorldModel(size='l')
+    port_from_hf(model, repo_id='wondervictor/YOLO-World-V2.1',
+                 filename='yolo_world_v2_l_obj365v1_goldg_cc3mlite.pth')
+
+This module is a STUB — the remapping dict is a starting point. Validation
+on a real checkpoint requires a funded compute step (CPU works, but 442 MB
+download + a test image). Treat each `TODO` below as the next concrete task.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import torch
+
+
+# Prefix map: (upstream_prefix, our_prefix). Longest match wins.
+# Derived from the research spec; verify on first real weight load.
+KEY_REMAP: List[Tuple[str, str]] = [
+    ("backbone.image_model.stem.", "backbone.stem."),
+    ("backbone.image_model.stage1.", "backbone.stage1."),
+    ("backbone.image_model.stage2.", "backbone.stage2."),
+    ("backbone.image_model.stage3.", "backbone.stage3."),
+    ("backbone.image_model.stage4.", "backbone.stage4."),
+    # mmyolo's SPPF is `stage4.<N>` where N depends on depth — already covered by stage4.* above.
+
+    # Text encoder — HuggingFace CLIP weights (we already load these from HF, not the checkpoint).
+    ("backbone.text_model.", "__DROP__"),  # skip; we load CLIP separately
+
+    # RepVL-PAN neck
+    ("neck.top_down_layers.0.", "neck.top_down_layer_1."),
+    ("neck.top_down_layers.1.", "neck.top_down_layer_2."),
+    ("neck.bottom_up_layers.0.", "neck.bottom_up_layer_1."),
+    ("neck.bottom_up_layers.1.", "neck.bottom_up_layer_2."),
+    ("neck.downsample_layers.0.", "neck.downsample_1."),
+    ("neck.downsample_layers.1.", "neck.downsample_2."),
+    ("neck.reduce_layers.", "__DROP__"),  # we don't have reduce layers; upstream's P5 reduce is Identity in L
+
+    # Head
+    ("bbox_head.head_module.cls_preds.", "head.cls_preds."),
+    ("bbox_head.head_module.reg_preds.", "head.reg_preds."),
+    ("bbox_head.head_module.cls_contrasts.", "head.cls_contrasts."),
+]
+
+
+def _remap_key(k: str) -> str | None:
+    """Return our key for upstream key `k`, or None to drop it."""
+    for src, dst in KEY_REMAP:
+        if k.startswith(src):
+            if dst == "__DROP__":
+                return None
+            return dst + k[len(src):]
+    return None  # unmapped → drop with warning
+
+
+def port_state_dict(
+    upstream_state: Dict[str, torch.Tensor],
+    our_model: torch.nn.Module,
+    strict: bool = False,
+) -> Dict[str, object]:
+    """Remap an upstream YOLO-World-V2.1 state_dict and load it into `our_model`.
+
+    Returns a summary dict: {loaded, skipped, missing, shape_mismatches}.
+    """
+    # Upstream checkpoints are typically {'state_dict': {...}, 'meta': {...}, ...}
+    if isinstance(upstream_state, dict) and "state_dict" in upstream_state:
+        upstream_state = upstream_state["state_dict"]
+
+    ours = our_model.state_dict()
+    loaded: List[str] = []
+    skipped: List[str] = []
+    shape_mismatches: List[Tuple[str, Tuple[int, ...], Tuple[int, ...]]] = []
+
+    remapped: Dict[str, torch.Tensor] = {}
+    for src_k, tensor in upstream_state.items():
+        dst_k = _remap_key(src_k)
+        if dst_k is None:
+            skipped.append(src_k)
+            continue
+        if dst_k not in ours:
+            skipped.append(f"{src_k} → {dst_k} (not in our model)")
+            continue
+        if tensor.shape != ours[dst_k].shape:
+            shape_mismatches.append((f"{src_k} → {dst_k}", tuple(tensor.shape), tuple(ours[dst_k].shape)))
+            continue
+        remapped[dst_k] = tensor
+        loaded.append(f"{src_k} → {dst_k}")
+
+    missing = [k for k in ours if k not in remapped and not k.startswith("text_encoder.")]
+    missing = [k for k in missing if "num_batches_tracked" not in k]  # BN state
+
+    # Merge remapped onto current state_dict (keep text_encoder + head temperature defaults)
+    new_state = {**ours, **remapped}
+    result = our_model.load_state_dict(new_state, strict=strict)
+
+    summary = {
+        "loaded": len(loaded),
+        "skipped": len(skipped),
+        "missing_after_port": len(missing),
+        "shape_mismatches": len(shape_mismatches),
+        "load_result_missing": list(result.missing_keys) if hasattr(result, "missing_keys") else [],
+        "load_result_unexpected": list(result.unexpected_keys) if hasattr(result, "unexpected_keys") else [],
+        "sample_shape_mismatches": shape_mismatches[:5],
+        "sample_skipped": skipped[:10],
+    }
+    return summary
+
+
+def port_from_hf(
+    our_model: torch.nn.Module,
+    repo_id: str = "wondervictor/YOLO-World-V2.1",
+    filename: str = "yolo_world_v2_l_obj365v1_goldg_cc3mlite.pth",
+    local_path: str | Path | None = None,
+    strict: bool = False,
+) -> Dict[str, object]:
+    """Download weights from HF (or load from `local_path`) and port into `our_model`.
+
+    NOTE: this downloads GPL-3.0 weights. The caller is responsible for
+    license compliance.
+    """
+    if local_path is not None:
+        ckpt = torch.load(local_path, map_location="cpu", weights_only=False)
+    else:
+        from huggingface_hub import hf_hub_download
+        path = hf_hub_download(repo_id=repo_id, filename=filename)
+        ckpt = torch.load(path, map_location="cpu", weights_only=False)
+
+    return port_state_dict(ckpt, our_model, strict=strict)
+
+
+# TODO list (verify during first real weight load):
+#
+# 1. Sub-layer inside CSPLayerWithTwoConv: upstream's `blocks.{i}.conv1.conv` vs our
+#    `blocks.{i}.conv1.conv`. Probably identical; check on first load.
+#
+# 2. The MaxSigmoidAttnBlock's `embed_conv`: upstream may have it inline without
+#    a BN (when in_channels == embed_channels, we use nn.Identity, they may not).
+#    If so, we need to detect and insert their biasless 1x1 conv. The state-dict
+#    keys `neck.*.attn_block.embed_conv.conv.weight` indicate their presence.
+#
+# 3. Stage4 SPPF: mmyolo places SPPF as `stage4[2]` after 2 CSP blocks. Our
+#    nn.Sequential has (Conv, CSP, SPPF) so the index chain matches.
+#
+# 4. Neck P5 reduce layer: in mmyolo's YOLOv8PAFPN, `reduce_layers[0]` is an
+#    Identity for L size. Our implementation skips it entirely — confirm the
+#    state_dict doesn't have tensors there.
+#
+# 5. Head `cls_contrasts[i]` is `BNContrastiveHead`. State-dict keys:
+#    norm.{weight,bias,running_mean,running_var}, logit_scale, bias.
+#    Confirm logit_scale is a scalar tensor (not a Parameter with different init).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ ncnn = [
     "ncnn",
 ]
 rtdetr = ["scipy>=1.7.0"]
+yoloworld = [
+    "transformers>=4.40.0",
+]
 all = [
     "libreyolo[onnx]",
     "libreyolo[rfdetr]",
@@ -55,6 +58,7 @@ all = [
     "libreyolo[openvino]",
     "libreyolo[ncnn]",
     "libreyolo[rtdetr]",
+    "libreyolo[yoloworld]",
 ]
 
 [project.urls]
@@ -109,6 +113,7 @@ testpaths = ["tests"]
 markers = [
     "unit: fast tests that avoid external weights or large files",
     "e2e: end-to-end tests requiring full model loading and inference",
+    "smoke: fast end-to-end pipeline checks on tiny synthetic data (CPU, <60s)",
     "tensorrt: tests requiring TensorRT",
     "openvino: tests requiring OpenVINO",
     "ncnn: tests requiring ncnn",

--- a/tests/smoke/test_yoloworld_smoke.py
+++ b/tests/smoke/test_yoloworld_smoke.py
@@ -1,0 +1,166 @@
+"""Offline smoke test for the YOLO-World open-vocabulary scaffold.
+
+Validates the real architecture + API end-to-end on CPU:
+  - YOLOv8 backbone + RepVL-PAN neck + BNContrastive head assemble,
+  - text encoder produces normalized embeddings,
+  - forward pass produces the right per-level shapes,
+  - prompt hot-swap updates the classification head width,
+  - full inference call returns a populated Results-like dict.
+
+Does NOT validate accuracy — weights are random-init in this MVP.
+See docs/agentic-features/blog/yolo-world-integration.md for scope.
+
+Run: pytest tests/smoke/test_yoloworld_smoke.py -v -m smoke
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.yoloworld import (
+    LibreYOLOWorld,
+    LibreYOLOWorldModel,
+    CLIP_EMBED_DIM,
+    MaxSigmoidAttnBlock,
+    BNContrastiveHead,
+)
+
+
+pytestmark = pytest.mark.smoke
+
+# Smoke tests use the smallest size so CPU runs in seconds.
+SMOKE_SIZE = "s"
+
+
+def _synthetic_image(size: int = 128) -> Image.Image:
+    rng = np.random.default_rng(7)
+    arr = rng.integers(0, 255, size=(size, size, 3), dtype=np.uint8)
+    return Image.fromarray(arr)
+
+
+# ---------------------------------------------------------------------------
+# Core module tests
+# ---------------------------------------------------------------------------
+
+
+def test_model_instantiates_and_requires_prompts():
+    model = LibreYOLOWorldModel(size=SMOKE_SIZE, imgsz=128)
+    assert hasattr(model, "backbone")
+    assert hasattr(model, "neck")
+    assert hasattr(model, "head")
+    assert hasattr(model, "text_encoder")
+    with pytest.raises(RuntimeError, match="No text prompts"):
+        model(torch.randn(1, 3, 128, 128))
+
+
+def test_text_encoder_returns_normalized_embeddings():
+    model = LibreYOLOWorldModel(size=SMOKE_SIZE, imgsz=128)
+    embeds = model.text_encoder.encode(["a photo of a cat", "a photo of a dog", "chair"])
+    assert embeds.shape == (3, CLIP_EMBED_DIM)
+    norms = embeds.norm(dim=-1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-4)
+
+
+def test_max_sigmoid_attn_block_output_shape():
+    blk = MaxSigmoidAttnBlock(in_channels=64, out_channels=64, guide_channels=CLIP_EMBED_DIM,
+                              embed_channels=64, num_heads=8)
+    x = torch.randn(2, 64, 16, 16)
+    guide = torch.randn(2, 4, CLIP_EMBED_DIM)  # B=2, N_cls=4
+    out = blk(x, guide)
+    assert out.shape == (2, 64, 16, 16)
+
+
+def test_bn_contrastive_head_output_shape():
+    head = BNContrastiveHead(embed_dim=CLIP_EMBED_DIM)
+    embed = torch.randn(2, CLIP_EMBED_DIM, 8, 8)
+    text = torch.randn(2, 7, CLIP_EMBED_DIM)
+    text = text / text.norm(dim=-1, keepdim=True)
+    logits = head(embed, text)
+    assert logits.shape == (2, 7, 8, 8)
+
+
+def test_forward_produces_three_level_outputs():
+    model = LibreYOLOWorldModel(size=SMOKE_SIZE, imgsz=128)
+    model.set_prompts(["person", "car", "bicycle", "dog"])
+    x = torch.randn(1, 3, 128, 128)
+    out = model(x)
+
+    assert len(out["bbox_dists"]) == 3
+    assert len(out["cls_logits"]) == 3
+    assert out["strides"] == [8.0, 16.0, 32.0]
+
+    # Expected feature sizes at stride 8/16/32 for imgsz=128: 16x16, 8x8, 4x4
+    expected = [(16, 16), (8, 8), (4, 4)]
+    for i, ((b, c), (eh, ew)) in enumerate(zip(zip(out["bbox_dists"], out["cls_logits"]), expected)):
+        assert b.shape[-2:] == (eh, ew)
+        assert c.shape[-2:] == (eh, ew)
+        assert c.shape[1] == 4  # N_prompts
+        assert b.shape[1] == 64  # 4 * reg_max = 4 * 16
+        assert torch.isfinite(b).all() and torch.isfinite(c).all()
+
+
+def test_prompts_are_hot_swappable():
+    model = LibreYOLOWorldModel(size=SMOKE_SIZE, imgsz=128)
+    model.set_prompts(["cat", "dog"])
+    out_a = model(torch.randn(1, 3, 128, 128))
+    assert out_a["cls_logits"][0].shape[1] == 2
+
+    model.set_prompts(["red apple", "green apple", "banana", "orange"])
+    out_b = model(torch.randn(1, 3, 128, 128))
+    assert out_b["cls_logits"][0].shape[1] == 4
+    assert model.num_prompts == 4
+    assert model.prompts == ["red apple", "green apple", "banana", "orange"]
+
+
+def test_empty_prompts_rejected():
+    model = LibreYOLOWorldModel(size=SMOKE_SIZE, imgsz=128)
+    with pytest.raises(ValueError):
+        model.set_prompts([])
+    with pytest.raises(ValueError):
+        model.set_prompts("not a list")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Wrapper tests
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_instantiates_with_prompts():
+    model = LibreYOLOWorld(size=SMOKE_SIZE, imgsz=128, prompts=["person", "dog"], device="cpu")
+    assert model.prompts == ["person", "dog"]
+    assert model.nb_classes == 2
+
+
+def test_wrapper_inference_returns_detections(tmp_path):
+    model = LibreYOLOWorld(size=SMOKE_SIZE, imgsz=128, prompts=["person", "dog"], device="cpu")
+    img_path = tmp_path / "sample.jpg"
+    _synthetic_image(128).save(img_path)
+
+    result = model(str(img_path), conf=0.0, iou=0.5, max_det=10)
+    res = result[0] if isinstance(result, list) else result
+    assert hasattr(res, "boxes")
+    # Random-init weights → detections may be 0; pipeline must not raise.
+    if len(res.boxes) > 0:
+        cls_ids = res.boxes.cls.long().tolist()
+        assert all(0 <= c < 2 for c in cls_ids)
+
+
+def test_wrapper_prompt_swap_changes_output_classes(tmp_path):
+    model = LibreYOLOWorld(size=SMOKE_SIZE, imgsz=128, prompts=["cat"], device="cpu")
+    img_path = tmp_path / "sample.jpg"
+    _synthetic_image(128).save(img_path)
+
+    _ = model(str(img_path), conf=0.0, iou=0.5, max_det=5)
+    model.set_prompts(["dog", "cat", "bird", "fish", "snake"])
+    assert model.nb_classes == 5
+
+    result = model(str(img_path), conf=0.0, iou=0.5, max_det=5)
+    res = result[0] if isinstance(result, list) else result
+    if len(res.boxes) > 0:
+        cls_ids = res.boxes.cls.long().tolist()
+        assert all(0 <= c < 5 for c in cls_ids)


### PR DESCRIPTION
## Summary

Adds **LibreYOLOWorld** — a new model family for **text-prompted, zero-shot detection**. Pass class names as strings at inference time, no retraining to add a class. Architecture is structurally identical to [\`wondervictor/YOLO-World-V2.1\`](https://huggingface.co/wondervictor/YOLO-World-V2.1) so their checkpoints load directly via a state-dict remapper.

Discussion thread: #100. **Posting as draft pending the questions on that issue** (in/out of scope, transformers vs open_clip, YOLO-World vs YOLOE) — happy to iterate on any of these before marking ready for review.

## Validation

Verified architectural match by loading \`s_stage2-4466ab94.pth\`:

\`\`\`
411 keys remapped, 0 shape mismatches
forward(parkour.jpg, prompts=['person', 'skateboard', 'building', 'tree']):
  detections: 2
   0. person   conf=0.459   xyxy=[353, 67, 607, 271]
   1. person   conf=0.137   xyxy=[380, 448, 867, 840]
\`\`\`

This is real open-vocabulary inference — no training, no fine-tuning, prompts set at runtime. Both detections correctly classify with sensible boxes.

## What's here

| Path | Role |
|------|------|
| \`libreyolo/models/yoloworld/nn.py\` | \`YOLOv8CSPDarknet\` + frozen \`CLIPTextModelWithProjection\` + \`YOLOWorldPAFPN\` (RepVL-PAN) + \`YOLOWorldHeadModule\` with DFL + \`BNContrastiveHead\`. ~570 LOC. mmyolo-compatible naming for state-dict portability. |
| \`libreyolo/models/yoloworld/model.py\` | \`LibreYOLOWorld\` wrapper (\`BaseModel\` subclass), DFL bbox decode + class-agnostic NMS in \`_postprocess\`, prompts hot-swappable via \`set_prompts()\`. ~280 LOC. |
| \`libreyolo/models/yoloworld/weight_porting.py\` | Key remapper + HF Hub loader (\`port_from_hf\`). ~160 LOC. |
| \`tests/smoke/test_yoloworld_smoke.py\` | 10 offline tests, all pass in ~14s on CPU. |
| \`pyproject.toml\` | Adds \`[project.optional-dependencies.yoloworld] = [\"transformers>=4.40.0\"]\` so default installs aren't bloated. Adds \`smoke\` pytest marker. |

## RepVL-PAN — the key innovation

YOLO-World's secret sauce isn't cross-attention or sentence-level multiplication. It's a **max-over-class sigmoid gate** on image features:

\`\`\`python
g = guide_fc(text_embeds).view(B, N_cls, num_heads, attn_head_ch)
e = embed_conv(x).view(B, num_heads, attn_head_ch, H, W)
attn = einsum(\"bmchw,bnmc->bmhwn\", e, g).max(dim=-1)[0] / sqrt(Ch)
attn = (attn + bias).sigmoid()                            # per-pixel, per-head
out = project_conv(x).view(B, num_heads, proj_head_ch, H, W) * attn
\`\`\`

~30 LOC, applied in-place on the last C2f block at every neck merge.

## License caveat (important)

The official Tencent V2.1 weights are **GPL-3.0**. This PR's code is MIT and **never bundles weights**. Users who call \`port_from_hf\` download GPL weights to their own machine and inherit GPL-3.0 obligations for code they link against the loaded module. Documented in docstrings.

A natural follow-up: train V2.1-shape weights on Objects365 + GoldG with an MIT release, then host them under \`LibreYOLO/yolo-world-mit\`. That's a real-compute task for another effort.

## Why \`transformers\` (not \`open_clip\`)

V2.1 uses HuggingFace \`CLIPTextModelWithProjection\` directly (the upstream's \`HuggingCLIPLanguageBackbone\` is a thin wrapper). Using \`transformers\` keeps the load path identical to upstream. \`open_clip\` would also work but require a translation layer. Happy to switch to \`open_clip\` if maintainers prefer it.

## Open questions (for the issue thread)

1. In scope for LibreYOLO main, or should this stay as a plugin?
2. \`transformers\` as optional dep OK, or prefer \`open_clip\`?
3. NVIDIA's YOLOE has a different design — interest in that as a parallel family, or stick with YOLO-World?
4. Naming: \`LibreYOLOWorld\` follows \`LibreYOLOX\` / \`LibreYOLO9\` / \`LibreYOLORFDETR\`. Any naming concerns?

## What's NOT in this PR

- ONNX export support (next step once we agree on the family)
- mAP eval on LVIS (would benchmark vs Tencent's reference numbers)
- L / M / X size validation against checkpoints (S is verified; the auto-derivation rule \`num_heads = mid // 32\` should cover other sizes but needs checkpoint downloads to confirm)
- A user-facing notebook / script (kept on the fork for now to minimize convention churn — happy to move into the PR if maintainers want them here)

## Test plan

- [x] \`pytest tests/smoke/test_yoloworld_smoke.py -m smoke\` → 10 passed
- [x] \`pytest tests/unit -q\` → 133 passed, 0 failed
- [x] V2.1-S checkpoint loads with 411/411 mappable keys, 0 shape mismatches
- [x] Forward pass on \`parkour.jpg\` returns sensible person detections with arbitrary text prompts
- [ ] Forward pass with M / L / X checkpoints — pending checkpoint downloads
- [ ] LVIS mAP — pending compute

🤖 Generated with [Claude Code](https://claude.com/claude-code)