### PR TITLE
Auto-convert bare upstream RF-DETR checkpoints as COCO (nc=80)

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -133,6 +133,19 @@ When metadata is missing or incomplete:
   checkpoints. Convert them with the appropriate `weights/convert_*.py` script
   before loading.
 
+### RF-DETR COCO normalization
+
+Upstream RF-DETR checkpoints expose a 91-output `class_embed` head
+(`raw_nc = 90`, COCO's 90 classes + background). Auto-conversion normalizes a
+*COCO* RF-DETR to LibreYOLO's COCO-80 convention (`nc = 80`, with the COCO
+remap applied at post-process). A checkpoint is treated as COCO when it carries
+80 names, a `coco` dataset hint, **or** no class/dataset metadata at all — a
+bare upstream state-dict is the canonical Roboflow COCO-pretrained checkpoint
+(the only metadata-less 91-output RF-DETR in distribution). A genuine custom
+90-class RF-DETR is preserved as `nc = 90`: it is identified by either a
+`names`/`class_names` list or a non-COCO dataset hint (e.g.
+`args.dataset_file`), so the bare-checkpoint COCO fallback does not fire for it.
+
 Schema helpers live in `libreyolo/utils/serialization.py`:
 
 ```python

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -138,13 +138,20 @@ When metadata is missing or incomplete:
 Upstream RF-DETR checkpoints expose a 91-output `class_embed` head
 (`raw_nc = 90`, COCO's 90 classes + background). Auto-conversion normalizes a
 *COCO* RF-DETR to LibreYOLO's COCO-80 convention (`nc = 80`, with the COCO
-remap applied at post-process). A checkpoint is treated as COCO when it carries
-80 names, a `coco` dataset hint, **or** no class/dataset metadata at all — a
-bare upstream state-dict is the canonical Roboflow COCO-pretrained checkpoint
-(the only metadata-less 91-output RF-DETR in distribution). A genuine custom
-90-class RF-DETR is preserved as `nc = 90`: it is identified by either a
-`names`/`class_names` list or a non-COCO dataset hint (e.g.
-`args.dataset_file`), so the bare-checkpoint COCO fallback does not fire for it.
+remap applied at post-process). A checkpoint is treated as COCO when it:
+
+- carries exactly 80 names, **or**
+- declares an explicit class count of 80 (`nc` / `args.num_classes`), **or**
+- has a `coco` dataset hint, **or**
+- has **no** class or dataset metadata at all — a bare upstream state-dict is
+  the canonical Roboflow COCO-pretrained checkpoint (the only metadata-less
+  91-output RF-DETR in distribution).
+
+A genuine custom 90-class RF-DETR is preserved as `nc = 90`. It is identified
+by a `names`/`class_names` list, an explicit non-80 class count, or a non-COCO
+dataset hint (e.g. `args.dataset_file`), so the bare-checkpoint COCO fallback
+does not fire for it. Empty placeholders (`""`, `{}`, `[]`) are ignored when
+deciding whether a dataset hint is present.
 
 Schema helpers live in `libreyolo/utils/serialization.py`:
 

--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -537,23 +537,35 @@ def _is_coco_rfdetr_checkpoint(loaded: Any) -> bool:
     if name_count == 80:
         return True
 
+    # Any non-empty value under a dataset field is a hint that the checkpoint
+    # declared its own dataset; only a string can positively identify COCO.
     has_dataset_hint = False
     for field in ("dataset", "dataset_file", "dataset_name", "data"):
         value = _metadata_value(loaded, field)
-        if isinstance(value, str) and value.strip():
-            has_dataset_hint = True
+        if value is None:
+            continue
+        if isinstance(value, str):
+            if not value.strip():
+                continue
             if "coco" in value.lower():
                 return True
+        has_dataset_hint = True
 
-    # A bare upstream RF-DETR state_dict carries no class metadata at all --
-    # no names AND no dataset hint of any kind. The only metadata-less
-    # 91-output RF-DETR in distribution is Roboflow's COCO-pretrained
+    # Explicit class-count metadata (top-level nc, or args.num_classes/nc)
+    # means the checkpoint declared its own class space, so it is not a bare
+    # upstream state_dict even when it omits names.
+    has_class_count = any(
+        _metadata_value(loaded, field) is not None for field in ("nc", "num_classes")
+    )
+
+    # A bare upstream RF-DETR state_dict carries NO class metadata at all -- no
+    # names, no dataset hint of any kind, and no explicit class count. The only
+    # such 91-output RF-DETR in distribution is Roboflow's COCO-pretrained
     # checkpoint, so treat it as COCO: its 90-class arch head then normalizes
     # to LibreYOLO's COCO-80, identical to the published LibreYOLO weights. A
-    # genuine custom 90-class model carries names or a (non-COCO) dataset hint
-    # and is left untouched (returns False) -- guarding the fallback on the
-    # absence of BOTH avoids mislabeling such a model as COCO.
-    if name_count is None and not has_dataset_hint:
+    # genuine custom 90-class model carries names, a (non-COCO) dataset hint,
+    # or an explicit class count and is left untouched (returns False).
+    if name_count is None and not has_dataset_hint and not has_class_count:
         return True
 
     return False

--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -537,18 +537,23 @@ def _is_coco_rfdetr_checkpoint(loaded: Any) -> bool:
     if name_count == 80:
         return True
 
+    has_dataset_hint = False
     for field in ("dataset", "dataset_file", "dataset_name", "data"):
         value = _metadata_value(loaded, field)
-        if isinstance(value, str) and "coco" in value.lower():
-            return True
+        if isinstance(value, str) and value.strip():
+            has_dataset_hint = True
+            if "coco" in value.lower():
+                return True
 
-    # A bare upstream RF-DETR state_dict carries no class metadata at all
-    # (no names, no dataset hint). The only metadata-less 91-output RF-DETR
-    # in distribution is Roboflow's COCO-pretrained checkpoint, so treat it
-    # as COCO: its 90-class arch head then normalizes to LibreYOLO's COCO-80,
-    # identical to the published LibreYOLO weights. A genuine custom 90-class
-    # model is saved with names/metadata and is left untouched (returns False).
-    if name_count is None:
+    # A bare upstream RF-DETR state_dict carries no class metadata at all --
+    # no names AND no dataset hint of any kind. The only metadata-less
+    # 91-output RF-DETR in distribution is Roboflow's COCO-pretrained
+    # checkpoint, so treat it as COCO: its 90-class arch head then normalizes
+    # to LibreYOLO's COCO-80, identical to the published LibreYOLO weights. A
+    # genuine custom 90-class model carries names or a (non-COCO) dataset hint
+    # and is left untouched (returns False) -- guarding the fallback on the
+    # absence of BOTH avoids mislabeling such a model as COCO.
+    if name_count is None and not has_dataset_hint:
         return True
 
     return False

--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -530,6 +530,21 @@ def _wrap_claim(
 # ---------------------------------------------------------------------------
 
 
+def _has_metadata_value(value: Any) -> bool:
+    """True when ``value`` is a non-empty metadata hint of any type.
+
+    Empty placeholders (``""``, ``{}``, ``[]``) are treated as absent so they
+    do not count as a dataset hint.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (dict, list, tuple, set)):
+        return len(value) > 0
+    return True
+
+
 def _is_coco_rfdetr_checkpoint(loaded: Any) -> bool:
     """Return True only when metadata supports RF-DETR COCO remapping."""
     names = _checkpoint_names(loaded)
@@ -537,35 +552,41 @@ def _is_coco_rfdetr_checkpoint(loaded: Any) -> bool:
     if name_count == 80:
         return True
 
-    # Any non-empty value under a dataset field is a hint that the checkpoint
+    # An explicit class count is the checkpoint declaring its own class space:
+    # 80 is COCO; any other value (including RF-DETR's 90 arch count) means the
+    # checkpoint carries class metadata and is not a bare upstream state_dict.
+    declared_nc = None
+    for field in ("nc", "num_classes"):
+        value = _metadata_value(loaded, field)
+        if value is None:
+            continue
+        try:
+            declared_nc = int(value)
+        except (TypeError, ValueError):
+            declared_nc = -1  # present but unparseable -> still "declared"
+        break
+    if declared_nc == 80:
+        return True
+
+    # A non-empty value under a dataset field is a hint that the checkpoint
     # declared its own dataset; only a string can positively identify COCO.
     has_dataset_hint = False
     for field in ("dataset", "dataset_file", "dataset_name", "data"):
         value = _metadata_value(loaded, field)
-        if value is None:
+        if not _has_metadata_value(value):
             continue
-        if isinstance(value, str):
-            if not value.strip():
-                continue
-            if "coco" in value.lower():
-                return True
+        if isinstance(value, str) and "coco" in value.lower():
+            return True
         has_dataset_hint = True
 
-    # Explicit class-count metadata (top-level nc, or args.num_classes/nc)
-    # means the checkpoint declared its own class space, so it is not a bare
-    # upstream state_dict even when it omits names.
-    has_class_count = any(
-        _metadata_value(loaded, field) is not None for field in ("nc", "num_classes")
-    )
-
     # A bare upstream RF-DETR state_dict carries NO class metadata at all -- no
-    # names, no dataset hint of any kind, and no explicit class count. The only
+    # names, no explicit class count, and no dataset hint of any kind. The only
     # such 91-output RF-DETR in distribution is Roboflow's COCO-pretrained
     # checkpoint, so treat it as COCO: its 90-class arch head then normalizes
     # to LibreYOLO's COCO-80, identical to the published LibreYOLO weights. A
-    # genuine custom 90-class model carries names, a (non-COCO) dataset hint,
-    # or an explicit class count and is left untouched (returns False).
-    if name_count is None and not has_dataset_hint and not has_class_count:
+    # genuine custom 90-class model carries names, an explicit class count, or
+    # a (non-COCO) dataset hint and is left untouched (returns False).
+    if name_count is None and declared_nc is None and not has_dataset_hint:
         return True
 
     return False

--- a/libreyolo/models/autoconvert.py
+++ b/libreyolo/models/autoconvert.py
@@ -533,13 +533,24 @@ def _wrap_claim(
 def _is_coco_rfdetr_checkpoint(loaded: Any) -> bool:
     """Return True only when metadata supports RF-DETR COCO remapping."""
     names = _checkpoint_names(loaded)
-    if _name_count(names) == 80:
+    name_count = _name_count(names)
+    if name_count == 80:
         return True
 
     for field in ("dataset", "dataset_file", "dataset_name", "data"):
         value = _metadata_value(loaded, field)
         if isinstance(value, str) and "coco" in value.lower():
             return True
+
+    # A bare upstream RF-DETR state_dict carries no class metadata at all
+    # (no names, no dataset hint). The only metadata-less 91-output RF-DETR
+    # in distribution is Roboflow's COCO-pretrained checkpoint, so treat it
+    # as COCO: its 90-class arch head then normalizes to LibreYOLO's COCO-80,
+    # identical to the published LibreYOLO weights. A genuine custom 90-class
+    # model is saved with names/metadata and is left untouched (returns False).
+    if name_count is None:
+        return True
+
     return False
 
 

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -299,6 +299,16 @@ class TestAutoconvertOrchestration:
             90,
         )[0] == 90
 
+    def test_rfdetr_90_class_with_empty_dataset_container_is_bare_coco(self):
+        # Empty placeholders ({} / []) are not real dataset hints, so an
+        # otherwise-bare checkpoint still normalizes to COCO-80.
+        assert autoconvert_module._rfdetr_class_metadata({"data": {}}, 90)[0] == 80
+        assert autoconvert_module._rfdetr_class_metadata({"data": []}, 90)[0] == 80
+
+    def test_rfdetr_explicit_nc80_is_honored_as_coco(self):
+        # A checkpoint that explicitly declares 80 classes is COCO.
+        assert autoconvert_module._rfdetr_class_metadata({"nc": 80}, 90)[0] == 80
+
     def test_returns_none_for_non_upstream_file(self, tmp_path):
         src = tmp_path / "random.pt"
         torch.save({"some.random.tensor": torch.zeros(4)}, src)

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -283,6 +283,22 @@ class TestAutoconvertOrchestration:
             90,
         )[0] == 90
 
+    def test_rfdetr_90_class_with_non_string_dataset_hint_not_coerced(self):
+        # A non-string dataset hint (e.g. a data-config dict) is still a hint;
+        # the bare-checkpoint COCO fallback must NOT fire.
+        assert autoconvert_module._rfdetr_class_metadata(
+            {"data": {"path": "/datasets/custom90"}},
+            90,
+        )[0] == 90
+
+    def test_rfdetr_90_class_with_explicit_num_classes_not_coerced(self):
+        # Explicit class-count metadata marks the class space as declared, so
+        # even without names it is not a bare checkpoint -> stays nc=90.
+        assert autoconvert_module._rfdetr_class_metadata(
+            {"args": argparse.Namespace(num_classes=90)},
+            90,
+        )[0] == 90
+
     def test_returns_none_for_non_upstream_file(self, tmp_path):
         src = tmp_path / "random.pt"
         torch.save({"some.random.tensor": torch.zeros(4)}, src)

--- a/tests/unit/test_autoconvert.py
+++ b/tests/unit/test_autoconvert.py
@@ -269,6 +269,20 @@ class TestAutoconvertOrchestration:
             90,
         )[0] == 80
 
+    def test_rfdetr_bare_90_class_state_dict_maps_to_coco80(self):
+        # A metadata-less upstream RF-DETR state_dict (no names, no dataset
+        # hint) is the canonical Roboflow COCO-pretrained checkpoint, so its
+        # 90 arch-classes normalize to LibreYOLO's COCO-80.
+        assert autoconvert_module._rfdetr_class_metadata({}, 90)[0] == 80
+
+    def test_rfdetr_90_class_with_non_coco_dataset_hint_not_coerced(self):
+        # A non-COCO dataset hint (even without a names list) must NOT trigger
+        # the bare-checkpoint COCO fallback; the custom 90-class head stands.
+        assert autoconvert_module._rfdetr_class_metadata(
+            {"args": argparse.Namespace(dataset_file="custom90")},
+            90,
+        )[0] == 90
+
     def test_returns_none_for_non_upstream_file(self, tmp_path):
         src = tmp_path / "random.pt"
         torch.save({"some.random.tensor": torch.zeros(4)}, src)


### PR DESCRIPTION
## Problem

Loading a **bare upstream RF-DETR `state_dict`** (Roboflow's COCO-pretrained
weights — `class_embed.bias` shape `[91]`, no `names`/`nc`/dataset metadata)
auto-converts to **`nb_classes=90`** instead of `80`.

`_is_coco_rfdetr_checkpoint()` only recognized a COCO checkpoint via (a) exactly
80 names, or (b) a `"coco"` dataset metadata field. A bare metadata-less
checkpoint has neither, so it fell through to the conservative
"custom 90-class head" path and stayed `nc=90`.

## Impact

With `nb_classes=90`, RF-DETR's `_postprocess` **skips the COCO 91→80 class
remap** (the remap is gated on `nb_classes == 80`) and returns raw 91-class
labels. Any consumer that expects LibreYOLO's COCO-80 convention — e.g. COCO
mAP evaluation that maps 80→91 category IDs — then **double-maps every class**,
collapsing mAP to ~0.001 even though boxes and scores are correct.

This silently corrupts results: the model loads, runs, and emits confident,
well-localized detections — only the class IDs are wrong.

## Fix

Treat a **metadata-less 90-class RF-DETR as the canonical Roboflow COCO
checkpoint** — it is the only metadata-less 91-output RF-DETR in distribution —
so it normalizes to COCO-80, identical to the published LibreYOLO weights.
Genuine custom 90-class models are saved with `names`/metadata and are
unaffected (the change only triggers when `name_count is None`).

```python
# in _is_coco_rfdetr_checkpoint(), reached only when raw_nc == 90:
if name_count is None:   # bare state_dict, no class metadata at all
    return True
```

## Validation

COCO `val2017-mini500`, RF-DETR PyTorch, before → after:

| model | before | after | published nc=80 |
|---|---|---|---|
| rfdetr-n | 0.001 | **0.5135** | 0.5138 |
| rfdetr-s | 0.001 | **0.5512** | 0.5511 |
| rfdetr-m | 0.001 | **0.5732** | 0.5737 |
| rfdetr-l | 0.001 | **0.5855** | 0.5855 |

All four now match the published nc=80 weights within ±0.0005.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved auto-detection and normalization of RF-DETR COCO checkpoints to reliably recognize COCO-80 configurations.
  * Prevents unintended COCO fallback when checkpoints are custom/non-COCO 90-class variants.
  * Empty placeholder metadata values are no longer treated as dataset hints.

* **Documentation**
  * Added a “RF-DETR COCO normalization” guide clarifying detection and conversion rules.

* **Tests**
  * Expanded unit coverage for COCO-80 fallback vs 90-class preservation across different metadata and dataset-hint inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->