### PR TITLE
Remove the .resolve from the get_img_files method

### DIFF
--- a/libreyolo/data/utils.py
+++ b/libreyolo/data/utils.py
@@ -175,14 +175,14 @@ def get_img_files(path: Union[str, Path, List], prefix: str = "") -> List[Path]:
                         # Relative to txt file's parent directory
                         img_path = path.parent / img_path
                     if img_path.exists() and img_path.suffix.lower() in IMG_FORMATS:
-                        img_files.append(img_path.resolve())
+                        img_files.append(img_path)
         return sorted(img_files)
 
     elif path.suffix.lower() in IMG_FORMATS:
         # Single image file
         if not path.exists():
             raise FileNotFoundError(f"Image file not found: {path}")
-        return [path.resolve()]
+        return [path]
 
     else:
         raise ValueError(f"Unsupported path format: {path}")


### PR DESCRIPTION
This PR addresses the bug where using .resolve() for the images path in the get_img_files method would replace the paths generated by symlinks, therefore conflicting with the logic of replacing 'images' with 'labels' in the images path, causing not to find the labels. Closes #187