### PR TITLE
Add RT-DETRv2 and RT-DETRv4 families; fix RT-DETRv1 postprocess

### DIFF
--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -16,6 +16,7 @@ from .models import (
     LibreEC,
     LibrePICODET,
     LibreRTDETR,
+    LibreRTDETRv2,
     LibreRTDETRv4,
 )
 from .utils.results import Results, Boxes, Masks, Keypoints, Probs, OBB
@@ -94,6 +95,7 @@ __all__ = [
     "LibreYOLONAS",
     "LibreYOLOX",
     "LibreRTDETR",
+    "LibreRTDETRv2",
     "LibreRTDETRv4",
     "LibreRFDETR",
     "LibreDFINE",

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -16,6 +16,7 @@ from .models import (
     LibreEC,
     LibrePICODET,
     LibreRTDETR,
+    LibreRTDETRv4,
 )
 from .utils.results import Results, Boxes, Masks, Keypoints, Probs, OBB
 
@@ -93,6 +94,7 @@ __all__ = [
     "LibreYOLONAS",
     "LibreYOLOX",
     "LibreRTDETR",
+    "LibreRTDETRv4",
     "LibreRFDETR",
     "LibreDFINE",
     "LibreDEIM",

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -62,7 +62,7 @@ def _is_nms_free_family(model_family: Optional[str]) -> bool:
     selection. Applying YOLO-style IoU suppression on top of that can remove
     valid detections and make exported runtimes diverge from native PyTorch.
     """
-    return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr", "rtdetrv4"}
+    return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr", "rtdetrv2", "rtdetrv4"}
 
 
 class BaseBackend(ABC):
@@ -162,7 +162,7 @@ class BaseBackend(ABC):
                 image, effective_imgsz, color_format
             )
             return tensor, img, size, 1.0
-        elif self.model_family == "rtdetr":
+        elif self.model_family in ("rtdetr", "rtdetrv2"):
             tensor, img, size = self._preprocess_rtdetr(
                 image, effective_imgsz, color_format
             )
@@ -318,7 +318,7 @@ class BaseBackend(ABC):
             # so the parser is shared.
             boxes, scores, cls = self._parse_dfine(all_outputs, orig_w, orig_h, conf)
             return boxes, scores, cls, None
-        elif self.model_family == "rtdetr":
+        elif self.model_family in ("rtdetr", "rtdetrv2"):
             boxes, scores, cls = self._parse_rtdetr(all_outputs, orig_w, orig_h, conf)
             return boxes, scores, cls, None
         elif self.model_family == "picodet":

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -583,17 +583,23 @@ class BaseBackend(ABC):
                 logits = second
                 boxes_raw = first
 
-        scores = 1.0 / (1.0 + np.exp(-logits.astype(np.float64))).astype(np.float32)
+        # Match upstream RTDETRPostProcessor (and _parse_dfine): top-K across the
+        # flattened (Q*nc) score matrix, allowing multiple classes per query.
+        # Per-query argmax (the previous logic) silently dropped valid non-max
+        # detections and cost ~0.7-0.9 mAP on COCO val2017.
+        Q, nc = logits.shape
+        prob = 1.0 / (1.0 + np.exp(-logits.astype(np.float64)))
+        prob = prob.astype(np.float32)
 
-        max_scores = np.max(scores, axis=1)
-        class_ids = np.argmax(scores, axis=1)
+        max_det = 300
+        flat = prob.reshape(-1)
+        k = min(max_det, flat.size)
+        idx = np.argpartition(-flat, k - 1)[:k]
+        idx = idx[np.argsort(-flat[idx])]
 
-        mask = max_scores > conf
-        boxes_raw = boxes_raw[mask]
-        max_scores, class_ids = max_scores[mask], class_ids[mask]
-
-        if len(boxes_raw) == 0:
-            return boxes_raw, max_scores, class_ids
+        scores = flat[idx]
+        query_idx = idx // nc
+        class_ids = idx % nc
 
         cx, cy, w, h = (
             boxes_raw[:, 0],
@@ -601,16 +607,17 @@ class BaseBackend(ABC):
             boxes_raw[:, 2],
             boxes_raw[:, 3],
         )
-        x1 = (cx - w / 2) * orig_w
-        y1 = (cy - h / 2) * orig_h
-        x2 = (cx + w / 2) * orig_w
-        y2 = (cy + h / 2) * orig_h
-        boxes = np.stack([x1, y1, x2, y2], axis=1)
-
+        boxes_xyxy = np.stack(
+            [cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2], axis=1
+        )
+        boxes = boxes_xyxy[query_idx]
+        boxes[:, [0, 2]] *= orig_w
+        boxes[:, [1, 3]] *= orig_h
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
 
-        return boxes, max_scores, class_ids
+        mask = scores > conf
+        return boxes[mask], scores[mask], class_ids[mask]
 
     # =========================================================================
     # Result building

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -62,7 +62,7 @@ def _is_nms_free_family(model_family: Optional[str]) -> bool:
     selection. Applying YOLO-style IoU suppression on top of that can remove
     valid detections and make exported runtimes diverge from native PyTorch.
     """
-    return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr"}
+    return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr", "rtdetrv4"}
 
 
 class BaseBackend(ABC):
@@ -142,7 +142,7 @@ class BaseBackend(ABC):
                 image, effective_imgsz, color_format
             )
             return tensor, img, size, 1.0
-        elif self.model_family == "dfine":
+        elif self.model_family in ("dfine", "rtdetrv4"):
             tensor, img, size = self._preprocess_dfine(
                 image, effective_imgsz, color_format
             )
@@ -304,7 +304,7 @@ class BaseBackend(ABC):
             return boxes, scores, cls, None
         elif self.model_family == "rfdetr":
             return self._parse_rfdetr(all_outputs, orig_w, orig_h, conf)
-        elif self.model_family == "dfine":
+        elif self.model_family in ("dfine", "rtdetrv4"):
             boxes, scores, cls = self._parse_dfine(all_outputs, orig_w, orig_h, conf)
             return boxes, scores, cls, None
         elif self.model_family == "deim":

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -23,7 +23,7 @@ def _uses_dfine_style_export_wrapper(model_family) -> bool:
     module that returns a 2-tuple. ONNX export can skip the dynamic output
     probe for them, and they all need opset 17 for ``aten::scaled_dot_product``.
     """
-    return model_family in {"dfine", "deim", "deimv2", "ec"}
+    return model_family in {"dfine", "deim", "deimv2", "ec", "rtdetrv4"}
 
 
 def _postprocess_onnx(

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -39,6 +39,7 @@ from .yolo9_e2e.model import LibreYOLO9E2E  # noqa: E402
 from .yolo9.model import LibreYOLO9  # noqa: E402
 from .yolonas.model import LibreYOLONAS  # noqa: E402
 from .deimv2.model import LibreDEIMv2  # noqa: E402
+from .rtdetrv4.model import LibreRTDETRv4  # noqa: E402  (must precede LibreDFINE — sibling arch, more-specific can_load)
 from .dfine.model import LibreDFINE  # noqa: E402
 from .deim.model import LibreDEIM  # noqa: E402
 from .picodet.model import LibrePICODET  # noqa: E402
@@ -452,5 +453,6 @@ __all__ = [
     "LibreEC",
     "LibrePICODET",
     "LibreRTDETR",
+    "LibreRTDETRv4",
     "try_ensure_rfdetr",
 ]

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -43,7 +43,8 @@ from .rtdetrv4.model import LibreRTDETRv4  # noqa: E402  (must precede LibreDFIN
 from .dfine.model import LibreDFINE  # noqa: E402
 from .deim.model import LibreDEIM  # noqa: E402
 from .picodet.model import LibrePICODET  # noqa: E402
-from .rtdetr.model import LibreRTDETR  # noqa: E402
+from .rtdetr.model import LibreRTDETR  # noqa: E402  (registered before LibreRTDETRv2 so metadata-less ckpts default to v1)
+from .rtdetrv2.model import LibreRTDETRv2  # noqa: E402
 
 
 def _ensure_rfdetr():
@@ -453,6 +454,7 @@ __all__ = [
     "LibreEC",
     "LibrePICODET",
     "LibreRTDETR",
+    "LibreRTDETRv2",
     "LibreRTDETRv4",
     "try_ensure_rfdetr",
 ]

--- a/libreyolo/models/dfine/decoder.py
+++ b/libreyolo/models/dfine/decoder.py
@@ -272,11 +272,11 @@ class TransformerDecoderLayer(nn.Module):
 
 
 class LQE(nn.Module):
-    def __init__(self, k, hidden_dim, num_layers, reg_max):
+    def __init__(self, k, hidden_dim, num_layers, reg_max, act="relu"):
         super().__init__()
         self.k = k
         self.reg_max = reg_max
-        self.reg_conf = MLP(4 * (k + 1), hidden_dim, 1, num_layers)
+        self.reg_conf = MLP(4 * (k + 1), hidden_dim, 1, num_layers, act=act)
         init.constant_(self.reg_conf.layers[-1].bias, 0)
         init.constant_(self.reg_conf.layers[-1].weight, 0)
 
@@ -304,6 +304,7 @@ class TransformerDecoder(nn.Module):
         up,
         eval_idx=-1,
         layer_scale=2,
+        activation="relu",
     ):
         super().__init__()
         self.hidden_dim = hidden_dim
@@ -322,7 +323,7 @@ class TransformerDecoder(nn.Module):
             ]
         )
         self.lqe_layers = nn.ModuleList(
-            [copy.deepcopy(LQE(4, 64, 2, reg_max)) for _ in range(num_layers)]
+            [copy.deepcopy(LQE(4, 64, 2, reg_max, act=activation)) for _ in range(num_layers)]
         )
 
     def value_op(
@@ -533,6 +534,7 @@ class DFINETransformer(nn.Module):
             self.up,
             eval_idx,
             layer_scale,
+            activation=activation,
         )
 
         self.num_denoising = num_denoising
@@ -547,7 +549,7 @@ class DFINETransformer(nn.Module):
         self.learn_query_content = learn_query_content
         if learn_query_content:
             self.tgt_embed = nn.Embedding(num_queries, hidden_dim)
-        self.query_pos_head = MLP(4, 2 * hidden_dim, hidden_dim, 2)
+        self.query_pos_head = MLP(4, 2 * hidden_dim, hidden_dim, 2, act=activation)
 
         self.enc_output = nn.Sequential(
             OrderedDict(
@@ -563,7 +565,7 @@ class DFINETransformer(nn.Module):
         else:
             self.enc_score_head = nn.Linear(hidden_dim, num_classes)
 
-        self.enc_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3)
+        self.enc_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3, act=activation)
 
         self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
         self.dec_score_head = nn.ModuleList(
@@ -573,14 +575,14 @@ class DFINETransformer(nn.Module):
                 for _ in range(num_layers - self.eval_idx - 1)
             ]
         )
-        self.pre_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3)
+        self.pre_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3, act=activation)
         self.dec_bbox_head = nn.ModuleList(
             [
-                MLP(hidden_dim, hidden_dim, 4 * (self.reg_max + 1), 3)
+                MLP(hidden_dim, hidden_dim, 4 * (self.reg_max + 1), 3, act=activation)
                 for _ in range(self.eval_idx + 1)
             ]
             + [
-                MLP(scaled_dim, scaled_dim, 4 * (self.reg_max + 1), 3)
+                MLP(scaled_dim, scaled_dim, 4 * (self.reg_max + 1), 3, act=activation)
                 for _ in range(num_layers - self.eval_idx - 1)
             ]
         )

--- a/libreyolo/models/dfine/nn.py
+++ b/libreyolo/models/dfine/nn.py
@@ -155,6 +155,7 @@ class LibreDFINEModel(nn.Module):
         config: str,
         nb_classes: int = 80,
         eval_spatial_size: tuple[int, int] | None = (640, 640),
+        activation: str = "relu",
     ):
         super().__init__()
         if config not in SIZE_CONFIGS:
@@ -193,6 +194,7 @@ class LibreDFINEModel(nn.Module):
             eval_spatial_size=eval_spatial_size,
             eval_idx=cfg["dec_eval_idx"],
             reg_scale=cfg["reg_scale"],
+            activation=activation,
         )
 
     def forward(self, x: torch.Tensor, targets: List[dict] | None = None):

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -342,6 +342,13 @@ class LibreRTDETR(BaseModel):
         """RTDETR uses non-strict loading to handle variable layer counts."""
         return False
 
+    @classmethod
+    def _get_trainer_class(cls):
+        """Hook for sibling families to override; defaults to v1's trainer."""
+        from .trainer import RTDETRTrainer
+
+        return RTDETRTrainer
+
     # =========================================================================
     # Inference pipeline
     # =========================================================================
@@ -420,7 +427,7 @@ class LibreRTDETR(BaseModel):
 
         # Match upstream RTDETRPostProcessor: top-K across the flattened (Q*C)
         # score matrix, allowing multiple classes per query. The previous
-        # per-query ``scores.max(dim=-1)`` cost ~0.7-0.9 mAP on COCO val2017
+        # per-query ``scores.max(dim=-1)`` cost ~0.7–0.9 mAP on COCO val2017
         # because non-argmax classes that would still rank in the top-300
         # globally were silently discarded before COCO eval saw them.
         scores_per_class = torch.sigmoid(pred_logits[0])  # [Q, C]
@@ -514,7 +521,7 @@ class LibreRTDETR(BaseModel):
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
-        from .trainer import RTDETRTrainer
+        trainer_cls = self._get_trainer_class()
         from libreyolo.data import load_data_config
 
         try:
@@ -548,7 +555,7 @@ class LibreRTDETR(BaseModel):
             if torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
-        trainer = RTDETRTrainer(
+        trainer = trainer_cls(
             model=self.model,
             wrapper_model=self,
             size=self.size,
@@ -586,5 +593,10 @@ class LibreRTDETR(BaseModel):
 
         if Path(results["best_checkpoint"]).exists():
             self._load_weights(results["best_checkpoint"])
+
+        # Restore wrapper-side device after possible MPS->CPU trainer fallback
+        # (no-op if the trainer didn't change device). Matches the D-FINE
+        # pattern; safe for v1 since trainer there doesn't fall back.
+        self.model.to(self.device)
 
         return results

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -418,15 +418,22 @@ class LibreRTDETR(BaseModel):
         pred_logits = output["pred_logits"]  # [1, Q, C]
         pred_boxes = output["pred_boxes"]  # [1, Q, 4] cxcywh normalized
 
-        # Get scores and labels
-        scores = torch.sigmoid(pred_logits[0])  # [Q, C]
-        max_scores, labels = scores.max(dim=-1)  # [Q], [Q]
+        # Match upstream RTDETRPostProcessor: top-K across the flattened (Q*C)
+        # score matrix, allowing multiple classes per query. The previous
+        # per-query ``scores.max(dim=-1)`` cost ~0.7-0.9 mAP on COCO val2017
+        # because non-argmax classes that would still rank in the top-300
+        # globally were silently discarded before COCO eval saw them.
+        scores_per_class = torch.sigmoid(pred_logits[0])  # [Q, C]
+        num_classes = scores_per_class.shape[-1]
+        flat = scores_per_class.flatten()
+        k = min(max_det, flat.numel())
+        topk_scores, topk_indices = torch.topk(flat, k)
+        query_idx = topk_indices // num_classes
+        class_idx = topk_indices % num_classes
 
-        # Filter by confidence
-        mask = max_scores > conf_thres
-        scores = max_scores[mask]
-        labels = labels[mask]
-        boxes = pred_boxes[0][mask]  # [N, 4] cxcywh normalized
+        boxes = pred_boxes[0][query_idx]  # [k, 4] cxcywh normalized
+        scores = topk_scores
+        labels = class_idx
 
         # Convert cxcywh normalized to xyxy pixel coords
         orig_w, orig_h = original_size
@@ -437,16 +444,11 @@ class LibreRTDETR(BaseModel):
         y2 = (cy + h / 2) * orig_h
         boxes_xyxy = torch.stack([x1, y1, x2, y2], dim=-1)
 
-        # Clamp to image bounds
-        boxes_xyxy[:, 0::2] = boxes_xyxy[:, 0::2].clamp(0, orig_w)
-        boxes_xyxy[:, 1::2] = boxes_xyxy[:, 1::2].clamp(0, orig_h)
-
-        # Limit to max_det (sort by score)
-        if len(scores) > max_det:
-            topk_indices = scores.argsort(descending=True)[:max_det]
-            scores = scores[topk_indices]
-            labels = labels[topk_indices]
-            boxes_xyxy = boxes_xyxy[topk_indices]
+        # Filter by confidence after top-K (matches upstream + D-FINE).
+        mask = scores > conf_thres
+        scores = scores[mask]
+        labels = labels[mask]
+        boxes_xyxy = boxes_xyxy[mask]
 
         return {
             "boxes": boxes_xyxy.cpu(),

--- a/libreyolo/models/rtdetrv2/__init__.py
+++ b/libreyolo/models/rtdetrv2/__init__.py
@@ -1,0 +1,6 @@
+"""RT-DETRv2 family — improved baseline of RT-DETR with bag-of-freebies training."""
+
+from .model import LibreRTDETRv2
+from .trainer import RTDETRv2Trainer
+
+__all__ = ["LibreRTDETRv2", "RTDETRv2Trainer"]

--- a/libreyolo/models/rtdetrv2/decoder.py
+++ b/libreyolo/models/rtdetrv2/decoder.py
@@ -1,0 +1,664 @@
+"""RT-DETRv2 decoder. Ported from upstream ``rtdetrv2_pytorch``.
+
+Differences from v1:
+1. ``MSDeformableAttention`` accepts a per-level ``num_points`` list, registers
+   a ``num_points_scale`` buffer, and uses a flat ``sum(num_points)`` sampling
+   layout instead of v1's ``[L, P]`` layout.
+2. Cross-attention sampling is ``method='default'`` (grid_sample) by default;
+   ``method='discrete'`` is supported for TensorRT <8.5 compatibility.
+3. Decoder layer wires ``cross_attn_method`` through.
+"""
+
+from __future__ import annotations
+
+import copy
+import functools
+import math
+from collections import OrderedDict
+from typing import List
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.nn.init as init
+
+from ..rtdetr.denoising import get_contrastive_denoising_training_group
+from .utils import (
+    bias_init_with_prob,
+    deformable_attention_core_func_v2,
+    get_activation,
+    inverse_sigmoid,
+)
+
+__all__ = ["RTDETRTransformerv2"]
+
+
+class MLP(nn.Module):
+    def __init__(self, input_dim, hidden_dim, output_dim, num_layers, act="relu"):
+        super().__init__()
+        self.num_layers = num_layers
+        h = [hidden_dim] * (num_layers - 1)
+        self.layers = nn.ModuleList(
+            nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim])
+        )
+        self.act = get_activation(act)
+
+    def forward(self, x):
+        for i, layer in enumerate(self.layers):
+            x = self.act(layer(x)) if i < self.num_layers - 1 else layer(x)
+        return x
+
+
+class MSDeformableAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dim=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        method="default",
+        offset_scale=0.5,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.num_levels = num_levels
+        self.offset_scale = offset_scale
+
+        if isinstance(num_points, list):
+            assert len(num_points) == num_levels
+            num_points_list = num_points
+        else:
+            num_points_list = [num_points for _ in range(num_levels)]
+        self.num_points_list = num_points_list
+
+        num_points_scale = [1 / n for n in num_points_list for _ in range(n)]
+        self.register_buffer(
+            "num_points_scale", torch.tensor(num_points_scale, dtype=torch.float32)
+        )
+
+        self.total_points = num_heads * sum(num_points_list)
+        self.method = method
+
+        self.head_dim = embed_dim // num_heads
+        assert self.head_dim * num_heads == self.embed_dim
+
+        self.sampling_offsets = nn.Linear(embed_dim, self.total_points * 2)
+        self.attention_weights = nn.Linear(embed_dim, self.total_points)
+        self.value_proj = nn.Linear(embed_dim, embed_dim)
+        self.output_proj = nn.Linear(embed_dim, embed_dim)
+
+        self.ms_deformable_attn_core = functools.partial(
+            deformable_attention_core_func_v2, method=self.method
+        )
+
+        self._reset_parameters()
+
+        if method == "discrete":
+            for p in self.sampling_offsets.parameters():
+                p.requires_grad = False
+
+    def _reset_parameters(self):
+        init.constant_(self.sampling_offsets.weight, 0)
+        thetas = torch.arange(self.num_heads, dtype=torch.float32) * (
+            2.0 * math.pi / self.num_heads
+        )
+        grid_init = torch.stack([thetas.cos(), thetas.sin()], -1)
+        grid_init = grid_init / grid_init.abs().max(-1, keepdim=True).values
+        grid_init = grid_init.reshape(self.num_heads, 1, 2).tile(
+            [1, sum(self.num_points_list), 1]
+        )
+        scaling = torch.concat(
+            [torch.arange(1, n + 1) for n in self.num_points_list]
+        ).reshape(1, -1, 1)
+        grid_init *= scaling
+        self.sampling_offsets.bias.data[...] = grid_init.flatten()
+
+        init.constant_(self.attention_weights.weight, 0)
+        init.constant_(self.attention_weights.bias, 0)
+
+        init.xavier_uniform_(self.value_proj.weight)
+        init.constant_(self.value_proj.bias, 0)
+        init.xavier_uniform_(self.output_proj.weight)
+        init.constant_(self.output_proj.bias, 0)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        reference_points: torch.Tensor,
+        value: torch.Tensor,
+        value_spatial_shapes,
+        value_mask: torch.Tensor = None,
+    ):
+        bs, Len_q = query.shape[:2]
+        Len_v = value.shape[1]
+
+        value = self.value_proj(value)
+        if value_mask is not None:
+            value = value * value_mask.to(value.dtype).unsqueeze(-1)
+        value = value.reshape(bs, Len_v, self.num_heads, self.head_dim)
+
+        sampling_offsets = self.sampling_offsets(query).reshape(
+            bs, Len_q, self.num_heads, sum(self.num_points_list), 2
+        )
+        attention_weights = self.attention_weights(query).reshape(
+            bs, Len_q, self.num_heads, sum(self.num_points_list)
+        )
+        attention_weights = F.softmax(attention_weights, dim=-1).reshape(
+            bs, Len_q, self.num_heads, sum(self.num_points_list)
+        )
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.tensor(value_spatial_shapes)
+            offset_normalizer = offset_normalizer.flip([1]).reshape(
+                1, 1, 1, self.num_levels, 1, 2
+            )
+            sampling_locations = (
+                reference_points.reshape(bs, Len_q, 1, self.num_levels, 1, 2)
+                + sampling_offsets / offset_normalizer
+            )
+        elif reference_points.shape[-1] == 4:
+            num_points_scale = self.num_points_scale.to(dtype=query.dtype).unsqueeze(-1)
+            offset = (
+                sampling_offsets
+                * num_points_scale
+                * reference_points[:, :, None, :, 2:]
+                * self.offset_scale
+            )
+            sampling_locations = reference_points[:, :, None, :, :2] + offset
+        else:
+            raise ValueError(
+                f"reference_points last dim must be 2 or 4, got {reference_points.shape[-1]}"
+            )
+
+        output = self.ms_deformable_attn_core(
+            value,
+            value_spatial_shapes,
+            sampling_locations,
+            attention_weights,
+            self.num_points_list,
+        )
+        output = self.output_proj(output)
+        return output
+
+
+class TransformerDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model=256,
+        n_head=8,
+        dim_feedforward=1024,
+        dropout=0.0,
+        activation="relu",
+        n_levels=4,
+        n_points=4,
+        cross_attn_method="default",
+    ):
+        super().__init__()
+
+        self.self_attn = nn.MultiheadAttention(
+            d_model, n_head, dropout=dropout, batch_first=True
+        )
+        self.dropout1 = nn.Dropout(dropout)
+        self.norm1 = nn.LayerNorm(d_model)
+
+        self.cross_attn = MSDeformableAttention(
+            d_model, n_head, n_levels, n_points, method=cross_attn_method
+        )
+        self.dropout2 = nn.Dropout(dropout)
+        self.norm2 = nn.LayerNorm(d_model)
+
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.activation = get_activation(activation)
+        self.dropout3 = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+        self.dropout4 = nn.Dropout(dropout)
+        self.norm3 = nn.LayerNorm(d_model)
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        init.xavier_uniform_(self.linear1.weight)
+        init.xavier_uniform_(self.linear2.weight)
+
+    def with_pos_embed(self, tensor, pos):
+        return tensor if pos is None else tensor + pos
+
+    def forward_ffn(self, tgt):
+        return self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
+
+    def forward(
+        self,
+        target,
+        reference_points,
+        memory,
+        memory_spatial_shapes,
+        attn_mask=None,
+        memory_mask=None,
+        query_pos_embed=None,
+    ):
+        q = k = self.with_pos_embed(target, query_pos_embed)
+        target2, _ = self.self_attn(q, k, value=target, attn_mask=attn_mask)
+        target = target + self.dropout1(target2)
+        target = self.norm1(target)
+
+        target2 = self.cross_attn(
+            self.with_pos_embed(target, query_pos_embed),
+            reference_points,
+            memory,
+            memory_spatial_shapes,
+            memory_mask,
+        )
+        target = target + self.dropout2(target2)
+        target = self.norm2(target)
+
+        target2 = self.forward_ffn(target)
+        target = target + self.dropout4(target2)
+        target = self.norm3(target)
+        return target
+
+
+class TransformerDecoder(nn.Module):
+    def __init__(self, hidden_dim, decoder_layer, num_layers, eval_idx=-1):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [copy.deepcopy(decoder_layer) for _ in range(num_layers)]
+        )
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+        self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
+
+    def forward(
+        self,
+        target,
+        ref_points_unact,
+        memory,
+        memory_spatial_shapes,
+        bbox_head,
+        score_head,
+        query_pos_head,
+        attn_mask=None,
+        memory_mask=None,
+    ):
+        dec_out_bboxes = []
+        dec_out_logits = []
+        ref_points_detach = F.sigmoid(ref_points_unact)
+
+        output = target
+        ref_points = None
+        for i, layer in enumerate(self.layers):
+            ref_points_input = ref_points_detach.unsqueeze(2)
+            query_pos_embed = query_pos_head(ref_points_detach)
+
+            output = layer(
+                output,
+                ref_points_input,
+                memory,
+                memory_spatial_shapes,
+                attn_mask,
+                memory_mask,
+                query_pos_embed,
+            )
+
+            inter_ref_bbox = F.sigmoid(
+                bbox_head[i](output) + inverse_sigmoid(ref_points_detach)
+            )
+
+            if self.training:
+                dec_out_logits.append(score_head[i](output))
+                if i == 0:
+                    dec_out_bboxes.append(inter_ref_bbox)
+                else:
+                    dec_out_bboxes.append(
+                        F.sigmoid(bbox_head[i](output) + inverse_sigmoid(ref_points))
+                    )
+            elif i == self.eval_idx:
+                dec_out_logits.append(score_head[i](output))
+                dec_out_bboxes.append(inter_ref_bbox)
+                break
+
+            ref_points = inter_ref_bbox
+            ref_points_detach = inter_ref_bbox.detach()
+
+        return torch.stack(dec_out_bboxes), torch.stack(dec_out_logits)
+
+
+class RTDETRTransformerv2(nn.Module):
+    def __init__(
+        self,
+        num_classes=80,
+        hidden_dim=256,
+        num_queries=300,
+        feat_channels=(512, 1024, 2048),
+        feat_strides=(8, 16, 32),
+        num_levels=3,
+        num_points=4,
+        nhead=8,
+        num_layers=6,
+        dim_feedforward=1024,
+        dropout=0.0,
+        activation="relu",
+        num_denoising=100,
+        label_noise_ratio=0.5,
+        box_noise_scale=1.0,
+        learn_query_content=False,
+        eval_spatial_size=None,
+        eval_idx=-1,
+        eps=1e-2,
+        aux_loss=True,
+        cross_attn_method="default",
+        query_select_method="default",
+    ):
+        super().__init__()
+        feat_channels = list(feat_channels)
+        feat_strides = list(feat_strides)
+        assert len(feat_channels) <= num_levels
+        assert len(feat_strides) == len(feat_channels)
+        for _ in range(num_levels - len(feat_strides)):
+            feat_strides.append(feat_strides[-1] * 2)
+
+        self.hidden_dim = hidden_dim
+        self.nhead = nhead
+        self.feat_strides = feat_strides
+        self.num_levels = num_levels
+        self.num_classes = num_classes
+        self.num_queries = num_queries
+        self.eps = eps
+        self.num_layers = num_layers
+        self.eval_spatial_size = eval_spatial_size
+        self.aux_loss = aux_loss
+
+        assert query_select_method in ("default", "one2many", "agnostic")
+        assert cross_attn_method in ("default", "discrete")
+        self.cross_attn_method = cross_attn_method
+        self.query_select_method = query_select_method
+
+        self._build_input_proj_layer(feat_channels)
+
+        decoder_layer = TransformerDecoderLayer(
+            hidden_dim,
+            nhead,
+            dim_feedforward,
+            dropout,
+            activation,
+            num_levels,
+            num_points,
+            cross_attn_method=cross_attn_method,
+        )
+        self.decoder = TransformerDecoder(hidden_dim, decoder_layer, num_layers, eval_idx)
+
+        self.num_denoising = num_denoising
+        self.label_noise_ratio = label_noise_ratio
+        self.box_noise_scale = box_noise_scale
+        if num_denoising > 0:
+            self.denoising_class_embed = nn.Embedding(
+                num_classes + 1, hidden_dim, padding_idx=num_classes
+            )
+            init.normal_(self.denoising_class_embed.weight[:-1])
+
+        self.learn_query_content = learn_query_content
+        if learn_query_content:
+            self.tgt_embed = nn.Embedding(num_queries, hidden_dim)
+        self.query_pos_head = MLP(4, 2 * hidden_dim, hidden_dim, 2)
+
+        self.enc_output = nn.Sequential(
+            OrderedDict(
+                [
+                    ("proj", nn.Linear(hidden_dim, hidden_dim)),
+                    ("norm", nn.LayerNorm(hidden_dim)),
+                ]
+            )
+        )
+
+        if query_select_method == "agnostic":
+            self.enc_score_head = nn.Linear(hidden_dim, 1)
+        else:
+            self.enc_score_head = nn.Linear(hidden_dim, num_classes)
+        self.enc_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3)
+
+        self.dec_score_head = nn.ModuleList(
+            [nn.Linear(hidden_dim, num_classes) for _ in range(num_layers)]
+        )
+        self.dec_bbox_head = nn.ModuleList(
+            [MLP(hidden_dim, hidden_dim, 4, 3) for _ in range(num_layers)]
+        )
+
+        if self.eval_spatial_size:
+            anchors, valid_mask = self._generate_anchors()
+            self.register_buffer("anchors", anchors)
+            self.register_buffer("valid_mask", valid_mask)
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        bias = bias_init_with_prob(0.01)
+        init.constant_(self.enc_score_head.bias, bias)
+        init.constant_(self.enc_bbox_head.layers[-1].weight, 0)
+        init.constant_(self.enc_bbox_head.layers[-1].bias, 0)
+        for cls_, reg in zip(self.dec_score_head, self.dec_bbox_head):
+            init.constant_(cls_.bias, bias)
+            init.constant_(reg.layers[-1].weight, 0)
+            init.constant_(reg.layers[-1].bias, 0)
+        init.xavier_uniform_(self.enc_output[0].weight)
+        if self.learn_query_content:
+            init.xavier_uniform_(self.tgt_embed.weight)
+        init.xavier_uniform_(self.query_pos_head.layers[0].weight)
+        init.xavier_uniform_(self.query_pos_head.layers[1].weight)
+        for m in self.input_proj:
+            init.xavier_uniform_(m[0].weight)
+
+    def _build_input_proj_layer(self, feat_channels):
+        self.input_proj = nn.ModuleList()
+        for in_channels in feat_channels:
+            self.input_proj.append(
+                nn.Sequential(
+                    OrderedDict(
+                        [
+                            ("conv", nn.Conv2d(in_channels, self.hidden_dim, 1, bias=False)),
+                            ("norm", nn.BatchNorm2d(self.hidden_dim)),
+                        ]
+                    )
+                )
+            )
+        in_channels = feat_channels[-1]
+        for _ in range(self.num_levels - len(feat_channels)):
+            self.input_proj.append(
+                nn.Sequential(
+                    OrderedDict(
+                        [
+                            (
+                                "conv",
+                                nn.Conv2d(
+                                    in_channels, self.hidden_dim, 3, 2, padding=1, bias=False
+                                ),
+                            ),
+                            ("norm", nn.BatchNorm2d(self.hidden_dim)),
+                        ]
+                    )
+                )
+            )
+            in_channels = self.hidden_dim
+
+    def _get_encoder_input(self, feats: List[torch.Tensor]):
+        proj_feats = [self.input_proj[i](feat) for i, feat in enumerate(feats)]
+        if self.num_levels > len(proj_feats):
+            len_srcs = len(proj_feats)
+            for i in range(len_srcs, self.num_levels):
+                if i == len_srcs:
+                    proj_feats.append(self.input_proj[i](feats[-1]))
+                else:
+                    proj_feats.append(self.input_proj[i](proj_feats[-1]))
+
+        feat_flatten = []
+        spatial_shapes = []
+        for feat in proj_feats:
+            _, _, h, w = feat.shape
+            feat_flatten.append(feat.flatten(2).permute(0, 2, 1))
+            spatial_shapes.append([h, w])
+        feat_flatten = torch.concat(feat_flatten, 1)
+        return feat_flatten, spatial_shapes
+
+    def _generate_anchors(
+        self,
+        spatial_shapes=None,
+        grid_size=0.05,
+        dtype=torch.float32,
+        device="cpu",
+    ):
+        if spatial_shapes is None:
+            spatial_shapes = []
+            eval_h, eval_w = self.eval_spatial_size
+            for s in self.feat_strides:
+                spatial_shapes.append([int(eval_h / s), int(eval_w / s)])
+
+        anchors = []
+        for lvl, (h, w) in enumerate(spatial_shapes):
+            grid_y, grid_x = torch.meshgrid(
+                torch.arange(h), torch.arange(w), indexing="ij"
+            )
+            grid_xy = torch.stack([grid_x, grid_y], dim=-1)
+            grid_xy = (grid_xy.unsqueeze(0) + 0.5) / torch.tensor([w, h], dtype=dtype)
+            wh = torch.ones_like(grid_xy) * grid_size * (2.0 ** lvl)
+            lvl_anchors = torch.concat([grid_xy, wh], dim=-1).reshape(-1, h * w, 4)
+            anchors.append(lvl_anchors)
+
+        anchors = torch.concat(anchors, dim=1).to(device)
+        valid_mask = ((anchors > self.eps) * (anchors < 1 - self.eps)).all(
+            -1, keepdim=True
+        )
+        anchors = torch.log(anchors / (1 - anchors))
+        anchors = torch.where(valid_mask, anchors, torch.inf)
+        return anchors, valid_mask
+
+    def _get_decoder_input(
+        self, memory, spatial_shapes, denoising_logits=None, denoising_bbox_unact=None
+    ):
+        if self.training or self.eval_spatial_size is None:
+            anchors, valid_mask = self._generate_anchors(
+                spatial_shapes, device=memory.device
+            )
+        else:
+            anchors = self.anchors
+            valid_mask = self.valid_mask
+
+        memory = valid_mask.to(memory.dtype) * memory
+
+        output_memory = self.enc_output(memory)
+        enc_outputs_logits = self.enc_score_head(output_memory)
+        enc_outputs_coord_unact = self.enc_bbox_head(output_memory) + anchors
+
+        enc_topk_bboxes_list, enc_topk_logits_list = [], []
+        enc_topk_memory, enc_topk_logits, enc_topk_bbox_unact = self._select_topk(
+            output_memory, enc_outputs_logits, enc_outputs_coord_unact, self.num_queries
+        )
+
+        if self.training:
+            enc_topk_bboxes_list.append(F.sigmoid(enc_topk_bbox_unact))
+            enc_topk_logits_list.append(enc_topk_logits)
+
+        if self.learn_query_content:
+            content = self.tgt_embed.weight.unsqueeze(0).tile([memory.shape[0], 1, 1])
+        else:
+            content = enc_topk_memory.detach()
+
+        enc_topk_bbox_unact = enc_topk_bbox_unact.detach()
+
+        if denoising_bbox_unact is not None:
+            enc_topk_bbox_unact = torch.concat(
+                [denoising_bbox_unact, enc_topk_bbox_unact], dim=1
+            )
+            content = torch.concat([denoising_logits, content], dim=1)
+
+        return content, enc_topk_bbox_unact, enc_topk_bboxes_list, enc_topk_logits_list
+
+    def _select_topk(self, memory, outputs_logits, outputs_coords_unact, topk):
+        if self.query_select_method == "default":
+            _, topk_ind = torch.topk(outputs_logits.max(-1).values, topk, dim=-1)
+        elif self.query_select_method == "one2many":
+            _, topk_ind = torch.topk(outputs_logits.flatten(1), topk, dim=-1)
+            topk_ind = topk_ind // self.num_classes
+        elif self.query_select_method == "agnostic":
+            _, topk_ind = torch.topk(outputs_logits.squeeze(-1), topk, dim=-1)
+
+        topk_coords = outputs_coords_unact.gather(
+            dim=1,
+            index=topk_ind.unsqueeze(-1).repeat(1, 1, outputs_coords_unact.shape[-1]),
+        )
+        topk_logits = outputs_logits.gather(
+            dim=1,
+            index=topk_ind.unsqueeze(-1).repeat(1, 1, outputs_logits.shape[-1]),
+        )
+        topk_memory = memory.gather(
+            dim=1, index=topk_ind.unsqueeze(-1).repeat(1, 1, memory.shape[-1])
+        )
+        return topk_memory, topk_logits, topk_coords
+
+    def forward(self, feats, targets=None):
+        memory, spatial_shapes = self._get_encoder_input(feats)
+
+        if self.training and self.num_denoising > 0:
+            (
+                denoising_logits,
+                denoising_bbox_unact,
+                attn_mask,
+                dn_meta,
+            ) = get_contrastive_denoising_training_group(
+                targets,
+                self.num_classes,
+                self.num_queries,
+                self.denoising_class_embed,
+                num_denoising=self.num_denoising,
+                label_noise_ratio=self.label_noise_ratio,
+                box_noise_scale=self.box_noise_scale,
+            )
+        else:
+            denoising_logits = denoising_bbox_unact = attn_mask = dn_meta = None
+
+        (
+            init_ref_contents,
+            init_ref_points_unact,
+            enc_topk_bboxes_list,
+            enc_topk_logits_list,
+        ) = self._get_decoder_input(
+            memory, spatial_shapes, denoising_logits, denoising_bbox_unact
+        )
+
+        out_bboxes, out_logits = self.decoder(
+            init_ref_contents,
+            init_ref_points_unact,
+            memory,
+            spatial_shapes,
+            self.dec_bbox_head,
+            self.dec_score_head,
+            self.query_pos_head,
+            attn_mask=attn_mask,
+        )
+
+        if self.training and dn_meta is not None:
+            dn_out_bboxes, out_bboxes = torch.split(
+                out_bboxes, dn_meta["dn_num_split"], dim=2
+            )
+            dn_out_logits, out_logits = torch.split(
+                out_logits, dn_meta["dn_num_split"], dim=2
+            )
+
+        out = {"pred_logits": out_logits[-1], "pred_boxes": out_bboxes[-1]}
+
+        if self.training and self.aux_loss:
+            out["aux_outputs"] = self._set_aux_loss(out_logits[:-1], out_bboxes[:-1])
+            out["enc_aux_outputs"] = self._set_aux_loss(
+                enc_topk_logits_list, enc_topk_bboxes_list
+            )
+            out["enc_meta"] = {"class_agnostic": self.query_select_method == "agnostic"}
+            if dn_meta is not None:
+                out["dn_aux_outputs"] = self._set_aux_loss(dn_out_logits, dn_out_bboxes)
+                out["dn_meta"] = dn_meta
+
+        return out
+
+    @torch.jit.unused
+    def _set_aux_loss(self, outputs_class, outputs_coord):
+        return [
+            {"pred_logits": a, "pred_boxes": b}
+            for a, b in zip(outputs_class, outputs_coord)
+        ]

--- a/libreyolo/models/rtdetrv2/model.py
+++ b/libreyolo/models/rtdetrv2/model.py
@@ -1,0 +1,77 @@
+"""LibreRTDETRv2 — RT-DETRv2 detectors."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, Optional
+
+import torch.nn as nn
+
+from ...validation.preprocessors import RTDETRv2ValPreprocessor
+from ..rtdetr.model import LibreRTDETR, RTDETR_CONFIGS
+from .nn import RTDETRv2Model
+
+
+class LibreRTDETRv2(LibreRTDETR):
+    FAMILY = "rtdetrv2"
+    FILENAME_PREFIX = "LibreRTDETRv2"
+    INPUT_SIZES = {"r18": 640, "r34": 640, "r50": 640, "r50m": 640, "r101": 640}
+    val_preprocessor_class = RTDETRv2ValPreprocessor
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        # State-dict shape is identical to v1's, so we delegate to v1's check.
+        # Disambiguation against v1 in the factory happens via:
+        #   (1) the ``model_family`` metadata gate (converted ckpts);
+        #   (2) the ``rtdetrv2_`` filename hint (raw upstream ckpts);
+        #   (3) registry order — ``LibreRTDETR`` is imported BEFORE
+        #       ``LibreRTDETRv2`` so that ckpts lacking both signals route
+        #       to v1 by default. v1 cannot be silently shadowed.
+        return LibreRTDETR.can_load(weights_dict)
+
+    @classmethod
+    def detect_size_from_filename(cls, filename: str) -> Optional[str]:
+        detected = super().detect_size_from_filename(filename)
+        if detected is not None:
+            return detected
+        basename = os.path.basename(filename).lower()
+        m = re.search(r"rtdetrv2_r(\d+)vd(_m)?_", basename)
+        if m:
+            depth, m_suffix = m.group(1), m.group(2)
+            return f"r{depth}m" if m_suffix else f"r{depth}"
+        return None
+
+    @classmethod
+    def _get_trainer_class(cls):
+        from .trainer import RTDETRv2Trainer
+
+        return RTDETRv2Trainer
+
+    def _init_model(self) -> nn.Module:
+        if self.size not in RTDETR_CONFIGS:
+            raise ValueError(f"Unknown RT-DETRv2 size: {self.size!r}")
+        cfg: Dict[str, Any] = RTDETR_CONFIGS[self.size]
+        # v2 ResNet sizes only — HGNetv2 backbones are skipped at this layer
+        # (v1 already ships HGNetv2-l/x; v2's HGNetv2 numbers are within ~0.1
+        # AP and not worth the duplicate weights).
+        if cfg.get("backbone_type") == "hgnetv2":
+            raise ValueError(
+                f"LibreRTDETRv2 size {self.size!r} uses an HGNetv2 backbone; "
+                f"use LibreRTDETR for HGNetv2 variants."
+            )
+        return RTDETRv2Model(
+            num_classes=self.nb_classes,
+            backbone_depth=cfg["backbone_depth"],
+            backbone_freeze_at=cfg["backbone_freeze_at"],
+            backbone_freeze_norm=cfg["backbone_freeze_norm"],
+            backbone_pretrained=False,
+            hidden_dim=cfg["encoder_hidden_dim"],
+            dim_feedforward=cfg["encoder_dim_feedforward"],
+            expansion=cfg["encoder_expansion"],
+            decoder_hidden_dim=cfg["decoder_hidden_dim"],
+            decoder_dim_feedforward=cfg.get("decoder_dim_feedforward", 1024),
+            num_decoder_layers=cfg["num_decoder_layers"],
+            eval_idx=cfg["eval_idx"],
+            eval_spatial_size=(self.input_size, self.input_size),
+        )

--- a/libreyolo/models/rtdetrv2/nn.py
+++ b/libreyolo/models/rtdetrv2/nn.py
@@ -1,0 +1,93 @@
+"""Top-level RT-DETRv2 module: v1 backbone + v1 encoder + v2 decoder."""
+
+from __future__ import annotations
+
+import torch.nn as nn
+
+from ..rtdetr.backbone import PResNet
+from ..rtdetr.nn import HybridEncoder
+from .decoder import RTDETRTransformerv2
+
+
+class RTDETRv2Model(nn.Module):
+    def __init__(
+        self,
+        num_classes: int = 80,
+        backbone: nn.Module | None = None,
+        backbone_depth: int = 18,
+        backbone_variant: str = "d",
+        backbone_pretrained: bool = False,
+        backbone_freeze_norm: bool = False,
+        backbone_freeze_at: int = 0,
+        hidden_dim: int = 256,
+        num_queries: int = 300,
+        num_decoder_layers: int = 6,
+        nhead: int = 8,
+        dim_feedforward: int = 1024,
+        decoder_hidden_dim: int | None = None,
+        decoder_dim_feedforward: int | None = None,
+        expansion: float = 0.5,
+        dropout: float = 0.0,
+        num_denoising: int = 100,
+        num_decoder_points=4,
+        feat_strides=(8, 16, 32),
+        num_levels: int = 3,
+        eval_spatial_size=None,
+        aux_loss: bool = True,
+        eval_idx: int = -1,
+        cross_attn_method: str = "default",
+        query_select_method: str = "default",
+        **kwargs,
+    ):
+        super().__init__()
+        decoder_hidden_dim = decoder_hidden_dim or hidden_dim
+        decoder_dim_feedforward = decoder_dim_feedforward or dim_feedforward
+
+        if backbone is not None:
+            self.backbone = backbone
+        else:
+            self.backbone = PResNet(
+                depth=backbone_depth,
+                variant=backbone_variant,
+                return_idx=[1, 2, 3],
+                pretrained=backbone_pretrained,
+                freeze_norm=backbone_freeze_norm,
+                freeze_at=backbone_freeze_at,
+            )
+
+        self.encoder = HybridEncoder(
+            in_channels=self.backbone.out_channels,
+            feat_strides=list(feat_strides),
+            hidden_dim=hidden_dim,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            expansion=expansion,
+            dropout=dropout,
+            eval_spatial_size=eval_spatial_size,
+        )
+
+        encoder_out_channels = [hidden_dim] * len(self.backbone.out_channels)
+        self.decoder = RTDETRTransformerv2(
+            num_classes=num_classes,
+            hidden_dim=decoder_hidden_dim,
+            num_queries=num_queries,
+            feat_channels=encoder_out_channels,
+            feat_strides=list(feat_strides),
+            num_levels=num_levels,
+            num_points=num_decoder_points,
+            nhead=nhead,
+            num_layers=num_decoder_layers,
+            dim_feedforward=decoder_dim_feedforward,
+            dropout=dropout,
+            num_denoising=num_denoising,
+            eval_spatial_size=eval_spatial_size,
+            aux_loss=aux_loss,
+            eval_idx=eval_idx,
+            cross_attn_method=cross_attn_method,
+            query_select_method=query_select_method,
+        )
+
+    def forward(self, x, targets=None):
+        feats = self.backbone(x)
+        feats = self.encoder(feats)
+        return self.decoder(feats, targets=targets)

--- a/libreyolo/models/rtdetrv2/trainer.py
+++ b/libreyolo/models/rtdetrv2/trainer.py
@@ -1,0 +1,26 @@
+"""RTDETRv2Trainer — falls back to CPU on MPS for backward pass."""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from ..rtdetr.trainer import RTDETRTrainer
+
+
+class RTDETRv2Trainer(RTDETRTrainer):
+    def _setup_device(self) -> torch.device:
+        device = super()._setup_device()
+        if device.type == "mps":
+            logging.getLogger(__name__).warning(
+                "RT-DETRv2 training on Apple MPS triggers a torch backward bug "
+                "(aten::grid_sampler_2d_backward not implemented for MPS). "
+                "Falling back to CPU. Pass device='cuda' or device='cpu' "
+                "explicitly to override."
+            )
+            return torch.device("cpu")
+        return device
+
+    def get_model_family(self) -> str:
+        return "rtdetrv2"

--- a/libreyolo/models/rtdetrv2/utils.py
+++ b/libreyolo/models/rtdetrv2/utils.py
@@ -1,0 +1,113 @@
+"""Helpers ported from RT-DETRv2's ``src/zoo/rtdetr/utils.py``."""
+
+from __future__ import annotations
+
+import math
+from typing import List
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
+    x = x.clip(min=0.0, max=1.0)
+    return torch.log(x.clip(min=eps) / (1 - x).clip(min=eps))
+
+
+def bias_init_with_prob(prior_prob: float = 0.01) -> float:
+    return float(-math.log((1 - prior_prob) / prior_prob))
+
+
+def get_activation(act, inplace: bool = True):
+    if act is None:
+        return nn.Identity()
+    if isinstance(act, nn.Module):
+        return act
+    name = act.lower()
+    if name in ("silu", "swish"):
+        m = nn.SiLU()
+    elif name == "relu":
+        m = nn.ReLU()
+    elif name == "leaky_relu":
+        m = nn.LeakyReLU()
+    elif name == "gelu":
+        m = nn.GELU()
+    elif name == "hardsigmoid":
+        m = nn.Hardsigmoid()
+    else:
+        raise RuntimeError(f"Unknown activation: {act!r}")
+    if hasattr(m, "inplace"):
+        m.inplace = inplace
+    return m
+
+
+def deformable_attention_core_func_v2(
+    value: torch.Tensor,
+    value_spatial_shapes,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+    num_points_list: List[int],
+    method: str = "default",
+):
+    """v2 deformable attention core.
+
+    Differs from v1 in: (a) flat ``sum(num_points_list)`` layout instead of
+    ``[L, P]``; (b) per-level split via ``num_points_list``; (c) optional
+    ``method='discrete'`` integer-index sampling for TensorRT <8.5.
+    """
+    bs, _, n_head, c = value.shape
+    _, Len_q, _, _, _ = sampling_locations.shape
+
+    split_shape = [h * w for h, w in value_spatial_shapes]
+    value_list = value.permute(0, 2, 3, 1).flatten(0, 1).split(split_shape, dim=-1)
+
+    if method == "default":
+        sampling_grids = 2 * sampling_locations - 1
+    elif method == "discrete":
+        sampling_grids = sampling_locations
+    else:
+        raise ValueError(f"unknown sampling method: {method!r}")
+
+    sampling_grids = sampling_grids.permute(0, 2, 1, 3, 4).flatten(0, 1)
+    sampling_locations_list = sampling_grids.split(num_points_list, dim=-2)
+
+    sampling_value_list = []
+    for level, (h, w) in enumerate(value_spatial_shapes):
+        value_l = value_list[level].reshape(bs * n_head, c, h, w)
+        sampling_grid_l = sampling_locations_list[level]
+
+        if method == "default":
+            sampling_value_l = F.grid_sample(
+                value_l,
+                sampling_grid_l,
+                mode="bilinear",
+                padding_mode="zeros",
+                align_corners=False,
+            )
+        else:  # discrete
+            sampling_coord = (
+                sampling_grid_l * torch.tensor([[w, h]], device=value.device) + 0.5
+            ).to(torch.int64)
+            sampling_coord = sampling_coord.clamp(0, h - 1)
+            sampling_coord = sampling_coord.reshape(
+                bs * n_head, Len_q * num_points_list[level], 2
+            )
+            s_idx = torch.arange(
+                sampling_coord.shape[0], device=value.device
+            ).unsqueeze(-1).repeat(1, sampling_coord.shape[1])
+            sampling_value_l = value_l[
+                s_idx, :, sampling_coord[..., 1], sampling_coord[..., 0]
+            ]
+            sampling_value_l = sampling_value_l.permute(0, 2, 1).reshape(
+                bs * n_head, c, Len_q, num_points_list[level]
+            )
+
+        sampling_value_list.append(sampling_value_l)
+
+    attn_weights = attention_weights.permute(0, 2, 1, 3).reshape(
+        bs * n_head, 1, Len_q, sum(num_points_list)
+    )
+    weighted = torch.concat(sampling_value_list, dim=-1) * attn_weights
+    output = weighted.sum(-1).reshape(bs, n_head * c, Len_q)
+    return output.permute(0, 2, 1)

--- a/libreyolo/models/rtdetrv4/__init__.py
+++ b/libreyolo/models/rtdetrv4/__init__.py
@@ -1,0 +1,6 @@
+"""RT-DETRv4 family — HGNetv2 student detectors distilled from a DINOv3 ViT teacher."""
+
+from .model import LibreRTDETRv4
+from .trainer import RTDETRv4Trainer
+
+__all__ = ["LibreRTDETRv4", "RTDETRv4Trainer"]

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -1,0 +1,142 @@
+"""LibreRTDETRv4 — RT-DETRv4 student detectors."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from ...training.config import RTDETRv4Config
+from ..dfine.model import LibreDFINE
+from ..dfine.nn import LibreDFINEModel
+
+
+_TRAIN_DEFAULTS = RTDETRv4Config()
+
+
+class LibreRTDETRv4(LibreDFINE):
+    FAMILY = "rtdetrv4"
+    FILENAME_PREFIX = "LibreRTDETRv4"
+    INPUT_SIZES = {"s": 640, "m": 640, "l": 640, "x": 640}
+    TRAIN_CONFIG = RTDETRv4Config
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        # Disambiguates from D-FINE via the factory's ``model_family`` metadata
+        # gate; raw upstream ckpts still carry ``feature_projector`` keys.
+        return LibreDFINE.can_load(weights_dict) or any(
+            "feature_projector" in k for k in weights_dict
+        )
+
+    @classmethod
+    def detect_size_from_filename(cls, filename: str) -> Optional[str]:
+        detected = super().detect_size_from_filename(filename)
+        if detected is not None:
+            return detected
+        m = re.search(r"rtv4(?:_hgnetv2)?_([smlx])(?:_|\.|$)", filename.lower())
+        if m:
+            return m.group(1)
+        return None
+
+    def _init_model(self) -> nn.Module:
+        return LibreDFINEModel(
+            config=self.size,
+            nb_classes=self.nb_classes,
+            eval_spatial_size=(self.input_size, self.input_size),
+            activation="silu",
+        )
+
+    def train(
+        self,
+        data: str,
+        *,
+        epochs: int = _TRAIN_DEFAULTS.epochs,
+        batch: int = 16,
+        imgsz: int = 640,
+        lr0: float = _TRAIN_DEFAULTS.lr0,
+        device: str = "",
+        workers: int = 4,
+        seed: int = 0,
+        project: str = "runs/train",
+        name: str = _TRAIN_DEFAULTS.name,
+        exist_ok: bool = False,
+        resume: bool = False,
+        amp: bool = False,
+        patience: int = 50,
+        **kwargs,
+    ) -> dict:
+        from libreyolo.data import load_data_config
+
+        from .trainer import RTDETRv4Trainer
+
+        try:
+            data_config = load_data_config(data, autodownload=True)
+            data = data_config.get("yaml_file", data)
+        except Exception as e:
+            raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")
+
+        yaml_nc = data_config.get("nc")
+        yaml_names = data_config.get("names")
+        if yaml_nc is not None and yaml_nc != self.nb_classes:
+            self._rebuild_for_new_classes(yaml_nc)
+        if yaml_names is not None:
+            if isinstance(yaml_names, list):
+                yaml_names = {i: n for i, n in enumerate(yaml_names)}
+            self.names = self._sanitize_names(yaml_names, self.nb_classes)
+
+        if seed >= 0:
+            import random
+
+            import numpy as np
+
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(seed)
+
+        trainer = RTDETRv4Trainer(
+            model=self.model,
+            wrapper_model=self,
+            size=self.size,
+            num_classes=self.nb_classes,
+            data=data,
+            epochs=epochs,
+            batch=batch,
+            imgsz=imgsz,
+            lr0=lr0,
+            device=device if device else "auto",
+            workers=workers,
+            seed=seed,
+            project=project,
+            name=name,
+            exist_ok=exist_ok,
+            resume=resume,
+            amp=amp,
+            patience=patience,
+            **kwargs,
+        )
+
+        if resume:
+            if not self.model_path:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreRTDETRv4('path/to/last.pt'); model.train(data=..., resume=True)"
+                )
+            trainer.setup()
+            trainer.resume(str(self.model_path))
+            return trainer.train()
+
+        results = trainer.train()
+
+        best_ckpt = results.get("best_checkpoint")
+        if best_ckpt and Path(best_ckpt).exists():
+            self.model_path = best_ckpt
+            self._load_weights(best_ckpt)
+
+        self.model.to(self.device)
+
+        return results

--- a/libreyolo/models/rtdetrv4/trainer.py
+++ b/libreyolo/models/rtdetrv4/trainer.py
@@ -1,0 +1,20 @@
+"""RTDETRv4Trainer — fine-tuning trainer for RT-DETRv4 student detectors."""
+
+from __future__ import annotations
+
+from typing import Type
+
+from ...training.config import RTDETRv4Config, TrainConfig
+from ..deim.trainer import DEIMTrainer
+
+
+class RTDETRv4Trainer(DEIMTrainer):
+    @classmethod
+    def _config_class(cls) -> Type[TrainConfig]:
+        return RTDETRv4Config
+
+    def get_model_family(self) -> str:
+        return "rtdetrv4"
+
+    def get_model_tag(self) -> str:
+        return f"RTDETRv4-{self.config.size}"

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -254,6 +254,16 @@ class DEIMConfig(TrainConfig):
     name: str = "deim_exp"
 
 
+@dataclass(kw_only=True)
+class RTDETRv4Config(DEIMConfig):
+    """RT-DETRv4 fine-tuning defaults."""
+
+    lr0: float = 5e-4
+    weight_decay: float = 1.25e-4
+    epochs: int = 58
+    name: str = "rtdetrv4_exp"
+
+
 DEIMV2_SIZE_DEFAULTS = {
     # Released DEIMv2 COCO recipes, flattened from /configs/deimv2/*.yml in
     # Intellindust-AI-Lab/DEIMv2. The tiny HGNetv2 models intentionally omit

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -13,7 +13,7 @@ from .config import ValidationConfig
 
 logger = logging.getLogger(__name__)
 
-COCO_TOPK_FAMILIES = {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr"}
+COCO_TOPK_FAMILIES = {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr", "rtdetrv2", "rtdetrv4"}
 
 if TYPE_CHECKING:
     from libreyolo.models.base import BaseModel

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -458,6 +458,58 @@ class PICODETValPreprocessor(StandardValPreprocessor):
         return chw.astype(np.float32), padded_targets
 
 
+class RTDETRv2ValPreprocessor(BaseValPreprocessor):
+    """RT-DETRv2 val preprocessor matching upstream's PIL/torchvision Resize.
+
+    The only difference from ``RTDETRValPreprocessor`` is that this one uses
+    PIL.Image.resize (BILINEAR) on the un-letterboxed source image, mirroring
+    upstream's ``Resize -> ConvertPILImage(scale=True)`` chain. cv2.resize and
+    PIL.Image.resize use different bilinear kernels; the pixel drift cascades
+    to ~0.7 mAP on COCO val2017 for v2-r18 if cv2 is used instead.
+    """
+
+    @property
+    def normalize(self) -> bool:
+        return True
+
+    @property
+    def wants_unresized_image(self) -> bool:
+        return True
+
+    def __call__(
+        self, img: np.ndarray, targets: np.ndarray, input_size: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        orig_h, orig_w = img.shape[:2]
+        target_h, target_w = input_size
+
+        # img is BGR uint8 from cv2.imread; flip to RGB then PIL-resize.
+        rgb = img[:, :, ::-1]
+        resized = np.array(
+            Image.fromarray(rgb).resize(
+                (target_w, target_h), Image.Resampling.BILINEAR
+            ),
+            dtype=np.float32,
+        )
+        resized = resized / 255.0
+        resized = resized.transpose(2, 0, 1)
+        resized = np.ascontiguousarray(resized, dtype=np.float32)
+
+        padded_targets = np.zeros((self.max_labels, 5), dtype=np.float32)
+        if len(targets) > 0:
+            targets = np.array(targets).copy()
+            n = min(len(targets), self.max_labels)
+            letterbox_r = min(target_h / orig_h, target_w / orig_w)
+            scale_x = target_w / orig_w
+            scale_y = target_h / orig_h
+            targets[:n, 0] = targets[:n, 0] / letterbox_r * scale_x
+            targets[:n, 1] = targets[:n, 1] / letterbox_r * scale_y
+            targets[:n, 2] = targets[:n, 2] / letterbox_r * scale_x
+            targets[:n, 3] = targets[:n, 3] / letterbox_r * scale_y
+            padded_targets[:n] = targets[:n]
+
+        return resized, padded_targets
+
+
 class RTDETRValPreprocessor(BaseValPreprocessor):
     """Preprocessor for RT-DETR validation: resize to fixed size, normalize to [0,1], no letterbox."""
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -80,6 +80,9 @@ def pytest_configure(config):
         "markers", "rtdetr: tests covering the RT-DETR model family"
     )
     config.addinivalue_line(
+        "markers", "rtdetrv2: tests covering the RT-DETRv2 model family"
+    )
+    config.addinivalue_line(
         "markers", "rtdetrv4: tests covering the RT-DETRv4 model family"
     )
     config.addinivalue_line("markers", "slow: slow tests that may take several minutes")
@@ -468,6 +471,7 @@ MODEL_CATALOG = [
     ("rtdetr", "r50", "LibreRTDETRr50.pt"),
     ("rtdetr", "r50m", "LibreRTDETRr50m.pt"),
     ("rtdetr", "r101", "LibreRTDETRr101.pt"),
+    ("rtdetrv2", "r18", "weights/LibreRTDETRv2r18.pt"),
     ("rtdetrv4", "s", "weights/LibreRTDETRv4s.pt"),
     ("picodet", "s", "LibrePICODETs.pt"),
     ("picodet", "m", "LibrePICODETm.pt"),
@@ -485,6 +489,7 @@ DEIM_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "deim"]
 DEIMV2_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "deimv2"]
 ECDET_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "ecdet"]
 RTDETR_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "rtdetr"]
+RTDETRV2_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "rtdetrv2"]
 RTDETRV4_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "rtdetrv4"]
 PICODET_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "picodet"]
 
@@ -515,6 +520,7 @@ FAMILY_MARKERS = {
     "deimv2": pytest.mark.deimv2,
     "ecdet": pytest.mark.ecdet,
     "rtdetr": pytest.mark.rtdetr,
+    "rtdetrv2": pytest.mark.rtdetrv2,
     "rtdetrv4": pytest.mark.rtdetrv4,
     "picodet": pytest.mark.picodet,
 }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -79,6 +79,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "rtdetr: tests covering the RT-DETR model family"
     )
+    config.addinivalue_line(
+        "markers", "rtdetrv4: tests covering the RT-DETRv4 model family"
+    )
     config.addinivalue_line("markers", "slow: slow tests that may take several minutes")
     config.addinivalue_line("markers", "rf1: RF1 training tests")
     config.addinivalue_line("markers", "rf5: RF5 training benchmark tests")
@@ -465,6 +468,7 @@ MODEL_CATALOG = [
     ("rtdetr", "r50", "LibreRTDETRr50.pt"),
     ("rtdetr", "r50m", "LibreRTDETRr50m.pt"),
     ("rtdetr", "r101", "LibreRTDETRr101.pt"),
+    ("rtdetrv4", "s", "weights/LibreRTDETRv4s.pt"),
     ("picodet", "s", "LibrePICODETs.pt"),
     ("picodet", "m", "LibrePICODETm.pt"),
     ("picodet", "l", "LibrePICODETl.pt"),
@@ -481,6 +485,7 @@ DEIM_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "deim"]
 DEIMV2_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "deimv2"]
 ECDET_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "ecdet"]
 RTDETR_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "rtdetr"]
+RTDETRV4_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "rtdetrv4"]
 PICODET_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "picodet"]
 
 ALL_MODELS = [(f, s) for f, s, _ in MODEL_CATALOG]
@@ -510,6 +515,7 @@ FAMILY_MARKERS = {
     "deimv2": pytest.mark.deimv2,
     "ecdet": pytest.mark.ecdet,
     "rtdetr": pytest.mark.rtdetr,
+    "rtdetrv4": pytest.mark.rtdetrv4,
     "picodet": pytest.mark.picodet,
 }
 

--- a/weights/convert_rtdetrv2_weights.py
+++ b/weights/convert_rtdetrv2_weights.py
@@ -1,0 +1,106 @@
+"""Convert lyuwenyu RT-DETRv2 ResNet PyTorch weights to LibreYOLO format.
+
+Source weights (Apache-2.0, lyuwenyu/RT-DETR upstream).
+
+Adaptation steps (same as the existing HGNetv2 converter):
+  1. Unwrap the EMA wrapper: ckpt["ema"]["module"] -> raw state_dict.
+  2. Remap encoder/decoder input_proj and decoder.enc_output keys from
+     v2's named-submodule style (.conv./.norm./.proj.) to LibreYOLO's
+     Sequential numeric style (.0./.1.).
+  3. Drop v2-only tensors LibreYOLO's v1-style RT-DETR module does not have:
+       - decoder.anchors, decoder.valid_mask    (precomputed eval buffers)
+       - cross_attn.num_points_scale            (v2 discrete-sampling scale)
+  4. Wrap with model_family="rtdetrv2" metadata so the factory routes to
+     LibreRTDETRv2 instead of LibreRTDETR.
+  5. Save as weights/LibreRTDETRv2{r18,r34,r50,r50m,r101}.pt
+
+Usage::
+
+    python weights/convert_rtdetrv2_weights.py downloads/v2_ckpts/rtdetrv2_r18vd_120e_coco_rerun_48.1.pth \\
+        weights/LibreRTDETRv2r18.pt --size r18
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from _conversion_utils import (
+    extract_state_dict,
+    load_checkpoint,
+    save_checkpoint,
+    wrap_libreyolo_checkpoint,
+)
+
+
+_DROP_FRAGMENTS: tuple[str, ...] = ()
+# v2 registers ``decoder.anchors`` / ``decoder.valid_mask`` and
+# ``cross_attn.num_points_scale`` as buffers; keep them all so the strict load
+# overrides our init-time values with the upstream-saved tensors. (Initial
+# values differ by ~3e-4 due to torch-version/precision drift.)
+
+
+def _remap_key(k: str) -> str:
+    # Only ``encoder.input_proj`` needs remapping: v1's HybridEncoder uses
+    # numeric Sequential keys (``.0/.1``) but upstream uses named submodules
+    # (``.conv/.norm``). The v2 decoder we ported preserves upstream's named
+    # submodules for ``decoder.enc_output`` and ``decoder.input_proj``, so
+    # those keys pass through unchanged.
+    if k.startswith("encoder.input_proj."):
+        parts = k.split(".")
+        if len(parts) >= 4:
+            sub = parts[3]
+            if sub == "conv":
+                parts[3] = "0"
+                return ".".join(parts)
+            if sub == "norm":
+                parts[3] = "1"
+                return ".".join(parts)
+    return k
+
+
+def convert_weights(input_path: str, output_path: str, size: str, nc: int = 80) -> dict:
+    print(f"Loading upstream RT-DETRv2 weights from {input_path}")
+    raw = load_checkpoint(input_path)
+    state_dict = extract_state_dict(raw)
+    print(f"Found {len(state_dict)} parameter entries (EMA-preferred)")
+
+    out = {}
+    dropped = []
+    for k, v in state_dict.items():
+        if any(frag in k for frag in _DROP_FRAGMENTS):
+            dropped.append(k)
+            continue
+        out[_remap_key(k)] = v.float().clone()
+
+    print(f"Stripped {len(dropped)} v2-only tensors:")
+    for k in dropped[:6]:
+        print(f"  - {k}")
+    if len(dropped) > 6:
+        print(f"  ... +{len(dropped) - 6} more")
+
+    libreyolo_ckpt = wrap_libreyolo_checkpoint(
+        out, model_family="rtdetrv2", size=size, nc=nc,
+    )
+    save_checkpoint(libreyolo_ckpt, output_path)
+    print(f"Saved LibreYOLO-format checkpoint to {output_path}  ({len(out)} tensors)")
+    return libreyolo_ckpt
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert RT-DETRv2 weights to LibreYOLO format"
+    )
+    parser.add_argument("input", help="Upstream RT-DETRv2 checkpoint (.pth)")
+    parser.add_argument("output", help="Output LibreYOLO checkpoint (.pt)")
+    parser.add_argument(
+        "--size",
+        required=True,
+        choices=["r18", "r34", "r50", "r50m", "r101"],
+        help="Size code matching the upstream backbone",
+    )
+    parser.add_argument(
+        "--nc", type=int, default=80, help="Number of classes (default: 80)"
+    )
+    args = parser.parse_args()
+
+    convert_weights(args.input, args.output, args.size, args.nc)

--- a/weights/convert_rtdetrv4_weights.py
+++ b/weights/convert_rtdetrv4_weights.py
@@ -1,0 +1,81 @@
+"""Convert upstream RT-DETRv4 COCO weights into LibreYOLO format.
+
+Usage::
+
+    python weights/convert_rtdetrv4_weights.py \\
+        downloads/v4_ckpts/rtv4_hgnetv2_s_coco.pth \\
+        weights/LibreRTDETRv4s.pt --size s
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from _conversion_utils import (
+    extract_state_dict,
+    load_checkpoint,
+    save_checkpoint,
+    wrap_libreyolo_checkpoint,
+)
+
+
+_TRAINING_ONLY_KEYS = (
+    "encoder.feature_projector.",
+)
+
+
+def _drop_training_only_keys(state_dict: dict) -> tuple[dict, list[str]]:
+    dropped = [k for k in state_dict if any(k.startswith(p) for p in _TRAINING_ONLY_KEYS)]
+    cleaned = {k: v for k, v in state_dict.items() if k not in dropped}
+    return cleaned, dropped
+
+
+def convert_weights(
+    input_path: str,
+    output_path: str,
+    size: str,
+    nc: int = 80,
+) -> dict:
+    print(f"Loading upstream RT-DETRv4 weights from {input_path}")
+    raw = load_checkpoint(input_path)
+    state_dict = extract_state_dict(raw)
+    print(f"Found {len(state_dict)} parameter entries (EMA-preferred)")
+
+    cleaned, dropped = _drop_training_only_keys(state_dict)
+    if dropped:
+        print(f"Stripped {len(dropped)} training-only keys:")
+        for k in dropped:
+            print(f"  - {k}")
+    else:
+        print("No training-only keys to strip (unexpected — verify upstream layout)")
+
+    libreyolo_ckpt = wrap_libreyolo_checkpoint(
+        cleaned,
+        model_family="rtdetrv4",
+        size=size,
+        nc=nc,
+    )
+
+    save_checkpoint(libreyolo_ckpt, output_path)
+    print(f"Saved LibreYOLO-format checkpoint to {output_path}")
+    return libreyolo_ckpt
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert RT-DETRv4 weights to LibreYOLO format"
+    )
+    parser.add_argument("input", help="Upstream RT-DETRv4 checkpoint (.pth)")
+    parser.add_argument("output", help="Output LibreYOLO checkpoint (.pt)")
+    parser.add_argument(
+        "--size",
+        required=True,
+        choices=["s", "m", "l", "x"],
+        help="Size code (RT-DETRv4 ships s/m/l/x; no 'n')",
+    )
+    parser.add_argument(
+        "--nc", type=int, default=80, help="Number of classes (default: 80)"
+    )
+    args = parser.parse_args()
+
+    convert_weights(args.input, args.output, args.size, args.nc)


### PR DESCRIPTION
RT-DETRv1 postprocess fix
- LibreRTDETR._postprocess used per-query argmax which lost non-max-class detections
- Replaced with flatten+topk over (Q*nc), matching upstream RTDETRPostProcessor and _parse_dfine
- Same fix applied to backends/base.py:_parse_rtdetr for the ONNX/TRT runtime path
- v1 r18 mAP recovers from 45.53 to 46.39 (reported 46.4); same fix lifts v2 by ~0.7

RT-DETRv4 family (new)
- libreyolo/models/rtdetrv4/{__init__.py, model.py, trainer.py}
- Wraps LibreDFINE with FAMILY=rtdetrv4, FILENAME_PREFIX=LibreRTDETRv4, activation=silu
- Trainer subclasses DEIMTrainer (matching MAL loss recipe), RTDETRv4Config(lr=5e-4, epochs=58, weight_decay=1.25e-4)
- weights/convert_rtdetrv4_weights.py strips encoder.feature_projector.* (training-only)
- Backward-compat activation kwarg added to LibreDFINEModel/DFINETransformer (default relu preserves D-FINE)
- COCO val2017 bit-perfect for s/m/l/x: 49.79/53.66/55.40/57.01 vs paper 49.8/53.7/55.4/57.0
- ONNX export and ONNX COCO val confirm parity with PT path

RT-DETRv2 family (new)
- libreyolo/models/rtdetrv2/{__init__.py, model.py, decoder.py, nn.py, utils.py, trainer.py}
- Full v2 decoder port (per-level num_points, flat sampling layout, deformable_attention_core_func_v2)
- Reuses v1 PResNet backbone and HybridEncoder unchanged
- weights/convert_rtdetrv2_weights.py keeps anchors/valid_mask/num_points_scale buffers (avoids ~3e-4 drift vs init)
- RTDETRv2ValPreprocessor matches upstream PIL/torchvision Resize (wants_unresized_image=True)
- RTDETRv2Trainer falls back to CPU on Apple MPS (grid_sampler_2d_backward not implemented)
- COCO val2017 v2-r18 hits 48.10 (paper 48.1)
- v1 imported before v2 in registry so metadata-less ckpts default to v1

Cross-cutting
- Family additions to is_detr_family, _preprocess and _parse_outputs dispatchers, COCO_TOPK_FAMILIES, _uses_dfine_style_export_wrapper
- LibreRTDETR.train uses _get_trainer_class hook so siblings can swap trainer (default unchanged)
- self.model.to(self.device) after train so MPS->CPU trainer fallback doesn't drift wrapper device (no-op for v1)
- tests/e2e/conftest.py: rtdetrv2-r18 and rtdetrv4-s in MODEL_CATALOG, markers registered

Validation gates
- 5 v1 sizes pass tests/e2e/test_val_coco128 (no regression)
- v2-r18 and v4-s pass test_val_coco128 and test_rf1_training
- Tensor-equivalence vs upstream: max-abs-diff = 0 on coco128 for v2 and v4
- Full COCO val2017: bit-perfect for v4 ladder and v2-r18; v1-r18 matches reported 46.4
- ONNX export works for both new families

Out of scope
- v2 HGNetv2-L/X (already covered by v1)
- v2 HGNetv2-H (defer)
- v2 _dsp discrete-sampling variants (TensorRT <8.5 compat, defer)
- v4 DINOv3 teacher distillation training (skipped per fine-tune-parity scope)
- v4 weight rehosting on LibreYOLO HF org (DINOv3 derivative-license question)