### PR TITLE
Add LibreSAM tier for promptable segmentation (SAM family)

### DIFF
--- a/docs/adr/0005-libresam-contract.md
+++ b/docs/adr/0005-libresam-contract.md
@@ -1,0 +1,140 @@
+# ADR 0005: LibreSAM Contract For Promptable Segmentation
+
+- Status: Proposed
+- Date: 2026-06-14
+- Scope: New model tier (promptable segmentation models — the SAM family)
+
+## Context
+
+LibreYOLO has two model entry points:
+
+- `LibreYOLO(...)` — a weight-sniffing factory over faithful detectors. Every
+  member runs one **promptless** forward and returns *all* objects with
+  calibrated scores; members register via `can_load` into `BaseModel._registry`.
+  `LibreEC` proves masks (`segment` task) live happily here, because its masks
+  are produced automatically with no prompt.
+- `LibreVLM(...)` — a parallel tier (ADR 0002) for generative open-vocabulary
+  detectors. It is separated by **contract fidelity**, not architecture, and
+  loads through the permissive `transformers` model API so LibreYOLO ships no
+  model source and stays MIT.
+
+Promptable segmentation (the SAM family) fits neither:
+
+- It is **promptable**: a forward is meaningless without a per-image *spatial*
+  prompt (a point or box) supplied at call time. "A detection" becomes "the
+  thing you pointed at", not "everything found".
+- It is **interactive/stateful**: the heavy image encoder runs once
+  (`set_image`), then many cheap prompts reuse the cached embedding.
+- Its output is **masks**, and its scores are real mask-quality (predicted-IoU)
+  values, not detection confidences.
+
+Forcing this through the promptless `InferenceRunner` (preprocess → forward →
+postprocess → NMS) would misrepresent the call shape. So, as with LibreVLM, the
+line is drawn on contract, and the tier owns its own `predict` surface.
+
+## Decision
+
+Add a third tier, `LibreSAM`, for promptable segmentation. It mirrors LibreVLM's
+shape:
+
+- A base class `LibreSAMModel(BaseModel)` that does **not** define `can_load`,
+  keeping the family out of the detector `_registry` and the `LibreYOLO`
+  factory.
+- Loads through the permissive `transformers` `SamModel` / `SamProcessor` API;
+  ships no model source. SAM-1 code and weights are Apache-2.0, so the default
+  family is clean MIT with no license gate.
+- Returns the same `Results` (with `masks`, plus tight `boxes` derived from the
+  masks via `masks_to_boxes`, class id `0` = `"object"`), so downstream code is
+  unchanged.
+
+The default family is **SAM-1** (`facebook/sam-vit-base` / `-large` / `-huge`),
+autodownloaded on first use.
+
+## Public API
+
+The surface mirrors the de-facto-standard promptable interface (sourced from
+public documentation, clean-room), expressed with LibreYOLO's own loading idiom
+(size aliases + autodownload, as LibreVLM does — not checkpoint-filename
+dispatch):
+
+```python
+from libreyolo import LibreSAM
+
+model = LibreSAM("base")                                   # autodownloads (Apache-2.0)
+model.predict("img.jpg", points=[900, 370], labels=[1])    # point  -> mask
+model.predict("img.jpg", bboxes=[100, 100, 200, 200])      # box    -> mask
+model.predict("img.jpg")                                   # segment everything (grid AMG)
+
+model.set_image("img.jpg")                                 # encode once...
+a = model.predict(points=[500, 375], labels=[1])           # ...prompt cheaply
+b = model.predict(bboxes=[100, 100, 200, 200])
+model.reset_image()
+
+r.masks.xy        # polygons
+r.boxes.xyxy      # tight boxes derived from masks
+```
+
+- Points/boxes accept the documented flexible nesting (`[x, y]` = one object;
+  `[[x, y], ...]` = N objects; `[[[x, y], ...], ...]` = grouped per object), and
+  numpy arrays. Labels are `1` positive / `0` negative, default all positive.
+- `multimask=True` returns *all* of SAM's ambiguity masks per prompt (whole vs
+  part); the default returns the single best by predicted IoU.
+- `conf` filters by predicted mask-IoU (mask quality, **not** a detection
+  confidence). `None` keeps all in the prompted path and applies the family grid
+  threshold in "segment everything"; `0.0` disables filtering in either mode.
+- `device=` on `predict` moves the model and invalidates the cached embedding.
+
+## Internal Contract
+
+`LibreSAMModel` satisfies `BaseModel`'s abstract hooks but overrides `predict()`
+/ `__call__` directly rather than driving `InferenceRunner` — the promptless
+preprocess/forward/postprocess hooks have no meaning here and raise. The
+encode-once lifecycle lives in `set_image()` (caches image embeddings) and is
+reused by every later `predict()` until `reset_image()` or a device change.
+
+| Field             | Meaning                                              |
+|-------------------|------------------------------------------------------|
+| `FAMILY`          | family id (`sam`)                                    |
+| `FILENAME_PREFIX` | `Libre`-prefixed weights-dir prefix                  |
+| `HF_REPOS`        | `{size: hf_repo_id}`; drives autodownload            |
+| `INPUT_SIZES`     | `{size: nominal_px}` (1024; the processor owns resize)|
+
+## Confidence
+
+Returned `conf` is SAM's predicted mask-IoU (mask quality), surfaced honestly as
+a soft score, not a calibrated detection confidence. `val()` (mAP) is
+unsupported — promptable masks have no fixed class set to score against.
+
+## Licensing
+
+SAM-1 code and weights are Apache-2.0; no gate, no notice. SAM-3's custom "SAM
+License" is gated (download requires accepting Meta's terms) and would follow
+the existing LibreVLM license-notice pattern when added — never vendoring the
+SAM-licensed modeling code.
+
+## Out Of Scope (v1)
+
+- SAM-2 (Hiera backbone, video/memory) and SAM-3 (concept/open-vocab seg,
+  gated). Both slot onto this same tier later.
+- Mask prompts (`masks=`), `train()`, `val()`, `export()`, and `track()` raise.
+- "Segment everything" is a simplified grid AMG (predicted-IoU threshold +
+  box-IoU dedup); it omits stability-score filtering, multi-crop, and mask-IoU
+  dedup, and is documented as approximate. The prompted path is the precise API.
+
+## Consequences
+
+### Positive
+
+- Promptable, interactive segmentation behind a familiar predict surface and the
+  standard `Results`.
+- No change to the detector factory; the family is fully isolated.
+- A new SAM variant is a small adapter (repos, sizes).
+
+### Negative
+
+- `BaseModel`'s abstract surface is detector-shaped, so SAM stubs four unused
+  hooks (the same tax LibreVLM pays). A future slim `transformers`-backed
+  intermediate base could de-duplicate the weight-acquisition/dtype logic the
+  two tiers now share.
+- The simplified AMG under-segments crowded scenes versus the reference
+  generator.

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -93,6 +93,8 @@ def __getattr__(name):
         "LibreInternVL3": (".models.vlm", "LibreInternVL3"),
         "LibreFlorence2": (".models.vlm", "LibreFlorence2"),
         "LibreKosmos2": (".models.vlm", "LibreKosmos2"),
+        "LibreSAM": (".models.sam", "LibreSAM"),
+        "LibreSAM1": (".models.sam", "LibreSAM1"),
         "DATASETS_DIR": (".data", "DATASETS_DIR"),
         "load_data_config": (".data", "load_data_config"),
         "check_dataset": (".data", "check_dataset"),
@@ -138,6 +140,9 @@ __all__ = [
     "LibreInternVL3",
     "LibreFlorence2",
     "LibreKosmos2",
+    # Promptable-segmentation tier (optional, requires libreyolo[sam])
+    "LibreSAM",
+    "LibreSAM1",
     # Results
     "Results",
     "Boxes",

--- a/libreyolo/models/sam/__init__.py
+++ b/libreyolo/models/sam/__init__.py
@@ -1,0 +1,12 @@
+"""LibreSAM tier: promptable segmentation models (SAM family).
+
+See ``model.py`` for the ``LibreSAM(...)`` factory and ``base.py`` for the
+``LibreSAMModel`` interactive contract.
+"""
+
+from __future__ import annotations
+
+from .base import LibreSAMModel
+from .model import LibreSAM, LibreSAM1
+
+__all__ = ["LibreSAM", "LibreSAMModel", "LibreSAM1"]

--- a/libreyolo/models/sam/base.py
+++ b/libreyolo/models/sam/base.py
@@ -1,0 +1,604 @@
+"""Base class for the ``LibreSAM`` tier: promptable segmentation models.
+
+A promptable segmenter is fundamentally different from the detectors in the
+``LibreYOLO`` factory: instead of one promptless forward returning every
+object, it runs a heavy image encoder once and then answers cheap *spatial
+prompts* (points, boxes) by returning a mask. So this tier exposes an
+interactive surface — ``set_image()`` to encode once, then ``predict(points=,
+bboxes=)`` to prompt many times — plus a "segment everything" mode when no
+prompt is given.
+
+The model is loaded through the permissive ``transformers`` model API (so
+LibreYOLO ships no model source and stays MIT, exactly as the LibreVLM tier
+does). Like LibreVLM, this base does NOT define ``can_load``, which keeps the
+family out of the state-dict ``_registry`` and the ``LibreYOLO`` factory.
+
+See ``docs/adr/0005-libresam-contract.md`` for the contract and the
+clean-room API notes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from ...utils.image_loader import ImageInput, ImageLoader
+from ...utils.results import Boxes, Masks, Results
+from ..base.model import BaseModel
+from .prompts import (
+    build_point_grid,
+    normalize_boxes,
+    normalize_labels,
+    normalize_points,
+)
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "LibreSAM models require the 'sam' extra. Install with:\n"
+    "    pip install 'libreyolo[sam]'"
+)
+_SNAPSHOT_COMPLETE_MARKER = ".libreyolo_snapshot_complete"
+
+
+def _is_empty_prompt(prompt) -> bool:
+    """True for ``None`` and empty containers (so they route to "everything").
+
+    Accepts lists/tuples/numpy arrays; a non-empty array of coordinates is not
+    empty. Anything without a length (e.g. a stray scalar) is treated as a real
+    prompt and left for normalization to validate.
+    """
+    if prompt is None:
+        return True
+    try:
+        return len(prompt) == 0
+    except TypeError:
+        return False
+
+
+class LibreSAMModel(BaseModel):
+    """Promptable segmentation model with an encode-once / prompt-many surface."""
+
+    # Subclasses override these.
+    FAMILY: ClassVar[str] = ""
+    FILENAME_PREFIX: ClassVar[str] = ""
+    HF_REPOS: ClassVar[Dict[str, str]] = {}
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {}
+    SUPPORTED_TASKS: ClassVar[tuple] = ("segment",)
+    DEFAULT_TASK: ClassVar[str] = "segment"
+
+    # The interactive lifecycle is bespoke; the detection pipeline's
+    # multi-scale TTA is meaningless here.
+    TTA_ENABLED: ClassVar[bool] = False
+
+    # "Segment everything" defaults (basic automatic mask generation).
+    DEFAULT_POINTS_PER_SIDE: ClassVar[int] = 32
+    DEFAULT_PRED_IOU_THRESH: ClassVar[float] = 0.88
+    GRID_CHUNK: ClassVar[int] = 64
+    AMG_NMS_IOU: ClassVar[float] = 0.7
+
+    # Off by default: SAM families load through native transformers classes.
+    SNAPSHOT_IGNORE_PATTERNS: ClassVar[tuple[str, ...]] = (
+        "*.onnx",
+        "onnx/*",
+        "*.tflite",
+        "*.msgpack",
+        "*.h5",
+    )
+
+    # =========================================================================
+    # Construction
+    # =========================================================================
+
+    def __init__(
+        self,
+        size: str,
+        *,
+        device: str = "auto",
+        task: str | None = None,
+        multimask: bool = False,
+        **kwargs,
+    ):
+        if size not in self.HF_REPOS:
+            raise ValueError(
+                f"Invalid size {size!r} for {type(self).__name__}. "
+                f"Must be one of: {', '.join(self.HF_REPOS)}"
+            )
+        self._default_multimask = multimask
+        # Single foreground class; promptable masks are class-agnostic "object".
+        super().__init__(
+            model_path=self.HF_REPOS[size],
+            size=size,
+            nb_classes=1,
+            device=device,
+            task=task,
+            **kwargs,
+        )
+        self.names = {0: "object"}
+        self.model.eval()
+        self._clear_image_state()
+
+    # =========================================================================
+    # Weight acquisition (autodownload via Hugging Face)
+    # =========================================================================
+
+    @staticmethod
+    def _snapshot_complete(local_dir: Path) -> bool:
+        """True only if the marker, config, and an actual weight file exist.
+
+        config.json + marker alone is not proof: an interrupted download can
+        write them without the safetensors/bin payload, so check for a weight
+        file too (mirrors the LibreVLM weight-acquisition guard).
+        """
+        if not (local_dir / _SNAPSHOT_COMPLETE_MARKER).exists():
+            return False
+        if not (local_dir / "config.json").exists():
+            return False
+        return any(local_dir.glob("*.safetensors")) or any(local_dir.glob("*.bin"))
+
+    def _ensure_weights(self) -> str:
+        """Return a local weights dir for this size, downloading if needed.
+
+        Downloads into ``weights/<FILENAME_PREFIX><size>/`` (copies, no
+        symlinks) to match LibreYOLO's ``weights/`` convention and avoid the
+        symlinked HF cache, which needs admin/Developer Mode on Windows.
+        """
+        repo = self.HF_REPOS[self.size]
+        local_dir = Path("weights") / f"{self.FILENAME_PREFIX}{self.size}"
+        if self._snapshot_complete(local_dir):
+            return str(local_dir)
+        try:
+            from huggingface_hub import snapshot_download
+            import transformers  # noqa: F401  (ships with the extra)
+        except ImportError as exc:
+            raise ImportError(_INSTALL_HINT) from exc
+        logger.info(
+            "Downloading %s weights from %s -> %s ...", self.FAMILY, repo, local_dir
+        )
+        snapshot_download(
+            repo,
+            local_dir=str(local_dir),
+            ignore_patterns=list(self.SNAPSHOT_IGNORE_PATTERNS),
+        )
+        (local_dir / _SNAPSHOT_COMPLETE_MARKER).write_text(
+            json.dumps({"repo": repo}) + "\n", encoding="utf-8"
+        )
+        if not self._snapshot_complete(local_dir):
+            (local_dir / _SNAPSHOT_COMPLETE_MARKER).unlink(missing_ok=True)
+            raise FileNotFoundError(
+                f"Downloaded snapshot for {repo} is missing config or weight "
+                f"files in {local_dir}."
+            )
+        return str(local_dir)
+
+    def _resolve_dtype(self) -> "torch.dtype":
+        """Always fp32 — including on CUDA.
+
+        Unlike the (multi-GB) VLM tier, SAM-1 checkpoints are small enough that
+        fp32 inference is cheap, and half precision actively hurts SAM: mask
+        logits lose boundary fidelity, and — more importantly — bf16's 8-bit
+        mantissa rounds prompt-point coordinates by several pixels once they
+        exceed 256 (the model frame goes up to 1024), silently shifting where
+        the user clicked. Half precision can return later as an explicit opt-in.
+        """
+        return torch.float32
+
+    def _load_pretrained(self, snapshot_dir: str):
+        try:
+            from transformers import SamModel, SamProcessor
+        except ImportError as exc:
+            raise ImportError(_INSTALL_HINT) from exc
+        model = SamModel.from_pretrained(snapshot_dir, dtype=self._resolve_dtype())
+        processor = SamProcessor.from_pretrained(snapshot_dir)
+        return model, processor
+
+    def _init_model(self) -> nn.Module:
+        snapshot_dir = self._ensure_weights()
+        model, processor = self._load_pretrained(snapshot_dir)
+        self.processor = processor
+        self._model_dtype = next(model.parameters()).dtype
+        return model
+
+    # =========================================================================
+    # Abstract hooks: SAM does not use the promptless detection pipeline.
+    # =========================================================================
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {name: module for name, module in self.model.named_modules() if name}
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        raise NotImplementedError(
+            "LibreSAM families preprocess through the transformers processor."
+        )
+
+    def _preprocess(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreSAM uses set_image()/predict(points=, bboxes=) directly, "
+            "not the promptless detection pipeline."
+        )
+
+    def _forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreSAM uses set_image()/predict(points=, bboxes=) directly."
+        )
+
+    def _postprocess(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreSAM uses set_image()/predict(points=, bboxes=) directly."
+        )
+
+    # =========================================================================
+    # Interactive image session (encode once, prompt many)
+    # =========================================================================
+
+    def _clear_image_state(self) -> None:
+        self._image = None
+        self._image_path = None
+        self._image_embeddings = None
+
+    def set_image(
+        self, source: ImageInput, color_format: str = "auto"
+    ) -> "LibreSAMModel":
+        """Encode an image once so later ``predict()`` prompts are cheap.
+
+        Runs the heavy image encoder a single time and caches the embeddings.
+        Subsequent ``predict(points=...)`` / ``predict(bboxes=...)`` calls reuse
+        them. Call ``reset_image()`` to clear. Returns ``self`` to allow
+        chaining.
+        """
+        img = ImageLoader.load(source, color_format=color_format)
+        enc = self.processor(images=img, return_tensors="pt")
+        pixel_values = enc["pixel_values"].to(self.device, dtype=self._model_dtype)
+        with torch.no_grad():
+            self._image_embeddings = self.model.get_image_embeddings(pixel_values)
+        self._image = img
+        self._image_path = source if isinstance(source, (str, Path)) else None
+        return self
+
+    def reset_image(self) -> "LibreSAMModel":
+        """Drop the cached image and embeddings from ``set_image()``."""
+        self._clear_image_state()
+        return self
+
+    # =========================================================================
+    # Prediction
+    # =========================================================================
+
+    def predict(
+        self,
+        source: Optional[ImageInput] = None,
+        *,
+        points=None,
+        bboxes=None,
+        labels=None,
+        masks=None,
+        conf: Optional[float] = None,
+        multimask: Optional[bool] = None,
+        max_det: int = 300,
+        device: Optional[str] = None,
+        color_format: str = "auto",
+        points_per_side: Optional[int] = None,
+    ) -> Results:
+        """Promptable segmentation.
+
+        Pass ``points``/``bboxes`` to segment specific objects, or omit all
+        prompts to segment everything. With ``source=None`` the image cached by
+        ``set_image()`` is reused. Returns a standard ``Results`` carrying
+        ``masks`` (and tight ``boxes`` derived from them).
+
+        Args:
+            source: Image to segment. ``None`` reuses ``set_image()``.
+            points: ``[x, y]`` / ``[[x, y], ...]`` / ``[[[x, y], ...], ...]``.
+                Plain ``[x, y]`` pixel coordinates; numpy arrays are accepted.
+            bboxes: ``[x1, y1, x2, y2]`` or a list of them (one mask per box).
+            labels: Point labels, ``1`` positive / ``0`` negative (default all
+                positive), shaped to match ``points``.
+            conf: Drop masks whose *predicted IoU* (mask-quality score, not a
+                detection confidence) is below this. ``None`` keeps all in the
+                prompted path and applies the family's grid threshold in
+                "segment everything"; pass ``0.0`` to disable filtering in
+                either mode.
+            multimask: Return all of SAM's ambiguity masks per prompt (3 masks,
+                whole-vs-part) instead of the single best one. Defaults to the
+                model's construction setting.
+            max_det: Cap on returned masks.
+            device: Move the model to this device for this and later calls
+                (invalidates any cached ``set_image`` embeddings).
+            points_per_side: Grid density for "segment everything" (default
+                ``DEFAULT_POINTS_PER_SIDE``; on CPU the default of 32 runs
+                ~1024 decoder passes and is slow — lower it for interactivity).
+        """
+        if masks is not None:
+            raise NotImplementedError(
+                "Mask prompts are not supported in LibreSAM v1; "
+                "use points= or bboxes=."
+            )
+        if device is not None:
+            self._set_device(device)
+        multimask = self._default_multimask if multimask is None else multimask
+        img, image_path, cached_emb = self._resolve_image(source, color_format)
+        conf_thres = 0.0 if conf is None else float(conf)
+
+        if _is_empty_prompt(points) and _is_empty_prompt(bboxes):
+            amg_thresh = self.DEFAULT_PRED_IOU_THRESH if conf is None else conf_thres
+            return self._segment_everything(
+                img,
+                image_path,
+                points_per_side=points_per_side or self.DEFAULT_POINTS_PER_SIDE,
+                pred_iou_thresh=amg_thresh,
+                max_det=max_det,
+                cached_emb=cached_emb,
+            )
+
+        npoints = normalize_points(points)
+        nlabels = normalize_labels(labels, npoints)
+        nboxes = normalize_boxes(bboxes)
+        if npoints is not None and nboxes is not None and len(npoints) != len(nboxes):
+            raise ValueError(
+                f"points has {len(npoints)} objects but bboxes has "
+                f"{len(nboxes)}; when combining points and boxes they must "
+                "pair per object."
+            )
+
+        proc_kwargs: Dict[str, Any] = {}
+        if npoints is not None:
+            proc_kwargs["input_points"] = [npoints]
+            proc_kwargs["input_labels"] = [nlabels]
+        if nboxes is not None:
+            proc_kwargs["input_boxes"] = [nboxes]
+
+        enc = self.processor(images=img, return_tensors="pt", **proc_kwargs)
+        model_inputs = self._build_model_inputs(enc, cached_emb)
+        with torch.no_grad():
+            outputs = self.model(**model_inputs, multimask_output=multimask)
+
+        sel_masks, sel_conf = self._post_process(outputs, enc, multimask)
+        return self._assemble_results(
+            sel_masks, sel_conf, img, image_path, conf_thres=conf_thres, max_det=max_det
+        )
+
+    def __call__(self, source: Optional[ImageInput] = None, **kwargs) -> Results:
+        return self.predict(source, **kwargs)
+
+    def _set_device(self, device: str) -> "LibreSAMModel":
+        """Move the model to ``device`` and drop any stale cached embeddings."""
+        dev = str(device).strip()
+        if dev.isdigit():
+            dev = f"cuda:{dev}"
+        target = torch.device(dev)
+        if target != self.device:
+            self.device = target
+            self.model.to(target)
+            self._clear_image_state()
+        return self
+
+    # ---- prediction internals ------------------------------------------------
+
+    def _resolve_image(self, source, color_format):
+        """Return ``(pil_image, path, cached_embeddings_or_None)``."""
+        if source is not None:
+            img = ImageLoader.load(source, color_format=color_format)
+            path = source if isinstance(source, (str, Path)) else None
+            return img, path, None
+        if self._image is None:
+            raise RuntimeError(
+                "No image set. Pass source=... or call set_image(...) first."
+            )
+        return self._image, self._image_path, self._image_embeddings
+
+    def _build_model_inputs(self, enc, cached_emb) -> Dict[str, Any]:
+        """Assemble model kwargs, reusing cached embeddings when available."""
+        inputs: Dict[str, Any] = {}
+        for key in ("input_points", "input_labels", "input_boxes"):
+            if key in enc:
+                inputs[key] = enc[key].to(self.device)
+        if cached_emb is not None:
+            inputs["image_embeddings"] = cached_emb
+        else:
+            inputs["pixel_values"] = enc["pixel_values"].to(
+                self.device, dtype=self._model_dtype
+            )
+        return inputs
+
+    def _post_process_masks(self, pred_masks, enc):
+        """Upscale low-res masks to the original image resolution."""
+        fn = getattr(self.processor, "post_process_masks", None)
+        if fn is None:
+            fn = self.processor.image_processor.post_process_masks
+        return fn(
+            pred_masks.cpu(),
+            enc["original_sizes"],
+            enc["reshaped_input_sizes"],
+        )
+
+    def _post_process(self, outputs, enc, multimask):
+        """Return ``(masks (Q,H,W) bool, conf (Q,))`` selecting the best mask."""
+        masks = self._post_process_masks(outputs.pred_masks, enc)[0]  # (Q, M, H, W)
+        scores = outputs.iou_scores[0].detach().cpu().float()  # (Q, M)
+        return self._select_best(masks, scores, multimask)
+
+    @staticmethod
+    def _select_best(masks, scores, multimask):
+        """Select masks per prompt from the model's ``M`` candidates.
+
+        ``multimask=True`` keeps every candidate — SAM's whole-vs-part ambiguity
+        masks — so ``(Q, M, H, W)`` flattens to ``(Q*M, H, W)`` and the caller
+        gets all three. Otherwise the single highest-IoU candidate per prompt is
+        returned.
+        """
+        masks = masks.cpu()
+        scores = scores.cpu().float()
+        if multimask:
+            q, m = masks.shape[0], masks.shape[1]
+            sel = masks.reshape(q * m, *masks.shape[2:])
+            conf = scores.reshape(q * m)
+        else:
+            idx = scores.argmax(dim=1)
+            q = torch.arange(masks.shape[0])
+            sel = masks[q, idx]
+            conf = scores[q, idx]
+        return sel.bool(), conf.float()
+
+    def _assemble_results(
+        self, masks, conf, img, image_path, *, conf_thres, max_det
+    ) -> Results:
+        from torchvision.ops import masks_to_boxes
+
+        width, height = img.size
+        orig_shape = (height, width)
+
+        if conf_thres > 0:
+            keep = conf >= conf_thres
+            masks, conf = masks[keep], conf[keep]
+        # Drop empty masks (a box cannot be derived from them).
+        if masks.shape[0]:
+            nonempty = masks.flatten(1).any(dim=1)
+            masks, conf = masks[nonempty], conf[nonempty]
+        if masks.shape[0] > max_det:
+            top = conf.argsort(descending=True)[:max_det]
+            masks, conf = masks[top], conf[top]
+
+        if masks.shape[0] == 0:
+            return self._empty_results(orig_shape, image_path)
+
+        boxes = masks_to_boxes(masks.float())
+        cls = torch.zeros(masks.shape[0], dtype=torch.float32)
+        return Results(
+            boxes=Boxes(boxes, conf, cls),
+            orig_shape=orig_shape,
+            path=str(image_path) if image_path else None,
+            names=self.names,
+            masks=Masks(masks, orig_shape),
+        )
+
+    def _empty_results(self, orig_shape, image_path) -> Results:
+        return Results(
+            boxes=Boxes(
+                torch.zeros((0, 4), dtype=torch.float32),
+                torch.zeros(0, dtype=torch.float32),
+                torch.zeros(0, dtype=torch.float32),
+            ),
+            orig_shape=orig_shape,
+            path=str(image_path) if image_path else None,
+            names=self.names,
+        )
+
+    def _segment_everything(
+        self,
+        img,
+        image_path,
+        *,
+        points_per_side,
+        pred_iou_thresh,
+        max_det,
+        cached_emb,
+    ) -> Results:
+        """Basic automatic mask generation by prompting a dense point grid.
+
+        A deliberately simplified AMG: prompt the model on a uniform grid, keep
+        the best mask per point, drop low-confidence/empty masks, and dedupe
+        with box-IoU NMS. It is NOT a drop-in for the reference
+        AutomaticMaskGenerator — it omits stability-score filtering, multi-crop,
+        and mask-IoU dedup, so it under-segments crowded scenes and can merge
+        distinct objects that share a bounding box. The prompted path
+        (points/boxes) is the precise, recommended API; reach upstream for
+        exhaustive automatic masks.
+        """
+        from torchvision.ops import batched_nms, masks_to_boxes
+
+        width, height = img.size
+        orig_shape = (height, width)
+
+        # Encode the image once even in one-shot mode, so the grid reuses it.
+        if cached_emb is None:
+            enc0 = self.processor(images=img, return_tensors="pt")
+            pixel_values = enc0["pixel_values"].to(self.device, dtype=self._model_dtype)
+            with torch.no_grad():
+                cached_emb = self.model.get_image_embeddings(pixel_values)
+
+        grid = build_point_grid(points_per_side)
+        pixel_points = [[float(x * width), float(y * height)] for x, y in grid]
+        # Preprocess the image and all grid points ONCE. The per-image resize
+        # metadata (original_sizes/reshaped_input_sizes) is identical for every
+        # chunk, so only the prompt tensor is sliced below — this avoids
+        # re-running the full image preprocessing once per chunk.
+        enc = self.processor(
+            images=img,
+            input_points=[[[p] for p in pixel_points]],  # 1 image, N points, 1 each
+            return_tensors="pt",
+        )
+        full_points = enc["input_points"].to(self.device)  # (1, N, 1, 2)
+
+        all_masks: List[torch.Tensor] = []
+        all_conf: List[torch.Tensor] = []
+        for i in range(0, full_points.shape[1], self.GRID_CHUNK):
+            chunk = full_points[:, i : i + self.GRID_CHUNK]
+            with torch.no_grad():
+                outputs = self.model(
+                    input_points=chunk,
+                    image_embeddings=cached_emb,
+                    multimask_output=True,
+                )
+            # Keep the best of the 3 candidates per grid point.
+            sel, conf = self._post_process(outputs, enc, multimask=False)
+            all_masks.append(sel)
+            all_conf.append(conf)
+
+        masks = torch.cat(all_masks, dim=0)
+        conf = torch.cat(all_conf, dim=0)
+
+        keep = conf >= pred_iou_thresh
+        masks, conf = masks[keep], conf[keep]
+        if masks.shape[0]:
+            nonempty = masks.flatten(1).any(dim=1)
+            masks, conf = masks[nonempty], conf[nonempty]
+        if masks.shape[0] == 0:
+            return self._empty_results(orig_shape, image_path)
+
+        boxes = masks_to_boxes(masks.float())
+        cls = torch.zeros(masks.shape[0], dtype=torch.int64)
+        keep = batched_nms(boxes, conf, cls, self.AMG_NMS_IOU)[:max_det]
+        masks, conf, boxes = masks[keep], conf[keep], boxes[keep]
+        cls_final = torch.zeros(masks.shape[0], dtype=torch.float32)
+
+        return Results(
+            boxes=Boxes(boxes, conf, cls_final),
+            orig_shape=orig_shape,
+            path=str(image_path) if image_path else None,
+            names=self.names,
+            masks=Masks(masks, orig_shape),
+        )
+
+    # =========================================================================
+    # Out of scope for the inference-first SAM tier
+    # =========================================================================
+
+    def track(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self).__name__} is an image segmenter; video tracking is "
+            "out of scope for LibreSAM v1. Use predict() per frame."
+        )
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"Training is out of scope for {type(self).__name__} in LibreYOLO. "
+            "Fine-tune the model upstream and load the resulting weights."
+        )
+
+    def val(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"Dataset validation is not supported for {type(self).__name__}: "
+            "promptable masks have no fixed class set to score against."
+        )
+
+    def export(self, format: str = "onnx", **kwargs) -> str:
+        raise NotImplementedError(
+            f"{type(self).__name__} export is out of scope for LibreSAM v1. "
+            "Run it through predict() instead."
+        )

--- a/libreyolo/models/sam/base.py
+++ b/libreyolo/models/sam/base.py
@@ -83,7 +83,12 @@ class LibreSAMModel(BaseModel):
     AMG_NMS_IOU: ClassVar[float] = 0.7
 
     # Off by default: SAM families load through native transformers classes.
+    # The SAM repos publish both safetensors and a duplicate ``pytorch_model.bin``
+    # pickle (1.25-2.56 GB for large/huge); transformers prefers safetensors, so
+    # skip the .bin to avoid downloading a checkpoint that is never loaded.
     SNAPSHOT_IGNORE_PATTERNS: ClassVar[tuple[str, ...]] = (
+        "*.bin",
+        "*.bin.index.json",
         "*.onnx",
         "onnx/*",
         "*.tflite",
@@ -584,8 +589,12 @@ class LibreSAMModel(BaseModel):
         masks = torch.cat(all_masks, dim=0)
         conf = torch.cat(all_conf, dim=0)
 
-        keep = conf >= pred_iou_thresh
-        masks, conf = masks[keep], conf[keep]
+        # Only filter when a positive threshold is set — SAM's IoU head is
+        # unbounded, so a 0.0 threshold (keep all) must not drop negative
+        # scores, matching the prompted path's conf=0.0 behavior.
+        if pred_iou_thresh > 0:
+            keep = conf >= pred_iou_thresh
+            masks, conf = masks[keep], conf[keep]
         if masks.shape[0]:
             nonempty = masks.flatten(1).any(dim=1)
             masks, conf = masks[nonempty], conf[nonempty]

--- a/libreyolo/models/sam/base.py
+++ b/libreyolo/models/sam/base.py
@@ -325,12 +325,32 @@ class LibreSAMModel(BaseModel):
         img, image_path, cached_emb = self._resolve_image(source, color_format)
         conf_thres = 0.0 if conf is None else float(conf)
 
-        if _is_empty_prompt(points) and _is_empty_prompt(bboxes):
+        # An empty container means "this prompt type is absent", so a
+        # dynamically-built box-only / point-only call doesn't trip
+        # normalization (which would reject [] as nesting depth 0).
+        if _is_empty_prompt(points):
+            points = None
+        if _is_empty_prompt(bboxes):
+            bboxes = None
+
+        if points is None and bboxes is None:
+            if labels is not None:
+                raise ValueError(
+                    "labels were given without points. Pass points= for a "
+                    "prompted call, or omit labels to segment everything."
+                )
+            # Only None takes the default; an explicit (invalid) 0 must reach
+            # build_point_grid's validation rather than silently expanding.
+            grid = (
+                self.DEFAULT_POINTS_PER_SIDE
+                if points_per_side is None
+                else points_per_side
+            )
             amg_thresh = self.DEFAULT_PRED_IOU_THRESH if conf is None else conf_thres
             return self._segment_everything(
                 img,
                 image_path,
-                points_per_side=points_per_side or self.DEFAULT_POINTS_PER_SIDE,
+                points_per_side=grid,
                 pred_iou_thresh=amg_thresh,
                 max_det=max_det,
                 cached_emb=cached_emb,
@@ -372,7 +392,9 @@ class LibreSAMModel(BaseModel):
         Cached embeddings are moved to the new device rather than dropped, so an
         interactive session survives a device switch.
         """
-        dev = str(device).strip()
+        dev = str(device).strip().lower()
+        if dev in ("", "auto"):
+            return self  # sentinel: keep the currently selected device
         if dev.isdigit():
             dev = f"cuda:{dev}"
         target = torch.device(dev)

--- a/libreyolo/models/sam/base.py
+++ b/libreyolo/models/sam/base.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional
 
 import torch
 import torch.nn as nn
@@ -188,7 +188,7 @@ class LibreSAMModel(BaseModel):
         """
         return torch.float32
 
-    def _load_pretrained(self, snapshot_dir: str):
+    def _load_pretrained(self, snapshot_dir: str) -> tuple:
         try:
             from transformers import SamModel, SamProcessor
         except ImportError as exc:
@@ -367,7 +367,11 @@ class LibreSAMModel(BaseModel):
         return self.predict(source, **kwargs)
 
     def _set_device(self, device: str) -> "LibreSAMModel":
-        """Move the model to ``device`` and drop any stale cached embeddings."""
+        """Move the model to ``device``, keeping any ``set_image()`` session.
+
+        Cached embeddings are moved to the new device rather than dropped, so an
+        interactive session survives a device switch.
+        """
         dev = str(device).strip()
         if dev.isdigit():
             dev = f"cuda:{dev}"
@@ -375,7 +379,8 @@ class LibreSAMModel(BaseModel):
         if target != self.device:
             self.device = target
             self.model.to(target)
-            self._clear_image_state()
+            if self._image_embeddings is not None:
+                self._image_embeddings = self._image_embeddings.to(target)
         return self
 
     # ---- prediction internals ------------------------------------------------
@@ -531,17 +536,21 @@ class LibreSAMModel(BaseModel):
         enc = self.processor(
             images=img,
             input_points=[[[p] for p in pixel_points]],  # 1 image, N points, 1 each
+            input_labels=[[[1] for _ in pixel_points]],  # all positive prompts
             return_tensors="pt",
         )
         full_points = enc["input_points"].to(self.device)  # (1, N, 1, 2)
+        full_labels = enc["input_labels"].to(self.device)  # (1, N, 1)
 
         all_masks: List[torch.Tensor] = []
         all_conf: List[torch.Tensor] = []
         for i in range(0, full_points.shape[1], self.GRID_CHUNK):
             chunk = full_points[:, i : i + self.GRID_CHUNK]
+            chunk_labels = full_labels[:, i : i + self.GRID_CHUNK]
             with torch.no_grad():
                 outputs = self.model(
                     input_points=chunk,
+                    input_labels=chunk_labels,
                     image_embeddings=cached_emb,
                     multimask_output=True,
                 )

--- a/libreyolo/models/sam/model.py
+++ b/libreyolo/models/sam/model.py
@@ -1,0 +1,90 @@
+"""LibreSAM: promptable segmentation models behind a familiar surface.
+
+User-facing entry point is the ``LibreSAM(...)`` factory, a sibling to the
+``LibreYOLO(...)`` and ``LibreVLM(...)`` factories. It returns a promptable
+segmenter with an interactive, encode-once / prompt-many surface:
+
+    from libreyolo import LibreSAM
+
+    model = LibreSAM("base")                 # autodownloads (Apache-2.0)
+    r = model.predict("image.jpg", points=[900, 370], labels=[1])  # point -> mask
+    r = model.predict("image.jpg", bboxes=[100, 100, 200, 200])    # box   -> mask
+    r = model.predict("image.jpg")                                  # segment everything
+    r.masks.xy          # polygons
+    r.boxes.xyxy        # tight boxes derived from masks
+
+    model.set_image("image.jpg")             # encode once...
+    a = model.predict(points=[500, 375], labels=[1])   # ...prompt cheaply
+    b = model.predict(bboxes=[100, 100, 200, 200])
+    model.reset_image()
+
+The default family is SAM-1, whose code and weights are Apache-2.0, loaded
+through the permissive ``transformers`` model API. See
+``docs/adr/0005-libresam-contract.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple, Type
+
+from .base import LibreSAMModel
+
+
+class LibreSAM1(LibreSAMModel):
+    """SAM-1 promptable segmenter (ViT-B/L/H image encoder)."""
+
+    FAMILY = "sam"
+    FILENAME_PREFIX = "LibreSAM"
+    HF_REPOS = {
+        "base": "facebook/sam-vit-base",
+        "large": "facebook/sam-vit-large",
+        "huge": "facebook/sam-vit-huge",
+    }
+    INPUT_SIZES = {"base": 1024, "large": 1024, "huge": 1024}
+
+
+# alias -> (family class, size)
+_ALIASES: Dict[str, Tuple[Type[LibreSAMModel], str]] = {
+    "base": (LibreSAM1, "base"),
+    "large": (LibreSAM1, "large"),
+    "huge": (LibreSAM1, "huge"),
+    "b": (LibreSAM1, "base"),
+    "l": (LibreSAM1, "large"),
+    "h": (LibreSAM1, "huge"),
+    "sam-base": (LibreSAM1, "base"),
+    "sam-large": (LibreSAM1, "large"),
+    "sam-huge": (LibreSAM1, "huge"),
+    "sam_b": (LibreSAM1, "base"),
+    "sam_l": (LibreSAM1, "large"),
+    "sam_h": (LibreSAM1, "huge"),
+}
+
+_DEFAULT_MODEL = "base"
+
+
+def LibreSAM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreSAMModel:
+    """Load a promptable segmentation model by name.
+
+    Args:
+        model: Size alias — ``"base"`` (default), ``"large"``, or ``"huge"``
+            (also ``"sam_b"``/``"sam_l"``/``"sam_h"``, or ``"b"``/``"l"``/``"h"``).
+        **kwargs: Forwarded to the family constructor: ``device``, and
+            ``multimask`` (when True, ``predict`` returns all of SAM's ambiguity
+            masks per prompt — 3 whole-vs-part masks — instead of the single
+            best one; can also be set per-call on ``predict``).
+
+    Returns:
+        A ``LibreSAMModel`` with the interactive ``set_image``/``predict`` surface.
+    """
+    key = str(model).strip().lower()
+    match = _ALIASES.get(key)
+    if match is None:
+        raise ValueError(
+            f"Unknown SAM model {model!r}. Known aliases: "
+            f"{', '.join(sorted(_ALIASES))}."
+        )
+    family_cls, size = match
+    return family_cls(size=size, **kwargs)
+
+
+__all__ = ["LibreSAM", "LibreSAM1"]

--- a/libreyolo/models/sam/prompts.py
+++ b/libreyolo/models/sam/prompts.py
@@ -101,6 +101,19 @@ def normalize_labels(
 
     lbls = _to_list(labels)
     d = _depth(lbls)
+    if d not in (1, 2):
+        raise ValueError(
+            f"labels must be [l, ...] or [[l, ...], ...]; got nesting depth {d}."
+        )
+    # Validate raw values against the documented {0, 1} set before any int()
+    # cast — otherwise a typo like 2, or a float that truncates (1.9 -> 1),
+    # would slip through and produce a plausible-but-wrong mask.
+    flat = lbls if d == 1 else [v for obj in lbls for v in obj]
+    for v in flat:
+        if v != 0 and v != 1:
+            raise ValueError(
+                f"point labels must be 1 (positive) or 0 (negative); got {v!r}."
+            )
     if d == 1:
         # Flat labels. With a single object, map them to that object's points —
         # the natural positive/negative-click vector, e.g. labels=[1, 0] for
@@ -109,12 +122,8 @@ def normalize_labels(
             out = [[int(v) for v in lbls]]
         else:
             out = [[int(v)] for v in lbls]
-    elif d == 2:  # [[l, ...], ...] -> labels per object, as given
+    else:  # d == 2 -> [[l, ...], ...] labels per object, as given
         out = [[int(v) for v in obj] for obj in lbls]
-    else:
-        raise ValueError(
-            f"labels must be [l, ...] or [[l, ...], ...]; got nesting depth {d}."
-        )
 
     if len(out) != len(canonical_points):
         raise ValueError(

--- a/libreyolo/models/sam/prompts.py
+++ b/libreyolo/models/sam/prompts.py
@@ -105,12 +105,18 @@ def normalize_labels(
         raise ValueError(
             f"labels must be [l, ...] or [[l, ...], ...]; got nesting depth {d}."
         )
+    # Mixed nesting like [[1], 0] reports depth 2 but is not uniformly nested;
+    # flattening it would raise TypeError, so reject it as a clear ValueError.
+    if d == 2 and any(not isinstance(obj, list) for obj in lbls):
+        raise ValueError(
+            "labels must be [l, ...] or [[l, ...], ...]; mixed nesting is invalid."
+        )
     # Validate raw values against the documented {0, 1} set before any int()
     # cast — otherwise a typo like 2, or a float that truncates (1.9 -> 1),
     # would slip through and produce a plausible-but-wrong mask.
     flat = lbls if d == 1 else [v for obj in lbls for v in obj]
     for v in flat:
-        if v != 0 and v != 1:
+        if v not in (0, 1):
             raise ValueError(
                 f"point labels must be 1 (positive) or 0 (negative); got {v!r}."
             )

--- a/libreyolo/models/sam/prompts.py
+++ b/libreyolo/models/sam/prompts.py
@@ -1,0 +1,152 @@
+"""Pure prompt-normalization for the LibreSAM tier.
+
+The promptable-segmentation API accepts points and boxes in the flexible,
+user-friendly shapes documented for the de-facto standard interface, then
+coerces them into the single canonical nesting the underlying processor
+expects:
+
+    points -> [point_batch, num_points, 2]   (one entry per object/mask)
+    labels -> [point_batch, num_points]
+    boxes  -> [num_boxes, 4]
+
+Nesting depth carries meaning, matching the documented public surface:
+
+    points=[x, y]                      one object, one point
+    points=[[x, y], [x, y]]            two objects, one point each
+    points=[[[x, y], [x, y]]]          one object, two points (grouped)
+
+Everything here is pure (lists in, lists out) so it can be unit-tested fully
+offline without torch, transformers, or model weights.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+
+def _to_list(x):
+    """Recursively convert array-likes/tuples to plain nested lists.
+
+    numpy arrays and torch tensors (the natural carriers of click/box
+    coordinates in CV code) are coerced via ``tolist()`` so a valid ``(N, 2)``
+    array is accepted rather than rejected as "nesting depth 0".
+    """
+    if hasattr(x, "tolist") and not isinstance(x, (list, tuple, str, bytes)):
+        x = x.tolist()
+    if isinstance(x, (list, tuple)):
+        return [_to_list(v) for v in x]
+    return x
+
+
+def _depth(x) -> int:
+    """Nesting depth of a (non-empty) nested list; 0 for a scalar."""
+    d = 0
+    while isinstance(x, (list, tuple)) and len(x) > 0:
+        d += 1
+        x = x[0]
+    return d
+
+
+def normalize_points(points) -> Optional[List[List[List[float]]]]:
+    """Coerce user points into ``[point_batch, num_points, 2]``.
+
+    Returns ``None`` when ``points`` is ``None`` so callers can omit the key.
+    """
+    if points is None:
+        return None
+    pts = _to_list(points)
+    d = _depth(pts)
+    if d == 1:  # [x, y] -> one object, one point
+        canonical = [[list(pts)]]
+    elif d == 2:  # [[x, y], ...] -> N objects, one point each
+        canonical = [[list(p)] for p in pts]
+    elif d == 3:  # [[[x, y], ...], ...] -> objects x points, as given
+        canonical = [[list(p) for p in obj] for obj in pts]
+    else:
+        raise ValueError(
+            "points must be [x, y], [[x, y], ...], or [[[x, y], ...], ...]; "
+            f"got nesting depth {d}."
+        )
+    for obj in canonical:
+        for p in obj:
+            if len(p) != 2:
+                raise ValueError(f"each point must be [x, y]; got {p!r}.")
+    return canonical
+
+
+def normalize_labels(
+    labels, canonical_points: Optional[Sequence[Sequence[Sequence[float]]]]
+) -> Optional[List[List[int]]]:
+    """Coerce point labels to ``[point_batch, num_points]`` matching points.
+
+    ``1`` = positive (object), ``0`` = negative (background). When ``labels`` is
+    ``None`` every point defaults to positive. The shape must line up with the
+    normalized points or a ``ValueError`` is raised.
+    """
+    if canonical_points is None:
+        if labels is not None:
+            raise ValueError("labels given without points.")
+        return None
+    if labels is None:
+        return [[1] * len(obj) for obj in canonical_points]
+
+    lbls = _to_list(labels)
+    d = _depth(lbls)
+    if d == 1:  # [l, ...] -> one label per object (one point each)
+        out = [[int(v)] for v in lbls]
+    elif d == 2:  # [[l, ...], ...] -> labels per object, as given
+        out = [[int(v) for v in obj] for obj in lbls]
+    else:
+        raise ValueError(
+            f"labels must be [l, ...] or [[l, ...], ...]; got nesting depth {d}."
+        )
+
+    if len(out) != len(canonical_points):
+        raise ValueError(
+            f"labels has {len(out)} objects but points has "
+            f"{len(canonical_points)}."
+        )
+    for lab, obj in zip(out, canonical_points):
+        if len(lab) != len(obj):
+            raise ValueError(
+                "labels and points disagree on number of points per object: "
+                f"{len(lab)} vs {len(obj)}."
+            )
+    return out
+
+
+def normalize_boxes(boxes) -> Optional[List[List[float]]]:
+    """Coerce user boxes into ``[num_boxes, 4]`` xyxy. ``None`` passes through."""
+    if boxes is None:
+        return None
+    bx = _to_list(boxes)
+    d = _depth(bx)
+    if d == 1:  # [x1, y1, x2, y2] -> single box
+        out = [list(bx)]
+    elif d == 2:  # [[x1, y1, x2, y2], ...] -> as given
+        out = [list(b) for b in bx]
+    else:
+        raise ValueError(
+            "boxes must be [x1, y1, x2, y2] or [[x1, y1, x2, y2], ...]; "
+            f"got nesting depth {d}."
+        )
+    for b in out:
+        if len(b) != 4:
+            raise ValueError(f"each box must be [x1, y1, x2, y2]; got {b!r}.")
+    return out
+
+
+def build_point_grid(points_per_side: int) -> List[List[float]]:
+    """A uniform grid of ``points_per_side**2`` points, normalized to [0, 1].
+
+    Used to drive "segment everything" by prompting the model on a dense grid,
+    the standard automatic-mask-generation strategy.
+    """
+    if points_per_side < 1:
+        raise ValueError("points_per_side must be >= 1.")
+    offset = 1.0 / (2 * points_per_side)
+    grid = []
+    for j in range(points_per_side):
+        for i in range(points_per_side):
+            grid.append([offset + i / points_per_side, offset + j / points_per_side])
+    return grid

--- a/libreyolo/models/sam/prompts.py
+++ b/libreyolo/models/sam/prompts.py
@@ -71,6 +71,15 @@ def normalize_points(points) -> Optional[List[List[List[float]]]]:
         for p in obj:
             if len(p) != 2:
                 raise ValueError(f"each point must be [x, y]; got {p!r}.")
+    # SAM batches objects into one tensor, so every object must carry the same
+    # number of points; ragged counts otherwise fail deep in the processor with
+    # an opaque numpy "inhomogeneous shape" error. Reject them clearly.
+    if len({len(obj) for obj in canonical}) > 1:
+        raise ValueError(
+            "every object must have the same number of points; got per-object "
+            f"counts {[len(obj) for obj in canonical]}. Pad them to equal length "
+            "or prompt the objects in separate predict() calls."
+        )
     return canonical
 
 
@@ -92,8 +101,14 @@ def normalize_labels(
 
     lbls = _to_list(labels)
     d = _depth(lbls)
-    if d == 1:  # [l, ...] -> one label per object (one point each)
-        out = [[int(v)] for v in lbls]
+    if d == 1:
+        # Flat labels. With a single object, map them to that object's points —
+        # the natural positive/negative-click vector, e.g. labels=[1, 0] for
+        # points=[[[px, py], [nx, ny]]]. With several objects, one label each.
+        if len(canonical_points) == 1:
+            out = [[int(v) for v in lbls]]
+        else:
+            out = [[int(v)] for v in lbls]
     elif d == 2:  # [[l, ...], ...] -> labels per object, as given
         out = [[int(v) for v in obj] for obj in lbls]
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ vlm = [
     # SmolVLM2's processor requires num2words.
     "num2words>=0.5.0",
 ]
+sam = [
+    # Promptable-segmentation families (SAM) load through transformers
+    # (SamModel/SamProcessor); huggingface_hub ships with it.
+    "transformers>=5.1.0",
+]
 tensorrt = [
     # No CUDA on macOS; marker drops these. Version pin must match the
     # [[tool.uv.dependency-metadata]] blocks below.
@@ -112,6 +117,7 @@ all = [
     "libreyolo[gaze]",
     "libreyolo[coreml]",
     "libreyolo[vlm]",
+    "libreyolo[sam]",
     "libreyolo[tensorboard]",
     "libreyolo[mlflow]",
     "libreyolo[wandb]",
@@ -253,6 +259,7 @@ markers = [
     "rtmdet: tests covering the RTMDet model family",
     "l2cs: tests covering the L2CS gaze estimation family",
     "vlm: tests covering the LibreVLM (VLM-as-detector) tier",
+    "sam: tests covering the LibreSAM (promptable-segmentation) tier",
     "rf1: RF1 training tests",
     "rf5: RF5 training benchmark tests",
     "slow: slow tests that may take several minutes",

--- a/tests/e2e/test_sam_smoke.py
+++ b/tests/e2e/test_sam_smoke.py
@@ -1,0 +1,98 @@
+"""End-to-end smoke test for the LibreSAM promptable segmenter.
+
+Heavy: downloads the SAM-1 base weights (Apache-2.0) and loads the model, so it
+is gated behind the sam/network/external_data markers and skipped if
+transformers is unavailable. The model is loaded once via a module-scoped
+fixture.
+"""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sam,
+    pytest.mark.network,
+    pytest.mark.external_data,
+]
+
+pytest.importorskip("transformers", reason="LibreSAM requires the 'sam' extra")
+
+
+@pytest.fixture(scope="module")
+def sam_model():
+    from libreyolo import LibreSAM
+
+    return LibreSAM("base", device="cpu")
+
+
+def test_point_prompt_returns_mask(sam_model):
+    from libreyolo import Results, SAMPLE_IMAGE
+
+    result = sam_model.predict(SAMPLE_IMAGE, points=[640, 360], labels=[1])
+
+    assert isinstance(result, Results)
+    assert result.masks is not None
+    assert len(result.masks) >= 1
+    # Tight boxes are derived from the masks; same Results contract.
+    assert result.boxes.xyxy.shape[1] == 4
+    assert len(result.boxes.conf) == len(result.masks)
+    assert sam_model.names[0] == "object"
+
+
+def test_box_prompt_returns_mask(sam_model):
+    from libreyolo import SAMPLE_IMAGE
+
+    result = sam_model.predict(SAMPLE_IMAGE, bboxes=[100, 100, 500, 500])
+    assert result.masks is not None
+    h, w = result.orig_shape
+    # Mask is upscaled to the original image resolution.
+    assert result.masks.data.shape[-2:] == (h, w)
+
+
+def test_multimask_returns_all_ambiguity_masks(sam_model):
+    from libreyolo import SAMPLE_IMAGE
+
+    single = sam_model.predict(SAMPLE_IMAGE, points=[640, 360], labels=[1])
+    triple = sam_model.predict(
+        SAMPLE_IMAGE, points=[640, 360], labels=[1], multimask=True
+    )
+    # multimask must actually surface SAM's 3 whole-vs-part masks, not 1.
+    assert len(single.masks) == 1
+    assert len(triple.masks) == 3
+
+
+def test_segment_everything_runs(sam_model):
+    from libreyolo import Results, SAMPLE_IMAGE
+
+    # Small grid keeps the CPU pass fast; just exercise the AMG path.
+    result = sam_model.predict(SAMPLE_IMAGE, points_per_side=6)
+    assert isinstance(result, Results)
+    assert result.masks is not None
+    assert len(result.masks) == len(result.boxes.xyxy)
+
+
+def test_interactive_session_reuses_embeddings(sam_model):
+    from libreyolo import SAMPLE_IMAGE
+
+    sam_model.set_image(SAMPLE_IMAGE)
+    try:
+        a = sam_model.predict(points=[640, 360], labels=[1])
+        b = sam_model.predict(bboxes=[100, 100, 500, 500])
+        assert a.masks is not None and b.masks is not None
+    finally:
+        sam_model.reset_image()
+
+
+def test_interactive_surface_and_scope(sam_model):
+    """Mirrors the documented promptable surface; detector-only ops are out."""
+    assert callable(sam_model)
+    assert hasattr(sam_model, "set_image")
+    assert hasattr(sam_model, "reset_image")
+    assert sam_model.task == "segment"
+    with pytest.raises(RuntimeError):
+        # No image set and no source given.
+        sam_model.reset_image().predict(points=[10, 10], labels=[1])
+    with pytest.raises(NotImplementedError):
+        sam_model.train()
+    with pytest.raises(NotImplementedError):
+        sam_model.track("video.mp4")

--- a/tests/unit/test_sam_logic.py
+++ b/tests/unit/test_sam_logic.py
@@ -1,0 +1,141 @@
+"""Offline tests for LibreSAM logic that needs no model weights.
+
+Covers mask selection, the segment-everything dispatch guard, and the factory
+alias errors — paths that were bug-prone in review but are reachable without
+downloading a checkpoint.
+"""
+
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.sam.base import LibreSAMModel, _is_empty_prompt
+from libreyolo.models.sam.model import LibreSAM, LibreSAM1
+
+pytestmark = pytest.mark.unit
+
+
+def _bare_model():
+    """A LibreSAM instance with no weights — just enough state for the pure
+    result-assembly logic (built via ``__new__`` to skip the download)."""
+    m = object.__new__(LibreSAM1)
+    m.names = {0: "object"}
+    return m
+
+
+class TestSelectBest:
+    def _candidates(self):
+        # Two prompts, three candidate masks each (2, 3, 2, 2).
+        masks = torch.zeros((2, 3, 2, 2), dtype=torch.bool)
+        masks[0, 1, 0, 0] = True  # prompt 0 best is candidate 1
+        masks[1, 2, 1, 1] = True  # prompt 1 best is candidate 2
+        scores = torch.tensor([[0.1, 0.9, 0.2], [0.3, 0.4, 0.8]])
+        return masks, scores
+
+    def test_single_best_picks_argmax_per_prompt(self):
+        masks, scores = self._candidates()
+        sel, conf = LibreSAMModel._select_best(masks, scores, multimask=False)
+        # One mask per prompt, each the highest-IoU candidate.
+        assert sel.shape == (2, 2, 2)
+        assert torch.allclose(conf, torch.tensor([0.9, 0.8]))
+        assert bool(sel[0, 0, 0]) and bool(sel[1, 1, 1])
+
+    def test_multimask_returns_all_candidates_flattened(self):
+        masks, scores = self._candidates()
+        sel, conf = LibreSAMModel._select_best(masks, scores, multimask=True)
+        # All 2*3 = 6 masks surfaced (the documented "3 ambiguity masks").
+        assert sel.shape == (6, 2, 2)
+        assert torch.allclose(conf, scores.reshape(6))
+
+
+class TestAssembleResults:
+    """The conf/empty/max_det filtering in _assemble_results (no weights)."""
+
+    def test_conf_filter_then_empty_drop(self):
+        m = _bare_model()
+        masks = torch.zeros((3, 8, 8), dtype=torch.bool)
+        masks[0, 0:4, 0:4] = True  # conf 0.9 -> kept
+        masks[1, 5:7, 5:7] = True  # conf 0.5 -> below conf_thres, dropped
+        # masks[2] stays empty -> dropped even though its conf (0.7) passes
+        conf = torch.tensor([0.9, 0.5, 0.7])
+        r = m._assemble_results(
+            masks, conf, Image.new("RGB", (8, 8)), None, conf_thres=0.6, max_det=10
+        )
+        assert len(r.masks) == 1
+        assert float(r.boxes.conf[0]) == pytest.approx(0.9)
+        assert tuple(r.orig_shape) == (8, 8)
+        # Box is the tight extent of the kept mask (cols/rows 0..3).
+        assert r.boxes.xyxy[0].tolist() == [0.0, 0.0, 3.0, 3.0]
+
+    def test_max_det_keeps_highest_conf_in_order(self):
+        m = _bare_model()
+        masks = torch.zeros((3, 8, 8), dtype=torch.bool)
+        masks[0, 0:2, 0:2] = True
+        masks[1, 2:4, 2:4] = True
+        masks[2, 4:6, 4:6] = True
+        conf = torch.tensor([0.3, 0.9, 0.6])
+        r = m._assemble_results(
+            masks, conf, Image.new("RGB", (8, 8)), None, conf_thres=0.0, max_det=2
+        )
+        assert len(r.masks) == 2
+        assert [round(float(c), 1) for c in r.boxes.conf] == [0.9, 0.6]
+
+    def test_all_filtered_returns_empty_contract(self):
+        m = _bare_model()
+        masks = torch.zeros((2, 8, 8), dtype=torch.bool)
+        masks[0, 0, 0] = True
+        masks[1, 1, 1] = True
+        conf = torch.tensor([0.1, 0.2])
+        r = m._assemble_results(
+            masks, conf, Image.new("RGB", (8, 8)), None, conf_thres=0.9, max_det=10
+        )
+        # Empty result: no masks, boxes is a well-formed (0, 4) tensor.
+        assert r.masks is None
+        assert tuple(r.boxes.xyxy.shape) == (0, 4)
+        assert len(r.boxes.conf) == 0
+
+
+class TestResolveDtype:
+    def test_fp32_on_cpu(self):
+        m = object.__new__(LibreSAM1)
+        m.device = torch.device("cpu")
+        assert m._resolve_dtype() == torch.float32
+
+    def test_fp32_even_on_cuda(self):
+        # torch.device("cuda") constructs without a GPU present; the point is
+        # that SAM never silently downcasts to half on GPU.
+        m = object.__new__(LibreSAM1)
+        m.device = torch.device("cuda")
+        assert m._resolve_dtype() == torch.float32
+
+
+class TestEmptyPromptDispatch:
+    def test_none_is_empty(self):
+        assert _is_empty_prompt(None) is True
+
+    def test_empty_list_is_empty(self):
+        # A dynamically-built empty prompt routes to "segment everything",
+        # not a cryptic normalization error.
+        assert _is_empty_prompt([]) is True
+
+    def test_real_point_is_not_empty(self):
+        assert _is_empty_prompt([900, 370]) is False
+
+    def test_numpy_point_is_not_empty(self):
+        import numpy as np
+
+        assert _is_empty_prompt(np.array([900, 370])) is False
+
+
+class TestFactoryAliases:
+    def test_unknown_alias_raises_without_download(self):
+        # Alias resolution happens before any model construction/download.
+        with pytest.raises(ValueError, match="Unknown SAM model"):
+            LibreSAM("xl")
+
+    def test_case_and_whitespace_insensitive(self):
+        from libreyolo.models.sam.model import _ALIASES
+
+        # The factory lowercases/strips before lookup; both resolve.
+        assert "sam_b" in _ALIASES
+        assert _ALIASES["b"][1] == "base"

--- a/tests/unit/test_sam_logic.py
+++ b/tests/unit/test_sam_logic.py
@@ -109,6 +109,13 @@ class TestResolveDtype:
         assert m._resolve_dtype() == torch.float32
 
 
+class TestSnapshotIgnore:
+    def test_bin_is_ignored(self):
+        # SAM repos ship a duplicate pytorch_model.bin next to safetensors;
+        # transformers prefers safetensors, so the pickle must not be fetched.
+        assert "*.bin" in LibreSAM1.SNAPSHOT_IGNORE_PATTERNS
+
+
 class TestSetDevice:
     def test_auto_and_empty_are_noop(self):
         # 'auto'/'' are sentinels meaning "keep current device" — they must not

--- a/tests/unit/test_sam_logic.py
+++ b/tests/unit/test_sam_logic.py
@@ -109,6 +109,16 @@ class TestResolveDtype:
         assert m._resolve_dtype() == torch.float32
 
 
+class TestSetDevice:
+    def test_auto_and_empty_are_noop(self):
+        # 'auto'/'' are sentinels meaning "keep current device" — they must not
+        # be fed to torch.device() (which would raise), matching the runner.
+        m = object.__new__(LibreSAM1)
+        m.device = torch.device("cpu")
+        assert m._set_device("auto").device == torch.device("cpu")
+        assert m._set_device("").device == torch.device("cpu")
+
+
 class TestEmptyPromptDispatch:
     def test_none_is_empty(self):
         assert _is_empty_prompt(None) is True

--- a/tests/unit/test_sam_prompts.py
+++ b/tests/unit/test_sam_prompts.py
@@ -51,6 +51,12 @@ class TestNormalizePoints:
             [[900, 370]],
         ]
 
+    def test_ragged_point_counts_raise_clearly(self):
+        # One 1-click object + one 2-click object would fail deep in the
+        # processor with an opaque numpy error; reject it up front.
+        with pytest.raises(ValueError, match="same number of points"):
+            normalize_points([[[400, 370]], [[500, 370], [600, 370]]])
+
 
 class TestNormalizeLabels:
     def test_default_all_positive(self):
@@ -68,6 +74,12 @@ class TestNormalizeLabels:
     def test_explicit_grouped_labels(self):
         pts = normalize_points([[[400, 370], [900, 370]]])
         assert normalize_labels([[1, 0]], pts) == [[1, 0]]
+
+    def test_flat_labels_on_single_object_are_per_point(self):
+        # The natural positive/negative click on ONE object: points grouped,
+        # labels flat [1, 0] should map to that object's two points.
+        pts = normalize_points([[[400, 370], [900, 370]]])
+        assert normalize_labels([1, 0], pts) == [[1, 0]]
 
     def test_shape_mismatch_raises(self):
         pts = normalize_points([[400, 370], [900, 370]])

--- a/tests/unit/test_sam_prompts.py
+++ b/tests/unit/test_sam_prompts.py
@@ -81,6 +81,13 @@ class TestNormalizeLabels:
         pts = normalize_points([[[400, 370], [900, 370]]])
         assert normalize_labels([1, 0], pts) == [[1, 0]]
 
+    def test_mixed_nesting_labels_raise_value_error(self):
+        # [[1], 0] reports depth 2 but isn't uniformly nested — must be a clean
+        # ValueError, not a TypeError from flattening a scalar.
+        pts = normalize_points([[400, 370], [900, 370]])
+        with pytest.raises(ValueError, match="mixed nesting"):
+            normalize_labels([[1], 0], pts)
+
     def test_out_of_range_label_raises(self):
         # A typo'd label (2) would silently produce a wrong mask; reject it.
         pts = normalize_points([900, 370])

--- a/tests/unit/test_sam_prompts.py
+++ b/tests/unit/test_sam_prompts.py
@@ -81,6 +81,21 @@ class TestNormalizeLabels:
         pts = normalize_points([[[400, 370], [900, 370]]])
         assert normalize_labels([1, 0], pts) == [[1, 0]]
 
+    def test_out_of_range_label_raises(self):
+        # A typo'd label (2) would silently produce a wrong mask; reject it.
+        pts = normalize_points([900, 370])
+        with pytest.raises(ValueError, match="1 .positive. or 0 .negative."):
+            normalize_labels([2], pts)
+
+    def test_truncating_float_label_raises(self):
+        pts = normalize_points([900, 370])
+        with pytest.raises(ValueError, match="1 .positive. or 0 .negative."):
+            normalize_labels([1.9], pts)
+
+    def test_float_one_point_zero_is_accepted(self):
+        pts = normalize_points([900, 370])
+        assert normalize_labels([1.0], pts) == [[1]]
+
     def test_shape_mismatch_raises(self):
         pts = normalize_points([[400, 370], [900, 370]])
         with pytest.raises(ValueError):

--- a/tests/unit/test_sam_prompts.py
+++ b/tests/unit/test_sam_prompts.py
@@ -1,0 +1,121 @@
+"""Unit tests for LibreSAM prompt normalization (offline, no model weights)."""
+
+import numpy as np
+import pytest
+
+from libreyolo.models.sam.prompts import (
+    build_point_grid,
+    normalize_boxes,
+    normalize_labels,
+    normalize_points,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestNormalizePoints:
+    def test_none_passthrough(self):
+        assert normalize_points(None) is None
+
+    def test_single_point(self):
+        # Documented: points=[x, y] -> one object, one point.
+        assert normalize_points([900, 370]) == [[[900, 370]]]
+
+    def test_multiple_points_are_separate_objects(self):
+        # Documented: points=[[x, y], [x, y]] -> two objects, one point each.
+        assert normalize_points([[400, 370], [900, 370]]) == [
+            [[400, 370]],
+            [[900, 370]],
+        ]
+
+    def test_grouped_points_per_object(self):
+        # Documented: points=[[[x, y], [x, y]]] -> one object, two points.
+        assert normalize_points([[[400, 370], [900, 370]]]) == [
+            [[400, 370], [900, 370]]
+        ]
+
+    def test_tuples_accepted(self):
+        assert normalize_points((900, 370)) == [[[900, 370]]]
+
+    def test_bad_point_length_raises(self):
+        with pytest.raises(ValueError):
+            normalize_points([[1, 2, 3]])
+
+    def test_numpy_1d_point(self):
+        # numpy is the natural carrier of click coords; must be accepted.
+        assert normalize_points(np.array([900, 370])) == [[[900, 370]]]
+
+    def test_numpy_2d_points_are_separate_objects(self):
+        assert normalize_points(np.array([[400, 370], [900, 370]])) == [
+            [[400, 370]],
+            [[900, 370]],
+        ]
+
+
+class TestNormalizeLabels:
+    def test_default_all_positive(self):
+        pts = normalize_points([[400, 370], [900, 370]])
+        assert normalize_labels(None, pts) == [[1], [1]]
+
+    def test_default_for_grouped(self):
+        pts = normalize_points([[[400, 370], [900, 370]]])
+        assert normalize_labels(None, pts) == [[1, 1]]
+
+    def test_explicit_flat_labels_map_per_object(self):
+        pts = normalize_points([[400, 370], [900, 370]])
+        assert normalize_labels([1, 0], pts) == [[1], [0]]
+
+    def test_explicit_grouped_labels(self):
+        pts = normalize_points([[[400, 370], [900, 370]]])
+        assert normalize_labels([[1, 0]], pts) == [[1, 0]]
+
+    def test_shape_mismatch_raises(self):
+        pts = normalize_points([[400, 370], [900, 370]])
+        with pytest.raises(ValueError):
+            normalize_labels([1], pts)
+
+    def test_labels_without_points_raises(self):
+        with pytest.raises(ValueError):
+            normalize_labels([1], None)
+
+
+class TestNormalizeBoxes:
+    def test_none_passthrough(self):
+        assert normalize_boxes(None) is None
+
+    def test_single_box(self):
+        assert normalize_boxes([100, 100, 200, 200]) == [[100, 100, 200, 200]]
+
+    def test_multiple_boxes(self):
+        assert normalize_boxes([[10, 10, 20, 20], [30, 30, 40, 40]]) == [
+            [10, 10, 20, 20],
+            [30, 30, 40, 40],
+        ]
+
+    def test_bad_box_length_raises(self):
+        with pytest.raises(ValueError):
+            normalize_boxes([1, 2, 3])
+
+    def test_numpy_single_box(self):
+        assert normalize_boxes(np.array([100, 100, 200, 200])) == [
+            [100, 100, 200, 200]
+        ]
+
+
+class TestBuildPointGrid:
+    def test_count(self):
+        assert len(build_point_grid(16)) == 256
+
+    def test_normalized_range_and_symmetry(self):
+        grid = build_point_grid(2)
+        # 2x2 grid centered in each quadrant: 0.25 and 0.75 on each axis.
+        assert grid == [
+            [0.25, 0.25],
+            [0.75, 0.25],
+            [0.25, 0.75],
+            [0.75, 0.75],
+        ]
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError):
+            build_point_grid(0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new promptable segmentation tiers: `LibreSAM` (and `LibreSAM1`) with point/box prompting, multimask support, and automatic “segment everything”.
  * Introduced an interactive workflow with `set_image`/`reset_image` and cached image embeddings for faster repeated predictions.
  * Added factory model-name aliases (e.g., base/large/huge) for easier selection.
* **Documentation**
  * Added an ADR documenting the LibreSAM tier contract and expected inference behaviors.
* **Tests**
  * Added LibreSAM e2e smoke tests plus unit tests for prompt normalization and result selection/filtering.
* **Chores**
  * Added optional `sam` dependency group and a `sam` pytest marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->