### PR TITLE
Add a 'Flagship models' section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ model = LibreYOLO("LibreYOLO9t.pt")
 result = model(SAMPLE_IMAGE, save=True)
 ```
 
+## Flagship models
+
+LibreYOLO recommends these model families because they offer the best balance
+and receive the heaviest testing:
+
+- **YOLOv9** for CNN-based YOLO models.
+- **RF-DETR** for transformer-based detection and segmentation.
+
 ## Compatibility
 
 `✓` supported, `exp` experimental. Empty cells are not currently supported.
@@ -63,11 +71,11 @@ result = model(SAMPLE_IMAGE, save=True)
     </tr>
   </thead>
   <tbody>
-    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
     <tr><td>YOLOv9</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+    <tr><td>RF-DETR</td><td>✓</td><td>✓</td><td></td><td>exp</td><td>✓</td><td></td><td>✓</td><td>✓</td><td></td></tr>
+    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
     <tr><td>YOLOv9-E2E</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>YOLO-NAS</td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-    <tr><td>RF-DETR</td><td>✓</td><td>✓</td><td></td><td>exp</td><td>✓</td><td></td><td>✓</td><td>✓</td><td></td></tr>
     <tr><td>D-FINE</td><td>✓</td><td></td><td></td><td>exp</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
     <tr><td>DEIM</td><td>✓</td><td></td><td></td><td>exp</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
     <tr><td>DEIMv2</td><td>✓</td><td></td><td></td><td>exp</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,13 @@ model = LibreYOLO("LibreYOLO9t.pt")
 result = model(SAMPLE_IMAGE, save=True)
 ```
 
+## 旗舰模型
+
+LibreYOLO 推荐以下模型系列，因为它们在性能上达到最佳平衡，并且接受最充分的测试：
+
+- **YOLOv9**：基于 CNN 的 YOLO 模型。
+- **RF-DETR**：基于 Transformer 的检测与分割模型。
+
 ## 兼容性
 
 `✓` 表示支持，`exp` 表示实验性支持。空单元格表示当前不支持。
@@ -65,11 +72,11 @@ result = model(SAMPLE_IMAGE, save=True)
     </tr>
   </thead>
   <tbody>
-    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
     <tr><td>YOLOv9</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+    <tr><td>RF-DETR</td><td>✓</td><td>✓</td><td></td><td>exp</td><td>✓</td><td></td><td>✓</td><td>✓</td><td></td></tr>
+    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
     <tr><td>YOLOv9-E2E</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>YOLO-NAS</td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-    <tr><td>RF-DETR</td><td>✓</td><td>✓</td><td></td><td>exp</td><td>✓</td><td></td><td>✓</td><td>✓</td><td></td></tr>
     <tr><td>D-FINE</td><td>✓</td><td></td><td></td><td>exp</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
     <tr><td>DEIM</td><td>✓</td><td></td><td></td><td>exp</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
     <tr><td>DEIMv2</td><td>✓</td><td></td><td></td><td>exp</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>


### PR DESCRIPTION
## Summary

Closes #231.

LibreYOLO supports a lot of model families, which can leave a new user unsure
where to start. This PR updates the README so that people are clearly steered
toward **YOLOv9** and **RF-DETR** as the two families we want them to reach for
first:

- **YOLOv9** — the recommended CNN-based YOLO model.
- **RF-DETR** — the recommended transformer-based model, covering both detection
  and segmentation.

These two get the heaviest testing and offer the best balance, so making them
the obvious default lowers the chance of users picking a less-supported model.

## Changes

- Adds a **Flagship models** section near the top of `README.md` and
  `README.zh-CN.md`, right after the quickstart, recommending YOLOv9 and RF-DETR.
- Reorders the compatibility table in both READMEs so YOLOv9 and RF-DETR appear
  as the first two rows.
