### PR TITLE
fix: align COCO eval between json and yolo label paths (#152)

### DIFF
--- a/libreyolo/config/datasets/coco-val-only.yaml
+++ b/libreyolo/config/datasets/coco-val-only.yaml
@@ -103,6 +103,12 @@ download: |
 
   dir = Path(yaml["path"])
 
+  # Download annotations (COCO JSON) - required for proper COCO evaluation
+  download(
+      [ASSETS_URL + "/instances_val2017.json"],
+      dir=dir / "annotations",
+  )
+
   # Download labels (YOLO format) - includes both train and val labels
   download([ASSETS_URL + "/coco2017labels.zip"], dir=dir.parent)
 

--- a/libreyolo/config/datasets/coco.yaml
+++ b/libreyolo/config/datasets/coco.yaml
@@ -105,6 +105,9 @@ download: |
 
   dir = Path(yaml["path"])
 
+  # Download annotations (COCO JSON) - required for proper COCO evaluation
+  download([ASSETS_URL + "/instances_val2017.json"], dir=dir / "annotations")
+
   # Download labels (YOLO format)
   download([ASSETS_URL + "/coco2017labels.zip"], dir=dir.parent)
 

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -433,10 +433,7 @@ class DetectionValidator(BaseValidator):
                 self.val_preproc is not None and self.val_preproc.uses_letterbox
             )
             conf_thres = self.config.conf_thres
-            if (
-                self._coco_annotation_file is not None
-                and self.model.FAMILY in COCO_TOPK_FAMILIES
-            ):
+            if self.model.FAMILY in COCO_TOPK_FAMILIES:
                 # Upstream DETR-style COCO eval keeps the ranked top-k set and
                 # lets pycocotools handle score ordering, rather than applying
                 # a pre-eval confidence cutoff.


### PR DESCRIPTION
https://github.com/LibreYOLO/libreyolo/issues/152

- Removes _coco_annotation_file guard so DETR top-k cutoff (conf_thres=0) applies to both JSON and YOLO paths
- Adds COCO annotations download so the validator defaults to JSON path (which carries proper iscrowd, area, etc.)