### PR TITLE
Speed up NMS via batched_nms (rebase of #216 + yolo9-seg bridge)

### DIFF
--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -14,13 +14,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Tuple, Union
 
 import torch
+from torchvision.ops import batched_nms
 
 from ...utils.drawing import draw_boxes, draw_keypoints, draw_masks, draw_tile_grid
 from ...utils.general import (
     get_safe_stem,
     get_slice_bboxes,
     log_saved_result,
-    nms,
     resolve_save_path,
 )
 from ...utils.image_loader import ImageInput, ImageLoader
@@ -530,24 +530,19 @@ class InferenceRunner:
         if not boxes:
             return [], [], []
 
+        from torchvision.ops import batched_nms
+
         boxes_t = torch.tensor(boxes, dtype=torch.float32, device=self.model.device)
         scores_t = torch.tensor(scores, dtype=torch.float32, device=self.model.device)
         classes_t = torch.tensor(classes, dtype=torch.int64, device=self.model.device)
 
-        final_boxes, final_scores, final_classes = [], [], []
-
-        for cls_id in torch.unique(classes_t):
-            mask = classes_t == cls_id
-            cls_boxes = boxes_t[mask]
-            cls_scores = scores_t[mask]
-
-            keep = nms(cls_boxes, cls_scores, iou_thres)
-
-            final_boxes.extend(cls_boxes[keep].cpu().tolist())
-            final_scores.extend(cls_scores[keep].cpu().tolist())
-            final_classes.extend([cls_id.item()] * len(keep))
-
-        return final_boxes, final_scores, final_classes
+        # Single per-class-batched dispatch instead of one NMS call per class.
+        keep = batched_nms(boxes_t, scores_t, classes_t, iou_thres)
+        return (
+            boxes_t[keep].cpu().tolist(),
+            scores_t[keep].cpu().tolist(),
+            classes_t[keep].cpu().tolist(),
+        )
 
     def _predict_tiled(
         self,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -530,8 +530,6 @@ class InferenceRunner:
         if not boxes:
             return [], [], []
 
-        from torchvision.ops import batched_nms
-
         boxes_t = torch.tensor(boxes, dtype=torch.float32, device=self.model.device)
         scores_t = torch.tensor(scores, dtype=torch.float32, device=self.model.device)
         classes_t = torch.tensor(classes, dtype=torch.int64, device=self.model.device)

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -554,7 +554,8 @@ class BaseModel(ABC):
         classes: Optional[List[int]] = None,
     ) -> Results:
         """Merge TTA detections from multiple augmented views via per-class NMS."""
-        from ...utils.general import nms as _nms
+        from torchvision.ops import batched_nms
+
         from ...utils.results import Boxes, Masks, Results
 
         orig_w, orig_h = original_size
@@ -632,18 +633,10 @@ class BaseModel(ABC):
         scores_cat = torch.cat(all_scores, dim=0)
         classes_cat = torch.cat(all_classes, dim=0)
 
-        # Per-class NMS — collect global indices of kept boxes
-        keep_idx: List[int] = []
-        for cls_id in torch.unique(classes_cat):
-            mask = classes_cat == cls_id
-            global_idx = torch.where(mask)[0]
-            local_keep = _nms(boxes_cat[mask], scores_cat[mask], iou_thres)
-            keep_idx.extend(global_idx[local_keep].tolist())
-
-        if not keep_idx:
+        # Per-class NMS in a single batched dispatch (class-offset trick).
+        keep = batched_nms(boxes_cat, scores_cat, classes_cat.long(), iou_thres)
+        if len(keep) == 0:
             return _empty_results()
-
-        keep = torch.tensor(keep_idx, dtype=torch.long)
         final_boxes = boxes_cat[keep]
         final_scores = scores_cat[keep]
         final_classes = classes_cat[keep]

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Tup
 import torch
 import torch.nn as nn
 from PIL import Image
+from torchvision.ops import batched_nms
 
 from ...tasks import (
     detect_task_suffix,
@@ -554,8 +555,6 @@ class BaseModel(ABC):
         classes: Optional[List[int]] = None,
     ) -> Results:
         """Merge TTA detections from multiple augmented views via per-class NMS."""
-        from torchvision.ops import batched_nms
-
         from ...utils.results import Boxes, Masks, Results
 
         orig_w, orig_h = original_size

--- a/libreyolo/models/yolo9/utils.py
+++ b/libreyolo/models/yolo9/utils.py
@@ -7,10 +7,10 @@ Provides preprocessing and postprocessing functions for YOLOv9 inference.
 import numpy as np
 import torch
 import torch.nn.functional as F
+from torchvision.ops import batched_nms
 from typing import Tuple, Dict
 from PIL import Image
 
-from ...utils.general import nms
 from ...utils.image_loader import ImageLoader, ImageInput
 
 
@@ -94,22 +94,32 @@ def _nms_keep_indices(
     iou_thres: float,
     max_det: int,
 ) -> torch.Tensor:
-    keep_indices = []
-    for cls in torch.unique(class_ids):
-        cls_mask = class_ids == cls
-        if not cls_mask.any():
-            continue
-        cls_indices = torch.where(cls_mask)[0]
-        cls_keep = nms(boxes[cls_mask], scores[cls_mask], iou_thres)
-        keep_indices.append(cls_indices[cls_keep])
-
-    if not keep_indices:
+    if boxes.numel() == 0:
         return torch.zeros(0, dtype=torch.long, device=boxes.device)
 
-    keep = torch.cat(keep_indices)
+    # Drop non-finite rows — batched_nms is undefined on NaN/Inf inputs.
+    finite_mask = torch.isfinite(boxes).all(dim=1) & torch.isfinite(scores)
+    if not finite_mask.all():
+        valid_indices = torch.where(finite_mask)[0]
+        if len(valid_indices) == 0:
+            return torch.zeros(0, dtype=torch.long, device=boxes.device)
+        boxes = boxes[finite_mask]
+        scores = scores[finite_mask]
+        class_ids = class_ids[finite_mask]
+    else:
+        valid_indices = None
+
+    keep = batched_nms(boxes, scores, class_ids, iou_thres)
+    if len(keep) == 0:
+        return torch.zeros(0, dtype=torch.long, device=boxes.device)
+
     if len(keep) > max_det:
         _, order = torch.topk(scores[keep], max_det)
         keep = keep[order]
+
+    # Map back to original indices when we filtered non-finite rows above.
+    if valid_indices is not None:
+        keep = valid_indices[keep]
     return keep
 
 

--- a/libreyolo/utils/general.py
+++ b/libreyolo/utils/general.py
@@ -403,10 +403,11 @@ def postprocess_detections(
     if len(keep_indices) == 0:
         return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
 
-    # ``batched_nms`` returns indices already sorted by descending score, so
-    # the first ``max_det`` are the top-K — no extra topk needed.
+    # Use topk rather than relying on batched_nms output order, which is an
+    # undocumented implementation detail that could change across torchvision versions.
     if len(keep_indices) > max_det:
-        keep_indices = keep_indices[:max_det]
+        _, top_indices = torch.topk(scores[keep_indices], max_det)
+        keep_indices = keep_indices[top_indices]
 
     final_boxes = boxes[keep_indices].cpu().numpy()
     final_scores = scores[keep_indices].cpu().numpy()

--- a/libreyolo/utils/general.py
+++ b/libreyolo/utils/general.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple, Union
 from urllib.parse import urlparse
 
 import torch
+import torchvision.ops
 
 logger = logging.getLogger(__name__)
 
@@ -381,16 +382,22 @@ def postprocess_detections(
     if len(boxes) == 0:
         return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
 
-    # Per-class NMS
-    # Single batched-NMS call across all classes. Equivalent to the previous
-    # ``for cls in unique_classes: torchvision.ops.nms(boxes + cls*max_wh, ...)``
-    # loop but in one CUDA dispatch instead of one per class — eliminates the
-    # ~80-iteration Python loop on COCO (especially during validation, which
-    # forces conf_thres=0.0 and so cannot rely on the conf prefilter to shrink
-    # ``unique_classes``). torchvision is a hard dependency via torch itself,
-    # so no fallback is needed.
-    import torchvision.ops
+    # Drop NaN/Inf boxes — batched_nms has undefined behaviour on non-finite
+    # values and can return wrong indices or raise on CUDA.
+    finite_mask = torch.isfinite(boxes).all(dim=1) & torch.isfinite(scores)
+    if not finite_mask.all():
+        boxes = boxes[finite_mask]
+        scores = scores[finite_mask]
+        class_ids = class_ids[finite_mask]
 
+    if len(boxes) == 0:
+        return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
+
+    # Per-class NMS — single batched dispatch instead of one kernel per class.
+    # Equivalent to the previous ``for cls in unique_classes: ops.nms(...)``
+    # loop (same class-offset trick, same CUDA kernel) but avoids the ~80-
+    # iteration Python loop on COCO, especially during validation which forces
+    # conf_thres=0.0 and so cannot rely on the conf prefilter to shrink classes.
     keep_indices = torchvision.ops.batched_nms(boxes, scores, class_ids, iou_thres)
 
     if len(keep_indices) == 0:

--- a/libreyolo/utils/general.py
+++ b/libreyolo/utils/general.py
@@ -282,81 +282,6 @@ def get_slice_bboxes(
 # =============================================================================
 
 
-def nms(
-    boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float = 0.45
-) -> torch.Tensor:
-    """
-    Non-Maximum Suppression using torch operations.
-
-    Args:
-        boxes: Boxes in xyxy format (N, 4)
-        scores: Confidence scores (N,)
-        iou_threshold: IoU threshold for suppression
-
-    Returns:
-        Indices of boxes to keep
-    """
-    if len(boxes) == 0:
-        return torch.tensor([], dtype=torch.long, device=boxes.device)
-
-    # Filter out boxes with NaN or Inf values
-    valid_mask = torch.isfinite(boxes).all(dim=1) & torch.isfinite(scores)
-    if not valid_mask.any():
-        return torch.tensor([], dtype=torch.long, device=boxes.device)
-
-    if not valid_mask.all():
-        valid_indices = torch.where(valid_mask)[0]
-        boxes = boxes[valid_mask]
-        scores = scores[valid_mask]
-    else:
-        valid_indices = None
-
-    _, order = scores.sort(0, descending=True)
-    keep = []
-
-    while len(order) > 0:
-        i = order[0]
-        keep.append(i.item())
-
-        if len(order) == 1:
-            break
-
-        box_i = boxes[i]
-        boxes_remaining = boxes[order[1:]]
-
-        x1_i, y1_i, x2_i, y2_i = box_i
-        x1_r, y1_r, x2_r, y2_r = (
-            boxes_remaining[:, 0],
-            boxes_remaining[:, 1],
-            boxes_remaining[:, 2],
-            boxes_remaining[:, 3],
-        )
-
-        x1_inter = torch.max(x1_i, x1_r)
-        y1_inter = torch.max(y1_i, y1_r)
-        x2_inter = torch.min(x2_i, x2_r)
-        y2_inter = torch.min(y2_i, y2_r)
-
-        inter_area = torch.clamp(x2_inter - x1_inter, min=0) * torch.clamp(
-            y2_inter - y1_inter, min=0
-        )
-
-        area_i = (x2_i - x1_i) * (y2_i - y1_i)
-        area_r = (x2_r - x1_r) * (y2_r - y1_r)
-        union_area = area_i + area_r - inter_area
-
-        iou = inter_area / (union_area + 1e-7)
-        order = order[1:][iou < iou_threshold]
-
-    keep_tensor = torch.tensor(keep, dtype=torch.long, device=boxes.device)
-
-    # Map back to original indices if we filtered invalid boxes
-    if valid_indices is not None:
-        keep_tensor = valid_indices[keep_tensor]
-
-    return keep_tensor
-
-
 def make_anchors(
     feats: List[torch.Tensor], strides: List[int], grid_cell_offset: float = 0.5
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -457,43 +382,24 @@ def postprocess_detections(
         return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
 
     # Per-class NMS
-    try:
-        import torchvision.ops
+    # Single batched-NMS call across all classes. Equivalent to the previous
+    # ``for cls in unique_classes: torchvision.ops.nms(boxes + cls*max_wh, ...)``
+    # loop but in one CUDA dispatch instead of one per class — eliminates the
+    # ~80-iteration Python loop on COCO (especially during validation, which
+    # forces conf_thres=0.0 and so cannot rely on the conf prefilter to shrink
+    # ``unique_classes``). torchvision is a hard dependency via torch itself,
+    # so no fallback is needed.
+    import torchvision.ops
 
-        use_torchvision_nms = True
-    except ImportError:
-        use_torchvision_nms = False
+    keep_indices = torchvision.ops.batched_nms(boxes, scores, class_ids, iou_thres)
 
-    unique_classes = torch.unique(class_ids)
-    keep_indices_list = []
-
-    for cls in unique_classes:
-        cls_mask = class_ids == cls
-        cls_boxes = boxes[cls_mask]
-        cls_scores = scores[cls_mask]
-
-        if len(cls_boxes) == 0:
-            continue
-
-        if use_torchvision_nms:
-            max_wh = 7680.0
-            boxes_for_nms = cls_boxes + cls.float() * max_wh
-            cls_keep = torchvision.ops.nms(boxes_for_nms, cls_scores, iou_thres)
-        else:
-            cls_keep = nms(cls_boxes, cls_scores, iou_thres)
-
-        cls_indices = torch.where(cls_mask)[0]
-        keep_indices_list.append(cls_indices[cls_keep])
-
-    if len(keep_indices_list) == 0:
+    if len(keep_indices) == 0:
         return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
 
-    keep_indices = torch.cat(keep_indices_list)
-
+    # ``batched_nms`` returns indices already sorted by descending score, so
+    # the first ``max_det`` are the top-K — no extra topk needed.
     if len(keep_indices) > max_det:
-        final_scores_temp = scores[keep_indices]
-        _, top_indices = torch.topk(final_scores_temp, max_det)
-        keep_indices = keep_indices[top_indices]
+        keep_indices = keep_indices[:max_det]
 
     final_boxes = boxes[keep_indices].cpu().numpy()
     final_scores = scores[keep_indices].cpu().numpy()
@@ -505,124 +411,3 @@ def postprocess_detections(
         "classes": final_classes.tolist(),
         "num_detections": len(final_boxes),
     }
-
-
-def postprocess_batch(
-    batch_boxes: torch.Tensor,
-    batch_scores: torch.Tensor,
-    batch_class_ids: torch.Tensor,
-    batch_indices: torch.Tensor,
-    batch_size: int,
-    conf_thres: float = 0.25,
-    iou_thres: float = 0.45,
-    input_size: int = 640,
-    original_sizes: List[Tuple[int, int]] | None = None,
-    max_det: int = 300,
-    device: torch.device | None = None,
-) -> List[Dict]:
-    """
-    Batched post-processing for efficient validation.
-
-    Processes all detections from a batch at once using GPU-accelerated operations,
-    then splits results per image. This is much faster than processing images
-    one at a time in a Python loop.
-
-    Args:
-        batch_boxes: All boxes from batch (N_total, 4) in xyxy format
-        batch_scores: All scores from batch (N_total,)
-        batch_class_ids: All class IDs from batch (N_total,)
-        batch_indices: Image index for each detection (N_total,) - which image each box belongs to
-        batch_size: Number of images in batch
-        conf_thres: Confidence threshold (already applied if boxes are pre-filtered)
-        iou_thres: IoU threshold for NMS
-        input_size: Model input size for scaling
-        original_sizes: List of (width, height) tuples for each image
-        max_det: Maximum detections per image
-        device: Device for computations
-
-    Returns:
-        List of detection dicts, one per image in batch
-    """
-    try:
-        import torchvision.ops
-
-        has_torchvision = True
-    except ImportError:
-        has_torchvision = False
-
-    results = []
-
-    if len(batch_boxes) == 0:
-        for _ in range(batch_size):
-            results.append(
-                {
-                    "boxes": torch.zeros((0, 4), device=device),
-                    "scores": torch.zeros(0, device=device),
-                    "classes": torch.zeros(0, dtype=torch.int64, device=device),
-                    "num_detections": 0,
-                }
-            )
-        return results
-
-    # Batched NMS using class offsets: offset boxes by batch_idx and class_id
-    # to prevent cross-image and cross-class suppression in a single call
-    if has_torchvision:
-        max_wh = 7680.0  # max expected image dimension
-        max_batch_offset = max_wh * 100  # large offset between batches
-
-        combined_idx = (
-            batch_indices.float() * max_batch_offset + batch_class_ids.float() * max_wh
-        )
-        boxes_for_nms = batch_boxes + combined_idx.unsqueeze(1)
-        keep = torchvision.ops.nms(boxes_for_nms, batch_scores, iou_thres)
-
-        batch_boxes = batch_boxes[keep]
-        batch_scores = batch_scores[keep]
-        batch_class_ids = batch_class_ids[keep]
-        batch_indices = batch_indices[keep]
-
-    # Split results by image
-    for img_idx in range(batch_size):
-        img_mask = batch_indices == img_idx
-
-        if not img_mask.any():
-            results.append(
-                {
-                    "boxes": torch.zeros((0, 4), device=device),
-                    "scores": torch.zeros(0, device=device),
-                    "classes": torch.zeros(0, dtype=torch.int64, device=device),
-                    "num_detections": 0,
-                }
-            )
-            continue
-
-        img_boxes = batch_boxes[img_mask].detach()
-        img_scores = batch_scores[img_mask].detach()
-        img_classes = batch_class_ids[img_mask].detach()
-
-        if original_sizes is not None and img_idx < len(original_sizes):
-            orig_w, orig_h = original_sizes[img_idx]
-            scale_x = orig_w / input_size
-            scale_y = orig_h / input_size
-            img_boxes = img_boxes.clone()
-            img_boxes[:, [0, 2]] *= scale_x
-            img_boxes[:, [1, 3]] *= scale_y
-            img_boxes[:, [0, 2]] = torch.clamp(img_boxes[:, [0, 2]], 0, orig_w)
-            img_boxes[:, [1, 3]] = torch.clamp(img_boxes[:, [1, 3]], 0, orig_h)
-
-        if len(img_boxes) > max_det:
-            _, top_k = torch.topk(img_scores, max_det)
-            img_boxes = img_boxes[top_k]
-            img_scores = img_scores[top_k]
-            img_classes = img_classes[top_k]
-
-        results.append(
-            {
-                "boxes": img_boxes,
-                "scores": img_scores,
-                "classes": img_classes,
-                "num_detections": len(img_boxes),
-            }
-        )
-
-    return results

--- a/scripts/spot_check_val_map.py
+++ b/scripts/spot_check_val_map.py
@@ -59,8 +59,8 @@ MODEL_REGISTRY: dict[str, tuple[str, str]] = {
 }
 
 VAL_KWARGS = dict(
-    data="coco128.yaml",
-    batch=16,
+    data="coco.yaml",
+    batch=32,
     conf=0.001,   # COCO-standard low threshold to exercise NMS fully
     iou=0.6,
     verbose=False,
@@ -178,8 +178,8 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--device",
-        default="auto",
-        help="Device string passed to LibreYOLO (default: auto).",
+        default="cuda",
+        help="Device string passed to LibreYOLO (default: cuda).",
     )
     return p.parse_args()
 

--- a/scripts/spot_check_val_map.py
+++ b/scripts/spot_check_val_map.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+spot_check_val_map.py — Verify that postprocess_detections refactors leave
+mAP bit-equivalent on YOLOX and YOLO9.
+
+Runs model.val() on coco128 (128 images, ~30 s per model on CPU, <10 s on GPU)
+for one or more models, then either:
+  - Saves a baseline JSON  (first run, or --save-baseline)
+  - Compares against a stored baseline  (subsequent runs)
+  - Just prints results    (--no-baseline)
+
+The NMS change is mathematically equivalent, so we expect values to match to
+at least 4 decimal places.
+
+Usage:
+    # First run — establish baseline:
+    python scripts/spot_check_val_map.py --save-baseline baseline_map.json
+
+    # Subsequent runs — compare:
+    python scripts/spot_check_val_map.py --baseline baseline_map.json
+
+    # Specific models only:
+    python scripts/spot_check_val_map.py --models yolox-n yolo9-t --baseline baseline_map.json
+
+    # Just print (no comparison):
+    python scripts/spot_check_val_map.py --no-baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+# Make the repo importable when run directly from the project root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+# ---------------------------------------------------------------------------
+# Model registry — smallest models from each affected family.
+# Extend with e.g. "yolox-s", "yolo9-s" for a broader check.
+# ---------------------------------------------------------------------------
+DEFAULT_MODELS = ["yolox-n", "yolo9-t"]
+
+# Map model-id → (weights_filename, size_arg)
+MODEL_REGISTRY: dict[str, tuple[str, str]] = {
+    "yolox-n": ("LibreYOLOXn.pt", "n"),
+    "yolox-t": ("LibreYOLOXt.pt", "t"),
+    "yolox-s": ("LibreYOLOXs.pt", "s"),
+    "yolox-m": ("LibreYOLOXm.pt", "m"),
+    "yolox-l": ("LibreYOLOXl.pt", "l"),
+    "yolox-x": ("LibreYOLOXx.pt", "x"),
+    "yolo9-t": ("LibreYOLO9t.pt", "t"),
+    "yolo9-s": ("LibreYOLO9s.pt", "s"),
+    "yolo9-m": ("LibreYOLO9m.pt", "m"),
+    "yolo9-c": ("LibreYOLO9c.pt", "c"),
+}
+
+VAL_KWARGS = dict(
+    data="coco128.yaml",
+    batch=16,
+    conf=0.001,   # COCO-standard low threshold to exercise NMS fully
+    iou=0.6,
+    verbose=False,
+)
+
+# Tolerance for "bit-equivalent": 1e-3 covers floating-point noise from
+# reordering ops (e.g. per-class loop → batched_nms) while still catching real divergence.
+TOLERANCE = 1e-3
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _weights_path(weights_file: str) -> Path:
+    """Resolve weights: current dir → weights/ subdir."""
+    p = Path(weights_file)
+    if p.exists():
+        return p
+    candidate = Path("weights") / weights_file
+    if candidate.exists():
+        return candidate
+    return p  # let LibreYOLO raise a clear error
+
+
+def run_val(model_id: str, device: str) -> dict:
+    """Load model, run val on coco128, return metric dict."""
+    from libreyolo import LibreYOLO
+
+    weights_file, size = MODEL_REGISTRY[model_id]
+    weights = _weights_path(weights_file)
+
+    print(f"  Loading {model_id} from {weights} ...")
+    model = LibreYOLO(str(weights), size=size, device=device)
+
+    t0 = time.perf_counter()
+    results = model.val(**VAL_KWARGS)
+    elapsed = time.perf_counter() - t0
+
+    metrics = {
+        k.replace("metrics/", ""): round(float(v), 6)
+        for k, v in results.items()
+        if k.startswith("metrics/")
+    }
+    metrics["_elapsed_s"] = round(elapsed, 1)
+    return metrics
+
+
+def compare(model_id: str, current: dict, baseline: dict, tol: float) -> bool:
+    """Print per-metric diff; return True when all within tolerance."""
+    keys = [k for k in current if not k.startswith("_")]
+    ok = True
+    rows = []
+    for k in sorted(keys):
+        cur = current.get(k, float("nan"))
+        base = baseline.get(k, float("nan"))
+        diff = abs(cur - base)
+        flag = "" if diff <= tol else "  ← MISMATCH"
+        rows.append((k, base, cur, diff, flag))
+        if flag:
+            ok = False
+
+    col_w = max(len(r[0]) for r in rows)
+    header = f"  {'metric':<{col_w}}  {'baseline':>10}  {'current':>10}  {'|diff|':>10}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for k, base, cur, diff, flag in rows:
+        print(f"  {k:<{col_w}}  {base:>10.6f}  {cur:>10.6f}  {diff:>10.2e}{flag}")
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--models",
+        nargs="+",
+        default=DEFAULT_MODELS,
+        choices=list(MODEL_REGISTRY),
+        metavar="MODEL",
+        help=f"Models to check (default: {' '.join(DEFAULT_MODELS)}). "
+             f"Available: {', '.join(MODEL_REGISTRY)}",
+    )
+    p.add_argument(
+        "--baseline",
+        metavar="FILE",
+        help="JSON baseline to compare against.",
+    )
+    p.add_argument(
+        "--save-baseline",
+        metavar="FILE",
+        help="Run val and save results as a new baseline JSON (skips comparison).",
+    )
+    p.add_argument(
+        "--no-baseline",
+        action="store_true",
+        help="Just print results without saving or comparing.",
+    )
+    p.add_argument(
+        "--tol",
+        type=float,
+        default=TOLERANCE,
+        help=f"Absolute tolerance for mAP comparison (default: {TOLERANCE}).",
+    )
+    p.add_argument(
+        "--save",
+        metavar="FILE",
+        help="Save current results to FILE (compatible with all modes, e.g. new.json).",
+    )
+    p.add_argument(
+        "--device",
+        default="auto",
+        help="Device string passed to LibreYOLO (default: auto).",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Validate mode flags
+    modes = sum([
+        bool(args.baseline),
+        bool(args.save_baseline),
+        args.no_baseline,
+    ])
+    if modes > 1:
+        print("ERROR: --baseline, --save-baseline, and --no-baseline are mutually exclusive.", file=sys.stderr)
+        return 2
+    if modes == 0:
+        # Default: compare if baseline exists, else just print
+        default_baseline = Path("scripts/baseline.json")
+        if default_baseline.exists():
+            args.baseline = str(default_baseline)
+            print(f"Auto-detected baseline: {default_baseline}")
+        else:
+            args.no_baseline = True
+
+    baseline_data: dict = {}
+    if args.baseline:
+        baseline_path = Path(args.baseline)
+        if not baseline_path.exists():
+            print(f"ERROR: baseline file not found: {baseline_path}", file=sys.stderr)
+            return 2
+        baseline_data = json.loads(baseline_path.read_text())
+
+    # ---------------------------------------------------------------------------
+    # Run validation for each requested model
+    # ---------------------------------------------------------------------------
+    all_results: dict[str, dict] = {}
+    failures: list[str] = []
+
+    for model_id in args.models:
+        print(f"\n{'─'*60}")
+        print(f"  {model_id}")
+        print(f"{'─'*60}")
+        try:
+            metrics = run_val(model_id, args.device)
+        except FileNotFoundError as exc:
+            print(f"  SKIP — weights not found: {exc}")
+            continue
+        except Exception as exc:
+            print(f"  ERROR — {exc}")
+            failures.append(model_id)
+            continue
+
+        all_results[model_id] = metrics
+        map_val = metrics.get("mAP50-95", float("nan"))
+        map50   = metrics.get("mAP50",    float("nan"))
+        print(f"  mAP50-95 = {map_val:.4f}  |  mAP50 = {map50:.4f}  ({metrics['_elapsed_s']:.1f}s)")
+
+        if args.baseline and model_id in baseline_data:
+            print()
+            ok = compare(model_id, metrics, baseline_data[model_id], args.tol)
+            if not ok:
+                failures.append(model_id)
+                print(f"  RESULT: MISMATCH (tol={args.tol})")
+            else:
+                print(f"  RESULT: OK (all within tol={args.tol})")
+        elif args.baseline:
+            print(f"  NOTE: {model_id} not in baseline — skipping comparison.")
+
+    # ---------------------------------------------------------------------------
+    # Save results if requested
+    # ---------------------------------------------------------------------------
+    if args.save_baseline and all_results:
+        out = Path(args.save_baseline)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(all_results, indent=2) + "\n")
+        print(f"\nBaseline saved to {out}")
+
+    if args.save and all_results:
+        out = Path(args.save)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(all_results, indent=2) + "\n")
+        print(f"\nResults saved to {out}")
+
+    # ---------------------------------------------------------------------------
+    # Summary
+    # ---------------------------------------------------------------------------
+    print(f"\n{'━'*60}")
+    skipped = set(args.models) - set(all_results)
+    if skipped:
+        print(f"  Skipped (no weights): {', '.join(sorted(skipped))}")
+    if failures:
+        print(f"  FAILED: {', '.join(failures)}")
+        print("━" * 60)
+        return 1
+    if all_results:
+        print(f"  All {len(all_results)} model(s) passed.")
+    else:
+        print("  No models were validated (all skipped).")
+    print("━" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_postprocess_detections.py
+++ b/tests/unit/test_postprocess_detections.py
@@ -1,0 +1,180 @@
+"""Unit tests for postprocess_detections in libreyolo.utils.general."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from libreyolo.utils.general import postprocess_detections
+
+pytestmark = pytest.mark.unit
+
+
+def _make(boxes, scores, classes):
+    return (
+        torch.tensor(boxes, dtype=torch.float32),
+        torch.tensor(scores, dtype=torch.float32),
+        torch.tensor(classes, dtype=torch.int64),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic correctness
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty():
+    boxes = torch.zeros((0, 4))
+    scores = torch.zeros(0)
+    class_ids = torch.zeros(0, dtype=torch.int64)
+    result = postprocess_detections(boxes, scores, class_ids)
+    assert result["num_detections"] == 0
+    assert result["boxes"] == []
+
+
+def test_single_box_kept():
+    boxes, scores, class_ids = _make([[10, 10, 50, 50]], [0.9], [0])
+    result = postprocess_detections(boxes, scores, class_ids, conf_thres=0.0)
+    assert result["num_detections"] == 1
+    assert result["scores"][0] == pytest.approx(0.9)
+
+
+def test_high_overlap_same_class_suppressed():
+    # Two nearly identical boxes for the same class — lower score must be dropped.
+    boxes, scores, class_ids = _make(
+        [[0, 0, 100, 100], [1, 1, 101, 101]],
+        [0.9, 0.7],
+        [0, 0],
+    )
+    result = postprocess_detections(boxes, scores, class_ids, iou_thres=0.5)
+    assert result["num_detections"] == 1
+    assert result["scores"][0] == pytest.approx(0.9)
+
+
+def test_high_overlap_different_classes_both_kept():
+    # Same boxes, different classes — batched_nms must not suppress across classes.
+    boxes, scores, class_ids = _make(
+        [[0, 0, 100, 100], [0, 0, 100, 100]],
+        [0.9, 0.8],
+        [0, 1],
+    )
+    result = postprocess_detections(boxes, scores, class_ids, iou_thres=0.5)
+    assert result["num_detections"] == 2
+
+
+def test_multi_class_independence():
+    """Suppression within each class is independent; results are score-sorted."""
+    boxes, scores, class_ids = _make(
+        [
+            [0, 0, 10, 10],   # cls 0, score 0.9 — kept
+            [0, 0, 10, 10],   # cls 0, score 0.5 — suppressed (same box)
+            [50, 50, 60, 60], # cls 1, score 0.8 — kept (different class + location)
+            [50, 50, 60, 60], # cls 1, score 0.3 — suppressed (same box)
+        ],
+        [0.9, 0.5, 0.8, 0.3],
+        [0, 0, 1, 1],
+    )
+    result = postprocess_detections(boxes, scores, class_ids, iou_thres=0.5)
+    assert result["num_detections"] == 2
+    # Results should be sorted by descending score.
+    assert result["scores"][0] >= result["scores"][1]
+
+
+def test_output_sorted_by_descending_score():
+    boxes, scores, class_ids = _make(
+        [[0, 0, 10, 10], [20, 20, 30, 30], [40, 40, 50, 50]],
+        [0.5, 0.9, 0.7],
+        [0, 1, 2],
+    )
+    result = postprocess_detections(boxes, scores, class_ids)
+    s = result["scores"]
+    assert s == sorted(s, reverse=True), "scores must be in descending order"
+
+
+# ---------------------------------------------------------------------------
+# max_det
+# ---------------------------------------------------------------------------
+
+
+def test_max_det_limits_output():
+    n = 20
+    boxes = torch.arange(n * 4, dtype=torch.float32).reshape(n, 4)
+    # Make valid (x1<x2, y1<y2) by offsetting columns
+    boxes[:, 2] += 100
+    boxes[:, 3] += 100
+    scores = torch.linspace(0.1, 0.9, n)
+    class_ids = torch.arange(n, dtype=torch.int64)  # all different — none suppressed
+
+    result = postprocess_detections(boxes, scores, class_ids, max_det=5)
+    assert result["num_detections"] == 5
+    # Should be the top-5 by score.
+    assert min(result["scores"]) > scores[n - 6].item() - 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Finite-values guard
+# ---------------------------------------------------------------------------
+
+
+def test_nan_boxes_dropped():
+    boxes, scores, class_ids = _make(
+        [[float("nan"), 0, 10, 10], [0, 0, 10, 10]],
+        [0.9, 0.8],
+        [0, 1],
+    )
+    result = postprocess_detections(boxes, scores, class_ids)
+    # NaN box must be dropped; only the clean box survives.
+    assert result["num_detections"] == 1
+    assert result["scores"][0] == pytest.approx(0.8)
+
+
+def test_inf_boxes_dropped():
+    boxes, scores, class_ids = _make(
+        [[0, 0, float("inf"), 10], [20, 20, 30, 30]],
+        [0.95, 0.6],
+        [0, 0],
+    )
+    result = postprocess_detections(boxes, scores, class_ids)
+    assert result["num_detections"] == 1
+    assert result["scores"][0] == pytest.approx(0.6)
+
+
+def test_nan_score_dropped():
+    boxes, scores, class_ids = _make(
+        [[0, 0, 10, 10], [20, 20, 30, 30]],
+        [float("nan"), 0.7],
+        [0, 1],
+    )
+    result = postprocess_detections(boxes, scores, class_ids)
+    assert result["num_detections"] == 1
+    assert result["scores"][0] == pytest.approx(0.7)
+
+
+def test_all_nan_returns_empty():
+    boxes, scores, class_ids = _make(
+        [[float("nan"), 0, 10, 10]],
+        [0.9],
+        [0],
+    )
+    result = postprocess_detections(boxes, scores, class_ids)
+    assert result["num_detections"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Scaling / original_size
+# ---------------------------------------------------------------------------
+
+
+def test_boxes_scaled_to_original_size():
+    # Box covers half the 640-input image; after scaling to 1280×960 it should double.
+    boxes, scores, class_ids = _make([[0, 0, 320, 320]], [0.9], [0])
+    result = postprocess_detections(
+        boxes, scores, class_ids,
+        input_size=640,
+        original_size=(1280, 960),
+    )
+    b = result["boxes"][0]
+    assert b[2] == pytest.approx(640.0)   # 320 * (1280/640)
+    assert b[3] == pytest.approx(480.0)   # 320 * (960/640)


### PR DESCRIPTION
Rebase of #216 (imagra93) onto latest `dev`, with a bridge commit for the YOLO9 segmentation NMS path that landed on dev after #216 was opened.

## Attribution
- Original NMS speedup commit: **xuban ceccon** (preserved via cherry-pick)
- Tests, finite-guard restore, spot-check script, topk refactor: **imagra93** (preserved via cherry-pick)
- yolo9-seg `_nms_keep_indices` bridge: this PR

Co-authored-by: imagra93 <imanolgranada@gmail.com>

## What's included from #216
- `libreyolo/utils/general.py`, `libreyolo/models/base/inference.py`, `libreyolo/models/base/model.py`: per-class loops collapsed to a single `torchvision.ops.batched_nms` dispatch
- `tests/unit/test_postprocess_detections.py`: 12 unit tests
- `scripts/spot_check_val_map.py`: mAP regression harness

## What's excluded from #216 (deferred to follow-up PRs)
- LFS pointer handler in `tests/e2e/test_rf1_training.py` (unrelated to NMS)
- `scripts/run_e2e_nms.sh`, `scripts/check_nms_map.sh` (bash-only; the first has a status-capture bug)
- `scripts/baseline.json`, `scripts/new.json` (environment-specific generated outputs)

## What this PR adds on top
- `libreyolo/models/yolo9/utils.py:_nms_keep_indices` ported to `batched_nms` (the seg path didn't exist when #216 was opened)

## Status — work in progress
Open follow-ups before merge-ready:
- Finite-values guard at `_merge_tile_detections` and `_merge_tta` (the deleted `nms()` filtered NaN/Inf; the new merge-site calls do not)
- `boxes.float()` cast before `batched_nms` to neutralise fp16 overflow on CUDA TTA
- Re-run `spot_check_val_map.py` against `dev` baseline to confirm mAP is still within tolerance post-rebase

## Tests
- All 12 PR unit tests pass on the rebased branch
- Full unit suite: 843 passed / 41 skipped (the 5 failures in `test_train_callbacks.py` and `test_training_artifacts.py` pre-exist on `dev`)

Closes #202.
Supersedes #216.