### PR TITLE
fix(coreml): round-trip task metadata through CoreMLBackend

### DIFF
--- a/libreyolo/backends/coreml.py
+++ b/libreyolo/backends/coreml.py
@@ -7,6 +7,7 @@ rest of LibreYOLO (Results, drawing, etc.) sees the same interface.
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import sys
@@ -17,6 +18,7 @@ import numpy as np
 import torch
 from PIL import Image
 
+from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.general import COCO_CLASSES
 from ..utils.image_loader import ImageLoader
 from .base import BaseBackend
@@ -41,6 +43,19 @@ def _to_compute_unit(compute_units: str):
             f"Must be one of: {sorted(mapping)}"
         )
     return mapping[key]
+
+
+def _normalize_metadata_supported_tasks(value) -> tuple[str, ...]:
+    try:
+        return normalize_supported_tasks(value)
+    except ValueError:
+        if isinstance(value, str):
+            try:
+                parsed = ast.literal_eval(value)
+            except (SyntaxError, ValueError):
+                raise
+            return normalize_supported_tasks(parsed)
+        raise
 
 
 class CoreMLBackend(BaseBackend):
@@ -89,10 +104,25 @@ class CoreMLBackend(BaseBackend):
             if self.model.user_defined_metadata
             else {}
         )
-        model_family, names, imgsz, has_embedded_nms = self._parse_metadata(
+        (
+            model_family,
+            model_size,
+            metadata_task,
+            supported_tasks,
+            default_task,
+            names,
+            imgsz,
+            has_embedded_nms,
+        ) = self._parse_metadata(
             meta,
             nb_classes,
             output_names=self.output_names,
+        )
+        resolved_task = resolve_task(
+            explicit_task=task,
+            checkpoint_task=metadata_task,
+            default_task=default_task,
+            supported_tasks=supported_tasks,
         )
 
         self._has_embedded_nms = has_embedded_nms
@@ -104,7 +134,10 @@ class CoreMLBackend(BaseBackend):
             imgsz=imgsz,
             model_family=model_family,
             names=names if names else self.build_names(nb_classes),
-            task=task,
+            model_size=model_size,
+            task=resolved_task,
+            supported_tasks=supported_tasks,
+            default_task=default_task,
         )
 
     @staticmethod
@@ -115,6 +148,12 @@ class CoreMLBackend(BaseBackend):
         output_names: list[str] | None = None,
     ):
         model_family: Optional[str] = meta.get("model_family") or None
+        model_size: Optional[str] = meta.get("model_size") or None
+        default_task = normalize_task(meta.get("default_task"), default="detect")
+        metadata_task = normalize_task(meta.get("task"), default=default_task)
+        supported_tasks = _normalize_metadata_supported_tasks(
+            meta.get("supported_tasks", (metadata_task,))
+        )
         names: Optional[dict] = None
         imgsz = 640
         has_embedded_nms = False
@@ -150,7 +189,16 @@ class CoreMLBackend(BaseBackend):
                 "coordinates",
             }
 
-        return model_family, names, imgsz, has_embedded_nms
+        return (
+            model_family,
+            model_size,
+            metadata_task,
+            supported_tasks,
+            default_task,
+            names,
+            imgsz,
+            has_embedded_nms,
+        )
 
     def _parse_outputs(
         self,

--- a/libreyolo/export/coreml.py
+++ b/libreyolo/export/coreml.py
@@ -215,7 +215,7 @@ def _stringify_metadata(metadata: dict) -> dict:
     """
     out: dict[str, str] = {}
     for k, v in metadata.items():
-        if isinstance(v, dict):
+        if isinstance(v, (dict, list, tuple)):
             out[str(k)] = json.dumps(v)
         else:
             out[str(k)] = str(v)

--- a/tests/unit/test_export_coreml.py
+++ b/tests/unit/test_export_coreml.py
@@ -1,9 +1,9 @@
 """Unit tests for CoreML export. Mocks coremltools so it runs on every platform."""
 
 import sys
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
-import numpy as np
 import pytest
 import torch
 
@@ -24,7 +24,7 @@ except ImportError:
     _fake_ct.target.iOS15 = "iOS15"
     sys.modules["coremltools"] = _fake_ct
 
-from libreyolo.export.coreml import _to_compute_unit  # noqa: E402
+from libreyolo.export.coreml import _stringify_metadata, _to_compute_unit  # noqa: E402
 
 
 pytestmark = pytest.mark.unit
@@ -187,6 +187,18 @@ class TestExportCoreML:
         decoded = json.loads(mlmodel.user_defined_metadata["names"])
         assert decoded == {"0": "person", "1": "cat"}
 
+    def test_supported_tasks_json_encoded(self):
+        import json
+
+        metadata = _stringify_metadata(
+            {
+                "supported_tasks": ["detect", "segment"],
+                "default_task": "detect",
+            }
+        )
+
+        assert json.loads(metadata["supported_tasks"]) == ["detect", "segment"]
+
     def test_rtdetr_dict_output_is_flattened_for_trace(self):
         from libreyolo.export.coreml import _wrap_for_family
 
@@ -296,3 +308,59 @@ class TestCoreMLBackendModule:
         from libreyolo.models import LibreYOLO
         LibreYOLO(str(pkg), nb_classes=80, device="cpu")
         sentinel.assert_called_once()
+
+    def test_backend_preserves_task_metadata(self, tmp_path, monkeypatch):
+        fake, mlmodel = _patch_ct(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+
+        pkg = tmp_path / "fake.mlpackage"
+        pkg.mkdir()
+
+        mlmodel.user_defined_metadata = {
+            "model_family": "rfdetr",
+            "model_size": "n",
+            "task": "segment",
+            "default_task": "detect",
+            "supported_tasks": '["detect", "segment"]',
+            "names": '{"0": "person"}',
+            "imgsz": "512",
+        }
+        mlmodel.get_spec.return_value = SimpleNamespace(
+            description=SimpleNamespace(
+                output=[
+                    SimpleNamespace(name="boxes"),
+                    SimpleNamespace(name="logits"),
+                    SimpleNamespace(name="masks"),
+                ]
+            )
+        )
+        fake.models.MLModel.return_value = mlmodel
+
+        from libreyolo.backends.coreml import CoreMLBackend
+
+        backend = CoreMLBackend(str(pkg), nb_classes=80)
+
+        assert backend.model_family == "rfdetr"
+        assert backend.model_size == "n"
+        assert backend.size == "n"
+        assert backend.task == "segment"
+        assert backend.DEFAULT_TASK == "detect"
+        assert backend.SUPPORTED_TASKS == ("detect", "segment")
+        assert backend.imgsz == 512
+        assert backend.names == {0: "person"}
+
+    def test_backend_parses_legacy_supported_tasks_repr(self):
+        from libreyolo.backends.coreml import CoreMLBackend
+
+        parsed = CoreMLBackend._parse_metadata(
+            {
+                "task": "segment",
+                "default_task": "detect",
+                "supported_tasks": "['detect', 'segment']",
+            },
+            default_nb_classes=80,
+        )
+
+        assert parsed[2] == "segment"
+        assert parsed[3] == ("detect", "segment")
+        assert parsed[4] == "detect"


### PR DESCRIPTION
CoreMLBackend._parse_metadata only extracted model_family, names, imgsz, and embedded-NMS flags from the model's user_defined_metadata, dropping model_size, task, supported_tasks, and default_task even though BaseExporter writes all four. Consequence: a CoreML export of a segmentation-capable model (e.g. yolo9-seg) would reload as a default detect backend, losing mask/task behavior.

- backends/coreml.py: parse model_size/task/supported_tasks/default_task out of user_defined_metadata and pass through to BaseBackend; tolerate list/tuple metadata that arrives as a literal-eval'd string.
- export/coreml.py: JSON-encode list/tuple metadata so supported_tasks round-trips cleanly through Core ML's string-only metadata channel.
- tests/unit/test_export_coreml.py: regression coverage for the round-trip.