### PR TITLE
Improve RF-DETR fidelity

### DIFF
--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -25,6 +25,11 @@ from ..utils.video import collect_video_results, is_video_file, run_video_infere
 logger = logging.getLogger(__name__)
 
 
+class _BackendEvalProxy:
+    def eval(self):
+        return self
+
+
 def _nms_numpy(
     boxes: np.ndarray, scores: np.ndarray, iou_threshold: float = 0.45
 ) -> list:
@@ -65,6 +70,13 @@ def _is_nms_free_family(model_family: Optional[str]) -> bool:
     return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr", "rtdetrv2", "rtdetrv4"}
 
 
+def _rfdetr_num_select(task: str, model_size: Optional[str]) -> int:
+    """Return RF-DETR's configured top-k selection for exported backends."""
+    if task == "segment":
+        return {"n": 100, "s": 100, "m": 200, "l": 200}.get(model_size or "", 300)
+    return 300
+
+
 class BaseBackend(ABC):
     """Abstract base class for all inference backends.
 
@@ -103,6 +115,15 @@ class BaseBackend(ABC):
             supported_tasks=self.SUPPORTED_TASKS,
         )
         self.names = names
+        self.FAMILY = model_family or "export"
+        try:
+            self.size = model_size or "export"
+        except AttributeError:
+            # Some concrete backends expose size as a computed read-only property.
+            pass
+        self.input_size = imgsz
+        if not hasattr(self, "model"):
+            self.model = _BackendEvalProxy()
 
     # =========================================================================
     # Abstract interface
@@ -579,7 +600,11 @@ class BaseBackend(ABC):
 
         scores = 1.0 / (1.0 + np.exp(-logits.astype(np.float64))).astype(np.float32)
         num_queries, num_classes = scores.shape
-        k = min(300, num_queries * num_classes)
+        model_size = self.model_size or getattr(self, "size", None)
+        k = min(
+            _rfdetr_num_select(self.task, model_size),
+            num_queries * num_classes,
+        )
         flat_indexes = np.argpartition(scores.reshape(-1), -k)[-k:]
         flat_indexes = flat_indexes[np.argsort(scores.reshape(-1)[flat_indexes])[::-1]]
         max_scores = scores.reshape(-1)[flat_indexes]
@@ -823,6 +848,182 @@ class BaseBackend(ABC):
         if nb_classes == 80:
             return {i: n for i, n in enumerate(COCO_CLASSES)}
         return {i: f"class_{i}" for i in range(nb_classes)}
+
+    def eval(self):
+        return self
+
+    def _get_model_name(self) -> str:
+        return self.model_family or "export"
+
+    def _get_input_size(self) -> int:
+        return self.imgsz
+
+    def _get_val_preprocessor(self, img_size: int | None = None):
+        if img_size is None:
+            img_size = self._get_input_size()
+
+        from ..validation.preprocessors import (
+            DAMOYOLOValPreprocessor,
+            DEIMValPreprocessor,
+            DEIMv2ValPreprocessor,
+            DFINEValPreprocessor,
+            ECValPreprocessor,
+            PICODETValPreprocessor,
+            RFDETRValPreprocessor,
+            RTDETRValPreprocessor,
+            RTDETRv2ValPreprocessor,
+            RTMDetValPreprocessor,
+            StandardValPreprocessor,
+            YOLO9E2EValPreprocessor,
+            YOLO9ValPreprocessor,
+            YOLONASValPreprocessor,
+            YOLOXValPreprocessor,
+        )
+
+        preprocessor_cls = {
+            "damoyolo": DAMOYOLOValPreprocessor,
+            "deim": DEIMValPreprocessor,
+            "deimv2": DEIMv2ValPreprocessor,
+            "dfine": DFINEValPreprocessor,
+            "ec": ECValPreprocessor,
+            "picodet": PICODETValPreprocessor,
+            "rfdetr": RFDETRValPreprocessor,
+            "rtdetr": RTDETRValPreprocessor,
+            "rtdetrv2": RTDETRv2ValPreprocessor,
+            "rtdetrv4": DFINEValPreprocessor,
+            "rtmdet": RTMDetValPreprocessor,
+            "yolo9": YOLO9ValPreprocessor,
+            "yolo9_e2e": YOLO9E2EValPreprocessor,
+            "yolonas": YOLONASValPreprocessor,
+            "yolox": YOLOXValPreprocessor,
+        }.get(self.model_family, StandardValPreprocessor)
+        return preprocessor_cls(img_size=(img_size, img_size))
+
+    def _forward(self, input_tensor: torch.Tensor):
+        blob = input_tensor.detach().cpu().numpy()
+        try:
+            outputs = self._run_inference(blob)
+        except Exception:
+            if blob.shape[0] <= 1:
+                raise
+            per_image_outputs = [
+                self._run_inference(blob[i : i + 1]) for i in range(blob.shape[0])
+            ]
+            outputs = [
+                np.concatenate(
+                    [np.asarray(item[j]) for item in per_image_outputs], axis=0
+                )
+                for j in range(len(per_image_outputs[0]))
+            ]
+        return [torch.from_numpy(np.asarray(output)) for output in outputs]
+
+    @staticmethod
+    def _as_numpy_outputs(output) -> list:
+        if isinstance(output, torch.Tensor):
+            return [output.detach().cpu().numpy()]
+        if isinstance(output, np.ndarray):
+            return [output]
+        if isinstance(output, (list, tuple)):
+            arrays = []
+            for item in output:
+                if isinstance(item, torch.Tensor):
+                    arrays.append(item.detach().cpu().numpy())
+                else:
+                    arrays.append(np.asarray(item))
+            return arrays
+        return [np.asarray(output)]
+
+    def _postprocess(
+        self,
+        output,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        input_size: int | None = None,
+        letterbox: bool = False,
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        effective_imgsz = input_size if input_size is not None else self.imgsz
+        outputs = self._as_numpy_outputs(output)
+        boxes, max_scores, class_ids, masks = self._parse_outputs(
+            outputs, effective_imgsz, original_size, conf_thres, ratio=ratio
+        )
+        result = self._build_result(
+            boxes,
+            max_scores,
+            class_ids,
+            masks=masks,
+            orig_shape=(int(original_size[1]), int(original_size[0])),
+            image_path=None,
+            iou=iou_thres,
+            classes=None,
+            max_det=max_det,
+        )
+
+        det: Dict[str, object] = {
+            "num_detections": len(result),
+            "boxes": result.boxes.xyxy,
+            "scores": result.boxes.conf,
+            "classes": result.boxes.cls.to(torch.int64),
+        }
+        if result.masks is not None:
+            det["masks"] = result.masks.data
+        return det
+
+    def val(
+        self,
+        data: str | None = None,
+        batch: int = 16,
+        imgsz: int | None = None,
+        conf: float = 0.001,
+        iou: float = 0.6,
+        workers: int = 4,
+        allow_download_scripts: bool = False,
+        device: str | None = None,
+        split: str = "val",
+        augment: bool = False,
+        save_json: bool = False,
+        verbose: bool = True,
+        **kwargs,
+    ) -> Dict:
+        from ..validation import (
+            DetectionValidator,
+            SegmentationValidator,
+            ValidationConfig,
+        )
+
+        if augment:
+            raise ValueError(
+                "Augmented validation is not supported for exported backends"
+            )
+        if imgsz is None:
+            imgsz = self._get_input_size()
+
+        validation_device = device or (
+            "cuda" if self.device == "cuda" and torch.cuda.is_available() else "cpu"
+        )
+        config = ValidationConfig(
+            data=data,
+            batch_size=batch,
+            imgsz=imgsz,
+            conf_thres=conf,
+            iou_thres=iou,
+            num_workers=workers,
+            allow_download_scripts=allow_download_scripts,
+            device=validation_device,
+            split=split,
+            augment=augment,
+            save_json=save_json,
+            verbose=verbose,
+            **kwargs,
+        )
+        validator_cls = (
+            SegmentationValidator if self.task == "segment" else DetectionValidator
+        )
+        validator = validator_cls(model=self, config=config)
+        return validator()
 
     # =========================================================================
     # Inference pipeline

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -67,12 +67,6 @@ class OnnxBackend(BaseBackend):
         self.session = ort.InferenceSession(onnx_path, providers=providers)
         self.input_name = self.session.get_inputs()[0].name
 
-        input_shape = self.session.get_inputs()[0].shape
-        if len(input_shape) == 4 and isinstance(input_shape[2], int):
-            imgsz = input_shape[2]
-        else:
-            imgsz = 640  # dynamic shape; use default
-
         (
             model_family,
             model_size,
@@ -80,7 +74,15 @@ class OnnxBackend(BaseBackend):
             supported_tasks,
             default_task,
             names,
+            metadata_imgsz,
         ) = self._read_onnx_metadata(onnx_path, nb_classes)
+        input_shape = self.session.get_inputs()[0].shape
+        if len(input_shape) == 4 and isinstance(input_shape[2], int):
+            imgsz = input_shape[2]
+        elif metadata_imgsz is not None:
+            imgsz = metadata_imgsz
+        else:
+            imgsz = 640  # dynamic shape without metadata; use default
         resolved_task = resolve_task(
             explicit_task=task,
             checkpoint_task=metadata_task,
@@ -106,7 +108,8 @@ class OnnxBackend(BaseBackend):
         """Read libreyolo metadata embedded in an ONNX model file.
 
         Returns:
-            Tuple of (model_family, model_size, task, supported_tasks, default_task, names).
+            Tuple of (model_family, model_size, task, supported_tasks,
+            default_task, names, imgsz).
         """
         model_family = None
         model_size = None
@@ -114,6 +117,7 @@ class OnnxBackend(BaseBackend):
         default_task = "detect"
         supported_tasks = ("detect",)
         names = None
+        imgsz = None
         try:
             import onnx
 
@@ -124,6 +128,8 @@ class OnnxBackend(BaseBackend):
                 model_family = meta["model_family"]
             if "model_size" in meta:
                 model_size = meta["model_size"]
+            if "imgsz" in meta:
+                imgsz = int(meta["imgsz"])
             if "default_task" in meta:
                 default_task = normalize_task(meta["default_task"], default="detect")
             if "task" in meta:
@@ -150,7 +156,7 @@ class OnnxBackend(BaseBackend):
         except Exception as e:
             logger.warning("Failed to read ONNX metadata from %s: %s", onnx_path, e)
 
-        return model_family, model_size, task, supported_tasks, default_task, names
+        return model_family, model_size, task, supported_tasks, default_task, names, imgsz
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run ONNX Runtime inference."""

--- a/libreyolo/backends/openvino.py
+++ b/libreyolo/backends/openvino.py
@@ -98,13 +98,9 @@ class OpenVINOBackend(BaseBackend):
         ov_model = core.read_model(str(xml_path))
         self.compiled_model = core.compile_model(ov_model, ov_device)
 
-        input_shape = ov_model.inputs[0].shape
-        if (
-            len(input_shape) == 4
-            and isinstance(input_shape[2], int)
-            and input_shape[2] > 0
-        ):
-            imgsz = input_shape[2]
+        static_imgsz = self._read_static_input_imgsz(ov_model)
+        if static_imgsz is not None:
+            imgsz = static_imgsz
 
         super().__init__(
             model_path=str(model_dir),
@@ -118,6 +114,20 @@ class OpenVINOBackend(BaseBackend):
             supported_tasks=supported_tasks,
             default_task=default_task,
         )
+
+    @staticmethod
+    def _read_static_input_imgsz(ov_model) -> int | None:
+        try:
+            input_shape = ov_model.inputs[0].shape
+        except RuntimeError:
+            # Some converted models keep a dynamic input shape. In that case,
+            # use the exported metadata size read before compiling.
+            return None
+
+        input_h = input_shape[2] if len(input_shape) == 4 else None
+        if isinstance(input_h, int) and input_h > 0:
+            return input_h
+        return None
 
     @staticmethod
     def _read_metadata(metadata_path: Path, nb_classes_override: int | None = None):

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -1,6 +1,7 @@
 """TensorRT inference backend for LibreYOLO."""
 
 import json
+import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -68,12 +69,6 @@ class TensorRTBackend(BaseBackend):
         supported_tasks = normalize_supported_tasks(
             self._metadata.get("supported_tasks", (metadata_task,))
         )
-        resolved_task = resolve_task(
-            explicit_task=task,
-            checkpoint_task=metadata_task,
-            default_task=default_task,
-            supported_tasks=supported_tasks,
-        )
         self._sidecar_size = self._metadata.get("model_size")
 
         sidecar_names = self._metadata.get("names")
@@ -116,12 +111,25 @@ class TensorRTBackend(BaseBackend):
 
         imgsz = self.input_shape[2]  # (B, C, H, W); assumes square
         self._dynamic_batch = self.input_shape[0] == -1  # -1 = dynamic batch
-        self._max_batch = 1 if self._dynamic_batch else self.input_shape[0]
+        self._max_batch = self._detect_max_batch()
 
         self._allocate_buffers()
 
         if model_family is None:
             model_family = self._detect_model_family()
+        if not self._metadata:
+            inferred_task = self._detect_task_from_filename()
+            if inferred_task is not None:
+                metadata_task = inferred_task
+                default_task = inferred_task
+                supported_tasks = (inferred_task,)
+
+        resolved_task = resolve_task(
+            explicit_task=task,
+            checkpoint_task=metadata_task,
+            default_task=default_task,
+            supported_tasks=supported_tasks,
+        )
 
         super().__init__(
             model_path=engine_path,
@@ -161,6 +169,26 @@ class TensorRTBackend(BaseBackend):
             shape = _resolve_shape(self.output_shapes[name])
             size = int(np.prod(shape))
             self.outputs[name] = torch.zeros(size, dtype=torch.float32, device="cuda")
+
+    def _detect_max_batch(self) -> int:
+        """Return the largest batch size this engine can execute."""
+        if not self._dynamic_batch:
+            return int(self.input_shape[0])
+
+        try:
+            profile_shapes = self.engine.get_tensor_profile_shape(self.input_name, 0)
+            return int(profile_shapes[2][0])
+        except (AttributeError, IndexError, TypeError, ValueError):
+            pass
+
+        metadata_max = self._metadata.get("trt_max_batch")
+        if metadata_max is not None:
+            try:
+                return max(1, int(metadata_max))
+            except (TypeError, ValueError):
+                pass
+
+        return 1
 
     def _detect_model_family(self) -> Optional[str]:
         """Detect model family from output shapes when sidecar metadata is absent."""
@@ -203,6 +231,17 @@ class TensorRTBackend(BaseBackend):
             has_pred_boxes = any("pred_boxes" in n for n in self.output_names)
             if has_pred_logits and has_pred_boxes:
                 return "rtdetr"
+        return None
+
+    def _detect_task_from_filename(self) -> Optional[str]:
+        stem = Path(self.model_path).stem.lower()
+        if re.search(r"(?:^|[_-])(?:seg|segment)(?:[_-]|$)", stem):
+            return "segment"
+        if re.search(
+            r"(?:rfdetr|rf-detr)[_-]?(?:xx|2xl|xl|[nsmlx])[_-]?(?:seg|segment)",
+            stem,
+        ):
+            return "segment"
         return None
 
     def _infer(self, input_array: np.ndarray) -> Dict[str, np.ndarray]:
@@ -278,7 +317,14 @@ class TensorRTBackend(BaseBackend):
         together in a single forward pass. Otherwise falls back to sequential
         processing.
         """
-        can_batch = batch > 1 and (self._dynamic_batch or self._max_batch >= batch)
+        effective_batch = batch
+        if self._dynamic_batch:
+            effective_batch = min(batch, self._max_batch)
+
+        can_batch = batch > 1 and (
+            (self._dynamic_batch and effective_batch > 1)
+            or (not self._dynamic_batch and self._max_batch >= batch)
+        )
         if not can_batch:
             return super()._process_in_batches(
                 image_paths,
@@ -296,8 +342,8 @@ class TensorRTBackend(BaseBackend):
         effective_imgsz = imgsz if imgsz is not None else self.imgsz
         results = []
 
-        for i in range(0, len(image_paths), batch):
-            chunk_paths = image_paths[i : i + batch]
+        for i in range(0, len(image_paths), effective_batch):
+            chunk_paths = image_paths[i : i + effective_batch]
 
             tensors = []
             preprocess_info = []
@@ -360,9 +406,18 @@ class TensorRTBackend(BaseBackend):
         if self._sidecar_size is not None:
             return self._sidecar_size
         stem = Path(self.model_path).stem.lower()
-        for s in ["n", "t", "s", "m", "l", "x", "c"]:
-            if s in stem:
-                return s
+        for pattern in (
+            r"(?:rfdetr|rf-detr)[_-]?(xx|2xl|xl|[nsmlx])(?:[_-]|$|seg|segment)",
+            r"(?:rfdetr|rf-detr)[_-]?(?:seg|segment)[_-]?(xx|2xl|xl|[nsmlx])(?:[_-]|$)",
+        ):
+            rfdetr_match = re.search(pattern, stem)
+            if rfdetr_match is not None:
+                size = rfdetr_match.group(1)
+                return {"xl": "x", "2xl": "xx"}.get(size, size)
+
+        token_match = re.search(r"(?:^|[_-])(xx|[ntsmlxc])(?:[_-]|$)", stem)
+        if token_match is not None:
+            return token_match.group(1)
         return "unknown"
 
     def _get_model_name(self) -> str:

--- a/libreyolo/cli/commands/predict.py
+++ b/libreyolo/cli/commands/predict.py
@@ -271,13 +271,17 @@ def predict_cmd(
             detections.append(det)
             class_counts[cls_name] = class_counts.get(cls_name, 0) + 1
 
-        result_list.append(
-            {
-                "path": r.path or str(source),
-                "original_shape": list(r.orig_shape),
-                "detections": detections,
+        result_data = {
+            "path": r.path or str(source),
+            "original_shape": list(r.orig_shape),
+            "detections": detections,
+        }
+        if r.masks is not None:
+            result_data["masks"] = {
+                "count": len(r.masks),
+                "shape": list(r.masks.data.shape),
             }
-        )
+        result_list.append(result_data)
         # Human summary line (ultralytics format):
         # image 1/3 parkour.jpg: 640x480 3 persons, 2 skateboards, 45.2ms
         h, w = r.orig_shape

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -48,6 +48,7 @@ def train_cmd(
     warmup_epochs: int = typer.Option(5, help="Warmup duration"),
     warmup_lr_start: float = typer.Option(0.0, help="Initial warmup LR"),
     min_lr_ratio: float = typer.Option(0.05, help="Minimum LR ratio"),
+    lr_drop: int = typer.Option(100, help="RF-DETR step LR drop epoch"),
     # Augmentation
     mosaic: float = typer.Option(1.0, help="Mosaic probability"),
     mixup: float = typer.Option(1.0, help="Mixup probability"),
@@ -151,6 +152,7 @@ def train_cmd(
         "warmup_epochs": warmup_epochs,
         "warmup_lr_start": warmup_lr_start,
         "min_lr_ratio": min_lr_ratio,
+        "lr_drop": lr_drop,
         "mosaic": mosaic,
         "mixup": mixup,
         "hsv_prob": hsv_prob,
@@ -213,6 +215,7 @@ def train_cmd(
                 "weight_decay": params["weight_decay"],
                 "eval_interval": params["eval_interval"],
                 "warmup_epochs": params["warmup_epochs"],
+                "lr_drop": params["lr_drop"],
                 "ema": params["ema"],
                 "ema_decay": params["ema_decay"],
                 "save_period": params["save_period"],

--- a/libreyolo/cli/commands/val.py
+++ b/libreyolo/cli/commands/val.py
@@ -15,6 +15,23 @@ from ..command_utils import (
 from ..output import OutputHandler
 
 
+def _rounded_metric(metrics: dict, key: str) -> float | None:
+    if key not in metrics:
+        return None
+    return round(float(metrics[key]), 4)
+
+
+def _metric_group(metrics: dict, suffix: str) -> dict[str, float] | None:
+    group = {
+        "mAP50": _rounded_metric(metrics, f"metrics/mAP50{suffix}"),
+        "mAP50_95": _rounded_metric(metrics, f"metrics/mAP50-95{suffix}"),
+        "precision": _rounded_metric(metrics, f"metrics/precision{suffix}"),
+        "recall": _rounded_metric(metrics, f"metrics/recall{suffix}"),
+    }
+    out = {k: v for k, v in group.items() if v is not None}
+    return out or None
+
+
 def val_cmd(
     model: str = typer.Option(..., help="Model weights path"),
     data: str = typer.Option(
@@ -88,7 +105,6 @@ def val_cmd(
             verbose=verbose and not quiet,
             save_dir=save_dir,
             data_dir=data_dir,
-            use_coco_eval=use_coco_eval,
             half=half,
             max_det=max_det,
         )
@@ -100,8 +116,14 @@ def val_cmd(
     # Extract metrics (keys like "metrics/mAP50", "metrics/mAP50-95")
     mAP50 = metrics.get("metrics/mAP50", 0.0)
     mAP50_95 = metrics.get("metrics/mAP50-95", metrics.get("metrics/mAP50_95", 0.0))
-    precision = metrics.get("metrics/precision", 0.0)
-    recall = metrics.get("metrics/recall", 0.0)
+    precision = metrics.get(
+        "metrics/precision",
+        metrics.get("metrics/precision(M)", metrics.get("metrics/precision(B)", 0.0)),
+    )
+    recall = metrics.get(
+        "metrics/recall",
+        metrics.get("metrics/recall(M)", metrics.get("metrics/recall(B)", 0.0)),
+    )
 
     data_out = {
         "model": model,
@@ -116,12 +138,29 @@ def val_cmd(
             "recall": round(recall, 4),
         },
     }
+    box_metrics = _metric_group(metrics, "(B)")
+    mask_metrics = _metric_group(metrics, "(M)")
+    if box_metrics is not None:
+        data_out["box_metrics"] = box_metrics
+    if mask_metrics is not None:
+        data_out["mask_metrics"] = mask_metrics
 
     if not json_output:
-        data_out["_human_text"] = (
+        human_text = (
             f"Validating {loaded_model.FAMILY}-{loaded_model.size} on {data} ({split}):\n"
             f"  mAP50: {mAP50:.4f}  mAP50-95: {mAP50_95:.4f}  "
             f"P: {precision:.4f}  R: {recall:.4f}"
         )
+        if box_metrics is not None:
+            human_text += (
+                f"\n  Box mAP50: {box_metrics.get('mAP50', 0.0):.4f}  "
+                f"Box mAP50-95: {box_metrics.get('mAP50_95', 0.0):.4f}"
+            )
+        if mask_metrics is not None:
+            human_text += (
+                f"\n  Mask mAP50: {mask_metrics.get('mAP50', 0.0):.4f}  "
+                f"Mask mAP50-95: {mask_metrics.get('mAP50_95', 0.0):.4f}"
+            )
+        data_out["_human_text"] = human_text
 
     out.result(data_out)

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -57,6 +57,10 @@ def _build_name_map() -> None:
             _CLI_NAME_TO_WEIGHTS[cli_name] = _weight_filename_for_cli(
                 rfcls, size_code
             )
+        for size_code in getattr(rfcls, "SEG_INPUT_SIZES", {}):
+            cli_name = f"{rfcls.FAMILY}-{size_code}-seg"
+            weight_name = f"{rfcls.FILENAME_PREFIX}{size_code}-seg{rfcls.WEIGHT_EXT}"
+            _CLI_NAME_TO_WEIGHTS[cli_name] = weight_name
 
 
 def get_all_cli_names() -> list[str]:
@@ -356,6 +360,8 @@ def _build_rfdetr_train_kwargs(
         "warmup_lr_start": "warmup_lr_start",
         "min_lr_ratio": "min_lr_ratio",
         "no_aug_epochs": "no_aug_epochs",
+        "scheduler": "scheduler",
+        "lr_drop": "lr_drop",
         "ema": "use_ema",
         "ema_decay": "ema_decay",
         "save_period": "checkpoint_interval",

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -32,20 +32,129 @@ def _yolo_coords_to_rings(
     ring = np.array(coords, dtype=np.float32).reshape(-1, 2)
     ring[:, 0] *= width
     ring[:, 1] *= height
-    return [ring]
+    return _attach_dense_mask([ring], width=width, height=height)
 
 
-def _coco_segmentation_to_rings(segmentation) -> List[np.ndarray]:
-    """Convert COCO polygon segmentation to pixel-space rings."""
-    if not isinstance(segmentation, list):
+def _yolo_box_to_ring(cx: float, cy: float, w: float, h: float, width: int, height: int) -> List[np.ndarray]:
+    """Convert one normalized YOLO bbox row to a rectangular ring."""
+    x1 = (cx - w / 2) * width
+    y1 = (cy - h / 2) * height
+    x2 = (cx + w / 2) * width
+    y2 = (cy + h / 2) * height
+    ring = np.array(
+        [[x1, y1], [x2, y1], [x2, y2], [x1, y2]],
+        dtype=np.float32,
+    )
+    ring[:, 0] = np.clip(ring[:, 0], 0.0, float(width))
+    ring[:, 1] = np.clip(ring[:, 1], 0.0, float(height))
+    return _attach_dense_mask([ring], width=width, height=height)
+
+
+class DenseMaskRing(np.ndarray):
+    """Polygon ring carrying the original dense mask for mask-aware transforms."""
+
+    def __new__(cls, ring: np.ndarray, mask: np.ndarray):
+        obj = np.asarray(ring, dtype=np.float32).view(cls)
+        obj.dense_mask = np.ascontiguousarray(mask.astype(np.uint8))
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.dense_mask = getattr(obj, "dense_mask", None)
+
+    def copy(self, order="C"):
+        copied = super().copy(order).view(type(self))
+        copied.dense_mask = None if self.dense_mask is None else self.dense_mask.copy()
+        return copied
+
+
+def _attach_dense_mask(
+    rings: List[np.ndarray],
+    *,
+    width: int,
+    height: int,
+) -> List[np.ndarray]:
+    """Attach a rasterized mask to polygon rings for mask-aware crop transforms."""
+    valid_rings = [
+        np.asarray(ring, dtype=np.float32)
+        for ring in rings
+        if ring is not None and len(ring) >= 3
+    ]
+    if not valid_rings:
+        return rings
+
+    mask = np.zeros((height, width), dtype=np.uint8)
+    polygons = [np.round(ring).astype(np.int32) for ring in valid_rings]
+    cv2.fillPoly(mask, polygons, color=1)
+
+    out = [np.asarray(ring, dtype=np.float32).copy() for ring in rings]
+    for idx, ring in enumerate(out):
+        if ring is not None and len(ring) >= 3:
+            out[idx] = DenseMaskRing(ring, mask)
+            break
+    return out
+
+
+def _mask_to_rings(mask: np.ndarray) -> List[np.ndarray]:
+    """Convert a binary mask to polygon rings using OpenCV contours."""
+    mask_u8 = np.ascontiguousarray(mask.astype(np.uint8))
+    contours, _ = cv2.findContours(mask_u8, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
+    rings = []
+    for contour in contours:
+        ring = contour.reshape(-1, 2)
+        if ring.shape[0] >= 3:
+            rings.append(ring.astype(np.float32))
+    if rings or mask_u8.sum() == 0:
+        return rings
+
+    ys, xs = np.where(mask_u8 > 0)
+    x1, x2 = float(xs.min()), float(xs.max() + 1)
+    y1, y2 = float(ys.min()), float(ys.max() + 1)
+    return [
+        np.array(
+            [[x1, y1], [x2, y1], [x2, y2], [x1, y2]],
+            dtype=np.float32,
+        )
+    ]
+
+
+def _coco_segmentation_to_rings(
+    segmentation,
+    *,
+    height: int | None = None,
+    width: int | None = None,
+) -> List[np.ndarray]:
+    """Convert COCO polygon or RLE segmentation to pixel-space rings."""
+    if isinstance(segmentation, list):
+        rings = []
+        for polygon in segmentation:
+            if polygon is None or len(polygon) < 6:
+                continue
+            ring = np.array(polygon, dtype=np.float32).reshape(-1, 2)
+            rings.append(ring)
+        if height is not None and width is not None:
+            return _attach_dense_mask(rings, width=width, height=height)
+        return rings
+
+    if not isinstance(segmentation, dict):
+        return []
+    try:
+        from pycocotools import mask as mask_utils
+    except ImportError:
         return []
 
-    rings = []
-    for polygon in segmentation:
-        if polygon is None or len(polygon) < 6:
-            continue
-        ring = np.array(polygon, dtype=np.float32).reshape(-1, 2)
-        rings.append(ring)
+    rle = segmentation
+    if isinstance(rle.get("counts"), list):
+        if height is None or width is None:
+            return []
+        rle = mask_utils.frPyObjects(rle, height, width)
+    decoded = mask_utils.decode(rle)
+    if decoded.ndim == 3:
+        decoded = decoded.any(axis=2)
+    rings = _mask_to_rings(decoded)
+    if rings:
+        rings[0] = DenseMaskRing(rings[0], decoded)
     return rings
 
 
@@ -230,7 +339,7 @@ class YOLODataset(Dataset):
                         else:
                             cx, cy, w, h = map(float, parts[1:5])
                             if self.load_segments:
-                                segments.append([])
+                                segments.append(_yolo_box_to_ring(cx, cy, w, h, width, height))
 
                         # Convert normalized xywh to pixel xyxy
                         x1 = (cx - w / 2) * width
@@ -468,7 +577,11 @@ class COCODataset(Dataset):
                 objs.append(obj)
                 if self.load_segments:
                     segments.append(
-                        _coco_segmentation_to_rings(obj.get("segmentation", []))
+                        _coco_segmentation_to_rings(
+                            obj.get("segmentation", []),
+                            height=height,
+                            width=width,
+                        )
                     )
 
         num_objs = len(objs)

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -183,7 +183,12 @@ class BaseExporter(ABC):
                 else None
             )
 
-            metadata = self._build_metadata(precision, dynamic, onnx_path)
+            metadata = self._build_metadata(
+                precision,
+                dynamic,
+                onnx_path,
+                imgsz=imgsz,
+            )
 
             result = self._export(
                 nn_model,
@@ -258,8 +263,11 @@ class BaseExporter(ABC):
                 "DEIMv2 export uses fixed decoder anchors; imgsz must match "
                 f"the native size {native_imgsz}, got {imgsz}."
             )
-        if device is None:
-            device = self.model.device
+        if device is None or str(device).lower() == "auto":
+            if self.model._get_model_name() == "rfdetr":
+                device = torch.device("cpu")
+            else:
+                device = self.model.device
         else:
             device = torch.device(device)
         if output_path is None:
@@ -268,10 +276,13 @@ class BaseExporter(ABC):
 
     def _auto_output_path(self, half: bool, int8: bool) -> str:
         model_name = self.model._get_model_name().lower()
+        task = getattr(self.model, "task", "detect")
+        is_segment = task == "segment" or getattr(self.model, "_is_segmentation", False) is True
+        task_suffix = "_seg" if is_segment else ""
         precision_suffix = "_int8" if int8 else ("_fp16" if half else "")
         return str(
             Path("weights")
-            / f"{model_name}_{self.model.size}{precision_suffix}{self.suffix}"
+            / f"{model_name}_{self.model.size}{task_suffix}{precision_suffix}{self.suffix}"
         )
 
     @contextmanager
@@ -434,14 +445,23 @@ class BaseExporter(ABC):
             simplify=simplify,
             dynamic=dynamic,
             half=False,
-            metadata=self._build_onnx_metadata(dynamic=dynamic, half=False),
+            metadata=self._build_onnx_metadata(
+                dynamic=dynamic,
+                half=False,
+                imgsz=int(dummy.shape[-1]),
+            ),
         )
 
     def _build_metadata(
-        self, precision: str, dynamic: bool, onnx_path: Optional[str]
+        self,
+        precision: str,
+        dynamic: bool,
+        onnx_path: Optional[str],
+        imgsz: Optional[int] = None,
     ) -> dict:
         """Build metadata dict for non-ONNX formats (native Python types)."""
         task, supported_tasks, default_task = self._task_metadata()
+        metadata_imgsz = int(imgsz if imgsz is not None else self.model._get_input_size())
         meta = {
             "libreyolo_version": _get_version(),
             "model_family": self.model._get_model_name(),
@@ -451,7 +471,7 @@ class BaseExporter(ABC):
             "default_task": default_task,
             "nb_classes": self.model.nb_classes,
             "names": {str(k): v for k, v in self.model.names.items()},
-            "imgsz": self.model._get_input_size(),
+            "imgsz": metadata_imgsz,
             "precision": precision,
             "dynamic": dynamic,
         }
@@ -459,9 +479,16 @@ class BaseExporter(ABC):
             meta["exported_from"] = str(Path(onnx_path).name)
         return meta
 
-    def _build_onnx_metadata(self, *, dynamic: bool, half: bool) -> dict:
+    def _build_onnx_metadata(
+        self,
+        *,
+        dynamic: bool,
+        half: bool,
+        imgsz: Optional[int] = None,
+    ) -> dict:
         """Build metadata dict for ONNX (all-string values, JSON-encoded names)."""
         task, supported_tasks, default_task = self._task_metadata()
+        metadata_imgsz = int(imgsz if imgsz is not None else self.model._get_input_size())
         return {
             "libreyolo_version": _get_version(),
             "model_family": self.model._get_model_name(),
@@ -471,7 +498,7 @@ class BaseExporter(ABC):
             "default_task": default_task,
             "nb_classes": str(self.model.nb_classes),
             "names": json.dumps({str(k): v for k, v in self.model.names.items()}),
-            "imgsz": str(self.model._get_input_size()),
+            "imgsz": str(metadata_imgsz),
             "dynamic": str(dynamic),
             "half": str(half),
             "segmentation": str(getattr(self.model, "_is_segmentation", False)).lower(),
@@ -487,6 +514,8 @@ class BaseExporter(ABC):
         default_task = getattr(self.model, "DEFAULT_TASK", "detect")
         if not isinstance(default_task, str):
             default_task = "detect"
+        if self.model._get_model_name() == "rfdetr":
+            return task, [task], task
         return task, list(supported_tasks), default_task
 
     def _print_summary(self, result: str, precision: str, imgsz: int):
@@ -540,7 +569,11 @@ class OnnxExporter(BaseExporter):
             simplify=simplify,
             dynamic=dynamic,
             half=half,
-            metadata=self._build_onnx_metadata(dynamic=dynamic, half=half),
+            metadata=self._build_onnx_metadata(
+                dynamic=dynamic,
+                half=half,
+                imgsz=int(dummy.shape[-1]),
+            ),
         )
 
 
@@ -581,12 +614,25 @@ class TensorRTExporter(BaseExporter):
         dynamic,
         verbose,
         workspace=4.0,
+        min_batch=1,
+        opt_batch=1,
+        max_batch=8,
         hardware_compatibility="none",
         gpu_device=0,
         trt_config=None,
         **kwargs,
     ):
         from .tensorrt import export_tensorrt
+
+        trt_metadata = dict(metadata or {})
+        if dynamic:
+            trt_metadata.update(
+                {
+                    "trt_min_batch": int(min_batch),
+                    "trt_opt_batch": int(opt_batch),
+                    "trt_max_batch": int(max_batch),
+                }
+            )
 
         logger.info("Step 2/2: Building TensorRT engine")
         return export_tensorrt(
@@ -598,10 +644,13 @@ class TensorRTExporter(BaseExporter):
             calibration_data=calibration_data,
             dynamic=dynamic,
             verbose=verbose,
+            min_batch=min_batch,
+            opt_batch=opt_batch,
+            max_batch=max_batch,
             hardware_compatibility=hardware_compatibility,
             device=gpu_device,
             config=trt_config,
-            metadata=metadata,
+            metadata=trt_metadata,
         )
 
 
@@ -649,8 +698,8 @@ class NcnnExporter(BaseExporter):
     supports_fp16 = False
     apply_model_half = False
 
-    def _build_metadata(self, precision, dynamic, onnx_path):
-        meta = super()._build_metadata(precision, dynamic, onnx_path)
+    def _build_metadata(self, precision, dynamic, onnx_path, imgsz=None):
+        meta = super()._build_metadata(precision, dynamic, onnx_path, imgsz=imgsz)
         meta["dynamic"] = False
         meta.pop("exported_from", None)
         return meta

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -23,7 +23,7 @@ def _uses_dfine_style_export_wrapper(model_family) -> bool:
     module that returns a 2-tuple. ONNX export can skip the dynamic output
     probe for them, and they all need opset 17 for ``aten::scaled_dot_product``.
     """
-    return model_family in {"dfine", "deim", "deimv2", "ec", "rtdetrv4"}
+    return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetrv4"}
 
 
 def _postprocess_onnx(
@@ -145,13 +145,14 @@ def export_onnx(
         metadata["segmentation"] = "true"
     elif is_seg:
         output_names = (
-            ["pred_boxes", "pred_logits", "pred_masks"]
+            ["dets", "labels", "masks"]
             if model_family == "rfdetr"
             else ["boxes", "scores", "masks"]
         )
+        input_name = "input" if model_family == "rfdetr" else "images"
         dynamic_axes = (
             {
-                "images": {0: "batch"},
+                input_name: {0: "batch"},
                 output_names[0]: {0: "batch"},
                 output_names[1]: {0: "batch"},
                 output_names[2]: {0: "batch"},
@@ -161,14 +162,15 @@ def export_onnx(
         )
         metadata["segmentation"] = "true"
     elif model_family == "rfdetr":
-        # RF-DETR's RFDETRExportWrapper returns (pred_boxes, pred_logits) — the
-        # tuple order is the inverse of D-FINE / DEIM / EC's (pred_logits, pred_boxes).
-        output_names = ["pred_boxes", "pred_logits"]
+        # RF-DETR's RFDETRExportWrapper returns (boxes, logits), and upstream
+        # names those ONNX outputs dets/labels.
+        input_name = "input"
+        output_names = ["dets", "labels"]
         dynamic_axes = (
             {
-                "images": {0: "batch"},
-                "pred_boxes": {0: "batch"},
-                "pred_logits": {0: "batch"},
+                input_name: {0: "batch"},
+                "dets": {0: "batch"},
+                "labels": {0: "batch"},
             }
             if dynamic
             else None
@@ -191,11 +193,12 @@ def export_onnx(
             {"images": {0: "batch"}, "output": {0: "batch"}} if dynamic else None
         )
 
+    input_names = ["input"] if model_family == "rfdetr" else ["images"]
     export_kwargs = {
         "export_params": True,
         "opset_version": opset,
         "do_constant_folding": True,
-        "input_names": ["images"],
+        "input_names": input_names,
         "output_names": output_names,
         "dynamic_axes": dynamic_axes,
     }

--- a/libreyolo/export/tensorrt.py
+++ b/libreyolo/export/tensorrt.py
@@ -240,6 +240,17 @@ def export_tensorrt(
             opt_batch = cfg.dynamic.opt_batch
             max_batch = cfg.dynamic.max_batch
 
+    if metadata is not None:
+        metadata = dict(metadata)
+        if dynamic:
+            metadata.update(
+                {
+                    "trt_min_batch": int(min_batch),
+                    "trt_opt_batch": int(opt_batch),
+                    "trt_max_batch": int(max_batch),
+                }
+            )
+
     check_tensorrt_available()
     import tensorrt as trt
 

--- a/libreyolo/models/rfdetr/backbone.py
+++ b/libreyolo/models/rfdetr/backbone.py
@@ -62,6 +62,9 @@ class PositionEmbeddingSine(nn.Module):
         if scale is None:
             scale = 2 * math.pi
         self.scale = scale
+        dim_t = torch.arange(num_pos_feats, dtype=torch.float32)
+        dim_t = temperature ** (2 * torch.div(dim_t, 2, rounding_mode="floor") / num_pos_feats)
+        self.register_buffer("dim_t", dim_t, persistent=False)
         self._export = False
 
     def export(self):
@@ -70,7 +73,6 @@ class PositionEmbeddingSine(nn.Module):
         self.forward = self.forward_export
 
     def forward(self, tensor_list: NestedTensor, align_dim_orders=True):
-        x = tensor_list.tensors
         mask = tensor_list.mask
         assert mask is not None
         not_mask = ~mask
@@ -81,8 +83,7 @@ class PositionEmbeddingSine(nn.Module):
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * self.scale
             x_embed = x_embed / (x_embed[:, :, -1:] + eps) * self.scale
 
-        dim_t = torch.arange(self.num_pos_feats, dtype=torch.float32, device=x.device)
-        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)
+        dim_t = self.dim_t
 
         pos_x = x_embed[:, :, :, None] / dim_t
         pos_y = y_embed[:, :, :, None] / dim_t
@@ -106,8 +107,7 @@ class PositionEmbeddingSine(nn.Module):
             y_embed = y_embed / (y_embed[:, -1:, :] + eps) * self.scale
             x_embed = x_embed / (x_embed[:, :, -1:] + eps) * self.scale
 
-        dim_t = torch.arange(self.num_pos_feats, dtype=torch.float32, device=mask.device)
-        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)
+        dim_t = self.dim_t
 
         pos_x = x_embed[:, :, :, None] / dim_t
         pos_y = y_embed[:, :, :, None] / dim_t

--- a/libreyolo/models/rfdetr/config.py
+++ b/libreyolo/models/rfdetr/config.py
@@ -11,30 +11,37 @@ class RFDETRConfig(TrainConfig):
 
     epochs: int = 100
     batch: int = 4
+    nbs: int | None = 16
     lr0: float = 1e-4
     device: str = "auto"
 
-    workers: int = 2
+    workers: int = 0
     weight_decay: float = 1e-4
     eval_interval: int = 1
     warmup_epochs: int = 0
     warmup_lr_start: float = 1e-6
     no_aug_epochs: int = 0
     min_lr_ratio: float = 0.0
+    lr_drop: int = 100
 
     ema: bool = True
     ema_decay: float = 0.993
+    ema_tau: int = 100
     seed: int | None = None
 
     patience: int = 0
     optimizer: str = "adamw"
-    scheduler: str = "flat_cosine"
+    scheduler: str = "step"
     mosaic_prob: float = 0.0
     mixup_prob: float = 0.0
     hsv_prob: float = 0.0
     degrees: float = 0.0
     translate: float = 0.0
     shear: float = 0.0
+    multi_scale: bool = True
+    expanded_scales: bool = True
+    do_random_resize_via_padding: bool = False
+    crop_resize_prob: float = 0.5
     amp: bool = True
     backbone_lr_mult: float = 0.1
     clip_max_norm: float = 0.1

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -3,18 +3,18 @@
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
+import numpy as np
 import torch
 import torch.nn as nn
-import torchvision.transforms.functional as F
 from PIL import Image
 
 from ..base import BaseModel
 from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.serialization import load_trusted_torch_file
-from .nn import LibreRFDETRModel
+from .nn import LibreRFDETRModel, RFDETR_CONFIGS, RFDETR_SEG_CONFIGS
 from .config import RFDETRConfig
-from .utils import postprocess, IMAGENET_MEAN, IMAGENET_STD
+from .utils import postprocess, preprocess_numpy
 from .trainer import RFDETRTrainer
 from ...validation.preprocessors import RFDETRValPreprocessor
 
@@ -105,6 +105,20 @@ _COCO91_TO_COCO80 = {
 }
 
 
+_RFDETR_UPSTREAM_WEIGHT_URLS = {
+    "rf-detr-nano.pth": "https://storage.googleapis.com/rfdetr/nano_coco/checkpoint_best_regular.pth",
+    "rf-detr-small.pth": "https://storage.googleapis.com/rfdetr/small_coco/checkpoint_best_regular.pth",
+    "rf-detr-medium.pth": "https://storage.googleapis.com/rfdetr/medium_coco/checkpoint_best_regular.pth",
+    "rf-detr-large-2026.pth": "https://storage.googleapis.com/rfdetr/rf-detr-large-2026.pth",
+    "rf-detr-seg-nano.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-n-ft.pth",
+    "rf-detr-seg-small.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-s-ft.pth",
+    "rf-detr-seg-medium.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-m-ft.pth",
+    "rf-detr-seg-large.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-l-ft.pth",
+    "rf-detr-seg-xlarge.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-xl-ft.pth",
+    "rf-detr-seg-xxlarge.pt": "https://storage.googleapis.com/rfdetr/rf-detr-seg-2xl-ft.pth",
+}
+
+
 def _checkpoint_model_state(checkpoint: dict[str, Any]) -> dict[str, torch.Tensor]:
     """Extract a tensor state dict from RF-DETR/LibreYOLO checkpoint variants."""
     if "model" in checkpoint and isinstance(checkpoint["model"], dict):
@@ -146,7 +160,7 @@ class LibreRFDETR(BaseModel):
     FAMILY = "rfdetr"
     FILENAME_PREFIX = "LibreRFDETR"
     INPUT_SIZES = {"n": 384, "s": 512, "m": 576, "l": 704}
-    SEG_INPUT_SIZES = {"n": 312, "s": 384, "m": 432, "l": 504}
+    SEG_INPUT_SIZES = {"n": 312, "s": 384, "m": 432, "l": 504, "x": 624, "xx": 768}
     SUPPORTED_TASKS = ("detect", "segment")
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,
@@ -163,7 +177,6 @@ class LibreRFDETR(BaseModel):
         "mixup",
         "degrees",
         "shear",
-        "scheduler",
         "mosaic_scale",
         "mixup_scale",
         "optimizer",
@@ -200,7 +213,14 @@ class LibreRFDETR(BaseModel):
         is_seg = any(k.startswith("segmentation_head") for k in weights_dict)
 
         RESOLUTION_TO_SIZE = {384: "n", 512: "s", 576: "m", 704: "l"}
-        SEG_RESOLUTION_TO_SIZE = {312: "n", 384: "s", 432: "m", 504: "l"}
+        SEG_RESOLUTION_TO_SIZE = {
+            312: "n",
+            384: "s",
+            432: "m",
+            504: "l",
+            624: "x",
+            768: "xx",
+        }
         res_map = SEG_RESOLUTION_TO_SIZE if is_seg else RESOLUTION_TO_SIZE
 
         args = full_ckpt.get("args")
@@ -219,13 +239,24 @@ class LibreRFDETR(BaseModel):
         pos_key = "backbone.0.encoder.encoder.embeddings.position_embeddings"
         if pos_key in weights_dict:
             pos_tokens = weights_dict[pos_key].shape[1]
-            if pos_tokens == 577:
-                return "n"
-            if pos_tokens == 1025:
-                return "s"
-            if pos_tokens == 1297:
-                return "m"
-            return "l"
+            token_map = (
+                {
+                    26 * 26 + 1: "n",
+                    32 * 32 + 1: "s",
+                    36 * 36 + 1: "m",
+                    42 * 42 + 1: "l",
+                    52 * 52 + 1: "x",
+                    64 * 64 + 1: "xx",
+                }
+                if is_seg
+                else {
+                    24 * 24 + 1: "n",
+                    32 * 32 + 1: "s",
+                    36 * 36 + 1: "m",
+                    44 * 44 + 1: "l",
+                }
+            )
+            return token_map.get(pos_tokens)
 
         return None
 
@@ -235,6 +266,13 @@ class LibreRFDETR(BaseModel):
         if "class_embed.bias" in weights_dict:
             return weights_dict["class_embed.bias"].shape[0] - 1
         return None
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        upstream_url = _RFDETR_UPSTREAM_WEIGHT_URLS.get(Path(filename).name.lower())
+        if upstream_url is not None:
+            return upstream_url
+        return super().get_download_url(filename)
 
     # =========================================================================
     # Initialization
@@ -250,15 +288,6 @@ class LibreRFDETR(BaseModel):
         task: str | None = None,
         **kwargs,
     ):
-        if isinstance(model_path, dict) and not model_path:
-            weight_source = None
-        elif isinstance(model_path, str):
-            weight_source = self._resolve_weights_path(model_path)
-        else:
-            weight_source = model_path
-
-        self._weight_source = weight_source
-
         # Resolve task: explicit `task` > legacy `segmentation` flag > filename / checkpoint inference.
         if task is not None and segmentation and normalize_task(task) != "segment":
             raise ValueError(
@@ -267,6 +296,28 @@ class LibreRFDETR(BaseModel):
         resolved_task = task
         if resolved_task is None and segmentation:
             resolved_task = "segment"
+
+        if isinstance(model_path, dict) and not model_path:
+            weight_source = None
+        elif model_path is None:
+            cfgs = (
+                RFDETR_SEG_CONFIGS
+                if normalize_task(resolved_task) == "segment"
+                else RFDETR_CONFIGS
+            )
+            cfg = cfgs.get(size)
+            default_weights = cfg.pretrain_weights if cfg is not None else None
+            weight_source = (
+                self._resolve_weights_path(default_weights)
+                if default_weights is not None
+                else None
+            )
+        elif isinstance(model_path, str):
+            weight_source = self._resolve_weights_path(model_path)
+        else:
+            weight_source = model_path
+
+        self._weight_source = weight_source
 
         if weight_source is not None:
             filename_task = (
@@ -395,10 +446,8 @@ class LibreRFDETR(BaseModel):
         orig_w, orig_h = img.size
         orig_size = (orig_w, orig_h)
 
-        img_tensor = F.to_tensor(img)
-        img_tensor = F.normalize(img_tensor, IMAGENET_MEAN, IMAGENET_STD)
-        img_tensor = F.resize(img_tensor, (effective_res, effective_res))
-        img_tensor = img_tensor.unsqueeze(0)
+        img_chw, _ = preprocess_numpy(np.array(img), effective_res)
+        img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
 
         return img_tensor, img, orig_size, 1.0
 
@@ -422,7 +471,12 @@ class LibreRFDETR(BaseModel):
             }
 
         logits = output["pred_logits"]
-        num_select = min(kwargs.get("num_select", max_det), logits.shape[-2] * logits.shape[-1])
+        default_num_select = getattr(self.model, "num_select", max_det)
+        requested_num_select = kwargs.get(
+            "num_select",
+            default_num_select if max_det == 300 else max_det,
+        )
+        num_select = min(requested_num_select, logits.shape[-2] * logits.shape[-1])
 
         # original_size is (width, height); rfdetr postprocess expects (height, width)
         orig_w, orig_h = original_size
@@ -497,8 +551,7 @@ class LibreRFDETR(BaseModel):
                     f"but is being loaded into '{self.FAMILY}'."
                 )
 
-            state_dict = _checkpoint_model_state(loaded)
-            missing, unexpected = self.model.load_state_dict(state_dict, strict=False)
+            missing, unexpected = self.model.load_state_dict(loaded, strict=False)
             if unexpected:
                 raise RuntimeError(
                     f"Unexpected RF-DETR checkpoint keys: {sorted(unexpected)[:10]}"
@@ -550,6 +603,10 @@ class LibreRFDETR(BaseModel):
     def export(self, format: str = "onnx", *, opset: int = 17, **kwargs) -> str:
         """Export model. RF-DETR requires opset >= 17 for LayerNormalization."""
         return super().export(format, opset=opset, **kwargs)
+
+    def val(self, *args, workers: int = 0, **kwargs) -> Dict:
+        """Run RF-DETR validation with a Windows-safe worker default."""
+        return super().val(*args, workers=workers, **kwargs)
 
     def train(
         self,

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -109,6 +109,28 @@ RFDETR_SEG_CONFIGS: dict[str, RFDETRSizeConfig] = {
         pretrain_weights="rf-detr-seg-large.pt",
         segmentation_head=True,
     ),
+    "x": RFDETRSizeConfig(
+        patch_size=12,
+        num_windows=2,
+        dec_layers=6,
+        resolution=624,
+        positional_encoding_size=52,
+        num_queries=300,
+        num_select=300,
+        pretrain_weights="rf-detr-seg-xlarge.pt",
+        segmentation_head=True,
+    ),
+    "xx": RFDETRSizeConfig(
+        patch_size=12,
+        num_windows=2,
+        dec_layers=6,
+        resolution=768,
+        positional_encoding_size=64,
+        num_queries=300,
+        num_select=300,
+        pretrain_weights="rf-detr-seg-xxlarge.pt",
+        segmentation_head=True,
+    ),
 }
 
 
@@ -232,6 +254,70 @@ def _resize_query_param(tensor: torch.Tensor, target_rows: int) -> torch.Tensor:
     return tensor.repeat(repeats, *([1] * (tensor.ndim - 1)))[:target_rows]
 
 
+def _get_arg(args: Any, name: str) -> Any:
+    if args is None:
+        return None
+    if isinstance(args, dict):
+        return args.get(name)
+    return getattr(args, name, None)
+
+
+def _slice_query_param_per_group(
+    tensor: torch.Tensor,
+    *,
+    ckpt_num_queries: int,
+    ckpt_group_detr: int,
+    target_num_queries: int,
+    target_group_detr: int,
+) -> torch.Tensor:
+    """Resize packed Group-DETR query rows without mixing group slots."""
+    if ckpt_num_queries <= 0 or ckpt_group_detr <= 0 or target_num_queries <= 0 or target_group_detr <= 0:
+        return tensor[: target_num_queries * target_group_detr]
+
+    expected_rows = ckpt_num_queries * ckpt_group_detr
+    if tensor.shape[0] != expected_rows:
+        return tensor[: target_num_queries * target_group_detr]
+
+    if ckpt_num_queries == target_num_queries and ckpt_group_detr == target_group_detr:
+        return tensor
+
+    keep_groups = min(ckpt_group_detr, target_group_detr)
+    keep_queries = min(ckpt_num_queries, target_num_queries)
+    pieces = [
+        tensor[group_idx * ckpt_num_queries : group_idx * ckpt_num_queries + keep_queries]
+        for group_idx in range(keep_groups)
+    ]
+    return torch.cat(pieces, dim=0)
+
+
+def _resize_query_param_from_checkpoint(
+    tensor: torch.Tensor,
+    *,
+    checkpoint_args: Any,
+    target_num_queries: int,
+    target_group_detr: int,
+) -> torch.Tensor:
+    ckpt_num_queries = _get_arg(checkpoint_args, "num_queries")
+    ckpt_group_detr = _get_arg(checkpoint_args, "group_detr")
+    try:
+        ckpt_num_queries = int(ckpt_num_queries) if ckpt_num_queries is not None else None
+        ckpt_group_detr = int(ckpt_group_detr) if ckpt_group_detr is not None else None
+    except (TypeError, ValueError):
+        ckpt_num_queries = None
+        ckpt_group_detr = None
+
+    if ckpt_num_queries is not None and ckpt_group_detr is not None:
+        return _slice_query_param_per_group(
+            tensor,
+            ckpt_num_queries=ckpt_num_queries,
+            ckpt_group_detr=ckpt_group_detr,
+            target_num_queries=target_num_queries,
+            target_group_detr=target_group_detr,
+        )
+
+    return _resize_query_param(tensor, target_num_queries * target_group_detr)
+
+
 class LibreRFDETRModel(nn.Module):
     """RF-DETR model built from LibreYOLO-local RF-DETR modules."""
 
@@ -276,6 +362,7 @@ class LibreRFDETRModel(nn.Module):
         return build_criterion_and_postprocessors(self.args)
 
     def load_state_dict(self, state_dict: dict[str, Any], strict: bool = True):
+        checkpoint_args = state_dict.get("args") if isinstance(state_dict, dict) else None
         state_dict = _unwrap_state_dict(state_dict)
 
         class_bias = state_dict.get("class_embed.bias")
@@ -284,10 +371,14 @@ class LibreRFDETRModel(nn.Module):
             self.nb_classes = int(class_bias.shape[0]) - 1
             self.args.num_classes = self.nb_classes
 
-        desired_queries = self.args.num_queries * self.args.group_detr
         for key in ("refpoint_embed.weight", "query_feat.weight"):
             if key in state_dict:
-                state_dict[key] = _resize_query_param(state_dict[key], desired_queries)
+                state_dict[key] = _resize_query_param_from_checkpoint(
+                    state_dict[key],
+                    checkpoint_args=checkpoint_args,
+                    target_num_queries=self.args.num_queries,
+                    target_group_detr=self.args.group_detr,
+                )
 
         interpolate_position_embeddings(state_dict, self.args.positional_encoding_size)
         return self.model.load_state_dict(state_dict, strict=strict)
@@ -339,4 +430,5 @@ __all__ = [
     "PostProcess",
     "create_rfdetr_model",
     "interpolate_position_embeddings",
+    "_slice_query_param_per_group",
 ]

--- a/libreyolo/models/rfdetr/seg_transforms.py
+++ b/libreyolo/models/rfdetr/seg_transforms.py
@@ -1,44 +1,107 @@
-"""RF-DETR segmentation transforms: letterbox + flip + ImageNet norm + polygon rasterization.
+"""RF-DETR transforms: resize/crop policy + flip + ImageNet norm + mask rasterization.
 
 Mirrors DFINETrainTransform's output contract for detection (cxcywh pixel coords on the
 resized canvas, ImageNet-normalized CHW float32 RGB) and additionally rasterizes per-instance
-polygon rings to a dense (max_labels, mask_h, mask_w) float32 tensor. The mask resolution is
-input_dim / mask_downsample_ratio (default 4) to match the SegmentationHead's downsample.
+polygon rings to a dense (max_labels, H, W) float32 tensor at the transformed image resolution.
 
-Strong augmentations (mosaic, mixup, photometric distort, IoU crop, zoom out) are intentionally
-omitted: torchvision.v2 supports Mask tv_tensors but the polygon-rings → boxes consistency under
-those ops needs explicit per-instance copies that are out of scope for the initial seg port.
+Mosaic, mixup, photometric distort, IoU crop, and zoom-out are intentionally omitted; RF-DETR
+training uses a direct square canvas with an optional upstream-style random resize/crop branch.
 """
 
 from __future__ import annotations
 
 import random
-from typing import List, Optional, Sequence
 
 import cv2
 import numpy as np
-import torch
 
 
 _IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32).reshape(3, 1, 1)
 _IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32).reshape(3, 1, 1)
 
 
-def _letterbox(img: np.ndarray, input_dim) -> tuple[np.ndarray, float]:
-    """BGR HWC → padded RGB HWC, returning the resize ratio."""
-    padded = np.full((input_dim[0], input_dim[1], 3), 114, dtype=np.uint8)
-    r = min(input_dim[0] / img.shape[0], input_dim[1] / img.shape[1])
-    new_w, new_h = int(round(img.shape[1] * r)), int(round(img.shape[0] * r))
+def compute_multi_scale_scales(
+    resolution: int,
+    expanded_scales: bool = False,
+    patch_size: int = 16,
+    num_windows: int = 4,
+) -> list[int]:
+    divisor = patch_size * num_windows
+    base_num_patches_per_window = resolution // divisor
+    offsets = (
+        [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]
+        if expanded_scales
+        else [-3, -2, -1, 0, 1, 2, 3, 4]
+    )
+    return [
+        (base_num_patches_per_window + offset) * divisor
+        for offset in offsets
+        if (base_num_patches_per_window + offset) * divisor >= divisor * 2
+    ]
+
+
+def _resolve_training_size(
+    imgsz: int,
+    *,
+    multi_scale: bool,
+    expanded_scales: bool,
+    do_random_resize_via_padding: bool,
+    patch_size: int,
+    num_windows: int,
+) -> int:
+    if not multi_scale:
+        return imgsz
+    scales = compute_multi_scale_scales(imgsz, expanded_scales, patch_size, num_windows)
+    if not scales:
+        return imgsz
+    # LibreYOLO stacks per-sample transform outputs directly. Upstream's
+    # default also disables per-step random resize and uses the largest expanded
+    # square scale, so keep one stable canvas per dataloader.
+    if not do_random_resize_via_padding:
+        return scales[-1]
+    return imgsz
+
+
+def _resize_square(img: np.ndarray, input_dim) -> tuple[np.ndarray, float, float]:
+    """BGR HWC -> resized RGB HWC, returning x/y scale factors."""
+    target_h, target_w = input_dim
+    scale_x = target_w / img.shape[1]
+    scale_y = target_h / img.shape[0]
+    resized = cv2.resize(img, (target_w, target_h), interpolation=cv2.INTER_LINEAR)
+    resized = resized[:, :, ::-1]  # BGR -> RGB
+    return resized, scale_x, scale_y
+
+
+def _resize_shortest_side(img: np.ndarray, size: int) -> tuple[np.ndarray, float, float]:
+    h, w = img.shape[:2]
+    scale = size / max(1, min(h, w))
+    new_w = max(1, int(round(w * scale)))
+    new_h = max(1, int(round(h * scale)))
     resized = cv2.resize(img, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
-    padded[:new_h, :new_w] = resized
-    padded = padded[:, :, ::-1]  # BGR → RGB
-    return padded, r
+    return resized, scale, scale
 
 
 def _copy_segments(segments):
     if segments is None:
         return None
     return [[ring.copy() for ring in instance] for instance in segments]
+
+
+def _dense_mask(ring):
+    return getattr(ring, "dense_mask", None)
+
+
+def _set_dense_mask(ring, mask):
+    if hasattr(ring, "dense_mask"):
+        ring.dense_mask = np.ascontiguousarray(mask.astype(np.uint8))
+
+
+def _instance_dense_mask(instance):
+    for ring in instance:
+        mask = _dense_mask(ring)
+        if mask is not None:
+            return mask
+    return None
 
 
 def _flip_segments_lr(segments, width):
@@ -53,12 +116,15 @@ def _flip_segments_lr(segments, width):
                 continue
             r = ring.copy()
             r[:, 0] = width - r[:, 0]
+            mask = _dense_mask(r)
+            if mask is not None:
+                _set_dense_mask(r, mask[:, ::-1])
             flipped.append(r)
         out.append(flipped)
     return out
 
 
-def _scale_segments(segments, scale: float):
+def _scale_segments_xy(segments, scale_x: float, scale_y: float):
     if segments is None:
         return None
     out = []
@@ -68,8 +134,44 @@ def _scale_segments(segments, scale: float):
             if ring is None or len(ring) == 0:
                 scaled.append(ring)
                 continue
-            scaled.append(ring.astype(np.float32, copy=True) * scale)
+            mask = _dense_mask(ring)
+            ring_scaled = ring.astype(np.float32, copy=True)
+            if mask is not None:
+                ring_scaled = ring_scaled.view(type(ring))
+            ring_scaled[:, 0] *= scale_x
+            ring_scaled[:, 1] *= scale_y
+            if mask is not None:
+                new_w = max(1, int(round(mask.shape[1] * scale_x)))
+                new_h = max(1, int(round(mask.shape[0] * scale_y)))
+                scaled_mask = cv2.resize(
+                    mask,
+                    (new_w, new_h),
+                    interpolation=cv2.INTER_NEAREST,
+                )
+                _set_dense_mask(ring_scaled, scaled_mask)
+            scaled.append(ring_scaled)
         out.append(scaled)
+    return out
+
+
+def _crop_segments(segments, left: int, top: int, width: int, height: int):
+    if segments is None:
+        return None
+    out = []
+    for instance in segments:
+        cropped = []
+        for ring in instance:
+            if ring is None or len(ring) == 0:
+                cropped.append(ring)
+                continue
+            mask = _dense_mask(ring)
+            r = ring.copy()
+            r[:, 0] = np.clip(r[:, 0] - left, 0.0, float(width))
+            r[:, 1] = np.clip(r[:, 1] - top, 0.0, float(height))
+            if mask is not None:
+                _set_dense_mask(r, mask[top : top + height, left : left + width])
+            cropped.append(r)
+        out.append(cropped)
     return out
 
 
@@ -97,6 +199,14 @@ def _rasterize_segments(segments, image_shape, mask_shape, max_masks):
     sy = mask_h / max(float(img_h), 1.0)
 
     for idx, instance in enumerate(segments[:max_masks]):
+        dense_mask = _instance_dense_mask(instance)
+        if dense_mask is not None:
+            mask = dense_mask
+            if mask.shape != mask_shape:
+                mask = cv2.resize(mask, (mask_w, mask_h), interpolation=cv2.INTER_NEAREST)
+            masks[idx] = (mask > 0).astype(np.float32)
+            continue
+
         polygons = []
         for ring in instance:
             if ring is None or len(ring) < 3:
@@ -111,7 +221,7 @@ def _rasterize_segments(segments, image_shape, mask_shape, max_masks):
 
 
 class RFDETRSegTransform:
-    """Per-sample seg transform: letterbox + flip + ImageNet norm + polygon rasterization.
+    """Per-sample seg transform: square resize + flip + ImageNet norm + polygon rasterization.
 
     Output: ``(img_chw_float_rgb_imagenet, padded_labels [max_labels, 5] cxcywh-pixel,
     masks [max_labels, mask_h, mask_w] float32)``.
@@ -121,7 +231,7 @@ class RFDETRSegTransform:
     """
 
     # Surfaced so YOLODataset/COCODataset hand us the original image, not the
-    # pre-letterboxed one — we need original pixel coords for polygon scaling.
+    # pre-resized one — we need original pixel coords for polygon scaling.
     wants_unresized_image = True
 
     def __init__(
@@ -130,18 +240,45 @@ class RFDETRSegTransform:
         flip_prob: float = 0.5,
         imgsz: int = 512,
         mask_downsample_ratio: int = 4,
+        multi_scale: bool = False,
+        expanded_scales: bool = False,
+        do_random_resize_via_padding: bool = False,
+        patch_size: int = 16,
+        num_windows: int = 4,
+        crop_resize_prob: float = 0.0,
+        crop_intermediate_sizes: tuple[int, ...] = (400, 500, 600),
+        crop_min_size: int = 384,
+        crop_max_size: int = 600,
     ):
         self.max_labels = max_labels
         self.flip_prob = flip_prob
         self.imgsz = imgsz
         self.mask_downsample_ratio = mask_downsample_ratio
+        self.multi_scale = multi_scale
+        self.expanded_scales = expanded_scales
+        self.do_random_resize_via_padding = do_random_resize_via_padding
+        self.patch_size = patch_size
+        self.num_windows = num_windows
+        self.crop_resize_prob = crop_resize_prob
+        self.crop_intermediate_sizes = crop_intermediate_sizes
+        self.crop_min_size = crop_min_size
+        self.crop_max_size = crop_max_size
+        self.target_size = _resolve_training_size(
+            imgsz,
+            multi_scale=multi_scale,
+            expanded_scales=expanded_scales,
+            do_random_resize_via_padding=do_random_resize_via_padding,
+            patch_size=patch_size,
+            num_windows=num_windows,
+        )
 
     def disable_strong_augs(self):
         # Compatibility shim: no strong augs to disable.
         return
 
     def __call__(self, image: np.ndarray, targets: np.ndarray, input_dim, segments=None):
-        target_h, target_w = input_dim
+        del input_dim
+        target_h = target_w = self.target_size
         boxes = targets[:, :4].astype(np.float32, copy=True) if len(targets) else np.zeros((0, 4), np.float32)
         labels = targets[:, 4].astype(np.float32, copy=True) if len(targets) else np.zeros((0,), np.float32)
         segments_t = _copy_segments(segments)
@@ -154,11 +291,34 @@ class RFDETRSegTransform:
                 boxes[:, [0, 2]] = w_orig - boxes[:, [2, 0]]
             segments_t = _flip_segments_lr(segments_t, w_orig)
 
-        # Letterbox-resize. Same logic as YOLO9's preproc — returns ratio r.
-        img_rgb, r = _letterbox(image, input_dim)
+        if len(boxes) and self.crop_resize_prob > 0 and random.random() < self.crop_resize_prob:
+            image, scale_x, scale_y = _resize_shortest_side(
+                image,
+                random.choice(self.crop_intermediate_sizes),
+            )
+            boxes[:, [0, 2]] *= scale_x
+            boxes[:, [1, 3]] *= scale_y
+            segments_t = _scale_segments_xy(segments_t, scale_x, scale_y)
+
+            h_mid, w_mid = image.shape[:2]
+            max_crop = min(self.crop_max_size, h_mid, w_mid)
+            min_crop = min(self.crop_min_size, max_crop)
+            if max_crop >= 2:
+                crop_size = random.randint(min_crop, max_crop)
+                top = random.randint(0, max(0, h_mid - crop_size))
+                left = random.randint(0, max(0, w_mid - crop_size))
+                image = image[top : top + crop_size, left : left + crop_size]
+                boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]] - left, 0.0, float(crop_size))
+                boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]] - top, 0.0, float(crop_size))
+                segments_t = _crop_segments(segments_t, left, top, crop_size, crop_size)
+
+        # RF-DETR's square training/inference path resizes directly to the model
+        # canvas, so boxes and masks use independent x/y scale factors.
+        img_rgb, scale_x, scale_y = _resize_square(image, (target_h, target_w))
         if len(boxes):
-            boxes *= r
-        segments_t = _scale_segments(segments_t, r)
+            boxes[:, [0, 2]] *= scale_x
+            boxes[:, [1, 3]] *= scale_y
+        segments_t = _scale_segments_xy(segments_t, scale_x, scale_y)
 
         # Drop boxes that collapsed below 1px after resize. Apply the same keep mask
         # to segments so per-instance alignment is preserved.
@@ -191,10 +351,7 @@ class RFDETRSegTransform:
         img_out = (img_out - _IMAGENET_MEAN) / _IMAGENET_STD
         img_out = np.ascontiguousarray(img_out)
 
-        mask_shape = (
-            target_h // self.mask_downsample_ratio,
-            target_w // self.mask_downsample_ratio,
-        )
+        mask_shape = (target_h, target_w)
         masks = _rasterize_segments(
             segments_t,
             image_shape=(target_h, target_w),
@@ -203,6 +360,14 @@ class RFDETRSegTransform:
         )
 
         return img_out, padded, masks
+
+
+class RFDETRDetTransform(RFDETRSegTransform):
+    """RF-DETR detection transform using the same square geometry."""
+
+    def __call__(self, image: np.ndarray, targets: np.ndarray, input_dim):
+        img, labels, _ = super().__call__(image, targets, input_dim, segments=None)
+        return img, labels
 
 
 class RFDETRSegPassThroughDataset:

--- a/libreyolo/models/rfdetr/segmentation.py
+++ b/libreyolo/models/rfdetr/segmentation.py
@@ -151,8 +151,15 @@ class DepthwiseConvBlock(nn.Module):
             if layer_scale_init_value > 0
             else None
         )
+        self._export = False
+
+    def export(self):
+        self._export = True
 
     def _depthwise_conv(self, x: torch.Tensor) -> torch.Tensor:
+        if self._export:
+            return self.dwconv(x)
+
         # Custom autograd Function so cuDNN is disabled in both forward AND
         # backward.  A plain context-manager only covers forward; the backward
         # for nn.Conv2d runs outside that scope and re-enables cuDNN,

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -2,18 +2,49 @@
 
 from __future__ import annotations
 
+import random
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Dict, List, Optional, Type
 
 import torch
+import torch.nn.functional as F
 
 from ...data import load_data_config
 from ...training.config import TrainConfig
-from ...training.scheduler import FlatCosineScheduler
+from ...training.scheduler import BaseScheduler, CosineAnnealingScheduler, FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import RFDETRConfig
-from ..dfine.transforms import DFINEPassThroughDataset, DFINETrainTransform
-from .seg_transforms import RFDETRSegPassThroughDataset, RFDETRSegTransform
+from ..dfine.transforms import DFINEPassThroughDataset
+from .seg_transforms import (
+    RFDETRDetTransform,
+    RFDETRSegPassThroughDataset,
+    RFDETRSegTransform,
+    compute_multi_scale_scales,
+)
+
+
+class RFDETRStepScheduler(BaseScheduler):
+    """RF-DETR upstream-style warmup plus step decay schedule."""
+
+    def __init__(
+        self,
+        lr: float,
+        iters_per_epoch: int,
+        total_epochs: int,
+        warmup_epochs: float = 0.0,
+        lr_drop: int = 100,
+    ):
+        super().__init__(lr, iters_per_epoch, total_epochs)
+        self.warmup_iters = int(iters_per_epoch * warmup_epochs)
+        self.drop_iter = int(iters_per_epoch * lr_drop)
+
+    def update_lr(self, iters: int) -> float:
+        if self.warmup_iters > 0 and iters < self.warmup_iters:
+            return self.lr * float(iters) / float(max(1, self.warmup_iters))
+        if iters < self.drop_iter:
+            return self.lr
+        return self.lr * 0.1
 
 
 class RFDETRTrainer(BaseTrainer):
@@ -38,7 +69,7 @@ class RFDETRTrainer(BaseTrainer):
 
     @property
     def effective_lr(self) -> float:
-        return self.config.lr0 * self.config.batch / 16
+        return self.config.lr0
 
     def get_model_family(self) -> str:
         return "rfdetr"
@@ -47,24 +78,54 @@ class RFDETRTrainer(BaseTrainer):
         return f"LibreRFDETR-{self.config.size}"
 
     def create_transforms(self):
+        patch_size = int(getattr(self.model, "patch_size", 16))
+        num_windows = int(getattr(self.model, "num_windows", 4))
         if getattr(self.wrapper_model, "task", "detect") == "segment":
             preproc = RFDETRSegTransform(
                 max_labels=300,
                 flip_prob=self.config.flip_prob,
                 imgsz=self.config.imgsz,
                 mask_downsample_ratio=4,
+                multi_scale=self.config.multi_scale,
+                expanded_scales=self.config.expanded_scales,
+                do_random_resize_via_padding=self.config.do_random_resize_via_padding,
+                patch_size=patch_size,
+                num_windows=num_windows,
+                crop_resize_prob=self.config.crop_resize_prob,
             )
             return preproc, RFDETRSegPassThroughDataset
-        preproc = DFINETrainTransform(
+        preproc = RFDETRDetTransform(
             max_labels=300,
             flip_prob=self.config.flip_prob,
             imgsz=self.config.imgsz,
-            imagenet_norm=True,
-            strong_augs=False,
+            multi_scale=self.config.multi_scale,
+            expanded_scales=self.config.expanded_scales,
+            do_random_resize_via_padding=self.config.do_random_resize_via_padding,
+            patch_size=patch_size,
+            num_windows=num_windows,
+            crop_resize_prob=self.config.crop_resize_prob,
         )
         return preproc, DFINEPassThroughDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        scheduler = str(getattr(self.config, "scheduler", "step")).lower()
+        if scheduler == "step":
+            return RFDETRStepScheduler(
+                lr=self.effective_lr,
+                iters_per_epoch=iters_per_epoch,
+                total_epochs=self.config.epochs,
+                warmup_epochs=self.config.warmup_epochs,
+                lr_drop=getattr(self.config, "lr_drop", self.config.epochs),
+            )
+        if scheduler == "cosine":
+            return CosineAnnealingScheduler(
+                lr=self.effective_lr,
+                iters_per_epoch=iters_per_epoch,
+                total_epochs=self.config.epochs,
+                warmup_epochs=self.config.warmup_epochs,
+                warmup_lr_start=0.0,
+                min_lr_ratio=self.config.min_lr_ratio,
+            )
         return FlatCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
@@ -74,6 +135,60 @@ class RFDETRTrainer(BaseTrainer):
             no_aug_epochs=self.config.no_aug_epochs,
             min_lr_ratio=self.config.min_lr_ratio,
         )
+
+    def _multi_scale_scales(self) -> list[int]:
+        if not self.config.multi_scale or self.config.do_random_resize_via_padding:
+            return []
+        patch_size = int(getattr(self.model, "patch_size", 16))
+        num_windows = int(getattr(self.model, "num_windows", 4))
+        return compute_multi_scale_scales(
+            self.config.imgsz,
+            self.config.expanded_scales,
+            patch_size,
+            num_windows,
+        )
+
+    def _apply_multi_scale_batch(
+        self,
+        imgs: torch.Tensor,
+        targets: torch.Tensor,
+        polygons,
+        *,
+        step: int,
+    ):
+        scales = self._multi_scale_scales()
+        if not scales:
+            return imgs, targets, polygons
+
+        rng = random.Random(step)
+        scale = rng.choice(scales)
+        current_h, current_w = imgs.shape[-2:]
+        if current_h == scale and current_w == scale:
+            return imgs, targets, polygons
+
+        scale_x = scale / float(current_w)
+        scale_y = scale / float(current_h)
+        imgs = F.interpolate(
+            imgs,
+            size=(scale, scale),
+            mode="bilinear",
+            align_corners=False,
+        )
+
+        targets = targets.clone()
+        targets[..., 1] *= scale_x
+        targets[..., 2] *= scale_y
+        targets[..., 3] *= scale_x
+        targets[..., 4] *= scale_y
+
+        if isinstance(polygons, torch.Tensor):
+            polygons = F.interpolate(
+                polygons.float(),
+                size=(scale, scale),
+                mode="nearest",
+            )
+
+        return imgs, targets, polygons
 
     def on_setup(self):
         if self.model.nb_classes != self.config.num_classes:
@@ -97,6 +212,15 @@ class RFDETRTrainer(BaseTrainer):
                 }
 
     def _setup_optimizer(self) -> torch.optim.Optimizer:
+        upstream_groups = self._setup_upstream_optimizer_groups()
+        if upstream_groups:
+            return torch.optim.AdamW(
+                upstream_groups,
+                lr=self.effective_lr,
+                weight_decay=self.config.weight_decay,
+                betas=(0.9, 0.999),
+            )
+
         backbone_wd, backbone_no_wd, head_wd, head_no_wd = [], [], [], []
         for name, param in self.model.named_parameters():
             if not param.requires_grad:
@@ -126,6 +250,62 @@ class RFDETRTrainer(BaseTrainer):
             groups.append({"params": backbone_no_wd, "lr": lr * bb_mult, "weight_decay": 0.0, "lr_mult": bb_mult})
         return torch.optim.AdamW(groups, betas=(0.9, 0.999))
 
+    def _setup_upstream_optimizer_groups(self) -> list[dict]:
+        core_model = getattr(self.model, "model", self.model)
+        backbone = getattr(core_model, "backbone", None)
+        if backbone is None:
+            return []
+        try:
+            backbone_encoder = backbone[0]
+        except (TypeError, IndexError):
+            return []
+        if not hasattr(backbone_encoder, "get_named_param_lr_pairs"):
+            return []
+
+        model_args = getattr(self.model, "args", getattr(core_model, "args", None))
+        if model_args is None:
+            return []
+        args = SimpleNamespace(**vars(model_args))
+        args.lr = self.effective_lr
+        args.weight_decay = self.config.weight_decay
+
+        backbone_param_by_name = backbone_encoder.get_named_param_lr_pairs(
+            args,
+            prefix="backbone.0",
+        )
+        if not backbone_param_by_name:
+            return []
+
+        base_lr = max(float(self.effective_lr), 1e-12)
+        decoder_key = "transformer.decoder"
+        groups = []
+        decoder_params = []
+        other_params = []
+        for name, param in core_model.named_parameters():
+            if not param.requires_grad:
+                continue
+            if name in backbone_param_by_name:
+                continue
+            if decoder_key in name:
+                decoder_params.append(param)
+            else:
+                other_params.append(param)
+
+        for param in other_params:
+            groups.append({"params": param, "lr": self.effective_lr, "lr_mult": 1.0})
+
+        for param_group in backbone_param_by_name.values():
+            group = dict(param_group)
+            group["lr_mult"] = float(group["lr"]) / base_lr
+            groups.append(group)
+
+        decoder_lr = self.effective_lr * float(getattr(args, "lr_component_decay", 1.0))
+        decoder_lr_mult = decoder_lr / base_lr
+        for param in decoder_params:
+            groups.append({"params": param, "lr": decoder_lr, "lr_mult": decoder_lr_mult})
+
+        return groups
+
     def _scale_lr(self, base_lr: float, param_group: dict) -> float:
         return base_lr * float(param_group.get("lr_mult", 1.0))
 
@@ -143,7 +323,11 @@ class RFDETRTrainer(BaseTrainer):
         # a [B, max_labels, mask_h, mask_w] float32 tensor whose slot i aligns
         # with target slot i. Slice by the same ``valid`` box mask to hand the
         # criterion per-image ``[N_valid, mask_h, mask_w]`` tensors.
-        masks_batch = polygons if is_seg and isinstance(polygons, torch.Tensor) else None
+        masks_batch = (
+            polygons.to(self.device, non_blocking=True)
+            if is_seg and isinstance(polygons, torch.Tensor)
+            else None
+        )
 
         target_list = []
         for batch_idx in range(batch_size):

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -44,8 +44,9 @@ def gen_sineembed_for_position(pos_tensor, dim=128):
     # n_query, bs, _ = pos_tensor.size()
     # sineembed_tensor = torch.zeros(n_query, bs, 256)
     scale = 2 * math.pi
-    dim_t = torch.arange(dim, dtype=pos_tensor.dtype, device=pos_tensor.device)
-    dim_t = 10000 ** (2 * (dim_t // 2) / dim)
+    dim = int(dim)
+    dim_t = pos_tensor.new_ones((dim,), dtype=pos_tensor.dtype).cumsum(0) - 1
+    dim_t = 10000 ** (2 * torch.div(dim_t, 2, rounding_mode="floor") / dim)
     x_embed = pos_tensor[:, :, 0] * scale
     y_embed = pos_tensor[:, :, 1] * scale
     pos_x = x_embed[:, :, None] / dim_t
@@ -94,11 +95,8 @@ def gen_encoder_output_proposals(memory, memory_padding_mask=None, spatial_shape
             valid_height = torch.zeros_like(memory[:, 0, 0]).long() + height
             valid_width = torch.zeros_like(memory[:, 0, 0]).long() + width
 
-        grid_y, grid_x = torch.meshgrid(
-            torch.linspace(0, height - 1, height, dtype=torch.float32, device=memory.device),
-            torch.linspace(0, width - 1, width, dtype=torch.float32, device=memory.device),
-            indexing="ij",
-        )
+        grid_y = memory.new_ones((height, width), dtype=torch.float32).cumsum(0) - 1
+        grid_x = memory.new_ones((height, width), dtype=torch.float32).cumsum(1) - 1
         grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)  # height, width, 2
 
         # reshape(-1, ...) and unsqueeze(0) broadcasting avoid hardcoding N_ in ONNX

--- a/libreyolo/training/ema.py
+++ b/libreyolo/training/ema.py
@@ -24,12 +24,14 @@ class ModelEMA:
     From https://github.com/rwightman/pytorch-image-models
     """
 
-    def __init__(self, model, decay=0.9999, updates=0):
+    def __init__(self, model, decay=0.9999, updates=0, tau=2000):
         self.ema = deepcopy(model.module if is_parallel(model) else model).eval()
         self.updates = updates
-        self.decay = lambda x: decay * (
-            1 - math.exp(-x / 2000)
-        )  # ramp-up during early epochs
+        self.tau = tau
+        if tau <= 0:
+            self.decay = lambda x: decay
+        else:
+            self.decay = lambda x: decay * (1 - math.exp(-x / tau))
         for p in self.ema.parameters():
             p.requires_grad_(False)
 
@@ -53,7 +55,7 @@ class ModelEMA:
         sets a constant decay — the right choice when ``set_decay`` is called
         mid-training and the model is already past its noisy initial phase.
         """
-        if ramp:
-            self.decay = lambda x: decay * (1 - math.exp(-x / 2000))
+        if ramp and self.tau > 0:
+            self.decay = lambda x: decay * (1 - math.exp(-x / self.tau))
         else:
             self.decay = lambda x: decay

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -397,6 +397,7 @@ class BaseTrainer(ABC):
         self._setup_data()
         self.optimizer = self._setup_optimizer()
         self.lr_scheduler = self.create_scheduler(self._scheduler_steps_per_epoch())
+        self._initialize_scheduler_lr()
 
         if self.config.amp and self.device.type == "cuda":
             self.scaler = GradScaler("cuda")
@@ -405,8 +406,13 @@ class BaseTrainer(ABC):
             self.scaler = None
 
         if self.config.ema:
-            self.ema_model = ModelEMA(self.model, decay=self.config.ema_decay)
-            logger.info(f"Using EMA with decay={self.config.ema_decay}")
+            ema_tau = getattr(self.config, "ema_tau", 2000)
+            self.ema_model = ModelEMA(
+                self.model, decay=self.config.ema_decay, tau=ema_tau
+            )
+            logger.info(
+                "Using EMA with decay=%s, tau=%s", self.config.ema_decay, ema_tau
+            )
 
         self.save_dir = self._get_save_dir()
 
@@ -479,7 +485,10 @@ class BaseTrainer(ABC):
                 self._dispatch_artifact_callbacks("on_train_epoch_end", event)
                 self.callbacks.on_train_epoch_end(event)
 
-                if self.patience_counter >= self.config.patience:
+                if (
+                    self.config.patience > 0
+                    and self.patience_counter >= self.config.patience
+                ):
                     logger.info(
                         f"Early stopping triggered after {epoch + 1} epochs "
                         f"(patience={self.config.patience}, no improvement for {self.patience_counter} epochs)"
@@ -757,6 +766,18 @@ class BaseTrainer(ABC):
     def _should_clip_gradients(self) -> bool:
         return self._get_clip_max_norm() > 0.0
 
+    def _set_optimizer_lr(self, base_lr: float) -> None:
+        for param_group in self.optimizer.param_groups:
+            param_group["lr"] = self._scale_lr(base_lr, param_group)
+
+    def _initialize_scheduler_lr(self) -> None:
+        if self.optimizer is None or self.lr_scheduler is None:
+            return
+        warmup_iters = getattr(self.lr_scheduler, "warmup_iters", 0)
+        if warmup_iters is None or warmup_iters <= 0:
+            return
+        self._set_optimizer_lr(self.lr_scheduler.update_lr(0))
+
     def _gradient_clip_parameters(self) -> List[torch.nn.Parameter]:
         if self.optimizer is None:
             return []
@@ -815,6 +836,13 @@ class BaseTrainer(ABC):
 
             imgs = imgs.to(self.device, non_blocking=True)
             targets = targets.to(self.device, non_blocking=True)
+            if hasattr(self, "_apply_multi_scale_batch"):
+                imgs, targets, polygons = self._apply_multi_scale_batch(
+                    imgs,
+                    targets,
+                    polygons,
+                    step=self.current_iter,
+                )
 
             # Forward + backward
             if self.scaler is not None:
@@ -850,8 +878,7 @@ class BaseTrainer(ABC):
 
             # LR update
             lr = self.lr_scheduler.update_lr(self.current_iter + 1)
-            for param_group in self.optimizer.param_groups:
-                param_group["lr"] = self._scale_lr(lr, param_group)
+            self._set_optimizer_lr(lr)
             num_batches += 1
 
             # Progress bar
@@ -918,6 +945,13 @@ class BaseTrainer(ABC):
 
             imgs = imgs.to(self.device, non_blocking=True)
             targets = targets.to(self.device, non_blocking=True)
+            if hasattr(self, "_apply_multi_scale_batch"):
+                imgs, targets, polygons = self._apply_multi_scale_batch(
+                    imgs,
+                    targets,
+                    polygons,
+                    step=opt_step,
+                )
 
             if batch_idx % accum == 0:
                 self.optimizer.zero_grad(set_to_none=True)
@@ -951,8 +985,7 @@ class BaseTrainer(ABC):
                     self.ema_model.update(self.model)
                 # LR update
                 lr = self.lr_scheduler.update_lr(opt_step + 1)
-                for param_group in self.optimizer.param_groups:
-                    param_group["lr"] = self._scale_lr(lr, param_group)
+                self._set_optimizer_lr(lr)
 
             loss_val = loss.item() * actual_window
             loss_components = self._scalar_mapping(self.get_loss_components(outputs))

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -449,6 +449,12 @@ class DetectionValidator(BaseValidator):
             return str(img_dir / coco_img["file_name"])
         return None
 
+    def _uses_topk_coco_scoring(self) -> bool:
+        family = getattr(self.model, "FAMILY", None) or getattr(
+            self.model, "model_family", None
+        )
+        return family in COCO_TOPK_FAMILIES
+
     def _run_validation_augmented(self) -> None:
         """Per-image TTA validation using model._predict_augment (PIL-level flip+scale)."""
         import sys
@@ -477,7 +483,7 @@ class DetectionValidator(BaseValidator):
         )
 
         conf_thres = self.config.conf_thres
-        if self._coco_annotation_file is not None and self.model.FAMILY in COCO_TOPK_FAMILIES:
+        if self._uses_topk_coco_scoring():
             conf_thres = 0.0
 
         total_start = time.time()
@@ -541,10 +547,7 @@ class DetectionValidator(BaseValidator):
         uses_letterbox = self.val_preproc is not None and self.val_preproc.uses_letterbox
 
         conf_thres = self.config.conf_thres
-        if (
-            self._coco_annotation_file is not None
-            and self.model.FAMILY in COCO_TOPK_FAMILIES
-        ):
+        if self._uses_topk_coco_scoring():
             conf_thres = 0.0
 
         detections = []

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -164,21 +164,30 @@ class RFDETRValPreprocessor(BaseValPreprocessor):
     def custom_normalization(self) -> bool:
         return True  # ImageNet mean/std applied here; validator must not rescale
 
+    @property
+    def wants_unresized_image(self) -> bool:
+        # RF-DETR's validation/inference pipeline is a single direct resize from
+        # the source image to the square model canvas.
+        return True
+
     def __call__(
         self, img: np.ndarray, targets: np.ndarray, input_size: Tuple[int, int]
     ) -> Tuple[np.ndarray, np.ndarray]:
         orig_h, orig_w = img.shape[:2]
         target_h, target_w = input_size
 
-        resized_img = cv2.resize(
-            img, (target_w, target_h), interpolation=cv2.INTER_LINEAR
-        )
+        rgb_img = img[:, :, ::-1]  # BGR -> RGB
+        if target_h == target_w:
+            from ..models.rfdetr.utils import preprocess_numpy
 
-        resized_img = resized_img[:, :, ::-1]  # BGR → RGB
-        resized_img = resized_img.astype(np.float32) / 255.0
-        resized_img = (resized_img - self.MEAN) / self.STD  # ImageNet normalization
-
-        resized_img = resized_img.transpose(2, 0, 1)  # HWC → CHW
+            resized_img, _ = preprocess_numpy(rgb_img, target_h)
+        else:
+            pil_img = Image.fromarray(rgb_img).resize(
+                (target_w, target_h), Image.Resampling.BILINEAR
+            )
+            resized_img = np.array(pil_img, dtype=np.float32) / 255.0
+            resized_img = (resized_img - self.MEAN) / self.STD
+            resized_img = resized_img.transpose(2, 0, 1)
         resized_img = np.ascontiguousarray(resized_img, dtype=np.float32)
 
         padded_targets = np.zeros((self.max_labels, 5), dtype=np.float32)

--- a/tests/e2e/test_onnx.py
+++ b/tests/e2e/test_onnx.py
@@ -447,12 +447,13 @@ class TestONNXSegmentation:
         exported = pt_model.export(format="onnx", output_path=onnx_path, simplify=False)
         assert Path(exported).exists()
 
-        # Verify ONNX has 3 outputs (boxes, logits, masks).
-        # RF-DETR uses the pred_* naming convention (matches the PyTorch dict output).
+        # Verify ONNX has upstream RF-DETR output names (boxes, logits, masks).
         onnx_model = onnx.load(exported)
+        input_names = [i.name for i in onnx_model.graph.input]
         output_names = [o.name for o in onnx_model.graph.output]
+        assert input_names == ["input"]
         assert len(output_names) == 3, f"Expected 3 outputs, got {output_names}"
-        assert "pred_masks" in output_names
+        assert output_names == ["dets", "labels", "masks"]
 
         # Verify segmentation metadata
         meta = {p.key: p.value for p in onnx_model.metadata_props}
@@ -492,3 +493,32 @@ class TestONNXSegmentation:
         assert abs(pt_count - onnx_count) <= max(3, pt_count * 0.3), (
             f"Detection count mismatch: PT={pt_count}, ONNX={onnx_count}"
         )
+
+    def test_dynamic_onnx_seg_export_produces_masks(self, sample_image, tmp_path):
+        """Dynamic ONNX RF-DETR-seg export should load back and return masks."""
+        from libreyolo import LibreYOLO
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        pt_model = LibreYOLO("LibreRFDETRn-seg.pt", device=device)
+        onnx_path = str(tmp_path / "rfdetr_n_seg_dynamic.onnx")
+        exported = pt_model.export(
+            format="onnx", output_path=onnx_path, simplify=False, dynamic=True
+        )
+
+        onnx_model = onnx.load(exported)
+        output_names = [o.name for o in onnx_model.graph.output]
+        assert output_names == ["dets", "labels", "masks"]
+        input_dims = [
+            d.dim_param or d.dim_value
+            for d in onnx_model.graph.input[0].type.tensor_type.shape.dim
+        ]
+        assert input_dims[0] == "batch"
+
+        onnx_model_loaded = LibreYOLO(exported, device=device)
+        result = onnx_model_loaded(sample_image, conf=0.25)
+
+        if len(result) > 0:
+            assert result.masks is not None, "Dynamic ONNX seg model should return masks"
+            assert len(result.masks) == len(result), "One mask per detection"
+            assert result.masks.data.shape[1:] == result.orig_shape

--- a/tests/e2e/test_openvino.py
+++ b/tests/e2e/test_openvino.py
@@ -114,6 +114,33 @@ class TestOpenVINOExportFP32:
         assert Path(exported_path).is_dir(), "OpenVINO output directory not created"
 
 
+@requires_openvino
+@requires_rfdetr
+@pytest.mark.rfdetr
+class TestOpenVINORFDETRSegmentation:
+    """Test OpenVINO export and inference for RF-DETR segmentation."""
+
+    def test_openvino_seg_export_produces_masks(self, sample_image, tmp_path):
+        from libreyolo import LibreYOLO
+
+        pt_model = LibreYOLO("LibreRFDETRn-seg.pt", device="cpu")
+        ov_path = str(tmp_path / "rfdetr_n_seg_openvino")
+        exported_path = pt_model.export(
+            format="openvino", output_path=ov_path, half=True
+        )
+
+        exported_dir = Path(exported_path)
+        assert (exported_dir / "model.xml").exists(), "model.xml not found"
+        assert (exported_dir / "model.bin").exists(), "model.bin not found"
+
+        ov_model = LibreYOLO(exported_path, device="cpu")
+        result = ov_model(sample_image, conf=0.25)
+        if len(result) > 0:
+            assert result.masks is not None, "OpenVINO seg model should return masks"
+            assert len(result.masks) == len(result), "One mask per detection"
+            assert result.masks.data.shape[1:] == result.orig_shape
+
+
 class TestOpenVINOMetadata:
     """Test OpenVINO metadata export."""
 

--- a/tests/e2e/test_rf1_training.py
+++ b/tests/e2e/test_rf1_training.py
@@ -199,6 +199,8 @@ def test_rf1_training(family, size, weights, dataset_data_yaml, tmp_path):
     # that causes SIGSEGV when export tests have run beforehand in the same process.
     if family == "rfdetr":
         output_dir = str(tmp_path / f"rfdetr_{size}")
+        data_yaml_py = repr(str(dataset_data_yaml))
+        output_dir_py = repr(output_dir)
         run_in_subprocess(
             f"""
             from libreyolo import LibreYOLO
@@ -206,19 +208,19 @@ def test_rf1_training(family, size, weights, dataset_data_yaml, tmp_path):
             model = LibreYOLO("{weights}", size="{size}")
 
             pre = model.val(
-                data="{dataset_data_yaml}", split="test", batch=8, conf=0.001, iou=0.6
+                data={data_yaml_py}, split="test", batch=8, conf=0.001, iou=0.6
             )
             pre_map = pre["metrics/mAP50-95"]
 
             model.train(
-                data="{dataset_data_yaml}",
+                data={data_yaml_py},
                 epochs=10,
                 batch_size=2,
-                output_dir="{output_dir}",
+                output_dir={output_dir_py},
             )
 
             post = model.val(
-                data="{dataset_data_yaml}", split="test", batch=8, conf=0.001, iou=0.6
+                data={data_yaml_py}, split="test", batch=8, conf=0.001, iou=0.6
             )
             post_map = post["metrics/mAP50-95"]
 

--- a/tests/e2e/test_rfdetr_seg_training.py
+++ b/tests/e2e/test_rfdetr_seg_training.py
@@ -114,8 +114,9 @@ def dataset():
 def test_rfdetr_seg_training(dataset, tmp_path):
     """Train RF-DETR-Seg-Nano on fire-smoke-seg, verify training produces a seg checkpoint."""
     output_dir = str(tmp_path / "rfdetr_seg_n")
-    dataset_dir = str(dataset)
     data_yaml = str(dataset / "data.yaml")
+    output_dir_py = repr(output_dir)
+    data_yaml_py = repr(data_yaml)
 
     run_in_subprocess(
         f"""
@@ -135,10 +136,10 @@ def test_rfdetr_seg_training(dataset, tmp_path):
         # 2. Train on fire-smoke-seg dataset (short run — smoke that the
         # train loop runs end-to-end and writes a LibreYOLO-style checkpoint).
         result = model.train(
-            data="{data_yaml}",
+            data={data_yaml_py},
             epochs=2,
             batch_size=2,
-            output_dir="{output_dir}",
+            output_dir={output_dir_py},
         )
 
         # 3. Verify checkpoint was produced under LibreYOLO conventions:
@@ -168,7 +169,7 @@ def test_rfdetr_seg_training(dataset, tmp_path):
         # 6. Post-training mask mAP — only a sanity floor, not an improvement check
         # (2-epoch run on 141 train images is too short to guarantee improvement).
         post = model.val(
-            data="{data_yaml}", split="test", batch=4, conf=0.001, iou=0.6
+            data={data_yaml_py}, split="test", batch=4, conf=0.001, iou=0.6
         )
         assert "metrics/mAP50-95(M)" in post, "Validation did not return mask mAP"
         post_map = post["metrics/mAP50-95(M)"]
@@ -183,6 +184,7 @@ def test_rfdetr_seg_training(dataset, tmp_path):
 
 def test_rfdetr_seg_inference_only(dataset):
     """Verify seg model inference produces valid masks on dataset images."""
+    dataset_py = repr(str(dataset))
     run_in_subprocess(
         f"""
         from pathlib import Path
@@ -195,7 +197,7 @@ def test_rfdetr_seg_inference_only(dataset):
         )
 
         # Run inference on a few test images
-        test_dir = Path("{dataset}") / "test" / "images"
+        test_dir = Path({dataset_py}) / "test" / "images"
         test_images = sorted(test_dir.glob("*.jpg"))[:5]
         assert len(test_images) > 0, "No test images found"
 
@@ -229,6 +231,8 @@ def test_rfdetr_seg_resume_training(dataset, tmp_path):
     """Train 1 epoch, resume from best.pt, train 1 more epoch — verify seg keys survive."""
     output_dir = str(tmp_path / "rfdetr_seg_resume")
     data_yaml = str(dataset / "data.yaml")
+    output_dir_py = repr(output_dir)
+    data_yaml_py = repr(data_yaml)
 
     run_in_subprocess(
         f"""
@@ -237,7 +241,7 @@ def test_rfdetr_seg_resume_training(dataset, tmp_path):
         from pathlib import Path
         from libreyolo.models.rfdetr.model import LibreRFDETR
 
-        output_dir = "{output_dir}"
+        output_dir = {output_dir_py}
 
         # Phase 1: Train 1 epoch
         print("Phase 1: Training 1 epoch...")
@@ -247,7 +251,7 @@ def test_rfdetr_seg_resume_training(dataset, tmp_path):
             segmentation=True,
         )
         result = model.train(
-            data="{data_yaml}",
+            data={data_yaml_py},
             epochs=1,
             batch_size=2,
             output_dir=output_dir,
@@ -273,8 +277,8 @@ def test_rfdetr_seg_resume_training(dataset, tmp_path):
             segmentation=True,
         )
         result2 = model2.train(
-            data="{data_yaml}",
-            epochs=1,
+            data={data_yaml_py},
+            epochs=2,
             batch_size=2,
             output_dir=output_dir,
             resume=best_ckpt,
@@ -282,6 +286,7 @@ def test_rfdetr_seg_resume_training(dataset, tmp_path):
         best2 = result2.get("best_checkpoint")
         assert best2 and Path(best2).exists(), "Phase 2 best.pt missing"
         ckpt2 = torch.load(best2, map_location="cpu", weights_only=False)
+        assert ckpt2.get("epoch", -1) >= 1, "Resume did not run an additional epoch"
         state2 = ckpt2.get("model", ckpt2)
         seg_keys2 = [k for k in state2 if "segmentation_head" in k]
         assert len(seg_keys2) > 0, "Resumed checkpoint missing segmentation_head keys"

--- a/tests/e2e/test_tensorrt.py
+++ b/tests/e2e/test_tensorrt.py
@@ -97,6 +97,41 @@ class TestTensorRTExportFP16:
         torch.cuda.empty_cache()
 
 
+@requires_tensorrt
+@requires_rfdetr
+@pytest.mark.rfdetr
+class TestTensorRTRFDETRSegmentation:
+    """Test TensorRT export and inference for RF-DETR segmentation."""
+
+    def test_tensorrt_seg_export_produces_masks(self, sample_image, tmp_path):
+        import json
+
+        from libreyolo import LibreYOLO
+
+        pt_model = LibreYOLO("LibreRFDETRn-seg.pt", device="cuda")
+        engine_path = str(tmp_path / "rfdetr_n_seg.engine")
+        exported_path = pt_model.export(
+            format="tensorrt",
+            output_path=engine_path,
+            half=True,
+        )
+
+        engine = Path(exported_path)
+        assert engine.exists(), "TensorRT engine not created"
+        metadata_path = Path(str(engine) + ".json")
+        assert metadata_path.exists(), "TensorRT metadata sidecar not created"
+        metadata = json.loads(metadata_path.read_text())
+        assert metadata["model_family"] == "rfdetr"
+        assert metadata["task"] == "segment"
+
+        trt_model = LibreYOLO(exported_path, device="cuda")
+        result = trt_model(sample_image, conf=0.25)
+        if len(result) > 0:
+            assert result.masks is not None, "TensorRT seg model should return masks"
+            assert len(result.masks) == len(result), "One mask per detection"
+            assert result.masks.data.shape[1:] == result.orig_shape
+
+
 class TestTensorRTExportFP32:
     """Test TensorRT FP32 export for all models."""
 

--- a/tests/e2e/test_torchscript.py
+++ b/tests/e2e/test_torchscript.py
@@ -63,6 +63,32 @@ class TestTorchScriptExport:
         """Test RF-DETR models (requires extra dependencies)."""
         self._run_export_test(model_type, size, tmp_path)
 
+    @requires_rfdetr
+    @pytest.mark.slow
+    def test_torchscript_export_rfdetr_seg(self, tmp_path):
+        """Test RF-DETR segmentation export returns mask logits."""
+        from libreyolo import LibreYOLO
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        pt_model = LibreYOLO("LibreRFDETRn-seg.pt", device=device)
+
+        ts_path = str(tmp_path / "rfdetr_n_seg.torchscript")
+        exported_path = pt_model.export(format="torchscript", output_path=ts_path)
+        assert Path(exported_path).exists(), "TorchScript file not created"
+        assert Path(exported_path).stat().st_size > 0, "TorchScript file is empty"
+
+        loaded = torch.jit.load(exported_path, map_location=device)
+        loaded.eval()
+
+        input_size = pt_model._get_input_size()
+        dummy_input = torch.randn(1, 3, input_size, input_size, device=device)
+        with torch.no_grad():
+            output = loaded(dummy_input)
+
+        assert isinstance(output, tuple)
+        assert len(output) == 3
+        assert output[2].ndim == 4
+
     def _run_export_test(self, model_type, size, tmp_path):
         """Common TorchScript export test implementation."""
         device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -90,11 +90,15 @@ def test_train_dry_run_uses_rfdetr_defaults():
     assert cfg["epochs"] == 100
     assert cfg["batch"] == 4
     assert cfg["lr0"] == 0.0001
-    assert cfg["workers"] == 2
+    assert cfg["workers"] == 0
     assert cfg["weight_decay"] == 0.0001
     assert cfg["eval_interval"] == 1
     assert cfg["warmup_epochs"] == 0
+    assert cfg["lr_drop"] == 100
     assert cfg["ema_decay"] == 0.993
+    from libreyolo.models.rfdetr.config import RFDETRConfig
+
+    assert RFDETRConfig().ema_tau == 100
     assert "optimizer" not in cfg
     assert "scheduler" not in cfg
 
@@ -109,6 +113,7 @@ def test_train_dry_run_rfdetr_user_override_wins():
             "epochs=3",
             "batch=2",
             "lr0=0.001",
+            "lr_drop=7",
             "--dry-run",
             "--json",
         ],
@@ -120,6 +125,7 @@ def test_train_dry_run_rfdetr_user_override_wins():
     assert cfg["epochs"] == 3
     assert cfg["batch"] == 2
     assert cfg["lr0"] == 0.001
+    assert cfg["lr_drop"] == 7
 
 
 def test_train_rfdetr_actual_call_uses_reported_defaults(monkeypatch, tmp_path):
@@ -158,10 +164,12 @@ def test_train_rfdetr_actual_call_uses_reported_defaults(monkeypatch, tmp_path):
     assert kwargs["epochs"] == 100
     assert kwargs["batch_size"] == 4
     assert kwargs["lr"] == 0.0001
-    assert kwargs["num_workers"] == 2
+    assert kwargs["num_workers"] == 0
     assert kwargs["weight_decay"] == 0.0001
     assert kwargs["eval_interval"] == 1
     assert kwargs["warmup_epochs"] == 0
+    assert kwargs["scheduler"] == "step"
+    assert kwargs["lr_drop"] == 100
     assert kwargs["use_ema"] is True
     assert kwargs["ema_decay"] == 0.993
     assert kwargs["early_stopping"] is False
@@ -169,3 +177,71 @@ def test_train_rfdetr_actual_call_uses_reported_defaults(monkeypatch, tmp_path):
     data = json.loads(result.stdout)
     assert data["model_family"] == "rfdetr"
     assert data["epochs_completed"] == 100
+
+
+def test_train_rfdetr_scheduler_override_reaches_trainer(monkeypatch, tmp_path):
+    app = _make_app()
+    captured = {}
+
+    class _RFDETRLike:
+        FAMILY = "rfdetr"
+        device = "cpu"
+
+        def train(self, data, **kwargs):
+            captured["kwargs"] = kwargs
+            return {"output_dir": str(tmp_path / "rfdetr_exp")}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda out, model, model_path, device: _RFDETRLike(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "data=dummy.yaml",
+            "model=LibreRFDETRm.pt",
+            "scheduler=cosine",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["scheduler"] == "cosine"
+    assert "ignores these parameters" not in result.output
+
+
+def test_train_rfdetr_lr_drop_override_reaches_trainer(monkeypatch, tmp_path):
+    app = _make_app()
+    captured = {}
+
+    class _RFDETRLike:
+        FAMILY = "rfdetr"
+        device = "cpu"
+
+        def train(self, data, **kwargs):
+            captured["kwargs"] = kwargs
+            return {"output_dir": str(tmp_path / "rfdetr_exp")}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda out, model, model_path, device: _RFDETRLike(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "data=dummy.yaml",
+            "model=LibreRFDETRm.pt",
+            "lr_drop=12",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["lr_drop"] == 12
+    assert "ignores these parameters" not in result.output

--- a/tests/unit/cli/test_command_utils.py
+++ b/tests/unit/cli/test_command_utils.py
@@ -18,7 +18,7 @@ from libreyolo.cli.command_utils import (
     get_loaded_model_input_size,
 )
 from libreyolo.cli.parsing import KeyValueCommand
-from libreyolo.utils.results import Boxes, Results
+from libreyolo.utils.results import Boxes, Masks, Results
 
 pytestmark = pytest.mark.unit
 
@@ -167,6 +167,68 @@ def test_val_runtime_error_includes_stage_context(failing_app):
     data = json.loads(result.stdout)
     assert data["error"] == "io_error"
     assert data["message"] == "Validation failed: disk full"
+
+
+def test_val_json_reports_segmentation_metric_groups(monkeypatch):
+    app = _make_app([("val", val.val_cmd), ("info", special.info_cmd)])
+
+    class _SegModel:
+        FAMILY = "rfdetr"
+        size = "n"
+        device = "cpu"
+
+        def val(self, **kwargs):
+            assert "use_coco_eval" not in kwargs
+            return {
+                "metrics/mAP50": 0.7,
+                "metrics/mAP50-95": 0.6,
+                "metrics/mAP50(B)": 0.55,
+                "metrics/mAP50-95(B)": 0.45,
+                "metrics/precision(M)": 0.82,
+                "metrics/recall(M)": 0.52,
+                "metrics/mAP50(M)": 0.72,
+                "metrics/mAP50-95(M)": 0.62,
+            }
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.val.resolve_model_or_exit",
+        lambda out, model: model,
+    )
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.val.load_model_or_exit",
+        lambda out, model, model_path, device: _SegModel(),
+    )
+    monkeypatch.setattr(
+        "libreyolo.utils.general.increment_path",
+        lambda path, exist_ok=False, mkdir=False: Path(path),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "val",
+            "data=fire-smoke.yaml",
+            "model=LibreRFDETRn-seg.pt",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_family"] == "rfdetr"
+    assert data["metrics"]["mAP50_95"] == 0.6
+    assert data["metrics"]["precision"] == 0.82
+    assert data["metrics"]["recall"] == 0.52
+    assert data["box_metrics"] == {
+        "mAP50": 0.55,
+        "mAP50_95": 0.45,
+    }
+    assert data["mask_metrics"] == {
+        "mAP50": 0.72,
+        "mAP50_95": 0.62,
+        "precision": 0.82,
+        "recall": 0.52,
+    }
 
 
 def test_export_runtime_error_includes_stage_context(failing_app):
@@ -436,6 +498,57 @@ def test_predict_exported_backend_does_not_receive_native_only_kwargs(monkeypatc
     data = json.loads(result.stdout)
     assert data["model_family"] == "yolox"
     assert data["results"][0]["detections"][0]["class"] == "person"
+
+
+def test_predict_json_reports_segmentation_masks(monkeypatch):
+    app = _make_app([("predict", predict.predict_cmd), ("info", special.info_cmd)])
+
+    class _SegBackendLike:
+        model_family = "rfdetr"
+        imgsz = 312
+        device = "cpu"
+
+        def __call__(self, source, **kwargs):
+            boxes = Boxes(
+                torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+                torch.tensor([0.9]),
+                torch.tensor([0]),
+            )
+            masks = Masks(torch.ones(1, 10, 20, dtype=torch.bool), (10, 20))
+            return Results(
+                boxes=boxes,
+                masks=masks,
+                orig_shape=(10, 20),
+                path=source,
+                names={0: "person"},
+            )
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.predict.resolve_model_or_exit",
+        lambda out, model: model,
+    )
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.predict.load_model_or_exit",
+        lambda out, model, model_path, device: _SegBackendLike(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "predict",
+            "source=libreyolo/assets/parkour.jpg",
+            "model=rfdetr-seg.onnx",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_family"] == "rfdetr"
+    assert data["results"][0]["masks"] == {
+        "count": 1,
+        "shape": [1, 10, 20],
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -40,9 +40,15 @@ class TestResolveModelName:
         assert resolve_model_name("deimv2-n") == "LibreDEIMv2n.pt"
         assert resolve_model_name("deimv2-x") == "LibreDEIMv2x.pt"
 
+    def test_rfdetr_seg_sizes(self):
+        assert resolve_model_name("rfdetr-n-seg") == "LibreRFDETRn-seg.pt"
+        assert resolve_model_name("rfdetr-x-seg") == "LibreRFDETRx-seg.pt"
+        assert resolve_model_name("rfdetr-xx-seg") == "LibreRFDETRxx-seg.pt"
+
     def test_case_insensitive(self):
         assert resolve_model_name("YOLOX-S") == "LibreYOLOXs.pt"
         assert resolve_model_name("Yolo9-T") == "LibreYOLO9t.pt"
+        assert resolve_model_name("RFDETR-N-SEG") == "LibreRFDETRn-seg.pt"
 
     def test_local_path_passthrough(self):
         assert resolve_model_name("best.pt") == "best.pt"
@@ -58,6 +64,8 @@ class TestResolveModelName:
     def test_known_weight_filename_detection(self):
         assert is_known_weight_filename("LibreYOLOXs.pt") is True
         assert is_known_weight_filename("weights/LibreYOLOXs.pt") is True
+        assert is_known_weight_filename("LibreRFDETRn-seg.pt") is True
+        assert is_known_weight_filename("weights/LibreRFDETRxx-seg.pt") is True
         assert is_known_weight_filename("not-a-real-model.pt") is False
 
 

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -14,6 +14,7 @@ class _DummyBackend(BaseBackend):
         model_family: str,
         task: str | None = None,
         supported_tasks=("detect",),
+        model_size: str | None = None,
     ):
         super().__init__(
             model_path="dummy",
@@ -21,6 +22,7 @@ class _DummyBackend(BaseBackend):
             device="cpu",
             imgsz=640,
             model_family=model_family,
+            model_size=model_size,
             names={0: "class_0", 1: "class_1"},
             task=task,
             supported_tasks=supported_tasks,
@@ -94,6 +96,67 @@ def test_rfdetr_backend_uses_topk_over_queries_and_classes():
     assert scores[0] > scores[1] > 0.5
     np.testing.assert_allclose(parsed_boxes[0], [37.5, 37.5, 62.5, 62.5])
     np.testing.assert_allclose(parsed_boxes[1], [37.5, 37.5, 62.5, 62.5])
+
+
+def test_rfdetr_seg_backend_uses_variant_num_select():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="segment",
+        supported_tasks=("segment",),
+        model_size="n",
+    )
+    num_queries = 150
+    boxes = np.tile(
+        np.array([[0.5, 0.5, 0.25, 0.25]], dtype=np.float32),
+        (1, num_queries, 1),
+    )
+    logits = np.linspace(10.0, 1.0, num_queries, dtype=np.float32).reshape(
+        1, num_queries, 1
+    )
+    masks = np.ones((1, num_queries, 4, 4), dtype=np.float32)
+
+    parsed_boxes, scores, classes, parsed_masks = backend._parse_rfdetr(
+        [boxes, logits, masks],
+        orig_w=16,
+        orig_h=16,
+        conf=0.5,
+    )
+
+    assert len(parsed_boxes) == 100
+    assert len(scores) == 100
+    assert classes.tolist() == [0] * 100
+    assert parsed_masks.shape == (100, 16, 16)
+
+
+def test_rfdetr_seg_backend_uses_detected_size_for_num_select_without_metadata():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="segment",
+        supported_tasks=("segment",),
+        model_size=None,
+    )
+    backend.size = "n"
+    num_queries = 150
+    boxes = np.tile(
+        np.array([[0.5, 0.5, 0.25, 0.25]], dtype=np.float32),
+        (1, num_queries, 1),
+    )
+    logits = np.linspace(10.0, 1.0, num_queries, dtype=np.float32).reshape(
+        1, num_queries, 1
+    )
+    masks = np.ones((1, num_queries, 4, 4), dtype=np.float32)
+
+    parsed_boxes, scores, classes, parsed_masks = backend._parse_rfdetr(
+        [boxes, logits, masks],
+        orig_w=16,
+        orig_h=16,
+        conf=0.5,
+    )
+
+    assert len(parsed_boxes) == 100
+    assert len(scores) == 100
+    assert classes.tolist() == [0] * 100
+    assert parsed_masks.shape == (100, 16, 16)
 
 
 def test_yolo_backend_still_applies_nms():

--- a/tests/unit/test_backend_validation_adapter.py
+++ b/tests/unit/test_backend_validation_adapter.py
@@ -1,0 +1,102 @@
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.backends.base import BaseBackend
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Backend(BaseBackend):
+    def __init__(self, task: str = "segment"):
+        super().__init__(
+            model_path="model.onnx",
+            nb_classes=2,
+            device="cpu",
+            imgsz=560,
+            model_family="rfdetr",
+            names={0: "fire", 1: "smoke"},
+            model_size="n",
+            task=task,
+            supported_tasks=("detect", "segment"),
+            default_task="detect",
+        )
+
+    def _run_inference(self, blob: np.ndarray) -> list:
+        batch = blob.shape[0]
+        return [
+            np.zeros((batch, 100, 4), dtype=np.float32),
+            np.zeros((batch, 100, 2), dtype=np.float32),
+            np.zeros((batch, 100, 35, 35), dtype=np.float32),
+        ]
+
+
+def test_backend_val_uses_exported_model_adapter(monkeypatch):
+    captured = {}
+
+    class _Validator:
+        def __init__(self, model, config):
+            captured["model"] = model
+            captured["config"] = config
+
+        def __call__(self):
+            return {"metrics/mAP50": 0.5}
+
+    monkeypatch.setattr("libreyolo.validation.SegmentationValidator", _Validator)
+
+    backend = _Backend(task="segment")
+    metrics = backend.val(
+        data="data.yaml",
+        batch=4,
+        imgsz=None,
+        conf=0.01,
+        iou=0.7,
+        workers=0,
+        device="cpu",
+        split="test",
+    )
+
+    assert metrics == {"metrics/mAP50": 0.5}
+    assert captured["model"] is backend
+    assert captured["config"].imgsz == 560
+    assert captured["config"].batch_size == 4
+    assert captured["config"].conf_thres == 0.01
+    assert backend.FAMILY == "rfdetr"
+    assert backend.size == "n"
+
+
+def test_backend_val_rejects_augment():
+    with pytest.raises(ValueError, match="Augmented validation"):
+        _Backend().val(data="data.yaml", augment=True)
+
+
+def test_backend_forward_falls_back_for_fixed_batch_exports():
+    class _FixedBatchBackend(_Backend):
+        def _run_inference(self, blob: np.ndarray) -> list:
+            if blob.shape[0] != 1:
+                raise RuntimeError("expected batch 1")
+            return [
+                np.full((1, 2, 4), blob.sum(), dtype=np.float32),
+                np.full((1, 2, 2), blob.sum(), dtype=np.float32),
+            ]
+
+    outputs = _FixedBatchBackend(task="detect")._forward(torch.ones(3, 3, 4, 4))
+
+    assert [tuple(output.shape) for output in outputs] == [(3, 2, 4), (3, 2, 2)]
+    assert outputs[0][:, 0, 0].tolist() == [48.0, 48.0, 48.0]
+
+
+def test_backend_init_allows_read_only_size_property():
+    class _ReadOnlySizeBackend(_Backend):
+        @property
+        def size(self) -> str:
+            return self.model_size or "computed"
+
+        def __init__(self):
+            super().__init__(task="detect")
+
+    backend = _ReadOnlySizeBackend()
+
+    assert backend.size == "n"
+    assert backend.FAMILY == "rfdetr"

--- a/tests/unit/test_coco_validation.py
+++ b/tests/unit/test_coco_validation.py
@@ -182,6 +182,29 @@ def test_detection_validator_emits_bbox_alias_metrics():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("family", "expected"),
+    [
+        ("rfdetr", True),
+        ("dfine", True),
+        ("yolox", False),
+    ],
+)
+def test_detection_validator_topk_coco_scoring_applies_to_yolo_coco_api(
+    family, expected
+):
+    from types import SimpleNamespace
+
+    from libreyolo.validation.detection_validator import DetectionValidator
+
+    validator = DetectionValidator.__new__(DetectionValidator)
+    validator.model = SimpleNamespace(FAMILY=family)
+    validator._coco_annotation_file = None
+
+    assert validator._uses_topk_coco_scoring() is expected
+
+
+@pytest.mark.unit
 def test_segmentation_validator_updates_bbox_and_mask_evaluators():
     from types import SimpleNamespace
 

--- a/tests/unit/test_ema.py
+++ b/tests/unit/test_ema.py
@@ -1,0 +1,36 @@
+import math
+
+import pytest
+import torch.nn as nn
+
+from libreyolo.training.ema import ModelEMA
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_model_ema_uses_configurable_tau():
+    model = nn.Linear(2, 2)
+    ema = ModelEMA(model, decay=0.993, tau=100)
+
+    assert ema.decay(1) == pytest.approx(0.993 * (1 - math.exp(-1 / 100)))
+
+
+def test_model_ema_ramped_set_decay_keeps_configured_tau():
+    model = nn.Linear(2, 2)
+    ema = ModelEMA(model, decay=0.993, tau=100)
+
+    ema.set_decay(0.9, ramp=True)
+
+    assert ema.decay(1) == pytest.approx(0.9 * (1 - math.exp(-1 / 100)))
+
+
+def test_model_ema_tau_zero_uses_constant_decay():
+    model = nn.Linear(2, 2)
+    ema = ModelEMA(model, decay=0.993, tau=0)
+
+    assert ema.decay(1) == pytest.approx(0.993)
+
+    ema.set_decay(0.9, ramp=True)
+
+    assert ema.decay(1) == pytest.approx(0.9)

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -16,6 +16,7 @@ from libreyolo.export.exporter import (
     TensorRTExporter,
     TorchScriptExporter,
 )
+from libreyolo.export.onnx import export_onnx
 
 pytestmark = pytest.mark.unit
 
@@ -39,6 +40,25 @@ class _TinyModel(nn.Module):
         x = self.pool(x)
         x = x.view(x.size(0), -1)
         return self.fc(x)
+
+
+class _TinyRFDETRExport(nn.Module):
+    """Small RF-DETR-shaped export module for ONNX schema tests."""
+
+    def __init__(self, *, segmentation=False):
+        super().__init__()
+        self.segmentation = segmentation
+        self.anchor = nn.Parameter(torch.zeros(()))
+
+    def forward(self, x):
+        batch = x.shape[0]
+        signal = x.mean(dim=(1, 2, 3), keepdim=True) + self.anchor
+        boxes = signal.reshape(batch, 1, 1).expand(batch, 3, 4)
+        logits = signal.reshape(batch, 1, 1).expand(batch, 3, 2)
+        if self.segmentation:
+            masks = signal.expand(batch, 3, 8, 8)
+            return boxes, logits, masks
+        return boxes, logits
 
 
 def _make_wrapper(nb_classes=4, model_name="TESTYOLO", size="s", input_size=32):
@@ -94,6 +114,171 @@ class TestExporterFormats:
         assert metadata["supported_tasks"] == ["detect", "segment"]
         assert metadata["default_task"] == "detect"
 
+    def test_rfdetr_export_metadata_is_single_task(self):
+        wrapper = _make_wrapper(model_name="rfdetr")
+        wrapper.task = "segment"
+        wrapper.SUPPORTED_TASKS = ("detect", "segment")
+        wrapper.DEFAULT_TASK = "detect"
+
+        metadata = TensorRTExporter(wrapper)._build_metadata(
+            precision="fp32",
+            dynamic=False,
+            onnx_path=None,
+        )
+
+        assert metadata["task"] == "segment"
+        assert metadata["supported_tasks"] == ["segment"]
+        assert metadata["default_task"] == "segment"
+
+    def test_tensorrt_export_forwards_dynamic_batch_profile(
+        self, monkeypatch, tmp_path
+    ):
+        wrapper = _make_wrapper(model_name="rfdetr")
+        captured = {}
+
+        def fake_export_tensorrt(**kwargs):
+            captured.update(kwargs)
+            return str(tmp_path / "model.engine")
+
+        monkeypatch.setattr(
+            "libreyolo.export.tensorrt.export_tensorrt",
+            fake_export_tensorrt,
+        )
+
+        metadata = {"model_family": "rfdetr"}
+        TensorRTExporter(wrapper)._export(
+            wrapper.model,
+            torch.zeros(1, 3, 32, 32),
+            output_path=str(tmp_path / "model.engine"),
+            precision="fp16",
+            metadata=metadata,
+            calibration_data=None,
+            onnx_path=str(tmp_path / "model.onnx"),
+            half=True,
+            int8=False,
+            dynamic=True,
+            verbose=False,
+            min_batch=2,
+            opt_batch=4,
+            max_batch=16,
+        )
+
+        assert captured["min_batch"] == 2
+        assert captured["opt_batch"] == 4
+        assert captured["max_batch"] == 16
+        assert captured["metadata"]["trt_min_batch"] == 2
+        assert captured["metadata"]["trt_opt_batch"] == 4
+        assert captured["metadata"]["trt_max_batch"] == 16
+        assert "trt_max_batch" not in metadata
+
+    def test_rfdetr_export_defaults_to_cpu(self):
+        wrapper = _make_wrapper(model_name="rfdetr")
+        wrapper.device = torch.device("cuda")
+
+        imgsz, device, output_path = OnnxExporter(wrapper)._resolve_params(
+            output_path=None,
+            imgsz=None,
+            device=None,
+            half=False,
+            int8=False,
+        )
+
+        assert imgsz == 32
+        assert device == torch.device("cpu")
+        assert output_path.endswith(".onnx")
+
+    def test_rfdetr_export_auto_device_defaults_to_cpu(self):
+        wrapper = _make_wrapper(model_name="rfdetr")
+        wrapper.device = torch.device("cuda")
+
+        _imgsz, device, _output_path = OnnxExporter(wrapper)._resolve_params(
+            output_path=None,
+            imgsz=None,
+            device="auto",
+            half=False,
+            int8=False,
+        )
+
+        assert device == torch.device("cpu")
+
+    def test_rfdetr_export_auto_opset_is_17(self, monkeypatch, tmp_path):
+        captured = {}
+        wrapper = _make_wrapper(model_name="rfdetr")
+        wrapper.model = _TinyRFDETRExport(segmentation=False)
+        wrapper.task = "detect"
+        wrapper.SUPPORTED_TASKS = ("detect",)
+        wrapper.DEFAULT_TASK = "detect"
+
+        def fake_export_onnx(_nn_model, _dummy, **kwargs):
+            captured.update(kwargs)
+            Path(kwargs["output_path"]).write_bytes(b"onnx")
+            return kwargs["output_path"]
+
+        monkeypatch.setattr("libreyolo.export.exporter.export_onnx", fake_export_onnx)
+        output_path = tmp_path / "rfdetr.onnx"
+
+        exported = OnnxExporter(wrapper)(
+            output_path=str(output_path),
+            simplify=False,
+            dynamic=False,
+            device="cpu",
+        )
+
+        assert exported == str(output_path)
+        assert captured["opset"] == 17
+
+    @pytest.mark.parametrize(
+        ("segmentation", "expected_outputs"),
+        [
+            (False, ["dets", "labels"]),
+            (True, ["dets", "labels", "masks"]),
+        ],
+    )
+    def test_rfdetr_onnx_uses_upstream_io_names(
+        self, tmp_path, segmentation, expected_outputs
+    ):
+        onnx = pytest.importorskip("onnx")
+        output_path = tmp_path / "rfdetr.onnx"
+
+        export_onnx(
+            _TinyRFDETRExport(segmentation=segmentation),
+            torch.zeros(1, 3, 32, 32),
+            output_path=str(output_path),
+            opset=17,
+            simplify=False,
+            dynamic=False,
+            half=False,
+            metadata={
+                "model_family": "rfdetr",
+                "task": "segment" if segmentation else "detect",
+                "segmentation": "true" if segmentation else "false",
+            },
+        )
+
+        proto = onnx.load(output_path)
+        assert [i.name for i in proto.graph.input] == ["input"]
+        assert [o.name for o in proto.graph.output] == expected_outputs
+
+    def test_onnx_metadata_uses_export_imgsz_override(self, tmp_path):
+        onnx = pytest.importorskip("onnx")
+        wrapper = _make_wrapper(model_name="TESTYOLO", input_size=32)
+        output_path = tmp_path / "custom_imgsz.onnx"
+
+        OnnxExporter(wrapper)(
+            output_path=str(output_path),
+            imgsz=48,
+            simplify=False,
+            dynamic=False,
+        )
+
+        proto = onnx.load(output_path)
+        meta = {p.key: p.value for p in proto.metadata_props}
+        assert meta["imgsz"] == "48"
+
+        from libreyolo.backends.onnx import OnnxBackend
+
+        assert OnnxBackend._read_onnx_metadata(str(output_path), 4)[-1] == 48
+
 
 class TestExporterValidation:
     def test_invalid_format_raises(self):
@@ -128,6 +313,17 @@ class TestOutputPathGeneration:
             finally:
                 os.chdir(orig)
 
+    def test_auto_path_includes_segmentation_task(self):
+        wrapper = _make_wrapper(model_name="rfdetr", size="n")
+        wrapper.task = "segment"
+        exporter = OnnxExporter(wrapper)
+        assert exporter._auto_output_path(half=False, int8=False) == str(
+            Path("weights") / "rfdetr_n_seg.onnx"
+        )
+        assert exporter._auto_output_path(half=True, int8=False) == str(
+            Path("weights") / "rfdetr_n_seg_fp16.onnx"
+        )
+
     def test_explicit_path(self):
         wrapper = _make_wrapper()
         exporter = TorchScriptExporter(wrapper)
@@ -153,6 +349,88 @@ class TestTorchScriptExport:
             dummy = torch.randn(1, 3, 32, 32)
             result = loaded(dummy)
             assert result.shape == (1, 4)
+
+    def test_rfdetr_position_embedding_dim_buffer_not_checkpointed(self):
+        from libreyolo.models.rfdetr.backbone import PositionEmbeddingSine
+
+        module = PositionEmbeddingSine(num_pos_feats=8, normalize=True)
+
+        assert "dim_t" not in module.state_dict()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_rfdetr_position_embedding_torchscript_loads_on_cuda(self, tmp_path):
+        from libreyolo.models.rfdetr.backbone import PositionEmbeddingSine
+
+        module = PositionEmbeddingSine(num_pos_feats=8, normalize=True)
+        module.export()
+        mask = torch.zeros(1, 4, 4, dtype=torch.bool)
+        traced = torch.jit.trace(module, mask)
+        path = tmp_path / "position_embedding.pt"
+        torch.jit.save(traced, str(path))
+
+        loaded = torch.jit.load(str(path), map_location="cuda")
+        out = loaded(mask.to("cuda"))
+
+        assert out.device.type == "cuda"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_rfdetr_proposal_grid_torchscript_loads_on_cuda(self, tmp_path):
+        from libreyolo.models.rfdetr.transformer import gen_encoder_output_proposals
+
+        class ProposalModule(nn.Module):
+            def forward(self, memory):
+                _, proposals = gen_encoder_output_proposals(
+                    memory,
+                    spatial_shapes=[(2, 2)],
+                    unsigmoid=False,
+                )
+                return proposals
+
+        module = ProposalModule()
+        memory = torch.zeros(1, 4, 8)
+        traced = torch.jit.trace(module, memory)
+        path = tmp_path / "proposal_grid.pt"
+        torch.jit.save(traced, str(path))
+
+        loaded = torch.jit.load(str(path), map_location="cuda")
+        out = loaded(memory.to("cuda"))
+
+        assert out.device.type == "cuda"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_rfdetr_sine_embedding_torchscript_loads_on_cuda(self, tmp_path):
+        from libreyolo.models.rfdetr.transformer import gen_sineembed_for_position
+
+        class SineModule(nn.Module):
+            def forward(self, pos):
+                return gen_sineembed_for_position(pos, 128.0)
+
+        module = SineModule()
+        pos = torch.rand(2, 3, 4)
+        traced = torch.jit.trace(module, pos)
+        path = tmp_path / "sine_embedding.pt"
+        torch.jit.save(traced, str(path))
+
+        loaded = torch.jit.load(str(path), map_location="cuda")
+        out = loaded(pos.to("cuda"))
+
+        assert out.device.type == "cuda"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_rfdetr_seg_depthwise_block_torchscript_loads_on_cuda(self, tmp_path):
+        from libreyolo.models.rfdetr.segmentation import DepthwiseConvBlock
+
+        module = DepthwiseConvBlock(4)
+        module.export()
+        x = torch.randn(1, 4, 8, 8)
+        traced = torch.jit.trace(module, x)
+        path = tmp_path / "seg_depthwise_block.pt"
+        torch.jit.save(traced, str(path))
+
+        loaded = torch.jit.load(str(path), map_location="cuda")
+        out = loaded(x.to("cuda"))
+
+        assert out.device.type == "cuda"
 
 
 class TestModelStateRestored:

--- a/tests/unit/test_openvino_backend.py
+++ b/tests/unit/test_openvino_backend.py
@@ -1,0 +1,47 @@
+import pytest
+
+from libreyolo.backends.openvino import OpenVINOBackend
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeOutput:
+    def __init__(self, shape):
+        self._shape = shape
+
+    @property
+    def shape(self):
+        if isinstance(self._shape, Exception):
+            raise self._shape
+        return self._shape
+
+
+class _FakeModel:
+    def __init__(self, shape):
+        self.inputs = [_FakeOutput(shape)]
+
+
+def test_openvino_backend_reads_static_input_imgsz():
+    model = _FakeModel([1, 3, 384, 384])
+
+    assert OpenVINOBackend._read_static_input_imgsz(model) == 384
+
+
+def test_openvino_backend_ignores_dynamic_input_shape():
+    model = _FakeModel(RuntimeError("to_shape was called on a dynamic shape"))
+
+    assert OpenVINOBackend._read_static_input_imgsz(model) is None
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 3],
+        [1, 3, -1, -1],
+        [1, 3, "?", "?"],
+    ],
+)
+def test_openvino_backend_ignores_non_static_input_imgsz(shape):
+    model = _FakeModel(shape)
+
+    assert OpenVINOBackend._read_static_input_imgsz(model) is None

--- a/tests/unit/test_rfdetr_preprocess.py
+++ b/tests/unit/test_rfdetr_preprocess.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+pytestmark = pytest.mark.unit
+
+
+def test_rfdetr_native_preprocess_matches_numpy_helper():
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+    from libreyolo.models.rfdetr.utils import preprocess_numpy
+
+    rgb = np.random.default_rng(0).integers(0, 256, (37, 53, 3), dtype=np.uint8)
+    model = LibreRFDETR(model_path={}, size="n", device="cpu")
+
+    tensor, _, original_size, ratio = model._preprocess(
+        Image.fromarray(rgb, mode="RGB"),
+        input_size=64,
+    )
+    expected, _ = preprocess_numpy(rgb, 64)
+
+    assert original_size == (53, 37)
+    assert ratio == 1.0
+    torch.testing.assert_close(tensor[0], torch.from_numpy(expected), atol=0, rtol=0)
+
+
+def test_rfdetr_val_preprocessor_matches_numpy_helper_and_scales_targets():
+    from libreyolo.models.rfdetr.utils import preprocess_numpy
+    from libreyolo.validation.preprocessors import RFDETRValPreprocessor
+
+    bgr = np.random.default_rng(1).integers(0, 256, (37, 53, 3), dtype=np.uint8)
+    rgb = bgr[:, :, ::-1]
+    targets = np.array([[5, 7, 40, 30, 2]], dtype=np.float32)
+    preprocessor = RFDETRValPreprocessor((64, 64), max_labels=4)
+
+    image, labels = preprocessor(bgr, targets, (64, 64))
+    expected_image, _ = preprocess_numpy(rgb, 64)
+
+    np.testing.assert_array_equal(image, expected_image)
+    np.testing.assert_allclose(
+        labels[0],
+        np.array(
+            [
+                5 * 64 / 53,
+                7 * 64 / 37,
+                40 * 64 / 53,
+                30 * 64 / 37,
+                2,
+            ],
+            dtype=np.float32,
+        ),
+    )
+    assert labels[1:].sum() == 0
+
+
+def test_rfdetr_val_preprocessor_requests_original_image():
+    from libreyolo.validation.preprocessors import RFDETRValPreprocessor
+
+    preprocessor = RFDETRValPreprocessor((64, 64), max_labels=4)
+
+    assert preprocessor.wants_unresized_image is True

--- a/tests/unit/test_segmentation.py
+++ b/tests/unit/test_segmentation.py
@@ -192,6 +192,8 @@ class TestFactorySegDetection:
         assert LibreRFDETR.detect_size_from_filename("LibreRFDETRn-seg.pt") == "n"
         assert LibreRFDETR.detect_size_from_filename("LibreRFDETRm-seg.pt") == "m"
         assert LibreRFDETR.detect_size_from_filename("LibreRFDETRl-seg.pt") == "l"
+        assert LibreRFDETR.detect_size_from_filename("LibreRFDETRx-seg.pt") == "x"
+        assert LibreRFDETR.detect_size_from_filename("LibreRFDETRxx-seg.pt") == "xx"
 
     def test_detect_task_from_seg_filename(self):
         from libreyolo.models.rfdetr.model import LibreRFDETR
@@ -212,6 +214,22 @@ class TestFactorySegDetection:
         assert (
             url
             == "https://huggingface.co/LibreYOLO/LibreRFDETRs-seg/resolve/main/LibreRFDETRs-seg.pt"
+        )
+
+    def test_download_url_upstream_default_weights(self):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        assert (
+            LibreRFDETR.get_download_url("rf-detr-seg-nano.pt")
+            == "https://storage.googleapis.com/rfdetr/rf-detr-seg-n-ft.pth"
+        )
+        assert (
+            LibreRFDETR.get_download_url("rf-detr-seg-xlarge.pt")
+            == "https://storage.googleapis.com/rfdetr/rf-detr-seg-xl-ft.pth"
+        )
+        assert (
+            LibreRFDETR.get_download_url("rf-detr-seg-xxlarge.pt")
+            == "https://storage.googleapis.com/rfdetr/rf-detr-seg-2xl-ft.pth"
         )
 
     def test_download_url_det(self):
@@ -340,6 +358,39 @@ class TestPolygonLabelParsing:
             assert len(segments[0]) == 1
             assert segments[0][0].shape == (4, 2)
             assert segments[0][0][2].tolist() == [80.0, 80.0]
+            assert getattr(segments[0][0], "dense_mask", None) is not None
+
+    def test_yolo_dataset_bbox_rows_become_rectangle_segments_when_requested(self):
+        import tempfile
+        from pathlib import Path
+
+        from libreyolo.data.dataset import YOLODataset
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            img_dir = Path(tmpdir) / "images" / "train"
+            lbl_dir = Path(tmpdir) / "labels" / "train"
+            img_dir.mkdir(parents=True)
+            lbl_dir.mkdir(parents=True)
+
+            Image.new("RGB", (100, 80)).save(img_dir / "test.jpg")
+            (lbl_dir / "test.txt").write_text("0 0.5 0.5 0.4 0.5\n")
+
+            seg_ds = YOLODataset(
+                data_dir=tmpdir,
+                split="train",
+                img_size=(100, 100),
+                load_segments=True,
+            )
+
+            ring = seg_ds.segments[0][0][0]
+            assert ring.shape == (4, 2)
+            assert ring.tolist() == [
+                [30.0, 20.0],
+                [70.0, 20.0],
+                [70.0, 60.0],
+                [30.0, 60.0],
+            ]
+            assert getattr(ring, "dense_mask", None) is not None
 
     def test_yolo_collate_preserves_segments_when_present(self):
         from libreyolo.data.dataset import yolox_collate_fn
@@ -404,6 +455,149 @@ class TestPolygonLabelParsing:
         assert labels[0, 0] == 0
         assert masks[0].sum() > 0
 
+    def test_rfdetr_seg_transform_keeps_full_resolution_masks(self):
+        from libreyolo.models.rfdetr.seg_transforms import RFDETRSegTransform
+
+        image = np.zeros((64, 64, 3), dtype=np.uint8)
+        targets = np.array([[16, 16, 48, 48, 0]], dtype=np.float32)
+        segments = [
+            [np.array([[16, 16], [48, 16], [48, 48], [16, 48]], dtype=np.float32)]
+        ]
+        transform = RFDETRSegTransform(
+            max_labels=4,
+            flip_prob=0.0,
+            imgsz=64,
+            mask_downsample_ratio=4,
+        )
+
+        img, labels, masks = transform(image, targets, (64, 64), segments)
+
+        assert img.shape == (3, 64, 64)
+        assert labels.shape == (4, 5)
+        assert masks.shape == (4, 64, 64)
+        assert labels[0, 0] == 0
+        assert masks[0].sum() > 0
+
+    def test_rfdetr_seg_transform_square_resizes_non_square_images(self):
+        from libreyolo.models.rfdetr.seg_transforms import RFDETRSegTransform
+
+        image = np.zeros((40, 80, 3), dtype=np.uint8)
+        targets = np.array([[20, 10, 60, 30, 0]], dtype=np.float32)
+        segments = [
+            [np.array([[20, 10], [60, 10], [60, 30], [20, 30]], dtype=np.float32)]
+        ]
+        transform = RFDETRSegTransform(max_labels=4, flip_prob=0.0, imgsz=80)
+
+        _, labels, masks = transform(image, targets, (80, 80), segments)
+
+        assert labels[0].tolist() == pytest.approx([0, 40, 40, 40, 40])
+        assert masks[0, 40, 40] == 1
+
+    def test_rfdetr_multi_scale_matches_upstream_scale_grid(self):
+        from libreyolo.models.rfdetr.seg_transforms import (
+            RFDETRDetTransform,
+            compute_multi_scale_scales,
+        )
+
+        scales = compute_multi_scale_scales(
+            384,
+            expanded_scales=True,
+            patch_size=16,
+            num_windows=2,
+        )
+
+        assert scales == [224, 256, 288, 320, 352, 384, 416, 448, 480, 512, 544]
+
+        transform = RFDETRDetTransform(
+            max_labels=4,
+            flip_prob=0.0,
+            imgsz=384,
+            multi_scale=True,
+            expanded_scales=True,
+            patch_size=16,
+            num_windows=2,
+        )
+
+        image = np.zeros((100, 100, 3), dtype=np.uint8)
+        targets = np.array([[25, 25, 75, 75, 0]], dtype=np.float32)
+        img, labels = transform(image, targets, (384, 384))
+
+        assert img.shape == (3, 544, 544)
+        assert labels[0].tolist() == pytest.approx([0, 272, 272, 272, 272])
+
+    def test_rfdetr_crop_resize_branch_updates_boxes_and_masks(self, monkeypatch):
+        from libreyolo.models.rfdetr.seg_transforms import RFDETRSegTransform
+
+        monkeypatch.setattr("libreyolo.models.rfdetr.seg_transforms.random.random", lambda: 0.0)
+        monkeypatch.setattr("libreyolo.models.rfdetr.seg_transforms.random.choice", lambda seq: seq[0])
+
+        randint_values = iter([20, 10, 10])
+        monkeypatch.setattr(
+            "libreyolo.models.rfdetr.seg_transforms.random.randint",
+            lambda _a, _b: next(randint_values),
+        )
+
+        image = np.zeros((40, 40, 3), dtype=np.uint8)
+        targets = np.array([[10, 10, 30, 30, 0]], dtype=np.float32)
+        segments = [
+            [np.array([[10, 10], [30, 10], [30, 30], [10, 30]], dtype=np.float32)]
+        ]
+        transform = RFDETRSegTransform(
+            max_labels=4,
+            flip_prob=0.0,
+            imgsz=40,
+            crop_resize_prob=1.0,
+            crop_intermediate_sizes=(40,),
+            crop_min_size=20,
+            crop_max_size=20,
+        )
+
+        _, labels, masks = transform(image, targets, (40, 40), segments)
+
+        assert labels[0].tolist() == pytest.approx([0, 20, 20, 40, 40])
+        assert masks[0, 20, 20] == 1
+
+    def test_rfdetr_crop_uses_dense_polygon_mask(self, monkeypatch):
+        import cv2
+
+        from libreyolo.data.dataset import DenseMaskRing
+        from libreyolo.models.rfdetr.seg_transforms import RFDETRSegTransform
+
+        monkeypatch.setattr("libreyolo.models.rfdetr.seg_transforms.random.random", lambda: 0.0)
+        monkeypatch.setattr("libreyolo.models.rfdetr.seg_transforms.random.choice", lambda seq: seq[0])
+
+        randint_values = iter([20, 10, 10])
+        monkeypatch.setattr(
+            "libreyolo.models.rfdetr.seg_transforms.random.randint",
+            lambda _a, _b: next(randint_values),
+        )
+
+        image = np.zeros((40, 40, 3), dtype=np.uint8)
+        targets = np.array([[0, 0, 40, 40, 0]], dtype=np.float32)
+        ring = np.array([[0, 0], [40, 20], [0, 40]], dtype=np.float32)
+        dense = np.zeros((40, 40), dtype=np.uint8)
+        cv2.fillPoly(dense, [ring.astype(np.int32)], color=1)
+        segments = [[DenseMaskRing(ring, dense)]]
+        transform = RFDETRSegTransform(
+            max_labels=4,
+            flip_prob=0.0,
+            imgsz=40,
+            crop_resize_prob=1.0,
+            crop_intermediate_sizes=(40,),
+            crop_min_size=20,
+            crop_max_size=20,
+        )
+
+        _, _, masks = transform(image, targets, (40, 40), segments)
+
+        expected = cv2.resize(
+            dense[10:30, 10:30],
+            (40, 40),
+            interpolation=cv2.INTER_NEAREST,
+        )
+        assert masks[0].sum() == pytest.approx(float(expected.sum()))
+        assert np.array_equal(masks[0] > 0, expected > 0)
+
     def test_coco_dataset_preserves_multiple_segment_rings(self, tmp_path):
         import json
 
@@ -467,6 +661,158 @@ class TestPolygonLabelParsing:
             [14.0, 5.0],
             [10.0, 5.0],
         ]
+        assert getattr(dataset.segments[0][0][0], "dense_mask", None) is not None
+
+    def test_coco_dataset_decodes_rle_segments_when_requested(self, tmp_path):
+        import json
+
+        from PIL import Image
+        from pycocotools import mask as mask_utils
+
+        from libreyolo.data.dataset import COCODataset
+
+        images_dir = tmp_path / "train2017"
+        ann_dir = tmp_path / "annotations"
+        images_dir.mkdir()
+        ann_dir.mkdir()
+
+        Image.new("RGB", (20, 10)).save(images_dir / "img.jpg")
+        mask = np.zeros((10, 20), dtype=np.uint8)
+        mask[2:6, 3:9] = 1
+        rle = mask_utils.encode(np.asfortranarray(mask))
+        rle["counts"] = rle["counts"].decode("ascii")
+
+        (ann_dir / "instances_train2017.json").write_text(
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "id": 1,
+                            "file_name": "img.jpg",
+                            "width": 20,
+                            "height": 10,
+                        }
+                    ],
+                    "annotations": [
+                        {
+                            "id": 1,
+                            "image_id": 1,
+                            "category_id": 1,
+                            "bbox": [3, 2, 6, 4],
+                            "area": int(mask.sum()),
+                            "iscrowd": 0,
+                            "segmentation": rle,
+                        }
+                    ],
+                    "categories": [{"id": 1, "name": "cat"}],
+                }
+            )
+        )
+
+        dataset = COCODataset(
+            data_dir=str(tmp_path),
+            json_file="instances_train2017.json",
+            name="train2017",
+            img_size=(10, 20),
+            load_segments=True,
+        )
+
+        rings = dataset.segments[0][0]
+        assert rings
+        assert sum(len(ring) for ring in rings) >= 4
+
+    def test_coco_rle_segments_preserve_holes_for_rfdetr(self, tmp_path):
+        import json
+
+        from PIL import Image
+        from pycocotools import mask as mask_utils
+
+        from libreyolo.data.dataset import COCODataset
+        from libreyolo.models.rfdetr.seg_transforms import RFDETRSegTransform
+
+        images_dir = tmp_path / "train2017"
+        ann_dir = tmp_path / "annotations"
+        images_dir.mkdir()
+        ann_dir.mkdir()
+
+        Image.new("RGB", (12, 12)).save(images_dir / "img.jpg")
+        mask = np.zeros((12, 12), dtype=np.uint8)
+        mask[2:10, 2:10] = 1
+        mask[5:8, 5:8] = 0
+        rle = mask_utils.encode(np.asfortranarray(mask))
+        rle["counts"] = rle["counts"].decode("ascii")
+
+        (ann_dir / "instances_train2017.json").write_text(
+            json.dumps(
+                {
+                    "images": [
+                        {
+                            "id": 1,
+                            "file_name": "img.jpg",
+                            "width": 12,
+                            "height": 12,
+                        }
+                    ],
+                    "annotations": [
+                        {
+                            "id": 1,
+                            "image_id": 1,
+                            "category_id": 1,
+                            "bbox": [2, 2, 8, 8],
+                            "area": int(mask.sum()),
+                            "iscrowd": 0,
+                            "segmentation": rle,
+                        }
+                    ],
+                    "categories": [{"id": 1, "name": "cat"}],
+                }
+            )
+        )
+
+        dataset = COCODataset(
+            data_dir=str(tmp_path),
+            json_file="instances_train2017.json",
+            name="train2017",
+            img_size=(12, 12),
+            load_segments=True,
+        )
+        transform = RFDETRSegTransform(max_labels=4, flip_prob=0.0, imgsz=12)
+
+        _, _, masks = transform(
+            np.array(Image.open(images_dir / "img.jpg"))[:, :, ::-1],
+            dataset.annotations[0][0],
+            (12, 12),
+            dataset.segments[0],
+        )
+
+        assert masks[0, 3, 3] == 1
+        assert masks[0, 6, 6] == 0
+
+    def test_coco_rle_segments_preserve_sparse_masks_for_rfdetr(self):
+        from pycocotools import mask as mask_utils
+
+        from libreyolo.data.dataset import _coco_segmentation_to_rings
+        from libreyolo.models.rfdetr.seg_transforms import RFDETRSegTransform
+
+        mask = np.zeros((16, 16), dtype=np.uint8)
+        np.fill_diagonal(mask, 1)
+        rle = mask_utils.encode(np.asfortranarray(mask))
+        rle["counts"] = rle["counts"].decode("ascii")
+
+        segments = [
+            _coco_segmentation_to_rings(
+                rle,
+                height=mask.shape[0],
+                width=mask.shape[1],
+            )
+        ]
+        image = np.zeros((16, 16, 3), dtype=np.uint8)
+        targets = np.array([[0, 0, 16, 16, 0]], dtype=np.float32)
+        transform = RFDETRSegTransform(max_labels=1, flip_prob=0.0, imgsz=16)
+
+        _, _, masks = transform(image, targets, (16, 16), segments)
+
+        np.testing.assert_array_equal(masks[0].astype(np.uint8), mask)
 
 
 class TestDrawMasks:
@@ -619,6 +965,316 @@ class TestDetectSegmentation:
         model.task = "detect"
         assert model._is_segmentation is False
         assert "_is_segmentation" not in model.__dict__
+
+    def test_detect_size_uses_segmentation_position_embedding_tokens(self):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        weights = {
+            "segmentation_head.blocks.0.dwconv.weight": torch.zeros(1),
+            "backbone.0.encoder.encoder.embeddings.position_embeddings": torch.zeros(1, 26 * 26 + 1, 384),
+        }
+
+        assert LibreRFDETR.detect_size(weights) == "n"
+
+    def test_default_none_uses_upstream_pretrained_weight_name(self, monkeypatch):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        monkeypatch.setattr(
+            LibreRFDETR,
+            "_resolve_weights_path",
+            staticmethod(lambda name: f"resolved/{name}"),
+        )
+        monkeypatch.setattr(
+            LibreRFDETR,
+            "_detect_segmentation",
+            staticmethod(lambda _path: False),
+        )
+        monkeypatch.setattr(LibreRFDETR, "_load_weights", lambda self, _path: None)
+
+        model = LibreRFDETR(model_path=None, size="n", device="cpu")
+
+        assert model._weight_source == "resolved/rf-detr-nano.pth"
+
+    def test_default_none_uses_segmentation_pretrained_weight_name(self, monkeypatch):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        monkeypatch.setattr(
+            LibreRFDETR,
+            "_resolve_weights_path",
+            staticmethod(lambda name: f"resolved/{name}"),
+        )
+        monkeypatch.setattr(LibreRFDETR, "_load_weights", lambda self, _path: None)
+
+        model = LibreRFDETR(
+            model_path=None,
+            size="n",
+            segmentation=True,
+            device="cpu",
+        )
+
+        assert model._weight_source == "resolved/rf-detr-seg-nano.pt"
+
+    def test_upstream_seg_xlarge_configs_are_available(self):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+        from libreyolo.models.rfdetr.nn import RFDETR_SEG_CONFIGS
+
+        assert LibreRFDETR.SEG_INPUT_SIZES["x"] == 624
+        assert LibreRFDETR.SEG_INPUT_SIZES["xx"] == 768
+        assert RFDETR_SEG_CONFIGS["x"].pretrain_weights == "rf-detr-seg-xlarge.pt"
+        assert RFDETR_SEG_CONFIGS["xx"].pretrain_weights == "rf-detr-seg-xxlarge.pt"
+        assert RFDETR_SEG_CONFIGS["x"].num_select == 300
+        assert RFDETR_SEG_CONFIGS["xx"].num_select == 300
+
+
+class TestRFDETRQueryLoading:
+    """Tests for RF-DETR Group-DETR query tensor resizing."""
+
+    def test_query_resize_preserves_per_group_layout(self):
+        from libreyolo.models.rfdetr.nn import _slice_query_param_per_group
+
+        tensor = torch.arange(6).view(6, 1)
+        resized = _slice_query_param_per_group(
+            tensor,
+            ckpt_num_queries=3,
+            ckpt_group_detr=2,
+            target_num_queries=2,
+            target_group_detr=2,
+        )
+
+        assert resized.squeeze(1).tolist() == [0, 1, 3, 4]
+
+    def test_wrapper_preserves_checkpoint_args_for_model_load(self):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        wrapper = LibreRFDETR(model_path={}, size="n", device="cpu")
+        checkpoint = {"model": {}, "args": {"num_queries": 3, "group_detr": 2}}
+        seen = {}
+
+        def fake_load_state_dict(state_dict, strict=False):
+            seen["state_dict"] = state_dict
+            seen["strict"] = strict
+            return [], []
+
+        wrapper.model.load_state_dict = fake_load_state_dict
+
+        wrapper._load_weights(checkpoint)
+
+        assert seen["state_dict"] is checkpoint
+        assert seen["strict"] is False
+
+
+class TestRFDETRSegTrainer:
+    """Tests for RF-DETR segmentation trainer plumbing."""
+
+    def test_rfdetr_training_defaults_are_windows_safe(self):
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+
+        assert RFDETRConfig().workers == 0
+
+    def test_rfdetr_training_uses_upstream_lr_and_accumulation_defaults(self):
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        trainer = RFDETRTrainer.__new__(RFDETRTrainer)
+        trainer.config = RFDETRConfig(batch=2, lr0=1e-4)
+
+        assert trainer.config.nbs == 16
+        assert trainer._accum_steps == 8
+        assert trainer.config.scheduler == "step"
+        assert trainer.config.lr_drop == 100
+        assert trainer.effective_lr == pytest.approx(1e-4)
+
+    def test_rfdetr_step_scheduler_matches_upstream_default(self):
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        trainer = RFDETRTrainer.__new__(RFDETRTrainer)
+        trainer.config = RFDETRConfig(
+            epochs=100,
+            batch=4,
+            nbs=16,
+            lr0=1e-4,
+            warmup_epochs=0,
+            lr_drop=100,
+        )
+
+        scheduler = trainer.create_scheduler(iters_per_epoch=7)
+
+        assert scheduler.update_lr(1) == pytest.approx(1e-4)
+        assert scheduler.update_lr(699) == pytest.approx(1e-4)
+        assert scheduler.update_lr(700) == pytest.approx(1e-5)
+
+    def test_rfdetr_step_scheduler_warmup_uses_optimizer_steps(self):
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        trainer = RFDETRTrainer.__new__(RFDETRTrainer)
+        trainer.config = RFDETRConfig(
+            epochs=2,
+            batch=4,
+            nbs=16,
+            lr0=1e-4,
+            warmup_epochs=1,
+            lr_drop=100,
+        )
+
+        scheduler = trainer.create_scheduler(iters_per_epoch=7)
+
+        assert scheduler.update_lr(1) == pytest.approx(1e-4 / 7)
+        assert scheduler.update_lr(7) == pytest.approx(1e-4)
+
+    def test_rfdetr_detection_transform_uses_original_images(self):
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        trainer = RFDETRTrainer.__new__(RFDETRTrainer)
+        trainer.config = RFDETRConfig(imgsz=384)
+        trainer.model = type("Model", (), {"patch_size": 16, "num_windows": 2})()
+        trainer.wrapper_model = type("Wrapper", (), {"task": "detect"})()
+
+        preproc, _ = trainer.create_transforms()
+
+        assert preproc.wants_unresized_image is True
+        assert preproc.target_size == 544
+
+    def test_rfdetr_trainer_applies_batch_multi_scale_to_images_boxes_and_masks(self):
+        from types import MethodType
+
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        trainer = RFDETRTrainer.__new__(RFDETRTrainer)
+        trainer.config = RFDETRConfig(imgsz=64, multi_scale=True)
+        trainer._multi_scale_scales = MethodType(lambda self: [32], trainer)
+
+        imgs = torch.ones(2, 3, 64, 64)
+        targets = torch.zeros(2, 4, 5)
+        targets[:, 0] = torch.tensor([1.0, 32.0, 32.0, 16.0, 16.0])
+        masks = torch.zeros(2, 4, 64, 64)
+        masks[:, 0, 16:48, 16:48] = 1
+
+        imgs_out, targets_out, masks_out = trainer._apply_multi_scale_batch(
+            imgs,
+            targets,
+            masks,
+            step=0,
+        )
+
+        assert imgs_out.shape[-2:] == (32, 32)
+        assert masks_out.shape[-2:] == (32, 32)
+        expected = torch.tensor(
+            [[1.0, 16.0, 16.0, 8.0, 8.0], [1.0, 16.0, 16.0, 8.0, 8.0]]
+        )
+        assert torch.allclose(targets_out[:, 0], expected)
+        assert masks_out[:, 0].sum().item() == pytest.approx(2 * 16 * 16)
+
+    def test_rfdetr_optimizer_uses_upstream_param_lrs(self):
+        from types import SimpleNamespace
+
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        class FakeBackboneEncoder(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.encoder_weight = torch.nn.Parameter(torch.ones(()))
+
+            def get_named_param_lr_pairs(self, args, prefix="backbone.0"):
+                lr = args.lr_encoder * args.lr_component_decay**2
+                return {
+                    f"{prefix}.encoder_weight": {
+                        "params": self.encoder_weight,
+                        "lr": lr,
+                        "weight_decay": args.weight_decay,
+                    }
+                }
+
+        class FakeCore(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.backbone = torch.nn.ModuleList([FakeBackboneEncoder()])
+                self.transformer = torch.nn.Module()
+                self.transformer.decoder = torch.nn.Linear(1, 1)
+                self.head = torch.nn.Linear(1, 1)
+
+        class FakeWrapper(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = FakeCore()
+                self.args = SimpleNamespace(
+                    lr_encoder=2e-4,
+                    lr_component_decay=0.5,
+                    lr_vit_layer_decay=0.8,
+                    out_feature_indexes=[0],
+                    weight_decay=1e-4,
+                )
+
+        trainer = RFDETRTrainer.__new__(RFDETRTrainer)
+        trainer.config = RFDETRConfig(lr0=1e-4, weight_decay=0.01)
+        trainer.model = FakeWrapper()
+
+        optimizer = trainer._setup_optimizer()
+        groups_by_param = {
+            id(group["params"][0]): group
+            for group in optimizer.param_groups
+        }
+        core = trainer.model.model
+        backbone_group = groups_by_param[id(core.backbone[0].encoder_weight)]
+        decoder_group = groups_by_param[id(core.transformer.decoder.weight)]
+        head_group = groups_by_param[id(core.head.weight)]
+
+        assert backbone_group["lr"] == pytest.approx(5e-5)
+        assert backbone_group["weight_decay"] == pytest.approx(0.01)
+        assert backbone_group["lr_mult"] == pytest.approx(0.5)
+        assert decoder_group["lr"] == pytest.approx(5e-5)
+        assert decoder_group["lr_mult"] == pytest.approx(0.5)
+        assert head_group["lr"] == pytest.approx(1e-4)
+        assert head_group["lr_mult"] == pytest.approx(1.0)
+        assert trainer._scale_lr(1e-5, backbone_group) == pytest.approx(5e-6)
+
+    def test_rfdetr_validation_defaults_are_windows_safe(self):
+        import inspect
+
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        assert inspect.signature(LibreRFDETR.val).parameters["workers"].default == 0
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_seg_masks_move_to_training_device_before_indexing(self):
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        class DummyModel(torch.nn.Module):
+            def forward(self, imgs, targets=None):
+                return {
+                    "loss": torch.ones(
+                        (), device=imgs.device, requires_grad=True
+                    )
+                }
+
+        class DummyCriterion:
+            weight_dict = {"loss": 1.0}
+
+            def __call__(self, outputs, targets):
+                self.targets = targets
+                return {"loss": outputs["loss"]}
+
+        trainer = object.__new__(RFDETRTrainer)
+        trainer.device = torch.device("cuda")
+        trainer.wrapper_model = type("Wrapper", (), {"task": "segment"})()
+        trainer.model = DummyModel().to(trainer.device)
+        trainer.criterion = DummyCriterion()
+
+        imgs = torch.zeros(1, 3, 8, 8, device=trainer.device)
+        targets = torch.tensor(
+            [[[0.0, 4.0, 4.0, 2.0, 2.0]]],
+            device=trainer.device,
+        )
+        cpu_masks = torch.ones(1, 1, 8, 8)
+
+        out = trainer.on_forward(imgs, targets, polygons=cpu_masks)
+
+        assert out["total_loss"].device.type == "cuda"
+        assert trainer.criterion.targets[0]["masks"].device.type == "cuda"
 
 
 class TestPolygonToCxcywh:

--- a/tests/unit/test_tensorrt_backend.py
+++ b/tests/unit/test_tensorrt_backend.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pytest
+import numpy as np
+import torch
 
 from libreyolo.backends.tensorrt import TensorRTBackend
 
@@ -12,6 +14,7 @@ def _bare_tensorrt_backend(path: str, model_family: str | None = None):
     backend = TensorRTBackend.__new__(TensorRTBackend)
     backend.model_path = path
     backend.model_family = model_family
+    backend._sidecar_size = None
     backend.output_names = ["pred_logits", "pred_boxes"]
     backend.output_shapes = {
         "pred_logits": (1, 300, 80),
@@ -41,3 +44,127 @@ def test_tensorrt_backend_reports_deimv2_model_name():
     backend = _bare_tensorrt_backend("LibreDEIMv2_s.engine", model_family="deimv2")
 
     assert backend._get_model_name() == "deimv2"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_size"),
+    [
+        ("LibreRFDETR_s.engine", "s"),
+        ("LibreRFDETRs.engine", "s"),
+        ("rfdetr_n_seg.engine", "n"),
+        ("rf-detr-seg-xl.engine", "x"),
+        ("rf-detr-seg-2xl.engine", "xx"),
+        ("LibreDEIMv2_s.engine", "s"),
+    ],
+)
+def test_tensorrt_sidecarless_size_detection_avoids_family_letters(
+    path, expected_size
+):
+    backend = _bare_tensorrt_backend(path, model_family="rfdetr")
+
+    assert backend.size == expected_size
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "rfdetr_n_seg.engine",
+        "LibreRFDETRn-seg.engine",
+        "LibreRFDETR_seg_n.engine",
+    ],
+)
+def test_tensorrt_sidecarless_rfdetr_seg_task_detection(path):
+    backend = _bare_tensorrt_backend(path, model_family="rfdetr")
+
+    assert backend._detect_task_from_filename() == "segment"
+
+
+def test_tensorrt_dynamic_max_batch_uses_engine_profile():
+    class _Engine:
+        def get_tensor_profile_shape(self, name, profile_index):
+            assert name == "input"
+            assert profile_index == 0
+            return (
+                (1, 3, 64, 64),
+                (4, 3, 64, 64),
+                (16, 3, 64, 64),
+            )
+
+    backend = _bare_tensorrt_backend("LibreRFDETR_s.engine", model_family="rfdetr")
+    backend._dynamic_batch = True
+    backend.engine = _Engine()
+    backend.input_name = "input"
+    backend._metadata = {}
+
+    assert backend._detect_max_batch() == 16
+
+
+def test_tensorrt_dynamic_max_batch_falls_back_to_metadata():
+    class _Engine:
+        pass
+
+    backend = _bare_tensorrt_backend("LibreRFDETR_s.engine", model_family="rfdetr")
+    backend._dynamic_batch = True
+    backend.engine = _Engine()
+    backend.input_name = "input"
+    backend._metadata = {"trt_max_batch": "12"}
+
+    assert backend._detect_max_batch() == 12
+
+
+def test_tensorrt_dynamic_batching_caps_requested_batch_to_profile():
+    backend = _bare_tensorrt_backend("LibreRFDETR_s.engine", model_family="rfdetr")
+    backend._dynamic_batch = True
+    backend._max_batch = 2
+    backend.imgsz = 64
+    backend.output_names = ["dets", "labels"]
+    infer_batches = []
+
+    def preprocess(path, imgsz, color_format):
+        return (
+            torch.zeros(1, 3, imgsz, imgsz),
+            np.zeros((imgsz, imgsz, 3), dtype=np.uint8),
+            (imgsz, imgsz),
+        )
+
+    def infer(batched_input):
+        infer_batches.append(batched_input.shape[0])
+        return {
+            "dets": np.zeros((batched_input.shape[0], 1, 4), dtype=np.float32),
+            "labels": np.zeros((batched_input.shape[0], 1, 2), dtype=np.float32),
+        }
+
+    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0):
+        return (
+            np.zeros((0, 4), dtype=np.float32),
+            np.zeros((0,), dtype=np.float32),
+            np.zeros((0,), dtype=np.int64),
+            None,
+        )
+
+    def build_result(
+        boxes,
+        max_scores,
+        class_ids,
+        *,
+        masks,
+        orig_shape,
+        image_path,
+        iou,
+        classes,
+        max_det,
+    ):
+        return image_path
+
+    backend._preprocess = preprocess
+    backend._infer = infer
+    backend._parse_outputs = parse_outputs
+    backend._build_result = build_result
+
+    results = backend._process_in_batches(
+        ["a.jpg", "b.jpg", "c.jpg", "d.jpg", "e.jpg"],
+        batch=8,
+    )
+
+    assert infer_batches == [2, 2, 1]
+    assert results == ["a.jpg", "b.jpg", "c.jpg", "d.jpg", "e.jpg"]

--- a/tests/unit/test_trainer_grad_clip.py
+++ b/tests/unit/test_trainer_grad_clip.py
@@ -43,6 +43,21 @@ class OneBatchLoader:
         return 1
 
 
+class MultiBatchLoader:
+    def __init__(self, num_batches):
+        self.dataset = SimpleNamespace()
+        self.num_batches = num_batches
+
+    def __iter__(self):
+        for _ in range(self.num_batches):
+            imgs = torch.zeros(1, 1)
+            targets = torch.zeros(1, 1)
+            yield imgs, targets, (None,), (0,)
+
+    def __len__(self):
+        return self.num_batches
+
+
 class DummyLoss:
     def __init__(self, param, events):
         self.param = param
@@ -96,6 +111,7 @@ def _build_trainer(*, clip_max_norm=None, scaler=None, events=None):
     trainer.train_loader = OneBatchLoader()
     trainer.config = SimpleNamespace(
         epochs=1,
+        batch=1,
         log_interval=999,
         eval_interval=-1,
     )
@@ -207,6 +223,55 @@ def test_amp_gradient_clipping_unscales_before_clip(monkeypatch):
         "scaler_step",
     ]
     assert events[8:10] == ["step", "scaler_update"]
+
+
+def test_nbs_accumulation_delays_optimizer_step():
+    events = []
+    trainer, param, events = _build_trainer(clip_max_norm=0.0, events=events)
+    trainer.train_loader = MultiBatchLoader(num_batches=3)
+    trainer.config.nbs = trainer.config.batch * 2
+    _wrap_optimizer_steps(trainer, events)
+
+    def on_forward(imgs, targets, polygons=None):
+        events.append("forward")
+        return {"total_loss": (param * 0).sum() + 1.0}
+
+    trainer.on_forward = on_forward
+
+    TinyTrainer._train_epoch(trainer, 0)
+
+    assert events == [
+        "zero_grad",
+        "forward",
+        "forward",
+        "step",
+        "zero_grad",
+        "forward",
+        "step",
+    ]
+
+
+def test_scheduler_warmup_lr_is_applied_before_first_step():
+    trainer, param, _ = _build_trainer(clip_max_norm=0.0)
+    trainer.optimizer = torch.optim.SGD(
+        [
+            {"params": [param], "lr": 0.1, "lr_mult": 0.5},
+        ],
+        lr=0.1,
+    )
+    trainer._scale_lr = lambda base_lr, group: base_lr * group.get("lr_mult", 1.0)
+
+    class WarmupScheduler:
+        warmup_iters = 4
+
+        def update_lr(self, iters):
+            return 0.01 if iters == 0 else 0.1
+
+    trainer.lr_scheduler = WarmupScheduler()
+
+    trainer._initialize_scheduler_lr()
+
+    assert trainer.optimizer.param_groups[0]["lr"] == pytest.approx(0.005)
 
 
 @pytest.mark.parametrize("clip_max_norm", [-0.1, float("nan"), float("inf"), "bad"])


### PR DESCRIPTION
- Aligns the native LibreYOLO RF-DETR port more closely with upstream RF-DETR.
- Keeps gradient accumulation on the repo-wide `nbs` API instead of reintroducing `grad_accum_steps`.
- Sets RF-DETR defaults to `batch=4, nbs=16`, matching upstream's effective `batch_size=4, grad_accum_steps=4` behavior.
- Aligns RF-DETR scheduler defaults, warmup/step LR behavior, EMA tau handling, optimizer parameter groups, multi-scale handling, and gradient clipping.
- Adds RF-DETR segmentation training support for YOLO polygons, COCO polygons, and COCO RLE masks.
- Adds RF-DETR segmentation inference and validation support, including mask metrics and predict JSON mask metadata.
- Adds upstream RF-DETR segmentation XL/2XL variants (`rf-detr-seg-xlarge.pt`, `rf-detr-seg-xxlarge.pt`), which are Apache-2.0 segmentation weights.
- Adds RF-DETR segmentation export/backend coverage for ONNX, TorchScript, OpenVINO, and TensorRT.
- Allows exported RF-DETR backends to run validation paths, not only prediction paths.
- Fixes exported RF-DETR backend metadata/postprocess handling, including sidecarless TensorRT segmentation `num_select` inference.
- Adds focused unit and e2e coverage for RF-DETR fidelity, segmentation, export, and backend behavior.
- Rebases cleanly on latest `dev` and keeps the PR as one squashed commit.
- Validated with RF-DETR unit/export suites, RF-DETR segmentation e2e training, coco128 RF-DETR validation, full COCO val2017 RF-DETR-n validation on GPU, and a TensorRT RF-DETR segmentation export/reload/mask smoke test.