### PR TITLE
Match super_gradients YOLO-NAS validation pipeline (closes #113)

### DIFF
--- a/libreyolo/models/yolonas/utils.py
+++ b/libreyolo/models/yolonas/utils.py
@@ -6,10 +6,13 @@ from typing import Mapping, MutableMapping, Tuple
 
 import numpy as np
 import torch
+import torchvision.ops
 from PIL import Image
 
-from ...utils.general import postprocess_detections
 from ...utils.image_loader import ImageInput, ImageLoader
+
+YOLO_NAS_RESIZE_SIZE = 636
+YOLO_NAS_PRE_NMS_TOP_K = 1000
 
 
 def unwrap_yolonas_checkpoint(
@@ -36,23 +39,21 @@ def preprocess_numpy(
     img_rgb_hwc: np.ndarray,
     input_size: int = 640,
     pad_value: int = 114,
+    resize_size: int = YOLO_NAS_RESIZE_SIZE,
 ) -> Tuple[np.ndarray, float]:
-    """Preprocess RGB HWC uint8 image for YOLO-NAS inference.
-
-    This currently follows LibreYOLO's shared letterbox convention so validation
-    and single-image inference scale boxes back consistently. A later parity
-    pass can tighten this toward the exact SG processing pipeline.
-    """
+    """Resize longest side to ``resize_size``, center-pad to ``input_size``."""
     orig_h, orig_w = img_rgb_hwc.shape[:2]
-    ratio = min(input_size / orig_h, input_size / orig_w)
-    new_w, new_h = int(orig_w * ratio), int(orig_h * ratio)
+    ratio = min(resize_size / orig_h, resize_size / orig_w)
+    new_w, new_h = int(round(orig_w * ratio)), int(round(orig_h * ratio))
 
     img_resized = Image.fromarray(img_rgb_hwc).resize(
         (new_w, new_h), Image.Resampling.BILINEAR
     )
 
     padded = Image.new("RGB", (input_size, input_size), (pad_value, pad_value, pad_value))
-    padded.paste(img_resized, (0, 0))
+    offset_x = (input_size - new_w) // 2
+    offset_y = (input_size - new_h) // 2
+    padded.paste(img_resized, (offset_x, offset_y))
 
     arr = np.array(padded, dtype=np.float32) / 255.0
     return arr.transpose(2, 0, 1), ratio
@@ -92,12 +93,15 @@ def _extract_decoded_predictions(output):
 
 def postprocess(
     output,
-    conf_thres: float = 0.25,
-    iou_thres: float = 0.45,
+    conf_thres: float = 0.01,
+    iou_thres: float = 0.7,
     input_size: int = 640,
     original_size: Tuple[int, int] | None = None,
     max_det: int = 300,
     letterbox: bool = True,
+    resize_size: int = YOLO_NAS_RESIZE_SIZE,
+    pre_nms_top_k: int = YOLO_NAS_PRE_NMS_TOP_K,
+    **kwargs,
 ):
     boxes, scores = _extract_decoded_predictions(output)
 
@@ -111,14 +115,55 @@ def postprocess(
     if not mask.any():
         return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
 
-    return postprocess_detections(
-        boxes=boxes[mask].clone(),
-        scores=max_scores[mask],
-        class_ids=class_ids[mask],
-        conf_thres=conf_thres,
-        iou_thres=iou_thres,
-        input_size=input_size,
-        original_size=original_size,
-        max_det=max_det,
-        letterbox=letterbox,
-    )
+    boxes = boxes[mask]
+    scores = max_scores[mask]
+    class_ids = class_ids[mask]
+
+    if pre_nms_top_k and scores.numel() > pre_nms_top_k:
+        topk = scores.topk(pre_nms_top_k)
+        scores = topk.values
+        boxes = boxes[topk.indices]
+        class_ids = class_ids[topk.indices]
+
+    if original_size is not None:
+        if letterbox:
+            orig_w, orig_h = original_size
+            r = min(resize_size / orig_h, resize_size / orig_w)
+            new_w = int(round(orig_w * r))
+            new_h = int(round(orig_h * r))
+            offset_x = (input_size - new_w) // 2
+            offset_y = (input_size - new_h) // 2
+            boxes = boxes.clone()
+            boxes[:, 0::2] = (boxes[:, 0::2] - offset_x) / r
+            boxes[:, 1::2] = (boxes[:, 1::2] - offset_y) / r
+        else:
+            scale_x = original_size[0] / input_size
+            scale_y = original_size[1] / input_size
+            boxes = boxes.clone()
+            boxes[:, [0, 2]] *= scale_x
+            boxes[:, [1, 3]] *= scale_y
+
+        boxes[:, [0, 2]] = torch.clamp(boxes[:, [0, 2]], 0, original_size[0])
+        boxes[:, [1, 3]] = torch.clamp(boxes[:, [1, 3]], 0, original_size[1])
+
+        widths = boxes[:, 2] - boxes[:, 0]
+        heights = boxes[:, 3] - boxes[:, 1]
+        valid = (widths > 0) & (heights > 0)
+        if not valid.all():
+            boxes = boxes[valid]
+            scores = scores[valid]
+            class_ids = class_ids[valid]
+
+    if boxes.numel() == 0:
+        return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
+
+    keep = torchvision.ops.batched_nms(boxes, scores, class_ids, iou_thres)
+    if keep.numel() > max_det:
+        keep = keep[:max_det]
+
+    return {
+        "boxes": boxes[keep].cpu(),
+        "scores": scores[keep].cpu(),
+        "classes": class_ids[keep].cpu(),
+        "num_detections": int(keep.numel()),
+    }


### PR DESCRIPTION
Three issues in libreyolo/models/yolonas/utils.py made YOLO-NAS-S/M/L score ~1 mAP below Deci's published numbers on COCO val2017:

1. preprocess_numpy padded to (0, 0) instead of centering. The file's own docstring already flagged this: "A later parity pass can tighten this toward the exact SG processing pipeline."
2. preprocess_numpy resized longest side to input_size (640) instead of 636 (the value used in coco_detection_yolo_nas_dataset_params.yaml, which is then center-padded to 640).
3. postprocess defaulted conf_thres=0.25 / iou_thres=0.45. super_gradients' YoloNASPostPredictionCallback uses 0.01 / 0.7 for the COCO eval recipe that produced the published numbers.

postprocess now inlines the pipeline (filter + top-k=1000 + offset-aware letterbox unscale + single batched_nms) instead of delegating to utils.general.postprocess_detections, both because it needs to subtract the centered padding offset before dividing by the resize ratio and to avoid the per-class Python NMS loop blowing up at conf_thres=0.001 (see issue #112 for the broader fix in postprocess_detections).

