### PR TITLE
fix: normalise bare integer device strings in BaseValidator._setup_device

### DIFF
--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -60,6 +60,19 @@ def _nms_numpy(
     return keep
 
 
+def _is_pytorch_cuda_device(device_str: str) -> bool:
+    """Return True only when device_str is a valid PyTorch CUDA device string.
+
+    Non-PyTorch runtimes (OpenVINO "gpu", CoreML "coreml", ncnn "ncnn") store
+    backend-specific device identifiers in self.device that are not parseable
+    by torch.device(); calling torch.device() on them raises RuntimeError.
+    """
+    try:
+        return torch.device(device_str).type == "cuda"
+    except RuntimeError:
+        return False
+
+
 def _is_nms_free_family(model_family: Optional[str]) -> bool:
     """Whether backend outputs should bypass generic NMS.
 
@@ -1002,7 +1015,7 @@ class BaseBackend(ABC):
             imgsz = self._get_input_size()
 
         validation_device = device or (
-            self.device if torch.device(self.device).type == "cuda" and torch.cuda.is_available() else "cpu"
+            self.device if _is_pytorch_cuda_device(self.device) and torch.cuda.is_available() else "cpu"
         )
         config = ValidationConfig(
             data=data,

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1002,7 +1002,7 @@ class BaseBackend(ABC):
             imgsz = self._get_input_size()
 
         validation_device = device or (
-            "cuda" if self.device == "cuda" and torch.cuda.is_available() else "cpu"
+            self.device if torch.device(self.device).type == "cuda" and torch.cuda.is_available() else "cpu"
         )
         config = ValidationConfig(
             data=data,

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -70,7 +70,10 @@ class BaseValidator(ABC):
             else:
                 device = torch.device("cpu")
         else:
-            device = torch.device(self.config.device)
+            device_str = self.config.device
+            if device_str.isdigit():
+                device_str = f"cuda:{device_str}"
+            device = torch.device(device_str)
         return device
 
     def _setup(self, **kwargs) -> None:

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -70,7 +70,7 @@ class BaseValidator(ABC):
             else:
                 device = torch.device("cpu")
         else:
-            device_str = self.config.device
+            device_str = str(self.config.device)
             if device_str.isdigit():
                 device_str = f"cuda:{device_str}"
             device = torch.device(device_str)

--- a/tests/unit/test_validator_device.py
+++ b/tests/unit/test_validator_device.py
@@ -1,0 +1,47 @@
+"""BaseValidator._setup_device normalisation tests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from libreyolo.validation.config import ValidationConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _setup_device(device: str) -> "torch.device":
+    from libreyolo.validation.base import BaseValidator
+
+    class _StubValidator(BaseValidator):
+        def _setup_dataloader(self): pass
+        def _init_metrics(self): pass
+        def _preprocess_batch(self, b): pass
+        def _postprocess_predictions(self, p, b): pass
+        def _update_metrics(self, p, t, i, ids=None): pass
+        def _compute_metrics(self): return {}
+
+    config = ValidationConfig(data="x.yaml", device=device)
+    v = object.__new__(_StubValidator)
+    v.config = config
+    return v._setup_device()
+
+
+def test_bare_integer_device_string_normalised():
+    with patch("torch.cuda.is_available", return_value=True):
+        device = _setup_device("0")
+    assert device.type == "cuda"
+    assert str(device) == "cuda:0"
+
+
+def test_bare_integer_string_two_digit():
+    with patch("torch.cuda.is_available", return_value=True):
+        device = _setup_device("10")
+    assert device.type == "cuda"
+    assert str(device) == "cuda:10"
+
+
+def test_named_device_strings_pass_through():
+    assert _setup_device("cpu").type == "cpu"
+    assert str(_setup_device("cuda:0")) == "cuda:0"


### PR DESCRIPTION
BaseValidator._setup_device() passes self.config.device directly to torch.device(). When a user passes a bare GPU index — device="0" or device="1" — PyTorch raises RuntimeError: Invalid device string: '0', crashing before any inference runs.

Fix: normalise bare integer strings to "cuda:<n>" before the torch.device() call, matching the pattern already used in InferenceRunner._set_device():


device_str = self.config.device
if device_str.isdigit():
    device_str = f"cuda:{device_str}"
device = torch.device(device_str)
BaseModel.val() passes the device string through raw to ValidationConfig, so fixing _setup_device() covers that path. InferenceRunner already handles this — no change needed there.