### PR TITLE
[smoke test] Kasu auto-review trigger check (do not merge)

### DIFF
--- a/_kasu_smoke.py
+++ b/_kasu_smoke.py
@@ -1,0 +1,14 @@
+"""Smoke test for the Kasu PR reviewer. DO NOT MERGE - safe to delete."""
+
+
+def average_price(items):
+    """Average unit price across cart line items."""
+    total = 0
+    for it in items:
+        total += it["price"]
+    return total / len(items)  # bug: ZeroDivisionError when items is empty
+
+
+def last_item(items):
+    """Return the last line item."""
+    return items[len(items)]  # bug: off-by-one, IndexError; should be len(items) - 1

--- a/_kasu_smoke.py
+++ b/_kasu_smoke.py
@@ -12,3 +12,6 @@ def average_price(items):
 def last_item(items):
     """Return the last line item."""
     return items[len(items)]  # bug: off-by-one, IndexError; should be len(items) - 1
+
+
+# retrigger kasu after concurrency fix


### PR DESCRIPTION
**Smoke test — please do not merge.** Verifies that `kasubot[bot]` auto-triggers on a new PR.

This adds a throwaway `_kasu_smoke.py` with **two intentional bugs**:
1. `average_price` → `ZeroDivisionError` on an empty list.
2. `last_item` → off-by-one `IndexError` (`len(items)` instead of `len(items) - 1`).

Expecting kasubot (GLM-5.2) to flag both, alongside Codex / Cursor / CodeRabbit. Will be closed after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test module with helper functions for smoke testing validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->