### PR TITLE
400 coco dataset format has hardcoded path

### DIFF
--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -16,12 +16,25 @@ Applies to `detect`, `segment`, `pose`, and `obb`.
 - `names`: required list or integer-keyed class mapping.
 - `nc`: optional; must match `names` when present.
 - `download`: optional; Python download scripts require explicit opt-in.
+- `annotations`: optional mapping of split names to native COCO JSON files.
 
 `train`, `val`, and `test` may be image directories, image-list `.txt` files,
 or lists of those values. Label paths follow:
 
 ```text
 images/.../image.jpg -> labels/.../image.txt
+```
+
+For native COCO JSON datasets, `annotations` maps a split to the JSON file and
+the split path gives the image root:
+
+```yaml
+path: dataset
+train: images/train
+val: images/val
+annotations:
+  train: annotations/train.json
+  val: annotations/val.json
 ```
 
 Do not require `task` in dataset YAML. Explicit model/task selection wins.

--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -16,7 +16,8 @@ Applies to `detect`, `segment`, `pose`, and `obb`.
 - `names`: required list or integer-keyed class mapping.
 - `nc`: optional; must match `names` when present.
 - `download`: optional; Python download scripts require explicit opt-in.
-- `annotations`: optional mapping of split names to native COCO JSON files.
+- `annotations`: optional mapping of split names to native COCO JSON files for
+  detection and instance segmentation.
 
 `train`, `val`, and `test` may be image directories, image-list `.txt` files,
 or lists of those values. Label paths follow:
@@ -25,8 +26,8 @@ or lists of those values. Label paths follow:
 images/.../image.jpg -> labels/.../image.txt
 ```
 
-For native COCO JSON datasets, `annotations` maps a split to the JSON file and
-the split path gives the image root:
+For native COCO JSON detection/instance-segmentation datasets, `annotations`
+maps a split to the JSON file and the split path gives the image root:
 
 ```yaml
 path: dataset

--- a/libreyolo/data/__init__.py
+++ b/libreyolo/data/__init__.py
@@ -40,6 +40,8 @@ from .semantic_dataset import (
 from .utils import (
     DATASETS_DIR,
     check_dataset,
+    get_coco_annotation_file,
+    get_coco_image_dir,
     get_img_files,
     img2label_paths,
     load_data_config,
@@ -49,6 +51,8 @@ from .yolo_coco_api import YOLOCocoAPI, create_yolo_coco_api, parse_yolo_label_l
 __all__ = [
     "DATASETS_DIR",
     "check_dataset",
+    "get_coco_annotation_file",
+    "get_coco_image_dir",
     "get_img_files",
     "img2label_paths",
     "load_data_config",

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -530,7 +530,7 @@ class COCODataset(ImageCacheMixin, Dataset):
                 "Install with: pip install pycocotools"
             )
 
-        self.data_dir = data_dir
+        self.data_dir = Path(data_dir)
         self.json_file = json_file
         self.name = name
         self.img_size = img_size
@@ -539,8 +539,8 @@ class COCODataset(ImageCacheMixin, Dataset):
         self.load_segments = load_segments
 
         # Load COCO annotations
-        ann_file = os.path.join(data_dir, "annotations", json_file)
-        self.coco = COCO(ann_file)
+        ann_file = self._annotation_path()
+        self.coco = COCO(str(ann_file))
 
         # Remove useless info to save memory
         self._remove_useless_info()
@@ -553,6 +553,14 @@ class COCODataset(ImageCacheMixin, Dataset):
 
         # Pre-load annotations
         self.annotations = self._load_coco_annotations()
+
+    def _annotation_path(self) -> Path:
+        path = Path(self.json_file)
+        if path.is_absolute():
+            return path
+        if path.parent != Path("."):
+            return self.data_dir / path
+        return self.data_dir / "annotations" / path
 
     def _remove_useless_info(self):
         """Remove useless info from COCO to save memory."""
@@ -666,7 +674,10 @@ class COCODataset(ImageCacheMixin, Dataset):
     def _image_path(self, index: int) -> Path:
         """Source image path for given index (used for disk caching)."""
         file_name = self.annotations[index][3]
-        return Path(self.data_dir) / self.name / file_name
+        image_root = Path(self.name)
+        if image_root.is_absolute():
+            return image_root / file_name
+        return self.data_dir / image_root / file_name
 
     def _decode_image(self, index: int) -> np.ndarray:
         """Decode image from disk for given index."""

--- a/libreyolo/data/utils.py
+++ b/libreyolo/data/utils.py
@@ -6,6 +6,7 @@ Provides dataset auto-download, path resolution, and configuration loading.
 Supports YAML configs with:
 - Directory paths (e.g., val: images/val)
 - Text file paths (e.g., val: val2017.txt)
+- COCO JSON annotation paths (e.g., annotations: {val: annotations/val.json})
 - List paths (e.g., val: [path1, path2])
 - Python download scripts
 """
@@ -234,6 +235,7 @@ def load_data_config(
     Supports YAML formats:
     - Directory paths: train/val point to directories (e.g., "images/train")
     - File list paths: train/val can be .txt files (e.g., "train2017.txt")
+    - Native COCO JSON annotations via annotations: {train: "...", val: "..."}
 
     If the dataset doesn't exist locally and a download URL/script is specified
     in the YAML, it will be automatically downloaded.
@@ -251,6 +253,7 @@ def load_data_config(
         - train/val/test: Resolved paths (directory or .txt file)
         - {split}_img_files: List of resolved image paths (when discoverable)
         - {split}_label_files: List of resolved label paths (when discoverable)
+        - {split}_annotation_file: Resolved COCO JSON path (when configured)
         - names: Class names dict or list
         - nc: Number of classes
 
@@ -303,10 +306,54 @@ def load_data_config(
                 # Split path doesn't exist yet or contains no supported images.
                 pass
 
+    _resolve_coco_annotation_paths(config, dataset_path)
+
     # Keep 'root' for backward compatibility
     config["root"] = str(dataset_path)
 
     return config
+
+
+def _resolve_coco_annotation_paths(config: Dict, dataset_path: Path) -> None:
+    annotations = config.get("annotations")
+    if annotations is None:
+        return
+    if not isinstance(annotations, dict):
+        raise ValueError(
+            "Dataset 'annotations' must map split names to COCO JSON paths, "
+            "for example: annotations: {train: annotations/train.json}"
+        )
+
+    for split in ("train", "val", "test"):
+        annotation_path = annotations.get(split)
+        if not annotation_path:
+            continue
+        path = Path(annotation_path)
+        if not path.is_absolute():
+            path = dataset_path / path
+        config[f"{split}_annotation_file"] = str(path)
+
+
+def get_coco_annotation_file(config: Dict, split: str) -> Optional[str]:
+    """Return the resolved COCO JSON path for a split, if configured."""
+    annotation_file = config.get(f"{split}_annotation_file")
+    return str(annotation_file) if annotation_file else None
+
+
+def get_coco_image_dir(config: Dict, split: str, default: str) -> str:
+    """Return the resolved image root to pair with a configured COCO JSON file."""
+    split_path = config.get(split)
+    if isinstance(split_path, list):
+        raise ValueError(
+            "Native COCO JSON loading expects one image directory per split; "
+            f"got a list for '{split}'."
+        )
+    if str(split_path).endswith(".txt"):
+        raise ValueError(
+            "Native COCO JSON loading expects an image directory, not an image "
+            f"list file for '{split}'."
+        )
+    return str(split_path) if split_path else default
 
 
 def _resolve_dataset_path(config: Dict, yaml_path: Path) -> Path:

--- a/libreyolo/data/utils.py
+++ b/libreyolo/data/utils.py
@@ -348,7 +348,7 @@ def get_coco_image_dir(config: Dict, split: str, default: str) -> str:
             "Native COCO JSON loading expects one image directory per split; "
             f"got a list for '{split}'."
         )
-    if str(split_path).endswith(".txt"):
+    if Path(str(split_path)).suffix.lower() == ".txt":
         raise ValueError(
             "Native COCO JSON loading expects an image directory, not an image "
             f"list file for '{split}'."

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -37,7 +37,13 @@ import torch
 from torch.amp import autocast
 from tqdm import tqdm
 
-from ...data import get_img_files, img2label_paths, load_data_config
+from ...data import (
+    get_coco_annotation_file,
+    get_coco_image_dir,
+    get_img_files,
+    img2label_paths,
+    load_data_config,
+)
 from ...data.dataset import COCODataset, YOLODataset
 from ...training.config import DEIMConfig, TrainConfig
 from ...training.scheduler import FlatCosineScheduler
@@ -310,10 +316,19 @@ class DEIMTrainer(BaseTrainer):
             self.num_classes = data_cfg.get("nc", self.config.num_classes)
 
             ann_file = Path(data_dir) / "annotations" / "instances_train2017.json"
+            coco_ann_file = get_coco_annotation_file(data_cfg, "train")
             img_files = data_cfg.get("train_img_files")
             label_files = data_cfg.get("train_label_files")
 
-            if img_files:
+            if coco_ann_file:
+                train_dataset = COCODataset(
+                    data_dir=data_dir,
+                    json_file=coco_ann_file,
+                    name=get_coco_image_dir(data_cfg, "train", "train2017"),
+                    img_size=img_size,
+                    preproc=preproc,
+                )
+            elif img_files:
                 train_dataset = YOLODataset(
                     img_files=img_files,
                     label_files=label_files,

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -37,7 +37,13 @@ import torch
 from torch.amp import autocast
 from tqdm import tqdm
 
-from ...data import get_img_files, img2label_paths, load_data_config
+from ...data import (
+    get_coco_annotation_file,
+    get_coco_image_dir,
+    get_img_files,
+    img2label_paths,
+    load_data_config,
+)
 from ...data.dataset import COCODataset, YOLODataset
 from ...training.config import DFINEConfig, TrainConfig
 from ...training.scheduler import FlatCosineScheduler
@@ -287,10 +293,19 @@ class DFINETrainer(BaseTrainer):
             self.num_classes = data_cfg.get("nc", self.config.num_classes)
 
             ann_file = Path(data_dir) / "annotations" / "instances_train2017.json"
+            coco_ann_file = get_coco_annotation_file(data_cfg, "train")
             img_files = data_cfg.get("train_img_files")
             label_files = data_cfg.get("train_label_files")
 
-            if img_files:
+            if coco_ann_file:
+                train_dataset = COCODataset(
+                    data_dir=data_dir,
+                    json_file=coco_ann_file,
+                    name=get_coco_image_dir(data_cfg, "train", "train2017"),
+                    img_size=img_size,
+                    preproc=preproc,
+                )
+            elif img_files:
                 train_dataset = YOLODataset(
                     img_files=img_files,
                     label_files=label_files,

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -46,7 +46,13 @@ from .distributed import (
 from .ema import ModelEMA
 from .freezing import FreezeGroup, apply_freeze, default_freeze_groups
 from ..data.dataset import YOLODataset, COCODataset, create_dataloader
-from ..data import load_data_config, get_img_files, img2label_paths
+from ..data import (
+    get_coco_annotation_file,
+    get_coco_image_dir,
+    get_img_files,
+    img2label_paths,
+    load_data_config,
+)
 from ..utils.serialization import (
     SCHEMA_VERSION,
     build_class_names,
@@ -447,12 +453,27 @@ class BaseTrainer(ABC):
             )
 
             ann_file = Path(data_dir) / "annotations" / "instances_train2017.json"
+            coco_ann_file = get_coco_annotation_file(data_cfg, "train")
 
             # Prefer pre-resolved file lists from load_data_config (.txt format)
             img_files = data_cfg.get("train_img_files")
             label_files = data_cfg.get("train_label_files")
 
-            if img_files:
+            if coco_ann_file:
+                if load_obb:
+                    raise ValueError(
+                        "YOLO9 OBB training expects YOLO OBB txt labels; "
+                        "COCO JSON OBB loading is not implemented."
+                    )
+                train_dataset = COCODataset(
+                    data_dir=data_dir,
+                    json_file=coco_ann_file,
+                    name=get_coco_image_dir(data_cfg, "train", "train2017"),
+                    img_size=img_size,
+                    preproc=preproc,
+                    load_segments=load_segments,
+                )
+            elif img_files:
                 train_dataset = YOLODataset(
                     img_files=img_files,
                     label_files=label_files,

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -87,7 +87,13 @@ class DetectionValidator(BaseValidator):
 
         Supports directory-based datasets, .txt file format, and COCO JSON.
         """
-        from libreyolo.data import load_data_config, get_img_files, img2label_paths
+        from libreyolo.data import (
+            get_coco_annotation_file,
+            get_coco_image_dir,
+            get_img_files,
+            img2label_paths,
+            load_data_config,
+        )
         from libreyolo.data.dataset import YOLODataset, COCODataset
         from torch.utils.data import DataLoader
 
@@ -100,6 +106,7 @@ class DetectionValidator(BaseValidator):
         label_files = None
         split_name = self.config.split
         data_cfg = None
+        explicit_coco_annotation = None
 
         if self.config.data:
             data_cfg = load_data_config(
@@ -118,6 +125,10 @@ class DetectionValidator(BaseValidator):
             # Check for pre-resolved file lists (from .txt format)
             img_files_key = f"{self.config.split}_img_files"
             label_files_key = f"{self.config.split}_label_files"
+            explicit_coco_annotation = get_coco_annotation_file(
+                data_cfg,
+                self.config.split,
+            )
 
             if img_files_key in data_cfg:
                 img_files = data_cfg[img_files_key]
@@ -166,13 +177,29 @@ class DetectionValidator(BaseValidator):
         self._coco_label_to_category_id = None
         self._yolo_coco_img_files = None
         self._yolo_coco_label_files = None
-        coco_annotation_file = self._find_coco_annotation_file(data_path)
+        coco_annotation_file = (
+            Path(explicit_coco_annotation)
+            if explicit_coco_annotation
+            else self._find_coco_annotation_file(data_path)
+        )
 
         if coco_annotation_file is not None:
             # Prefer official COCO JSON when it is present. This preserves
             # COCO image ids, category ids, crowd annotations, and area ranges.
-            json_file = coco_annotation_file.name
-            split_name = self._resolve_coco_image_dir(data_path, json_file)
+            json_file = (
+                str(coco_annotation_file)
+                if explicit_coco_annotation
+                else coco_annotation_file.name
+            )
+            split_name = (
+                get_coco_image_dir(
+                    data_cfg,
+                    self.config.split,
+                    self._resolve_coco_image_dir(data_path, coco_annotation_file.name),
+                )
+                if data_cfg is not None
+                else self._resolve_coco_image_dir(data_path, coco_annotation_file.name)
+            )
 
             dataset = COCODataset(
                 data_dir=str(data_path),

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -191,15 +191,17 @@ class DetectionValidator(BaseValidator):
                 if explicit_coco_annotation
                 else coco_annotation_file.name
             )
-            split_name = (
-                get_coco_image_dir(
+            if explicit_coco_annotation and data_cfg is not None:
+                split_name = get_coco_image_dir(
                     data_cfg,
                     self.config.split,
                     self._resolve_coco_image_dir(data_path, coco_annotation_file.name),
                 )
-                if data_cfg is not None
-                else self._resolve_coco_image_dir(data_path, coco_annotation_file.name)
-            )
+            else:
+                split_name = self._resolve_coco_image_dir(
+                    data_path,
+                    coco_annotation_file.name,
+                )
 
             dataset = COCODataset(
                 data_dir=str(data_path),

--- a/tests/unit/test_coco_validation.py
+++ b/tests/unit/test_coco_validation.py
@@ -221,6 +221,75 @@ def test_detection_validator_uses_explicit_coco_json_paths(tmp_path):
 
 
 @pytest.mark.unit
+def test_detection_validator_accepts_txt_split_with_discovered_coco_json(tmp_path):
+    pytest.importorskip("pycocotools")
+    from libreyolo.data.dataset import COCODataset
+    from libreyolo.validation.detection_validator import DetectionValidator
+
+    image_dir = tmp_path / "val2017"
+    ann_dir = tmp_path / "annotations"
+    image_dir.mkdir()
+    ann_dir.mkdir()
+    Image.new("RGB", (64, 64), color="white").save(image_dir / "sample.jpg")
+    (ann_dir / "instances_val2017.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {"id": 10, "file_name": "sample.jpg", "width": 64, "height": 64}
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 10,
+                        "category_id": 42,
+                        "bbox": [8, 8, 16, 16],
+                        "area": 256,
+                        "iscrowd": 0,
+                    }
+                ],
+                "categories": [{"id": 42, "name": "vehicle"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "val2017.txt").write_text("val2017/sample.jpg\n", encoding="utf-8")
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        "path: " + str(tmp_path).replace("\\", "/") + "\n"
+        "train: val2017.txt\n"
+        "val: val2017.txt\n"
+        "nc: 1\n"
+        "names:\n"
+        "  0: vehicle\n",
+        encoding="utf-8",
+    )
+    validator = DetectionValidator.__new__(DetectionValidator)
+    validator.config = SimpleNamespace(
+        data=str(yaml_path),
+        data_dir=None,
+        split="val",
+        allow_download_scripts=False,
+        imgsz=64,
+        batch_size=1,
+        num_workers=0,
+    )
+    validator.model = SimpleNamespace(
+        _get_input_size=lambda: 64,
+        _get_val_preprocessor=lambda img_size: None,
+    )
+    validator.device = torch.device("cpu")
+    validator.nc = 1
+    validator.class_names = None
+
+    loader = validator._setup_dataloader()
+
+    assert isinstance(loader.dataset, COCODataset)
+    assert loader.dataset.json_file == "instances_val2017.json"
+    assert loader.dataset.name == "val2017"
+    assert loader.dataset._image_path(0) == image_dir / "sample.jpg"
+
+
+@pytest.mark.unit
 def test_coco_evaluator_encodes_masks_json_safe():
     from libreyolo.validation.coco_evaluator import COCOEvaluator
 

--- a/tests/unit/test_coco_validation.py
+++ b/tests/unit/test_coco_validation.py
@@ -47,9 +47,8 @@ class _DummyEvaluator:
         return dict(self.metrics)
 
 
-def _null_val_preprocessor(*, img_size):
+def _null_val_preprocessor(*, img_size: int) -> None:
     assert img_size > 0
-    return None
 
 
 def create_mock_yolo_dataset(tmp_path):

--- a/tests/unit/test_coco_validation.py
+++ b/tests/unit/test_coco_validation.py
@@ -47,6 +47,11 @@ class _DummyEvaluator:
         return dict(self.metrics)
 
 
+def _null_val_preprocessor(*, img_size):
+    assert img_size > 0
+    return None
+
+
 def create_mock_yolo_dataset(tmp_path):
     """Create a minimal mock YOLO dataset for testing."""
     # Create directory structure
@@ -206,7 +211,7 @@ def test_detection_validator_uses_explicit_coco_json_paths(tmp_path):
     )
     validator.model = SimpleNamespace(
         _get_input_size=lambda: 64,
-        _get_val_preprocessor=lambda img_size: None,
+        _get_val_preprocessor=_null_val_preprocessor,
     )
     validator.device = torch.device("cpu")
     validator.nc = 1
@@ -275,7 +280,7 @@ def test_detection_validator_accepts_txt_split_with_discovered_coco_json(tmp_pat
     )
     validator.model = SimpleNamespace(
         _get_input_size=lambda: 64,
-        _get_val_preprocessor=lambda img_size: None,
+        _get_val_preprocessor=_null_val_preprocessor,
     )
     validator.device = torch.device("cpu")
     validator.nc = 1

--- a/tests/unit/test_coco_validation.py
+++ b/tests/unit/test_coco_validation.py
@@ -5,6 +5,7 @@ Tests that COCO evaluator is properly integrated into the validation pipeline
 using mock data (no GPU or real datasets needed).
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -147,6 +148,76 @@ def test_coco_evaluator_integration(tmp_path):
     ]
     for key in expected_keys:
         assert key in metrics, f"Missing metric: {key}"
+
+
+@pytest.mark.unit
+def test_detection_validator_uses_explicit_coco_json_paths(tmp_path):
+    pytest.importorskip("pycocotools")
+    from libreyolo.data.dataset import COCODataset
+    from libreyolo.validation.detection_validator import DetectionValidator
+
+    image_dir = tmp_path / "images" / "custom_val"
+    ann_dir = tmp_path / "custom_annotations"
+    image_dir.mkdir(parents=True)
+    ann_dir.mkdir()
+    Image.new("RGB", (64, 64), color="white").save(image_dir / "sample.jpg")
+    (ann_dir / "valid.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {"id": 10, "file_name": "sample.jpg", "width": 64, "height": 64}
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 10,
+                        "category_id": 42,
+                        "bbox": [8, 8, 16, 16],
+                        "area": 256,
+                        "iscrowd": 0,
+                    }
+                ],
+                "categories": [{"id": 42, "name": "vehicle"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        "path: " + str(tmp_path).replace("\\", "/") + "\n"
+        "train: images/custom_val\n"
+        "val: images/custom_val\n"
+        "annotations:\n"
+        "  val: custom_annotations/valid.json\n"
+        "nc: 1\n"
+        "names:\n"
+        "  0: vehicle\n",
+        encoding="utf-8",
+    )
+    validator = DetectionValidator.__new__(DetectionValidator)
+    validator.config = SimpleNamespace(
+        data=str(yaml_path),
+        data_dir=None,
+        split="val",
+        allow_download_scripts=False,
+        imgsz=64,
+        batch_size=1,
+        num_workers=0,
+    )
+    validator.model = SimpleNamespace(
+        _get_input_size=lambda: 64,
+        _get_val_preprocessor=lambda img_size: None,
+    )
+    validator.device = torch.device("cpu")
+    validator.nc = 1
+    validator.class_names = None
+
+    loader = validator._setup_dataloader()
+
+    assert isinstance(loader.dataset, COCODataset)
+    assert loader.dataset.json_file == str(ann_dir / "valid.json")
+    assert loader.dataset.name == str(image_dir)
+    assert loader.dataset._image_path(0) == image_dir / "sample.jpg"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -166,7 +166,7 @@ def test_load_data_config_resolves_coco_annotation_paths(tmp_path):
     )
 
 
-@pytest.mark.parametrize("split_value", [["images/a", "images/b"], "train.txt"])
+@pytest.mark.parametrize("split_value", [["images/a", "images/b"], "train.txt", "TRAIN.TXT"])
 def test_coco_image_dir_requires_single_directory(split_value):
     with pytest.raises(ValueError, match="Native COCO JSON loading expects"):
         get_coco_image_dir({"train": split_value}, "train", "train2017")

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -9,6 +9,7 @@ from PIL import Image
 from libreyolo.data.utils import (
     BUILTIN_DATASETS_DIR,
     get_img_files,
+    get_coco_image_dir,
     img2label_paths,
     load_data_config,
 )
@@ -133,6 +134,42 @@ def test_load_data_config_resolves_directory_test_split(tmp_path):
     assert config["test"] == str(images_dir)
     assert config["test_img_files"] == [image_path]
     assert config["test_label_files"] == [label_path]
+
+
+def test_load_data_config_resolves_coco_annotation_paths(tmp_path):
+    dataset_root = tmp_path / "dataset"
+    (dataset_root / "annotations").mkdir(parents=True)
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(dataset_root),
+                "train": "images/train",
+                "val": "images/val",
+                "annotations": {
+                    "train": "annotations/train.json",
+                    "val": str(dataset_root / "annotations" / "valid.json"),
+                },
+                "names": ["marble"],
+                "nc": 1,
+            }
+        )
+    )
+
+    config = load_data_config(str(yaml_path), autodownload=False)
+
+    assert config["train_annotation_file"] == str(
+        dataset_root / "annotations" / "train.json"
+    )
+    assert config["val_annotation_file"] == str(
+        dataset_root / "annotations" / "valid.json"
+    )
+
+
+@pytest.mark.parametrize("split_value", [["images/a", "images/b"], "train.txt"])
+def test_coco_image_dir_requires_single_directory(split_value):
+    with pytest.raises(ValueError, match="Native COCO JSON loading expects"):
+        get_coco_image_dir({"train": split_value}, "train", "train2017")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_yolo9_layers.py
+++ b/tests/unit/test_yolo9_layers.py
@@ -1,5 +1,7 @@
 """Unit tests for YOLOv9 layers."""
 
+import json
+
 import pytest
 import numpy as np
 import torch
@@ -723,6 +725,72 @@ def test_yolo9_trainer_disables_proxy_mosaic_for_obb(tmp_path):
     assert train_dataset.mixup_prob == 0.0
     assert train_dataset.preproc.vertical_flip_prob == 0.5
     assert train_dataset.dataset.num_classes == 1
+
+
+def test_yolo9_trainer_uses_explicit_coco_json_paths(tmp_path):
+    pytest.importorskip("pycocotools")
+    from libreyolo.data.dataset import COCODataset
+
+    image_dir = tmp_path / "images" / "custom_train"
+    ann_dir = tmp_path / "custom_annotations"
+    image_dir.mkdir(parents=True)
+    ann_dir.mkdir()
+    Image.new("RGB", (64, 64), color="white").save(image_dir / "sample.jpg")
+    (ann_dir / "train.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {"id": 10, "file_name": "sample.jpg", "width": 64, "height": 64}
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 10,
+                        "category_id": 42,
+                        "bbox": [8, 8, 16, 16],
+                        "area": 256,
+                        "iscrowd": 0,
+                    }
+                ],
+                "categories": [{"id": 42, "name": "vehicle"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        "path: " + str(tmp_path).replace("\\", "/") + "\n"
+        "train: images/custom_train\n"
+        "val: images/custom_train\n"
+        "annotations:\n"
+        "  train: custom_annotations/train.json\n"
+        "nc: 1\n"
+        "names:\n"
+        "  0: vehicle\n",
+        encoding="utf-8",
+    )
+    wrapper = type(
+        "Wrapper",
+        (),
+        {"task": "detect", "nb_classes": 1, "names": {0: "vehicle"}},
+    )()
+    trainer = YOLO9Trainer(
+        model=torch.nn.Conv2d(3, 3, 1),
+        wrapper_model=wrapper,
+        data=str(data_yaml),
+        epochs=1,
+        batch=1,
+        imgsz=64,
+        workers=0,
+        device="cpu",
+    )
+
+    train_dataset = trainer._setup_data()
+
+    assert isinstance(train_dataset.dataset, COCODataset)
+    assert train_dataset.dataset.json_file == str(ann_dir / "train.json")
+    assert train_dataset.dataset.name == str(image_dir)
+    assert train_dataset.dataset._image_path(0) == image_dir / "sample.jpg"
 
 
 def test_yolo9_trainer_checkpoint_uses_resolved_data_classes_for_obb(tmp_path):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `annotations` mapping in dataset YAML configs to specify per-split COCO JSON annotation files.
  * Trainers and validation now use resolved COCO annotation paths and matching COCO image directories when provided.

* **Bug Fixes**
  * Improved COCO annotation and image-root resolution with consistent handling of relative/absolute paths and split layouts.

* **Documentation**
  * Extended dataset schema docs with the `annotations` contract and YAML examples.

* **Tests**
  * Added/updated unit tests to verify explicit COCO JSON usage and correct dataloader/dataset wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->