### PR TITLE
Augment option

### DIFF
--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -56,6 +56,7 @@ class InferenceRunner:
         tiling: bool = False,
         overlap_ratio: float = 0.2,
         output_file_format: Optional[str] = None,
+        augment: bool = False,
         **kwargs,
     ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """
@@ -79,6 +80,10 @@ class InferenceRunner:
             tiling: Enable tiled inference for large images.
             overlap_ratio: Tile overlap ratio.
             output_file_format: Output format ("jpg", "png", "webp").
+            augment: If True, enable Test Time Augmentation (TTA). Runs
+                inference at three scales (0.83×, 1.0×, 1.33×) with and
+                without horizontal flip, then merges via class-wise NMS.
+                Detection only; ignored for video.
             **kwargs: Additional arguments for postprocessing.
 
         Returns:
@@ -134,6 +139,7 @@ class InferenceRunner:
                 tiling=tiling,
                 overlap_ratio=overlap_ratio,
                 output_file_format=output_file_format,
+                augment=augment,
                 **kwargs,
             )
 
@@ -150,6 +156,21 @@ class InferenceRunner:
                 max_det=max_det,
                 color_format=color_format,
                 overlap_ratio=overlap_ratio,
+                output_file_format=output_file_format,
+                **kwargs,
+            )
+
+        if augment:
+            return self._predict_tta(
+                source,
+                save=save,
+                output_path=output_path,
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                color_format=color_format,
                 output_file_format=output_file_format,
                 **kwargs,
             )
@@ -195,6 +216,7 @@ class InferenceRunner:
         tiling: bool = False,
         overlap_ratio: float = 0.2,
         output_file_format: Optional[str] = None,
+        augment: bool = False,
         **kwargs,
     ) -> List[Results]:
         """Process multiple images in batches."""
@@ -215,6 +237,22 @@ class InferenceRunner:
                             max_det=max_det,
                             color_format=color_format,
                             overlap_ratio=overlap_ratio,
+                            output_file_format=output_file_format,
+                            **kwargs,
+                        )
+                    )
+                elif augment:
+                    results.append(
+                        self._predict_tta(
+                            path,
+                            save=save,
+                            output_path=output_path,
+                            conf=conf,
+                            iou=iou,
+                            imgsz=imgsz,
+                            classes=classes,
+                            max_det=max_det,
+                            color_format=color_format,
                             output_file_format=output_file_format,
                             **kwargs,
                         )
@@ -412,6 +450,148 @@ class InferenceRunner:
                 image_path,
                 ext=ext,
             )
+            annotated_img.save(save_path)
+            result.saved_path = str(save_path)
+
+        return result
+
+    def _predict_tta(
+        self,
+        image: ImageInput,
+        save: bool = False,
+        output_path: str | None = None,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[int] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        color_format: str = "auto",
+        output_file_format: Optional[str] = None,
+        **kwargs,
+    ) -> Results:
+        """Run TTA inference (detection only).
+
+        Augments at three scales (0.83×, 1.0×, 1.33×) × {original, h-flip},
+        collects all predictions in original image space, then merges via
+        class-wise NMS.
+        """
+        from PIL import Image as PILImage
+
+        if self.model.task != "detect":
+            raise NotImplementedError(
+                f"TTA is only supported for detection, not '{self.model.task}'."
+            )
+
+        image_path = image if isinstance(image, (str, Path)) else None
+        img_pil = ImageLoader.load(image, color_format=color_format)
+        orig_w, orig_h = img_pil.size
+
+        all_boxes: List[torch.Tensor] = []
+        all_scores: List[torch.Tensor] = []
+        all_classes: List[torch.Tensor] = []
+
+        for scale in (0.83, 1.0, 1.33):
+            for flipped in (False, True):
+                if scale == 1.0:
+                    aug = img_pil
+                else:
+                    new_w = int(orig_w * scale)
+                    new_h = int(orig_h * scale)
+                    aug = img_pil.resize(
+                        (new_w, new_h), PILImage.Resampling.BILINEAR
+                    )
+
+                if flipped:
+                    aug = aug.transpose(PILImage.Transpose.FLIP_LEFT_RIGHT)
+
+                result = self._predict_single(
+                    aug,
+                    save=False,
+                    conf=conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    max_det=max_det,
+                    **kwargs,
+                )
+
+                if len(result) == 0:
+                    continue
+
+                boxes = result.boxes.xyxy.clone()  # (N, 4) in aug image space
+                scaled_w = int(orig_w * scale)
+
+                if flipped:
+                    x1 = scaled_w - boxes[:, 2]
+                    x2 = scaled_w - boxes[:, 0]
+                    boxes = torch.stack([x1, boxes[:, 1], x2, boxes[:, 3]], dim=1)
+
+                boxes = boxes / scale
+                boxes[:, 0::2].clamp_(0, orig_w)
+                boxes[:, 1::2].clamp_(0, orig_h)
+
+                all_boxes.append(boxes)
+                all_scores.append(result.boxes.conf)
+                all_classes.append(result.boxes.cls)
+
+        if not all_boxes:
+            detections: Dict = {
+                "boxes": torch.zeros((0, 4), dtype=torch.float32),
+                "scores": torch.zeros((0,), dtype=torch.float32),
+                "classes": torch.zeros((0,), dtype=torch.float32),
+                "num_detections": 0,
+            }
+            return self._wrap_results(
+                detections, (orig_w, orig_h), image_path, classes
+            )
+
+        boxes_t = torch.cat(all_boxes, dim=0)
+        scores_t = torch.cat(all_scores, dim=0)
+        classes_t = torch.cat(all_classes, dim=0)
+
+        # Class-wise NMS on merged detections from all augmentations
+        keep_boxes: List[torch.Tensor] = []
+        keep_scores: List[torch.Tensor] = []
+        keep_classes: List[torch.Tensor] = []
+        for cls_id in classes_t.unique():
+            mask = classes_t == cls_id
+            keep = nms(boxes_t[mask], scores_t[mask], iou)
+            keep_boxes.append(boxes_t[mask][keep])
+            keep_scores.append(scores_t[mask][keep])
+            keep_classes.append(classes_t[mask][keep])
+
+        merged_boxes = torch.cat(keep_boxes, dim=0)
+        merged_scores = torch.cat(keep_scores, dim=0)
+        merged_classes = torch.cat(keep_classes, dim=0)
+
+        if len(merged_scores) > max_det:
+            _, top_idx = merged_scores.topk(max_det)
+            merged_boxes = merged_boxes[top_idx]
+            merged_scores = merged_scores[top_idx]
+            merged_classes = merged_classes[top_idx]
+
+        detections = {
+            "boxes": merged_boxes,
+            "scores": merged_scores,
+            "classes": merged_classes,
+            "num_detections": len(merged_boxes),
+        }
+        result = self._wrap_results(
+            detections, (orig_w, orig_h), image_path, classes
+        )
+
+        if save:
+            if len(result) > 0:
+                annotated_img = draw_boxes(
+                    img_pil,
+                    result.boxes.xyxy.tolist(),
+                    result.boxes.conf.tolist(),
+                    result.boxes.cls.tolist(),
+                    class_names=result.names,
+                )
+            else:
+                annotated_img = img_pil.copy()
+            ext = output_file_format or "jpg"
+            save_path = resolve_save_path(output_path, image_path, ext=ext)
             annotated_img.save(save_path)
             result.saved_path = str(save_path)
 

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -455,6 +455,15 @@ class InferenceRunner:
 
         return result
 
+    # Families that resize directly to a fixed square (no letterbox, ratio=1.0).
+    # Multi-scale TTA is a no-op for them because _preprocess always rescales
+    # the PIL image back to the same fixed resolution regardless of its input
+    # size — so a 0.83× or 1.33× PIL image ends up identical to the original
+    # at the network level. Only horizontal flip adds genuine augmentation.
+    _FIXED_SIZE_FAMILIES: frozenset[str] = frozenset(
+        {"rfdetr", "rtdetr", "dfine", "deim", "deimv2", "ec"}
+    )
+
     def _predict_tta(
         self,
         image: ImageInput,
@@ -471,9 +480,16 @@ class InferenceRunner:
     ) -> Results:
         """Run TTA inference (detection only).
 
-        Augments at three scales (0.83×, 1.0×, 1.33×) × {original, h-flip},
-        collects all predictions in original image space, then merges via
-        class-wise NMS.
+        Letterbox families (YOLOX, YOLOv9, YOLO-NAS, PicoDet):
+            3 scales × 2 flips = 6 passes. Scaling the PIL image genuinely
+            changes what the network sees because letterbox preserves aspect
+            ratio and embeds scale information in the ratio used for decoding.
+
+        Fixed-size families (RF-DETR, RT-DETR, D-FINE, DEIM, EC):
+            Flip-only (2 passes). These models resize the PIL image to a fixed
+            square regardless of its input dimensions, so a 0.83× or 1.33×
+            variant would be stretched back to the same resolution at the
+            network level — adding cost with no benefit.
         """
         from PIL import Image as PILImage
 
@@ -486,11 +502,14 @@ class InferenceRunner:
         img_pil = ImageLoader.load(image, color_format=color_format)
         orig_w, orig_h = img_pil.size
 
+        fixed_size = self.model.FAMILY in self._FIXED_SIZE_FAMILIES
+        scales = (1.0,) if fixed_size else (0.83, 1.0, 1.33)
+
         all_boxes: List[torch.Tensor] = []
         all_scores: List[torch.Tensor] = []
         all_classes: List[torch.Tensor] = []
 
-        for scale in (0.83, 1.0, 1.33):
+        for scale in scales:
             for flipped in (False, True):
                 if scale == 1.0:
                     aug = img_pil

--- a/libreyolo/utils/predict_args.py
+++ b/libreyolo/utils/predict_args.py
@@ -7,7 +7,6 @@ import warnings
 
 NOOP_PREDICT_KWARGS = {
     "agnostic_nms",
-    "augment",
     "boxes",
     "dnn",
     "half",
@@ -20,6 +19,7 @@ NOOP_PREDICT_KWARGS = {
 }
 REJECTED_PREDICT_KWARGS = {"visualize", "embed"}
 ACCEPTED_PREDICT_KWARGS = {
+    "augment",
     "classes",
     "conf",
     "device",

--- a/tests/unit/test_predict_kwargs.py
+++ b/tests/unit/test_predict_kwargs.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.unit
 
 def test_noop_predict_kwargs_warn_and_are_removed():
     with pytest.warns(UserWarning, match="no-op"):
-        remaining = normalize_predict_kwargs({"augment": True})
+        remaining = normalize_predict_kwargs({"verbose": True})
     assert remaining == {}
 
 
@@ -17,7 +17,6 @@ def test_noop_predict_kwargs_warn_and_are_removed():
     "key",
     [
         "agnostic_nms",
-        "augment",
         "boxes",
         "dnn",
         "half",
@@ -43,6 +42,7 @@ def test_rejected_predict_kwargs_fail_clearly():
 @pytest.mark.parametrize(
     "key,value",
     [
+        ("augment", True),
         ("classes", [0]),
         ("conf", 0.25),
         ("device", "cpu"),


### PR DESCRIPTION
## Add `augment` argument for inference (Test-Time Augmentation)

This PR adds the `augment` argument to object detection inference, replicating the TTA (Test-Time Augmentation) behavior from YOLO.

When enabled, multiple augmented versions of each image are run through the model and the predictions are merged, improving detection quality at the cost of inference speed.

### Experiments on COCO val2017 (5000 images)

**YOLOX-s** — 6-pass TTA (3 scales × flip)

| Metric | Baseline | TTA | Δ |
|---|---|---|---|
| mAP50-95 | 0.3897 | 0.3969 | +0.0072 |
| mAP50 | 0.5794 | 0.5872 | +0.0078 |
| mAP75 | 0.4221 | 0.4307 | +0.0086 |
| Recall | 0.5601 | 0.5875 | +0.0274 |
| mAP-S | 0.2223 | 0.2268 | +0.0045 |
| mAP-M | 0.4326 | 0.4422 | +0.0096 |
| mAP-L | 0.5224 | 0.5339 | +0.0115 |

Inference overhead: 6.8× (17ms → 115ms/img)