### PR TITLE
[codex] Add contributor and release documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,20 @@
-# Package publishing process
+# Contributing
 
-Relevan files:
-- MANIFEST.in to exclude weights/artifacts from the package (sdist)
-- .github/workflows/publish.yml to run CI + publish to PyPI via OIDC
+Thanks for your interest in contributing to LibreYOLO.
 
-To publish a new version:
-- Bump version in pyproject.toml (source of truth), commit, push to main
-- Go to github.com/LibreYOLO/libreyolo/releases/new and create/publish a release with tag vX.Y.Z (this triggers the workflow)
-- Go to the Actions run and approve the publish step at the end (GitHub Environment gate): github.com/LibreYOLO/libreyolo/actions
+LibreYOLO is an MIT-licensed computer vision library focused on YOLO-style
+training and inference. Contributions are welcome, but maintainer review time
+is limited. Keep changes focused, tested, and aligned with the project.
 
-Security:
-- Publishing approvals are enforced via GitHub Environments: github.com/LibreYOLO/libreyolo/settings/environments
-- No PyPI tokens stored in GitHub; uses Trusted Publishing (OIDC)
+## Before opening a PR
+
+- For anything non-trivial, open an issue before submitting a PR so we can
+  agree on the approach before review time is spent.
+- PRs must link to an issue.
+- A good PR solves one clearly described problem.
+- Use common sense and keep scope tight.
+
+## LLM policy
+
+- Do not add LLMs as co-authors in commits.
+- Do not open LLM-generated issues.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,24 @@
+# Releasing
+
+Maintainer-only notes for publishing LibreYOLO to PyPI.
+
+## Relevant files
+
+- `MANIFEST.in` excludes weights and other large artifacts from the source distribution.
+- `.github/workflows/publish.yml` runs CI and publishes to PyPI via Trusted Publishing (OIDC).
+
+## Publishing a new version
+
+1. Bump the version in `pyproject.toml` and treat it as the source of truth.
+2. Commit the version bump and push it to `main`.
+3. Create and publish a GitHub release with tag `vX.Y.Z`:
+   `https://github.com/LibreYOLO/libreyolo/releases/new`
+4. Open the Actions run and approve the final publish step:
+   `https://github.com/LibreYOLO/libreyolo/actions`
+
+## Security
+
+- Publishing approvals are enforced through GitHub Environments:
+  `https://github.com/LibreYOLO/libreyolo/settings/environments`
+- No PyPI token is stored in GitHub.
+- Publishing uses Trusted Publishing (OIDC).


### PR DESCRIPTION
## What changed

- moved PyPI/package publishing instructions out of `CONTRIBUTING.md` into a new `RELEASING.md`
- rewrote `CONTRIBUTING.md` as contributor-facing guidance
- added lightweight contribution policy around issue-first PRs, tight scope, and LLM usage

## Why

`CONTRIBUTING.md` was holding maintainer-only release operations instead of contributor guidance. Splitting the docs makes contributor expectations clearer and gives package publishing its own dedicated maintainer document.

## Impact

- contributors now have a clearer entry point for PR expectations
- maintainers have a dedicated release/publishing reference
- no code or runtime behavior changes

## Validation

- docs-only change
- no tests run
