### PR TITLE
Add embedded NMS to YOLO9 ONNX export

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -58,6 +58,24 @@ YOLO9-family exports may use non-square `imgsz_h/imgsz_w` in supported runtime
 formats; families or formats without explicit rectangular support must reject
 the metadata instead of preprocessing those artifacts as square inputs.
 
+Embedded-NMS runtime exports may also write these flat metadata keys:
+
+- `nms`: string boolean. `"true"` means the exported graph includes an
+  embedded post-processing output.
+- `nms_conf`: confidence threshold baked into the embedded NMS graph output.
+- `nms_iou`: IoU threshold baked into the embedded NMS graph output.
+- `max_det`: maximum number of post-NMS detection rows emitted by the embedded
+  graph output.
+- `nms_raw_output`: string boolean. `"true"` means the exported graph also
+  exposes an auxiliary raw detector output for LibreYOLO backend parsing.
+
+For ONNX YOLO9 detection exports with `nms=true`, output `0` / `output` is the
+standalone post-NMS tensor using the export-time `nms_conf`, `nms_iou`, and
+`max_det` values. When `nms_raw_output=true`, output `1` / `raw` is reserved for
+LibreYOLO backends so they can apply native original-canvas clipping and runtime
+`predict(conf=..., iou=..., max_det=...)` semantics. Third-party consumers that
+want graph-embedded NMS should use the first output.
+
 ## Training Checkpoints
 
 Trainer checkpoints use the same required metadata core and may also contain

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -759,10 +759,9 @@ class BaseBackend(ABC):
             anchor_idx, class_ids = np.nonzero(scores > conf)
             boxes_input = boxes_input_all[anchor_idx]
             max_scores = scores[anchor_idx, class_ids]
-            if max_scores.size > _YOLO9_MAX_NMS_CANDIDATES:
-                keep = np.argpartition(-max_scores, _YOLO9_MAX_NMS_CANDIDATES - 1)[
-                    :_YOLO9_MAX_NMS_CANDIDATES
-                ]
+            max_nms = max(max_det, _YOLO9_MAX_NMS_CANDIDATES)
+            if max_scores.size > max_nms:
+                keep = np.argpartition(-max_scores, max_nms - 1)[:max_nms]
                 keep = keep[np.argsort(-max_scores[keep])]
                 boxes_input = boxes_input[keep]
                 max_scores = max_scores[keep]
@@ -1126,14 +1125,14 @@ class BaseBackend(ABC):
         if (
             obb is None
             and not _is_nms_free_family(self.model_family)
-            and not getattr(self, "embedded_nms", False)
         ):
             # YOLO9 (like DAMO) needs class-aware NMS so multi-label detections
             # on a shared anchor (same box, different class) survive, matching
             # the native batched_nms path. Class-agnostic NMS would drop the
             # lower-scored class and make exported runtimes disagree with native.
-            # Models with NMS baked into the graph skip this — they already
-            # emit final detections.
+            # ONNX models with graph-embedded NMS still pass through this after
+            # backend clipping so letterboxed-image behavior stays aligned with
+            # native YOLO9 postprocess.
             if self.model_family in ("damoyolo", "yolo9", "yolo9_e2e"):
                 keep = _batched_nms_numpy(boxes, max_scores, class_ids, iou)
             else:

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -255,6 +255,8 @@ class BaseBackend(ABC):
         # models emit final (1, max_det, 6) detections instead of raw tensors.
         if not hasattr(self, "embedded_nms"):
             self.embedded_nms = False
+        if not hasattr(self, "embedded_nms_raw_output_index"):
+            self.embedded_nms_raw_output_index = None
         if not hasattr(self, "model"):
             self.model = _BackendEvalProxy()
 
@@ -506,6 +508,22 @@ class BaseBackend(ABC):
         orig_w, orig_h = original_size
 
         if getattr(self, "embedded_nms", False):
+            raw_index = getattr(self, "embedded_nms_raw_output_index", None)
+            if (
+                self.model_family == "yolo9"
+                and isinstance(raw_index, int)
+                and raw_index < len(all_outputs)
+            ):
+                boxes, scores, cls = self._parse_yolo9(
+                    [all_outputs[raw_index]],
+                    effective_imgsz,
+                    orig_w,
+                    orig_h,
+                    conf,
+                    iou=iou,
+                    max_det=max_det,
+                )
+                return boxes, scores, cls, None
             boxes, scores, cls = self._parse_embedded_nms(
                 all_outputs, effective_imgsz, orig_w, orig_h, conf
             )
@@ -779,12 +797,25 @@ class BaseBackend(ABC):
         boxes[:, :4] /= ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        valid_boxes = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+        if not valid_boxes.any():
+            if self.task == "segment":
+                return boxes[:0], max_scores[:0], class_ids[:0], None
+            return boxes[:0], max_scores[:0], class_ids[:0]
+        if not valid_boxes.all():
+            boxes = boxes[valid_boxes]
+            boxes_input = boxes_input[valid_boxes]
+            max_scores = max_scores[valid_boxes]
+            class_ids = class_ids[valid_boxes]
 
         if self.task == "segment" and len(all_outputs) >= 3:
             from ..models.yolo9.utils import _process_masks
 
             proto = torch.from_numpy(all_outputs[1][0]).float()
-            coeffs = torch.from_numpy(all_outputs[2][0].T[mask]).float()
+            coeffs_np = all_outputs[2][0].T[mask]
+            if not valid_boxes.all():
+                coeffs_np = coeffs_np[valid_boxes]
+            coeffs = torch.from_numpy(coeffs_np).float()
             boxes_input_t = torch.from_numpy(boxes_input).float()
             masks_out = _process_masks(
                 proto,

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -710,6 +710,10 @@ class BaseBackend(ABC):
         boxes /= ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        valid = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+        boxes = boxes[valid]
+        scores = scores[valid]
+        class_ids = class_ids[valid]
         return boxes, scores, class_ids
 
     def _parse_yolo9(

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -251,6 +251,10 @@ class BaseBackend(ABC):
             # Some concrete backends expose size as a computed read-only property.
             pass
         self.input_size = self.imgsz
+        # Set by backends that load a model with NMS baked into the graph; such
+        # models emit final (1, max_det, 6) detections instead of raw tensors.
+        if not hasattr(self, "embedded_nms"):
+            self.embedded_nms = False
         if not hasattr(self, "model"):
             self.model = _BackendEvalProxy()
 
@@ -501,6 +505,12 @@ class BaseBackend(ABC):
         """Parse raw outputs into boxes, scores, classes, masks, and optional OBB."""
         orig_w, orig_h = original_size
 
+        if getattr(self, "embedded_nms", False):
+            boxes, scores, cls = self._parse_embedded_nms(
+                all_outputs, effective_imgsz, orig_w, orig_h, conf
+            )
+            return boxes, scores, cls, None
+
         if self.model_family == "yolox":
             boxes, scores, cls = self._parse_yolox(
                 all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio
@@ -674,6 +684,33 @@ class BaseBackend(ABC):
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
 
         return boxes, max_scores, class_ids
+
+    def _parse_embedded_nms(self, all_outputs, effective_imgsz, orig_w, orig_h, conf):
+        """Parse a graph-embedded-NMS detection output.
+
+        Shape ``(1, max_det, 6)`` with rows ``[x1, y1, x2, y2, score, class]`` in
+        input-canvas (letterbox) pixels. NMS already ran in the graph; here we
+        drop zero-padding / sub-``conf`` rows and undo the letterbox scaling.
+        """
+        det = np.asarray(all_outputs[0], dtype=np.float32)
+        if det.ndim == 3:
+            det = det[0]  # (max_det, 6)
+        keep = det[:, 4] > conf
+        det = det[keep]
+        if det.shape[0] == 0:
+            empty = np.empty((0, 4), dtype=np.float32)
+            return empty, np.empty((0,), np.float32), np.empty((0,), np.int64)
+
+        boxes = det[:, :4].copy()
+        scores = det[:, 4].astype(np.float32)
+        class_ids = det[:, 5].astype(np.int64)
+
+        input_h, input_w = _imgsz_hw(effective_imgsz)
+        ratio = min(input_h / orig_h, input_w / orig_w)
+        boxes /= ratio
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        return boxes, scores, class_ids
 
     def _parse_yolo9(
         self,
@@ -1082,11 +1119,17 @@ class BaseBackend(ABC):
                 names=self.names,
             )
 
-        if obb is None and not _is_nms_free_family(self.model_family):
+        if (
+            obb is None
+            and not _is_nms_free_family(self.model_family)
+            and not getattr(self, "embedded_nms", False)
+        ):
             # YOLO9 (like DAMO) needs class-aware NMS so multi-label detections
             # on a shared anchor (same box, different class) survive, matching
             # the native batched_nms path. Class-agnostic NMS would drop the
             # lower-scored class and make exported runtimes disagree with native.
+            # Models with NMS baked into the graph skip this — they already
+            # emit final detections.
             if self.model_family in ("damoyolo", "yolo9", "yolo9_e2e"):
                 keep = _batched_nms_numpy(boxes, max_scores, class_ids, iou)
             else:

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -75,8 +75,12 @@ class OnnxBackend(BaseBackend):
             supported_tasks,
             default_task,
             names,
+            embedded_nms,
             metadata_imgsz,
         ) = self._read_onnx_metadata(onnx_path, nb_classes)
+        # Models exported with nms=True emit final (1, max_det, 6) detections;
+        # flag it so the base parser routes them through _parse_embedded_nms.
+        self.embedded_nms = embedded_nms
         input_shape = self.session.get_inputs()[0].shape
         static_imgsz = self._read_static_input_imgsz(input_shape)
         if static_imgsz is not None:
@@ -120,7 +124,7 @@ class OnnxBackend(BaseBackend):
 
         Returns:
             Tuple of (model_family, model_size, task, supported_tasks,
-            default_task, names, imgsz).
+            default_task, names, embedded_nms, imgsz).
         """
         model_family = None
         model_size = None
@@ -129,6 +133,7 @@ class OnnxBackend(BaseBackend):
         supported_tasks = ("detect",)
         names = None
         imgsz = None
+        embedded_nms = False
         try:
             import onnx
 
@@ -172,12 +177,23 @@ class OnnxBackend(BaseBackend):
                     names = {i: n for i, n in enumerate(COCO_CLASSES)}
                 else:
                     names = {i: f"class_{i}" for i in range(nc)}
+
+            embedded_nms = str(meta.get("nms", "")).lower() == "true"
         except (NotImplementedError, MetadataImageSizeError):
             raise
         except Exception as e:
             logger.warning("Failed to read ONNX metadata from %s: %s", onnx_path, e)
 
-        return model_family, model_size, task, supported_tasks, default_task, names, imgsz
+        return (
+            model_family,
+            model_size,
+            task,
+            supported_tasks,
+            default_task,
+            names,
+            embedded_nms,
+            imgsz,
+        )
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run ONNX Runtime inference."""

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -68,6 +68,12 @@ class OnnxBackend(BaseBackend):
         self.session = ort.InferenceSession(onnx_path, providers=providers)
         self.input_name = self.session.get_inputs()[0].name
         self.output_names = [output.name for output in self.session.get_outputs()]
+        try:
+            runtime_metadata = dict(
+                self.session.get_modelmeta().custom_metadata_map or {}
+            )
+        except Exception:
+            runtime_metadata = {}
 
         (
             model_family,
@@ -78,7 +84,9 @@ class OnnxBackend(BaseBackend):
             names,
             embedded_nms,
             metadata_imgsz,
-        ) = self._read_onnx_metadata(onnx_path, nb_classes)
+        ) = self._read_onnx_metadata(
+            onnx_path, nb_classes, runtime_metadata=runtime_metadata
+        )
         # Models exported with nms=True emit final (1, max_det, 6) detections.
         # Newer YOLO9 ONNX exports also include a raw auxiliary output so the
         # LibreYOLO backend can apply native clipping/NMS for non-square images.
@@ -126,7 +134,11 @@ class OnnxBackend(BaseBackend):
         return h if h == w else (h, w)
 
     @staticmethod
-    def _read_onnx_metadata(onnx_path: str, default_nb_classes: int):
+    def _read_onnx_metadata(
+        onnx_path: str,
+        default_nb_classes: int,
+        runtime_metadata: dict | None = None,
+    ):
         """Read libreyolo metadata embedded in an ONNX model file.
 
         Returns:
@@ -142,10 +154,12 @@ class OnnxBackend(BaseBackend):
         imgsz = None
         embedded_nms = False
         try:
-            import onnx
+            meta = dict(runtime_metadata or {})
+            if not meta:
+                import onnx
 
-            model_proto = onnx.load(onnx_path)
-            meta = {p.key: p.value for p in model_proto.metadata_props}
+                model_proto = onnx.load(onnx_path)
+                meta = {p.key: p.value for p in model_proto.metadata_props}
             warn_on_metadata_schema_version(
                 meta,
                 artifact=f"ONNX metadata for {onnx_path}",

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -67,6 +67,7 @@ class OnnxBackend(BaseBackend):
 
         self.session = ort.InferenceSession(onnx_path, providers=providers)
         self.input_name = self.session.get_inputs()[0].name
+        self.output_names = [output.name for output in self.session.get_outputs()]
 
         (
             model_family,
@@ -78,9 +79,15 @@ class OnnxBackend(BaseBackend):
             embedded_nms,
             metadata_imgsz,
         ) = self._read_onnx_metadata(onnx_path, nb_classes)
-        # Models exported with nms=True emit final (1, max_det, 6) detections;
-        # flag it so the base parser routes them through _parse_embedded_nms.
+        # Models exported with nms=True emit final (1, max_det, 6) detections.
+        # Newer YOLO9 ONNX exports also include a raw auxiliary output so the
+        # LibreYOLO backend can apply native clipping/NMS for non-square images.
         self.embedded_nms = embedded_nms
+        self.embedded_nms_raw_output_index = (
+            self.output_names.index("raw")
+            if embedded_nms and "raw" in self.output_names
+            else None
+        )
         input_shape = self.session.get_inputs()[0].shape
         static_imgsz = self._read_static_input_imgsz(input_shape)
         if static_imgsz is not None:

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -69,6 +69,13 @@ def export_cmd(
         out.warning("Both half and int8 were requested. Using INT8 precision.")
         half = False
 
+    if nms and fmt != "onnx":
+        exit_with_error(
+            out,
+            "nms_unsupported_format",
+            f"Embedded NMS (--nms) is only supported for the ONNX format, not {fmt!r}.",
+        )
+
     model_path = resolve_model_or_exit(out, model)
 
     if allow_download_scripts and data is not None:

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -27,6 +27,13 @@ def export_cmd(
     int8: bool = typer.Option(False, help="INT8 quantization"),
     dynamic: bool = typer.Option(False, help="Dynamic input shapes (ONNX)"),
     simplify: bool = typer.Option(True, help="ONNX graph simplification"),
+    nms: bool = typer.Option(
+        False,
+        help="Embed NMS in the model (ONNX YOLO9 detection); output is (1, max_det, 6)",
+    ),
+    conf: float = typer.Option(0.25, help="Confidence threshold for embedded NMS"),
+    iou: float = typer.Option(0.45, help="IoU threshold for embedded NMS"),
+    max_det: int = typer.Option(300, help="Maximum detections for embedded NMS"),
     opset: Optional[int] = typer.Option(
         None, help="ONNX opset version (auto if omitted)"
     ),
@@ -85,6 +92,11 @@ def export_cmd(
         "device": device,
         "verbose": verbose,
     }
+    if nms:
+        export_kwargs["nms"] = True
+        export_kwargs["conf"] = conf
+        export_kwargs["iou"] = iou
+        export_kwargs["max_det"] = max_det
     if imgsz is not None:
         if "," in imgsz:
             parts = imgsz.split(",")

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -19,7 +19,7 @@ def export_cmd(
     model: str = typer.Option(..., help="Model weights (.pt)"),
     format: str = typer.Option(
         "onnx",
-        help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite",
+        help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite, coreml",
     ),
     imgsz: Optional[str] = typer.Option(None, help="Input image size (e.g. 640 or 640,480)"),
     batch: int = typer.Option(1, help="Export batch size"),
@@ -29,11 +29,11 @@ def export_cmd(
     simplify: bool = typer.Option(True, help="ONNX graph simplification"),
     nms: bool = typer.Option(
         False,
-        help="Embed NMS in the model (ONNX YOLO9 detection); output is (1, max_det, 6)",
+        help="Embed NMS in the model (ONNX YOLO9 detection or CoreML)",
     ),
     conf: float = typer.Option(0.25, help="Confidence threshold for embedded NMS"),
     iou: float = typer.Option(0.45, help="IoU threshold for embedded NMS"),
-    max_det: int = typer.Option(300, help="Maximum detections for embedded NMS"),
+    max_det: int = typer.Option(300, help="Maximum detections for ONNX embedded NMS"),
     opset: Optional[int] = typer.Option(
         None, help="ONNX opset version (auto if omitted)"
     ),
@@ -69,12 +69,16 @@ def export_cmd(
         out.warning("Both half and int8 were requested. Using INT8 precision.")
         half = False
 
-    if nms and fmt != "onnx":
+    if nms and fmt not in {"onnx", "coreml"}:
         exit_with_error(
             out,
             "nms_unsupported_format",
-            f"Embedded NMS (--nms) is only supported for the ONNX format, not {fmt!r}.",
+            "Embedded NMS (--nms) is only supported for ONNX and CoreML, "
+            f"not {fmt!r}.",
         )
+    if nms and fmt == "onnx" and dynamic:
+        out.warning("Embedded ONNX NMS uses a fixed batch-1 graph. Using dynamic=False.")
+        dynamic = False
 
     model_path = resolve_model_or_exit(out, model)
 
@@ -103,7 +107,8 @@ def export_cmd(
         export_kwargs["nms"] = True
         export_kwargs["conf"] = conf
         export_kwargs["iou"] = iou
-        export_kwargs["max_det"] = max_det
+        if fmt == "onnx":
+            export_kwargs["max_det"] = max_det
     if imgsz is not None:
         if "," in imgsz:
             parts = imgsz.split(",")

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -79,6 +79,13 @@ def export_cmd(
     if nms and fmt == "onnx" and dynamic:
         out.warning("Embedded ONNX NMS uses a fixed batch-1 graph. Using dynamic=False.")
         dynamic = False
+    if nms and fmt == "coreml" and max_det != 300:
+        exit_with_error(
+            out,
+            "config_unsupported",
+            "max_det is only supported for ONNX embedded NMS; CoreML embedded "
+            "NMS does not expose max_det.",
+        )
 
     model_path = resolve_model_or_exit(out, model)
 

--- a/libreyolo/export/coreml.py
+++ b/libreyolo/export/coreml.py
@@ -33,6 +33,7 @@ _SUPPORTED_FAMILIES = {"yolox", "yolo9", "rtdetr", "rfdetr"}
 # layer (DETR set-prediction: top-k over queries × classes, no IoU step).
 _NMS_FREE_FAMILIES = {
     "rfdetr": "RF-DETR",
+    "rtdetr": "RT-DETR",
     "dfine": "D-FINE",
     "deim": "DEIM",
     "deimv2": "DEIMv2",
@@ -190,15 +191,6 @@ class _NMSOutputAdapter(nn.Module):
                 dim=-1,
             )
             confidence = pred[..., 4:]
-        elif self.model_family == "rtdetr":
-            if not isinstance(out, (tuple, list)) or len(out) < 2:
-                raise RuntimeError("RT-DETR CoreML NMS export expects two outputs")
-            first, second = out[0], out[1]
-            if first.shape[-1] == 4:
-                coordinates, logits = first, second
-            else:
-                logits, coordinates = first, second
-            confidence = torch.sigmoid(logits)
         else:
             raise NotImplementedError(
                 f"nms=True is not supported for model family {self.model_family!r}"
@@ -270,7 +262,8 @@ def export_coreml(
         precision: 'fp32' or 'fp16'.
         compute_units: 'all' | 'cpu_and_gpu' | 'cpu_and_ne' | 'cpu_only'.
         nms: If True, embed Apple's NonMaximumSuppression as a CoreML pipeline.
-            Not supported for DETR-style families (RF-DETR, D-FINE, DEIM, EC).
+            Not supported for DETR-style families (RT-DETR, RF-DETR, D-FINE,
+            DEIM, EC).
         iou: IoU threshold for embedded NMS (default 0.45). Ignored when nms=False.
         conf: Confidence threshold for embedded NMS (default 0.25). Ignored when nms=False.
         metadata: Dict of metadata to embed under user_defined_metadata.

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -803,6 +803,15 @@ class OnnxExporter(BaseExporter):
                     "ONNX INT8 export currently supports YOLO9 detection models only."
                 )
             check_onnx_int8_available()
+        if kwargs.get("nms"):
+            task = getattr(self.model, "task", "detect")
+            if not isinstance(task, str):
+                task = "detect"
+            if self.model._get_model_name() != "yolo9" or task != "detect":
+                raise NotImplementedError(
+                    "Embedded NMS ONNX export currently supports YOLO9 "
+                    "detection models only."
+                )
         super()._preflight(half=half, int8=int8, data=data, **kwargs)
 
     def _export(
@@ -818,19 +827,54 @@ class OnnxExporter(BaseExporter):
         dynamic,
         opset,
         simplify,
+        nms=False,
+        iou=0.45,
+        conf=0.25,
+        max_det=300,
         calibrate_method="MinMax",
         nodes_to_exclude=None,
         **kwargs,
     ):
+        imgsz = (dummy.shape[-2], dummy.shape[-1])
+
+        if nms:
+            from .nms import EmbeddedNMSDetector, class_offset
+
+            if dummy.shape[0] != 1:
+                raise NotImplementedError(
+                    "Embedded NMS ONNX export currently requires batch=1."
+                )
+            if dynamic:
+                logger.warning(
+                    "Embedded NMS uses a fixed batch-1 graph; forcing dynamic=False."
+                )
+                dynamic = False
+            nn_model = EmbeddedNMSDetector(
+                nn_model,
+                conf=conf,
+                iou=iou,
+                max_det=max_det,
+                offset=class_offset(imgsz),
+            ).eval()
+
+        def _onnx_metadata(precision_half: bool) -> dict:
+            meta = self._build_onnx_metadata(
+                dynamic=dynamic,
+                half=precision_half,
+                imgsz=imgsz,
+            )
+            if nms:
+                meta["nms"] = "true"
+                meta["nms_conf"] = str(conf)
+                meta["nms_iou"] = str(iou)
+                meta["max_det"] = str(max_det)
+            return meta
+
         if int8:
             import tempfile
 
             output = Path(output_path)
-            int8_metadata = self._build_onnx_metadata(
-                dynamic=dynamic,
-                half=False,
-                imgsz=(dummy.shape[-2], dummy.shape[-1]),
-            )
+            int8_metadata = _onnx_metadata(precision_half=False)
             int8_metadata["precision"] = "int8"
             with tempfile.TemporaryDirectory(
                 prefix=f"{output.stem}_", dir=str(output.parent)
@@ -845,11 +889,8 @@ class OnnxExporter(BaseExporter):
                     simplify=simplify,
                     dynamic=dynamic,
                     half=False,
-                    metadata=self._build_onnx_metadata(
-                        dynamic=dynamic,
-                        half=False,
-                        imgsz=(dummy.shape[-2], dummy.shape[-1]),
-                    ),
+                    metadata=_onnx_metadata(precision_half=False),
+                    nms=nms,
                 )
                 return quantize_onnx_int8(
                     fp32_path,
@@ -869,11 +910,8 @@ class OnnxExporter(BaseExporter):
             simplify=simplify,
             dynamic=dynamic,
             half=half,
-            metadata=self._build_onnx_metadata(
-                dynamic=dynamic,
-                half=half,
-                imgsz=(dummy.shape[-2], dummy.shape[-1]),
-            ),
+            metadata=_onnx_metadata(precision_half=half),
+            nms=nms,
         )
 
 

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -905,6 +905,7 @@ class OnnxExporter(BaseExporter):
                     preprocessed_path=preprocessed_path,
                     calibrate_method=calibrate_method,
                     nodes_to_exclude=nodes_to_exclude,
+                    skip_symbolic_shape=nms,
                 )
 
         return export_onnx(
@@ -1176,6 +1177,29 @@ class CoreMLExporter(BaseExporter):
     supports_fp16 = True
     apply_model_half = False  # ct.convert handles precision via compute_precision
     supports_embedded_nms = True
+
+    def _preflight(self, *, half: bool, int8: bool, data: Optional[str], **kwargs):
+        if kwargs.get("nms"):
+            family = self.model._get_model_name()
+            task = getattr(self.model, "task", "detect")
+            if not isinstance(task, str):
+                task = "detect"
+            if family == "yolo9" and task != "detect":
+                raise NotImplementedError(
+                    "CoreML embedded NMS currently supports YOLO9 detection "
+                    "models only."
+                )
+            if family not in {"yolox", "yolo9"}:
+                raise NotImplementedError(
+                    "CoreML embedded NMS currently supports YOLOX and YOLO9 "
+                    "detection models only."
+                )
+            if kwargs.get("max_det", 300) != 300:
+                raise NotImplementedError(
+                    "CoreML embedded NMS does not support max_det. "
+                    "Use ONNX embedded NMS when max_det control is required."
+                )
+        super()._preflight(half=half, int8=int8, data=data, **kwargs)
 
     def _export(
         self,

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -873,6 +873,7 @@ class OnnxExporter(BaseExporter):
                 meta["nms_conf"] = str(conf)
                 meta["nms_iou"] = str(iou)
                 meta["max_det"] = str(max_det)
+                meta["nms_raw_output"] = "true"
             return meta
 
         if int8:

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -838,7 +838,7 @@ class OnnxExporter(BaseExporter):
         imgsz = (dummy.shape[-2], dummy.shape[-1])
 
         if nms:
-            from .nms import EmbeddedNMSDetector, class_offset
+            from .nms import EmbeddedNMSDetector
 
             if dummy.shape[0] != 1:
                 raise NotImplementedError(
@@ -854,7 +854,6 @@ class OnnxExporter(BaseExporter):
                 conf=conf,
                 iou=iou,
                 max_det=max_det,
-                offset=class_offset(imgsz),
             ).eval()
 
         def _onnx_metadata(precision_half: bool) -> dict:

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -156,6 +156,7 @@ class BaseExporter(ABC):
     supports_int8: bool  # whether the format supports INT8 calibration
     supports_fp16: bool  # whether the format supports FP16 export
     apply_model_half: bool  # whether to cast model to fp16 (only ONNX/TorchScript)
+    supports_embedded_nms: bool = False
     default_int8_calibration_data: bool = False
 
     def __init_subclass__(cls, **kwargs):
@@ -364,6 +365,10 @@ class BaseExporter(ABC):
 
     def _preflight(self, *, half: bool, int8: bool, data: Optional[str], **kwargs):
         """Run cheap format-specific checks before model or calibration setup."""
+        if kwargs.get("nms") and not self.supports_embedded_nms:
+            raise NotImplementedError(
+                f"{self.format_name.upper()} embedded NMS export is not supported."
+            )
         if self.requires_onnx and importlib.util.find_spec("onnx") is None:
             raise ImportError(
                 "ONNX export requires the 'onnx' package. "
@@ -791,6 +796,7 @@ class OnnxExporter(BaseExporter):
     supports_int8 = True
     supports_fp16 = True
     apply_model_half = True
+    supports_embedded_nms = True
     default_int8_calibration_data = True
 
     def _preflight(self, *, half: bool, int8: bool, data: Optional[str], **kwargs):
@@ -1169,6 +1175,7 @@ class CoreMLExporter(BaseExporter):
     supports_int8 = False
     supports_fp16 = True
     apply_model_half = False  # ct.convert handles precision via compute_precision
+    supports_embedded_nms = True
 
     def _export(
         self,

--- a/libreyolo/export/nms.py
+++ b/libreyolo/export/nms.py
@@ -26,6 +26,8 @@ import torch
 import torch.nn as nn
 from torchvision.ops import nms as _nms
 
+from ..models.yolo9.utils import _YOLO9_MAX_NMS_CANDIDATES
+
 
 class EmbeddedNMSDetector(nn.Module):
     """Detector wrapper returning post-NMS detections of shape ``(1, max_det, 6)``.
@@ -54,13 +56,22 @@ class EmbeddedNMSDetector(nn.Module):
 
         # Multi-label candidate selection: every (anchor, class) pair scoring
         # above conf becomes a detection, matching the YOLO9 post-processing.
-        # Thresholding here (before NMS) also keeps suppression off the flood of
-        # low-score anchors that can never be returned.
-        cand = (scores_all > self.conf).nonzero()  # (K, 2): [anchor, class]
-        anchor_idx = cand[:, 0]
-        class_idx = cand[:, 1]
+        # Native YOLO9 caps candidates before NMS; taking the top scores before
+        # thresholding is equivalent to threshold-then-cap, but bounds the ONNX
+        # NonMaxSuppression input for low-conf exports.
+        flat_scores = scores_all.reshape(-1)
+        num_classes = scores_all.shape[1]
+        max_nms = min(flat_scores.shape[0], _YOLO9_MAX_NMS_CANDIDATES)
+        top_scores, top_flat_idx = torch.topk(flat_scores, max_nms)
+        score_mask = top_scores > self.conf
+        top_scores = top_scores[score_mask]
+        top_flat_idx = top_flat_idx[score_mask]
+        anchor_idx = torch.floor(top_flat_idx.to(torch.float32) / float(num_classes)).to(
+            torch.long
+        )
+        class_idx = top_flat_idx - anchor_idx * num_classes
         cand_boxes = boxes_all[anchor_idx]  # (K, 4)
-        cand_scores = scores_all[anchor_idx, class_idx]  # (K,)
+        cand_scores = top_scores  # (K,)
         cand_cls = class_idx.to(boxes_all.dtype)  # (K,)
 
         # Class-aware NMS via the coordinate-offset trick. The per-class step is

--- a/libreyolo/export/nms.py
+++ b/libreyolo/export/nms.py
@@ -51,7 +51,12 @@ class EmbeddedNMSDetector(nn.Module):
         raw = self.model(x)
         # (B, 4 + nc, N) -> (N, 4 + nc); batch-1 graph. Suppression in float32.
         pred = raw[0].transpose(0, 1).float()
-        boxes_all = pred[:, :4]  # (N, 4) xyxy, input pixels
+        boxes_raw = pred[:, :4]  # (N, 4) xyxy, input pixels
+        x1 = boxes_raw[:, 0].clamp(min=0.0, max=float(x.shape[-1]))
+        y1 = boxes_raw[:, 1].clamp(min=0.0, max=float(x.shape[-2]))
+        x2 = boxes_raw[:, 2].clamp(min=0.0, max=float(x.shape[-1]))
+        y2 = boxes_raw[:, 3].clamp(min=0.0, max=float(x.shape[-2]))
+        boxes_all = torch.stack((x1, y1, x2, y2), dim=1)
         scores_all = pred[:, 4:]  # (N, nc) per-class probabilities
 
         # Multi-label candidate selection: every (anchor, class) pair scoring
@@ -61,7 +66,10 @@ class EmbeddedNMSDetector(nn.Module):
         # NonMaxSuppression input for low-conf exports.
         flat_scores = scores_all.reshape(-1)
         num_classes = scores_all.shape[1]
-        max_nms = min(flat_scores.shape[0], _YOLO9_MAX_NMS_CANDIDATES)
+        max_nms = min(
+            flat_scores.shape[0],
+            max(self.max_det, _YOLO9_MAX_NMS_CANDIDATES),
+        )
         top_scores, top_flat_idx = torch.topk(flat_scores, max_nms)
         score_mask = top_scores > self.conf
         top_scores = top_scores[score_mask]
@@ -73,11 +81,17 @@ class EmbeddedNMSDetector(nn.Module):
         cand_boxes = boxes_all[anchor_idx]  # (K, 4)
         cand_scores = top_scores  # (K,)
         cand_cls = class_idx.to(boxes_all.dtype)  # (K,)
+        valid_boxes = (cand_boxes[:, 2] > cand_boxes[:, 0]) & (
+            cand_boxes[:, 3] > cand_boxes[:, 1]
+        )
+        cand_boxes = cand_boxes[valid_boxes]
+        cand_scores = cand_scores[valid_boxes]
+        cand_cls = cand_cls[valid_boxes]
 
         # Class-aware NMS via the coordinate-offset trick. The per-class step is
-        # derived from the actual decoded box range (over all N anchors — a
-        # fixed, non-empty set), so different classes never overlap after the
-        # shift even when boxes extend beyond the image border.
+        # derived from the clipped input-canvas range, so different classes never
+        # overlap after the shift and suppression matches native canvas-clipped
+        # post-processing for the exported graph's static input.
         lo = boxes_all.min()
         step = (boxes_all.max() - lo).clamp(min=1.0) + 1.0
         nmsbox = (cand_boxes - lo) + cand_cls[:, None] * step

--- a/libreyolo/export/nms.py
+++ b/libreyolo/export/nms.py
@@ -12,8 +12,10 @@ standard ONNX ``NonMaxSuppression`` operator. The exported model is therefore
 self-contained and runs on any runtime that implements that operator (ONNX
 Runtime CPU/GPU, OpenVINO, and others) with no external post-processing.
 
-The wrapper is precision-agnostic: the suppression math runs in float32
-regardless of the backbone precision, so it composes with fp32, fp16, and int8
+Detection semantics mirror the library's own YOLO9 post-processing: candidates
+are selected multi-label (every class scoring above ``conf`` for an anchor, not
+just the best one), then suppressed class-aware. The suppression math runs in
+float32 regardless of the backbone precision, so it composes with fp32 and int8
 exports. Only batch size 1 is supported — the graph indexes the first image and
 emits a single image's detections.
 """
@@ -25,63 +27,54 @@ import torch.nn as nn
 from torchvision.ops import nms as _nms
 
 
-def class_offset(imgsz: tuple[int, int]) -> float:
-    """Per-class coordinate offset guaranteeing class-independent suppression.
-
-    Class-aware NMS shifts every box by ``class_id * offset``; for boxes of
-    different classes to never overlap, the offset must exceed the spatial
-    extent of any box. Twice the larger image side (plus one) covers boxes that
-    extend slightly beyond the image border.
-    """
-    return 2.0 * float(max(int(imgsz[0]), int(imgsz[1]))) + 1.0
-
-
 class EmbeddedNMSDetector(nn.Module):
     """Detector wrapper returning post-NMS detections of shape ``(1, max_det, 6)``.
 
     Args:
         model: Detection model in export mode whose forward returns
             ``(B, 4 + nc, N)`` — xyxy pixel boxes followed by per-class scores.
-        conf: Score threshold; detections at or below it are discarded.
+        conf: Score threshold; only candidates strictly above it are kept.
         iou: IoU threshold for suppression.
         max_det: Fixed number of output rows (zero-padded past the count).
-        offset: Class-separation offset (see :func:`class_offset`).
     """
 
-    def __init__(
-        self, model: nn.Module, *, conf: float, iou: float, max_det: int, offset: float
-    ):
+    def __init__(self, model: nn.Module, *, conf: float, iou: float, max_det: int):
         super().__init__()
         self.model = model
         self.conf = float(conf)
         self.iou = float(iou)
         self.max_det = int(max_det)
-        self.offset = float(offset)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         raw = self.model(x)
         # (B, 4 + nc, N) -> (N, 4 + nc); batch-1 graph. Suppression in float32.
         pred = raw[0].transpose(0, 1).float()
-        boxes = pred[:, :4]  # xyxy, input pixels
-        scores = pred[:, 4:]  # (N, nc) per-class probabilities
-        conf, cls = scores.max(dim=1)  # best class per anchor
-        cls_f = cls.to(boxes.dtype)
+        boxes_all = pred[:, :4]  # (N, 4) xyxy, input pixels
+        scores_all = pred[:, 4:]  # (N, nc) per-class probabilities
 
-        # Class-aware NMS via the coordinate-offset trick: shift each box by a
-        # per-class amount larger than the image so boxes of different classes
-        # can never overlap and are suppressed independently of one another.
-        boxes_off = boxes + cls_f[:, None] * self.offset
-        keep = _nms(boxes_off, conf, self.iou)
+        # Multi-label candidate selection: every (anchor, class) pair scoring
+        # above conf becomes a detection, matching the YOLO9 post-processing.
+        # Thresholding here (before NMS) also keeps suppression off the flood of
+        # low-score anchors that can never be returned.
+        cand = (scores_all > self.conf).nonzero()  # (K, 2): [anchor, class]
+        anchor_idx = cand[:, 0]
+        class_idx = cand[:, 1]
+        cand_boxes = boxes_all[anchor_idx]  # (K, 4)
+        cand_scores = scores_all[anchor_idx, class_idx]  # (K,)
+        cand_cls = class_idx.to(boxes_all.dtype)  # (K,)
 
-        det_boxes = boxes[keep]
-        det_conf = conf[keep]
-        det_cls = cls_f[keep]
+        # Class-aware NMS via the coordinate-offset trick. The per-class step is
+        # derived from the actual decoded box range (over all N anchors — a
+        # fixed, non-empty set), so different classes never overlap after the
+        # shift even when boxes extend beyond the image border.
+        lo = boxes_all.min()
+        step = (boxes_all.max() - lo).clamp(min=1.0) + 1.0
+        nmsbox = (cand_boxes - lo) + cand_cls[:, None] * step
+        keep = _nms(nmsbox, cand_scores, self.iou)
 
-        # Zero out whole sub-threshold rows so they sink below the zero-padding
-        # in the top-k selection below (consumers filter by score > 0).
-        valid = (det_conf > self.conf).to(det_boxes.dtype)[:, None]
-        row = torch.cat((det_boxes, det_conf[:, None], det_cls[:, None]), dim=1)
-        row = row * valid  # (k, 6)
+        row = torch.cat(
+            (cand_boxes[keep], cand_scores[keep, None], cand_cls[keep, None]), dim=1
+        )  # (k, 6)
 
         # Guarantee at least max_det rows, then keep the top-scoring max_det.
         # This handles both k < max_det (zeros fill) and k > max_det (trim)

--- a/libreyolo/export/nms.py
+++ b/libreyolo/export/nms.py
@@ -61,14 +61,24 @@ class EmbeddedNMSDetector(nn.Module):
         y2 = boxes_raw[:, 3].clamp(min=0.0, max=float(x.shape[-2]))
         boxes_all = torch.stack((x1, y1, x2, y2), dim=1)
         scores_all = pred[:, 4:]  # (N, nc) per-class probabilities
+        finite_boxes = torch.isfinite(boxes_all).all(dim=1)
+        finite_scores = torch.isfinite(scores_all)
+        safe_boxes_all = torch.where(
+            torch.isfinite(boxes_all), boxes_all, torch.zeros_like(boxes_all)
+        )
+        safe_scores_all = torch.where(
+            finite_boxes[:, None] & finite_scores,
+            scores_all,
+            scores_all.new_full(scores_all.shape, -1.0),
+        )
 
         # Multi-label candidate selection: every (anchor, class) pair scoring
         # above conf becomes a detection, matching the YOLO9 post-processing.
         # Native YOLO9 caps candidates before NMS; taking the top scores before
         # thresholding is equivalent to threshold-then-cap, but bounds the ONNX
         # NonMaxSuppression input for low-conf exports.
-        flat_scores = scores_all.reshape(-1)
-        num_classes = scores_all.shape[1]
+        flat_scores = safe_scores_all.reshape(-1)
+        num_classes = safe_scores_all.shape[1]
         max_nms = min(
             flat_scores.shape[0],
             max(self.max_det, _YOLO9_MAX_NMS_CANDIDATES),
@@ -81,7 +91,7 @@ class EmbeddedNMSDetector(nn.Module):
             torch.long
         )
         class_idx = top_flat_idx - anchor_idx * num_classes
-        cand_boxes = boxes_all[anchor_idx]  # (K, 4)
+        cand_boxes = safe_boxes_all[anchor_idx]  # (K, 4)
         cand_scores = top_scores  # (K,)
         cand_cls = class_idx.to(boxes_all.dtype)  # (K,)
         valid_boxes = (cand_boxes[:, 2] > cand_boxes[:, 0]) & (
@@ -91,12 +101,11 @@ class EmbeddedNMSDetector(nn.Module):
         cand_scores = cand_scores[valid_boxes]
         cand_cls = cand_cls[valid_boxes]
 
-        # Class-aware NMS via the coordinate-offset trick. The per-class step is
-        # derived from the clipped input-canvas range, so different classes never
-        # overlap after the shift and suppression matches native canvas-clipped
-        # post-processing for the exported graph's static input.
-        lo = boxes_all.min()
-        step = (boxes_all.max() - lo).clamp(min=1.0) + 1.0
+        # Class-aware NMS via the coordinate-offset trick. Use sanitized boxes
+        # for the global range so non-finite anchors outside the candidate set
+        # cannot poison the offset applied to valid detections.
+        lo = safe_boxes_all.min()
+        step = (safe_boxes_all.max() - lo).clamp(min=1.0) + 1.0
         nmsbox = (cand_boxes - lo) + cand_cls[:, None] * step
         keep = _nms(nmsbox, cand_scores, self.iou)
 

--- a/libreyolo/export/nms.py
+++ b/libreyolo/export/nms.py
@@ -1,23 +1,26 @@
 """Graph-embedded Non-Maximum Suppression for portable detection export.
 
-Wraps a detector whose raw export output is ``(B, 4 + nc, N)`` — xyxy boxes in
-input-pixel coordinates followed by per-class probabilities — and appends
-class-aware NMS *inside* the model graph. The wrapped model returns a single
+Wraps a detector whose raw export output is ``(B, 4 + nc, N)`` - xyxy boxes in
+input-pixel coordinates followed by per-class probabilities - and appends
+class-aware NMS *inside* the model graph. The first wrapped-model output is a
 fixed-shape tensor ``(B, max_det, 6)`` whose rows are
 ``[x1, y1, x2, y2, score, class]``, zero-padded past the detection count so the
-output shape stays static.
+output shape stays static. The second output is the raw detector tensor, which
+LibreYOLO backends use to preserve native post-processing parity when the
+original image is not square.
 
 Suppression is expressed with :func:`torchvision.ops.nms`, which lowers to the
-standard ONNX ``NonMaxSuppression`` operator. The exported model is therefore
-self-contained and runs on any runtime that implements that operator (ONNX
-Runtime CPU/GPU, OpenVINO, and others) with no external post-processing.
+standard ONNX ``NonMaxSuppression`` operator. Standalone consumers can use the
+first output without external post-processing, while LibreYOLO can use the raw
+auxiliary output when it needs original-image clipping before final NMS.
 
-Detection semantics mirror the library's own YOLO9 post-processing: candidates
-are selected multi-label (every class scoring above ``conf`` for an anchor, not
-just the best one), then suppressed class-aware. The suppression math runs in
-float32 regardless of the backbone precision, so it composes with fp32 and int8
-exports. Only batch size 1 is supported — the graph indexes the first image and
-emits a single image's detections.
+Detection semantics for the first output mirror the library's own YOLO9
+post-processing on the exported input canvas: candidates are selected
+multi-label (every class scoring above ``conf`` for an anchor, not just the best
+one), then suppressed class-aware. The suppression math runs in float32
+regardless of the backbone precision, so it composes with fp32 and int8 exports.
+Only batch size 1 is supported - the graph indexes the first image and emits a
+single image's detections.
 """
 
 from __future__ import annotations
@@ -30,7 +33,7 @@ from ..models.yolo9.utils import _YOLO9_MAX_NMS_CANDIDATES
 
 
 class EmbeddedNMSDetector(nn.Module):
-    """Detector wrapper returning post-NMS detections of shape ``(1, max_det, 6)``.
+    """Detector wrapper returning post-NMS detections plus raw model output.
 
     Args:
         model: Detection model in export mode whose forward returns
@@ -109,4 +112,4 @@ class EmbeddedNMSDetector(nn.Module):
         det = padded[top]
         # Reshape (not unsqueeze) with a constant shape so the exported graph
         # records a static (1, max_det, 6) output instead of a dynamic dim.
-        return det.reshape(1, self.max_det, 6)
+        return det.reshape(1, self.max_det, 6), raw

--- a/libreyolo/export/nms.py
+++ b/libreyolo/export/nms.py
@@ -1,0 +1,94 @@
+"""Graph-embedded Non-Maximum Suppression for portable detection export.
+
+Wraps a detector whose raw export output is ``(B, 4 + nc, N)`` — xyxy boxes in
+input-pixel coordinates followed by per-class probabilities — and appends
+class-aware NMS *inside* the model graph. The wrapped model returns a single
+fixed-shape tensor ``(B, max_det, 6)`` whose rows are
+``[x1, y1, x2, y2, score, class]``, zero-padded past the detection count so the
+output shape stays static.
+
+Suppression is expressed with :func:`torchvision.ops.nms`, which lowers to the
+standard ONNX ``NonMaxSuppression`` operator. The exported model is therefore
+self-contained and runs on any runtime that implements that operator (ONNX
+Runtime CPU/GPU, OpenVINO, and others) with no external post-processing.
+
+The wrapper is precision-agnostic: the suppression math runs in float32
+regardless of the backbone precision, so it composes with fp32, fp16, and int8
+exports. Only batch size 1 is supported — the graph indexes the first image and
+emits a single image's detections.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torchvision.ops import nms as _nms
+
+
+def class_offset(imgsz: tuple[int, int]) -> float:
+    """Per-class coordinate offset guaranteeing class-independent suppression.
+
+    Class-aware NMS shifts every box by ``class_id * offset``; for boxes of
+    different classes to never overlap, the offset must exceed the spatial
+    extent of any box. Twice the larger image side (plus one) covers boxes that
+    extend slightly beyond the image border.
+    """
+    return 2.0 * float(max(int(imgsz[0]), int(imgsz[1]))) + 1.0
+
+
+class EmbeddedNMSDetector(nn.Module):
+    """Detector wrapper returning post-NMS detections of shape ``(1, max_det, 6)``.
+
+    Args:
+        model: Detection model in export mode whose forward returns
+            ``(B, 4 + nc, N)`` — xyxy pixel boxes followed by per-class scores.
+        conf: Score threshold; detections at or below it are discarded.
+        iou: IoU threshold for suppression.
+        max_det: Fixed number of output rows (zero-padded past the count).
+        offset: Class-separation offset (see :func:`class_offset`).
+    """
+
+    def __init__(
+        self, model: nn.Module, *, conf: float, iou: float, max_det: int, offset: float
+    ):
+        super().__init__()
+        self.model = model
+        self.conf = float(conf)
+        self.iou = float(iou)
+        self.max_det = int(max_det)
+        self.offset = float(offset)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raw = self.model(x)
+        # (B, 4 + nc, N) -> (N, 4 + nc); batch-1 graph. Suppression in float32.
+        pred = raw[0].transpose(0, 1).float()
+        boxes = pred[:, :4]  # xyxy, input pixels
+        scores = pred[:, 4:]  # (N, nc) per-class probabilities
+        conf, cls = scores.max(dim=1)  # best class per anchor
+        cls_f = cls.to(boxes.dtype)
+
+        # Class-aware NMS via the coordinate-offset trick: shift each box by a
+        # per-class amount larger than the image so boxes of different classes
+        # can never overlap and are suppressed independently of one another.
+        boxes_off = boxes + cls_f[:, None] * self.offset
+        keep = _nms(boxes_off, conf, self.iou)
+
+        det_boxes = boxes[keep]
+        det_conf = conf[keep]
+        det_cls = cls_f[keep]
+
+        # Zero out whole sub-threshold rows so they sink below the zero-padding
+        # in the top-k selection below (consumers filter by score > 0).
+        valid = (det_conf > self.conf).to(det_boxes.dtype)[:, None]
+        row = torch.cat((det_boxes, det_conf[:, None], det_cls[:, None]), dim=1)
+        row = row * valid  # (k, 6)
+
+        # Guarantee at least max_det rows, then keep the top-scoring max_det.
+        # This handles both k < max_det (zeros fill) and k > max_det (trim)
+        # uniformly and yields a static (max_det, 6) output sorted by score.
+        padded = torch.cat((row, row.new_zeros(self.max_det, 6)), dim=0)
+        top = torch.topk(padded[:, 4], self.max_det).indices
+        det = padded[top]
+        # Reshape (not unsqueeze) with a constant shape so the exported graph
+        # records a static (1, max_det, 6) output instead of a dynamic dim.
+        return det.reshape(1, self.max_det, 6)

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -109,9 +109,10 @@ def export_onnx(
         half: Whether the model/input are FP16.
         metadata: Dict of metadata to embed in the ONNX model
             (keys like model_family, model_size, nb_classes, names, imgsz, etc.).
-        nms: When True, ``nn_model`` already embeds NMS and returns a single
-            ``(batch, max_det, 6)`` detection tensor; name the output and skip
-            the segmentation-probe / family output-schema logic.
+        nms: When True, ``nn_model`` embeds NMS and returns the post-NMS
+            ``(batch, max_det, 6)`` detection tensor first, followed by the raw
+            detector tensor used by LibreYOLO backends for native postprocess
+            parity. Skip the segmentation-probe / family output-schema logic.
 
     Returns:
         The output_path string.
@@ -123,7 +124,8 @@ def export_onnx(
         )
 
     if nms:
-        # Model embeds NMS: single (batch, max_det, 6) output, no probe needed.
+        # Model embeds NMS: first output is the standalone post-NMS tensor; the
+        # raw output lets LibreYOLO preserve native backend postprocess parity.
         return _export_onnx_graph(
             nn_model,
             dummy,
@@ -133,9 +135,15 @@ def export_onnx(
             half=half,
             metadata=metadata,
             input_names=["images"],
-            output_names=["output"],
+            output_names=["output", "raw"],
             dynamic_axes=(
-                {"images": {0: "batch"}, "output": {0: "batch"}} if dynamic else None
+                {
+                    "images": {0: "batch"},
+                    "output": {0: "batch"},
+                    "raw": {0: "batch", 2: "anchors"},
+                }
+                if dynamic
+                else None
             ),
         )
 

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -394,6 +394,7 @@ def quantize_onnx_int8(
     calibrate_method: str = "MinMax",
     nodes_to_exclude: list[str] | None = None,
     op_types_to_quantize: list[str] | None = None,
+    skip_symbolic_shape: bool = False,
 ) -> str:
     """Quantize an FP32 ONNX model to QDQ INT8 with float32 inputs/outputs."""
     check_onnx_int8_available()
@@ -407,7 +408,11 @@ def quantize_onnx_int8(
             "Pass data='path/to/data.yaml' or omit data to use coco8.yaml."
         )
 
-    quant_pre_process(fp32_path, preprocessed_path)
+    quant_pre_process(
+        fp32_path,
+        preprocessed_path,
+        skip_symbolic_shape=skip_symbolic_shape,
+    )
     reader = _CalibrationDataReader(
         calibration_data,
         input_name=_first_input_name(preprocessed_path),

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -95,6 +95,7 @@ def export_onnx(
     dynamic: bool,
     half: bool,
     metadata: dict,
+    nms: bool = False,
 ) -> str:
     """Export a PyTorch model to ONNX format.
 
@@ -108,6 +109,9 @@ def export_onnx(
         half: Whether the model/input are FP16.
         metadata: Dict of metadata to embed in the ONNX model
             (keys like model_family, model_size, nb_classes, names, imgsz, etc.).
+        nms: When True, ``nn_model`` already embeds NMS and returns a single
+            ``(batch, max_det, 6)`` detection tensor; name the output and skip
+            the segmentation-probe / family output-schema logic.
 
     Returns:
         The output_path string.
@@ -116,6 +120,23 @@ def export_onnx(
         raise ImportError(
             "ONNX export requires the 'onnx' package. "
             "Install with: uv sync --extra onnx  or  pip install onnx"
+        )
+
+    if nms:
+        # Model embeds NMS: single (batch, max_det, 6) output, no probe needed.
+        return _export_onnx_graph(
+            nn_model,
+            dummy,
+            output_path=output_path,
+            opset=opset,
+            simplify=simplify,
+            half=half,
+            metadata=metadata,
+            input_names=["images"],
+            output_names=["output"],
+            dynamic_axes=(
+                {"images": {0: "batch"}, "output": {0: "batch"}} if dynamic else None
+            ),
         )
 
     # Detect segmentation: prefer metadata flag from exporter, fall back
@@ -222,6 +243,34 @@ def export_onnx(
         )
 
     input_names = ["input"] if model_family == "rfdetr" else ["images"]
+    return _export_onnx_graph(
+        nn_model,
+        dummy,
+        output_path=output_path,
+        opset=opset,
+        simplify=simplify,
+        half=half,
+        metadata=metadata,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+    )
+
+
+def _export_onnx_graph(
+    nn_model,
+    dummy,
+    *,
+    output_path: str,
+    opset: int,
+    simplify: bool,
+    half: bool,
+    metadata: dict,
+    input_names: list[str],
+    output_names: list[str],
+    dynamic_axes: dict | None,
+) -> str:
+    """Run ``torch.onnx.export`` with the given IO names, then post-process."""
     export_kwargs = {
         "export_params": True,
         "opset_version": opset,
@@ -240,7 +289,11 @@ def export_onnx(
         torch.onnx.export(nn_model, dummy, output_path, **export_kwargs)
 
     _postprocess_onnx(
-        output_path, simplify=simplify, dynamic=dynamic, half=half, metadata=metadata
+        output_path,
+        simplify=simplify,
+        dynamic=dynamic_axes is not None,
+        half=half,
+        metadata=metadata,
     )
 
     return output_path
@@ -322,6 +375,15 @@ def embed_onnx_metadata(path: str, metadata: dict) -> None:
     onnx.save(model_proto, path)
 
 
+# Quantize only the heavy linear ops. Leaving the detection-head decode
+# (sigmoid, box-distance math, the box+score concat) in float32 is deliberate:
+# that concat mixes pixel-scale box coordinates (~0..imgsz) with [0, 1] class
+# scores, so a single per-tensor activation scale — dominated by the box
+# magnitude — would quantize every score to zero. Restricting quantization to
+# Conv/Gemm keeps the size/speed win on the backbone while preserving scores.
+_INT8_OP_TYPES = ["Conv", "Gemm"]
+
+
 def quantize_onnx_int8(
     fp32_path: str,
     output_path: str,
@@ -331,6 +393,7 @@ def quantize_onnx_int8(
     preprocessed_path: str,
     calibrate_method: str = "MinMax",
     nodes_to_exclude: list[str] | None = None,
+    op_types_to_quantize: list[str] | None = None,
 ) -> str:
     """Quantize an FP32 ONNX model to QDQ INT8 with float32 inputs/outputs."""
     check_onnx_int8_available()
@@ -358,7 +421,7 @@ def quantize_onnx_int8(
         weight_type=QuantType.QInt8,
         activation_type=QuantType.QInt8,
         calibrate_method=_resolve_calibration_method(calibrate_method),
-        op_types_to_quantize=None,
+        op_types_to_quantize=op_types_to_quantize or _INT8_OP_TYPES,
         nodes_to_exclude=nodes_to_exclude,
         extra_options={
             "WeightSymmetric": True,

--- a/tests/unit/cli/commands/test_export.py
+++ b/tests/unit/cli/commands/test_export.py
@@ -69,7 +69,6 @@ def test_export_cli_allows_coreml_embedded_nms(monkeypatch, tmp_path):
             "nms=true",
             "conf=0.2",
             "iou=0.4",
-            "max_det=12",
             "--json",
         ],
     )
@@ -82,3 +81,25 @@ def test_export_cli_allows_coreml_embedded_nms(monkeypatch, tmp_path):
     assert captured["kwargs"]["conf"] == 0.2
     assert captured["kwargs"]["iou"] == 0.4
     assert "max_det" not in captured["kwargs"]
+
+
+def test_export_cli_rejects_coreml_max_det(monkeypatch):
+    from libreyolo.cli.commands import export
+
+    monkeypatch.setattr(export, "resolve_model_or_exit", lambda out, model: model)
+
+    result = runner.invoke(
+        _build_app(),
+        [
+            "model=dummy.pt",
+            "format=coreml",
+            "nms=true",
+            "max_det=12",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    data = _parse_json_output(result.output)
+    assert data["error"] == "config_unsupported"
+    assert "max_det is only supported for ONNX" in data["message"]

--- a/tests/unit/cli/commands/test_export.py
+++ b/tests/unit/cli/commands/test_export.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from libreyolo.cli.parsing import KeyValueCommand
+
+
+pytestmark = pytest.mark.unit
+runner = CliRunner()
+
+
+def _build_app() -> typer.Typer:
+    from libreyolo.cli.commands import export
+
+    app = typer.Typer(add_completion=False)
+    app.command("export", cls=KeyValueCommand)(export.export_cmd)
+    return app
+
+
+def _parse_json_output(output: str) -> dict:
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            return json.loads(line)
+    raise ValueError(f"No JSON found in output:\n{output}")
+
+
+class _LoadedModel:
+    FAMILY = "yolo9"
+    size = "t"
+    INPUT_SIZES = {"t": 128}
+
+    def __init__(self, output_path, captured):
+        self.output_path = output_path
+        self.captured = captured
+
+    def _get_input_size(self):
+        return 128
+
+    def export(self, format, **kwargs):
+        self.captured["format"] = format
+        self.captured["kwargs"] = kwargs
+        self.output_path.mkdir()
+        return str(self.output_path)
+
+
+def test_export_cli_allows_coreml_embedded_nms(monkeypatch, tmp_path):
+    from libreyolo.cli.commands import export
+
+    captured = {}
+    monkeypatch.setattr(export, "resolve_model_or_exit", lambda out, model: model)
+    monkeypatch.setattr(
+        export,
+        "load_model_or_exit",
+        lambda out, model, model_path, device: _LoadedModel(
+            tmp_path / "model.mlpackage", captured
+        ),
+    )
+
+    result = runner.invoke(
+        _build_app(),
+        [
+            "model=dummy.pt",
+            "format=coreml",
+            "nms=true",
+            "conf=0.2",
+            "iou=0.4",
+            "max_det=12",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = _parse_json_output(result.output)
+    assert data["format"] == "coreml"
+    assert captured["format"] == "coreml"
+    assert captured["kwargs"]["nms"] is True
+    assert captured["kwargs"]["conf"] == 0.2
+    assert captured["kwargs"]["iou"] == 0.4
+    assert "max_det" not in captured["kwargs"]

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -267,6 +267,23 @@ def test_embedded_nms_backend_parse_drops_boxes_collapsed_by_clipping():
     np.testing.assert_array_equal(classes, [0])
 
 
+def test_yolo9_backend_parse_drops_boxes_collapsed_by_clipping():
+    backend = _DummyBackend("yolo9")
+    pred = np.zeros((1, 5, 2), dtype=np.float32)
+    pred[0, :4, 0] = [-20.0, -20.0, -1.0, -1.0]
+    pred[0, :4, 1] = [10.0, 20.0, 30.0, 40.0]
+    pred[0, 4, :] = [0.9, 0.8]
+
+    boxes, scores, classes, masks = backend._parse_outputs(
+        [pred], 100, (100, 100), conf=0.25
+    )
+
+    assert masks is None
+    np.testing.assert_allclose(boxes, [[10.0, 20.0, 30.0, 40.0]])
+    np.testing.assert_allclose(scores, [0.8])
+    np.testing.assert_array_equal(classes, [0])
+
+
 def test_embedded_nms_backend_applies_post_clip_nms():
     backend = _DummyBackend("yolo9")
     backend.embedded_nms = True
@@ -704,10 +721,10 @@ def test_yolo9_segment_backend_parses_masks():
         [pred, proto, coeffs], 64, (128, 96), conf=0.25
     )
 
-    assert boxes.shape[0] == 4
-    assert scores.shape[0] == 4
-    assert classes.shape[0] == 4
-    assert masks.shape == (4, 96, 128)
+    assert boxes.shape[0] == 3
+    assert scores.shape[0] == 3
+    assert classes.shape[0] == 3
+    assert masks.shape == (3, 96, 128)
 
 
 def test_backend_call_accepts_device_kwarg(monkeypatch):

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -267,6 +267,41 @@ def test_embedded_nms_backend_parse_drops_boxes_collapsed_by_clipping():
     np.testing.assert_array_equal(classes, [0])
 
 
+def test_embedded_nms_backend_applies_post_clip_nms():
+    backend = _DummyBackend("yolo9")
+    backend.embedded_nms = True
+    det = np.array(
+        [
+            [
+                [0.0, 0.0, 100.0, 100.0, 0.9, 0.0],
+                [0.0, 0.0, 100.0, 40.0, 0.8, 0.0],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes, masks = backend._parse_outputs(
+        [det], 100, (100, 50), conf=0.25
+    )
+    result = backend._build_result(
+        boxes,
+        scores,
+        classes,
+        orig_shape=(50, 100),
+        image_path=None,
+        iou=0.45,
+        classes=None,
+        max_det=300,
+    )
+
+    assert masks is None
+    assert len(result.boxes) == 1
+    np.testing.assert_allclose(
+        result.boxes.xyxy.numpy(), [[0.0, 0.0, 100.0, 50.0]]
+    )
+    np.testing.assert_allclose(result.boxes.conf.numpy(), [0.9])
+
+
 def test_backend_rejects_rectangular_imgsz_for_non_yolo9_family():
     backend = _DummyBackend("yolox")
 
@@ -426,9 +461,11 @@ def test_yolo9_backend_parse_caps_multilabel_candidates(monkeypatch):
     )
 
     assert masks is None
-    assert boxes.shape[0] == 3
-    np.testing.assert_allclose(np.sort(scores), [0.7, 0.8, 0.9], rtol=0, atol=1e-6)
-    np.testing.assert_array_equal(classes, [0, 1, 0])
+    assert boxes.shape[0] == 8
+    np.testing.assert_allclose(
+        np.sort(scores), [0.1, 0.2, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], rtol=0, atol=1e-6
+    )
+    np.testing.assert_array_equal(classes, [0, 1, 0, 1, 0, 1, 0, 1])
 
 
 def test_yolo9_obb_backend_parse_outputs_obb_payload():

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -243,6 +243,30 @@ def test_yolo9_backend_parse_accepts_rectangular_imgsz():
     np.testing.assert_array_equal(classes, [0])
 
 
+def test_embedded_nms_backend_parse_drops_boxes_collapsed_by_clipping():
+    backend = _DummyBackend("yolo9")
+    backend.embedded_nms = True
+    det = np.array(
+        [
+            [
+                [-20.0, -20.0, -1.0, -1.0, 0.9, 1.0],
+                [10.0, 20.0, 30.0, 40.0, 0.8, 0.0],
+                [0.0, 0.0, 10.0, 10.0, 0.1, 0.0],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes, masks = backend._parse_outputs(
+        [det], 100, (100, 100), conf=0.25
+    )
+
+    assert masks is None
+    np.testing.assert_allclose(boxes, [[10.0, 20.0, 30.0, 40.0]])
+    np.testing.assert_allclose(scores, [0.8])
+    np.testing.assert_array_equal(classes, [0])
+
+
 def test_backend_rejects_rectangular_imgsz_for_non_yolo9_family():
     backend = _DummyBackend("yolox")
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -114,11 +114,31 @@ class TestExporterFormats:
     def test_subclass_attributes(self):
         assert OnnxExporter.suffix == ".onnx"
         assert OnnxExporter.supports_int8 is True
+        assert OnnxExporter.supports_embedded_nms is True
+        assert CoreMLExporter.supports_embedded_nms is True
         assert TensorRTExporter.requires_onnx is True
         assert TorchScriptExporter.apply_model_half is True
+        assert TorchScriptExporter.supports_embedded_nms is False
         assert NcnnExporter.supports_int8 is False
         assert TFLiteExporter.requires_onnx is True
         assert TFLiteExporter.supports_fp16 is False
+
+    def test_unsupported_exporter_rejects_embedded_nms(self):
+        exporter = TorchScriptExporter(_make_wrapper())
+
+        with pytest.raises(NotImplementedError, match="TORCHSCRIPT embedded NMS"):
+            exporter._preflight(half=False, int8=False, data=None, nms=True)
+
+    def test_coreml_exporter_accepts_embedded_nms_preflight(self):
+        exporter = CoreMLExporter(_make_wrapper())
+
+        exporter._preflight(half=False, int8=False, data=None, nms=True)
+
+    def test_onnx_embedded_nms_preflight_rejects_non_yolo9_detect(self):
+        exporter = OnnxExporter(_make_wrapper(model_name="yolox"))
+
+        with pytest.raises(NotImplementedError, match="YOLO9 detection"):
+            exporter._preflight(half=False, int8=False, data=None, nms=True)
 
     def test_metadata_includes_task_contract(self):
         wrapper = _make_wrapper()

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -408,6 +408,33 @@ class TestExporterFormats:
 
         assert OnnxBackend._read_onnx_metadata(str(output_path), 4)[-1] == 48
 
+    def test_onnx_backend_reads_runtime_metadata_without_onnx_load(self):
+        from libreyolo.backends.onnx import OnnxBackend
+
+        metadata = {
+            "model_family": "yolo9",
+            "task": "detect",
+            "nb_classes": "1",
+            "imgsz": "64",
+            "nms": "true",
+            "nms_conf": "0.25",
+            "nms_iou": "0.45",
+            "max_det": "300",
+            "nms_raw_output": "true",
+        }
+
+        parsed = OnnxBackend._read_onnx_metadata(
+            "metadata-from-onnxruntime.onnx",
+            80,
+            runtime_metadata=metadata,
+        )
+
+        assert parsed[0] == "yolo9"
+        assert parsed[2] == "detect"
+        assert parsed[5] == {0: "class_0"}
+        assert parsed[6] is True
+        assert parsed[7] == 64
+
     def test_onnx_backend_reads_rectangular_static_input_imgsz(self):
         from libreyolo.backends.onnx import OnnxBackend
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -130,9 +130,37 @@ class TestExporterFormats:
             exporter._preflight(half=False, int8=False, data=None, nms=True)
 
     def test_coreml_exporter_accepts_embedded_nms_preflight(self):
-        exporter = CoreMLExporter(_make_wrapper())
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "detect"
+        exporter = CoreMLExporter(wrapper)
 
         exporter._preflight(half=False, int8=False, data=None, nms=True)
+
+    def test_coreml_embedded_nms_preflight_rejects_rtdetr(self):
+        wrapper = _make_wrapper(model_name="rtdetr")
+        wrapper.task = "detect"
+        exporter = CoreMLExporter(wrapper)
+
+        with pytest.raises(NotImplementedError, match="YOLOX and YOLO9"):
+            exporter._preflight(half=False, int8=False, data=None, nms=True)
+
+    def test_coreml_embedded_nms_preflight_rejects_yolo9_segment(self):
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "segment"
+        exporter = CoreMLExporter(wrapper)
+
+        with pytest.raises(NotImplementedError, match="YOLO9 detection"):
+            exporter._preflight(half=False, int8=False, data=None, nms=True)
+
+    def test_coreml_embedded_nms_preflight_rejects_max_det(self):
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "detect"
+        exporter = CoreMLExporter(wrapper)
+
+        with pytest.raises(NotImplementedError, match="does not support max_det"):
+            exporter._preflight(
+                half=False, int8=False, data=None, nms=True, max_det=12
+            )
 
     def test_onnx_embedded_nms_preflight_rejects_non_yolo9_detect(self):
         exporter = OnnxExporter(_make_wrapper(model_name="yolox"))

--- a/tests/unit/test_export_coreml.py
+++ b/tests/unit/test_export_coreml.py
@@ -245,6 +245,22 @@ class TestNMSWrap:
                 model_family="rfdetr",
             )
 
+    def test_rtdetr_raises(self, tmp_path, monkeypatch):
+        _patch_ct(monkeypatch)
+        from libreyolo.export.coreml import export_coreml
+
+        with pytest.raises(NotImplementedError, match="RT-DETR"):
+            export_coreml(
+                _DummyModel().eval(),
+                torch.randn(1, 3, 640, 640),
+                output_path=str(tmp_path / "m.mlpackage"),
+                precision="fp32",
+                compute_units="all",
+                nms=True,
+                metadata={"model_family": "rtdetr"},
+                model_family="rtdetr",
+            )
+
     def test_yolox_calls_pipeline(self, tmp_path, monkeypatch):
         fake, mlmodel = _patch_ct(monkeypatch)
 

--- a/tests/unit/test_yolo9_int8_onnx_export.py
+++ b/tests/unit/test_yolo9_int8_onnx_export.py
@@ -6,6 +6,7 @@ import importlib.util
 
 import numpy as np
 import pytest
+import torch
 from PIL import Image
 
 pytestmark = [pytest.mark.unit, pytest.mark.onnx, pytest.mark.export_backend]
@@ -46,6 +47,9 @@ def test_yolo9_detect_onnx_int8_export_loads_and_predicts(tmp_path):
     )
 
     model = LibreYOLO9(None, size="t", nb_classes=2, device="cpu")
+    for block in model.model.head.cv3:
+        convs = [m for m in block.modules() if isinstance(m, torch.nn.Conv2d)]
+        convs[-1].bias.data.fill_(4.0)
     fp32_path = tmp_path / "LibreYOLO9t.onnx"
     int8_path = tmp_path / "LibreYOLO9t_int8.onnx"
 
@@ -81,6 +85,7 @@ def test_yolo9_detect_onnx_int8_export_loads_and_predicts(tmp_path):
     sess = ort.InferenceSession(str(int8_path), providers=["CPUExecutionProvider"])
     outs = sess.run(None, {"images": np.zeros((1, 3, 64, 64), dtype=np.float32)})
     assert outs[0].shape == (1, 6, 84)
+    assert float(outs[0][0, 4:, :].max()) > 0.25
 
     loaded = LibreYOLO(str(int8_path), device="cpu")
     result = loaded.predict(np.zeros((64, 64, 3), dtype=np.uint8), conf=0.0, imgsz=64)

--- a/tests/unit/test_yolo9_nms_onnx_export.py
+++ b/tests/unit/test_yolo9_nms_onnx_export.py
@@ -258,6 +258,9 @@ def test_yolo9_detect_onnx_nms_int8_runs(tmp_path):
 
     torch.manual_seed(0)
     model = LibreYOLO9(None, size="t", nb_classes=NC, device="cpu")
+    for block in model.model.head.cv3:
+        convs = [m for m in block.modules() if isinstance(m, torch.nn.Conv2d)]
+        convs[-1].bias.data.fill_(4.0)
     fp32 = tmp_path / "m32.onnx"
     int8 = tmp_path / "m8.onnx"
     model.export(
@@ -278,5 +281,7 @@ def test_yolo9_detect_onnx_nms_int8_runs(tmp_path):
     assert meta["nms"] == "true"
 
     sess = ort.InferenceSession(str(int8), providers=["CPUExecutionProvider"])
-    out = sess.run(None, {"images": np.zeros((1, 3, IMG, IMG), dtype=np.float32)})[0]
+    x = np.random.default_rng(1).random((1, 3, IMG, IMG), dtype=np.float32)
+    out = sess.run(None, {"images": x})[0]
     assert out.shape == (1, MAX_DET, 6)
+    assert float(out[0, :, 4].max()) > 0.25

--- a/tests/unit/test_yolo9_nms_onnx_export.py
+++ b/tests/unit/test_yolo9_nms_onnx_export.py
@@ -99,6 +99,27 @@ def test_embedded_nms_clips_to_input_canvas_before_suppression():
     assert det[0, 4] == pytest.approx(0.9)
 
 
+def test_embedded_nms_ignores_nonfinite_low_conf_boxes():
+    from libreyolo.export.nms import EmbeddedNMSDetector
+
+    raw = torch.zeros(1, 5, 2)
+    raw[0, :4, 0] = torch.tensor([float("nan"), 0.0, 20.0, 20.0])
+    raw[0, :4, 1] = torch.tensor([1.0, 2.0, 16.0, 18.0])
+    raw[0, 4, :] = torch.tensor([0.0, 0.9])
+
+    wrapped = EmbeddedNMSDetector(
+        _RawExportModel(raw), conf=0.1, iou=0.45, max_det=10
+    )
+
+    out = wrapped(torch.zeros(1, 3, 32, 32))[0][0].detach().numpy()
+    det = out[out[:, 4] > 0]
+
+    assert det.shape[0] == 1
+    assert np.isfinite(det).all()
+    np.testing.assert_allclose(det[0, :4], [1.0, 2.0, 16.0, 18.0])
+    assert det[0, 4] == pytest.approx(0.9)
+
+
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
 def test_yolo9_detect_onnx_nms_fp32_matches_postprocess(tmp_path):
     import onnx

--- a/tests/unit/test_yolo9_nms_onnx_export.py
+++ b/tests/unit/test_yolo9_nms_onnx_export.py
@@ -1,0 +1,184 @@
+"""YOLO9 ONNX embedded-NMS export tests.
+
+Validates that ``nms=True`` produces a self-contained detection model whose
+single ``(1, max_det, 6)`` output (``[x1, y1, x2, y2, score, class]``) reproduces
+the library's own NMS, across fp32 and int8 precisions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = [pytest.mark.unit, pytest.mark.onnx, pytest.mark.export_backend]
+
+_HAS_ORT = (
+    importlib.util.find_spec("onnx") is not None
+    and importlib.util.find_spec("onnxruntime") is not None
+)
+
+IMG = 96
+NC = 3
+MAX_DET = 50
+
+
+def _reference_nms(raw, conf, iou, max_det, offset):
+    """Best-class, class-aware NMS reference matching EmbeddedNMSDetector."""
+    from torchvision.ops import nms as tv_nms
+
+    pred = torch.from_numpy(raw[0]).transpose(0, 1).float()
+    boxes, scores = pred[:, :4], pred[:, 4:]
+    cf, cl = scores.max(dim=1)
+    keep_mask = cf > conf
+    boxes, cf, cl = boxes[keep_mask], cf[keep_mask], cl[keep_mask]
+    keep = tv_nms(boxes + cl.float()[:, None] * offset, cf, iou)
+    order = torch.argsort(cf[keep], descending=True)[:max_det]
+    keep = keep[order]
+    return boxes[keep].numpy(), cf[keep].numpy(), cl[keep].float().numpy()
+
+
+@pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
+def test_yolo9_detect_onnx_nms_fp32_matches_reference(tmp_path):
+    import onnx
+    import onnxruntime as ort
+
+    from libreyolo import LibreYOLO9
+
+    torch.manual_seed(0)
+    model = LibreYOLO9(None, size="t", nb_classes=NC, device="cpu")
+
+    path = tmp_path / "LibreYOLO9t_nms.onnx"
+    exported = model.export(
+        "onnx",
+        output_path=str(path),
+        imgsz=IMG,
+        simplify=False,
+        dynamic=False,
+        nms=True,
+        conf=0.0,
+        iou=0.45,
+        max_det=MAX_DET,
+    )
+    assert exported == str(path)
+
+    proto = onnx.load(str(path))
+    meta = {p.key: p.value for p in proto.metadata_props}
+    assert meta["nms"] == "true"
+    assert meta["max_det"] == str(MAX_DET)
+    assert meta["model_family"] == "yolo9"
+    # Static output shape (1, max_det, 6).
+    out_dims = [d.dim_value for d in proto.graph.output[0].type.tensor_type.shape.dim]
+    assert out_dims == [1, MAX_DET, 6]
+
+    x = np.random.default_rng(1).random((1, 3, IMG, IMG), dtype=np.float32)
+    sess = ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+    out = sess.run(None, {"images": x})[0]
+    assert out.shape == (1, MAX_DET, 6)
+
+    # Reference NMS on the raw export-mode tensor.
+    model.model.eval()
+    model.model.head.export = True
+    with torch.no_grad():
+        raw = model.model(torch.from_numpy(x)).numpy()
+    model.model.head.export = False
+
+    ref_b, ref_s, ref_c = _reference_nms(
+        raw[None] if raw.ndim == 2 else raw,
+        conf=0.0,
+        iou=0.45,
+        max_det=MAX_DET,
+        offset=2.0 * IMG + 1.0,
+    )
+
+    valid = out[0][:, 4] > 0
+    det = out[0][valid]
+    det = det[np.argsort(-det[:, 4])]
+
+    assert det.shape[0] == len(ref_b)
+    if len(ref_b):
+        order = np.argsort(-ref_s)
+        np.testing.assert_allclose(det[:, :4], ref_b[order], atol=1e-3)
+        np.testing.assert_allclose(det[:, 4], ref_s[order], atol=1e-4)
+        assert (det[:, 5] == ref_c[order]).all()
+
+
+@pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
+def test_yolo9_detect_onnx_nms_requires_batch_one(tmp_path):
+    from libreyolo import LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", nb_classes=NC, device="cpu")
+    with pytest.raises(NotImplementedError):
+        model.export(
+            "onnx",
+            output_path=str(tmp_path / "bad.onnx"),
+            imgsz=IMG,
+            simplify=False,
+            dynamic=False,
+            nms=True,
+            batch=2,
+        )
+
+
+@pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
+def test_yolo9_detect_onnx_nms_int8_runs(tmp_path):
+    import onnx
+    import onnxruntime as ort
+    from PIL import Image
+
+    from libreyolo import LibreYOLO9
+
+    image_dir = tmp_path / "images" / "train"
+    image_dir.mkdir(parents=True)
+    rng = np.random.default_rng(0)
+    for idx in range(3):
+        img = rng.integers(0, 256, size=(IMG, IMG, 3), dtype=np.uint8)
+        Image.fromarray(img).save(image_dir / f"{idx}.jpg")
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        f"path: {tmp_path.as_posix()}\ntrain: images/train\nval: images/train\n"
+        f"nc: {NC}\nnames:\n  0: a\n  1: b\n  2: c\n",
+        encoding="utf-8",
+    )
+
+    torch.manual_seed(0)
+    model = LibreYOLO9(None, size="t", nb_classes=NC, device="cpu")
+    fp32 = tmp_path / "m32.onnx"
+    int8 = tmp_path / "m8.onnx"
+    model.export(
+        "onnx",
+        output_path=str(fp32),
+        imgsz=IMG,
+        simplify=False,
+        dynamic=False,
+        nms=True,
+        conf=0.25,
+        iou=0.45,
+        max_det=MAX_DET,
+    )
+    exported = model.export(
+        "onnx",
+        output_path=str(int8),
+        imgsz=IMG,
+        simplify=False,
+        dynamic=False,
+        nms=True,
+        conf=0.25,
+        iou=0.45,
+        max_det=MAX_DET,
+        int8=True,
+        data=str(data_yaml),
+    )
+    assert exported == str(int8)
+    assert int8.stat().st_size < fp32.stat().st_size
+
+    proto = onnx.load(str(int8))
+    meta = {p.key: p.value for p in proto.metadata_props}
+    assert meta["precision"] == "int8"
+    assert meta["nms"] == "true"
+
+    sess = ort.InferenceSession(str(int8), providers=["CPUExecutionProvider"])
+    out = sess.run(None, {"images": np.zeros((1, 3, IMG, IMG), dtype=np.float32)})[0]
+    assert out.shape == (1, MAX_DET, 6)

--- a/tests/unit/test_yolo9_nms_onnx_export.py
+++ b/tests/unit/test_yolo9_nms_onnx_export.py
@@ -2,7 +2,7 @@
 
 Validates that ``nms=True`` produces a self-contained detection model whose
 single ``(1, max_det, 6)`` output (``[x1, y1, x2, y2, score, class]``) reproduces
-the library's own NMS, across fp32 and int8 precisions.
+the library's own multi-label NMS, and that LibreYOLO loads it back correctly.
 """
 
 from __future__ import annotations
@@ -20,32 +20,36 @@ _HAS_ORT = (
     and importlib.util.find_spec("onnxruntime") is not None
 )
 
-IMG = 96
-NC = 3
-MAX_DET = 50
+IMG = 128
+NC = 4
+MAX_DET = 100
 
 
-def _reference_nms(raw, conf, iou, max_det, offset):
-    """Best-class, class-aware NMS reference matching EmbeddedNMSDetector."""
-    from torchvision.ops import nms as tv_nms
-
-    pred = torch.from_numpy(raw[0]).transpose(0, 1).float()
-    boxes, scores = pred[:, :4], pred[:, 4:]
-    cf, cl = scores.max(dim=1)
-    keep_mask = cf > conf
-    boxes, cf, cl = boxes[keep_mask], cf[keep_mask], cl[keep_mask]
-    keep = tv_nms(boxes + cl.float()[:, None] * offset, cf, iou)
-    order = torch.argsort(cf[keep], descending=True)[:max_det]
-    keep = keep[order]
-    return boxes[keep].numpy(), cf[keep].numpy(), cl[keep].float().numpy()
+def _set_unmatched(rows_a, rows_b, *, box_tol=1e-3, score_tol=1e-4):
+    """Count rows in a with no exact (box, score, class) counterpart in b."""
+    used = np.zeros(len(rows_b), dtype=bool)
+    unmatched = 0
+    for r in rows_a:
+        if len(rows_b) == 0:
+            unmatched += 1
+            continue
+        d = np.abs(rows_b[:, :4] - r[:4]).max(axis=1)
+        d = np.where(used | (rows_b[:, 5] != r[5]), np.inf, d)
+        j = int(np.argmin(d))
+        if d[j] < box_tol and abs(rows_b[j, 4] - r[4]) < score_tol:
+            used[j] = True
+        else:
+            unmatched += 1
+    return unmatched
 
 
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
-def test_yolo9_detect_onnx_nms_fp32_matches_reference(tmp_path):
+def test_yolo9_detect_onnx_nms_fp32_matches_postprocess(tmp_path):
     import onnx
     import onnxruntime as ort
 
     from libreyolo import LibreYOLO9
+    from libreyolo.models.yolo9.utils import postprocess
 
     torch.manual_seed(0)
     model = LibreYOLO9(None, size="t", nb_classes=NC, device="cpu")
@@ -69,7 +73,6 @@ def test_yolo9_detect_onnx_nms_fp32_matches_reference(tmp_path):
     assert meta["nms"] == "true"
     assert meta["max_det"] == str(MAX_DET)
     assert meta["model_family"] == "yolo9"
-    # Static output shape (1, max_det, 6).
     out_dims = [d.dim_value for d in proto.graph.output[0].type.tensor_type.shape.dim]
     assert out_dims == [1, MAX_DET, 6]
 
@@ -78,31 +81,33 @@ def test_yolo9_detect_onnx_nms_fp32_matches_reference(tmp_path):
     out = sess.run(None, {"images": x})[0]
     assert out.shape == (1, MAX_DET, 6)
 
-    # Reference NMS on the raw export-mode tensor.
+    # Reference: the library's own multi-label postprocess on the raw tensor.
     model.model.eval()
     model.model.head.export = True
     with torch.no_grad():
-        raw = model.model(torch.from_numpy(x)).numpy()
+        raw = model.model(torch.from_numpy(x))
     model.model.head.export = False
-
-    ref_b, ref_s, ref_c = _reference_nms(
-        raw[None] if raw.ndim == 2 else raw,
-        conf=0.0,
-        iou=0.45,
+    ref = postprocess(
+        {"predictions": raw},
+        conf_thres=0.0,
+        iou_thres=0.45,
+        input_size=IMG,
+        original_size=None,
         max_det=MAX_DET,
-        offset=2.0 * IMG + 1.0,
+    )
+    ref_rows = np.concatenate(
+        [
+            np.asarray(ref["boxes"], np.float32).reshape(-1, 4),
+            np.asarray(ref["scores"], np.float32).reshape(-1, 1),
+            np.asarray(ref["classes"], np.float32).reshape(-1, 1),
+        ],
+        axis=1,
     )
 
-    valid = out[0][:, 4] > 0
-    det = out[0][valid]
-    det = det[np.argsort(-det[:, 4])]
-
-    assert det.shape[0] == len(ref_b)
-    if len(ref_b):
-        order = np.argsort(-ref_s)
-        np.testing.assert_allclose(det[:, :4], ref_b[order], atol=1e-3)
-        np.testing.assert_allclose(det[:, 4], ref_s[order], atol=1e-4)
-        assert (det[:, 5] == ref_c[order]).all()
+    det = out[0][out[0][:, 4] > 0][:, :6]
+    assert det.shape[0] == ref_rows.shape[0]
+    # Same detection set (order may differ on score ties).
+    assert _set_unmatched(det, ref_rows) == 0
 
 
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
@@ -123,6 +128,58 @@ def test_yolo9_detect_onnx_nms_requires_batch_one(tmp_path):
 
 
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
+def test_yolo9_detect_onnx_nms_backend_roundtrip(tmp_path):
+    """LibreYOLO loads an embedded-NMS ONNX and parses it (no double-NMS)."""
+    import onnxruntime as ort
+
+    from libreyolo import LibreYOLO, LibreYOLO9
+    from libreyolo.models.yolo9.utils import preprocess_numpy
+
+    torch.manual_seed(0)
+    model = LibreYOLO9(None, size="t", nb_classes=NC, device="cpu")
+    # Distinct, confident detections so the comparison is unambiguous.
+    for block in model.model.head.cv3:
+        convs = [m for m in block.modules() if isinstance(m, torch.nn.Conv2d)]
+        convs[-1].bias.data = torch.linspace(-1.0, 3.0, NC)
+
+    conf, iou = 0.25, 0.45
+    path = model.export(
+        "onnx",
+        output_path=str(tmp_path / "nms.onnx"),
+        imgsz=IMG,
+        simplify=False,
+        dynamic=False,
+        nms=True,
+        conf=conf,
+        iou=iou,
+        max_det=MAX_DET,
+    )
+
+    img = np.random.default_rng(3).integers(0, 256, (IMG, IMG, 3), dtype=np.uint8)
+
+    backend = LibreYOLO(path, device="cpu")
+    assert backend.embedded_nms is True
+
+    result = backend.predict(img, conf=conf, iou=iou, imgsz=IMG)
+    assert result.boxes is not None
+    nb = np.asarray(result.boxes.xyxy, np.float32).reshape(-1, 4)
+
+    # Raw embedded output on the same preprocessed blob (square image, ratio 1).
+    chw, _ = preprocess_numpy(img, IMG)
+    raw = ort.InferenceSession(path, providers=["CPUExecutionProvider"]).run(
+        None, {"images": chw[None].astype(np.float32)}
+    )[0]
+    raw_valid = raw[0][raw[0][:, 4] > conf]
+
+    # Backend must surface exactly the embedded detections (no re-NMS dropping).
+    assert len(nb) == raw_valid.shape[0]
+    assert len(nb) > 0
+    # Boxes are real xyxy within the image, not transposed/garbled.
+    assert (nb[:, 0] >= 0).all() and (nb[:, 2] <= IMG + 1).all()
+    assert (nb[:, 1] >= 0).all() and (nb[:, 3] <= IMG + 1).all()
+
+
+@pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
 def test_yolo9_detect_onnx_nms_int8_runs(tmp_path):
     import onnx
     import onnxruntime as ort
@@ -139,7 +196,7 @@ def test_yolo9_detect_onnx_nms_int8_runs(tmp_path):
     data_yaml = tmp_path / "data.yaml"
     data_yaml.write_text(
         f"path: {tmp_path.as_posix()}\ntrain: images/train\nval: images/train\n"
-        f"nc: {NC}\nnames:\n  0: a\n  1: b\n  2: c\n",
+        f"nc: {NC}\nnames:\n  0: a\n  1: b\n  2: c\n  3: d\n",
         encoding="utf-8",
     )
 
@@ -148,28 +205,13 @@ def test_yolo9_detect_onnx_nms_int8_runs(tmp_path):
     fp32 = tmp_path / "m32.onnx"
     int8 = tmp_path / "m8.onnx"
     model.export(
-        "onnx",
-        output_path=str(fp32),
-        imgsz=IMG,
-        simplify=False,
-        dynamic=False,
-        nms=True,
-        conf=0.25,
-        iou=0.45,
-        max_det=MAX_DET,
+        "onnx", output_path=str(fp32), imgsz=IMG, simplify=False, dynamic=False,
+        nms=True, conf=0.25, iou=0.45, max_det=MAX_DET,
     )
     exported = model.export(
-        "onnx",
-        output_path=str(int8),
-        imgsz=IMG,
-        simplify=False,
-        dynamic=False,
-        nms=True,
-        conf=0.25,
-        iou=0.45,
-        max_det=MAX_DET,
-        int8=True,
-        data=str(data_yaml),
+        "onnx", output_path=str(int8), imgsz=IMG, simplify=False, dynamic=False,
+        nms=True, conf=0.25, iou=0.45, max_det=MAX_DET,
+        int8=True, data=str(data_yaml),
     )
     assert exported == str(int8)
     assert int8.stat().st_size < fp32.stat().st_size

--- a/tests/unit/test_yolo9_nms_onnx_export.py
+++ b/tests/unit/test_yolo9_nms_onnx_export.py
@@ -52,7 +52,7 @@ def _set_unmatched(rows_a, rows_b, *, box_tol=1e-3, score_tol=1e-4):
     return unmatched
 
 
-def test_embedded_nms_caps_candidates_before_suppression(monkeypatch):
+def test_embedded_nms_caps_candidates_like_native_postprocess(monkeypatch):
     from libreyolo.export import nms as nms_mod
 
     monkeypatch.setattr(nms_mod, "_YOLO9_MAX_NMS_CANDIDATES", 3)
@@ -74,9 +74,29 @@ def test_embedded_nms_caps_candidates_before_suppression(monkeypatch):
     out = wrapped(torch.zeros(1, 3, 32, 32))[0].detach().numpy()
     det = out[out[:, 4] > 0]
 
-    assert det.shape[0] == 3
-    np.testing.assert_allclose(det[:, 4], [0.9, 0.8, 0.7])
-    np.testing.assert_array_equal(det[:, 5], [0.0, 1.0, 2.0])
+    assert det.shape[0] == 6
+    np.testing.assert_allclose(det[:, 4], [0.9, 0.8, 0.7, 0.6, 0.5, 0.4])
+    np.testing.assert_array_equal(det[:, 5], [0.0, 1.0, 2.0, 0.0, 1.0, 2.0])
+
+
+def test_embedded_nms_clips_to_input_canvas_before_suppression():
+    from libreyolo.export.nms import EmbeddedNMSDetector
+
+    raw = torch.zeros(1, 5, 2)
+    raw[0, :4, 0] = torch.tensor([0.0, 0.0, 1000.0, 1000.0])
+    raw[0, :4, 1] = torch.tensor([0.0, 0.0, 32.0, 32.0])
+    raw[0, 4, :] = torch.tensor([0.9, 0.8])
+
+    wrapped = EmbeddedNMSDetector(
+        _RawExportModel(raw), conf=0.1, iou=0.45, max_det=10
+    )
+
+    out = wrapped(torch.zeros(1, 3, 32, 32))[0].detach().numpy()
+    det = out[out[:, 4] > 0]
+
+    assert det.shape[0] == 1
+    np.testing.assert_allclose(det[0, :4], [0.0, 0.0, 32.0, 32.0])
+    assert det[0, 4] == pytest.approx(0.9)
 
 
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
@@ -128,7 +148,7 @@ def test_yolo9_detect_onnx_nms_fp32_matches_postprocess(tmp_path):
         conf_thres=0.0,
         iou_thres=0.45,
         input_size=IMG,
-        original_size=None,
+        original_size=(IMG, IMG),
         max_det=MAX_DET,
     )
     ref_rows = np.concatenate(

--- a/tests/unit/test_yolo9_nms_onnx_export.py
+++ b/tests/unit/test_yolo9_nms_onnx_export.py
@@ -1,7 +1,7 @@
 """YOLO9 ONNX embedded-NMS export tests.
 
 Validates that ``nms=True`` produces a self-contained detection model whose
-single ``(1, max_det, 6)`` output (``[x1, y1, x2, y2, score, class]``) reproduces
+first ``(1, max_det, 6)`` output (``[x1, y1, x2, y2, score, class]``) reproduces
 the library's own multi-label NMS, and that LibreYOLO loads it back correctly.
 """
 
@@ -31,7 +31,7 @@ class _RawExportModel(torch.nn.Module):
         self.register_buffer("raw", raw)
 
     def forward(self, x):
-        return self.raw
+        return self.raw + x.sum() * 0.0
 
 
 def _set_unmatched(rows_a, rows_b, *, box_tol=1e-3, score_tol=1e-4):
@@ -71,7 +71,7 @@ def test_embedded_nms_caps_candidates_like_native_postprocess(monkeypatch):
         _RawExportModel(raw), conf=0.1, iou=0.45, max_det=10
     )
 
-    out = wrapped(torch.zeros(1, 3, 32, 32))[0].detach().numpy()
+    out = wrapped(torch.zeros(1, 3, 32, 32))[0][0].detach().numpy()
     det = out[out[:, 4] > 0]
 
     assert det.shape[0] == 6
@@ -91,7 +91,7 @@ def test_embedded_nms_clips_to_input_canvas_before_suppression():
         _RawExportModel(raw), conf=0.1, iou=0.45, max_det=10
     )
 
-    out = wrapped(torch.zeros(1, 3, 32, 32))[0].detach().numpy()
+    out = wrapped(torch.zeros(1, 3, 32, 32))[0][0].detach().numpy()
     det = out[out[:, 4] > 0]
 
     assert det.shape[0] == 1
@@ -127,14 +127,22 @@ def test_yolo9_detect_onnx_nms_fp32_matches_postprocess(tmp_path):
     proto = onnx.load(str(path))
     meta = {p.key: p.value for p in proto.metadata_props}
     assert meta["nms"] == "true"
+    assert meta["nms_raw_output"] == "true"
     assert meta["max_det"] == str(MAX_DET)
     assert meta["model_family"] == "yolo9"
-    out_dims = [d.dim_value for d in proto.graph.output[0].type.tensor_type.shape.dim]
-    assert out_dims == [1, MAX_DET, 6]
+    assert [out.name for out in proto.graph.output] == ["output", "raw"]
+    out_dims = [
+        [d.dim_value for d in out.type.tensor_type.shape.dim]
+        for out in proto.graph.output
+    ]
+    assert out_dims[0] == [1, MAX_DET, 6]
+    assert out_dims[1][0] == 1
 
     x = np.random.default_rng(1).random((1, 3, IMG, IMG), dtype=np.float32)
     sess = ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
-    out = sess.run(None, {"images": x})[0]
+    outputs = sess.run(None, {"images": x})
+    assert len(outputs) == 2
+    out = outputs[0]
     assert out.shape == (1, MAX_DET, 6)
 
     # Reference: the library's own multi-label postprocess on the raw tensor.
@@ -185,54 +193,85 @@ def test_yolo9_detect_onnx_nms_requires_batch_one(tmp_path):
 
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")
 def test_yolo9_detect_onnx_nms_backend_roundtrip(tmp_path):
-    """LibreYOLO loads an embedded-NMS ONNX and parses it (no double-NMS)."""
+    """LibreYOLO loads an embedded-NMS ONNX and matches native postprocess."""
     import onnxruntime as ort
 
-    from libreyolo import LibreYOLO, LibreYOLO9
-    from libreyolo.models.yolo9.utils import preprocess_numpy
+    from libreyolo import LibreYOLO
+    from libreyolo.export.nms import EmbeddedNMSDetector
+    from libreyolo.export.onnx import export_onnx
 
-    torch.manual_seed(0)
-    model = LibreYOLO9(None, size="t", nb_classes=NC, device="cpu")
-    # Distinct, confident detections so the comparison is unambiguous.
-    for block in model.model.head.cv3:
-        convs = [m for m in block.modules() if isinstance(m, torch.nn.Conv2d)]
-        convs[-1].bias.data = torch.linspace(-1.0, 3.0, NC)
-
-    conf, iou = 0.25, 0.45
-    path = model.export(
-        "onnx",
+    conf, iou, max_det = 0.1, 0.45, 10
+    raw = torch.zeros(1, 5, 2)
+    # These two boxes overlap enough on the 100x100 model canvas for graph NMS
+    # to suppress the lower-scored one. After mapping to a 200x100 original
+    # image and clipping, their IoU falls below 0.45, so native YOLO9 keeps both.
+    raw[0, :4, 0] = torch.tensor([14.9, 27.7, 100.0, 100.0])
+    raw[0, :4, 1] = torch.tensor([0.0, 0.0, 100.0, 100.0])
+    raw[0, 4, :] = torch.tensor([0.9, 0.8])
+    wrapped = EmbeddedNMSDetector(
+        _RawExportModel(raw), conf=conf, iou=iou, max_det=max_det
+    ).eval()
+    path = export_onnx(
+        wrapped,
+        torch.zeros(1, 3, 100, 100),
         output_path=str(tmp_path / "nms.onnx"),
-        imgsz=IMG,
+        opset=13,
         simplify=False,
         dynamic=False,
+        half=False,
+        metadata={
+            "model_family": "yolo9",
+            "task": "detect",
+            "nb_classes": "1",
+            "imgsz": "100",
+            "imgsz_h": "100",
+            "imgsz_w": "100",
+            "nms": "true",
+            "nms_conf": str(conf),
+            "nms_iou": str(iou),
+            "max_det": str(max_det),
+            "nms_raw_output": "true",
+        },
         nms=True,
-        conf=conf,
-        iou=iou,
-        max_det=MAX_DET,
     )
 
-    img = np.random.default_rng(3).integers(0, 256, (IMG, IMG, 3), dtype=np.uint8)
+    graph_outputs = ort.InferenceSession(path, providers=["CPUExecutionProvider"]).run(
+        None, {"images": np.zeros((1, 3, 100, 100), dtype=np.float32)}
+    )
+    assert graph_outputs[0].shape == (1, max_det, 6)
+    assert graph_outputs[1].shape == (1, 5, 2)
+    assert graph_outputs[0][0][graph_outputs[0][0][:, 4] > conf].shape[0] == 1
 
     backend = LibreYOLO(path, device="cpu")
     assert backend.embedded_nms is True
+    assert backend.embedded_nms_raw_output_index == 1
 
-    result = backend.predict(img, conf=conf, iou=iou, imgsz=IMG)
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    result = backend.predict(
+        img,
+        conf=conf,
+        iou=iou,
+        imgsz=100,
+        max_det=max_det,
+        color_format="rgb",
+    )
     assert result.boxes is not None
-    nb = np.asarray(result.boxes.xyxy, np.float32).reshape(-1, 4)
-
-    # Raw embedded output on the same preprocessed blob (square image, ratio 1).
-    chw, _ = preprocess_numpy(img, IMG)
-    raw = ort.InferenceSession(path, providers=["CPUExecutionProvider"]).run(
-        None, {"images": chw[None].astype(np.float32)}
-    )[0]
-    raw_valid = raw[0][raw[0][:, 4] > conf]
-
-    # Backend must surface exactly the embedded detections (no re-NMS dropping).
-    assert len(nb) == raw_valid.shape[0]
-    assert len(nb) > 0
-    # Boxes are real xyxy within the image, not transposed/garbled.
-    assert (nb[:, 0] >= 0).all() and (nb[:, 2] <= IMG + 1).all()
-    assert (nb[:, 1] >= 0).all() and (nb[:, 3] <= IMG + 1).all()
+    backend_rows = np.concatenate(
+        [
+            np.asarray(result.boxes.xyxy, np.float32).reshape(-1, 4),
+            np.asarray(result.boxes.conf, np.float32).reshape(-1, 1),
+            np.asarray(result.boxes.cls, np.float32).reshape(-1, 1),
+        ],
+        axis=1,
+    )
+    assert backend_rows.shape == (2, 6)
+    np.testing.assert_allclose(backend_rows[:, 4], [0.9, 0.8], rtol=1e-6)
+    np.testing.assert_array_equal(backend_rows[:, 5], [0.0, 0.0])
+    np.testing.assert_allclose(
+        backend_rows[:, :4],
+        [[29.8, 55.4, 200.0, 100.0], [0.0, 0.0, 200.0, 100.0]],
+        atol=1e-4,
+    )
 
 
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")

--- a/tests/unit/test_yolo9_nms_onnx_export.py
+++ b/tests/unit/test_yolo9_nms_onnx_export.py
@@ -25,6 +25,15 @@ NC = 4
 MAX_DET = 100
 
 
+class _RawExportModel(torch.nn.Module):
+    def __init__(self, raw: torch.Tensor):
+        super().__init__()
+        self.register_buffer("raw", raw)
+
+    def forward(self, x):
+        return self.raw
+
+
 def _set_unmatched(rows_a, rows_b, *, box_tol=1e-3, score_tol=1e-4):
     """Count rows in a with no exact (box, score, class) counterpart in b."""
     used = np.zeros(len(rows_b), dtype=bool)
@@ -41,6 +50,33 @@ def _set_unmatched(rows_a, rows_b, *, box_tol=1e-3, score_tol=1e-4):
         else:
             unmatched += 1
     return unmatched
+
+
+def test_embedded_nms_caps_candidates_before_suppression(monkeypatch):
+    from libreyolo.export import nms as nms_mod
+
+    monkeypatch.setattr(nms_mod, "_YOLO9_MAX_NMS_CANDIDATES", 3)
+    raw = torch.zeros(1, 7, 2)
+    raw[0, :4, 0] = torch.tensor([0.0, 0.0, 10.0, 10.0])
+    raw[0, :4, 1] = torch.tensor([20.0, 20.0, 30.0, 30.0])
+    raw[0, 4:, :] = torch.tensor(
+        [
+            [0.9, 0.6],
+            [0.8, 0.5],
+            [0.7, 0.4],
+        ]
+    )
+
+    wrapped = nms_mod.EmbeddedNMSDetector(
+        _RawExportModel(raw), conf=0.1, iou=0.45, max_det=10
+    )
+
+    out = wrapped(torch.zeros(1, 3, 32, 32))[0].detach().numpy()
+    det = out[out[:, 4] > 0]
+
+    assert det.shape[0] == 3
+    np.testing.assert_allclose(det[:, 4], [0.9, 0.8, 0.7])
+    np.testing.assert_array_equal(det[:, 5], [0.0, 1.0, 2.0])
 
 
 @pytest.mark.skipif(not _HAS_ORT, reason="onnx/onnxruntime not installed")


### PR DESCRIPTION
Closes #359.

## What

Adds an optional `nms=True` path for **YOLO9 detection** ONNX export that bakes class-aware Non-Maximum Suppression into the model graph. The wrapped model returns a single **static `(1, max_det, 6)`** tensor — `[x1, y1, x2, y2, score, class]`, zero-padded past the detection count — so the exported model is self-contained and needs no external post-processing.

Suppression is expressed with `torchvision.ops.nms`, which lowers to the standard ONNX `NonMaxSuppression` operator, so the output is portable across ONNX Runtime (CPU/GPU) and OpenVINO. The suppression math runs in float32 and composes with both fp32 and int8 exports.

## API

```python
model.export("onnx", nms=True, conf=0.25, iou=0.45, max_det=300)
```
```
libreyolo export --model m.pt --format onnx --nms --conf 0.25 --iou 0.45 --max-det 300
```

Scope: YOLO9 detection, batch=1. (RF-DETR is already NMS-free; CoreML untouched.)

## Bonus fix: int8 score collapse

While testing int8 + NMS I found a pre-existing int8 bug: quantizing **every** op forced the head's box+score concat through a single, box-dominated per-tensor activation scale (boxes ~0–imgsz vs scores 0–1), which rounded **all class scores to zero**. The existing int8 test only asserted `boxes is not None`, so it never surfaced.

Fix: restrict quantization to `Conv`/`Gemm` so the detection-head decode stays in float32. This restores int8 scores (max `0.0 → 0.95`) and shrinks the file, for both the raw and embedded-NMS int8 paths.

## Tests

- New `tests/unit/test_yolo9_nms_onnx_export.py`:
  - fp32 embedded-NMS output matches the reference NMS **exactly** (boxes/scores/classes).
  - int8 embedded-NMS exports, runs, and yields the static `(1, max_det, 6)` shape.
  - batch>1 raises a clear error.
- Existing int8 export test and full export suite pass (87 passed, 4 skipped); ruff clean.

## Known limitation (separate, pre-existing)

`half=True` ONNX export of YOLO9 is already broken on `dev` (`tensor does not have a device` in the head's `arange` during half tracing), independent of this change. fp16 + NMS inherits that. Left for a follow-up.