### PR TITLE
Cast preprocessor blob to ONNX input dtype

### DIFF
--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -11,6 +11,14 @@ from .base import BaseBackend
 
 logger = logging.getLogger(__name__)
 
+# ONNX Runtime advertises input tensor dtype as a string; map the ones a
+# LibreYOLO export can emit (fp32 default, fp16 via half=True) to numpy.
+# Other types fall back to float32, matching the preprocessor's output.
+_ORT_INPUT_DTYPES = {
+    "tensor(float)": np.float32,
+    "tensor(float16)": np.float16,
+}
+
 
 class OnnxBackend(BaseBackend):
     """ONNX runtime inference backend for LibreYOLO models.
@@ -65,9 +73,11 @@ class OnnxBackend(BaseBackend):
             resolved_device = "cpu"
 
         self.session = ort.InferenceSession(onnx_path, providers=providers)
-        self.input_name = self.session.get_inputs()[0].name
+        model_input = self.session.get_inputs()[0]
+        self.input_name = model_input.name
+        self.input_dtype = _ORT_INPUT_DTYPES.get(model_input.type, np.float32)
 
-        input_shape = self.session.get_inputs()[0].shape
+        input_shape = model_input.shape
         if len(input_shape) == 4 and isinstance(input_shape[2], int):
             imgsz = input_shape[2]
         else:
@@ -154,4 +164,6 @@ class OnnxBackend(BaseBackend):
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run ONNX Runtime inference."""
+        if blob.dtype != self.input_dtype:
+            blob = blob.astype(self.input_dtype, copy=False)
         return self.session.run(None, {self.input_name: blob})

--- a/tests/e2e/test_onnx.py
+++ b/tests/e2e/test_onnx.py
@@ -163,6 +163,13 @@ class TestONNXExportHalf:
         input_type = onnx_model.graph.input[0].type.tensor_type.elem_type
         assert input_type == onnx.TensorProto.FLOAT16, "Input should be FP16"
 
+        # Smoke-test inference: backend must cast the float32 preprocessed
+        # blob to the model's declared float16 input dtype.
+        from libreyolo import LibreYOLO
+
+        onnx_model_runner = LibreYOLO(model_path=exported_path)
+        onnx_model_runner(sample_image)
+
 
 class TestONNXMetadata:
     """Test ONNX export metadata."""


### PR DESCRIPTION
## Summary

- Fix `OnnxBackend._run_inference` to cast the preprocessed float32 blob to the ONNX model's declared input dtype. FP16-exported models currently fail at the first inference call with `Unexpected input data type. Actual: (tensor(float)), expected: (tensor(float16))`.
- Cache the resolved numpy dtype once at session init (`_ORT_INPUT_DTYPES` map → `self.input_dtype`); cast in `_run_inference` only when the blob dtype differs (`copy=False`, so FP32 is a no-op).
- Extend the existing `TestONNXExportHalf.test_onnx_fp16_export` to actually load the exported file through `LibreYOLO` and run inference. The previous assertion only checked the input dtype on disk, which is why the regression was never caught.

## Motivation

Trying to benchmark a `half=True` ONNX export through `LibreYOLO(...)` (via `vision-analysis-benchmark`'s `--precision fp16` path) reproduced the failure on every model family. The dtype concern is naturally local to `OnnxBackend` — preprocess is shared and always emits FP32, and each backend already adapts to its own runtime (TRT/OpenVINO follow the same pattern), so no new constructor args or precision plumbing are needed.

## Test plan

- [x] `pytest tests/e2e/test_onnx.py::TestONNXExportHalf -m ""` passes on `yolox-n` and `yolox-s`
- [x] End-to-end FP16 inference verified via `vision-analysis-benchmark` (`yolox-s`, ONNXRuntime CPU): full COCO val2017 run produced a valid submission with `runtime.precision = "fp16"` and mAP@0.5 = 0.395
- [x] FP32 path unchanged (regression-tested with `yolox-s` FP32)
- [ ] Note: the new inference smoke test exposes a separate, pre-existing issue with `yolo9-t` FP16 export — the produced graph contains a `Range` op with FP16 inputs that ORT rejects (`InvalidGraph`). That's an export-side bug, not addressed here; happy to file a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)