### PR TITLE
384 support in memory batch processing via lists in predict

### DIFF
--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1699,7 +1699,14 @@ class BaseBackend(ABC):
         of ``batch`` images runs as a single forward pass; otherwise images
         run sequentially.
         """
-        if batch > 1 and self._supports_batched_inference():
+        use_batched = (
+            batch > 1
+            and self._supports_batched_inference()
+            # Latched by _predict_batch after a runtime rejects a stacked
+            # blob, so a long list does not retry (and warn) once per chunk.
+            and not getattr(self, "_batched_inference_failed", False)
+        )
+        if use_batched:
             results = []
             for start in range(0, len(images), batch):
                 results.extend(
@@ -1779,11 +1786,12 @@ class BaseBackend(ABC):
             isinstance(t, torch.Tensor) and t.dim() == 4 and t.shape == tensors[0].shape
             for t in tensors
         )
-        if stackable:
+        if stackable and not getattr(self, "_batched_inference_failed", False):
             blob = np.concatenate([t.numpy() for t in tensors], axis=0)
             try:
                 all_outputs = self._run_inference(blob)
             except Exception as e:
+                self._batched_inference_failed = True
                 logger.warning(
                     "Batched inference failed for %s (%s); falling back to "
                     "sequential processing.",

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1598,8 +1598,13 @@ class BaseBackend(ABC):
         classes: Optional[List[int]] = None,
         max_det: int = 300,
         color_format: str = "auto",
+        save_stem: Optional[str] = None,
     ) -> Results:
-        """Run inference on a single image."""
+        """Run inference on a single image.
+
+        ``save_stem`` overrides the saved filename stem for in-memory images
+        (which have no path to derive one from).
+        """
         image_path = image if isinstance(image, (str, Path)) else None
         effective_imgsz = self._resolve_predict_imgsz(imgsz)
 
@@ -1620,7 +1625,12 @@ class BaseBackend(ABC):
                 image_path=image_path,
             )
             if save:
-                self._save_annotated(result, original_img, image_path, output_path)
+                self._save_annotated(
+                    result,
+                    original_img,
+                    image_path if image_path is not None else save_stem,
+                    output_path,
+                )
             return result
 
         parsed = self._parse_outputs(
@@ -1651,13 +1661,18 @@ class BaseBackend(ABC):
         )
 
         if save:
-            self._save_annotated(result, original_img, image_path, output_path)
+            self._save_annotated(
+                result,
+                original_img,
+                image_path if image_path is not None else save_stem,
+                output_path,
+            )
 
         return result
 
     def _process_in_batches(
         self,
-        image_paths: List[Path],
+        images: List,
         batch: int = 1,
         save: bool = False,
         output_path: str | None = None,
@@ -1668,24 +1683,25 @@ class BaseBackend(ABC):
         max_det: int = 300,
         color_format: str = "auto",
     ) -> List[Results]:
-        """Process multiple images sequentially."""
+        """Process multiple images (file paths or in-memory) sequentially."""
         results = []
-        for i in range(0, len(image_paths), batch):
-            chunk = image_paths[i : i + batch]
-            for path in chunk:
-                results.append(
-                    self._predict_single(
-                        path,
-                        save=save,
-                        output_path=output_path,
-                        conf=conf,
-                        iou=iou,
-                        imgsz=imgsz,
-                        classes=classes,
-                        max_det=max_det,
-                        color_format=color_format,
-                    )
+        for idx, image in enumerate(images):
+            results.append(
+                self._predict_single(
+                    image,
+                    save=save,
+                    output_path=output_path,
+                    conf=conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    classes=classes,
+                    max_det=max_det,
+                    color_format=color_format,
+                    save_stem=(
+                        None if isinstance(image, (str, Path)) else f"image{idx}"
+                    ),
                 )
+            )
         return results
 
     # =========================================================================
@@ -1701,7 +1717,7 @@ class BaseBackend(ABC):
 
     def __call__(
         self,
-        source: Union[str, Path, Image.Image, np.ndarray, None] = None,
+        source: Union[str, Path, Image.Image, np.ndarray, list, tuple, None] = None,
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -1719,7 +1735,7 @@ class BaseBackend(ABC):
         color_format: str = "auto",
         **kwargs,
     ) -> Union[Results, List[Results], Generator[Results, None, None]]:
-        """Run inference on an image, directory, or video."""
+        """Run inference on an image, list of images, directory, or video."""
         normalize_predict_kwargs(kwargs)
         if device not in (None, "", "auto", self.device):
             logger.warning(
@@ -1747,6 +1763,21 @@ class BaseBackend(ABC):
             if stream:
                 return gen
             return collect_video_results(gen, source, vid_stride)
+
+        # Handle in-memory batch input (list/tuple of images)
+        if isinstance(source, (list, tuple)):
+            return self._process_in_batches(
+                list(source),
+                batch=batch,
+                save=save,
+                output_path=output_path,
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                color_format=color_format,
+            )
 
         if isinstance(source, (str, Path)) and Path(source).is_dir():
             image_paths = ImageLoader.collect_images(source)

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1670,6 +1670,16 @@ class BaseBackend(ABC):
 
         return result
 
+    def _supports_batched_inference(self) -> bool:
+        """Whether ``_run_inference`` accepts stacked (N, C, H, W) blobs.
+
+        Default False: traced/compiled runtimes are typically baked to
+        batch 1. Backends whose artifact declares a dynamic batch axis
+        (ONNX, OpenVINO) override this; TensorRT manages batching itself
+        in its own ``_process_in_batches``.
+        """
+        return False
+
     def _process_in_batches(
         self,
         images: List,
@@ -1683,7 +1693,31 @@ class BaseBackend(ABC):
         max_det: int = 300,
         color_format: str = "auto",
     ) -> List[Results]:
-        """Process multiple images (file paths or in-memory) sequentially."""
+        """Process multiple images (file paths or in-memory).
+
+        When ``batch > 1`` and the runtime accepts stacked blobs, each chunk
+        of ``batch`` images runs as a single forward pass; otherwise images
+        run sequentially.
+        """
+        if batch > 1 and self._supports_batched_inference():
+            results = []
+            for start in range(0, len(images), batch):
+                results.extend(
+                    self._predict_batch(
+                        images[start : start + batch],
+                        start_idx=start,
+                        save=save,
+                        output_path=output_path,
+                        conf=conf,
+                        iou=iou,
+                        imgsz=imgsz,
+                        classes=classes,
+                        max_det=max_det,
+                        color_format=color_format,
+                    )
+                )
+            return results
+
         results = []
         for idx, image in enumerate(images):
             results.append(
@@ -1702,6 +1736,130 @@ class BaseBackend(ABC):
                     ),
                 )
             )
+        return results
+
+    def _predict_batch(
+        self,
+        chunk: List,
+        start_idx: int,
+        *,
+        save: bool = False,
+        output_path: str | None = None,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[ImageSize] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        color_format: str = "auto",
+    ) -> List[Results]:
+        """Run one stacked forward pass over a chunk of images.
+
+        Mirrors ``_predict_single`` step for step, except the preprocessed
+        tensors are concatenated into a single blob for ``_run_inference``
+        and the outputs are sliced back per image (``[i : i + 1]`` keeps the
+        batch dim, which every output parser already expects). Falls back to
+        the sequential path if the blob cannot be stacked or the runtime
+        rejects the batched call.
+        """
+        effective_imgsz = self._resolve_predict_imgsz(imgsz)
+
+        preprocessed = []
+        for image in chunk:
+            input_tensor, original_img, original_size, ratio = self._preprocess(
+                image, effective_imgsz, color_format
+            )
+            image_path = image if isinstance(image, (str, Path)) else None
+            preprocessed.append(
+                (input_tensor, original_img, original_size, ratio, image_path)
+            )
+
+        tensors = [item[0] for item in preprocessed]
+        all_outputs = None
+        stackable = all(
+            isinstance(t, torch.Tensor) and t.dim() == 4 and t.shape == tensors[0].shape
+            for t in tensors
+        )
+        if stackable:
+            blob = np.concatenate([t.numpy() for t in tensors], axis=0)
+            try:
+                all_outputs = self._run_inference(blob)
+            except Exception as e:
+                logger.warning(
+                    "Batched inference failed for %s (%s); falling back to "
+                    "sequential processing.",
+                    Path(self.model_path).name,
+                    e,
+                )
+        if all_outputs is None:
+            return [
+                self._predict_single(
+                    image,
+                    save=save,
+                    output_path=output_path,
+                    conf=conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    classes=classes,
+                    max_det=max_det,
+                    color_format=color_format,
+                    save_stem=(
+                        None
+                        if isinstance(image, (str, Path))
+                        else f"image{start_idx + offset}"
+                    ),
+                )
+                for offset, image in enumerate(chunk)
+            ]
+
+        results = []
+        for offset, (_, original_img, original_size, ratio, image_path) in enumerate(
+            preprocessed
+        ):
+            per_image = [
+                np.asarray(output)[offset : offset + 1] for output in all_outputs
+            ]
+            save_name = (
+                image_path if image_path is not None else f"image{start_idx + offset}"
+            )
+            orig_w, orig_h = original_size
+            orig_shape = (orig_h, orig_w)
+
+            if self.task == "classify":
+                result = self._build_classify_result(
+                    per_image,
+                    orig_shape=orig_shape,
+                    image_path=image_path,
+                )
+            else:
+                parsed = self._parse_outputs(
+                    per_image,
+                    effective_imgsz,
+                    original_size,
+                    conf,
+                    ratio=ratio,
+                    iou=iou,
+                    max_det=max_det,
+                )
+                boxes, max_scores, class_ids, masks, obb, keypoints = (
+                    self._unpack_parsed_outputs(parsed)
+                )
+                result = self._build_result(
+                    boxes,
+                    max_scores,
+                    class_ids,
+                    masks=masks,
+                    obb=obb,
+                    keypoints=keypoints,
+                    orig_shape=orig_shape,
+                    image_path=image_path,
+                    iou=iou,
+                    classes=classes,
+                    max_det=max_det,
+                )
+
+            if save:
+                self._save_annotated(result, original_img, save_name, output_path)
+            results.append(result)
         return results
 
     # =========================================================================

--- a/libreyolo/backends/ncnn.py
+++ b/libreyolo/backends/ncnn.py
@@ -205,6 +205,17 @@ class NcnnBackend(BaseBackend):
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run ncnn inference."""
+        if blob.ndim == 4 and blob.shape[0] != 1:
+            # An ncnn extractor runs one image per forward pass. Without this
+            # guard a stacked blob would silently use only blob[0] and return
+            # a single image's outputs for the whole batch (corrupting, e.g.,
+            # batched validation, which relies on failures to trigger its
+            # per-image fallback).
+            raise ValueError(
+                "NCNNBackend runs one image per forward pass; "
+                f"got batch size {blob.shape[0]}."
+            )
+
         import ncnn as _ncnn
 
         # ncnn.Mat expects a C-contiguous (C, H, W) float32 array.

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -97,6 +97,11 @@ class OnnxBackend(BaseBackend):
             else None
         )
         input_shape = self.session.get_inputs()[0].shape
+        # Dynamic-batch exports carry a symbolic dim ("batch") or None at
+        # axis 0; static exports carry an int.
+        self._dynamic_batch_axis = bool(input_shape) and not isinstance(
+            input_shape[0], int
+        )
         static_imgsz = self._read_static_input_imgsz(input_shape)
         if static_imgsz is not None:
             imgsz = static_imgsz
@@ -215,6 +220,11 @@ class OnnxBackend(BaseBackend):
             embedded_nms,
             imgsz,
         )
+
+    def _supports_batched_inference(self) -> bool:
+        # Embedded-NMS graphs are exported batch-1; everything else with a
+        # dynamic batch axis accepts stacked blobs directly.
+        return self._dynamic_batch_axis and not self.embedded_nms
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run ONNX Runtime inference."""

--- a/libreyolo/backends/openvino.py
+++ b/libreyolo/backends/openvino.py
@@ -100,6 +100,7 @@ class OpenVINOBackend(BaseBackend):
 
         core = ov.Core()
         ov_model = core.read_model(str(xml_path))
+        self._dynamic_batch_axis = self._detect_dynamic_batch_axis(ov_model)
         self.compiled_model = core.compile_model(ov_model, ov_device)
 
         static_imgsz = self._read_static_input_imgsz(ov_model)
@@ -118,6 +119,21 @@ class OpenVINOBackend(BaseBackend):
             supported_tasks=supported_tasks,
             default_task=default_task,
         )
+
+    @staticmethod
+    def _detect_dynamic_batch_axis(ov_model) -> bool:
+        """True when the model input declares a dynamic batch dimension.
+
+        OpenVINO models converted from dynamic-axes ONNX keep the symbolic
+        batch dim and accept stacked (N, C, H, W) blobs as-is.
+        """
+        try:
+            return bool(ov_model.inputs[0].get_partial_shape()[0].is_dynamic)
+        except Exception:
+            return False
+
+    def _supports_batched_inference(self) -> bool:
+        return self._dynamic_batch_axis and not getattr(self, "embedded_nms", False)
 
     @staticmethod
     def _read_static_input_imgsz(ov_model) -> ImageSize | None:

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -407,32 +407,42 @@ class TensorRTBackend(BaseBackend):
                     batch_outputs[name][idx : idx + 1] for name in self.output_names
                 ]
 
-                parsed = self._parse_outputs(
-                    per_image,
-                    effective_imgsz,
-                    orig_size,
-                    conf,
-                    ratio=ratio if ratio is not None else 1.0,
-                )
-                boxes, max_scores, class_ids, masks, obb, keypoints = (
-                    self._unpack_parsed_outputs(parsed)
-                )
-
                 orig_w, orig_h = orig_size
                 orig_shape = (orig_h, orig_w)
-                result = self._build_result(
-                    boxes,
-                    max_scores,
-                    class_ids,
-                    masks=masks,
-                    obb=obb,
-                    keypoints=keypoints,
-                    orig_shape=orig_shape,
-                    image_path=image_path,
-                    iou=iou,
-                    classes=classes,
-                    max_det=max_det,
-                )
+                # Mirror _predict_single: classify exports skip the detection
+                # parser, and iou/max_det reach parsers that apply NMS.
+                if self.task == "classify":
+                    result = self._build_classify_result(
+                        per_image,
+                        orig_shape=orig_shape,
+                        image_path=image_path,
+                    )
+                else:
+                    parsed = self._parse_outputs(
+                        per_image,
+                        effective_imgsz,
+                        orig_size,
+                        conf,
+                        ratio=ratio if ratio is not None else 1.0,
+                        iou=iou,
+                        max_det=max_det,
+                    )
+                    boxes, max_scores, class_ids, masks, obb, keypoints = (
+                        self._unpack_parsed_outputs(parsed)
+                    )
+                    result = self._build_result(
+                        boxes,
+                        max_scores,
+                        class_ids,
+                        masks=masks,
+                        obb=obb,
+                        keypoints=keypoints,
+                        orig_shape=orig_shape,
+                        image_path=image_path,
+                        iou=iou,
+                        classes=classes,
+                        max_det=max_det,
+                    )
 
                 if save:
                     self._save_annotated(result, orig_img, save_name, output_path)

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -325,7 +325,7 @@ class TensorRTBackend(BaseBackend):
 
     def _process_in_batches(
         self,
-        image_paths: List,
+        images: List,
         batch: int = 1,
         save: bool = False,
         output_path: str | None = None,
@@ -353,7 +353,7 @@ class TensorRTBackend(BaseBackend):
         )
         if not can_batch:
             return super()._process_in_batches(
-                image_paths,
+                images,
                 batch=batch,
                 save=save,
                 output_path=output_path,
@@ -368,27 +368,41 @@ class TensorRTBackend(BaseBackend):
         effective_imgsz = self._resolve_predict_imgsz(imgsz)
         results = []
 
-        for i in range(0, len(image_paths), effective_batch):
-            chunk_paths = image_paths[i : i + effective_batch]
+        for i in range(0, len(images), effective_batch):
+            chunk = images[i : i + effective_batch]
 
             tensors = []
             preprocess_info = []
-            for path in chunk_paths:
-                preprocess_out = self._preprocess(path, effective_imgsz, color_format)
+            for offset, image in enumerate(chunk):
+                preprocess_out = self._preprocess(image, effective_imgsz, color_format)
                 if len(preprocess_out) == 4:
                     tensor, orig_img, orig_size, ratio = preprocess_out
                 else:
                     tensor, orig_img, orig_size = preprocess_out
                     ratio = None
                 tensors.append(tensor)
-                preprocess_info.append((orig_img, orig_size, ratio, path))
+                # In-memory images have no path: keep Results.path None and
+                # use an indexed stem so save=True does not overwrite files.
+                image_path = image if isinstance(image, (str, Path)) else None
+                save_name = (
+                    image_path if image_path is not None else f"image{i + offset}"
+                )
+                preprocess_info.append(
+                    (orig_img, orig_size, ratio, image_path, save_name)
+                )
 
             batched_input = np.concatenate(
                 [t.numpy() for t in tensors], axis=0
             )  # (B, C, H, W)
             batch_outputs = self._infer(batched_input)
 
-            for idx, (orig_img, orig_size, ratio, path) in enumerate(preprocess_info):
+            for idx, (
+                orig_img,
+                orig_size,
+                ratio,
+                image_path,
+                save_name,
+            ) in enumerate(preprocess_info):
                 per_image = [
                     batch_outputs[name][idx : idx + 1] for name in self.output_names
                 ]
@@ -414,14 +428,14 @@ class TensorRTBackend(BaseBackend):
                     obb=obb,
                     keypoints=keypoints,
                     orig_shape=orig_shape,
-                    image_path=path,
+                    image_path=image_path,
                     iou=iou,
                     classes=classes,
                     max_det=max_det,
                 )
 
                 if save:
-                    self._save_annotated(result, orig_img, path, output_path)
+                    self._save_annotated(result, orig_img, save_name, output_path)
 
                 results.append(result)
 

--- a/libreyolo/cli/commands/predict.py
+++ b/libreyolo/cli/commands/predict.py
@@ -113,7 +113,11 @@ def predict_cmd(
         False, help="FP16 inference (CUDA only, requires model support)"
     ),
     save: bool = typer.Option(False, help="Save annotated images"),
-    batch: int = typer.Option(1, help="Batch size for directories"),
+    batch: int = typer.Option(
+        1,
+        help="Images per forward pass for directory sources "
+        "(batch > 1 runs true batched inference on supported models)",
+    ),
     tiling: bool = typer.Option(False, help="Tiled inference for large images"),
     overlap_ratio: float = typer.Option(0.2, help="Tile overlap ratio"),
     output_path: Optional[str] = typer.Option(None, help="Explicit output path"),

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -69,7 +69,7 @@ class InferenceRunner:
 
     def __call__(
         self,
-        source: ImageInput | Sequence[ImageInput] | None = None,
+        source: ImageInput | list[ImageInput] | tuple[ImageInput, ...] | None = None,
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -930,9 +930,15 @@ class InferenceRunner:
         color_format: str = "auto",
         overlap_ratio: float = 0.2,
         output_file_format: Optional[str] = None,
+        save_stem: Optional[str] = None,
         **kwargs,
     ) -> Results:
-        """Run tiled inference on large images."""
+        """Run tiled inference on large images.
+
+        ``save_stem`` overrides the saved artifact stem for in-memory images
+        (which have no path to derive one from); it is threaded into the
+        single-image fallbacks below and into the tiled save directory name.
+        """
 
         # Tiling is a detection-time technique; for whole-image classification
         # and dense semantic maps it is meaningless, so fall back to a single
@@ -949,6 +955,7 @@ class InferenceRunner:
                 max_det=max_det,
                 color_format=color_format,
                 output_file_format=output_file_format,
+                save_stem=save_stem,
                 **kwargs,
             )
 
@@ -986,6 +993,7 @@ class InferenceRunner:
                 max_det=max_det,
                 color_format=color_format,
                 output_file_format=output_file_format,
+                save_stem=save_stem,
                 **kwargs,
             )
 
@@ -1056,7 +1064,7 @@ class InferenceRunner:
             if isinstance(image_path, (str, Path)):
                 stem = get_safe_stem(image_path)
             else:
-                stem = "inference"
+                stem = save_stem or "inference"
             model_tag = f"{self.model._get_model_name()}_{self.model.size}"
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
 

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -40,6 +40,7 @@ from ...utils.general import (
     log_saved_result,
     resolve_save_path,
 )
+from ...postprocess.slicing import slice_batch_outputs
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.predict_args import normalize_predict_kwargs
 from ...utils.results import (
@@ -103,7 +104,10 @@ class InferenceRunner:
             classes: Filter to specific class IDs.
             max_det: Maximum detections per image.
             save: If True, saves annotated image or video.
-            batch: Batch size for directory processing.
+            batch: Images per forward pass for directory and list sources.
+                With batch > 1, supported families run a single stacked
+                forward per chunk (true batched inference); batch=1 keeps
+                the sequential one-forward-per-image behavior.
             stream: If True, return a generator yielding per-frame Results.
                 Recommended for video to avoid high memory usage.
             vid_stride: Process every N-th video frame (default: 1).
@@ -294,7 +298,40 @@ class InferenceRunner:
         augment: bool = False,
         **kwargs,
     ) -> List[Results]:
-        """Process multiple images (file paths or in-memory) sequentially."""
+        """Process multiple images (file paths or in-memory).
+
+        With ``batch > 1`` — and no tiling/TTA — each chunk of ``batch``
+        images runs as one stacked forward pass; the batched output is
+        sliced back per image and fed to the family's existing batch-1
+        postprocess. Otherwise images run sequentially, one forward each.
+        """
+        use_batched = (
+            batch > 1
+            and not tiling
+            and not (augment and getattr(self.model, "TTA_ENABLED", False))
+            and getattr(self.model, "SUPPORTS_BATCHED_PREDICT", False)
+        )
+        if use_batched:
+            results = []
+            for start in range(0, len(images), batch):
+                results.extend(
+                    self._predict_batch(
+                        images[start : start + batch],
+                        start_idx=start,
+                        save=save,
+                        output_path=output_path,
+                        conf=conf,
+                        iou=iou,
+                        imgsz=imgsz,
+                        classes=classes,
+                        max_det=max_det,
+                        color_format=color_format,
+                        output_file_format=output_file_format,
+                        **kwargs,
+                    )
+                )
+            return results
+
         results = []
         for idx, image in enumerate(images):
             # In-memory images have no filename to derive a save name from;
@@ -355,6 +392,104 @@ class InferenceRunner:
                         **kwargs,
                     )
                 )
+        return results
+
+    def _predict_batch(
+        self,
+        chunk: Sequence[ImageInput],
+        start_idx: int,
+        save: bool = False,
+        output_path: str | None = None,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[int] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        color_format: str = "auto",
+        output_file_format: Optional[str] = None,
+        **kwargs,
+    ) -> List[Results]:
+        """Run one stacked forward pass over a chunk of images.
+
+        Mirrors ``_predict_single`` step for step; the only difference is
+        that the chunk's preprocessed tensors are concatenated into a single
+        batch for the forward pass and the output is sliced back per image.
+        ``start_idx`` is the chunk's offset in the full source list, used for
+        the indexed save names of in-memory images.
+        """
+        effective_imgsz = imgsz if imgsz is not None else self.model._get_input_size()
+        kwargs["input_size"] = effective_imgsz
+
+        preprocessed = []
+        for image in chunk:
+            input_tensor, original_img, original_size, ratio = self.model._preprocess(
+                image, color_format, input_size=effective_imgsz
+            )
+            preprocessed.append(
+                (input_tensor, original_img, original_size, ratio, image)
+            )
+
+        tensors = [item[0] for item in preprocessed]
+        stackable = all(
+            isinstance(t, torch.Tensor) and t.dim() == 4 and t.shape == tensors[0].shape
+            for t in tensors
+        )
+        if not stackable:
+            # Preprocess did not yield uniform (1, C, H, W) tensors; keep
+            # correctness over speed and run the chunk sequentially.
+            return [
+                self._predict_single(
+                    image,
+                    save=save,
+                    output_path=output_path,
+                    conf=conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    classes=classes,
+                    max_det=max_det,
+                    color_format=color_format,
+                    output_file_format=output_file_format,
+                    save_stem=(
+                        None
+                        if isinstance(image, (str, Path))
+                        else f"image{start_idx + offset}"
+                    ),
+                    **kwargs,
+                )
+                for offset, image in enumerate(chunk)
+            ]
+
+        stacked = torch.cat(tensors, dim=0)
+        with torch.no_grad():
+            output = self.model._forward(stacked.to(self.model.device))
+
+        results = []
+        for offset, (_, original_img, original_size, ratio, image) in enumerate(
+            preprocessed
+        ):
+            detections = self.model._postprocess(
+                slice_batch_outputs(output, offset),
+                conf,
+                iou,
+                original_size,
+                max_det=max_det,
+                ratio=ratio,
+                classes=classes,
+                **kwargs,
+            )
+            image_path = image if isinstance(image, (str, Path)) else None
+            result = self._wrap_results(detections, original_size, image_path, classes)
+            if save:
+                ext = output_file_format or "jpg"
+                save_path = resolve_save_path(
+                    output_path,
+                    image_path
+                    if image_path is not None
+                    else f"image{start_idx + offset}",
+                    ext=ext,
+                )
+                self._save_annotated_image(result, original_img, save_path)
+            results.append(result)
         return results
 
     def _save_annotated_image(self, result: Results, original_img, save_path: Path) -> None:

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -11,7 +11,16 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import torch
 from torchvision.ops import batched_nms
@@ -59,7 +68,7 @@ class InferenceRunner:
 
     def __call__(
         self,
-        source: ImageInput | None = None,
+        source: ImageInput | Sequence[ImageInput] | None = None,
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -83,10 +92,11 @@ class InferenceRunner:
         **kwargs,
     ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """
-        Run inference on an image, directory, or video.
+        Run inference on an image, list of images, directory, or video.
 
         Args:
-            source: Input image, directory path, or video file path.
+            source: Input image, list/tuple of in-memory images, directory
+                path, or video file path.
             conf: Confidence threshold.
             iou: IoU threshold for NMS.
             imgsz: Input size override (None = model default).
@@ -149,6 +159,26 @@ class InferenceRunner:
             if stream:
                 return gen
             return collect_video_results(gen, source, vid_stride)
+
+        # Handle in-memory batch input (list/tuple of images)
+        if isinstance(source, (list, tuple)):
+            return self._process_in_batches(
+                list(source),
+                batch=batch,
+                save=save,
+                output_path=output_path,
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                color_format=color_format,
+                tiling=tiling,
+                overlap_ratio=overlap_ratio,
+                output_file_format=output_file_format,
+                augment=augment,
+                **kwargs,
+            )
 
         # Handle directory input
         if isinstance(source, (str, Path)) and Path(source).is_dir():
@@ -248,7 +278,7 @@ class InferenceRunner:
 
     def _process_in_batches(
         self,
-        image_paths: List[Path],
+        images: Sequence[ImageInput],
         batch: int = 1,
         save: bool = False,
         output_path: str | None = None,
@@ -264,61 +294,67 @@ class InferenceRunner:
         augment: bool = False,
         **kwargs,
     ) -> List[Results]:
-        """Process multiple images in batches."""
+        """Process multiple images (file paths or in-memory) sequentially."""
         results = []
-        for i in range(0, len(image_paths), batch):
-            chunk = image_paths[i : i + batch]
-            for path in chunk:
-                if tiling:
-                    results.append(
-                        self._predict_tiled(
-                            path,
-                            save=save,
-                            output_path=output_path,
-                            conf=conf,
-                            iou=iou,
-                            imgsz=imgsz,
-                            classes=classes,
-                            max_det=max_det,
-                            color_format=color_format,
-                            overlap_ratio=overlap_ratio,
-                            output_file_format=output_file_format,
-                            **kwargs,
-                        )
-                    )
-                elif augment and getattr(self.model, "TTA_ENABLED", False):
-                    result = self.model._predict_augment(
-                        path,
+        for idx, image in enumerate(images):
+            # In-memory images have no filename to derive a save name from;
+            # index them so save=True does not overwrite a single file.
+            save_stem = None if isinstance(image, (str, Path)) else f"image{idx}"
+            if tiling:
+                results.append(
+                    self._predict_tiled(
+                        image,
+                        save=save,
+                        output_path=output_path,
                         conf=conf,
                         iou=iou,
                         imgsz=imgsz,
                         classes=classes,
                         max_det=max_det,
                         color_format=color_format,
+                        overlap_ratio=overlap_ratio,
+                        output_file_format=output_file_format,
                         **kwargs,
                     )
-                    if save:
-                        ext = output_file_format or "jpg"
-                        save_path = resolve_save_path(output_path, path, ext=ext)
-                        img_pil = ImageLoader.load(path, color_format=color_format)
-                        self._save_annotated_image(result, img_pil, save_path)
-                    results.append(result)
-                else:
-                    results.append(
-                        self._predict_single(
-                            path,
-                            save=save,
-                            output_path=output_path,
-                            conf=conf,
-                            iou=iou,
-                            imgsz=imgsz,
-                            classes=classes,
-                            max_det=max_det,
-                            color_format=color_format,
-                            output_file_format=output_file_format,
-                            **kwargs,
-                        )
+                )
+            elif augment and getattr(self.model, "TTA_ENABLED", False):
+                result = self.model._predict_augment(
+                    image,
+                    conf=conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    classes=classes,
+                    max_det=max_det,
+                    color_format=color_format,
+                    **kwargs,
+                )
+                if save:
+                    ext = output_file_format or "jpg"
+                    save_path = resolve_save_path(
+                        output_path,
+                        image if save_stem is None else save_stem,
+                        ext=ext,
                     )
+                    img_pil = ImageLoader.load(image, color_format=color_format)
+                    self._save_annotated_image(result, img_pil, save_path)
+                results.append(result)
+            else:
+                results.append(
+                    self._predict_single(
+                        image,
+                        save=save,
+                        output_path=output_path,
+                        conf=conf,
+                        iou=iou,
+                        imgsz=imgsz,
+                        classes=classes,
+                        max_det=max_det,
+                        color_format=color_format,
+                        output_file_format=output_file_format,
+                        save_stem=save_stem,
+                        **kwargs,
+                    )
+                )
         return results
 
     def _save_annotated_image(self, result: Results, original_img, save_path: Path) -> None:
@@ -594,9 +630,14 @@ class InferenceRunner:
         max_det: int = 300,
         color_format: str = "auto",
         output_file_format: Optional[str] = None,
+        save_stem: Optional[str] = None,
         **kwargs,
     ) -> Results:
-        """Run inference on a single image."""
+        """Run inference on a single image.
+
+        ``save_stem`` overrides the saved filename stem for in-memory images
+        (which have no path to derive one from).
+        """
         image_path = image if isinstance(image, (str, Path)) else None
 
         # Resolve input size
@@ -634,7 +675,7 @@ class InferenceRunner:
             ext = output_file_format or "jpg"
             save_path = resolve_save_path(
                 output_path,
-                image_path,
+                image_path if image_path is not None else save_stem,
                 ext=ext,
             )
             self._save_annotated_image(result, original_img, save_path)

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -109,7 +109,9 @@ class InferenceRunner:
                 forward per chunk (true batched inference); batch=1 keeps
                 the sequential one-forward-per-image behavior.
             stream: If True, return a generator yielding per-frame Results.
-                Recommended for video to avoid high memory usage.
+                Recommended for video to avoid high memory usage. Applies to
+                video sources only; list and directory sources always return
+                a fully materialized list.
             vid_stride: Process every N-th video frame (default: 1).
             show: If True, display annotated frames in a window (video only).
             output_path: Optional output path.
@@ -310,6 +312,11 @@ class InferenceRunner:
             and not tiling
             and not (augment and getattr(self.model, "TTA_ENABLED", False))
             and getattr(self.model, "SUPPORTS_BATCHED_PREDICT", False)
+            # A train-mode network (weightless init, or predict mid-training)
+            # would normalize the stacked chunk with cross-image BatchNorm
+            # batch statistics, letting chunk-mates change each other's
+            # results; keep per-image forwards there.
+            and not getattr(getattr(self.model, "model", None), "training", False)
         )
         if use_batched:
             results = []
@@ -351,6 +358,10 @@ class InferenceRunner:
                         color_format=color_format,
                         overlap_ratio=overlap_ratio,
                         output_file_format=output_file_format,
+                        # Reaches _predict_single through the small-image and
+                        # classify/semantic fallbacks so in-memory saves stay
+                        # indexed there too.
+                        save_stem=save_stem,
                         **kwargs,
                     )
                 )
@@ -398,6 +409,7 @@ class InferenceRunner:
         self,
         chunk: Sequence[ImageInput],
         start_idx: int,
+        *,
         save: bool = False,
         output_path: str | None = None,
         conf: float = 0.25,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -25,6 +25,7 @@ from typing import (
 import torch
 from torchvision.ops import batched_nms
 
+from ...postprocess.slicing import slice_batch_outputs
 from ...utils.drawing import (
     draw_boxes,
     draw_keypoints,
@@ -40,7 +41,6 @@ from ...utils.general import (
     log_saved_result,
     resolve_save_path,
 )
-from ...postprocess.slicing import slice_batch_outputs
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.predict_args import normalize_predict_kwargs
 from ...utils.results import (
@@ -302,7 +302,7 @@ class InferenceRunner:
     ) -> List[Results]:
         """Process multiple images (file paths or in-memory).
 
-        With ``batch > 1`` — and no tiling/TTA — each chunk of ``batch``
+        With ``batch > 1`` (and no tiling/TTA) each chunk of ``batch``
         images runs as one stacked forward pass; the batched output is
         sliced back per image and fed to the family's existing batch-1
         postprocess. Otherwise images run sequentially, one forward each.
@@ -443,7 +443,11 @@ class InferenceRunner:
 
         tensors = [item[0] for item in preprocessed]
         stackable = all(
-            isinstance(t, torch.Tensor) and t.dim() == 4 and t.shape == tensors[0].shape
+            isinstance(t, torch.Tensor)
+            and t.dim() == 4
+            and t.shape == tensors[0].shape
+            and t.dtype == tensors[0].dtype
+            and t.device == tensors[0].device
             for t in tensors
         )
         if not stackable:

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -118,7 +118,7 @@ class BaseModel(ABC):
     val_preprocessor_class = StandardValPreprocessor
     EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset[str]] = frozenset()
 
-    # Batched-predict policy — True when ``_preprocess`` yields stackable
+    # Batched-predict policy: True when ``_preprocess`` yields stackable
     # (1, C, H, W) tensors and every tensor in the ``_forward`` output keeps
     # a leading batch dim (the contract batched validation already relies
     # on). Set False where that does not hold (e.g. generative VLMs).

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -118,6 +118,12 @@ class BaseModel(ABC):
     val_preprocessor_class = StandardValPreprocessor
     EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset[str]] = frozenset()
 
+    # Batched-predict policy — True when ``_preprocess`` yields stackable
+    # (1, C, H, W) tensors and every tensor in the ``_forward`` output keeps
+    # a leading batch dim (the contract batched validation already relies
+    # on). Set False where that does not hold (e.g. generative VLMs).
+    SUPPORTS_BATCHED_PREDICT: ClassVar[bool] = True
+
     # TTA policy — subclasses may override
     TTA_ENABLED: ClassVar[bool] = True
     # True for families that resize to a fixed square regardless of input size

--- a/libreyolo/models/l2cs/model.py
+++ b/libreyolo/models/l2cs/model.py
@@ -55,6 +55,9 @@ class LibreL2CS(BaseModel):
 
     # TTA, tiling, and validation all make no sense for two-stage gaze.
     TTA_ENABLED = False
+    # Gaze runs through GazeInferenceRunner (per-face crops), never the
+    # stacked single-forward predict path.
+    SUPPORTS_BATCHED_PREDICT = False
 
     # State-dict fingerprint shared by every L2CS checkpoint.
     _SIGNATURE_KEYS = ("fc_yaw_gaze.weight", "fc_pitch_gaze.weight")

--- a/libreyolo/models/vlm/base.py
+++ b/libreyolo/models/vlm/base.py
@@ -73,6 +73,11 @@ class LibreVLMModel(BaseModel):
     # Multi-scale TTA / tiling are meaningless for a fixed-resolution generator.
     TTA_ENABLED: ClassVar[bool] = False
 
+    # ``_preprocess`` returns an HF BatchEncoding (not a stackable image
+    # tensor) and ``_forward`` runs autoregressive generation, so the stacked
+    # single-forward predict path does not apply.
+    SUPPORTS_BATCHED_PREDICT: ClassVar[bool] = False
+
     # Family-specific weight license, printed once before the first download.
     _LICENSE_NOTICE: ClassVar[str] = ""
     _LICENSE_NOTICE_SHOWN: ClassVar[bool] = False

--- a/libreyolo/postprocess/__init__.py
+++ b/libreyolo/postprocess/__init__.py
@@ -3,7 +3,9 @@
 One module per family. Each module is a collection of pure functions
 (model outputs in -> detections dict out) moved verbatim from the
 family's ``models/<family>/utils.py``; the old import paths keep
-working via re-exports there.
+working via re-exports there. ``slicing.py`` is the one shared,
+family-agnostic module: per-image views of batched forward outputs,
+used by both the validators and batched predict.
 
 Design rule: modules in this package must not import from
 ``libreyolo.models`` at module level. ``libreyolo/models/__init__.py``

--- a/libreyolo/postprocess/slicing.py
+++ b/libreyolo/postprocess/slicing.py
@@ -22,6 +22,13 @@ def slice_batch_outputs(output: Any, batch_idx: int) -> Any:
     batch's tensors and ``[0]``-indexing would yield the first image's
     detections for every image in the batch. Non-tensor leaves (flags,
     scalars, ``None``) pass through unchanged.
+
+    Contract note: list/tuple values INSIDE a dict pass through unsliced
+    (matching the long-standing validation behavior this was extracted
+    from). Today no family postprocess reads per-image data from such keys
+    (yolo9 ``raw_outputs``, yolonas ``raw_predictions`` are unread); a new
+    family that does must keep every read key a tensor or nested dict of
+    tensors, or override its slicing.
     """
     if isinstance(output, dict):
         sliced = {}

--- a/libreyolo/postprocess/slicing.py
+++ b/libreyolo/postprocess/slicing.py
@@ -1,0 +1,46 @@
+"""Per-image slicing of batched model outputs.
+
+Shared by the validators and the batched predict path: a batched forward
+output goes in, and one image's view comes out with the batch dimension
+kept (``[i : i + 1]``), so the family's existing batch-1 postprocess
+accepts it unchanged.
+"""
+
+from typing import Any
+
+import torch
+
+
+def slice_batch_outputs(output: Any, batch_idx: int) -> Any:
+    """Extract predictions for a single image from batched model output.
+
+    Tensors are sliced to ``[batch_idx : batch_idx + 1]`` (batch dim kept);
+    dicts are sliced value-wise (one nested-dict level deep); lists and
+    tuples recurse so nested list-of-tensor outputs (e.g. PICODET's
+    per-level ``(List[cls_scores], List[bbox_preds])``) are sliced too.
+    Without the recursion every per-image postprocess would get the full
+    batch's tensors and ``[0]``-indexing would yield the first image's
+    detections for every image in the batch. Non-tensor leaves (flags,
+    scalars, ``None``) pass through unchanged.
+    """
+    if isinstance(output, dict):
+        sliced = {}
+        for key, value in output.items():
+            if isinstance(value, dict):
+                sliced[key] = {
+                    k: v[batch_idx : batch_idx + 1]
+                    if isinstance(v, torch.Tensor)
+                    else v
+                    for k, v in value.items()
+                }
+            elif isinstance(value, torch.Tensor):
+                sliced[key] = value[batch_idx : batch_idx + 1]
+            else:
+                sliced[key] = value
+        return sliced
+    elif isinstance(output, torch.Tensor):
+        return output[batch_idx : batch_idx + 1]
+    elif isinstance(output, (list, tuple)):
+        return type(output)(slice_batch_outputs(p, batch_idx) for p in output)
+    else:
+        return output

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
+from ..postprocess.slicing import slice_batch_outputs
 from .base import BaseValidator
 from .config import ValidationConfig
 
@@ -393,34 +394,7 @@ class DetectionValidator(BaseValidator):
 
     def _slice_batch_predictions(self, preds: Any, batch_idx: int) -> Any:
         """Extract predictions for a single image from batched model output."""
-        if isinstance(preds, dict):
-            sliced = {}
-            for key, value in preds.items():
-                if isinstance(value, dict):
-                    sliced[key] = {
-                        k: v[batch_idx : batch_idx + 1]
-                        if isinstance(v, torch.Tensor)
-                        else v
-                        for k, v in value.items()
-                    }
-                elif isinstance(value, torch.Tensor):
-                    sliced[key] = value[batch_idx : batch_idx + 1]
-                else:
-                    sliced[key] = value
-            return sliced
-        elif isinstance(preds, torch.Tensor):
-            return preds[batch_idx : batch_idx + 1]
-        elif isinstance(preds, (list, tuple)):
-            # Recurse so nested list-of-tensor outputs (e.g. PICODET's per-level
-            # ``(List[cls_scores], List[bbox_preds])``) are sliced too. Without
-            # this every per-image postprocess gets the full batch's tensors
-            # and ``[0]``-indexing yields the first image's slice for every
-            # image in the batch.
-            return type(preds)(
-                self._slice_batch_predictions(p, batch_idx) for p in preds
-            )
-        else:
-            return preds
+        return slice_batch_outputs(preds, batch_idx)
 
     def _det_from_result(self, result) -> Dict[str, torch.Tensor]:
         """Convert a Results object (from _predict_augment) to a detection dict."""

--- a/libreyolo/validation/obb_validator.py
+++ b/libreyolo/validation/obb_validator.py
@@ -19,6 +19,7 @@ from libreyolo.data.obb import (
     xywhr_iou,
 )
 
+from ..postprocess.slicing import slice_batch_outputs
 from .base import BaseValidator
 from .config import ValidationConfig
 from .detection_validator import val_collate_fn
@@ -259,18 +260,7 @@ class OBBValidator(BaseValidator):
         return detections
 
     def _slice_batch_predictions(self, preds: Any, batch_idx: int) -> Any:
-        if isinstance(preds, dict):
-            return {
-                key: value[batch_idx : batch_idx + 1]
-                if isinstance(value, torch.Tensor)
-                else value
-                for key, value in preds.items()
-            }
-        if isinstance(preds, torch.Tensor):
-            return preds[batch_idx : batch_idx + 1]
-        if isinstance(preds, (list, tuple)):
-            return type(preds)(self._slice_batch_predictions(p, batch_idx) for p in preds)
-        return preds
+        return slice_batch_outputs(preds, batch_idx)
 
     def _update_metrics(
         self,

--- a/libreyolo/validation/point_validator.py
+++ b/libreyolo/validation/point_validator.py
@@ -10,6 +10,7 @@ import numpy as np
 from scipy.optimize import linear_sum_assignment
 from torch.utils.data import DataLoader
 
+from ..postprocess.slicing import slice_batch_outputs
 from .base import BaseValidator
 from .config import ValidationConfig
 
@@ -341,23 +342,7 @@ class PointValidator(BaseValidator):
 
     def _slice_batch_predictions(self, preds: Any, batch_idx: int) -> Any:
         """Extract predictions for a single image from batched model output."""
-        import torch
-
-        if isinstance(preds, dict):
-            sliced: Dict[str, Any] = {}
-            for key, value in preds.items():
-                if isinstance(value, torch.Tensor):
-                    sliced[key] = value[batch_idx: batch_idx + 1]
-                else:
-                    sliced[key] = value
-            return sliced
-        elif isinstance(preds, torch.Tensor):
-            return preds[batch_idx: batch_idx + 1]
-        elif isinstance(preds, (list, tuple)):
-            return type(preds)(
-                self._slice_batch_predictions(p, batch_idx) for p in preds
-            )
-        return preds
+        return slice_batch_outputs(preds, batch_idx)
 
     def _update_metrics(
         self,

--- a/tests/e2e/test_deterministic_inference.py
+++ b/tests/e2e/test_deterministic_inference.py
@@ -128,13 +128,18 @@ def test_batched_list_predict_matches_sequential(family, size, weights, sample_i
         batched = model(images, conf=0.25, batch=2)
 
         assert len(sequential) == len(batched) == 2
-        _assert_detection_output_is_stable(family, sequential[0], batched[0])
+        assert len(sequential[0]) > 0, f"{family} returned no detections"
         for r_seq, r_bat in zip(sequential, batched):
             assert r_seq.orig_shape == r_bat.orig_shape
             assert len(r_seq) == len(r_bat), (
                 f"{family} batched detection count diverged: "
                 f"{len(r_seq)} -> {len(r_bat)}"
             )
+            # Full box/score/class parity for every image with detections
+            # (the rotated view may legitimately drop to zero for some
+            # families; the count check above still covers it).
+            if len(r_seq) > 0:
+                _assert_detection_output_is_stable(family, r_seq, r_bat)
     finally:
         del model
         cuda_cleanup()

--- a/tests/e2e/test_deterministic_inference.py
+++ b/tests/e2e/test_deterministic_inference.py
@@ -100,3 +100,41 @@ def test_native_inference_is_stable(family, size, weights, sample_image):
     finally:
         del model
         cuda_cleanup()
+
+
+@pytest.mark.parametrize(
+    "family,size,weights",
+    GENERAL_NIGHTLY_INFERENCE_PARAMS,
+)
+def test_batched_list_predict_matches_sequential(family, size, weights, sample_image):
+    """batch>1 over an in-memory list reproduces sequential results (issue #384).
+
+    Real weights give well-separated scores, so the comparison is immune to
+    the NMS tie-order noise random-init parity tests would suffer from.
+    """
+    if family in ("l2cs", "vlm"):
+        pytest.skip(f"{family} does not use the stacked batched predict path")
+
+    from libreyolo.utils.image_loader import ImageLoader
+
+    weights = require_test_weights(weights, expected_family=family)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = LibreYOLO(weights, size=size, device=device)
+    try:
+        pil = ImageLoader.load(sample_image)
+        images = [pil, pil.rotate(90, expand=True)]
+
+        sequential = model(images, conf=0.25, batch=1)
+        batched = model(images, conf=0.25, batch=2)
+
+        assert len(sequential) == len(batched) == 2
+        _assert_detection_output_is_stable(family, sequential[0], batched[0])
+        for r_seq, r_bat in zip(sequential, batched):
+            assert r_seq.orig_shape == r_bat.orig_shape
+            assert len(r_seq) == len(r_bat), (
+                f"{family} batched detection count diverged: "
+                f"{len(r_seq)} -> {len(r_bat)}"
+            )
+    finally:
+        del model
+        cuda_cleanup()

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -127,6 +127,23 @@ def test_runner_tiling_list_save_uses_indexed_filenames(tmp_path):
     assert sorted(p.name for p in out_dir.iterdir()) == ["image0.jpg", "image1.jpg"]
 
 
+def test_runner_tiling_list_save_indexes_large_image_dirs(tmp_path):
+    """The full tiled path derives its save directory stem from save_stem."""
+    runner = InferenceRunner(_StubModel())
+    out_dir = tmp_path / "out"
+    # 64px images exceed the 32px stub input size, so the real tiled path
+    # runs and writes one timestamped directory per image.
+    images = [
+        np.zeros((64, 64, 3), dtype=np.uint8),
+        np.zeros((64, 64, 3), dtype=np.uint8),
+    ]
+
+    runner(images, tiling=True, save=True, output_path=str(out_dir))
+
+    stems = sorted(p.name.split("_stub_")[0] for p in out_dir.iterdir())
+    assert stems == ["image0", "image1"]
+
+
 # =============================================================================
 # Exported-backend pipeline (BaseBackend and TensorRT batching)
 # =============================================================================
@@ -178,6 +195,7 @@ def test_backend_sequential_batches_pass_indexed_save_stems():
 
 def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
     backend = _bare_backend()
+    backend.task = "detect"
     backend._dynamic_batch = True
     backend._max_batch = 2
     backend.imgsz = 64
@@ -197,7 +215,10 @@ def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
             "labels": np.zeros((batched_input.shape[0], 1, 2), dtype=np.float32),
         }
 
-    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0):
+    seen_parse_kwargs = []
+
+    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300):
+        seen_parse_kwargs.append({"iou": iou, "max_det": max_det})
         return (
             np.zeros((0, 4), dtype=np.float32),
             np.zeros((0,), dtype=np.float32),
@@ -236,11 +257,15 @@ def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
     backend._save_annotated = save_annotated
 
     images = [np.zeros((8, 8, 3), dtype=np.uint8)] * 3
-    results = backend._process_in_batches(images, batch=2, save=True)
+    results = backend._process_in_batches(
+        images, batch=2, save=True, iou=0.6, max_det=50
+    )
 
     assert len(results) == 3
     assert built_paths == [None, None, None]
     assert saved_names == ["image0", "image1", "image2"]
+    # iou/max_det must reach the parser, mirroring _predict_single.
+    assert seen_parse_kwargs == [{"iou": 0.6, "max_det": 50}] * 3
 
 
 # =============================================================================

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -111,6 +111,22 @@ def test_runner_list_save_uses_indexed_filenames(tmp_path):
     assert sorted(p.name for p in out_dir.iterdir()) == ["image0.jpg", "image1.jpg"]
 
 
+def test_runner_tiling_list_save_uses_indexed_filenames(tmp_path):
+    """The tiling branch must thread save_stem through its fallbacks too."""
+    runner = InferenceRunner(_StubModel())
+    out_dir = tmp_path / "out"
+    # 16px images are below the 32px stub input size, so _predict_tiled takes
+    # its small-image fallback into _predict_single.
+    images = [
+        np.zeros((16, 16, 3), dtype=np.uint8),
+        np.zeros((16, 16, 3), dtype=np.uint8),
+    ]
+
+    runner(images, tiling=True, save=True, output_path=str(out_dir))
+
+    assert sorted(p.name for p in out_dir.iterdir()) == ["image0.jpg", "image1.jpg"]
+
+
 # =============================================================================
 # Exported-backend pipeline (BaseBackend and TensorRT batching)
 # =============================================================================
@@ -374,11 +390,13 @@ def _rand_images(seed, sizes):
     return [rng.integers(0, 255, size=(h, w, 3), dtype=np.uint8) for h, w in sizes]
 
 
-def _assert_results_parity(sequential, batched):
+def _assert_results_parity(sequential, batched, require_detections=False):
     assert len(sequential) == len(batched)
     for r_seq, r_bat in zip(sequential, batched):
         assert r_seq.orig_shape == r_bat.orig_shape
         assert len(r_seq) == len(r_bat)
+        if require_detections:
+            assert len(r_seq) > 0, "parity comparison has no detections to compare"
         if r_seq.boxes is not None and len(r_seq) > 0:
             torch.testing.assert_close(
                 r_seq.boxes.xyxy, r_bat.boxes.xyxy, rtol=1e-3, atol=1e-3
@@ -398,7 +416,9 @@ def _assert_results_parity(sequential, batched):
 
 
 @pytest.mark.parametrize("task", ["detect", "segment", "pose"])
-def test_yolo9_batched_predict_matches_sequential(task):
+def test_yolo9_batched_predict_smoke_matches_sequential(task):
+    """Full real forward+postprocess smoke; random-init weights rarely clear
+    conf=0.25, so numeric coverage lives in the marker-routing tests below."""
     from libreyolo import LibreYOLO9
 
     torch.manual_seed(0)
@@ -410,6 +430,134 @@ def test_yolo9_batched_predict_matches_sequential(task):
     batched = model(images, conf=0.25, batch=2, imgsz=64)
 
     _assert_results_parity(sequential, batched)
+
+
+def test_yolo9_segment_batched_routing_with_marker_outputs():
+    """Deterministic per-image routing proof for boxes, classes, and masks.
+
+    The forward is replaced with a hand-marked batched dict: image i's slice
+    carries score s_i on anchor a_i / class c_i, and a proto/coefficient pair
+    that decodes to a full mask only when image i is paired with its own
+    proto. Any cross-image slicing mistake yields the wrong class/score or an
+    empty mask.
+    """
+    from libreyolo import LibreYOLO9
+
+    torch.manual_seed(0)
+    model = LibreYOLO9(None, size="t", task="segment", device="cpu")
+    model.model.eval()
+    with torch.no_grad():
+        template = model._forward(torch.zeros(3, 3, 64, 64))
+
+    preds = torch.zeros_like(template["predictions"])  # (3, 4+nc, A)
+    coeffs = torch.zeros_like(template["mask_coeffs"])  # (3, 32, A)
+    proto = torch.full_like(template["proto"], -8.0)  # (3, 32, Hp, Wp)
+    box_input = torch.tensor([8.0, 8.0, 40.0, 40.0])
+    anchors, classes_, scores = (10, 11, 12), (0, 5, 10), (0.9, 0.8, 0.7)
+    for i, (a_i, c_i, s_i) in enumerate(zip(anchors, classes_, scores)):
+        preds[i, 0:4, a_i] = box_input
+        preds[i, 4 + c_i, a_i] = s_i
+        coeffs[i, i, a_i] = 8.0
+        proto[i, i] = 8.0
+    marked = {"predictions": preds, "proto": proto, "mask_coeffs": coeffs}
+
+    def fake_forward(tensor):
+        assert tuple(tensor.shape) == (3, 3, 64, 64), "expected one stacked forward"
+        return marked
+
+    model._forward = fake_forward
+    sizes = [(64, 64), (32, 32), (16, 16)]
+    images = [np.zeros((h, w, 3), dtype=np.uint8) for h, w in sizes]
+
+    results = model(images, batch=3, imgsz=64, conf=0.25)
+
+    for i, (result, (orig_h, orig_w)) in enumerate(zip(results, sizes)):
+        assert len(result) == 1
+        assert int(result.boxes.cls[0]) == classes_[i]
+        torch.testing.assert_close(
+            result.boxes.conf[0], torch.tensor(scores[i]), rtol=1e-5, atol=1e-6
+        )
+        ratio = min(64 / orig_h, 64 / orig_w)
+        torch.testing.assert_close(
+            result.boxes.xyxy[0], box_input / ratio, rtol=1e-5, atol=1e-4
+        )
+        assert result.masks is not None
+        assert result.masks.data.sum() > 0, (
+            "empty mask: image was decoded with another image's proto"
+        )
+
+
+def test_yolo9_pose_batched_routing_with_marker_outputs():
+    """Deterministic per-image routing proof for keypoints under batching."""
+    from libreyolo import LibreYOLO9
+
+    torch.manual_seed(0)
+    model = LibreYOLO9(None, size="t", task="pose", device="cpu")
+    model.model.eval()
+    with torch.no_grad():
+        template = model._forward(torch.zeros(3, 3, 64, 64))
+
+    preds = torch.zeros_like(template["predictions"])  # (3, 5, A)
+    kpts = torch.zeros_like(template["keypoints"])  # (3, A, 17, 3)
+    box_input = torch.tensor([8.0, 8.0, 40.0, 40.0])
+    anchors, scores = (10, 11, 12), (0.9, 0.8, 0.7)
+    kpt_xs = (20.0, 24.0, 28.0)
+    for i, (a_i, s_i, x_i) in enumerate(zip(anchors, scores, kpt_xs)):
+        preds[i, 0:4, a_i] = box_input
+        preds[i, 4, a_i] = s_i
+        kpts[i, a_i, :, 0] = x_i
+        kpts[i, a_i, :, 1] = 24.0
+        kpts[i, a_i, :, 2] = 0.9
+    marked = {"predictions": preds, "keypoints": kpts}
+
+    def fake_forward(tensor):
+        assert tuple(tensor.shape) == (3, 3, 64, 64), "expected one stacked forward"
+        return marked
+
+    model._forward = fake_forward
+    sizes = [(64, 64), (32, 32), (16, 16)]
+    images = [np.zeros((h, w, 3), dtype=np.uint8) for h, w in sizes]
+
+    results = model(images, batch=3, imgsz=64, conf=0.25)
+
+    for i, (result, (orig_h, orig_w)) in enumerate(zip(results, sizes)):
+        assert len(result) == 1
+        ratio = min(64 / orig_h, 64 / orig_w)
+        assert result.keypoints is not None
+        kpt = result.keypoints.data[0]  # (17, 3)
+        torch.testing.assert_close(
+            kpt[:, 0],
+            torch.full((17,), kpt_xs[i] / ratio),
+            rtol=1e-5,
+            atol=1e-4,
+        )
+        # Keypoint confidence is not rescaled by original size.
+        torch.testing.assert_close(
+            kpt[:, 2], torch.full((17,), 0.9), rtol=1e-5, atol=1e-6
+        )
+
+
+def test_batched_gate_skips_train_mode_models():
+    """Train-mode BatchNorm would mix chunk-mates; the gate keeps it sequential."""
+
+    class _TrainFlag:
+        training = True
+
+    model = _BatchedStubModel()
+    model.model = _TrainFlag()
+    runner = InferenceRunner(model)
+    images = [np.full((8, 8, 3), v, dtype=np.uint8) for v in (10, 60, 200)]
+
+    results = runner(images, batch=3)
+
+    assert model.forward_shapes == [(1, 3, 32, 32)] * 3
+    assert [float(r.boxes.conf[0]) for r in results] == [10.0, 60.0, 200.0]
+
+    # Flipping to eval restores the stacked path.
+    model.model.training = False
+    model.forward_shapes.clear()
+    runner(images, batch=3)
+    assert model.forward_shapes == [(3, 3, 32, 32)]
 
 
 def test_yolo9_batched_forward_slices_match_single_forwards():
@@ -454,7 +602,7 @@ def test_deimv2_batched_predict_matches_sequential():
     sequential = model(images, conf=0.0, batch=1, max_det=20)
     batched = model(images, conf=0.0, batch=2, max_det=20)
 
-    _assert_results_parity(sequential, batched)
+    _assert_results_parity(sequential, batched, require_detections=True)
 
 
 def test_picodet_batched_predict_matches_sequential():
@@ -468,7 +616,7 @@ def test_picodet_batched_predict_matches_sequential():
     sequential = model(images, conf=0.001, batch=1, max_det=20)
     batched = model(images, conf=0.001, batch=2, max_det=20)
 
-    _assert_results_parity(sequential, batched)
+    _assert_results_parity(sequential, batched, require_detections=True)
 
 
 # =============================================================================
@@ -560,9 +708,16 @@ def test_backend_predict_batch_falls_back_when_runtime_rejects_batch():
     images = [np.full((8, 8, 3), v, dtype=np.uint8) for v in (10, 60, 200)]
     results = BaseBackend._process_in_batches(backend, images, batch=2)
 
-    # Chunk of 2 fails batched, re-runs per image; final chunk of 1 succeeds.
+    # Chunk of 2 fails batched, re-runs per image; final chunk of 1 runs
+    # sequentially because the failure latched batching off.
     assert blob_shapes == [(2, 3, 32, 32), (1, 3, 32, 32), (1, 3, 32, 32), (1, 3, 32, 32)]
     assert [marker for _, marker in results] == [10.0, 60.0, 200.0]
+    assert backend._batched_inference_failed is True
+
+    # Subsequent calls never retry the stacked path.
+    blob_shapes.clear()
+    BaseBackend._process_in_batches(backend, images, batch=2)
+    assert blob_shapes == [(1, 3, 32, 32)] * 3
 
 
 def test_backend_without_batch_support_stays_sequential():
@@ -620,6 +775,46 @@ def test_onnx_supports_batched_inference_flag():
     assert not backend._supports_batched_inference()
 
     backend.embedded_nms = False
+    backend._dynamic_batch_axis = False
+    assert not backend._supports_batched_inference()
+
+
+def test_openvino_detects_dynamic_batch_axis():
+    from libreyolo.backends.openvino import OpenVINOBackend
+
+    class _Dim:
+        def __init__(self, dynamic):
+            self.is_dynamic = dynamic
+
+    class _Input:
+        def __init__(self, dynamic):
+            self._dynamic = dynamic
+
+        def get_partial_shape(self):
+            return [_Dim(self._dynamic)]
+
+    class _Model:
+        def __init__(self, dynamic):
+            self.inputs = [_Input(dynamic)]
+
+    assert OpenVINOBackend._detect_dynamic_batch_axis(_Model(True)) is True
+    assert OpenVINOBackend._detect_dynamic_batch_axis(_Model(False)) is False
+
+    class _Broken:
+        inputs = []
+
+    # API mismatch / older runtimes degrade to "no batching", never raise.
+    assert OpenVINOBackend._detect_dynamic_batch_axis(_Broken()) is False
+
+
+def test_openvino_supports_batched_inference_flag():
+    from libreyolo.backends.openvino import OpenVINOBackend
+
+    backend = OpenVINOBackend.__new__(OpenVINOBackend)
+    backend._dynamic_batch_axis = True
+    backend.embedded_nms = False
+    assert backend._supports_batched_inference()
+
     backend._dynamic_batch_axis = False
     assert not backend._supports_batched_inference()
 

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -1,0 +1,227 @@
+"""Tests for in-memory batch prediction via list/tuple sources (issue #384)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.backends.base import BaseBackend
+from libreyolo.backends.tensorrt import TensorRTBackend
+from libreyolo.models.base.inference import InferenceRunner
+from libreyolo.utils.image_loader import ImageLoader
+
+
+pytestmark = pytest.mark.unit
+
+
+class _StubModel:
+    """Minimal stand-in for a BaseModel as seen by InferenceRunner."""
+
+    task = "detect"
+    TTA_ENABLED = False
+    size = "n"
+    names = {0: "thing"}
+    device = torch.device("cpu")
+
+    def _get_input_size(self):
+        return 32
+
+    def _get_model_name(self):
+        return "stub"
+
+    def _preprocess(self, image, color_format="auto", input_size=None):
+        assert not isinstance(image, (list, tuple))
+        pil = ImageLoader.load(image, color_format=color_format)
+        return torch.zeros(1, 3, 32, 32), pil, pil.size, 1.0
+
+    def _forward(self, tensor):
+        return tensor
+
+    def _postprocess(
+        self,
+        output,
+        conf,
+        iou,
+        original_size,
+        max_det=300,
+        ratio=1.0,
+        classes=None,
+        **kwargs,
+    ):
+        return {
+            "boxes": [[1.0, 1.0, 5.0, 5.0]],
+            "scores": [0.9],
+            "classes": [0],
+            "num_detections": 1,
+        }
+
+
+# =============================================================================
+# PyTorch pipeline (InferenceRunner)
+# =============================================================================
+
+
+def test_runner_accepts_list_of_in_memory_images():
+    runner = InferenceRunner(_StubModel())
+    images = [
+        np.zeros((16, 20, 3), dtype=np.uint8),
+        np.zeros((16, 20, 3), dtype=np.uint8),
+    ]
+
+    results = runner(images)
+
+    assert isinstance(results, list)
+    assert len(results) == 2
+    assert all(r.path is None for r in results)
+    assert all(len(r) == 1 for r in results)
+
+
+def test_runner_accepts_tuple_and_empty_list():
+    runner = InferenceRunner(_StubModel())
+
+    assert runner([]) == []
+
+    results = runner((np.zeros((8, 8, 3), dtype=np.uint8),))
+    assert len(results) == 1
+
+
+def test_runner_list_mixes_paths_and_in_memory_images(tmp_path):
+    img_file = tmp_path / "photo.png"
+    Image.new("RGB", (10, 10)).save(img_file)
+    runner = InferenceRunner(_StubModel())
+
+    results = runner([str(img_file), np.zeros((8, 8, 3), dtype=np.uint8)])
+
+    assert results[0].path == str(img_file)
+    assert results[1].path is None
+
+
+def test_runner_list_save_uses_indexed_filenames(tmp_path):
+    runner = InferenceRunner(_StubModel())
+    out_dir = tmp_path / "out"
+    images = [
+        np.zeros((16, 16, 3), dtype=np.uint8),
+        np.zeros((16, 16, 3), dtype=np.uint8),
+    ]
+
+    runner(images, save=True, output_path=str(out_dir))
+
+    assert sorted(p.name for p in out_dir.iterdir()) == ["image0.jpg", "image1.jpg"]
+
+
+# =============================================================================
+# Exported-backend pipeline (BaseBackend and TensorRT batching)
+# =============================================================================
+
+
+def _bare_backend():
+    backend = TensorRTBackend.__new__(TensorRTBackend)
+    backend.model_path = "LibreRFDETR_s.engine"
+    backend.model_family = "rfdetr"
+    backend._sidecar_size = None
+    backend.device = "cpu"
+    return backend
+
+
+def test_backend_call_routes_list_to_process_in_batches():
+    backend = _bare_backend()
+    seen = {}
+
+    def fake_process(images, **kwargs):
+        seen["images"] = images
+        seen["batch"] = kwargs.get("batch")
+        return ["r"] * len(images)
+
+    backend._process_in_batches = fake_process
+
+    out = backend([np.zeros((8, 8, 3), dtype=np.uint8)] * 3, batch=2)
+
+    assert out == ["r", "r", "r"]
+    assert seen["batch"] == 2
+    assert len(seen["images"]) == 3
+
+
+def test_backend_sequential_batches_pass_indexed_save_stems():
+    backend = _bare_backend()
+    stems = []
+
+    def fake_single(image, **kwargs):
+        stems.append(kwargs["save_stem"])
+        return "r"
+
+    backend._predict_single = fake_single
+
+    BaseBackend._process_in_batches(
+        backend, ["a.jpg", np.zeros((4, 4, 3), dtype=np.uint8)]
+    )
+
+    assert stems == [None, "image1"]
+
+
+def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
+    backend = _bare_backend()
+    backend._dynamic_batch = True
+    backend._max_batch = 2
+    backend.imgsz = 64
+    backend.output_names = ["dets", "labels"]
+
+    def preprocess(image, imgsz, color_format):
+        assert isinstance(image, np.ndarray)
+        return (
+            torch.zeros(1, 3, imgsz, imgsz),
+            np.zeros((imgsz, imgsz, 3), dtype=np.uint8),
+            (imgsz, imgsz),
+        )
+
+    def infer(batched_input):
+        return {
+            "dets": np.zeros((batched_input.shape[0], 1, 4), dtype=np.float32),
+            "labels": np.zeros((batched_input.shape[0], 1, 2), dtype=np.float32),
+        }
+
+    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0):
+        return (
+            np.zeros((0, 4), dtype=np.float32),
+            np.zeros((0,), dtype=np.float32),
+            np.zeros((0,), dtype=np.int64),
+            None,
+        )
+
+    built_paths = []
+
+    def build_result(
+        boxes,
+        max_scores,
+        class_ids,
+        *,
+        masks,
+        obb=None,
+        keypoints=None,
+        orig_shape,
+        image_path,
+        iou,
+        classes,
+        max_det,
+    ):
+        built_paths.append(image_path)
+        return image_path
+
+    saved_names = []
+
+    def save_annotated(result, orig_img, image_path, output_path):
+        saved_names.append(image_path)
+
+    backend._preprocess = preprocess
+    backend._infer = infer
+    backend._parse_outputs = parse_outputs
+    backend._build_result = build_result
+    backend._save_annotated = save_annotated
+
+    images = [np.zeros((8, 8, 3), dtype=np.uint8)] * 3
+    results = backend._process_in_batches(images, batch=2, save=True)
+
+    assert len(results) == 3
+    assert built_paths == [None, None, None]
+    assert saved_names == ["image0", "image1", "image2"]

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -225,3 +225,408 @@ def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
     assert len(results) == 3
     assert built_paths == [None, None, None]
     assert saved_names == ["image0", "image1", "image2"]
+
+
+# =============================================================================
+# True batched inference — PyTorch pipeline mechanics
+# =============================================================================
+
+
+class _BatchedStubModel:
+    """Stub with the batched-predict contract: stackable tensors, dict output.
+
+    Each image's preprocessed tensor is filled with the image's mean pixel
+    value, so per-image routing through the batched forward can be asserted
+    from the Results scores.
+    """
+
+    task = "detect"
+    TTA_ENABLED = False
+    SUPPORTS_BATCHED_PREDICT = True
+    names = {0: "thing"}
+    device = torch.device("cpu")
+
+    def __init__(self):
+        self.forward_shapes = []
+
+    def _get_input_size(self):
+        return 32
+
+    def _preprocess(self, image, color_format="auto", input_size=None):
+        pil = ImageLoader.load(image, color_format=color_format)
+        marker = float(np.asarray(pil, dtype=np.float32).mean())
+        return torch.full((1, 3, 32, 32), marker), pil, pil.size, 1.0
+
+    def _forward(self, tensor):
+        self.forward_shapes.append(tuple(tensor.shape))
+        return {"predictions": tensor, "obb": False}
+
+    def _postprocess(
+        self,
+        output,
+        conf,
+        iou,
+        original_size,
+        max_det=300,
+        ratio=1.0,
+        classes=None,
+        **kwargs,
+    ):
+        assert output["predictions"].shape[0] == 1, "expected a batch-1 slice"
+        marker = float(output["predictions"].flatten()[0])
+        return {
+            "boxes": [[0.0, 0.0, 1.0, 1.0]],
+            "scores": [marker],
+            "classes": [0],
+            "num_detections": 1,
+        }
+
+
+def test_batched_runner_stacks_chunks_and_routes_each_image():
+    model = _BatchedStubModel()
+    runner = InferenceRunner(model)
+    images = [
+        np.full((16, 24, 3), 10, dtype=np.uint8),
+        np.full((20, 12, 3), 60, dtype=np.uint8),
+        np.full((8, 8, 3), 200, dtype=np.uint8),
+    ]
+
+    results = runner(images, batch=2)
+
+    # One stacked forward per chunk: 2 + 1.
+    assert model.forward_shapes == [(2, 3, 32, 32), (1, 3, 32, 32)]
+    # Scores carry each image's marker — order and per-image routing held.
+    assert [float(r.boxes.conf[0]) for r in results] == [10.0, 60.0, 200.0]
+    # Per-image original sizes survived the batched path.
+    assert [r.orig_shape for r in results] == [(16, 24), (20, 12), (8, 8)]
+
+
+def test_batched_runner_keeps_paths_and_indexed_save_names(tmp_path):
+    img_file = tmp_path / "photo.png"
+    Image.new("RGB", (10, 10), color=(60, 60, 60)).save(img_file)
+    out_dir = tmp_path / "out"
+    model = _BatchedStubModel()
+    runner = InferenceRunner(model)
+    images = [
+        np.full((16, 16, 3), 10, dtype=np.uint8),
+        str(img_file),
+        np.full((16, 16, 3), 200, dtype=np.uint8),
+    ]
+
+    results = runner(images, batch=3, save=True, output_path=str(out_dir))
+
+    assert model.forward_shapes == [(3, 3, 32, 32)]
+    assert results[0].path is None
+    assert results[1].path == str(img_file)
+    assert results[2].path is None
+    assert sorted(p.name for p in out_dir.iterdir()) == [
+        "image0.jpg",
+        "image2.jpg",
+        "photo.jpg",
+    ]
+
+
+def test_runner_without_batched_flag_stays_sequential():
+    class _Counting(_StubModel):
+        def __init__(self):
+            self.forward_shapes = []
+
+        def _forward(self, tensor):
+            self.forward_shapes.append(tuple(tensor.shape))
+            return tensor
+
+    model = _Counting()
+    runner = InferenceRunner(model)
+
+    runner([np.zeros((8, 8, 3), dtype=np.uint8)] * 3, batch=2)
+
+    assert model.forward_shapes == [(1, 3, 32, 32)] * 3
+
+
+def test_batched_runner_falls_back_when_tensors_not_stackable():
+    class _RaggedStub(_BatchedStubModel):
+        def _preprocess(self, image, color_format="auto", input_size=None):
+            pil = ImageLoader.load(image, color_format=color_format)
+            side = 32 if pil.size[0] >= 16 else 16
+            return torch.zeros(1, 3, side, side), pil, pil.size, 1.0
+
+    model = _RaggedStub()
+    runner = InferenceRunner(model)
+    images = [
+        np.zeros((8, 24, 3), dtype=np.uint8),
+        np.zeros((8, 8, 3), dtype=np.uint8),
+    ]
+
+    results = runner(images, batch=2)
+
+    assert len(results) == 2
+    # Ragged shapes → chunk re-ran sequentially, one forward per image.
+    assert model.forward_shapes == [(1, 3, 32, 32), (1, 3, 16, 16)]
+
+
+# =============================================================================
+# True batched inference — parity against sequential, real models
+# =============================================================================
+
+
+def _rand_images(seed, sizes):
+    rng = np.random.default_rng(seed)
+    return [rng.integers(0, 255, size=(h, w, 3), dtype=np.uint8) for h, w in sizes]
+
+
+def _assert_results_parity(sequential, batched):
+    assert len(sequential) == len(batched)
+    for r_seq, r_bat in zip(sequential, batched):
+        assert r_seq.orig_shape == r_bat.orig_shape
+        assert len(r_seq) == len(r_bat)
+        if r_seq.boxes is not None and len(r_seq) > 0:
+            torch.testing.assert_close(
+                r_seq.boxes.xyxy, r_bat.boxes.xyxy, rtol=1e-3, atol=1e-3
+            )
+            torch.testing.assert_close(
+                r_seq.boxes.conf, r_bat.boxes.conf, rtol=1e-3, atol=1e-3
+            )
+            torch.testing.assert_close(
+                r_seq.boxes.cls, r_bat.boxes.cls, rtol=0.0, atol=0.0
+            )
+        if r_seq.keypoints is not None and len(r_seq) > 0:
+            torch.testing.assert_close(
+                r_seq.keypoints.data, r_bat.keypoints.data, rtol=1e-3, atol=1e-3
+            )
+        if r_seq.masks is not None and len(r_seq) > 0:
+            assert r_seq.masks.data.shape == r_bat.masks.data.shape
+
+
+@pytest.mark.parametrize("task", ["detect", "segment", "pose"])
+def test_yolo9_batched_predict_matches_sequential(task):
+    from libreyolo import LibreYOLO9
+
+    torch.manual_seed(0)
+    model = LibreYOLO9(None, size="t", task=task, device="cpu")
+    model.model.eval()  # weightless init leaves train mode; BN must use running stats
+    images = _rand_images(7, [(64, 48), (40, 80), (56, 56)])
+
+    sequential = model(images, conf=0.25, batch=1, imgsz=64)
+    batched = model(images, conf=0.25, batch=2, imgsz=64)
+
+    _assert_results_parity(sequential, batched)
+
+
+def test_yolo9_batched_forward_slices_match_single_forwards():
+    from libreyolo import LibreYOLO9
+    from libreyolo.postprocess.slicing import slice_batch_outputs
+
+    torch.manual_seed(0)
+    model = LibreYOLO9(None, size="t", device="cpu")
+    model.model.eval()
+    first = torch.rand(1, 3, 64, 64)
+    second = torch.rand(1, 3, 64, 64)
+
+    with torch.no_grad():
+        out_batched = model._forward(torch.cat([first, second]))
+        out_first = model._forward(first)
+        out_second = model._forward(second)
+
+    torch.testing.assert_close(
+        slice_batch_outputs(out_batched, 0)["predictions"],
+        out_first["predictions"],
+        rtol=1e-4,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(
+        slice_batch_outputs(out_batched, 1)["predictions"],
+        out_second["predictions"],
+        rtol=1e-4,
+        atol=1e-5,
+    )
+
+
+def test_deimv2_batched_predict_matches_sequential():
+    from libreyolo import LibreDEIMv2
+
+    torch.manual_seed(0)
+    model = LibreDEIMv2(None, size="atto", device="cpu")
+    model.model.eval()
+    images = _rand_images(11, [(48, 64), (64, 48), (32, 32)])
+
+    # conf=0.0 + top-k selection → a fixed number of rows per image, so the
+    # comparison always has signal even with random weights.
+    sequential = model(images, conf=0.0, batch=1, max_det=20)
+    batched = model(images, conf=0.0, batch=2, max_det=20)
+
+    _assert_results_parity(sequential, batched)
+
+
+def test_picodet_batched_predict_matches_sequential():
+    from libreyolo import LibrePICODET
+
+    torch.manual_seed(0)
+    model = LibrePICODET(None, size="s", device="cpu")
+    model.model.eval()
+    images = _rand_images(13, [(48, 64), (40, 40)])
+
+    sequential = model(images, conf=0.001, batch=1, max_det=20)
+    batched = model(images, conf=0.001, batch=2, max_det=20)
+
+    _assert_results_parity(sequential, batched)
+
+
+# =============================================================================
+# True batched inference — exported-backend pipeline (BaseBackend)
+# =============================================================================
+
+
+def _batchable_backend():
+    backend = _bare_backend()
+    backend.imgsz = 32
+    backend.task = "detect"
+    return backend
+
+
+def _marker_preprocess(image, imgsz, color_format):
+    marker = float(np.asarray(image, dtype=np.float32).mean())
+    return (
+        torch.full((1, 3, imgsz, imgsz), marker),
+        np.zeros((imgsz, imgsz, 3), dtype=np.uint8),
+        (imgsz, imgsz),
+        1.0,
+    )
+
+
+def _marker_parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300):
+    marker = float(np.asarray(per_image[0]).ravel()[0])
+    return (
+        np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32),
+        np.array([marker], dtype=np.float32),
+        np.array([0], dtype=np.int64),
+        None,
+    )
+
+
+def _marker_build_result(
+    boxes,
+    max_scores,
+    class_ids,
+    *,
+    masks,
+    obb=None,
+    keypoints=None,
+    orig_shape,
+    image_path,
+    iou,
+    classes,
+    max_det,
+):
+    return (image_path, float(max_scores[0]))
+
+
+def test_backend_predict_batch_runs_single_stacked_inference():
+    backend = _batchable_backend()
+    blob_shapes = []
+
+    def run_inference(blob):
+        blob_shapes.append(blob.shape)
+        return [blob[:, :1, :1, :1].reshape(blob.shape[0], 1)]
+
+    backend._preprocess = _marker_preprocess
+    backend._run_inference = run_inference
+    backend._parse_outputs = _marker_parse_outputs
+    backend._build_result = _marker_build_result
+    backend._supports_batched_inference = lambda: True
+
+    images = [np.full((8, 8, 3), v, dtype=np.uint8) for v in (10, 60, 200)]
+    results = BaseBackend._process_in_batches(backend, images, batch=2)
+
+    assert blob_shapes == [(2, 3, 32, 32), (1, 3, 32, 32)]
+    assert results == [(None, 10.0), (None, 60.0), (None, 200.0)]
+
+
+def test_backend_predict_batch_falls_back_when_runtime_rejects_batch():
+    backend = _batchable_backend()
+    blob_shapes = []
+
+    def run_inference(blob):
+        blob_shapes.append(blob.shape)
+        if blob.shape[0] != 1:
+            raise RuntimeError("static batch-1 graph")
+        return [blob[:, :1, :1, :1].reshape(blob.shape[0], 1)]
+
+    backend._preprocess = _marker_preprocess
+    backend._run_inference = run_inference
+    backend._parse_outputs = _marker_parse_outputs
+    backend._build_result = _marker_build_result
+    backend._supports_batched_inference = lambda: True
+
+    images = [np.full((8, 8, 3), v, dtype=np.uint8) for v in (10, 60, 200)]
+    results = BaseBackend._process_in_batches(backend, images, batch=2)
+
+    # Chunk of 2 fails batched, re-runs per image; final chunk of 1 succeeds.
+    assert blob_shapes == [(2, 3, 32, 32), (1, 3, 32, 32), (1, 3, 32, 32), (1, 3, 32, 32)]
+    assert [marker for _, marker in results] == [10.0, 60.0, 200.0]
+
+
+def test_backend_without_batch_support_stays_sequential():
+    backend = _batchable_backend()
+    blob_shapes = []
+
+    def run_inference(blob):
+        blob_shapes.append(blob.shape)
+        return [blob[:, :1, :1, :1].reshape(blob.shape[0], 1)]
+
+    backend._preprocess = _marker_preprocess
+    backend._run_inference = run_inference
+    backend._parse_outputs = _marker_parse_outputs
+    backend._build_result = _marker_build_result
+
+    images = [np.full((8, 8, 3), v, dtype=np.uint8) for v in (10, 60)]
+    results = BaseBackend._process_in_batches(backend, images, batch=2)
+
+    assert blob_shapes == [(1, 3, 32, 32), (1, 3, 32, 32)]
+    assert len(results) == 2
+
+
+def test_onnx_backend_batched_list_predict_matches_sequential(tmp_path):
+    """End to end: dynamic ONNX export of a real model, list predict, batch>1."""
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxruntime")
+
+    from libreyolo import LibreDEIMv2
+    from libreyolo.backends.onnx import OnnxBackend
+
+    torch.manual_seed(0)
+    model = LibreDEIMv2(None, size="atto", device="cpu")
+    out_path = tmp_path / "LibreDEIMv2_atto.onnx"
+    model.export("onnx", output_path=str(out_path), simplify=False, dynamic=True)
+
+    backend = OnnxBackend(str(out_path), device="cpu")
+    assert backend._supports_batched_inference()
+
+    images = _rand_images(17, [(48, 64), (64, 48), (32, 40)])
+    sequential = backend(images, conf=0.0, batch=1, max_det=20)
+    batched = backend(images, conf=0.0, batch=2, max_det=20)
+
+    _assert_results_parity(sequential, batched)
+
+
+def test_onnx_supports_batched_inference_flag():
+    from libreyolo.backends.onnx import OnnxBackend
+
+    backend = OnnxBackend.__new__(OnnxBackend)
+    backend._dynamic_batch_axis = True
+    backend.embedded_nms = False
+    assert backend._supports_batched_inference()
+
+    backend.embedded_nms = True
+    assert not backend._supports_batched_inference()
+
+    backend.embedded_nms = False
+    backend._dynamic_batch_axis = False
+    assert not backend._supports_batched_inference()
+
+
+def test_ncnn_run_inference_rejects_batched_blob():
+    from libreyolo.backends.ncnn import NcnnBackend
+
+    backend = NcnnBackend.__new__(NcnnBackend)
+    with pytest.raises(ValueError, match="one image per forward pass"):
+        backend._run_inference(np.zeros((2, 3, 8, 8), dtype=np.float32))

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -244,7 +244,7 @@ def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
 
 
 # =============================================================================
-# True batched inference — PyTorch pipeline mechanics
+# True batched inference: PyTorch pipeline mechanics
 # =============================================================================
 
 
@@ -311,7 +311,7 @@ def test_batched_runner_stacks_chunks_and_routes_each_image():
 
     # One stacked forward per chunk: 2 + 1.
     assert model.forward_shapes == [(2, 3, 32, 32), (1, 3, 32, 32)]
-    # Scores carry each image's marker — order and per-image routing held.
+    # Scores carry each image's marker; order and per-image routing held.
     assert [float(r.boxes.conf[0]) for r in results] == [10.0, 60.0, 200.0]
     # Per-image original sizes survived the batched path.
     assert [r.orig_shape for r in results] == [(16, 24), (20, 12), (8, 8)]
@@ -381,7 +381,7 @@ def test_batched_runner_falls_back_when_tensors_not_stackable():
 
 
 # =============================================================================
-# True batched inference — parity against sequential, real models
+# True batched inference: parity against sequential, real models
 # =============================================================================
 
 
@@ -390,13 +390,11 @@ def _rand_images(seed, sizes):
     return [rng.integers(0, 255, size=(h, w, 3), dtype=np.uint8) for h, w in sizes]
 
 
-def _assert_results_parity(sequential, batched, require_detections=False):
+def _assert_results_parity(sequential, batched):
     assert len(sequential) == len(batched)
     for r_seq, r_bat in zip(sequential, batched):
         assert r_seq.orig_shape == r_bat.orig_shape
         assert len(r_seq) == len(r_bat)
-        if require_detections:
-            assert len(r_seq) > 0, "parity comparison has no detections to compare"
         if r_seq.boxes is not None and len(r_seq) > 0:
             torch.testing.assert_close(
                 r_seq.boxes.xyxy, r_bat.boxes.xyxy, rtol=1e-3, atol=1e-3
@@ -589,7 +587,15 @@ def test_yolo9_batched_forward_slices_match_single_forwards():
     )
 
 
-def test_deimv2_batched_predict_matches_sequential():
+def test_deimv2_batched_predict_smoke_matches_sequential():
+    """Real forward smoke with tie-robust assertions.
+
+    Random-init weights make every (query, class) score a near-tie, and
+    stacked vs single forwards can differ bitwise (BLAS path selection,
+    e.g. macOS Accelerate), flipping which rows win top-k. Counts and
+    sorted scores are stable under such flips; exact box parity lives in
+    the marker-routing test below and the real-weights nightly tier.
+    """
     from libreyolo import LibreDEIMv2
 
     torch.manual_seed(0)
@@ -597,15 +603,97 @@ def test_deimv2_batched_predict_matches_sequential():
     model.model.eval()
     images = _rand_images(11, [(48, 64), (64, 48), (32, 32)])
 
-    # conf=0.0 + top-k selection → a fixed number of rows per image, so the
+    # conf=0.0 + top-k selection: a fixed number of rows per image, so the
     # comparison always has signal even with random weights.
     sequential = model(images, conf=0.0, batch=1, max_det=20)
     batched = model(images, conf=0.0, batch=2, max_det=20)
 
-    _assert_results_parity(sequential, batched, require_detections=True)
+    assert len(sequential) == len(batched) == 3
+    for r_seq, r_bat in zip(sequential, batched):
+        assert r_seq.orig_shape == r_bat.orig_shape
+        assert len(r_seq) == len(r_bat) == 20
+        torch.testing.assert_close(
+            r_seq.boxes.conf.sort(descending=True).values,
+            r_bat.boxes.conf.sort(descending=True).values,
+            rtol=1e-3,
+            atol=1e-3,
+        )
 
 
-def test_picodet_batched_predict_matches_sequential():
+def test_deimv2_batched_routing_with_marker_outputs():
+    """Deterministic per-image routing proof for the DETR dict contract.
+
+    The forward is replaced with a hand-marked batched dict: image i's
+    slice carries one hot query at a distinct class/score/box, and each
+    image has a distinct original size. Any cross-image slicing mistake
+    flips the class or score; any original-size routing mistake breaks
+    the box scaling.
+    """
+    from libreyolo import LibreDEIMv2
+
+    torch.manual_seed(0)
+    model = LibreDEIMv2(None, size="atto", device="cpu")
+    model.model.eval()
+
+    num_queries, num_classes = 8, 80
+    logits = torch.full((3, num_queries, num_classes), -10.0)
+    boxes = torch.full((3, num_queries, 4), 0.5)
+    queries, classes_, logit_vals = (2, 4, 6), (0, 3, 7), (2.0, 1.5, 1.0)
+    centers = (0.3, 0.5, 0.7)
+    for i, (q_i, c_i, l_i, cx_i) in enumerate(
+        zip(queries, classes_, logit_vals, centers)
+    ):
+        logits[i, q_i, c_i] = l_i
+        boxes[i, q_i] = torch.tensor([cx_i, 0.5, 0.2, 0.4])
+    marked = {"pred_logits": logits, "pred_boxes": boxes}
+
+    native = model._get_input_size()
+
+    def fake_forward(tensor):
+        assert tuple(tensor.shape) == (
+            3,
+            3,
+            native,
+            native,
+        ), "expected one stacked forward"
+        return marked
+
+    model._forward = fake_forward
+    sizes = [(64, 64), (32, 48), (16, 24)]
+    images = [np.zeros((h, w, 3), dtype=np.uint8) for h, w in sizes]
+
+    results = model(images, batch=3, conf=0.25)
+
+    for i, (result, (orig_h, orig_w)) in enumerate(zip(results, sizes)):
+        assert len(result) == 1
+        assert int(result.boxes.cls[0]) == classes_[i]
+        torch.testing.assert_close(
+            result.boxes.conf[0],
+            torch.tensor(logit_vals[i]).sigmoid(),
+            rtol=1e-5,
+            atol=1e-6,
+        )
+        cx = centers[i]
+        expected = torch.tensor(
+            [
+                (cx - 0.1) * orig_w,
+                (0.5 - 0.2) * orig_h,
+                (cx + 0.1) * orig_w,
+                (0.5 + 0.2) * orig_h,
+            ]
+        )
+        torch.testing.assert_close(
+            result.boxes.xyxy[0], expected, rtol=1e-5, atol=1e-4
+        )
+
+
+def test_picodet_batched_predict_smoke_matches_sequential():
+    """Real forward smoke with tie-robust assertions.
+
+    See the DEIMv2 smoke note: random-init near-ties plus NMS make exact
+    box parity platform-dependent, so this asserts counts and shapes only.
+    Exact parity lives in the real-weights nightly tier.
+    """
     from libreyolo import LibrePICODET
 
     torch.manual_seed(0)
@@ -616,11 +704,15 @@ def test_picodet_batched_predict_matches_sequential():
     sequential = model(images, conf=0.001, batch=1, max_det=20)
     batched = model(images, conf=0.001, batch=2, max_det=20)
 
-    _assert_results_parity(sequential, batched, require_detections=True)
+    assert len(sequential) == len(batched) == 2
+    for r_seq, r_bat in zip(sequential, batched):
+        assert r_seq.orig_shape == r_bat.orig_shape
+        assert len(r_seq) == len(r_bat)
+        assert len(r_seq) > 0, "parity comparison has no detections to compare"
 
 
 # =============================================================================
-# True batched inference — exported-backend pipeline (BaseBackend)
+# True batched inference: exported-backend pipeline (BaseBackend)
 # =============================================================================
 
 

--- a/tests/unit/test_slice_batch_outputs.py
+++ b/tests/unit/test_slice_batch_outputs.py
@@ -1,0 +1,78 @@
+"""Tests for the shared batch-output slicer used by validation and predict."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.postprocess.slicing import slice_batch_outputs
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_slices_bare_tensor_keeping_batch_dim():
+    batched = torch.arange(24.0).reshape(3, 2, 4)
+
+    sliced = slice_batch_outputs(batched, 1)
+
+    assert sliced.shape == (1, 2, 4)
+    assert torch.equal(sliced, batched[1:2])
+
+
+def test_slices_dict_values_and_passes_non_tensors_through():
+    output = {
+        "predictions": torch.rand(2, 84, 100),
+        "obb": True,
+        "names": "unchanged",
+        "maybe": None,
+    }
+
+    sliced = slice_batch_outputs(output, 0)
+
+    assert torch.equal(sliced["predictions"], output["predictions"][0:1])
+    assert sliced["obb"] is True
+    assert sliced["names"] == "unchanged"
+    assert sliced["maybe"] is None
+
+
+def test_slices_one_level_of_nested_dicts():
+    output = {
+        "x8": {"features": torch.rand(2, 8, 4, 4), "tag": "keep"},
+    }
+
+    sliced = slice_batch_outputs(output, 1)
+
+    assert torch.equal(sliced["x8"]["features"], output["x8"]["features"][1:2])
+    assert sliced["x8"]["tag"] == "keep"
+
+
+def test_recurses_into_picodet_style_tuple_of_lists():
+    cls_scores = [torch.rand(2, 80, 8, 8), torch.rand(2, 80, 4, 4)]
+    bbox_preds = [torch.rand(2, 32, 8, 8), torch.rand(2, 32, 4, 4)]
+    output = (cls_scores, bbox_preds)
+
+    sliced = slice_batch_outputs(output, 1)
+
+    assert isinstance(sliced, tuple)
+    assert isinstance(sliced[0], list)
+    for original, single in zip(cls_scores, sliced[0]):
+        assert torch.equal(single, original[1:2])
+    for original, single in zip(bbox_preds, sliced[1]):
+        assert torch.equal(single, original[1:2])
+
+
+def test_list_of_per_scale_tensors_yolox_style():
+    output = [torch.rand(3, 85, s, s) for s in (8, 4, 2)]
+
+    sliced = slice_batch_outputs(output, 2)
+
+    assert isinstance(sliced, list)
+    for original, single in zip(output, sliced):
+        assert torch.equal(single, original[2:3])
+
+
+def test_scalar_passthrough():
+    assert slice_batch_outputs(7, 0) == 7
+    assert slice_batch_outputs(None, 1) is None
+    assert slice_batch_outputs("flag", 2) == "flag"

--- a/tests/unit/test_tensorrt_backend.py
+++ b/tests/unit/test_tensorrt_backend.py
@@ -10,11 +10,15 @@ from libreyolo.backends.tensorrt import TensorRTBackend
 pytestmark = pytest.mark.unit
 
 
-def _bare_tensorrt_backend(path: str, model_family: str | None = None):
+def _bare_tensorrt_backend(
+    path: str,
+    model_family: str | None = None,
+    task: str = "detect",
+):
     backend = TensorRTBackend.__new__(TensorRTBackend)
     backend.model_path = path
     backend.model_family = model_family
-    backend.task = "detect"
+    backend.task = task
     backend._sidecar_size = None
     backend.output_names = ["pred_logits", "pred_boxes"]
     backend.output_shapes = {
@@ -180,7 +184,9 @@ def test_tensorrt_dynamic_batching_caps_requested_batch_to_profile():
 
 
 def test_tensorrt_dynamic_batching_preserves_pose_keypoints():
-    backend = _bare_tensorrt_backend("LibreYOLO9t-pose.engine", model_family="yolo9")
+    backend = _bare_tensorrt_backend(
+        "LibreYOLO9t-pose.engine", model_family="yolo9", task="pose"
+    )
     backend._dynamic_batch = True
     backend._max_batch = 2
     backend.imgsz = 64

--- a/tests/unit/test_tensorrt_backend.py
+++ b/tests/unit/test_tensorrt_backend.py
@@ -14,6 +14,7 @@ def _bare_tensorrt_backend(path: str, model_family: str | None = None):
     backend = TensorRTBackend.__new__(TensorRTBackend)
     backend.model_path = path
     backend.model_family = model_family
+    backend.task = "detect"
     backend._sidecar_size = None
     backend.output_names = ["pred_logits", "pred_boxes"]
     backend.output_shapes = {
@@ -140,7 +141,7 @@ def test_tensorrt_dynamic_batching_caps_requested_batch_to_profile():
             "labels": np.zeros((batched_input.shape[0], 1, 2), dtype=np.float32),
         }
 
-    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0):
+    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300):
         return (
             np.zeros((0, 4), dtype=np.float32),
             np.zeros((0,), dtype=np.float32),
@@ -199,7 +200,7 @@ def test_tensorrt_dynamic_batching_preserves_pose_keypoints():
             "keypoints": np.ones((batched_input.shape[0], 1, 2, 3), dtype=np.float32),
         }
 
-    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0):
+    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300):
         return (
             np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32),
             np.array([0.9], dtype=np.float32),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch inference accepts in-memory image lists/tuples and generates deterministic indexed output names to avoid overwrites.
  * Backends now detect and respect dynamic-batching capability and route list inputs to batched processing when supported.

* **Bug Fixes**
  * NCNN rejects unsupported batched inputs instead of returning incorrect results.
  * Consistent per-image extraction from batched model outputs.

* **Documentation**
  * CLI batch help text clarified.

* **Tests**
  * Large unit and e2e test suite added for list-batch parity and backend behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->