### PR TITLE
Guard macOS ONNX simplification

### DIFF
--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -1,7 +1,10 @@
 """ONNX export implementation."""
 
 import importlib.util
+import platform
+import re
 import warnings
+from importlib import metadata as importlib_metadata
 
 import torch
 
@@ -51,6 +54,32 @@ def _set_metadata(model_proto, metadata: dict) -> None:
         entry.value = value
 
 
+def _package_version(name: str) -> tuple[int, int, int] | None:
+    try:
+        raw_version = importlib_metadata.version(name)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+    match = re.match(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?", raw_version)
+    return tuple(int(part or 0) for part in match.groups()) if match else None
+
+
+def _should_skip_onnx_simplify() -> bool:
+    """Avoid the known onnxsim macOS-arm crash before it can abort Python."""
+    if platform.system() != "Darwin" or platform.machine().lower() not in {
+        "arm64",
+        "aarch64",
+    }:
+        return False
+    onnx_version = _package_version("onnx")
+    onnxsim_version = _package_version("onnxsim")
+    return (
+        onnx_version is not None
+        and onnx_version >= (1, 22, 0)
+        and onnxsim_version is not None
+        and onnxsim_version <= (0, 6, 5)
+    )
+
+
 def _postprocess_onnx(
     path: str,
     *,
@@ -66,6 +95,15 @@ def _postprocess_onnx(
         return
 
     model_proto = onnx.load(path)
+
+    if simplify and _should_skip_onnx_simplify():
+        warnings.warn(
+            "Skipping ONNX simplification: onnx>=1.22 with onnxsim<=0.6.5 "
+            "can crash Python on macOS arm64.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+        simplify = False
 
     if simplify:
         try:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 
 import libreyolo.export.exporter as exporter_module
+import libreyolo.export.onnx as onnx_module
 from libreyolo.export.exporter import (
     BaseExporter,
     CoreMLExporter,
@@ -43,6 +44,23 @@ class _TinyModel(nn.Module):
         x = self.pool(x)
         x = x.view(x.size(0), -1)
         return self.fc(x)
+
+
+def test_onnx_simplify_skip_targets_known_macos_arm64_combo(monkeypatch):
+    versions = {"onnx": "1.22.0", "onnxsim": "0.6.5"}
+    monkeypatch.setattr(onnx_module.importlib_metadata, "version", versions.__getitem__)
+    monkeypatch.setattr(onnx_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(onnx_module.platform, "machine", lambda: "arm64")
+    assert onnx_module._should_skip_onnx_simplify()
+
+    versions["onnxsim"] = "0.6.6"
+    assert not onnx_module._should_skip_onnx_simplify()
+
+    versions.update(onnx="1.21.0", onnxsim="0.6.5")
+    assert not onnx_module._should_skip_onnx_simplify()
+
+    monkeypatch.setattr(onnx_module.platform, "system", lambda: "Linux")
+    assert not onnx_module._should_skip_onnx_simplify()
 
 
 class _TinyRFDETRExport(nn.Module):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved ONNX export reliability on macOS ARM64 by automatically disabling graph simplification for a known crash-prone set of library versions.
  * When simplification is skipped, ONNX export behavior remains stable and model metadata is preserved, with a runtime warning emitted when applicable.

* **Tests**
  * Added unit tests to verify the simplification-skip decision logic across targeted macOS ARM64 and version scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->