### PR TITLE
fix: sync wrapper_model.device after model.to() in BaseTrainer.setup

### DIFF
--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -501,6 +501,8 @@ class BaseTrainer(ABC):
         if is_main_process():
             logger.info("Setting up training...")
         self.model.to(self.device)
+        if self.wrapper_model is not None:
+            self.wrapper_model.device = self.device
 
         # SyncBatchNorm conversion: only meaningful under DDP. Single-GPU
         # runs skip this regardless of the flag so single-GPU is unchanged.

--- a/tests/unit/test_rfdetr_seg_trainer_smoke.py
+++ b/tests/unit/test_rfdetr_seg_trainer_smoke.py
@@ -1,0 +1,77 @@
+"""RF-DETR seg trainer smoke tests — wiring only, no data."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+
+def _make_trainer(task="segment"):
+    from libreyolo import LibreRFDETR
+    from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+    wrapper = LibreRFDETR(None, size="s", task=task, device="cpu")
+    trainer = RFDETRTrainer(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="s",
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=2,
+        imgsz=560,
+        device="cpu",
+        amp=False,
+        ema=False,
+        no_aug_epochs=0,
+        warmup_epochs=0,
+        eval_interval=-1,
+    )
+    return wrapper, trainer
+
+
+def _fake_train_loader(n=2):
+    loader = MagicMock()
+    loader.__len__ = MagicMock(return_value=n)
+    return loader
+
+
+def _fake_scheduler():
+    sched = MagicMock()
+    sched.update_lr = MagicMock(return_value=1e-4)
+    return sched
+
+
+def _fake_optimizer(model):
+    dummy = torch.nn.Linear(2, 2)
+    return torch.optim.AdamW(dummy.parameters(), lr=1e-4)
+
+
+def test_setup_syncs_wrapper_device_to_trainer_device():
+    """wrapper_model.device must equal trainer.device after setup()."""
+    wrapper, trainer = _make_trainer(task="segment")
+
+    # Poison the wrapper device so we can detect that setup() corrects it.
+    wrapper.device = torch.device("meta")
+    assert wrapper.device != trainer.device
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with (
+            patch.object(trainer, "_setup_data", side_effect=lambda: setattr(trainer, "train_loader", _fake_train_loader())),
+            patch.object(trainer, "_setup_optimizer", side_effect=lambda: _fake_optimizer(trainer.model)),
+            patch.object(trainer, "create_scheduler", return_value=_fake_scheduler()),
+            patch.object(trainer, "on_setup"),
+            patch("libreyolo.training.trainer.barrier"),
+            patch.object(trainer, "_get_save_dir", return_value=Path(tmp)),
+        ):
+            trainer.setup()
+
+    assert wrapper.device == trainer.device, (
+        f"wrapper.device={wrapper.device!r} was not synced to trainer.device={trainer.device!r}"
+    )

--- a/tests/unit/test_rfdetr_seg_trainer_smoke.py
+++ b/tests/unit/test_rfdetr_seg_trainer_smoke.py
@@ -1,31 +1,58 @@
-"""RF-DETR seg trainer smoke tests — wiring only, no data."""
+"""BaseTrainer device-sync smoke tests — wiring only, no data."""
 
 from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+import torch.nn as nn
 
 pytestmark = pytest.mark.unit
 
 
-def _make_trainer(task="segment"):
-    from libreyolo import LibreRFDETR
-    from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+class _MinimalTrainer:
+    """Minimal concrete BaseTrainer that satisfies all abstract methods."""
 
-    wrapper = LibreRFDETR(None, size="s", task=task, device="cpu")
-    trainer = RFDETRTrainer(
-        model=wrapper.model,
+    def get_model_family(self):
+        return "test"
+
+    def get_model_tag(self):
+        return "test-s"
+
+    def create_transforms(self):
+        return None, None
+
+    def create_scheduler(self, _iters_per_epoch):
+        sched = MagicMock()
+        sched.update_lr = MagicMock(return_value=1e-4)
+        return sched
+
+    def get_loss_components(self, _outputs):
+        return {}
+
+
+def _make_trainer(wrapper_device="meta"):
+    from libreyolo.training.trainer import BaseTrainer
+
+    # Dynamically create a concrete subclass.
+    Trainer = type("_T", (_MinimalTrainer, BaseTrainer), {})
+
+    model = nn.Linear(4, 4)
+    wrapper = SimpleNamespace(device=torch.device(wrapper_device), task="detect")
+
+    trainer = Trainer(
+        model=model,
         wrapper_model=wrapper,
         size="s",
-        num_classes=80,
+        num_classes=2,
         data=None,
         epochs=1,
         batch=2,
-        imgsz=560,
+        imgsz=64,
         device="cpu",
         amp=False,
         ema=False,
@@ -36,42 +63,23 @@ def _make_trainer(task="segment"):
     return wrapper, trainer
 
 
-def _fake_train_loader(n=2):
-    loader = MagicMock()
-    loader.__len__ = MagicMock(return_value=n)
-    return loader
-
-
-def _fake_scheduler():
-    sched = MagicMock()
-    sched.update_lr = MagicMock(return_value=1e-4)
-    return sched
-
-
-def _fake_optimizer(model):
-    dummy = torch.nn.Linear(2, 2)
-    return torch.optim.AdamW(dummy.parameters(), lr=1e-4)
-
-
 def test_setup_syncs_wrapper_device_to_trainer_device():
     """wrapper_model.device must equal trainer.device after setup()."""
-    wrapper, trainer = _make_trainer(task="segment")
-
-    # Poison the wrapper device so we can detect that setup() corrects it.
-    wrapper.device = torch.device("meta")
+    wrapper, trainer = _make_trainer(wrapper_device="meta")
     assert wrapper.device != trainer.device
+
+    fake_loader = MagicMock()
+    fake_loader.__len__ = MagicMock(return_value=2)
 
     with tempfile.TemporaryDirectory() as tmp:
         with (
-            patch.object(trainer, "_setup_data", side_effect=lambda: setattr(trainer, "train_loader", _fake_train_loader())),
-            patch.object(trainer, "_setup_optimizer", side_effect=lambda: _fake_optimizer(trainer.model)),
-            patch.object(trainer, "create_scheduler", return_value=_fake_scheduler()),
-            patch.object(trainer, "on_setup"),
+            patch.object(trainer, "_setup_data", side_effect=lambda: setattr(trainer, "train_loader", fake_loader)),
+            patch.object(trainer, "_setup_optimizer", return_value=torch.optim.SGD(trainer.model.parameters(), lr=1e-4)),
             patch("libreyolo.training.trainer.barrier"),
             patch.object(trainer, "_get_save_dir", return_value=Path(tmp)),
         ):
             trainer.setup()
 
     assert wrapper.device == trainer.device, (
-        f"wrapper.device={wrapper.device!r} was not synced to trainer.device={trainer.device!r}"
+        f"wrapper.device={wrapper.device!r} not synced to trainer.device={trainer.device!r}"
     )


### PR DESCRIPTION
BaseTrainer.setup() moves the model to the resolved device with self.model.to(self.device) but never updates wrapper_model.device. Under DDP, the concrete device is only known after the process group initialises (e.g. cuda:0), so the wrapper was left reporting its construction-time value ("cpu"). Any inference call or device-aware allocation routed through the wrapper after setup() would use the wrong device.

Fix: immediately after model.to(device), copy the resolved device onto the wrapper:


if self.wrapper_model is not None:
    self.wrapper_model.device = self.device
No subclass overrides setup(), so there are no conflicts.

Affected trainers: all of them — YOLO9, RF-DETR, D-FINE, RT-DETR.