### PR TITLE
Fix export opset and output names

### DIFF
--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -19,12 +19,13 @@ import torch
 
 from .onnx import (
     _get_version,
-    _uses_dfine_style_export_wrapper,
+    _requires_onnx_opset17,
     check_onnx_int8_available,
     export_onnx,
     quantize_onnx_int8,
 )
 from .torchscript import export_torchscript
+from ..tasks import task_to_suffix
 from ..utils.serialization import SCHEMA_VERSION
 
 logger = logging.getLogger(__name__)
@@ -245,7 +246,7 @@ class BaseExporter(ABC):
             # in the tuple export wrapper). Other families default to 13.
             opset = (
                 17
-                if _uses_dfine_style_export_wrapper(self.model._get_model_name())
+                if _requires_onnx_opset17(self.model._get_model_name())
                 else 13
             )
 
@@ -446,26 +447,37 @@ class BaseExporter(ABC):
         return imgsz, device, output_path
 
     def _auto_output_path(self, half: bool, int8: bool) -> str:
-        model_name = self.model._get_model_name().lower()
-        task = getattr(self.model, "task", "detect")
-        is_segment = (
-            task == "segment" or getattr(self.model, "_is_segmentation", False) is True
-        )
-        if is_segment:
-            task_suffix = "_seg"
-        elif task == "pose":
-            task_suffix = "_pose"
-        elif task == "obb":
-            task_suffix = "_obb"
-        elif task == "classify":
-            task_suffix = "_cls"
-        else:
-            task_suffix = ""
+        stem = self._auto_output_stem()
         precision_suffix = "_int8" if int8 else ("_fp16" if half else "")
-        return str(
-            Path("weights")
-            / f"{model_name}_{self.model.size}{task_suffix}{precision_suffix}{self.suffix}"
-        )
+        return str(Path("weights") / f"{stem}{precision_suffix}{self.suffix}")
+
+    def _auto_output_stem(self) -> str:
+        model_path = getattr(self.model, "model_path", None)
+        if isinstance(model_path, (str, Path)):
+            source = Path(model_path)
+            if source.suffix.lower() in {".pt", ".pth", ".safetensors"}:
+                return source.stem
+
+        prefix = getattr(self.model, "FILENAME_PREFIX", None)
+        size = getattr(self.model, "size", None)
+        if isinstance(prefix, str) and prefix and isinstance(size, str) and size:
+            task_suffix = self._auto_output_task_suffix()
+            return f"{prefix}{size}{task_suffix}"
+
+        model_name = self.model._get_model_name().lower()
+        return f"{model_name}_{self.model.size}"
+
+    def _auto_output_task_suffix(self) -> str:
+        task = getattr(self.model, "task", "detect")
+        if not isinstance(task, str):
+            task = "detect"
+        if getattr(self.model, "_is_segmentation", False) is True:
+            task = "segment"
+        try:
+            suffix = task_to_suffix(task)
+        except ValueError:
+            return ""
+        return f"-{suffix}" if suffix else ""
 
     @contextmanager
     def _model_context(self, device, half, int8, batch, imgsz):

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -487,8 +487,10 @@ class BaseExporter(ABC):
             task = "segment"
         try:
             suffix = task_to_suffix(task)
-        except ValueError:
-            return ""
+        except ValueError as exc:
+            raise ValueError(
+                f"Unsupported task for auto output naming: {task!r}"
+            ) from exc
         return f"-{suffix}" if suffix else ""
 
     @contextmanager

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -538,7 +538,7 @@ class BaseExporter(ABC):
             nn_model = ECExportWrapper(nn_model).to(device)
             nn_model.eval()
             dfine_wrapped = True  # share the YOLOX-head-export skip path below
-        elif family in {"rtdetr", "rtdetrv2"}:
+        elif family in {"rtdetr", "rtdetrv2", "rtdetrv4"}:
             nn_model = _RTDETRExportWrapper(nn_model).to(device)
             nn_model.eval()
             dfine_wrapped = True

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -125,6 +125,18 @@ _RECTANGULAR_EXPORT_FORMATS = {
 }
 
 
+class _RTDETRExportWrapper(torch.nn.Module):
+    """Trace RT-DETR dict outputs as the two tensors used by exported backends."""
+
+    def __init__(self, model: torch.nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x):
+        outputs = self.model(x)
+        return outputs["pred_logits"], outputs["pred_boxes"]
+
+
 # =============================================================================
 # BaseExporter ABC
 # =============================================================================
@@ -524,6 +536,10 @@ class BaseExporter(ABC):
             nn_model = ECExportWrapper(nn_model).to(device)
             nn_model.eval()
             dfine_wrapped = True  # share the YOLOX-head-export skip path below
+        elif family in {"rtdetr", "rtdetrv2"}:
+            nn_model = _RTDETRExportWrapper(nn_model).to(device)
+            nn_model.eval()
+            dfine_wrapped = True
         elif family == "rfdetr" and getattr(self.model, "task", None) == "classify":
             # Classification has no detection decoder; trace the backbone +
             # linear classifier directly (it returns logits). The detection

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -26,6 +26,20 @@ def _uses_dfine_style_export_wrapper(model_family) -> bool:
     return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetrv4"}
 
 
+def _requires_onnx_opset17(model_family) -> bool:
+    """Whether the family needs opset 17 for ONNX auto-opset selection."""
+    return model_family in {
+        "dfine",
+        "deim",
+        "deimv2",
+        "ec",
+        "rfdetr",
+        "rtdetr",
+        "rtdetrv2",
+        "rtdetrv4",
+    }
+
+
 def _set_metadata(model_proto, metadata: dict) -> None:
     """Replace ONNX metadata with the provided key/value pairs."""
     del model_proto.metadata_props[:]

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -5,6 +5,17 @@ import warnings
 
 import torch
 
+_DETR_TUPLE_OUTPUT_FAMILIES = {
+    "dfine",
+    "deim",
+    "deimv2",
+    "ec",
+    "rfdetr",
+    "rtdetr",
+    "rtdetrv2",
+    "rtdetrv4",
+}
+
 
 def _get_version() -> str:
     """Return the installed libreyolo version string."""
@@ -23,21 +34,12 @@ def _uses_dfine_style_export_wrapper(model_family) -> bool:
     module that returns a 2-tuple. ONNX export can skip the dynamic output
     probe for them, and they all need opset 17 for ``aten::scaled_dot_product``.
     """
-    return model_family in {"dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetrv4"}
+    return model_family in _DETR_TUPLE_OUTPUT_FAMILIES
 
 
 def _requires_onnx_opset17(model_family) -> bool:
     """Whether the family needs opset 17 for ONNX auto-opset selection."""
-    return model_family in {
-        "dfine",
-        "deim",
-        "deimv2",
-        "ec",
-        "rfdetr",
-        "rtdetr",
-        "rtdetrv2",
-        "rtdetrv4",
-    }
+    return model_family in _DETR_TUPLE_OUTPUT_FAMILIES
 
 
 def _set_metadata(model_proto, metadata: dict) -> None:

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -727,7 +727,7 @@ def test_tensorrt_backend_detects_obb_task_from_filename():
     from libreyolo.backends.tensorrt import TensorRTBackend
 
     backend = object.__new__(TensorRTBackend)
-    backend.model_path = "weights/yolo9_t_obb.engine"
+    backend.model_path = "weights/LibreYOLO9t-obb.engine"
 
     assert backend._detect_task_from_filename() == "obb"
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -68,6 +68,21 @@ class _TinyRFDETRExport(nn.Module):
         return boxes, logits
 
 
+class _TinyRTDETRExport(nn.Module):
+    """Small RT-DETR-shaped module that returns the native output dict."""
+
+    def __init__(self):
+        super().__init__()
+        self.anchor = nn.Parameter(torch.zeros(()))
+
+    def forward(self, x):
+        batch = x.shape[0]
+        signal = x.mean(dim=(1, 2, 3), keepdim=True) + self.anchor
+        logits = signal.reshape(batch, 1, 1).expand(batch, 3, 2)
+        boxes = signal.reshape(batch, 1, 1).expand(batch, 3, 4)
+        return {"pred_logits": logits, "pred_boxes": boxes}
+
+
 class _TinyRFDETRClassifierRoot(nn.Module):
     """Small RF-DETR classification root with a classifier submodule."""
 
@@ -355,12 +370,18 @@ class TestExporterFormats:
         wrapper = _make_wrapper(model_name=family)
         if family == "rfdetr":
             wrapper.model = _TinyRFDETRExport(segmentation=False)
+        elif family in {"rtdetr", "rtdetrv2"}:
+            wrapper.model = _TinyRTDETRExport()
         wrapper.task = "detect"
         wrapper.SUPPORTED_TASKS = ("detect",)
         wrapper.DEFAULT_TASK = "detect"
 
         def fake_export_onnx(_nn_model, _dummy, **kwargs):
             captured.update(kwargs)
+            if family in {"rtdetr", "rtdetrv2"}:
+                output = _nn_model(_dummy)
+                captured["output_is_tuple"] = isinstance(output, tuple)
+                captured["output_len"] = len(output)
             Path(kwargs["output_path"]).write_bytes(b"onnx")
             return kwargs["output_path"]
 
@@ -376,6 +397,9 @@ class TestExporterFormats:
 
         assert exported == str(output_path)
         assert captured["opset"] == 17
+        if family in {"rtdetr", "rtdetrv2"}:
+            assert captured["output_is_tuple"] is True
+            assert captured["output_len"] == 2
 
     @pytest.mark.parametrize(
         ("task", "segmentation", "obb", "expected_outputs"),
@@ -409,6 +433,30 @@ class TestExporterFormats:
         proto = onnx.load(output_path)
         assert [i.name for i in proto.graph.input] == ["input"]
         assert [o.name for o in proto.graph.output] == expected_outputs
+
+    @pytest.mark.parametrize("family", ["rtdetr", "rtdetrv2"])
+    def test_rtdetr_onnx_uses_detr_io_names(self, tmp_path, family):
+        onnx = pytest.importorskip("onnx")
+        output_path = tmp_path / f"{family}.onnx"
+
+        export_onnx(
+            _TinyRTDETRExport(),
+            torch.zeros(1, 3, 32, 32),
+            output_path=str(output_path),
+            opset=17,
+            simplify=False,
+            dynamic=False,
+            half=False,
+            metadata={
+                "model_family": family,
+                "task": "detect",
+                "segmentation": "false",
+            },
+        )
+
+        proto = onnx.load(output_path)
+        assert [i.name for i in proto.graph.input] == ["images"]
+        assert [o.name for o in proto.graph.output] == ["pred_logits", "pred_boxes"]
 
     def test_onnx_metadata_uses_export_imgsz_override(self, tmp_path):
         onnx = pytest.importorskip("onnx")

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -434,24 +434,21 @@ class TestExporterFormats:
         assert [i.name for i in proto.graph.input] == ["input"]
         assert [o.name for o in proto.graph.output] == expected_outputs
 
-    @pytest.mark.parametrize("family", ["rtdetr", "rtdetrv2"])
+    @pytest.mark.parametrize("family", ["rtdetr", "rtdetrv2", "rtdetrv4"])
     def test_rtdetr_onnx_uses_detr_io_names(self, tmp_path, family):
         onnx = pytest.importorskip("onnx")
+        wrapper = _make_wrapper(model_name=family, input_size=32)
+        wrapper.model = _TinyRTDETRExport()
+        wrapper.task = "detect"
+        wrapper.SUPPORTED_TASKS = ("detect",)
+        wrapper.DEFAULT_TASK = "detect"
         output_path = tmp_path / f"{family}.onnx"
 
-        export_onnx(
-            _TinyRTDETRExport(),
-            torch.zeros(1, 3, 32, 32),
+        OnnxExporter(wrapper)(
             output_path=str(output_path),
-            opset=17,
             simplify=False,
             dynamic=False,
-            half=False,
-            metadata={
-                "model_family": family,
-                "task": "detect",
-                "segmentation": "false",
-            },
+            device="cpu",
         )
 
         proto = onnx.load(output_path)

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -957,6 +957,15 @@ class TestOutputPathGeneration:
             Path("weights") / "LibreRFDETRn-obb_fp16.onnx"
         )
 
+    def test_auto_path_rejects_unknown_task(self):
+        wrapper = _make_wrapper(model_name="yolo9", size="t")
+        wrapper.FILENAME_PREFIX = "LibreYOLO9"
+        wrapper.task = "bad-task"
+        exporter = OnnxExporter(wrapper)
+
+        with pytest.raises(ValueError, match="Unsupported task for auto output naming"):
+            exporter._auto_output_path(half=False, int8=False)
+
     def test_explicit_path(self):
         wrapper = _make_wrapper()
         exporter = TorchScriptExporter(wrapper)

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -88,6 +88,8 @@ def _make_wrapper(nb_classes=4, model_name="TESTYOLO", size="s", input_size=32):
     wrapper.nb_classes = nb_classes
     wrapper.names = {i: f"class_{i}" for i in range(nb_classes)}
     wrapper.device = torch.device("cpu")
+    wrapper.model_path = None
+    wrapper.FILENAME_PREFIX = ""
     wrapper._get_model_name.return_value = model_name
     wrapper._get_input_size.return_value = input_size
     return wrapper
@@ -347,10 +349,12 @@ class TestExporterFormats:
 
         assert device == torch.device("cuda:0")
 
-    def test_rfdetr_export_auto_opset_is_17(self, monkeypatch, tmp_path):
+    @pytest.mark.parametrize("family", ["rfdetr", "rtdetr", "rtdetrv2"])
+    def test_detr_export_auto_opset_is_17(self, monkeypatch, tmp_path, family):
         captured = {}
-        wrapper = _make_wrapper(model_name="rfdetr")
-        wrapper.model = _TinyRFDETRExport(segmentation=False)
+        wrapper = _make_wrapper(model_name=family)
+        if family == "rfdetr":
+            wrapper.model = _TinyRFDETRExport(segmentation=False)
         wrapper.task = "detect"
         wrapper.SUPPORTED_TASKS = ("detect",)
         wrapper.DEFAULT_TASK = "detect"
@@ -361,7 +365,7 @@ class TestExporterFormats:
             return kwargs["output_path"]
 
         monkeypatch.setattr("libreyolo.export.exporter.export_onnx", fake_export_onnx)
-        output_path = tmp_path / "rfdetr.onnx"
+        output_path = tmp_path / f"{family}.onnx"
 
         exported = OnnxExporter(wrapper)(
             output_path=str(output_path),
@@ -843,6 +847,7 @@ class TestExporterValidation:
 class TestOutputPathGeneration:
     def test_auto_path_torchscript(self):
         wrapper = _make_wrapper(model_name="yolo9", size="t")
+        wrapper.model_path = "weights/LibreYOLO9t.pt"
         exporter = TorchScriptExporter(wrapper)
         with tempfile.TemporaryDirectory() as tmpdir:
             import os
@@ -851,44 +856,57 @@ class TestOutputPathGeneration:
             try:
                 os.chdir(tmpdir)
                 path = exporter()
-                assert path == str(Path("weights") / "yolo9_t.torchscript")
+                assert path == str(Path("weights") / "LibreYOLO9t.torchscript")
                 assert Path(path).exists()
             finally:
                 os.chdir(orig)
 
+    def test_auto_path_prefers_weight_file_stem(self):
+        wrapper = _make_wrapper(model_name="yolo9", size="t")
+        wrapper.FILENAME_PREFIX = "LibreYOLO9"
+        wrapper.model_path = "runs/train/best.pt"
+        exporter = OnnxExporter(wrapper)
+
+        assert exporter._auto_output_path(half=False, int8=False) == str(
+            Path("weights") / "best.onnx"
+        )
+
     def test_auto_path_includes_segmentation_task(self):
         wrapper = _make_wrapper(model_name="rfdetr", size="n")
+        wrapper.FILENAME_PREFIX = "LibreRFDETR"
         wrapper.task = "segment"
         exporter = OnnxExporter(wrapper)
         assert exporter._auto_output_path(half=False, int8=False) == str(
-            Path("weights") / "rfdetr_n_seg.onnx"
+            Path("weights") / "LibreRFDETRn-seg.onnx"
         )
         assert exporter._auto_output_path(half=True, int8=False) == str(
-            Path("weights") / "rfdetr_n_seg_fp16.onnx"
+            Path("weights") / "LibreRFDETRn-seg_fp16.onnx"
         )
 
     def test_auto_path_includes_obb_task(self):
         wrapper = _make_wrapper(model_name="yolo9", size="t")
+        wrapper.FILENAME_PREFIX = "LibreYOLO9"
         wrapper.task = "obb"
         exporter = OnnxExporter(wrapper)
 
         assert exporter._auto_output_path(half=False, int8=False) == str(
-            Path("weights") / "yolo9_t_obb.onnx"
+            Path("weights") / "LibreYOLO9t-obb.onnx"
         )
         assert exporter._auto_output_path(half=True, int8=False) == str(
-            Path("weights") / "yolo9_t_obb_fp16.onnx"
+            Path("weights") / "LibreYOLO9t-obb_fp16.onnx"
         )
 
     def test_auto_path_includes_rfdetr_obb_task(self):
         wrapper = _make_wrapper(model_name="rfdetr", size="n")
+        wrapper.FILENAME_PREFIX = "LibreRFDETR"
         wrapper.task = "obb"
         exporter = OnnxExporter(wrapper)
 
         assert exporter._auto_output_path(half=False, int8=False) == str(
-            Path("weights") / "rfdetr_n_obb.onnx"
+            Path("weights") / "LibreRFDETRn-obb.onnx"
         )
         assert exporter._auto_output_path(half=True, int8=False) == str(
-            Path("weights") / "rfdetr_n_obb_fp16.onnx"
+            Path("weights") / "LibreRFDETRn-obb_fp16.onnx"
         )
 
     def test_explicit_path(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ONNX opset auto-selection for DETR-style exports, consistently defaulting to opset 17 when required.
  * Refined automatic export filename generation with clearer stems, precision suffixes, and task-specific suffixing (including correct handling for segmentation).
  * Updated RT-DETR/RT-DETRv2/RT-DETRv4 ONNX export outputs to match expected tuple/tensor structures.

* **Tests**
  * Expanded and parameterized ONNX/TorchScript export tests for deterministic output naming, opset selection, and DETR IO naming/output expectations.
  * Updated TensorRT OBB filename detection test to reflect the new engine naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->