### PR TITLE
feat(rfdetr): opt RFDETRTrainer into training artifacts

### DIFF
--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -48,6 +48,8 @@ class RFDETRStepScheduler(BaseScheduler):
 
 
 class RFDETRTrainer(BaseTrainer):
+    artifact_model_families = ("rfdetr",)
+
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:
         return RFDETRConfig

--- a/tests/unit/test_training_artifacts.py
+++ b/tests/unit/test_training_artifacts.py
@@ -185,6 +185,12 @@ def test_yolonas_trainer_opts_into_artifacts():
     assert YOLONASPoseTrainer.artifact_model_families == ("yolonas",)
 
 
+def test_rfdetr_trainer_opts_into_artifacts():
+    from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+    assert "rfdetr" in RFDETRTrainer.artifact_model_families
+
+
 def test_yolonas_pose_trainer_writes_artifacts_through_base_path(tmp_path):
     from libreyolo.models.yolonas.pose_trainer import YOLONASPoseTrainer
 


### PR DESCRIPTION
## Summary
- Add `artifact_model_families = ("rfdetr",)` to `RFDETRTrainer` so it
  participates in the training-artifact pipeline (alongside yolov8, yolonas, etc.)
- Add `test_rfdetr_trainer_opts_into_artifacts` to guard the registration