### PR TITLE
Fix 80 classes hardcoded "bug"

### DIFF
--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -396,10 +396,19 @@ class BaseModel(ABC):
                         )
 
                 ckpt_nc = loaded.get("nc")
+                ckpt_names = loaded.get("names")
+
+                # Infer nc from names if missing from checkpoint
+                if ckpt_nc is None and ckpt_names is not None:
+                    ckpt_nc = len(ckpt_names)
+
+                # Infer nc from existing tensor detect_nb_classes
+                if ckpt_nc is None and hasattr(self, "detect_nb_classes"):
+                    ckpt_nc = self.detect_nb_classes(state_dict)
+
                 if ckpt_nc is not None and ckpt_nc != self.nb_classes:
                     self._rebuild_for_new_classes(ckpt_nc)
 
-                ckpt_names = loaded.get("names")
                 effective_nc = ckpt_nc if ckpt_nc is not None else self.nb_classes
                 if ckpt_names is not None:
                     self.names = self._sanitize_names(ckpt_names, effective_nc)

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -272,6 +272,11 @@ class LibreYOLO9(BaseModel):
 
         yaml_nc = data_config.get("nc")
         yaml_names = data_config.get("names")
+
+        # If no nc in data.yaml, infer it by counting.
+        if yaml_nc is None and yaml_names is not None:
+            yaml_nc = len(yaml_names)
+
         if yaml_nc is not None and yaml_nc != self.nb_classes:
             self._rebuild_for_new_classes(yaml_nc)
 


### PR DESCRIPTION
This should fix the "we have 80 classes if you don't put nc: in data.yaml" bug when training YOLO9.