### PR TITLE
259 clean multi gpu

### DIFF
--- a/libreyolo/cli/command_utils.py
+++ b/libreyolo/cli/command_utils.py
@@ -142,6 +142,11 @@ def get_user_provided_params() -> Set[str]:
     ctx = click.get_current_context(silent=True)
     if ctx is None:
         return set()
+    # KeyValueCommand.parse_args stores the set in ctx.meta for reliable access
+    # regardless of click version or test-runner context behaviour.
+    if "user_provided" in ctx.meta:
+        return ctx.meta["user_provided"]
+    # Fallback for plain click commands not using KeyValueCommand.
     return {
         p.name
         for p in ctx.command.params

--- a/libreyolo/cli/parsing.py
+++ b/libreyolo/cli/parsing.py
@@ -49,14 +49,51 @@ class KeyValueCommand(TyperCommand):
     """Typer command that accepts both key=value and --key value syntax."""
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        # Identify boolean flag parameter names from the command definition
+        # Build bool_flags and a CLI-name → param-name reverse map.
+        # Use getattr throughout to be robust across typer/click versions
+        # (TyperOption may not be a direct subclass of click.Option in all envs).
         bool_flags: set[str] = set()
+        cli_to_param: dict[str, str] = {}
         for param in self.params:
-            if isinstance(param, click.Option) and param.is_flag:
+            if not getattr(param, "opts", None):
+                continue
+            param_name = getattr(param, "name", None)
+            for opt in param.opts:
+                if opt.startswith("--"):
+                    cli_key = opt.lstrip("-").replace("-", "_")
+                    if param_name:
+                        cli_to_param[cli_key] = param_name
+            for opt in getattr(param, "secondary_opts", []):
+                if opt.startswith("--"):
+                    cli_key = opt.lstrip("-").replace("-", "_")
+                    if param_name:
+                        cli_to_param[cli_key] = param_name
+            if getattr(param, "is_flag", False):
                 for opt in param.opts:
-                    bool_flags.add(opt.lstrip("-"))
-                for opt in param.secondary_opts:
-                    bool_flags.add(opt.lstrip("-"))
+                    if opt.startswith("--"):
+                        bool_flags.add(opt.lstrip("-"))
+                for opt in getattr(param, "secondary_opts", []):
+                    if opt.startswith("--"):
+                        bool_flags.add(opt.lstrip("-"))
+
+        # Compute which params the user explicitly provided from the raw args,
+        # and store them in ctx.meta so get_user_provided_params() can retrieve
+        # them without relying on click's ParameterSource tracking (which can
+        # be unreliable inside typer's test runner on some Python versions).
+        user_provided: set[str] = set()
+        for arg in args:
+            if arg.startswith("--"):
+                raw = arg.lstrip("-").split("=")[0].replace("-", "_")
+                user_provided.add(cli_to_param.get(raw, raw))
+            elif re.match(r"^[a-zA-Z_][a-zA-Z0-9_-]*=", arg):
+                key = arg.split("=")[0].replace("-", "_")
+                user_provided.add(cli_to_param.get(key, key))
+            elif re.match(r"^[a-zA-Z_][a-zA-Z0-9_-]*$", arg):
+                # Bare word: only counts if it's a known bool flag
+                key = arg.replace("-", "_")
+                if arg.replace("_", "-") in bool_flags or arg in bool_flags:
+                    user_provided.add(cli_to_param.get(key, key))
+        ctx.meta["user_provided"] = user_provided
 
         new_args = rewrite_known_bool_flags(args, bool_flags)
         parsed_args: list[str] = []

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -21,6 +21,7 @@ from PIL import Image, UnidentifiedImageError
 from tqdm import tqdm
 
 from .utils import polygon_to_cxcywh
+from libreyolo.training.distributed import is_main_process
 
 logger = logging.getLogger(__name__)
 
@@ -228,7 +229,9 @@ class YOLODataset(Dataset):
         """Load all annotations."""
         total = len(self.img_files)
         source = self._annotation_source()
-        logger.info("Loading %d YOLO annotations from %s...", total, source)
+        main = is_main_process()
+        if main:
+            logger.info("Loading %d YOLO annotations from %s...", total, source)
         start = time.perf_counter()
 
         pairs = list(zip(self.img_files, self.label_files))
@@ -238,6 +241,7 @@ class YOLODataset(Dataset):
             img_file, label_file = pair
             return self._load_label(label_file, img_file)
 
+        tqdm_disable = not (main and sys.stderr.isatty())
         if max_workers > 1:
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 annotations = list(
@@ -246,7 +250,7 @@ class YOLODataset(Dataset):
                         total=total,
                         desc=f"Loading YOLO annotations ({source})",
                         file=sys.stderr,
-                        disable=not sys.stderr.isatty(),
+                        disable=tqdm_disable,
                     )
                 )
         else:
@@ -257,16 +261,17 @@ class YOLODataset(Dataset):
                     total=total,
                     desc=f"Loading YOLO annotations ({source})",
                     file=sys.stderr,
-                    disable=not sys.stderr.isatty(),
+                    disable=tqdm_disable,
                 )
             ]
 
-        logger.info(
-            "Loaded %d YOLO annotations from %s in %.2fs",
-            total,
-            source,
-            time.perf_counter() - start,
-        )
+        if main:
+            logger.info(
+                "Loaded %d YOLO annotations from %s in %.2fs",
+                total,
+                source,
+                time.perf_counter() - start,
+            )
         if self.load_segments:
             self.segments = [item[1] for item in annotations]
             annotations = [item[0] for item in annotations]

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -184,7 +184,7 @@ class BaseModel(ABC):
 
         # Signal _init_model that weights will be loaded immediately after, so
         # subclasses can skip pretrained backbone downloads that would be wasted.
-        self._loading_from_weights = isinstance(model_path, (str, dict))
+        self._loading_from_weights = isinstance(model_path, (str, Path, dict))
         try:
             self.model = self._init_model()
         finally:

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -182,7 +182,13 @@ class BaseModel(ABC):
         if isinstance(model_path, str):
             model_path = self._resolve_weights_path(model_path)
 
-        self.model = self._init_model()
+        # Signal _init_model that weights will be loaded immediately after, so
+        # subclasses can skip pretrained backbone downloads that would be wasted.
+        self._loading_from_weights = isinstance(model_path, (str, dict))
+        try:
+            self.model = self._init_model()
+        finally:
+            self._loading_from_weights = False
 
         if model_path is None:
             self.model_path = None
@@ -309,7 +315,14 @@ class BaseModel(ABC):
         old_state = self.model.state_dict()
         self.nb_classes = new_nb_classes
         self.names = {i: f"class_{i}" for i in range(new_nb_classes)}
-        self.model = self._init_model()
+        # Signal _init_model to skip pretrained backbone downloads — old_state
+        # already holds all backbone weights which are restored below, so
+        # downloading pretrained weights here is pure waste.
+        self._in_rebuild = True
+        try:
+            self.model = self._init_model()
+        finally:
+            self._in_rebuild = False
 
         new_state = self.model.state_dict()
         for key in old_state:

--- a/libreyolo/models/damoyolo/loss.py
+++ b/libreyolo/models/damoyolo/loss.py
@@ -174,9 +174,11 @@ def _quality_focal_loss(pred, target, beta: float = 2.0, use_sigmoid: bool = Tru
     if use_sigmoid:
         func = F.binary_cross_entropy_with_logits
     else:
-        # F.binary_cross_entropy is unsafe under AMP autocast — promote to float32
+        # F.binary_cross_entropy is blocked inside AMP autocast regions regardless of dtype.
+        # Step outside autocast and promote to float32.
         def func(inp, tgt, **kw):
-            return F.binary_cross_entropy(inp.float(), tgt.float(), **kw)
+            with torch.amp.autocast("cuda", enabled=False):
+                return F.binary_cross_entropy(inp.float(), tgt.float(), **kw)
     pred_sigmoid = pred.sigmoid() if use_sigmoid else pred
     scale_factor = pred_sigmoid
     zerolabel = scale_factor.new_zeros(pred.shape)

--- a/libreyolo/models/damoyolo/loss.py
+++ b/libreyolo/models/damoyolo/loss.py
@@ -171,7 +171,12 @@ class DistributionFocalLoss(nn.Module):
 @_weighted
 def _quality_focal_loss(pred, target, beta: float = 2.0, use_sigmoid: bool = True):
     label, score = target  # both shape (N,)
-    func = F.binary_cross_entropy_with_logits if use_sigmoid else F.binary_cross_entropy
+    if use_sigmoid:
+        func = F.binary_cross_entropy_with_logits
+    else:
+        # F.binary_cross_entropy is unsafe under AMP autocast — promote to float32
+        def func(inp, tgt, **kw):
+            return F.binary_cross_entropy(inp.float(), tgt.float(), **kw)
     pred_sigmoid = pred.sigmoid() if use_sigmoid else pred
     scale_factor = pred_sigmoid
     zerolabel = scale_factor.new_zeros(pred.shape)
@@ -290,9 +295,11 @@ class AlignOTAAssigner:
         valid_pred_rep = valid_pred.unsqueeze(1).repeat(1, num_gt, 1)
 
         soft_label = gt_onehot * pairwise_ious[..., None]
-        scale_factor = soft_label - valid_pred_rep
+        valid_pred_rep_f = valid_pred_rep.float()
+        soft_label_f = soft_label.float()
+        scale_factor = soft_label_f - valid_pred_rep_f
         cls_cost = (
-            F.binary_cross_entropy(valid_pred_rep, soft_label, reduction="none")
+            F.binary_cross_entropy(valid_pred_rep_f, soft_label_f, reduction="none")
             * scale_factor.abs().pow(2.0)
         ).sum(dim=-1)
 

--- a/libreyolo/models/damoyolo/model.py
+++ b/libreyolo/models/damoyolo/model.py
@@ -9,6 +9,7 @@ import cv2
 import numpy as np
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 from PIL import Image
 
 from ...training.config import DAMOYOLOConfig
@@ -237,6 +238,7 @@ class LibreDAMOYOLO(BaseModel):
 
     # ---- training --------------------------------------------------------
 
+    @ddp_aware(experimental_key="allow_experimental")
     def train(
         self,
         data: str,
@@ -282,20 +284,6 @@ class LibreDAMOYOLO(BaseModel):
                 "Not validated: small-dataset fine-tune convergence, "
                 "multi-GPU, SADA augmentation."
             )
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, allow_experimental=allow_experimental, epochs=epochs,
-                batch=batch, imgsz=imgsz, lr0=lr0, optimizer=optimizer,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
-                amp=amp, patience=patience,
-                allow_download_scripts=allow_download_scripts, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from pathlib import Path
 
         from libreyolo.data import load_data_config

--- a/libreyolo/models/damoyolo/model.py
+++ b/libreyolo/models/damoyolo/model.py
@@ -317,7 +317,7 @@ class LibreDAMOYOLO(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = DAMOYOLOTrainer(

--- a/libreyolo/models/damoyolo/model.py
+++ b/libreyolo/models/damoyolo/model.py
@@ -282,6 +282,20 @@ class LibreDAMOYOLO(BaseModel):
                 "Not validated: small-dataset fine-tune convergence, "
                 "multi-GPU, SADA augmentation."
             )
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, allow_experimental=allow_experimental, epochs=epochs,
+                batch=batch, imgsz=imgsz, lr0=lr0, optimizer=optimizer,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
+                amp=amp, patience=patience,
+                allow_download_scripts=allow_download_scripts, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from pathlib import Path
 
         from libreyolo.data import load_data_config

--- a/libreyolo/models/damoyolo/nn.py
+++ b/libreyolo/models/damoyolo/nn.py
@@ -1154,8 +1154,7 @@ class ZeroHead(nn.Module):
         """Dispatch to train/eval. Eval returns ``(cls, boxes)`` (xyxy in
         model-input pixels). Train returns a dict of loss components.
         """
-        if self.training:
-            assert targets is not None, "ZeroHead.forward(targets=None) in train mode"
+        if self.training and targets is not None:
             return self._forward_train(xin, targets)
         return self._forward_eval(xin)
 

--- a/libreyolo/models/deim/decoder.py
+++ b/libreyolo/models/deim/decoder.py
@@ -814,7 +814,7 @@ class DEIMTransformer(nn.Module):
     def forward(self, feats, targets=None):
         memory, spatial_shapes = self._get_encoder_input(feats)
 
-        if self.training and self.num_denoising > 0:
+        if self.training and self.num_denoising > 0 and targets is not None:
             denoising_logits, denoising_bbox_unact, attn_mask, dn_meta = (
                 get_contrastive_denoising_training_group(
                     targets,

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 
 from ...utils.image_loader import ImageInput
 from ...training.config import DEIMConfig
@@ -176,6 +177,7 @@ class LibreDEIM(BaseModel):
         # regenerated at forward time from eval_spatial_size. Tolerate drift.
         return False
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -200,18 +202,6 @@ class LibreDEIM(BaseModel):
         For v1 inference-only usage, just don't call this. To fine-tune from
         upstream weights, pass ``data="coco128.yaml"`` (or your own data yaml).
         """
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
-                patience=patience, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from libreyolo.data import load_data_config
 
         from .trainer import DEIMTrainer

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -200,6 +200,18 @@ class LibreDEIM(BaseModel):
         For v1 inference-only usage, just don't call this. To fine-tune from
         upstream weights, pass ``data="coco128.yaml"`` (or your own data yaml).
         """
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
+                patience=patience, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from libreyolo.data import load_data_config
 
         from .trainer import DEIMTrainer

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -229,7 +229,7 @@ class LibreDEIM(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = DEIMTrainer(

--- a/libreyolo/models/deimv2/engine/deim/deim_decoder.py
+++ b/libreyolo/models/deimv2/engine/deim/deim_decoder.py
@@ -691,7 +691,7 @@ class DEIMTransformer(nn.Module):
         memory, spatial_shapes = self._get_encoder_input(feats)
 
         # prepare denoising training
-        if self.training and self.num_denoising > 0:
+        if self.training and self.num_denoising > 0 and targets is not None:
             denoising_logits, denoising_bbox_unact, attn_mask, dn_meta = (
                 get_contrastive_denoising_training_group(
                     targets,

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 
 from ...training.config import DEIMv2Config
 from ...utils.image_loader import ImageInput
@@ -196,6 +197,7 @@ class LibreDEIMv2(BaseModel):
     def _strict_loading(self) -> bool:
         return False
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -216,18 +218,6 @@ class LibreDEIMv2(BaseModel):
         **kwargs,
     ) -> dict:
         """Fine-tune DEIMv2 on a YOLO-format dataset config."""
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
-                patience=patience, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from libreyolo.data import load_data_config
 
         from .trainer import DEIMv2Trainer

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -247,7 +247,7 @@ class LibreDEIMv2(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer_kwargs = {

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -216,6 +216,18 @@ class LibreDEIMv2(BaseModel):
         **kwargs,
     ) -> dict:
         """Fine-tune DEIMv2 on a YOLO-format dataset config."""
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
+                patience=patience, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from libreyolo.data import load_data_config
 
         from .trainer import DEIMv2Trainer

--- a/libreyolo/models/dfine/decoder.py
+++ b/libreyolo/models/dfine/decoder.py
@@ -813,7 +813,7 @@ class DFINETransformer(nn.Module):
     def forward(self, feats, targets=None):
         memory, spatial_shapes = self._get_encoder_input(feats)
 
-        if self.training and self.num_denoising > 0:
+        if self.training and self.num_denoising > 0 and targets is not None:
             denoising_logits, denoising_bbox_unact, attn_mask, dn_meta = (
                 get_contrastive_denoising_training_group(
                     targets,

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 
 from ...utils.image_loader import ImageInput
 from ...validation.preprocessors import DFINEValPreprocessor
@@ -174,6 +175,7 @@ class LibreDFINE(BaseModel):
         # regenerated at forward time from eval_spatial_size. Tolerate drift.
         return False
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -198,18 +200,6 @@ class LibreDFINE(BaseModel):
         For v1 inference-only usage, just don't call this. To fine-tune from
         upstream weights, pass ``data="coco128.yaml"`` (or your own data yaml).
         """
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
-                patience=patience, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from libreyolo.data import load_data_config
 
         from .trainer import DFINETrainer

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -198,6 +198,18 @@ class LibreDFINE(BaseModel):
         For v1 inference-only usage, just don't call this. To fine-tune from
         upstream weights, pass ``data="coco128.yaml"`` (or your own data yaml).
         """
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
+                patience=patience, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from libreyolo.data import load_data_config
 
         from .trainer import DFINETrainer

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -227,7 +227,7 @@ class LibreDFINE(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = DFINETrainer(

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 
 from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput
@@ -262,6 +263,7 @@ class LibreEC(BaseModel):
         # forward time. Mirror the D-FINE policy.
         return False
 
+    @ddp_aware(experimental_key="allow_experimental")
     def train(
         self,
         data: str,
@@ -312,18 +314,6 @@ class LibreEC(BaseModel):
                 "validated: full fine-tune convergence, multi-GPU, the "
                 "stop_aug_epoch best-reload trick, Obj365→COCO class remap."
             )
-
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, allow_experimental=allow_experimental, epochs=epochs,
-                batch=batch, imgsz=imgsz, lr0=lr0, device=device, workers=workers,
-                seed=seed, project=project, name=name, exist_ok=exist_ok,
-                resume=resume, amp=amp, patience=patience, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
 
         from pathlib import Path
 

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -343,7 +343,7 @@ class LibreEC(BaseModel):
             _r.seed(seed)
             _np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = ECTrainer(

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -313,6 +313,18 @@ class LibreEC(BaseModel):
                 "stop_aug_epoch best-reload trick, Obj365→COCO class remap."
             )
 
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, allow_experimental=allow_experimental, epochs=epochs,
+                batch=batch, imgsz=imgsz, lr0=lr0, device=device, workers=workers,
+                seed=seed, project=project, name=name, exist_ok=exist_ok,
+                resume=resume, amp=amp, patience=patience, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from pathlib import Path
 
         from libreyolo.data import load_data_config

--- a/libreyolo/models/picodet/model.py
+++ b/libreyolo/models/picodet/model.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 from PIL import Image
 
 from ...training.config import PICODETConfig
@@ -150,6 +151,7 @@ class LibrePICODET(BaseModel):
 
     # ---- training --------------------------------------------------------
 
+    @ddp_aware(experimental_key="allow_experimental")
     def train(
         self,
         data: str,
@@ -199,20 +201,6 @@ class LibrePICODET(BaseModel):
                 "export. What's NOT validated: small-dataset fine-tune "
                 "convergence, multi-GPU, augmentation policy beyond hflip."
             )
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, allow_experimental=allow_experimental, epochs=epochs,
-                batch=batch, imgsz=imgsz, lr0=lr0, optimizer=optimizer,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
-                amp=amp, patience=patience,
-                allow_download_scripts=allow_download_scripts, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from pathlib import Path
 
         from libreyolo.data import load_data_config

--- a/libreyolo/models/picodet/model.py
+++ b/libreyolo/models/picodet/model.py
@@ -232,7 +232,7 @@ class LibrePICODET(BaseModel):
             import numpy as np
 
             random.seed(seed); np.random.seed(seed); torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = PICODETTrainer(

--- a/libreyolo/models/picodet/model.py
+++ b/libreyolo/models/picodet/model.py
@@ -199,6 +199,20 @@ class LibrePICODET(BaseModel):
                 "export. What's NOT validated: small-dataset fine-tune "
                 "convergence, multi-GPU, augmentation policy beyond hflip."
             )
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, allow_experimental=allow_experimental, epochs=epochs,
+                batch=batch, imgsz=imgsz, lr0=lr0, optimizer=optimizer,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
+                amp=amp, patience=patience,
+                allow_download_scripts=allow_download_scripts, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from pathlib import Path
 
         from libreyolo.data import load_data_config

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar, Dict, Optional, Tuple
 import numpy as np
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 from PIL import Image
 
 from ..base import BaseModel
@@ -608,6 +609,7 @@ class LibreRFDETR(BaseModel):
         """Run RF-DETR validation with a Windows-safe worker default."""
         return super().val(*args, workers=workers, **kwargs)
 
+    @ddp_aware(batch_key="batch_size")
     def train(
         self,
         data: str,
@@ -632,23 +634,6 @@ class LibreRFDETR(BaseModel):
                 a plain Python script — DDP workers are spawned automatically,
                 no torchrun required.
         """
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-
-        device = kwargs.get("device", "")
-        devices = parse_device_arg(device)
-        if len(devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data,
-                epochs=epochs,
-                batch_size=batch_size,
-                lr=lr,
-                output_dir=output_dir,
-                resume=resume,
-                **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(devices), batch_key="batch_size")
-
         output_path = Path(output_dir)
         train_kwargs = dict(kwargs)
         batch = train_kwargs.pop("batch", None)

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -620,20 +620,7 @@ class LibreRFDETR(BaseModel):
         resume: str | None = None,
         **kwargs,
     ) -> Dict:
-        """Fine-tune RF-DETR through LibreYOLO's native trainer.
-
-        Args:
-            data: Path to data.yaml.
-            epochs: Training epochs.
-            batch_size: Global batch size (divided by world_size per GPU under DDP).
-            lr: Initial learning rate.
-            output_dir: Root output directory.
-            resume: Path to checkpoint to resume from.
-            **kwargs: Extra trainer kwargs, including ``device``. Pass
-                ``device="0,1"`` (or a list) to enable multi-GPU training from
-                a plain Python script — DDP workers are spawned automatically,
-                no torchrun required.
-        """
+        """Fine-tune RF-DETR through LibreYOLO's native trainer."""
         output_path = Path(output_dir)
         train_kwargs = dict(kwargs)
         batch = train_kwargs.pop("batch", None)

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -763,6 +763,25 @@ def _rfdetr_spawn_ddp(model_instance: "LibreRFDETR", train_kw: dict, nprocs: int
         tmp_weights,
     )
 
+    # Resolve batch_size=-1 here (main process, before spawning) so workers
+    # receive a concrete value and need no inter-process coordination.
+    if train_kw.get("batch_size") == -1:
+        from libreyolo.training.autobatch import autobatch as _autobatch
+
+        probe_device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
+        model_instance.model.to(probe_device)
+        nbs = train_kw.get("nbs") or 32
+        resolved = _autobatch(
+            model_instance.model,
+            imgsz=train_kw.get("imgsz", 640),
+            amp=train_kw.get("amp", True),
+            max_probe=nbs,
+        )
+        resolved = max(nprocs, (resolved // nprocs) * nprocs)
+        train_kw = {**train_kw, "batch_size": resolved}
+        model_instance.model.cpu()
+        torch.cuda.empty_cache()
+
     init_kw = {
         "size": model_instance.size,
         "nb_classes": model_instance.nb_classes,

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -708,6 +708,3 @@ class LibreRFDETR(BaseModel):
             self.model.to(self.device).eval()
 
         return result
-
-
-# =============================================================================

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -618,7 +618,36 @@ class LibreRFDETR(BaseModel):
         resume: str | None = None,
         **kwargs,
     ) -> Dict:
-        """Fine-tune RF-DETR through LibreYOLO's native trainer."""
+        """Fine-tune RF-DETR through LibreYOLO's native trainer.
+
+        Args:
+            data: Path to data.yaml.
+            epochs: Training epochs.
+            batch_size: Global batch size (divided by world_size per GPU under DDP).
+            lr: Initial learning rate.
+            output_dir: Root output directory.
+            resume: Path to checkpoint to resume from.
+            **kwargs: Extra trainer kwargs, including ``device``. Pass
+                ``device="0,1"`` (or a list) to enable multi-GPU training from
+                a plain Python script — DDP workers are spawned automatically,
+                no torchrun required.
+        """
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+
+        device = kwargs.get("device", "")
+        devices = parse_device_arg(device)
+        if len(devices) > 1 and not has_torchrun_env():
+            train_kw = dict(
+                data=data,
+                epochs=epochs,
+                batch_size=batch_size,
+                lr=lr,
+                output_dir=output_dir,
+                resume=resume,
+                **kwargs,
+            )
+            return _rfdetr_spawn_ddp(self, train_kw, len(devices))
+
         output_path = Path(output_dir)
         train_kwargs = dict(kwargs)
         batch = train_kwargs.pop("batch", None)
@@ -678,3 +707,92 @@ class LibreRFDETR(BaseModel):
             self.model.to(self.device).eval()
 
         return result
+
+
+# =============================================================================
+# DDP auto-spawn helpers (module-level so mp.spawn can pickle them by name)
+# =============================================================================
+
+
+def _rfdetr_ddp_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+    weights_path: str,
+    init_kw: dict,
+    train_kw: dict,
+) -> None:
+    """Worker function run in each spawned DDP process for RF-DETR training."""
+    import json
+    import os
+    from pathlib import Path
+
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(nprocs)
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    model = LibreRFDETR(weights_path, **init_kw)
+    result = model.train(**train_kw)
+
+    if rank == 0:
+        safe = {k: v for k, v in result.items() if isinstance(v, (int, float, str, bool, type(None)))}
+        Path(result_path).write_text(json.dumps(safe))
+
+
+def _rfdetr_spawn_ddp(model_instance: "LibreRFDETR", train_kw: dict, nprocs: int) -> dict:
+    """Save weights to a temp file, spawn DDP workers, and collect results."""
+    import json
+    import os
+    import tempfile
+    from pathlib import Path
+
+    import torch
+
+    from libreyolo.training.distributed import spawn_ddp_train
+
+    fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
+    os.close(fd)
+    torch.save(
+        {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
+        tmp_weights,
+    )
+
+    init_kw = {
+        "size": model_instance.size,
+        "nb_classes": model_instance.nb_classes,
+        "device": "auto",
+        "task": model_instance.task,
+    }
+
+    fd, tmp_result = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+
+    try:
+        spawn_ddp_train(
+            _rfdetr_ddp_worker,
+            spawn_args=(tmp_weights, init_kw, train_kw),
+            nprocs=nprocs,
+            result_path=tmp_result,
+        )
+    finally:
+        Path(tmp_weights).unlink(missing_ok=True)
+
+    result: dict = {}
+    tmp_result_path = Path(tmp_result)
+    if tmp_result_path.exists():
+        result = json.loads(tmp_result_path.read_text())
+        tmp_result_path.unlink()
+
+    best = result.get("best_checkpoint")
+    if best and Path(best).exists():
+        model_instance.model_path = best
+        model_instance._load_weights(best)
+        model_instance.model.to(model_instance.device).eval()
+
+    return result

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -637,6 +637,7 @@ class LibreRFDETR(BaseModel):
         device = kwargs.get("device", "")
         devices = parse_device_arg(device)
         if len(devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
             train_kw = dict(
                 data=data,
                 epochs=epochs,
@@ -646,7 +647,7 @@ class LibreRFDETR(BaseModel):
                 resume=resume,
                 **kwargs,
             )
-            return _rfdetr_spawn_ddp(self, train_kw, len(devices))
+            return spawn_for_model(self, train_kw, len(devices), batch_key="batch_size")
 
         output_path = Path(output_dir)
         train_kwargs = dict(kwargs)
@@ -710,108 +711,3 @@ class LibreRFDETR(BaseModel):
 
 
 # =============================================================================
-# DDP auto-spawn helpers (module-level so mp.spawn can pickle them by name)
-# =============================================================================
-
-
-def _rfdetr_ddp_worker(
-    rank: int,
-    nprocs: int,
-    master_addr: str,
-    master_port: int,
-    result_path: str,
-    weights_path: str,
-    init_kw: dict,
-    train_kw: dict,
-) -> None:
-    """Worker function run in each spawned DDP process for RF-DETR training."""
-    import json
-    import os
-    from pathlib import Path
-
-    os.environ["RANK"] = str(rank)
-    os.environ["LOCAL_RANK"] = str(rank)
-    os.environ["WORLD_SIZE"] = str(nprocs)
-    os.environ["MASTER_ADDR"] = master_addr
-    os.environ["MASTER_PORT"] = str(master_port)
-
-    from libreyolo.models.rfdetr.model import LibreRFDETR
-
-    model = LibreRFDETR(weights_path, **init_kw)
-    result = model.train(**train_kw)
-
-    if rank == 0:
-        safe = {k: v for k, v in result.items() if isinstance(v, (int, float, str, bool, type(None)))}
-        Path(result_path).write_text(json.dumps(safe))
-
-
-def _rfdetr_spawn_ddp(model_instance: "LibreRFDETR", train_kw: dict, nprocs: int) -> dict:
-    """Save weights to a temp file, spawn DDP workers, and collect results."""
-    import json
-    import os
-    import tempfile
-    from pathlib import Path
-
-    import torch
-
-    from libreyolo.training.distributed import spawn_ddp_train
-
-    fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
-    os.close(fd)
-    torch.save(
-        {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
-        tmp_weights,
-    )
-
-    # Resolve batch_size=-1 here (main process, before spawning) so workers
-    # receive a concrete value and need no inter-process coordination.
-    if train_kw.get("batch_size") == -1:
-        from libreyolo.training.autobatch import autobatch as _autobatch
-
-        probe_device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
-        model_instance.model.to(probe_device)
-        nbs = train_kw.get("nbs") or 32
-        resolved = _autobatch(
-            model_instance.model,
-            imgsz=train_kw.get("imgsz", 640),
-            amp=train_kw.get("amp", True),
-            max_probe=nbs,
-        )
-        resolved = max(nprocs, (resolved // nprocs) * nprocs)
-        train_kw = {**train_kw, "batch_size": resolved}
-        model_instance.model.cpu()
-        torch.cuda.empty_cache()
-
-    init_kw = {
-        "size": model_instance.size,
-        "nb_classes": model_instance.nb_classes,
-        "device": "auto",
-        "task": model_instance.task,
-    }
-
-    fd, tmp_result = tempfile.mkstemp(suffix=".json")
-    os.close(fd)
-
-    try:
-        spawn_ddp_train(
-            _rfdetr_ddp_worker,
-            spawn_args=(tmp_weights, init_kw, train_kw),
-            nprocs=nprocs,
-            result_path=tmp_result,
-        )
-    finally:
-        Path(tmp_weights).unlink(missing_ok=True)
-
-    result: dict = {}
-    tmp_result_path = Path(tmp_result)
-    if tmp_result_path.exists():
-        result = json.loads(tmp_result_path.read_text())
-        tmp_result_path.unlink()
-
-    best = result.get("best_checkpoint")
-    if best and Path(best).exists():
-        model_instance.model_path = best
-        model_instance._load_weights(best)
-        model_instance.model.to(model_instance.device).eval()
-
-    return result

--- a/libreyolo/models/rtdetr/loss.py
+++ b/libreyolo/models/rtdetr/loss.py
@@ -311,11 +311,17 @@ class SetCriterion(nn.Module):
         # Match last layer outputs to targets
         indices = self.matcher(outputs_without_aux, targets)
 
-        # Compute number of target boxes for normalization
+        # Compute number of target boxes for normalization.
+        # Under DDP, all-reduce so every rank divides by the global count,
+        # not just its own per-rank batch. Without this, losses would be
+        # scaled by per-rank box counts, which diverge from single-GPU semantics.
         num_boxes = sum(len(t["labels"]) for t in targets)
         num_boxes = torch.as_tensor(
             [num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device
         )
+        import torch.distributed as _dist
+        if _dist.is_available() and _dist.is_initialized():
+            _dist.all_reduce(num_boxes, op=_dist.ReduceOp.SUM)
         num_boxes = torch.clamp(num_boxes, min=1).item()
 
         # Compute all requested losses

--- a/libreyolo/models/rtdetr/loss.py
+++ b/libreyolo/models/rtdetr/loss.py
@@ -13,6 +13,7 @@ Reference: https://github.com/lyuwenyu/RT-DETR
 """
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
@@ -319,9 +320,8 @@ class SetCriterion(nn.Module):
         num_boxes = torch.as_tensor(
             [num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device
         )
-        import torch.distributed as _dist
-        if _dist.is_available() and _dist.is_initialized():
-            _dist.all_reduce(num_boxes, op=_dist.ReduceOp.SUM)
+        if dist.is_available() and dist.is_initialized():
+            dist.all_reduce(num_boxes, op=dist.ReduceOp.SUM)
         num_boxes = torch.clamp(num_boxes, min=1).item()
 
         # Compute all requested losses

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 from PIL import Image
 
 from ..base import BaseModel
@@ -472,6 +473,7 @@ class LibreRTDETR(BaseModel):
         """Export model. RTDETR requires opset >= 17 for deformable attention (F.grid_sample)."""
         return super().export(format, opset=opset, **kwargs)
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -523,21 +525,6 @@ class LibreRTDETR(BaseModel):
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                lr_backbone=lr_backbone, optimizer=optimizer, scheduler=scheduler,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
-                amp=amp, patience=patience,
-                allow_download_scripts=allow_download_scripts, callbacks=callbacks,
-                **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         trainer_cls = self._get_trainer_class()
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -523,6 +523,21 @@ class LibreRTDETR(BaseModel):
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                lr_backbone=lr_backbone, optimizer=optimizer, scheduler=scheduler,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
+                amp=amp, patience=patience,
+                allow_download_scripts=allow_download_scripts, callbacks=callbacks,
+                **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         trainer_cls = self._get_trainer_class()
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -556,7 +556,7 @@ class LibreRTDETR(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = trainer_cls(

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -301,6 +301,11 @@ class LibreRTDETR(BaseModel):
     def _init_model(self) -> nn.Module:
         """Initialize the RTDETR model."""
         cfg = RTDETR_CONFIGS[self.size]
+        # Skip pretrained download when weights will be loaded immediately after
+        # (_loading_from_weights) or when called from _rebuild_for_new_classes
+        # (_in_rebuild) — in both cases the backbone weights are overwritten anyway.
+        skip = getattr(self, "_in_rebuild", False) or getattr(self, "_loading_from_weights", False)
+        pretrained = cfg["backbone_pretrained"] and not skip
         backbone_kwargs: Dict[str, Any] = {}
         if cfg.get("backbone_type") == "hgnetv2":
             from .hgnetv2 import HGNetv2
@@ -310,14 +315,14 @@ class LibreRTDETR(BaseModel):
                 return_idx=[1, 2, 3],
                 freeze_at=cfg["backbone_freeze_at"],
                 freeze_norm=cfg["backbone_freeze_norm"],
-                pretrained=cfg["backbone_pretrained"],
+                pretrained=pretrained,
             )
         else:
             backbone_kwargs.update(
                 backbone_depth=cfg["backbone_depth"],
                 backbone_freeze_at=cfg["backbone_freeze_at"],
                 backbone_freeze_norm=cfg["backbone_freeze_norm"],
-                backbone_pretrained=cfg["backbone_pretrained"],
+                backbone_pretrained=pretrained,
             )
         return RTDETRModel(
             num_classes=self.nb_classes,

--- a/libreyolo/models/rtdetr/trainer.py
+++ b/libreyolo/models/rtdetr/trainer.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Type
 
 import torch
 
+from libreyolo.training.distributed import is_main_process
 from libreyolo.training.trainer import BaseTrainer
 from libreyolo.training.config import TrainConfig
 from libreyolo.training.scheduler import (
@@ -292,12 +293,12 @@ class RTDETRTrainer(BaseTrainer):
         else:
             raise ValueError(f"Unsupported optimizer: {config.optimizer}")
 
-        # Log parameter groups
-        logger.info(f"Optimizer: {optimizer_name}")
-        for i, g in enumerate(opt_groups):
-            logger.info(
-                f"  - Group {i}: lr={g['lr']:.6f}, wd={g.get('weight_decay', base_wd):.6f}, "
-                f"lr_ratio={g.get('lr_ratio', 1.0):.4f}, params={len(g['params'])}"
-            )
+        if is_main_process():
+            logger.info(f"Optimizer: {optimizer_name}")
+            for i, g in enumerate(opt_groups):
+                logger.info(
+                    f"  - Group {i}: lr={g['lr']:.6f}, wd={g.get('weight_decay', base_wd):.6f}, "
+                    f"lr_ratio={g.get('lr_ratio', 1.0):.4f}, params={len(g['params'])}"
+                )
 
         return optimizer

--- a/libreyolo/models/rtdetr/trainer.py
+++ b/libreyolo/models/rtdetr/trainer.py
@@ -84,6 +84,13 @@ class RTDETRTrainer(BaseTrainer):
     def _config_class(cls) -> Type[TrainConfig]:
         return RTDETRConfig
 
+    def _ddp_find_unused_parameters(self) -> bool:
+        # RT-DETR's denoising_class_embed is skipped when a batch has no GT
+        # boxes (get_contrastive_denoising_training_group returns None).
+        # DDP must re-scan the graph each iteration rather than assuming a
+        # fixed set of used parameters (static_graph=True is incompatible here).
+        return True
+
     @property
     def effective_lr(self) -> float:
         """Optimizer base learning rate."""

--- a/libreyolo/models/rtdetrv2/decoder.py
+++ b/libreyolo/models/rtdetrv2/decoder.py
@@ -596,7 +596,7 @@ class RTDETRTransformerv2(nn.Module):
     def forward(self, feats, targets=None):
         memory, spatial_shapes = self._get_encoder_input(feats)
 
-        if self.training and self.num_denoising > 0:
+        if self.training and self.num_denoising > 0 and targets is not None:
             (
                 denoising_logits,
                 denoising_bbox_unact,

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 
 from ...training.config import RTDETRv4Config
 from ..dfine.model import LibreDFINE
@@ -49,6 +50,7 @@ class LibreRTDETRv4(LibreDFINE):
             activation="silu",
         )
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -68,18 +70,6 @@ class LibreRTDETRv4(LibreDFINE):
         patience: int = 50,
         **kwargs,
     ) -> dict:
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
-                patience=patience, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from libreyolo.data import load_data_config
 
         from .trainer import RTDETRv4Trainer

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -97,7 +97,7 @@ class LibreRTDETRv4(LibreDFINE):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = RTDETRv4Trainer(

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -68,6 +68,18 @@ class LibreRTDETRv4(LibreDFINE):
         patience: int = 50,
         **kwargs,
     ) -> dict:
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, resume=resume, amp=amp,
+                patience=patience, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from libreyolo.data import load_data_config
 
         from .trainer import RTDETRv4Trainer

--- a/libreyolo/models/rtmdet/loss.py
+++ b/libreyolo/models/rtmdet/loss.py
@@ -329,7 +329,7 @@ class BatchDynamicSoftLabelAssigner(nn.Module):
         assigned_bboxes[fg_mask] = gt_bboxes[batch_index, matched_gt_inds]
 
         assign_metrics = gt_bboxes.new_zeros(pred_scores[..., 0].shape)
-        assign_metrics[fg_mask] = matched_pred_ious
+        assign_metrics[fg_mask] = matched_pred_ious.to(assign_metrics.dtype)
 
         return {
             "assigned_labels": assigned_labels,

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 from PIL import Image
 
 from ...training.config import RTMDetConfig
@@ -177,6 +178,7 @@ class LibreRTMDet(BaseModel):
     # Training (experimental)
     # =========================================================================
 
+    @ddp_aware(experimental_key="allow_experimental")
     def train(
         self,
         data: str,
@@ -232,20 +234,6 @@ class LibreRTMDet(BaseModel):
                 "Not validated: training convergence, multi-GPU, the strict "
                 "two-stage pipeline switch, cached Mosaic/MixUp throughput."
             )
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, allow_experimental=allow_experimental, epochs=epochs,
-                batch=batch, imgsz=imgsz, lr0=lr0, optimizer=optimizer,
-                device=device, workers=workers, seed=seed, project=project,
-                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
-                amp=amp, patience=patience,
-                allow_download_scripts=allow_download_scripts, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from libreyolo.data import load_data_config
 
         from .trainer import RTMDetTrainer

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -265,7 +265,7 @@ class LibreRTMDet(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = RTMDetTrainer(

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -232,6 +232,20 @@ class LibreRTMDet(BaseModel):
                 "Not validated: training convergence, multi-GPU, the strict "
                 "two-stage pipeline switch, cached Mosaic/MixUp throughput."
             )
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, allow_experimental=allow_experimental, epochs=epochs,
+                batch=batch, imgsz=imgsz, lr0=lr0, optimizer=optimizer,
+                device=device, workers=workers, seed=seed, project=project,
+                name=name, exist_ok=exist_ok, pretrained=pretrained, resume=resume,
+                amp=amp, patience=patience,
+                allow_download_scripts=allow_download_scripts, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from libreyolo.data import load_data_config
 
         from .trainer import RTMDetTrainer

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 from PIL import Image
 
 from ..base import BaseModel
@@ -231,6 +232,7 @@ class LibreYOLO9(BaseModel):
     # Public API
     # =========================================================================
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -274,27 +276,11 @@ class LibreYOLO9(BaseModel):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-                Not propagated to DDP workers when auto-spawning.
+                Must be picklable when using DDP auto-spawn.
 
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-
-        devices = parse_device_arg(device)
-        if len(devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data,
-                epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                optimizer=optimizer, device=device, workers=workers,
-                seed=seed, project=project, name=name, exist_ok=exist_ok,
-                resume=resume, amp=amp, patience=patience,
-                allow_download_scripts=allow_download_scripts,
-                **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(devices))
-
         from .trainer import YOLO9Trainer
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -314,7 +314,7 @@ class LibreYOLO9(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = YOLO9Trainer(

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -374,6 +374,3 @@ class LibreYOLO9(BaseModel):
             self._load_weights(results["best_checkpoint"])
 
         return results
-
-
-# =============================================================================

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -260,13 +260,11 @@ class LibreYOLO9(BaseModel):
         Args:
             data: Path to data.yaml file (required).
             epochs: Number of epochs to train.
-            batch: Batch size (global — divided by world_size per GPU under DDP).
+            batch: Batch size.
             imgsz: Input image size.
             lr0: Initial learning rate.
             optimizer: Optimizer name ('SGD', 'Adam', 'AdamW').
-            device: Device(s) to train on. Single GPU: ``"0"``; multi-GPU:
-                ``"0,1"`` or ``[0, 1]``. Multi-GPU from a plain script spawns
-                DDP workers automatically (no torchrun required).
+            device: Device to train on ('' = auto-detect).
             workers: Number of dataloader workers.
             seed: Random seed for reproducibility.
             project: Root directory for training runs.
@@ -276,7 +274,6 @@ class LibreYOLO9(BaseModel):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-                Must be picklable when using DDP auto-spawn.
 
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -283,6 +283,7 @@ class LibreYOLO9(BaseModel):
 
         devices = parse_device_arg(device)
         if len(devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
             train_kw = dict(
                 data=data,
                 epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
@@ -292,7 +293,7 @@ class LibreYOLO9(BaseModel):
                 allow_download_scripts=allow_download_scripts,
                 **kwargs,
             )
-            return _yolo9_spawn_ddp(self, train_kw, len(devices))
+            return spawn_for_model(self, train_kw, len(devices))
 
         from .trainer import YOLO9Trainer
         from libreyolo.data import load_data_config
@@ -376,109 +377,3 @@ class LibreYOLO9(BaseModel):
 
 
 # =============================================================================
-# DDP auto-spawn helpers (module-level so mp.spawn can pickle them by name)
-# =============================================================================
-
-
-def _yolo9_ddp_worker(
-    rank: int,
-    nprocs: int,
-    master_addr: str,
-    master_port: int,
-    result_path: str,
-    weights_path: str,
-    init_kw: dict,
-    train_kw: dict,
-) -> None:
-    """Worker function run in each spawned DDP process for YOLO9 training."""
-    import json
-    import os
-    from pathlib import Path
-
-    os.environ["RANK"] = str(rank)
-    os.environ["LOCAL_RANK"] = str(rank)
-    os.environ["WORLD_SIZE"] = str(nprocs)
-    os.environ["MASTER_ADDR"] = master_addr
-    os.environ["MASTER_PORT"] = str(master_port)
-
-    from libreyolo.models.yolo9.model import LibreYOLO9
-
-    model = LibreYOLO9(weights_path, **init_kw)
-    result = model.train(**train_kw)
-
-    if rank == 0:
-        safe = {k: v for k, v in result.items() if isinstance(v, (int, float, str, bool, type(None)))}
-        Path(result_path).write_text(json.dumps(safe))
-
-
-def _yolo9_spawn_ddp(model_instance: "LibreYOLO9", train_kw: dict, nprocs: int) -> dict:
-    """Save weights to a temp file, spawn DDP workers, and collect results."""
-    import json
-    import os
-    import tempfile
-    from pathlib import Path
-
-    import torch
-
-    from libreyolo.training.distributed import spawn_ddp_train
-
-    fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
-    os.close(fd)
-    torch.save(
-        {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
-        tmp_weights,
-    )
-
-    # Resolve batch=-1 here (main process, before spawning) so workers receive
-    # a concrete value and need no inter-process coordination for autobatch.
-    if train_kw.get("batch") == -1:
-        from libreyolo.training.autobatch import autobatch as _autobatch
-
-        probe_device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
-        model_instance.model.to(probe_device)
-        nbs = train_kw.get("nbs") or 64
-        resolved = _autobatch(
-            model_instance.model,
-            imgsz=train_kw.get("imgsz", 640),
-            amp=train_kw.get("amp", True),
-            max_probe=nbs,
-        )
-        resolved = max(nprocs, (resolved // nprocs) * nprocs)
-        train_kw = {**train_kw, "batch": resolved}
-        model_instance.model.cpu()
-        torch.cuda.empty_cache()
-
-    init_kw = {
-        "size": model_instance.size,
-        "reg_max": model_instance.reg_max,
-        "num_masks": model_instance.num_masks,
-        "proto_channels": model_instance.proto_channels,
-        "nb_classes": model_instance.nb_classes,
-        "device": "auto",
-        "task": model_instance.task,
-    }
-
-    fd, tmp_result = tempfile.mkstemp(suffix=".json")
-    os.close(fd)
-
-    try:
-        spawn_ddp_train(
-            _yolo9_ddp_worker,
-            spawn_args=(tmp_weights, init_kw, train_kw),
-            nprocs=nprocs,
-            result_path=tmp_result,
-        )
-    finally:
-        Path(tmp_weights).unlink(missing_ok=True)
-
-    result: dict = {}
-    tmp_result_path = Path(tmp_result)
-    if tmp_result_path.exists():
-        result = json.loads(tmp_result_path.read_text())
-        tmp_result_path.unlink()
-
-    best = result.get("best_checkpoint")
-    if best and Path(best).exists():
-        model_instance._load_weights(best)
-
-    return result

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -429,6 +429,25 @@ def _yolo9_spawn_ddp(model_instance: "LibreYOLO9", train_kw: dict, nprocs: int) 
         tmp_weights,
     )
 
+    # Resolve batch=-1 here (main process, before spawning) so workers receive
+    # a concrete value and need no inter-process coordination for autobatch.
+    if train_kw.get("batch") == -1:
+        from libreyolo.training.autobatch import autobatch as _autobatch
+
+        probe_device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
+        model_instance.model.to(probe_device)
+        nbs = train_kw.get("nbs") or 64
+        resolved = _autobatch(
+            model_instance.model,
+            imgsz=train_kw.get("imgsz", 640),
+            amp=train_kw.get("amp", True),
+            max_probe=nbs,
+        )
+        resolved = max(nprocs, (resolved // nprocs) * nprocs)
+        train_kw = {**train_kw, "batch": resolved}
+        model_instance.model.cpu()
+        torch.cuda.empty_cache()
+
     init_kw = {
         "size": model_instance.size,
         "reg_max": model_instance.reg_max,

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -258,11 +258,13 @@ class LibreYOLO9(BaseModel):
         Args:
             data: Path to data.yaml file (required).
             epochs: Number of epochs to train.
-            batch: Batch size.
+            batch: Batch size (global — divided by world_size per GPU under DDP).
             imgsz: Input image size.
             lr0: Initial learning rate.
             optimizer: Optimizer name ('SGD', 'Adam', 'AdamW').
-            device: Device to train on ('' = auto-detect).
+            device: Device(s) to train on. Single GPU: ``"0"``; multi-GPU:
+                ``"0,1"`` or ``[0, 1]``. Multi-GPU from a plain script spawns
+                DDP workers automatically (no torchrun required).
             workers: Number of dataloader workers.
             seed: Random seed for reproducibility.
             project: Root directory for training runs.
@@ -272,10 +274,26 @@ class LibreYOLO9(BaseModel):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
+                Not propagated to DDP workers when auto-spawning.
 
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+
+        devices = parse_device_arg(device)
+        if len(devices) > 1 and not has_torchrun_env():
+            train_kw = dict(
+                data=data,
+                epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                optimizer=optimizer, device=device, workers=workers,
+                seed=seed, project=project, name=name, exist_ok=exist_ok,
+                resume=resume, amp=amp, patience=patience,
+                allow_download_scripts=allow_download_scripts,
+                **kwargs,
+            )
+            return _yolo9_spawn_ddp(self, train_kw, len(devices))
+
         from .trainer import YOLO9Trainer
         from libreyolo.data import load_data_config
 
@@ -355,3 +373,93 @@ class LibreYOLO9(BaseModel):
             self._load_weights(results["best_checkpoint"])
 
         return results
+
+
+# =============================================================================
+# DDP auto-spawn helpers (module-level so mp.spawn can pickle them by name)
+# =============================================================================
+
+
+def _yolo9_ddp_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+    weights_path: str,
+    init_kw: dict,
+    train_kw: dict,
+) -> None:
+    """Worker function run in each spawned DDP process for YOLO9 training."""
+    import json
+    import os
+    from pathlib import Path
+
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(nprocs)
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9(weights_path, **init_kw)
+    result = model.train(**train_kw)
+
+    if rank == 0:
+        safe = {k: v for k, v in result.items() if isinstance(v, (int, float, str, bool, type(None)))}
+        Path(result_path).write_text(json.dumps(safe))
+
+
+def _yolo9_spawn_ddp(model_instance: "LibreYOLO9", train_kw: dict, nprocs: int) -> dict:
+    """Save weights to a temp file, spawn DDP workers, and collect results."""
+    import json
+    import os
+    import tempfile
+    from pathlib import Path
+
+    import torch
+
+    from libreyolo.training.distributed import spawn_ddp_train
+
+    fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
+    os.close(fd)
+    torch.save(
+        {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
+        tmp_weights,
+    )
+
+    init_kw = {
+        "size": model_instance.size,
+        "reg_max": model_instance.reg_max,
+        "num_masks": model_instance.num_masks,
+        "proto_channels": model_instance.proto_channels,
+        "nb_classes": model_instance.nb_classes,
+        "device": "auto",
+        "task": model_instance.task,
+    }
+
+    fd, tmp_result = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+
+    try:
+        spawn_ddp_train(
+            _yolo9_ddp_worker,
+            spawn_args=(tmp_weights, init_kw, train_kw),
+            nprocs=nprocs,
+            result_path=tmp_result,
+        )
+    finally:
+        Path(tmp_weights).unlink(missing_ok=True)
+
+    result: dict = {}
+    tmp_result_path = Path(tmp_result)
+    if tmp_result_path.exists():
+        result = json.loads(tmp_result_path.read_text())
+        tmp_result_path.unlink()
+
+    best = result.get("best_checkpoint")
+    if best and Path(best).exists():
+        model_instance._load_weights(best)
+
+    return result

--- a/libreyolo/models/yolo9_e2e/model.py
+++ b/libreyolo/models/yolo9_e2e/model.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 
 from ..yolo9.model import LibreYOLO9
 from .config import YOLO9E2EConfig
@@ -149,6 +150,7 @@ class LibreYOLO9E2E(LibreYOLO9):
     # Public API
     # =====================================================================
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -193,19 +195,6 @@ class LibreYOLO9E2E(LibreYOLO9):
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                optimizer=optimizer, device=device, workers=workers, seed=seed,
-                project=project, name=name, exist_ok=exist_ok, resume=resume,
-                amp=amp, patience=patience,
-                allow_download_scripts=allow_download_scripts, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from libreyolo.data import load_data_config
 
         from .trainer import YOLO9E2ETrainer

--- a/libreyolo/models/yolo9_e2e/model.py
+++ b/libreyolo/models/yolo9_e2e/model.py
@@ -225,7 +225,7 @@ class LibreYOLO9E2E(LibreYOLO9):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = YOLO9E2ETrainer(

--- a/libreyolo/models/yolo9_e2e/model.py
+++ b/libreyolo/models/yolo9_e2e/model.py
@@ -193,6 +193,19 @@ class LibreYOLO9E2E(LibreYOLO9):
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                optimizer=optimizer, device=device, workers=workers, seed=seed,
+                project=project, name=name, exist_ok=exist_ok, resume=resume,
+                amp=amp, patience=patience,
+                allow_download_scripts=allow_download_scripts, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from libreyolo.data import load_data_config
 
         from .trainer import YOLO9E2ETrainer

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 
 from ..base import BaseModel
 from ...tasks import normalize_task
@@ -359,6 +360,7 @@ class LibreYOLONAS(BaseModel):
                 f"Failed to load YOLO-NAS weights from {model_path}: {e}"
             ) from e
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -406,18 +408,6 @@ class LibreYOLONAS(BaseModel):
                 patience=patience,
                 **kwargs,
             )
-
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                optimizer=optimizer, device=device, workers=workers, seed=seed,
-                project=project, name=name, exist_ok=exist_ok, resume=resume,
-                amp=amp, patience=patience, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
 
         name = name or "yolonas_exp"
         from libreyolo.data import load_data_config

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -438,7 +438,7 @@ class LibreYOLONAS(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = YOLONASTrainer(
@@ -561,7 +561,7 @@ class LibreYOLONAS(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = YOLONASPoseTrainer(

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -407,6 +407,18 @@ class LibreYOLONAS(BaseModel):
                 **kwargs,
             )
 
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                optimizer=optimizer, device=device, workers=workers, seed=seed,
+                project=project, name=name, exist_ok=exist_ok, resume=resume,
+                amp=amp, patience=patience, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         name = name or "yolonas_exp"
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from libreyolo.training.ddp_spawn import ddp_aware
 from PIL import Image
 
 from ..base import BaseModel
@@ -168,6 +169,7 @@ class LibreYOLOX(BaseModel):
     # Public API
     # =========================================================================
 
+    @ddp_aware()
     def train(
         self,
         data: str,
@@ -213,19 +215,6 @@ class LibreYOLOX(BaseModel):
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
-        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-        _devices = parse_device_arg(device)
-        if len(_devices) > 1 and not has_torchrun_env():
-            from libreyolo.training.ddp_spawn import spawn_for_model
-            train_kw = dict(
-                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
-                optimizer=optimizer, device=device, workers=workers, seed=seed,
-                project=project, name=name, exist_ok=exist_ok, pretrained=pretrained,
-                resume=resume, amp=amp, patience=patience,
-                allow_download_scripts=allow_download_scripts, **kwargs,
-            )
-            return spawn_for_model(self, train_kw, len(_devices))
-
         from .trainer import YOLOXTrainer
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -213,6 +213,19 @@ class LibreYOLOX(BaseModel):
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.
         """
+        from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+        _devices = parse_device_arg(device)
+        if len(_devices) > 1 and not has_torchrun_env():
+            from libreyolo.training.ddp_spawn import spawn_for_model
+            train_kw = dict(
+                data=data, epochs=epochs, batch=batch, imgsz=imgsz, lr0=lr0,
+                optimizer=optimizer, device=device, workers=workers, seed=seed,
+                project=project, name=name, exist_ok=exist_ok, pretrained=pretrained,
+                resume=resume, amp=amp, patience=patience,
+                allow_download_scripts=allow_download_scripts, **kwargs,
+            )
+            return spawn_for_model(self, train_kw, len(_devices))
+
         from .trainer import YOLOXTrainer
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -246,7 +246,7 @@ class LibreYOLOX(BaseModel):
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)
-            if torch.cuda.is_available():
+            if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
         trainer = YOLOXTrainer(

--- a/libreyolo/models/yolox/nn.py
+++ b/libreyolo/models/yolox/nn.py
@@ -543,6 +543,8 @@ class YOLOXHead(nn.Module):
             outputs.append(output)
 
         if self.training:
+            if labels is None:
+                return torch.cat(outputs, 1)
             return self.get_losses(
                 imgs,
                 x_shifts,

--- a/libreyolo/models/yolox/trainer.py
+++ b/libreyolo/models/yolox/trainer.py
@@ -55,14 +55,14 @@ class YOLOXTrainer(BaseTrainer):
         }
 
     def on_setup(self):
-        if hasattr(self.model, "head") and hasattr(
-            self.model.head, "initialize_biases"
-        ):
-            self.model.head.initialize_biases(0.01)
+        raw = getattr(self.model, "module", self.model)
+        if hasattr(raw, "head") and hasattr(raw.head, "initialize_biases"):
+            raw.head.initialize_biases(0.01)
 
     def on_mosaic_disable(self):
         self.train_loader.dataset.close_mosaic()
-        self.model.head.use_l1 = True
+        raw = getattr(self.model, "module", self.model)
+        raw.head.use_l1 = True
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         return self.model(imgs, targets)

--- a/libreyolo/training/autobatch.py
+++ b/libreyolo/training/autobatch.py
@@ -183,7 +183,7 @@ def autobatch(
         logger.warning("AutoBatch: non-positive slope — keeping batch=%d", default)
         return default
 
-    raw = (target_gib - intercept) / slope
+    raw = min((target_gib - intercept) / slope, max_probe)
     result = _floor_pow2_strict(raw)
     result = max(1, min(result, _BATCH_SAFE_MAX))
 
@@ -276,6 +276,17 @@ def resolve_auto_batch(
 
     ws = max(1, world_size)
     result = max(ws, (result // ws) * ws)
+
+    if nbs is not None and nbs > 0 and result > nbs:
+        logger.warning(
+            "AutoBatch: world_size=%d exceeds nbs=%d — global batch floored to %d "
+            "(each rank needs at least 1 sample). Gradient accumulation will not "
+            "reach the intended effective batch size.",
+            world_size,
+            nbs,
+            result,
+        )
+
     return result
 
 

--- a/libreyolo/training/autobatch.py
+++ b/libreyolo/training/autobatch.py
@@ -235,8 +235,7 @@ def resolve_auto_batch(
     exceeds the nominal batch size.  This means adding GPUs reduces the number
     of accumulation steps rather than shrinking per-GPU batch size.
 
-    When *nbs* is not provided the global batch is simply rounded down to the
-    nearest multiple of *world_size*.
+    When *nbs* is not provided the global batch is ``per_gpu * world_size``.
 
     Args:
         model: Model on the target device (not yet DDP-wrapped).
@@ -290,7 +289,8 @@ def resolve_auto_batch(
                 ws, nbs, global_batch,
             )
     else:
-        global_batch = max(ws, (per_gpu // ws) * ws)
+        # Scale per-GPU capacity to global; per_gpu * ws is always divisible by ws.
+        global_batch = max(ws, per_gpu * ws)
 
     logger.info("AutoBatch: per-GPU=%d  world_size=%d  global=%d", per_gpu, ws, global_batch)
     return global_batch

--- a/libreyolo/training/autobatch.py
+++ b/libreyolo/training/autobatch.py
@@ -229,13 +229,14 @@ def resolve_auto_batch(
 ) -> int:
     """Run ``autobatch`` on rank 0 and broadcast the result to all ranks.
 
-    Under DDP all ranks call this function; only rank 0 runs the probe.
-    The result is rounded down to the nearest multiple of *world_size* so
-    ``batch // world_size`` gives every rank the same number of samples.
+    The probe runs on a single GPU and returns the per-GPU capacity.  Under
+    DDP that capacity is scaled by *world_size* to form the global batch,
+    capped at *nbs* so the effective batch (global x accumulation steps) never
+    exceeds the nominal batch size.  This means adding GPUs reduces the number
+    of accumulation steps rather than shrinking per-GPU batch size.
 
-    When *nbs* is provided it is used as *max_probe* so the probe covers all
-    batch sizes up to nbs.  The result is a power of 2 which always divides
-    any power-of-2 nbs, so ``accum_steps = nbs // batch`` is exact.
+    When *nbs* is not provided the global batch is simply rounded down to the
+    nearest multiple of *world_size*.
 
     Args:
         model: Model on the target device (not yet DDP-wrapped).
@@ -244,24 +245,26 @@ def resolve_auto_batch(
         fraction: Target fraction of total VRAM (default 0.70).
         world_size: Number of DDP ranks (1 for single-GPU).
         default: Fallback when CUDA is unavailable.
-        nbs: Nominal batch size — used as the upper probe limit.
+        nbs: Nominal batch size — caps the global batch and sets the probe
+            limit so per-GPU capacity never exceeds nbs.
 
     Returns:
-        Global batch size (power of 2), divisible by *world_size* and ≥ 1.
+        Global batch size, divisible by *world_size* and ≥ 1.
     """
+    ws = max(1, world_size)
     max_probe = nbs if (nbs is not None and nbs > 0) else _DEFAULT_MAX_PROBE
 
     if is_main_process():
         try:
-            result = autobatch(
+            per_gpu = autobatch(
                 model, imgsz=imgsz, amp=amp, fraction=fraction,
                 default=default, max_probe=max_probe,
             )
         except Exception as exc:
             logger.warning("AutoBatch: probe failed (%s) — using default %d", exc, default)
-            result = default
+            per_gpu = default
     else:
-        result = 0
+        per_gpu = 0
 
     if is_distributed():
         import torch.distributed as dist
@@ -270,24 +273,27 @@ def resolve_auto_batch(
         # silently on NCCL when rank 0 is delayed; a long tensor broadcast is
         # a simpler and more reliable primitive for a single integer.
         device = next(model.parameters()).device
-        t = torch.tensor([result], dtype=torch.long, device=device)
+        t = torch.tensor([per_gpu], dtype=torch.long, device=device)
         dist.broadcast(t, src=0)
-        result = int(t.item())
+        per_gpu = int(t.item())
 
-    ws = max(1, world_size)
-    result = max(ws, (result // ws) * ws)
+    if nbs is not None and nbs > 0:
+        # Scale per-GPU capacity to global, capped at nbs so that more GPUs
+        # reduce accumulation steps rather than shrinking per-GPU batch.
+        global_batch = min(per_gpu * ws, nbs)
+        # Round down to a multiple of world_size (each rank gets equal share).
+        global_batch = max(ws, (global_batch // ws) * ws)
+        if global_batch > nbs:
+            logger.warning(
+                "AutoBatch: world_size=%d exceeds nbs=%d — global batch is %d. "
+                "Gradient accumulation will not reach the intended effective batch size.",
+                ws, nbs, global_batch,
+            )
+    else:
+        global_batch = max(ws, (per_gpu // ws) * ws)
 
-    if nbs is not None and nbs > 0 and result > nbs:
-        logger.warning(
-            "AutoBatch: world_size=%d exceeds nbs=%d — global batch floored to %d "
-            "(each rank needs at least 1 sample). Gradient accumulation will not "
-            "reach the intended effective batch size.",
-            world_size,
-            nbs,
-            result,
-        )
-
-    return result
+    logger.info("AutoBatch: per-GPU=%d  world_size=%d  global=%d", per_gpu, ws, global_batch)
+    return global_batch
 
 
 __all__ = ["autobatch", "resolve_auto_batch", "_fit_batch_size", "_floor_pow2_strict"]

--- a/libreyolo/training/autobatch.py
+++ b/libreyolo/training/autobatch.py
@@ -201,7 +201,7 @@ def autobatch(
         logger.warning("AutoBatch: non-positive slope — keeping batch=%d", default)
         return default
 
-    raw = min((target_gib - intercept) / slope, max_probe)
+    raw = (target_gib - intercept) / slope
     result = _floor_pow2_strict(raw)
     result = max(1, min(result, _BATCH_SAFE_MAX))
 

--- a/libreyolo/training/autobatch.py
+++ b/libreyolo/training/autobatch.py
@@ -143,6 +143,20 @@ def autobatch(
     probe_sizes: List[int] = []
     probe_mem: List[float] = []
 
+    _bn_types = (
+        nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d,
+        nn.SyncBatchNorm,
+    )
+    bn_bufs: dict = {}
+    for name, mod in model.named_modules():
+        if isinstance(mod, _bn_types):
+            saved = {}
+            for attr in ("running_mean", "running_var", "num_batches_tracked"):
+                buf = getattr(mod, attr, None)
+                if buf is not None:
+                    saved[attr] = buf.clone()
+            bn_bufs[name] = saved
+
     was_training = model.training
     model.train()
     try:
@@ -172,6 +186,10 @@ def autobatch(
                 raise
     finally:
         model.train(was_training)
+        for name, mod in model.named_modules():
+            if isinstance(mod, _bn_types) and name in bn_bufs:
+                for attr, val in bn_bufs[name].items():
+                    getattr(mod, attr).copy_(val)
         torch.cuda.empty_cache()
 
     if len(probe_sizes) < 2:

--- a/libreyolo/training/autobatch.py
+++ b/libreyolo/training/autobatch.py
@@ -1,0 +1,282 @@
+"""Automatic batch-size estimation for training workloads.
+
+Probes the model at small batch sizes in *training mode with a backward pass*,
+fits a line to the (batch → GPU memory) curve, and extrapolates to find the
+largest global batch that stays within a target fraction of total VRAM.
+
+Why train mode + backward (not eval + no_grad like Ultralytics):
+  Eval+no_grad only measures inference memory.  During training PyTorch retains
+  all intermediate activations for backward, and gradient tensors are allocated.
+  For deep CNNs like YOLO9 this adds 5-10× the memory seen at inference.
+  Probing with a backward pass captures the true training memory footprint.
+
+Result is always a power of 2 strictly below the extrapolated value, so it
+composes cleanly with power-of-2 nbs values for gradient accumulation.
+
+Global batch semantics (Ultralytics-mirror): the returned value is the GLOBAL
+batch. Under DDP the trainer divides it by world_size for per-rank loaders.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import math
+from typing import List
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from libreyolo.training.distributed import (
+    is_distributed,
+    is_main_process,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_FRACTION: float = 0.70
+_DEFAULT_MAX_PROBE: int = 64
+_BATCH_SAFE_MAX: int = 1024
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _floor_pow2_strict(x: float) -> int:
+    """Return the largest power of 2 *strictly less than* x.
+
+    This is intentionally conservative: the probe targets 70 % of VRAM but
+    the fit is an approximation, so we never bet on the exact extrapolated
+    value.  Returns 1 for x ≤ 2.
+
+    Examples:  33.0 → 32,  32.0 → 16,  65.0 → 64,  17.5 → 16
+    """
+    if x <= 2:
+        return 1
+    p = int(math.log2(x))   # floor(log2(x))
+    result = 1 << p          # 2^p  ≤  x
+    if result >= x:          # exact power of 2 — go one step lower
+        result >>= 1
+    return max(1, result)
+
+
+def _find_grad_tensor(obj) -> torch.Tensor | None:
+    """Return the first tensor with requires_grad=True found anywhere in obj.
+
+    Handles tensors, tuples/lists (nested), and dicts. Returns None when no
+    differentiable tensor is present (e.g. model output is None or detached).
+    """
+    if isinstance(obj, torch.Tensor):
+        return obj if obj.requires_grad else None
+    if isinstance(obj, (tuple, list)):
+        for item in obj:
+            t = _find_grad_tensor(item)
+            if t is not None:
+                return t
+    if isinstance(obj, dict):
+        for v in obj.values():
+            t = _find_grad_tensor(v)
+            if t is not None:
+                return t
+    return None
+
+
+# =============================================================================
+# Core probe
+# =============================================================================
+
+
+def autobatch(
+    model: nn.Module,
+    imgsz: int = 640,
+    amp: bool = True,
+    fraction: float = _DEFAULT_FRACTION,
+    default: int = 16,
+    max_probe: int = _DEFAULT_MAX_PROBE,
+) -> int:
+    """Estimate the optimal *global* batch size for the given model and image size.
+
+    Probes in training mode with a backward pass at powers-of-2 batch sizes up
+    to *max_probe*, fits a line to the (batch → peak memory) curve, extrapolates
+    to *fraction* of total VRAM, then returns the largest power of 2 strictly
+    below that value.  Returns *default* when CUDA is unavailable or probing
+    fails.
+
+    Args:
+        model: Model already resident on the target CUDA device.
+        imgsz: Square input size (height == width).
+        amp: Whether AMP (autocast) will be used during training.
+        fraction: Target fraction of *total* VRAM to occupy (default 0.70).
+        default: Fallback batch size for non-CUDA devices or probe failures.
+        max_probe: Largest batch size to probe (default 64; set to nbs).
+
+    Returns:
+        Estimated optimal global batch size — a power of 2, always ≥ 1.
+    """
+    device = next(model.parameters()).device
+
+    if device.type != "cuda":
+        logger.info("AutoBatch: non-CUDA device (%s) — keeping batch=%d", device.type, default)
+        return default
+
+    props = torch.cuda.get_device_properties(device)
+    total_gib = props.total_memory / 1024**3
+    target_gib = total_gib * fraction
+
+    logger.info(
+        "AutoBatch: %s  total=%.1f GiB  target=%.0f%%",
+        props.name,
+        total_gib,
+        fraction * 100,
+    )
+
+    # Powers of 2 from 1 up to max_probe
+    probe_batches: List[int] = []
+    b = 1
+    while b <= max_probe:
+        probe_batches.append(b)
+        b *= 2
+
+    probe_sizes: List[int] = []
+    probe_mem: List[float] = []
+
+    was_training = model.training
+    model.train()
+    try:
+        ctx = torch.autocast("cuda") if amp else contextlib.nullcontext()
+        for b in probe_batches:
+            try:
+                torch.cuda.empty_cache()
+                torch.cuda.reset_peak_memory_stats(device)
+                x = torch.zeros(b, 3, imgsz, imgsz, dtype=torch.float32, device=device)
+                with ctx:
+                    out = model(x)
+                t = _find_grad_tensor(out)
+                if t is not None:
+                    t.float().sum().backward()
+                model.zero_grad(set_to_none=True)
+                mem = torch.cuda.max_memory_allocated(device) / 1024**3
+                probe_sizes.append(b)
+                probe_mem.append(mem)
+                logger.debug("AutoBatch: batch=%d  mem=%.3f GiB", b, mem)
+                if mem > total_gib * 0.90:
+                    break
+            except RuntimeError as exc:
+                if "out of memory" in str(exc).lower():
+                    torch.cuda.empty_cache()
+                    model.zero_grad(set_to_none=True)
+                    break
+                raise
+    finally:
+        model.train(was_training)
+        torch.cuda.empty_cache()
+
+    if len(probe_sizes) < 2:
+        logger.warning("AutoBatch: too few probe points — keeping batch=%d", default)
+        return default
+
+    slope, intercept = np.polyfit(probe_sizes, probe_mem, 1)
+    if slope <= 0:
+        logger.warning("AutoBatch: non-positive slope — keeping batch=%d", default)
+        return default
+
+    raw = (target_gib - intercept) / slope
+    result = _floor_pow2_strict(raw)
+    result = max(1, min(result, _BATCH_SAFE_MAX))
+
+    logger.info(
+        "AutoBatch: estimated optimal global batch = %d  (raw=%.1f, target=%.1f GiB)",
+        result,
+        raw,
+        target_gib,
+    )
+    return result
+
+
+def _fit_batch_size(
+    probe_sizes: List[int],
+    probe_mem: List[float],
+    target_gib: float,
+) -> int | None:
+    """Fit a line to (batch → memory) samples and extrapolate to *target_gib*.
+
+    Returns the rounded optimal batch size clamped to [1, _BATCH_SAFE_MAX],
+    or None when the slope is non-positive (degenerate fit).
+    """
+    slope, intercept = np.polyfit(probe_sizes, probe_mem, 1)
+    if slope <= 0:
+        return None
+    optimal = int(round((target_gib - intercept) / slope))
+    return max(1, min(optimal, _BATCH_SAFE_MAX))
+
+
+# =============================================================================
+# DDP-aware resolver
+# =============================================================================
+
+
+def resolve_auto_batch(
+    model: nn.Module,
+    imgsz: int = 640,
+    amp: bool = True,
+    fraction: float = _DEFAULT_FRACTION,
+    world_size: int = 1,
+    default: int = 16,
+    nbs: int | None = None,
+) -> int:
+    """Run ``autobatch`` on rank 0 and broadcast the result to all ranks.
+
+    Under DDP all ranks call this function; only rank 0 runs the probe.
+    The result is rounded down to the nearest multiple of *world_size* so
+    ``batch // world_size`` gives every rank the same number of samples.
+
+    When *nbs* is provided it is used as *max_probe* so the probe covers all
+    batch sizes up to nbs.  The result is a power of 2 which always divides
+    any power-of-2 nbs, so ``accum_steps = nbs // batch`` is exact.
+
+    Args:
+        model: Model on the target device (not yet DDP-wrapped).
+        imgsz: Square input size.
+        amp: Whether AMP is active.
+        fraction: Target fraction of total VRAM (default 0.70).
+        world_size: Number of DDP ranks (1 for single-GPU).
+        default: Fallback when CUDA is unavailable.
+        nbs: Nominal batch size — used as the upper probe limit.
+
+    Returns:
+        Global batch size (power of 2), divisible by *world_size* and ≥ 1.
+    """
+    max_probe = nbs if (nbs is not None and nbs > 0) else _DEFAULT_MAX_PROBE
+
+    if is_main_process():
+        try:
+            result = autobatch(
+                model, imgsz=imgsz, amp=amp, fraction=fraction,
+                default=default, max_probe=max_probe,
+            )
+        except Exception as exc:
+            logger.warning("AutoBatch: probe failed (%s) — using default %d", exc, default)
+            result = default
+    else:
+        result = 0
+
+    if is_distributed():
+        import torch.distributed as dist
+
+        # broadcast_object_list relies on pickle serialisation which can fail
+        # silently on NCCL when rank 0 is delayed; a long tensor broadcast is
+        # a simpler and more reliable primitive for a single integer.
+        device = next(model.parameters()).device
+        t = torch.tensor([result], dtype=torch.long, device=device)
+        dist.broadcast(t, src=0)
+        result = int(t.item())
+
+    ws = max(1, world_size)
+    result = max(ws, (result // ws) * ws)
+    return result
+
+
+__all__ = ["autobatch", "resolve_auto_batch", "_fit_batch_size", "_floor_pow2_strict"]

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -183,10 +183,7 @@ class YOLO9Config(TrainConfig):
     name: str = "yolo9_exp"
     workers: int = 8
     mask_downsample_ratio: int = 4
-    # MultimediaTechLab's upstream YOLOv9 hardcodes sync_batchnorm=True in
-    # its Lightning trainer. Carry that default here for multi-GPU runs;
-    # single-GPU runs ignore the flag (conversion only fires under DDP).
-    sync_bn: bool = True
+    sync_bn: bool = False
 
 
 @dataclass(kw_only=True)

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -56,7 +56,7 @@ class TrainConfig:
     # ``batch // world_size`` (Ultralytics-mirror semantics).
     # Set to -1 to enable automatic selection: the trainer probes GPU memory
     # at small batch sizes, fits a linear model, and picks the largest batch
-    # that fits within 60 % of free VRAM (same approach as Ultralytics).
+    # that fits within 70 % of total VRAM.
     batch: int = 16
     # Single device or multi-device spec. Accepts:
     #   - "auto" / "" → auto-pick (cuda → mps → cpu)

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -54,6 +54,9 @@ class TrainConfig:
     epochs: int = 300
     # Global batch size. Under multi-GPU DDP the per-rank batch is
     # ``batch // world_size`` (Ultralytics-mirror semantics).
+    # Set to -1 to enable automatic selection: the trainer probes GPU memory
+    # at small batch sizes, fits a linear model, and picks the largest batch
+    # that fits within 60 % of free VRAM (same approach as Ultralytics).
     batch: int = 16
     # Single device or multi-device spec. Accepts:
     #   - "auto" / "" → auto-pick (cuda → mps → cpu)

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -160,7 +160,7 @@ def spawn_for_model(
 
     # When resuming, workers must load from the real checkpoint so that
     # trainer.resume() can read 'epoch', 'optimizer', etc.  The temp-weights
-    # file only carries {"model": ...} which lacks those keys.
+    # file only carries a plain state dict which lacks those keys.
     resuming = bool(train_kw.get("resume")) and getattr(model_instance, "model_path", None)
     if resuming:
         tmp_weights = str(model_instance.model_path)
@@ -169,7 +169,7 @@ def spawn_for_model(
         fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
         os.close(fd)
         torch.save(
-            {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
+            {k: v.cpu() for k, v in model_instance.model.state_dict().items()},
             tmp_weights,
         )
         tmp_weights_to_delete = tmp_weights

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -127,19 +127,19 @@ def spawn_for_model(
     # Resolve batch=-1 here (main process, before spawning) so every worker
     # receives a concrete integer and needs no inter-process coordination.
     if train_kw.get(batch_key) == -1:
-        from libreyolo.training.autobatch import autobatch as _autobatch
+        from libreyolo.training.autobatch import resolve_auto_batch
 
         probe_device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
         model_instance.model.to(probe_device)
         nbs = train_kw.get("nbs") or 64
         imgsz = train_kw.get("imgsz") or getattr(model_instance, "input_size", None) or 640
-        resolved = _autobatch(
+        resolved = resolve_auto_batch(
             model_instance.model,
             imgsz=int(imgsz),
             amp=bool(train_kw.get("amp", True)),
-            max_probe=nbs,
+            world_size=nprocs,
+            nbs=nbs,
         )
-        resolved = max(nprocs, (resolved // nprocs) * nprocs)
         train_kw = {**train_kw, batch_key: resolved}
         model_instance.model.cpu()
         torch.cuda.empty_cache()

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -250,6 +250,9 @@ def spawn_for_model(
             )
             model_instance.model.to(target).eval()
             model_instance.device = target
+    elif _model_moved:
+        model_instance.model.to(_original_device)
+        torch.cuda.empty_cache()
 
     return result
 
@@ -280,13 +283,7 @@ def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
     def decorator(train_fn):
         @functools.wraps(train_fn)
         def wrapper(self, *args, **kwargs):
-            import multiprocessing
             from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
-
-            # Prevent recursive spawn: if we're already inside a spawned worker
-            # process, fall straight through to the single-device training path.
-            if multiprocessing.parent_process() is not None:
-                return train_fn(self, *args, **kwargs)
 
             sig = inspect.signature(train_fn)
             bound = sig.bind(self, *args, **kwargs)

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -16,6 +16,7 @@ worker (RANK env var is set).
 """
 from __future__ import annotations
 
+import functools
 import inspect
 import json
 import logging
@@ -186,4 +187,60 @@ def spawn_for_model(
     return result
 
 
-__all__ = ["spawn_for_model", "_libreyolo_ddp_worker", "_build_init_kw"]
+# ---------------------------------------------------------------------------
+# DDP-aware decorator
+# ---------------------------------------------------------------------------
+
+
+def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
+    """Decorator that adds automatic DDP spawn to a model ``train()`` method.
+
+    When the decorated method is called with a multi-GPU device spec from
+    outside a torchrun process, it captures all arguments via
+    :mod:`inspect`, delegates to :func:`spawn_for_model`, and returns the
+    result without running the method body on the calling process.
+
+    Args:
+        batch_key: Key in the captured kwargs that holds the batch size.
+            Defaults to ``"batch"``; RF-DETR uses ``"batch_size"``.
+        experimental_key: If set, names a boolean kwarg (e.g.
+            ``"allow_experimental"``) that must be truthy before DDP spawn
+            is attempted. When it is falsy the decorator falls through to
+            the function body immediately, letting the body raise its own
+            validation error on the main process rather than inside a
+            spawned worker.
+    """
+    def decorator(train_fn):
+        @functools.wraps(train_fn)
+        def wrapper(self, *args, **kwargs):
+            from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+
+            sig = inspect.signature(train_fn)
+            bound = sig.bind(self, *args, **kwargs)
+            bound.apply_defaults()
+
+            train_kw: dict = {}
+            for k, v in bound.arguments.items():
+                if k == "self":
+                    continue
+                elif k == "kwargs":  # **kwargs parameter — flatten into train_kw
+                    train_kw.update(v)
+                else:
+                    train_kw[k] = v
+
+            device = train_kw.get("device", "")
+            devices = parse_device_arg(device)
+            if len(devices) > 1 and not has_torchrun_env():
+                if experimental_key and not train_kw.get(experimental_key, True):
+                    # Guard not satisfied — fall through so the function body
+                    # raises its validation error cleanly on the main process.
+                    return train_fn(self, *args, **kwargs)
+                return spawn_for_model(self, train_kw, len(devices), batch_key=batch_key)
+
+            return train_fn(self, *args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+__all__ = ["ddp_aware", "spawn_for_model", "_libreyolo_ddp_worker", "_build_init_kw"]

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -175,7 +175,7 @@ def spawn_for_model(
         first_device = devices[0] if devices else 0
         probe_device = torch.device("cuda", first_device) if torch.cuda.is_available() else torch.device("cpu")
         model_instance.model.to(probe_device)
-        nbs = train_kw.get("nbs") or 64
+        nbs = train_kw.get("nbs")  # None = uncapped, matches trainer path
         imgsz = train_kw.get("imgsz") or getattr(model_instance, "input_size", None) or 640
         resolved = resolve_auto_batch(
             model_instance.model,
@@ -230,6 +230,7 @@ def spawn_for_model(
                 else torch.device("cpu")
             )
             model_instance.model.to(target).eval()
+            model_instance.device = target
 
     return result
 

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -118,12 +118,21 @@ def spawn_for_model(
     """
     from libreyolo.training.distributed import spawn_ddp_train
 
-    fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
-    os.close(fd)
-    torch.save(
-        {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
-        tmp_weights,
-    )
+    # When resuming, workers must load from the real checkpoint so that
+    # trainer.resume() can read 'epoch', 'optimizer', etc.  The temp-weights
+    # file only carries {"model": ...} which lacks those keys.
+    resuming = bool(train_kw.get("resume")) and getattr(model_instance, "model_path", None)
+    if resuming:
+        tmp_weights = str(model_instance.model_path)
+        tmp_weights_to_delete = None
+    else:
+        fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
+        os.close(fd)
+        torch.save(
+            {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
+            tmp_weights,
+        )
+        tmp_weights_to_delete = tmp_weights
 
     # Resolve batch=-1 here (main process, before spawning) so every worker
     # receives a concrete integer and needs no inter-process coordination.
@@ -159,7 +168,8 @@ def spawn_for_model(
             result_path=tmp_result,
         )
     finally:
-        Path(tmp_weights).unlink(missing_ok=True)
+        if tmp_weights_to_delete:
+            Path(tmp_weights_to_delete).unlink(missing_ok=True)
 
     result: dict = {}
     tmp_result_path = Path(tmp_result)

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -69,7 +69,13 @@ def _libreyolo_ddp_worker(
             dist.destroy_process_group()
 
     if rank == 0:
-        safe = {k: v for k, v in result.items() if isinstance(v, (int, float, str, bool, type(None)))}
+        safe = {}
+        for k, v in result.items():
+            try:
+                json.dumps(v)
+                safe[k] = v
+            except (TypeError, ValueError):
+                pass
         Path(result_path).write_text(json.dumps(safe))
 
 
@@ -254,7 +260,13 @@ def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
     def decorator(train_fn):
         @functools.wraps(train_fn)
         def wrapper(self, *args, **kwargs):
+            import multiprocessing
             from libreyolo.training.distributed import parse_device_arg, has_torchrun_env
+
+            # Prevent recursive spawn: if we're already inside a spawned worker
+            # process, fall straight through to the single-device training path.
+            if multiprocessing.parent_process() is not None:
+                return train_fn(self, *args, **kwargs)
 
             sig = inspect.signature(train_fn)
             bound = sig.bind(self, *args, **kwargs)

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -21,6 +21,7 @@ import inspect
 import json
 import logging
 import os
+import pickle
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -93,6 +94,26 @@ def _build_init_kw(model_instance: Any) -> dict:
     return kw
 
 
+def _filter_picklable(kw: dict) -> dict:
+    """Return a copy of *kw* with non-picklable values removed.
+
+    mp.spawn serialises its args via pickle; callbacks and locally-defined
+    functions will crash workers at start-up.  We drop them with a warning
+    rather than propagating a confusing PicklingError deep in spawn.
+    """
+    safe = {}
+    for k, v in kw.items():
+        try:
+            pickle.dumps(v)
+            safe[k] = v
+        except Exception:
+            logger.warning(
+                "DDP spawn: dropping non-picklable kwarg %r (type: %s)",
+                k, type(v).__name__,
+            )
+    return safe
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -103,6 +124,7 @@ def spawn_for_model(
     train_kw: dict,
     nprocs: int,
     *,
+    devices: list | None = None,
     batch_key: str = "batch",
 ) -> dict:
     """Save weights, optionally probe autobatch, spawn DDP workers, return results.
@@ -139,7 +161,8 @@ def spawn_for_model(
     if train_kw.get(batch_key) == -1:
         from libreyolo.training.autobatch import resolve_auto_batch
 
-        probe_device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
+        first_device = devices[0] if devices else 0
+        probe_device = torch.device("cuda", first_device) if torch.cuda.is_available() else torch.device("cpu")
         model_instance.model.to(probe_device)
         nbs = train_kw.get("nbs") or 64
         imgsz = train_kw.get("imgsz") or getattr(model_instance, "input_size", None) or 640
@@ -156,6 +179,7 @@ def spawn_for_model(
         logger.info("AutoBatch (pre-spawn): resolved global batch = %d", resolved)
 
     init_kw = _build_init_kw(model_instance)
+    safe_train_kw = _filter_picklable(train_kw)
 
     fd, tmp_result = tempfile.mkstemp(suffix=".json")
     os.close(fd)
@@ -163,9 +187,10 @@ def spawn_for_model(
     try:
         spawn_ddp_train(
             _libreyolo_ddp_worker,
-            spawn_args=(tmp_weights, init_kw, train_kw),
+            spawn_args=(tmp_weights, init_kw, safe_train_kw),
             nprocs=nprocs,
             result_path=tmp_result,
+            devices=devices,
         )
     finally:
         if tmp_weights_to_delete:
@@ -187,8 +212,9 @@ def spawn_for_model(
             model_instance.model_path = ckpt
         model_instance._load_weights(ckpt)
         if hasattr(model_instance, "model"):
+            first_device = devices[0] if devices else 0
             target = (
-                torch.device("cuda", 0)
+                torch.device("cuda", first_device)
                 if torch.cuda.is_available()
                 else torch.device("cpu")
             )
@@ -241,11 +267,16 @@ def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
             device = train_kw.get("device", "")
             devices = parse_device_arg(device)
             if len(devices) > 1 and not has_torchrun_env():
+                if not torch.cuda.is_available():
+                    raise RuntimeError(
+                        f"Multi-GPU DDP requires CUDA. Got device={device!r} but "
+                        "CUDA is not available on this machine."
+                    )
                 if experimental_key and not train_kw.get(experimental_key, True):
                     # Guard not satisfied — fall through so the function body
                     # raises its validation error cleanly on the main process.
                     return train_fn(self, *args, **kwargs)
-                return spawn_for_model(self, train_kw, len(devices), batch_key=batch_key)
+                return spawn_for_model(self, train_kw, len(devices), devices=devices, batch_key=batch_key)
 
             return train_fn(self, *args, **kwargs)
 

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -55,6 +55,9 @@ def _libreyolo_ddp_worker(
     os.environ["MASTER_ADDR"] = master_addr
     os.environ["MASTER_PORT"] = str(master_port)
 
+    if torch.cuda.is_available():
+        torch.cuda.set_device(rank)
+
     init_kw = dict(init_kw)  # copy — don't mutate caller's dict
     module_path = init_kw.pop("_module")
     class_name = init_kw.pop("_class")
@@ -106,23 +109,27 @@ def _build_init_kw(model_instance: Any) -> dict:
 
 
 def _filter_picklable(kw: dict) -> dict:
-    """Return a copy of *kw* with non-picklable values removed.
+    """Raise RuntimeError if any value in *kw* is not picklable.
 
     mp.spawn serialises its args via pickle; callbacks and locally-defined
-    functions will crash workers at start-up.  We drop them with a warning
-    rather than propagating a confusing PicklingError deep in spawn.
+    functions will crash workers at start-up.  Raising early with a clear
+    message is better than a confusing PicklingError deep inside spawn, or
+    silently missing training kwargs.
     """
-    safe = {}
+    bad = []
     for k, v in kw.items():
         try:
             pickle.dumps(v)
-            safe[k] = v
         except Exception:
-            logger.warning(
-                "DDP spawn: dropping non-picklable kwarg %r (type: %s)",
-                k, type(v).__name__,
-            )
-    return safe
+            bad.append(f"{k!r} (type: {type(v).__name__})")
+    if bad:
+        raise RuntimeError(
+            "DDP spawn: the following train() kwargs are not picklable and "
+            "cannot be passed to worker processes:\n"
+            + "\n".join(f"  {b}" for b in bad)
+            + "\nRemove or replace them before calling train() with a multi-GPU device."
+        )
+    return dict(kw)
 
 
 # ---------------------------------------------------------------------------

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -174,17 +174,21 @@ def spawn_for_model(
         )
         tmp_weights_to_delete = tmp_weights
 
-    # Resolve batch=-1 here (main process, before spawning) so every worker
-    # receives a concrete integer and needs no inter-process coordination.
-    if train_kw.get(batch_key) == -1:
-        from libreyolo.training.autobatch import resolve_auto_batch
+    # Capture original device so it can be restored if any pre-spawn step fails.
+    _param = next(iter(model_instance.model.parameters()), None)
+    _original_device = _param.device if _param is not None else torch.device("cpu")
+    _model_moved = False
 
-        first_device = devices[0] if devices else 0
-        probe_device = torch.device("cuda", first_device) if torch.cuda.is_available() else torch.device("cpu")
-        _param = next(iter(model_instance.model.parameters()), None)
-        _original_device = _param.device if _param is not None else torch.device("cpu")
-        try:
+    try:
+        # Resolve batch=-1 here (main process, before spawning) so every worker
+        # receives a concrete integer and needs no inter-process coordination.
+        if train_kw.get(batch_key) == -1:
+            from libreyolo.training.autobatch import resolve_auto_batch
+
+            first_device = devices[0] if devices else 0
+            probe_device = torch.device("cuda", first_device) if torch.cuda.is_available() else torch.device("cpu")
             model_instance.model.to(probe_device)
+            _model_moved = True
             nbs = train_kw.get("nbs")  # None = uncapped, matches trainer path
             imgsz = train_kw.get("imgsz") or getattr(model_instance, "input_size", None) or 640
             resolved = resolve_auto_batch(
@@ -197,14 +201,15 @@ def spawn_for_model(
             train_kw = {**train_kw, batch_key: resolved}
             model_instance.model.cpu()
             torch.cuda.empty_cache()
-        except Exception:
+            logger.info("AutoBatch (pre-spawn): resolved global batch = %d", resolved)
+
+        init_kw = _build_init_kw(model_instance)
+        safe_train_kw = _filter_picklable(train_kw)
+    except Exception:
+        if _model_moved:
             model_instance.model.to(_original_device)
             torch.cuda.empty_cache()
-            raise
-        logger.info("AutoBatch (pre-spawn): resolved global batch = %d", resolved)
-
-    init_kw = _build_init_kw(model_instance)
-    safe_train_kw = _filter_picklable(train_kw)
+        raise
 
     fd, tmp_result = tempfile.mkstemp(suffix=".json")
     os.close(fd)

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -61,7 +61,12 @@ def _libreyolo_ddp_worker(
     cls = getattr(importlib.import_module(module_path), class_name)
 
     model = cls(weights_path, **init_kw)
-    result = model.train(**train_kw)
+    try:
+        result = model.train(**train_kw)
+    finally:
+        import torch.distributed as dist
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
 
     if rank == 0:
         safe = {k: v for k, v in result.items() if isinstance(v, (int, float, str, bool, type(None)))}

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -181,19 +181,26 @@ def spawn_for_model(
 
         first_device = devices[0] if devices else 0
         probe_device = torch.device("cuda", first_device) if torch.cuda.is_available() else torch.device("cpu")
-        model_instance.model.to(probe_device)
-        nbs = train_kw.get("nbs")  # None = uncapped, matches trainer path
-        imgsz = train_kw.get("imgsz") or getattr(model_instance, "input_size", None) or 640
-        resolved = resolve_auto_batch(
-            model_instance.model,
-            imgsz=int(imgsz),
-            amp=bool(train_kw.get("amp", True)),
-            world_size=nprocs,
-            nbs=nbs,
-        )
-        train_kw = {**train_kw, batch_key: resolved}
-        model_instance.model.cpu()
-        torch.cuda.empty_cache()
+        _param = next(iter(model_instance.model.parameters()), None)
+        _original_device = _param.device if _param is not None else torch.device("cpu")
+        try:
+            model_instance.model.to(probe_device)
+            nbs = train_kw.get("nbs")  # None = uncapped, matches trainer path
+            imgsz = train_kw.get("imgsz") or getattr(model_instance, "input_size", None) or 640
+            resolved = resolve_auto_batch(
+                model_instance.model,
+                imgsz=int(imgsz),
+                amp=bool(train_kw.get("amp", True)),
+                world_size=nprocs,
+                nbs=nbs,
+            )
+            train_kw = {**train_kw, batch_key: resolved}
+            model_instance.model.cpu()
+            torch.cuda.empty_cache()
+        except Exception:
+            model_instance.model.to(_original_device)
+            torch.cuda.empty_cache()
+            raise
         logger.info("AutoBatch (pre-spawn): resolved global batch = %d", resolved)
 
     init_kw = _build_init_kw(model_instance)

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -1,0 +1,189 @@
+"""Generic DDP worker + spawn helper for all LibreYOLO model train() methods.
+
+Each model's train() calls spawn_for_model() when device='0,1' (or similar)
+is given and we're NOT in a torchrun environment.  spawn_for_model() handles:
+
+  1. Saving model weights to a temp file.
+  2. Resolving batch=-1 via autobatch (single-GPU probe, before spawning).
+  3. Spawning DDP workers via mp.spawn.
+  4. Loading the best checkpoint back into the caller's model instance.
+
+The generic worker (_libreyolo_ddp_worker) re-imports the correct model class
+using module/class info packed into init_kw, rebuilds the model from saved
+weights, and calls model.train(**train_kw) — which falls through to the
+single-device path because has_torchrun_env() returns True inside the spawned
+worker (RANK env var is set).
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level worker (must be importable by name for mp.spawn pickling)
+# ---------------------------------------------------------------------------
+
+
+def _libreyolo_ddp_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+    weights_path: str,
+    init_kw: dict,
+    train_kw: dict,
+) -> None:
+    """Generic DDP worker: reconstruct any LibreYOLO model and start training."""
+    import importlib
+
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(nprocs)
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+
+    init_kw = dict(init_kw)  # copy — don't mutate caller's dict
+    module_path = init_kw.pop("_module")
+    class_name = init_kw.pop("_class")
+    cls = getattr(importlib.import_module(module_path), class_name)
+
+    model = cls(weights_path, **init_kw)
+    result = model.train(**train_kw)
+
+    if rank == 0:
+        safe = {k: v for k, v in result.items() if isinstance(v, (int, float, str, bool, type(None)))}
+        Path(result_path).write_text(json.dumps(safe))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_init_kw(model_instance: Any) -> dict:
+    """Collect __init__ kwargs needed to reconstruct *model_instance* in a worker.
+
+    Uses inspect so each model's specific params are included automatically
+    without needing to enumerate them per-model.
+    """
+    cls = type(model_instance)
+    sig = inspect.signature(cls.__init__)
+    supported = set(sig.parameters) - {"self", "model_path", "kwargs"}
+
+    kw: dict = {
+        "_module": cls.__module__,
+        "_class": cls.__name__,
+        "device": "auto",
+    }
+    for attr in ("size", "nb_classes", "reg_max", "task", "num_masks", "proto_channels", "num_keypoints"):
+        if attr in supported and hasattr(model_instance, attr):
+            kw[attr] = getattr(model_instance, attr)
+    return kw
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def spawn_for_model(
+    model_instance: Any,
+    train_kw: dict,
+    nprocs: int,
+    *,
+    batch_key: str = "batch",
+) -> dict:
+    """Save weights, optionally probe autobatch, spawn DDP workers, return results.
+
+    Args:
+        model_instance: LibreYOLO model object (has .model nn.Module).
+        train_kw: All kwargs forwarded to model.train() inside workers.
+        nprocs: Number of DDP ranks (= number of GPUs).
+        batch_key: Key in train_kw for batch size (default 'batch').
+
+    Returns:
+        Training result dict from rank-0 worker.
+    """
+    from libreyolo.training.distributed import spawn_ddp_train
+
+    fd, tmp_weights = tempfile.mkstemp(suffix=".pt")
+    os.close(fd)
+    torch.save(
+        {"model": {k: v.cpu() for k, v in model_instance.model.state_dict().items()}},
+        tmp_weights,
+    )
+
+    # Resolve batch=-1 here (main process, before spawning) so every worker
+    # receives a concrete integer and needs no inter-process coordination.
+    if train_kw.get(batch_key) == -1:
+        from libreyolo.training.autobatch import autobatch as _autobatch
+
+        probe_device = torch.device("cuda", 0) if torch.cuda.is_available() else torch.device("cpu")
+        model_instance.model.to(probe_device)
+        nbs = train_kw.get("nbs") or 64
+        imgsz = train_kw.get("imgsz") or getattr(model_instance, "input_size", None) or 640
+        resolved = _autobatch(
+            model_instance.model,
+            imgsz=int(imgsz),
+            amp=bool(train_kw.get("amp", True)),
+            max_probe=nbs,
+        )
+        resolved = max(nprocs, (resolved // nprocs) * nprocs)
+        train_kw = {**train_kw, batch_key: resolved}
+        model_instance.model.cpu()
+        torch.cuda.empty_cache()
+        logger.info("AutoBatch (pre-spawn): resolved global batch = %d", resolved)
+
+    init_kw = _build_init_kw(model_instance)
+
+    fd, tmp_result = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+
+    try:
+        spawn_ddp_train(
+            _libreyolo_ddp_worker,
+            spawn_args=(tmp_weights, init_kw, train_kw),
+            nprocs=nprocs,
+            result_path=tmp_result,
+        )
+    finally:
+        Path(tmp_weights).unlink(missing_ok=True)
+
+    result: dict = {}
+    tmp_result_path = Path(tmp_result)
+    if tmp_result_path.exists():
+        result = json.loads(tmp_result_path.read_text())
+        tmp_result_path.unlink()
+
+    # Prefer best.pt; fall back to last.pt (e.g. single-epoch runs where
+    # validation mAP is 0 so is_best is never set).
+    best = result.get("best_checkpoint")
+    last = result.get("last_checkpoint")
+    ckpt = next((p for p in (best, last) if p and Path(p).exists()), None)
+    if ckpt:
+        if hasattr(model_instance, "model_path"):
+            model_instance.model_path = ckpt
+        model_instance._load_weights(ckpt)
+        if hasattr(model_instance, "model"):
+            target = (
+                torch.device("cuda", 0)
+                if torch.cuda.is_available()
+                else torch.device("cpu")
+            )
+            model_instance.model.to(target).eval()
+
+    return result
+
+
+__all__ = ["spawn_for_model", "_libreyolo_ddp_worker", "_build_init_kw"]

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -323,7 +323,17 @@ def spawn_ddp_train(
 
     prev_cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
     if devices:
-        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(d) for d in devices)
+        if prev_cvd is not None:
+            # devices are logical indices into the existing mask — translate to
+            # physical GPU IDs so the new mask is correct inside spawned workers.
+            existing = [x.strip() for x in prev_cvd.split(",") if x.strip()]
+            try:
+                new_cvd = ",".join(existing[d] for d in devices)
+            except IndexError:
+                new_cvd = ",".join(str(d) for d in devices)
+        else:
+            new_cvd = ",".join(str(d) for d in devices)
+        os.environ["CUDA_VISIBLE_DEVICES"] = new_cvd
     try:
         # Close the reservation socket as late as possible — just before
         # spawning — so the OS cannot hand the port to another process in the

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -135,6 +135,8 @@ def init_distributed(timeout_seconds: int = 10800) -> None:
     Expects ``RANK``, ``LOCAL_RANK``, ``WORLD_SIZE`` to be set in the
     environment (which torchrun does automatically).
     """
+    import inspect
+
     if not dist.is_available():
         raise RuntimeError("torch.distributed is not available in this build")
     if dist.is_initialized():
@@ -147,14 +149,17 @@ def init_distributed(timeout_seconds: int = 10800) -> None:
         )
     backend = _select_backend()
     local_rank = int(os.environ["LOCAL_RANK"])
-    device_id = torch.device("cuda", local_rank) if torch.cuda.is_available() else None
-    dist.init_process_group(
-        backend=backend,
-        timeout=timedelta(seconds=timeout_seconds),
-        rank=int(os.environ["RANK"]),
-        world_size=int(os.environ["WORLD_SIZE"]),
-        device_id=device_id,
-    )
+    init_kwargs: dict = {
+        "backend": backend,
+        "timeout": timedelta(seconds=timeout_seconds),
+        "rank": int(os.environ["RANK"]),
+        "world_size": int(os.environ["WORLD_SIZE"]),
+    }
+    # device_id was added in PyTorch 2.0; guard so we stay compatible with older builds
+    pg_sig = inspect.signature(dist.init_process_group)
+    if "device_id" in pg_sig.parameters and torch.cuda.is_available():
+        init_kwargs["device_id"] = torch.device("cuda", local_rank)
+    dist.init_process_group(**init_kwargs)
 
 
 def shutdown_distributed() -> None:
@@ -261,11 +266,18 @@ def seed_for_rank(base_seed: int) -> int:
 # =============================================================================
 
 
-def _find_free_port() -> int:
-    """Bind to port 0 and let the OS pick a free port."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
+def _find_free_port() -> tuple:
+    """Bind to port 0 and return ``(port, socket)``.
+
+    The caller is responsible for closing the socket.  Keeping it open
+    until just before ``mp.spawn`` is called minimises the TOCTOU window
+    between OS port selection and torch.distributed's TCPStore binding.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    return port, s
 
 
 def spawn_ddp_train(
@@ -300,13 +312,20 @@ def spawn_ddp_train(
     """
     import torch.multiprocessing as mp
 
+    port_sock = None
     if master_port is None:
-        master_port = _find_free_port()
+        master_port, port_sock = _find_free_port()
 
     prev_cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
     if devices:
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(d) for d in devices)
     try:
+        # Close the reservation socket as late as possible — just before
+        # spawning — so the OS cannot hand the port to another process in the
+        # gap between our bind(0) call and torch.distributed's TCPStore bind.
+        if port_sock is not None:
+            port_sock.close()
+            port_sock = None
         mp.spawn(
             worker_fn,
             args=(nprocs, master_addr, master_port, result_path) + spawn_args,
@@ -314,6 +333,8 @@ def spawn_ddp_train(
             join=True,
         )
     finally:
+        if port_sock is not None:
+            port_sock.close()
         if devices:
             if prev_cvd is None:
                 os.environ.pop("CUDA_VISIBLE_DEVICES", None)

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -160,7 +160,7 @@ def init_distributed(timeout_seconds: int = 10800) -> None:
     # so wrap defensively and omit the kwarg on failure.
     try:
         pg_sig = inspect.signature(dist.init_process_group)
-        if "device_id" in pg_sig.parameters and torch.cuda.is_available():
+        if "device_id" in pg_sig.parameters and backend == "nccl" and torch.cuda.is_available():
             init_kwargs["device_id"] = torch.device("cuda", local_rank)
     except (TypeError, ValueError):
         pass

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -13,8 +13,9 @@ DDP everything is a no-op.
 from __future__ import annotations
 
 import os
+import socket
 from datetime import timedelta
-from typing import List, Optional, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -252,6 +253,55 @@ def seed_for_rank(base_seed: int) -> int:
     return base_seed + 1 + get_rank()
 
 
+# =============================================================================
+# Auto-spawn DDP helpers
+# =============================================================================
+
+
+def _find_free_port() -> int:
+    """Bind to port 0 and let the OS pick a free port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def spawn_ddp_train(
+    worker_fn: Callable,
+    spawn_args: Tuple,
+    nprocs: int,
+    result_path: str,
+    master_addr: str = "127.0.0.1",
+    master_port: Optional[int] = None,
+) -> None:
+    """Spawn *nprocs* DDP workers via :func:`torch.multiprocessing.spawn`.
+
+    Each worker is called as::
+
+        worker_fn(rank, nprocs, master_addr, master_port, result_path, *spawn_args)
+
+    The worker is responsible for setting RANK/LOCAL_RANK/WORLD_SIZE/MASTER_*
+    env vars, initialising the process group, running training, and writing a
+    result JSON to *result_path* (rank 0 only).
+
+    This is the internal engine behind the auto-spawn path triggered when a
+    user calls ``model.train(device="0,1")`` from a plain Python script (no
+    torchrun). The model's ``train()`` method calls this helper, collects the
+    result JSON from *result_path*, and returns it to the caller — so the user
+    gets a clean blocking call without any subprocess plumbing.
+    """
+    import torch.multiprocessing as mp
+
+    if master_port is None:
+        master_port = _find_free_port()
+
+    mp.spawn(
+        worker_fn,
+        args=(nprocs, master_addr, master_port, result_path) + spawn_args,
+        nprocs=nprocs,
+        join=True,
+    )
+
+
 __all__ = [
     "DeviceArg",
     "barrier",
@@ -267,6 +317,7 @@ __all__ = [
     "scale_loss_for_ddp",
     "seed_for_rank",
     "shutdown_distributed",
+    "spawn_ddp_train",
     "unwrap_model",
     "wants_distributed",
 ]

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -272,6 +272,7 @@ def spawn_ddp_train(
     result_path: str,
     master_addr: str = "127.0.0.1",
     master_port: Optional[int] = None,
+    devices: Optional[List[int]] = None,
 ) -> None:
     """Spawn *nprocs* DDP workers via :func:`torch.multiprocessing.spawn`.
 
@@ -288,18 +289,33 @@ def spawn_ddp_train(
     torchrun). The model's ``train()`` method calls this helper, collects the
     result JSON from *result_path*, and returns it to the caller — so the user
     gets a clean blocking call without any subprocess plumbing.
+
+    When *devices* is provided, ``CUDA_VISIBLE_DEVICES`` is set to the
+    comma-joined device indices before spawning so that ``cuda:N`` inside each
+    worker maps to the N-th requested physical GPU.  The original value is
+    restored after spawning completes.
     """
     import torch.multiprocessing as mp
 
     if master_port is None:
         master_port = _find_free_port()
 
-    mp.spawn(
-        worker_fn,
-        args=(nprocs, master_addr, master_port, result_path) + spawn_args,
-        nprocs=nprocs,
-        join=True,
-    )
+    prev_cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if devices:
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(d) for d in devices)
+    try:
+        mp.spawn(
+            worker_fn,
+            args=(nprocs, master_addr, master_port, result_path) + spawn_args,
+            nprocs=nprocs,
+            join=True,
+        )
+    finally:
+        if devices:
+            if prev_cvd is None:
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            else:
+                os.environ["CUDA_VISIBLE_DEVICES"] = prev_cvd
 
 
 __all__ = [

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -146,11 +146,14 @@ def init_distributed(timeout_seconds: int = 10800) -> None:
             "`torchrun --nproc_per_node=2 your_script.py`."
         )
     backend = _select_backend()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device_id = torch.device("cuda", local_rank) if torch.cuda.is_available() else None
     dist.init_process_group(
         backend=backend,
         timeout=timedelta(seconds=timeout_seconds),
         rank=int(os.environ["RANK"]),
         world_size=int(os.environ["WORLD_SIZE"]),
+        device_id=device_id,
     )
 
 

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -315,7 +315,19 @@ def spawn_ddp_train(
     worker maps to the N-th requested physical GPU.  The original value is
     restored after spawning completes.
     """
+    import multiprocessing
     import torch.multiprocessing as mp
+
+    if multiprocessing.current_process().name != "MainProcess":
+        raise RuntimeError(
+            "spawn_ddp_train() was called from inside a spawned subprocess. "
+            "This usually means your script calls model.train(device=...) at "
+            "the top level without a 'if __name__ == \"__main__\":' guard. "
+            "Each spawned worker re-imports __main__, which re-launches "
+            "training and causes infinite recursion. Wrap your training call:\n\n"
+            "    if __name__ == '__main__':\n"
+            "        model.train(device='0,1')\n"
+        )
 
     port_sock = None
     if master_port is None:

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -155,10 +155,15 @@ def init_distributed(timeout_seconds: int = 10800) -> None:
         "rank": int(os.environ["RANK"]),
         "world_size": int(os.environ["WORLD_SIZE"]),
     }
-    # device_id was added in PyTorch 2.0; guard so we stay compatible with older builds
-    pg_sig = inspect.signature(dist.init_process_group)
-    if "device_id" in pg_sig.parameters and torch.cuda.is_available():
-        init_kwargs["device_id"] = torch.device("cuda", local_rank)
+    # device_id was added in PyTorch 2.0; guard so we stay compatible with older builds.
+    # inspect.signature() can raise ValueError/TypeError on some C-extension builds,
+    # so wrap defensively and omit the kwarg on failure.
+    try:
+        pg_sig = inspect.signature(dist.init_process_group)
+        if "device_id" in pg_sig.parameters and torch.cuda.is_available():
+            init_kwargs["device_id"] = torch.device("cuda", local_rank)
+    except (TypeError, ValueError):
+        pass
     dist.init_process_group(**init_kwargs)
 
 

--- a/libreyolo/training/scheduler.py
+++ b/libreyolo/training/scheduler.py
@@ -45,7 +45,7 @@ class WarmupCosineScheduler(BaseScheduler):
         self.min_lr = lr * min_lr_ratio
 
     def update_lr(self, iters: int) -> float:
-        if iters <= self.warmup_iters:
+        if self.warmup_iters > 0 and iters <= self.warmup_iters:
             # Quadratic warmup
             lr = (self.lr - self.warmup_lr_start) * pow(
                 iters / float(self.warmup_iters), 2

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -514,6 +514,17 @@ class BaseTrainer(ABC):
         self.lr_scheduler = self.create_scheduler(self._scheduler_steps_per_epoch())
         self._initialize_scheduler_lr()
 
+        # resume() may be called before setup() when the optimizer doesn't exist
+        # yet. Apply the deferred state now so momentum buffers and LR are restored.
+        if getattr(self, "_resume_optimizer_state", None) is not None:
+            try:
+                self.optimizer.load_state_dict(self._resume_optimizer_state)
+                logger.info("Optimizer state restored from resume checkpoint")
+            except Exception as e:
+                logger.warning(f"Could not load deferred optimizer state: {e}")
+            finally:
+                self._resume_optimizer_state = None
+
         # DDP wrap AFTER optimizer setup so _setup_optimizer's
         # named_parameters() sees the raw model. EMA below also reads the
         # raw model — ModelEMA already unwraps via is_parallel() check.
@@ -985,7 +996,10 @@ class BaseTrainer(ABC):
         warmup_iters = getattr(self.lr_scheduler, "warmup_iters", 0)
         if warmup_iters is None or warmup_iters <= 0:
             return
-        self._set_optimizer_lr(self.lr_scheduler.update_lr(0))
+        # When resuming, fast-forward to the correct schedule position rather
+        # than resetting to the warmup-start LR.
+        init_iter = getattr(self, "start_epoch", 0) * self._scheduler_steps_per_epoch()
+        self._set_optimizer_lr(self.lr_scheduler.update_lr(init_iter))
 
     def _gradient_clip_parameters(self) -> List[torch.nn.Parameter]:
         if self.optimizer is None:
@@ -1483,12 +1497,17 @@ class BaseTrainer(ABC):
 
         self.start_epoch = checkpoint["epoch"] + 1
 
-        if self.optimizer is not None and "optimizer" in checkpoint:
-            try:
-                self.optimizer.load_state_dict(checkpoint["optimizer"])
-                logger.info("Optimizer state restored")
-            except Exception as e:
-                logger.warning(f"Could not load optimizer state: {e}")
+        if "optimizer" in checkpoint:
+            if self.optimizer is not None:
+                try:
+                    self.optimizer.load_state_dict(checkpoint["optimizer"])
+                    logger.info("Optimizer state restored")
+                except Exception as e:
+                    logger.warning(f"Could not load optimizer state: {e}")
+            else:
+                # setup() hasn't run yet — defer until the optimizer exists.
+                self._resume_optimizer_state = checkpoint["optimizer"]
+                logger.info("Optimizer state deferred until after setup()")
 
         if "best_metric_value" in checkpoint or "best_mAP50_95" in checkpoint:
             checkpoint_metric_key = checkpoint.get("best_metric_key", "metrics/mAP50-95")

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1146,7 +1146,8 @@ class BaseTrainer(ABC):
             name: value / max(num_batches, 1)
             for name, value in loss_component_sums.items()
         }
-        logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
+        if is_main_process():
+            logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
 
         # Validation
         val_metrics = None
@@ -1274,7 +1275,8 @@ class BaseTrainer(ABC):
             name: value / max(num_batches, 1)
             for name, value in loss_component_sums.items()
         }
-        logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
+        if is_main_process():
+            logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
 
         # Validation
         val_metrics = None

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -659,11 +659,12 @@ class BaseTrainer(ABC):
                 self.callbacks.on_train_start(start_event)
 
             no_aug_start = self.config.epochs - self.config.no_aug_epochs
-            if is_main_process() and self.config.no_aug_epochs > 0 and self.start_epoch > no_aug_start:
-                logger.info(
-                    f"Resumed past no-aug threshold (epoch {self.start_epoch} > {no_aug_start}), "
-                    f"disabling mosaic/mixup immediately"
-                )
+            if self.config.no_aug_epochs > 0 and self.start_epoch > no_aug_start:
+                if is_main_process():
+                    logger.info(
+                        f"Resumed past no-aug threshold (epoch {self.start_epoch} > {no_aug_start}), "
+                        f"disabling mosaic/mixup immediately"
+                    )
                 self.on_mosaic_disable()
 
             for epoch in range(self.start_epoch, self.config.epochs):

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -271,9 +271,11 @@ class BaseTrainer(ABC):
                 )
             n = len(parse_device_arg(raw_device))
             raise RuntimeError(
-                f"Multi-GPU device {raw_device!r} requires launching with torchrun. "
-                f"Example: `torchrun --nproc_per_node={n} your_script.py`. "
-                "Inside the script, leave your model.train(...) call unchanged."
+                f"Multi-GPU device {raw_device!r} was passed directly to the trainer "
+                "without an active process group. Use the model API instead — it "
+                f"spawns DDP workers automatically: model.train(data=..., device={raw_device!r}). "
+                f"Alternatively launch with torchrun: "
+                f"`torchrun --nproc_per_node={n} your_script.py`."
             )
 
         device_str = str(raw_device).strip().lower() if not isinstance(raw_device, int) else str(raw_device)

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -332,10 +332,11 @@ class BaseTrainer(ABC):
         )
         optimizer.add_param_group({"params": pg2, "lr": lr})
 
-        logger.info(f"Optimizer: {opt_name}")
-        logger.info(f"  - pg0 (BN): {len(pg0)} params")
-        logger.info(f"  - pg1 (Conv, wd={self.config.weight_decay}): {len(pg1)} params")
-        logger.info(f"  - pg2 (Bias): {len(pg2)} params")
+        if is_main_process():
+            logger.info(f"Optimizer: {opt_name}")
+            logger.info(f"  - pg0 (BN): {len(pg0)} params")
+            logger.info(f"  - pg1 (Conv, wd={self.config.weight_decay}): {len(pg1)} params")
+            logger.info(f"  - pg2 (Bias): {len(pg2)} params")
         return optimizer
 
     def _get_save_dir(self) -> Path:
@@ -609,10 +610,11 @@ class BaseTrainer(ABC):
         try:
             self.setup()
 
-            logger.info(f"Starting training for {self.config.epochs} epochs")
-            logger.info(f"Model: {self.get_model_tag()}")
-            logger.info(f"Batch size: {self.config.batch}")
-            logger.info(f"Learning rate: {self.effective_lr}")
+            if is_main_process():
+                logger.info(f"Starting training for {self.config.epochs} epochs")
+                logger.info(f"Model: {self.get_model_tag()}")
+                logger.info(f"Batch size: {self.config.batch}")
+                logger.info(f"Learning rate: {self.effective_lr}")
 
             start_event = self._build_train_start_event()
             # Artifact + user callbacks fire on rank 0 only — they write
@@ -623,7 +625,7 @@ class BaseTrainer(ABC):
                 self.callbacks.on_train_start(start_event)
 
             no_aug_start = self.config.epochs - self.config.no_aug_epochs
-            if self.config.no_aug_epochs > 0 and self.start_epoch > no_aug_start:
+            if is_main_process() and self.config.no_aug_epochs > 0 and self.start_epoch > no_aug_start:
                 logger.info(
                     f"Resumed past no-aug threshold (epoch {self.start_epoch} > {no_aug_start}), "
                     f"disabling mosaic/mixup immediately"
@@ -634,9 +636,10 @@ class BaseTrainer(ABC):
                 self.current_epoch = epoch
 
                 if epoch == no_aug_start:
-                    logger.info(
-                        f"Disabling mosaic/mixup for final {self.config.no_aug_epochs} epochs"
-                    )
+                    if is_main_process():
+                        logger.info(
+                            f"Disabling mosaic/mixup for final {self.config.no_aug_epochs} epochs"
+                        )
                     self.on_mosaic_disable()
 
                 epoch_start_time = time.time()
@@ -685,7 +688,7 @@ class BaseTrainer(ABC):
                 if self.is_distributed:
                     import torch.distributed as _dist
 
-                    flag = torch.tensor(int(should_stop), dtype=torch.int)
+                    flag = torch.tensor(int(should_stop), dtype=torch.int, device=self.device)
                     _dist.broadcast(flag, src=0)
                     should_stop = bool(flag.item())
                 if should_stop:
@@ -697,7 +700,8 @@ class BaseTrainer(ABC):
                     break
 
             total_time = time.time() - start_time
-            logger.info(f"Training complete in {total_time / 3600:.2f} hours")
+            if is_main_process():
+                logger.info(f"Training complete in {total_time / 3600:.2f} hours")
 
             results = self._build_train_results()
             end_event = self._build_train_end_event(total_time, results)

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -506,6 +506,19 @@ class BaseTrainer(ABC):
 
         self.on_setup()
 
+        if getattr(self.config, "batch", 16) == -1:
+            from libreyolo.training.autobatch import resolve_auto_batch
+
+            self.config.batch = resolve_auto_batch(
+                self.model,
+                imgsz=self.config.imgsz,
+                amp=self.config.amp,
+                world_size=self.world_size,
+                nbs=getattr(self.config, "nbs", None),
+            )
+            if is_main_process():
+                logger.info("AutoBatch: resolved global batch size = %d", self.config.batch)
+
         self._setup_data()
         self.optimizer = self._setup_optimizer()
         self.lr_scheduler = self.create_scheduler(self._scheduler_steps_per_epoch())

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -479,7 +479,7 @@ class BaseTrainer(ABC):
             batch_size=per_rank_batch,
             num_workers=self.config.workers,
             shuffle=True,
-            pin_memory=True,
+            pin_memory=self.device.type == "cuda",
             sampler=sampler,
         )
 

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -528,10 +528,10 @@ class BaseTrainer(ABC):
         self._setup_data()
         self.optimizer = self._setup_optimizer()
         self.lr_scheduler = self.create_scheduler(self._scheduler_steps_per_epoch())
-        self._initialize_scheduler_lr()
 
         # resume() may be called before setup() when the optimizer doesn't exist
-        # yet. Apply the deferred state now so momentum buffers and LR are restored.
+        # yet. Apply the deferred state now so momentum buffers are restored before
+        # _initialize_scheduler_lr() sets the correct LR on top.
         if getattr(self, "_resume_optimizer_state", None) is not None:
             try:
                 self.optimizer.load_state_dict(self._resume_optimizer_state)
@@ -540,6 +540,8 @@ class BaseTrainer(ABC):
                 logger.warning(f"Could not load deferred optimizer state: {e}")
             finally:
                 self._resume_optimizer_state = None
+
+        self._initialize_scheduler_lr()
 
         # DDP wrap AFTER optimizer setup so _setup_optimizer's
         # named_parameters() sees the raw model. EMA below also reads the
@@ -1012,11 +1014,6 @@ class BaseTrainer(ABC):
     def _initialize_scheduler_lr(self) -> None:
         if self.optimizer is None or self.lr_scheduler is None:
             return
-        warmup_iters = getattr(self.lr_scheduler, "warmup_iters", 0)
-        if warmup_iters is None or warmup_iters <= 0:
-            return
-        # When resuming, fast-forward to the correct schedule position rather
-        # than resetting to the warmup-start LR.
         init_iter = getattr(self, "start_epoch", 0) * self._scheduler_steps_per_epoch()
         self._set_optimizer_lr(self.lr_scheduler.update_lr(init_iter))
 
@@ -1575,3 +1572,9 @@ class BaseTrainer(ABC):
             f"Resumed from epoch {self.start_epoch} "
             f"(will train to epoch {self.config.epochs})"
         )
+
+        # setup() may have already run (immediate path: setup → resume). Re-sync
+        # the LR now that start_epoch is known — _initialize_scheduler_lr() is
+        # idempotent and fast-forwards to the correct schedule position.
+        if self.lr_scheduler is not None and self.train_loader is not None:
+            self._initialize_scheduler_lr()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "tqdm>=4.65.0",
     "pycocotools>=2.0.0",
     "typer>=0.9.0",
+    "click>=8.0.0",
     "safetensors>=0.4.0",
     "scipy>=1.7.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "pycocotools>=2.0.0",
     "typer>=0.9.0",
     "safetensors>=0.4.0",
-    "pandas>=2.3.3",
     "scipy>=1.15.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "pycocotools>=2.0.0",
     "typer>=0.9.0",
     "safetensors>=0.4.0",
+    "pandas>=2.3.3",
+    "scipy>=1.15.3",
 ]
 
 [dependency-groups]

--- a/tests/unit/test_autobatch.py
+++ b/tests/unit/test_autobatch.py
@@ -348,6 +348,63 @@ def test_trainer_batch_minus1_calls_resolve_auto_batch():
     assert trainer.config.batch == 24
 
 
+# =============================================================================
+# resolve_auto_batch — nbs-aware per-GPU scaling
+# =============================================================================
+
+
+def test_resolve_nbs_1gpu_uses_accumulation():
+    """1 GPU: global = per_gpu (≤ nbs), accumulation makes up the rest."""
+    # per_gpu=16, nbs=32, world_size=1 → global=min(16,32)=16
+    with patch("libreyolo.training.autobatch.autobatch", return_value=16):
+        result = resolve_auto_batch(
+            nn.Linear(4, 2), imgsz=32, amp=False, world_size=1, nbs=32,
+        )
+    assert result == 16  # accumulate=round(32/16)=2 → effective=32=nbs
+
+
+def test_resolve_nbs_2gpu_scales_to_nbs():
+    """2 GPUs: global = per_gpu * world_size capped at nbs — no accumulation needed."""
+    # per_gpu=16, nbs=32, world_size=2 → global=min(32,32)=32
+    with patch("libreyolo.training.autobatch.autobatch", return_value=16):
+        result = resolve_auto_batch(
+            nn.Linear(4, 2), imgsz=32, amp=False, world_size=2, nbs=32,
+        )
+    assert result == 32  # per-rank=16, accumulate=1 → effective=32=nbs
+
+
+def test_resolve_nbs_4gpu_caps_at_nbs():
+    """4 GPUs with headroom: global is capped at nbs, not per_gpu * world_size."""
+    # per_gpu=16, nbs=32, world_size=4 → min(64,32)=32 → round to mult of 4 → 32
+    with patch("libreyolo.training.autobatch.autobatch", return_value=16):
+        result = resolve_auto_batch(
+            nn.Linear(4, 2), imgsz=32, amp=False, world_size=4, nbs=32,
+        )
+    assert result == 32  # per-rank=8, accumulate=1 → effective=32=nbs
+
+
+def test_resolve_nbs_result_divisible_by_world_size():
+    """Global batch is always divisible by world_size."""
+    with patch("libreyolo.training.autobatch.autobatch", return_value=16):
+        for ws in (1, 2, 4, 8):
+            result = resolve_auto_batch(
+                nn.Linear(4, 2), imgsz=32, amp=False, world_size=ws, nbs=64,
+            )
+            assert result % ws == 0, f"world_size={ws}: {result} not divisible"
+
+
+def test_resolve_nbs_world_size_exceeds_nbs_warns(caplog):
+    """world_size > nbs forces global > nbs — a warning must be emitted."""
+    import logging
+    with patch("libreyolo.training.autobatch.autobatch", return_value=4):
+        with caplog.at_level(logging.WARNING, logger="libreyolo.training.autobatch"):
+            result = resolve_auto_batch(
+                nn.Linear(4, 2), imgsz=32, amp=False, world_size=8, nbs=4,
+            )
+    assert result >= 8
+    assert any("world_size" in r.message and "nbs" in r.message for r in caplog.records)
+
+
 @_requires_trainer
 def test_trainer_explicit_batch_skips_resolve():
     """Explicit batch > 0 must never trigger autobatch."""

--- a/tests/unit/test_autobatch.py
+++ b/tests/unit/test_autobatch.py
@@ -214,6 +214,27 @@ def test_autobatch_clamps_to_safe_max():
     assert result <= _BATCH_SAFE_MAX
 
 
+def test_autobatch_extrapolation_not_capped_at_max_probe():
+    """Extrapolated raw value must not be capped at max_probe before rounding.
+
+    slope=0.05 GiB/sample, intercept=0, total=8 GiB, fraction=0.70 →
+    raw = 5.6 / 0.05 = 112, which exceeds the default max_probe=64.
+    _floor_pow2_strict(112) = 64.  The old (incorrect) code would clamp raw to
+    64 first, giving _floor_pow2_strict(64) = 32.
+    """
+    slope_gib = 0.05
+
+    def mem_fn(b):
+        return int(slope_gib * b * 1024**3)
+
+    model = nn.Linear(4, 2)
+    with _make_cuda_patches(mem_fn, total_gib=8.0, model=model):
+        result = autobatch(model, imgsz=32, amp=False, fraction=0.70, default=16)
+
+    # raw ≈ 112  →  _floor_pow2_strict(112) = 64
+    assert result == _floor_pow2_strict(8.0 * 0.70 / slope_gib)
+
+
 def test_autobatch_returns_default_on_oom_at_first_probe():
     """OOM on batch=1 → < 2 probe points → return default."""
     call_count = [0]

--- a/tests/unit/test_autobatch.py
+++ b/tests/unit/test_autobatch.py
@@ -263,9 +263,9 @@ def test_resolve_rounds_down_to_world_size_multiple():
         result = resolve_auto_batch(
             nn.Linear(4, 2), imgsz=32, amp=False, world_size=4, default=16
         )
-    # 13 // 4 * 4 = 12
+    # per-GPU=13 scaled to global: 13 * 4 = 52
     assert result % 4 == 0
-    assert result == 12
+    assert result == 52
 
 
 def test_resolve_minimum_is_world_size():
@@ -278,12 +278,13 @@ def test_resolve_minimum_is_world_size():
 
 
 def test_resolve_exact_multiple_unchanged():
-    """An autobatch result already divisible by world_size is returned as-is."""
+    """Global batch is per-GPU * world_size (no nbs cap)."""
     with patch("libreyolo.training.autobatch.autobatch", return_value=32):
         result = resolve_auto_batch(
             nn.Linear(4, 2), imgsz=32, amp=False, world_size=8, default=16
         )
-    assert result == 32
+    # per-GPU=32 scaled to global: 32 * 8 = 256
+    assert result == 256
 
 
 # =============================================================================

--- a/tests/unit/test_autobatch.py
+++ b/tests/unit/test_autobatch.py
@@ -1,0 +1,365 @@
+"""Unit tests for libreyolo.training.autobatch.
+
+Tests are CPU-only and avoid triggering real CUDA initialisation.
+The linear-fit core (_fit_batch_size) is tested directly; higher-level
+functions are tested by patching autobatch() itself rather than mocking
+CUDA internals.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = pytest.mark.unit
+
+from libreyolo.training.autobatch import (
+    _BATCH_SAFE_MAX,
+    _fit_batch_size,
+    _floor_pow2_strict,
+    autobatch,
+    resolve_auto_batch,
+)
+
+
+# =============================================================================
+# _floor_pow2_strict
+# =============================================================================
+
+
+def test_floor_pow2_strict_basic():
+    """Values above 2 return the largest power of 2 strictly less than x."""
+    assert _floor_pow2_strict(33.0) == 32
+    assert _floor_pow2_strict(65.0) == 64
+    assert _floor_pow2_strict(17.5) == 16
+    assert _floor_pow2_strict(5.0) == 4
+
+
+def test_floor_pow2_strict_exact_power_goes_lower():
+    """An exact power of 2 returns the next lower power (strictly less than)."""
+    assert _floor_pow2_strict(32.0) == 16
+    assert _floor_pow2_strict(64.0) == 32
+    assert _floor_pow2_strict(4.0) == 2
+
+
+def test_floor_pow2_strict_small_values():
+    """Values ≤ 2 return 1."""
+    assert _floor_pow2_strict(2.0) == 1
+    assert _floor_pow2_strict(1.5) == 1
+    assert _floor_pow2_strict(0.5) == 1
+
+
+def test_floor_pow2_strict_result_divides_nbs():
+    """For typical nbs values the result always divides nbs (power-of-2 property)."""
+    for nbs in (32, 64, 128):
+        for raw in (raw_val + 0.1 for raw_val in range(3, nbs * 2)):
+            result = _floor_pow2_strict(raw)
+            if result <= nbs:
+                assert nbs % result == 0, f"raw={raw:.1f} → {result} does not divide nbs={nbs}"
+
+
+# =============================================================================
+# _fit_batch_size — pure math, no I/O
+# =============================================================================
+
+
+def test_fit_exact_linear():
+    """Perfect linear data → extrapolation is exact."""
+    # mem = 0.10 * batch + 0.50  GiB
+    slope, intercept = 0.10, 0.50
+    probes = [1, 2, 4, 8, 16]
+    mems = [slope * b + intercept for b in probes]
+    target = 4.80  # free_gib * fraction = 8.0 * 0.60
+
+    result = _fit_batch_size(probes, mems, target)
+    expected = round((target - intercept) / slope)  # 43
+    assert result == expected
+
+
+def test_fit_clamps_to_safe_max():
+    """Extrapolated value above _BATCH_SAFE_MAX is clamped."""
+    # Tiny slope → huge extrapolated batch
+    probes = [1, 2, 4, 8, 16]
+    mems = [0.0001 * b for b in probes]
+    result = _fit_batch_size(probes, mems, target_gib=100.0)
+    assert result == _BATCH_SAFE_MAX
+
+
+def test_fit_minimum_one():
+    """Extrapolated batch below 1 is clamped to 1."""
+    # Target already exceeded at batch=1 → negative extrapolation → clamped to 1
+    probes = [1, 2, 4]
+    mems = [5.0, 6.0, 8.0]  # already above target
+    result = _fit_batch_size(probes, mems, target_gib=1.0)
+    assert result == 1
+
+
+def test_fit_non_positive_slope_returns_none():
+    """Flat or negative slope (degenerate data) returns None."""
+    probes = [1, 2, 4]
+    mems = [2.0, 2.0, 2.0]  # flat → slope = 0
+    assert _fit_batch_size(probes, mems, target_gib=4.0) is None
+
+    mems_dec = [3.0, 2.0, 1.0]  # decreasing → slope < 0
+    assert _fit_batch_size(probes, mems_dec, target_gib=4.0) is None
+
+
+# =============================================================================
+# autobatch — CPU fallback
+# =============================================================================
+
+
+def test_autobatch_cpu_returns_default():
+    """Non-CUDA device must return the default without probing."""
+    model = nn.Linear(4, 2)
+    result = autobatch(model, imgsz=32, amp=False, default=8)
+    assert result == 8
+
+
+def test_autobatch_cpu_ignores_fraction():
+    """Fraction is irrelevant on CPU — default is always returned."""
+    model = nn.Linear(4, 2)
+    assert autobatch(model, imgsz=32, amp=False, fraction=0.99, default=24) == 24
+
+
+# =============================================================================
+# autobatch — CUDA paths via patching the probe internals
+# =============================================================================
+
+
+def _make_cuda_patches(probe_mem_fn, total_gib=8.0, model=None):
+    """Return context managers that fake a CUDA environment inside autobatch.
+
+    *probe_mem_fn(batch_size)* returns peak allocated memory in bytes for a
+    given batch size probe call.  torch.zeros is patched to stay on CPU so no
+    real CUDA initialisation occurs.  *model.forward* is mocked to a no-op so
+    shape-mismatches in the probe model are avoided.
+    """
+    import contextlib
+
+    class _FakeDevice:
+        type = "cuda"
+        index = 0
+
+        def __str__(self):
+            return "cuda:0"
+
+    class _FakeParam:
+        """Stand-in for a model parameter; carries a .device attribute."""
+        device = _FakeDevice()
+
+    class _FakeProps:
+        name = "FakeGPU"
+        total_memory = int(total_gib * 1024**3)
+
+    peak = [0]
+    _real_zeros = torch.zeros  # capture before patching to avoid recursion
+
+    def _fake_zeros(*args, dtype=None, device=None):  # noqa: ARG001
+        b = args[0]
+        peak[0] = probe_mem_fn(b)
+        return _real_zeros(*args, dtype=dtype or torch.float32)
+
+    @contextlib.contextmanager
+    def _ctx():
+        base = [
+            patch("libreyolo.training.autobatch.next", return_value=_FakeParam()),
+            patch("torch.cuda.get_device_properties", return_value=_FakeProps()),
+            patch("torch.cuda.memory_reserved", return_value=0),
+            patch("torch.cuda.reset_peak_memory_stats"),
+            patch("torch.cuda.max_memory_allocated", side_effect=lambda *_: peak[0]),
+            patch("torch.cuda.empty_cache"),
+            patch("torch.zeros", side_effect=_fake_zeros),
+        ]
+        fwd = [patch.object(model, "forward", return_value=None)] if model is not None else []
+        with contextlib.ExitStack() as stack:
+            for p in base + fwd:
+                stack.enter_context(p)
+            yield
+
+    return _ctx()
+
+
+def test_autobatch_linear_extrapolates_correctly():
+    """With linear memory growth the result is _floor_pow2_strict of the extrapolation."""
+    slope_gib = 0.10
+    intercept_gib = 0.50
+    total_gib = 8.0
+    fraction = 0.70
+
+    def mem_fn(b):
+        return int((slope_gib * b + intercept_gib) * 1024**3)
+
+    model = nn.Linear(4, 2)
+    with _make_cuda_patches(mem_fn, total_gib=total_gib, model=model):
+        result = autobatch(model, imgsz=32, amp=False, fraction=fraction, default=16)
+
+    raw = (total_gib * fraction - intercept_gib) / slope_gib
+    expected = _floor_pow2_strict(raw)
+    assert result == expected
+
+
+def test_autobatch_clamps_to_safe_max():
+    """Tiny memory-per-sample → extrapolation → clamped to _BATCH_SAFE_MAX."""
+    def mem_fn(b):
+        return int(b * 0.0001 * 1024**3)
+
+    model = nn.Linear(4, 2)
+    with _make_cuda_patches(mem_fn, total_gib=128.0, model=model):
+        result = autobatch(model, imgsz=32, amp=False, default=16)
+
+    assert result <= _BATCH_SAFE_MAX
+
+
+def test_autobatch_returns_default_on_oom_at_first_probe():
+    """OOM on batch=1 → < 2 probe points → return default."""
+    call_count = [0]
+
+    def mem_fn(*_):
+        call_count[0] += 1
+        raise RuntimeError("CUDA out of memory")
+
+    model = nn.Linear(4, 2)
+    with _make_cuda_patches(mem_fn, model=model):
+        result = autobatch(model, imgsz=32, amp=False, default=7)
+
+    assert result == 7
+
+
+def test_autobatch_returns_default_on_oom_at_second_probe():
+    """OOM on batch=2 leaves 1 point → fallback to default."""
+    call_count = [0]
+
+    def mem_fn(*_):
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            raise RuntimeError("CUDA out of memory")
+        return int(0.5 * 1024**3)
+
+    model = nn.Linear(4, 2)
+    with _make_cuda_patches(mem_fn, model=model):
+        result = autobatch(model, imgsz=32, amp=False, default=5)
+
+    assert result == 5
+
+
+# =============================================================================
+# resolve_auto_batch — single-process path
+# =============================================================================
+
+
+def test_resolve_cpu_returns_default():
+    model = nn.Linear(4, 2)
+    result = resolve_auto_batch(model, imgsz=32, amp=False, world_size=1, default=12)
+    assert result == 12
+
+
+def test_resolve_rounds_down_to_world_size_multiple():
+    """Result is always divisible by world_size."""
+    with patch("libreyolo.training.autobatch.autobatch", return_value=13):
+        result = resolve_auto_batch(
+            nn.Linear(4, 2), imgsz=32, amp=False, world_size=4, default=16
+        )
+    # 13 // 4 * 4 = 12
+    assert result % 4 == 0
+    assert result == 12
+
+
+def test_resolve_minimum_is_world_size():
+    """Result is always ≥ world_size (each rank gets ≥1 sample)."""
+    with patch("libreyolo.training.autobatch.autobatch", return_value=1):
+        result = resolve_auto_batch(
+            nn.Linear(4, 2), imgsz=32, amp=False, world_size=8, default=16
+        )
+    assert result >= 8
+
+
+def test_resolve_exact_multiple_unchanged():
+    """An autobatch result already divisible by world_size is returned as-is."""
+    with patch("libreyolo.training.autobatch.autobatch", return_value=32):
+        result = resolve_auto_batch(
+            nn.Linear(4, 2), imgsz=32, amp=False, world_size=8, default=16
+        )
+    assert result == 32
+
+
+# =============================================================================
+# Trainer wiring: batch=-1 triggers resolve_auto_batch
+# =============================================================================
+
+
+try:
+    from libreyolo.training.trainer import BaseTrainer as _BaseTrainer
+    _HAS_TRAINER = True
+except Exception:
+    _BaseTrainer = object  # type: ignore[assignment,misc]
+    _HAS_TRAINER = False
+
+_requires_trainer = pytest.mark.skipif(not _HAS_TRAINER, reason="libreyolo trainer unavailable")
+
+
+class _ConstScheduler:
+    def update_lr(self, _): return 0.01
+
+
+def _make_minimal_trainer(batch):
+    class _MinimalTrainer(_BaseTrainer):
+        def get_model_family(self): return "test"
+        def get_model_tag(self): return "test"
+        def create_transforms(self): return None, None
+        def create_scheduler(self, iters): return _ConstScheduler()
+        def get_loss_components(self, outputs): return {}
+        def on_forward(self, imgs, targets, polygons=None):
+            return {"total_loss": self.model(imgs).mean()}
+        def _setup_data(self):
+            self.train_loader = [None] * 4  # fake length; content never iterated
+        def _setup_optimizer(self):
+            return torch.optim.SGD(self.model.parameters(), lr=0.01)
+
+    return _MinimalTrainer(
+        model=nn.Linear(4, 2),
+        num_classes=2,
+        epochs=1,
+        batch=batch,
+        device="cpu",
+        amp=False,
+        ema=False,
+    )
+
+
+@_requires_trainer
+def test_trainer_batch_minus1_calls_resolve_auto_batch():
+    """setup() must call resolve_auto_batch and update config.batch when batch=-1."""
+    trainer = _make_minimal_trainer(batch=-1)
+    calls = []
+
+    def _fake_resolve(m, imgsz, amp, world_size, **_):
+        calls.append(world_size)
+        return 24
+
+    # Patch in the autobatch module (local import inside setup())
+    with patch("libreyolo.training.autobatch.resolve_auto_batch", side_effect=_fake_resolve):
+        trainer.setup()
+
+    assert len(calls) == 1, "resolve_auto_batch must be called exactly once"
+    assert trainer.config.batch == 24
+
+
+@_requires_trainer
+def test_trainer_explicit_batch_skips_resolve():
+    """Explicit batch > 0 must never trigger autobatch."""
+    trainer = _make_minimal_trainer(batch=8)
+    calls = []
+
+    def _fake_resolve(*a, **kw):
+        calls.append(1)
+        return 99
+
+    with patch("libreyolo.training.autobatch.resolve_auto_batch", side_effect=_fake_resolve):
+        trainer.setup()
+
+    assert calls == [], "resolve_auto_batch must not be called for explicit batch"
+    assert trainer.config.batch == 8

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -294,12 +294,14 @@ def _rtdetr_ddp_worker(rank: int, world_size: int, port: int, out_dir: str) -> N
 
     Exercises two forward passes:
       1. Normal batch (has GT boxes) — denoising_class_embed is active.
+         Asserted via presence of '_dn_' keys in the loss dict.
       2. All-empty batch (no GT boxes) — denoising path returns None, so
          denoising_class_embed has no gradient. With find_unused_parameters=True
          DDP handles this correctly; with False + static_graph=True it would
          silently corrupt training (or hang under NCCL).
-    Also verifies that RTDETRLoss.all_reduce(num_boxes) fires when a process
-    group is active.
+         Asserted via absence of '_dn_' keys in the loss dict.
+    Each rank contributes a different box count so the all_reduce(num_boxes)
+    path in RTDETRLoss is exercised with a non-trivial reduction.
     """
     out_path = Path(out_dir) / f"rank_{rank}.txt"
     try:
@@ -338,11 +340,11 @@ def _rtdetr_ddp_worker(rank: int, world_size: int, port: int, out_dir: str) -> N
         # Verify the fix: RT-DETR must use find_unused_parameters=True so that
         # empty-target batches (where denoising_class_embed is unused) don't
         # cause DDP to mishandle the gradient for that parameter.
-        assert trainer._ddp_find_unused_parameters(), (
+        find_unused = trainer._ddp_find_unused_parameters()
+        assert find_unused, (
             "RTDETRTrainer must return True from _ddp_find_unused_parameters() "
             "because denoising_class_embed is conditionally used."
         )
-        find_unused = trainer._ddp_find_unused_parameters()
         ddp_model = nn.parallel.DistributedDataParallel(
             wrapper.model,
             find_unused_parameters=find_unused,
@@ -365,6 +367,13 @@ def _rtdetr_ddp_worker(rank: int, world_size: int, port: int, out_dir: str) -> N
         loss1 = out1["total_loss"]
         if not torch.isfinite(loss1):
             raise RuntimeError(f"non-finite loss (pass 1) on rank {rank}: {loss1.item()}")
+        # Denoising path must be active: valid box → max_gt_num > 0 → _dn_ loss keys appear.
+        dn_keys1 = [k for k in out1 if "_dn_" in k]
+        if not dn_keys1:
+            raise RuntimeError(
+                f"pass 1: denoising path was not exercised on rank {rank} "
+                f"(no '_dn_' keys in loss dict); target box coordinates may be invalid"
+            )
         loss1_scaled = scale_loss_for_ddp(loss1)
         optimizer.zero_grad()
         loss1_scaled.backward()
@@ -383,6 +392,13 @@ def _rtdetr_ddp_worker(rank: int, world_size: int, port: int, out_dir: str) -> N
         loss2 = out2["total_loss"]
         if not torch.isfinite(loss2):
             raise RuntimeError(f"non-finite loss (pass 2) on rank {rank}: {loss2.item()}")
+        # Denoising path must be inactive: no valid boxes → max_gt_num == 0 → no _dn_ keys.
+        dn_keys2 = [k for k in out2 if "_dn_" in k]
+        if dn_keys2:
+            raise RuntimeError(
+                f"pass 2: expected denoising to be skipped on rank {rank} "
+                f"(all-zero targets) but found {dn_keys2}"
+            )
         loss2_scaled = scale_loss_for_ddp(loss2)
         optimizer.zero_grad()
         loss2_scaled.backward()

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -356,8 +356,10 @@ def _rtdetr_ddp_worker(rank: int, world_size: int, port: int, out_dir: str) -> N
         torch.manual_seed(100 + rank)
         imgs = torch.randn(1, 3, 320, 320)
         targets = torch.zeros(1, 30, 5)
-        # Each rank gets a box with a different class label so per-rank num_boxes differ
-        targets[0, 0] = torch.tensor([float(rank % 2), 160.0, 120.0, 80.0, 60.0])
+        # Each rank gets a box with a different class label so per-rank num_boxes differ.
+        # Format: [cls, x1, y1, x2, y2] — x2 > x1 and y2 > y1 required for the box
+        # to survive the convert_targets_for_detr validity filter.
+        targets[0, 0] = torch.tensor([float(rank % 2), 80.0, 60.0, 160.0, 120.0])
 
         out1 = trainer.on_forward(imgs, targets)
         loss1 = out1["total_loss"]

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -289,6 +289,121 @@ def _rfdetr_ddp_worker(rank: int, world_size: int, port: int, out_dir: str) -> N
             dist.destroy_process_group()
 
 
+def _rtdetr_ddp_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+    """Two-rank DDP smoke for RT-DETR.
+
+    Exercises two forward passes:
+      1. Normal batch (has GT boxes) — denoising_class_embed is active.
+      2. All-empty batch (no GT boxes) — denoising path returns None, so
+         denoising_class_embed has no gradient. With find_unused_parameters=True
+         DDP handles this correctly; with False + static_graph=True it would
+         silently corrupt training (or hang under NCCL).
+    Also verifies that RTDETRLoss.all_reduce(num_boxes) fires when a process
+    group is active.
+    """
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        _setup_pg(rank, world_size, port)
+
+        from libreyolo import LibreRTDETR
+        from libreyolo.models.rtdetr.trainer import RTDETRTrainer
+        from libreyolo.training.distributed import (
+            get_world_size,
+            scale_loss_for_ddp,
+            unwrap_model,
+        )
+
+        torch.manual_seed(0)
+        wrapper = LibreRTDETR(None, size="r18", device="cpu")
+        wrapper.model.train()
+
+        trainer = RTDETRTrainer(
+            model=wrapper.model,
+            wrapper_model=wrapper,
+            size="r18",
+            num_classes=wrapper.nb_classes,  # match model (default 80)
+            data=None,
+            epochs=1,
+            batch=1,
+            imgsz=320,
+            device="cpu",
+            amp=False,
+            ema=False,
+            no_aug_epochs=0,
+            warmup_epochs=0,
+            eval_interval=-1,
+        )
+        trainer.on_setup()  # builds criterion
+
+        # Verify the fix: RT-DETR must use find_unused_parameters=True so that
+        # empty-target batches (where denoising_class_embed is unused) don't
+        # cause DDP to mishandle the gradient for that parameter.
+        assert trainer._ddp_find_unused_parameters(), (
+            "RTDETRTrainer must return True from _ddp_find_unused_parameters() "
+            "because denoising_class_embed is conditionally used."
+        )
+        find_unused = trainer._ddp_find_unused_parameters()
+        ddp_model = nn.parallel.DistributedDataParallel(
+            wrapper.model,
+            find_unused_parameters=find_unused,
+            gradient_as_bucket_view=False,
+            static_graph=not find_unused,
+        )
+        trainer.model = ddp_model
+        optimizer = torch.optim.AdamW(unwrap_model(ddp_model).parameters(), lr=1e-4)
+
+        # --- Pass 1: normal batch (GT boxes present, denoising path active) ---
+        torch.manual_seed(100 + rank)
+        imgs = torch.randn(1, 3, 320, 320)
+        targets = torch.zeros(1, 30, 5)
+        # Each rank gets a box with a different class label so per-rank num_boxes differ
+        targets[0, 0] = torch.tensor([float(rank % 2), 160.0, 120.0, 80.0, 60.0])
+
+        out1 = trainer.on_forward(imgs, targets)
+        loss1 = out1["total_loss"]
+        if not torch.isfinite(loss1):
+            raise RuntimeError(f"non-finite loss (pass 1) on rank {rank}: {loss1.item()}")
+        loss1_scaled = scale_loss_for_ddp(loss1)
+        optimizer.zero_grad()
+        loss1_scaled.backward()
+        optimizer.step()
+
+        ok, diag = _params_match_across_ranks(ddp_model)
+        if not ok:
+            raise RuntimeError(f"parameters diverged after pass 1: {diag}")
+
+        # --- Pass 2: all-empty batch (no GT boxes → denoising_class_embed unused) ---
+        torch.manual_seed(200 + rank)
+        imgs2 = torch.randn(1, 3, 320, 320)
+        targets2 = torch.zeros(1, 30, 5)  # all-zero targets = no valid boxes
+
+        out2 = trainer.on_forward(imgs2, targets2)
+        loss2 = out2["total_loss"]
+        if not torch.isfinite(loss2):
+            raise RuntimeError(f"non-finite loss (pass 2) on rank {rank}: {loss2.item()}")
+        loss2_scaled = scale_loss_for_ddp(loss2)
+        optimizer.zero_grad()
+        loss2_scaled.backward()
+        optimizer.step()
+
+        ok, diag = _params_match_across_ranks(ddp_model)
+        if not ok:
+            raise RuntimeError(f"parameters diverged after pass 2 (empty targets): {diag}")
+
+        world = get_world_size()
+        out_path.write_text(
+            f"ok world={world} loss1={float(loss1.detach().item()):.6f} "
+            f"loss2={float(loss2.detach().item()):.6f}\n"
+        )
+
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -361,6 +476,27 @@ def test_rfdetr_ddp_2_ranks_cpu_gloo(tmp_path):
     but it's never exercised without an actual process group.
     """
     outputs = _spawn_and_check(_rfdetr_ddp_worker, n_ranks=2, tmp_path=tmp_path)
+    for rank, text in outputs.items():
+        assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+def test_rtdetr_ddp_2_ranks_cpu_gloo(tmp_path):
+    """Two-rank DDP smoke for RT-DETR.
+
+    Covers two regressions specific to RT-DETR DDP:
+      1. find_unused_parameters=True — RTDETRTrainer must declare this so
+         denoising_class_embed (unused when a batch has no GT boxes) is
+         handled correctly by DDP's reducer.
+      2. dist.all_reduce(num_boxes) in RTDETRLoss — ensures every rank
+         normalises losses by the *global* box count, not just its own.
+    The second forward pass uses an all-zero target tensor (no valid boxes)
+    to exercise the empty-target code path where denoising is skipped.
+    """
+    outputs = _spawn_and_check(_rtdetr_ddp_worker, n_ranks=2, tmp_path=tmp_path)
     for rank, text in outputs.items():
         assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
 

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -673,6 +673,22 @@ def test_multi_gpu_device_raises_without_torchrun():
 # =============================================================================
 
 
+def _cvd_recording_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+) -> None:
+    """Worker that writes the inherited CUDA_VISIBLE_DEVICES to the result file."""
+    import json
+
+    if rank == 0:
+        Path(result_path).write_text(json.dumps({
+            "cvd": os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+        }))
+
+
 def _spawn_helper_worker(
     rank: int,
     nprocs: int,
@@ -723,3 +739,69 @@ def test_spawn_ddp_train_helper(tmp_path):
     data = json.loads((tmp_path / "result.json").read_text())
     assert data["world"] == 2
     assert data["rank"] == 0
+
+
+def test_spawn_ddp_train_translates_existing_cuda_visible_devices(tmp_path, monkeypatch):
+    """When CUDA_VISIBLE_DEVICES is already set, spawn_ddp_train must translate
+    requested device indices through the existing mask rather than overwriting
+    with raw indices.  devices=[0,1] with mask "2,3" → workers see "2,3"."""
+    import json
+
+    from libreyolo.training.distributed import spawn_ddp_train
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    result_path = str(tmp_path / "result.json")
+    spawn_ddp_train(
+        _cvd_recording_worker,
+        spawn_args=(),
+        nprocs=2,
+        result_path=result_path,
+        devices=[0, 1],
+    )
+
+    data = json.loads((tmp_path / "result.json").read_text())
+    assert data["cvd"] == "2,3", (
+        f"expected CUDA_VISIBLE_DEVICES='2,3' inside worker, got {data['cvd']!r}"
+    )
+    assert os.environ.get("CUDA_VISIBLE_DEVICES") == "2,3", "original mask not restored"
+
+
+def test_spawn_for_model_writes_flat_state_dict(tmp_path):
+    """Bootstrap temp-weights file must be a plain tensor dict, not wrapped in
+    {\"model\": ...}, so all loaders (including RF-DETR) can call load_state_dict
+    directly on it without unexpected-key errors."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from libreyolo.training.ddp_spawn import spawn_for_model
+
+    inner_model = nn.Linear(4, 2)
+
+    model_instance = MagicMock()
+    model_instance.model = inner_model
+    model_instance.model_path = None
+
+    saved: dict = {}
+
+    def capture_save(obj, path):
+        saved["obj"] = obj
+
+    def fake_spawn(worker_fn, spawn_args, nprocs, result_path, **kw):
+        Path(result_path).write_text("{}")
+
+    with patch("torch.save", side_effect=capture_save), \
+         patch("libreyolo.training.distributed.spawn_ddp_train", side_effect=fake_spawn), \
+         patch("libreyolo.training.ddp_spawn._build_init_kw", return_value={}), \
+         patch("libreyolo.training.ddp_spawn._filter_picklable", side_effect=lambda x: x):
+        spawn_for_model(model_instance, train_kw={}, nprocs=2, devices=[0, 1])
+
+    assert saved, "torch.save was never called"
+    obj = saved["obj"]
+    assert isinstance(obj, dict), "saved object must be a dict"
+    assert "model" not in obj, (
+        "bootstrap weights must not be wrapped in {'model': ...}; "
+        "RF-DETR's loader passes the dict directly to load_state_dict"
+    )
+    assert all(isinstance(v, torch.Tensor) for v in obj.values()), (
+        "all values in the bootstrap state dict must be tensors"
+    )

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -1,17 +1,18 @@
 """End-to-end DDP integration test for yolo9 and rf-detr.
 
-Spawns 2 child processes using ``torch.multiprocessing.spawn`` with the
-Gloo backend (works on CPU + Windows) and exercises the full BaseTrainer
-DDP path: process group init, DDP model wrap, per-rank forward,
-``loss * world_size`` backward, optimizer step, parameter sync check
+Spawns 2 child processes using ``torch.multiprocessing.spawn`` and exercises
+the full BaseTrainer DDP path: process group init, DDP model wrap, per-rank
+forward, ``loss * world_size`` backward, optimizer step, parameter sync check
 across ranks, and checkpoint round-trip.
 
-This is the load-bearing proof that the DDP plumbing works end-to-end.
+Two backend tiers:
+
+  Gloo / CPU  (always runs)   — ``test_*_gloo`` — no GPU required, 10-30s.
+  NCCL / CUDA (skipped if <2 GPUs available) — ``test_*_nccl`` — each rank
+      gets its own GPU (rank i → cuda:i), exercises the CUDA transport layer.
+
 Single-GPU regression is covered by the existing trainer smoke tests
 (test_dfine_trainer_smoke.py et al.) which keep passing untouched.
-
-Runs on CPU; no GPU required. Slow because of process spawn overhead
-(~10–30s on Windows), so the file is intentionally short.
 """
 
 from __future__ import annotations
@@ -445,16 +446,205 @@ def test_syncbn_weights_land_in_no_weight_decay_group():
     )
 
 
+# =============================================================================
+# NCCL workers — each rank owns its own GPU (rank i → cuda:i)
+# =============================================================================
+
+
+def _yolo9_nccl_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+    """NCCL-backend variant of ``_yolo9_ddp_worker``.
+
+    Each rank is assigned to ``cuda:{rank}`` so the test exercises real
+    inter-GPU NCCL communication rather than intra-device Gloo calls.
+    """
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
+        os.environ["RANK"] = str(rank)
+        os.environ["LOCAL_RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+
+        from libreyolo import LibreYOLO9
+        from libreyolo.training.distributed import (
+            get_world_size,
+            scale_loss_for_ddp,
+            unwrap_model,
+        )
+
+        torch.manual_seed(0)
+        wrapper = LibreYOLO9(None, size="t", device=str(device))
+        wrapper.model.train()
+
+        ddp_model = nn.parallel.DistributedDataParallel(
+            wrapper.model,
+            device_ids=[rank],
+            output_device=rank,
+            gradient_as_bucket_view=False,
+            static_graph=True,
+        )
+        optimizer = torch.optim.SGD(unwrap_model(ddp_model).parameters(), lr=0.01)
+
+        torch.manual_seed(100 + rank)
+        imgs = torch.randn(1, 3, 320, 320, device=device)
+        targets = torch.zeros(1, 30, 5, device=device)
+        targets[0, 0] = torch.tensor([float(rank), 160.0, 120.0, 80.0, 60.0], device=device)
+
+        out = ddp_model(imgs, targets=targets)
+        loss = out["total_loss"]
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"non-finite loss on rank {rank}: {loss.item()}")
+        loss = scale_loss_for_ddp(loss)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        ok, diag = _params_match_across_ranks(ddp_model)
+        if not ok:
+            raise RuntimeError(f"parameters diverged across ranks after step: {diag}")
+
+        mem_mb = torch.cuda.max_memory_allocated(rank) / 1e6
+        world = get_world_size()
+        out_path.write_text(
+            f"ok world={world} loss={float(loss.detach().item()):.6f} mem_mb={mem_mb:.1f}\n"
+        )
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _rfdetr_nccl_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+    """NCCL-backend variant of ``_rfdetr_ddp_worker``."""
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
+        os.environ["RANK"] = str(rank)
+        os.environ["LOCAL_RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+
+        from libreyolo import LibreRFDETR
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+        from libreyolo.training.distributed import (
+            get_world_size,
+            scale_loss_for_ddp,
+            unwrap_model,
+        )
+
+        torch.manual_seed(0)
+        wrapper = LibreRFDETR(None, size="n", device=str(device), segmentation=False)
+        wrapper.model.train()
+
+        trainer = RFDETRTrainer(
+            model=wrapper.model,
+            wrapper_model=wrapper,
+            size="n",
+            num_classes=80,
+            data=None,
+            epochs=1,
+            batch=1,
+            imgsz=320,
+            device=str(device),
+            amp=False,
+            ema=False,
+            no_aug_epochs=0,
+            warmup_epochs=0,
+            eval_interval=-1,
+        )
+        trainer.on_setup()
+
+        find_unused = trainer._ddp_find_unused_parameters()
+        ddp_model = nn.parallel.DistributedDataParallel(
+            wrapper.model,
+            device_ids=[rank],
+            output_device=rank,
+            find_unused_parameters=find_unused,
+            gradient_as_bucket_view=False,
+            static_graph=not find_unused,
+        )
+        trainer.model = ddp_model
+        optimizer = torch.optim.AdamW(unwrap_model(ddp_model).parameters(), lr=1e-4)
+
+        torch.manual_seed(200 + rank)
+        imgs = torch.randn(1, 3, 320, 320, device=device)
+        targets = torch.zeros(1, 30, 5, device=device)
+        targets[0, 0] = torch.tensor([float(rank), 160.0, 120.0, 80.0, 60.0], device=device)
+
+        out = trainer.on_forward(imgs, targets)
+        loss = out["total_loss"]
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"non-finite loss on rank {rank}: {loss.item()}")
+        loss = scale_loss_for_ddp(loss)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        ok, diag = _params_match_across_ranks(ddp_model)
+        if not ok:
+            raise RuntimeError(f"parameters diverged across ranks after step: {diag}")
+
+        mem_mb = torch.cuda.max_memory_allocated(rank) / 1e6
+        world = get_world_size()
+        out_path.write_text(
+            f"ok world={world} loss={float(loss.detach().item()):.6f} mem_mb={mem_mb:.1f}\n"
+        )
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+_NEEDS_2_GPUS = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="requires 2+ CUDA GPUs",
+)
+
+
+@_NEEDS_2_GPUS
+def test_yolo9_ddp_2_ranks_nccl(tmp_path):
+    """Two-rank NCCL DDP smoke for yolo9 (rank i → cuda:i).
+
+    Exercises the CUDA transport path that production torchrun launches use,
+    complementing the Gloo/CPU test which validates the DDP plumbing logic.
+    """
+    outputs = _spawn_and_check(_yolo9_nccl_worker, n_ranks=2, tmp_path=tmp_path)
+    for rank, text in outputs.items():
+        assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
+
+
+@_NEEDS_2_GPUS
+def test_rfdetr_ddp_2_ranks_nccl(tmp_path):
+    """Two-rank NCCL DDP smoke for rf-detr (rank i → cuda:i)."""
+    outputs = _spawn_and_check(_rfdetr_nccl_worker, n_ranks=2, tmp_path=tmp_path)
+    for rank, text in outputs.items():
+        assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
+
+
 def test_multi_gpu_device_raises_without_torchrun():
-    """If the user passes ``device=[0,1]`` without launching with torchrun
-    the trainer must fail with a clear message pointing them at it."""
-    # Build a minimal trainer-like setup that exercises _setup_device alone.
+    """Instantiating ``YOLO9Trainer`` directly with ``device=[0,1]`` (bypassing
+    the model API) and without a running process group must raise with a clear
+    message.
+
+    Note: the *model* API (``model.train(device=[0,1])``) now auto-spawns DDP
+    workers instead of raising.  This test intentionally goes through the
+    trainer constructor to verify the safety check on that lower-level surface.
+    """
     from libreyolo import LibreYOLO9
     from libreyolo.models.yolo9.trainer import YOLO9Trainer
 
-    # CUDA may or may not be available; the parser fails CUDA-missing case
-    # before the torchrun check. Skip if CUDA truly absent so we exercise
-    # the torchrun-pointer path.
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA to exercise the torchrun-missing path")
 
@@ -476,3 +666,60 @@ def test_multi_gpu_device_raises_without_torchrun():
             warmup_epochs=0,
             eval_interval=-1,
         )
+
+
+# =============================================================================
+# Auto-spawn helper
+# =============================================================================
+
+
+def _spawn_helper_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+) -> None:
+    """Trivial worker used by test_spawn_ddp_train_helper.
+
+    Mirrors the production worker pattern: receives env-var values as
+    arguments, sets them, then verifies they round-trip correctly.
+    """
+    import json
+    import os
+    from pathlib import Path
+
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(nprocs)
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+
+    assert os.environ["RANK"] == str(rank)
+    assert os.environ["LOCAL_RANK"] == str(rank)
+    assert os.environ["WORLD_SIZE"] == str(nprocs)
+
+    if rank == 0:
+        Path(result_path).write_text(json.dumps({"rank": rank, "world": nprocs}))
+
+
+def test_spawn_ddp_train_helper(tmp_path):
+    """``spawn_ddp_train`` sets env vars in each worker and lets rank-0 write
+    the result file.  Does not require GPUs or an active process group —
+    it only tests the spawn-and-env-setup plumbing."""
+    import json
+
+    from libreyolo.training.distributed import spawn_ddp_train
+
+    result_path = str(tmp_path / "result.json")
+    spawn_ddp_train(
+        _spawn_helper_worker,
+        spawn_args=(),
+        nprocs=2,
+        result_path=result_path,
+    )
+
+    assert (tmp_path / "result.json").exists(), "rank-0 did not write result file"
+    data = json.loads((tmp_path / "result.json").read_text())
+    assert data["world"] == 2
+    assert data["rank"] == 0

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -766,6 +766,92 @@ def test_spawn_ddp_train_translates_existing_cuda_visible_devices(tmp_path, monk
     assert os.environ.get("CUDA_VISIBLE_DEVICES") == "2,3", "original mask not restored"
 
 
+def test_spawn_for_model_restores_model_device_on_autobatch_probe_error():
+    """If resolve_auto_batch raises during the pre-spawn probe, the model must be
+    moved back to its original device and the exception must propagate.
+
+    Uses a thin wrapper model so .to() calls are tracked without real CUDA ops.
+    torch.cuda.is_available is patched True so the probe_device is cuda:0 (the
+    interesting path); the wrapper's .to() skips the actual CUDA move so the
+    test works on CPU-only machines.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from libreyolo.training.ddp_spawn import spawn_for_model
+
+    device_log: list = []
+
+    class _TrackingModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self._inner = nn.Linear(4, 2)
+
+        def forward(self, x):
+            return self._inner(x)
+
+        def parameters(self, recurse=True):
+            return self._inner.parameters(recurse)
+
+        def state_dict(self, *a, **kw):
+            return self._inner.state_dict(*a, **kw)
+
+        def to(self, device, **kw):
+            device_log.append(device)
+            # Skip real CUDA moves so the test runs on CPU-only machines.
+            if not (isinstance(device, torch.device) and device.type == "cuda"):
+                self._inner.to(device, **kw)
+            return self
+
+        def cpu(self):
+            return self.to(torch.device("cpu"))
+
+    tracking = _TrackingModel()
+    model_instance = MagicMock()
+    model_instance.model = tracking
+    model_instance.model_path = None
+
+    with patch("torch.save"), \
+         patch("torch.cuda.is_available", return_value=True), \
+         patch("torch.cuda.empty_cache"), \
+         patch("libreyolo.training.autobatch.resolve_auto_batch",
+               side_effect=RuntimeError("probe failed")):
+        with pytest.raises(RuntimeError, match="probe failed"):
+            spawn_for_model(model_instance, train_kw={"batch": -1}, nprocs=2, devices=[0])
+
+    # Model must have been moved to probe_device (cuda:0) …
+    assert any(
+        isinstance(d, torch.device) and d.type == "cuda" for d in device_log
+    ), f"model never moved to probe device: {device_log}"
+    # … and then restored to the original device (cpu) by the except handler.
+    assert device_log[-1] == torch.device("cpu"), (
+        f"model not restored to cpu after probe error: {device_log}"
+    )
+
+
+def test_spawn_for_model_propagates_autobatch_error_on_cpu_path():
+    """CPU-only path (cuda unavailable): autobatch failure must propagate even
+    though probe_device == original_device == cpu (no real device move)."""
+    from unittest.mock import MagicMock, patch
+
+    from libreyolo.training.ddp_spawn import spawn_for_model
+
+    inner_model = nn.Linear(4, 2)
+    model_instance = MagicMock()
+    model_instance.model = inner_model
+    model_instance.model_path = None
+
+    with patch("torch.save"), \
+         patch("torch.cuda.is_available", return_value=False), \
+         patch("torch.cuda.empty_cache"), \
+         patch("libreyolo.training.autobatch.resolve_auto_batch",
+               side_effect=RuntimeError("cpu probe error")):
+        with pytest.raises(RuntimeError, match="cpu probe error"):
+            spawn_for_model(model_instance, train_kw={"batch": -1}, nprocs=2, devices=[0])
+
+    # Model must still be accessible on cpu.
+    assert next(inner_model.parameters()).device.type == "cpu"
+
+
 def test_spawn_for_model_writes_flat_state_dict(tmp_path):
     """Bootstrap temp-weights file must be a plain tensor dict, not wrapped in
     {\"model\": ...}, so all loaders (including RF-DETR) can call load_state_dict

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -719,6 +719,59 @@ def _spawn_helper_worker(
         Path(result_path).write_text(json.dumps({"rank": rank, "world": nprocs}))
 
 
+def _spawn_ddp_train_from_subprocess(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+) -> None:
+    """Worker that tries to call spawn_ddp_train from inside a subprocess.
+
+    Used by test_spawn_ddp_train_raises_from_subprocess to verify the guard.
+    Writes 'ok' if RuntimeError is raised, 'fail' otherwise.
+    """
+    import json
+    from pathlib import Path
+
+    from libreyolo.training.distributed import spawn_ddp_train
+
+    try:
+        spawn_ddp_train(lambda *a: None, spawn_args=(), nprocs=1, result_path=result_path)
+    except RuntimeError as exc:
+        if "__main__" in str(exc) or "spawned subprocess" in str(exc):
+            if rank == 0:
+                Path(result_path).write_text(json.dumps({"guard": "raised"}))
+        return
+    # No error raised — guard is missing.
+    if rank == 0:
+        Path(result_path).write_text(json.dumps({"guard": "missing"}))
+
+
+def test_spawn_ddp_train_raises_from_subprocess(tmp_path):
+    """spawn_ddp_train must raise RuntimeError with a helpful message when
+    called from inside a spawned subprocess (the recursive-launch pattern that
+    happens when a user's top-level script lacks an if __name__=='__main__' guard).
+    """
+    import json
+
+    from libreyolo.training.distributed import spawn_ddp_train
+
+    result_path = str(tmp_path / "guard_result.json")
+    spawn_ddp_train(
+        _spawn_ddp_train_from_subprocess,
+        spawn_args=(),
+        nprocs=1,
+        result_path=result_path,
+    )
+
+    assert (tmp_path / "guard_result.json").exists(), "worker did not write result"
+    data = json.loads((tmp_path / "guard_result.json").read_text())
+    assert data.get("guard") == "raised", (
+        "spawn_ddp_train did not raise RuntimeError when called from a subprocess"
+    )
+
+
 def test_spawn_ddp_train_helper(tmp_path):
     """``spawn_ddp_train`` sets env vars in each worker and lets rank-0 write
     the result file.  Does not require GPUs or an active process group —
@@ -850,6 +903,66 @@ def test_spawn_for_model_propagates_autobatch_error_on_cpu_path():
 
     # Model must still be accessible on cpu.
     assert next(inner_model.parameters()).device.type == "cpu"
+
+
+def test_spawn_for_model_restores_model_device_when_filter_picklable_fails():
+    """If _filter_picklable raises after a successful autobatch probe (model now
+    on CPU), spawn_for_model must restore the model to its original device.
+
+    Uses the same _TrackingModel approach so .to() calls are logged without
+    real CUDA ops on CPU-only machines.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from libreyolo.training.ddp_spawn import spawn_for_model
+
+    device_log: list = []
+
+    class _TrackingModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self._inner = nn.Linear(4, 2)
+
+        def forward(self, x):
+            return self._inner(x)
+
+        def parameters(self, recurse=True):
+            return self._inner.parameters(recurse)
+
+        def state_dict(self, *a, **kw):
+            return self._inner.state_dict(*a, **kw)
+
+        def to(self, device, **kw):
+            device_log.append(device)
+            if not (isinstance(device, torch.device) and device.type == "cuda"):
+                self._inner.to(device, **kw)
+            return self
+
+        def cpu(self):
+            return self.to(torch.device("cpu"))
+
+    tracking = _TrackingModel()
+    model_instance = MagicMock()
+    model_instance.model = tracking
+    model_instance.model_path = None
+
+    with patch("torch.save"), \
+         patch("torch.cuda.is_available", return_value=True), \
+         patch("torch.cuda.empty_cache"), \
+         patch("libreyolo.training.autobatch.resolve_auto_batch", return_value=8), \
+         patch("libreyolo.training.ddp_spawn._filter_picklable",
+               side_effect=TypeError("unpicklable callback")):
+        with pytest.raises(TypeError, match="unpicklable callback"):
+            spawn_for_model(model_instance, train_kw={"batch": -1}, nprocs=2, devices=[0])
+
+    # Autobatch succeeded: model moved to cuda:0 then to cpu.
+    # _filter_picklable then failed: model must be restored to original (cpu).
+    assert any(
+        isinstance(d, torch.device) and d.type == "cuda" for d in device_log
+    ), f"model never moved to probe device: {device_log}"
+    assert device_log[-1] == torch.device("cpu"), (
+        f"model not restored to original device after filter_picklable error: {device_log}"
+    )
 
 
 def test_spawn_for_model_writes_flat_state_dict(tmp_path):

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,98 @@
+"""Unit tests for libreyolo.training.scheduler.
+
+Focuses on edge cases: zero warmup, LR monotonicity, boundary values.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from libreyolo.training.scheduler import WarmupCosineScheduler
+
+pytestmark = pytest.mark.unit
+
+
+# =============================================================================
+# WarmupCosineScheduler — warmup_epochs=0 regression (ZeroDivisionError fix)
+# =============================================================================
+
+
+def test_warmup_cosine_zero_warmup_does_not_raise_at_iter_zero():
+    """warmup_epochs=0: update_lr(0) must not divide by zero."""
+    sched = WarmupCosineScheduler(
+        lr=0.01, iters_per_epoch=100, total_epochs=100, warmup_epochs=0
+    )
+    lr = sched.update_lr(0)
+    assert isinstance(lr, float)
+    assert 0.0 <= lr <= 0.01
+
+
+def test_warmup_cosine_zero_warmup_full_lr_at_iter_zero():
+    """With no warmup and no plateau, iter=0 is the peak of the cosine → lr."""
+    sched = WarmupCosineScheduler(
+        lr=0.01, iters_per_epoch=100, total_epochs=100, warmup_epochs=0, plateau_epochs=0
+    )
+    assert sched.update_lr(0) == pytest.approx(0.01, abs=1e-9)
+
+
+def test_warmup_cosine_zero_warmup_monotone_decay():
+    """With no warmup the LR must be non-increasing for every iteration."""
+    sched = WarmupCosineScheduler(
+        lr=0.01, iters_per_epoch=10, total_epochs=10, warmup_epochs=0, plateau_epochs=0
+    )
+    lrs = [sched.update_lr(i) for i in range(100)]
+    for prev, curr in zip(lrs, lrs[1:]):
+        assert prev >= curr - 1e-10, f"LR increased: {prev} → {curr}"
+
+
+# =============================================================================
+# WarmupCosineScheduler — normal warmup sanity checks
+# =============================================================================
+
+
+def test_warmup_cosine_starts_at_warmup_lr_start():
+    """iter=0 with warmup active must equal warmup_lr_start (quadratic: 0^2 = 0)."""
+    sched = WarmupCosineScheduler(
+        lr=0.01, iters_per_epoch=100, total_epochs=100, warmup_epochs=5, warmup_lr_start=0.0
+    )
+    assert sched.update_lr(0) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_warmup_cosine_peaks_at_end_of_warmup():
+    """At the last warmup iter the LR should equal lr (quadratic reaches 1.0)."""
+    iters_per_epoch = 100
+    warmup_epochs = 5
+    sched = WarmupCosineScheduler(
+        lr=0.01, iters_per_epoch=iters_per_epoch, total_epochs=100, warmup_epochs=warmup_epochs
+    )
+    warmup_iters = iters_per_epoch * warmup_epochs
+    assert sched.update_lr(warmup_iters) == pytest.approx(0.01, abs=1e-9)
+
+
+def test_warmup_cosine_plateau_is_min_lr():
+    """Iterations past the plateau boundary must return min_lr."""
+    sched = WarmupCosineScheduler(
+        lr=0.01, iters_per_epoch=100, total_epochs=100, warmup_epochs=0,
+        plateau_epochs=10, min_lr_ratio=0.05
+    )
+    min_lr = 0.01 * 0.05
+    total_iters = 100 * 100
+    plateau_iters = 100 * 10
+    # Last iteration is firmly in plateau
+    assert sched.update_lr(total_iters - plateau_iters) == pytest.approx(min_lr, abs=1e-9)
+    assert sched.update_lr(total_iters) == pytest.approx(min_lr, abs=1e-9)
+
+
+def test_warmup_cosine_cosine_midpoint():
+    """At the midpoint of cosine annealing the LR should be midway between lr and min_lr."""
+    iters_per_epoch = 100
+    total_epochs = 100
+    sched = WarmupCosineScheduler(
+        lr=0.01, iters_per_epoch=iters_per_epoch, total_epochs=total_epochs,
+        warmup_epochs=0, plateau_epochs=0, min_lr_ratio=0.0
+    )
+    mid = (iters_per_epoch * total_epochs) // 2
+    # cos(pi * 0.5) = 0 → lr = min_lr + 0.5*(lr - min_lr)*(1+0) = lr/2
+    assert sched.update_lr(mid) == pytest.approx(0.005, abs=1e-3)

--- a/tests/unit/test_trainer_grad_clip.py
+++ b/tests/unit/test_trainer_grad_clip.py
@@ -280,3 +280,69 @@ def test_invalid_clip_max_norm_raises(clip_max_norm):
 
     with pytest.raises(ValueError, match="clip_max_norm"):
         trainer._get_clip_max_norm()
+
+
+def test_initialize_scheduler_lr_fastforwards_on_resume():
+    """On resume, _initialize_scheduler_lr fast-forwards past warmup instead of resetting to iter 0."""
+    trainer, param, _ = _build_trainer(clip_max_norm=0.0)
+    trainer.optimizer = torch.optim.SGD(
+        [{"params": [param], "lr": 0.1, "lr_mult": 1.0}],
+        lr=0.1,
+    )
+    trainer._scale_lr = lambda base_lr, group: base_lr * group.get("lr_mult", 1.0)
+
+    class WarmupScheduler:
+        warmup_iters = 4
+
+        def update_lr(self, iters):
+            # Warmup-start (iter 0) is near-zero; post-warmup (iter > 4) is 0.1.
+            return 0.0001 if iters == 0 else 0.1
+
+    trainer.lr_scheduler = WarmupScheduler()
+    # Simulate a resume from epoch 5 (warmup is long past).
+    # OneBatchLoader has len=1, so steps_per_epoch=1, init_iter=5.
+    trainer.start_epoch = 5
+
+    trainer._initialize_scheduler_lr()
+
+    # Must use post-warmup LR, not the near-zero warmup-start.
+    assert trainer.optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
+
+
+def test_resume_before_setup_defers_optimizer_state(tmp_path):
+    """Optimizer state is deferred when resume() is called before setup() exists."""
+    # Build a trainer and do one step to populate SGD momentum buffers.
+    trainer, param, _ = _build_trainer(clip_max_norm=0.0)
+    param.grad = torch.ones_like(param)
+    trainer.optimizer.step()
+    saved_lr = trainer.optimizer.param_groups[0]["lr"]
+    saved_opt_state = trainer.optimizer.state_dict()
+
+    # Persist a minimal checkpoint (validate_checkpoint_metadata warns but doesn't raise).
+    ckpt_path = tmp_path / "last.pt"
+    torch.save(
+        {
+            "model": trainer.model.state_dict(),
+            "epoch": 2,
+            "optimizer": saved_opt_state,
+        },
+        ckpt_path,
+    )
+
+    # New trainer with no optimizer yet (simulates pre-setup() state).
+    trainer2, param2, _ = _build_trainer(clip_max_norm=0.0)
+    trainer2.optimizer = None
+
+    trainer2.resume(str(ckpt_path))
+
+    # State must be deferred, not silently dropped.
+    assert getattr(trainer2, "_resume_optimizer_state", None) is not None
+    assert trainer2.start_epoch == 3
+
+    # Simulate what setup() does: create optimizer then apply deferred state.
+    trainer2.optimizer = torch.optim.SGD([param2], lr=0.9)  # wrong LR on purpose
+    trainer2.optimizer.load_state_dict(trainer2._resume_optimizer_state)
+    trainer2._resume_optimizer_state = None
+
+    # The restored optimizer must carry the saved LR, not the initialisation LR.
+    assert trainer2.optimizer.param_groups[0]["lr"] == pytest.approx(saved_lr)

--- a/tools/ddp_torchrun_smoke.py
+++ b/tools/ddp_torchrun_smoke.py
@@ -1,0 +1,417 @@
+"""DDP smoke test designed to be launched with torchrun.
+
+Complements hw_ddp_smoke.py (mp.spawn + Gloo on one GPU) by exercising the
+real torchrun launch path: LOCAL_RANK env var → has_torchrun_env() → init_distributed().
+
+Launch:
+    # 2 ranks on the same machine (shares GPU(s) if only one available)
+    torchrun --nproc_per_node=2 tools/ddp_torchrun_smoke.py
+
+    # Single model
+    torchrun --nproc_per_node=2 tools/ddp_torchrun_smoke.py --model rfdetr
+
+    # More steps
+    torchrun --nproc_per_node=2 tools/ddp_torchrun_smoke.py --steps 5
+
+    # CPU-only (uses Gloo automatically)
+    torchrun --nproc_per_node=2 tools/ddp_torchrun_smoke.py --device cpu
+
+What this covers beyond the existing tests:
+    - torchrun env path: has_torchrun_env() → init_distributed() (BaseTrainer.__init__ path)
+    - NCCL backend when CUDA available (Gloo fallback on CPU or single-GPU)
+    - Multiple training steps
+    - EMA buffer broadcast from rank-0 to all ranks (broadcast_ema_buffers)
+    - DistributedSampler: each rank gets distinct indices, set_epoch changes them
+    - Checkpoint save on rank-0 + load round-trip into a single-process model
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data.distributed import DistributedSampler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_torchrun_env() -> None:
+    if "LOCAL_RANK" not in os.environ:
+        sys.exit(
+            "\nERROR: LOCAL_RANK not in environment.\n"
+            "Launch this script with torchrun, not python directly:\n\n"
+            "    torchrun --nproc_per_node=2 tools/ddp_torchrun_smoke.py\n"
+        )
+
+
+def _log(rank: int, msg: str) -> None:
+    print(f"[rank {rank}] {msg}", flush=True)
+
+
+def _ok(rank: int, msg: str) -> None:
+    print(f"[rank {rank}] OK  {msg}", flush=True)
+
+
+def _params_match(model: nn.Module, world_size: int, atol: float = 2e-5) -> tuple[bool, str]:
+    """All-reduce each param and verify sum == local * world_size within tolerance."""
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        local = p.detach().clone()
+        summed = p.detach().clone()
+        dist.all_reduce(summed, op=dist.ReduceOp.SUM)
+        expected = local * world_size
+        if not torch.allclose(summed, expected, atol=atol, rtol=1e-4):
+            delta = (summed - expected).abs().max().item()
+            return False, f"param {name!r} diverged: max_abs={delta:.3e}"
+    return True, "ok"
+
+
+# ---------------------------------------------------------------------------
+# DistributedSampler test
+# ---------------------------------------------------------------------------
+
+
+def run_sampler_test(rank: int, world_size: int) -> None:
+    """Verify DistributedSampler gives non-overlapping indices and that
+    set_epoch changes the shuffled order."""
+    dataset = TensorDataset(torch.arange(200))
+    sampler0 = DistributedSampler(dataset, num_replicas=world_size, rank=rank,
+                                   shuffle=True, drop_last=True)
+
+    # Epoch 0 indices for this rank
+    sampler0.set_epoch(0)
+    indices_e0 = list(sampler0)
+
+    # Epoch 1 should differ
+    sampler0.set_epoch(1)
+    indices_e1 = list(sampler0)
+
+    # Gather all indices across ranks. NCCL requires CUDA tensors; Gloo works on CPU.
+    backend = dist.get_backend()
+    tensor_device = torch.device("cuda") if backend == "nccl" else torch.device("cpu")
+    local_t = torch.tensor(indices_e0, dtype=torch.long, device=tensor_device)
+    all_tensors = [torch.zeros_like(local_t) for _ in range(world_size)]
+    dist.all_gather(all_tensors, local_t)
+
+    if rank == 0:
+        # Check no overlap between any two ranks
+        seen: set[int] = set()
+        for r, t in enumerate(all_tensors):
+            idxs = set(t.tolist())
+            overlap = seen & idxs
+            assert not overlap, f"ranks share indices: {overlap}"
+            seen |= idxs
+
+        # Check epoch shuffle changes indices
+        assert indices_e0 != indices_e1, "set_epoch did not change indices"
+
+    _ok(rank, "sampler: non-overlapping indices, set_epoch changes order")
+
+
+# ---------------------------------------------------------------------------
+# EMA broadcast test
+# ---------------------------------------------------------------------------
+
+
+def run_ema_broadcast_test(rank: int, world_size: int, device: torch.device) -> None:
+    """Verify broadcast_ema_buffers syncs rank-0's EMA to all other ranks.
+
+    Pattern: all ranks create identical EMA, rank-0 modifies it, all call
+    broadcast, then verify values are identical again.
+    """
+    from libreyolo import LibreYOLO9
+    from libreyolo.training.distributed import broadcast_ema_buffers
+    from libreyolo.training.ema import ModelEMA
+
+    torch.manual_seed(42)
+    wrapper = LibreYOLO9(None, size="t", device=str(device))
+    wrapper.model.eval()
+
+    ema = ModelEMA(wrapper.model)
+
+    # Only rank 0 updates EMA — simulates N training steps on rank-0 only
+    if rank == 0:
+        with torch.no_grad():
+            for p in ema.ema.parameters():
+                p.data.mul_(1.5).add_(0.3)
+
+    dist.barrier()
+
+    # Before broadcast: verify params differ across ranks (all_reduce sum != local * world)
+    if world_size > 1:
+        any_param = next(iter(ema.ema.parameters()))
+        local = any_param.detach().clone()
+        summed = any_param.detach().clone()
+        dist.all_reduce(summed, op=dist.ReduceOp.SUM)
+        pre_diverged = not torch.allclose(summed, local * world_size, atol=1e-5)
+    else:
+        pre_diverged = True  # trivially: single rank, nothing to diverge
+
+    # All ranks call broadcast (collective: rank-0 sends, others receive)
+    broadcast_ema_buffers(ema.ema, src=0)
+
+    # After broadcast: verify all ranks hold rank-0's EMA values.
+    # EMA params have requires_grad=False so _params_match skips them; use
+    # all_reduce directly on all params (no grad involved).
+    backend = dist.get_backend()
+    for name, p in ema.ema.named_parameters():
+        local = p.data.detach().clone()
+        summed = p.data.detach().clone()
+        dist.all_reduce(summed, op=dist.ReduceOp.SUM)
+        expected = local * world_size
+        if not torch.allclose(summed, expected, atol=1e-5, rtol=1e-4):
+            delta = (summed - expected).abs().max().item()
+            raise RuntimeError(f"EMA broadcast failed for param {name!r}: max_abs={delta:.3e}")
+
+    _ok(rank, f"EMA broadcast: {'pre-diverged as expected, ' if pre_diverged else ''}post-broadcast synced")
+
+
+# ---------------------------------------------------------------------------
+# YOLO9 multi-step DDP test
+# ---------------------------------------------------------------------------
+
+
+def run_yolo9(rank: int, world_size: int, device: torch.device, steps: int, out_dir: Path) -> None:
+    from libreyolo import LibreYOLO9
+    from libreyolo.training.distributed import scale_loss_for_ddp, unwrap_model
+
+    _log(rank, f"yolo9: building model on {device}")
+    torch.manual_seed(0)
+    wrapper = LibreYOLO9(None, size="t", device=str(device))
+    wrapper.model.train()
+
+    ddp_kwargs: dict = dict(gradient_as_bucket_view=False, static_graph=True)
+    if device.type == "cuda":
+        ddp_kwargs["device_ids"] = [device.index]
+        ddp_kwargs["output_device"] = device.index
+    ddp_model = nn.parallel.DistributedDataParallel(wrapper.model, **ddp_kwargs)
+    optimizer = torch.optim.SGD(unwrap_model(ddp_model).parameters(), lr=0.01, momentum=0.9)
+
+    for step in range(steps):
+        torch.manual_seed(step * 1000 + rank)
+        imgs = torch.randn(1, 3, 320, 320, device=device)
+        targets = torch.zeros(1, 30, 5, device=device)
+        targets[0, 0] = torch.tensor([float(rank), 160., 120., 80., 60.], device=device)
+
+        out = ddp_model(imgs, targets=targets)
+        loss = out["total_loss"]
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"non-finite loss at step {step}: {loss.item()}")
+
+        optimizer.zero_grad()
+        scale_loss_for_ddp(loss).backward()
+        optimizer.step()
+
+        ok, diag = _params_match(unwrap_model(ddp_model), world_size)
+        if not ok:
+            raise RuntimeError(f"step {step}: {diag}")
+        _log(rank, f"yolo9 step {step + 1}/{steps}  loss={loss.item():.4f}  params: synced")
+
+    # Checkpoint round-trip (rank-0 saves, rank-0 reloads into fresh single-GPU model)
+    if rank == 0:
+        ckpt = out_dir / "yolo9.pt"
+        torch.save({"model": unwrap_model(ddp_model).state_dict()}, ckpt)
+    dist.barrier()
+    if rank == 0:
+        fresh = LibreYOLO9(None, size="t", device="cpu")
+        sd = torch.load(out_dir / "yolo9.pt", weights_only=False)["model"]
+        _, unexpected = fresh.model.load_state_dict(sd, strict=False)
+        if unexpected:
+            raise RuntimeError(f"unexpected checkpoint keys: {sorted(unexpected)[:5]}")
+        _ok(rank, "yolo9 checkpoint round-trip: ok")
+    dist.barrier()
+
+    _ok(rank, f"yolo9: {steps} steps, param sync, checkpoint — PASS")
+
+
+# ---------------------------------------------------------------------------
+# RF-DETR multi-step DDP test
+# ---------------------------------------------------------------------------
+
+
+def run_rfdetr(rank: int, world_size: int, device: torch.device, steps: int, out_dir: Path) -> None:
+    from libreyolo import LibreRFDETR
+    from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+    from libreyolo.training.distributed import scale_loss_for_ddp, unwrap_model
+
+    _log(rank, f"rfdetr: building model on {device}")
+    torch.manual_seed(0)
+    wrapper = LibreRFDETR(None, size="n", device=str(device), segmentation=False)
+    wrapper.model.train()
+
+    trainer = RFDETRTrainer(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="n",
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=1,
+        imgsz=320,
+        device=str(device),
+        amp=False,
+        ema=False,
+        no_aug_epochs=0,
+        warmup_epochs=0,
+        eval_interval=-1,
+    )
+    trainer.on_setup()
+
+    find_unused = trainer._ddp_find_unused_parameters()
+    ddp_kwargs: dict = dict(
+        find_unused_parameters=find_unused,
+        gradient_as_bucket_view=False,
+        static_graph=not find_unused,
+    )
+    if device.type == "cuda":
+        ddp_kwargs["device_ids"] = [device.index]
+        ddp_kwargs["output_device"] = device.index
+    ddp_model = nn.parallel.DistributedDataParallel(wrapper.model, **ddp_kwargs)
+    trainer.model = ddp_model
+    optimizer = torch.optim.AdamW(unwrap_model(ddp_model).parameters(), lr=1e-4)
+
+    for step in range(steps):
+        torch.manual_seed(step * 1000 + rank)
+        imgs = torch.randn(1, 3, 320, 320, device=device)
+        targets = torch.zeros(1, 30, 5, device=device)
+        targets[0, 0] = torch.tensor([float(rank), 160., 120., 80., 60.], device=device)
+
+        out = trainer.on_forward(imgs, targets)
+        loss = out["total_loss"]
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"non-finite loss at step {step}: {loss.item()}")
+
+        optimizer.zero_grad()
+        scale_loss_for_ddp(loss).backward()
+        optimizer.step()
+
+        ok, diag = _params_match(unwrap_model(ddp_model), world_size)
+        if not ok:
+            raise RuntimeError(f"step {step}: {diag}")
+        _log(rank, f"rfdetr step {step + 1}/{steps}  loss={loss.item():.4f}  params: synced")
+
+    if rank == 0:
+        ckpt = out_dir / "rfdetr.pt"
+        torch.save({"model": unwrap_model(ddp_model).state_dict()}, ckpt)
+    dist.barrier()
+    if rank == 0:
+        fresh = LibreRFDETR(None, size="n", device="cpu", segmentation=False)
+        sd = torch.load(out_dir / "rfdetr.pt", weights_only=False)["model"]
+        _, unexpected = fresh.model.load_state_dict(sd, strict=False)
+        if unexpected:
+            raise RuntimeError(f"unexpected checkpoint keys: {sorted(unexpected)[:5]}")
+        _ok(rank, "rfdetr checkpoint round-trip: ok")
+    dist.barrier()
+
+    _ok(rank, f"rfdetr: {steps} steps, param sync, checkpoint — PASS")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    _check_torchrun_env()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", choices=["yolo9", "rfdetr", "all"], default="all")
+    parser.add_argument("--steps", type=int, default=3)
+    parser.add_argument("--device", default="auto",
+                        help="'auto' picks cuda:LOCAL_RANK if available, else cpu")
+    args = parser.parse_args()
+
+    from libreyolo.training.distributed import init_distributed, get_rank, get_world_size, get_local_rank
+
+    # This is the production path: init_distributed reads RANK/LOCAL_RANK/WORLD_SIZE
+    # set by torchrun. BaseTrainer.__init__ does exactly this via has_torchrun_env().
+    init_distributed()
+    rank = get_rank()
+    world_size = get_world_size()
+    local_rank = get_local_rank()
+
+    if args.device == "auto":
+        if torch.cuda.is_available():
+            device = torch.device(f"cuda:{local_rank}")
+            torch.cuda.set_device(device)
+        else:
+            device = torch.device("cpu")
+    else:
+        device = torch.device(args.device)
+
+    backend = dist.get_backend()
+    if rank == 0:
+        print(f"\n=== ddp_torchrun_smoke: world={world_size}, backend={backend}, device={device} ===\n",
+              flush=True)
+
+    dist.barrier()
+
+    out_dir = Path(__file__).parent / "_ddp_torchrun_smoke"
+    if rank == 0:
+        out_dir.mkdir(exist_ok=True)
+    dist.barrier()
+
+    t0 = time.time()
+    families = ["yolo9", "rfdetr"] if args.model == "all" else [args.model]
+    passed: list[str] = []
+    failed: list[str] = []
+
+    # DistributedSampler correctness (all models share this infrastructure)
+    try:
+        run_sampler_test(rank, world_size)
+        passed.append("sampler")
+    except Exception as exc:
+        _log(rank, f"FAIL sampler: {exc}")
+        failed.append("sampler")
+
+    # EMA broadcast (uses YOLO9 model, model-agnostic)
+    try:
+        run_ema_broadcast_test(rank, world_size, device)
+        passed.append("ema_broadcast")
+    except Exception as exc:
+        _log(rank, f"FAIL ema_broadcast: {exc}")
+        failed.append("ema_broadcast")
+
+    for family in families:
+        try:
+            if family == "yolo9":
+                run_yolo9(rank, world_size, device, args.steps, out_dir)
+            else:
+                run_rfdetr(rank, world_size, device, args.steps, out_dir)
+            passed.append(family)
+        except Exception as exc:
+            import traceback
+            _log(rank, f"FAIL {family}: {exc}")
+            traceback.print_exc()
+            failed.append(family)
+
+    dist.barrier()
+    elapsed = time.time() - t0
+
+    if rank == 0:
+        print(f"\n{'='*60}", flush=True)
+        print(f"Results (world={world_size}, backend={backend}, {elapsed:.1f}s):", flush=True)
+        for name in passed:
+            print(f"  PASS  {name}", flush=True)
+        for name in failed:
+            print(f"  FAIL  {name}", flush=True)
+        print("=" * 60, flush=True)
+
+    dist.destroy_process_group()
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR cleans up the multi-GPU training API and introduces automatic batch-size estimation across all supported model families.

### Multi-GPU auto-spawn (`model.train(device="0,1")`)
Users can now pass a comma-separated device string directly to `.train()` from any plain Python script — no `torchrun`, no subprocess plumbing. Internally the library calls `spawn_ddp_train` which uses `torch.multiprocessing.spawn`, picks a free port automatically, and returns the result to the caller as a clean blocking call.

### Autobatch
New `libreyolo/training/autobatch.py` probes the model at increasing batch sizes in **training mode with a backward pass** (not eval+no_grad like Ultralytics), fits a line to the GPU memory curve, and extrapolates to the largest power-of-2 global batch that stays within 70 % of total VRAM. Training mode is required because PyTorch retains activations for backward — for deep CNNs like YOLO9 this is 5–10× the inference footprint.

### Model-wide wiring
All supported families (YOLOX, YOLO9, YOLO-NAS, DAMO-YOLO, RTMDet, RT-DETR variants, D-FINE, DEIM, EC, PicoDet, RF-DETR) have been updated to wire through the new multi-GPU and autobatch paths.

### Bug fixes
- Fixed loss computation in DAMO-YOLO and RTMDet that surfaced under multi-GPU runs.
- Fixed device flag propagation and logger initialisation.

## Test plan

- [x] `tests/unit/test_autobatch.py` — covers probe logic, power-of-2 rounding, and DDP global-batch semantics
- [x] `tests/unit/test_ddp_distributed.py` — expanded DDP spawn and barrier tests
- [x] `tools/ddp_torchrun_smoke.py` — end-to-end smoke test for torchrun and auto-spawn paths

> **Note:** nbs sweep is still running to determine the optimal default `nbs` values for the flagship models. Default values will be updated in a follow-up commit before merge.
