### PR TITLE
fix: RF-DETR imgsz silently overridden in train() and CLI

### DIFF
--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -377,6 +377,9 @@ def _build_rfdetr_train_kwargs(
             kwargs[target_name] = params[cli_name]
 
     provided = user_provided or set()
+    if "imgsz" in provided and params.get("imgsz") is not None:
+        kwargs["imgsz"] = params["imgsz"]
+
     if "patience" in params:
         kwargs["early_stopping"] = params["patience"] > 0
         kwargs["early_stopping_patience"] = params["patience"]

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -180,7 +180,6 @@ class LibreRFDETR(BaseModel):
 
     # CLI parameters intentionally ignored by native RF-DETR training.
     UNSUPPORTED_TRAIN_PARAMS: ClassVar[set[str]] = {
-        "imgsz",
         "mosaic",
         "mixup",
         "degrees",
@@ -658,9 +657,10 @@ class LibreRFDETR(BaseModel):
                 "exist_ok": True,
                 "size": self.size,
                 "num_classes": self.nb_classes,
-                "imgsz": self.input_size,
             }
         )
+        if train_kwargs.get("imgsz") is None:
+            train_kwargs["imgsz"] = self.input_size
 
         aliases = {
             "num_workers": "workers",

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -90,6 +90,19 @@ class RFDETRTrainer(BaseTrainer):
     def create_transforms(self):
         patch_size = int(getattr(self.model, "patch_size", 16))
         num_windows = int(getattr(self.model, "num_windows", 4))
+        block_size = patch_size * num_windows
+        # Only enforce divisibility when imgsz is the literal backbone input.
+        # With multi_scale=True the scale list is always block-aligned by
+        # compute_multi_scale_scales(), so imgsz just seeds the range.
+        fixed_size = not self.config.multi_scale or self.config.do_random_resize_via_padding
+        if fixed_size and self.config.imgsz % block_size != 0:
+            lo = (self.config.imgsz // block_size) * block_size
+            hi = lo + block_size
+            raise ValueError(
+                f"imgsz={self.config.imgsz} is not divisible by {block_size} "
+                f"(patch_size={patch_size} x num_windows={num_windows}). "
+                f"Use {lo} or {hi}."
+            )
         if getattr(self.wrapper_model, "task", "detect") == "segment":
             preproc = RFDETRSegTransform(
                 max_labels=300,

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -91,11 +91,9 @@ class RFDETRTrainer(BaseTrainer):
         patch_size = int(getattr(self.model, "patch_size", 16))
         num_windows = int(getattr(self.model, "num_windows", 4))
         block_size = patch_size * num_windows
-        # Only enforce divisibility when imgsz is the literal backbone input.
-        # With multi_scale=True the scale list is always block-aligned by
-        # compute_multi_scale_scales(), so imgsz just seeds the range.
-        fixed_size = not self.config.multi_scale or self.config.do_random_resize_via_padding
-        if fixed_size and self.config.imgsz % block_size != 0:
+        # Validation always uses the literal imgsz, so divisibility is required
+        # regardless of multi_scale mode.
+        if self.config.imgsz % block_size != 0:
             lo = (self.config.imgsz // block_size) * block_size
             hi = lo + block_size
             raise ValueError(

--- a/tests/unit/test_rfdetr_imgsz_override.py
+++ b/tests/unit/test_rfdetr_imgsz_override.py
@@ -1,0 +1,123 @@
+"""Unit tests for RF-DETR imgsz handling in train() and create_transforms()."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+rfdetr_model = pytest.importorskip("libreyolo.models.rfdetr.model")
+rfdetr_trainer = pytest.importorskip("libreyolo.models.rfdetr.trainer")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_wrapper(input_size: int = 504) -> rfdetr_model.LibreRFDETR:
+    wrapper = rfdetr_model.LibreRFDETR.__new__(rfdetr_model.LibreRFDETR)
+    wrapper.model = object()
+    wrapper.size = "l"
+    wrapper.nb_classes = 80
+    wrapper.input_size = input_size
+    return wrapper
+
+
+def _make_trainer(imgsz: int, *, multi_scale: bool = False) -> rfdetr_trainer.RFDETRTrainer:
+    """Construct a RFDETRTrainer stub without calling __init__."""
+    trainer = rfdetr_trainer.RFDETRTrainer.__new__(rfdetr_trainer.RFDETRTrainer)
+    trainer.config = rfdetr_trainer.RFDETRConfig(
+        data=None,
+        imgsz=imgsz,
+        multi_scale=multi_scale,
+        do_random_resize_via_padding=False,
+    )
+
+    class _FakeModel:
+        patch_size = 6
+        num_windows = 4  # block_size = 24
+
+    class _FakeWrapper:
+        task = "detect"
+
+    trainer.model = _FakeModel()
+    trainer.wrapper_model = _FakeWrapper()
+    return trainer
+
+
+# ---------------------------------------------------------------------------
+# train() kwarg assembly
+# ---------------------------------------------------------------------------
+
+def test_explicit_imgsz_is_not_overridden(monkeypatch, tmp_path):
+    """imgsz=624 supplied to train() must not be overwritten by model.input_size=504."""
+    captured = {}
+
+    class _DummyTrainer:
+        def __init__(self, model, wrapper_model=None, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def train(self):
+            return {"save_dir": str(tmp_path / "exp")}
+
+    monkeypatch.setattr(rfdetr_model, "RFDETRTrainer", _DummyTrainer)
+
+    wrapper = _make_wrapper(input_size=504)
+    wrapper.train(data="data.yaml", imgsz=624, output_dir=str(tmp_path / "run"))
+
+    assert captured["kwargs"]["imgsz"] == 624
+
+
+def test_default_imgsz_applied_when_not_supplied(monkeypatch, tmp_path):
+    """When imgsz is not passed, model.input_size is used as the fallback."""
+    captured = {}
+
+    class _DummyTrainer:
+        def __init__(self, model, wrapper_model=None, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def train(self):
+            return {"save_dir": str(tmp_path / "exp")}
+
+    monkeypatch.setattr(rfdetr_model, "RFDETRTrainer", _DummyTrainer)
+
+    wrapper = _make_wrapper(input_size=504)
+    wrapper.train(data="data.yaml", output_dir=str(tmp_path / "run"))
+
+    assert captured["kwargs"]["imgsz"] == 504
+
+
+def test_imgsz_none_falls_back_to_model_default(monkeypatch, tmp_path):
+    """imgsz=None must not be forwarded; model.input_size is used instead."""
+    captured = {}
+
+    class _DummyTrainer:
+        def __init__(self, model, wrapper_model=None, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def train(self):
+            return {"save_dir": str(tmp_path / "exp")}
+
+    monkeypatch.setattr(rfdetr_model, "RFDETRTrainer", _DummyTrainer)
+
+    wrapper = _make_wrapper(input_size=504)
+    wrapper.train(data="data.yaml", imgsz=None, output_dir=str(tmp_path / "run"))
+
+    assert captured["kwargs"]["imgsz"] == 504
+
+
+# ---------------------------------------------------------------------------
+# create_transforms() divisibility validation
+# ---------------------------------------------------------------------------
+
+def test_imgsz_not_divisible_by_block_size_raises():
+    """imgsz=500 with block_size=24 (6*4) and multi_scale=False must raise ValueError."""
+    trainer = _make_trainer(imgsz=500, multi_scale=False)
+    with pytest.raises(ValueError, match="not divisible by 24"):
+        trainer.create_transforms()
+
+
+def test_imgsz_not_divisible_allowed_with_multi_scale():
+    """With multi_scale=True the divisibility check is skipped."""
+    trainer = _make_trainer(imgsz=500, multi_scale=True)
+    # Must not raise; we don't care about the return value here.
+    trainer.create_transforms()

--- a/tests/unit/test_rfdetr_imgsz_override.py
+++ b/tests/unit/test_rfdetr_imgsz_override.py
@@ -116,8 +116,8 @@ def test_imgsz_not_divisible_by_block_size_raises():
         trainer.create_transforms()
 
 
-def test_imgsz_not_divisible_allowed_with_multi_scale():
-    """With multi_scale=True the divisibility check is skipped."""
+def test_imgsz_not_divisible_raises_with_multi_scale_too():
+    """Validation always uses literal imgsz, so divisibility is required even with multi_scale=True."""
     trainer = _make_trainer(imgsz=500, multi_scale=True)
-    # Must not raise; we don't care about the return value here.
-    trainer.create_transforms()
+    with pytest.raises(ValueError, match="not divisible by 24"):
+        trainer.create_transforms()


### PR DESCRIPTION
Three independent defects caused a user-supplied imgsz to be ignored when fine-tuning RF-DETR:

"`imgsz`" was listed in `UNSUPPORTED_TRAIN_PARAMS`, so BaseModel.train() stripped it before forwarding to `LibreRFDETR.train()`
`train_kwargs.update({"imgsz": self.input_size})` then unconditionally reset it to the model default

The CLI path (`_build_rfdetr_train_kwargs`) never forwarded `--imgsz` even when explicitly supplied

Also adds an early `ValueError` in `create_transforms()` when imgsz is not divisible by patch_size × num_windows. The check fires unconditionally because validation always uses the literal imgsz regardless of multi_scale mode.