### PR TITLE
Warn when dataset has no labels

### DIFF
--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -186,6 +186,9 @@ class YOLODataset(Dataset):
             annotations = [item[0] for item in annotations]
         else:
             self.segments = None
+
+        if sum(a[0].shape[0] for a in annotations) == 0:
+            logger.warning("No labels found in %d files from %s.", total, source)
         return annotations
 
     def _annotation_source(self) -> str:
@@ -439,6 +442,9 @@ class COCODataset(Dataset):
             annotations = [item[0] for item in annotations]
         else:
             self.segments = None
+
+        if sum(a[0].shape[0] for a in annotations) == 0:
+            logger.warning("No labels found in %d files from %s.", total, source)
         return annotations
 
     def _load_anno_from_id(self, id_: int) -> Tuple:

--- a/tests/unit/test_train_no_labels_warning.py
+++ b/tests/unit/test_train_no_labels_warning.py
@@ -1,0 +1,44 @@
+"""Empty-label warning during dataset load (issue #188)."""
+
+import logging
+
+import pytest
+from PIL import Image
+
+from libreyolo.data.dataset import YOLODataset
+
+pytestmark = pytest.mark.unit
+
+
+def _build_dataset(tmp_path, label_contents):
+    image_dir = tmp_path / "images"
+    label_dir = tmp_path / "labels"
+    image_dir.mkdir()
+    label_dir.mkdir()
+
+    img_files, label_files = [], []
+    for index, body in enumerate(label_contents):
+        img = image_dir / f"sample_{index}.jpg"
+        lbl = label_dir / f"sample_{index}.txt"
+        Image.new("RGB", (64, 64), color="white").save(img)
+        lbl.write_text(body)
+        img_files.append(img)
+        label_files.append(lbl)
+
+    return YOLODataset(img_files=img_files, label_files=label_files, img_size=(64, 64))
+
+
+def test_warns_when_all_label_files_empty(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger="libreyolo.data.dataset"):
+        _build_dataset(tmp_path, ["", "", ""])
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "no labels" in warnings[0].getMessage().lower()
+
+
+def test_silent_when_any_labels_present(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger="libreyolo.data.dataset"):
+        _build_dataset(tmp_path, ["0 0.5 0.5 0.25 0.5\n", "", ""])
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []


### PR DESCRIPTION
This fixes #188 
Adds a single `logger.warning` when a dataset is constructed with zero labels across all images. Added a few tests also for this.