### PR TITLE
Add focused nightly e2e

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,121 @@
+# SECURITY: do not add `pull_request` to this workflow. A self-hosted runner
+# attached to a public repo would execute arbitrary code from fork PRs.
+
+name: E2E nightly
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Run regardless of SHA cache"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Resolve stale target
+    runs-on: ubuntu-latest
+    outputs:
+      stale: ${{ steps.diff.outputs.stale }}
+      main_sha: ${{ steps.resolve.outputs.main }}
+    steps:
+      - id: resolve
+        name: Resolve current main SHA
+        run: |
+          set -euo pipefail
+          MAIN_SHA=$(git ls-remote https://github.com/LibreYOLO/libreyolo refs/heads/main | cut -f1)
+          echo "main=$MAIN_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved: main=$MAIN_SHA"
+
+      - id: cache-main
+        uses: actions/cache@v4
+        with:
+          path: .last-main
+          key: last-tested-main-${{ steps.resolve.outputs.main }}
+
+      - id: diff
+        name: Compute stale target list
+        env:
+          FORCE: ${{ inputs.force }}
+          HIT_MAIN: ${{ steps.cache-main.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [ "${FORCE:-false}" = "true" ]; then
+            STALE='["main"]'
+          elif [ "${HIT_MAIN:-}" = "true" ]; then
+            STALE='[]'
+          else
+            STALE='["main"]'
+          fi
+          echo "stale=$STALE" >> "$GITHUB_OUTPUT"
+          echo "Stale targets: $STALE"
+
+  e2e:
+    name: e2e (${{ matrix.target }})
+    needs: guard
+    if: needs.guard.outputs.stale != '[]'
+    runs-on: [self-hosted, gpu, libreyolo-e2e]
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.guard.outputs.stale) }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.target }}
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Create venv
+        run: uv venv --python 3.10
+
+      - name: Install from source
+        run: uv pip install --no-sources --torch-backend cu128 --group dev -e ".[rfdetr,onnx]"
+
+      - name: GPU sanity
+        run: uv run --no-sync python -c "import torch; print('CUDA:', torch.cuda.is_available(), torch.cuda.get_device_name(0) if torch.cuda.is_available() else '-')"
+
+      - name: Record nightly suite contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-sync python - <<'PY'
+          import os
+          from pathlib import Path
+
+          from tests.e2e.nightly_contract import (
+              nightly_markdown_summary,
+              nightly_summary_line,
+          )
+
+          print(nightly_summary_line())
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with Path(summary_path).open("a", encoding="utf-8") as f:
+                  f.write(nightly_markdown_summary())
+                  f.write("\n")
+          PY
+
+      - name: Run e2e
+        shell: bash
+        run: |
+          set -euo pipefail
+          make test_nightly
+
+      - name: Mark target as tested
+        if: success()
+        run: echo "ok ${{ github.run_id }}" > .last-${{ matrix.target }}
+
+      - name: Save tested-SHA cache
+        if: success() && matrix.target == 'main'
+        uses: actions/cache/save@v4
+        with:
+          path: .last-main
+          key: last-tested-main-${{ needs.guard.outputs.main_sha }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 UV := uv run --no-sync
 
 .DEFAULT_GOAL := help
-.PHONY: help setup format lint typecheck test test_e2e test_rf5 build clean
+.PHONY: help setup format lint typecheck test test_e2e test_general_nightly test_flagship_nightly test_nightly print_nightly_suite test_rf5 build clean
 
 help:
 	@echo "═══════════════════════════════════════════════════════════════════════════════"
@@ -18,6 +18,10 @@ help:
 	@echo "  test_e2e FROM=<file>          - Resume from a test file (e.g. FROM=test_rf1_training.py or FROM=rf1_training)"
 	@echo "  test_e2e MARKERS='<expr>'     - Run only matching e2e markers (e.g. MARKERS='e2e and not experimental_backend')"
 	@echo "  test_e2e MARKER='<expr>'      - Alias for MARKERS=..., also works with FROM=..."
+	@echo "  print_nightly_suite           - Print nightly suite version and contract"
+	@echo "  test_general_nightly          - Run YOLO9/RF-DETR all-size inference checks"
+	@echo "  test_flagship_nightly         - Run focused YOLO9/RF-DETR load, RF1, and ONNX checks"
+	@echo "  test_nightly                  - Run general + flagship nightly checks"
 	@echo "  test_rf5                      - Run RF5 training benchmark tests"
 	@echo "  build                         - Build package"
 	@echo "  clean                         - Remove build and test cache artifacts"
@@ -106,6 +110,19 @@ test_e2e:
 	echo "══════════════════════════════════════════════════════════════"; \
 	echo "  all done: $$passed passed, $$skipped skipped, $$failed failed"; \
 	echo "══════════════════════════════════════════════════════════════"
+
+print_nightly_suite:
+	@$(UV) python -c "from tests.e2e.nightly_contract import nightly_summary_line; print(nightly_summary_line())"
+
+test_general_nightly: print_nightly_suite
+	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='general_nightly'
+
+test_flagship_nightly: print_nightly_suite
+	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='flagship_nightly'
+
+test_nightly: print_nightly_suite
+	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='general_nightly'
+	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='flagship_nightly'
 
 test_rf5: clean
 	$(UV) pytest tests/e2e/test_rf5_training.py -m rf5 -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "tqdm>=4.65.0",
     "pycocotools>=2.0.0",
     "typer>=0.9.0",
+    "click>=8.0.0",
     "safetensors>=0.4.0",
 ]
 
@@ -36,7 +37,7 @@ onnx = [
     "onnxruntime>=1.16.0",
 ]
 rfdetr = [
-    "rfdetr>=1.6.2,<2.0.0",
+    "rfdetr[train,loggers]>=1.6.2,<2.0.0",
 ]
 tensorrt = [
     # No CUDA on macOS; marker drops these. Version pin must match the
@@ -152,6 +153,8 @@ testpaths = ["tests"]
 markers = [
     "unit: fast tests that avoid external weights or large files",
     "e2e: end-to-end tests requiring full model loading and inference",
+    "general_nightly: broad nightly inference contract",
+    "flagship_nightly: focused nightly flagship model contract",
     "export_backend: tests covering an export backend or serialized runtime format",
     "supported_backend: tests covering a release-blocking supported backend",
     "experimental_backend: tests covering an experimental backend",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,6 +10,8 @@ import pytest
 import torch
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_FAIL_ON_NIGHTLY_SKIP_ENV = "LIBREYOLO_FAIL_ON_NIGHTLY_SKIP"
+_NIGHTLY_MARKERS = ("general_nightly", "flagship_nightly")
 
 
 def _repo_python_env() -> dict[str, str]:
@@ -21,6 +23,36 @@ def _repo_python_env() -> dict[str, str]:
         paths.append(existing)
     env["PYTHONPATH"] = os.pathsep.join(paths)
     return env
+
+
+def _has_nightly_marker(item) -> bool:
+    return any(
+        item.get_closest_marker(marker) is not None for marker in _NIGHTLY_MARKERS
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Turn selected nightly skips into failures when the Make targets request it."""
+    outcome = yield
+    report = outcome.get_result()
+    if os.environ.get(_FAIL_ON_NIGHTLY_SKIP_ENV, "").lower() not in {
+        "1",
+        "true",
+        "yes",
+    }:
+        return
+    if report.when != "call" or report.outcome != "skipped":
+        return
+    if not _has_nightly_marker(item):
+        return
+
+    reason = str(report.longrepr)
+    report.outcome = "failed"
+    report.longrepr = (
+        f"Nightly-selected tests must execute, not skip.\nOriginal skip: {reason}"
+    )
+
 
 # ---------------------------------------------------------------------------
 # Force 'spawn' multiprocessing to prevent CUDA + fork segfaults.
@@ -38,6 +70,12 @@ multiprocessing.set_start_method("spawn", force=True)
 
 def pytest_configure(config):
     """Register custom markers (e2e marker registered in root conftest)."""
+    config.addinivalue_line(
+        "markers", "general_nightly: broad nightly inference contract"
+    )
+    config.addinivalue_line(
+        "markers", "flagship_nightly: focused nightly flagship model contract"
+    )
     config.addinivalue_line(
         "markers",
         "export_backend: tests covering an export backend or serialized runtime format",
@@ -72,9 +110,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line("markers", "dfine: tests covering the D-FINE model family")
     config.addinivalue_line("markers", "deim: tests covering the DEIM model family")
-    config.addinivalue_line(
-        "markers", "deimv2: tests covering the DEIMv2 model family"
-    )
+    config.addinivalue_line("markers", "deimv2: tests covering the DEIMv2 model family")
     config.addinivalue_line("markers", "ecdet: tests covering the ECDET model family")
     config.addinivalue_line(
         "markers", "rtdetr: tests covering the RT-DETR model family"
@@ -486,6 +522,20 @@ PICODET_SIZES = [s for f, s, _ in MODEL_CATALOG if f == "picodet"]
 ALL_MODELS = [(f, s) for f, s, _ in MODEL_CATALOG]
 ALL_MODELS_WITH_WEIGHTS = MODEL_CATALOG
 NON_RFDETR_MODELS = [(f, s) for f, s, _ in MODEL_CATALOG if f != "rfdetr"]
+FLAGSHIP_NIGHTLY_TRAINING_MODELS = {
+    ("yolo9", "t"),
+    ("rfdetr", "n"),
+}
+GENERAL_NIGHTLY_INFERENCE_MODELS = [
+    ("yolo9", "t", "LibreYOLO9t.pt"),
+    ("yolo9", "s", "LibreYOLO9s.pt"),
+    ("yolo9", "m", "LibreYOLO9m.pt"),
+    ("yolo9", "c", "LibreYOLO9c.pt"),
+    ("rfdetr", "n", "LibreRFDETRn.pt"),
+    ("rfdetr", "s", "LibreRFDETRs.pt"),
+    ("rfdetr", "m", "LibreRFDETRm.pt"),
+    ("rfdetr", "l", "LibreRFDETRl.pt"),
+]
 
 # Quick test set (for CI — smallest auto-available models only)
 QUICK_TEST_MODELS = [("yolox", "n"), ("yolo9", "t"), ("rtdetr", "r18")]
@@ -546,10 +596,36 @@ def model_cases(models, *, with_weights: bool = False, marks_resolver=None):
     return params
 
 
+def flagship_training_nightly_marks(family: str, size: str, *_):
+    """Return the flagship nightly mark for the smallest training cases only."""
+    if (family, size) in FLAGSHIP_NIGHTLY_TRAINING_MODELS:
+        return pytest.mark.flagship_nightly
+    return None
+
+
+def general_nightly_marks(*_):
+    """Return the general nightly mark for focused inference cases."""
+    return pytest.mark.general_nightly
+
+
 QUICK_TEST_PARAMS = model_cases(QUICK_TEST_MODELS)
 FULL_TEST_PARAMS = model_cases(FULL_TEST_MODELS)
 RFDETR_TEST_PARAMS = model_cases(RFDETR_TEST_MODELS)
 ALL_MODEL_WEIGHT_PARAMS = model_cases(ALL_MODELS_WITH_WEIGHTS, with_weights=True)
+NIGHTLY_TRAINING_WEIGHT_PARAMS = model_cases(
+    ALL_MODELS_WITH_WEIGHTS,
+    with_weights=True,
+    marks_resolver=flagship_training_nightly_marks,
+)
+FLAGSHIP_NIGHTLY_LOAD_PARAMS = model_cases(
+    GENERAL_NIGHTLY_INFERENCE_MODELS,
+    with_weights=True,
+)
+GENERAL_NIGHTLY_INFERENCE_PARAMS = model_cases(
+    GENERAL_NIGHTLY_INFERENCE_MODELS,
+    with_weights=True,
+    marks_resolver=general_nightly_marks,
+)
 
 
 def get_model_weights(family: str, size: str) -> str:

--- a/tests/e2e/nightly_contract.py
+++ b/tests/e2e/nightly_contract.py
@@ -1,0 +1,28 @@
+"""Versioned contract for the nightly e2e test suite."""
+
+NIGHTLY_E2E_SUITE_VERSION = "2.0"
+NIGHTLY_E2E_SUITE_CONTRACT = (
+    "general=YOLO9/RF-DETR native load+inference for every detection size; "
+    "flagship=simple YOLO9/RF-DETR load smoke for every detection size, "
+    "smallest-size RF1 training, and smallest-size ONNX export+inference"
+)
+NIGHTLY_E2E_SUITE_CHANGE_POLICY = (
+    "Bump minor for meaningful coverage additions or threshold/runtime changes; "
+    "bump major when a green run makes a materially different promise."
+)
+
+
+def nightly_summary_line() -> str:
+    return (
+        f"LibreYOLO nightly e2e suite v{NIGHTLY_E2E_SUITE_VERSION}: "
+        f"{NIGHTLY_E2E_SUITE_CONTRACT}"
+    )
+
+
+def nightly_markdown_summary() -> str:
+    return (
+        f"### LibreYOLO nightly e2e suite v{NIGHTLY_E2E_SUITE_VERSION}\n\n"
+        f"{NIGHTLY_E2E_SUITE_CONTRACT}\n\n"
+        f"{NIGHTLY_E2E_SUITE_CHANGE_POLICY}\n\n"
+        "Job summary generated at run-time.\n"
+    )

--- a/tests/e2e/test_deterministic_inference.py
+++ b/tests/e2e/test_deterministic_inference.py
@@ -1,0 +1,64 @@
+"""Nightly native inference checks for flagship detection families."""
+
+import pytest
+import torch
+
+from libreyolo import LibreYOLO
+
+from .conftest import (
+    GENERAL_NIGHTLY_INFERENCE_PARAMS,
+    cuda_cleanup,
+    require_test_weights,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.general_nightly]
+
+
+def _tensor(data):
+    return (
+        data.detach().cpu() if isinstance(data, torch.Tensor) else torch.as_tensor(data)
+    )
+
+
+def _assert_detection_output_is_stable(family, first, second):
+    assert first.boxes is not None, f"{family} did not return detection boxes"
+    assert second.boxes is not None, f"{family} did not return detection boxes"
+    assert len(first.boxes) > 0, f"{family} returned no detections"
+    assert len(first.boxes) == len(second.boxes), (
+        f"{family} detection count changed: {len(first.boxes)} -> {len(second.boxes)}"
+    )
+    assert first.orig_shape == second.orig_shape
+    assert first.names, f"{family} result has no class names"
+
+    n = min(5, len(first.boxes))
+    first_boxes = _tensor(first.boxes.xyxy[:n])
+    second_boxes = _tensor(second.boxes.xyxy[:n])
+    first_conf = _tensor(first.boxes.conf[:n])
+    second_conf = _tensor(second.boxes.conf[:n])
+    first_cls = _tensor(first.boxes.cls[:n])
+    second_cls = _tensor(second.boxes.cls[:n])
+
+    assert torch.isfinite(first_boxes).all(), f"{family} produced non-finite boxes"
+    assert torch.isfinite(first_conf).all(), f"{family} produced non-finite scores"
+
+    torch.testing.assert_close(first_boxes, second_boxes, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(first_conf, second_conf, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(first_cls, second_cls, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "family,size,weights",
+    GENERAL_NIGHTLY_INFERENCE_PARAMS,
+)
+def test_native_inference_is_stable(family, size, weights, sample_image):
+    """Every YOLO9/RF-DETR detection size loads and runs stable inference."""
+    weights = require_test_weights(weights, expected_family=family)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = LibreYOLO(weights, size=size, device=device)
+    try:
+        first = model(sample_image, conf=0.25)
+        second = model(sample_image, conf=0.25)
+        _assert_detection_output_is_stable(family, first, second)
+    finally:
+        del model
+        cuda_cleanup()

--- a/tests/e2e/test_flagship_load_smoke.py
+++ b/tests/e2e/test_flagship_load_smoke.py
@@ -1,0 +1,31 @@
+"""Focused nightly load smoke checks for flagship pretrained weights."""
+
+import pytest
+import torch
+
+from libreyolo import LibreYOLO
+
+from .conftest import (
+    FLAGSHIP_NIGHTLY_LOAD_PARAMS,
+    cuda_cleanup,
+    require_test_weights,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.flagship_nightly]
+
+
+@pytest.mark.parametrize(
+    "family,size,weights",
+    FLAGSHIP_NIGHTLY_LOAD_PARAMS,
+)
+def test_flagship_weights_load(family, size, weights):
+    """Load each YOLO9/RF-DETR detection size without running inference."""
+    weights = require_test_weights(weights, expected_family=family)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = LibreYOLO(weights, size=size, device=device)
+    try:
+        assert getattr(model, "nb_classes", 0) > 0
+        assert getattr(model, "names", None)
+    finally:
+        del model
+        cuda_cleanup()

--- a/tests/e2e/test_onnx.py
+++ b/tests/e2e/test_onnx.py
@@ -42,6 +42,20 @@ OFFICIAL_YOLONAS_WEIGHTS = {
     "m": Path("downloads/yolonas/yolo_nas_m_coco.pth"),
     "l": Path("downloads/yolonas/yolo_nas_l_coco.pth"),
 }
+FLAGSHIP_ONNX_COMPARE_PARAMS = [
+    pytest.param(
+        "yolo9",
+        "t",
+        marks=[pytest.mark.yolo9, pytest.mark.flagship_nightly],
+        id="yolo9-t",
+    ),
+    pytest.param(
+        "rfdetr",
+        "n",
+        marks=[requires_rfdetr, pytest.mark.rfdetr, pytest.mark.flagship_nightly],
+        id="rfdetr-n",
+    ),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +65,13 @@ OFFICIAL_YOLONAS_WEIGHTS = {
 
 class TestONNXExport:
     """Test ONNX export for all models."""
+
+    @pytest.mark.parametrize("model_type,size", FLAGSHIP_ONNX_COMPARE_PARAMS)
+    def test_flagship_onnx_export_inference(
+        self, model_type, size, sample_image, tmp_path
+    ):
+        """Nightly flagship ONNX export and inference parity for YOLO9/RF-DETR."""
+        self._run_onnx_test(model_type, size, sample_image, tmp_path)
 
     @pytest.mark.parametrize("model_type,size", QUICK_TEST_PARAMS)
     def test_onnx_export_quick(self, model_type, size, sample_image, tmp_path):

--- a/tests/e2e/test_rf1_training.py
+++ b/tests/e2e/test_rf1_training.py
@@ -27,6 +27,7 @@ from libreyolo import LibreYOLO
 from .conftest import (
     ALL_MODEL_WEIGHT_PARAMS,
     ALL_MODELS_WITH_WEIGHTS,
+    NIGHTLY_TRAINING_WEIGHT_PARAMS,
     cuda_cleanup,
     make_ids,
     require_test_weights,
@@ -183,7 +184,7 @@ def rf1_epochs(family: str) -> int:
 
 def rf1_workers(family: str) -> tuple[int, int]:
     """Return (train_workers, val_workers) for RF1 stability."""
-    if family in DETR_RF1_FAMILIES:
+    if family in DETR_RF1_FAMILIES or family == "yolo9":
         return 0, 0
     return 2, 4
 
@@ -236,7 +237,7 @@ def rf1_train_kwargs(family: str, size: str) -> dict:
 
 @pytest.mark.parametrize(
     "family,size,weights",
-    ALL_MODEL_WEIGHT_PARAMS,
+    NIGHTLY_TRAINING_WEIGHT_PARAMS,
 )
 def test_rf1_training(family, size, weights, dataset_coco, dataset_data_yaml, tmp_path):
     """Train on marbles, verify the model learns and clears a basic mAP floor."""


### PR DESCRIPTION
## Summary
- add a 03:00 UTC focused nightly e2e workflow for main
- version the nightly contract around YOLO9/RF-DETR load, inference, RF1 training, and ONNX export+inference
- install ONNX and RF-DETR training extras needed by the nightly path

## Tested
- docker runner: `uv pip install --no-sources --torch-backend cu128 --group dev -e .[rfdetr,onnx]`
- docker runner: `make test_nightly`