### PR TITLE
Imgsz yolo9 fix

### DIFF
--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -360,6 +360,9 @@ class InferenceRunner:
         # Resolve input size
         effective_imgsz = imgsz if imgsz is not None else self.model._get_input_size()
 
+        # Pass "effective_imgsz" immediately to kwargs
+        kwargs["input_size"] = effective_imgsz
+        
         # Preprocess
         input_tensor, original_img, original_size, ratio = self.model._preprocess(
             image, color_format, input_size=effective_imgsz
@@ -434,6 +437,9 @@ class InferenceRunner:
     ) -> Generator[Results, None, None]:
         """Run inference on a video file, yielding per-frame Results."""
         effective_imgsz = imgsz if imgsz is not None else self.model._get_input_size()
+
+        # Pass "effective_imgsz" immediately to kwargs
+        kwargs["input_size"] = effective_imgsz
 
         def predict_frame(pil_img):
             input_tensor, original_img, original_size, ratio = self.model._preprocess(

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -194,6 +194,7 @@ class BaseModel(ABC):
         original_size: Tuple[int, int],
         max_det: int = 300,
         ratio: float = 1.0,
+        **kwargs,
     ) -> Dict:
         """Postprocess model output to detections."""
         pass

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -181,7 +181,7 @@ class LibreYOLO9(BaseModel):
         color_format: str = "auto",
         input_size: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
-        effective_size = input_size if input_size is not None else 640
+        effective_size = input_size if input_size is not None else self._get_input_size()
         tensor, img, size = preprocess_image(
             image, input_size=effective_size, color_format=color_format
         )
@@ -197,9 +197,10 @@ class LibreYOLO9(BaseModel):
         iou_thres: float,
         original_size: Tuple[int, int],
         max_det: int = 300,
+        ratio: float = 1.0,
         **kwargs,
     ) -> Dict:
-        actual_input_size = kwargs.get("input_size", 640)
+        actual_input_size = kwargs.get("input_size", self._get_input_size())
         return postprocess(
             output,
             conf_thres=conf_thres,


### PR DESCRIPTION
Fix imgsz parameter not working for YOLO9 inference.

"effective_imgsz" should now be properly used by pre and post process, instead of always defaulting to 640.