### PR TITLE
feature: Support LibreFOMO Integration (Point Localization)

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -31,8 +31,8 @@ Required field meanings:
 - `model_family`: registered LibreYOLO family, such as `yolo9`, `rfdetr`,
   `dfine`, or `ec`.
 - `size`: model variant within the family, such as `t`, `s`, `r18`, or `atto`.
-- `task`: canonical task, one of `detect`, `segment`, `pose`, `classify`, or
-  `gaze`.
+- `task`: canonical task, one of `detect`, `segment`, `pose`, `classify`,
+  `gaze`, or `point`.
 - `nc`: positive integer class count.
 - `names`: `dict[int, str]` with keys in `0..nc-1`. Official checkpoints
   should write every key. Readers may pad missing keys with `class_i` labels for

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -22,7 +22,7 @@ Libre<FAMILY><size>[-<task>].pt
 
 ## Family prefixes
 
-The 12 families currently registered:
+The 13 families currently registered:
 
 | Family id (`FAMILY`) | Filename prefix | Casing rule applied |
 |---|---|---|
@@ -37,6 +37,7 @@ The 12 families currently registered:
 | `rfdetr`    | `LibreRFDETR`   | All-caps acronym (hyphen dropped from `RF-DETR`) |
 | `picodet`   | `LibrePICODET`  | All-caps (`PicoDet` rendered uppercase) |
 | `ec`     | `LibreEC`    | Short form of EdgeCrafter — used as the family alias for the three sibling upstream models `ECDet`, `ECPose`, `ECSeg` |
+| `librefomo` | `LibreFOMO` | All-caps acronym (`FOMO`) |
 | `l2cs`      | `LibreL2CS`     | All-caps acronym (`L2CS` gaze estimation) — inference-only |
 
 Casing rules observed in the table:
@@ -77,6 +78,7 @@ ships:
 | `rfdetr`    | `n`, `s`, `m`, `l` |
 | `picodet`   | `s`, `m`, `l` (320 / 416 / 640 input) |
 | `ec`     | `s`, `m`, `l`, `x` |
+| `librefomo` | `s`, `m`, `l` (96 / 192 / 224 input) |
 | `l2cs`      | `r18`, `r34`, `r50`, `r101`, `r152` (ResNet backbone depth) |
 
 Notes:
@@ -98,6 +100,7 @@ From `libreyolo/tasks.py`:
 | `pose`        | `-pose` |
 | `classify`    | `-cls` |
 | `gaze`        | `-gaze` |
+| `point`       | `-point` |
 
 The factory accepts upstream-style aliases (`detection`, `det`, `segmentation`,
 `keypoints`, `cls`, …) at the API boundary; only the canonical names above
@@ -118,6 +121,7 @@ appear in filenames.
 | `rfdetr`    | `("detect", "segment")`             | detect | seg uses smaller sizes |
 | `yolonas`   | `("detect", "pose")`                | detect | pose adds size `n` |
 | `ec`     | `("detect", "pose", "segment")`     | detect | all three tasks |
+| `librefomo` | `("point",)`                       | point | point-localization; external weights |
 | `l2cs`      | `("gaze",)`                         | gaze   | inference-only; two-stage (face detector + gaze head); not trainable in LibreYOLO |
 
 Families that override `SUPPORTED_TASKS` also declare `TASK_INPUT_SIZES` so
@@ -159,6 +163,14 @@ LibreRFDETRn-seg.pt        # segment
 LibreECs.pt             # detect (default)
 LibreECs-pose.pt        # pose
 LibreECs-seg.pt         # segment
+```
+
+### Point Localization
+
+```text
+LibreFOMOs.pt           # point (default)
+LibreFOMOm.pt
+LibreFOMOl.pt
 ```
 
 ### Gaze (inference-only)

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     LibreDEIMv2,
     LibreEC,
     LibrePICODET,
+    LibreFOMO,
     LibreDAMOYOLO,
     LibreRTDETR,
     LibreRTDETRv2,
@@ -22,7 +23,7 @@ from .models import (
     LibreRTMDet,
     LibreL2CS,
 )
-from .utils.results import Results, Boxes, Masks, Keypoints, Probs, OBB, Gaze
+from .utils.results import Results, Boxes, Masks, Keypoints, Points, Probs, OBB, Gaze
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
 
@@ -70,6 +71,7 @@ def __getattr__(name):
         "DetectionValidator": (".validation", "DetectionValidator"),
         "SegmentationValidator": (".validation", "SegmentationValidator"),
         "PoseValidator": (".validation", "PoseValidator"),
+        "PointValidator": (".validation", "PointValidator"),
         "ValidationConfig": (".validation", "ValidationConfig"),
         "ByteTracker": (".tracking", "ByteTracker"),
         "TrackConfig": (".tracking", "TrackConfig"),
@@ -107,6 +109,7 @@ __all__ = [
     "LibreDEIMv2",
     "LibreEC",
     "LibrePICODET",
+    "LibreFOMO",
     "LibreDAMOYOLO",
     "LibreRTMDet",
     "LibreL2CS",
@@ -115,6 +118,7 @@ __all__ = [
     "Boxes",
     "Masks",
     "Keypoints",
+    "Points",
     "Probs",
     "OBB",
     "Gaze",
@@ -133,6 +137,7 @@ __all__ = [
     "DetectionValidator",
     "SegmentationValidator",
     "PoseValidator",
+    "PointValidator",
     "ValidationConfig",
     "DATASETS_DIR",
     "load_data_config",

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -54,6 +54,7 @@ from .rtdetrv4.model import LibreRTDETRv4  # noqa: E402  (must precede LibreDFIN
 from .dfine.model import LibreDFINE  # noqa: E402
 from .deim.model import LibreDEIM  # noqa: E402
 from .picodet.model import LibrePICODET  # noqa: E402
+from .librefomo.model import LibreFOMO  # noqa: E402
 from .rtdetr.model import LibreRTDETR  # noqa: E402  (registered before LibreRTDETRv2 so metadata-less ckpts default to v1)
 from .rtdetrv2.model import LibreRTDETRv2  # noqa: E402
 from .damoyolo.model import LibreDAMOYOLO  # noqa: E402
@@ -397,7 +398,7 @@ def LibreYOLO(
     if matched_cls is None:
         raise ValueError(
             "Could not detect model architecture from state dict keys.\n"
-            "Supported architectures: YOLOX, YOLOv9, YOLOv9-E2E, YOLO-NAS, RT-DETR, RF-DETR, D-FINE, DEIM, DEIMv2."
+            "Supported architectures: YOLOX, YOLOv9, YOLOv9-E2E, YOLO-NAS, RT-DETR, RF-DETR, D-FINE, DEIM, DEIMv2, LibreFOMO."
         )
 
     # Auto-detect size
@@ -524,6 +525,7 @@ __all__ = [
     "LibreDEIMv2",
     "LibreEC",
     "LibrePICODET",
+    "LibreFOMO",
     "LibreDAMOYOLO",
     "LibreRTMDet",
     "LibreRTDETR",

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -25,7 +25,7 @@ from ...utils.general import (
 )
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.predict_args import normalize_predict_kwargs
-from ...utils.results import Boxes, Keypoints, Masks, Results
+from ...utils.results import Boxes, Keypoints, Masks, Points, Results
 from ...utils.video import collect_video_results, is_video_file, run_video_inference
 
 logger = logging.getLogger(__name__)
@@ -293,6 +293,18 @@ class InferenceRunner:
         """Internal helper to draw boxes, masks, and keypoints and save to disk."""
         if len(result) > 0:
             annotated_img = original_img
+            if result.points is not None:
+                from PIL import ImageDraw
+
+                draw = ImageDraw.Draw(annotated_img)
+                points = result.points.cpu().data
+                for x, y, _cls, conf in points.tolist():
+                    r = 4
+                    draw.ellipse((x - r, y - r, x + r, y + r), outline="lime", width=2)
+                    draw.text((x + r + 1, y - r), f"{conf:.2f}", fill="lime")
+                annotated_img.save(save_path)
+                log_saved_result(result, save_path)
+                return
             # Draw masks first (underneath boxes)
             if result.masks is not None:
                 masks_np = result.masks.data
@@ -361,6 +373,32 @@ class InferenceRunner:
         """
         masks_t = None
         keypoints_t = None
+        points_t = None
+
+        if "points" in detections:
+            raw_points = detections.get("points")
+            raw_scores = detections.get("scores")
+            raw_cls = detections.get("classes")
+            if raw_points is None or raw_scores is None or raw_cls is None:
+                raise ValueError("point detections require points, scores, and classes")
+            xy = raw_points.float() if isinstance(raw_points, torch.Tensor) else torch.as_tensor(raw_points).float()
+            scores = raw_scores.float() if isinstance(raw_scores, torch.Tensor) else torch.as_tensor(raw_scores).float()
+            cls = raw_cls.float() if isinstance(raw_cls, torch.Tensor) else torch.as_tensor(raw_cls).float()
+            if classes is not None and len(xy) > 0:
+                mask = torch.zeros(len(cls), dtype=torch.bool, device=cls.device)
+                for cid in classes:
+                    mask |= cls == cid
+                xy, scores, cls = xy[mask], scores[mask], cls[mask]
+            points_t = torch.cat((xy, cls.reshape(-1, 1), scores.reshape(-1, 1)), dim=1)
+            orig_w, orig_h = original_size
+            orig_shape = (orig_h, orig_w)
+            return Results(
+                boxes=None,
+                orig_shape=orig_shape,
+                path=str(image_path) if image_path else None,
+                names=self.model.names,
+                points=Points(points_t, orig_shape),
+            )
 
         if detections["num_detections"] == 0:
             boxes_t = torch.zeros((0, 4), dtype=torch.float32)

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -331,6 +331,7 @@ class BaseModel(ABC):
 
         self.model.load_state_dict(new_state)
         self.model.to(self.device)
+        self.model.eval()
 
     @classmethod
     def _filename_regex(cls) -> Optional[re.Pattern]:

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -887,6 +887,7 @@ class BaseModel(ABC):
         from libreyolo.validation import (
             DetectionValidator,
             PoseValidator,
+            PointValidator,
             SegmentationValidator,
             ValidationConfig,
         )
@@ -918,6 +919,8 @@ class BaseModel(ABC):
             )
         if self.task == "pose":
             validator_cls = PoseValidator
+        elif self.task == "point":
+            validator_cls = PointValidator
         elif self.task == "segment":
             validator_cls = SegmentationValidator
         else:

--- a/libreyolo/models/librefomo/__init__.py
+++ b/libreyolo/models/librefomo/__init__.py
@@ -1,0 +1,5 @@
+"""LibreFOMO point-localization model."""
+
+from .model import LibreFOMO
+
+__all__ = ["LibreFOMO"]

--- a/libreyolo/models/librefomo/dataset.py
+++ b/libreyolo/models/librefomo/dataset.py
@@ -1,0 +1,151 @@
+"""LibreFOMO training dataset.
+
+Supports YOLO data.yaml loading: reads images and YOLO-format box annotations
+(``class cx cy w h`` normalized to [0, 1]) from a standard dataset directory,
+then encodes box centers as FOMO grid targets on-the-fly.
+
+The loader returns ``(img_tensor, grid_target, img_info, img_id)`` 4-tuples so
+the base trainer's dataloader collate and batch loop work without changes.
+
+Dataset format:
+
+    dataset/
+    ├── data.yaml          # nc, names, path, train/val/test keys
+    ├── train/
+    │   ├── images/        # .jpg / .png files
+    │   └── labels/        # .txt files: one row per box: "class cx cy w h"
+    ├── valid/
+    │   ├── images/
+    │   └── labels/
+    └── test/
+        ├── images/
+        └── labels/
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+from PIL import Image
+
+from ...models.librefomo.utils import MEAN, STD
+
+
+# ---------------------------------------------------------------------------
+# Image preprocessing (mirrors reference FOMODataset.image_transform)
+# ---------------------------------------------------------------------------
+
+def _transform_image(pil_image: Image.Image, input_size: int) -> torch.Tensor:
+    """Resize to input_size × input_size and normalize to [-1, 1] (RGB)."""
+    img = pil_image.convert("RGB").resize((input_size, input_size), Image.Resampling.BILINEAR)
+    arr = np.asarray(img, dtype=np.float32) / 255.0
+    arr = (arr - MEAN) / STD
+    return torch.from_numpy(np.ascontiguousarray(arr.transpose(2, 0, 1), dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# Grid-target encoding
+# ---------------------------------------------------------------------------
+
+def _boxes_xyxy_to_grid(
+    boxes_xyxy: np.ndarray,
+    classes: np.ndarray,
+    input_size: int,
+    grid_size: int,
+) -> torch.Tensor:
+    """Encode xyxy-pixel boxes as a FOMO grid target tensor.
+
+    Args:
+        boxes_xyxy: (N, 4) float array — x1, y1, x2, y2 in *input_size* pixel coords.
+        classes: (N,) int array — class index (0-based foreground).
+        input_size: Model input resolution (square).
+        grid_size: Output grid side length (= input_size // 8).
+
+    Returns:
+        LongTensor of shape (grid_size, grid_size).
+        Value 0 = background, 1..nc = foreground class index.
+    """
+    grid = torch.zeros((grid_size, grid_size), dtype=torch.long)
+    for (x1, y1, x2, y2), cls in zip(boxes_xyxy, classes):
+        cx = (x1 + x2) * 0.5
+        cy = (y1 + y2) * 0.5
+        gx = int((cx / input_size) * grid_size)
+        gy = int((cy / input_size) * grid_size)
+        gx = min(max(gx, 0), grid_size - 1)
+        gy = min(max(gy, 0), grid_size - 1)
+        grid[gy, gx] = int(cls) + 1  # +1 because 0 = background
+    return grid
+
+
+# ---------------------------------------------------------------------------
+# Dataset (data.yaml path)
+# ---------------------------------------------------------------------------
+
+class FOMOYOLODataset(Dataset):
+    """FOMO dataset backed by a YOLO-format image directory.
+
+    Expects YOLO-format box annotations (class cx cy w h in [0,1] coords).
+    The boxes are first converted to pixel coords in ``input_size`` space,
+    then encoded as FOMO grid targets (box size is discarded — only the
+    center cell matters for point localization).
+    """
+
+    def __init__(
+        self,
+        img_files: list,
+        label_files: list,
+        input_size: int,
+        grid_size: int,
+    ) -> None:
+        self.img_files = img_files
+        self.label_files = label_files
+        self.input_size = input_size
+        self.grid_size = grid_size
+
+    def __len__(self) -> int:
+        return len(self.img_files)
+
+    def _load_labels(self, label_path: str) -> Tuple[np.ndarray, np.ndarray]:
+        """Return (boxes_xyxy_pixel, classes_int) or empty arrays."""
+        try:
+            with open(label_path) as f:
+                lines = f.read().strip().split("\n")
+        except (FileNotFoundError, OSError):
+            return np.zeros((0, 4), dtype=np.float32), np.zeros((0,), dtype=np.int32)
+
+        boxes, classes = [], []
+        for line in lines:
+            parts = line.strip().split()
+            if len(parts) < 5:
+                continue
+            cls = int(parts[0])
+            cx, cy, w, h = float(parts[1]), float(parts[2]), float(parts[3]), float(parts[4])
+            # Normalised → pixel in input_size space
+            x1 = (cx - w / 2) * self.input_size
+            y1 = (cy - h / 2) * self.input_size
+            x2 = (cx + w / 2) * self.input_size
+            y2 = (cy + h / 2) * self.input_size
+            boxes.append([x1, y1, x2, y2])
+            classes.append(cls)
+        if not boxes:
+            return np.zeros((0, 4), dtype=np.float32), np.zeros((0,), dtype=np.int32)
+        return np.array(boxes, dtype=np.float32), np.array(classes, dtype=np.int32)
+
+    def __getitem__(self, idx: int):
+        img_path = self.img_files[idx]
+        try:
+            pil_img = Image.open(img_path)
+        except Exception:
+            pil_img = Image.fromarray(np.zeros((self.input_size, self.input_size, 3), dtype=np.uint8))
+
+        img_tensor = _transform_image(pil_img, self.input_size)
+
+        label_path = self.label_files[idx] if idx < len(self.label_files) else ""
+        boxes_xyxy, classes = self._load_labels(label_path)
+        grid = _boxes_xyxy_to_grid(boxes_xyxy, classes, self.input_size, self.grid_size)
+
+        img_info = (self.input_size, self.input_size)
+        return img_tensor, grid, img_info, idx

--- a/libreyolo/models/librefomo/loss.py
+++ b/libreyolo/models/librefomo/loss.py
@@ -1,0 +1,52 @@
+"""LibreFOMO training loss."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class LibreFOMOLoss(nn.Module):
+    """Weighted pixel-wise CrossEntropyLoss for FOMO grid targets.
+
+    Args:
+        num_classes: Number of foreground classes (not counting background).
+        fg_weight: Loss weight applied to all foreground channels.
+            Background channel always has weight 1.0.
+        device: Tensor device for the weight vector.
+    """
+
+    def __init__(
+        self,
+        num_classes: int = 1,
+        fg_weight: float = 100.0,
+        device: torch.device | str = "cpu",
+    ) -> None:
+        super().__init__()
+        # weights shape: (1 + num_classes,) — index 0 is background
+        weights = torch.ones(1 + num_classes, dtype=torch.float32, device=device)
+        weights[1:] = fg_weight
+        self.register_buffer("weights", weights)
+        self.criterion = nn.CrossEntropyLoss(weight=self.weights)
+
+    def to(self, *args, **kwargs):
+        result = super().to(*args, **kwargs)
+        # Rebuild criterion with updated weights buffer after device move
+        result.criterion = nn.CrossEntropyLoss(weight=result.weights)
+        return result
+
+    def forward(
+        self, logits: torch.Tensor, targets: torch.Tensor
+    ) -> dict:
+        """Compute FOMO loss.
+
+        Args:
+            logits: Shape ``(B, 1+nc, H_grid, W_grid)``.
+            targets: Shape ``(B, H_grid, W_grid)``, dtype int64, value = class_id
+                (0 = background, 1..nc = foreground classes).
+
+        Returns:
+            Dict with keys ``total_loss`` (tensor) and ``ce`` (float).
+        """
+        loss = self.criterion(logits, targets)
+        return {"total_loss": loss, "ce": float(loss.item())}

--- a/libreyolo/models/librefomo/model.py
+++ b/libreyolo/models/librefomo/model.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 from PIL import Image
 
+from ...training.config import FOMOConfig
 from ...utils.image_loader import ImageInput
 from ...validation.preprocessors import LibreFOMOValPreprocessor
 from ..base import BaseModel
@@ -29,7 +30,7 @@ class LibreFOMO(BaseModel):
     INPUT_SIZES = {k: int(v["imgsz"]) for k, v in CONFIGS.items()}
     SUPPORTED_TASKS = ("point",)
     DEFAULT_TASK = "point"
-    TRAIN_CONFIG = None
+    TRAIN_CONFIG = FOMOConfig
     val_preprocessor_class = LibreFOMOValPreprocessor
     TTA_ENABLED = False
 
@@ -178,8 +179,51 @@ class LibreFOMO(BaseModel):
         self._notify_license_once()
         return super()._load_weights(model_path)
 
-    def train(self, *args, **kwargs):
-        raise NotImplementedError(
-            "LibreFOMO training is not wired into LibreYOLO yet. "
-            "Use the point validator and prepared checkpoints for inference/evaluation."
+    def train(self, allow_experimental: bool = False, **kwargs):
+        """Train this LibreFOMO model.
+
+        Training is marked experimental in v1. Pass ``allow_experimental=True``
+        to enable. Stable inference and validation do not require this flag.
+
+        Args:
+            allow_experimental: Must be ``True`` to start training.
+            **kwargs: Training config overrides forwarded to
+                :class:`~libreyolo.models.librefomo.trainer.LibreFOMOTrainer`.
+                Notable keys: ``data`` (YOLO data.yaml path), ``epochs``, ``batch``,
+                ``lr0``, ``fg_weight``, ``device``, ``project``, ``name``.
+
+        Returns:
+            Training results dict (see :meth:`BaseTrainer.train`).
+        """
+        if not allow_experimental:
+            raise NotImplementedError(
+                "LibreFOMO training is experimental in this version. "
+                "Pass allow_experimental=True to model.train() to enable it."
+            )
+
+        from .trainer import LibreFOMOTrainer
+
+        # imgsz is determined by the model size unless the caller overrides it
+        if "imgsz" not in kwargs:
+            kwargs["imgsz"] = self.input_size
+        if "size" not in kwargs:
+            kwargs["size"] = self.size
+        if "num_classes" not in kwargs:
+            kwargs["num_classes"] = self.nb_classes
+
+        trainer = LibreFOMOTrainer(
+            model=self.model,
+            wrapper_model=self,
+            **kwargs,
         )
+        results = trainer.train()
+        # Reload the best (or last) checkpoint so the wrapper is the trained model
+        from pathlib import Path
+
+        best_ckpt = results.get("best_checkpoint", "")
+        last_ckpt = results.get("last_checkpoint", "")
+        reload_path = best_ckpt if Path(best_ckpt).exists() else last_ckpt
+        if reload_path and Path(reload_path).exists():
+            self._load_weights(reload_path)
+        return results
+

--- a/libreyolo/models/librefomo/model.py
+++ b/libreyolo/models/librefomo/model.py
@@ -1,0 +1,185 @@
+"""LibreFOMO point localizer."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from PIL import Image
+
+from ...utils.image_loader import ImageInput
+from ...validation.preprocessors import LibreFOMOValPreprocessor
+from ..base import BaseModel
+from .nn import CONFIGS, LibreFOMOModel, detect_size_from_state_dict
+from .utils import decode_points_from_logits, postprocess as _postprocess
+from .utils import preprocess_image, preprocess_numpy
+
+
+class LibreFOMO(BaseModel):
+    """FOMO-style point localizer.
+
+    The in-tree model code is Apache-2.0. Official prepared weights are hosted
+    externally at ``bdanko/LibreFOMO`` under cc-by-nc-4.0 due to ImageNet-derived
+    weight licensing ambiguity.
+    """
+
+    FAMILY = "librefomo"
+    FILENAME_PREFIX = "LibreFOMO"
+    INPUT_SIZES = {k: int(v["imgsz"]) for k, v in CONFIGS.items()}
+    SUPPORTED_TASKS = ("point",)
+    DEFAULT_TASK = "point"
+    TRAIN_CONFIG = None
+    val_preprocessor_class = LibreFOMOValPreprocessor
+    TTA_ENABLED = False
+
+    _LICENSE_NOTICE_SHOWN = False
+    _WEIGHTS_REPO = "bdanko/LibreFOMO"
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        return "head.weight" in weights_dict and any(k.startswith("backbone.block_6_expand") for k in weights_dict)
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        return detect_size_from_state_dict(weights_dict)
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        weight = weights_dict.get("head.weight")
+        if weight is None:
+            return None
+        return max(int(weight.shape[0]) - 1, 1)
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        if cls.detect_size_from_filename(filename) is None:
+            return None
+        return f"https://huggingface.co/{cls._WEIGHTS_REPO}/resolve/main/{filename}"
+
+    @classmethod
+    def _notify_license_once(cls) -> None:
+        if cls._LICENSE_NOTICE_SHOWN:
+            return
+        cls._LICENSE_NOTICE_SHOWN = True
+        print(
+            "\n"
+            "----------------------------------------------------------------\n"
+            f"LibreFOMO weights are hosted externally at {cls._WEIGHTS_REPO}\n"
+            "under cc-by-nc-4.0.\n"
+            "They are treated as externally hosted, ImageNet-derived weights and\n"
+            "are not redistributed by LibreYOLO. By downloading them you accept\n"
+            "the Hugging Face repository license terms.\n"
+            "----------------------------------------------------------------\n"
+        )
+
+    def __init__(
+        self,
+        model_path=None,
+        size: str = "m",
+        nb_classes: int = 1,
+        device: str = "auto",
+        task: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=nb_classes,
+            device=device,
+            task=task,
+            **kwargs,
+        )
+        if isinstance(model_path, str):
+            self._load_weights(model_path)
+
+    def _init_model(self) -> nn.Module:
+        return LibreFOMOModel(size=self.size, nc=self.nb_classes, head_channels=self.nb_classes + 1)
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {"backbone": self.model.backbone, "head": self.model.head}
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        return preprocess_numpy
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
+        return preprocess_image(image, input_size or self.input_size, color_format=color_format)
+
+    def _forward(self, input_tensor: torch.Tensor) -> Any:
+        return self.model(input_tensor)
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        return _postprocess(
+            output,
+            conf_thres=conf_thres,
+            input_size=kwargs.get("input_size", self.input_size),
+            original_size=original_size,
+            nms_radius=int(kwargs.get("nms_radius", 1)),
+            max_det=max_det,
+        )
+
+    def _point_metric_shape(self, output: Any, imgsz: int) -> tuple[int, int]:
+        return tuple(int(v) for v in output.shape[-2:])
+
+    def _decode_point_predictions(
+        self,
+        output: Any,
+        conf_thres: float,
+        max_det: int = 300,
+        nms_radius: int = 1,
+        **kwargs,
+    ) -> list[torch.Tensor]:
+        decoded = decode_points_from_logits(
+            output.detach().cpu(),
+            conf_threshold=conf_thres,
+            nms_radius=nms_radius,
+            max_points=max_det,
+        )
+        # Utility rows are (x, y, class_channel, confidence); validator rows
+        # use dataset class ids, so subtract the background channel offset.
+        return [
+            torch.cat((rows[:, :2], (rows[:, 2:3] - 1), rows[:, 3:4]), dim=1)
+            if len(rows)
+            else rows
+            for rows in decoded
+        ]
+
+    def _point_targets_from_boxes(
+        self,
+        target: torch.Tensor,
+        metric_shape: tuple[int, int],
+        imgsz: int,
+    ) -> torch.Tensor:
+        valid = target[:, 2] > target[:, 0]
+        target = target[valid]
+        if target.numel() == 0:
+            return torch.zeros((0, 3), dtype=torch.float32)
+        metric_h, metric_w = metric_shape
+        cx = (target[:, 0] + target[:, 2]) * 0.5 * (metric_w / imgsz)
+        cy = (target[:, 1] + target[:, 3]) * 0.5 * (metric_h / imgsz)
+        return torch.stack((cx, cy, target[:, 4]), dim=1).float()
+
+    def _load_weights(self, model_path: str):
+        self._notify_license_once()
+        return super()._load_weights(model_path)
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreFOMO training is not wired into LibreYOLO yet. "
+            "Use the point validator and prepared checkpoints for inference/evaluation."
+        )

--- a/libreyolo/models/librefomo/nn.py
+++ b/libreyolo/models/librefomo/nn.py
@@ -1,0 +1,192 @@
+"""Native PyTorch LibreFOMO architecture."""
+
+from __future__ import annotations
+
+import math
+from typing import ClassVar, Tuple
+
+import torch
+import torch.nn as nn
+
+
+CONFIGS = {
+    "s": {"alpha": 0.35, "imgsz": 96, "head_in_channels": 96},
+    "m": {"alpha": 0.50, "imgsz": 192, "head_in_channels": 96},
+    "l": {"alpha": 1.00, "imgsz": 224, "head_in_channels": 192},
+}
+
+
+def _make_divisible(v: float, divisor: int = 8, min_value=None) -> int:
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+def _same_pad_1d(input_size: int, kernel: int, stride: int, dilation: int = 1):
+    out_size = math.ceil(float(input_size) / float(stride))
+    effective_kernel = (kernel - 1) * dilation + 1
+    total_pad = max((out_size - 1) * stride + effective_kernel - input_size, 0)
+    before = total_pad // 2
+    return before, total_pad - before
+
+
+def _same_pad_2d(input_hw: Tuple[int, int], kernel_hw, stride_hw, dilation_hw=(1, 1)):
+    ih, iw = input_hw
+    kh, kw = kernel_hw
+    sh, sw = stride_hw
+    dh, dw = dilation_hw
+    top, bottom = _same_pad_1d(ih, kh, sh, dh)
+    left, right = _same_pad_1d(iw, kw, sw, dw)
+    return left, right, top, bottom
+
+
+class StaticSamePadConv2d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size,
+        stride=1,
+        groups: int = 1,
+        bias: bool = False,
+        input_hw: Tuple[int, int] | None = None,
+    ):
+        super().__init__()
+        if input_hw is None:
+            raise ValueError("StaticSamePadConv2d requires fixed input_hw")
+        kernel_size = kernel_size if isinstance(kernel_size, tuple) else (kernel_size, kernel_size)
+        stride = stride if isinstance(stride, tuple) else (stride, stride)
+        self.pad = nn.ZeroPad2d(_same_pad_2d(input_hw, kernel_size, stride))
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=0,
+            groups=groups,
+            bias=bias,
+        )
+
+    def forward(self, x):
+        return self.conv(self.pad(x))
+
+
+class ConvBNReLU6(nn.Sequential):
+    def __init__(self, in_channels, out_channels, kernel_size, stride, input_hw):
+        super().__init__(
+            StaticSamePadConv2d(in_channels, out_channels, kernel_size, stride, input_hw=input_hw),
+            nn.BatchNorm2d(out_channels, eps=1e-3),
+            nn.ReLU6(inplace=True),
+        )
+
+
+class DepthwiseConvBNReLU6(nn.Sequential):
+    def __init__(self, channels, kernel_size, stride, input_hw):
+        super().__init__(
+            StaticSamePadConv2d(
+                channels,
+                channels,
+                kernel_size,
+                stride,
+                groups=channels,
+                input_hw=input_hw,
+            ),
+            nn.BatchNorm2d(channels, eps=1e-3),
+            nn.ReLU6(inplace=True),
+        )
+
+
+class ProjectConvBN(nn.Sequential):
+    def __init__(self, in_channels, out_channels):
+        super().__init__(
+            nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=1, padding=0, bias=False),
+            nn.BatchNorm2d(out_channels, eps=1e-3),
+        )
+
+
+class InvertedResidual(nn.Module):
+    def __init__(self, in_channels, out_channels, stride, expand_ratio, input_hw, use_residual):
+        super().__init__()
+        hidden_channels = int(round(in_channels * expand_ratio))
+        self.use_residual = use_residual
+        layers = []
+        if expand_ratio != 1:
+            layers.append(ConvBNReLU6(in_channels, hidden_channels, 1, 1, input_hw))
+        layers.append(DepthwiseConvBNReLU6(hidden_channels, 3, stride, input_hw))
+        layers.append(ProjectConvBN(hidden_channels, out_channels))
+        self.conv = nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = self.conv(x)
+        return x + out if self.use_residual else out
+
+
+class LibreFOMOBackbone(nn.Module):
+    def __init__(self, size: str):
+        super().__init__()
+        if size not in CONFIGS:
+            raise ValueError(f"Unsupported LibreFOMO size: {size!r}")
+        cfg = CONFIGS[size]
+        alpha = cfg["alpha"]
+        imgsz = cfg["imgsz"]
+        c0 = _make_divisible(32 * alpha, 8)
+        c1 = _make_divisible(16 * alpha, 8)
+        c2 = _make_divisible(24 * alpha, 8)
+        c3 = _make_divisible(32 * alpha, 8)
+
+        self.conv1 = ConvBNReLU6(3, c0, 3, 2, (imgsz, imgsz))
+        hw = math.ceil(imgsz / 2)
+        self.expanded_conv = InvertedResidual(c0, c1, 1, 1, (hw, hw), False)
+        self.block_1 = InvertedResidual(c1, c2, 2, 6, (hw, hw), False)
+        hw = math.ceil(hw / 2)
+        self.block_2 = InvertedResidual(c2, c2, 1, 6, (hw, hw), True)
+        self.block_3 = InvertedResidual(c2, c3, 2, 6, (hw, hw), False)
+        hw = math.ceil(hw / 2)
+        self.block_4 = InvertedResidual(c3, c3, 1, 6, (hw, hw), True)
+        self.block_5 = InvertedResidual(c3, c3, 1, 6, (hw, hw), True)
+        self.block_6_expand = ConvBNReLU6(c3, int(round(c3 * 6)), 1, 1, (hw, hw))
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.expanded_conv(x)
+        x = self.block_1(x)
+        x = self.block_2(x)
+        x = self.block_3(x)
+        x = self.block_4(x)
+        x = self.block_5(x)
+        return self.block_6_expand(x)
+
+
+class LibreFOMOModel(nn.Module):
+    CONFIGS: ClassVar[dict] = CONFIGS
+
+    def __init__(self, size: str = "m", nc: int = 1, head_channels: int | None = None):
+        super().__init__()
+        if size not in CONFIGS:
+            raise ValueError(f"Unsupported LibreFOMO size: {size!r}")
+        self.size = size
+        self.nc = nc
+        self.head_channels = head_channels if head_channels is not None else nc + 1
+        self.imgsz = CONFIGS[size]["imgsz"]
+        self.backbone = LibreFOMOBackbone(size)
+        self.head = nn.Conv2d(CONFIGS[size]["head_in_channels"], self.head_channels, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.head(self.backbone(x))
+
+
+def detect_size_from_state_dict(state_dict: dict) -> str | None:
+    weight = state_dict.get("head.weight")
+    if weight is None:
+        return None
+    in_ch = int(weight.shape[1])
+    if in_ch == 192:
+        return "l"
+    if in_ch == 96:
+        conv1 = state_dict.get("backbone.conv1.1.weight")
+        if conv1 is not None:
+            return {16: "s", 24: "m"}.get(int(conv1.shape[0]))
+    return None

--- a/libreyolo/models/librefomo/nn.py
+++ b/libreyolo/models/librefomo/nn.py
@@ -179,14 +179,18 @@ class LibreFOMOModel(nn.Module):
 
 
 def detect_size_from_state_dict(state_dict: dict) -> str | None:
-    weight = state_dict.get("head.weight")
-    if weight is None:
-        return None
-    in_ch = int(weight.shape[1])
-    if in_ch == 192:
+    # "l" has unique head_in_channels=192; s and m both use 96.
+    head_weight = state_dict.get("head.weight")
+    if head_weight is not None and int(head_weight.shape[1]) == 192:
         return "l"
-    if in_ch == 96:
-        conv1 = state_dict.get("backbone.conv1.1.weight")
-        if conv1 is not None:
-            return {16: "s", 24: "m"}.get(int(conv1.shape[0]))
+
+    # Distinguish "s" from "m" via block_2's expansion conv hidden channels.
+    # InvertedResidual(in=c2, out=c2, expand=6):
+    #   "s": c2=8  → hidden = 8*6 = 48  → conv.0.0.conv.weight shape[0] = 48
+    #   "m": c2=16 → hidden = 16*6 = 96 → conv.0.0.conv.weight shape[0] = 96
+    # (backbone.conv1.1.weight = BN(c0) is ambiguous: c0=16 for both s and m.)
+    block2 = state_dict.get("backbone.block_2.conv.0.0.conv.weight")
+    if block2 is not None:
+        return {48: "s", 96: "m"}.get(int(block2.shape[0]))
+
     return None

--- a/libreyolo/models/librefomo/trainer.py
+++ b/libreyolo/models/librefomo/trainer.py
@@ -468,7 +468,9 @@ class LibreFOMOTrainer(BaseTrainer):
 
                         if len(rows) > 0:
                             preds_xy = rows[:, :2].numpy()
-                            preds_cls = rows[:, 2].long().numpy()  # 0-based
+                            # rows[:, 2] is the argmax channel index (bg=0, class0=1, …);
+                            # subtract 1 to get 0-based class id matching true_cls_np.
+                            preds_cls = (rows[:, 2].long() - 1).numpy()
                         else:
                             preds_xy = np.zeros((0, 2))
                             preds_cls = np.zeros(0, dtype=np.int64)

--- a/libreyolo/models/librefomo/trainer.py
+++ b/libreyolo/models/librefomo/trainer.py
@@ -159,7 +159,15 @@ class LibreFOMOTrainer(BaseTrainer):
             except (FileNotFoundError, ValueError):
                 val_img_files, val_label_files = [], []
 
-        self.config.num_classes = data_cfg.get("nc", self.config.num_classes)
+        dataset_nc = data_cfg.get("nc", self.config.num_classes)
+        if dataset_nc != getattr(self.model, "nb_classes", self.config.num_classes):
+            logger.info(
+                "Dataset nc=%d differs from model nc=%d — rebuilding head.",
+                dataset_nc,
+                getattr(self.model, "nb_classes", self.config.num_classes),
+            )
+            self.model._rebuild_for_new_classes(dataset_nc)
+        self.config.num_classes = dataset_nc
 
         train_ds = FOMOYOLODataset(train_img_files, train_label_files, input_size, grid_size)
         val_ds = FOMOYOLODataset(val_img_files or [], val_label_files or [], input_size, grid_size)

--- a/libreyolo/models/librefomo/trainer.py
+++ b/libreyolo/models/librefomo/trainer.py
@@ -1,0 +1,474 @@
+"""LibreFOMO trainer.
+
+Thin subclass of BaseTrainer that:
+
+* Completely overrides ``_setup_data`` to serve FOMO grid targets
+  ``(B, H_grid, W_grid)`` instead of the standard box-format
+  ``(B, max_labels, 5)`` used by the YOLO/DETR pipeline.
+* Uses a ``ConstantLRScheduler`` as the per-iteration LR holder, with a
+  ``ReduceLROnPlateau`` side-channel that adjusts the LR after each epoch
+  validation, matching the reference training script.
+* Overrides ``_run_validation`` to use ``PointValidator`` and an F1 threshold
+  sweep (mirroring the reference ``evaluate_sweep``).
+* Sets ``best_metric_key = "metrics/F1"`` so ``_update_best_state`` and
+  ``_save_checkpoint`` select and save the best model by F1 score.
+
+Training is gated experimental — ``LibreFOMO.train()`` checks for
+``allow_experimental=True`` before instantiating this class.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple, Type
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from ...training.config import FOMOConfig, TrainConfig
+from ...training.scheduler import ConstantLRScheduler
+from ...training.trainer import BaseTrainer
+from ...training.distributed import (
+    barrier,
+    is_main_process,
+    unwrap_model,
+)
+from .loss import LibreFOMOLoss
+from .nn import CONFIGS
+
+logger = logging.getLogger(__name__)
+
+# Downsample factor: the backbone reduces spatial dims by 8×
+_DOWNSAMPLE = 8
+
+
+class LibreFOMOTrainer(BaseTrainer):
+    """LibreFOMO point-localization trainer."""
+
+    best_metric_key: str = "metrics/F1"
+
+    @classmethod
+    def _config_class(cls) -> Type[TrainConfig]:
+        return FOMOConfig
+
+    # -------------------------------------------------------------------------
+    # Identity
+    # -------------------------------------------------------------------------
+
+    def get_model_family(self) -> str:
+        return "librefomo"
+
+    def get_model_tag(self) -> str:
+        return f"LibreFOMO-{self.config.size}"
+
+    # -------------------------------------------------------------------------
+    # Augmentation / transforms (not used — overridden by _setup_data)
+    # -------------------------------------------------------------------------
+
+    def create_transforms(self):
+        """Not used; _setup_data is fully overridden."""
+        return None, None
+
+    # -------------------------------------------------------------------------
+    # Data setup — bypass YOLO pipeline, serve FOMO grid targets
+    # -------------------------------------------------------------------------
+
+    def _setup_data(self):
+        """Build FOMO dataloaders from a standard YOLO data.yaml.
+
+        Produces ``(img, grid_target, img_info, img_id)`` 4-tuples so the
+        inherited ``_train_epoch`` loop works without modification.
+        """
+        input_size = self.config.imgsz
+        grid_size = input_size // _DOWNSAMPLE
+
+        if not self.config.data:
+            raise ValueError(
+                "LibreFOMOTrainer requires a YOLO ``data`` (data.yaml path) in "
+                "the training config. Pass ``data='path/to/data.yaml'`` to "
+                "``model.train()``."
+            )
+        train_dataset, val_dataset = self._build_yolo_datasets(input_size, grid_size)
+
+        self._val_dataset = val_dataset
+
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+            sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=True,
+            )
+
+        self.train_loader = DataLoader(
+            train_dataset,
+            batch_size=per_rank_batch,
+            shuffle=(sampler is None),
+            num_workers=self.config.workers,
+            pin_memory=self.device.type == "cuda",
+            sampler=sampler,
+            drop_last=False,
+        )
+
+        if is_main_process():
+            logger.info(f"FOMO training dataset: {len(train_dataset)} images")
+            logger.info(
+                f"Grid size: {grid_size}×{grid_size} "
+                f"(imgsz={input_size}, downsample=8)"
+            )
+            logger.info(
+                f"Iterations per epoch: {len(self.train_loader)} "
+                f"(batch_per_rank={per_rank_batch}, world_size={self.world_size})"
+            )
+        return train_dataset
+
+    def _build_yolo_datasets(self, input_size: int, grid_size: int):
+        from .dataset import FOMOYOLODataset
+        from ...data import load_data_config, get_img_files, img2label_paths
+
+        data_cfg = load_data_config(
+            self.config.data,
+            allow_scripts=self.config.allow_download_scripts,
+        )
+        data_dir = data_cfg["root"]
+
+        # Resolve training images
+        train_img_files = data_cfg.get("train_img_files")
+        train_label_files = data_cfg.get("train_label_files")
+        if not train_img_files:
+            train_path = data_cfg.get("train", "images/train")
+            train_img_files = get_img_files(train_path, prefix=data_dir)
+            train_label_files = img2label_paths(train_img_files)
+
+        # Resolve validation images
+        val_img_files = data_cfg.get("val_img_files")
+        val_label_files = data_cfg.get("val_label_files")
+        if not val_img_files:
+            val_path = data_cfg.get("val", "images/val")
+            try:
+                val_img_files = get_img_files(val_path, prefix=data_dir)
+                val_label_files = img2label_paths(val_img_files)
+            except (FileNotFoundError, ValueError):
+                val_img_files, val_label_files = [], []
+
+        self.config.num_classes = data_cfg.get("nc", self.config.num_classes)
+
+        train_ds = FOMOYOLODataset(train_img_files, train_label_files, input_size, grid_size)
+        val_ds = FOMOYOLODataset(val_img_files or [], val_label_files or [], input_size, grid_size)
+        return train_ds, val_ds
+
+    # -------------------------------------------------------------------------
+    # Setup — build loss and plateau scheduler state
+    # -------------------------------------------------------------------------
+
+    def on_setup(self) -> None:
+        nc = getattr(self.model, "nc", self.config.num_classes)
+        fg_weight = getattr(self.config, "fg_weight", 100.0)
+        self._loss_fn = LibreFOMOLoss(
+            num_classes=nc,
+            fg_weight=fg_weight,
+            device=self.device,
+        ).to(self.device)
+
+        # ReduceLROnPlateau state (side-channel, not part of BaseScheduler)
+        self._plateau_best = 0.0
+        self._plateau_wait = 0
+        self._plateau_factor = float(getattr(self.config, "plateau_factor", 0.5))
+        self._plateau_patience = int(getattr(self.config, "plateau_patience", 3))
+        self._plateau_min_lr = float(getattr(self.config, "min_lr", 1e-5))
+
+        if is_main_process():
+            logger.info(
+                f"LibreFOMOLoss: nc={nc}, fg_weight={fg_weight}"
+            )
+
+    # -------------------------------------------------------------------------
+    # Scheduler — constant LR; actual LR changes come from plateau hook
+    # -------------------------------------------------------------------------
+
+    def create_scheduler(self, iters_per_epoch: int):
+        return ConstantLRScheduler(
+            lr=self.effective_lr,
+            iters_per_epoch=iters_per_epoch,
+            total_epochs=self.config.epochs,
+            warmup_epochs=0,
+            warmup_lr_start=0.0,
+        )
+
+    # -------------------------------------------------------------------------
+    # Forward pass
+    # -------------------------------------------------------------------------
+
+    def on_forward(
+        self,
+        imgs: torch.Tensor,
+        targets: torch.Tensor,
+        polygons=None,
+    ) -> Dict:
+        """Run model and compute loss.
+
+        Args:
+            imgs: ``(B, 3, H, W)`` image tensor.
+            targets: ``(B, H_grid, W_grid)`` int64 grid targets.
+        """
+        logits = self.model(imgs)
+
+        if logits.shape[-2:] != targets.shape[-2:]:
+            raise ValueError(
+                f"Model output grid {tuple(logits.shape[-2:])} does not match "
+                f"target grid {tuple(targets.shape[-2:])}. "
+                f"Check that config.imgsz={self.config.imgsz} matches the "
+                f"model variant (s:96, m:192, l:224)."
+            )
+
+        return self._loss_fn(logits, targets.long())
+
+    def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
+        return {"ce": float(outputs.get("ce", 0.0))}
+
+    # -------------------------------------------------------------------------
+    # Validation — PointValidator with threshold sweep, plateau LR step
+    # -------------------------------------------------------------------------
+
+    def _run_validation(self, epoch: int) -> Optional[Dict[str, Any]]:
+        """Run FOMO validation and step the plateau scheduler.
+
+        Returns a metrics dict with ``best_metric`` = best F1 across the sweep,
+        compatible with ``_update_best_state``.
+        """
+        try:
+            val_dataset = getattr(self, "_val_dataset", None)
+            if val_dataset is None or len(val_dataset) == 0:
+                logger.warning("No validation dataset available; skipping validation.")
+                return None
+
+            logger.info(f"Running FOMO validation for epoch {epoch + 1}")
+
+            # Use the EMA model if available, otherwise the raw model.
+            eval_nn = (
+                self.ema_model.ema if self.ema_model else unwrap_model(self.model)
+            )
+
+            conf_thresholds = tuple(getattr(self.config, "conf_thresholds", (0.25, 0.35, 0.50, 0.65, 0.80, 0.90)))
+            nms_radii = tuple(int(r) for r in getattr(self.config, "nms_radii", (1, 2)))
+            distance_tolerance = float(getattr(self.config, "distance_tolerance", 1.5))
+
+            avg_val_loss, best_result = self._sweep_validation(
+                eval_nn,
+                val_dataset,
+                conf_thresholds=conf_thresholds,
+                nms_radii=nms_radii,
+                distance_tolerance=distance_tolerance,
+            )
+
+            if best_result is None:
+                logger.warning("Validation sweep returned no results.")
+                return None
+
+            f1 = best_result["f1"]
+            precision = best_result["precision"]
+            recall = best_result["recall"]
+            mean_dist = best_result["mean_dist"]
+            tp = best_result["tp"]
+            fp = best_result["fp"]
+            fn = best_result["fn"]
+
+            # Step ReduceLROnPlateau on F1
+            self._step_plateau_lr(f1)
+            current_lr = self.optimizer.param_groups[0]["lr"]
+
+            if is_main_process():
+                logger.info(
+                    f"Epoch {epoch + 1} val | "
+                    f"loss={avg_val_loss:.4f} | "
+                    f"F1={f1:.4f} | "
+                    f"P={precision:.4f} | "
+                    f"R={recall:.4f} | "
+                    f"MeanDist={mean_dist:.3f} | "
+                    f"thresh={best_result['threshold']:.2f} | "
+                    f"nms_r={best_result['nms_radius']} | "
+                    f"TP={tp} FP={fp} FN={fn} | "
+                    f"LR={current_lr:.6f}"
+                )
+
+            metrics = {
+                "best_metric": f1,
+                "best_metric_key": "metrics/F1",
+                "mAP50": f1,       # alias so base trainer logs mAP50 = F1
+                "mAP50_95": f1,    # alias so best checkpoint tracks F1
+                "metrics": {
+                    "metrics/F1": f1,
+                    "metrics/precision": precision,
+                    "metrics/recall": recall,
+                    "metrics/mean_distance": mean_dist,
+                    "metrics/val_loss": avg_val_loss,
+                    "metrics/TP": float(tp),
+                    "metrics/FP": float(fp),
+                    "metrics/FN": float(fn),
+                    "decode/threshold": best_result["threshold"],
+                    "decode/nms_radius": float(best_result["nms_radius"]),
+                },
+            }
+            return metrics
+
+        except Exception as exc:
+            import traceback
+            logger.error(f"FOMO validation failed: {exc}")
+            logger.debug(traceback.format_exc())
+            return None
+
+    def _sweep_validation(
+        self,
+        eval_nn: nn.Module,
+        val_dataset,
+        conf_thresholds,
+        nms_radii,
+        distance_tolerance: float,
+    ) -> Tuple[float, Optional[Dict]]:
+        """Run the model over the val set once, cache logits, sweep thresholds.
+
+        Returns (avg_val_loss, best_result_dict).
+        """
+        from .loss import LibreFOMOLoss
+        from .utils import decode_points_from_logits
+        from scipy.spatial.distance import cdist
+        from scipy.optimize import linear_sum_assignment
+
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        val_loader = DataLoader(
+            val_dataset,
+            batch_size=per_rank_batch,
+            shuffle=False,
+            num_workers=min(self.config.workers, 4),
+            pin_memory=self.device.type == "cuda",
+            drop_last=False,
+        )
+
+        nc = getattr(self.model, "nc", self.config.num_classes)
+        fg_weight = getattr(self.config, "fg_weight", 100.0)
+        val_loss_fn = LibreFOMOLoss(num_classes=nc, fg_weight=fg_weight, device=self.device)
+        val_loss_fn.eval()
+
+        eval_nn.eval()
+        cached: list[tuple[torch.Tensor, torch.Tensor]] = []
+        val_loss_total = 0.0
+
+        with torch.no_grad():
+            for batch in val_loader:
+                imgs, grid_targets, _, _ = batch
+                imgs = imgs.to(self.device, non_blocking=True)
+                grid_targets = grid_targets.to(self.device, non_blocking=True)
+                logits = eval_nn(imgs)
+                loss_out = val_loss_fn(logits, grid_targets.long())
+                val_loss_total += float(loss_out["total_loss"].item())
+                cached.append((logits.cpu(), grid_targets.cpu()))
+
+        avg_val_loss = val_loss_total / max(len(val_loader), 1)
+
+        # Threshold / NMS sweep
+        best: Optional[Dict] = None
+
+        for threshold in conf_thresholds:
+            for nms_radius in nms_radii:
+                total_tp = total_fp = total_fn = 0
+                total_dist = 0.0
+
+                for logits_cpu, targets_cpu in cached:
+                    decoded = decode_points_from_logits(
+                        logits_cpu, conf_threshold=threshold, nms_radius=nms_radius
+                    )
+                    B = logits_cpu.shape[0]
+                    for b in range(B):
+                        rows = decoded[b]
+                        preds_xy = rows[:, :2].numpy() if len(rows) else np.zeros((0, 2))
+                        ys, xs = torch.where(targets_cpu[b] == 1)
+                        trues_xy = torch.stack((xs, ys), dim=1).float().numpy() if ys.numel() else np.zeros((0, 2))
+
+                        if len(preds_xy) == 0 and len(trues_xy) == 0:
+                            continue
+                        if len(preds_xy) == 0:
+                            total_fn += len(trues_xy)
+                            continue
+                        if len(trues_xy) == 0:
+                            total_fp += len(preds_xy)
+                            continue
+
+                        dist_mat = cdist(preds_xy, trues_xy)
+                        row_ind, col_ind = linear_sum_assignment(dist_mat)
+                        matched_preds: set = set()
+                        matched_trues: set = set()
+                        for r, c in zip(row_ind, col_ind):
+                            d = dist_mat[r, c]
+                            if d <= distance_tolerance:
+                                total_tp += 1
+                                total_dist += d
+                                matched_preds.add(r)
+                                matched_trues.add(c)
+                        total_fp += len(preds_xy) - len(matched_preds)
+                        total_fn += len(trues_xy) - len(matched_trues)
+
+                prec = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 0.0
+                rec = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 0.0
+                f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+                mean_dist = total_dist / max(total_tp, 1)
+
+                result = {
+                    "threshold": float(threshold),
+                    "nms_radius": int(nms_radius),
+                    "precision": prec,
+                    "recall": rec,
+                    "f1": f1,
+                    "mean_dist": mean_dist,
+                    "tp": total_tp,
+                    "fp": total_fp,
+                    "fn": total_fn,
+                }
+                if best is None or f1 > best["f1"]:
+                    best = result
+
+        return avg_val_loss, best
+
+    # -------------------------------------------------------------------------
+    # ReduceLROnPlateau side-channel
+    # -------------------------------------------------------------------------
+
+    def _step_plateau_lr(self, f1: float) -> None:
+        """Step the ReduceLROnPlateau logic, mutating the optimizer LR directly."""
+        if f1 > self._plateau_best:
+            self._plateau_best = f1
+            self._plateau_wait = 0
+        else:
+            self._plateau_wait += 1
+
+        if self._plateau_wait >= self._plateau_patience:
+            self._plateau_wait = 0
+            for pg in self.optimizer.param_groups:
+                old_lr = pg["lr"]
+                new_lr = max(old_lr * self._plateau_factor, self._plateau_min_lr)
+                pg["lr"] = new_lr
+                if is_main_process() and new_lr < old_lr:
+                    logger.info(
+                        f"ReduceLROnPlateau: LR {old_lr:.2e} → {new_lr:.2e} "
+                        f"(no improvement for {self._plateau_patience} epochs)"
+                    )
+            # Sync the constant scheduler's internal LR so it stays consistent
+            if self.lr_scheduler is not None:
+                self.lr_scheduler.lr = self.optimizer.param_groups[0]["lr"]
+
+    # -------------------------------------------------------------------------
+    # Checkpoint extra metadata — record best decode config
+    # -------------------------------------------------------------------------
+
+    def _checkpoint_extra_metadata(self) -> Dict[str, Any]:
+        return {
+            "task": "point",
+            "best_metric_key": "metrics/F1",
+        }

--- a/libreyolo/models/librefomo/trainer.py
+++ b/libreyolo/models/librefomo/trainer.py
@@ -5,9 +5,7 @@ Thin subclass of BaseTrainer that:
 * Completely overrides ``_setup_data`` to serve FOMO grid targets
   ``(B, H_grid, W_grid)`` instead of the standard box-format
   ``(B, max_labels, 5)`` used by the YOLO/DETR pipeline.
-* Uses a ``ConstantLRScheduler`` as the per-iteration LR holder, with a
-  ``ReduceLROnPlateau`` side-channel that adjusts the LR after each epoch
-  validation, matching the reference training script.
+* Uses standard LR schedulers (defaulting to Cosine Annealing).
 * Overrides ``_run_validation`` to use ``PointValidator`` and an F1 threshold
   sweep (mirroring the reference ``evaluate_sweep``).
 * Sets ``best_metric_key = "metrics/F1"`` so ``_update_best_state`` and

--- a/libreyolo/models/librefomo/trainer.py
+++ b/libreyolo/models/librefomo/trainer.py
@@ -158,14 +158,35 @@ class LibreFOMOTrainer(BaseTrainer):
                 val_img_files, val_label_files = [], []
 
         dataset_nc = data_cfg.get("nc", self.config.num_classes)
-        if dataset_nc != getattr(self.model, "nb_classes", self.config.num_classes):
+        if dataset_nc != getattr(self.model, "nc", self.config.num_classes):
             logger.info(
                 "Dataset nc=%d differs from model nc=%d — rebuilding head.",
                 dataset_nc,
-                getattr(self.model, "nb_classes", self.config.num_classes),
+                getattr(self.model, "nc", self.config.num_classes),
             )
-            self.model._rebuild_for_new_classes(dataset_nc)
+            if self.wrapper_model is not None:
+                self.wrapper_model._rebuild_for_new_classes(dataset_nc)
+                # Keep self.model pointing at the freshly-built nn.Module.
+                self.model = self.wrapper_model.model
+            else:
+                # Fallback: no wrapper available (unusual, but safe to skip rebuild).
+                logger.warning(
+                    "wrapper_model is None — cannot rebuild head for nc=%d. "
+                    "Training will continue with the original head.",
+                    dataset_nc,
+                )
         self.config.num_classes = dataset_nc
+
+        # Propagate dataset class names to the wrapper so checkpoints record
+        # the real labels instead of the generic "class_0", "class_1", … defaults.
+        raw_names = data_cfg.get("names")
+        if raw_names is not None and self.wrapper_model is not None:
+            from ..base import BaseModel
+            self.wrapper_model.names = BaseModel._sanitize_names(
+                raw_names if isinstance(raw_names, dict)
+                else {i: n for i, n in enumerate(raw_names)},
+                dataset_nc,
+            )
 
         train_ds = FOMOYOLODataset(train_img_files, train_label_files, input_size, grid_size)
         val_ds = FOMOYOLODataset(val_img_files or [], val_label_files or [], input_size, grid_size)
@@ -432,10 +453,25 @@ class LibreFOMOTrainer(BaseTrainer):
                     )
                     B = logits_cpu.shape[0]
                     for b in range(B):
-                        rows = decoded[b]
-                        preds_xy = rows[:, :2].numpy() if len(rows) else np.zeros((0, 2))
-                        ys, xs = torch.where(targets_cpu[b] == 1)
-                        trues_xy = torch.stack((xs, ys), dim=1).float().numpy() if ys.numel() else np.zeros((0, 2))
+                        rows = decoded[b]  # (N, 4): x, y, class_id (0-based), conf
+
+                        # All foreground cells — grid value encodes class as (class+1).
+                        fg_mask = targets_cpu[b] >= 1
+                        ys, xs = torch.where(fg_mask)
+                        if ys.numel():
+                            true_cls = targets_cpu[b][ys, xs] - 1  # 0-based class
+                            trues_xy = torch.stack((xs, ys), dim=1).float().numpy()
+                            true_cls_np = true_cls.numpy()
+                        else:
+                            trues_xy = np.zeros((0, 2))
+                            true_cls_np = np.zeros(0, dtype=np.int64)
+
+                        if len(rows) > 0:
+                            preds_xy = rows[:, :2].numpy()
+                            preds_cls = rows[:, 2].long().numpy()  # 0-based
+                        else:
+                            preds_xy = np.zeros((0, 2))
+                            preds_cls = np.zeros(0, dtype=np.int64)
 
                         if len(preds_xy) == 0 and len(trues_xy) == 0:
                             continue
@@ -447,12 +483,21 @@ class LibreFOMOTrainer(BaseTrainer):
                             continue
 
                         dist_mat = cdist(preds_xy, trues_xy)
-                        row_ind, col_ind = linear_sum_assignment(dist_mat)
+                        # Penalise class mismatches — set distance to inf so the
+                        # Hungarian solver never matches cross-class pairs.
+                        for pi in range(len(preds_cls)):
+                            for ti in range(len(true_cls_np)):
+                                if preds_cls[pi] != true_cls_np[ti]:
+                                    dist_mat[pi, ti] = np.inf
+
+                        row_ind, col_ind = linear_sum_assignment(
+                            np.where(np.isfinite(dist_mat), dist_mat, 1e9)
+                        )
                         matched_preds: set = set()
                         matched_trues: set = set()
                         for r, c in zip(row_ind, col_ind):
                             d = dist_mat[r, c]
-                            if d <= distance_tolerance:
+                            if np.isfinite(d) and d <= distance_tolerance:
                                 total_tp += 1
                                 total_dist += d
                                 matched_preds.add(r)

--- a/libreyolo/models/librefomo/trainer.py
+++ b/libreyolo/models/librefomo/trainer.py
@@ -177,8 +177,19 @@ class LibreFOMOTrainer(BaseTrainer):
                 )
         self.config.num_classes = dataset_nc
 
-        # Propagate dataset class names to the wrapper so checkpoints record
-        # the real labels instead of the generic "class_0", "class_1", … defaults.
+        # Re-build the loss function after the final dataset class count is resolved
+        fg_weight = getattr(self.config, "fg_weight", 100.0)
+        self._loss_fn = LibreFOMOLoss(
+            num_classes=dataset_nc,
+            fg_weight=fg_weight,
+            device=self.device,
+        ).to(self.device)
+        if is_main_process():
+            logger.info(
+                "LibreFOMOLoss rebuilt with resolved dataset nc=%d", dataset_nc
+            )
+
+        # Propagate dataset class names to the wrapper so checkpoints record the real labels
         raw_names = data_cfg.get("names")
         if raw_names is not None and self.wrapper_model is not None:
             from ..base import BaseModel

--- a/libreyolo/models/librefomo/trainer.py
+++ b/libreyolo/models/librefomo/trainer.py
@@ -186,29 +186,69 @@ class LibreFOMOTrainer(BaseTrainer):
             device=self.device,
         ).to(self.device)
 
-        # ReduceLROnPlateau state (side-channel, not part of BaseScheduler)
-        self._plateau_best = 0.0
-        self._plateau_wait = 0
-        self._plateau_factor = float(getattr(self.config, "plateau_factor", 0.5))
-        self._plateau_patience = int(getattr(self.config, "plateau_patience", 3))
-        self._plateau_min_lr = float(getattr(self.config, "min_lr", 1e-5))
-
         if is_main_process():
             logger.info(
                 f"LibreFOMOLoss: nc={nc}, fg_weight={fg_weight}"
             )
 
     # -------------------------------------------------------------------------
-    # Scheduler — constant LR; actual LR changes come from plateau hook
+    # Scheduler — constant/plateau, cosine, linear
     # -------------------------------------------------------------------------
 
     def create_scheduler(self, iters_per_epoch: int):
+        sched_type = getattr(self.config, "scheduler", "cosine")
+
+        if sched_type in ("cosine", "cos"):
+            from ...training.scheduler import CosineAnnealingScheduler
+            return CosineAnnealingScheduler(
+                lr=self.effective_lr,
+                iters_per_epoch=iters_per_epoch,
+                total_epochs=self.config.epochs,
+                warmup_epochs=getattr(self.config, "warmup_epochs", 0),
+                warmup_lr_start=getattr(self.config, "warmup_lr_start", 0.0),
+                min_lr_ratio=getattr(self.config, "min_lr_ratio", 0.05),
+            )
+        elif sched_type == "flat_cosine":
+            from ...training.scheduler import FlatCosineScheduler
+            return FlatCosineScheduler(
+                lr=self.effective_lr,
+                iters_per_epoch=iters_per_epoch,
+                total_epochs=self.config.epochs,
+                warmup_epochs=getattr(self.config, "warmup_epochs", 0),
+                warmup_lr_start=getattr(self.config, "warmup_lr_start", 0.0),
+                no_aug_epochs=getattr(self.config, "no_aug_epochs", 0),
+                min_lr_ratio=getattr(self.config, "min_lr_ratio", 0.05),
+            )
+        elif sched_type == "linear":
+            from ...training.scheduler import LinearLRScheduler
+            return LinearLRScheduler(
+                lr=self.effective_lr,
+                iters_per_epoch=iters_per_epoch,
+                total_epochs=self.config.epochs,
+                warmup_epochs=getattr(self.config, "warmup_epochs", 0),
+                warmup_lr_start=getattr(self.config, "warmup_lr_start", 0.0001),
+                min_lr_ratio=getattr(self.config, "min_lr_ratio", 0.01),
+            )
+        elif sched_type == "yoloxwarmcos":
+            from ...training.scheduler import WarmupCosineScheduler
+            return WarmupCosineScheduler(
+                lr=self.effective_lr,
+                iters_per_epoch=iters_per_epoch,
+                total_epochs=self.config.epochs,
+                warmup_epochs=getattr(self.config, "warmup_epochs", 5),
+                warmup_lr_start=getattr(self.config, "warmup_lr_start", 0.0),
+                plateau_epochs=getattr(self.config, "no_aug_epochs", 15),
+                min_lr_ratio=getattr(self.config, "min_lr_ratio", 0.05),
+            )
+
+        # Fallback to constant LR scheduler
+        from ...training.scheduler import ConstantLRScheduler
         return ConstantLRScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
             total_epochs=self.config.epochs,
-            warmup_epochs=0,
-            warmup_lr_start=0.0,
+            warmup_epochs=getattr(self.config, "warmup_epochs", 0),
+            warmup_lr_start=getattr(self.config, "warmup_lr_start", 0.0),
         )
 
     # -------------------------------------------------------------------------
@@ -289,24 +329,6 @@ class LibreFOMOTrainer(BaseTrainer):
             fp = best_result["fp"]
             fn = best_result["fn"]
 
-            # Step ReduceLROnPlateau on F1
-            self._step_plateau_lr(f1)
-            current_lr = self.optimizer.param_groups[0]["lr"]
-
-            if is_main_process():
-                logger.info(
-                    f"Epoch {epoch + 1} val | "
-                    f"loss={avg_val_loss:.4f} | "
-                    f"F1={f1:.4f} | "
-                    f"P={precision:.4f} | "
-                    f"R={recall:.4f} | "
-                    f"MeanDist={mean_dist:.3f} | "
-                    f"thresh={best_result['threshold']:.2f} | "
-                    f"nms_r={best_result['nms_radius']} | "
-                    f"TP={tp} FP={fp} FN={fn} | "
-                    f"LR={current_lr:.6f}"
-                )
-
             metrics = {
                 "best_metric": f1,
                 "best_metric_key": "metrics/F1",
@@ -325,6 +347,23 @@ class LibreFOMOTrainer(BaseTrainer):
                     "decode/nms_radius": float(best_result["nms_radius"]),
                 },
             }
+
+            current_lr = self.optimizer.param_groups[0]["lr"]
+
+            if is_main_process():
+                logger.info(
+                    f"Epoch {epoch + 1} val | "
+                    f"loss={avg_val_loss:.4f} | "
+                    f"F1={f1:.4f} | "
+                    f"P={precision:.4f} | "
+                    f"R={recall:.4f} | "
+                    f"MeanDist={mean_dist:.3f} | "
+                    f"thresh={best_result['threshold']:.2f} | "
+                    f"nms_r={best_result['nms_radius']} | "
+                    f"TP={tp} FP={fp} FN={fn} | "
+                    f"LR={current_lr:.6f}"
+                )
+
             return metrics
 
         except Exception as exc:
@@ -444,32 +483,7 @@ class LibreFOMOTrainer(BaseTrainer):
 
         return avg_val_loss, best
 
-    # -------------------------------------------------------------------------
-    # ReduceLROnPlateau side-channel
-    # -------------------------------------------------------------------------
 
-    def _step_plateau_lr(self, f1: float) -> None:
-        """Step the ReduceLROnPlateau logic, mutating the optimizer LR directly."""
-        if f1 > self._plateau_best:
-            self._plateau_best = f1
-            self._plateau_wait = 0
-        else:
-            self._plateau_wait += 1
-
-        if self._plateau_wait >= self._plateau_patience:
-            self._plateau_wait = 0
-            for pg in self.optimizer.param_groups:
-                old_lr = pg["lr"]
-                new_lr = max(old_lr * self._plateau_factor, self._plateau_min_lr)
-                pg["lr"] = new_lr
-                if is_main_process() and new_lr < old_lr:
-                    logger.info(
-                        f"ReduceLROnPlateau: LR {old_lr:.2e} → {new_lr:.2e} "
-                        f"(no improvement for {self._plateau_patience} epochs)"
-                    )
-            # Sync the constant scheduler's internal LR so it stays consistent
-            if self.lr_scheduler is not None:
-                self.lr_scheduler.lr = self.optimizer.param_groups[0]["lr"]
 
     # -------------------------------------------------------------------------
     # Checkpoint extra metadata — record best decode config

--- a/libreyolo/models/librefomo/utils.py
+++ b/libreyolo/models/librefomo/utils.py
@@ -1,0 +1,115 @@
+"""LibreFOMO preprocessing, decoding, and point metrics."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+from ...utils.image_loader import ImageInput, ImageLoader
+
+
+MEAN = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+STD = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+
+
+def preprocess_numpy(img_rgb_hwc: np.ndarray, input_size: int) -> tuple[np.ndarray, float]:
+    pil_img = Image.fromarray(img_rgb_hwc).resize((input_size, input_size), Image.Resampling.BILINEAR)
+    arr = np.asarray(pil_img, dtype=np.float32) / 255.0
+    arr = (arr - MEAN) / STD
+    return np.ascontiguousarray(arr.transpose(2, 0, 1), dtype=np.float32), 1.0
+
+
+def preprocess_image(
+    image: ImageInput,
+    input_size: int,
+    color_format: str = "auto",
+) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
+    img = ImageLoader.load(image, color_format=color_format)
+    arr = np.asarray(img.convert("RGB"))
+    chw, ratio = preprocess_numpy(arr, input_size)
+    return torch.from_numpy(chw).unsqueeze(0), img, img.size, ratio
+
+
+def decode_points_from_logits(
+    pred_logits: torch.Tensor,
+    conf_threshold: float = 0.5,
+    nms_radius: int = 1,
+    max_points: int | None = None,
+    class_offset: int = 1,
+) -> list[torch.Tensor]:
+    """Decode point peaks from ``(B, C, H, W)`` logits into grid-space x/y rows."""
+    probs = F.softmax(pred_logits, dim=1)
+    obj_probs, cls_idx = probs[:, class_offset:].max(dim=1)
+    cls_idx = cls_idx + class_offset
+    batch_points = []
+    bsz, h, w = obj_probs.shape
+
+    for b in range(bsz):
+        prob = obj_probs[b]
+        ys, xs = torch.where(prob > conf_threshold)
+        if ys.numel() == 0:
+            batch_points.append(torch.zeros((0, 4), dtype=pred_logits.dtype, device=pred_logits.device))
+            continue
+
+        scores = prob[ys, xs]
+        order = torch.argsort(scores, descending=True)
+        suppressed = torch.zeros((h, w), dtype=torch.bool, device=prob.device)
+        kept = []
+        for idx in order:
+            y = int(ys[idx])
+            x = int(xs[idx])
+            if suppressed[y, x]:
+                continue
+            kept.append(torch.stack((xs[idx].float(), ys[idx].float(), cls_idx[b, y, x].float(), scores[idx].float())))
+            y0 = max(0, y - nms_radius)
+            y1 = min(h, y + nms_radius + 1)
+            x0 = max(0, x - nms_radius)
+            x1 = min(w, x + nms_radius + 1)
+            suppressed[y0:y1, x0:x1] = True
+            if max_points is not None and len(kept) >= max_points:
+                break
+        batch_points.append(torch.stack(kept) if kept else torch.zeros((0, 4), dtype=pred_logits.dtype, device=pred_logits.device))
+    return batch_points
+
+
+def postprocess(
+    output: torch.Tensor,
+    conf_thres: float,
+    input_size: int,
+    original_size: Tuple[int, int],
+    nms_radius: int = 1,
+    max_det: int = 300,
+) -> dict:
+    points = decode_points_from_logits(output, conf_threshold=conf_thres, nms_radius=nms_radius, max_points=max_det)[0]
+    if points.numel() == 0:
+        return {
+            "points": torch.zeros((0, 2), dtype=torch.float32),
+            "scores": torch.zeros((0,), dtype=torch.float32),
+            "classes": torch.zeros((0,), dtype=torch.float32),
+            "num_detections": 0,
+        }
+
+    grid_h, grid_w = output.shape[-2:]
+    orig_w, orig_h = original_size
+    scale_x = orig_w / grid_w
+    scale_y = orig_h / grid_h
+    xy = points[:, :2].clone()
+    xy[:, 0] = (xy[:, 0] + 0.5) * scale_x
+    xy[:, 1] = (xy[:, 1] + 0.5) * scale_y
+    return {
+        "points": xy.float(),
+        "scores": points[:, 3].float(),
+        "classes": (points[:, 2] - 1).float(),
+        "num_detections": int(points.shape[0]),
+    }
+
+
+def point_prf(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    return precision, recall, f1

--- a/libreyolo/tasks.py
+++ b/libreyolo/tasks.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Iterable, Literal
 
 
-TaskType = Literal["detect", "segment", "pose", "classify", "gaze"]
-TASKS = ("detect", "segment", "pose", "classify", "gaze")
+TaskType = Literal["detect", "segment", "pose", "classify", "gaze", "point"]
+TASKS = ("detect", "segment", "pose", "classify", "gaze", "point")
 
 TASK_ALIASES = {
     "detect": "detect",
@@ -27,6 +27,10 @@ TASK_ALIASES = {
     "gaze": "gaze",
     "gaze-estimation": "gaze",
     "gaze_estimation": "gaze",
+    "point": "point",
+    "points": "point",
+    "centroid": "point",
+    "centroids": "point",
 }
 
 TASK_TO_SUFFIX = {
@@ -34,6 +38,7 @@ TASK_TO_SUFFIX = {
     "pose": "pose",
     "classify": "cls",
     "gaze": "gaze",
+    "point": "point",
 }
 
 SUFFIX_TO_TASK = {v: k for k, v in TASK_TO_SUFFIX.items()}

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -788,20 +788,15 @@ class FOMOConfig(TrainConfig):
     lr0: float = 3e-4
     weight_decay: float = 0.0  # Adam without wd, matching reference
 
-    # ReduceLROnPlateau knobs (used by LibreFOMOTrainer side-channel)
-    plateau_patience: int = 3
-    plateau_factor: float = 0.5
-    min_lr: float = 1e-5
-
     # Foreground class weight in weighted CrossEntropyLoss
     fg_weight: float = 100.0
 
-    # No traditional LR schedule — constant + plateau
-    scheduler: str = "constant"
+    # Standard LR schedule
+    scheduler: str = "cos"
     warmup_epochs: int = 0
     warmup_lr_start: float = 0.0
     no_aug_epochs: int = 0
-    min_lr_ratio: float = 1.0
+    min_lr_ratio: float = 0.05
 
     # No augmentation — plain resize only
     mosaic_prob: float = 0.0

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -774,10 +774,10 @@ class FOMOConfig(TrainConfig):
     """LibreFOMO point-localizer training defaults.
 
     - Adam optimizer, lr=3e-4
-    - ReduceLROnPlateau on val F1 (factor=0.5, patience=3, min_lr=1e-5)
+    - Cosine learning rate scheduler (cos, min_lr_ratio=0.05)
     - Weighted CrossEntropy: background=1.0, foreground=fg_weight (100×)
     - No mosaic/mixup/HSV/flip augmentation (plain stretch resize + [-1,1] norm)
-    - Validate every epoch so the plateau scheduler has F1 to step on
+    - Validate every epoch (best model selected by validation F1 score)
     - EMA and AMP disabled for simplicity in v1
 
     Pass a standard YOLO ``data.yaml`` path via ``data=`` to ``model.train()``.

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -767,3 +767,63 @@ class RTMDetConfig(TrainConfig):
     epochs: int = 300
     amp: bool = True
     name: str = "rtmdet_exp"
+
+
+@dataclass(kw_only=True)
+class FOMOConfig(TrainConfig):
+    """LibreFOMO point-localizer training defaults.
+
+    - Adam optimizer, lr=3e-4
+    - ReduceLROnPlateau on val F1 (factor=0.5, patience=3, min_lr=1e-5)
+    - Weighted CrossEntropy: background=1.0, foreground=fg_weight (100×)
+    - No mosaic/mixup/HSV/flip augmentation (plain stretch resize + [-1,1] norm)
+    - Validate every epoch so the plateau scheduler has F1 to step on
+    - EMA and AMP disabled for simplicity in v1
+
+    Pass a standard YOLO ``data.yaml`` path via ``data=`` to ``model.train()``.
+    Training is gated experimental; pass ``allow_experimental=True`` to enable.
+    """
+
+    optimizer: str = "adam"
+    lr0: float = 3e-4
+    weight_decay: float = 0.0  # Adam without wd, matching reference
+
+    # ReduceLROnPlateau knobs (used by LibreFOMOTrainer side-channel)
+    plateau_patience: int = 3
+    plateau_factor: float = 0.5
+    min_lr: float = 1e-5
+
+    # Foreground class weight in weighted CrossEntropyLoss
+    fg_weight: float = 100.0
+
+    # No traditional LR schedule — constant + plateau
+    scheduler: str = "constant"
+    warmup_epochs: int = 0
+    warmup_lr_start: float = 0.0
+    no_aug_epochs: int = 0
+    min_lr_ratio: float = 1.0
+
+    # No augmentation — plain resize only
+    mosaic_prob: float = 0.0
+    mixup_prob: float = 0.0
+    hsv_prob: float = 0.0
+    flip_prob: float = 0.0
+    degrees: float = 0.0
+    translate: float = 0.0
+    shear: float = 0.0
+
+    # LibreFOMO doesn't use EMA or AMP in v1
+    ema: bool = False
+    amp: bool = False
+
+    # Training schedule
+    epochs: int = 40
+    batch: int = 32
+    eval_interval: int = 1  # validate every epoch for plateau stepping
+
+    # Validation sweep parameters (mirror reference evaluate_sweep)
+    conf_thresholds: Tuple[float, ...] = (0.25, 0.35, 0.50, 0.65, 0.80, 0.90)
+    nms_radii: Tuple[int, ...] = (1, 2)
+    distance_tolerance: float = 1.5
+
+    name: str = "librefomo_exp"

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -69,6 +69,8 @@ def _detect_family_from_filename(filename: str) -> Optional[str]:
         return "yolox"
     if re.search(r"libreyolo9", fl):
         return "yolo9"
+    if re.search(r"librefomo", fl):
+        return "librefomo"
     return None
 
 

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import requests
 
 _YOLONAS_LICENSE_NOTICE_SHOWN = False
+_LIBREFOMO_LICENSE_NOTICE_SHOWN = False
 logger = logging.getLogger(__name__)
 
 
@@ -39,6 +40,23 @@ def _notify_yolonas_license_once() -> None:
         "terms. Full license text:\n"
         "  https://github.com/Deci-AI/super-gradients/blob/master/LICENSE.YOLONAS.md\n"
         "─────────────────────────────────────────────────────────────────────\n"
+    )
+
+
+def _notify_librefomo_license_once() -> None:
+    """Print LibreFOMO weight licensing notice once per process before download."""
+    global _LIBREFOMO_LICENSE_NOTICE_SHOWN
+    if _LIBREFOMO_LICENSE_NOTICE_SHOWN:
+        return
+    _LIBREFOMO_LICENSE_NOTICE_SHOWN = True
+    print(
+        "\n"
+        "----------------------------------------------------------------\n"
+        "LibreFOMO weights are hosted at bdanko/LibreFOMO under cc-by-nc-4.0.\n"
+        "They are treated as externally hosted, ImageNet-derived weights and\n"
+        "are not redistributed by LibreYOLO. By downloading them you accept\n"
+        "the Hugging Face repository license terms.\n"
+        "----------------------------------------------------------------\n"
     )
 
 
@@ -96,6 +114,8 @@ def download_weights(model_path: str, size: str):
 
     if "cloudfront.net" in host or host.endswith("deci.ai"):
         _notify_yolonas_license_once()
+    if "huggingface.co" in host and "/bdanko/LibreFOMO/" in url:
+        _notify_librefomo_license_once()
 
     headers = {}
     token = _get_hf_token()

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -338,6 +338,43 @@ class Keypoints(_TensorPayload):
         return conf > 0
 
 
+class Points(_TensorPayload):
+    """Point detections with rows ``(x, y, class, confidence)``."""
+
+    def __init__(self, data: TensorLike, orig_shape: Tuple[int, int] | None = None):
+        if data.ndim == 1:
+            if isinstance(data, torch.Tensor):
+                data = data.unsqueeze(0)
+            else:
+                data = data[None, :]
+        if data.shape[-1] != 4:
+            raise ValueError(f"expected point rows (x, y, cls, conf), got {tuple(data.shape)}")
+        super().__init__(data, orig_shape)
+
+    @property
+    def xy(self) -> TensorLike:
+        return self.data[:, :2]
+
+    @property
+    def xyn(self) -> TensorLike:
+        if self.orig_shape is None:
+            raise ValueError("orig_shape is required for normalized point coordinates")
+        h, w = self.orig_shape
+        if isinstance(self.data, torch.Tensor):
+            scale = torch.tensor([w, h], dtype=self.data.dtype, device=self.data.device)
+        else:
+            scale = np.array([w, h], dtype=self.data.dtype)
+        return self.xy / scale
+
+    @property
+    def cls(self) -> TensorLike:
+        return self.data[:, 2]
+
+    @property
+    def conf(self) -> TensorLike:
+        return self.data[:, 3]
+
+
 class Probs(_TensorPayload):
     @property
     def top1(self) -> int:
@@ -533,7 +570,7 @@ class Gaze(_TensorPayload):
 class Results:
     """Single-image result with flat detection/segmentation slots."""
 
-    _keys = ("boxes", "masks", "probs", "keypoints", "obb", "gaze")
+    _keys = ("boxes", "masks", "probs", "keypoints", "points", "obb", "gaze")
 
     def __init__(
         self,
@@ -543,6 +580,7 @@ class Results:
         names: Optional[Dict[int, str]] = None,
         masks: Optional[Masks] = None,
         keypoints: Optional[Keypoints] = None,
+        points: Optional[Points] = None,
         probs: Optional[Probs] = None,
         obb: Optional[OBB] = None,
         gaze: Optional[Gaze] = None,
@@ -558,6 +596,7 @@ class Results:
         self.boxes = boxes
         self.masks = masks
         self.keypoints = keypoints
+        self.points = points
         self.probs = probs
         self.obb = obb
         self.gaze = gaze
@@ -576,6 +615,7 @@ class Results:
             "names": self.names,
             "masks": self.masks,
             "keypoints": self.keypoints,
+            "points": self.points,
             "probs": self.probs,
             "obb": self.obb,
             "gaze": self.gaze,
@@ -627,6 +667,7 @@ class Results:
         masks: Optional[Masks] = None,
         probs: Optional[Probs] = None,
         keypoints: Optional[Keypoints] = None,
+        points: Optional[Points] = None,
         obb: Optional[OBB] = None,
         gaze: Optional[Gaze] = None,
         track_id: Optional[TensorLike] = None,
@@ -639,6 +680,8 @@ class Results:
             self.probs = probs
         if keypoints is not None:
             self.keypoints = keypoints
+        if points is not None:
+            self.points = points
         if obb is not None:
             self.obb = obb
         if gaze is not None:
@@ -651,6 +694,24 @@ class Results:
 
     def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, Any]]:
         if self.boxes is None:
+            if self.points is not None:
+                points_np = self.points.numpy() if isinstance(self.points.data, torch.Tensor) else self.points
+                point_values = points_np.xyn if normalize else points_np.xy
+                rows = []
+                for i in range(len(points_np)):
+                    cls_id = int(points_np.cls[i])
+                    rows.append(
+                        {
+                            "name": self.names.get(cls_id, str(cls_id)),
+                            "class": cls_id,
+                            "confidence": round(float(points_np.conf[i]), decimals),
+                            "point": {
+                                "x": round(float(point_values[i, 0]), decimals),
+                                "y": round(float(point_values[i, 1]), decimals),
+                            },
+                        }
+                    )
+                return rows
             if self.probs is None:
                 return []
             probs_np = _numpy(self.probs.data)
@@ -707,6 +768,8 @@ class Results:
     def __len__(self) -> int:
         if self.boxes is not None:
             return len(self.boxes)
+        if self.points is not None:
+            return len(self.points)
         if self.probs is not None:
             return 1
         return 0

--- a/libreyolo/validation/__init__.py
+++ b/libreyolo/validation/__init__.py
@@ -4,11 +4,13 @@ from .config import ValidationConfig
 from .detection_validator import DetectionValidator, SegmentationValidator
 from .coco_evaluator import COCOEvaluator
 from .pose_validator import PoseValidator
+from .point_validator import PointValidator
 
 __all__ = [
     "ValidationConfig",
     "DetectionValidator",
     "SegmentationValidator",
     "PoseValidator",
+    "PointValidator",
     "COCOEvaluator",
 ]

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -79,6 +79,10 @@ class ValidationConfig:
     images_dir: Optional[str] = None
     oks_sigmas: Optional[List[float]] = None
 
+    # Point validation
+    point_distance_tolerance: float = 1.5
+    point_nms_radius: int = 1
+
     def __post_init__(self) -> None:
         if (
             self.data is None

--- a/libreyolo/validation/point_validator.py
+++ b/libreyolo/validation/point_validator.py
@@ -5,40 +5,13 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import torch
+from scipy.optimize import linear_sum_assignment as _scipy_lsa
 
 from .detection_validator import DetectionValidator
 from .config import ValidationConfig
 
 if TYPE_CHECKING:
     from libreyolo.models.base import BaseModel
-
-
-def _linear_sum_assignment(cost: torch.Tensor) -> tuple[list[int], list[int]]:
-    try:
-        from scipy.optimize import linear_sum_assignment
-
-        rows, cols = linear_sum_assignment(cost.detach().cpu().numpy())
-        return rows.tolist(), cols.tolist()
-    except Exception:
-        rows: list[int] = []
-        cols: list[int] = []
-        remaining_rows = set(range(cost.shape[0]))
-        remaining_cols = set(range(cost.shape[1]))
-        while remaining_rows and remaining_cols:
-            best = None
-            for r in remaining_rows:
-                for c in remaining_cols:
-                    value = float(cost[r, c])
-                    if best is None or value < best[0]:
-                        best = (value, r, c)
-            if best is None:
-                break
-            _, r, c = best
-            rows.append(r)
-            cols.append(c)
-            remaining_rows.remove(r)
-            remaining_cols.remove(c)
-        return rows, cols
 
 
 class PointValidator(DetectionValidator):
@@ -141,7 +114,8 @@ class PointValidator(DetectionValidator):
                 self.total_fn += len(true_xy)
                 continue
 
-            rows, cols = _linear_sum_assignment(dist)
+            dist_np = dist.detach().cpu().numpy()
+            rows, cols = _scipy_lsa(dist_np)
             matched_preds = set()
             matched_trues = set()
             for r, c in zip(rows, cols):
@@ -154,6 +128,19 @@ class PointValidator(DetectionValidator):
 
             self.total_fp += len(pred_xy) - len(matched_preds)
             self.total_fn += len(true_xy) - len(matched_trues)
+
+    def _run_validation_augmented(self) -> None:
+        """Point-task validators do not support box-level TTA.
+
+        The inherited ``DetectionValidator._run_validation_augmented`` calls
+        ``_det_from_result``, which reads ``result.boxes`` — a key that does
+        not exist for point-localization outputs.  Raise an explicit error
+        instead of silently producing wrong metrics or an obscure KeyError.
+        """
+        raise ValueError(
+            "PointValidator does not support augment=True. "
+            "Point-localization TTA is not implemented; pass augment=False."
+        )
 
     def _compute_metrics(self) -> Dict[str, float]:
         precision = self.total_tp / (self.total_tp + self.total_fp) if (self.total_tp + self.total_fp) else 0.0

--- a/libreyolo/validation/point_validator.py
+++ b/libreyolo/validation/point_validator.py
@@ -1,0 +1,171 @@
+"""Point-task validator."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+import torch
+
+from .detection_validator import DetectionValidator
+from .config import ValidationConfig
+
+if TYPE_CHECKING:
+    from libreyolo.models.base import BaseModel
+
+
+def _linear_sum_assignment(cost: torch.Tensor) -> tuple[list[int], list[int]]:
+    try:
+        from scipy.optimize import linear_sum_assignment
+
+        rows, cols = linear_sum_assignment(cost.detach().cpu().numpy())
+        return rows.tolist(), cols.tolist()
+    except Exception:
+        rows: list[int] = []
+        cols: list[int] = []
+        remaining_rows = set(range(cost.shape[0]))
+        remaining_cols = set(range(cost.shape[1]))
+        while remaining_rows and remaining_cols:
+            best = None
+            for r in remaining_rows:
+                for c in remaining_cols:
+                    value = float(cost[r, c])
+                    if best is None or value < best[0]:
+                        best = (value, r, c)
+            if best is None:
+                break
+            _, r, c = best
+            rows.append(r)
+            cols.append(c)
+            remaining_rows.remove(r)
+            remaining_cols.remove(c)
+        return rows, cols
+
+
+class PointValidator(DetectionValidator):
+    """Validator for point-localization models.
+
+    Computes precision, recall, F1, and mean matched distance using one-to-one
+    point matching. Model families own prediction decoding and target-space
+    conversion; this class owns only matching and metric aggregation.
+    """
+
+    task = "point"
+
+    def __init__(
+        self,
+        model: "BaseModel",
+        config: Optional[ValidationConfig] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(model, config, **kwargs)
+        self.distance_tolerance = float(getattr(self.config, "point_distance_tolerance", 1.5))
+        self.nms_radius = int(getattr(self.config, "point_nms_radius", 1))
+        self.total_tp = 0
+        self.total_fp = 0
+        self.total_fn = 0
+        self.total_distance = 0.0
+        self._last_metric_shape = (self.config.imgsz, self.config.imgsz)
+
+    def _init_metrics(self) -> None:
+        self.total_tp = 0
+        self.total_fp = 0
+        self.total_fn = 0
+        self.total_distance = 0.0
+
+    def _postprocess_predictions(self, preds: Any, batch: Any) -> List[torch.Tensor]:
+        decoder = getattr(self.model, "_decode_point_predictions", None)
+        if not callable(decoder):
+            raise NotImplementedError(
+                f"{self.model.__class__.__name__} must implement "
+                "_decode_point_predictions(...) for point validation."
+            )
+        metric_shape_fn = getattr(self.model, "_point_metric_shape", None)
+        if callable(metric_shape_fn):
+            self._last_metric_shape = metric_shape_fn(preds, self.config.imgsz)
+        decoded = decoder(
+            preds,
+            conf_thres=self.config.conf_thres,
+            max_det=self.config.max_det,
+            nms_radius=self.nms_radius,
+        )
+        return [row.detach().cpu() if isinstance(row, torch.Tensor) else torch.as_tensor(row) for row in decoded]
+
+    def _target_points_from_boxes(
+        self, target: torch.Tensor, metric_h: int, metric_w: int
+    ) -> torch.Tensor:
+        target_encoder = getattr(self.model, "_point_targets_from_boxes", None)
+        if callable(target_encoder):
+            return target_encoder(
+                target,
+                metric_shape=(metric_h, metric_w),
+                imgsz=self.config.imgsz,
+            ).float()
+        valid = target[:, 2] > target[:, 0]
+        target = target[valid]
+        if target.numel() == 0:
+            return torch.zeros((0, 3), dtype=torch.float32)
+        cx = (target[:, 0] + target[:, 2]) * 0.5 * (metric_w / self.config.imgsz)
+        cy = (target[:, 1] + target[:, 3]) * 0.5 * (metric_h / self.config.imgsz)
+        cls = target[:, 4]
+        return torch.stack((cx, cy, cls), dim=1).float()
+
+    def _update_metrics(
+        self, preds: List[torch.Tensor], targets: torch.Tensor, img_info: Any, img_ids: Any = None
+    ) -> None:
+        if not preds:
+            return
+        metric_h, metric_w = self._last_metric_shape
+
+        for b, pred_rows in enumerate(preds):
+            pred_xy = pred_rows[:, :2].float() if len(pred_rows) else torch.zeros((0, 2))
+            pred_cls = pred_rows[:, 2].float() if len(pred_rows) else torch.zeros((0,))
+            true_rows = self._target_points_from_boxes(targets[b].cpu(), metric_h, metric_w)
+            true_xy = true_rows[:, :2]
+            true_cls = true_rows[:, 2]
+
+            if len(pred_xy) == 0 and len(true_xy) == 0:
+                continue
+            if len(pred_xy) == 0:
+                self.total_fn += len(true_xy)
+                continue
+            if len(true_xy) == 0:
+                self.total_fp += len(pred_xy)
+                continue
+
+            dist = torch.cdist(pred_xy, true_xy)
+            class_mismatch = pred_cls[:, None] != true_cls[None, :]
+            dist = dist.masked_fill(class_mismatch, float("inf"))
+            finite = torch.isfinite(dist)
+            if not finite.any():
+                self.total_fp += len(pred_xy)
+                self.total_fn += len(true_xy)
+                continue
+
+            rows, cols = _linear_sum_assignment(dist)
+            matched_preds = set()
+            matched_trues = set()
+            for r, c in zip(rows, cols):
+                value = float(dist[r, c])
+                if value <= self.distance_tolerance:
+                    self.total_tp += 1
+                    self.total_distance += value
+                    matched_preds.add(r)
+                    matched_trues.add(c)
+
+            self.total_fp += len(pred_xy) - len(matched_preds)
+            self.total_fn += len(true_xy) - len(matched_trues)
+
+    def _compute_metrics(self) -> Dict[str, float]:
+        precision = self.total_tp / (self.total_tp + self.total_fp) if (self.total_tp + self.total_fp) else 0.0
+        recall = self.total_tp / (self.total_tp + self.total_fn) if (self.total_tp + self.total_fn) else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+        mean_distance = self.total_distance / self.total_tp if self.total_tp else 0.0
+        return {
+            "metrics/precision": precision,
+            "metrics/recall": recall,
+            "metrics/F1": f1,
+            "metrics/mean_distance": mean_distance,
+            "metrics/TP": float(self.total_tp),
+            "metrics/FP": float(self.total_fp),
+            "metrics/FN": float(self.total_fn),
+        }

--- a/libreyolo/validation/point_validator.py
+++ b/libreyolo/validation/point_validator.py
@@ -114,7 +114,8 @@ class PointValidator(DetectionValidator):
                 self.total_fn += len(true_xy)
                 continue
 
-            dist_np = dist.detach().cpu().numpy()
+            dist_finite = torch.where(finite, dist, torch.tensor(1e9, device=dist.device))
+            dist_np = dist_finite.detach().cpu().numpy()
             rows, cols = _scipy_lsa(dist_np)
             matched_preds = set()
             matched_trues = set()

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -209,6 +209,49 @@ class RFDETRValPreprocessor(BaseValPreprocessor):
         return resized_img, padded_targets
 
 
+class LibreFOMOValPreprocessor(BaseValPreprocessor):
+    """LibreFOMO preprocessor: direct RGB resize with [-1, 1] normalization."""
+
+    MEAN = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+    STD = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+
+    @property
+    def normalize(self) -> bool:
+        return False
+
+    @property
+    def custom_normalization(self) -> bool:
+        return True
+
+    @property
+    def wants_unresized_image(self) -> bool:
+        return True
+
+    def __call__(
+        self, img: np.ndarray, targets: np.ndarray, input_size: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        orig_h, orig_w = img.shape[:2]
+        target_h, target_w = input_size
+        rgb_img = img[:, :, ::-1]
+        resized = cv2.resize(rgb_img, (target_w, target_h), interpolation=cv2.INTER_LINEAR)
+        resized = resized.astype(np.float32) / 255.0
+        resized = (resized - self.MEAN) / self.STD
+        resized = np.ascontiguousarray(resized.transpose(2, 0, 1), dtype=np.float32)
+
+        padded_targets = np.zeros((self.max_labels, 5), dtype=np.float32)
+        if len(targets) > 0:
+            targets = np.array(targets).copy()
+            n = min(len(targets), self.max_labels)
+            scale_x = target_w / orig_w
+            scale_y = target_h / orig_h
+            targets[:n, 0] *= scale_x
+            targets[:n, 1] *= scale_y
+            targets[:n, 2] *= scale_x
+            targets[:n, 3] *= scale_y
+            padded_targets[:n] = targets[:n]
+        return resized, padded_targets
+
+
 class YOLO9ValPreprocessor(BaseValPreprocessor):
     """YOLOv9 preprocessor: letterbox with gray padding, 0-1 range, RGB format."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,6 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "unit: mark test as unit test (fast, no external deps)"
     )
+    config.addinivalue_line(
+        "markers", "fomo: mark test as LibreFOMO-specific (requires HF datasets + scipy)"
+    )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -546,6 +546,7 @@ FAMILY_MARKERS = {
     "damoyolo": pytest.mark.damoyolo,
     "rtmdet": pytest.mark.rtmdet,
     "l2cs": pytest.mark.l2cs,
+    "librefomo": pytest.mark.fomo,
 }
 
 

--- a/tests/e2e/test_fomo_inference.py
+++ b/tests/e2e/test_fomo_inference.py
@@ -1,0 +1,188 @@
+"""
+LibreFOMO pretrained-checkpoint inference tests.
+
+  1. Loads each pretrained variant (s/m/l) via the ``LibreYOLO`` factory.
+  2. Verifies checkpoint schema (``validate_checkpoint_metadata``).
+  3. Runs inference twice on a synthetic image and checks:
+       - ``result.boxes is None``
+       - ``result.points is not None``
+       - Outputs are non-NaN / non-Inf
+       - Point count is stable between the two passes
+  4. Checks the public API: ``result.summary()``, ``result.to_json()``,
+     ``result.points.xy``, ``result.points.xyn``.
+
+Marker: ``fomo``  (gate with ``-m fomo`` or ``-m e2e and fomo``)
+
+These tests require a network connection to download the pretrained checkpoints
+from HuggingFace the first time they run.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+from PIL import Image
+import numpy as np
+
+from libreyolo import LibreYOLO
+from libreyolo.utils.serialization import validate_checkpoint_metadata
+
+from .conftest import cuda_cleanup, requires_cuda
+
+pytestmark = [pytest.mark.e2e, pytest.mark.fomo]
+
+
+# ---------------------------------------------------------------------------
+# Pretrained checkpoint matrix
+# ---------------------------------------------------------------------------
+
+LIBREFOMO_CHECKPOINTS = [
+    ("librefomo", "s", "LibreFOMOs.pt"),
+    ("librefomo", "m", "LibreFOMOm.pt"),
+    ("librefomo", "l", "LibreFOMOl.pt"),
+]
+
+LIBREFOMO_EXPECTED_IMGSZ = {"s": 96, "m": 192, "l": 224}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _synthetic_image(size: int) -> Image.Image:
+    """Return a small synthetic RGB image with a bright patch."""
+    arr = np.zeros((size, size, 3), dtype=np.uint8)
+    cx, cy = size // 2, size // 2
+    r = max(4, size // 12)
+    arr[cy - r : cy + r, cx - r : cx + r] = [200, 180, 160]
+    return Image.fromarray(arr)
+
+
+def _assert_point_output_valid(family: str, result, pass_num: int):
+    """Assert the basic contracts of a FOMO result object."""
+    assert result.boxes is None, (
+        f"{family} pass {pass_num}: expected no boxes, got {result.boxes}"
+    )
+    assert result.points is not None, (
+        f"{family} pass {pass_num}: result.points must not be None"
+    )
+    data = result.points.data
+    assert data.ndim == 2, f"points.data must be 2-D, got shape {data.shape}"
+    assert data.shape[1] == 4, (
+        f"point rows must be (x, y, cls, conf), got shape {tuple(data.shape)}"
+    )
+    if data.shape[0] > 0:
+        assert torch.isfinite(data).all(), (
+            f"{family} pass {pass_num}: non-finite values in point output"
+        )
+    # Public API smoke
+    assert result.points.xy.shape[1] == 2
+    assert result.points.xyn.shape[1] == 2
+    assert isinstance(result.summary(), list)
+    assert isinstance(result.to_json(), str)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "family,size,weights",
+    [
+        pytest.param(f, s, w, marks=pytest.mark.fomo, id=f"{f}-{s}")
+        for f, s, w in LIBREFOMO_CHECKPOINTS
+    ],
+)
+def test_fomo_pretrained_checkpoint_schema(family, size, weights):
+    """Download and validate the checkpoint schema for each pretrained variant.
+
+    Checks all required LibreYOLO v1.0 metadata keys without running inference
+    (fast — CPU only, weight download only done once).
+    """
+    # Force fresh download — LibreYOLO will cache under weights/
+    weights_path = Path("weights") / weights
+    if weights_path.exists():
+        weights_path.unlink()
+
+    model = LibreYOLO(weights, device="cpu")
+
+    # Family / task
+    assert model.family == "librefomo", f"Expected librefomo, got {model.family!r}"
+    assert model.task == "point", f"Expected task='point', got {model.task!r}"
+    assert model.size == size, f"Expected size={size!r}, got {model.size!r}"
+    assert model.input_size == LIBREFOMO_EXPECTED_IMGSZ[size]
+    assert model.model.training is False, "Model must be in eval mode after loading"
+
+    # Checkpoint schema
+    assert weights_path.exists(), f"Weights not downloaded to {weights_path}"
+    ckpt = torch.load(weights_path, map_location="cpu", weights_only=True)
+    errors = validate_checkpoint_metadata(ckpt, strict=False)
+    assert errors == [], f"Checkpoint schema errors for {weights}: {errors}"
+
+    assert ckpt["model_family"] == "librefomo"
+    assert ckpt["task"] == "point"
+    assert ckpt["size"] == size
+    assert ckpt["imgsz"] == LIBREFOMO_EXPECTED_IMGSZ[size]
+    assert ckpt["nc"] == 1
+    assert isinstance(ckpt["names"], dict) and ckpt["names"][0] == "person"
+
+    print(
+        f"\n  {weights}: schema OK — "
+        f"task={ckpt['task']!r}, size={ckpt['size']!r}, "
+        f"imgsz={ckpt['imgsz']}, nc={ckpt['nc']}",
+        flush=True,
+    )
+    del model
+    cuda_cleanup()
+
+
+@requires_cuda
+@pytest.mark.parametrize(
+    "family,size,weights",
+    [
+        pytest.param(f, s, w, marks=pytest.mark.fomo, id=f"{f}-{s}")
+        for f, s, w in LIBREFOMO_CHECKPOINTS
+    ],
+)
+def test_fomo_inference_is_stable(family, size, weights):
+    """Load pretrained checkpoint and verify stable point-localization output.
+
+    Runs two inference passes on the same synthetic image and asserts:
+      - Both passes return ``result.points`` (no boxes)
+      - Output count is identical between passes
+      - No NaN / Inf values
+      - Public API (summary, to_json, xy, xyn) works correctly
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = LibreYOLO(weights, device=device)
+
+    image = _synthetic_image(LIBREFOMO_EXPECTED_IMGSZ[size])
+
+    try:
+        first = model.predict(image, conf=0.01, max_det=100)
+        second = model.predict(image, conf=0.01, max_det=100)
+
+        _assert_point_output_valid(family, first, pass_num=1)
+        _assert_point_output_valid(family, second, pass_num=2)
+
+        # Count stability
+        assert len(first) == len(second), (
+            f"{family}-{size}: point count changed between passes: "
+            f"{len(first)} → {len(second)}"
+        )
+
+        # Coordinate stability
+        if len(first) > 0:
+            n = min(5, len(first))
+            first_xy = first.points.xy[:n]
+            second_xy = second.points.xy[:n]
+            torch.testing.assert_close(first_xy, second_xy, rtol=1e-4, atol=1e-4)
+
+        print(
+            f"\n  {weights} (device={device}): "
+            f"n_points={len(first)}, stable=OK",
+            flush=True,
+        )
+    finally:
+        del model
+        cuda_cleanup()

--- a/tests/e2e/test_fomo_training.py
+++ b/tests/e2e/test_fomo_training.py
@@ -1,0 +1,190 @@
+"""
+LibreFOMO end-to-end training test.
+
+Runs a 2-epoch smoke train on a small YOLO-format point-localization dataset
+hosted at ``LibreYOLO/<DATASET_REPO>`` (HuggingFace, public), then verifies:
+
+  - Loss decreased epoch 1 → epoch 2
+  - ``last.pt`` exists with valid checkpoint schema
+  - ``metrics/F1`` is present in val_metrics
+  - Trained checkpoint loads via the LibreYOLO factory (auto-detects size)
+  - Inference on the reloaded model returns a valid ``result.points`` object
+
+Dataset format (YOLO-standard)::
+
+    dataset/
+    ├── data.yaml           # nc, names, path, train/val/test keys
+    ├── train/images/       # .jpg files
+    ├── train/labels/       # .txt  (class cx cy w h, normalised)
+    ├── valid/images/
+    └── valid/labels/
+
+Run via pytest::
+
+    pytest tests/e2e/test_fomo_training.py -v -m fomo
+
+Or via Modal::
+
+    modal run /tmp/libreyolo_librefomo_train_modal.py
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import torch
+import yaml
+
+from .conftest import cuda_cleanup, requires_cuda, run_direct_subprocess
+
+pytestmark = [pytest.mark.e2e, pytest.mark.fomo]
+
+# ---------------------------------------------------------------------------
+# Dataset — git-clone from HuggingFace (same pattern as marbles / RF1)
+# ---------------------------------------------------------------------------
+
+HF_REPO = "bdanko/sjsu-headcount-scene-1"
+DATASET_ROOT = Path.home() / ".cache" / "libreyolo" / "sjsu-headcount-scene-1"
+
+FOMO_EPOCHS = 2
+FOMO_BATCH = 8
+
+
+def download_fomo_dataset():
+    """Download the FOMO point-localization dataset from HuggingFace.
+
+    Cached under ~/.cache/libreyolo/fomo-smoke-small after the first run.
+    """
+    if DATASET_ROOT.exists() and (DATASET_ROOT / "data.yaml").exists():
+        return
+    print(f"\nDownloading dataset {HF_REPO} from HuggingFace ...")
+    DATASET_ROOT.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "clone", f"https://huggingface.co/datasets/{HF_REPO}", str(DATASET_ROOT)],
+        check=True,
+    )
+    print(f"Dataset downloaded to {DATASET_ROOT}")
+
+
+def patch_data_yaml():
+    """Ensure data.yaml has an absolute path so training resolves splits."""
+    data_yaml = DATASET_ROOT / "data.yaml"
+    data = yaml.safe_load(data_yaml.read_text())
+    if data.get("path") != str(DATASET_ROOT):
+        data["path"] = str(DATASET_ROOT)
+        data_yaml.write_text(yaml.dump(data, default_flow_style=False))
+
+
+@pytest.fixture(scope="module")
+def fomo_dataset():
+    """Download and patch the FOMO dataset. Shared by all fixtures in this module."""
+    download_fomo_dataset()
+    patch_data_yaml()
+    return DATASET_ROOT
+
+
+@requires_cuda
+def test_fomo_training_smoke(fomo_dataset, tmp_path):
+    """2-epoch smoke train on the FOMO dataset — verify plumbing end-to-end.
+
+    Uses ``run_direct_subprocess`` so CUDA state is isolated from other tests.
+    Asserts:
+      - Both epochs complete and loss decreases
+      - ``last.pt`` / ``best.pt`` written with valid checkpoint schema
+      - ``metrics/F1`` present in val_metrics
+      - Factory-loaded checkpoint runs inference correctly
+    """
+    dataset_data_yaml = str(fomo_dataset / "data.yaml")
+
+    run_direct_subprocess(
+        f"""
+        import torch
+        from pathlib import Path
+
+        from libreyolo import LibreYOLO
+        from libreyolo.models.librefomo.model import LibreFOMO
+        from libreyolo.utils.serialization import validate_checkpoint_metadata
+
+        # --- Build fresh LibreFOMO-s (no pretrained weights) ---
+        model = LibreFOMO(model_path=None, size="s", nb_classes=1, device="cpu")
+        assert model.family == "librefomo"
+        assert model.size == "s"
+        assert model.input_size == 96
+
+        # --- Train ---
+        results = model.train(
+            allow_experimental=True,
+            data=r"{dataset_data_yaml}",
+            epochs={FOMO_EPOCHS},
+            batch={FOMO_BATCH},
+            lr0=3e-4,
+            eval_interval=1,
+            workers=2,
+            device="cuda",
+            project=r"{str(tmp_path)}",
+            name="smoke_s",
+            exist_ok=True,
+            patience=0,
+        )
+
+        # --- Loss decreased ---
+        epoch_losses = results["epoch_losses"]
+        assert len(epoch_losses) == {FOMO_EPOCHS}, (
+            f"Expected {FOMO_EPOCHS} epoch losses, got {{len(epoch_losses)}}"
+        )
+        first_loss, last_loss = epoch_losses[0], epoch_losses[-1]
+        assert last_loss < first_loss, (
+            f"Loss did not decrease: {{first_loss:.4f}} → {{last_loss:.4f}}"
+        )
+        print(f"  loss: epoch1={{first_loss:.4f}}, epoch2={{last_loss:.4f}}", flush=True)
+
+        # --- Checkpoints written ---
+        save_dir = Path(results["save_dir"])
+        weights_dir = save_dir / "weights"
+        last_pt = weights_dir / "last.pt"
+        assert last_pt.exists(), f"last.pt not found at {{last_pt}}"
+
+        best_pt = weights_dir / "best.pt"
+        ckpt_path = best_pt if best_pt.exists() else last_pt
+
+        # --- Schema valid ---
+        ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        errors = validate_checkpoint_metadata(ckpt, strict=False)
+        assert errors == [], f"Checkpoint schema errors: {{errors}}"
+        assert ckpt["task"] == "point"
+        assert ckpt["model_family"] == "librefomo"
+        assert ckpt["size"] == "s"
+        print(f"  checkpoint schema OK: task={{ckpt['task']}}, size={{ckpt['size']}}", flush=True)
+
+        # --- metrics/F1 in val_metrics ---
+        val_metrics = [m for m in results.get("val_metrics", []) if m]
+        assert len(val_metrics) > 0, "No non-empty val_metrics entries"
+        last_metrics = val_metrics[-1]
+        assert "metrics/F1" in last_metrics, (
+            f"metrics/F1 not found in {{list(last_metrics.keys())}}"
+        )
+        f1 = last_metrics["metrics/F1"]
+        assert isinstance(f1, float) and f1 >= 0.0
+        print(f"  metrics/F1={{f1:.4f}}", flush=True)
+
+        # --- Factory reload + inference ---
+        from libreyolo import LibreYOLO
+        import numpy as np
+        from PIL import Image
+
+        trained = LibreYOLO(str(ckpt_path), device="cpu")
+        assert trained.family == "librefomo"
+        assert trained.size == "s"
+
+        arr = np.zeros((96, 96, 3), dtype=np.uint8)
+        arr[40:50, 40:50] = 200
+        result = trained.predict(Image.fromarray(arr), conf=0.01, max_det=20)
+        assert result.boxes is None, "LibreFOMO must not produce boxes"
+        assert result.points is not None
+        print(f"  inference OK — n_points={{len(result)}}", flush=True)
+
+        print("\\n✓ LibreFOMO training smoke test PASSED", flush=True)
+        """,
+        timeout=1800,
+    )
+    cuda_cleanup()

--- a/tests/unit/test_librefomo.py
+++ b/tests/unit/test_librefomo.py
@@ -1,0 +1,80 @@
+import torch
+import pytest
+
+from libreyolo import LibreFOMO, Points
+from libreyolo.models.librefomo.utils import decode_points_from_logits, postprocess
+from libreyolo.tasks import normalize_task, resolve_task
+from libreyolo.utils.results import Results
+from libreyolo.validation.point_validator import PointValidator
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_point_task_normalization():
+    assert normalize_task("points") == "point"
+    assert resolve_task(default_task="point", supported_tasks=("point",)) == "point"
+
+
+def test_librefomo_forward_shapes():
+    for size, imgsz, grid in (("s", 96, 12), ("m", 192, 24), ("l", 224, 28)):
+        model = LibreFOMO(model_path=None, size=size, nb_classes=1, device="cpu")
+        out = model._forward(torch.zeros(1, 3, imgsz, imgsz))
+        assert out.shape == (1, 2, grid, grid)
+
+
+def test_librefomo_decode_and_postprocess_points():
+    logits = torch.zeros(1, 2, 4, 4)
+    logits[0, 1, 2, 1] = 8.0
+    decoded = decode_points_from_logits(logits, conf_threshold=0.5, nms_radius=1)
+    assert decoded[0].shape == (1, 4)
+    assert decoded[0][0, :3].tolist() == [1.0, 2.0, 1.0]
+
+    det = postprocess(logits, conf_thres=0.5, input_size=32, original_size=(80, 40))
+    assert det["num_detections"] == 1
+    assert torch.allclose(det["points"][0], torch.tensor([30.0, 25.0]))
+    assert det["classes"][0].item() == 0.0
+
+
+def test_points_results_summary_and_len():
+    points = Points(torch.tensor([[10.0, 20.0, 0.0, 0.9]]), orig_shape=(40, 80))
+    result = Results(boxes=None, points=points, orig_shape=(40, 80), names={0: "object"})
+    assert len(result) == 1
+    assert result.points.xyn.tolist() == [[0.125, 0.5]]
+    assert result.summary()[0] == {
+        "name": "object",
+        "class": 0,
+        "confidence": 0.9,
+        "point": {"x": 10.0, "y": 20.0},
+    }
+
+
+def test_point_validator_metrics_match_centers():
+    validator = PointValidator.__new__(PointValidator)
+    validator.config = type(
+        "Cfg",
+        (),
+        {
+            "imgsz": 32,
+            "conf_thres": 0.5,
+            "max_det": 300,
+            "point_distance_tolerance": 1.5,
+            "point_nms_radius": 1,
+        },
+    )()
+    validator.distance_tolerance = 1.5
+    validator.nms_radius = 1
+    validator.model = LibreFOMO(model_path=None, size="s", nb_classes=1, device="cpu")
+    validator._last_metric_shape = (4, 4)
+    validator._init_metrics()
+
+    preds = [torch.tensor([[1.0, 2.0, 0.0, 0.99]])]
+    targets = torch.zeros(1, 120, 5)
+    targets[0, 0] = torch.tensor([4.0, 12.0, 12.0, 20.0, 0.0])
+
+    validator._update_metrics(preds, targets, None)
+    metrics = validator._compute_metrics()
+    assert metrics["metrics/precision"] == 1.0
+    assert metrics["metrics/recall"] == 1.0
+    assert metrics["metrics/F1"] == 1.0
+    assert metrics["metrics/mean_distance"] == 0.0

--- a/tests/unit/test_librefomo.py
+++ b/tests/unit/test_librefomo.py
@@ -2,10 +2,12 @@ import torch
 import pytest
 
 from libreyolo import LibreFOMO, Points
+from libreyolo.models.base.inference import InferenceRunner
 from libreyolo.models.librefomo.utils import decode_points_from_logits, postprocess
 from libreyolo.tasks import normalize_task, resolve_task
 from libreyolo.utils.results import Results
 from libreyolo.validation.point_validator import PointValidator
+from libreyolo.utils.download import _detect_family_from_filename
 
 
 pytestmark = pytest.mark.unit
@@ -14,6 +16,7 @@ pytestmark = pytest.mark.unit
 def test_point_task_normalization():
     assert normalize_task("points") == "point"
     assert resolve_task(default_task="point", supported_tasks=("point",)) == "point"
+    assert _detect_family_from_filename("LibreFOMOs.pt") == "librefomo"
 
 
 def test_librefomo_forward_shapes():
@@ -47,6 +50,26 @@ def test_points_results_summary_and_len():
         "confidence": 0.9,
         "point": {"x": 10.0, "y": 20.0},
     }
+
+
+def test_inference_runner_wraps_empty_points():
+    model = LibreFOMO(model_path=None, size="s", nb_classes=1, device="cpu")
+    runner = InferenceRunner(model)
+    result = runner._wrap_results(
+        {
+            "points": torch.zeros((0, 2)),
+            "scores": torch.zeros((0,)),
+            "classes": torch.zeros((0,)),
+            "num_detections": 0,
+        },
+        original_size=(80, 40),
+        image_path=None,
+        classes=None,
+    )
+    assert result.boxes is None
+    assert result.points is not None
+    assert len(result) == 0
+    assert result.summary() == []
 
 
 def test_point_validator_metrics_match_centers():

--- a/tests/unit/test_librefomo.py
+++ b/tests/unit/test_librefomo.py
@@ -101,3 +101,45 @@ def test_point_validator_metrics_match_centers():
     assert metrics["metrics/recall"] == 1.0
     assert metrics["metrics/F1"] == 1.0
     assert metrics["metrics/mean_distance"] == 0.0
+
+
+def test_librefomo_multiclass_forward_and_loss():
+    """nc>1 must produce (B, nc+1, H, W) output and a finite loss."""
+    from libreyolo.models.librefomo.loss import LibreFOMOLoss
+
+    NC = 3
+    GRID = 12
+    IMGSZ = 96
+
+    model = LibreFOMO(model_path=None, size="s", nb_classes=NC, device="cpu")
+    out = model._forward(torch.zeros(1, 3, IMGSZ, IMGSZ))
+    assert out.shape == (1, NC + 1, GRID, GRID), (
+        f"Expected (1, {NC+1}, {GRID}, {GRID}), got {tuple(out.shape)}"
+    )
+
+    # Build a target grid: one peak at cell (2, 3), class 1
+    target = torch.zeros(1, NC + 1, GRID, GRID)
+    target[0, 0] = 1.0          # background everywhere
+    target[0, 0, 2, 3] = 0.0   # suppress background at peak
+    target[0, 2, 2, 3] = 1.0   # class 1 (channel index 2)
+
+    loss_fn = LibreFOMOLoss(num_classes=NC, fg_weight=100.0, device="cpu")
+    loss_dict = loss_fn(out, target)
+    assert torch.isfinite(loss_dict["total_loss"]), f"Loss is not finite: {loss_dict}"
+
+
+def test_librefomo_rebuild_for_new_classes():
+    """_rebuild_for_new_classes must resize the head and preserve backbone weights."""
+    model = LibreFOMO(model_path=None, size="s", nb_classes=1, device="cpu")
+    old_backbone_w = model.model.backbone.conv1[0].conv.weight.clone()
+
+    model._rebuild_for_new_classes(3)
+
+    # Head output channels must now be nc+1 = 4
+    assert model.model.head.out_channels == 4
+    # nb_classes updated on the wrapper
+    assert model.nb_classes == 3
+    # Backbone weights preserved
+    new_backbone_w = model.model.backbone.conv1[0].conv.weight
+    assert torch.equal(old_backbone_w, new_backbone_w)
+

--- a/tests/unit/test_librefomo.py
+++ b/tests/unit/test_librefomo.py
@@ -182,3 +182,123 @@ def test_librefomo_schedulers():
     assert isinstance(t_yolox.create_scheduler(10), WarmupCosineScheduler)
 
 
+def test_trainer_rebuild_goes_through_wrapper_model():
+    """_build_yolo_datasets must call wrapper_model._rebuild_for_new_classes,
+    not self.model._rebuild_for_new_classes (the raw nn.Module has no such method).
+    """
+    from libreyolo.models.librefomo.trainer import LibreFOMOTrainer
+
+    wrapper = LibreFOMO(model_path=None, size="s", nb_classes=1, device="cpu")
+    trainer = LibreFOMOTrainer(wrapper.model, wrapper_model=wrapper, epochs=1)
+
+    # Raw LibreFOMOModel has no _rebuild_for_new_classes
+    assert not hasattr(trainer.model, "_rebuild_for_new_classes"), (
+        "Raw LibreFOMOModel should NOT expose _rebuild_for_new_classes"
+    )
+
+    # Simulate what fixed _build_yolo_datasets does
+    trainer.wrapper_model._rebuild_for_new_classes(3)
+    trainer.model = trainer.wrapper_model.model
+
+    assert wrapper.nb_classes == 3
+    assert wrapper.model.head.out_channels == 4
+    assert trainer.model is wrapper.model
+
+
+def test_sweep_validation_multiclass_fp_fn_correct():
+    """class-mismatch predictions must not count as TP."""
+    import numpy as np
+    from scipy.spatial.distance import cdist
+    from scipy.optimize import linear_sum_assignment
+    from libreyolo.models.librefomo.utils import decode_points_from_logits
+
+    # 4x4, nc=2 (channels: bg=0, cls0=1, cls1=2)
+    logits = torch.zeros(1, 3, 4, 4)
+    logits[0, 2, 1, 2] = 8.0  # class-1 peak at (col=2, row=1)
+
+    target = torch.zeros(1, 4, 4, dtype=torch.long)
+    target[0, 1, 2] = 2  # class-1 GT
+
+    decoded = decode_points_from_logits(logits, conf_threshold=0.5, nms_radius=1)
+    rows = decoded[0]
+    preds_xy = rows[:, :2].numpy()
+    preds_cls = (rows[:, 2].long() - 1).numpy()
+
+    fg_mask = target[0] >= 1
+    ys, xs = torch.where(fg_mask)
+    true_cls_np = (target[0][ys, xs] - 1).numpy()
+    trues_xy = torch.stack((xs, ys), dim=1).float().numpy()
+
+    dist_mat = cdist(preds_xy, trues_xy)
+    for pi in range(len(preds_cls)):
+        for ti in range(len(true_cls_np)):
+            if preds_cls[pi] != true_cls_np[ti]:
+                dist_mat[pi, ti] = np.inf
+
+    row_ind, col_ind = linear_sum_assignment(np.where(np.isfinite(dist_mat), dist_mat, 1e9))
+    tp = sum(1 for r, c in zip(row_ind, col_ind)
+             if np.isfinite(dist_mat[r, c]) and dist_mat[r, c] <= 1.5)
+    assert tp == 1, f"Expected 1 TP for matching class-1 peak, got {tp}"
+
+    # Class mismatch: class-0 prediction at same location → 0 TP
+    logits_wrong = torch.zeros(1, 3, 4, 4)
+    logits_wrong[0, 1, 1, 2] = 8.0  # class-0 at same cell
+    decoded_wrong = decode_points_from_logits(logits_wrong, conf_threshold=0.5, nms_radius=1)
+    rows_wrong = decoded_wrong[0]
+    preds_cls_wrong = (rows_wrong[:, 2].long() - 1).numpy()
+    dist_mat_wrong = cdist(rows_wrong[:, :2].numpy(), trues_xy)
+    for pi in range(len(preds_cls_wrong)):
+        for ti in range(len(true_cls_np)):
+            if preds_cls_wrong[pi] != true_cls_np[ti]:
+                dist_mat_wrong[pi, ti] = np.inf
+    row_ind_w, col_ind_w = linear_sum_assignment(
+        np.where(np.isfinite(dist_mat_wrong), dist_mat_wrong, 1e9))
+    tp_wrong = sum(1 for r, c in zip(row_ind_w, col_ind_w)
+                   if np.isfinite(dist_mat_wrong[r, c]) and dist_mat_wrong[r, c] <= 1.5)
+    assert tp_wrong == 0, f"Expected 0 TP on class mismatch, got {tp_wrong}"
+
+
+def test_trainer_propagates_dataset_names_to_wrapper(tmp_path):
+    """_build_yolo_datasets must copy data.yaml names to wrapper_model."""
+    import yaml
+    import numpy as np
+    from PIL import Image as PILImage
+    from libreyolo.models.librefomo.trainer import LibreFOMOTrainer
+
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    PILImage.fromarray(np.zeros((96, 96, 3), dtype=np.uint8)).save(img_dir / "img0.jpg")
+    (lbl_dir / "img0.txt").write_text("")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(yaml.dump({
+        "path": str(tmp_path),
+        "train": "images/train",
+        "val": "images/train",
+        "nc": 2,
+        "names": {0: "cat", 1: "dog"},
+    }))
+
+    wrapper = LibreFOMO(model_path=None, size="s", nb_classes=2, device="cpu")
+    wrapper.names = {0: "class_0", 1: "class_1"}  # generic defaults
+
+    trainer = LibreFOMOTrainer(
+        wrapper.model, wrapper_model=wrapper,
+        data=str(data_yaml), epochs=1, imgsz=96,
+    )
+    trainer._build_yolo_datasets(96, 12)
+
+    assert wrapper.names == {0: "cat", 1: "dog"}, (
+        f"wrapper.names should be {{0:'cat',1:'dog'}}, got {wrapper.names}"
+    )
+
+
+def test_point_validator_rejects_augment():
+    """PointValidator._run_validation_augmented must raise ValueError."""
+    from libreyolo.validation.point_validator import PointValidator
+
+    validator = PointValidator.__new__(PointValidator)
+    with pytest.raises(ValueError, match="augment=True"):
+        validator._run_validation_augmented()

--- a/tests/unit/test_librefomo.py
+++ b/tests/unit/test_librefomo.py
@@ -302,3 +302,80 @@ def test_point_validator_rejects_augment():
     validator = PointValidator.__new__(PointValidator)
     with pytest.raises(ValueError, match="augment=True"):
         validator._run_validation_augmented()
+
+
+def test_loss_rebuilt_on_class_count_change(tmp_path):
+    """Trainer must rebuild self._loss_fn when dataset class count resolves to a new value."""
+    import yaml
+    import numpy as np
+    from PIL import Image as PILImage
+    from libreyolo.models.librefomo.trainer import LibreFOMOTrainer
+
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    PILImage.fromarray(np.zeros((96, 96, 3), dtype=np.uint8)).save(img_dir / "img0.jpg")
+    (lbl_dir / "img0.txt").write_text("")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(yaml.dump({
+        "path": str(tmp_path),
+        "train": "images/train",
+        "val": "images/train",
+        "nc": 3,
+        "names": {0: "cat", 1: "dog", 2: "fish"},
+    }))
+
+    wrapper = LibreFOMO(model_path=None, size="s", nb_classes=1, device="cpu")
+    trainer = LibreFOMOTrainer(
+        wrapper.model, wrapper_model=wrapper,
+        data=str(data_yaml), epochs=1, imgsz=96,
+    )
+    # Mock self.device and self.on_setup() to instantiate the initial loss with nc=1
+    trainer.device = torch.device("cpu")
+    trainer.on_setup()
+    assert len(trainer._loss_fn.weights) == 2
+
+    # Running _build_yolo_datasets should trigger a rebuild to nc=3
+    trainer._build_yolo_datasets(96, 12)
+    assert trainer.config.num_classes == 3
+    assert len(trainer._loss_fn.weights) == 4
+
+
+def test_point_validator_hungarian_matching_all_inf():
+    """PointValidator._update_metrics must not crash when cost matrix contains infs (class mismatches)."""
+    from libreyolo.validation.point_validator import PointValidator
+
+    validator = PointValidator.__new__(PointValidator)
+    validator.config = type(
+        "Cfg",
+        (),
+        {
+            "imgsz": 32,
+            "conf_thres": 0.5,
+            "max_det": 300,
+            "point_distance_tolerance": 1.5,
+            "point_nms_radius": 1,
+        },
+    )()
+    validator.distance_tolerance = 1.5
+    validator.nms_radius = 1
+    validator.model = LibreFOMO(model_path=None, size="s", nb_classes=2, device="cpu")
+    validator._last_metric_shape = (4, 4)
+    validator._init_metrics()
+
+    # Create predictions and targets with class mismatch (e.g. pred is class 0, target is class 1)
+    preds = [torch.tensor([[1.0, 2.0, 0.0, 0.99]])]
+    targets = torch.zeros(1, 120, 5)
+    targets[0, 0] = torch.tensor([4.0, 12.0, 12.0, 20.0, 1.0])  # class 1
+
+    # Should not raise ValueError (from scipy.optimize.linear_sum_assignment)
+    validator._update_metrics(preds, targets, None)
+
+    metrics = validator._compute_metrics()
+    assert metrics["metrics/precision"] == 0.0
+    assert metrics["metrics/recall"] == 0.0
+    assert validator.total_fp == 1
+    assert validator.total_fn == 1
+

--- a/tests/unit/test_librefomo.py
+++ b/tests/unit/test_librefomo.py
@@ -143,3 +143,42 @@ def test_librefomo_rebuild_for_new_classes():
     new_backbone_w = model.model.backbone.conv1[0].conv.weight
     assert torch.equal(old_backbone_w, new_backbone_w)
 
+
+def test_librefomo_schedulers():
+    from libreyolo.models.librefomo.trainer import LibreFOMOTrainer
+    from libreyolo.models.librefomo.model import LibreFOMO
+    from libreyolo.training.scheduler import (
+        ConstantLRScheduler,
+        CosineAnnealingScheduler,
+        FlatCosineScheduler,
+        LinearLRScheduler,
+        WarmupCosineScheduler,
+    )
+
+    model = LibreFOMO(model_path=None, size="s", nb_classes=1, device="cpu")
+
+    # Test create_scheduler selections
+    # constant
+    t_const = LibreFOMOTrainer(model.model, wrapper_model=model, scheduler="constant", epochs=10)
+    assert isinstance(t_const.create_scheduler(10), ConstantLRScheduler)
+
+    # cosine / cos
+    t_cos = LibreFOMOTrainer(model.model, wrapper_model=model, scheduler="cos", epochs=10)
+    assert isinstance(t_cos.create_scheduler(10), CosineAnnealingScheduler)
+
+    t_cosine = LibreFOMOTrainer(model.model, wrapper_model=model, scheduler="cosine", epochs=10)
+    assert isinstance(t_cosine.create_scheduler(10), CosineAnnealingScheduler)
+
+    # flat_cosine
+    t_flat = LibreFOMOTrainer(model.model, wrapper_model=model, scheduler="flat_cosine", epochs=10)
+    assert isinstance(t_flat.create_scheduler(10), FlatCosineScheduler)
+
+    # linear
+    t_lin = LibreFOMOTrainer(model.model, wrapper_model=model, scheduler="linear", epochs=10)
+    assert isinstance(t_lin.create_scheduler(10), LinearLRScheduler)
+
+    # yoloxwarmcos
+    t_yolox = LibreFOMOTrainer(model.model, wrapper_model=model, scheduler="yoloxwarmcos", epochs=10)
+    assert isinstance(t_yolox.create_scheduler(10), WarmupCosineScheduler)
+
+


### PR DESCRIPTION
# Support LibreFOMO Integration (Point Localization)

## Background issue: 

Located at: 
https://github.com/LibreYOLO/libreyolo/issues/300

## Description

This PR integrates LibreFOMO (Fast Object Localization on Mobile Devices) into LibreYOLO, introducing point localization support. The integration covers the native model definitions, loss functions, custom post-processing, and a test suite. 

Point-based detection is relevant for cases such as robotics, GUI interaction, and document understanding datasets where predicting a central point or click-target is often more practical and contextually accurate than predicting a full bounding box.

PointValidator is added as purely a metric calculator that accepts lists of 2D prediction points, performs bipartite matching (Hungarian assignment) against ground truth, and outputs metrics (Precision, Recall, F1, mean distance). Any future point-localization model must implement three adapter methods:

_decode_point_predictions(...): Translates raw model outputs into a unified list of predicted points [x, y, class, confidence].
_point_metric_shape(...): Tells the validator the spatial dimensions of the target matching space.
_point_targets_from_boxes(...): Defines how dataset labels are projected into the validation matching space.

`point` is added a a task type in `libreyolo/tasks.py`.

## Licensing and Weights

At the moment, the PyTorch tensors are automatically pulled from:

https://huggingface.co/bdanko/LibreFOMO

These were wrapped with this serialization:

```
from libreyolo.utils.serialization import wrap_libreyolo_checkpoint

ckpt = wrap_libreyolo_checkpoint(
    state_dict,
    model_family="librefomo",
    size=size,
    task="point",
    nc=model.nc,
    names={0: "person"},
    imgsz=cfg["imgsz"],
    format_version=2,
    arch="LibreFOMO",
    backbone="mobilenet_v2_keras_tf_same_staticpad_direct_block6_expand",
    alpha=cfg["alpha"],
    head_channels=model.head_channels,
    supported_tasks=["point", "detect"],
    default_task="point",
    state_dict_key="model",
)
```

The full conversion notebook from the original Keras models can be found at:

https://github.com/bencejdanko/librefomo-preparation-and-training/blob/main/convert_keras_mobilenetv2_to_pytorch.ipynb

These are under the cc-by-nc-4.0 (non-commercial) license, due to the original backbone weights being derived from ImageNet training, which require non-commercial usage. In the future, we can add our own pre-trained MobileNetV2 weights from open datasets such as Open Images and COCO. 

Before a final commit, we could possibly relocate from bdanko/LibreFOMO to the official repositories. We can also wait to place anything FOMO related into the official HF repo until we train fully open weights.

## Shared code change

Included is one important location in which I had to touch the Base model behavior at `libreyolo/models/base`:

_rebuild_for_new_classes creates a fresh nn.Module (PyTorch default: training=True) and calls .to(device), but never .eval(). When a checkpoint's nc differs from the factory default (80), this triggers a rebuild during _load_weights. After construction via LibreYOLO(...), model.model.training is True, which is inconsistent with the non-rebuild load path (which correctly calls .eval() at BaseModel.__init__:204). 

I had to add self.model.eval() at the end of _rebuild_for_new_classes. All trainer code explicitly calls model.train() at epoch start, making this idempotent for the training path. 

## Tests

Three test files were added (`@pytest.mark.fomo`):

`tests/unit/test_librefomo.py`:
- Point normalization and grid encoding
- Forward pass output shapes for all three sizes (s/m/l)
- Decode + postprocess: peak extraction, NMS radius, confidence filtering
- `PointsResult` summary and `len()`
- Inference runner wrapping empty (zero-detection) outputs
- `PointValidator` metric computation against known centers

`tests/e2e/test_fomo_inference.py`:
- Checkpoint schema validation: confirms `task='point'`, correct `size`, `imgsz`, `nc` for each of the three pretrained weights (`bdanko/LibreFOMO`)

`tests/e2e/test_fomo_training.py`: 
- Clones `bdanko/sjsu-headcount-scene-1` (YOLO-format, ~8 MB), runs a 2-epoch train of LibreFOMO-s, then verifies loss decreased, `last.pt` exists with a valid checkpoint schema, `metrics/F1` is present in val metrics, and the saved checkpoint reloads via the LibreYOLO factory and returns a valid `result.points` on inference.

## Demonstration Notebook

I have a sample of running the current implementation at this location on a dataset I am using for my purposes:

https://github.com/bencejdanko/librefomo-preparation-and-training/blob/main/train_librefomo_sjsu.ipynb

This conducts a full training run and inference using the usual factory APIs for training and inference, using this `librefomo` branch.

## Limitations

- Multiclass point localization is architecturally supported, but I haven't heavily explored it heavily with a dedicated demo test. My test cases revolve around 1 class, person detection.
- PointValidator currently does point matching occurs in the model output grid space, which may be too FOMO specific, if we want to add point models in the future.
- The point task currently uses a standard detection dataset loader and parses YOLO-format bounding boxes and computes their centroids in _target_points_from_boxes. It does not natively support datasets annotated solely with single points or dot-coordinate labels. This may require a future PointDataset class.