### PR TITLE
Fix: auto-download weights when not found in _load_weights

### DIFF
--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -260,9 +260,21 @@ class BaseModel(ABC):
         Auto-rebuilds model architecture if checkpoint has different nc.
         Also handles DDP prefix stripping and cross-family rejection.
         """
-        if not Path(model_path).exists():
-            raise FileNotFoundError(f"Model weights file not found: {model_path}")
+        path = Path(model_path)
+        if not path.exists() and path.parent == Path("."):
+            weights_path = Path("weights") / path.name
+            if weights_path.exists():
+                model_path = str(weights_path)
+                path = weights_path
 
+        if not path.exists():
+            from ...utils.download import download_weights
+
+            download_weights(model_path, self.size)
+            path = Path(model_path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"Model weights not found at {model_path}")
         try:
             loaded = torch.load(model_path, map_location="cpu", weights_only=False)
 


### PR DESCRIPTION
## Description
This PR fixes the issue where `_load_weights` raises an exception when weights are missing instead of downloading them automatically.

## Changes
- Added fallback to `download_weights()` in `_load_weights`
- Exception is raised only if download fails

## Related issue
Fixes #125