### PR TITLE
[codex] Improve dataset loading feedback

### DIFF
--- a/libreyolo/config/datasets/coco.yaml
+++ b/libreyolo/config/datasets/coco.yaml
@@ -101,7 +101,7 @@ names:
 # Download script (auto-downloads if dataset not found locally)
 download: |
   from pathlib import Path
-  from libreyolo.utils.downloads import ASSETS_URL, download
+  from libreyolo.data.utils import ASSETS_URL, download
 
   dir = Path(yaml["path"])
 

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -5,7 +5,11 @@ Supports both COCO JSON format and YOLO txt format.
 """
 
 import copy
+import logging
 import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import List, Tuple
 
@@ -14,8 +18,11 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
 from PIL import Image, UnidentifiedImageError
+from tqdm import tqdm
 
 from .utils import polygon_to_cxcywh
+
+logger = logging.getLogger(__name__)
 
 
 class YOLODataset(Dataset):
@@ -107,11 +114,59 @@ class YOLODataset(Dataset):
 
     def _load_annotations(self) -> List:
         """Load all annotations."""
-        annotations = []
-        for img_file, label_file in zip(self.img_files, self.label_files):
-            anno = self._load_label(label_file, img_file)
-            annotations.append(anno)
+        total = len(self.img_files)
+        source = self._annotation_source()
+        logger.info("Loading %d YOLO annotations from %s...", total, source)
+        start = time.perf_counter()
+
+        pairs = list(zip(self.img_files, self.label_files))
+        max_workers = min(8, os.cpu_count() or 1, total)
+
+        def load_one(pair):
+            img_file, label_file = pair
+            return self._load_label(label_file, img_file)
+
+        if max_workers > 1:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                annotations = list(
+                    tqdm(
+                        executor.map(load_one, pairs),
+                        total=total,
+                        desc=f"Loading YOLO annotations ({source})",
+                        file=sys.stderr,
+                        disable=not sys.stderr.isatty(),
+                    )
+                )
+        else:
+            annotations = [
+                load_one(pair)
+                for pair in tqdm(
+                    pairs,
+                    total=total,
+                    desc=f"Loading YOLO annotations ({source})",
+                    file=sys.stderr,
+                    disable=not sys.stderr.isatty(),
+                )
+            ]
+
+        logger.info(
+            "Loaded %d YOLO annotations from %s in %.2fs",
+            total,
+            source,
+            time.perf_counter() - start,
+        )
         return annotations
+
+    def _annotation_source(self) -> str:
+        """Return a compact source label for annotation loading progress."""
+        if self.split is not None:
+            return str(self.split)
+        if self.label_files:
+            label_dir = self.label_files[0].parent
+            if label_dir.parent.name:
+                return f"{label_dir.parent.name}/{label_dir.name}"
+            return str(label_dir)
+        return "dataset"
 
     def _load_label(self, label_file: Path, img_file: Path) -> Tuple:
         """Load annotation for a single image."""
@@ -291,7 +346,27 @@ class COCODataset(Dataset):
 
     def _load_coco_annotations(self) -> List:
         """Load all annotations."""
-        return [self._load_anno_from_id(id_) for id_ in self.ids]
+        total = len(self.ids)
+        source = f"{self.name}/{self.json_file}"
+        logger.info("Loading %d COCO annotations from %s...", total, source)
+        start = time.perf_counter()
+        annotations = [
+            self._load_anno_from_id(id_)
+            for id_ in tqdm(
+                self.ids,
+                total=total,
+                desc=f"Loading COCO annotations ({self.name})",
+                file=sys.stderr,
+                disable=not sys.stderr.isatty(),
+            )
+        ]
+        logger.info(
+            "Loaded %d COCO annotations from %s in %.2fs",
+            total,
+            source,
+            time.perf_counter() - start,
+        )
+        return annotations
 
     def _load_anno_from_id(self, id_: int) -> Tuple:
         """Load annotation for a single image ID."""

--- a/tests/unit/test_dataset_loading.py
+++ b/tests/unit/test_dataset_loading.py
@@ -1,0 +1,52 @@
+"""Tests for dataset annotation loading."""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from libreyolo.data.dataset import YOLODataset
+
+pytestmark = pytest.mark.unit
+
+
+def test_yolo_annotation_loading_preserves_order_and_shape(tmp_path, monkeypatch):
+    monkeypatch.setattr("libreyolo.data.dataset.os.cpu_count", lambda: 8)
+
+    image_dir = tmp_path / "images"
+    label_dir = tmp_path / "labels"
+    image_dir.mkdir()
+    label_dir.mkdir()
+
+    order = [3, 1, 4, 0, 2, 7, 5, 9, 6, 8]
+    for index in order:
+        width = 100 + index
+        height = 80 + index
+        Image.new("RGB", (width, height), color="white").save(
+            image_dir / f"sample_{index}.jpg"
+        )
+        (label_dir / f"sample_{index}.txt").write_text("0 0.5 0.5 0.25 0.5\n")
+
+    img_files = [image_dir / f"sample_{index}.jpg" for index in order]
+    label_files = [label_dir / f"sample_{index}.txt" for index in order]
+
+    dataset = YOLODataset(
+        img_files=img_files,
+        label_files=label_files,
+        img_size=(64, 64),
+    )
+
+    assert [annotation[3] for annotation in dataset.annotations] == [
+        image_path.name for image_path in img_files
+    ]
+
+    for index, annotation in zip(order, dataset.annotations):
+        labels, img_info, resized_info, file_name = annotation
+        width = 100 + index
+        height = 80 + index
+        scale = min(64 / height, 64 / width)
+
+        assert isinstance(labels, np.ndarray)
+        assert labels.shape == (1, 5)
+        assert img_info == (height, width)
+        assert resized_info == (int(height * scale), int(width * scale))
+        assert file_name == f"sample_{index}.jpg"


### PR DESCRIPTION
## Summary

- Add progress/timing feedback while YOLO and COCO dataset annotations are preloaded.
- Parallelize YOLO annotation preloading with ordered `ThreadPoolExecutor.map`, keeping `self.annotations` aligned with `img_files`.
- Fix the built-in `coco.yaml` download script import path so the dataset YAML can call the existing LibreYOLO download helpers.
- Add a unit test covering threaded YOLO annotation order and tuple-shape compatibility.

## Why

Issue #146 reports that large dataset loading is slow and silent. The main user-facing problem is that training can appear stuck while annotations are being indexed. This keeps the loading contract intact while adding progress visibility and a narrow parallelization path for the per-image YOLO label/header reads.

## Validation

- `python3 -m pytest tests/unit/test_dataset_loading.py tests/unit/test_data_utils.py tests/unit/test_segmentation.py -q`
- `python3 -m py_compile libreyolo/data/dataset.py`
- `git diff --check`

## Benchmark Notes

This local machine only has about 14 GiB free, and the full COCO train image zip is about 19 GB plus extraction, so full `train2017` timing could not be run here. The existing local COCO copy has `val2017` images but no `train2017` images.

On the local cache-hot `val2017` subset, the patched threaded path is not faster than baseline, so the speedup still needs to be validated on the server/full COCO train environment where the 15-minute load was observed. The progress and timing feedback is validated immediately.
