### PR TITLE
Drop eager dense-mask allocation for polygon segments

### DIFF
--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -32,7 +32,7 @@ def _yolo_coords_to_rings(
     ring = np.array(coords, dtype=np.float32).reshape(-1, 2)
     ring[:, 0] *= width
     ring[:, 1] *= height
-    return _attach_dense_mask([ring], width=width, height=height)
+    return [ring]
 
 
 def _yolo_box_to_ring(cx: float, cy: float, w: float, h: float, width: int, height: int) -> List[np.ndarray]:
@@ -47,11 +47,17 @@ def _yolo_box_to_ring(cx: float, cy: float, w: float, h: float, width: int, heig
     )
     ring[:, 0] = np.clip(ring[:, 0], 0.0, float(width))
     ring[:, 1] = np.clip(ring[:, 1], 0.0, float(height))
-    return _attach_dense_mask([ring], width=width, height=height)
+    return [ring]
 
 
 class DenseMaskRing(np.ndarray):
-    """Polygon ring carrying the original dense mask for mask-aware transforms."""
+    """Polygon ring carrying a dense mask for mask-aware transforms.
+
+    Used when the polygon ring is a lossy approximation of the true mask
+    (e.g., a contour extracted from an RLE-decoded mask). For polygon-sourced
+    annotations the ring is itself exact, so a plain ndarray is stored instead
+    and consumers that need crop-fidelity materialize the mask on demand.
+    """
 
     def __new__(cls, ring: np.ndarray, mask: np.ndarray):
         obj = np.asarray(ring, dtype=np.float32).view(cls)
@@ -67,33 +73,6 @@ class DenseMaskRing(np.ndarray):
         copied = super().copy(order).view(type(self))
         copied.dense_mask = None if self.dense_mask is None else self.dense_mask.copy()
         return copied
-
-
-def _attach_dense_mask(
-    rings: List[np.ndarray],
-    *,
-    width: int,
-    height: int,
-) -> List[np.ndarray]:
-    """Attach a rasterized mask to polygon rings for mask-aware crop transforms."""
-    valid_rings = [
-        np.asarray(ring, dtype=np.float32)
-        for ring in rings
-        if ring is not None and len(ring) >= 3
-    ]
-    if not valid_rings:
-        return rings
-
-    mask = np.zeros((height, width), dtype=np.uint8)
-    polygons = [np.round(ring).astype(np.int32) for ring in valid_rings]
-    cv2.fillPoly(mask, polygons, color=1)
-
-    out = [np.asarray(ring, dtype=np.float32).copy() for ring in rings]
-    for idx, ring in enumerate(out):
-        if ring is not None and len(ring) >= 3:
-            out[idx] = DenseMaskRing(ring, mask)
-            break
-    return out
 
 
 def _mask_to_rings(mask: np.ndarray) -> List[np.ndarray]:
@@ -133,8 +112,6 @@ def _coco_segmentation_to_rings(
                 continue
             ring = np.array(polygon, dtype=np.float32).reshape(-1, 2)
             rings.append(ring)
-        if height is not None and width is not None:
-            return _attach_dense_mask(rings, width=width, height=height)
         return rings
 
     if not isinstance(segmentation, dict):

--- a/libreyolo/models/rfdetr/seg_transforms.py
+++ b/libreyolo/models/rfdetr/seg_transforms.py
@@ -104,6 +104,44 @@ def _instance_dense_mask(instance):
     return None
 
 
+def _materialize_dense_masks_for_crop(segments, image_shape):
+    if segments is None:
+        return None
+
+    from ...data.dataset import DenseMaskRing
+
+    height, width = image_shape
+    out = []
+    for instance in segments:
+        if _instance_dense_mask(instance) is not None:
+            out.append(instance)
+            continue
+
+        valid_rings = [
+            np.asarray(ring, dtype=np.float32)
+            for ring in instance
+            if ring is not None and len(ring) >= 3
+        ]
+        if not valid_rings:
+            out.append(instance)
+            continue
+
+        mask = np.zeros((height, width), dtype=np.uint8)
+        polygons = [np.round(ring).astype(np.int32) for ring in valid_rings]
+        cv2.fillPoly(mask, polygons, color=1)
+
+        wrapped = []
+        attached = False
+        for ring in instance:
+            if not attached and ring is not None and len(ring) >= 3:
+                wrapped.append(DenseMaskRing(ring, mask))
+                attached = True
+            else:
+                wrapped.append(ring)
+        out.append(wrapped)
+    return out
+
+
 def _flip_segments_lr(segments, width):
     if segments is None:
         return None
@@ -307,6 +345,7 @@ class RFDETRSegTransform:
                 crop_size = random.randint(min_crop, max_crop)
                 top = random.randint(0, max(0, h_mid - crop_size))
                 left = random.randint(0, max(0, w_mid - crop_size))
+                segments_t = _materialize_dense_masks_for_crop(segments_t, (h_mid, w_mid))
                 image = image[top : top + crop_size, left : left + crop_size]
                 boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]] - left, 0.0, float(crop_size))
                 boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]] - top, 0.0, float(crop_size))

--- a/tests/unit/test_segmentation.py
+++ b/tests/unit/test_segmentation.py
@@ -358,7 +358,11 @@ class TestPolygonLabelParsing:
             assert len(segments[0]) == 1
             assert segments[0][0].shape == (4, 2)
             assert segments[0][0][2].tolist() == [80.0, 80.0]
-            assert getattr(segments[0][0], "dense_mask", None) is not None
+            # Polygon-sourced rings should NOT carry a dataset-resident dense
+            # mask: that would OOM on full COCO (issue #270). Crop fidelity
+            # is preserved by materializing the mask lazily inside the
+            # RF-DETR transform when the crop branch fires.
+            assert getattr(segments[0][0], "dense_mask", None) is None
 
     def test_yolo_dataset_bbox_rows_become_rectangle_segments_when_requested(self):
         import tempfile
@@ -390,7 +394,7 @@ class TestPolygonLabelParsing:
                 [70.0, 60.0],
                 [30.0, 60.0],
             ]
-            assert getattr(ring, "dense_mask", None) is not None
+            assert getattr(ring, "dense_mask", None) is None
 
     def test_yolo_collate_preserves_segments_when_present(self):
         from libreyolo.data.dataset import yolox_collate_fn
@@ -557,6 +561,38 @@ class TestPolygonLabelParsing:
         assert labels[0].tolist() == pytest.approx([0, 20, 20, 40, 40])
         assert masks[0, 20, 20] == 1
 
+    def test_yolo_dataset_polygon_segments_do_not_allocate_dense_masks(self, tmp_path):
+        """Issue #270 regression: opening a polygon dataset must stay cheap.
+
+        Loading many polygon-annotated images must not allocate full-resolution
+        uint8 rasters per polygon; otherwise full-COCO loaders OOM-kill before
+        the first batch.
+        """
+        from libreyolo.data.dataset import YOLODataset
+
+        img_dir = tmp_path / "images" / "train"
+        lbl_dir = tmp_path / "labels" / "train"
+        img_dir.mkdir(parents=True)
+        lbl_dir.mkdir(parents=True)
+
+        for i in range(8):
+            Image.new("RGB", (640, 480)).save(img_dir / f"img_{i}.jpg")
+            (lbl_dir / f"img_{i}.txt").write_text(
+                "0 0.2 0.2 0.8 0.2 0.8 0.8 0.2 0.8\n" * 4
+            )
+
+        dataset = YOLODataset(
+            data_dir=str(tmp_path),
+            split="train",
+            img_size=(640, 640),
+            load_segments=True,
+        )
+
+        for instance_segments in dataset.segments:
+            for instance in instance_segments:
+                for ring in instance:
+                    assert getattr(ring, "dense_mask", None) is None
+
     def test_rfdetr_crop_uses_dense_polygon_mask(self, monkeypatch):
         import cv2
 
@@ -661,7 +697,8 @@ class TestPolygonLabelParsing:
             [14.0, 5.0],
             [10.0, 5.0],
         ]
-        assert getattr(dataset.segments[0][0][0], "dense_mask", None) is not None
+        # Polygon-sourced rings store no eager dense mask (issue #270).
+        assert getattr(dataset.segments[0][0][0], "dense_mask", None) is None
 
     def test_coco_dataset_decodes_rle_segments_when_requested(self, tmp_path):
         import json

--- a/tests/unit/test_segmentation.py
+++ b/tests/unit/test_segmentation.py
@@ -634,6 +634,51 @@ class TestPolygonLabelParsing:
         assert masks[0].sum() == pytest.approx(float(expected.sum()))
         assert np.array_equal(masks[0] > 0, expected > 0)
 
+    def test_rfdetr_crop_lazily_materializes_plain_polygon_mask(self, monkeypatch):
+        import cv2
+
+        from libreyolo.models.rfdetr.seg_transforms import RFDETRSegTransform
+
+        monkeypatch.setattr(
+            "libreyolo.models.rfdetr.seg_transforms.random.random", lambda: 0.0
+        )
+        monkeypatch.setattr(
+            "libreyolo.models.rfdetr.seg_transforms.random.choice", lambda seq: seq[0]
+        )
+
+        randint_values = iter([20, 10, 10])
+        monkeypatch.setattr(
+            "libreyolo.models.rfdetr.seg_transforms.random.randint",
+            lambda _a, _b: next(randint_values),
+        )
+
+        image = np.zeros((40, 40, 3), dtype=np.uint8)
+        targets = np.array([[0, 0, 40, 40, 0]], dtype=np.float32)
+        ring = np.array([[0, 0], [40, 20], [0, 40]], dtype=np.float32)
+        segments = [[ring]]
+        transform = RFDETRSegTransform(
+            max_labels=4,
+            flip_prob=0.0,
+            imgsz=40,
+            crop_resize_prob=1.0,
+            crop_intermediate_sizes=(40,),
+            crop_min_size=20,
+            crop_max_size=20,
+        )
+
+        _, _, masks = transform(image, targets, (40, 40), segments)
+
+        dense = np.zeros((40, 40), dtype=np.uint8)
+        cv2.fillPoly(dense, [ring.astype(np.int32)], color=1)
+        expected = cv2.resize(
+            dense[10:30, 10:30],
+            (40, 40),
+            interpolation=cv2.INTER_NEAREST,
+        )
+        assert masks[0].sum() == pytest.approx(float(expected.sum()))
+        assert np.array_equal(masks[0] > 0, expected > 0)
+        assert getattr(ring, "dense_mask", None) is None
+
     def test_coco_dataset_preserves_multiple_segment_rings(self, tmp_path):
         import json
 


### PR DESCRIPTION
Polygon-sourced rings stored on YOLODataset/COCODataset no longer carry a full-resolution rasterized mask. RF-DETR's crop branch materializes the mask lazily per __getitem__, so crop fidelity is preserved without the dataset-wide allocation that OOM-killed full-COCO loaders (issue #270).