### PR TITLE
fix trainer resume

### DIFF
--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -590,6 +590,7 @@ class LibreRTDETR(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreRTDETR('path/to/last.pt'); model.train(data=..., resume=True)"
                 )
+            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -402,10 +402,18 @@ class BaseTrainer(ABC):
             self._dispatch_artifact_callbacks("on_train_start", start_event)
             self.callbacks.on_train_start(start_event)
 
+            no_aug_start = self.config.epochs - self.config.no_aug_epochs
+            if self.config.no_aug_epochs > 0 and self.start_epoch > no_aug_start:
+                logger.info(
+                    f"Resumed past no-aug threshold (epoch {self.start_epoch} > {no_aug_start}), "
+                    f"disabling mosaic/mixup immediately"
+                )
+                self.on_mosaic_disable()
+
             for epoch in range(self.start_epoch, self.config.epochs):
                 self.current_epoch = epoch
 
-                if epoch == self.config.epochs - self.config.no_aug_epochs:
+                if epoch == no_aug_start:
                     logger.info(
                         f"Disabling mosaic/mixup for final {self.config.no_aug_epochs} epochs"
                     )


### PR DESCRIPTION
`setup()` creates `self.ema_model` and `self.optimizer`. Without it, `resume()` hits `if self.ema_model and ...` → `False` and silently skips restoring the EMA weights and update counter, and skips optimizer state restoration since `self.optimizer` is `None`. `trainer.train()` then creates a fresh EMA from the resumed training-model weights, losing the accumulated EMA state from the checkpoint.

Every other family (YOLOX, YOLOv9, PicoDet, EC, YOLO-NAS, DAMO-YOLO, D-FINE, DEIM, DEIMv2, RTDETRv4, RTMDet, YOLOv9-E2E) already follows the correct `trainer.setup()` → `trainer.resume()` order. RTDETR was the sole exception.

---

The pre-loop `on_mosaic_disable()` call fixes a silent resume bug. The in-loop check `if epoch == no_aug_start` only fires when the training loop actually reaches that epoch — if you resume at `start_epoch > no_aug_start`, that epoch is never revisited and mosaic/mixup stays enabled when it shouldn't be.

The `>` boundary (not `>=`) is intentional: the pre-loop call only covers epochs that have already passed `no_aug_start`. When `start_epoch == no_aug_start`, the in-loop check fires on the very first iteration and handles it correctly, with no double call.