### PR TITLE
fix: guard model.to() calls against backend proxies in inference and validation

### DIFF
--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -212,7 +212,8 @@ class InferenceRunner:
         target = torch.device(device_str)
         if target != self.model.device:
             self.model.device = target
-            self.model.model.to(target)
+            if hasattr(self.model.model, "to"):
+                self.model.model.to(target)
 
     def _process_in_batches(
         self,

--- a/libreyolo/models/l2cs/inference.py
+++ b/libreyolo/models/l2cs/inference.py
@@ -343,4 +343,5 @@ class GazeInferenceRunner:
         target = torch.device(device_str)
         if target != self.model.device:
             self.model.device = target
-            self.model.model.to(target)
+            if hasattr(self.model.model, "to"):
+                self.model.model.to(target)

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -94,6 +94,9 @@ class BaseValidator(ABC):
         }
 
         self._init_metrics()
+        if hasattr(self.model.model, "to"):
+            self.model.model.to(self.device)
+            self.model.device = self.device
         self._warmup_model()
 
         if self.config.verbose:

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -94,9 +94,6 @@ class BaseValidator(ABC):
         }
 
         self._init_metrics()
-        if hasattr(self.model.model, "to"):
-            self.model.model.to(self.device)
-            self.model.device = self.device
         self._warmup_model()
 
         if self.config.verbose:

--- a/tests/unit/test_backend_validation_adapter.py
+++ b/tests/unit/test_backend_validation_adapter.py
@@ -133,3 +133,51 @@ def test_set_device_does_not_call_to_on_backend_proxy():
 
     # model.device is updated; proxy is left untouched (no .to() call).
     assert fake_model.device == torch.device("cuda:0")
+
+
+def test_validator_setup_does_not_overwrite_backend_device():
+    """When model.model is a _BackendEvalProxy, _setup() must not touch model.device."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, patch
+
+    from libreyolo.backends.base import _BackendEvalProxy
+    from libreyolo.validation.base import BaseValidator
+    from libreyolo.validation.config import ValidationConfig
+
+    class _StubValidator(BaseValidator):
+        def _setup_dataloader(self): return MagicMock(__len__=lambda s: 0)
+        def _init_metrics(self): pass
+        def _preprocess_batch(self, b): pass
+        def _postprocess_predictions(self, p, b): pass
+        def _update_metrics(self, p, t, i, ids=None): pass
+        def _compute_metrics(self): return {}
+
+    proxy = _BackendEvalProxy()
+    original_device = torch.device("cpu")
+    fake_model = SimpleNamespace(
+        device=original_device,
+        model=proxy,
+        _get_model_name=lambda: "test",
+        size="n",
+    )
+
+    config = ValidationConfig(data="x.yaml", device="cpu")
+    v = _StubValidator.__new__(_StubValidator)
+    v.model = fake_model
+    v.config = config
+    v.device = torch.device("cpu")
+    v.dataloader = None
+    v.seen = 0
+    v.speed = {"preprocess": 0.0, "inference": 0.0, "postprocess": 0.0, "total": 0.0}
+    v.save_dir = None
+
+    with (
+        patch.object(v, "_setup_dataloader", return_value=MagicMock()),
+        patch.object(v, "_init_metrics"),
+        patch.object(v, "_warmup_model"),
+        patch("pathlib.Path.mkdir"),
+    ):
+        v._setup()
+
+    # proxy has no .to() so model.device must be unchanged
+    assert fake_model.device is original_device

--- a/tests/unit/test_backend_validation_adapter.py
+++ b/tests/unit/test_backend_validation_adapter.py
@@ -100,3 +100,36 @@ def test_backend_init_allows_read_only_size_property():
 
     assert backend.size == "n"
     assert backend.FAMILY == "rfdetr"
+
+
+def test_backend_eval_proxy_has_no_to():
+    from libreyolo.backends.base import _BackendEvalProxy
+
+    proxy = _BackendEvalProxy()
+    assert not hasattr(proxy, "to")
+    assert hasattr(proxy, "eval")
+
+
+def test_set_device_does_not_call_to_on_backend_proxy():
+    """_set_device must not raise when model.model is a _BackendEvalProxy."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from libreyolo.backends.base import _BackendEvalProxy
+    from libreyolo.models.base.inference import InferenceRunner
+
+    proxy = _BackendEvalProxy()
+    fake_model = SimpleNamespace(
+        device=torch.device("cpu"),
+        model=proxy,
+    )
+
+    runner = object.__new__(InferenceRunner)
+    runner.model = fake_model
+
+    # Calling _set_device with a different device must not raise AttributeError.
+    with patch("torch.cuda.is_available", return_value=True):
+        runner._set_device("cuda:0")
+
+    # model.device is updated; proxy is left untouched (no .to() call).
+    assert fake_model.device == torch.device("cuda:0")

--- a/tests/unit/test_backend_validation_adapter.py
+++ b/tests/unit/test_backend_validation_adapter.py
@@ -135,49 +135,24 @@ def test_set_device_does_not_call_to_on_backend_proxy():
     assert fake_model.device == torch.device("cuda:0")
 
 
-def test_validator_setup_does_not_overwrite_backend_device():
-    """When model.model is a _BackendEvalProxy, _setup() must not touch model.device."""
+def test_l2cs_set_device_does_not_call_to_on_backend_proxy():
+    """GazeInferenceRunner._set_device must also tolerate _BackendEvalProxy."""
     from types import SimpleNamespace
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from libreyolo.backends.base import _BackendEvalProxy
-    from libreyolo.validation.base import BaseValidator
-    from libreyolo.validation.config import ValidationConfig
-
-    class _StubValidator(BaseValidator):
-        def _setup_dataloader(self): return MagicMock(__len__=lambda s: 0)
-        def _init_metrics(self): pass
-        def _preprocess_batch(self, b): pass
-        def _postprocess_predictions(self, p, b): pass
-        def _update_metrics(self, p, t, i, ids=None): pass
-        def _compute_metrics(self): return {}
+    from libreyolo.models.l2cs.inference import GazeInferenceRunner
 
     proxy = _BackendEvalProxy()
-    original_device = torch.device("cpu")
     fake_model = SimpleNamespace(
-        device=original_device,
+        device=torch.device("cpu"),
         model=proxy,
-        _get_model_name=lambda: "test",
-        size="n",
     )
 
-    config = ValidationConfig(data="x.yaml", device="cpu")
-    v = _StubValidator.__new__(_StubValidator)
-    v.model = fake_model
-    v.config = config
-    v.device = torch.device("cpu")
-    v.dataloader = None
-    v.seen = 0
-    v.speed = {"preprocess": 0.0, "inference": 0.0, "postprocess": 0.0, "total": 0.0}
-    v.save_dir = None
+    runner = object.__new__(GazeInferenceRunner)
+    runner.model = fake_model
 
-    with (
-        patch.object(v, "_setup_dataloader", return_value=MagicMock()),
-        patch.object(v, "_init_metrics"),
-        patch.object(v, "_warmup_model"),
-        patch("pathlib.Path.mkdir"),
-    ):
-        v._setup()
+    with patch("torch.cuda.is_available", return_value=True):
+        runner._set_device("cuda:0")
 
-    # proxy has no .to() so model.device must be unchanged
-    assert fake_model.device is original_device
+    assert fake_model.device == torch.device("cuda:0")


### PR DESCRIPTION
InferenceRunner._set_device() in models/base/inference.py and GazeInferenceRunner._set_device() in models/l2cs/inference.py both call self.model.model.to(device) unconditionally. When the inner model is a _BackendEvalProxy (ONNX / TensorRT backend), the proxy has no .to() method — device management is the runtime's responsibility — so the call raises AttributeError and prediction fails.

Fix: wrap both .to() calls with a hasattr guard. model.device is still updated so the wrapper reflects the intended device; only the PyTorch-specific .to() transfer is skipped for proxies.