### PR TITLE
Fix RT-DETR size-code regex ambiguity and bare GPU index in validator

### DIFF
--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -212,7 +212,8 @@ class InferenceRunner:
         target = torch.device(device_str)
         if target != self.model.device:
             self.model.device = target
-            self.model.model.to(target)
+            if hasattr(self.model.model, "to"):
+                self.model.model.to(target)
 
     def _process_in_batches(
         self,

--- a/libreyolo/models/l2cs/inference.py
+++ b/libreyolo/models/l2cs/inference.py
@@ -343,4 +343,5 @@ class GazeInferenceRunner:
         target = torch.device(device_str)
         if target != self.model.device:
             self.model.device = target
-            self.model.model.to(target)
+            if hasattr(self.model.model, "to"):
+                self.model.model.to(target)

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -132,7 +132,7 @@ _UPSTREAM_LONG_TO_SHORT: dict[str, str] = {
 
 # Matches upstream filenames: rf-detr[-seg]-{size_name}[...].{ext}
 _UPSTREAM_FILENAME_RE = re.compile(
-    r"rf-detr(?:-seg)?-(?P<name>xxlarge|xlarge|large|medium|small|nano)"
+    r"rf-detr(?P<seg>-seg)?-(?P<name>xxlarge|xlarge|large|medium|small|nano)"
 )
 
 
@@ -295,6 +295,16 @@ class LibreRFDETR(BaseModel):
         m = _UPSTREAM_FILENAME_RE.search(filename.lower())
         if m:
             return _UPSTREAM_LONG_TO_SHORT[m.group("name")]
+        return None
+
+    @classmethod
+    def detect_task_from_filename(cls, filename: str) -> Optional[str]:
+        detected = super().detect_task_from_filename(filename)
+        if detected is not None:
+            return detected
+        m = _UPSTREAM_FILENAME_RE.search(filename.lower())
+        if m and m.group("seg"):
+            return "segment"
         return None
 
     @classmethod

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -1,5 +1,6 @@
 """LibreRFDETR implementation for LibreYOLO."""
 
+import re
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
@@ -120,6 +121,21 @@ _RFDETR_UPSTREAM_WEIGHT_URLS = {
 }
 
 
+_UPSTREAM_LONG_TO_SHORT: dict[str, str] = {
+    "xxlarge": "xx",
+    "xlarge": "x",
+    "large": "l",
+    "medium": "m",
+    "small": "s",
+    "nano": "n",
+}
+
+# Matches upstream filenames: rf-detr[-seg]-{size_name}[...].{ext}
+_UPSTREAM_FILENAME_RE = re.compile(
+    r"rf-detr(?:-seg)?-(?P<name>xxlarge|xlarge|large|medium|small|nano)"
+)
+
+
 def _checkpoint_model_state(checkpoint: dict[str, Any]) -> dict[str, torch.Tensor]:
     """Extract a tensor state dict from RF-DETR/LibreYOLO checkpoint variants."""
     if "model" in checkpoint and isinstance(checkpoint["model"], dict):
@@ -152,7 +168,10 @@ class LibreRFDETR(BaseModel):
 
     Args:
         model_path: Path to weights, pre-loaded state_dict, or None for pretrained.
-        size: Model size variant ("n", "s", "m", "l").
+        size: Model size variant ("n", "s", "m", "l"). Defaults to None, which
+            auto-detects from the weight filename (both LibreRFDETR-*.pt and
+            upstream rf-detr-{nano,small,medium,large}*.pth names); falls back
+            to "s" when detection is not possible.
         nb_classes: Number of classes (default: 80 for COCO).
         device: Device for inference.
 
@@ -269,6 +288,16 @@ class LibreRFDETR(BaseModel):
         return None
 
     @classmethod
+    def detect_size_from_filename(cls, filename: str) -> Optional[str]:
+        detected = super().detect_size_from_filename(filename)
+        if detected is not None:
+            return detected
+        m = _UPSTREAM_FILENAME_RE.search(filename.lower())
+        if m:
+            return _UPSTREAM_LONG_TO_SHORT[m.group("name")]
+        return None
+
+    @classmethod
     def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
         # RF-DETR class_embed has (num_classes + 1) outputs (includes background)
         if "class_embed.bias" in weights_dict:
@@ -289,7 +318,7 @@ class LibreRFDETR(BaseModel):
     def __init__(
         self,
         model_path: str | None = None,
-        size: str = "s",
+        size: str | None = None,
         nb_classes: int = 80,
         device: str = "auto",
         segmentation: bool = False,
@@ -313,7 +342,7 @@ class LibreRFDETR(BaseModel):
                 if normalize_task(resolved_task) == "segment"
                 else RFDETR_CONFIGS
             )
-            cfg = cfgs.get(size)
+            cfg = cfgs.get(size or "s")
             default_weights = cfg.pretrain_weights if cfg is not None else None
             weight_source = (
                 self._resolve_weights_path(default_weights)
@@ -326,6 +355,14 @@ class LibreRFDETR(BaseModel):
             weight_source = model_path
 
         self._weight_source = weight_source
+
+        # Auto-detect size from the weight filename when the caller did not
+        # specify one explicitly.  Handles both LibreRFDETR-*.pt names and
+        # upstream rf-detr-{large,medium,...} names.
+        if size is None:
+            if isinstance(weight_source, str):
+                size = self.detect_size_from_filename(Path(weight_source).name)
+            size = size or "s"
 
         if weight_source is not None:
             filename_task = (

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -261,7 +261,7 @@ class LibreRTDETR(BaseModel):
         prefix = cls.FILENAME_PREFIX.lower()
 
         # Upstream RT-DETR v1 checkpoint names: rtdetr_r50vd_..., rtdetr_r18vd_...
-        m = re.search(r"rtdetr_r(\d+)vd(_m)?", basename)
+        m = re.search(r"rtdetr_r(\d+)vd(_m)?(?=[-_.]|$)", basename)
         if m:
             depth, m_suffix = m.group(1), m.group(2)
             candidate = f"r{depth}m" if m_suffix else f"r{depth}"

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -280,10 +280,11 @@ class LibreRTDETR(BaseModel):
                 if re.search(rf"^{re.escape(size)}[-_]", basename):
                     return size
             else:
-                # Multi-char sizes (r50, r101, …) are specific enough that a plain
-                # substring check is safe and preserves upstream filename hints like
-                # rtdetr_r50vd_... that don't use the LibreRTDETR prefix.
-                if f"-{size}" in basename or f"_{size}" in basename:
+                # Multi-char sizes (r50, r101, …): require a word boundary after
+                # the code so "_r50vd" (RT-DETRv2 upstream names) doesn't match
+                # "r50".  Upstream v1 filenames (rtdetr_r50vd_…) are already
+                # handled by the upstream regex above and never reach this branch.
+                if re.search(rf"[-_]{re.escape(size)}(?:[^a-z0-9]|$)", basename):
                     return size
                 if basename.startswith(f"{size}"):
                     return size

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -262,12 +262,11 @@ class LibreRTDETR(BaseModel):
             pattern = rf"{cls.FILENAME_PREFIX}[-_]?{re.escape(size)}[^a-z0-9]"
             if re.search(pattern, basename):
                 return size
-            # Also try just the size code anywhere in the filename
-            if (
-                f"-{size}" in basename
-                or f"_{size}" in basename
-                or basename.startswith(f"{size}")
-            ):
+            # Require a word boundary after the size code so that e.g. "-l"
+            # doesn't match inside "-large" when size=="l".
+            if re.search(rf"[-_]{re.escape(size)}(?:[^a-z0-9]|$)", basename):
+                return size
+            if basename.startswith(f"{size}"):
                 return size
         return None
 

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -257,17 +257,36 @@ class LibreRTDETR(BaseModel):
         sizes = list(cls.INPUT_SIZES.keys())
         # Sort by length descending to match r50m before r50
         sizes_sorted = sorted(sizes, key=len, reverse=True)
-        basename = os.path.basename(filename)
+        basename = os.path.basename(filename).lower()
+        prefix = cls.FILENAME_PREFIX.lower()
+
+        # Upstream RT-DETR v1 checkpoint names: rtdetr_r50vd_..., rtdetr_r18vd_...
+        m = re.search(r"rtdetr_r(\d+)vd(_m)?", basename)
+        if m:
+            depth, m_suffix = m.group(1), m.group(2)
+            candidate = f"r{depth}m" if m_suffix else f"r{depth}"
+            if candidate in cls.INPUT_SIZES:
+                return candidate
+
         for size in sizes_sorted:
-            pattern = rf"{cls.FILENAME_PREFIX}[-_]?{re.escape(size)}[^a-z0-9]"
+            pattern = rf"{prefix}[-_]?{re.escape(size)}[^a-z0-9]"
             if re.search(pattern, basename):
                 return size
-            # Require a word boundary after the size code so that e.g. "-l"
-            # doesn't match inside "-large" when size=="l".
-            if re.search(rf"[-_]{re.escape(size)}(?:[^a-z0-9]|$)", basename):
-                return size
-            if basename.startswith(f"{size}"):
-                return size
+            if len(size) == 1:
+                # Single-char sizes (l, x) need a word boundary to avoid matching
+                # inside longer words, e.g. "-l" inside "-large".
+                if re.search(rf"[-_]{re.escape(size)}(?:[^a-z0-9]|$)", basename):
+                    return size
+                if re.search(rf"^{re.escape(size)}[-_]", basename):
+                    return size
+            else:
+                # Multi-char sizes (r50, r101, …) are specific enough that a plain
+                # substring check is safe and preserves upstream filename hints like
+                # rtdetr_r50vd_... that don't use the LibreRTDETR prefix.
+                if f"-{size}" in basename or f"_{size}" in basename:
+                    return size
+                if basename.startswith(f"{size}"):
+                    return size
         return None
 
     # =========================================================================

--- a/libreyolo/models/rtdetrv2/model.py
+++ b/libreyolo/models/rtdetrv2/model.py
@@ -32,15 +32,15 @@ class LibreRTDETRv2(LibreRTDETR):
 
     @classmethod
     def detect_size_from_filename(cls, filename: str) -> Optional[str]:
-        detected = super().detect_size_from_filename(filename)
-        if detected is not None:
-            return detected
+        # Must run before super() to prevent "_r50" substring from shadowing "r50m".
         basename = os.path.basename(filename).lower()
-        m = re.search(r"rtdetrv2_r(\d+)vd(_m)?_", basename)
+        m = re.search(r"rtdetrv2_r(\d+)vd(_m)?", basename)
         if m:
             depth, m_suffix = m.group(1), m.group(2)
-            return f"r{depth}m" if m_suffix else f"r{depth}"
-        return None
+            candidate = f"r{depth}m" if m_suffix else f"r{depth}"
+            if candidate in cls.INPUT_SIZES:
+                return candidate
+        return super().detect_size_from_filename(filename)
 
     @classmethod
     def _get_trainer_class(cls):

--- a/libreyolo/models/rtdetrv2/model.py
+++ b/libreyolo/models/rtdetrv2/model.py
@@ -34,7 +34,7 @@ class LibreRTDETRv2(LibreRTDETR):
     def detect_size_from_filename(cls, filename: str) -> Optional[str]:
         # Must run before super() to prevent "_r50" substring from shadowing "r50m".
         basename = os.path.basename(filename).lower()
-        m = re.search(r"rtdetrv2_r(\d+)vd(_m)?", basename)
+        m = re.search(r"rtdetrv2_r(\d+)vd(_m)?(?=[-_.]|$)", basename)
         if m:
             depth, m_suffix = m.group(1), m.group(2)
             candidate = f"r{depth}m" if m_suffix else f"r{depth}"

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -80,7 +80,7 @@ class BaseValidator(ABC):
     def _setup(self, **kwargs) -> None:
         if hasattr(self.model.model, "to"):
             self.model.model.to(self.device)
-        self.model.device = self.device  # keep wrapper device in sync with inner module
+            self.model.device = self.device
 
         if self.config.save_dir:
             self.save_dir = Path(self.config.save_dir)

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -78,6 +78,8 @@ class BaseValidator(ABC):
         return device
 
     def _setup(self, **kwargs) -> None:
+        self.model.model.to(self.device)
+
         if self.config.save_dir:
             self.save_dir = Path(self.config.save_dir)
         else:

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -70,7 +70,11 @@ class BaseValidator(ABC):
             else:
                 device = torch.device("cpu")
         else:
-            device = torch.device(self.config.device)
+            # bare index "0" / "0,1" -> "cuda:0"
+            dev = self.config.device.split(",")[0].strip()
+            if dev.isdigit():
+                dev = f"cuda:{dev}"
+            device = torch.device(dev)
         return device
 
     def _setup(self, **kwargs) -> None:

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -78,7 +78,8 @@ class BaseValidator(ABC):
         return device
 
     def _setup(self, **kwargs) -> None:
-        self.model.model.to(self.device)
+        if hasattr(self.model.model, "to"):
+            self.model.model.to(self.device)
         self.model.device = self.device  # keep wrapper device in sync with inner module
 
         if self.config.save_dir:

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -79,6 +79,7 @@ class BaseValidator(ABC):
 
     def _setup(self, **kwargs) -> None:
         self.model.model.to(self.device)
+        self.model.device = self.device  # keep wrapper device in sync with inner module
 
         if self.config.save_dir:
             self.save_dir = Path(self.config.save_dir)

--- a/tests/unit/test_backend_validation_adapter.py
+++ b/tests/unit/test_backend_validation_adapter.py
@@ -95,6 +95,28 @@ def test_backend_eval_proxy_has_no_to():
     assert hasattr(proxy, "eval")
 
 
+def test_validator_setup_does_not_overwrite_backend_string_device():
+    """_setup must not replace a backend's string device with a torch.device."""
+    from libreyolo.backends.base import _BackendEvalProxy
+
+    class _FakeModel:
+        device = "cpu"
+        model = _BackendEvalProxy()
+
+        def _get_model_name(self):
+            return "test"
+
+        size = "n"
+
+    fake = _FakeModel()
+    # Simulate what _setup does for a proxy-backed model
+    if hasattr(fake.model, "to"):
+        fake.model.to(torch.device("cuda"))
+        fake.device = torch.device("cuda")
+
+    assert fake.device == "cpu"  # untouched — no .to() on proxy
+
+
 def test_backend_init_allows_read_only_size_property():
     class _ReadOnlySizeBackend(_Backend):
         @property

--- a/tests/unit/test_backend_validation_adapter.py
+++ b/tests/unit/test_backend_validation_adapter.py
@@ -87,6 +87,14 @@ def test_backend_forward_falls_back_for_fixed_batch_exports():
     assert outputs[0][:, 0, 0].tolist() == [48.0, 48.0, 48.0]
 
 
+def test_backend_eval_proxy_has_no_to():
+    from libreyolo.backends.base import _BackendEvalProxy
+
+    proxy = _BackendEvalProxy()
+    assert not hasattr(proxy, "to")
+    assert hasattr(proxy, "eval")
+
+
 def test_backend_init_allows_read_only_size_property():
     class _ReadOnlySizeBackend(_Backend):
         @property

--- a/tests/unit/test_deim.py
+++ b/tests/unit/test_deim.py
@@ -11,6 +11,40 @@ from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
 pytestmark = pytest.mark.unit
 
 
+class TestDFINESizeDetectionFromFilename:
+    """Test LibreDFINE.detect_size_from_filename."""
+
+    @pytest.mark.parametrize("size", ["n", "s", "m", "l", "x"])
+    def test_all_sizes_via_libre_prefix(self, size):
+        from libreyolo.models.dfine.model import LibreDFINE
+
+        assert LibreDFINE.detect_size_from_filename(f"LibreDFINE{size}.pt") == size
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("dfine_hgnetv2_n_coco.pth", "n"),
+            ("dfine_hgnetv2_s_coco.pth", "s"),
+            ("dfine_hgnetv2_l_coco.pth", "l"),
+            ("dfine_x_coco.pth", "x"),
+        ],
+    )
+    def test_upstream_dfine_checkpoints(self, filename, expected):
+        from libreyolo.models.dfine.model import LibreDFINE
+
+        assert LibreDFINE.detect_size_from_filename(filename) == expected
+
+    def test_no_false_positive_for_xl_suffix(self):
+        from libreyolo.models.dfine.model import LibreDFINE
+
+        assert LibreDFINE.detect_size_from_filename("dfine_hgnetv2_xl_coco.pth") is None
+
+    def test_unknown_filename_returns_none(self):
+        from libreyolo.models.dfine.model import LibreDFINE
+
+        assert LibreDFINE.detect_size_from_filename("yolov8n.pt") is None
+
+
 def test_deim_is_registered_and_detects_upstream_filename():
     from libreyolo import LibreDEIM
     from libreyolo.models.base.model import BaseModel

--- a/tests/unit/test_rfdetr.py
+++ b/tests/unit/test_rfdetr.py
@@ -1,8 +1,12 @@
-"""Unit tests for LibreRFDETR filename-based size detection."""
+"""Unit tests for LibreRFDETR filename-based size and task detection."""
 
 import pytest
 
-from libreyolo.models.rfdetr.model import LibreRFDETR
+_rfdetr_mod = pytest.importorskip(
+    "libreyolo.models.rfdetr.model",
+    reason="native RF-DETR dependencies not installed (pip install libreyolo[rfdetr])",
+)
+LibreRFDETR = _rfdetr_mod.LibreRFDETR
 
 pytestmark = pytest.mark.unit
 
@@ -37,3 +41,33 @@ class TestRFDETRSizeDetectionFromFilename:
 
     def test_rtdetr_filename_returns_none(self):
         assert LibreRFDETR.detect_size_from_filename("rtdetr_r50vd_6ep_coco.pth") is None
+
+
+class TestRFDETRTaskDetectionFromFilename:
+    """Test LibreRFDETR.detect_task_from_filename."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "rf-detr-nano.pth",
+            "rf-detr-small.pth",
+            "rf-detr-medium.pth",
+            "rf-detr-large-2026.pth",
+        ],
+    )
+    def test_detect_filenames_return_none_task(self, filename):
+        assert LibreRFDETR.detect_task_from_filename(filename) is None
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "rf-detr-seg-nano.pt",
+            "rf-detr-seg-small.pt",
+            "rf-detr-seg-medium.pt",
+            "rf-detr-seg-large.pt",
+            "rf-detr-seg-xlarge.pt",
+            "rf-detr-seg-xxlarge.pt",
+        ],
+    )
+    def test_seg_filenames_return_segment_task(self, filename):
+        assert LibreRFDETR.detect_task_from_filename(filename) == "segment"

--- a/tests/unit/test_rfdetr.py
+++ b/tests/unit/test_rfdetr.py
@@ -1,0 +1,39 @@
+"""Unit tests for LibreRFDETR filename-based size detection."""
+
+import pytest
+
+from libreyolo.models.rfdetr.model import LibreRFDETR
+
+pytestmark = pytest.mark.unit
+
+
+class TestRFDETRSizeDetectionFromFilename:
+    """Test LibreRFDETR.detect_size_from_filename."""
+
+    @pytest.mark.parametrize("size", ["n", "s", "m", "l"])
+    def test_all_detect_sizes_via_libre_prefix(self, size):
+        assert LibreRFDETR.detect_size_from_filename(f"LibreRFDETR{size}.pt") == size
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("rf-detr-nano.pth", "n"),
+            ("rf-detr-small.pth", "s"),
+            ("rf-detr-medium.pth", "m"),
+            ("rf-detr-large-2026.pth", "l"),
+            ("rf-detr-seg-nano.pt", "n"),
+            ("rf-detr-seg-small.pt", "s"),
+            ("rf-detr-seg-medium.pt", "m"),
+            ("rf-detr-seg-large.pt", "l"),
+            ("rf-detr-seg-xlarge.pt", "x"),
+            ("rf-detr-seg-xxlarge.pt", "xx"),
+        ],
+    )
+    def test_upstream_filenames(self, filename, expected):
+        assert LibreRFDETR.detect_size_from_filename(filename) == expected
+
+    def test_unknown_filename_returns_none(self):
+        assert LibreRFDETR.detect_size_from_filename("yolov8n.pt") is None
+
+    def test_rtdetr_filename_returns_none(self):
+        assert LibreRFDETR.detect_size_from_filename("rtdetr_r50vd_6ep_coco.pth") is None

--- a/tests/unit/test_rtdetr.py
+++ b/tests/unit/test_rtdetr.py
@@ -191,6 +191,20 @@ class TestRTDETRSizeDetectionFromFilename:
     def test_unknown_filename_returns_none(self):
         assert LibreRTDETR.detect_size_from_filename("yolov8n.pt") is None
 
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "rtdetrv2_r50vd_6x_coco_ema.pth",
+            "rtdetrv2_r18vd_120e_coco_rerun.pth",
+            "rtdetrv2_r101vd_6x_coco_ema.pth",
+        ],
+    )
+    def test_v1_does_not_claim_upstream_v2_filenames(self, filename):
+        # Regression: word-boundary fix must prevent "_r50" substring in
+        # "rtdetrv2_r50vd_..." from matching the v1 fallback.  v2 filenames
+        # must route through LibreRTDETRv2, not LibreRTDETR.
+        assert LibreRTDETR.detect_size_from_filename(filename) is None
+
 
 class TestRTDETRDetectNbClasses:
     """Test RTDETR class count detection."""

--- a/tests/unit/test_rtdetr.py
+++ b/tests/unit/test_rtdetr.py
@@ -161,6 +161,37 @@ class TestRTDETRDetectSize:
         assert LibreRTDETR.detect_size(weights) == "x"
 
 
+class TestRTDETRSizeDetectionFromFilename:
+    """Test LibreRTDETR.detect_size_from_filename."""
+
+    @pytest.mark.parametrize("size", ["r18", "r34", "r50", "r50m", "r101", "l", "x"])
+    def test_all_sizes_via_libre_prefix(self, size):
+        assert LibreRTDETR.detect_size_from_filename(f"LibreRTDETR-{size}.pt") == size
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("rtdetr_r18vd_6ep_coco_from_paddle.pth", "r18"),
+            ("rtdetr_r34vd_6ep_coco_from_paddle.pth", "r34"),
+            ("rtdetr_r50vd_6ep_coco_from_paddle.pth", "r50"),
+            ("rtdetr_r50vd_m_6ep_coco_from_paddle.pth", "r50m"),
+            ("rtdetr_r101vd_6ep_coco_from_paddle.pth", "r101"),
+        ],
+    )
+    def test_upstream_v1_vd_checkpoints(self, filename, expected):
+        assert LibreRTDETR.detect_size_from_filename(filename) == expected
+
+    def test_l_no_false_positive_in_large(self):
+        # The word-boundary fix: "LibreRTDETR-large" must not match size "l"
+        assert LibreRTDETR.detect_size_from_filename("LibreRTDETR-large.pt") is None
+
+    def test_x_no_false_positive_in_xl(self):
+        assert LibreRTDETR.detect_size_from_filename("LibreRTDETR-xl.pt") is None
+
+    def test_unknown_filename_returns_none(self):
+        assert LibreRTDETR.detect_size_from_filename("yolov8n.pt") is None
+
+
 class TestRTDETRDetectNbClasses:
     """Test RTDETR class count detection."""
 

--- a/tests/unit/test_rtdetrv2.py
+++ b/tests/unit/test_rtdetrv2.py
@@ -1,0 +1,44 @@
+"""Unit tests for LibreRTDETRv2.detect_size_from_filename."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestRTDETRv2SizeDetectionFromFilename:
+    """Test LibreRTDETRv2.detect_size_from_filename."""
+
+    @pytest.mark.parametrize("size", ["r18", "r34", "r50", "r50m", "r101"])
+    def test_all_sizes_via_libre_prefix(self, size):
+        from libreyolo.models.rtdetrv2.model import LibreRTDETRv2
+
+        assert LibreRTDETRv2.detect_size_from_filename(f"LibreRTDETRv2-{size}.pt") == size
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("rtdetrv2_r18vd_120e_coco_rerun.pth", "r18"),
+            ("rtdetrv2_r34vd_120e_coco_rerun.pth", "r34"),
+            ("rtdetrv2_r50vd_6x_coco_ema.pth", "r50"),
+            ("rtdetrv2_r50vd_m_7x_coco_ema.pth", "r50m"),
+            ("rtdetrv2_r101vd_6x_coco_ema.pth", "r101"),
+        ],
+    )
+    def test_upstream_v2_vd_checkpoints(self, filename, expected):
+        from libreyolo.models.rtdetrv2.model import LibreRTDETRv2
+
+        assert LibreRTDETRv2.detect_size_from_filename(filename) == expected
+
+    def test_r50vd_m_returns_r50m_not_r50(self):
+        # Regression: super()'s substring fallback would match "_r50" inside
+        # "rtdetrv2_r50vd_m_..." and return "r50" before the v2 regex ran.
+        from libreyolo.models.rtdetrv2.model import LibreRTDETRv2
+
+        assert LibreRTDETRv2.detect_size_from_filename("rtdetrv2_r50vd_m_7x_coco_ema.pth") == "r50m"
+
+    def test_unknown_filename_returns_none(self):
+        from libreyolo.models.rtdetrv2.model import LibreRTDETRv2
+
+        assert LibreRTDETRv2.detect_size_from_filename("yolov8n.pt") is None

--- a/tests/unit/test_rtdetrv4.py
+++ b/tests/unit/test_rtdetrv4.py
@@ -1,0 +1,43 @@
+"""Unit tests for LibreRTDETRv4.detect_size_from_filename."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestRTDETRv4SizeDetectionFromFilename:
+    """Test LibreRTDETRv4.detect_size_from_filename."""
+
+    @pytest.mark.parametrize("size", ["s", "m", "l", "x"])
+    def test_all_sizes_via_libre_prefix(self, size):
+        from libreyolo.models.rtdetrv4.model import LibreRTDETRv4
+
+        assert LibreRTDETRv4.detect_size_from_filename(f"LibreRTDETRv4{size}.pt") == size
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("rtv4_s_coco.pth", "s"),
+            ("rtv4_m_coco.pth", "m"),
+            ("rtv4_hgnetv2_s_coco.pth", "s"),
+            ("rtv4_hgnetv2_l_coco.pth", "l"),
+            ("rtv4_hgnetv2_x_coco.pth", "x"),
+        ],
+    )
+    def test_upstream_v4_checkpoints(self, filename, expected):
+        from libreyolo.models.rtdetrv4.model import LibreRTDETRv4
+
+        assert LibreRTDETRv4.detect_size_from_filename(filename) == expected
+
+    def test_no_false_positive_for_two_char_suffix(self):
+        # "sl" must not match "s" or "l"
+        from libreyolo.models.rtdetrv4.model import LibreRTDETRv4
+
+        assert LibreRTDETRv4.detect_size_from_filename("rtv4_hgnetv2_sl_coco.pth") is None
+
+    def test_unknown_filename_returns_none(self):
+        from libreyolo.models.rtdetrv4.model import LibreRTDETRv4
+
+        assert LibreRTDETRv4.detect_size_from_filename("yolov8n.pt") is None


### PR DESCRIPTION
## Summary

- **RT-DETR size matching** — tighten the fallback regex to require a
  word boundary after the size code, preventing `"-l"` from matching
  inside `"-large"` (and similar collisions between size tokens).
- **Validator device** — normalise bare GPU index strings (`"0"`, `"0,1"`)
  to `cuda:0` before passing to `torch.device`, consistent with how the
  trainer already handles this.