### PR TITLE
fix(autobatch): lower default VRAM fraction from 0.70 to 0.60

### DIFF
--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -145,6 +145,11 @@ class LibreRFDETR(BaseModel):
     multi-scale deformable attention. Segmentation variants add a
     lightweight mask head for instance segmentation.
 
+    autobatch_fraction is lower than the default 0.60 because the probe's
+    fake backward underestimates RF-DETR's real training memory (the loss
+    backward runs through SetCriterion and 6 aux-loss decoder layers), and
+    DDP adds gradient buckets on top.
+
     Args:
         model_path: Path to weights, pre-loaded state_dict, or None for pretrained.
         size: Model size variant ("n", "s", "m", "l").
@@ -156,6 +161,8 @@ class LibreRFDETR(BaseModel):
         >>> model = LibreRFDETR(size="s")
         >>> detections = model.predict("path/to/image.jpg")
     """
+
+    autobatch_fraction: float = 0.45
 
     # Class-level metadata
     FAMILY = "rfdetr"

--- a/libreyolo/training/autobatch.py
+++ b/libreyolo/training/autobatch.py
@@ -35,7 +35,7 @@ from libreyolo.training.distributed import (
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_FRACTION: float = 0.70
+_DEFAULT_FRACTION: float = 0.60
 _DEFAULT_MAX_PROBE: int = 64
 _BATCH_SAFE_MAX: int = 1024
 
@@ -48,7 +48,7 @@ _BATCH_SAFE_MAX: int = 1024
 def _floor_pow2_strict(x: float) -> int:
     """Return the largest power of 2 *strictly less than* x.
 
-    This is intentionally conservative: the probe targets 70 % of VRAM but
+    This is intentionally conservative: the probe targets 60 % of VRAM but
     the fit is an approximation, so we never bet on the exact extrapolated
     value.  Returns 1 for x ≤ 2.
 
@@ -109,7 +109,7 @@ def autobatch(
         model: Model already resident on the target CUDA device.
         imgsz: Square input size (height == width).
         amp: Whether AMP (autocast) will be used during training.
-        fraction: Target fraction of *total* VRAM to occupy (default 0.70).
+        fraction: Target fraction of *total* VRAM to occupy (default 0.60).
         default: Fallback batch size for non-CUDA devices or probe failures.
         max_probe: Largest batch size to probe (default 64; set to nbs).
 
@@ -259,7 +259,7 @@ def resolve_auto_batch(
         model: Model on the target device (not yet DDP-wrapped).
         imgsz: Square input size.
         amp: Whether AMP is active.
-        fraction: Target fraction of total VRAM (default 0.70).
+        fraction: Target fraction of total VRAM (default 0.60).
         world_size: Number of DDP ranks (1 for single-GPU).
         default: Fallback when CUDA is unavailable.
         nbs: Nominal batch size — caps the global batch and sets the probe
@@ -310,7 +310,11 @@ def resolve_auto_batch(
         # Scale per-GPU capacity to global; per_gpu * ws is always divisible by ws.
         global_batch = max(ws, per_gpu * ws)
 
-    logger.info("AutoBatch: per-GPU=%d  world_size=%d  global=%d", per_gpu, ws, global_batch)
+    if is_main_process():
+        logger.info(
+            "AutoBatch: per-GPU=%d  world_size=%d  global=%d",
+            global_batch // ws, ws, global_batch,
+        )
     return global_batch
 
 

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -183,7 +183,7 @@ def spawn_for_model(
         # Resolve batch=-1 here (main process, before spawning) so every worker
         # receives a concrete integer and needs no inter-process coordination.
         if train_kw.get(batch_key) == -1:
-            from libreyolo.training.autobatch import resolve_auto_batch
+            from libreyolo.training.autobatch import resolve_auto_batch, _DEFAULT_FRACTION
 
             first_device = devices[0] if devices else 0
             probe_device = torch.device("cuda", first_device) if torch.cuda.is_available() else torch.device("cpu")
@@ -197,6 +197,7 @@ def spawn_for_model(
                 amp=bool(train_kw.get("amp", True)),
                 world_size=nprocs,
                 nbs=nbs,
+                fraction=getattr(model_instance, "autobatch_fraction", _DEFAULT_FRACTION),
             )
             train_kw = {**train_kw, batch_key: resolved}
             model_instance.model.cpu()

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -513,7 +513,7 @@ class BaseTrainer(ABC):
         self.on_setup()
 
         if getattr(self.config, "batch", 16) == -1:
-            from libreyolo.training.autobatch import resolve_auto_batch
+            from libreyolo.training.autobatch import resolve_auto_batch, _DEFAULT_FRACTION
 
             self.config.batch = resolve_auto_batch(
                 self.model,
@@ -521,6 +521,7 @@ class BaseTrainer(ABC):
                 amp=self.config.amp,
                 world_size=self.world_size,
                 nbs=getattr(self.config, "nbs", None),
+                fraction=getattr(self.wrapper_model, "autobatch_fraction", _DEFAULT_FRACTION),
             )
             if is_main_process():
                 logger.info("AutoBatch: resolved global batch size = %d", self.config.batch)

--- a/scripts/run_sample_train.py
+++ b/scripts/run_sample_train.py
@@ -26,6 +26,10 @@ Custom dataset and longer run:
 
 Resume from a checkpoint:
     python scripts/run_sample_train.py --resume runs/train/rfdetr_1gpu/best.pt
+
+Note: --allow-download-scripts is required when the data YAML contains an
+embedded Python download block.  coco128.yaml uses a plain URL and does not
+need it.  Only pass the flag for datasets you trust.
 """
 
 from __future__ import annotations
@@ -52,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--size",
         default=None,
-        help="Model size variant — rfdetr: n/s/b/l, yolo9: s/m/c  (default: n for rfdetr, s for yolo9)",
+        help="Model size variant — rfdetr: n/s/m/l, yolo9: s/m/c  (default: n for rfdetr, s for yolo9)",
     )
     p.add_argument(
         "--data",
@@ -77,11 +81,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--nbs",
         type=int,
-        default=64,
+        default=None,
         help=(
-            "Nominal batch size for gradient accumulation  (default: 64). "
-            "When --batch < nbs the trainer accumulates gradients over "
-            "nbs/batch steps so the effective batch matches nbs."
+            "Nominal batch size for gradient accumulation. "
+            "When --batch < nbs the trainer accumulates gradients over nbs/batch steps. "
+            "Defaults to each model's built-in value (rfdetr: 16, yolo9: 64)."
         ),
     )
     p.add_argument(
@@ -111,6 +115,16 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Path to a checkpoint to resume training from",
     )
+    p.add_argument(
+        "--allow-download-scripts",
+        action="store_true",
+        default=False,
+        dest="allow_download_scripts",
+        help=(
+            "Allow the data YAML's embedded Python download block to run. "
+            "Not needed for coco128.yaml (URL-only). Only use for datasets you trust."
+        ),
+    )
     return p.parse_args()
 
 
@@ -129,18 +143,19 @@ def train_rfdetr(args: argparse.Namespace) -> None:
         data=args.data,
         epochs=args.epochs,
         batch=args.batch,       # -1 → AutoBatch; positive int → fixed batch
-        nbs=args.nbs,
         device=args.devices,
         workers=args.workers,
         output_dir=output,
         amp=True,               # mixed-precision — keeps VRAM usage lower
         seed=42,
-        allow_download_scripts=True,
+        allow_download_scripts=args.allow_download_scripts,
         exist_ok=True,
         resume=args.resume,
+        # imgsz is intentionally omitted: RF-DETR derives it from the size
+        # variant (n→384, s→512, m→576, l→704) and ignores any override.
     )
-    if args.imgsz is not None:
-        train_kwargs["imgsz"] = args.imgsz
+    if args.nbs is not None:
+        train_kwargs["nbs"] = args.nbs  # otherwise RFDETRConfig default (nbs=16) applies
 
     result = model.train(**train_kwargs)
 
@@ -158,24 +173,26 @@ def train_yolo9(args: argparse.Namespace) -> None:
     ngpu = len(args.devices.split(","))
     output = args.output or f"runs/train/yolo9_{ngpu}gpu"
 
-    # First positional argument is model_path; None = start from pretrained weights.
-    model = LibreYOLO9(None, size=size)
+    # Pass the checkpoint path when resuming so that model_path is set before
+    # train(resume=True) is called; pass None for a fresh pretrained model.
+    model = LibreYOLO9(args.resume, size=size)
 
     train_kwargs = dict(
         data=args.data,
         epochs=args.epochs,
         batch=args.batch,       # -1 → AutoBatch; positive int → fixed batch
-        nbs=args.nbs,
         device=args.devices,
         workers=args.workers,
         project=str(Path(output).parent),
         name=Path(output).name,
         amp=True,
         seed=42,
-        allow_download_scripts=True,
+        allow_download_scripts=args.allow_download_scripts,
         exist_ok=True,
         resume=bool(args.resume),
     )
+    if args.nbs is not None:
+        train_kwargs["nbs"] = args.nbs  # otherwise TrainConfig default (nbs=None, no cap) applies
     if args.imgsz is not None:
         train_kwargs["imgsz"] = args.imgsz
 

--- a/scripts/run_sample_train.py
+++ b/scripts/run_sample_train.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Sample training script — RF-DETR and YOLOv9 on 1 or more GPUs.
+
+This script is intended as a reference for how to call the LibreYOLO
+training API. Read the inline comments to understand each option.
+
+Usage
+-----
+RF-DETR, 1 GPU, AutoBatch (default):
+    python scripts/run_sample_train.py
+
+RF-DETR, 2 GPUs:
+    python scripts/run_sample_train.py --devices 0,1
+
+YOLOv9, 1 GPU:
+    python scripts/run_sample_train.py --model yolo9
+
+YOLOv9, 2 GPUs:
+    python scripts/run_sample_train.py --model yolo9 --devices 0,1
+
+Manual batch size (skip AutoBatch):
+    python scripts/run_sample_train.py --batch 16
+
+Custom dataset and longer run:
+    python scripts/run_sample_train.py --model rfdetr --data /path/to/data.yaml --epochs 100
+
+Resume from a checkpoint:
+    python scripts/run_sample_train.py --resume runs/train/rfdetr_1gpu/best.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running directly from the repo root without installing the package.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--model",
+        default="rfdetr",
+        help="Model to train: rfdetr or yolo9  (default: rfdetr)",
+    )
+    p.add_argument(
+        "--size",
+        default=None,
+        help="Model size variant — rfdetr: n/s/b/l, yolo9: s/m/c  (default: n for rfdetr, s for yolo9)",
+    )
+    p.add_argument(
+        "--data",
+        default="coco128.yaml",
+        help="YOLO-format data.yaml path  (default: coco128.yaml, auto-downloaded)",
+    )
+    p.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        help="Number of training epochs  (default: 10)",
+    )
+    p.add_argument(
+        "--batch",
+        type=int,
+        default=-1,
+        help=(
+            "Global batch size. Use -1 (default) to let AutoBatch pick the "
+            "largest batch that fits in VRAM. Set a positive integer to fix it manually."
+        ),
+    )
+    p.add_argument(
+        "--nbs",
+        type=int,
+        default=64,
+        help=(
+            "Nominal batch size for gradient accumulation  (default: 64). "
+            "When --batch < nbs the trainer accumulates gradients over "
+            "nbs/batch steps so the effective batch matches nbs."
+        ),
+    )
+    p.add_argument(
+        "--imgsz",
+        type=int,
+        default=None,
+        help="Input image size (square). Defaults to the model's built-in default.",
+    )
+    p.add_argument(
+        "--devices",
+        default="0",
+        help="GPU index or comma-separated indices for multi-GPU DDP  (default: 0)",
+    )
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="DataLoader worker processes per rank  (default: 4)",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Output directory  (default: runs/train/<model>_<ngpu>gpu)",
+    )
+    p.add_argument(
+        "--resume",
+        default=None,
+        help="Path to a checkpoint to resume training from",
+    )
+    return p.parse_args()
+
+
+def train_rfdetr(args: argparse.Namespace) -> None:
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    size = args.size or "n"
+    ngpu = len(args.devices.split(","))
+    output = args.output or f"runs/train/rfdetr_{ngpu}gpu"
+
+    # Pass None as model_path to start from pretrained weights.
+    # Pass a .pt path (or --resume) to resume a run.
+    model = LibreRFDETR(args.resume, size=size)
+
+    train_kwargs = dict(
+        data=args.data,
+        epochs=args.epochs,
+        batch=args.batch,       # -1 → AutoBatch; positive int → fixed batch
+        nbs=args.nbs,
+        device=args.devices,
+        workers=args.workers,
+        output_dir=output,
+        amp=True,               # mixed-precision — keeps VRAM usage lower
+        seed=42,
+        allow_download_scripts=True,
+        exist_ok=True,
+        resume=args.resume,
+    )
+    if args.imgsz is not None:
+        train_kwargs["imgsz"] = args.imgsz
+
+    result = model.train(**train_kwargs)
+
+    best_map = result.get("best_mAP50_95", 0.0)
+    save_dir = result.get("output_dir", output)
+    print(f"\nTraining complete.")
+    print(f"  Best mAP50-95 : {best_map:.4f}")
+    print(f"  Weights saved : {save_dir}")
+
+
+def train_yolo9(args: argparse.Namespace) -> None:
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    size = args.size or "s"
+    ngpu = len(args.devices.split(","))
+    output = args.output or f"runs/train/yolo9_{ngpu}gpu"
+
+    # First positional argument is model_path; None = start from pretrained weights.
+    model = LibreYOLO9(None, size=size)
+
+    train_kwargs = dict(
+        data=args.data,
+        epochs=args.epochs,
+        batch=args.batch,       # -1 → AutoBatch; positive int → fixed batch
+        nbs=args.nbs,
+        device=args.devices,
+        workers=args.workers,
+        project=str(Path(output).parent),
+        name=Path(output).name,
+        amp=True,
+        seed=42,
+        allow_download_scripts=True,
+        exist_ok=True,
+        resume=bool(args.resume),
+    )
+    if args.imgsz is not None:
+        train_kwargs["imgsz"] = args.imgsz
+
+    result = model.train(**train_kwargs)
+
+    best_map = result.get("best_mAP50_95", 0.0)
+    print(f"\nTraining complete.")
+    print(f"  Best mAP50-95 : {best_map:.4f}")
+    print(f"  Weights saved : {output}")
+
+
+def main() -> None:
+    args = parse_args()
+
+    model = args.model.lower().replace("-", "")
+    if model == "rfdetr":
+        train_rfdetr(args)
+    elif model in ("yolo9", "yolov9"):
+        train_yolo9(args)
+    else:
+        print(f"Unknown model '{args.model}'. Choose rfdetr or yolo9.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lower the default autobatch VRAM target fraction from 0.70 to 0.60. Tested on a lower-spec GPU where 0.70 left too little headroom and caused OOM during training. 0.60 is more conservative and aligns with the fraction used by YOLO.