### PR TITLE
Add RF-DETR depth task

### DIFF
--- a/docs/adr/0006-depth-task-contract.md
+++ b/docs/adr/0006-depth-task-contract.md
@@ -1,0 +1,50 @@
+# ADR 0006: Depth Task Contract
+
+## Status
+
+Accepted.
+
+## Context
+
+Monocular depth estimation predicts a dense per-pixel depth map from one image.
+Single-image metric depth in meters does not transfer cleanly across cameras:
+focal length, sensor size, and scene scale are entangled. A model that emits
+meters for one camera can silently overclaim on another camera.
+
+RF-DETR's DINOv2 backbone is a good fit for dense relative depth because the
+encoder already provides global image context and multi-scale projected
+features. The depth task should still have a family-agnostic public contract so
+other model families can implement it later.
+
+## Decision
+
+LibreYOLO defines a canonical `depth` task whose prediction primitive is
+`Results.depth_map`: a dense `(H, W)` float map on the original image canvas.
+Values are relative inverse depth, where higher values mean closer to the
+camera. No metric unit is implied.
+
+Training targets are plain depth maps in any dataset-consistent unit. Pixels
+with `0`, negative, NaN, or inf values are invalid. The RF-DETR depth head uses
+a scale-and-shift-invariant objective in inverse-depth space with trimmed
+residuals and multi-scale gradient matching.
+
+Validation aligns predictions to ground truth with a per-image positive scale
+and shift in inverse-depth space. Non-positive fitted scales fall back to a
+median shift so inverted predictions cannot validate as perfect. Reported
+metrics are AbsRel, RMSE, and delta1/2/3; best-checkpoint fitness is delta1.
+
+Depth checkpoints use `task: "depth"`, `nc: 1`, and
+`names: {0: "depth"}` for checkpoint-schema compatibility. The class slot does
+not represent a semantic class.
+
+Export, tiled inference, tracking, TTA, augmented validation, and LoRA are
+explicitly rejected until each has a depth-aware runtime contract.
+
+## Consequences
+
+- Depth results never fabricate boxes; `Results.boxes` is `None`.
+- Metric depth requires user-side calibration against known distances.
+- Hosted depth weights must be trained only on data whose license permits the
+  intended redistribution and commercial use.
+- Future model families can implement `depth` without redefining dataset,
+  results, validator, or checkpoint behavior.

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -32,7 +32,7 @@ Required field meanings:
   `dfine`, or `ec`.
 - `size`: model variant within the family, such as `t`, `s`, `r18`, or `atto`.
 - `task`: canonical task, one of `detect`, `segment`, `semantic`, `pose`,
-  `classify`, `gaze`, `obb`, or `point`.
+  `classify`, `gaze`, `obb`, `point`, or `depth`.
 - `nc`: positive integer class count.
 - `names`: `dict[int, str]` with keys in `0..nc-1`. Official checkpoints
   should write every key. Readers may pad missing keys with `class_i` labels for
@@ -47,6 +47,10 @@ Pose checkpoints additionally include:
   expose keypoints as `x,y,visibility`.
 - `oks_sigmas`: optional list of per-keypoint OKS sigmas. When omitted, loaders
   and validators use the task default for `num_keypoints`.
+
+Depth checkpoints use the task string `depth`, `nc: 1`, and
+`names: {0: "depth"}`. The single class-like slot exists only for checkpoint
+schema compatibility; depth predictions are dense float maps, not classes.
 
 The schema is intentionally flat. Existing LibreYOLO checkpoints and loaders
 already use top-level keys such as `model_family`, `size`, `nc`, `names`, and

--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -110,6 +110,12 @@ YAML adds two optional keys on top of the common contract:
 
 - `depths_dir`: depth directory name substituted for `images` in each image
   path (default `depths`).
+- `depth_stem_suffix`: optional suffix appended to the image stem before
+  depth extension lookup. When omitted, both same-stem files and the common
+  `_depth` suffix are tried.
+- `depth_mask_suffix`: optional suffix appended to the resolved depth stem to
+  find a validity mask (default `_mask`). If the mask exists, mask values
+  `<= 0`, NaN, and inf invalidate the corresponding depth pixels.
 - `depth_scale`: divisor for integer-typed depth maps (default `256.0`, the
   common 16-bit PNG convention where stored value / 256 is the depth).
 

--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -89,6 +89,34 @@ the object classes (`nc` grows by one).
 
 Canonical loader: `libreyolo.data.SemanticDataset`.
 
+## depth
+
+Depth estimation pairs each image with a dense single-channel depth map instead
+of a `.txt` label file:
+
+```text
+images/.../image.jpg -> <depths_dir>/.../image.png
+```
+
+Depth rules:
+
+- single channel PNG/TIF or `.npy`;
+- map resolution must equal the paired image resolution;
+- values are plain depth in a dataset-consistent unit;
+- `0`, negative, NaN, and inf mark invalid pixels and are excluded from loss
+  and metrics.
+
+YAML adds two optional keys on top of the common contract:
+
+- `depths_dir`: depth directory name substituted for `images` in each image
+  path (default `depths`).
+- `depth_scale`: divisor for integer-typed depth maps (default `256.0`, the
+  common 16-bit PNG convention where stored value / 256 is the depth).
+
+Float `.npy` maps are used as-is and do not apply `depth_scale`.
+
+Canonical loader: `libreyolo.data.DepthDataset`.
+
 ## pose
 
 YAML adds:

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -110,6 +110,7 @@ From `libreyolo/tasks.py`:
 | `gaze`        | `-gaze` |
 | `obb`         | `-obb` |
 | `point`       | `-point` |
+| `depth`       | `-depth` |
 
 The factory accepts selected upstream-style aliases (`detection`, `det`,
 `segmentation`, `keypoints`, `cls`, …) at the API boundary; only the canonical
@@ -125,6 +126,11 @@ pixel with no instance separation. `segment` remains the task for
 instance segmentation (per-object masks). Semantic models expose
 `Results.semantic_mask` and use per-pixel validation metrics (mIoU,
 pixel accuracy) instead of box/mask mAP.
+
+`depth` is the task for dense monocular depth estimation. Models expose
+`Results.depth_map`, a float `(H, W)` relative inverse-depth map on the
+original image canvas. Higher values mean closer to the camera; no metric unit
+is implied without user-side calibration.
 
 Dataset and label contracts are documented in
 [`dataset_schema.md`](dataset_schema.md). A task is supported by a model family
@@ -142,7 +148,7 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 | `deimv2`    | `("detect",)` (default)             | detect | detect-only |
 | `rtdetr`    | `("detect",)` (default)             | detect | detect-only |
 | `picodet`   | `("detect",)` (default)             | detect | detect-only |
-| `rfdetr`    | `("detect", "segment", "semantic", "pose", "classify", "obb")` | detect | classify uses 224; semantic uses 518; seg uses smaller sizes; pose/OBB use detect sizes |
+| `rfdetr`    | `("detect", "segment", "semantic", "pose", "classify", "obb", "depth")` | detect | classify uses 224; semantic/depth use 518; seg uses smaller sizes; pose/OBB use detect sizes |
 | `yolonas`   | `("detect", "pose")`                | detect | pose adds size `n` |
 | `ec`     | `("detect", "pose", "segment")`     | detect | all three tasks |
 | `l2cs`      | `("gaze",)`                         | gaze   | inference-only; two-stage (face detector + gaze head); not trainable in LibreYOLO |
@@ -193,13 +199,14 @@ LibreYOLO9t-pose.pt        # pose
 LibreYOLO9t-cls.pt         # classify
 LibreYOLO9t-obb.pt         # obb
 
-# rfdetr - detect + segment + semantic + pose + classify + obb
+# rfdetr - detect + segment + semantic + pose + classify + obb + depth
 LibreRFDETRn.pt            # detect
 LibreRFDETRn-seg.pt        # segment
 LibreRFDETRn-sem.pt        # semantic
 LibreRFDETRn-pose.pt       # pose
 LibreRFDETRn-cls.pt        # classify
 LibreRFDETRn-obb.pt        # obb
+LibreRFDETRn-depth.pt      # depth
 
 # ec — detect + pose + segment
 LibreECs.pt             # detect (default)

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -32,6 +32,7 @@ from .utils.results import (
     OBB,
     Gaze,
     SemanticMask,
+    DepthMap,
 )
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
@@ -83,6 +84,7 @@ def __getattr__(name):
         "SegmentationValidator": (".validation", "SegmentationValidator"),
         "PoseValidator": (".validation", "PoseValidator"),
         "SemanticValidator": (".validation", "SemanticValidator"),
+        "DepthValidator": (".validation", "DepthValidator"),
         "ValidationConfig": (".validation", "ValidationConfig"),
         "ByteTracker": (".tracking", "ByteTracker"),
         "TrackConfig": (".tracking", "TrackConfig"),
@@ -148,6 +150,7 @@ __all__ = [
     "OBB",
     "Gaze",
     "SemanticMask",
+    "DepthMap",
     # Assets
     "SAMPLE_IMAGE",
     # Tracking
@@ -167,6 +170,7 @@ __all__ = [
     "SegmentationValidator",
     "PoseValidator",
     "SemanticValidator",
+    "DepthValidator",
     "ValidationConfig",
     "DATASETS_DIR",
     "load_data_config",

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -186,7 +186,10 @@ def train_cmd(
     model: str = typer.Option("yolox-s", help="Model name or path to weights"),
     task: Optional[str] = typer.Option(
         None,
-        help="Explicit task override: detect, segment, semantic, pose, classify, gaze, obb",
+        help=(
+            "Explicit task override: detect, segment, semantic, pose, classify, "
+            "gaze, obb, point, depth"
+        ),
     ),
     # Training
     epochs: int = typer.Option(300, help="Training epochs"),

--- a/libreyolo/data/__init__.py
+++ b/libreyolo/data/__init__.py
@@ -25,6 +25,12 @@ from .pose_metadata import (
     default_oks_sigmas,
 )
 from .pose_dataset import YOLOPoseDataset, parse_yolo_pose_label_line, pose_collate_fn
+from .depth_dataset import (
+    DepthDataset,
+    depth_collate_fn,
+    img2depth_paths,
+    resolve_depth_data,
+)
 from .semantic_dataset import (
     SemanticDataset,
     img2mask_paths,
@@ -65,6 +71,10 @@ __all__ = [
     "classify_collate_fn",
     "get_class_names",
     "resolve_classify_data",
+    "DepthDataset",
+    "depth_collate_fn",
+    "img2depth_paths",
+    "resolve_depth_data",
     "SemanticDataset",
     "img2mask_paths",
     "resolve_semantic_data",

--- a/libreyolo/data/depth_dataset.py
+++ b/libreyolo/data/depth_dataset.py
@@ -15,6 +15,11 @@ The dataset YAML follows the common contract (``path``/``train``/``val``/
 
 - ``depths_dir``: depth directory name substituted for ``images`` in each
   image path (default ``depths``).
+- ``depth_stem_suffix``: optional suffix appended to the image stem before
+  searching for a depth extension. When omitted, both the same stem and the
+  common ``_depth`` suffix are tried.
+- ``depth_mask_suffix``: optional suffix appended to the resolved depth stem
+  to find a validity mask. Existing masks are applied automatically.
 - ``depth_scale``: divisor applied to integer-typed depth files (default
   ``256.0``, the common 16-bit PNG encoding where ``value / 256`` is the
   stored depth). Float files (``.npy``) are used as-is.
@@ -45,11 +50,27 @@ logger = logging.getLogger(__name__)
 _PAD_COLOR = 114
 
 DEPTH_FORMATS = (".png", ".npy", ".tif", ".tiff")
+DEPTH_STEM_SUFFIXES = ("", "_depth")
+DEPTH_MASK_SUFFIX = "_mask"
 
 DEFAULT_DEPTH_SCALE = 256.0
 
 
-def img2depth_paths(img_paths: List[Path], depths_dir: str = "depths") -> List[Path]:
+def _as_tuple(value: object, default: Tuple[str, ...]) -> Tuple[str, ...]:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple)) and all(isinstance(v, str) for v in value):
+        return tuple(value)
+    raise TypeError("depth stem suffixes must be a string or a list of strings.")
+
+
+def img2depth_paths(
+    img_paths: List[Path],
+    depths_dir: str = "depths",
+    stem_suffixes: Tuple[str, ...] = DEPTH_STEM_SUFFIXES,
+) -> List[Path]:
     """Convert image paths to depth-map paths.
 
     Convention mirrors ``img2label_paths``: replace ``images`` with
@@ -63,15 +84,45 @@ def img2depth_paths(img_paths: List[Path], depths_dir: str = "depths") -> List[P
             path_str = path_str.replace(f"{sep}images{sep}", f"{sep}{depths_dir}{sep}")
             path_str = path_str.replace(f"{sep}images", f"{sep}{depths_dir}")
         base = Path(path_str)
-        for suffix in DEPTH_FORMATS:
-            candidate = base.with_suffix(suffix)
+        candidates = [
+            base.with_name(f"{base.stem}{stem_suffix}").with_suffix(suffix)
+            for stem_suffix in stem_suffixes
+            for suffix in DEPTH_FORMATS
+        ]
+        for candidate in candidates:
+            if candidate == img_path:
+                continue
             if candidate.exists():
                 base = candidate
                 break
         else:
-            base = base.with_suffix(".png")
+            first_suffix = stem_suffixes[0] if stem_suffixes else ""
+            base = base.with_name(f"{base.stem}{first_suffix}").with_suffix(".png")
         depth_paths.append(base)
     return depth_paths
+
+
+def img2depth_mask_paths(
+    depth_paths: List[Path],
+    mask_suffix: str = DEPTH_MASK_SUFFIX,
+) -> List[Path | None]:
+    """Resolve optional validity masks for depth files.
+
+    Existing masks are returned; missing masks are represented by ``None`` so
+    datasets without explicit masks keep using the depth values themselves for
+    validity.
+    """
+    mask_paths: List[Path | None] = []
+    for depth_path in depth_paths:
+        base = depth_path.with_name(f"{depth_path.stem}{mask_suffix}")
+        mask_path = None
+        for suffix in DEPTH_FORMATS:
+            candidate = base.with_suffix(suffix)
+            if candidate.exists():
+                mask_path = candidate
+                break
+        mask_paths.append(mask_path)
+    return mask_paths
 
 
 def _load_depth_file(depth_path: Path, depth_scale: float) -> np.ndarray:
@@ -106,6 +157,21 @@ def _load_depth_file(depth_path: Path, depth_scale: float) -> np.ndarray:
     depth[~np.isfinite(depth)] = 0.0
     depth[depth < 0] = 0.0
     return depth
+
+
+def _load_depth_mask_file(mask_path: Path) -> np.ndarray:
+    if mask_path.suffix.lower() == ".npy":
+        mask = np.load(mask_path)
+    else:
+        with Image.open(mask_path) as mask_img:
+            mask = np.asarray(mask_img)
+    if mask.ndim == 3 and mask.shape[-1] == 1:
+        mask = mask[..., 0]
+    if mask.ndim != 2:
+        raise ValueError(
+            f"Depth mask {mask_path} has shape {mask.shape}; expected (H, W)."
+        )
+    return np.isfinite(mask) & (mask > 0)
 
 
 def resolve_depth_data(data: str | Path, allow_scripts: bool = False) -> Dict:
@@ -162,7 +228,15 @@ class DepthDataset(Dataset):
             )
 
         self.depths_dir = str(data_config.get("depths_dir") or "depths")
-        self.depth_files = img2depth_paths(self.img_files, self.depths_dir)
+        stem_suffixes = _as_tuple(
+            data_config.get("depth_stem_suffix")
+            if "depth_stem_suffix" in data_config
+            else data_config.get("depth_stem_suffixes"),
+            DEPTH_STEM_SUFFIXES,
+        )
+        self.depth_files = img2depth_paths(
+            self.img_files, self.depths_dir, stem_suffixes=stem_suffixes
+        )
         missing = [str(p) for p in self.depth_files if not p.exists()]
         if missing:
             preview = ", ".join(missing[:3])
@@ -171,12 +245,27 @@ class DepthDataset(Dataset):
                 f"(e.g. {preview}). Expected depth maps under "
                 f"'{self.depths_dir}' mirroring the images tree."
             )
+        self.depth_mask_suffix = str(
+            data_config.get("depth_mask_suffix") or DEPTH_MASK_SUFFIX
+        )
+        self.depth_mask_files = img2depth_mask_paths(
+            self.depth_files, self.depth_mask_suffix
+        )
 
     def __len__(self) -> int:
         return len(self.img_files)
 
     def _load_target_depth(self, index: int, orig_shape: Tuple[int, int]) -> np.ndarray:
         depth = _load_depth_file(self.depth_files[index], self.depth_scale)
+        mask_path = self.depth_mask_files[index]
+        if mask_path is not None:
+            mask = _load_depth_mask_file(mask_path)
+            if mask.shape != depth.shape:
+                raise ValueError(
+                    f"Depth mask {mask_path} shape {mask.shape} does not match "
+                    f"depth map shape {depth.shape}."
+                )
+            depth[~mask] = 0.0
         if depth.shape != orig_shape:
             raise ValueError(
                 f"Depth map {self.depth_files[index]} shape {depth.shape} "

--- a/libreyolo/data/depth_dataset.py
+++ b/libreyolo/data/depth_dataset.py
@@ -1,0 +1,268 @@
+"""Monocular-depth dataset for LibreYOLO.
+
+Depth datasets pair each image with a dense single-channel depth map; pixels
+with value ``0`` (or negative / non-finite values) are invalid and excluded
+from loss and metrics::
+
+    dataset/
+        images/train/*.jpg
+        images/val/*.jpg
+        depths/train/*.png     # same stem as the paired image
+        depths/val/*.png
+
+The dataset YAML follows the common contract (``path``/``train``/``val``/
+``test``) plus two depth keys:
+
+- ``depths_dir``: depth directory name substituted for ``images`` in each
+  image path (default ``depths``).
+- ``depth_scale``: divisor applied to integer-typed depth files (default
+  ``256.0``, the common 16-bit PNG encoding where ``value / 256`` is the
+  stored depth). Float files (``.npy``) are used as-is.
+
+Ground-truth values are plain depth (distance from the camera) in whatever
+unit the dataset uses; the relative-depth training objective is
+scale-and-shift invariant, so no unit normalization is required.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from .utils import get_img_files, load_data_config
+
+logger = logging.getLogger(__name__)
+
+# Letterbox padding color for the image canvas (matches detection letterbox).
+_PAD_COLOR = 114
+
+DEPTH_FORMATS = (".png", ".npy", ".tif", ".tiff")
+
+DEFAULT_DEPTH_SCALE = 256.0
+
+
+def img2depth_paths(img_paths: List[Path], depths_dir: str = "depths") -> List[Path]:
+    """Convert image paths to depth-map paths.
+
+    Convention mirrors ``img2label_paths``: replace ``images`` with
+    ``depths_dir`` in the path and look for a depth-capable extension with
+    the same stem.
+    """
+    depth_paths = []
+    for img_path in img_paths:
+        path_str = str(img_path)
+        for sep in (os.sep, "/", "\\"):
+            path_str = path_str.replace(f"{sep}images{sep}", f"{sep}{depths_dir}{sep}")
+            path_str = path_str.replace(f"{sep}images", f"{sep}{depths_dir}")
+        base = Path(path_str)
+        for suffix in DEPTH_FORMATS:
+            candidate = base.with_suffix(suffix)
+            if candidate.exists():
+                base = candidate
+                break
+        else:
+            base = base.with_suffix(".png")
+        depth_paths.append(base)
+    return depth_paths
+
+
+def _load_depth_file(depth_path: Path, depth_scale: float) -> np.ndarray:
+    """Read a depth file into a float32 ``(H, W)`` array of depth values.
+
+    Integer-typed data (16-bit PNG / TIF) is divided by ``depth_scale``;
+    float data (``.npy``, float TIF) is used as-is. Non-finite and negative
+    values are mapped to ``0`` (invalid).
+    """
+    if depth_path.suffix.lower() == ".npy":
+        depth = np.load(depth_path)
+    else:
+        with Image.open(depth_path) as depth_img:
+            if depth_img.mode in ("I", "I;16", "L", "F"):
+                depth = np.asarray(depth_img)
+            else:
+                raise ValueError(
+                    f"Depth map {depth_path} has mode '{depth_img.mode}'. "
+                    "Depth maps must be single-channel images "
+                    "(PNG/TIF modes I, I;16, L, or F)."
+                )
+    if depth.ndim == 3 and depth.shape[-1] == 1:
+        depth = depth[..., 0]
+    if depth.ndim != 2:
+        raise ValueError(
+            f"Depth map {depth_path} has shape {depth.shape}; expected (H, W)."
+        )
+    if np.issubdtype(depth.dtype, np.integer):
+        depth = depth.astype(np.float32) / float(depth_scale)
+    else:
+        depth = depth.astype(np.float32)
+    depth[~np.isfinite(depth)] = 0.0
+    depth[depth < 0] = 0.0
+    return depth
+
+
+def resolve_depth_data(data: str | Path, allow_scripts: bool = False) -> Dict:
+    """Load and sanity-check a depth dataset YAML config.
+
+    Returns the ``load_data_config`` dict. ``allow_scripts`` is forwarded to
+    ``load_data_config`` so explicitly allowed Python download scripts run.
+    """
+    config = load_data_config(str(data), allow_scripts=allow_scripts)
+    return config
+
+
+class DepthDataset(Dataset):
+    """Dense depth dataset returning ``(img, depth, info, id)``.
+
+    Images are letterboxed (default) or stretched to ``imgsz``; depth maps
+    follow with nearest-neighbor geometry and invalid (``0``) padding.
+    Training augmentation applies horizontal flips only — geometric scale
+    changes are unnecessary because the training objective is
+    scale-and-shift invariant.
+    """
+
+    def __init__(
+        self,
+        data_config: Dict,
+        split: str,
+        imgsz: int,
+        augment: bool = False,
+        resize_mode: str = "letterbox",
+    ):
+        if resize_mode not in ("letterbox", "stretch"):
+            raise ValueError(
+                f"resize_mode must be 'letterbox' or 'stretch', got {resize_mode!r}"
+            )
+        self.split = split
+        self.imgsz = int(imgsz)
+        self.augment = augment
+        self.resize_mode = resize_mode
+        self.depth_scale = float(
+            data_config.get("depth_scale", DEFAULT_DEPTH_SCALE)
+        )
+        if self.depth_scale <= 0:
+            raise ValueError(f"depth_scale must be positive, got {self.depth_scale}")
+
+        split_value = data_config.get(split)
+        if not split_value:
+            raise ValueError(f"Depth dataset config has no '{split}' split.")
+        self.img_files = data_config.get(f"{split}_img_files") or get_img_files(
+            split_value
+        )
+        if not self.img_files:
+            raise FileNotFoundError(
+                f"No images found for depth split '{split}' at {split_value}."
+            )
+
+        self.depths_dir = str(data_config.get("depths_dir") or "depths")
+        self.depth_files = img2depth_paths(self.img_files, self.depths_dir)
+        missing = [str(p) for p in self.depth_files if not p.exists()]
+        if missing:
+            preview = ", ".join(missing[:3])
+            raise FileNotFoundError(
+                f"{len(missing)} depth file(s) missing for split '{split}' "
+                f"(e.g. {preview}). Expected depth maps under "
+                f"'{self.depths_dir}' mirroring the images tree."
+            )
+
+    def __len__(self) -> int:
+        return len(self.img_files)
+
+    def _load_target_depth(self, index: int, orig_shape: Tuple[int, int]) -> np.ndarray:
+        depth = _load_depth_file(self.depth_files[index], self.depth_scale)
+        if depth.shape != orig_shape:
+            raise ValueError(
+                f"Depth map {self.depth_files[index]} shape {depth.shape} "
+                f"does not match image shape {orig_shape}."
+            )
+        return depth
+
+    def _resize(
+        self, img: np.ndarray, depth: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, float, Tuple[int, int]]:
+        """Resize image (bilinear) and depth (nearest) and pad to imgsz."""
+        h0, w0 = img.shape[:2]
+        if self.resize_mode == "stretch":
+            new_w = new_h = self.imgsz
+            ratio = 1.0
+        else:
+            ratio = min(self.imgsz / h0, self.imgsz / w0)
+            new_w = max(1, int(round(w0 * ratio)))
+            new_h = max(1, int(round(h0 * ratio)))
+
+        img_pil = Image.fromarray(img).resize((new_w, new_h), Image.BILINEAR)
+        # Nearest-neighbor keeps depth discontinuities sharp instead of
+        # inventing intermediate depths along object boundaries.
+        depth_pil = Image.fromarray(depth, mode="F").resize(
+            (new_w, new_h), Image.NEAREST
+        )
+        img = np.array(img_pil)
+        depth = np.asarray(depth_pil).astype(np.float32)
+
+        # Top-left anchored padding, matching the family inference letterbox
+        # (content at the origin, pad at bottom/right). Pad depth with 0 so
+        # padded pixels are invalid and self-exclude from loss and metrics.
+        pad_h = self.imgsz - new_h
+        pad_w = self.imgsz - new_w
+        if pad_h or pad_w:
+            img = np.pad(
+                img,
+                ((0, pad_h), (0, pad_w), (0, 0)),
+                constant_values=_PAD_COLOR,
+            )
+            depth = np.pad(
+                depth,
+                ((0, pad_h), (0, pad_w)),
+                constant_values=0.0,
+            )
+        return img, depth, ratio, (0, 0)
+
+    def __getitem__(self, index: int):
+        img_path = self.img_files[index]
+        with Image.open(img_path) as img_pil:
+            img = np.array(img_pil.convert("RGB"))
+        orig_shape = img.shape[:2]
+        depth = self._load_target_depth(index, orig_shape)
+
+        if self.augment and random.random() < 0.5:
+            img = np.ascontiguousarray(img[:, ::-1])
+            depth = np.ascontiguousarray(depth[:, ::-1])
+
+        img, depth, ratio, pad = self._resize(img, depth)
+
+        img_tensor = (
+            torch.from_numpy(np.ascontiguousarray(img))
+            .permute(2, 0, 1)
+            .float()
+            .div_(255.0)
+        )
+        depth_tensor = torch.from_numpy(np.ascontiguousarray(depth)).float()
+        img_info = {
+            "orig_shape": (int(orig_shape[0]), int(orig_shape[1])),
+            "ratio": float(ratio),
+            "pad": (int(pad[0]), int(pad[1])),
+            "resize_mode": self.resize_mode,
+            "img_path": str(img_path),
+        }
+        return img_tensor, depth_tensor, img_info, index
+
+
+def depth_collate_fn(batch):
+    """Collate depth samples into the trainer's 4-tuple batch shape.
+
+    Returns ``(imgs, depths, img_infos, img_ids)``: ``imgs`` is ``[B,3,H,W]``
+    float in ``[0, 1]`` and ``depths`` is ``[B,H,W]`` float32 with invalid
+    pixels set to ``0``.
+    """
+    imgs = torch.stack([item[0] for item in batch], dim=0)
+    depths = torch.stack([item[1] for item in batch], dim=0)
+    img_infos = [item[2] for item in batch]
+    img_ids = [item[3] for item in batch]
+    return imgs, depths, img_infos, img_ids

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -235,6 +235,12 @@ class BaseExporter(ABC):
                 "output plus backend argmax parsing) before exporting semantic "
                 "models."
             )
+        if getattr(self.model, "task", "detect") == "depth":
+            raise NotImplementedError(
+                "Export for depth models is not implemented yet. "
+                "Add a depth-aware export/runtime contract (dense float "
+                "output plus backend parsing) before exporting depth models."
+            )
         half, int8 = self._validate(half, int8, data)
         self._preflight(half=half, int8=int8, data=data, **kwargs)
         data = self._resolve_calibration_data(int8, data)

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -31,6 +31,7 @@ from ...utils.drawing import (
     draw_keypoints,
     draw_masks,
     draw_obb,
+    draw_depth_map,
     draw_points,
     draw_semantic_mask,
     draw_tile_grid,
@@ -45,6 +46,7 @@ from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.predict_args import normalize_predict_kwargs
 from ...utils.results import (
     Boxes,
+    DepthMap,
     Keypoints,
     Masks,
     OBB,
@@ -525,6 +527,14 @@ class InferenceRunner:
             annotated_img.save(save_path)
             log_saved_result(result, save_path)
             return
+        if result.boxes is None and getattr(result, "depth_map", None) is not None:
+            depth_data = result.depth_map.data
+            if isinstance(depth_data, torch.Tensor):
+                depth_data = depth_data.cpu().numpy()
+            annotated_img = draw_depth_map(original_img, depth_data)
+            annotated_img.save(save_path)
+            log_saved_result(result, save_path)
+            return
         if result.boxes is None and getattr(result, "points", None) is not None:
             if len(result.points) > 0:
                 annotated_img = draw_points(
@@ -650,6 +660,23 @@ class InferenceRunner:
                 path=str(image_path) if image_path else None,
                 names=self.model.names,
                 semantic_mask=SemanticMask(semantic_t.long(), (orig_h, orig_w)),
+            )
+
+        # Depth: a dense relative inverse-depth map, no boxes.
+        depth_data = detections.get("depth")
+        if depth_data is not None:
+            orig_w, orig_h = original_size
+            depth_t = (
+                depth_data
+                if isinstance(depth_data, torch.Tensor)
+                else torch.as_tensor(depth_data)
+            )
+            return Results(
+                boxes=None,
+                orig_shape=(orig_h, orig_w),
+                path=str(image_path) if image_path else None,
+                names=self.model.names,
+                depth_map=DepthMap(depth_t.float(), (orig_h, orig_w)),
             )
 
         points_data = detections.get("points")
@@ -957,6 +984,11 @@ class InferenceRunner:
                 output_file_format=output_file_format,
                 save_stem=save_stem,
                 **kwargs,
+            )
+        if getattr(self.model, "task", "detect") == "depth":
+            raise ValueError(
+                "Tiled inference does not support depth maps yet. "
+                "Use non-tiled inference for depth models."
             )
 
         if getattr(self.model, "_is_segmentation", False):

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -709,6 +709,11 @@ class BaseModel(ABC):
                 "Test-time augmentation does not support semantic segmentation yet. "
                 "Use augment=False for semantic models."
             )
+        if getattr(self, "task", "detect") == "depth":
+            raise ValueError(
+                "Test-time augmentation does not support depth estimation yet. "
+                "Use augment=False for depth models."
+            )
 
         from PIL import Image as PILImage
         from ...utils.image_loader import ImageLoader
@@ -968,6 +973,11 @@ class BaseModel(ABC):
                 "Tracking does not support point results yet. "
                 "Use predict() for point models."
             )
+        if task == "depth":
+            raise NotImplementedError(
+                "Tracking does not support depth maps yet. "
+                "Use predict() for depth models."
+            )
 
         from ...tracking import ByteTracker, TrackConfig
         from ...utils.drawing import draw_boxes, draw_masks
@@ -1093,6 +1103,7 @@ class BaseModel(ABC):
         """
         from libreyolo.validation import (
             ClassifyValidator,
+            DepthValidator,
             DetectionValidator,
             OBBValidator,
             PointValidator,
@@ -1126,6 +1137,11 @@ class BaseModel(ABC):
                 "Augmented validation does not support semantic segmentation "
                 "yet. Use augment=False for semantic models."
             )
+        if augment and self.task == "depth":
+            raise ValueError(
+                "Augmented validation does not support depth estimation yet. "
+                "Use augment=False for depth models."
+            )
 
         config = ValidationConfig(
             data=data,
@@ -1157,6 +1173,8 @@ class BaseModel(ABC):
             validator_cls = SegmentationValidator
         elif self.task == "semantic":
             validator_cls = SemanticValidator
+        elif self.task == "depth":
+            validator_cls = DepthValidator
         elif self.task == "classify":
             validator_cls = ClassifyValidator
         elif self.task == "obb":

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -176,7 +176,17 @@ class LibreRFDETR(BaseModel):
     # Semantic runs the DINOv2 backbone at its native pretrained 518 square
     # (37 positional tokens * patch_size 14).
     SEM_INPUT_SIZES = {"n": 518, "s": 518, "m": 518, "l": 518}
-    SUPPORTED_TASKS = ("detect", "segment", "semantic", "pose", "classify", "obb")
+    # Depth uses the same DINOv2-native patch grid as semantic segmentation.
+    DEPTH_INPUT_SIZES = {"n": 518, "s": 518, "m": 518, "l": 518}
+    SUPPORTED_TASKS = (
+        "detect",
+        "segment",
+        "semantic",
+        "pose",
+        "classify",
+        "obb",
+        "depth",
+    )
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,
         "segment": SEG_INPUT_SIZES,
@@ -184,12 +194,15 @@ class LibreRFDETR(BaseModel):
         "pose": INPUT_SIZES,
         "classify": CLS_INPUT_SIZES,
         "obb": INPUT_SIZES,
+        "depth": DEPTH_INPUT_SIZES,
     }
     # DETR-family preprocessing stretches to a fixed square (no letterbox).
     semantic_resize_mode = "stretch"
+    depth_resize_mode = "stretch"
     # Semantic inputs must align with the DINOv2-native patch grid
     # (patch_size 14 x num_windows 1) used by the semantic backbone.
     semantic_imgsz_divisor = 14
+    depth_imgsz_divisor = 14
     EXPERIMENTAL_WEIGHT_FILENAMES = frozenset({"librerfdetrn-pose.pt"})
     TRAIN_CONFIG = RFDETRConfig
     val_preprocessor_class = RFDETRValPreprocessor
@@ -233,6 +246,10 @@ class LibreRFDETR(BaseModel):
         # head, so they lack the detection/decoder markers above. Recognize the
         # backbone-plus-linear-head signature so the factory can route them.
         if "linear.weight" in weights_dict and any(
+            k.startswith("backbone.") for k in weights_dict
+        ):
+            return True
+        if "depth_head.weight" in weights_dict and any(
             k.startswith("backbone.") for k in weights_dict
         ):
             return True
@@ -302,6 +319,8 @@ class LibreRFDETR(BaseModel):
     def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
         if "linear.weight" in weights_dict:
             return int(weights_dict["linear.weight"].shape[0])
+        if "depth_head.weight" in weights_dict:
+            return 1
         # RF-DETR class_embed has (num_classes + 1) outputs (includes background)
         if "class_embed.bias" in weights_dict:
             detected = int(weights_dict["class_embed.bias"].shape[0]) - 1
@@ -353,7 +372,7 @@ class LibreRFDETR(BaseModel):
         resolved_task = task
         if resolved_task is None and segmentation:
             resolved_task = "segment"
-        if normalize_task(resolved_task) == "pose" and nb_classes == 80:
+        if normalize_task(resolved_task) in ("pose", "depth") and nb_classes == 80:
             nb_classes = 1
         self.num_keypoints = int(num_keypoints)
         self.keypoint_dim = int(keypoint_dim)
@@ -365,10 +384,10 @@ class LibreRFDETR(BaseModel):
         if isinstance(model_path, dict) and not model_path:
             weight_source = None
         elif (
-            normalize_task(resolved_task) in ("classify", "semantic")
+            normalize_task(resolved_task) in ("classify", "semantic", "depth")
             and model_path is None
         ):
-            # Classification and semantic build their own pretrained DINOv2
+            # Classification and dense heads build their own pretrained DINOv2
             # backbone; the detection checkpoints do not apply.
             weight_source = None
         elif normalize_task(resolved_task) == "pose" and model_path is None:
@@ -423,6 +442,9 @@ class LibreRFDETR(BaseModel):
                         f"but task={requested_task!r} was requested."
                     )
 
+        if normalize_task(resolved_task) == "depth":
+            nb_classes = 1
+
         self._model_num_classes = nb_classes
         if isinstance(weight_source, dict):
             weight_state = _checkpoint_model_state(weight_source)
@@ -453,6 +475,12 @@ class LibreRFDETR(BaseModel):
         if weight_source is not None:
             self._load_weights(weight_source)
             self.model.eval()
+            if self._is_depth:
+                self.nb_classes = 1
+                self.names = {0: "depth"}
+        elif self._is_depth:
+            self.nb_classes = 1
+            self.names = {0: "depth"}
         elif self._is_pose and self.nb_classes == 1 and self.names.get(0) == "class_0":
             self.names = {0: "person"}
 
@@ -473,6 +501,10 @@ class LibreRFDETR(BaseModel):
     @property
     def _is_semantic(self) -> bool:
         return self.task == "semantic"
+
+    @property
+    def _is_depth(self) -> bool:
+        return self.task == "depth"
 
     @property
     def _is_obb(self) -> bool:
@@ -535,6 +567,10 @@ class LibreRFDETR(BaseModel):
         state = _checkpoint_model_state(ckpt) if isinstance(ckpt, dict) else {}
         if "linear.weight" in state and any(k.startswith("backbone.") for k in state):
             return "classify"
+        if "depth_head.weight" in state and any(
+            k.startswith("backbone.") for k in state
+        ):
+            return "depth"
         if "predict.weight" in state and any(k.startswith("backbone.") for k in state):
             return "semantic"
         if any(k.startswith("segmentation_head") for k in state):
@@ -595,6 +631,7 @@ class LibreRFDETR(BaseModel):
             classification=self._is_classification,
             obb=self._is_obb,
             semantic=self._is_semantic,
+            depth=self._is_depth,
             num_keypoints=self.num_keypoints,
         )
 
@@ -621,6 +658,13 @@ class LibreRFDETR(BaseModel):
             self.model.nb_classes = new_nc
             self.model.to(self.device)
             self.names = {i: f"class_{i}" for i in range(new_nc)}
+            return
+        if self._is_depth:
+            if int(new_nc) != 1:
+                raise ValueError("RF-DETR depth models require exactly one output channel")
+            self.nb_classes = 1
+            self._model_num_classes = 1
+            self.names = {0: "depth"}
             return
         super()._rebuild_for_new_classes(new_nc)
 
@@ -695,6 +739,17 @@ class LibreRFDETR(BaseModel):
             img_tensor = torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0)
             return img_tensor, img, orig_size, 1.0
 
+        if self._is_depth:
+            if effective_res % self.depth_imgsz_divisor:
+                raise ValueError(
+                    f"RF-DETR depth imgsz={effective_res} must be divisible "
+                    f"by {self.depth_imgsz_divisor} (DINOv2 patch grid)."
+                )
+            resized = img.resize((effective_res, effective_res), Image.BILINEAR)
+            arr = np.asarray(resized, dtype=np.float32) / 255.0
+            img_tensor = torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0)
+            return img_tensor, img, orig_size, 1.0
+
         img_chw, _ = preprocess_numpy(np.array(img), effective_res)
         img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
 
@@ -732,6 +787,18 @@ class LibreRFDETR(BaseModel):
                 align_corners=False,
             )
             return {"semantic": logits.argmax(dim=1)[0].cpu()}
+        if self._is_depth:
+            depth = output
+            if isinstance(depth, dict):
+                depth = depth.get("depth", depth.get("predictions"))
+            orig_w, orig_h = original_size
+            depth = torch.nn.functional.interpolate(
+                depth.float(),
+                size=(orig_h, orig_w),
+                mode="bilinear",
+                align_corners=False,
+            )
+            return {"depth": depth[0, 0].cpu()}
         if isinstance(output, tuple):
             tuple_output = output
             output = {"pred_boxes": tuple_output[0], "pred_logits": tuple_output[1]}
@@ -927,11 +994,68 @@ class LibreRFDETR(BaseModel):
             self.names = self._sanitize_names(ckpt_names, self.nb_classes)
         self.model.to(self.device)
 
+    def _load_depth_weights(self, model_path: str | dict[str, Any]) -> None:
+        """Load a LibreYOLO depth checkpoint into the dense depth estimator."""
+        if isinstance(model_path, str):
+            loaded = load_trusted_torch_file(
+                model_path,
+                map_location="cpu",
+                context="RF-DETR depth weights",
+            )
+        else:
+            loaded = model_path
+        if not isinstance(loaded, dict):
+            raise TypeError("RF-DETR depth checkpoints must be dictionaries")
+
+        ckpt_task = loaded.get("task")
+        if isinstance(ckpt_task, str) and normalize_task(ckpt_task) != "depth":
+            raise RuntimeError(
+                f"Checkpoint was trained for task={normalize_task(ckpt_task)!r}, "
+                "but is being loaded into an RF-DETR depth model. "
+                "Load it with the matching task."
+            )
+
+        ckpt_nc = loaded.get("nc")
+        if ckpt_nc is None:
+            names = loaded.get("names")
+            ckpt_nc = len(names) if names else None
+        if ckpt_nc is None:
+            state = _checkpoint_model_state(loaded)
+            ckpt_nc = 1 if state.get("depth_head.weight") is not None else None
+        if ckpt_nc is not None and int(ckpt_nc) != 1:
+            raise RuntimeError(
+                f"RF-DETR depth checkpoints must declare nc=1, got nc={ckpt_nc}."
+            )
+
+        result = self.model.load_state_dict(loaded, strict=False)
+        missing = list(getattr(result, "missing_keys", []) or [])
+        unexpected = list(getattr(result, "unexpected_keys", []) or [])
+        if any(k.startswith("depth_head.") for k in missing) or any(
+            ("class_embed" in k or "transformer" in k or "query" in k)
+            for k in unexpected
+        ):
+            raise RuntimeError(
+                "Checkpoint does not look like an RF-DETR depth model "
+                "(its weights do not match the backbone + dense depth decoder). "
+                "Load a depth checkpoint or the correct task."
+            )
+
+        self.nb_classes = 1
+        ckpt_names = loaded.get("names")
+        self.names = (
+            self._sanitize_names(ckpt_names, 1)
+            if ckpt_names is not None
+            else {0: "depth"}
+        )
+        self.model.to(self.device)
+
     def _load_weights(self, model_path: str | dict[str, Any]):
         if self._is_classification:
             return self._load_classify_weights(model_path)
         if self._is_semantic:
             return self._load_semantic_weights(model_path)
+        if self._is_depth:
+            return self._load_depth_weights(model_path)
         try:
             if isinstance(model_path, str):
                 if not Path(model_path).exists():

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -567,6 +567,203 @@ class RFDETRSemanticSegmenter(nn.Module):
         )
 
 
+class RFDETRDepthEstimator(nn.Module):
+    """Dense monocular-depth model: RF-DETR's DINOv2 backbone + decoder.
+
+    The model predicts relative inverse depth: higher values mean closer to
+    the camera. It keeps RF-DETR's DINOv2 encoder/projector and replaces the
+    query decoder with a dense top-down decoder. Training targets are plain
+    depth maps where ``0``/non-finite pixels are invalid.
+    """
+
+    _PATCH_SIZE = 14
+    _POS_ENC_SIZE = 37  # 37 * 14 == 518, DINOv2's pretrained image_size
+    _NUM_WINDOWS = 1
+
+    _TRIM_RATIO = 0.2
+    _GRAD_SCALES = 4
+    _GRAD_WEIGHT = 0.5
+
+    def __init__(
+        self,
+        config: str = "s",
+        device: str = "cpu",
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        if config not in RFDETR_CONFIGS:
+            raise ValueError(
+                f"Invalid RF-DETR size: {config}. Must be one of {sorted(RFDETR_CONFIGS)}"
+            )
+        cfg = RFDETR_CONFIGS[config]
+        self.config_name = config
+        self.hidden_dim = cfg.hidden_dim
+        self.patch_size = self._PATCH_SIZE
+        self.num_windows = self._NUM_WINDOWS
+        self.resolution = self._POS_ENC_SIZE * self._PATCH_SIZE
+
+        joiner = self._build_backbone(cfg, device)
+        self.backbone = joiner[0]
+
+        num_levels = len(cfg.projector_scale)
+        self.laterals = nn.ModuleList(
+            nn.Conv2d(self.hidden_dim, self.hidden_dim, 1) for _ in range(num_levels)
+        )
+        self.refine = nn.ModuleList(
+            self._make_refine_block(self.hidden_dim) for _ in range(num_levels)
+        )
+        self.output_refine = nn.Sequential(
+            nn.Conv2d(self.hidden_dim, self.hidden_dim, 3, padding=1),
+            nn.GroupNorm(32, self.hidden_dim),
+            nn.GELU(),
+            nn.Conv2d(self.hidden_dim, self.hidden_dim, 3, padding=1),
+            nn.GroupNorm(32, self.hidden_dim),
+            nn.GELU(),
+        )
+        self.drop = nn.Dropout2d(p=dropout)
+        self.depth_head = nn.Conv2d(self.hidden_dim, 1, 1)
+        self.depth_activation = nn.Softplus(beta=1.0, threshold=20.0)
+
+        mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1)
+        std = torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1)
+        self.register_buffer("pixel_mean", mean, persistent=False)
+        self.register_buffer("pixel_std", std, persistent=False)
+
+    @staticmethod
+    def _make_refine_block(channels: int) -> nn.Sequential:
+        return nn.Sequential(
+            nn.Conv2d(channels, channels, 3, padding=1),
+            nn.GroupNorm(32, channels),
+            nn.GELU(),
+            nn.Conv2d(channels, channels, 3, padding=1),
+            nn.GroupNorm(32, channels),
+            nn.GELU(),
+        )
+
+    def _build_backbone(self, cfg: RFDETRSizeConfig, device: str):
+        kwargs = dict(
+            encoder=cfg.encoder,
+            vit_encoder_num_layers=12,
+            pretrained_encoder=None,
+            window_block_indexes=None,
+            drop_path=0.0,
+            out_channels=cfg.hidden_dim,
+            out_feature_indexes=list(cfg.out_feature_indexes),
+            projector_scale=list(cfg.projector_scale),
+            use_cls_token=False,
+            hidden_dim=cfg.hidden_dim,
+            position_embedding="sine",
+            freeze_encoder=False,
+            layer_norm=True,
+            target_shape=(self.resolution, self.resolution),
+            rms_norm=False,
+            backbone_lora=False,
+            force_no_pretrain=False,
+            gradient_checkpointing=False,
+            patch_size=self._PATCH_SIZE,
+            num_windows=self._NUM_WINDOWS,
+            positional_encoding_size=self._POS_ENC_SIZE,
+        )
+        try:
+            return build_backbone(load_dinov2_weights=True, **kwargs)
+        except Exception as exc:  # pragma: no cover - offline / hub failure
+            logger = __import__("logging").getLogger(__name__)
+            logger.warning(
+                "Could not load pretrained DINOv2 weights (%s); building the "
+                "depth backbone from random init.",
+                exc,
+            )
+            return build_backbone(load_dinov2_weights=False, **kwargs)
+
+    @staticmethod
+    def _normalize(values: torch.Tensor, valid: torch.Tensor) -> torch.Tensor:
+        flat = values[valid]
+        shift = flat.median()
+        scale = (flat - shift).abs().mean().clamp_min(1e-6)
+        return (values - shift) / scale
+
+    def _ssi_loss_single(
+        self, pred: torch.Tensor, gt_depth: torch.Tensor
+    ) -> torch.Tensor | None:
+        valid = (gt_depth > 0) & torch.isfinite(gt_depth) & torch.isfinite(pred)
+        if int(valid.sum()) < 2:
+            return None
+
+        gt_inverse = torch.zeros_like(gt_depth)
+        gt_inverse[valid] = 1.0 / gt_depth[valid]
+        pred_n = self._normalize(pred, valid)
+        gt_n = self._normalize(gt_inverse, valid)
+
+        residuals = (pred_n - gt_n).abs()[valid]
+        keep = max(1, int(residuals.numel() * (1.0 - self._TRIM_RATIO)))
+        if keep < residuals.numel():
+            residuals, _ = torch.sort(residuals)
+            residuals = residuals[:keep]
+        data_term = residuals.mean()
+
+        residual_map = pred_n - gt_n
+        valid_map = valid
+        grad_term = pred.new_zeros(())
+        for _ in range(self._GRAD_SCALES):
+            grad_x = (residual_map[:, 1:] - residual_map[:, :-1]).abs()
+            mask_x = valid_map[:, 1:] & valid_map[:, :-1]
+            grad_y = (residual_map[1:, :] - residual_map[:-1, :]).abs()
+            mask_y = valid_map[1:, :] & valid_map[:-1, :]
+            denom = mask_x.sum() + mask_y.sum()
+            if int(denom) > 0:
+                grad_term = grad_term + (
+                    grad_x[mask_x].sum() + grad_y[mask_y].sum()
+                ) / denom.clamp_min(1)
+            if min(residual_map.shape) < 4:
+                break
+            residual_map = residual_map[::2, ::2]
+            valid_map = valid_map[::2, ::2]
+
+        return data_term + self._GRAD_WEIGHT * grad_term
+
+    def _decode_features(self, feats) -> torch.Tensor:
+        fused = self.laterals[-1](feats[-1].tensors)
+        fused = self.refine[-1](fused)
+        for idx in range(len(feats) - 2, -1, -1):
+            lateral = self.laterals[idx](feats[idx].tensors)
+            fused = F.interpolate(
+                fused, size=lateral.shape[-2:], mode="bilinear", align_corners=False
+            )
+            fused = self.refine[idx](fused + lateral)
+        return self.output_refine(fused)
+
+    def forward(self, x: torch.Tensor, targets=None):
+        b, _, h, w = x.shape
+        x = (x - self.pixel_mean) / self.pixel_std
+        mask = torch.zeros((b, h, w), dtype=torch.bool, device=x.device)
+        feats = self.backbone(NestedTensor(x, mask))
+
+        fused = self._decode_features(feats)
+        pred = self.depth_activation(self.depth_head(self.drop(fused)))
+
+        if self.training and targets is not None:
+            pred = F.interpolate(
+                pred, size=targets.shape[-2:], mode="bilinear", align_corners=False
+            )[:, 0]
+            losses = [
+                loss
+                for loss in (
+                    self._ssi_loss_single(pred[i], targets[i].float())
+                    for i in range(pred.shape[0])
+                )
+                if loss is not None
+            ]
+            if losses:
+                loss = torch.stack(losses).mean()
+            else:
+                loss = pred.sum() * 0.0
+            return {"total_loss": loss, "depth": loss}
+
+        return F.interpolate(
+            pred, size=(h, w), mode="bilinear", align_corners=False
+        )
+
+
 class LibreRFDETRModel(nn.Module):
     """RF-DETR model built from LibreYOLO-local RF-DETR modules."""
 
@@ -580,16 +777,21 @@ class LibreRFDETRModel(nn.Module):
         classification: bool = False,
         obb: bool = False,
         semantic: bool = False,
+        depth: bool = False,
         num_keypoints: int = 17,
         oks_sigmas=None,
     ):
         super().__init__()
 
-        if sum(bool(x) for x in (segmentation, pose, classification, obb, semantic)) > 1:
+        if (
+            sum(bool(x) for x in (segmentation, pose, classification, obb, semantic, depth))
+            > 1
+        ):
             raise ValueError("RF-DETR can enable only one task head at a time")
 
         self.classification = classification
         self.semantic = semantic
+        self.depth = depth
         if classification:
             # Backbone-only classification path: no detection decoder/criterion.
             self.config_name = config
@@ -620,6 +822,21 @@ class LibreRFDETRModel(nn.Module):
             self.hidden_dim = self.segmenter.hidden_dim
             self.patch_size = self.segmenter.patch_size
             self.num_windows = self.segmenter.num_windows
+            self.model = None
+            self.postprocess = None
+            return
+
+        if depth:
+            # Backbone-only dense path: no detection decoder/criterion.
+            self.config_name = config
+            self.config = RFDETR_CONFIGS[config]
+            self.nb_classes = 1
+            self.segmentation = False
+            self.depth_estimator = RFDETRDepthEstimator(config=config, device=device)
+            self.resolution = self.depth_estimator.resolution
+            self.hidden_dim = self.depth_estimator.hidden_dim
+            self.patch_size = self.depth_estimator.patch_size
+            self.num_windows = self.depth_estimator.num_windows
             self.model = None
             self.postprocess = None
             return
@@ -663,6 +880,8 @@ class LibreRFDETRModel(nn.Module):
             return self.classifier(x, targets=targets)
         if self.semantic:
             return self.segmenter(x, targets=targets)
+        if self.depth:
+            return self.depth_estimator(x, targets=targets)
         return self.model(x, targets=targets)
 
     def build_criterion_and_postprocess(self):
@@ -675,6 +894,10 @@ class LibreRFDETRModel(nn.Module):
             )
         if self.semantic:
             return self.segmenter.load_state_dict(
+                _unwrap_state_dict(state_dict), strict=strict
+            )
+        if self.depth:
+            return self.depth_estimator.load_state_dict(
                 _unwrap_state_dict(state_dict), strict=strict
             )
 
@@ -716,6 +939,8 @@ class LibreRFDETRModel(nn.Module):
             return self.classifier.state_dict(*args, **kwargs)
         if self.semantic:
             return self.segmenter.state_dict(*args, **kwargs)
+        if self.depth:
+            return self.depth_estimator.state_dict(*args, **kwargs)
         return self.model.state_dict(*args, **kwargs)
 
 
@@ -748,6 +973,7 @@ def create_rfdetr_model(
     segmentation: bool = False,
     pose: bool = False,
     obb: bool = False,
+    depth: bool = False,
     num_keypoints: int = 17,
     oks_sigmas=None,
 ) -> LibreRFDETRModel:
@@ -758,6 +984,7 @@ def create_rfdetr_model(
         segmentation=segmentation,
         pose=pose,
         obb=obb,
+        depth=depth,
         num_keypoints=num_keypoints,
         oks_sigmas=oks_sigmas,
     )
@@ -766,6 +993,7 @@ def create_rfdetr_model(
 __all__ = [
     "LibreRFDETRModel",
     "RFDETRClassifier",
+    "RFDETRDepthEstimator",
     "RFDETRSemanticSegmenter",
     "RFDETRExportWrapper",
     "RFDETR_CONFIGS",

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -87,11 +87,13 @@ class RFDETRTrainer(BaseTrainer):
         task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
         if task == "pose":
             self.best_metric_key = "metrics/keypoints_mAP50-95"
+        elif task == "depth":
+            self.best_metric_key = "metrics/delta1"
         # Classification resolves its class count from the ImageFolder dataset
         # in _setup_classify_data; semantic resolves it from the mask dataset
         # in _setup_semantic_data (including the polygon-fallback background
         # class) — neither reads a detection YAML here.
-        if task in ("classify", "semantic"):
+        if task in ("classify", "semantic", "depth"):
             return
         if self.config.data:
             data_cfg = load_data_config(
@@ -157,6 +159,28 @@ class RFDETRTrainer(BaseTrainer):
             head = getattr(segmenter, "predict", None)
             if head is not None:
                 groups.append(("head", head))
+            return groups or super().get_freeze_groups()
+
+        depth_estimator = (
+            getattr(self.model, "depth_estimator", None) if core_model is None else None
+        )
+        if depth_estimator is not None:
+            self._append_backbone_freeze_groups(
+                groups,
+                getattr(depth_estimator, "backbone", None),
+            )
+            head_modules = tuple(
+                module
+                for module in (
+                    getattr(depth_estimator, "laterals", None),
+                    getattr(depth_estimator, "refine", None),
+                    getattr(depth_estimator, "output_refine", None),
+                    getattr(depth_estimator, "depth_head", None),
+                )
+                if module is not None
+            )
+            if head_modules:
+                groups.append(("head", head_modules))
             return groups or super().get_freeze_groups()
 
         backbone = getattr(core_model, "backbone", None)
@@ -355,6 +379,7 @@ class RFDETRTrainer(BaseTrainer):
         if getattr(getattr(self, "wrapper_model", None), "task", "detect") in (
             "classify",
             "semantic",
+            "depth",
         ):
             return imgs, targets, polygons
         scales = self._multi_scale_scales()
@@ -557,16 +582,16 @@ class RFDETRTrainer(BaseTrainer):
         # and size it from their datasets in _setup_classify_data /
         # _setup_semantic_data — no detection criterion or head
         # reinitialization is needed.
-        if task == "semantic" and getattr(self.config, "lora", False):
+        if task in ("semantic", "depth") and getattr(self.config, "lora", False):
             # LoRA injection targets the detection transformer; silently
             # fine-tuning the full semantic model while config says LoRA
             # would misrepresent the run.
             raise ValueError(
-                "RF-DETR semantic training does not support lora=True yet. "
+                f"RF-DETR {task} training does not support lora=True yet. "
                 "Use freeze='backbone.encoder' for parameter-efficient "
-                "semantic fine-tuning."
+                f"{task} fine-tuning."
             )
-        if task in ("classify", "semantic"):
+        if task in ("classify", "semantic", "depth"):
             return
         if self.model.nb_classes != self.config.num_classes:
             head_outputs = (
@@ -621,6 +646,7 @@ class RFDETRTrainer(BaseTrainer):
         if getattr(getattr(self, "wrapper_model", None), "task", "detect") in (
             "classify",
             "semantic",
+            "depth",
         ):
             # The DINOv2 backbone + projector is LayerNorm-only (no BatchNorm),
             # so the shared BN/conv/bias grouping leaves an empty first group.
@@ -817,9 +843,9 @@ class RFDETRTrainer(BaseTrainer):
         polygons: Optional[List] = None,
     ) -> Dict:
         task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
-        if task in ("classify", "semantic"):
+        if task in ("classify", "semantic", "depth"):
             # ``targets`` are class indices [B] (classify) or dense class maps
-            # [B, H, W] (semantic); the model head returns the loss dict
+            # [B, H, W] (semantic/depth); the model head returns the loss dict
             # directly.
             return self.model(imgs, targets=targets)
 
@@ -858,6 +884,11 @@ class RFDETRTrainer(BaseTrainer):
         if loss_task == "semantic":
             value = outputs.get("sem", 0)
             return {"sem": value.item() if isinstance(value, torch.Tensor) else float(value)}
+        if loss_task == "depth":
+            value = outputs.get("depth", 0)
+            return {
+                "depth": value.item() if isinstance(value, torch.Tensor) else float(value)
+            }
 
         def _sum_with_prefix(prefix: str) -> float:
             total = 0.0

--- a/libreyolo/tasks.py
+++ b/libreyolo/tasks.py
@@ -8,9 +8,27 @@ from typing import Iterable, Literal
 
 
 TaskType = Literal[
-    "detect", "segment", "semantic", "pose", "classify", "gaze", "obb", "point"
+    "detect",
+    "segment",
+    "semantic",
+    "pose",
+    "classify",
+    "gaze",
+    "obb",
+    "point",
+    "depth",
 ]
-TASKS = ("detect", "segment", "semantic", "pose", "classify", "gaze", "obb", "point")
+TASKS = (
+    "detect",
+    "segment",
+    "semantic",
+    "pose",
+    "classify",
+    "gaze",
+    "obb",
+    "point",
+    "depth",
+)
 
 TASK_ALIASES = {
     "detect": "detect",
@@ -36,6 +54,11 @@ TASK_ALIASES = {
     "gaze_estimation": "gaze",
     "obb": "obb",
     "point": "point",
+    "depth": "depth",
+    "depth-estimation": "depth",
+    "depth_estimation": "depth",
+    "monodepth": "depth",
+    "monocular-depth": "depth",
 }
 
 TASK_TO_SUFFIX = {
@@ -46,6 +69,7 @@ TASK_TO_SUFFIX = {
     "gaze": "gaze",
     "obb": "obb",
     "point": "point",
+    "depth": "depth",
 }
 
 SUFFIX_TO_TASK = {v: k for k, v in TASK_TO_SUFFIX.items()}

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -424,6 +424,8 @@ class BaseTrainer(ABC):
             return self._setup_classify_data()
         if wrapper_task == "semantic":
             return self._setup_semantic_data()
+        if wrapper_task == "depth":
+            return self._setup_depth_data()
 
         img_size = self.input_size
         preproc, MosaicDatasetClass = self.create_transforms()
@@ -764,6 +766,81 @@ class BaseTrainer(ABC):
                 len(train_dataset),
                 num_classes,
             )
+            logger.info(
+                "Iterations per epoch: %d (batch_per_rank=%d, world_size=%d)",
+                len(self.train_loader),
+                per_rank_batch,
+                self.world_size,
+            )
+        return train_dataset
+
+    def _setup_depth_data(self):
+        """Build the depth train dataloader from a dataset YAML."""
+        from torch.utils.data import DataLoader
+
+        from ..data.depth_dataset import (
+            DepthDataset,
+            depth_collate_fn,
+            resolve_depth_data,
+        )
+
+        if not self.config.data:
+            raise ValueError("Depth training requires data= (a dataset YAML).")
+        data_config = resolve_depth_data(
+            self.config.data,
+            allow_scripts=self.config.allow_download_scripts,
+        )
+        resize_mode = getattr(self.wrapper_model, "depth_resize_mode", "letterbox")
+        divisor = getattr(self.wrapper_model, "depth_imgsz_divisor", None)
+        if divisor and self.config.imgsz % int(divisor):
+            raise ValueError(
+                f"Depth training imgsz={self.config.imgsz} must be divisible "
+                f"by {int(divisor)} for this model family."
+            )
+        train_dataset = DepthDataset(
+            data_config,
+            split="train",
+            imgsz=self.config.imgsz,
+            augment=True,
+            resize_mode=resize_mode,
+        )
+
+        self.num_classes = 1
+        self.config.num_classes = 1
+        if self.wrapper_model is not None:
+            self.wrapper_model.nb_classes = 1
+            self.wrapper_model.names = {0: "depth"}
+
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_dataset) >= self.world_size,
+            )
+
+        try:
+            visible_samples = len(sampler) if sampler is not None else len(train_dataset)
+        except TypeError:
+            visible_samples = len(train_dataset)
+        self.train_loader = DataLoader(
+            train_dataset,
+            batch_size=per_rank_batch,
+            shuffle=sampler is None,
+            sampler=sampler,
+            num_workers=self.config.workers,
+            pin_memory=self.device.type == "cuda",
+            collate_fn=depth_collate_fn,
+            drop_last=visible_samples >= per_rank_batch,
+        )
+
+        if is_main_process():
+            logger.info("Depth dataset: %d images", len(train_dataset))
             logger.info(
                 "Iterations per epoch: %d (batch_per_rank=%d, world_size=%d)",
                 len(self.train_loader),
@@ -1698,6 +1775,8 @@ class BaseTrainer(ABC):
             return self._run_classify_validation(epoch)
         if validation_task == "semantic":
             return self._run_semantic_validation(epoch)
+        if validation_task == "depth":
+            return self._run_depth_validation(epoch)
         try:
             from libreyolo.validation import (
                 DetectionValidator,
@@ -1899,6 +1978,59 @@ class BaseTrainer(ABC):
             }
         except Exception as e:
             logger.error(f"Semantic validation failed: {e}")
+            import traceback
+
+            logger.debug(f"Validation traceback:\n{traceback.format_exc()}")
+            return None
+
+    def _run_depth_validation(
+        self, epoch: int
+    ) -> Optional[Dict[str, Any]]:
+        """Validate the depth head (AbsRel / delta1) on the val split."""
+        try:
+            from libreyolo.validation import DepthValidator, ValidationConfig
+
+            if self.wrapper_model is None:
+                logger.error("Validation requires wrapper_model to be provided to trainer")
+                return None
+
+            logger.info(f"Running depth validation for epoch {epoch + 1}")
+            val_config = ValidationConfig(
+                data=self.config.data,
+                batch_size=self.config.batch,
+                imgsz=self.config.imgsz,
+                device=str(self.device),
+                half=self.config.amp and self.device.type == "cuda",
+                verbose=False,
+                num_workers=self.config.workers,
+                split="val",
+                allow_download_scripts=self.config.allow_download_scripts,
+            )
+
+            eval_pytorch_model = (
+                self.ema_model.ema if self.ema_model else unwrap_model(self.model)
+            )
+            original_model = self.wrapper_model.model
+            self.wrapper_model.model = eval_pytorch_model
+            try:
+                validator = DepthValidator(model=self.wrapper_model, config=val_config)
+                results = validator.run()
+            finally:
+                self.wrapper_model.model = original_model
+
+            raw_metrics = self._scalar_mapping(results)
+            delta1 = raw_metrics.get("metrics/delta1", 0.0)
+            abs_rel = raw_metrics.get("metrics/abs_rel", 0.0)
+            logger.info("Validation - delta1: %.4f, AbsRel: %.4f", delta1, abs_rel)
+            return {
+                "mAP50": delta1,
+                "mAP50_95": delta1,
+                "best_metric": delta1,
+                "best_metric_key": "metrics/delta1",
+                "metrics": raw_metrics,
+            }
+        except Exception as e:
+            logger.error(f"Depth validation failed: {e}")
             import traceback
 
             logger.debug(f"Validation traceback:\n{traceback.format_exc()}")

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -418,6 +418,64 @@ def draw_semantic_mask(
     return result.convert("RGB")
 
 
+# Anchor colors for the depth colormap, near (warm) to far (cold). Linear
+# interpolation between anchors gives a smooth ramp without a matplotlib
+# dependency.
+_DEPTH_COLOR_ANCHORS: Tuple[Tuple[int, int, int], ...] = (
+    (122, 4, 3),
+    (228, 65, 26),
+    (249, 152, 40),
+    (164, 252, 60),
+    (58, 222, 130),
+    (32, 144, 222),
+    (64, 67, 166),
+    (48, 18, 59),
+)
+
+
+@lru_cache(maxsize=1)
+def _depth_colormap_lut() -> np.ndarray:
+    """256-entry RGB lookup table interpolated between depth anchors."""
+    anchors = np.asarray(_DEPTH_COLOR_ANCHORS, dtype=np.float64)
+    positions = np.linspace(0.0, 1.0, len(anchors))
+    samples = np.linspace(0.0, 1.0, 256)
+    lut = np.stack(
+        [np.interp(samples, positions, anchors[:, c]) for c in range(3)], axis=1
+    )
+    return lut.round().astype(np.uint8)
+
+
+def draw_depth_map(
+    img: Image.Image,
+    depth_map: np.ndarray,
+    alpha: float = 1.0,
+) -> Image.Image:
+    """Render a relative inverse-depth map as a colormapped image."""
+    depth = np.asarray(depth_map, dtype=np.float32)
+    if depth.shape[:2] != (img.height, img.width):
+        depth_img = Image.fromarray(depth, mode="F")
+        depth_img = depth_img.resize((img.width, img.height), Image.BILINEAR)
+        depth = np.asarray(depth_img, dtype=np.float32)
+
+    finite = np.isfinite(depth)
+    normalized = np.zeros_like(depth, dtype=np.float32)
+    if finite.any():
+        values = depth[finite]
+        lo = float(values.min())
+        hi = float(values.max())
+        if hi - lo > 0:
+            normalized[finite] = (values - lo) / (hi - lo)
+    # Higher values are closer; index 0 of the LUT is the near anchor.
+    indices = ((1.0 - normalized) * 255).round().astype(np.uint8)
+    colored = _depth_colormap_lut()[indices]
+    colored[~finite] = 0
+
+    result = Image.fromarray(colored, mode="RGB")
+    if alpha < 1.0:
+        result = Image.blend(img.convert("RGB"), result, alpha)
+    return result
+
+
 # COCO 17-keypoint skeleton + colors (matches super-gradients defaults).
 COCO_KEYPOINT_EDGES: Tuple[Tuple[int, int], ...] = (
     (0, 1), (0, 2), (1, 2), (1, 3), (2, 4),

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -453,6 +453,65 @@ class SemanticMask(_TensorPayload):
         )
 
 
+class DepthMap(_TensorPayload):
+    """Dense relative inverse-depth map for a single image.
+
+    Data shape is ``(H, W)`` float values on the original image canvas. Higher
+    values mean closer to the camera. Values are relative, not metric meters.
+    """
+
+    def __init__(self, data: TensorLike, orig_shape: Tuple[int, int] | None = None):
+        if data.ndim != 2:
+            raise ValueError(
+                f"expected (H, W) depth map but got shape {tuple(data.shape)}"
+            )
+        if orig_shape is None:
+            orig_shape = (int(data.shape[0]), int(data.shape[1]))
+        super().__init__(data, orig_shape)
+
+    def _finite_values(self) -> np.ndarray:
+        values = np.asarray(_numpy(self.data), dtype=np.float32)
+        return values[np.isfinite(values)]
+
+    @property
+    def min(self) -> float:
+        values = self._finite_values()
+        return float(values.min()) if values.size else 0.0
+
+    @property
+    def max(self) -> float:
+        values = self._finite_values()
+        return float(values.max()) if values.size else 0.0
+
+    @property
+    def mean(self) -> float:
+        values = self._finite_values()
+        return float(values.mean()) if values.size else 0.0
+
+    def normalized(self) -> TensorLike:
+        """Depth map rescaled to ``[0, 1]`` over finite values."""
+        data = self.data
+        lo, hi = self.min, self.max
+        if hi - lo <= 0:
+            return data * 0
+        normalized = (data - lo) / (hi - lo)
+        if isinstance(normalized, torch.Tensor):
+            return torch.where(torch.isfinite(normalized), normalized, torch.zeros_like(normalized))
+        return np.where(np.isfinite(normalized), normalized, np.zeros_like(normalized))
+
+    def __getitem__(self, idx):
+        # Instance indexing does not apply to a dense map; keep it intact so
+        # shared Results slicing paths cannot corrupt the (H, W) layout.
+        return self.__class__(self.data, self.orig_shape)
+
+    def __repr__(self) -> str:
+        return (
+            f"DepthMap(shape={tuple(self.data.shape)}, "
+            f"range=({self.min:.4g}, {self.max:.4g}), "
+            f"orig_shape={self.orig_shape})"
+        )
+
+
 class OBB(_TensorPayload):
     def __init__(self, data: TensorLike, orig_shape: Tuple[int, int] | None = None):
         if data.ndim == 1:
@@ -625,7 +684,17 @@ class Gaze(_TensorPayload):
 class Results:
     """Single-image result with flat detection/segmentation slots."""
 
-    _keys = ("boxes", "masks", "probs", "keypoints", "obb", "gaze", "points", "semantic_mask")
+    _keys = (
+        "boxes",
+        "masks",
+        "probs",
+        "keypoints",
+        "obb",
+        "gaze",
+        "points",
+        "semantic_mask",
+        "depth_map",
+    )
 
     def __init__(
         self,
@@ -640,6 +709,7 @@ class Results:
         gaze: Optional[Gaze] = None,
         points: Optional[Points] = None,
         semantic_mask: Optional[SemanticMask] = None,
+        depth_map: Optional[DepthMap] = None,
         speed: Optional[Dict[str, float]] = None,
         track_id: Optional[TensorLike] = None,
         frame_idx: Optional[int] = None,
@@ -650,6 +720,8 @@ class Results:
             boxes = boxes.with_id(track_id)
         if points is not None and points.orig_shape is None:
             points = Points(points.data, orig_shape)
+        if depth_map is not None and depth_map.orig_shape is None:
+            depth_map = DepthMap(depth_map.data, orig_shape)
 
         self.boxes = boxes
         self.masks = masks
@@ -659,6 +731,7 @@ class Results:
         self.gaze = gaze
         self.points = points
         self.semantic_mask = semantic_mask
+        self.depth_map = depth_map
         self.orig_shape = orig_shape
         self.path = path
         self.names = names or {}
@@ -679,6 +752,7 @@ class Results:
             "gaze": self.gaze,
             "points": self.points,
             "semantic_mask": self.semantic_mask,
+            "depth_map": self.depth_map,
             "speed": dict(self.speed),
             "track_id": self.track_id,
             "frame_idx": self.frame_idx,
@@ -731,6 +805,7 @@ class Results:
         gaze: Optional[Gaze] = None,
         points: Optional[Points] = None,
         semantic_mask: Optional[SemanticMask] = None,
+        depth_map: Optional[DepthMap] = None,
         track_id: Optional[TensorLike] = None,
     ) -> "Results":
         if boxes is not None:
@@ -749,6 +824,8 @@ class Results:
             self.points = points if points.orig_shape is not None else Points(points.data, self.orig_shape)
         if semantic_mask is not None:
             self.semantic_mask = semantic_mask
+        if depth_map is not None:
+            self.depth_map = depth_map
         if track_id is not None:
             self.track_id = track_id
             if self.boxes is not None:
@@ -790,6 +867,15 @@ class Results:
                         }
                     )
                 return rows
+            if self.depth_map is not None:
+                return [
+                    {
+                        "name": "depth_map",
+                        "min": round(self.depth_map.min, decimals),
+                        "max": round(self.depth_map.max, decimals),
+                        "mean": round(self.depth_map.mean, decimals),
+                    }
+                ]
             if self.probs is None:
                 return []
             probs_np = _numpy(self.probs.data)
@@ -878,6 +964,8 @@ class Results:
             return 1
         if self.semantic_mask is not None:
             return 1
+        if self.depth_map is not None:
+            return 1
         return 0
 
     def __repr__(self) -> str:
@@ -892,6 +980,8 @@ class Results:
             parts.append(f"masks={self.masks}")
         if self.semantic_mask is not None:
             parts.append(f"semantic_mask={self.semantic_mask}")
+        if self.depth_map is not None:
+            parts.append(f"depth_map={self.depth_map}")
         if self.track_id is not None:
             parts.append(f"track_ids={len(self.track_id)}")
         if self.frame_idx is not None:

--- a/libreyolo/validation/__init__.py
+++ b/libreyolo/validation/__init__.py
@@ -7,6 +7,7 @@ from .obb_validator import OBBValidator
 from .coco_evaluator import COCOEvaluator
 from .pose_validator import PoseValidator
 from .point_validator import PointValidator
+from .depth_validator import DepthValidator
 from .semantic_validator import SemanticValidator
 from .val_plotter import ValPlotter, ConfusionMatrix
 
@@ -18,6 +19,7 @@ __all__ = [
     "OBBValidator",
     "PoseValidator",
     "PointValidator",
+    "DepthValidator",
     "SemanticValidator",
     "COCOEvaluator",
     "ValPlotter",

--- a/libreyolo/validation/depth_validator.py
+++ b/libreyolo/validation/depth_validator.py
@@ -1,0 +1,201 @@
+"""Monocular-depth validator for LibreYOLO.
+
+Computes the standard relative-depth metrics (AbsRel, RMSE, delta thresholds)
+over a dense depth validation split, reusing the :class:`BaseValidator`
+template (setup -> iterate -> finalize).
+
+Predictions are relative inverse depth; ground truth is plain depth. Each
+prediction is aligned to its ground truth with a per-image least-squares
+scale and shift in inverse-depth space before metrics are computed, the
+standard protocol for affine-invariant depth models. Pixels with invalid
+ground truth (``<= 0``) are excluded.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+from ..data.depth_dataset import (
+    DepthDataset,
+    depth_collate_fn,
+    resolve_depth_data,
+)
+from .base import BaseValidator
+
+logger = logging.getLogger(__name__)
+
+_EPS = 1e-6
+
+_METRIC_KEYS = (
+    "metrics/abs_rel",
+    "metrics/rmse",
+    "metrics/delta1",
+    "metrics/delta2",
+    "metrics/delta3",
+)
+
+
+def align_inverse_depth(
+    pred: torch.Tensor, gt_inverse: torch.Tensor
+) -> torch.Tensor:
+    """Least-squares scale-and-shift alignment of a prediction to a target.
+
+    Solves ``min_{s,t} sum((s * pred + t - gt_inverse)^2)`` over the given
+    flat tensors (valid pixels only) and returns the aligned prediction.
+    Falls back to a median shift when the system is degenerate (e.g. a
+    constant prediction) or when the fitted scale is non-positive. Depth
+    predictions are relative inverse depth where larger means closer, so a
+    negative scale would reward an inverted depth ordering.
+    """
+    pred = pred.double()
+    gt_inverse = gt_inverse.double()
+    n = pred.numel()
+    sum_p = pred.sum()
+    sum_pp = (pred * pred).sum()
+    sum_g = gt_inverse.sum()
+    sum_pg = (pred * gt_inverse).sum()
+    det = sum_pp * n - sum_p * sum_p
+    if float(det.abs()) < _EPS:
+        return pred + (gt_inverse.median() - pred.median())
+    scale = (sum_pg * n - sum_p * sum_g) / det
+    shift = (sum_pp * sum_g - sum_p * sum_pg) / det
+    if float(scale) <= _EPS:
+        return pred + (gt_inverse.median() - pred.median())
+    return scale * pred + shift
+
+
+class DepthValidator(BaseValidator):
+    """AbsRel / RMSE / delta-threshold validator for the depth task."""
+
+    task = "depth"
+
+    def _setup_dataloader(self) -> DataLoader:
+        if not self.config.data:
+            raise ValueError("Depth validation requires data= (a dataset YAML).")
+        data_config = resolve_depth_data(
+            self.config.data,
+            allow_scripts=getattr(self.config, "allow_download_scripts", False),
+        )
+        split = self.config.split or "val"
+
+        divisor = getattr(self.model, "depth_imgsz_divisor", None)
+        if divisor and self.config.imgsz % int(divisor):
+            raise ValueError(
+                f"Depth validation imgsz={self.config.imgsz} must be "
+                f"divisible by {int(divisor)} for this model family."
+            )
+        resize_mode = getattr(self.model, "depth_resize_mode", "letterbox")
+        dataset = DepthDataset(
+            data_config,
+            split=split,
+            imgsz=self.config.imgsz,
+            augment=False,
+            resize_mode=resize_mode,
+        )
+        return DataLoader(
+            dataset,
+            batch_size=self.config.batch_size,
+            shuffle=False,
+            num_workers=self.config.num_workers,
+            pin_memory=self.device.type == "cuda",
+            collate_fn=depth_collate_fn,
+        )
+
+    def _init_metrics(self) -> None:
+        self._metric_sums = {key: 0.0 for key in _METRIC_KEYS}
+        self._sqerr_sum = 0.0
+        self._valid_pixel_count = 0
+        self._image_count = 0
+
+    def _preprocess_batch(self, batch: Any) -> tuple:
+        images, targets, img_info, img_ids = batch
+        return images, targets, img_info, img_ids
+
+    def _postprocess_predictions(self, preds: Any, batch: Any) -> Any:
+        """Decode raw model output into ``[B, H, W]`` inverse-depth maps."""
+        output = preds
+        if isinstance(output, dict):
+            output = output.get("depth", output.get("predictions"))
+        if isinstance(output, (list, tuple)):
+            output = output[0]
+        output = torch.as_tensor(output)
+
+        targets = batch[1]
+        target_hw = tuple(targets.shape[-2:])
+        if output.ndim == 3:
+            output = output.unsqueeze(1)
+        if output.ndim != 4 or output.shape[1] != 1:
+            raise ValueError(
+                f"Depth validation expects [B, 1, H, W] output, got shape "
+                f"{tuple(output.shape)}."
+            )
+        if tuple(output.shape[-2:]) != target_hw:
+            output = F.interpolate(
+                output.float(), size=target_hw, mode="bilinear", align_corners=False
+            )
+        return output[:, 0]
+
+    def _update_metrics(
+        self, preds: Any, targets: Any, img_info: Any, img_ids: Any = None
+    ) -> None:
+        preds = preds.detach().cpu().float()
+        targets = targets.detach().cpu().float()
+        for pred, gt_depth in zip(preds, targets):
+            finite = torch.isfinite(pred) & torch.isfinite(gt_depth)
+            valid = (gt_depth > 0) & finite
+            valid_count = int(valid.sum())
+            if valid_count < 2:
+                continue
+            pred_valid = pred[valid]
+            gt_inverse = 1.0 / gt_depth[valid].double()
+
+            aligned = align_inverse_depth(pred_valid, gt_inverse)
+            depth = 1.0 / aligned.clamp_min(_EPS)
+            gt = gt_depth[valid].double()
+
+            residual = depth - gt
+            ratio = torch.maximum(depth / gt, gt / depth)
+            self._metric_sums["metrics/abs_rel"] += float(
+                (residual.abs() / gt).sum()
+            )
+            self._sqerr_sum += float((residual * residual).sum())
+            self._metric_sums["metrics/delta1"] += float((ratio < 1.25).sum())
+            self._metric_sums["metrics/delta2"] += float((ratio < 1.25**2).sum())
+            self._metric_sums["metrics/delta3"] += float((ratio < 1.25**3).sum())
+            self._valid_pixel_count += valid_count
+            self._image_count += 1
+
+    def _compute_metrics(self) -> Dict[str, float]:
+        if self._image_count == 0 or self._valid_pixel_count == 0:
+            raise ValueError(
+                "Depth validation found no images with at least two valid pixels."
+            )
+        count = float(self._valid_pixel_count)
+        metrics = {
+            "metrics/abs_rel": self._metric_sums["metrics/abs_rel"] / count,
+            "metrics/rmse": (self._sqerr_sum / count) ** 0.5,
+            "metrics/delta1": self._metric_sums["metrics/delta1"] / count,
+            "metrics/delta2": self._metric_sums["metrics/delta2"] / count,
+            "metrics/delta3": self._metric_sums["metrics/delta3"] / count,
+        }
+        metrics["fitness"] = metrics["metrics/delta1"]
+        return metrics
+
+    def _print_results(self, metrics: Dict[str, float]) -> None:
+        logger.info("=" * 50)
+        logger.info("Depth Validation Results")
+        logger.info("=" * 50)
+        logger.info("  AbsRel: %.4f", metrics.get("metrics/abs_rel", 0.0))
+        logger.info("  RMSE:   %.4f", metrics.get("metrics/rmse", 0.0))
+        logger.info("  delta1: %.4f", metrics.get("metrics/delta1", 0.0))
+        logger.info("  delta2: %.4f", metrics.get("metrics/delta2", 0.0))
+        logger.info("  delta3: %.4f", metrics.get("metrics/delta3", 0.0))
+        logger.info("=" * 50)
+
+
+__all__ = ["DepthValidator", "align_inverse_depth"]

--- a/tests/unit/test_depth_dataset.py
+++ b/tests/unit/test_depth_dataset.py
@@ -11,6 +11,7 @@ from PIL import Image
 from libreyolo.data.depth_dataset import (
     DepthDataset,
     depth_collate_fn,
+    img2depth_mask_paths,
     img2depth_paths,
     resolve_depth_data,
 )
@@ -75,6 +76,25 @@ class TestDepthPaths:
 
         paths = img2depth_paths([img], depths_dir="gt")
         assert paths[0] == target
+
+    def test_img2depth_paths_finds_depth_suffix_in_same_dir(self, tmp_path):
+        img = tmp_path / "val" / "indoors" / "a.png"
+        _write_image(img)
+        target = tmp_path / "val" / "indoors" / "a_depth.npy"
+        np.save(target, np.ones((30, 40), dtype=np.float32))
+
+        paths = img2depth_paths([img])
+        assert paths[0] == target
+
+    def test_img2depth_mask_paths_finds_depth_mask_suffix(self, tmp_path):
+        depth = tmp_path / "val" / "indoors" / "a_depth.npy"
+        depth.parent.mkdir(parents=True, exist_ok=True)
+        np.save(depth, np.ones((30, 40), dtype=np.float32))
+        mask = tmp_path / "val" / "indoors" / "a_depth_mask.npy"
+        np.save(mask, np.ones((30, 40), dtype=bool))
+
+        paths = img2depth_mask_paths([depth])
+        assert paths[0] == mask
 
 
 class TestDepthDataset:
@@ -156,6 +176,48 @@ class TestDepthDataset:
         _, depth, _, _ = ds[0]
         assert torch.isfinite(depth).all()
         assert float(depth.min()) >= 0.0
+
+    def test_applies_optional_depth_mask(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path, depth_format="npy")
+        mask = np.ones((30, 40), dtype=np.uint8)
+        mask[:, :10] = 0
+        np.save(tmp_path / "depths" / "train" / "img0_mask.npy", mask)
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+        _, depth, _, _ = ds[0]
+        assert float(depth[:, :10].sum()) == 0.0
+        assert float(depth[:, 10:].min()) > 0.0
+
+    def test_loads_diode_style_depth_and_mask(self, tmp_path):
+        root = tmp_path / "diode"
+        image = root / "val" / "indoors" / "scene_00001" / "scan_00001" / "00001.png"
+        _write_image(image)
+        depth = np.full((30, 40), 3.0, dtype=np.float32)
+        depth[0, 0] = 9.0
+        np.save(image.with_name("00001_depth.npy"), depth)
+        mask = np.ones((30, 40), dtype=np.uint8)
+        mask[0, 0] = 0
+        np.save(image.with_name("00001_depth_mask.npy"), mask)
+        yaml_path = root / "data.yaml"
+        yaml_path.write_text(
+            yaml.safe_dump(
+                {
+                    "path": str(root),
+                    "train": "val/indoors",
+                    "val": "val/indoors",
+                    "depth_stem_suffix": "_depth",
+                    "depth_mask_suffix": "_mask",
+                }
+            )
+        )
+
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+        _, target, _, _ = ds[0]
+        assert float(target[0, 0]) == 0.0
+        assert float(target.max()) == pytest.approx(3.0)
 
     def test_invalid_resize_mode_rejected(self, tmp_path):
         yaml_path = _make_dataset_root(tmp_path)

--- a/tests/unit/test_depth_dataset.py
+++ b/tests/unit/test_depth_dataset.py
@@ -1,0 +1,197 @@
+"""Unit tests for the depth dataset loader."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from PIL import Image
+
+from libreyolo.data.depth_dataset import (
+    DepthDataset,
+    depth_collate_fn,
+    img2depth_paths,
+    resolve_depth_data,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_image(path, size=(40, 30), color=(50, 90, 130)):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color=color).save(path)
+
+
+def _write_depth_png(path, shape=(30, 40), scale=256.0, near=2.0, far=8.0):
+    """Left half ``near`` units, right half ``far`` units, 16-bit PNG."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    depth = np.full(shape, far, dtype=np.float64)
+    depth[:, : shape[1] // 2] = near
+    encoded = (depth * scale).round().astype(np.uint16)
+    Image.fromarray(encoded).save(path)
+    return depth
+
+
+def _make_dataset_root(tmp_path, n_images=3, depth_format="png", extra_yaml=None):
+    for split in ("train", "val"):
+        for i in range(n_images):
+            _write_image(tmp_path / "images" / split / f"img{i}.jpg")
+            depth_path = tmp_path / "depths" / split / f"img{i}.{depth_format}"
+            if depth_format == "png":
+                _write_depth_png(depth_path)
+            else:
+                depth_path.parent.mkdir(parents=True, exist_ok=True)
+                depth = np.full((30, 40), 8.0, dtype=np.float32)
+                depth[:, :20] = 2.0
+                np.save(depth_path, depth)
+    config = {
+        "path": str(tmp_path),
+        "train": "images/train",
+        "val": "images/val",
+    }
+    if extra_yaml:
+        config.update(extra_yaml)
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(yaml.safe_dump(config))
+    return yaml_path
+
+
+class TestDepthPaths:
+    def test_img2depth_paths_substitutes_images_dir(self, tmp_path):
+        img = tmp_path / "images" / "train" / "a.jpg"
+        _write_image(img)
+        _write_depth_png(tmp_path / "depths" / "train" / "a.png")
+
+        paths = img2depth_paths([img])
+        assert paths[0] == tmp_path / "depths" / "train" / "a.png"
+
+    def test_img2depth_paths_custom_dir_and_npy(self, tmp_path):
+        img = tmp_path / "images" / "train" / "a.jpg"
+        _write_image(img)
+        target = tmp_path / "gt" / "train" / "a.npy"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        np.save(target, np.ones((30, 40), dtype=np.float32))
+
+        paths = img2depth_paths([img], depths_dir="gt")
+        assert paths[0] == target
+
+
+class TestDepthDataset:
+    def test_loads_16bit_png_with_scale(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+        img, depth, info, idx = ds[0]
+        assert img.shape == (3, 40, 40)
+        assert img.dtype == torch.float32
+        assert depth.shape == (40, 40)
+        # 16-bit PNG values divided by depth_scale=256 recover the units.
+        assert float(depth.min()) == pytest.approx(2.0, abs=1e-2)
+        assert float(depth.max()) == pytest.approx(8.0, abs=1e-2)
+
+    def test_loads_npy_float_depth_as_is(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path, depth_format="npy")
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+        _, depth, _, _ = ds[0]
+        assert float(depth.max()) == pytest.approx(8.0, abs=1e-5)
+
+    def test_custom_depth_scale(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path, extra_yaml={"depth_scale": 512.0})
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+        _, depth, _, _ = ds[0]
+        assert float(depth.max()) == pytest.approx(4.0, abs=1e-2)
+
+    def test_zero_depth_scale_is_rejected(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path, extra_yaml={"depth_scale": 0})
+        config = resolve_depth_data(yaml_path)
+
+        with pytest.raises(ValueError, match="depth_scale"):
+            DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+    def test_letterbox_pads_with_invalid_zero(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="letterbox")
+
+        _, depth, _, _ = ds[0]
+        assert depth.shape == (40, 40)
+        # 40x30 image letterboxed into 40x40: bottom 10 rows are padding,
+        # which must be invalid (0) so it self-excludes from loss/metrics.
+        assert float(depth[31:, :].abs().sum()) == 0.0
+        assert float(depth[:30, :].min()) > 0.0
+
+    def test_missing_depth_file_raises(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        (tmp_path / "depths" / "train" / "img0.png").unlink()
+        config = resolve_depth_data(yaml_path)
+
+        with pytest.raises(FileNotFoundError, match="depth file"):
+            DepthDataset(config, split="train", imgsz=40)
+
+    def test_shape_mismatch_raises(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        _write_depth_png(tmp_path / "depths" / "train" / "img0.png", shape=(10, 10))
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40)
+
+        with pytest.raises(ValueError, match="does not match image shape"):
+            _ = ds[0]
+
+    def test_negative_and_nonfinite_become_invalid(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path, depth_format="npy")
+        bad = np.full((30, 40), 5.0, dtype=np.float32)
+        bad[0, 0] = -3.0
+        bad[0, 1] = np.nan
+        bad[0, 2] = np.inf
+        np.save(tmp_path / "depths" / "train" / "img0.npy", bad)
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+        _, depth, _, _ = ds[0]
+        assert torch.isfinite(depth).all()
+        assert float(depth.min()) >= 0.0
+
+    def test_invalid_resize_mode_rejected(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        config = resolve_depth_data(yaml_path)
+
+        with pytest.raises(ValueError, match="resize_mode"):
+            DepthDataset(config, split="train", imgsz=40, resize_mode="crop")
+
+    def test_missing_split_raises(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        config = resolve_depth_data(yaml_path)
+        config.pop("test", None)
+
+        with pytest.raises(ValueError, match="no 'test' split"):
+            DepthDataset(config, split="test", imgsz=40)
+
+    def test_augment_preserves_shapes_and_values(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(
+            config, split="train", imgsz=40, augment=True, resize_mode="stretch"
+        )
+
+        for _ in range(4):
+            img, depth, _, _ = ds[0]
+            assert img.shape == (3, 40, 40)
+            assert depth.shape == (40, 40)
+            valid = depth[depth > 0]
+            assert set(np.unique(valid.numpy()).round(2)) <= {2.0, 8.0}
+
+    def test_collate_stacks_batch(self, tmp_path):
+        yaml_path = _make_dataset_root(tmp_path)
+        config = resolve_depth_data(yaml_path)
+        ds = DepthDataset(config, split="train", imgsz=40, resize_mode="stretch")
+
+        imgs, depths, infos, ids = depth_collate_fn([ds[0], ds[1]])
+        assert imgs.shape == (2, 3, 40, 40)
+        assert depths.shape == (2, 40, 40)
+        assert len(infos) == 2 and len(ids) == 2

--- a/tests/unit/test_depth_validator.py
+++ b/tests/unit/test_depth_validator.py
@@ -1,0 +1,237 @@
+"""Unit tests for the depth validator."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from PIL import Image
+
+from libreyolo.validation import DepthValidator, ValidationConfig
+from libreyolo.validation.depth_validator import align_inverse_depth
+
+pytestmark = pytest.mark.unit
+
+IMGSZ = 32
+
+NEAR_DEPTH = 2.0
+FAR_DEPTH = 8.0
+
+
+def _write_image(path: Path, width: int, height: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (width, height), color=(30, 60, 90)).save(path)
+
+
+def _write_depth(path: Path, array: np.ndarray, scale: float = 256.0) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (array * scale).round().astype(np.uint16)
+    Image.fromarray(encoded).save(path)
+
+
+def _make_dataset_yaml(root: Path, n_images: int = 2) -> Path:
+    """Square dataset: left half near (2.0), right half far (8.0)."""
+    for i in range(n_images):
+        _write_image(root / "images" / "val" / f"img{i}.jpg", IMGSZ, IMGSZ)
+        depth = np.full((IMGSZ, IMGSZ), FAR_DEPTH, dtype=np.float64)
+        depth[:, : IMGSZ // 2] = NEAR_DEPTH
+        _write_depth(root / "depths" / "val" / f"img{i}.png", depth)
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        "\n".join(
+            [
+                f"path: {root.as_posix()}",
+                "val: images/val",
+                "",
+            ]
+        )
+    )
+    return yaml_path
+
+
+class _StubDepthModel:
+    """Minimal model double satisfying the BaseValidator contract."""
+
+    size = "n"
+    names = {0: "depth"}
+    depth_resize_mode = "stretch"
+
+    def __init__(self, prediction: str = "perfect"):
+        self.model = nn.Identity()
+        self._prediction = prediction
+
+    def _get_model_name(self) -> str:
+        return "stub"
+
+    def _forward(self, images: torch.Tensor) -> torch.Tensor:
+        batch, _, height, width = images.shape
+        pred = torch.full((batch, 1, height, width), 1.0 / FAR_DEPTH)
+        pred[..., : width // 2] = 1.0 / NEAR_DEPTH
+        if self._prediction == "affine":
+            # An affine transform of the true inverse depth must be
+            # indistinguishable after scale-and-shift alignment.
+            pred = 3.0 * pred + 7.0
+        elif self._prediction == "inverted":
+            pred = pred.max() + pred.min() - pred
+        elif self._prediction == "flat":
+            pred = torch.ones((batch, 1, height, width))
+        return pred
+
+
+def _run_validator(tmp_path, prediction: str, **overrides):
+    yaml_path = _make_dataset_yaml(tmp_path)
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=IMGSZ,
+        batch_size=2,
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+        **overrides,
+    )
+    validator = DepthValidator(_StubDepthModel(prediction), config)
+    return validator.run()
+
+
+def test_align_inverse_depth_recovers_affine_transform():
+    gt = torch.rand(100).double() + 0.1
+    pred = 2.5 * gt - 0.7
+
+    aligned = align_inverse_depth(pred, gt)
+    assert torch.allclose(aligned, gt, atol=1e-6)
+
+
+def test_align_inverse_depth_degenerate_prediction_falls_back():
+    gt = torch.rand(50).double() + 0.1
+    pred = torch.full((50,), 4.0).double()
+
+    aligned = align_inverse_depth(pred, gt)
+    assert torch.isfinite(aligned).all()
+    assert float(aligned.median()) == pytest.approx(float(gt.median()), abs=1e-6)
+
+
+def test_perfect_predictions_score_perfect_metrics(tmp_path):
+    metrics = _run_validator(tmp_path, prediction="perfect")
+
+    assert metrics["metrics/abs_rel"] == pytest.approx(0.0, abs=1e-3)
+    assert metrics["metrics/delta1"] == pytest.approx(1.0)
+    assert metrics["fitness"] == pytest.approx(1.0)
+
+
+def test_affine_transformed_predictions_score_perfect_metrics(tmp_path):
+    # Relative depth contract: predictions are affine-invariant, so any
+    # scale/shift of the true inverse depth must validate perfectly.
+    metrics = _run_validator(tmp_path, prediction="affine")
+
+    assert metrics["metrics/abs_rel"] == pytest.approx(0.0, abs=1e-3)
+    assert metrics["metrics/delta1"] == pytest.approx(1.0)
+
+
+def test_inverted_predictions_do_not_score_perfect_metrics(tmp_path):
+    metrics = _run_validator(tmp_path, prediction="inverted")
+
+    assert metrics["metrics/abs_rel"] > 0.05
+    assert metrics["metrics/delta1"] < 1.0
+
+
+def test_flat_prediction_scores_imperfect_metrics(tmp_path):
+    metrics = _run_validator(tmp_path, prediction="flat")
+
+    assert np.isfinite(metrics["metrics/abs_rel"])
+    assert metrics["metrics/abs_rel"] > 0.05
+    assert metrics["metrics/delta1"] < 1.0
+
+
+def test_low_resolution_predictions_are_upsampled(tmp_path):
+    class _StrideFourModel(_StubDepthModel):
+        def _forward(self, images: torch.Tensor) -> torch.Tensor:
+            batch, _, height, width = images.shape
+            pred = torch.full(
+                (batch, 1, height // 4, width // 4), 1.0 / FAR_DEPTH
+            )
+            pred[..., : width // 8] = 1.0 / NEAR_DEPTH
+            return pred
+
+    yaml_path = _make_dataset_yaml(tmp_path)
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=IMGSZ,
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+    )
+    metrics = DepthValidator(_StrideFourModel(), config).run()
+
+    # Bilinear upsampling blurs the depth edge; everything else is exact.
+    assert metrics["metrics/delta1"] > 0.9
+
+
+def test_invalid_pixels_are_excluded(tmp_path):
+    # GT is valid on the left half only; a model predicting garbage on the
+    # invalid half must still score perfectly.
+    _write_image(tmp_path / "images" / "val" / "a.jpg", IMGSZ, IMGSZ)
+    depth = np.zeros((IMGSZ, IMGSZ), dtype=np.float64)
+    depth[:, : IMGSZ // 2] = NEAR_DEPTH
+    _write_depth(tmp_path / "depths" / "val" / "a.png", depth)
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(f"path: {tmp_path.as_posix()}\nval: images/val\n")
+
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=IMGSZ,
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+    )
+
+    class _HalfGarbageModel(_StubDepthModel):
+        def _forward(self, images: torch.Tensor) -> torch.Tensor:
+            batch, _, height, width = images.shape
+            pred = torch.full((batch, 1, height, width), 1.0 / NEAR_DEPTH)
+            pred[..., width // 2 :] = 123.0  # garbage where GT is invalid
+            return pred
+
+    metrics = DepthValidator(_HalfGarbageModel(), config).run()
+    assert metrics["metrics/abs_rel"] == pytest.approx(0.0, abs=1e-3)
+    assert metrics["metrics/delta1"] == pytest.approx(1.0)
+
+
+def test_all_invalid_pixels_raise(tmp_path):
+    _write_image(tmp_path / "images" / "val" / "a.jpg", IMGSZ, IMGSZ)
+    depth = np.zeros((IMGSZ, IMGSZ), dtype=np.float64)
+    _write_depth(tmp_path / "depths" / "val" / "a.png", depth)
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(f"path: {tmp_path.as_posix()}\nval: images/val\n")
+
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=IMGSZ,
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+    )
+
+    with pytest.raises(ValueError, match="no images with at least two valid pixels"):
+        DepthValidator(_StubDepthModel(), config).run()
+
+
+def test_imgsz_divisor_mismatch_raises(tmp_path):
+    yaml_path = _make_dataset_yaml(tmp_path)
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=IMGSZ,  # 32, not divisible by 14
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+    )
+    model = _StubDepthModel()
+    model.depth_imgsz_divisor = 14
+
+    with pytest.raises(ValueError, match="divisible by 14"):
+        DepthValidator(model, config).run()

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -8,6 +8,7 @@ from PIL import Image
 from libreyolo.models.base.inference import InferenceRunner
 from libreyolo.utils.results import (
     Boxes,
+    DepthMap,
     Keypoints,
     Masks,
     OBB,
@@ -16,7 +17,12 @@ from libreyolo.utils.results import (
     Results,
     SemanticMask,
 )
-from libreyolo.utils.drawing import draw_obb, draw_points, draw_semantic_mask
+from libreyolo.utils.drawing import (
+    draw_depth_map,
+    draw_obb,
+    draw_points,
+    draw_semantic_mask,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -246,6 +252,32 @@ class TestResults:
         assert result.probs.top1conf.item() == pytest.approx(0.7)
         assert result.probs.top5conf.tolist() == pytest.approx([0.7, 0.2, 0.1])
         assert result.summary()[0]["name"] == "b"
+
+    def test_depth_map_result_ignores_nonfinite_summary_values(self):
+        depth = DepthMap(torch.tensor([[1.0, float("nan")], [float("inf"), 3.0]]))
+        result = Results(
+            boxes=None,
+            orig_shape=(2, 2),
+            depth_map=depth,
+            names={0: "depth"},
+        )
+
+        assert len(result) == 1
+        row = result.summary()[0]
+        assert row["name"] == "depth_map"
+        assert row["min"] == pytest.approx(1.0)
+        assert row["max"] == pytest.approx(3.0)
+        assert row["mean"] == pytest.approx(2.0)
+        assert torch.isfinite(depth.normalized()).all()
+
+    def test_draw_depth_map_handles_nonfinite_values(self):
+        img = Image.new("RGB", (2, 2), color=(0, 0, 0))
+        depth = np.array([[1.0, np.nan], [np.inf, 3.0]], dtype=np.float32)
+
+        rendered = draw_depth_map(img, depth)
+
+        assert rendered.size == img.size
+        assert rendered.mode == "RGB"
 
     def test_keypoints_and_obb_accessors(self):
         keypoints = Keypoints(torch.tensor([[[10.0, 20.0, 0.9]]]), (100, 200))

--- a/tests/unit/test_rfdetr_depth.py
+++ b/tests/unit/test_rfdetr_depth.py
@@ -1,0 +1,393 @@
+"""Unit tests for RF-DETR depth estimation.
+
+Structural tests run against a lightweight fake backbone (monkeypatched
+``build_backbone``) so they stay hermetic; one real-backbone forward test is
+network-marked for nightly runs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import yaml as _yaml
+from PIL import Image
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_backbone_factory(hidden_dim: int, num_levels: int):
+    from libreyolo.models.rfdetr.nn import NestedTensor
+
+    class _FakeBackbone(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.proj = nn.Conv2d(3, hidden_dim, 14, stride=14)
+
+        def forward(self, nested):
+            x = self.proj(nested.tensors)
+            levels = [x]
+            for _ in range(num_levels - 1):
+                x = F.max_pool2d(x, 2, ceil_mode=True)
+                levels.append(x)
+            return [NestedTensor(t, None) for t in levels]
+
+    return _FakeBackbone()
+
+
+@pytest.fixture
+def fake_backbone(monkeypatch):
+    """Replace the DINOv2 backbone build with a tiny conv pyramid."""
+    import libreyolo.models.rfdetr.nn as rfdetr_nn
+
+    def _build(load_dinov2_weights=True, **kwargs):
+        backbone = _fake_backbone_factory(
+            kwargs["hidden_dim"], len(kwargs["projector_scale"])
+        )
+        return nn.Sequential(backbone, nn.Identity())
+
+    monkeypatch.setattr(rfdetr_nn, "build_backbone", _build)
+    return _build
+
+
+def _depth_targets(batch: int, size: int) -> torch.Tensor:
+    """Left half near (2.0), right half far (8.0)."""
+    targets = torch.full((batch, size, size), 8.0)
+    targets[..., : size // 2] = 2.0
+    return targets
+
+
+class TestDepthMetadata:
+    def test_task_registration(self):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        assert "depth" in LibreRFDETR.SUPPORTED_TASKS
+        assert LibreRFDETR.TASK_INPUT_SIZES["depth"]["n"] == 518
+        assert LibreRFDETR.depth_resize_mode == "stretch"
+        assert LibreRFDETR.depth_imgsz_divisor == 14
+
+    def test_can_load_recognizes_depth_signature(self):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        state = {
+            "backbone.encoder.proj.weight": torch.zeros(1),
+            "depth_head.weight": torch.zeros(1, 8, 1, 1),
+        }
+        assert LibreRFDETR.can_load(state)
+
+    def test_detect_task_from_source_prefers_metadata_then_signature(self):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        assert (
+            LibreRFDETR._detect_task_from_source({"task": "depth", "model": {}})
+            == "depth"
+        )
+        signature_ckpt = {
+            "model": {
+                "backbone.encoder.proj.weight": torch.zeros(1),
+                "depth_head.weight": torch.zeros(1, 8, 1, 1),
+            }
+        }
+        assert LibreRFDETR._detect_task_from_source(signature_ckpt) == "depth"
+
+
+class TestDepthEstimator:
+    def test_forward_loss_and_eval_shapes(self, fake_backbone):
+        from libreyolo.models.rfdetr.nn import RFDETRDepthEstimator
+
+        model = RFDETRDepthEstimator(config="n")
+        x = torch.rand(2, 3, 70, 70)
+
+        model.train()
+        targets = _depth_targets(2, 70)
+        targets[:, :8, :] = 0.0  # an invalid stripe
+        out = model(x, targets=targets)
+        assert set(out) == {"total_loss", "depth"}
+        assert torch.isfinite(out["total_loss"])
+        out["total_loss"].backward()
+        assert model.depth_head.weight.grad is not None
+
+        model.eval()
+        with torch.no_grad():
+            pred = model(x)
+        assert pred.shape == (2, 1, 70, 70)
+        assert float(pred.min()) >= 0.0  # non-negative inverse depth
+
+    def test_loss_decreases_under_optimization(self, fake_backbone):
+        from libreyolo.models.rfdetr.nn import RFDETRDepthEstimator
+
+        torch.manual_seed(0)
+        model = RFDETRDepthEstimator(config="n")
+        model.train()
+        x = torch.rand(2, 3, 70, 70)
+        targets = _depth_targets(2, 70)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+        first = None
+        last = None
+        for _ in range(8):
+            optimizer.zero_grad()
+            out = model(x, targets=targets)
+            out["total_loss"].backward()
+            optimizer.step()
+            last = float(out["total_loss"].detach())
+            if first is None:
+                first = last
+        assert last < first
+
+    def test_loss_is_scale_and_shift_invariant(self, fake_backbone):
+        from libreyolo.models.rfdetr.nn import RFDETRDepthEstimator
+
+        model = RFDETRDepthEstimator(config="n")
+        pred = torch.rand(40, 40) + 0.1
+        gt = torch.rand(40, 40) * 5 + 1.0
+
+        base = model._ssi_loss_single(pred, gt)
+        scaled = model._ssi_loss_single(4.0 * pred + 2.0, gt)
+        assert float(base) == pytest.approx(float(scaled), abs=1e-5)
+
+    def test_all_invalid_targets_yield_finite_zero_loss(self, fake_backbone):
+        from libreyolo.models.rfdetr.nn import RFDETRDepthEstimator
+
+        model = RFDETRDepthEstimator(config="n")
+        model.train()
+        out = model(
+            torch.rand(1, 3, 70, 70),
+            targets=torch.zeros((1, 70, 70)),
+        )
+
+        assert torch.isfinite(out["total_loss"])
+        assert float(out["total_loss"].detach()) == 0.0
+
+    def test_one_task_head_at_a_time(self, fake_backbone):
+        from libreyolo.models.rfdetr.nn import LibreRFDETRModel
+
+        with pytest.raises(ValueError, match="one task head"):
+            LibreRFDETRModel(config="n", depth=True, classification=True)
+
+    def test_wrapper_predict_returns_depth_map(self, fake_backbone, tmp_path):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (90, 45), color=(50, 90, 130)).save(img_path)
+
+        m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+        assert m.task == "depth"
+        assert m.input_size == 518
+
+        result = m.predict(str(img_path), imgsz=70)
+
+        assert result.boxes is None
+        assert result.depth_map is not None
+        assert tuple(result.depth_map.data.shape) == (45, 90)
+
+    def test_wrapper_predict_save_writes_colormap(self, fake_backbone, tmp_path):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (56, 56), color=(10, 20, 30)).save(img_path)
+
+        m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+        m.predict(
+            str(img_path),
+            imgsz=70,
+            save=True,
+            output_path=str(tmp_path / "out.jpg"),
+        )
+
+        assert (tmp_path / "out.jpg").exists()
+
+    def test_checkpoint_round_trip(self, fake_backbone, tmp_path):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+        state = {
+            "model": m.model.state_dict(),
+            "task": "depth",
+            "size": "n",
+            "nc": 1,
+            "names": {0: "depth"},
+        }
+        ckpt_path = tmp_path / "LibreRFDETRn-depth.pt"
+        torch.save(state, str(ckpt_path))
+
+        loaded = LibreRFDETR(model_path=str(ckpt_path), device="cpu")
+        assert loaded.task == "depth"
+        assert loaded.nb_classes == 1
+        assert loaded.names == {0: "depth"}
+
+    def test_detection_checkpoint_rejected_as_depth(self, fake_backbone, tmp_path):
+        from libreyolo.models.rfdetr.model import LibreRFDETR
+
+        ckpt_path = tmp_path / "det.pt"
+        torch.save({"model": {}, "task": "detect"}, str(ckpt_path))
+
+        with pytest.raises(ValueError, match="task="):
+            LibreRFDETR(model_path=str(ckpt_path), size="n", task="depth", device="cpu")
+
+
+def _make_depth_yaml(root, n_images=4, size=70):
+    for split in ("train", "val"):
+        for i in range(n_images):
+            img_dir = root / "images" / split
+            img_dir.mkdir(parents=True, exist_ok=True)
+            arr = np.zeros((size, size, 3), dtype=np.uint8)
+            arr[:, : size // 2] = (200, 40, 40)
+            arr[:, size // 2 :] = (40, 40, 200)
+            Image.fromarray(arr).save(img_dir / f"img{i}.jpg")
+            depth = np.full((size, size), 8.0)
+            depth[:, : size // 2] = 2.0
+            depth_dir = root / "depths" / split
+            depth_dir.mkdir(parents=True, exist_ok=True)
+            encoded = (depth * 256.0).round().astype(np.uint16)
+            Image.fromarray(encoded).save(depth_dir / f"img{i}.png")
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        _yaml.safe_dump(
+            {
+                "path": str(root),
+                "train": "images/train",
+                "val": "images/val",
+            }
+        )
+    )
+    return yaml_path
+
+
+def test_rfdetr_depth_train_smoke(fake_backbone, tmp_path):
+    """One epoch through the shared trainer with the stub backbone."""
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    yaml_path = _make_depth_yaml(tmp_path)
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+
+    res = m.train(
+        data=str(yaml_path),
+        epochs=1,
+        batch=2,
+        imgsz=70,
+        workers=0,
+        eval_interval=1,
+        project=str(tmp_path / "runs"),
+        name="depth_smoke",
+        exist_ok=True,
+        amp=False,
+        ema=False,
+        warmup_epochs=0,
+    )
+
+    assert np.isfinite(res["epoch_losses"][0])
+    assert res["epoch_metrics"][-1]["val_metrics"].get("metrics/delta1") is not None
+
+
+def test_rfdetr_depth_predict_rejects_non_patch_imgsz(fake_backbone, tmp_path):
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    img_path = tmp_path / "img.jpg"
+    Image.new("RGB", (64, 64), color=(10, 20, 30)).save(img_path)
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+
+    with pytest.raises(ValueError, match="divisible by 14"):
+        m.predict(str(img_path), imgsz=100)
+
+
+def test_rfdetr_depth_train_rejects_non_patch_imgsz(fake_backbone, tmp_path):
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    yaml_path = _make_depth_yaml(tmp_path)
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+
+    with pytest.raises(ValueError, match="divisible by 14"):
+        m.train(
+            data=str(yaml_path),
+            epochs=1,
+            batch=2,
+            imgsz=64,
+            workers=0,
+            eval_interval=0,
+            project=str(tmp_path / "runs"),
+            name="bad_imgsz",
+            exist_ok=True,
+            amp=False,
+            ema=False,
+            warmup_epochs=0,
+        )
+
+
+def test_rfdetr_depth_rejects_lora(fake_backbone, tmp_path):
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    yaml_path = _make_depth_yaml(tmp_path)
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+
+    with pytest.raises(ValueError, match="lora"):
+        m.train(
+            data=str(yaml_path),
+            epochs=1,
+            batch=2,
+            imgsz=70,
+            workers=0,
+            eval_interval=0,
+            project=str(tmp_path / "runs"),
+            name="lora_reject",
+            exist_ok=True,
+            amp=False,
+            ema=False,
+            warmup_epochs=0,
+            lora=True,
+        )
+
+
+def test_rfdetr_depth_tta_rejected(fake_backbone, tmp_path):
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    img_path = tmp_path / "img.jpg"
+    Image.new("RGB", (56, 56), color=(10, 20, 30)).save(img_path)
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+
+    with pytest.raises(ValueError, match="augment"):
+        m.predict(str(img_path), imgsz=70, augment=True)
+
+
+def test_rfdetr_depth_tiling_rejected(fake_backbone, tmp_path):
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    img_path = tmp_path / "img.jpg"
+    Image.new("RGB", (128, 128), color=(10, 20, 30)).save(img_path)
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+
+    with pytest.raises(ValueError, match="Tiled inference"):
+        m.predict(str(img_path), imgsz=70, tiling=True)
+
+
+def test_rfdetr_depth_tracking_rejected(fake_backbone, tmp_path):
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+
+    with pytest.raises(NotImplementedError, match="Tracking"):
+        list(m.track(tmp_path / "missing.mp4"))
+
+
+@pytest.mark.external_data
+@pytest.mark.network
+@pytest.mark.slow
+def test_rfdetr_depth_forward_real_backbone():
+    """RF-DETR depth build + forward (DINOv2 backbone; random-init if offline)."""
+    from libreyolo import LibreRFDETR
+
+    m = LibreRFDETR(model_path=None, size="n", task="depth", device="cpu")
+    assert m.task == "depth"
+    assert m.input_size == 518
+    assert m.model.depth
+
+    x = torch.rand(1, 3, 518, 518)
+    m.model.train()
+    out = m.model(x, targets=_depth_targets(1, 518))
+    assert "total_loss" in out
+
+    m.model.eval()
+    with torch.no_grad():
+        assert m.model(x).shape == (1, 1, 518, 518)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -40,6 +40,14 @@ def test_point_task_has_no_aliases():
             normalize_task(alias)
 
 
+def test_normalize_depth_task_aliases():
+    assert normalize_task("depth") == "depth"
+    assert normalize_task("depth-estimation") == "depth"
+    assert normalize_task("depth_estimation") == "depth"
+    assert normalize_task("monodepth") == "depth"
+    assert normalize_task("monocular-depth") == "depth"
+
+
 def test_task_type_literal_is_public():
     assert set(TaskType.__args__) == {
         "detect",
@@ -50,6 +58,7 @@ def test_task_type_literal_is_public():
         "gaze",
         "obb",
         "point",
+        "depth",
     }
 
 
@@ -91,8 +100,10 @@ def test_task_suffix_helpers():
     assert suffix_to_task("-sem") == "semantic"
     assert suffix_to_task("-obb") == "obb"
     assert suffix_to_task("-point") == "point"
+    assert suffix_to_task("-depth") == "depth"
     assert task_to_suffix("obb") == "obb"
     assert task_to_suffix("point") == "point"
+    assert task_to_suffix("depth") == "depth"
     assert task_to_suffix("semantic") == "sem"
     assert suffix_to_task("-unknown") is None
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added end-to-end depth estimation support (training, validation, inference) with dense `depth_map` outputs and depth colormap visualizations.
  * Introduced a depth dataset loader for aligned dense maps (PNG/TIF and `.npy`) with validity handling and collate support.
  * Extended task handling and RF-DETR depth model wiring; depth tiling/TTA/export/tracking are explicitly not supported yet.

* **Documentation**
  * Published canonical depth contracts and updated checkpoint/dataset/schema docs and task naming.

* **Tests**
  * Added unit tests covering depth datasets, validation, results visualization, and RF-DETR depth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->