### PR TITLE
Add Kasu AI PR reviewer pilot (GLM-5.2, kasubot[bot])

### DIFF
--- a/.github/workflows/kasu.yml
+++ b/.github/workflows/kasu.yml
@@ -38,20 +38,21 @@ jobs:
         (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
-          contains(github.event.comment.body, '/review')
+          contains(github.event.comment.body, '/review') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
         )
       )
     runs-on: ubuntu-latest
     steps:
       - name: Mint Kasu app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           app-id: ${{ vars.KASU_APP_ID }}
           private-key: ${{ secrets.KASU_APP_PRIVATE_KEY }}
 
       - name: Kasu review (GLM-5.2)
-        uses: EHxuban11/kasu@main
+        uses: EHxuban11/kasu@e639d10a4df023b90668ec35796c2457c5f5db8d  # pinned fork (main @ 2026-06-19)
         env:
           # Post as kasubot[bot] (the App token), NOT github-actions[bot]
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -64,6 +65,9 @@ jobs:
           config.custom_model_max_tokens: "128000"   # required for non-built-in models
 
           # --- Behavior: auto review + inline suggestions on every PR event ---
+          # Include "synchronize" so new pushes to an open PR get re-reviewed
+          # (PR-Agent's default pr_actions omits it).
+          github_action_config.pr_actions: '["opened","reopened","ready_for_review","synchronize"]'
           github_action_config.auto_review: "true"
           github_action_config.auto_improve: "true"     # CodeRabbit-style inline suggestions
           github_action_config.auto_describe: "false"   # don't rewrite PR descriptions

--- a/.github/workflows/kasu.yml
+++ b/.github/workflows/kasu.yml
@@ -21,10 +21,26 @@ on:
 permissions:
   contents: read
 
+# One review per PR at a time; cancel a superseded run on rapid pushes so parallel
+# runs don't duplicate GLM calls or race on the persistent review comment.
+concurrency:
+  group: kasu-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   kasu:
-    # Don't react to our own (or other bots') comments -> no loops, no cross-contamination.
-    if: ${{ github.event.sender.type != 'Bot' }}
+    # Run on PR events; for issue_comment, only on a PR thread AND only for an explicit
+    # "/review" command. Never react to bot senders -> no loops, no cross-contamination.
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      (
+        github.event_name == 'pull_request_target' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          contains(github.event.comment.body, '/review')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Mint Kasu app token

--- a/.github/workflows/kasu.yml
+++ b/.github/workflows/kasu.yml
@@ -1,0 +1,59 @@
+# Kasu — AI PR reviewer (GLM-5.2) piloted on LibreYOLO.
+# Harness code: EHxuban11/kasu (a pinned fork of The-PR-Agent/pr-agent, Apache-2.0).
+# Posts as the branded "kasubot[bot]" GitHub App. Diff-only; ignores other bots' comments.
+#
+# Install path: this file -> LibreYOLO/libreyolo/.github/workflows/kasu.yml
+# Already configured on the libreyolo repo:
+#   var    KASU_APP_ID            -> Kasu GitHub App ID (4089951)
+#   secret KASU_APP_PRIVATE_KEY   -> Kasu GitHub App private key
+#   secret GLM_API_KEY            -> GLM-5.2 key (OpenCode Go key for the pilot)
+
+name: kasu
+
+on:
+  # pull_request_target runs in the BASE repo context, so secrets ARE available
+  # even for fork PRs. We never check out or execute fork code (diff-only) -> safe.
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]   # lets you re-trigger with a "/review" comment
+
+permissions:
+  contents: read
+
+jobs:
+  kasu:
+    # Don't react to our own (or other bots') comments -> no loops, no cross-contamination.
+    if: ${{ github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint Kasu app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.KASU_APP_ID }}
+          private-key: ${{ secrets.KASU_APP_PRIVATE_KEY }}
+
+      - name: Kasu review (GLM-5.2)
+        uses: EHxuban11/kasu@main
+        env:
+          # Post as kasubot[bot] (the App token), NOT github-actions[bot]
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+          # --- Model: GLM-5.2 via the OpenAI-compatible OpenCode Go endpoint ---
+          OPENAI_KEY: ${{ secrets.GLM_API_KEY }}
+          OPENAI.API_BASE: https://opencode.ai/zen/go/v1
+          config.model: "openai/glm-5.2"
+          config.fallback_models: '["openai/kimi-k2.7-code"]'
+          config.custom_model_max_tokens: "128000"   # required for non-built-in models
+
+          # --- Behavior: auto review + inline suggestions on every PR event ---
+          github_action_config.auto_review: "true"
+          github_action_config.auto_improve: "true"     # CodeRabbit-style inline suggestions
+          github_action_config.auto_describe: "false"   # don't rewrite PR descriptions
+
+          # --- Diff-only / high-signal / no cross-contamination ---
+          config.publish_output: "true"
+          github.ignore_bot_pr: "true"           # skip PRs opened by other bots
+          pr_reviewer.persistent_comment: "true" # edit its own comment in place, don't stack
+          pr_reviewer.final_update_message: "false"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,18 @@
+# Redline review tuning — lives at the repo root of LibreYOLO/libreyolo.
+# PR-Agent's /review template is already diff-only (it has no variable for other
+# comments), so these settings just sharpen signal toward Codex/Cursor-level quality.
+
+[pr_reviewer]
+extra_instructions = """
+This is LibreYOLO, a PyTorch computer-vision training/inference library.
+Review ONLY the correctness and security of the changes in THIS diff:
+- logic errors, off-by-one, out-of-bounds / indexing bugs
+- None/undefined, shape/dtype mismatches, division-by-zero
+- broken edge cases, race conditions, resource/file/GPU-memory leaks
+- unsafe deserialization, path traversal, injection, secret leakage
+Do NOT comment on style, naming, formatting, or subjective preferences.
+For every issue: cite file:line, state the concrete failure scenario, and give a
+specific fix. Be high-signal and precise — do not invent issues or speculate.
+"""
+persistent_comment = true
+final_update_message = false


### PR DESCRIPTION
## Kasu — AI PR reviewer pilot (GLM-5.2)

Adds **Kasu**, a self-hosted AI PR reviewer, as a pilot on this repo. It reviews the
**diff only** and posts as the branded **`kasubot[bot]`** GitHub App — alongside Codex,
Cursor, and CodeRabbit, for a direct head-to-head quality comparison.

**What this adds**
- `.github/workflows/kasu.yml` — runs on PR events, mints a `kasubot[bot]` token, runs the reviewer.
- `.pr_agent.toml` — bug/security-focused, high-signal review tuning.

**How it works**
- Model: **GLM-5.2** via an OpenAI-compatible endpoint.
- Harness: a pinned fork of PR-Agent (Apache-2.0) at `EHxuban11/kasu`.
- Identity: posts as `kasubot[bot]` (GitHub App, App ID 4089951), not `github-actions[bot]`.
- **Diff-only / no cross-contamination:** only reads the diff + title + description; it does
  not ingest other bots' comment threads.
- **Fork-safe:** uses `pull_request_target` for secret access but never checks out or runs PR code.

**Secrets already configured on this repo:** `KASU_APP_ID` (var), `KASU_APP_PRIVATE_KEY`, `GLM_API_KEY`.

> Merging to `dev` activates `kasubot[bot]` on subsequent PR activity. Pilot only — pin the
> action to a commit SHA before any production/customer use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated PR review GitHub workflow that runs on key pull request events and when `/review` is posted in a PR thread.
  * Reviews are restricted to correctness and security, emphasizing logic/indexing errors, type mismatches, and relevant edge cases.
  * Bot-authored pull requests are skipped.
  * Review feedback is persisted and updated in place to avoid stacked messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->