### PR TITLE
Skip export_backend tests in nightly e2e

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -129,7 +129,7 @@ jobs:
         run: uv run --no-sync python -c "import torch; print('CUDA:', torch.cuda.is_available(), torch.cuda.get_device_name(0) if torch.cuda.is_available() else '-')"
 
       - name: Run e2e
-        run: uv run --no-sync pytest tests/e2e -v
+        run: uv run --no-sync pytest tests/e2e -v -m "not export_backend"
 
       - name: Mark target as tested
         if: success()


### PR DESCRIPTION
Nightly suite is meant to validate training / CLI / tracking / video / val paths against dev, main, and the PyPI release. The export backend tests (onnx, tensorrt, openvino, torchscript, ncnn) are the longest-running and most environment-fragile and are excluded so the three targets complete in a reasonable window.