### PR TITLE
417 add onnx support for every model and check onnx parity of every model with the pytorch versions

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -90,8 +90,10 @@ Pose runtime exports may also write these flat metadata keys:
 
 - `num_keypoints`: positive integer keypoint count used by the exported pose
   head.
-- `keypoint_dim`: pose output dimension, either `2` for xy or `3` for
-  xy+visibility.
+- `keypoint_dim`: pose output dimension. Common values are `2` for xy-only
+  exports and `3` for xy+visibility. GroupPose-style raw runtime exports may
+  use larger values, such as `8`, when the tensor includes precision or
+  class-logit fields consumed by LibreYOLO postprocessing.
 - `num_keypoints_per_class`: optional JSON-encoded list of per-class keypoint
   counts for GroupPose-style heads. Readers must preserve zero-keypoint class
   slots because they define the class-to-keypoint schema.

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -47,6 +47,10 @@ Pose checkpoints additionally include:
   expose keypoints as `x,y,visibility`.
 - `oks_sigmas`: optional list of per-keypoint OKS sigmas. When omitted, loaders
   and validators use the task default for `num_keypoints`.
+- `num_keypoints_per_class`: optional list of per-class keypoint counts for
+  GroupPose-style heads whose exported keypoint tensor is padded by class. Use
+  `0` for classes without keypoints. Runtime backends use this schema to select
+  the active keypoints for the predicted class.
 
 Depth checkpoints use the task string `depth`, `nc: 1`, and
 `names: {0: "depth"}`. The single class-like slot exists only for checkpoint
@@ -81,6 +85,16 @@ Embedded-NMS runtime exports may also write these flat metadata keys:
   graph output.
 - `nms_raw_output`: string boolean. `"true"` means the exported graph also
   exposes an auxiliary raw detector output for LibreYOLO backend parsing.
+
+Pose runtime exports may also write these flat metadata keys:
+
+- `num_keypoints`: positive integer keypoint count used by the exported pose
+  head.
+- `keypoint_dim`: pose output dimension, either `2` for xy or `3` for
+  xy+visibility.
+- `num_keypoints_per_class`: optional JSON-encoded list of per-class keypoint
+  counts for GroupPose-style heads. Readers must preserve zero-keypoint class
+  slots because they define the class-to-keypoint schema.
 
 For ONNX YOLO9 detection exports with `nms=true`, output `0` / `output` is the
 standalone post-NMS tensor using the export-time `nms_conf`, `nms_iou`, and

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -601,7 +601,7 @@ class BaseBackend(ABC):
         effective_imgsz: ImageSize,
         original_size: tuple,
         conf: float,
-        ratio: float = 1.0,
+        ratio: float | None = None,
         iou: float = 0.45,
         max_det: int = 300,
     ):
@@ -742,7 +742,7 @@ class BaseBackend(ABC):
         y2 = cy + h / 2
         boxes = np.stack([x1, y1, x2, y2], axis=1)
 
-        if ratio == 1.0:
+        if ratio is None or ratio == 1.0:
             input_h, input_w = _imgsz_hw(effective_imgsz)
             ratio = min(input_h / orig_h, input_w / orig_w)
         boxes /= ratio
@@ -817,7 +817,7 @@ class BaseBackend(ABC):
 
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, input_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, input_h)
-        if ratio == 1.0:
+        if ratio is None or ratio == 1.0:
             ratio = min(input_h / orig_h, input_w / orig_w)
         boxes = boxes / ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
@@ -2131,7 +2131,7 @@ class BaseBackend(ABC):
         input_size: ImageSize | None = None,
         letterbox: bool = False,
         max_det: int = 300,
-        ratio: float = 1.0,
+        ratio: float | None = None,
         **kwargs,
     ) -> Dict:
         effective_imgsz = self._resolve_predict_imgsz(input_size)

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -16,7 +16,12 @@ from ..models.yolo9.utils import (
     postprocess as yolo9_postprocess,
     preprocess_image,
 )
-from ..models.yolonas.utils import preprocess_image as yolonas_preprocess_image
+from ..models.yolonas.utils import (
+    YOLO_NAS_PRE_NMS_TOP_K,
+    YOLO_NAS_RESIZE_SIZE,
+    preprocess_image as yolonas_preprocess_image,
+    preprocess_pose_image as yolonas_preprocess_pose_image,
+)
 from ..models.yolox.utils import preprocess_image as yolox_preprocess_image
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.drawing import draw_boxes, draw_keypoints, draw_masks, draw_obb
@@ -185,8 +190,11 @@ def _is_nms_free_family(model_family: Optional[str]) -> bool:
     DETR-style families already emit a ranked set prediction after top-k
     selection. Applying YOLO-style IoU suppression on top of that can remove
     valid detections and make exported runtimes diverge from native PyTorch.
+    DAMO-YOLO is included because its parser calls the native DAMO batched-NMS
+    postprocessor directly.
     """
     return model_family in {
+        "damoyolo",
         "dfine",
         "deim",
         "deimv2",
@@ -195,6 +203,7 @@ def _is_nms_free_family(model_family: Optional[str]) -> bool:
         "rtdetr",
         "rtdetrv2",
         "rtdetrv4",
+        "yolo9_e2e",
     }
 
 
@@ -203,6 +212,33 @@ def _rfdetr_num_select(task: str, model_size: Optional[str]) -> int:
     if task == "segment":
         return {"n": 100, "s": 100, "m": 200, "l": 200}.get(model_size or "", 300)
     return 300
+
+
+def _logsumexp_np(values: np.ndarray, axis: int) -> np.ndarray:
+    max_values = np.max(values, axis=axis, keepdims=True)
+    return (
+        np.squeeze(max_values, axis=axis)
+        + np.log(np.sum(np.exp(values - max_values), axis=axis))
+    )
+
+
+def _rfdetr_keypoint_log_mean_trace_np(active_keypoints: np.ndarray) -> np.ndarray:
+    log_l11 = active_keypoints[..., 4]
+    l21 = active_keypoints[..., 5]
+    log_l22 = active_keypoints[..., 6]
+    w_find = 1.0 / (1.0 + np.exp(-active_keypoints[..., 2]))
+    log_t1 = -2.0 * log_l11
+    log_t2 = -2.0 * log_l22
+    log_t3 = 2.0 * np.log(np.clip(np.abs(l21), 1e-12, None)) + log_t1 + log_t2
+    log_trace_sigma = _logsumexp_np(
+        np.stack([log_t1, log_t2, log_t3], axis=-1),
+        axis=-1,
+    )
+    log_w_find = np.log(np.clip(w_find, 1e-12, None))
+    return _logsumexp_np(log_trace_sigma + log_w_find, axis=-1) - _logsumexp_np(
+        log_w_find,
+        axis=-1,
+    )
 
 
 class BaseBackend(ABC):
@@ -298,12 +334,19 @@ class BaseBackend(ABC):
                 image, input_size=effective_imgsz, color_format=color_format
             )
         elif self.model_family == "yolonas":
+            if self.task == "pose":
+                return yolonas_preprocess_pose_image(
+                    image, input_size=effective_imgsz, color_format=color_format
+                )
             return yolonas_preprocess_image(
                 image, input_size=effective_imgsz, color_format=color_format
             )
         elif self.model_family == "rfdetr":
             tensor, img, size = self._preprocess_rfdetr(
-                image, effective_imgsz, color_format
+                image,
+                effective_imgsz,
+                color_format,
+                task=self.task,
             )
             return tensor, img, size, 1.0
         elif self.model_family in ("dfine", "rtdetrv4"):
@@ -370,13 +413,32 @@ class BaseBackend(ABC):
         return img_tensor, img, original_size, 1.0
 
     @staticmethod
-    def _preprocess_rfdetr(image, input_size, color_format):
+    def _preprocess_rfdetr(image, input_size, color_format, task=None):
         """RF-DETR preprocessing: direct resize + ImageNet normalization."""
-        from ..models.rfdetr.utils import preprocess_numpy as rfdetr_preprocess_numpy
+        from ..models.rfdetr.utils import (
+            IMAGENET_MEAN,
+            IMAGENET_STD,
+            preprocess_numpy as rfdetr_preprocess_numpy,
+        )
 
         img = ImageLoader.load(image, color_format=color_format)
         original_size = img.size  # (W, H)
         original_img = img.copy()
+
+        if task == "pose":
+            h, w = _imgsz_hw(input_size)
+            arr = np.asarray(img, dtype=np.float32) / 255.0
+            img_tensor = torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0)
+            img_tensor = F.interpolate(
+                img_tensor,
+                size=(h, w),
+                mode="bilinear",
+                align_corners=False,
+                antialias=True,
+            )
+            mean = torch.tensor(IMAGENET_MEAN, dtype=torch.float32).view(1, 3, 1, 1)
+            std = torch.tensor(IMAGENET_STD, dtype=torch.float32).view(1, 3, 1, 1)
+            return (img_tensor - mean) / std, original_img, original_size
 
         img_chw, _ = rfdetr_preprocess_numpy(np.array(img), input_size)
         img_tensor = torch.from_numpy(img_chw).unsqueeze(0)
@@ -541,8 +603,12 @@ class BaseBackend(ABC):
             )
             return boxes, scores, cls, None
         elif self.model_family == "yolonas":
+            if self.task == "pose":
+                return self._parse_yolonas_pose(
+                    all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=ratio
+                )
             boxes, scores, cls = self._parse_yolonas(
-                all_outputs, orig_w, orig_h, conf, ratio=ratio
+                all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=ratio
             )
             return boxes, scores, cls, None
         elif self.model_family == "rfdetr":
@@ -557,8 +623,10 @@ class BaseBackend(ABC):
             boxes, scores, cls = self._parse_dfine(all_outputs, orig_w, orig_h, conf)
             return boxes, scores, cls, None
         elif self.model_family == "ec":
-            # EC emits the same {pred_logits, pred_boxes} schema as D-FINE
-            # so the parser is shared.
+            if self.task == "segment":
+                return self._parse_ec_segment(all_outputs, orig_w, orig_h, conf)
+            if self.task == "pose":
+                return self._parse_ec_pose(all_outputs, orig_w, orig_h, conf)
             boxes, scores, cls = self._parse_dfine(all_outputs, orig_w, orig_h, conf)
             return boxes, scores, cls, None
         elif self.model_family in ("rtdetr", "rtdetrv2"):
@@ -571,18 +639,26 @@ class BaseBackend(ABC):
             return boxes, scores, cls, None
         elif self.model_family == "rtmdet":
             boxes, scores, cls = self._parse_rtmdet(
-                all_outputs, orig_w, orig_h, conf, ratio
+                all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio
             )
             return boxes, scores, cls, None
         elif self.model_family == "damoyolo":
             boxes, scores, cls = self._parse_damoyolo(
-                all_outputs, effective_imgsz, orig_w, orig_h, conf
+                all_outputs,
+                effective_imgsz,
+                orig_w,
+                orig_h,
+                conf,
+                iou=iou,
+                max_det=max_det,
             )
             return boxes, scores, cls, None
         else:
             parsed = self._parse_yolo9(
                 all_outputs, effective_imgsz, orig_w, orig_h, conf, iou, max_det
             )
+            if len(parsed) == 6:
+                return parsed
             if len(parsed) == 5:
                 return parsed
             if len(parsed) == 4:
@@ -617,34 +693,90 @@ class BaseBackend(ABC):
         y2 = cy + h / 2
         boxes = np.stack([x1, y1, x2, y2], axis=1)
 
+        if ratio == 1.0:
+            input_h, input_w = _imgsz_hw(effective_imgsz)
+            ratio = min(input_h / orig_h, input_w / orig_w)
         boxes /= ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        valid_boxes = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+        boxes = boxes[valid_boxes]
+        max_scores = max_scores[valid_boxes]
+        class_ids = class_ids[valid_boxes]
 
         return boxes, max_scores, class_ids
 
-    def _parse_rtmdet(self, all_outputs, orig_w, orig_h, conf, ratio=1.0):
+    def _parse_rtmdet(
+        self, all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=1.0
+    ):
         """Parse RTMDet export-mode output: (B, N, 4 + nc) — xyxy (input-canvas pixels) + sigmoid scores.
 
         RTMDet exports use letterbox preprocessing, so the inverse scale is a
         single ``ratio`` (aspect-preserving), like YOLOX.
         """
         outputs = all_outputs[0][0]  # (N, 4 + nc)
-        boxes = outputs[:, :4]
+        boxes_all = outputs[:, :4]
         scores = outputs[:, 4:]
 
-        max_scores = np.max(scores, axis=1)
-        class_ids = np.argmax(scores, axis=1)
+        valid = scores > conf
+        if not valid.any():
+            return (
+                np.empty((0, 4), dtype=boxes_all.dtype),
+                np.empty((0,), dtype=scores.dtype),
+                np.empty((0,), dtype=np.int64),
+            )
 
-        mask = max_scores > conf
-        boxes, max_scores, class_ids = boxes[mask], max_scores[mask], class_ids[mask]
+        box_indices, class_ids = np.nonzero(valid)
+        max_scores = scores[box_indices, class_ids]
+
+        input_h, input_w = _imgsz_hw(effective_imgsz)
+        strides = (8, 16, 32)
+        level_sizes = [
+            int(np.ceil(input_h / stride)) * int(np.ceil(input_w / stride))
+            for stride in strides
+        ]
+        level_offsets = np.cumsum([0, *level_sizes])
+        if level_offsets[-1] == boxes_all.shape[0]:
+            nms_pre = 30000
+            keep_parts = []
+            for start, end in zip(level_offsets[:-1], level_offsets[1:]):
+                level_mask = (box_indices >= start) & (box_indices < end)
+                level_indices = np.nonzero(level_mask)[0]
+                if level_indices.size > nms_pre:
+                    level_scores = max_scores[level_indices]
+                    keep = np.argpartition(-level_scores, nms_pre - 1)[:nms_pre]
+                    keep = keep[np.argsort(-level_scores[keep])]
+                    level_indices = level_indices[keep]
+                keep_parts.append(level_indices)
+            keep_indices = (
+                np.concatenate(keep_parts)
+                if keep_parts
+                else np.empty((0,), dtype=np.int64)
+            )
+        else:
+            nms_pre = min(30000, max_scores.size)
+            keep_indices = np.argpartition(-max_scores, nms_pre - 1)[:nms_pre]
+            keep_indices = keep_indices[np.argsort(-max_scores[keep_indices])]
+
+        box_indices = box_indices[keep_indices]
+        max_scores = max_scores[keep_indices]
+        class_ids = class_ids[keep_indices]
+        boxes = boxes_all[box_indices].astype(np.float32, copy=True)
 
         if len(boxes) == 0:
             return boxes, max_scores, class_ids
 
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, input_w)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, input_h)
+        if ratio == 1.0:
+            ratio = min(input_h / orig_h, input_w / orig_w)
         boxes = boxes / ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        valid_boxes = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+        boxes = boxes[valid_boxes]
+        max_scores = max_scores[valid_boxes]
+        class_ids = class_ids[valid_boxes]
 
         return boxes, max_scores, class_ids
 
@@ -706,8 +838,20 @@ class BaseBackend(ABC):
 
         return boxes, max_scores, class_ids
 
-    def _parse_damoyolo(self, all_outputs, effective_imgsz, orig_w, orig_h, conf):
-        """Parse DAMO-YOLO output: (cls_scores, boxes) with stretch-resize inverse."""
+    def _parse_damoyolo(
+        self,
+        all_outputs,
+        effective_imgsz,
+        orig_w,
+        orig_h,
+        conf,
+        *,
+        iou: float = 0.6,
+        max_det: int = 300,
+    ):
+        """Parse DAMO-YOLO output via its native batched-NMS postprocessor."""
+        from ..postprocess.damoyolo import postprocess_predictions
+
         first = all_outputs[0][0]
         second = all_outputs[1][0]
         if first.shape[-1] == 4 and second.shape[-1] != 4:
@@ -717,35 +861,35 @@ class BaseBackend(ABC):
             scores = first
             boxes = second
 
-        valid = scores > conf
-        if not valid.any():
+        if not (scores > conf).any():
             return (
                 np.empty((0, 4), dtype=boxes.dtype),
                 np.empty((0,), dtype=scores.dtype),
                 np.empty((0,), dtype=np.int64),
             )
 
-        box_indices, class_ids = np.nonzero(valid)
-        boxes = boxes[box_indices].copy()
-        max_scores = scores[box_indices, class_ids]
+        input_h, input_w = _imgsz_hw(effective_imgsz)
+        device = (
+            torch.device(self.device)
+            if _is_pytorch_cuda_device(str(self.device)) and torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        cls_scores = torch.as_tensor(scores, dtype=torch.float32, device=device).unsqueeze(0)
+        box_tensor = torch.as_tensor(boxes, dtype=torch.float32, device=device).unsqueeze(0)
+        preds = postprocess_predictions(
+            cls_scores,
+            box_tensor,
+            orig_sizes=[(orig_w, orig_h)],
+            input_size=(input_h, input_w),
+            conf_thres=conf,
+            iou_thres=iou,
+            max_det=max_det,
+        )[0]
 
-        # DAMO's multi-label expansion floods NMS at low conf (~115k-670k (anchor,class) pairs);
-        # the shared 30k cap still left the pure-Python O(n^2) numpy NMS at ~0.5-5 s/img. Cap to
-        # top-1000 by score: numpy NMS drops to ~16 ms with exact parity, since NMS only
-        # suppresses lower-scored boxes and max_det (300) << 1000 (verified top-300 identical).
-        nms_pre = 1000
-        if max_scores.shape[0] > nms_pre:
-            keep = np.argpartition(-max_scores, nms_pre - 1)[:nms_pre]
-            boxes, max_scores, class_ids = boxes[keep], max_scores[keep], class_ids[keep]
-
-        scale_x = orig_w / effective_imgsz
-        scale_y = orig_h / effective_imgsz
-        boxes[:, [0, 2]] *= scale_x
-        boxes[:, [1, 3]] *= scale_y
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
-
-        return boxes, max_scores, class_ids
+        parsed_boxes = preds["boxes"].detach().cpu().numpy()
+        parsed_scores = preds["scores"].detach().cpu().numpy()
+        parsed_classes = preds["classes"].detach().cpu().numpy().astype(np.int64)
+        return parsed_boxes, parsed_scores, parsed_classes
 
     def _parse_embedded_nms(self, all_outputs, effective_imgsz, orig_w, orig_h, conf):
         """Parse a graph-embedded-NMS detection output.
@@ -810,8 +954,41 @@ class BaseBackend(ABC):
 
         boxes_input_all = outputs[:, :4]
         scores = outputs[:, 4:]
+        keypoints = None
+        keypoints_all = None
+        if self.task == "pose" and len(all_outputs) >= 2:
+            keypoints_all = np.asarray(all_outputs[1][0], dtype=np.float32)
 
-        if self.task == "segment":
+        if self.model_family == "yolo9_e2e" and self.task == "detect":
+            topk_anchors = min(max_det, scores.shape[0])
+            if topk_anchors == 0 or scores.shape[-1] == 0:
+                return (
+                    np.empty((0, 4), dtype=np.float32),
+                    np.empty((0,), dtype=np.float32),
+                    np.empty((0,), dtype=np.int64),
+                )
+
+            anchor_scores = np.max(scores, axis=1)
+            anchor_idx = np.argpartition(-anchor_scores, topk_anchors - 1)[
+                :topk_anchors
+            ]
+            anchor_idx = anchor_idx[np.argsort(-anchor_scores[anchor_idx])]
+            boxes_subset = boxes_input_all[anchor_idx]
+            scores_subset = scores[anchor_idx]
+
+            flat_scores = scores_subset.reshape(-1)
+            topk_scores = min(max_det, flat_scores.size)
+            flat_idx = np.argpartition(-flat_scores, topk_scores - 1)[:topk_scores]
+            flat_idx = flat_idx[np.argsort(-flat_scores[flat_idx])]
+            class_ids = flat_idx % scores_subset.shape[-1]
+            box_indices = flat_idx // scores_subset.shape[-1]
+            boxes_input = boxes_subset[box_indices]
+            max_scores = flat_scores[flat_idx]
+            keep = max_scores > conf
+            boxes_input = boxes_input[keep]
+            max_scores = max_scores[keep]
+            class_ids = class_ids[keep]
+        elif self.task == "segment":
             max_scores = np.max(scores, axis=1)
             class_ids = np.argmax(scores, axis=1)
             mask = max_scores > conf
@@ -821,6 +998,8 @@ class BaseBackend(ABC):
             anchor_idx, class_ids = np.nonzero(scores > conf)
             boxes_input = boxes_input_all[anchor_idx]
             max_scores = scores[anchor_idx, class_ids]
+            if keypoints_all is not None:
+                keypoints = keypoints_all[anchor_idx].copy()
             max_nms = max(max_det, _YOLO9_MAX_NMS_CANDIDATES)
             if max_scores.size > max_nms:
                 keep = np.argpartition(-max_scores, max_nms - 1)[:max_nms]
@@ -828,29 +1007,52 @@ class BaseBackend(ABC):
                 boxes_input = boxes_input[keep]
                 max_scores = max_scores[keep]
                 class_ids = class_ids[keep]
+                if keypoints is not None:
+                    keypoints = keypoints[keep]
 
         boxes = boxes_input.copy()
 
         if len(boxes) == 0:
             if self.task == "segment":
                 return boxes, max_scores, class_ids, None
+            if self.task == "pose" and keypoints_all is not None:
+                return boxes, max_scores, class_ids, None, None, keypoints_all[:0]
             return boxes, max_scores, class_ids
 
         input_h, input_w = _imgsz_hw(effective_imgsz)
         ratio = min(input_h / orig_h, input_w / orig_w)
         boxes[:, :4] /= ratio
+        if keypoints is not None:
+            keypoints[..., :2] /= ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        if keypoints is not None:
+            keypoints[..., 0] = np.clip(keypoints[..., 0], 0, orig_w)
+            keypoints[..., 1] = np.clip(keypoints[..., 1], 0, orig_h)
         valid_boxes = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
         if not valid_boxes.any():
             if self.task == "segment":
                 return boxes[:0], max_scores[:0], class_ids[:0], None
+            if self.task == "pose" and keypoints is not None:
+                return (
+                    boxes[:0],
+                    max_scores[:0],
+                    class_ids[:0],
+                    None,
+                    None,
+                    keypoints[:0],
+                )
             return boxes[:0], max_scores[:0], class_ids[:0]
         if not valid_boxes.all():
             boxes = boxes[valid_boxes]
             boxes_input = boxes_input[valid_boxes]
             max_scores = max_scores[valid_boxes]
             class_ids = class_ids[valid_boxes]
+            if keypoints is not None:
+                keypoints = keypoints[valid_boxes]
+
+        if self.task == "pose" and keypoints is not None:
+            return boxes, max_scores, class_ids, None, None, keypoints
 
         if self.task == "segment" and len(all_outputs) >= 3:
             from ..models.yolo9.utils import _process_masks
@@ -873,7 +1075,9 @@ class BaseBackend(ABC):
 
         return boxes, max_scores, class_ids
 
-    def _parse_yolonas(self, all_outputs, orig_w, orig_h, conf, ratio=1.0):
+    def _parse_yolonas(
+        self, all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=1.0
+    ):
         """Parse YOLO-NAS output: [boxes(B,N,4), scores(B,N,nc)] in input pixels."""
         first = all_outputs[0][0]
         second = all_outputs[1][0]
@@ -897,10 +1101,85 @@ class BaseBackend(ABC):
             return boxes, max_scores, class_ids
 
         boxes = boxes.astype(np.float32, copy=True)
-        boxes /= ratio
+        if YOLO_NAS_PRE_NMS_TOP_K and max_scores.size > YOLO_NAS_PRE_NMS_TOP_K:
+            keep = np.argpartition(-max_scores, YOLO_NAS_PRE_NMS_TOP_K - 1)[
+                :YOLO_NAS_PRE_NMS_TOP_K
+            ]
+            keep = keep[np.argsort(-max_scores[keep])]
+            boxes = boxes[keep]
+            max_scores = max_scores[keep]
+            class_ids = class_ids[keep]
+
+        input_h, input_w = _imgsz_hw(effective_imgsz)
+        resize_size = min(YOLO_NAS_RESIZE_SIZE, input_h, input_w)
+        ratio = min(resize_size / orig_h, resize_size / orig_w)
+        new_w = int(round(orig_w * ratio))
+        new_h = int(round(orig_h * ratio))
+        offset_x = (input_w - new_w) // 2
+        offset_y = (input_h - new_h) // 2
+        boxes[:, 0::2] = (boxes[:, 0::2] - offset_x) / ratio
+        boxes[:, 1::2] = (boxes[:, 1::2] - offset_y) / ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        valid_boxes = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+        boxes = boxes[valid_boxes]
+        max_scores = max_scores[valid_boxes]
+        class_ids = class_ids[valid_boxes]
         return boxes, max_scores, class_ids
+
+    def _parse_yolonas_pose(
+        self, all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=1.0
+    ):
+        """Parse YOLO-NAS pose: boxes, scores, keypoint xy, keypoint confidence."""
+        boxes = all_outputs[0][0]
+        scores = all_outputs[1][0].squeeze(-1)
+        keypoints_xy = all_outputs[2][0]
+        keypoints_conf = all_outputs[3][0]
+
+        mask = scores >= conf
+        boxes = boxes[mask].astype(np.float32, copy=True)
+        max_scores = scores[mask].astype(np.float32, copy=False)
+        keypoints_xy = keypoints_xy[mask].astype(np.float32, copy=True)
+        keypoints_conf = keypoints_conf[mask].astype(np.float32, copy=False)
+        class_ids = np.zeros((max_scores.shape[0],), dtype=np.int64)
+
+        if len(boxes) == 0:
+            keypoints = np.zeros((0, keypoints_xy.shape[-2], 3), dtype=np.float32)
+            return boxes, max_scores, class_ids, None, None, keypoints
+
+        pre_nms_top_k = 1000
+        if max_scores.size > pre_nms_top_k:
+            keep = np.argpartition(-max_scores, pre_nms_top_k - 1)[:pre_nms_top_k]
+            keep = keep[np.argsort(-max_scores[keep])]
+            boxes = boxes[keep]
+            max_scores = max_scores[keep]
+            keypoints_xy = keypoints_xy[keep]
+            keypoints_conf = keypoints_conf[keep]
+            class_ids = class_ids[keep]
+
+        input_h, input_w = _imgsz_hw(effective_imgsz)
+        resize_size = min(input_h, input_w)
+        scale = min(resize_size / orig_h, resize_size / orig_w)
+        boxes[:, 0::2] /= scale
+        boxes[:, 1::2] /= scale
+        keypoints_xy[..., 0] /= scale
+        keypoints_xy[..., 1] /= scale
+
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        keypoints_xy[..., 0] = np.clip(keypoints_xy[..., 0], 0, orig_w)
+        keypoints_xy[..., 1] = np.clip(keypoints_xy[..., 1], 0, orig_h)
+
+        valid = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+        if not valid.all():
+            boxes = boxes[valid]
+            max_scores = max_scores[valid]
+            class_ids = class_ids[valid]
+            keypoints_xy = keypoints_xy[valid]
+            keypoints_conf = keypoints_conf[valid]
+
+        keypoints = np.concatenate([keypoints_xy, keypoints_conf[..., None]], axis=-1)
+        return boxes, max_scores, class_ids, None, None, keypoints
 
     def _parse_dfine(self, all_outputs, orig_w, orig_h, conf, max_det: int = 300):
         """Parse D-FINE outputs: pred_logits (B, Q, nc) + pred_boxes (B, Q, 4) cxcywh [0,1].
@@ -944,6 +1223,97 @@ class BaseBackend(ABC):
         mask = scores > conf
         return boxes[mask], scores[mask], class_ids[mask].astype(np.int64)
 
+    def _parse_ec_segment(self, all_outputs, orig_w, orig_h, conf):
+        """Parse EC segmentation outputs: logits, normalized cxcywh boxes, masks."""
+        pred_logits = all_outputs[0][0]
+        pred_boxes = all_outputs[1][0]
+        pred_masks = all_outputs[2][0] if len(all_outputs) >= 3 else None
+
+        query_idx, class_ids, scores = self._ec_topk(pred_logits, max_det=300)
+        keep = scores > conf
+        query_idx = query_idx[keep]
+        class_ids = class_ids[keep]
+        max_scores = scores[keep]
+
+        boxes = self._scale_cxcywh_boxes(pred_boxes[query_idx], orig_w, orig_h)
+        masks_out = None
+        if pred_masks is not None and query_idx.size > 0:
+            masks_t = torch.from_numpy(pred_masks[query_idx]).unsqueeze(1).float()
+            masks_t = F.interpolate(
+                masks_t,
+                size=(int(orig_h), int(orig_w)),
+                mode="bilinear",
+                align_corners=False,
+            )
+            masks_out = (masks_t[:, 0] > 0.0).numpy()
+
+        return boxes, max_scores, class_ids.astype(np.int64), masks_out
+
+    def _parse_ec_pose(self, all_outputs, orig_w, orig_h, conf):
+        """Parse EC pose outputs: logits and normalized flattened keypoints."""
+        pred_logits = all_outputs[0][0]
+        pred_keypoints = all_outputs[1][0]
+
+        query_idx, _class_ids, scores = self._ec_topk(pred_logits, max_det=60)
+        keep = scores >= conf
+        query_idx = query_idx[keep]
+        max_scores = scores[keep]
+        class_ids = np.zeros((max_scores.shape[0],), dtype=np.int64)
+
+        if pred_keypoints.ndim >= 3 and pred_keypoints.shape[-1] == 2:
+            num_keypoints = int(pred_keypoints.shape[-2])
+        else:
+            num_keypoints = int(pred_keypoints.shape[-1]) // 2
+        if num_keypoints <= 0:
+            num_keypoints = int(getattr(self, "num_keypoints", 17) or 17)
+        if query_idx.size == 0:
+            empty_boxes = np.zeros((0, 4), dtype=np.float32)
+            empty_keypoints = np.zeros((0, num_keypoints, 3), dtype=np.float32)
+            return empty_boxes, max_scores, class_ids, None, None, empty_keypoints
+
+        keypoints_xy = pred_keypoints[query_idx].reshape(-1, num_keypoints, 2)
+        keypoints_xy = keypoints_xy.astype(np.float32, copy=True)
+        keypoints_xy[..., 0] *= float(orig_w)
+        keypoints_xy[..., 1] *= float(orig_h)
+
+        x_min = keypoints_xy[..., 0].min(axis=1)
+        y_min = keypoints_xy[..., 1].min(axis=1)
+        x_max = keypoints_xy[..., 0].max(axis=1)
+        y_max = keypoints_xy[..., 1].max(axis=1)
+        boxes = np.stack([x_min, y_min, x_max, y_max], axis=1)
+        visibility = np.ones((*keypoints_xy.shape[:-1], 1), dtype=np.float32)
+        keypoints = np.concatenate([keypoints_xy, visibility], axis=-1)
+        return boxes, max_scores, class_ids, None, None, keypoints
+
+    @staticmethod
+    def _ec_topk(pred_logits, max_det: int):
+        scores = 1.0 / (1.0 + np.exp(-pred_logits.astype(np.float64)))
+        scores = scores.astype(np.float32)
+        num_classes = scores.shape[-1]
+        flat = scores.reshape(-1)
+        k = min(max_det, flat.size)
+        idx = np.argpartition(-flat, k - 1)[:k]
+        idx = idx[np.argsort(-flat[idx])]
+        query_idx = idx // num_classes
+        class_ids = idx % num_classes
+        return query_idx, class_ids, flat[idx]
+
+    @staticmethod
+    def _scale_cxcywh_boxes(boxes_cxcywh, orig_w, orig_h):
+        cx, cy, w, h = (
+            boxes_cxcywh[:, 0],
+            boxes_cxcywh[:, 1],
+            boxes_cxcywh[:, 2],
+            boxes_cxcywh[:, 3],
+        )
+        boxes = np.stack([cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2], axis=1)
+        boxes = boxes.astype(np.float32, copy=False)
+        boxes[:, [0, 2]] *= orig_w
+        boxes[:, [1, 3]] *= orig_h
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        return boxes
+
     def _parse_rfdetr(self, all_outputs, orig_w, orig_h, conf):
         """Parse RF-DETR output: boxes (B,300,4) cxcywh [0,1] + logits (B,300,nc).
 
@@ -969,7 +1339,12 @@ class BaseBackend(ABC):
             if self.task == "obb":
                 raw_angles = all_outputs[2][0]
             elif self.task == "pose":
-                raw_keypoints = all_outputs[2][0]
+                raw_keypoint_output = all_outputs[2]
+                raw_keypoints = (
+                    raw_keypoint_output[0]
+                    if raw_keypoint_output.ndim == 4
+                    else raw_keypoint_output
+                )
             else:
                 raw_masks = all_outputs[2][0]
 
@@ -992,6 +1367,70 @@ class BaseBackend(ABC):
         )
         if raw_masks is not None:
             raw_masks = raw_masks[query_idx]
+
+        if (
+            self.task == "pose"
+            and keypoints_raw is not None
+            and keypoints_raw.ndim == 3
+            and keypoints_raw.shape[-1] >= 7
+            and num_classes > 1
+            and keypoints_raw.shape[1] % num_classes == 0
+        ):
+            max_num_keypoints = keypoints_raw.shape[1] // num_classes
+            grouped = keypoints_raw.reshape(
+                keypoints_raw.shape[0],
+                num_classes,
+                max_num_keypoints,
+                keypoints_raw.shape[-1],
+            )
+            selected = grouped[np.arange(len(class_ids)), class_ids]
+
+            # GroupPose exports use internal class 0 for no-keypoint detections
+            # and keypoint-bearing classes after it. Public pose labels are
+            # contiguous over only the keypoint-bearing classes (person -> 0).
+            keypoint_counts = np.full(num_classes, max_num_keypoints, dtype=np.int64)
+            if self.nb_classes == num_classes - 1:
+                keypoint_counts[0] = 0
+            active_counts = keypoint_counts[class_ids]
+            valid_pose_class = active_counts > 0
+
+            if np.any(valid_pose_class):
+                trace_alpha = 0.2
+                log_mean_traces = np.zeros(len(selected), dtype=np.float32)
+                for row_idx, active_count in enumerate(active_counts):
+                    if active_count <= 0:
+                        continue
+                    log_mean_traces[row_idx] = _rfdetr_keypoint_log_mean_trace_np(
+                        selected[row_idx : row_idx + 1, :active_count]
+                    )[0]
+                max_scores = max_scores * np.exp(-trace_alpha * log_mean_traces)
+
+            keypoints_selected = np.zeros(
+                (len(selected), max_num_keypoints, 3),
+                dtype=np.float32,
+            )
+            for row_idx, active_count in enumerate(active_counts):
+                if active_count <= 0:
+                    continue
+                keypoints_selected[row_idx, :active_count, :3] = selected[
+                    row_idx,
+                    :active_count,
+                    :3,
+                ]
+
+            kp_classes = np.flatnonzero(keypoint_counts > 0)
+            remap = np.full(num_classes, -1, dtype=class_ids.dtype)
+            remap[kp_classes] = np.arange(len(kp_classes), dtype=class_ids.dtype)
+
+            boxes_raw = boxes_raw[valid_pose_class]
+            max_scores = max_scores[valid_pose_class]
+            class_ids = remap[class_ids[valid_pose_class]]
+            if angles_raw is not None:
+                angles_raw = angles_raw[valid_pose_class]
+            if keypoints_raw is not None:
+                keypoints_raw = keypoints_selected[valid_pose_class]
+            if raw_masks is not None:
+                raw_masks = raw_masks[valid_pose_class]
 
         mask = max_scores > conf
         boxes_raw = boxes_raw[mask]
@@ -1248,7 +1687,14 @@ class BaseBackend(ABC):
             # ONNX models with graph-embedded NMS still pass through this after
             # backend clipping so letterboxed-image behavior stays aligned with
             # native YOLO9 postprocess.
-            if self.model_family in ("damoyolo", "yolo9", "yolo9_e2e", "yolox", "picodet"):
+            if self.model_family in (
+                "damoyolo",
+                "picodet",
+                "rtmdet",
+                "yolo9",
+                "yolonas",
+                "yolox",
+            ):
                 keep = _batched_nms_numpy(boxes, max_scores, class_ids, iou)
             else:
                 keep = _nms_numpy(boxes, max_scores, iou)
@@ -1398,6 +1844,7 @@ class BaseBackend(ABC):
         from ..validation.preprocessors import (
             DAMOYOLOValPreprocessor,
             DEIMValPreprocessor,
+            DEIMv2DINOValPreprocessor,
             DEIMv2ValPreprocessor,
             DFINEValPreprocessor,
             ECValPreprocessor,
@@ -1413,10 +1860,20 @@ class BaseBackend(ABC):
             YOLOXValPreprocessor,
         )
 
+        if self.model_family == "deimv2":
+            from ..models.deimv2.nn import DINO_SIZES
+
+            model_size = self.model_size or getattr(self, "size", None)
+            preprocessor_cls = (
+                DEIMv2DINOValPreprocessor
+                if model_size in DINO_SIZES
+                else DEIMv2ValPreprocessor
+            )
+            return preprocessor_cls(img_size=_imgsz_hw(img_size))
+
         preprocessor_cls = {
             "damoyolo": DAMOYOLOValPreprocessor,
             "deim": DEIMValPreprocessor,
-            "deimv2": DEIMv2ValPreprocessor,
             "dfine": DFINEValPreprocessor,
             "ec": ECValPreprocessor,
             "picodet": PICODETValPreprocessor,

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1,10 +1,11 @@
 """Base class for LibreYOLO inference backends."""
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -121,6 +122,24 @@ def _read_metadata_imgsz(
             ) from e
 
     return None
+
+
+def _read_pose_metadata(meta: dict) -> dict[str, Any]:
+    """Extract shared pose metadata from embedded or sidecar export metadata."""
+    pose_meta: dict[str, Any] = {}
+    if "num_keypoints" in meta:
+        pose_meta["num_keypoints"] = int(meta["num_keypoints"])
+    if "keypoint_dim" in meta:
+        pose_meta["keypoint_dim"] = int(meta["keypoint_dim"])
+    if "num_keypoints_per_class" in meta:
+        raw_schema = meta["num_keypoints_per_class"]
+        if isinstance(raw_schema, str):
+            raw_schema = json.loads(raw_schema)
+        if raw_schema is not None:
+            pose_meta["num_keypoints_per_class"] = [
+                int(count) for count in raw_schema
+            ]
+    return pose_meta
 
 
 def _nms_numpy(
@@ -266,6 +285,9 @@ class BaseBackend(ABC):
         task: str | None = None,
         supported_tasks=None,
         default_task: str | None = None,
+        num_keypoints: int | None = None,
+        keypoint_dim: int | None = None,
+        num_keypoints_per_class: list[int] | None = None,
     ):
         self.model_path = model_path
         self.nb_classes = nb_classes
@@ -302,6 +324,14 @@ class BaseBackend(ABC):
             self.embedded_nms = False
         if not hasattr(self, "embedded_nms_raw_output_index"):
             self.embedded_nms_raw_output_index = None
+        if num_keypoints is not None:
+            self.num_keypoints = int(num_keypoints)
+        if keypoint_dim is not None:
+            self.keypoint_dim = int(keypoint_dim)
+        if num_keypoints_per_class is not None:
+            self.num_keypoints_per_class = [
+                int(count) for count in num_keypoints_per_class
+            ]
         if not hasattr(self, "model"):
             self.model = _BackendEvalProxy()
 
@@ -1418,6 +1448,12 @@ class BaseBackend(ABC):
             else:
                 raw_masks = all_outputs[2][0]
 
+        if raw_keypoint_output is not None and not getattr(
+            self, "num_keypoints_per_class", None
+        ):
+            public_classes = int(self.nb_classes)
+            if 0 < public_classes < logits.shape[-1]:
+                logits = logits[:, :public_classes]
         scores = 1.0 / (1.0 + np.exp(-logits.astype(np.float64))).astype(np.float32)
         num_queries, num_classes = scores.shape
         if raw_keypoint_output is not None:

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -651,7 +651,13 @@ class BaseBackend(ABC):
             )
             return boxes, scores, cls, None
         elif self.model_family == "rfdetr":
-            return self._parse_rfdetr(all_outputs, orig_w, orig_h, conf)
+            return self._parse_rfdetr(
+                all_outputs,
+                orig_w,
+                orig_h,
+                conf,
+                max_det=max_det,
+            )
         elif self.model_family in ("dfine", "rtdetrv4"):
             boxes, scores, cls = self._parse_dfine(all_outputs, orig_w, orig_h, conf)
             return boxes, scores, cls, None
@@ -1433,7 +1439,7 @@ class BaseBackend(ABC):
             raise ValueError(f"Unexpected RF-DETR keypoint output shape: {raw.shape}")
         return raw
 
-    def _parse_rfdetr(self, all_outputs, orig_w, orig_h, conf):
+    def _parse_rfdetr(self, all_outputs, orig_w, orig_h, conf, max_det=300):
         """Parse RF-DETR output: boxes (B,300,4) cxcywh [0,1] + logits (B,300,nc).
 
         For segmentation models a third output is present:
@@ -1479,8 +1485,13 @@ class BaseBackend(ABC):
                 num_classes=num_classes,
             )
         model_size = self.model_size or getattr(self, "size", None)
+        num_select = (
+            _rfdetr_num_select(self.task, model_size)
+            if int(max_det) == 300
+            else int(max_det)
+        )
         k = min(
-            _rfdetr_num_select(self.task, model_size),
+            num_select,
             num_queries * num_classes,
         )
         flat_indexes = np.argpartition(scores.reshape(-1), -k)[-k:]

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -629,7 +629,9 @@ class BaseBackend(ABC):
                     all_outputs, orig_w, orig_h, conf, max_det=max_det
                 )
             if self.task == "pose":
-                return self._parse_ec_pose(all_outputs, orig_w, orig_h, conf)
+                return self._parse_ec_pose(
+                    all_outputs, orig_w, orig_h, conf, max_det=max_det
+                )
             boxes, scores, cls = self._parse_dfine(all_outputs, orig_w, orig_h, conf)
             return boxes, scores, cls, None
         elif self.model_family in ("rtdetr", "rtdetrv2"):
@@ -1114,10 +1116,11 @@ class BaseBackend(ABC):
             class_ids = class_ids[keep]
 
         input_h, input_w = _imgsz_hw(effective_imgsz)
-        resize_size = min(YOLO_NAS_RESIZE_SIZE, input_h, input_w)
-        ratio = min(resize_size / orig_h, resize_size / orig_w)
-        new_w = int(round(orig_w * ratio))
-        new_h = int(round(orig_h * ratio))
+        if ratio <= 0 or ratio == 1.0:
+            resize_size = min(YOLO_NAS_RESIZE_SIZE, input_h, input_w)
+            ratio = min(resize_size / orig_h, resize_size / orig_w)
+        new_w = round(orig_w * ratio)
+        new_h = round(orig_h * ratio)
         offset_x = (input_w - new_w) // 2
         offset_y = (input_h - new_h) // 2
         boxes[:, 0::2] = (boxes[:, 0::2] - offset_x) / ratio
@@ -1160,10 +1163,12 @@ class BaseBackend(ABC):
             keypoints_conf = keypoints_conf[keep]
             class_ids = class_ids[keep]
 
-        scale = min(
-            YOLO_NAS_POSE_RESIZE_SIZE / orig_h,
-            YOLO_NAS_POSE_RESIZE_SIZE / orig_w,
-        )
+        scale = ratio
+        if scale <= 0 or scale == 1.0:
+            scale = min(
+                YOLO_NAS_POSE_RESIZE_SIZE / orig_h,
+                YOLO_NAS_POSE_RESIZE_SIZE / orig_w,
+            )
         boxes[:, 0::2] /= scale
         boxes[:, 1::2] /= scale
         keypoints_xy[..., 0] /= scale
@@ -1227,7 +1232,9 @@ class BaseBackend(ABC):
         mask = scores > conf
         return boxes[mask], scores[mask], class_ids[mask].astype(np.int64)
 
-    def _parse_ec_segment(self, all_outputs, orig_w, orig_h, conf, max_det=300):
+    def _parse_ec_segment(
+        self, all_outputs, orig_w, orig_h, conf, max_det=300
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None]:
         """Parse EC segmentation outputs: logits, normalized cxcywh boxes, masks."""
         pred_logits = all_outputs[0][0]
         pred_boxes = all_outputs[1][0]
@@ -1253,12 +1260,12 @@ class BaseBackend(ABC):
 
         return boxes, max_scores, class_ids.astype(np.int64), masks_out
 
-    def _parse_ec_pose(self, all_outputs, orig_w, orig_h, conf):
+    def _parse_ec_pose(self, all_outputs, orig_w, orig_h, conf, max_det=300):
         """Parse EC pose outputs: logits and normalized flattened keypoints."""
         pred_logits = all_outputs[0][0]
         pred_keypoints = all_outputs[1][0]
 
-        query_idx, _class_ids, scores = self._ec_topk(pred_logits, max_det=60)
+        query_idx, _class_ids, scores = self._ec_topk(pred_logits, max_det=max_det)
         keep = scores >= conf
         query_idx = query_idx[keep]
         max_scores = scores[keep]
@@ -1318,6 +1325,49 @@ class BaseBackend(ABC):
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
         return boxes
 
+    def _normalize_rfdetr_keypoint_output(
+        self,
+        raw_keypoint_output,
+        *,
+        query_count: int,
+        num_classes: int,
+    ) -> np.ndarray:
+        raw = np.asarray(raw_keypoint_output)
+        if raw.ndim >= 3 and raw.shape[0] == 1 and raw.shape[1] == query_count:
+            raw = raw[0]
+        elif raw.ndim == 4 and raw.shape[0] == 1:
+            raw = raw[0]
+
+        if raw.ndim == 2:
+            schema = getattr(self, "num_keypoints_per_class", None)
+            if schema:
+                schema_counts = np.asarray([int(count) for count in schema], dtype=np.int64)
+                if schema_counts.size != num_classes or schema_counts.max() <= 0:
+                    raise ValueError(
+                        "Invalid RF-DETR GroupPose num_keypoints_per_class metadata "
+                        f"for {num_classes} classes: {list(schema_counts)}"
+                    )
+                slots = int(schema_counts.size * schema_counts.max())
+                if slots <= 0 or raw.shape[-1] % slots != 0:
+                    raise ValueError(
+                        "RF-DETR GroupPose flattened keypoint output cannot be "
+                        f"reshaped with schema {list(schema_counts)}: {raw.shape}"
+                    )
+                pred_dim = raw.shape[-1] // slots
+                raw = raw.reshape(raw.shape[0], slots, pred_dim)
+            else:
+                keypoint_dim = int(getattr(self, "keypoint_dim", 3) or 3)
+                if keypoint_dim <= 0 or raw.shape[-1] % keypoint_dim != 0:
+                    raise ValueError(
+                        "RF-DETR flattened keypoint output cannot be reshaped "
+                        f"with keypoint_dim={keypoint_dim}: {raw.shape}"
+                    )
+                raw = raw.reshape(raw.shape[0], raw.shape[-1] // keypoint_dim, keypoint_dim)
+
+        if raw.ndim != 3:
+            raise ValueError(f"Unexpected RF-DETR keypoint output shape: {raw.shape}")
+        return raw
+
     def _parse_rfdetr(self, all_outputs, orig_w, orig_h, conf):
         """Parse RF-DETR output: boxes (B,300,4) cxcywh [0,1] + logits (B,300,nc).
 
@@ -1338,6 +1388,7 @@ class BaseBackend(ABC):
             boxes_all = second
         raw_masks = None
         raw_keypoints = None
+        raw_keypoint_output = None
         raw_angles = None
         grouppose_active_keypoints = None
         if len(all_outputs) >= 3:
@@ -1345,16 +1396,17 @@ class BaseBackend(ABC):
                 raw_angles = all_outputs[2][0]
             elif self.task == "pose":
                 raw_keypoint_output = all_outputs[2]
-                raw_keypoints = (
-                    raw_keypoint_output[0]
-                    if raw_keypoint_output.ndim == 4
-                    else raw_keypoint_output
-                )
             else:
                 raw_masks = all_outputs[2][0]
 
         scores = 1.0 / (1.0 + np.exp(-logits.astype(np.float64))).astype(np.float32)
         num_queries, num_classes = scores.shape
+        if raw_keypoint_output is not None:
+            raw_keypoints = self._normalize_rfdetr_keypoint_output(
+                raw_keypoint_output,
+                query_count=num_queries,
+                num_classes=num_classes,
+            )
         model_size = self.model_size or getattr(self, "size", None)
         k = min(
             _rfdetr_num_select(self.task, model_size),
@@ -1393,7 +1445,10 @@ class BaseBackend(ABC):
                     keypoint_counts = schema_counts
                     max_num_keypoints = int(schema_counts.max())
                 else:
-                    max_num_keypoints = keypoints_raw.shape[1] // num_classes
+                    raise ValueError(
+                        "Invalid RF-DETR GroupPose num_keypoints_per_class metadata "
+                        f"for keypoint output {keypoints_raw.shape}: {list(schema_counts)}"
+                    )
             else:
                 max_num_keypoints = keypoints_raw.shape[1] // num_classes
             grouped = keypoints_raw.reshape(
@@ -1417,12 +1472,15 @@ class BaseBackend(ABC):
             if np.any(valid_pose_class):
                 trace_alpha = 0.2
                 log_mean_traces = np.zeros(len(selected), dtype=np.float32)
-                for row_idx, active_count in enumerate(active_counts):
+                for class_idx, active_count in enumerate(keypoint_counts):
                     if active_count <= 0:
                         continue
-                    log_mean_traces[row_idx] = _rfdetr_keypoint_log_mean_trace_np(
-                        selected[row_idx : row_idx + 1, :active_count]
-                    )[0]
+                    class_mask = class_ids == class_idx
+                    if not np.any(class_mask):
+                        continue
+                    log_mean_traces[class_mask] = _rfdetr_keypoint_log_mean_trace_np(
+                        selected[class_mask, :active_count]
+                    )
                 max_scores = max_scores * np.exp(-trace_alpha * log_mean_traces)
 
             keypoints_selected = np.zeros(

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1281,7 +1281,7 @@ class BaseBackend(ABC):
         scores_per_class = 1.0 / (1.0 + np.exp(-pred_logits.astype(np.float64)))
         scores_per_class = scores_per_class.astype(np.float32)
         query_scores = scores_per_class.max(axis=-1)
-        k = min(max_det, 60, query_scores.size)
+        k = min(max_det, query_scores.size)
         query_idx = np.argpartition(-query_scores, k - 1)[:k]
         query_idx = query_idx[np.argsort(-query_scores[query_idx])]
         scores = query_scores[query_idx]

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -18,6 +18,7 @@ from ..models.yolo9.utils import (
 )
 from ..models.yolonas.utils import (
     YOLO_NAS_PRE_NMS_TOP_K,
+    YOLO_NAS_POSE_RESIZE_SIZE,
     YOLO_NAS_RESIZE_SIZE,
     preprocess_image as yolonas_preprocess_image,
     preprocess_pose_image as yolonas_preprocess_pose_image,
@@ -624,7 +625,9 @@ class BaseBackend(ABC):
             return boxes, scores, cls, None
         elif self.model_family == "ec":
             if self.task == "segment":
-                return self._parse_ec_segment(all_outputs, orig_w, orig_h, conf)
+                return self._parse_ec_segment(
+                    all_outputs, orig_w, orig_h, conf, max_det=max_det
+                )
             if self.task == "pose":
                 return self._parse_ec_pose(all_outputs, orig_w, orig_h, conf)
             boxes, scores, cls = self._parse_dfine(all_outputs, orig_w, orig_h, conf)
@@ -1157,9 +1160,10 @@ class BaseBackend(ABC):
             keypoints_conf = keypoints_conf[keep]
             class_ids = class_ids[keep]
 
-        input_h, input_w = _imgsz_hw(effective_imgsz)
-        resize_size = min(input_h, input_w)
-        scale = min(resize_size / orig_h, resize_size / orig_w)
+        scale = min(
+            YOLO_NAS_POSE_RESIZE_SIZE / orig_h,
+            YOLO_NAS_POSE_RESIZE_SIZE / orig_w,
+        )
         boxes[:, 0::2] /= scale
         boxes[:, 1::2] /= scale
         keypoints_xy[..., 0] /= scale
@@ -1223,13 +1227,13 @@ class BaseBackend(ABC):
         mask = scores > conf
         return boxes[mask], scores[mask], class_ids[mask].astype(np.int64)
 
-    def _parse_ec_segment(self, all_outputs, orig_w, orig_h, conf):
+    def _parse_ec_segment(self, all_outputs, orig_w, orig_h, conf, max_det=300):
         """Parse EC segmentation outputs: logits, normalized cxcywh boxes, masks."""
         pred_logits = all_outputs[0][0]
         pred_boxes = all_outputs[1][0]
         pred_masks = all_outputs[2][0] if len(all_outputs) >= 3 else None
 
-        query_idx, class_ids, scores = self._ec_topk(pred_logits, max_det=300)
+        query_idx, class_ids, scores = self._ec_topk(pred_logits, max_det=max_det)
         keep = scores > conf
         query_idx = query_idx[keep]
         class_ids = class_ids[keep]
@@ -1335,6 +1339,7 @@ class BaseBackend(ABC):
         raw_masks = None
         raw_keypoints = None
         raw_angles = None
+        grouppose_active_keypoints = None
         if len(all_outputs) >= 3:
             if self.task == "obb":
                 raw_angles = all_outputs[2][0]
@@ -1376,7 +1381,21 @@ class BaseBackend(ABC):
             and num_classes > 1
             and keypoints_raw.shape[1] % num_classes == 0
         ):
-            max_num_keypoints = keypoints_raw.shape[1] // num_classes
+            schema = getattr(self, "num_keypoints_per_class", None)
+            keypoint_counts = None
+            if schema:
+                schema_counts = np.asarray([int(count) for count in schema], dtype=np.int64)
+                if (
+                    schema_counts.size == num_classes
+                    and schema_counts.max() > 0
+                    and keypoints_raw.shape[1] == schema_counts.size * int(schema_counts.max())
+                ):
+                    keypoint_counts = schema_counts
+                    max_num_keypoints = int(schema_counts.max())
+                else:
+                    max_num_keypoints = keypoints_raw.shape[1] // num_classes
+            else:
+                max_num_keypoints = keypoints_raw.shape[1] // num_classes
             grouped = keypoints_raw.reshape(
                 keypoints_raw.shape[0],
                 num_classes,
@@ -1388,9 +1407,10 @@ class BaseBackend(ABC):
             # GroupPose exports use internal class 0 for no-keypoint detections
             # and keypoint-bearing classes after it. Public pose labels are
             # contiguous over only the keypoint-bearing classes (person -> 0).
-            keypoint_counts = np.full(num_classes, max_num_keypoints, dtype=np.int64)
-            if self.nb_classes == num_classes - 1:
-                keypoint_counts[0] = 0
+            if keypoint_counts is None:
+                keypoint_counts = np.full(num_classes, max_num_keypoints, dtype=np.int64)
+                if self.nb_classes == num_classes - 1:
+                    keypoint_counts[0] = 0
             active_counts = keypoint_counts[class_ids]
             valid_pose_class = active_counts > 0
 
@@ -1409,6 +1429,10 @@ class BaseBackend(ABC):
                 (len(selected), max_num_keypoints, 3),
                 dtype=np.float32,
             )
+            active_keypoint_mask = np.zeros(
+                (len(selected), max_num_keypoints),
+                dtype=bool,
+            )
             for row_idx, active_count in enumerate(active_counts):
                 if active_count <= 0:
                     continue
@@ -1417,6 +1441,7 @@ class BaseBackend(ABC):
                     :active_count,
                     :3,
                 ]
+                active_keypoint_mask[row_idx, :active_count] = True
 
             kp_classes = np.flatnonzero(keypoint_counts > 0)
             remap = np.full(num_classes, -1, dtype=class_ids.dtype)
@@ -1429,6 +1454,7 @@ class BaseBackend(ABC):
                 angles_raw = angles_raw[valid_pose_class]
             if keypoints_raw is not None:
                 keypoints_raw = keypoints_selected[valid_pose_class]
+                grouppose_active_keypoints = active_keypoint_mask[valid_pose_class]
             if raw_masks is not None:
                 raw_masks = raw_masks[valid_pose_class]
 
@@ -1439,6 +1465,8 @@ class BaseBackend(ABC):
             angles_raw = angles_raw[mask]
         if keypoints_raw is not None:
             keypoints_raw = keypoints_raw[mask]
+            if grouppose_active_keypoints is not None:
+                grouppose_active_keypoints = grouppose_active_keypoints[mask]
         if raw_masks is not None:
             raw_masks = raw_masks[mask]
 
@@ -1468,6 +1496,8 @@ class BaseBackend(ABC):
                 angles_raw = angles_raw[valid]
             if keypoints_raw is not None:
                 keypoints_raw = keypoints_raw[valid]
+                if grouppose_active_keypoints is not None:
+                    grouppose_active_keypoints = grouppose_active_keypoints[valid]
             if raw_masks is not None:
                 raw_masks = raw_masks[valid]
 
@@ -1540,6 +1570,8 @@ class BaseBackend(ABC):
             keypoints_out[..., 0] *= float(orig_w)
             keypoints_out[..., 1] *= float(orig_h)
             keypoints_out[..., 2] = 1.0 / (1.0 + np.exp(-keypoints_out[..., 2]))
+            if grouppose_active_keypoints is not None:
+                keypoints_out[~grouppose_active_keypoints] = 0.0
 
         if self.task == "obb":
             return boxes, max_scores, class_ids, masks_out, obb_out

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1119,7 +1119,13 @@ class BaseBackend(ABC):
         return boxes, max_scores, class_ids
 
     def _parse_yolonas(
-        self, all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=1.0
+        self,
+        all_outputs,
+        effective_imgsz,
+        orig_w,
+        orig_h,
+        conf,
+        ratio: Optional[float] = None,
     ):
         """Parse YOLO-NAS output: [boxes(B,N,4), scores(B,N,nc)] in input pixels."""
         first = all_outputs[0][0]
@@ -1154,7 +1160,7 @@ class BaseBackend(ABC):
             class_ids = class_ids[keep]
 
         input_h, input_w = _imgsz_hw(effective_imgsz)
-        if ratio <= 0 or ratio == 1.0:
+        if ratio is None or ratio <= 0:
             resize_size = min(YOLO_NAS_RESIZE_SIZE, input_h, input_w)
             ratio = min(resize_size / orig_h, resize_size / orig_w)
         new_w = round(orig_w * ratio)
@@ -1178,7 +1184,7 @@ class BaseBackend(ABC):
         orig_w,
         orig_h,
         conf,
-        ratio=1.0,
+        ratio: Optional[float] = None,
         max_det=300,
     ):
         """Parse YOLO-NAS pose: boxes, scores, keypoint xy, keypoint confidence."""
@@ -1209,7 +1215,7 @@ class BaseBackend(ABC):
             class_ids = class_ids[keep]
 
         scale = ratio
-        if scale <= 0 or scale == 1.0:
+        if scale is None or scale <= 0:
             scale = min(
                 YOLO_NAS_POSE_RESIZE_SIZE / orig_h,
                 YOLO_NAS_POSE_RESIZE_SIZE / orig_w,

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -212,6 +212,8 @@ def _rfdetr_num_select(task: str, model_size: Optional[str]) -> int:
     """Return RF-DETR's configured top-k selection for exported backends."""
     if task == "segment":
         return {"n": 100, "s": 100, "m": 200, "l": 200}.get(model_size or "", 300)
+    if task == "pose" and model_size == "x":
+        return 100
     return 300
 
 
@@ -1176,8 +1178,6 @@ class BaseBackend(ABC):
 
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
-        keypoints_xy[..., 0] = np.clip(keypoints_xy[..., 0], 0, orig_w)
-        keypoints_xy[..., 1] = np.clip(keypoints_xy[..., 1], 0, orig_h)
 
         valid = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
         if not valid.all():
@@ -1265,7 +1265,10 @@ class BaseBackend(ABC):
         pred_logits = all_outputs[0][0]
         pred_keypoints = all_outputs[1][0]
 
-        query_idx, _class_ids, scores = self._ec_topk(pred_logits, max_det=max_det)
+        query_idx, _class_ids, scores = self._ec_topk(
+            pred_logits,
+            max_det=min(max_det, 60),
+        )
         keep = scores >= conf
         query_idx = query_idx[keep]
         max_scores = scores[keep]

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1301,7 +1301,12 @@ class BaseBackend(ABC):
         class_ids = class_ids[keep]
         max_scores = scores[keep]
 
-        boxes = self._scale_cxcywh_boxes(pred_boxes[query_idx], orig_w, orig_h)
+        boxes = self._scale_cxcywh_boxes(
+            pred_boxes[query_idx],
+            orig_w,
+            orig_h,
+            clip=False,
+        )
         masks_out = None
         if pred_masks is not None and query_idx.size > 0:
             masks_t = torch.from_numpy(pred_masks[query_idx]).unsqueeze(1).float()
@@ -1381,7 +1386,7 @@ class BaseBackend(ABC):
         return query_idx, class_ids, flat[idx]
 
     @staticmethod
-    def _scale_cxcywh_boxes(boxes_cxcywh, orig_w, orig_h):
+    def _scale_cxcywh_boxes(boxes_cxcywh, orig_w, orig_h, *, clip: bool = True):
         cx, cy, w, h = (
             boxes_cxcywh[:, 0],
             boxes_cxcywh[:, 1],
@@ -1392,8 +1397,9 @@ class BaseBackend(ABC):
         boxes = boxes.astype(np.float32, copy=False)
         boxes[:, [0, 2]] *= orig_w
         boxes[:, [1, 3]] *= orig_h
-        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
-        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
+        if clip:
+            boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
+            boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
         return boxes
 
     def _normalize_rfdetr_keypoint_output(

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -608,7 +608,13 @@ class BaseBackend(ABC):
         elif self.model_family == "yolonas":
             if self.task == "pose":
                 return self._parse_yolonas_pose(
-                    all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=ratio
+                    all_outputs,
+                    effective_imgsz,
+                    orig_w,
+                    orig_h,
+                    conf,
+                    ratio=ratio,
+                    max_det=max_det,
                 )
             boxes, scores, cls = self._parse_yolonas(
                 all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=ratio
@@ -1136,7 +1142,14 @@ class BaseBackend(ABC):
         return boxes, max_scores, class_ids
 
     def _parse_yolonas_pose(
-        self, all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=1.0
+        self,
+        all_outputs,
+        effective_imgsz,
+        orig_w,
+        orig_h,
+        conf,
+        ratio=1.0,
+        max_det=300,
     ):
         """Parse YOLO-NAS pose: boxes, scores, keypoint xy, keypoint confidence."""
         boxes = all_outputs[0][0]
@@ -1155,7 +1168,7 @@ class BaseBackend(ABC):
             keypoints = np.zeros((0, keypoints_xy.shape[-2], 3), dtype=np.float32)
             return boxes, max_scores, class_ids, None, None, keypoints
 
-        pre_nms_top_k = 1000
+        pre_nms_top_k = max(1000, int(max_det))
         if max_scores.size > pre_nms_top_k:
             keep = np.argpartition(-max_scores, pre_nms_top_k - 1)[:pre_nms_top_k]
             keep = keep[np.argsort(-max_scores[keep])]
@@ -1265,10 +1278,13 @@ class BaseBackend(ABC):
         pred_logits = all_outputs[0][0]
         pred_keypoints = all_outputs[1][0]
 
-        query_idx, _class_ids, scores = self._ec_topk(
-            pred_logits,
-            max_det=min(max_det, 60),
-        )
+        scores_per_class = 1.0 / (1.0 + np.exp(-pred_logits.astype(np.float64)))
+        scores_per_class = scores_per_class.astype(np.float32)
+        query_scores = scores_per_class.max(axis=-1)
+        k = min(max_det, 60, query_scores.size)
+        query_idx = np.argpartition(-query_scores, k - 1)[:k]
+        query_idx = query_idx[np.argsort(-query_scores[query_idx])]
+        scores = query_scores[query_idx]
         keep = scores >= conf
         query_idx = query_idx[keep]
         max_scores = scores[keep]
@@ -1360,7 +1376,7 @@ class BaseBackend(ABC):
                 raw = raw.reshape(raw.shape[0], slots, pred_dim)
             else:
                 keypoint_dim = int(getattr(self, "keypoint_dim", 3) or 3)
-                if keypoint_dim <= 0 or raw.shape[-1] % keypoint_dim != 0:
+                if keypoint_dim not in (2, 3) or raw.shape[-1] % keypoint_dim != 0:
                     raise ValueError(
                         "RF-DETR flattened keypoint output cannot be reshaped "
                         f"with keypoint_dim={keypoint_dim}: {raw.shape}"
@@ -1630,7 +1646,12 @@ class BaseBackend(ABC):
             keypoints_out = np.asarray(keypoints_raw, dtype=np.float32).copy()
             keypoints_out[..., 0] *= float(orig_w)
             keypoints_out[..., 1] *= float(orig_h)
-            keypoints_out[..., 2] = 1.0 / (1.0 + np.exp(-keypoints_out[..., 2]))
+            if keypoints_out.shape[-1] == 2:
+                visibility = np.ones((*keypoints_out.shape[:-1], 1), dtype=np.float32)
+                keypoints_out = np.concatenate([keypoints_out, visibility], axis=-1)
+            else:
+                keypoints_out[..., 2] = 1.0 / (1.0 + np.exp(-keypoints_out[..., 2]))
+                keypoints_out = keypoints_out[..., :3]
             if grouppose_active_keypoints is not None:
                 keypoints_out[~grouppose_active_keypoints] = 0.0
 

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1312,7 +1312,14 @@ class BaseBackend(ABC):
     def _parse_ec_pose(self, all_outputs, orig_w, orig_h, conf, max_det=300):
         """Parse EC pose outputs: logits and normalized flattened keypoints."""
         pred_logits = all_outputs[0][0]
+        pred_boxes = None
         pred_keypoints = all_outputs[1][0]
+        if len(all_outputs) >= 3:
+            maybe_boxes = all_outputs[1][0]
+            maybe_keypoints = all_outputs[2][0]
+            if maybe_boxes.shape[-1] == 4:
+                pred_boxes = maybe_boxes
+                pred_keypoints = maybe_keypoints
 
         scores_per_class = 1.0 / (1.0 + np.exp(-pred_logits.astype(np.float64)))
         scores_per_class = scores_per_class.astype(np.float32)
@@ -1342,11 +1349,14 @@ class BaseBackend(ABC):
         keypoints_xy[..., 0] *= float(orig_w)
         keypoints_xy[..., 1] *= float(orig_h)
 
-        x_min = keypoints_xy[..., 0].min(axis=1)
-        y_min = keypoints_xy[..., 1].min(axis=1)
-        x_max = keypoints_xy[..., 0].max(axis=1)
-        y_max = keypoints_xy[..., 1].max(axis=1)
-        boxes = np.stack([x_min, y_min, x_max, y_max], axis=1)
+        if pred_boxes is not None:
+            boxes = self._scale_cxcywh_boxes(pred_boxes[query_idx], orig_w, orig_h)
+        else:
+            x_min = keypoints_xy[..., 0].min(axis=1)
+            y_min = keypoints_xy[..., 1].min(axis=1)
+            x_max = keypoints_xy[..., 0].max(axis=1)
+            y_max = keypoints_xy[..., 1].max(axis=1)
+            boxes = np.stack([x_min, y_min, x_max, y_max], axis=1)
         visibility = np.ones((*keypoints_xy.shape[:-1], 1), dtype=np.float32)
         keypoints = np.concatenate([keypoints_xy, visibility], axis=-1)
         return boxes, max_scores, class_ids, None, None, keypoints

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1280,7 +1280,7 @@ class BaseBackend(ABC):
 
         scores_per_class = 1.0 / (1.0 + np.exp(-pred_logits.astype(np.float64)))
         scores_per_class = scores_per_class.astype(np.float32)
-        query_scores = scores_per_class.max(axis=-1)
+        query_scores = scores_per_class[..., 0]
         k = min(max_det, query_scores.size)
         query_idx = np.argpartition(-query_scores, k - 1)[:k]
         query_idx = query_idx[np.argsort(-query_scores[query_idx])]

--- a/libreyolo/backends/coreml.py
+++ b/libreyolo/backends/coreml.py
@@ -22,7 +22,13 @@ from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.general import COCO_CLASSES
 from ..utils.image_loader import ImageLoader
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, ImageSize, _imgsz_hw, _read_metadata_imgsz
+from .base import (
+    BaseBackend,
+    ImageSize,
+    _imgsz_hw,
+    _read_metadata_imgsz,
+    _read_pose_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +125,7 @@ class CoreMLBackend(BaseBackend):
             names,
             imgsz,
             has_embedded_nms,
+            pose_metadata,
         ) = self._parse_metadata(
             meta,
             nb_classes,
@@ -144,6 +151,7 @@ class CoreMLBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **pose_metadata,
         )
 
     @staticmethod
@@ -163,6 +171,7 @@ class CoreMLBackend(BaseBackend):
         names: Optional[dict] = None
         imgsz = 640
         has_embedded_nms = False
+        pose_metadata = _read_pose_metadata(meta)
 
         if "names" in meta:
             try:
@@ -206,6 +215,7 @@ class CoreMLBackend(BaseBackend):
             names,
             imgsz,
             has_embedded_nms,
+            pose_metadata,
         )
 
     def _parse_outputs(

--- a/libreyolo/backends/ncnn.py
+++ b/libreyolo/backends/ncnn.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, _read_metadata_imgsz
+from .base import BaseBackend, _read_metadata_imgsz, _read_pose_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +64,7 @@ class NcnnBackend(BaseBackend):
         imgsz = 640
         resolved_nb_classes = nb_classes if nb_classes is not None else 80
         names = self.build_names(resolved_nb_classes)
+        pose_metadata = {}
 
         metadata_path = model_dir / "metadata.yaml"
         if metadata_path.exists():
@@ -76,6 +77,7 @@ class NcnnBackend(BaseBackend):
                 imgsz,
                 resolved_nb_classes,
                 names,
+                pose_metadata,
             ) = self._read_metadata(metadata_path, nb_classes)
             task = resolve_task(
                 explicit_task=explicit_task,
@@ -129,6 +131,7 @@ class NcnnBackend(BaseBackend):
             task=task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **pose_metadata,
         )
 
     @staticmethod
@@ -163,7 +166,7 @@ class NcnnBackend(BaseBackend):
         """Read metadata from metadata.yaml file.
 
         Returns:
-            Tuple of (model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names).
+            Tuple of (model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names, pose_metadata).
         """
         import yaml
 
@@ -201,7 +204,17 @@ class NcnnBackend(BaseBackend):
         else:
             names = BaseBackend.build_names(nb_classes)
 
-        return model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names
+        return (
+            model_family,
+            model_size,
+            task,
+            supported_tasks,
+            default_task,
+            imgsz,
+            nb_classes,
+            names,
+            _read_pose_metadata(meta),
+        )
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run ncnn inference."""

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -8,7 +8,13 @@ import numpy as np
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.general import COCO_CLASSES
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, ImageSize, MetadataImageSizeError, _read_metadata_imgsz
+from .base import (
+    BaseBackend,
+    ImageSize,
+    MetadataImageSizeError,
+    _read_metadata_imgsz,
+    _read_pose_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -130,9 +136,8 @@ class OnnxBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **pose_metadata,
         )
-        for key, value in pose_metadata.items():
-            setattr(self, key, value)
 
     @staticmethod
     def _read_static_input_imgsz(input_shape) -> ImageSize | None:
@@ -242,19 +247,7 @@ class OnnxBackend(BaseBackend):
             logger.warning("Failed to read ONNX pose metadata from %s: %s", onnx_path, e)
             return {}
 
-        pose_meta = {}
-        if "num_keypoints" in meta:
-            pose_meta["num_keypoints"] = int(meta["num_keypoints"])
-        if "keypoint_dim" in meta:
-            pose_meta["keypoint_dim"] = int(meta["keypoint_dim"])
-        if "num_keypoints_per_class" in meta:
-            import json
-
-            raw_schema = json.loads(meta["num_keypoints_per_class"])
-            pose_meta["num_keypoints_per_class"] = [
-                int(count) for count in raw_schema
-            ]
-        return pose_meta
+        return _read_pose_metadata(meta)
 
     def _supports_batched_inference(self) -> bool:
         # Embedded-NMS graphs are exported batch-1; everything else with a

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -87,6 +87,9 @@ class OnnxBackend(BaseBackend):
         ) = self._read_onnx_metadata(
             onnx_path, nb_classes, runtime_metadata=runtime_metadata
         )
+        pose_metadata = self._read_onnx_pose_metadata(
+            onnx_path, runtime_metadata=runtime_metadata
+        )
         # Models exported with nms=True emit final (1, max_det, 6) detections.
         # Newer YOLO9 ONNX exports also include a raw auxiliary output so the
         # LibreYOLO backend can apply native clipping/NMS for non-square images.
@@ -128,6 +131,8 @@ class OnnxBackend(BaseBackend):
             supported_tasks=supported_tasks,
             default_task=default_task,
         )
+        for key, value in pose_metadata.items():
+            setattr(self, key, value)
 
     @staticmethod
     def _read_static_input_imgsz(input_shape) -> ImageSize | None:
@@ -220,6 +225,36 @@ class OnnxBackend(BaseBackend):
             embedded_nms,
             imgsz,
         )
+
+    @staticmethod
+    def _read_onnx_pose_metadata(
+        onnx_path: str,
+        runtime_metadata: dict | None = None,
+    ) -> dict:
+        try:
+            meta = dict(runtime_metadata or {})
+            if not meta:
+                import onnx
+
+                model_proto = onnx.load(onnx_path)
+                meta = {p.key: p.value for p in model_proto.metadata_props}
+        except Exception as e:
+            logger.warning("Failed to read ONNX pose metadata from %s: %s", onnx_path, e)
+            return {}
+
+        pose_meta = {}
+        if "num_keypoints" in meta:
+            pose_meta["num_keypoints"] = int(meta["num_keypoints"])
+        if "keypoint_dim" in meta:
+            pose_meta["keypoint_dim"] = int(meta["keypoint_dim"])
+        if "num_keypoints_per_class" in meta:
+            import json
+
+            raw_schema = json.loads(meta["num_keypoints_per_class"])
+            pose_meta["num_keypoints_per_class"] = [
+                int(count) for count in raw_schema
+            ]
+        return pose_meta
 
     def _supports_batched_inference(self) -> bool:
         # Embedded-NMS graphs are exported batch-1; everything else with a

--- a/libreyolo/backends/openvino.py
+++ b/libreyolo/backends/openvino.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, ImageSize, _read_metadata_imgsz
+from .base import BaseBackend, ImageSize, _read_metadata_imgsz, _read_pose_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +60,7 @@ class OpenVINOBackend(BaseBackend):
         imgsz = 640
         resolved_nb_classes = nb_classes if nb_classes is not None else 80
         names = self.build_names(resolved_nb_classes)
+        pose_metadata = {}
 
         metadata_path = model_dir / "metadata.yaml"
         if metadata_path.exists():
@@ -72,6 +73,7 @@ class OpenVINOBackend(BaseBackend):
                 imgsz,
                 resolved_nb_classes,
                 names,
+                pose_metadata,
             ) = self._read_metadata(metadata_path, nb_classes)
             task = resolve_task(
                 explicit_task=explicit_task,
@@ -118,6 +120,7 @@ class OpenVINOBackend(BaseBackend):
             task=task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **pose_metadata,
         )
 
     @staticmethod
@@ -156,7 +159,7 @@ class OpenVINOBackend(BaseBackend):
         """Read metadata from metadata.yaml file.
 
         Returns:
-            Tuple of (model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names).
+            Tuple of (model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names, pose_metadata).
         """
         import yaml
 
@@ -194,7 +197,17 @@ class OpenVINOBackend(BaseBackend):
         else:
             names = BaseBackend.build_names(nb_classes)
 
-        return model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names
+        return (
+            model_family,
+            model_size,
+            task,
+            supported_tasks,
+            default_task,
+            imgsz,
+            nb_classes,
+            names,
+            _read_pose_metadata(meta),
+        )
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run OpenVINO inference."""

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -11,7 +11,7 @@ import torch
 
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, ImageSize, _read_metadata_imgsz
+from .base import BaseBackend, ImageSize, _read_metadata_imgsz, _read_pose_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,7 @@ class TensorRTBackend(BaseBackend):
         supported_tasks = normalize_supported_tasks(
             self._metadata.get("supported_tasks", (metadata_task,))
         )
+        pose_metadata = _read_pose_metadata(self._metadata)
         self._sidecar_size = self._metadata.get("model_size") or self._metadata.get("size")
 
         sidecar_names = self._metadata.get("names")
@@ -157,6 +158,7 @@ class TensorRTBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **pose_metadata,
         )
 
     # =========================================================================

--- a/libreyolo/backends/torchscript.py
+++ b/libreyolo/backends/torchscript.py
@@ -12,7 +12,7 @@ import torch
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.general import COCO_CLASSES
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, _read_metadata_imgsz
+from .base import BaseBackend, _read_metadata_imgsz, _read_pose_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +78,7 @@ class TorchScriptBackend(BaseBackend):
         )
         if metadata_imgsz is not None:
             input_size = metadata_imgsz
+        pose_metadata = _read_pose_metadata(metadata)
 
         if nb_classes is not None:
             resolved_nb_classes = nb_classes
@@ -107,6 +108,7 @@ class TorchScriptBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **pose_metadata,
         )
 
     def _run_inference(self, blob: np.ndarray) -> list:

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -541,7 +541,9 @@ class BaseExporter(ABC):
         elif family == "ec":
             from ..models.ec.nn import ECExportWrapper
 
-            nn_model = ECExportWrapper(nn_model).to(device)
+            nn_model = ECExportWrapper(
+                nn_model, task=getattr(self.model, "task", "detect")
+            ).to(device)
             nn_model.eval()
             dfine_wrapped = True  # share the YOLOX-head-export skip path below
         elif family in {"rtdetr", "rtdetrv2", "rtdetrv4"}:
@@ -800,7 +802,9 @@ class BaseExporter(ABC):
             "dynamic": str(dynamic),
             "precision": "fp16" if half else "fp32",
             "half": str(half),
-            "segmentation": str(getattr(self.model, "_is_segmentation", False)).lower(),
+            "segmentation": str(
+                task == "segment" or getattr(self.model, "_is_segmentation", False)
+            ).lower(),
             "obb": str(task == "obb").lower(),
         }
         if task == "pose":

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -103,6 +103,27 @@ def _restore_rfdetr_export_state(snapshots):
             module._export = state["export"]
 
 
+def _pose_keypoint_shape_metadata(model) -> dict:
+    num_keypoints = getattr(
+        model, "num_keypoints", getattr(model, "POSE_NUM_KEYPOINTS", "")
+    )
+    keypoint_dim = getattr(model, "keypoint_dim", getattr(model, "KEYPOINT_DIM", ""))
+    meta = {"num_keypoints": num_keypoints, "keypoint_dim": keypoint_dim}
+
+    schema = getattr(model, "num_keypoints_per_class", None)
+    inner = getattr(model, "model", None)
+    if not schema and inner is not None:
+        schema = getattr(inner, "num_keypoints_per_class", None)
+    inner_model = getattr(inner, "model", None) if inner is not None else None
+    if not schema and inner_model is not None and hasattr(
+        inner_model, "get_num_keypoints_per_class"
+    ):
+        schema = inner_model.get_num_keypoints_per_class()
+    if schema:
+        meta["num_keypoints_per_class"] = [int(count) for count in schema]
+    return meta
+
+
 _FIXED_SQUARE_EXPORT_FAMILIES = {
     "dfine",
     "deim",
@@ -752,12 +773,7 @@ class BaseExporter(ABC):
         if onnx_path is not None:
             meta["exported_from"] = str(Path(onnx_path).name)
         if task == "pose":
-            meta.update(
-                {
-                    "num_keypoints": getattr(self.model, "num_keypoints", None),
-                    "keypoint_dim": getattr(self.model, "keypoint_dim", None),
-                }
-            )
+            meta.update(_pose_keypoint_shape_metadata(self.model))
         return meta
 
     def _build_onnx_metadata(
@@ -808,12 +824,17 @@ class BaseExporter(ABC):
             "obb": str(task == "obb").lower(),
         }
         if task == "pose":
+            pose_meta = _pose_keypoint_shape_metadata(self.model)
             meta.update(
                 {
-                    "num_keypoints": str(getattr(self.model, "num_keypoints", "")),
-                    "keypoint_dim": str(getattr(self.model, "keypoint_dim", "")),
+                    "num_keypoints": str(pose_meta["num_keypoints"]),
+                    "keypoint_dim": str(pose_meta["keypoint_dim"]),
                 }
             )
+            if "num_keypoints_per_class" in pose_meta:
+                meta["num_keypoints_per_class"] = json.dumps(
+                    pose_meta["num_keypoints_per_class"]
+                )
         return meta
 
     def _task_metadata(self) -> tuple[str, list[str], str]:

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -108,7 +108,6 @@ def _pose_keypoint_shape_metadata(model) -> dict:
         model, "num_keypoints", getattr(model, "POSE_NUM_KEYPOINTS", "")
     )
     keypoint_dim = getattr(model, "keypoint_dim", getattr(model, "KEYPOINT_DIM", ""))
-    meta = {"num_keypoints": num_keypoints, "keypoint_dim": keypoint_dim}
 
     schema = getattr(model, "num_keypoints_per_class", None)
     inner = getattr(model, "model", None)
@@ -119,6 +118,19 @@ def _pose_keypoint_shape_metadata(model) -> dict:
         inner_model, "get_num_keypoints_per_class"
     ):
         schema = inner_model.get_num_keypoints_per_class()
+
+    model_family = model._get_model_name() if hasattr(model, "_get_model_name") else ""
+    if model_family == "ec":
+        # EC pose exports raw xy-only tensors; visibility is appended by runtime
+        # postprocessing after decoding.
+        keypoint_dim = 2
+    elif model_family == "rfdetr" and schema:
+        # GroupPose RF-DETR exports the raw padded per-class tensor, whose
+        # keypoint payload is (x, y, findable, visible, log_l11, l21, log_l22,
+        # class_logit_boost).
+        keypoint_dim = 8
+
+    meta = {"num_keypoints": num_keypoints, "keypoint_dim": keypoint_dim}
     if schema:
         meta["num_keypoints_per_class"] = [int(count) for count in schema]
     return meta

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -264,11 +264,12 @@ def export_onnx(
             else None
         )
     elif is_ec_pose:
-        output_names = ["pred_logits", "pred_keypoints"]
+        output_names = ["pred_logits", "pred_boxes", "pred_keypoints"]
         dynamic_axes = (
             {
                 "images": {0: "batch"},
                 "pred_logits": {0: "batch", 1: "queries"},
+                "pred_boxes": {0: "batch", 1: "queries"},
                 "pred_keypoints": {0: "batch", 1: "queries", 2: "keypoint_values"},
             }
             if dynamic

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -205,21 +205,24 @@ def export_onnx(
     # to output count heuristic for direct export_onnx() calls. For known
     # DETR detection families we already know the output schema, so skip
     # the probe forward pass entirely and reuse the count below.
-    is_seg = metadata.get("segmentation") == "true"
+    task = metadata.get("task")
+    is_seg = metadata.get("segmentation") == "true" or task == "segment"
     is_yolo9_seg = (
         metadata.get("model_family") == "yolo9"
-        and metadata.get("task") == "segment"
+        and task == "segment"
     )
     is_yolo9_pose = (
         metadata.get("model_family") == "yolo9"
-        and metadata.get("task") == "pose"
+        and task == "pose"
     )
     is_rfdetr_pose = (
         metadata.get("model_family") == "rfdetr"
-        and metadata.get("task") == "pose"
+        and task == "pose"
     )
-    is_obb = metadata.get("task") == "obb"
-    is_classify = metadata.get("task") == "classify"
+    is_ec_pose = metadata.get("model_family") == "ec" and task == "pose"
+    is_yolonas_pose = metadata.get("model_family") == "yolonas" and task == "pose"
+    is_obb = task == "obb"
+    is_classify = task == "classify"
     known_detr_detection = _uses_dfine_style_export_wrapper(
         metadata.get("model_family")
     )
@@ -260,19 +263,50 @@ def export_onnx(
             if dynamic
             else None
         )
+    elif is_ec_pose:
+        output_names = ["pred_logits", "pred_keypoints"]
+        dynamic_axes = (
+            {
+                "images": {0: "batch"},
+                "pred_logits": {0: "batch", 1: "queries"},
+                "pred_keypoints": {0: "batch", 1: "queries", 2: "keypoint_values"},
+            }
+            if dynamic
+            else None
+        )
+    elif is_yolonas_pose:
+        output_names = [
+            "boxes",
+            "scores",
+            "keypoints_xy",
+            "keypoints_conf",
+        ]
+        dynamic_axes = (
+            {
+                "images": {0: "batch"},
+                "boxes": {0: "batch", 1: "anchors"},
+                "scores": {0: "batch", 1: "anchors"},
+                "keypoints_xy": {0: "batch", 1: "anchors", 2: "keypoints"},
+                "keypoints_conf": {0: "batch", 1: "anchors", 2: "keypoints"},
+            }
+            if dynamic
+            else None
+        )
     elif is_seg and not is_obb:
         output_names = (
             ["dets", "labels", "masks"]
             if model_family == "rfdetr"
+            else ["pred_logits", "pred_boxes", "pred_masks"]
+            if model_family == "ec"
             else ["boxes", "scores", "masks"]
         )
         input_name = "input" if model_family == "rfdetr" else "images"
         dynamic_axes = (
             {
                 input_name: {0: "batch"},
-                output_names[0]: {0: "batch"},
-                output_names[1]: {0: "batch"},
-                output_names[2]: {0: "batch"},
+                output_names[0]: {0: "batch", 1: "queries"},
+                output_names[1]: {0: "batch", 1: "queries"},
+                output_names[2]: {0: "batch", 1: "queries"},
             }
             if dynamic
             else None

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -264,12 +264,11 @@ def export_onnx(
             else None
         )
     elif is_ec_pose:
-        output_names = ["pred_logits", "pred_boxes", "pred_keypoints"]
+        output_names = ["pred_logits", "pred_keypoints"]
         dynamic_axes = (
             {
                 "images": {0: "batch"},
                 "pred_logits": {0: "batch", 1: "queries"},
-                "pred_boxes": {0: "batch", 1: "queries"},
                 "pred_keypoints": {0: "batch", 1: "queries", 2: "keypoint_values"},
             }
             if dynamic

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -10,7 +10,6 @@ All model families register here via ``__init_subclass__``. Adding a new model m
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 
 from .base import BaseModel
@@ -215,17 +214,6 @@ def LibreYOLO(
     ensure_default_logging()
     model_path = _resolve_weights_path(model_path)
 
-    if task is not None:
-        filename = Path(model_path).name
-        for cls in BaseModel._registry:
-            if cls.detect_size_from_filename(filename) is not None:
-                resolve_task(
-                    explicit_task=task,
-                    default_task=cls.DEFAULT_TASK,
-                    supported_tasks=cls.SUPPORTED_TASKS,
-                )
-                break
-
     # Non-PyTorch formats: delegate to inference backends
     if model_path.endswith(".onnx"):
         from ..backends.onnx import OnnxBackend
@@ -275,6 +263,17 @@ def LibreYOLO(
             return NcnnBackend(
                 model_path, nb_classes=nb_classes, device=device, task=task
             )
+
+    if task is not None:
+        filename = Path(model_path).name
+        for cls in BaseModel._registry:
+            if cls.detect_size_from_filename(filename) is not None:
+                resolve_task(
+                    explicit_task=task,
+                    default_task=cls.DEFAULT_TASK,
+                    supported_tasks=cls.SUPPORTED_TASKS,
+                )
+                break
 
     # Download if missing
     if not Path(model_path).exists():

--- a/libreyolo/models/ec/decoder.py
+++ b/libreyolo/models/ec/decoder.py
@@ -28,6 +28,7 @@ import torch.nn.init as init
 
 from ..dfine.denoising import get_contrastive_denoising_training_group
 from .utils import (
+    _grid_sample_bilinear_manual,
     bias_init_with_prob,
     deformable_attention_core_func_v2,
     distance2bbox,
@@ -1216,11 +1217,23 @@ def _ms_deform_attn_core_pytorch_pose(
     for lid_, (h, w) in enumerate(value_spatial_shapes):
         value_l = value[lid_].unflatten(2, (h, w))
         grid_l = sampling_grids[:, :, lid_]
-        sampling_value_list.append(
-            F.grid_sample(
-                value_l, grid_l,
-                mode="bilinear", padding_mode="zeros", align_corners=False,
+        if torch.onnx.is_in_onnx_export():
+            sampling_value = _grid_sample_bilinear_manual(
+                value_l,
+                grid_l,
+                padding_mode="zeros",
+                align_corners=False,
             )
+        else:
+            sampling_value = F.grid_sample(
+                value_l,
+                grid_l,
+                mode="bilinear",
+                padding_mode="zeros",
+                align_corners=False,
+            )
+        sampling_value_list.append(
+            sampling_value
         )
     attn = attention_weights.transpose(1, 2).reshape(
         bs * num_heads, 1, num_query, num_levels * num_points
@@ -1335,13 +1348,23 @@ class LQEPose(nn.Module):
     def forward(self, scores, pred_poses, feat):
         b, length = pred_poses.shape[:2]
         pred_poses = pred_poses.reshape(b, length, self.num_keypoints, 2)
-        sampling_values = F.grid_sample(
-            feat,
-            2 * pred_poses - 1,
-            mode="bilinear",
-            padding_mode="zeros",
-            align_corners=False,
-        ).permute(0, 2, 3, 1)
+        sampling_grid = 2 * pred_poses - 1
+        if torch.onnx.is_in_onnx_export():
+            sampling_values = _grid_sample_bilinear_manual(
+                feat,
+                sampling_grid,
+                padding_mode="zeros",
+                align_corners=False,
+            )
+        else:
+            sampling_values = F.grid_sample(
+                feat,
+                sampling_grid,
+                mode="bilinear",
+                padding_mode="zeros",
+                align_corners=False,
+            )
+        sampling_values = sampling_values.permute(0, 2, 3, 1)
         prob_topk = sampling_values.topk(self.k, dim=-1)[0]
         stat = torch.cat([prob_topk, prob_topk.mean(dim=-1, keepdim=True)], dim=-1)
         return scores + self.reg_conf(stat.reshape(b, length, -1))

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -245,7 +245,7 @@ class LibreEC(BaseModel):
                 conf_thres=conf_thres,
                 iou_thres=iou_thres,
                 original_size=original_size,
-                max_det=min(max_det, 60),  # ECPose ships with num_queries=60
+                max_det=max_det,
                 num_keypoints=self.POSE_NUM_KEYPOINTS,
             )
         if self.task == "segment":

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -38,6 +38,7 @@ class LibreEC(BaseModel):
         "segment": SEG_INPUT_SIZES,
     }
     POSE_NUM_KEYPOINTS = 17
+    KEYPOINT_DIM = 3
     val_preprocessor_class = ECValPreprocessor
 
     _GH_RELEASE_BASE = (
@@ -159,6 +160,8 @@ class LibreEC(BaseModel):
             # Pose head outputs 2 class logits (person, bg); user-facing single
             # class is "person" with index 0.
             nb_classes = 1
+        self.num_keypoints = self.POSE_NUM_KEYPOINTS
+        self.keypoint_dim = self.KEYPOINT_DIM
         super().__init__(
             model_path=model_path,
             size=size,

--- a/libreyolo/models/ec/nn.py
+++ b/libreyolo/models/ec/nn.py
@@ -294,5 +294,5 @@ class ECExportWrapper(nn.Module):
             keypoints = out["pred_keypoints"]
             if keypoints.dim() == 4:
                 keypoints = keypoints.flatten(-2)
-            return out["pred_logits"], keypoints
+            return out["pred_logits"], out["pred_boxes"], keypoints
         return out["pred_logits"], out["pred_boxes"]

--- a/libreyolo/models/ec/nn.py
+++ b/libreyolo/models/ec/nn.py
@@ -280,11 +280,19 @@ class LibreECPoseModel(nn.Module):
 class ECExportWrapper(nn.Module):
     """Tracing-friendly wrapper for ONNX/TorchScript export."""
 
-    def __init__(self, model: LibreECModel):
+    def __init__(self, model: LibreECModel, task: str = "detect"):
         super().__init__()
         self.model = model
+        self.task = task
         self.model.deploy()
 
     def forward(self, x):
         out = self.model(x)
+        if self.task == "segment":
+            return out["pred_logits"], out["pred_boxes"], out["pred_masks"]
+        if self.task == "pose":
+            keypoints = out["pred_keypoints"]
+            if keypoints.dim() == 4:
+                keypoints = keypoints.flatten(-2)
+            return out["pred_logits"], keypoints
         return out["pred_logits"], out["pred_boxes"]

--- a/libreyolo/models/ec/nn.py
+++ b/libreyolo/models/ec/nn.py
@@ -294,5 +294,5 @@ class ECExportWrapper(nn.Module):
             keypoints = out["pred_keypoints"]
             if keypoints.dim() == 4:
                 keypoints = keypoints.flatten(-2)
-            return out["pred_logits"], out["pred_boxes"], keypoints
+            return out["pred_logits"], keypoints
         return out["pred_logits"], out["pred_boxes"]

--- a/libreyolo/models/rfdetr/backbone.py
+++ b/libreyolo/models/rfdetr/backbone.py
@@ -566,7 +566,8 @@ class DinoV2(nn.Module):
                 size=(height, width),
                 mode="bicubic",
                 align_corners=False,
-                antialias=patch_pos_embed.device.type != "mps",
+                antialias=patch_pos_embed.device.type != "mps"
+                and not torch.onnx.is_in_onnx_export(),
             )
 
             patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).reshape(1, -1, dim)

--- a/libreyolo/models/rfdetr/dinov2.py
+++ b/libreyolo/models/rfdetr/dinov2.py
@@ -377,7 +377,8 @@ class WindowedDinov2WithRegistersEmbeddings(nn.Module):
             size=(torch_int(height), torch_int(width)),  # Explicit size instead of scale_factor
             mode="bicubic",
             align_corners=False,
-            antialias=patch_pos_embed.device.type != "mps",
+            antialias=patch_pos_embed.device.type != "mps"
+            and not torch.onnx.is_in_onnx_export(),
         ).to(dtype=target_dtype)
 
         # Validate output dimensions if not tracing

--- a/libreyolo/models/rfdetr/loss.py
+++ b/libreyolo/models/rfdetr/loss.py
@@ -29,6 +29,58 @@ from . import box_ops
 logger = logging.getLogger(__name__)
 
 
+def _classic_keypoint_losses(
+    src_keypoints: torch.Tensor,
+    target_keypoints: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-instance keypoint losses for classic RF-DETR pose heads."""
+    if src_keypoints.shape[-1] < 3:
+        raise ValueError("classic RF-DETR keypoints must have x, y, and visibility")
+    if src_keypoints.shape[-2] != target_keypoints.shape[-2]:
+        raise ValueError(
+            "classic RF-DETR keypoint count does not match target keypoint count: "
+            f"{src_keypoints.shape[-2]} vs {target_keypoints.shape[-2]}"
+        )
+
+    target = target_keypoints.to(device=src_keypoints.device, dtype=src_keypoints.dtype)
+    target_xy = target[..., :2]
+    target_vis = target[..., 2]
+
+    finite_xy = torch.isfinite(target_xy).all(dim=-1)
+    finite_vis = torch.isfinite(target_vis)
+    visible = finite_xy & finite_vis & (target_vis > 0)
+    visible_f = visible.to(src_keypoints.dtype)
+    visible_count = visible_f.sum(dim=-1).clamp(min=1.0)
+    loss_l1 = (
+        F.l1_loss(src_keypoints[..., :2], target_xy, reduction="none").sum(dim=-1)
+        * visible_f
+    ).sum(dim=-1) / visible_count
+
+    valid_vis_f = finite_vis.to(src_keypoints.dtype)
+    vis_count = valid_vis_f.sum(dim=-1).clamp(min=1.0)
+    pred_vis_logits = src_keypoints[..., 2]
+    target_findable = (target_vis > 0).to(src_keypoints.dtype)
+    target_visible = (target_vis > 1).to(src_keypoints.dtype)
+    loss_findable = (
+        F.binary_cross_entropy_with_logits(
+            pred_vis_logits,
+            target_findable,
+            reduction="none",
+        )
+        * valid_vis_f
+    ).sum(dim=-1) / vis_count
+    loss_visible = (
+        F.binary_cross_entropy_with_logits(
+            pred_vis_logits,
+            target_visible,
+            reduction="none",
+        )
+        * valid_vis_f
+    ).sum(dim=-1) / vis_count
+    loss_nll = torch.zeros_like(loss_l1)
+    return loss_l1, loss_findable, loss_visible, loss_nll
+
+
 @torch.no_grad()
 def accuracy(output: torch.Tensor, target: torch.Tensor, topk=(1,)):
     """Computes the precision@k for the specified values of k."""
@@ -529,40 +581,39 @@ class SetCriterion(nn.Module):
         return losses
 
     def loss_keypoints(self, outputs, targets, indices, num_boxes):
-        """Compute GroupPose keypoint losses on matched prediction/target pairs.
-
-        Ported from RF-DETR v1.8.0 (GroupPose keypoint additions). Produces the four
-        GroupPose loss terms ``loss_keypoints_l1`` / ``loss_keypoints_findable`` /
-        ``loss_keypoints_visible`` / ``loss_keypoints_nll``, each normalized by
-        ``num_boxes``. Per-instance keypoint classes are read from ``targets[*]['labels']``
-        and per-instance areas are derived from the cxcywh ``targets[*]['boxes']``
-        (``area = w * h``), matching the upstream criterion exactly.
-        """
+        """Compute RF-DETR keypoint losses on matched prediction/target pairs."""
         assert "pred_keypoints" in outputs, "pred_keypoints missing in model outputs"
         idx = self._get_src_permutation_idx(indices)
         src_keypoints = outputs["pred_keypoints"][idx]
         target_keypoints = torch.cat([target["keypoints"][j] for target, (_, j) in zip(targets, indices)], dim=0)
-        target_classes = torch.cat([target["labels"][j] for target, (_, j) in zip(targets, indices)], dim=0)
-        target_boxes = torch.cat([target["boxes"][j] for target, (_, j) in zip(targets, indices)], dim=0)
-        target_areas = target_boxes[:, 2] * target_boxes[:, 3]
 
-        # Class-index remap at the criterion boundary: lift the LibreYOLO
-        # contiguous pose label (person = 0) to the GroupPose internal schema
-        # class (person = 1 for ``[0, 17]``) before it indexes
-        # ``num_keypoints_per_class`` inside ``compute_l1_keypoint_loss``. Without
-        # this, label 0 selects the empty schema slot (0 keypoints) and the
-        # keypoint loss collapses to zero, so the head never trains.
-        target_classes = map_labels_to_keypoint_schema(
-            target_classes.to(src_keypoints.device), self.num_keypoints_per_class
-        )
+        if self.use_grouppose_keypoints:
+            target_classes = torch.cat([target["labels"][j] for target, (_, j) in zip(targets, indices)], dim=0)
+            target_boxes = torch.cat([target["boxes"][j] for target, (_, j) in zip(targets, indices)], dim=0)
+            target_areas = target_boxes[:, 2] * target_boxes[:, 3]
 
-        loss_l1, loss_findable, loss_visible, loss_nll = compute_l1_keypoint_loss(
-            all_pred_keypoints=src_keypoints,
-            target_keypoints=target_keypoints.to(src_keypoints.device),
-            target_classes=target_classes,
-            target_areas=target_areas.to(src_keypoints.device),
-            num_keypoints_per_class=self.num_keypoints_per_class,
-        )
+            # Class-index remap at the criterion boundary: lift the LibreYOLO
+            # contiguous pose label (person = 0) to the GroupPose internal schema
+            # class (person = 1 for ``[0, 17]``) before it indexes
+            # ``num_keypoints_per_class`` inside ``compute_l1_keypoint_loss``. Without
+            # this, label 0 selects the empty schema slot (0 keypoints) and the
+            # keypoint loss collapses to zero, so the head never trains.
+            target_classes = map_labels_to_keypoint_schema(
+                target_classes.to(src_keypoints.device), self.num_keypoints_per_class
+            )
+
+            loss_l1, loss_findable, loss_visible, loss_nll = compute_l1_keypoint_loss(
+                all_pred_keypoints=src_keypoints,
+                target_keypoints=target_keypoints.to(src_keypoints.device),
+                target_classes=target_classes,
+                target_areas=target_areas.to(src_keypoints.device),
+                num_keypoints_per_class=self.num_keypoints_per_class,
+            )
+        else:
+            loss_l1, loss_findable, loss_visible, loss_nll = _classic_keypoint_losses(
+                src_keypoints,
+                target_keypoints,
+            )
 
         return {
             "loss_keypoints_l1": loss_l1.sum() / num_boxes,

--- a/libreyolo/models/rfdetr/loss.py
+++ b/libreyolo/models/rfdetr/loss.py
@@ -60,7 +60,6 @@ def _classic_keypoint_losses(
     vis_count = valid_vis_f.sum(dim=-1).clamp(min=1.0)
     pred_vis_logits = src_keypoints[..., 2]
     target_findable = (target_vis > 0).to(src_keypoints.dtype)
-    target_visible = (target_vis > 1).to(src_keypoints.dtype)
     loss_findable = (
         F.binary_cross_entropy_with_logits(
             pred_vis_logits,
@@ -69,14 +68,7 @@ def _classic_keypoint_losses(
         )
         * valid_vis_f
     ).sum(dim=-1) / vis_count
-    loss_visible = (
-        F.binary_cross_entropy_with_logits(
-            pred_vis_logits,
-            target_visible,
-            reduction="none",
-        )
-        * valid_vis_f
-    ).sum(dim=-1) / vis_count
+    loss_visible = torch.zeros_like(loss_findable)
     loss_nll = torch.zeros_like(loss_l1)
     return loss_l1, loss_findable, loss_visible, loss_nll
 

--- a/libreyolo/models/rfdetr/lwdetr.py
+++ b/libreyolo/models/rfdetr/lwdetr.py
@@ -1132,14 +1132,16 @@ def build_criterion_and_postprocessors(args: Any):
     if args.segmentation_head:
         weight_dict["loss_mask_ce"] = args.mask_ce_loss_coef
         weight_dict["loss_mask_dice"] = args.mask_dice_loss_coef
-    # --- GroupPose keypoint additions (ported from RF-DETR v1.8.0). ---
-    # Gate on the new GroupPose flag (the legacy ``keypoint_head`` arg was removed).
-    has_keypoints = getattr(args, "use_grouppose_keypoints", False)
+    has_keypoints = bool(
+        getattr(args, "use_grouppose_keypoints", False)
+        or getattr(args, "keypoint_head", False)
+    )
     if has_keypoints:
         weight_dict["loss_keypoints_l1"] = args.keypoint_l1_loss_coef
         weight_dict["loss_keypoints_findable"] = args.keypoint_findable_loss_coef
         weight_dict["loss_keypoints_visible"] = args.keypoint_visible_loss_coef
-        weight_dict["loss_keypoints_nll"] = args.keypoint_nll_loss_coef
+        if getattr(args, "use_grouppose_keypoints", False):
+            weight_dict["loss_keypoints_nll"] = args.keypoint_nll_loss_coef
     # TODO this is a hack
     if args.aux_loss:
         aux_weight_dict = {}
@@ -1171,7 +1173,7 @@ def build_criterion_and_postprocessors(args: Any):
             use_position_supervised_loss=args.use_position_supervised_loss,
             ia_bce_loss=args.ia_bce_loss,
             mask_point_sample_ratio=args.mask_point_sample_ratio,
-            use_grouppose_keypoints=has_keypoints,
+            use_grouppose_keypoints=getattr(args, "use_grouppose_keypoints", False),
             num_keypoints_per_class=getattr(args, "num_keypoints_per_class", []),
         )
     else:
@@ -1186,7 +1188,7 @@ def build_criterion_and_postprocessors(args: Any):
             use_varifocal_loss=args.use_varifocal_loss,
             use_position_supervised_loss=args.use_position_supervised_loss,
             ia_bce_loss=args.ia_bce_loss,
-            use_grouppose_keypoints=has_keypoints,
+            use_grouppose_keypoints=getattr(args, "use_grouppose_keypoints", False),
             num_keypoints_per_class=getattr(args, "num_keypoints_per_class", []),
         )
     criterion.to(device)

--- a/libreyolo/models/rfdetr/lwdetr.py
+++ b/libreyolo/models/rfdetr/lwdetr.py
@@ -526,7 +526,9 @@ class LWDETR(nn.Module):
             raise RuntimeError("Cannot decode RF-DETR keypoints without keypoint_head.")
         raw = self.keypoint_head(hs).view(*hs.shape[:-1], self.num_keypoints, 3)
         if self.bbox_reparam:
-            xy = raw[..., :2] * reference[..., None, 2:] + reference[..., None, :2]
+            xy = (raw[..., :2].sigmoid() - 0.5) * reference[
+                ..., None, 2:
+            ] + reference[..., None, :2]
         else:
             xy = (raw[..., :2] + reference[..., None, :2]).sigmoid()
         return torch.cat((xy, raw[..., 2:3]), dim=-1)

--- a/libreyolo/models/rfdetr/lwdetr.py
+++ b/libreyolo/models/rfdetr/lwdetr.py
@@ -230,6 +230,8 @@ class LWDETR(nn.Module):
         lite_refpoint_refine=False,
         bbox_reparam=False,
         obb=False,
+        keypoint_head=False,
+        num_keypoints=17,
         # --- GroupPose keypoint additions (ported from RF-DETR v1.8.0). ---
         # All keypoint flags default to off so the detection/seg/obb construction
         # path remains byte-identical to the original.
@@ -305,6 +307,12 @@ class LWDETR(nn.Module):
             nn.init.constant_(self.keypoint_embed.layers[-1].bias.data, 0)
         else:
             self.keypoint_embed = None
+        self.keypoint_head = (
+            MLP(hidden_dim, hidden_dim, int(num_keypoints) * 3, 3)
+            if keypoint_head and not self.use_grouppose_keypoints
+            else None
+        )
+        self.num_keypoints = int(num_keypoints)
 
         self.register_buffer("_kp_active_mask", self._create_kp_active_mask(self.num_keypoints_per_class))
 
@@ -316,6 +324,9 @@ class LWDETR(nn.Module):
         # init bbox_mebed
         nn.init.constant_(self.bbox_embed.layers[-1].weight.data, 0)
         nn.init.constant_(self.bbox_embed.layers[-1].bias.data, 0)
+        if self.keypoint_head is not None:
+            nn.init.constant_(self.keypoint_head.layers[-1].weight.data, 0)
+            nn.init.constant_(self.keypoint_head.layers[-1].bias.data, 0)
         if self.angle_embed is not None:
             nn.init.constant_(self.angle_embed.layers[-1].weight.data, 0)
             nn.init.constant_(self.angle_embed.layers[-1].bias.data, 0)
@@ -433,7 +444,28 @@ class LWDETR(nn.Module):
 
         Ported from RF-DETR v1.8.0 (GroupPose keypoint additions).
         """
-        if not self.use_grouppose_keypoints or not num_keypoints_per_class:
+        if not num_keypoints_per_class:
+            return
+
+        if not self.use_grouppose_keypoints:
+            if self.keypoint_head is None:
+                return
+            if isinstance(num_keypoints_per_class, int):
+                num_keypoints = int(num_keypoints_per_class)
+            else:
+                active = [int(count) for count in num_keypoints_per_class if int(count) > 0]
+                if not active:
+                    return
+                num_keypoints = active[0]
+            hidden_dim = self.transformer.d_model
+            device = self.keypoint_head.layers[-1].weight.device
+            dtype = self.keypoint_head.layers[-1].weight.dtype
+            self.num_keypoints = num_keypoints
+            self.keypoint_head = MLP(
+                hidden_dim, hidden_dim, self.num_keypoints * 3, 3
+            ).to(device=device, dtype=dtype)
+            nn.init.constant_(self.keypoint_head.layers[-1].weight.data, 0)
+            nn.init.constant_(self.keypoint_head.layers[-1].bias.data, 0)
             return
 
         if isinstance(num_keypoints_per_class, int):
@@ -487,6 +519,17 @@ class LWDETR(nn.Module):
         if isinstance(enc_keypoint_embed, nn.ModuleList):
             for keypoint_embed in enc_keypoint_embed:
                 _reset_keypoint_gaussian_output_rows(keypoint_embed)
+
+    def _decode_keypoints(self, hs: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+        """Decode classic keypoint_head outputs to normalized image coordinates."""
+        if self.keypoint_head is None:
+            raise RuntimeError("Cannot decode RF-DETR keypoints without keypoint_head.")
+        raw = self.keypoint_head(hs).view(*hs.shape[:-1], self.num_keypoints, 3)
+        if self.bbox_reparam:
+            xy = raw[..., :2] * reference[..., None, 2:] + reference[..., None, :2]
+        else:
+            xy = (raw[..., :2] + reference[..., None, :2]).sigmoid()
+        return torch.cat((xy, raw[..., 2:3]), dim=-1)
 
     def export(self):
         self._export = True
@@ -717,6 +760,8 @@ class LWDETR(nn.Module):
                     )
                 outputs_keypoints = torch.stack(layer_outputs_keypoints, dim=0)
                 outputs_class = outputs_class + self._aggregate_keypoint_class_logits(outputs_keypoints)
+            elif self.keypoint_head is not None:
+                outputs_keypoints = self._decode_keypoints(hs, ref_unsigmoid)
 
             if self.segmentation_head is not None:
                 outputs_masks = seg_head_fwd(features[0].tensors, hs, samples.tensors.shape[-2:])
@@ -756,6 +801,8 @@ class LWDETR(nn.Module):
                     enc_kp_predictions.shape[1],
                 )
                 cls_enc = cls_enc + self._aggregate_keypoint_class_logits(keypoints_enc)
+            elif self.keypoint_head is not None:
+                keypoints_enc = self._decode_keypoints(hs_enc.unsqueeze(0), ref_enc.unsqueeze(0))[0]
 
             if self.segmentation_head is not None:
                 masks_enc = seg_head_fwd(
@@ -851,6 +898,13 @@ class LWDETR(nn.Module):
                     outputs_keypoints.shape[1],
                 )
                 outputs_class = outputs_class + self._aggregate_keypoint_class_logits(outputs_keypoints)
+            elif self.keypoint_head is not None:
+                decoded_keypoints = self._decode_keypoints(hs, ref_unsigmoid)
+                outputs_keypoints = (
+                    decoded_keypoints[-1]
+                    if decoded_keypoints.dim() == 5
+                    else decoded_keypoints
+                )
             if self.segmentation_head is not None:
                 outputs_masks = self.segmentation_head(
                     srcs[0],
@@ -876,6 +930,8 @@ class LWDETR(nn.Module):
                     enc_kp_predictions.shape[1],
                 )
                 outputs_class = outputs_class + self._aggregate_keypoint_class_logits(outputs_keypoints)
+            elif self.keypoint_head is not None:
+                outputs_keypoints = self._decode_keypoints(hs_enc.unsqueeze(0), ref_enc.unsqueeze(0))[0]
             if self.segmentation_head is not None:
                 outputs_masks = self.segmentation_head(
                     srcs[0],
@@ -1052,6 +1108,8 @@ def build_model(args: Any):
         lite_refpoint_refine=args.lite_refpoint_refine,
         bbox_reparam=args.bbox_reparam,
         obb=getattr(args, "obb", False),
+        keypoint_head=getattr(args, "keypoint_head", False),
+        num_keypoints=getattr(args, "num_keypoints", 17),
         # --- GroupPose keypoint additions (ported from RF-DETR v1.8.0). ---
         # Detection/seg/obb builder namespaces omit these; default to the
         # non-keypoint path so existing builds are unchanged.

--- a/libreyolo/models/rfdetr/matcher.py
+++ b/libreyolo/models/rfdetr/matcher.py
@@ -27,6 +27,60 @@ logger = logging.getLogger(__name__)
 _SANITIZED_COST_MARGIN = 1.0
 
 
+def _classic_keypoint_matching_cost(
+    all_pred_keypoints: torch.Tensor,
+    target_keypoints: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pairwise keypoint costs for classic RF-DETR pose heads."""
+    if all_pred_keypoints.shape[-1] < 3:
+        raise ValueError("classic RF-DETR keypoints must have x, y, and visibility")
+    if all_pred_keypoints.shape[-2] != target_keypoints.shape[-2]:
+        raise ValueError(
+            "classic RF-DETR keypoint count does not match target keypoint count: "
+            f"{all_pred_keypoints.shape[-2]} vs {target_keypoints.shape[-2]}"
+        )
+
+    pred = all_pred_keypoints
+    target = target_keypoints.to(device=pred.device, dtype=pred.dtype)
+    target_xy = target[..., :2]
+    target_vis = target[..., 2]
+
+    finite_xy = torch.isfinite(target_xy).all(dim=-1)
+    finite_vis = torch.isfinite(target_vis)
+    visible = finite_xy & finite_vis & (target_vis > 0)
+    visible_f = visible.to(pred.dtype)
+    visible_count = visible_f.sum(dim=-1).clamp(min=1.0)
+
+    l1 = (pred[:, :, None, :, :2] - target_xy[None, None, :, :, :]).abs().sum(dim=-1)
+    cost_l1 = (l1 * visible_f[None, None]).sum(dim=-1) / visible_count[None, None]
+
+    pred_vis_logits = pred[..., 2][:, :, None, :].expand(
+        -1, -1, target.shape[0], -1
+    )
+    valid_vis_f = finite_vis.to(pred.dtype)
+    vis_count = valid_vis_f.sum(dim=-1).clamp(min=1.0)
+    target_findable = (target_vis > 0).to(pred.dtype)
+    target_visible = (target_vis > 1).to(pred.dtype)
+    cost_findable = (
+        F.binary_cross_entropy_with_logits(
+            pred_vis_logits,
+            target_findable[None, None].expand_as(pred_vis_logits),
+            reduction="none",
+        )
+        * valid_vis_f[None, None]
+    ).sum(dim=-1) / vis_count[None, None]
+    cost_visible = (
+        F.binary_cross_entropy_with_logits(
+            pred_vis_logits,
+            target_visible[None, None].expand_as(pred_vis_logits),
+            reduction="none",
+        )
+        * valid_vis_f[None, None]
+    ).sum(dim=-1) / vis_count[None, None]
+    cost_nll = torch.zeros_like(cost_l1)
+    return cost_l1, cost_findable, cost_visible, cost_nll
+
+
 class HungarianMatcher(nn.Module):
     """This class computes an assignment between the targets and the predictions of the network
     For efficiency reasons, the targets don't include the no_object. Because of this, in general,
@@ -245,24 +299,32 @@ class HungarianMatcher(nn.Module):
 
         # --- GroupPose keypoint additions (ported from RF-DETR v1.8.0). ---
         if keypoints_present and tgt_keypoints is not None:
-            target_areas = tgt_bbox[:, 2] * tgt_bbox[:, 3]
-            # Class-index remap at the matcher boundary: lift the LibreYOLO
-            # contiguous pose label (person = 0) to the GroupPose internal schema
-            # class (person = 1 for ``[0, 17]``) so it indexes
-            # ``num_keypoints_per_class`` at the keypoint-bearing slot. Label 0
-            # would otherwise select the empty slot (0 keypoints) and the keypoint
-            # matching cost would collapse to zero. The classification cost above
-            # uses the same schema-space ids (``cls_tgt_ids``); reuse them here.
-            kp_target_classes = map_labels_to_keypoint_schema(
-                tgt_ids, self.num_keypoints_per_class
-            )
-            cost_l1, cost_findable, cost_visible, cost_nll = compute_keypoint_matching_cost(
-                all_pred_keypoints=outputs["pred_keypoints"],
-                target_keypoints=tgt_keypoints,
-                target_classes=kp_target_classes,
-                target_areas=target_areas,
-                num_keypoints_per_class=self.num_keypoints_per_class,
-            )
+            if self.num_keypoints_per_class:
+                target_areas = tgt_bbox[:, 2] * tgt_bbox[:, 3]
+                # Class-index remap at the matcher boundary: lift the LibreYOLO
+                # contiguous pose label (person = 0) to the GroupPose internal schema
+                # class (person = 1 for ``[0, 17]``) so it indexes
+                # ``num_keypoints_per_class`` at the keypoint-bearing slot. Label 0
+                # would otherwise select the empty slot (0 keypoints) and the keypoint
+                # matching cost would collapse to zero. The classification cost above
+                # uses the same schema-space ids (``cls_tgt_ids``); reuse them here.
+                kp_target_classes = map_labels_to_keypoint_schema(
+                    tgt_ids, self.num_keypoints_per_class
+                )
+                cost_l1, cost_findable, cost_visible, cost_nll = compute_keypoint_matching_cost(
+                    all_pred_keypoints=outputs["pred_keypoints"],
+                    target_keypoints=tgt_keypoints,
+                    target_classes=kp_target_classes,
+                    target_areas=target_areas,
+                    num_keypoints_per_class=self.num_keypoints_per_class,
+                )
+            else:
+                cost_l1, cost_findable, cost_visible, cost_nll = (
+                    _classic_keypoint_matching_cost(
+                        outputs["pred_keypoints"],
+                        tgt_keypoints,
+                    )
+                )
             cost_l1 = cost_l1.flatten(0, 1)
             cost_findable = cost_findable.flatten(0, 1)
             cost_visible = cost_visible.flatten(0, 1)

--- a/libreyolo/models/rfdetr/matcher.py
+++ b/libreyolo/models/rfdetr/matcher.py
@@ -60,7 +60,6 @@ def _classic_keypoint_matching_cost(
     valid_vis_f = finite_vis.to(pred.dtype)
     vis_count = valid_vis_f.sum(dim=-1).clamp(min=1.0)
     target_findable = (target_vis > 0).to(pred.dtype)
-    target_visible = (target_vis > 1).to(pred.dtype)
     cost_findable = (
         F.binary_cross_entropy_with_logits(
             pred_vis_logits,
@@ -69,14 +68,7 @@ def _classic_keypoint_matching_cost(
         )
         * valid_vis_f[None, None]
     ).sum(dim=-1) / vis_count[None, None]
-    cost_visible = (
-        F.binary_cross_entropy_with_logits(
-            pred_vis_logits,
-            target_visible[None, None].expand_as(pred_vis_logits),
-            reduction="none",
-        )
-        * valid_vis_f[None, None]
-    ).sum(dim=-1) / vis_count[None, None]
+    cost_visible = torch.zeros_like(cost_findable)
     cost_nll = torch.zeros_like(cost_l1)
     return cost_l1, cost_findable, cost_visible, cost_nll
 

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -303,7 +303,10 @@ class LibreRFDETR(BaseModel):
     @staticmethod
     def _has_grouppose_markers(weights_dict: dict, checkpoint: dict[str, Any]) -> bool:
         if "_kp_active_mask" in weights_dict:
-            return True
+            try:
+                return bool(torch.as_tensor(weights_dict["_kp_active_mask"]).any().item())
+            except Exception:
+                return bool(np.asarray(weights_dict["_kp_active_mask"]).any())
         if any("keypoint" in k for k in weights_dict if k.startswith("transformer.")):
             return True
         schema = checkpoint.get("num_keypoints_per_class")

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -171,20 +171,48 @@ class LibreRFDETR(BaseModel):
     autobatch_fraction: float = 0.45
 
     # Class-level metadata
-    FAMILY = "rfdetr"
-    FILENAME_PREFIX = "LibreRFDETR"
-    INPUT_SIZES = {"n": 384, "s": 512, "m": 576, "l": 704}
-    SEG_INPUT_SIZES = {"n": 312, "s": 384, "m": 432, "l": 504, "x": 624, "xx": 768}
+    FAMILY: ClassVar[str] = "rfdetr"
+    FILENAME_PREFIX: ClassVar[str] = "LibreRFDETR"
+    INPUT_SIZES: ClassVar[dict[str, int]] = {"n": 384, "s": 512, "m": 576, "l": 704}
+    SEG_INPUT_SIZES: ClassVar[dict[str, int]] = {
+        "n": 312,
+        "s": 384,
+        "m": 432,
+        "l": 504,
+        "x": 624,
+        "xx": 768,
+    }
     # Pose checkpoints use the dedicated RFDETR_POSE_CONFIGS resolutions.
-    POSE_INPUT_SIZES = {"n": 384, "s": 512, "m": 576, "l": 704, "x": 576}
+    POSE_INPUT_SIZES: ClassVar[dict[str, int]] = {
+        "n": 384,
+        "s": 512,
+        "m": 576,
+        "l": 704,
+        "x": 576,
+    }
     # Classification runs the DINOv2 backbone at 224 (divisible by patch_size 14).
-    CLS_INPUT_SIZES = {"n": 224, "s": 224, "m": 224, "l": 224}
+    CLS_INPUT_SIZES: ClassVar[dict[str, int]] = {
+        "n": 224,
+        "s": 224,
+        "m": 224,
+        "l": 224,
+    }
     # Semantic runs the DINOv2 backbone at its native pretrained 518 square
     # (37 positional tokens * patch_size 14).
-    SEM_INPUT_SIZES = {"n": 518, "s": 518, "m": 518, "l": 518}
+    SEM_INPUT_SIZES: ClassVar[dict[str, int]] = {
+        "n": 518,
+        "s": 518,
+        "m": 518,
+        "l": 518,
+    }
     # Depth uses the same DINOv2-native patch grid as semantic segmentation.
-    DEPTH_INPUT_SIZES = {"n": 518, "s": 518, "m": 518, "l": 518}
-    SUPPORTED_TASKS = (
+    DEPTH_INPUT_SIZES: ClassVar[dict[str, int]] = {
+        "n": 518,
+        "s": 518,
+        "m": 518,
+        "l": 518,
+    }
+    SUPPORTED_TASKS: ClassVar[tuple[str, ...]] = (
         "detect",
         "segment",
         "semantic",
@@ -193,7 +221,7 @@ class LibreRFDETR(BaseModel):
         "obb",
         "depth",
     )
-    TASK_INPUT_SIZES = {
+    TASK_INPUT_SIZES: ClassVar[dict[str, dict[str, int]]] = {
         "detect": INPUT_SIZES,
         "segment": SEG_INPUT_SIZES,
         "semantic": SEM_INPUT_SIZES,
@@ -209,7 +237,7 @@ class LibreRFDETR(BaseModel):
     # (patch_size 14 x num_windows 1) used by the semantic backbone.
     semantic_imgsz_divisor = 14
     depth_imgsz_divisor = 14
-    EXPERIMENTAL_WEIGHT_FILENAMES = frozenset(
+    EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset[str]] = frozenset(
         {
             "librerfdetrn-pose.pt",
             "librerfdetrs-pose.pt",
@@ -218,9 +246,9 @@ class LibreRFDETR(BaseModel):
             "librerfdetrx-pose.pt",
         }
     )
-    TRAIN_CONFIG = RFDETRConfig
-    val_preprocessor_class = RFDETRValPreprocessor
-    TTA_FIXED_SIZE = True  # resizes to a fixed square; multi-scale TTA is a no-op
+    TRAIN_CONFIG: ClassVar[type[RFDETRConfig]] = RFDETRConfig
+    val_preprocessor_class: ClassVar[type[RFDETRValPreprocessor]] = RFDETRValPreprocessor
+    TTA_FIXED_SIZE: ClassVar[bool] = True  # fixed square; multi-scale TTA is a no-op
 
     # CLI parameters intentionally ignored by native RF-DETR training.
     UNSUPPORTED_TRAIN_PARAMS: ClassVar[set[str]] = {
@@ -272,6 +300,23 @@ class LibreRFDETR(BaseModel):
             k.startswith("backbone.") for k in weights_dict
         )
 
+    @staticmethod
+    def _has_grouppose_markers(weights_dict: dict, checkpoint: dict[str, Any]) -> bool:
+        if "_kp_active_mask" in weights_dict:
+            return True
+        if any("keypoint" in k for k in weights_dict if k.startswith("transformer.")):
+            return True
+        schema = checkpoint.get("num_keypoints_per_class")
+        if schema:
+            return True
+        args = checkpoint.get("args")
+        if args is None:
+            return False
+        if isinstance(args, dict):
+            schema = args.get("num_keypoints_per_class")
+            return bool(schema)
+        return bool(getattr(args, "num_keypoints_per_class", None))
+
     @classmethod
     def detect_size(
         cls, weights_dict: dict, state_dict: dict | None = None
@@ -280,8 +325,14 @@ class LibreRFDETR(BaseModel):
         if isinstance(full_ckpt, dict) and isinstance(full_ckpt.get("size"), str):
             return full_ckpt["size"]
         is_seg = any(k.startswith("segmentation_head") for k in weights_dict)
+        is_grouppose = cls._has_grouppose_markers(weights_dict, full_ckpt)
 
-        RESOLUTION_TO_SIZE = {384: "n", 512: "s", 576: "m", 704: "l"}
+        RESOLUTION_TO_SIZE = {
+            384: "n",
+            512: "s",
+            576: "x" if is_grouppose else "m",
+            704: "l",
+        }
         SEG_RESOLUTION_TO_SIZE = {
             312: "n",
             384: "s",
@@ -321,7 +372,7 @@ class LibreRFDETR(BaseModel):
                 else {
                     24 * 24 + 1: "n",
                     32 * 32 + 1: "s",
-                    36 * 36 + 1: "m",
+                    36 * 36 + 1: "x" if is_grouppose else "m",
                     44 * 44 + 1: "l",
                 }
             )

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -175,9 +175,8 @@ class LibreRFDETR(BaseModel):
     FILENAME_PREFIX = "LibreRFDETR"
     INPUT_SIZES = {"n": 384, "s": 512, "m": 576, "l": 704}
     SEG_INPUT_SIZES = {"n": 312, "s": 384, "m": 432, "l": 504, "x": 624, "xx": 768}
-    # Pose checkpoints carry their own validation/export sizes. n/s/m/l use the
-    # classic keypoint_head path; x uses the GroupPose preview path.
-    POSE_INPUT_SIZES = {"n": 512, "s": 768, "m": 576, "l": 704, "x": 576}
+    # Pose checkpoints use the dedicated RFDETR_POSE_CONFIGS resolutions.
+    POSE_INPUT_SIZES = {"n": 384, "s": 512, "m": 576, "l": 704, "x": 576}
     # Classification runs the DINOv2 backbone at 224 (divisible by patch_size 14).
     CLS_INPUT_SIZES = {"n": 224, "s": 224, "m": 224, "l": 224}
     # Semantic runs the DINOv2 backbone at its native pretrained 518 square

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -18,7 +18,6 @@ from .nn import (
     LibreRFDETRModel,
     RFDETR_CONFIGS,
     RFDETR_SEG_CONFIGS,
-    RFDETR_POSE_CONFIGS,
 )
 from .config import RFDETRConfig
 from ...postprocess.rfdetr import postprocess
@@ -176,9 +175,9 @@ class LibreRFDETR(BaseModel):
     FILENAME_PREFIX = "LibreRFDETR"
     INPUT_SIZES = {"n": 384, "s": 512, "m": 576, "l": 704}
     SEG_INPUT_SIZES = {"n": 312, "s": 384, "m": 432, "l": 504, "x": 624, "xx": 768}
-    # Pose uses the dedicated GroupPose preset (adapted from RF-DETR v1.8.0);
-    # the keypoint preview runs the encoder at a 576 square.
-    POSE_INPUT_SIZES = {"x": 576}
+    # Pose checkpoints carry their own validation/export sizes. n/s/m/l use the
+    # classic keypoint_head path; x uses the GroupPose preview path.
+    POSE_INPUT_SIZES = {"n": 512, "s": 768, "m": 576, "l": 704, "x": 576}
     # Classification runs the DINOv2 backbone at 224 (divisible by patch_size 14).
     CLS_INPUT_SIZES = {"n": 224, "s": 224, "m": 224, "l": 224}
     # Semantic runs the DINOv2 backbone at its native pretrained 518 square
@@ -211,7 +210,15 @@ class LibreRFDETR(BaseModel):
     # (patch_size 14 x num_windows 1) used by the semantic backbone.
     semantic_imgsz_divisor = 14
     depth_imgsz_divisor = 14
-    EXPERIMENTAL_WEIGHT_FILENAMES = frozenset({"librerfdetrx-pose.pt"})
+    EXPERIMENTAL_WEIGHT_FILENAMES = frozenset(
+        {
+            "librerfdetrn-pose.pt",
+            "librerfdetrs-pose.pt",
+            "librerfdetrm-pose.pt",
+            "librerfdetrl-pose.pt",
+            "librerfdetrx-pose.pt",
+        }
+    )
     TRAIN_CONFIG = RFDETRConfig
     val_preprocessor_class = RFDETRValPreprocessor
     TTA_FIXED_SIZE = True  # resizes to a fixed square; multi-scale TTA is a no-op
@@ -1321,7 +1328,18 @@ class LibreRFDETR(BaseModel):
                     ignored.append("keypoint_head.")
                 if self._allow_detect_to_obb_transfer:
                     ignored.append("angle_embed.")
-                important = [k for k in missing if not k.startswith(tuple(ignored))]
+                inner = getattr(self.model, "model", None)
+                uses_grouppose = bool(
+                    getattr(inner, "use_grouppose_keypoints", False)
+                )
+                ignored_exact = set()
+                if not uses_grouppose:
+                    ignored_exact.add("_kp_active_mask")
+                important = [
+                    k
+                    for k in missing
+                    if k not in ignored_exact and not k.startswith(tuple(ignored))
+                ]
                 if important:
                     raise RuntimeError(
                         f"Missing RF-DETR checkpoint keys: {sorted(important)[:10]}"

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -267,7 +267,9 @@ def _make_args(
         dual_projector_kp_only=dual_projector_kp_only,
         # GroupPose keypoint flags ported from RF-DETR v1.8.0 (keypoint preview).
         use_grouppose_keypoints=use_grouppose_keypoints,
-        num_keypoints_per_class=list(num_keypoints_per_class) if num_keypoints_per_class else [],
+        num_keypoints_per_class=list(num_keypoints_per_class)
+        if num_keypoints_per_class is not None
+        else [],
         grouppose_keypoint_dim_downscale=grouppose_keypoint_dim_downscale,
         keypoint_cross_attn=keypoint_cross_attn,
         inter_instance_kp_attn=inter_instance_kp_attn,
@@ -943,7 +945,7 @@ class LibreRFDETRModel(nn.Module):
         # The n/s/m/l pose checkpoints carry normal keypoint_head.* tensors.
         self.num_keypoints_per_class = (
             list(num_keypoints_per_class)
-            if num_keypoints_per_class
+            if num_keypoints_per_class is not None
             else ([0, int(num_keypoints)] if pose and configs[config].grouppose_head else [])
         )
         # The GroupPose detection head must keep one logit column per keypoint

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -293,14 +293,11 @@ def _make_args(
         mask_ce_loss_coef=5.0,
         mask_dice_loss_coef=5.0,
         mask_point_sample_ratio=16,
-        # --- GroupPose keypoint additions (ported from RF-DETR v1.8.0). ---
-        # GroupPose keypoint loss coefficients per KeypointTrainConfig (all 1.0).
-        # They feed both the criterion weight_dict and the matcher cost. They stay
-        # 0.0 on the non-keypoint path so the detection/seg/obb matcher cost matrix
-        # is byte-identical when keypoints are off.
-        keypoint_l1_loss_coef=1.0 if use_grouppose_keypoints else 0.0,
-        keypoint_findable_loss_coef=1.0 if use_grouppose_keypoints else 0.0,
-        keypoint_visible_loss_coef=1.0 if use_grouppose_keypoints else 0.0,
+        # Keypoint losses feed both the criterion weight_dict and matcher cost.
+        # GroupPose adds the NLL term; classic pose heads emit (x, y, visibility).
+        keypoint_l1_loss_coef=1.0 if pose else 0.0,
+        keypoint_findable_loss_coef=1.0 if pose else 0.0,
+        keypoint_visible_loss_coef=1.0 if pose else 0.0,
         keypoint_nll_loss_coef=1.0 if use_grouppose_keypoints else 0.0,
         num_keypoints=int(num_keypoints),
         oks_sigmas=oks_sigmas,

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -1016,6 +1016,9 @@ class LibreRFDETRModel(nn.Module):
             )
 
         checkpoint_args = state_dict.get("args") if isinstance(state_dict, dict) else None
+        checkpoint_num_keypoints = (
+            state_dict.get("num_keypoints") if isinstance(state_dict, dict) else None
+        )
         state_dict = _unwrap_state_dict(state_dict)
 
         class_bias = state_dict.get("class_embed.bias")
@@ -1038,6 +1041,20 @@ class LibreRFDETRModel(nn.Module):
                 self.model.reinitialize_keypoint_head(ckpt_schema)
                 self.num_keypoints_per_class = ckpt_schema
                 self.args.num_keypoints_per_class = ckpt_schema
+        elif self.pose:
+            ckpt_num_keypoints = checkpoint_num_keypoints
+            if ckpt_num_keypoints is None:
+                final_weight = state_dict.get("keypoint_head.layers.2.weight")
+                if final_weight is not None and final_weight.shape[0] % 3 == 0:
+                    ckpt_num_keypoints = int(final_weight.shape[0] // 3)
+            if (
+                ckpt_num_keypoints is not None
+                and int(ckpt_num_keypoints) != self.model.num_keypoints
+            ):
+                num_keypoints = int(ckpt_num_keypoints)
+                self.model.reinitialize_keypoint_head(num_keypoints)
+                self.num_keypoints = num_keypoints
+                self.args.num_keypoints = num_keypoints
 
         for key in ("refpoint_embed.weight", "query_feat.weight"):
             if key in state_dict:

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -35,6 +35,7 @@ class RFDETRSizeConfig:
     pretrain_weights: str | None = None
     segmentation_head: bool = False
     mask_downsample_ratio: int = 4
+    grouppose_head: bool = False
     license: str = "Apache-2.0"
 
 
@@ -136,13 +137,36 @@ RFDETR_SEG_CONFIGS: dict[str, RFDETRSizeConfig] = {
 }
 
 
-# Keypoint/pose size configs (adapted from RF-DETR v1.8.0). The released
-# ``rf-detr-keypoint-preview`` checkpoint is an xlarge-encoder GroupPose model
-# with its own patch grid (12) / windowing (2) / positional grid (48) and a
+# Keypoint/pose size configs. The n/s/m/l checkpoints use the classic
+# keypoint_head path and keep the matching detection encoder presets. The x
+# checkpoint is a separate RF-DETR v1.8.0 GroupPose model with its own patch
+# grid, windowing, positional grid, and 100-query decoder.
 # 100-query decoder — none of the detection or segmentation presets match it,
-# so pose selects from this dedicated table. Detection/seg/obb presets above
-# are left untouched.
 RFDETR_POSE_CONFIGS: dict[str, RFDETRSizeConfig] = {
+    "n": RFDETRSizeConfig(
+        dec_layers=2,
+        resolution=384,
+        positional_encoding_size=24,
+        pretrain_weights="LibreRFDETRn-pose.pt",
+    ),
+    "s": RFDETRSizeConfig(
+        dec_layers=3,
+        resolution=512,
+        positional_encoding_size=32,
+        pretrain_weights="LibreRFDETRs-pose.pt",
+    ),
+    "m": RFDETRSizeConfig(
+        dec_layers=4,
+        resolution=576,
+        positional_encoding_size=36,
+        pretrain_weights="LibreRFDETRm-pose.pt",
+    ),
+    "l": RFDETRSizeConfig(
+        dec_layers=4,
+        resolution=704,
+        positional_encoding_size=44,
+        pretrain_weights="LibreRFDETRl-pose.pt",
+    ),
     "x": RFDETRSizeConfig(
         encoder="dinov2_windowed_small",
         hidden_dim=256,
@@ -160,6 +184,7 @@ RFDETR_POSE_CONFIGS: dict[str, RFDETRSizeConfig] = {
         positional_encoding_size=48,
         pretrain_weights="rf-detr-keypoint-preview-xlarge.pth",
         segmentation_head=False,
+        grouppose_head=True,
     ),
 }
 
@@ -914,17 +939,12 @@ class LibreRFDETRModel(nn.Module):
         self.obb = obb
         self.num_keypoints = int(num_keypoints)
 
-        # --- GroupPose keypoint additions (ported from RF-DETR v1.8.0). ---
-        # The released rf-detr-keypoint-preview checkpoint uses the GroupPose head
-        # with a 2-class schema [0, num_keypoints] (class 0 has no keypoints, the
-        # "person" class has ``num_keypoints``), dual_projector + kp-only routing,
-        # and a detection head whose ``out_features == len(schema)`` (so
-        # pred_logits is (B, Q, 2)). Detection/seg/obb builds leave all keypoint
-        # flags off.
+        # Only GroupPose configs use the [0, num_keypoints] keypoint-class schema.
+        # The n/s/m/l pose checkpoints carry normal keypoint_head.* tensors.
         self.num_keypoints_per_class = (
             list(num_keypoints_per_class)
             if num_keypoints_per_class
-            else ([0, int(num_keypoints)] if pose else [])
+            else ([0, int(num_keypoints)] if pose and configs[config].grouppose_head else [])
         )
         # The GroupPose detection head must keep one logit column per keypoint
         # class (``class_embed.out_features == len(schema)``); ``_make_args``
@@ -936,7 +956,7 @@ class LibreRFDETRModel(nn.Module):
         self.config = configs[config]
         self.nb_classes = nb_classes
         kp_kwargs = {}
-        if pose:
+        if pose and self.config.grouppose_head:
             kp_kwargs = dict(
                 use_grouppose_keypoints=True,
                 num_keypoints_per_class=self.num_keypoints_per_class,

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -48,15 +48,6 @@ def _pose_worker_init_fn(worker_id: int) -> None:
     np.random.seed(seed)
 
 
-def _is_classic_pose_training_model(model) -> bool:
-    core = getattr(model, "model", model)
-    core = getattr(core, "model", core)
-    return bool(
-        getattr(core, "keypoint_head", None) is not None
-        and not getattr(core, "use_grouppose_keypoints", False)
-    )
-
-
 class RFDETRStepScheduler(BaseScheduler):
     """RF-DETR upstream-style warmup plus step decay schedule."""
 
@@ -602,12 +593,6 @@ class RFDETRTrainer(BaseTrainer):
             )
         if task in ("classify", "semantic", "depth"):
             return
-        if task == "pose" and _is_classic_pose_training_model(self.model):
-            raise NotImplementedError(
-                "Classic RF-DETR pose training is not implemented because its "
-                "criterion does not include keypoint losses. Use a GroupPose RF-DETR "
-                "pose model or export/infer the classic pose checkpoints only."
-            )
         # --- GroupPose keypoint additions (adapted from RF-DETR v1.8.0). ---
         # The GroupPose detection head must keep one logit column per keypoint
         # class (``out_features == len(num_keypoints_per_class)``, e.g. 2 for
@@ -1109,12 +1094,15 @@ def train_rfdetr(
     from .model import LibreRFDETR
 
     # Detection/seg keep the historical default: None -> small. Pose defaults to
-    # the x GroupPose preview unless the caller asks for a specific pose size.
+    # the x GroupPose preview only when no checkpoint is available to identify a
+    # concrete pose architecture.
     resolved_size = size
-    if pose and resolved_size is None:
-        resolved_size = "x"
-    elif resolved_size is None:
-        resolved_size = "s"
+    if resolved_size is None:
+        if pose:
+            if pretrain_weights is None:
+                resolved_size = "x"
+        else:
+            resolved_size = "s"
 
     model = LibreRFDETR(
         model_path=pretrain_weights,

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -1093,14 +1093,10 @@ def train_rfdetr(
     """Compatibility helper around :class:`LibreRFDETR.train`."""
     from .model import LibreRFDETR
 
-    # --- GroupPose keypoint additions (adapted from RF-DETR v1.8.0). ---
-    # Pose has a single GroupPose preset ('x'); 's'/'m'/'l' are not in
-    # RFDETR_POSE_CONFIGS, so resolve any requested pose size to 'x' (the only
-    # valid option) instead of failing with "Invalid RF-DETR size: s".
-    # Detection/seg keep the historical default: None -> LibreRFDETR resolves to
-    # its own small default ('s'), byte-identical to the prior behavior.
+    # Detection/seg keep the historical default: None -> small. Pose defaults to
+    # the x GroupPose preview unless the caller asks for a specific pose size.
     resolved_size = size
-    if pose:
+    if pose and resolved_size is None:
         resolved_size = "x"
     elif resolved_size is None:
         resolved_size = "s"

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -48,6 +48,15 @@ def _pose_worker_init_fn(worker_id: int) -> None:
     np.random.seed(seed)
 
 
+def _is_classic_pose_training_model(model) -> bool:
+    core = getattr(model, "model", model)
+    core = getattr(core, "model", core)
+    return bool(
+        getattr(core, "keypoint_head", None) is not None
+        and not getattr(core, "use_grouppose_keypoints", False)
+    )
+
+
 class RFDETRStepScheduler(BaseScheduler):
     """RF-DETR upstream-style warmup plus step decay schedule."""
 
@@ -593,6 +602,12 @@ class RFDETRTrainer(BaseTrainer):
             )
         if task in ("classify", "semantic", "depth"):
             return
+        if task == "pose" and _is_classic_pose_training_model(self.model):
+            raise NotImplementedError(
+                "Classic RF-DETR pose training is not implemented because its "
+                "criterion does not include keypoint losses. Use a GroupPose RF-DETR "
+                "pose model or export/infer the classic pose checkpoints only."
+            )
         # --- GroupPose keypoint additions (adapted from RF-DETR v1.8.0). ---
         # The GroupPose detection head must keep one logit column per keypoint
         # class (``out_features == len(num_keypoints_per_class)``, e.g. 2 for

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -99,14 +99,9 @@ class LibreYOLONAS(BaseModel):
             return None
         task = cls.detect_task_from_filename(filename)
         if task == "pose":
-            # Pose checkpoints are intentionally NOT auto-downloadable: their
-            # SHA-256 is not pinned (only the detection s/m/l checkpoints are, see
-            # _DECI_CHECKPOINT_SHA256 / verify_downloaded_file), so we return no
-            # route rather than fetch an unverifiable third-party pickle that the
-            # checksum gate would then refuse. Pose weights must be staged
-            # manually. Detecting the task here still prevents a pose request from
-            # mis-routing to the detection URL.
-            return None
+            if size not in cls.POSE_INPUT_SIZES:
+                return None
+            return f"{cls._DECI_CDN_BASE}/yolo_nas_pose_{size}_coco_pose.pth"
         if size not in cls.INPUT_SIZES:
             return None
         return f"{cls._DECI_CDN_BASE}/yolo_nas_{size}_coco.pth"
@@ -349,6 +344,10 @@ class LibreYOLONAS(BaseModel):
         "yolo_nas_s_coco.pth": "c1b1d9148ab8ae5d5984699547e850955ff9efccaf568c67b3d605acb4bfe1cb",
         "yolo_nas_m_coco.pth": "b194fc7fa196f76161c6356558bedf04fb99a62325a74a36a4bec3ca8ba48250",
         "yolo_nas_l_coco.pth": "91a06beaa1ce1a651d6691e3198061da996eafc8890503238dedacbd4c392a32",
+        "yolo_nas_pose_n_coco_pose.pth": "3544cd4bef7a4930e79c2d9a9ec50167be6fa366be834d52d462393edfc3a64f",
+        "yolo_nas_pose_s_coco_pose.pth": "54f0933cb3760c5f9ba47e901c58d6d114cd206718667a586031bea0ab9ea849",
+        "yolo_nas_pose_m_coco_pose.pth": "6d0f92a589fd2f39a9fb92c42894cca76e81eaf2fcb3a00f1cac2e7089fb91ec",
+        "yolo_nas_pose_l_coco_pose.pth": "d05c55157b3eb917e43d3669cc1e99fbe35a8a93c7883b95b93036a81216c5ab",
     }
 
     @classmethod

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -73,8 +73,8 @@ class LibreYOLONAS(BaseModel):
     def detect_size_from_filename(cls, filename: str) -> Optional[str]:
         # Accept the LibreYOLO convention (LibreYOLONAS<size>.pt) handled by the
         # base regex, and also the native Deci filenames the CDN serves
-        # (yolo_nas_<size>_coco.pth / yolo_nas_pose_<size>_coco_pose.pth) so the
-        # checkpoints auto-download by their canonical upstream names.
+        # (yolo_nas_<size>_coco.pth / yolo_nas_pose_<size>_coco_pose.pth) so
+        # locally staged native checkpoints resolve to the right model size.
         size = super().detect_size_from_filename(filename)
         if size is not None:
             return size
@@ -84,9 +84,7 @@ class LibreYOLONAS(BaseModel):
     @classmethod
     def detect_task_from_filename(cls, filename: str) -> Optional[str]:
         # Native Deci pose checkpoints are named yolo_nas_pose_<size>_coco_pose.pth.
-        # Detect that here so get_download_url routes to the pose CDN URL; without
-        # it the base regex sees no task and a pose request fetches detection
-        # weights, which then fail the pose/detection checkpoint guard.
+        # Detect that here so local checkpoints route to the pose architecture.
         if re.search(r"yolo_nas_pose_[nsml]_coco", filename.lower()):
             return "pose"
         return super().detect_task_from_filename(filename)
@@ -100,9 +98,7 @@ class LibreYOLONAS(BaseModel):
             return None
         task = cls.detect_task_from_filename(filename)
         if task == "pose":
-            if size not in cls.POSE_INPUT_SIZES:
-                return None
-            return f"{cls._DECI_CDN_BASE}/yolo_nas_pose_{size}_coco_pose.pth"
+            return None
         if size not in cls.INPUT_SIZES:
             return None
         return f"{cls._DECI_CDN_BASE}/yolo_nas_{size}_coco.pth"
@@ -346,10 +342,6 @@ class LibreYOLONAS(BaseModel):
         "yolo_nas_s_coco.pth": "c1b1d9148ab8ae5d5984699547e850955ff9efccaf568c67b3d605acb4bfe1cb",
         "yolo_nas_m_coco.pth": "b194fc7fa196f76161c6356558bedf04fb99a62325a74a36a4bec3ca8ba48250",
         "yolo_nas_l_coco.pth": "91a06beaa1ce1a651d6691e3198061da996eafc8890503238dedacbd4c392a32",
-        "yolo_nas_pose_n_coco_pose.pth": "3544cd4bef7a4930e79c2d9a9ec50167be6fa366be834d52d462393edfc3a64f",
-        "yolo_nas_pose_s_coco_pose.pth": "54f0933cb3760c5f9ba47e901c58d6d114cd206718667a586031bea0ab9ea849",
-        "yolo_nas_pose_m_coco_pose.pth": "6d0f92a589fd2f39a9fb92c42894cca76e81eaf2fcb3a00f1cac2e7089fb91ec",
-        "yolo_nas_pose_l_coco_pose.pth": "d05c55157b3eb917e43d3669cc1e99fbe35a8a93c7883b95b93036a81216c5ab",
     }
 
     @classmethod

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -41,6 +41,7 @@ class LibreYOLONAS(BaseModel):
         "pose": POSE_INPUT_SIZES,
     }
     POSE_NUM_KEYPOINTS = 17
+    KEYPOINT_DIM = 3
     val_preprocessor_class = YOLONASValPreprocessor
 
     _REQUIRED_SIGNATURE_KEYS = (
@@ -172,6 +173,7 @@ class LibreYOLONAS(BaseModel):
         # Default keypoint count; overridden from checkpoint metadata/state
         # before model construction or from dataset kpt_shape in train().
         self.num_keypoints = self.POSE_NUM_KEYPOINTS
+        self.keypoint_dim = self.KEYPOINT_DIM
         if isinstance(model_path, dict):
             model_path = unwrap_yolonas_checkpoint(model_path)
             if resolved_task == "pose":

--- a/libreyolo/postprocess/ec.py
+++ b/libreyolo/postprocess/ec.py
@@ -110,7 +110,7 @@ def postprocess_pose(
     tensor of shape ``(N, num_keypoints, 3)`` with (x, y, vis).
     """
     out_logits = outputs["pred_logits"]
-    out_kpts = outputs["pred_keypoints"]  # (B, Q, K*2) flattened
+    out_kpts = outputs["pred_keypoints"]  # (B, Q, K*2) or (B, Q, K, 2)
     if out_logits.dim() == 3:
         out_logits = out_logits[0]
         out_kpts = out_kpts[0]
@@ -122,7 +122,11 @@ def postprocess_pose(
     query_idx = topk_indices // num_classes
     class_idx = topk_indices % num_classes
 
-    kpts_xy = out_kpts.unflatten(-1, (num_keypoints, 2))[query_idx]  # (N, K, 2) in [0,1]
+    if out_kpts.dim() >= 3 and out_kpts.shape[-1] == 2:
+        kpts_xy_all = out_kpts
+    else:
+        kpts_xy_all = out_kpts.unflatten(-1, (num_keypoints, 2))
+    kpts_xy = kpts_xy_all[query_idx]  # (N, K, 2) in [0,1]
 
     keep = scores >= conf_thres
     scores = scores[keep]

--- a/libreyolo/postprocess/ec.py
+++ b/libreyolo/postprocess/ec.py
@@ -115,8 +115,7 @@ def postprocess_pose(
         out_logits = out_logits[0]
         out_kpts = out_kpts[0]
 
-    prob = out_logits.sigmoid()
-    query_scores = prob.max(dim=-1).values
+    query_scores = out_logits[..., 0].sigmoid()
     scores, query_idx = torch.topk(
         query_scores,
         min(max_det, query_scores.numel()),

--- a/libreyolo/postprocess/ec.py
+++ b/libreyolo/postprocess/ec.py
@@ -115,12 +115,12 @@ def postprocess_pose(
         out_logits = out_logits[0]
         out_kpts = out_kpts[0]
 
-    num_classes = out_logits.shape[-1]
     prob = out_logits.sigmoid()
-    topk_values, topk_indices = torch.topk(prob.view(-1), min(max_det, prob.numel()))
-    scores = topk_values
-    query_idx = topk_indices // num_classes
-    class_idx = topk_indices % num_classes
+    query_scores = prob.max(dim=-1).values
+    scores, query_idx = torch.topk(
+        query_scores,
+        min(max_det, query_scores.numel()),
+    )
 
     if out_kpts.dim() >= 3 and out_kpts.shape[-1] == 2:
         kpts_xy_all = out_kpts
@@ -130,7 +130,6 @@ def postprocess_pose(
 
     keep = scores >= conf_thres
     scores = scores[keep]
-    class_idx = class_idx[keep]
     kpts_xy = kpts_xy[keep]
 
     if original_size is not None and kpts_xy.numel() > 0:

--- a/libreyolo/postprocess/rfdetr.py
+++ b/libreyolo/postprocess/rfdetr.py
@@ -144,6 +144,26 @@ def _postprocess_grouppose_keypoints(
     return scores_i, output_keypoints, output_keypoint_precision
 
 
+def _postprocess_classic_keypoints(
+    out_keypoints_i: torch.Tensor,
+    topk_boxes_i: torch.Tensor,
+    target_size: torch.Tensor,
+) -> torch.Tensor:
+    """Gather classic RF-DETR keypoints and scale them to pixel coordinates."""
+    keypoints_i = torch.gather(
+        out_keypoints_i,
+        0,
+        topk_boxes_i.unsqueeze(-1).unsqueeze(-1).repeat(
+            1, out_keypoints_i.shape[-2], out_keypoints_i.shape[-1]
+        ),
+    ).clone()
+    img_h, img_w = target_size
+    keypoints_i[..., 0] = keypoints_i[..., 0] * img_w
+    keypoints_i[..., 1] = keypoints_i[..., 1] * img_h
+    keypoints_i[..., 2] = keypoints_i[..., 2].sigmoid()
+    return keypoints_i
+
+
 def postprocess(
     outputs: dict[str, torch.Tensor],
     target_sizes: torch.Tensor,
@@ -270,7 +290,7 @@ def postprocess(
             # Threshold at 0.0 in logit space (= 0.5 probability)
             res_i["masks"] = (masks_i[:, 0] > 0.0).bool()  # (K, H, W)
 
-        if out_keypoints is not None:
+        if out_keypoints is not None and num_keypoints_per_class:
             # GroupPose keypoint decode (ported from RF-DETR v1.8.0). The raw
             # keypoints are (Q, num_classes * max_K, D); the predicted-class slot
             # is gathered per query, xy scaled to original pixels, confidence =
@@ -331,6 +351,12 @@ def postprocess(
             res_i["scores"] = scores_i[keep_kp]
             res_i["keypoints"] = keypoints_i[keep_kp]
             res_i["keypoint_precision_cholesky"] = precision_i[keep_kp]
+        elif out_keypoints is not None:
+            res_i["keypoints"] = _postprocess_classic_keypoints(
+                out_keypoints[i],
+                topk_boxes[i],
+                target_sizes[i],
+            )
 
         results.append(res_i)
 

--- a/libreyolo/validation/pose_validator.py
+++ b/libreyolo/validation/pose_validator.py
@@ -179,25 +179,36 @@ class PoseValidator(BaseValidator):
         annotation_file = get_coco_annotation_file(data_cfg, self.config.split)
         if annotation_file:
             data_root = Path(data_cfg["root"])
-            self._kpts_json = Path(annotation_file)
-            if not self._kpts_json.is_absolute():
-                self._kpts_json = data_root / self._kpts_json
+            kpts_json = Path(annotation_file)
+            if not kpts_json.is_absolute():
+                kpts_json = data_root / kpts_json
             default_image_dir = resolve_default_coco_image_dir(
                 data_root,
                 self.config.split,
-                self._kpts_json.name,
+                kpts_json.name,
             )
-            self._images_dir = Path(
+            images_dir = Path(
                 get_coco_image_dir(data_cfg, self.config.split, default_image_dir)
             )
-            if not self._images_dir.is_absolute():
-                self._images_dir = data_root / self._images_dir
-            if not self._kpts_json.exists():
-                raise FileNotFoundError(f"Annotations JSON not found: {self._kpts_json}")
-            if not self._images_dir.is_dir():
-                raise FileNotFoundError(f"Images dir not found: {self._images_dir}")
-            return
+            if not images_dir.is_absolute():
+                images_dir = data_root / images_dir
+            if kpts_json.exists() and self._is_coco_keypoints_annotation_file(kpts_json):
+                if not images_dir.is_dir():
+                    raise FileNotFoundError(f"Images dir not found: {images_dir}")
+                self._kpts_json = kpts_json
+                self._images_dir = images_dir
+                return
         self._kpts_json, self._images_dir = self._build_coco_gt_from_yolo()
+
+    @staticmethod
+    def _is_coco_keypoints_annotation_file(path: Path) -> bool:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        categories = data.get("categories") or []
+        if any(cat.get("keypoints") for cat in categories):
+            return True
+        annotations = data.get("annotations") or []
+        return any("keypoints" in ann and "num_keypoints" in ann for ann in annotations)
 
     def _build_coco_gt_from_yolo(self) -> tuple[Path, Path | None]:
         from PIL import Image

--- a/libreyolo/validation/pose_validator.py
+++ b/libreyolo/validation/pose_validator.py
@@ -311,6 +311,7 @@ class PoseValidator(BaseValidator):
         self._coco_gt = COCO(str(self._kpts_json))
         cats = self._coco_gt.loadCats(self._coco_gt.getCatIds())
         self._category_id = self._infer_category_id()
+        self._category_ids = [int(cat["id"]) for cat in sorted(cats, key=lambda c: int(c["id"]))]
         self._image_records = self._coco_gt.loadImgs(self._coco_gt.getImgIds())
         if self._num_keypoints is None:
             keypoints = cats[0].get("keypoints", []) if cats else []
@@ -344,6 +345,14 @@ class PoseValidator(BaseValidator):
             if cat.get("name") == "person":
                 return int(cat["id"])
         return int(cats[0]["id"])
+
+    def _prediction_category_id(self, cls_id: int) -> int:
+        category_ids = getattr(self, "_category_ids", [])
+        if 0 <= cls_id < len(category_ids):
+            return int(category_ids[cls_id])
+        if cls_id in category_ids:
+            return int(cls_id)
+        return int(self._category_id)
 
     # =========================================================================
     # Inference loop
@@ -438,7 +447,7 @@ class PoseValidator(BaseValidator):
             self._predictions.append(
                 {
                     "image_id": image_id,
-                    "category_id": int(cls_id),
+                    "category_id": self._prediction_category_id(int(cls_id)),
                     "keypoints": flat,
                     "score": float(score),
                 }

--- a/libreyolo/validation/pose_validator.py
+++ b/libreyolo/validation/pose_validator.py
@@ -299,6 +299,12 @@ class PoseValidator(BaseValidator):
                 )
                 ann_id += 1
 
+        if images and not annotations:
+            raise FileNotFoundError(
+                "No YOLO pose labels were found for the validation split. "
+                "Provide pose label files or a COCO keypoints annotation JSON."
+            )
+
         coco = {
             "info": {},
             "licenses": [],

--- a/libreyolo/validation/pose_validator.py
+++ b/libreyolo/validation/pose_validator.py
@@ -178,8 +178,10 @@ class PoseValidator(BaseValidator):
         )
         annotation_file = get_coco_annotation_file(data_cfg, self.config.split)
         if annotation_file:
-            self._kpts_json = Path(annotation_file)
             data_root = Path(data_cfg["root"])
+            self._kpts_json = Path(annotation_file)
+            if not self._kpts_json.is_absolute():
+                self._kpts_json = data_root / self._kpts_json
             default_image_dir = resolve_default_coco_image_dir(
                 data_root,
                 self.config.split,
@@ -188,6 +190,8 @@ class PoseValidator(BaseValidator):
             self._images_dir = Path(
                 get_coco_image_dir(data_cfg, self.config.split, default_image_dir)
             )
+            if not self._images_dir.is_absolute():
+                self._images_dir = data_root / self._images_dir
             if not self._kpts_json.exists():
                 raise FileNotFoundError(f"Annotations JSON not found: {self._kpts_json}")
             if not self._images_dir.is_dir():

--- a/libreyolo/validation/pose_validator.py
+++ b/libreyolo/validation/pose_validator.py
@@ -23,9 +23,12 @@ from tqdm import tqdm
 from libreyolo.data import (
     COCO17_OKS_SIGMAS,
     default_oks_sigmas,
+    get_coco_annotation_file,
+    get_coco_image_dir,
     get_img_files,
     img2label_paths,
     load_data_config,
+    resolve_default_coco_image_dir,
 )
 from libreyolo.data.pose_dataset import parse_yolo_pose_label_line
 
@@ -168,6 +171,28 @@ class PoseValidator(BaseValidator):
                 "PoseValidator requires either YOLO-pose data.yaml via data=... "
                 "or keypoints_json + images_dir."
             )
+        data_cfg = load_data_config(
+            self.config.data,
+            autodownload=True,
+            allow_scripts=self.config.allow_download_scripts,
+        )
+        annotation_file = get_coco_annotation_file(data_cfg, self.config.split)
+        if annotation_file:
+            self._kpts_json = Path(annotation_file)
+            data_root = Path(data_cfg["root"])
+            default_image_dir = resolve_default_coco_image_dir(
+                data_root,
+                self.config.split,
+                self._kpts_json.name,
+            )
+            self._images_dir = Path(
+                get_coco_image_dir(data_cfg, self.config.split, default_image_dir)
+            )
+            if not self._kpts_json.exists():
+                raise FileNotFoundError(f"Annotations JSON not found: {self._kpts_json}")
+            if not self._images_dir.is_dir():
+                raise FileNotFoundError(f"Images dir not found: {self._images_dir}")
+            return
         self._kpts_json, self._images_dir = self._build_coco_gt_from_yolo()
 
     def _build_coco_gt_from_yolo(self) -> tuple[Path, Path | None]:
@@ -436,6 +461,13 @@ class PoseValidator(BaseValidator):
                 "metrics/keypoints_mAP50-95": 0.0,
                 "metrics/keypoints_mAP50": 0.0,
                 "metrics/keypoints_mAP75": 0.0,
+                "metrics/keypoints_mAP_M": 0.0,
+                "metrics/keypoints_mAP_L": 0.0,
+                "metrics/keypoints_AR50-95": 0.0,
+                "metrics/keypoints_AR50": 0.0,
+                "metrics/keypoints_AR75": 0.0,
+                "metrics/keypoints_AR_M": 0.0,
+                "metrics/keypoints_AR_L": 0.0,
             }
 
         coco_dt = self._coco_gt.loadRes(str(pred_path))

--- a/tests/e2e/test_yolonas_pose_export.py
+++ b/tests/e2e/test_yolonas_pose_export.py
@@ -7,7 +7,7 @@ import importlib.util
 import numpy as np
 import pytest
 
-pytestmark = [pytest.mark.unit, pytest.mark.yolonas]
+pytestmark = [pytest.mark.e2e, pytest.mark.yolonas]
 
 
 @pytest.mark.skipif(

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -552,6 +552,28 @@ def test_ec_pose_backend_parses_flattened_keypoints():
     assert scores[0] > 0.99
 
 
+def test_ec_pose_backend_uses_exported_boxes_when_present():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.array([[[10.0, -10.0]]], dtype=np.float32)
+    boxes = np.array([[[0.5, 0.5, 0.8, 0.6]]], dtype=np.float32)
+    keypoints = np.array([[[0.45, 0.45, 0.55, 0.55]]], dtype=np.float32)
+
+    parsed_boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [logits, boxes, keypoints], 64, (200, 100), conf=0.5
+    )
+
+    assert scores.shape == (1,)
+    assert classes.tolist() == [0]
+    assert masks is None
+    assert obb is None
+    np.testing.assert_allclose(parsed_boxes, [[20.0, 20.0, 180.0, 80.0]])
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[90.0, 45.0], [110.0, 55.0]])
+
+
 def test_ec_pose_backend_does_not_clip_keypoints():
     backend = _DummyBackend(
         "ec",

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -590,6 +590,27 @@ def test_ec_pose_backend_honors_max_det():
     assert parsed_keypoints.shape == (2, 2, 3)
 
 
+def test_ec_pose_backend_caps_default_topk_to_query_count():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.ones((1, 60, 2), dtype=np.float32) * 10.0
+    keypoints = np.zeros((1, 60, 34), dtype=np.float32)
+
+    boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [logits, keypoints], 64, (100, 100), conf=0.0, max_det=300
+    )
+
+    assert boxes.shape == (60, 4)
+    assert scores.shape == (60,)
+    assert classes.tolist() == [0] * 60
+    assert masks is None
+    assert obb is None
+    assert parsed_keypoints.shape == (60, 17, 3)
+
+
 def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
     backend = _DummyBackend(
         "yolonas",
@@ -622,6 +643,30 @@ def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
     np.testing.assert_allclose(
         keypoints,
         [[[10.0, 20.0, 0.8], [30.0, 40.0, 0.7]]],
+    )
+
+
+def test_yolonas_pose_backend_does_not_clip_keypoints():
+    backend = _DummyBackend(
+        "yolonas",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    boxes = np.array([[[32.0, 32.0, 160.0, 128.0]]], dtype=np.float32)
+    scores = np.array([[[0.9]]], dtype=np.float32)
+    keypoints_xy = np.array([[[[-32.0, 64.0], [96.0, 800.0]]]], dtype=np.float32)
+    keypoints_conf = np.array([[[0.8, 0.7]]], dtype=np.float32)
+
+    _, _, _, _, _, keypoints = backend._parse_outputs(
+        [boxes, scores, keypoints_xy, keypoints_conf],
+        100,
+        (200, 100),
+        conf=0.5,
+    )
+
+    np.testing.assert_allclose(
+        keypoints,
+        [[[-10.0, 20.0, 0.8], [30.0, 250.0, 0.7]]],
     )
 
 
@@ -696,6 +741,31 @@ def test_rfdetr_seg_backend_uses_detected_size_for_num_select_without_metadata()
     assert len(scores) == 100
     assert classes.tolist() == [0] * 100
     assert parsed_masks.shape == (100, 16, 16)
+
+
+def test_rfdetr_x_pose_backend_uses_configured_num_select():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("pose",),
+        model_size="x",
+    )
+    boxes = np.tile(
+        np.array([[0.5, 0.5, 0.25, 0.25]], dtype=np.float32),
+        (1, 100, 1),
+    )
+    logits = np.ones((1, 100, 2), dtype=np.float32) * 10.0
+
+    parsed_boxes, scores, classes, masks, obb, keypoints = backend._parse_outputs(
+        [boxes, logits], 64, (100, 100), conf=0.5
+    )
+
+    assert parsed_boxes.shape == (100, 4)
+    assert scores.shape == (100,)
+    assert classes.shape == (100,)
+    assert masks is None
+    assert obb is None
+    assert keypoints is None
 
 
 def test_rfdetr_pose_backend_reshapes_batched_flattened_keypoints():

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -635,6 +635,30 @@ def test_ec_pose_backend_selects_unique_queries_before_collapsing_classes():
     np.testing.assert_allclose(parsed_keypoints[:, 0, :2], [[10.0, 10.0], [70.0, 70.0]])
 
 
+def test_ec_pose_backend_scores_person_logit_only():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.array([[[0.0, 10.0], [9.0, -10.0]]], dtype=np.float32)
+    keypoints = np.array(
+        [[[0.1, 0.1, 0.2, 0.2], [0.7, 0.7, 0.8, 0.8]]],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [logits, keypoints], 64, (100, 100), conf=0.0, max_det=1
+    )
+
+    assert boxes.shape == (1, 4)
+    assert scores.shape == (1,)
+    assert classes.tolist() == [0]
+    assert masks is None
+    assert obb is None
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[70.0, 70.0], [80.0, 80.0]])
+
+
 def test_ec_pose_backend_does_not_hard_cap_queries_at_sixty():
     backend = _DummyBackend(
         "ec",

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -535,6 +535,26 @@ def test_ec_segment_backend_parses_masks():
     assert parsed_masks[0].all()
 
 
+def test_ec_segment_backend_does_not_clip_boxes():
+    backend = _DummyBackend(
+        "ec",
+        task="segment",
+        supported_tasks=("detect", "segment"),
+    )
+    logits = np.array([[[10.0]]], dtype=np.float32)
+    boxes = np.array([[[0.05, 0.5, 0.3, 0.5]]], dtype=np.float32)
+    masks = np.ones((1, 1, 2, 2), dtype=np.float32)
+
+    parsed_boxes, scores, classes, parsed_masks = backend._parse_outputs(
+        [logits, boxes, masks], 64, (200, 100), conf=0.5
+    )
+
+    np.testing.assert_allclose(parsed_boxes, [[-20.0, 25.0, 40.0, 75.0]])
+    assert scores[0] > 0.99
+    np.testing.assert_array_equal(classes, [0])
+    assert parsed_masks.shape == (1, 100, 200)
+
+
 def test_ec_segment_backend_honors_max_det():
     backend = _DummyBackend(
         "ec",

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -77,6 +77,129 @@ def test_rfdetr_backend_skips_generic_nms():
     assert len(result.boxes) == 2
 
 
+def test_yolo9_e2e_backend_skips_generic_nms():
+    backend = _DummyBackend("yolo9_e2e")
+
+    boxes = np.array([[0, 0, 10, 10], [0, 0, 10, 10]], dtype=np.float32)
+    scores = np.array([0.9, 0.8], dtype=np.float32)
+    classes = np.array([0, 0], dtype=np.int64)
+
+    result = backend._build_result(
+        boxes,
+        scores,
+        classes,
+        orig_shape=(10, 10),
+        image_path=None,
+        iou=0.45,
+        classes=None,
+        max_det=300,
+    )
+
+    assert len(result.boxes) == 2
+
+
+def test_yolo9_e2e_backend_uses_native_topk_anchor_ranking():
+    backend = _DummyBackend("yolo9_e2e")
+    output = np.zeros((1, 6, 3), dtype=np.float32)
+    output[0, :4, :] = np.array(
+        [
+            [0, 10, 20],
+            [0, 10, 20],
+            [5, 15, 25],
+            [5, 15, 25],
+        ],
+        dtype=np.float32,
+    )
+    output[0, 4:, :] = np.array(
+        [
+            [0.89, 0.92, 0.50],
+            [0.91, 0.10, 0.99],
+        ],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes = backend._parse_yolo9(
+        [output],
+        effective_imgsz=100,
+        orig_w=100,
+        orig_h=100,
+        conf=0.001,
+        max_det=1,
+    )
+
+    assert len(boxes) == 1
+    assert classes.tolist() == [1]
+    np.testing.assert_allclose(scores, [0.99])
+    np.testing.assert_allclose(boxes[0], [20, 20, 25, 25])
+
+
+def test_yolox_backend_recomputes_validation_letterbox_ratio():
+    backend = _DummyBackend("yolox")
+    # Canvas-space xywh for an original 200x100 image letterboxed to 100x100.
+    output = np.array([[[50.0, 25.0, 20.0, 10.0, 0.9, 0.8, 0.1]]], dtype=np.float32)
+
+    boxes, scores, classes = backend._parse_yolox(
+        [output],
+        effective_imgsz=100,
+        orig_w=200,
+        orig_h=100,
+        conf=0.5,
+        ratio=1.0,
+    )
+
+    np.testing.assert_array_equal(classes, [0])
+    np.testing.assert_allclose(scores, [0.72], rtol=1e-6)
+    np.testing.assert_allclose(boxes, [[80.0, 40.0, 120.0, 60.0]])
+
+
+def test_rtmdet_backend_keeps_multilabel_candidates_and_class_aware_nms():
+    backend = _DummyBackend("rtmdet")
+    output = np.array(
+        [[[10.0, 10.0, 30.0, 30.0, 0.95, 0.9]]],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes = backend._parse_rtmdet(
+        [output],
+        effective_imgsz=64,
+        orig_w=64,
+        orig_h=64,
+        conf=0.5,
+    )
+    result = backend._build_result(
+        boxes,
+        scores,
+        classes,
+        orig_shape=(64, 64),
+        image_path=None,
+        iou=0.45,
+        classes=None,
+        max_det=300,
+    )
+
+    assert len(result.boxes) == 2
+    np.testing.assert_array_equal(result.boxes.cls.numpy().astype(np.int64), [0, 1])
+
+
+def test_yolonas_backend_undoes_center_padding():
+    backend = _DummyBackend("yolonas")
+    # Original 1000x500 image: resize to 636x318, center-pad in 640 canvas.
+    boxes_out = np.array([[[65.6, 192.8, 129.2, 256.4]]], dtype=np.float32)
+    scores_out = np.array([[[0.9, 0.1]]], dtype=np.float32)
+
+    boxes, scores, classes = backend._parse_yolonas(
+        [boxes_out, scores_out],
+        effective_imgsz=640,
+        orig_w=1000,
+        orig_h=500,
+        conf=0.5,
+    )
+
+    np.testing.assert_array_equal(classes, [0])
+    np.testing.assert_allclose(scores, [0.9], rtol=1e-6)
+    np.testing.assert_allclose(boxes, [[100.0, 50.0, 200.0, 150.0]], atol=1e-4)
+
+
 def test_rfdetr_backend_uses_topk_over_queries_and_classes():
     backend = _DummyBackend("rfdetr")
 
@@ -169,6 +292,44 @@ def test_rfdetr_pose_backend_parses_keypoints_not_masks():
     assert scores[0] > 0.99
 
 
+def test_rfdetr_pose_backend_decodes_grouppose_keypoint_slots():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    backend.nb_classes = 1
+    backend.names = {0: "person"}
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.4]]], dtype=np.float32)
+    logits = np.array([[[0.0, 10.0]]], dtype=np.float32)
+    keypoints = np.zeros((1, 1, 34, 8), dtype=np.float32)
+    keypoints[0, 0, 17, :7] = [0.25, 0.5, 2.0, 0.0, 0.0, 1.0, 0.0]
+    keypoints[0, 0, 18, :7] = [0.75, 0.25, -2.0, 0.0, 0.0, 1.0, 0.0]
+
+    parsed_boxes, scores, classes, masks, obb, parsed_keypoints = (
+        backend._parse_rfdetr(
+            [boxes, logits, keypoints],
+            orig_w=200,
+            orig_h=100,
+            conf=0.5,
+        )
+    )
+
+    assert masks is None
+    assert obb is None
+    assert classes.tolist() == [0]
+    assert parsed_boxes.shape == (1, 4)
+    assert parsed_keypoints.shape == (1, 17, 3)
+    np.testing.assert_allclose(parsed_keypoints[0, :2, 0], [50.0, 150.0])
+    np.testing.assert_allclose(parsed_keypoints[0, :2, 1], [50.0, 25.0])
+    np.testing.assert_allclose(
+        parsed_keypoints[0, :2, 2],
+        [0.880797, 0.119203],
+        rtol=1e-5,
+    )
+    assert 0.7 < scores[0] < 1.0
+
+
 def test_rfdetr_pose_backend_postprocess_returns_keypoints():
     backend = _DummyBackend(
         "rfdetr",
@@ -226,6 +387,169 @@ def test_rfdetr_seg_backend_uses_variant_num_select():
     assert len(scores) == 100
     assert classes.tolist() == [0] * 100
     assert parsed_masks.shape == (100, 16, 16)
+
+
+def test_yolonas_pose_backend_uses_pose_preprocessor(monkeypatch):
+    backend = _DummyBackend(
+        "yolonas",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    calls = []
+
+    def fake_pose_preprocess(image, input_size, color_format):
+        calls.append((image, input_size, color_format))
+        return "tensor", "image", (10, 20), 1.0
+
+    monkeypatch.setattr(
+        backend_base, "yolonas_preprocess_pose_image", fake_pose_preprocess
+    )
+
+    out = backend._preprocess("source.jpg", 640, "auto")
+
+    assert out == ("tensor", "image", (10, 20), 1.0)
+    assert calls == [("source.jpg", 640, "auto")]
+
+
+def test_deimv2_backend_uses_dino_val_preprocessor_for_dino_sizes():
+    from libreyolo.validation.preprocessors import (
+        DEIMv2DINOValPreprocessor,
+        DEIMv2ValPreprocessor,
+    )
+
+    dino_backend = _DummyBackend("deimv2", model_size="s")
+    hgnet_backend = _DummyBackend("deimv2", model_size="n")
+
+    assert isinstance(
+        dino_backend._get_val_preprocessor(img_size=640), DEIMv2DINOValPreprocessor
+    )
+    assert isinstance(hgnet_backend._get_val_preprocessor(img_size=640), DEIMv2ValPreprocessor)
+    assert not isinstance(
+        hgnet_backend._get_val_preprocessor(img_size=640),
+        DEIMv2DINOValPreprocessor,
+    )
+
+
+def test_ec_segment_backend_parses_masks():
+    backend = _DummyBackend(
+        "ec",
+        task="segment",
+        supported_tasks=("detect", "segment"),
+    )
+    logits = np.array([[[ -10.0, 10.0], [-10.0, -10.0]]], dtype=np.float32)
+    boxes = np.array([[[0.5, 0.5, 0.25, 0.5], [0.1, 0.1, 0.1, 0.1]]], dtype=np.float32)
+    masks = np.array(
+        [[[[1.0, 1.0], [1.0, 1.0]], [[-1.0, -1.0], [-1.0, -1.0]]]],
+        dtype=np.float32,
+    )
+
+    parsed_boxes, scores, classes, parsed_masks = backend._parse_outputs(
+        [logits, boxes, masks], 64, (200, 100), conf=0.5
+    )
+
+    assert parsed_boxes.shape == (1, 4)
+    np.testing.assert_allclose(parsed_boxes[0], [75.0, 25.0, 125.0, 75.0])
+    assert scores[0] > 0.99
+    np.testing.assert_array_equal(classes, [1])
+    assert parsed_masks.shape == (1, 100, 200)
+    assert parsed_masks[0].all()
+
+
+def test_ec_pose_backend_parses_flattened_keypoints():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.array([[[10.0, -10.0], [-10.0, -10.0]]], dtype=np.float32)
+    keypoints = np.array(
+        [[[0.25, 0.5, 0.75, 0.25], [0.0, 0.0, 0.0, 0.0]]],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [logits, keypoints], 64, (200, 100), conf=0.5
+    )
+
+    assert masks is None
+    assert obb is None
+    np.testing.assert_array_equal(classes, [0])
+    np.testing.assert_allclose(boxes, [[50.0, 25.0, 150.0, 50.0]])
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[50.0, 50.0], [150.0, 25.0]])
+    np.testing.assert_allclose(parsed_keypoints[0, :, 2], [1.0, 1.0])
+    assert scores[0] > 0.99
+
+
+def test_ec_pose_backend_does_not_clip_keypoints():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.array([[[10.0, -10.0]]], dtype=np.float32)
+    keypoints = np.array([[[-0.25, 1.25, 0.5, 0.5]]], dtype=np.float32)
+
+    boxes, _, _, _, _, parsed_keypoints = backend._parse_outputs(
+        [logits, keypoints], 64, (200, 100), conf=0.5
+    )
+
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[-50.0, 125.0], [100.0, 50.0]])
+    np.testing.assert_allclose(boxes, [[-50.0, 50.0, 100.0, 125.0]])
+
+
+def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
+    backend = _DummyBackend(
+        "yolonas",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    boxes = np.array([[[10.0, 10.0, 50.0, 40.0], [0.0, 0.0, 5.0, 5.0]]], dtype=np.float32)
+    scores = np.array([[[0.9], [0.1]]], dtype=np.float32)
+    keypoints_xy = np.array(
+        [[[[10.0, 20.0], [30.0, 40.0]], [[0.0, 0.0], [1.0, 1.0]]]],
+        dtype=np.float32,
+    )
+    keypoints_conf = np.array([[[0.8, 0.7], [0.1, 0.1]]], dtype=np.float32)
+
+    parsed_boxes, parsed_scores, classes, masks, obb, keypoints = backend._parse_outputs(
+        [boxes, scores, keypoints_xy, keypoints_conf],
+        100,
+        (200, 100),
+        conf=0.5,
+    )
+
+    assert masks is None
+    assert obb is None
+    np.testing.assert_array_equal(classes, [0])
+    np.testing.assert_allclose(parsed_boxes, [[20.0, 20.0, 100.0, 80.0]])
+    np.testing.assert_allclose(parsed_scores, [0.9])
+    np.testing.assert_allclose(
+        keypoints,
+        [[[20.0, 40.0, 0.8], [60.0, 80.0, 0.7]]],
+    )
+
+
+def test_yolo9_pose_backend_parses_keypoints():
+    backend = _DummyBackend(
+        "yolo9",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    pred = np.zeros((1, 5, 1), dtype=np.float32)
+    pred[0, :4, 0] = [10.0, 20.0, 50.0, 60.0]
+    pred[0, 4, 0] = 0.9
+    keypoints = np.array([[[[10.0, 20.0, 0.8], [50.0, 60.0, 0.7]]]], dtype=np.float32)
+
+    boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [pred, keypoints], 100, (100, 100), conf=0.5
+    )
+
+    assert masks is None
+    assert obb is None
+    np.testing.assert_array_equal(classes, [0])
+    np.testing.assert_allclose(boxes, [[10.0, 20.0, 50.0, 60.0]])
+    np.testing.assert_allclose(scores, [0.9])
+    np.testing.assert_allclose(parsed_keypoints, keypoints[0])
 
 
 def test_rfdetr_seg_backend_uses_detected_size_for_num_select_without_metadata():

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -566,6 +566,30 @@ def test_ec_pose_backend_does_not_clip_keypoints():
     np.testing.assert_allclose(boxes, [[-50.0, 50.0, 100.0, 125.0]])
 
 
+def test_ec_pose_backend_honors_max_det():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.array([[[10.0], [9.0], [8.0]]], dtype=np.float32)
+    keypoints = np.array(
+        [[[0.1, 0.1, 0.2, 0.2], [0.3, 0.3, 0.4, 0.4], [0.5, 0.5, 0.6, 0.6]]],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [logits, keypoints], 64, (100, 100), conf=0.0, max_det=2
+    )
+
+    assert boxes.shape == (2, 4)
+    assert scores.shape == (2,)
+    assert classes.tolist() == [0, 0]
+    assert masks is None
+    assert obb is None
+    assert parsed_keypoints.shape == (2, 2, 3)
+
+
 def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
     backend = _DummyBackend(
         "yolonas",
@@ -599,6 +623,25 @@ def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
         keypoints,
         [[[10.0, 20.0, 0.8], [30.0, 40.0, 0.7]]],
     )
+
+
+def test_yolonas_backend_uses_preprocess_ratio_for_large_canvas():
+    backend = _DummyBackend("yolonas")
+    boxes_out = np.array([[[384.0, 512.0, 448.0, 576.0]]], dtype=np.float32)
+    scores_out = np.array([[[0.9, 0.1]]], dtype=np.float32)
+
+    boxes, scores, classes = backend._parse_yolonas(
+        [boxes_out, scores_out],
+        effective_imgsz=1280,
+        orig_w=1000,
+        orig_h=500,
+        conf=0.5,
+        ratio=0.64,
+    )
+
+    np.testing.assert_array_equal(classes, [0])
+    np.testing.assert_allclose(scores, [0.9], rtol=1e-6)
+    np.testing.assert_allclose(boxes, [[100.0, 50.0, 200.0, 150.0]], atol=1e-4)
 
 
 def test_yolo9_pose_backend_parses_keypoints():
@@ -653,6 +696,62 @@ def test_rfdetr_seg_backend_uses_detected_size_for_num_select_without_metadata()
     assert len(scores) == 100
     assert classes.tolist() == [0] * 100
     assert parsed_masks.shape == (100, 16, 16)
+
+
+def test_rfdetr_pose_backend_reshapes_batched_flattened_keypoints():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("pose",),
+        model_size="n",
+    )
+    backend.keypoint_dim = 3
+    boxes = np.array(
+        [[[0.5, 0.5, 0.2, 0.2], [0.25, 0.25, 0.1, 0.1]]],
+        dtype=np.float32,
+    )
+    logits = np.array([[[10.0], [9.0]]], dtype=np.float32)
+    keypoints = np.array(
+        [
+            [
+                [0.1, 0.2, 2.0, 0.3, 0.4, 4.0],
+                [0.5, 0.6, 0.0, 0.7, 0.8, -2.0],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    parsed_boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [boxes, logits, keypoints], 64, (100, 200), conf=0.5
+    )
+
+    assert parsed_boxes.shape == (2, 4)
+    assert scores.shape == (2,)
+    assert classes.tolist() == [0, 0]
+    assert masks is None
+    assert obb is None
+    assert parsed_keypoints.shape == (2, 2, 3)
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[10.0, 40.0], [30.0, 80.0]])
+    np.testing.assert_allclose(
+        parsed_keypoints[0, :, 2],
+        [1.0 / (1.0 + np.exp(-2.0)), 1.0 / (1.0 + np.exp(-4.0))],
+    )
+
+
+def test_rfdetr_pose_backend_rejects_invalid_grouppose_schema():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("pose",),
+        model_size="n",
+    )
+    backend.num_keypoints_per_class = [0, 17, 4]
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.2]]], dtype=np.float32)
+    logits = np.array([[[10.0, 9.0]]], dtype=np.float32)
+    keypoints = np.zeros((1, 1, 34, 8), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="GroupPose"):
+        backend._parse_outputs([boxes, logits, keypoints], 64, (100, 100), conf=0.5)
 
 
 def test_yolo_backend_still_applies_nms():

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -18,6 +18,7 @@ class _DummyBackend(BaseBackend):
         supported_tasks=("detect",),
         model_size: str | None = None,
         imgsz=640,
+        **pose_metadata,
     ):
         super().__init__(
             model_path="dummy",
@@ -29,6 +30,7 @@ class _DummyBackend(BaseBackend):
             names={0: "class_0", 1: "class_1"},
             task=task,
             supported_tasks=supported_tasks,
+            **pose_metadata,
         )
 
     def _run_inference(self, blob: np.ndarray) -> list:
@@ -297,6 +299,7 @@ def test_rfdetr_pose_backend_decodes_grouppose_keypoint_slots():
         "rfdetr",
         task="pose",
         supported_tasks=("detect", "pose"),
+        num_keypoints_per_class=[0, 17],
     )
     backend.nb_classes = 1
     backend.names = {0: "person"}
@@ -932,6 +935,60 @@ def test_rfdetr_pose_backend_accepts_xy_only_keypoints():
     assert parsed_keypoints.shape == (1, 2, 3)
     np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[10.0, 40.0], [30.0, 80.0]])
     np.testing.assert_allclose(parsed_keypoints[0, :, 2], [1.0, 1.0])
+
+
+def test_backend_sets_pose_metadata_attributes():
+    assert backend_base._read_pose_metadata(
+        {"num_keypoints_per_class": "[0, 17, 4]"}
+    ) == {"num_keypoints_per_class": [0, 17, 4]}
+    assert backend_base._read_pose_metadata(
+        {"num_keypoints": "17", "keypoint_dim": "3", "num_keypoints_per_class": [0, 17]}
+    ) == {
+        "num_keypoints": 17,
+        "keypoint_dim": 3,
+        "num_keypoints_per_class": [0, 17],
+    }
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("pose",),
+        num_keypoints=17,
+        keypoint_dim=3,
+        num_keypoints_per_class=[0, 17, 4],
+    )
+
+    assert backend.num_keypoints == 17
+    assert backend.keypoint_dim == 3
+    assert backend.num_keypoints_per_class == [0, 17, 4]
+
+
+def test_rfdetr_classic_pose_slices_background_logits_before_topk():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("pose",),
+        model_size="n",
+        keypoint_dim=2,
+    )
+    backend.nb_classes = 1
+    backend.names = {0: "person"}
+    boxes = np.array(
+        [[[0.5, 0.5, 0.2, 0.2], [0.25, 0.25, 0.1, 0.1]]],
+        dtype=np.float32,
+    )
+    logits = np.array([[[-10.0, 12.0], [9.0, -12.0]]], dtype=np.float32)
+    keypoints = np.array([[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]]], dtype=np.float32)
+
+    parsed_boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [boxes, logits, keypoints], 64, (100, 200), conf=0.6
+    )
+
+    assert parsed_boxes.shape == (1, 4)
+    assert scores.shape == (1,)
+    assert classes.tolist() == [0]
+    assert masks is None
+    assert obb is None
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[50.0, 120.0], [70.0, 160.0]])
 
 
 def test_rfdetr_pose_backend_rejects_invalid_grouppose_schema():

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -705,6 +705,7 @@ def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
         100,
         (200, 100),
         conf=0.5,
+        ratio=None,
     )
 
     assert masks is None
@@ -734,6 +735,7 @@ def test_yolonas_pose_backend_does_not_clip_keypoints():
         100,
         (200, 100),
         conf=0.5,
+        ratio=None,
     )
 
     np.testing.assert_allclose(
@@ -762,6 +764,7 @@ def test_yolonas_pose_backend_preselects_requested_max_det():
         100,
         (200, 100),
         conf=0.0,
+        ratio=None,
         max_det=count,
     )
 

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -611,6 +611,30 @@ def test_ec_pose_backend_caps_default_topk_to_query_count():
     assert parsed_keypoints.shape == (60, 17, 3)
 
 
+def test_ec_pose_backend_selects_unique_queries_before_collapsing_classes():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.array([[[10.0, 9.0], [8.0, -10.0]]], dtype=np.float32)
+    keypoints = np.array(
+        [[[0.1, 0.1, 0.2, 0.2], [0.7, 0.7, 0.8, 0.8]]],
+        dtype=np.float32,
+    )
+
+    boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [logits, keypoints], 64, (100, 100), conf=0.0, max_det=2
+    )
+
+    assert boxes.shape == (2, 4)
+    assert scores.shape == (2,)
+    assert classes.tolist() == [0, 0]
+    assert masks is None
+    assert obb is None
+    np.testing.assert_allclose(parsed_keypoints[:, 0, :2], [[10.0, 10.0], [70.0, 70.0]])
+
+
 def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
     backend = _DummyBackend(
         "yolonas",
@@ -668,6 +692,37 @@ def test_yolonas_pose_backend_does_not_clip_keypoints():
         keypoints,
         [[[-10.0, 20.0, 0.8], [30.0, 250.0, 0.7]]],
     )
+
+
+def test_yolonas_pose_backend_preselects_requested_max_det():
+    backend = _DummyBackend(
+        "yolonas",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    count = 1001
+    boxes = np.tile(
+        np.array([[32.0, 32.0, 160.0, 128.0]], dtype=np.float32),
+        (1, count, 1),
+    )
+    scores = np.linspace(1.0, 0.1, count, dtype=np.float32).reshape(1, count, 1)
+    keypoints_xy = np.zeros((1, count, 2, 2), dtype=np.float32)
+    keypoints_conf = np.ones((1, count, 2), dtype=np.float32)
+
+    parsed_boxes, parsed_scores, classes, masks, obb, keypoints = backend._parse_outputs(
+        [boxes, scores, keypoints_xy, keypoints_conf],
+        100,
+        (200, 100),
+        conf=0.0,
+        max_det=count,
+    )
+
+    assert parsed_boxes.shape == (count, 4)
+    assert parsed_scores.shape == (count,)
+    assert classes.shape == (count,)
+    assert masks is None
+    assert obb is None
+    assert keypoints.shape == (count, 2, 3)
 
 
 def test_yolonas_backend_uses_preprocess_ratio_for_large_canvas():
@@ -806,6 +861,32 @@ def test_rfdetr_pose_backend_reshapes_batched_flattened_keypoints():
         parsed_keypoints[0, :, 2],
         [1.0 / (1.0 + np.exp(-2.0)), 1.0 / (1.0 + np.exp(-4.0))],
     )
+
+
+def test_rfdetr_pose_backend_accepts_xy_only_keypoints():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("pose",),
+        model_size="n",
+    )
+    backend.keypoint_dim = 2
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.2]]], dtype=np.float32)
+    logits = np.array([[[10.0]]], dtype=np.float32)
+    keypoints = np.array([[[0.1, 0.2, 0.3, 0.4]]], dtype=np.float32)
+
+    parsed_boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [boxes, logits, keypoints], 64, (100, 200), conf=0.5
+    )
+
+    assert parsed_boxes.shape == (1, 4)
+    assert scores.shape == (1,)
+    assert classes.tolist() == [0]
+    assert masks is None
+    assert obb is None
+    assert parsed_keypoints.shape == (1, 2, 3)
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[10.0, 40.0], [30.0, 80.0]])
+    np.testing.assert_allclose(parsed_keypoints[0, :, 2], [1.0, 1.0])
 
 
 def test_rfdetr_pose_backend_rejects_invalid_grouppose_schema():

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -330,6 +330,52 @@ def test_rfdetr_pose_backend_decodes_grouppose_keypoint_slots():
     assert 0.7 < scores[0] < 1.0
 
 
+def test_rfdetr_pose_backend_uses_exported_grouppose_schema():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    backend.nb_classes = 2
+    backend.names = {0: "person", 1: "tool"}
+    backend.num_keypoints_per_class = [0, 17, 4]
+
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.4]]], dtype=np.float32)
+    logits = np.array([[[-10.0, -10.0, 10.0]]], dtype=np.float32)
+    keypoints = np.zeros((1, 1, 51, 8), dtype=np.float32)
+    class_offset = 2 * 17
+    keypoints[0, 0, class_offset : class_offset + 4, :7] = np.array(
+        [
+            [0.25, 0.50, 2.0, 0.0, 0.0, 0.0, 0.0],
+            [0.75, 0.25, 2.0, 0.0, 0.0, 0.0, 0.0],
+            [0.50, 0.75, 2.0, 0.0, 0.0, 0.0, 0.0],
+            [0.10, 0.10, 2.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    keypoints[0, 0, class_offset + 4 : class_offset + 17, 2] = 10.0
+    keypoints[0, 0, class_offset + 4 : class_offset + 17, 4] = -10.0
+    keypoints[0, 0, class_offset + 4 : class_offset + 17, 6] = -10.0
+
+    parsed_boxes, scores, classes, masks, obb, parsed_keypoints = (
+        backend._parse_rfdetr(
+            [boxes, logits, keypoints],
+            orig_w=200,
+            orig_h=100,
+            conf=0.5,
+        )
+    )
+
+    assert masks is None
+    assert obb is None
+    assert classes.tolist() == [1]
+    assert parsed_boxes.shape == (1, 4)
+    assert parsed_keypoints.shape == (1, 17, 3)
+    assert scores[0] > 0.5
+    np.testing.assert_allclose(parsed_keypoints[0, :4, 0], [50.0, 150.0, 100.0, 20.0])
+    np.testing.assert_allclose(parsed_keypoints[0, 4:, :], 0.0)
+
+
 def test_rfdetr_pose_backend_postprocess_returns_keypoints():
     backend = _DummyBackend(
         "rfdetr",
@@ -455,6 +501,29 @@ def test_ec_segment_backend_parses_masks():
     assert parsed_masks[0].all()
 
 
+def test_ec_segment_backend_honors_max_det():
+    backend = _DummyBackend(
+        "ec",
+        task="segment",
+        supported_tasks=("detect", "segment"),
+    )
+    logits = np.array([[[10.0], [9.0], [8.0]]], dtype=np.float32)
+    boxes = np.array(
+        [[[0.1, 0.1, 0.1, 0.1], [0.5, 0.5, 0.2, 0.2], [0.8, 0.8, 0.1, 0.1]]],
+        dtype=np.float32,
+    )
+    masks = np.ones((1, 3, 2, 2), dtype=np.float32)
+
+    parsed_boxes, scores, classes, parsed_masks = backend._parse_outputs(
+        [logits, boxes, masks], 64, (100, 100), conf=0.5, max_det=1
+    )
+
+    assert parsed_boxes.shape == (1, 4)
+    assert scores.shape == (1,)
+    assert classes.tolist() == [0]
+    assert parsed_masks.shape == (1, 100, 100)
+
+
 def test_ec_pose_backend_parses_flattened_keypoints():
     backend = _DummyBackend(
         "ec",
@@ -503,10 +572,13 @@ def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
         task="pose",
         supported_tasks=("detect", "pose"),
     )
-    boxes = np.array([[[10.0, 10.0, 50.0, 40.0], [0.0, 0.0, 5.0, 5.0]]], dtype=np.float32)
+    boxes = np.array(
+        [[[32.0, 32.0, 160.0, 128.0], [0.0, 0.0, 5.0, 5.0]]],
+        dtype=np.float32,
+    )
     scores = np.array([[[0.9], [0.1]]], dtype=np.float32)
     keypoints_xy = np.array(
-        [[[[10.0, 20.0], [30.0, 40.0]], [[0.0, 0.0], [1.0, 1.0]]]],
+        [[[[32.0, 64.0], [96.0, 128.0]], [[0.0, 0.0], [1.0, 1.0]]]],
         dtype=np.float32,
     )
     keypoints_conf = np.array([[[0.8, 0.7], [0.1, 0.1]]], dtype=np.float32)
@@ -521,11 +593,11 @@ def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
     assert masks is None
     assert obb is None
     np.testing.assert_array_equal(classes, [0])
-    np.testing.assert_allclose(parsed_boxes, [[20.0, 20.0, 100.0, 80.0]])
+    np.testing.assert_allclose(parsed_boxes, [[10.0, 10.0, 50.0, 40.0]])
     np.testing.assert_allclose(parsed_scores, [0.9])
     np.testing.assert_allclose(
         keypoints,
-        [[[20.0, 40.0, 0.8], [60.0, 80.0, 0.7]]],
+        [[[10.0, 20.0, 0.8], [30.0, 40.0, 0.7]]],
     )
 
 

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -635,6 +635,27 @@ def test_ec_pose_backend_selects_unique_queries_before_collapsing_classes():
     np.testing.assert_allclose(parsed_keypoints[:, 0, :2], [[10.0, 10.0], [70.0, 70.0]])
 
 
+def test_ec_pose_backend_does_not_hard_cap_queries_at_sixty():
+    backend = _DummyBackend(
+        "ec",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+    )
+    logits = np.linspace(10.0, 1.0, 70, dtype=np.float32).reshape(1, 70, 1)
+    keypoints = np.zeros((1, 70, 34), dtype=np.float32)
+
+    boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [logits, keypoints], 64, (100, 100), conf=0.0, max_det=70
+    )
+
+    assert boxes.shape == (70, 4)
+    assert scores.shape == (70,)
+    assert classes.shape == (70,)
+    assert masks is None
+    assert obb is None
+    assert parsed_keypoints.shape == (70, 17, 3)
+
+
 def test_yolonas_pose_backend_parses_keypoints_and_bottom_right_letterbox():
     backend = _DummyBackend(
         "yolonas",

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -333,6 +333,37 @@ def test_rfdetr_pose_backend_decodes_grouppose_keypoint_slots():
     assert 0.7 < scores[0] < 1.0
 
 
+def test_rfdetr_grouppose_backend_honors_requested_max_det():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+        model_size="x",
+        num_keypoints_per_class=[0, 17],
+    )
+    backend.nb_classes = 1
+    backend.names = {0: "person"}
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.4]]], dtype=np.float32)
+    logits = np.array([[[10.0, 9.0]]], dtype=np.float32)
+    keypoints = np.zeros((1, 1, 34, 8), dtype=np.float32)
+    keypoints[0, 0, 17, :7] = [0.25, 0.5, 2.0, 0.0, 0.0, 1.0, 0.0]
+
+    parsed_boxes, scores, classes, masks, obb, parsed_keypoints = backend._parse_outputs(
+        [boxes, logits, keypoints],
+        64,
+        (200, 100),
+        conf=0.0,
+        max_det=1,
+    )
+
+    assert masks is None
+    assert obb is None
+    assert parsed_boxes.shape == (0, 4)
+    assert scores.shape == (0,)
+    assert classes.shape == (0,)
+    assert parsed_keypoints.shape == (0, 17, 3)
+
+
 def test_rfdetr_pose_backend_uses_exported_grouppose_schema():
     backend = _DummyBackend(
         "rfdetr",

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -848,6 +848,46 @@ def test_yolonas_backend_uses_preprocess_ratio_for_large_canvas():
     np.testing.assert_allclose(boxes, [[100.0, 50.0, 200.0, 150.0]], atol=1e-4)
 
 
+def test_yolonas_backend_recomputes_ratio_when_validation_omits_it():
+    backend = _DummyBackend("yolonas")
+    ratio = 636.0 / 1000.0
+    offset_x = 2.0
+    offset_y = 161.0
+    boxes_out = np.array(
+        [
+            [
+                [
+                    100.0 * ratio + offset_x,
+                    50.0 * ratio + offset_y,
+                    200.0 * ratio + offset_x,
+                    150.0 * ratio + offset_y,
+                ]
+            ]
+        ],
+        dtype=np.float32,
+    )
+    scores_out = np.array([[[0.9, 0.1]]], dtype=np.float32)
+
+    result = backend._postprocess(
+        [boxes_out, scores_out],
+        conf_thres=0.5,
+        iou_thres=0.6,
+        original_size=(1000, 500),
+        input_size=640,
+        letterbox=True,
+        max_det=300,
+    )
+
+    assert result["num_detections"] == 1
+    np.testing.assert_allclose(
+        result["boxes"].numpy(),
+        [[100.0, 50.0, 200.0, 150.0]],
+        atol=1e-4,
+    )
+    np.testing.assert_allclose(result["scores"].numpy(), [0.9], rtol=1e-6)
+    np.testing.assert_array_equal(result["classes"].numpy(), [0])
+
+
 def test_yolo9_pose_backend_parses_keypoints():
     backend = _DummyBackend(
         "yolo9",

--- a/tests/unit/test_ec_export_wrapper.py
+++ b/tests/unit/test_ec_export_wrapper.py
@@ -52,10 +52,9 @@ def test_ec_export_wrapper_flattens_deployed_pose_keypoints():
     wrapper = ECExportWrapper(_FakeEC(), task="pose")
     out = wrapper(torch.zeros(1, 3, 64, 64))
 
-    assert len(out) == 3
+    assert len(out) == 2
     assert out[0].shape == (1, 60, 2)
-    assert out[1].shape == (1, 60, 4)
-    assert out[2].shape == (1, 60, 34)
+    assert out[1].shape == (1, 60, 34)
 
 
 @pytest.mark.skipif(
@@ -112,7 +111,6 @@ def test_ec_pose_export_onnx_output_names(tmp_path):
             device = x.device
             return (
                 torch.zeros(batch, 2, 2, device=device),
-                torch.zeros(batch, 2, 4, device=device),
                 torch.zeros(batch, 2, 34, device=device),
             )
 
@@ -131,6 +129,5 @@ def test_ec_pose_export_onnx_output_names(tmp_path):
     proto = onnx.load(str(path))
     assert [o.name for o in proto.graph.output] == [
         "pred_logits",
-        "pred_boxes",
         "pred_keypoints",
     ]

--- a/tests/unit/test_ec_export_wrapper.py
+++ b/tests/unit/test_ec_export_wrapper.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+
+import torch
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeEC(torch.nn.Module):
+    def deploy(self):
+        self.deployed = True
+        return self
+
+    def forward(self, x):
+        batch = x.shape[0]
+        return {
+            "pred_logits": torch.zeros(batch, 60, 2),
+            "pred_boxes": torch.zeros(batch, 60, 4),
+            "pred_masks": torch.zeros(batch, 60, 8, 8),
+            "pred_keypoints": torch.zeros(batch, 60, 17, 2),
+        }
+
+
+def test_ec_export_wrapper_returns_detection_tuple():
+    from libreyolo.models.ec.nn import ECExportWrapper
+
+    wrapper = ECExportWrapper(_FakeEC(), task="detect")
+    out = wrapper(torch.zeros(1, 3, 64, 64))
+
+    assert len(out) == 2
+    assert out[0].shape == (1, 60, 2)
+    assert out[1].shape == (1, 60, 4)
+
+
+def test_ec_export_wrapper_returns_segmentation_tuple():
+    from libreyolo.models.ec.nn import ECExportWrapper
+
+    wrapper = ECExportWrapper(_FakeEC(), task="segment")
+    out = wrapper(torch.zeros(1, 3, 64, 64))
+
+    assert len(out) == 3
+    assert out[0].shape == (1, 60, 2)
+    assert out[1].shape == (1, 60, 4)
+    assert out[2].shape == (1, 60, 8, 8)
+
+
+def test_ec_export_wrapper_flattens_deployed_pose_keypoints():
+    from libreyolo.models.ec.nn import ECExportWrapper
+
+    wrapper = ECExportWrapper(_FakeEC(), task="pose")
+    out = wrapper(torch.zeros(1, 3, 64, 64))
+
+    assert len(out) == 2
+    assert out[0].shape == (1, 60, 2)
+    assert out[1].shape == (1, 60, 34)
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("onnx") is None,
+    reason="onnx not installed",
+)
+def test_ec_segment_export_onnx_output_names(tmp_path):
+    import onnx
+
+    from libreyolo.export.onnx import export_onnx
+
+    class SegmentModel(torch.nn.Module):
+        def forward(self, x):
+            batch = x.shape[0]
+            device = x.device
+            return (
+                torch.zeros(batch, 2, 3, device=device),
+                torch.zeros(batch, 2, 4, device=device),
+                torch.zeros(batch, 2, 4, 4, device=device),
+            )
+
+    path = tmp_path / "ec-seg.onnx"
+    export_onnx(
+        SegmentModel(),
+        torch.zeros(1, 3, 8, 8),
+        output_path=str(path),
+        opset=17,
+        simplify=False,
+        dynamic=False,
+        half=False,
+        metadata={"model_family": "ec", "task": "segment", "segmentation": "true"},
+    )
+
+    proto = onnx.load(str(path))
+    assert [o.name for o in proto.graph.output] == [
+        "pred_logits",
+        "pred_boxes",
+        "pred_masks",
+    ]
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("onnx") is None,
+    reason="onnx not installed",
+)
+def test_ec_pose_export_onnx_output_names(tmp_path):
+    import onnx
+
+    from libreyolo.export.onnx import export_onnx
+
+    class PoseModel(torch.nn.Module):
+        def forward(self, x):
+            batch = x.shape[0]
+            device = x.device
+            return (
+                torch.zeros(batch, 2, 2, device=device),
+                torch.zeros(batch, 2, 34, device=device),
+            )
+
+    path = tmp_path / "ec-pose.onnx"
+    export_onnx(
+        PoseModel(),
+        torch.zeros(1, 3, 8, 8),
+        output_path=str(path),
+        opset=17,
+        simplify=False,
+        dynamic=False,
+        half=False,
+        metadata={"model_family": "ec", "task": "pose"},
+    )
+
+    proto = onnx.load(str(path))
+    assert [o.name for o in proto.graph.output] == [
+        "pred_logits",
+        "pred_keypoints",
+    ]

--- a/tests/unit/test_ec_export_wrapper.py
+++ b/tests/unit/test_ec_export_wrapper.py
@@ -52,9 +52,10 @@ def test_ec_export_wrapper_flattens_deployed_pose_keypoints():
     wrapper = ECExportWrapper(_FakeEC(), task="pose")
     out = wrapper(torch.zeros(1, 3, 64, 64))
 
-    assert len(out) == 2
+    assert len(out) == 3
     assert out[0].shape == (1, 60, 2)
-    assert out[1].shape == (1, 60, 34)
+    assert out[1].shape == (1, 60, 4)
+    assert out[2].shape == (1, 60, 34)
 
 
 @pytest.mark.skipif(
@@ -111,6 +112,7 @@ def test_ec_pose_export_onnx_output_names(tmp_path):
             device = x.device
             return (
                 torch.zeros(batch, 2, 2, device=device),
+                torch.zeros(batch, 2, 4, device=device),
                 torch.zeros(batch, 2, 34, device=device),
             )
 
@@ -129,5 +131,6 @@ def test_ec_pose_export_onnx_output_names(tmp_path):
     proto = onnx.load(str(path))
     assert [o.name for o in proto.graph.output] == [
         "pred_logits",
+        "pred_boxes",
         "pred_keypoints",
     ]

--- a/tests/unit/test_ec_pose.py
+++ b/tests/unit/test_ec_pose.py
@@ -59,12 +59,17 @@ class TestPoseCheckpointDiscrimination:
 
 class TestPoseFamilyClassWiring:
     def test_pose_init_sets_task_and_metadata(self):
+        from libreyolo.export.exporter import OnnxExporter
+
         m = LibreEC(model_path=None, size="s", task="pose")
         assert m.task == "pose"
         assert m.family == "ec"
         assert m.nb_classes == 1
         assert m.names == {0: "person"}
         assert isinstance(m.model, LibreECPoseModel)
+        metadata = OnnxExporter(m)._build_onnx_metadata(dynamic=False, half=False)
+        assert metadata["num_keypoints"] == "17"
+        assert metadata["keypoint_dim"] == "3"
 
     def test_pose_checkpoint_reload_preserves_custom_class_name(self, tmp_path):
         src = LibreEC(model_path=None, size="s", task="pose", device="cpu")

--- a/tests/unit/test_ec_pose.py
+++ b/tests/unit/test_ec_pose.py
@@ -250,6 +250,23 @@ class TestPoseForwardAndPostprocess:
         assert det["boxes"].shape == (2, 4)
         np.testing.assert_allclose(det["keypoints"][:, 0, :2], [[10.0, 10.0], [70.0, 70.0]])
 
+    def test_wrapper_postprocess_does_not_hard_cap_queries_at_sixty(self, pose_model):
+        raw = {
+            "pred_logits": torch.linspace(10.0, 1.0, 70).reshape(1, 70, 1),
+            "pred_keypoints": torch.zeros(1, 70, 34),
+        }
+
+        det = pose_model._postprocess(
+            raw,
+            conf_thres=0.0,
+            iou_thres=0.0,
+            original_size=(100, 100),
+            max_det=70,
+        )
+
+        assert det["boxes"].shape == (70, 4)
+        assert det["keypoints"].shape == (70, 17, 3)
+
     def test_full_predict_pipeline(self, pose_model):
         # Exercise _wrap_results so the keypoint plumbing stays working.
         from PIL import Image

--- a/tests/unit/test_ec_pose.py
+++ b/tests/unit/test_ec_pose.py
@@ -69,7 +69,7 @@ class TestPoseFamilyClassWiring:
         assert isinstance(m.model, LibreECPoseModel)
         metadata = OnnxExporter(m)._build_onnx_metadata(dynamic=False, half=False)
         assert metadata["num_keypoints"] == "17"
-        assert metadata["keypoint_dim"] == "3"
+        assert metadata["keypoint_dim"] == "2"
 
     def test_pose_checkpoint_reload_preserves_custom_class_name(self, tmp_path):
         src = LibreEC(model_path=None, size="s", task="pose", device="cpu")

--- a/tests/unit/test_ec_pose.py
+++ b/tests/unit/test_ec_pose.py
@@ -250,6 +250,26 @@ class TestPoseForwardAndPostprocess:
         assert det["boxes"].shape == (2, 4)
         np.testing.assert_allclose(det["keypoints"][:, 0, :2], [[10.0, 10.0], [70.0, 70.0]])
 
+    def test_postprocess_scores_person_logit_only(self):
+        raw = {
+            "pred_logits": torch.tensor([[[0.0, 10.0], [9.0, -10.0]]]),
+            "pred_keypoints": torch.tensor(
+                [[[0.1, 0.1, 0.2, 0.2], [0.7, 0.7, 0.8, 0.8]]]
+            ),
+        }
+
+        det = postprocess_pose(
+            raw,
+            conf_thres=0.0,
+            iou_thres=0.0,
+            original_size=(100, 100),
+            max_det=1,
+            num_keypoints=2,
+        )
+
+        assert det["boxes"].shape == (1, 4)
+        np.testing.assert_allclose(det["keypoints"][0, :, :2], [[70.0, 70.0], [80.0, 80.0]])
+
     def test_wrapper_postprocess_does_not_hard_cap_queries_at_sixty(self, pose_model):
         raw = {
             "pred_logits": torch.linspace(10.0, 1.0, 70).reshape(1, 70, 1),

--- a/tests/unit/test_ec_pose.py
+++ b/tests/unit/test_ec_pose.py
@@ -230,6 +230,26 @@ class TestPoseForwardAndPostprocess:
         assert det["keypoints"].shape[-2] == 17
         assert det["keypoints"].shape[0] == det["boxes"].shape[0]
 
+    def test_postprocess_selects_unique_queries_before_collapsing_classes(self):
+        raw = {
+            "pred_logits": torch.tensor([[[10.0, 9.0], [8.0, -10.0]]]),
+            "pred_keypoints": torch.tensor(
+                [[[0.1, 0.1, 0.2, 0.2], [0.7, 0.7, 0.8, 0.8]]]
+            ),
+        }
+
+        det = postprocess_pose(
+            raw,
+            conf_thres=0.0,
+            iou_thres=0.0,
+            original_size=(100, 100),
+            max_det=2,
+            num_keypoints=2,
+        )
+
+        assert det["boxes"].shape == (2, 4)
+        np.testing.assert_allclose(det["keypoints"][:, 0, :2], [[10.0, 10.0], [70.0, 70.0]])
+
     def test_full_predict_pipeline(self, pose_model):
         # Exercise _wrap_results so the keypoint plumbing stays working.
         from PIL import Image

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -292,8 +292,25 @@ class TestExporterFormats:
 
         assert metadata["task"] == "pose"
         assert metadata["num_keypoints"] == "17"
-        assert metadata["keypoint_dim"] == "3"
+        assert metadata["keypoint_dim"] == "8"
         assert json.loads(metadata["num_keypoints_per_class"]) == [0, 17, 4]
+
+    def test_ec_pose_onnx_metadata_describes_exported_xy_keypoints(self):
+        wrapper = _make_wrapper(model_name="ec")
+        wrapper.task = "pose"
+        wrapper.SUPPORTED_TASKS = ("detect", "pose")
+        wrapper.DEFAULT_TASK = "detect"
+        wrapper.num_keypoints = 17
+        wrapper.keypoint_dim = 3
+
+        metadata = OnnxExporter(wrapper)._build_onnx_metadata(
+            dynamic=False,
+            half=False,
+        )
+
+        assert metadata["task"] == "pose"
+        assert metadata["num_keypoints"] == "17"
+        assert metadata["keypoint_dim"] == "2"
 
     def test_tensorrt_export_forwards_dynamic_batch_profile(
         self, monkeypatch, tmp_path

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,5 +1,6 @@
 """Unit tests for the unified Exporter module."""
 
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -274,6 +275,25 @@ class TestExporterFormats:
         assert metadata["task"] == "segment"
         assert metadata["supported_tasks"] == ["segment"]
         assert metadata["default_task"] == "segment"
+
+    def test_rfdetr_pose_onnx_metadata_preserves_grouppose_schema(self):
+        wrapper = _make_wrapper(model_name="rfdetr")
+        wrapper.task = "pose"
+        wrapper.SUPPORTED_TASKS = ("detect", "pose")
+        wrapper.DEFAULT_TASK = "detect"
+        wrapper.num_keypoints = 17
+        wrapper.keypoint_dim = 3
+        wrapper.num_keypoints_per_class = [0, 17, 4]
+
+        metadata = OnnxExporter(wrapper)._build_onnx_metadata(
+            dynamic=False,
+            half=False,
+        )
+
+        assert metadata["task"] == "pose"
+        assert metadata["num_keypoints"] == "17"
+        assert metadata["keypoint_dim"] == "3"
+        assert json.loads(metadata["num_keypoints_per_class"]) == [0, 17, 4]
 
     def test_tensorrt_export_forwards_dynamic_batch_profile(
         self, monkeypatch, tmp_path

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -434,3 +434,43 @@ def test_factory_warns_for_foreign_metadata_less_checkpoint(tmp_path, caplog):
 def test_factory_rejects_unsupported_explicit_task_from_filename():
     with pytest.raises(ValueError, match="not supported"):
         LibreYOLO("LibreYOLOXs.pt", task="segment")
+
+
+def test_factory_routes_onnx_before_native_task_validation(monkeypatch, tmp_path):
+    import libreyolo.backends.onnx as onnx_backend
+
+    class _DetectOnlyMatcher:
+        DEFAULT_TASK = "detect"
+        SUPPORTED_TASKS = ("detect",)
+
+        @classmethod
+        def detect_size_from_filename(cls, filename):
+            return "n"
+
+    captured = {}
+
+    class _FakeOnnxBackend:
+        def __init__(self, onnx_path, nb_classes=80, device="auto", task=None):
+            captured.update(
+                {
+                    "onnx_path": onnx_path,
+                    "nb_classes": nb_classes,
+                    "device": device,
+                    "task": task,
+                }
+            )
+
+    monkeypatch.setattr(BaseModel, "_registry", [_DetectOnlyMatcher])
+    monkeypatch.setattr(onnx_backend, "OnnxBackend", _FakeOnnxBackend)
+    onnx_path = tmp_path / "rfdetr-l-segment.onnx"
+    onnx_path.write_bytes(b"not a real onnx model")
+
+    loaded = LibreYOLO(str(onnx_path), task="segment", device="cpu")
+
+    assert isinstance(loaded, _FakeOnnxBackend)
+    assert captured == {
+        "onnx_path": str(onnx_path),
+        "nb_classes": 80,
+        "device": "cpu",
+        "task": "segment",
+    }

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -562,6 +562,87 @@ def test_prepare_pose_data_regenerates_for_box_only_annotation(tmp_path, monkeyp
     assert prepare_pose_data(pose_yaml) == tmp_path / "coco-val2017-mini500-pose.yaml"
 
 
+def test_prepare_pose_data_honors_selected_split(tmp_path, monkeypatch):
+    import vision_analysis_benchmark.onnx_parity as parity
+
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir(parents=True)
+    (annotations_dir / "instances_val2017.json").write_text(
+        json.dumps(
+            {
+                "annotations": [{"id": 1, "image_id": 1, "category_id": 0}],
+                "categories": [{"id": 0, "name": "person"}],
+            }
+        )
+    )
+    (annotations_dir / "person_keypoints_test-dev2017.json").write_text(
+        json.dumps(
+            {
+                "annotations": [],
+                "categories": [
+                    {
+                        "id": 0,
+                        "name": "person",
+                        "keypoints": [f"kpt_{idx}" for idx in range(17)],
+                    }
+                ],
+            }
+        )
+    )
+    (tmp_path / MINI500_ANNOTATION).write_text(
+        json.dumps({"images": [{"id": 1, "file_name": "a.jpg"}], "annotations": []})
+    )
+    (tmp_path / MINI500_IMAGE_DIR).mkdir(parents=True)
+    full_keypoints = tmp_path / "full_person_keypoints.json"
+    full_keypoints.write_text(
+        json.dumps(
+            {
+                "images": [{"id": 1, "file_name": "a.jpg"}],
+                "annotations": [
+                    {
+                        "id": 10,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "keypoints": [0] * 51,
+                        "num_keypoints": 0,
+                    }
+                ],
+                "categories": [
+                    {
+                        "id": 1,
+                        "name": "person",
+                        "keypoints": [f"kpt_{idx}" for idx in range(17)],
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        parity,
+        "_download_coco_person_keypoints",
+        lambda _dataset_root: full_keypoints,
+    )
+    pose_yaml = tmp_path / "coco-pose.yaml"
+    pose_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "test": "images/test2017",
+                "annotations": {
+                    "val": "annotations/instances_val2017.json",
+                    "test": "annotations/person_keypoints_test-dev2017.json",
+                },
+            }
+        )
+    )
+
+    assert prepare_pose_data(pose_yaml, split="val") == (
+        tmp_path / "coco-val2017-mini500-pose.yaml"
+    )
+    assert prepare_pose_data(pose_yaml, split="test") == pose_yaml
+
+
 def test_pose_direct_paths_honor_selected_split(tmp_path):
     annotation_path = tmp_path / "annotations" / "person_keypoints_test-dev2017.json"
     annotation_path.parent.mkdir(parents=True)

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from vision_analysis_benchmark.onnx_parity import (
+    COCO80_NAMES,
+    DEFAULT_CASES,
+    MINI500_ANNOTATION,
+    MINI500_IMAGE_DIR,
+    MINI500_POSE_ANNOTATION,
+    compare_metrics,
+    extract_metrics,
+    filter_cases,
+    metric_keys_for_task,
+    prepare_pose_data,
+    write_mini500_yaml,
+    write_mini500_pose_yaml,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _case_ids() -> set[str]:
+    return {case.id for case in DEFAULT_CASES}
+
+
+def test_default_cases_include_supported_onnx_scope():
+    case_ids = _case_ids()
+
+    assert "yolo9-t" in case_ids
+    assert "rfdetr-n" in case_ids
+    assert "yolox-n" in case_ids
+    assert "yolo9_e2e-t" in case_ids
+    assert "yolonas-s" in case_ids
+    assert "dfine-n" in case_ids
+    assert "deim-n" in case_ids
+    assert "deimv2-atto" in case_ids
+    assert "rtdetr-r18" in case_ids
+    assert "rtdetrv2-r18" in case_ids
+    assert "rtdetrv4-s" in case_ids
+    assert "picodet-s" in case_ids
+    assert "damoyolo-ns" in case_ids
+    assert "rtmdet-t" in case_ids
+    assert "ec-s" in case_ids
+
+
+def test_default_cases_include_new_segment_and_pose_paths():
+    case_ids = _case_ids()
+
+    assert "yolo9-s-segment" in case_ids
+    assert "rfdetr-s-segment" in case_ids
+    assert "ec-s-segment" in case_ids
+    assert "yolo9-s-pose" in case_ids
+    assert "rfdetr-x-pose" in case_ids
+    assert "yolonas-n-pose" in case_ids
+    assert "ec-s-pose" in case_ids
+
+
+def test_metric_keys_are_task_specific():
+    assert "metrics/mAP50-95" in metric_keys_for_task("detect")
+    assert "metrics/mAP50-95(M)" in metric_keys_for_task("segment")
+    assert "metrics/keypoints_mAP50-95" in metric_keys_for_task("pose")
+
+
+def test_extract_metrics_ignores_non_task_and_non_numeric_values():
+    metrics = {
+        "metrics/mAP50-95": "0.40",
+        "metrics/mAP50": 0.55,
+        "metrics/precision": "bad",
+        "metrics/recall": 0.72,
+        "metrics/mAP50-95(M)": 0.1,
+    }
+
+    assert extract_metrics(metrics, "detect") == {
+        "metrics/mAP50-95": 0.40,
+        "metrics/mAP50": 0.55,
+        "metrics/recall": 0.72,
+    }
+
+
+def test_compare_metrics_passes_within_absolute_tolerance():
+    comparisons = compare_metrics(
+        {
+            "metrics/mAP50-95": 0.50000,
+            "metrics/mAP50": 0.60000,
+            "metrics/precision": 0.70000,
+            "metrics/recall": 0.80000,
+        },
+        {
+            "metrics/mAP50-95": 0.50004,
+            "metrics/mAP50": 0.60003,
+            "metrics/precision": 0.70002,
+            "metrics/recall": 0.80001,
+        },
+        "detect",
+        abs_tolerance=1e-4,
+        rel_tolerance=0.0,
+    )
+
+    assert all(item.passed for item in comparisons)
+
+
+def test_compare_metrics_fails_missing_and_drifted_values():
+    comparisons = compare_metrics(
+        {
+            "metrics/keypoints_mAP50-95": 0.50,
+            "metrics/keypoints_mAP50": 0.60,
+            "metrics/keypoints_mAP75": 0.40,
+        },
+        {
+            "metrics/keypoints_mAP50-95": 0.45,
+            "metrics/keypoints_mAP50": 0.60,
+        },
+        "pose",
+        abs_tolerance=1e-4,
+        rel_tolerance=0.0,
+    )
+
+    by_key = {item.key: item for item in comparisons}
+    assert not by_key["metrics/keypoints_mAP50-95"].passed
+    assert by_key["metrics/keypoints_mAP75"].reason == "missing metric"
+
+
+def test_filter_cases_by_family_task_and_claim():
+    selected = filter_cases(
+        DEFAULT_CASES,
+        families=["ec"],
+        tasks=["pose"],
+        claims=["experimental"],
+    )
+
+    assert {case.id for case in selected} == {
+        "ec-s-pose",
+        "ec-m-pose",
+        "ec-l-pose",
+        "ec-x-pose",
+    }
+
+
+def test_filter_cases_can_return_empty_selection():
+    assert filter_cases(DEFAULT_CASES, families=["does-not-exist"]) == []
+
+
+def test_write_mini500_yaml_uses_explicit_annotation_mapping(tmp_path):
+    root = tmp_path / "mini500"
+    (root / Path(MINI500_ANNOTATION).parent).mkdir(parents=True)
+    (root / MINI500_ANNOTATION).write_text(json.dumps({"images": []}))
+    (root / MINI500_IMAGE_DIR).mkdir(parents=True)
+
+    yaml_path = write_mini500_yaml(root)
+    config = yaml.safe_load(yaml_path.read_text())
+
+    assert config["path"] == str(root.resolve())
+    assert config["val"] == MINI500_IMAGE_DIR
+    assert config["annotations"]["val"] == MINI500_ANNOTATION
+    assert config["names"] == COCO80_NAMES
+
+
+def test_write_mini500_pose_yaml_filters_keypoints_to_mini500_images(tmp_path):
+    root = tmp_path / "mini500"
+    (root / Path(MINI500_ANNOTATION).parent).mkdir(parents=True)
+    (root / MINI500_IMAGE_DIR).mkdir(parents=True)
+    (root / MINI500_ANNOTATION).write_text(
+        json.dumps(
+            {
+                "images": [{"id": 1, "file_name": "a.jpg"}, {"id": 2, "file_name": "b.jpg"}],
+                "annotations": [],
+            }
+        )
+    )
+    keypoints_path = tmp_path / "person_keypoints_val2017.json"
+    keypoints_path.write_text(
+        json.dumps(
+            {
+                "images": [
+                    {"id": 1, "file_name": "a.jpg"},
+                    {"id": 2, "file_name": "b.jpg"},
+                    {"id": 3, "file_name": "c.jpg"},
+                ],
+                "annotations": [
+                    {"id": 10, "image_id": 1, "category_id": 1},
+                    {"id": 11, "image_id": 3, "category_id": 1},
+                ],
+                "categories": [{"id": 1, "name": "person"}],
+            }
+        )
+    )
+
+    yaml_path = write_mini500_pose_yaml(root, full_keypoints_path=keypoints_path)
+    config = yaml.safe_load(yaml_path.read_text())
+    filtered = json.loads((root / MINI500_POSE_ANNOTATION).read_text())
+
+    assert config["annotations"]["val"] == MINI500_POSE_ANNOTATION
+    assert config["kpt_shape"] == [17, 3]
+    assert config["names"] == {0: "person"}
+    assert filtered["categories"] == [{"id": 0, "name": "person"}]
+    assert {image["id"] for image in filtered["images"]} == {1, 2}
+    assert [ann["id"] for ann in filtered["annotations"]] == [10]
+    assert {ann["category_id"] for ann in filtered["annotations"]} == {0}
+
+
+def test_prepare_pose_data_keeps_existing_pose_yaml(tmp_path):
+    pose_yaml = tmp_path / "pose.yaml"
+    pose_yaml.write_text(yaml.safe_dump({"kpt_shape": [17, 3]}))
+
+    assert prepare_pose_data(pose_yaml) == pose_yaml

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -18,6 +18,7 @@ from vision_analysis_benchmark.onnx_parity import (
     _ensure_case_weights_available,
     _load_onnx_for_parity,
     _preflight_case_weights,
+    _safe_hf_dataset_path,
     compare_metrics,
     extract_metrics,
     filter_cases,
@@ -235,6 +236,18 @@ def test_preflight_case_weights_does_not_hide_unrelated_file_errors(monkeypatch)
 
     with pytest.raises(FileNotFoundError, match="annotations file not found"):
         _preflight_case_weights(case)
+
+
+def test_safe_hf_dataset_path_rejects_traversal(tmp_path):
+    with pytest.raises(ValueError, match="Unsafe Hugging Face dataset path"):
+        _safe_hf_dataset_path("../outside.jpg", tmp_path)
+
+
+def test_safe_hf_dataset_path_returns_target_inside_dest(tmp_path):
+    rel, target = _safe_hf_dataset_path("images/val2017/frame.jpg", tmp_path)
+
+    assert str(rel) == "images/val2017/frame.jpg"
+    assert target == tmp_path.resolve() / "images" / "val2017" / "frame.jpg"
 
 
 def test_load_onnx_for_parity_uses_exported_metadata_task(tmp_path):

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -12,11 +12,13 @@ from vision_analysis_benchmark.onnx_parity import (
     MINI500_ANNOTATION,
     MINI500_IMAGE_DIR,
     MINI500_POSE_ANNOTATION,
+    _checkpoint_unavailable_reason,
     compare_metrics,
     extract_metrics,
     filter_cases,
     metric_keys_for_task,
     prepare_pose_data,
+    write_summary,
     write_mini500_yaml,
     write_mini500_pose_yaml,
 )
@@ -124,6 +126,51 @@ def test_compare_metrics_fails_missing_and_drifted_values():
     by_key = {item.key: item for item in comparisons}
     assert not by_key["metrics/keypoints_mAP50-95"].passed
     assert by_key["metrics/keypoints_mAP75"].reason == "missing metric"
+
+
+def test_checkpoint_unavailable_reason_is_weight_specific():
+    assert _checkpoint_unavailable_reason(
+        FileNotFoundError("Model weights file not found: weights/model.pt")
+    )
+    assert _checkpoint_unavailable_reason(
+        RuntimeError("Failed to download weights from https://example.test: 404 Client Error")
+    )
+    assert _checkpoint_unavailable_reason(
+        ValueError("Could not determine download URL for 'missing.pt'.")
+    )
+    assert _checkpoint_unavailable_reason(RuntimeError("ONNX export failed")) is None
+
+
+def test_write_summary_counts_unavailable_cases(tmp_path):
+    records = [
+        {
+            "case": {
+                "id": "missing-model",
+                "family": "family",
+                "size": "s",
+                "task": "detect",
+                "onnx_claim": "experimental",
+                "notes": "",
+            },
+            "status": "unavailable",
+            "error": "Model weights file not found: weights/missing.pt",
+            "unavailable_reason": "Model weights file not found: weights/missing.pt",
+        }
+    ]
+
+    write_summary(records, tmp_path)
+    summary = json.loads((tmp_path / "summary.json").read_text())
+    markdown = (tmp_path / "summary.md").read_text()
+
+    assert summary["counts"] == {
+        "total": 1,
+        "passed": 0,
+        "failed": 0,
+        "error": 0,
+        "unavailable": 1,
+    }
+    assert "unavailable `1`" in markdown
+    assert "Model weights file not found: weights/missing.pt" in markdown
 
 
 def test_filter_cases_by_family_task_and_claim():

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -258,7 +258,7 @@ def test_download_coco_person_keypoints_recovers_corrupt_zip(tmp_path, monkeypat
     zip_path.parent.mkdir()
     zip_path.write_bytes(b"partial")
 
-    def fake_download(_url, target):
+    def fake_download(_url, target) -> None:
         with zipfile.ZipFile(target, "w") as archive:
             archive.writestr(parity.COCO_PERSON_KEYPOINTS_MEMBER, "{}")
 

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -12,7 +12,9 @@ from vision_analysis_benchmark.onnx_parity import (
     MINI500_ANNOTATION,
     MINI500_IMAGE_DIR,
     MINI500_POSE_ANNOTATION,
+    ParityCase,
     _checkpoint_unavailable_reason,
+    _ensure_case_weights_available,
     compare_metrics,
     extract_metrics,
     filter_cases,
@@ -139,6 +141,45 @@ def test_checkpoint_unavailable_reason_is_weight_specific():
         ValueError("Could not determine download URL for 'missing.pt'.")
     )
     assert _checkpoint_unavailable_reason(RuntimeError("ONNX export failed")) is None
+
+
+def test_ensure_case_weights_available_downloads_canonical_path(tmp_path):
+    seen = {}
+    weight_path = tmp_path / "weights" / "missing.pt"
+
+    _ensure_case_weights_available(
+        ParityCase(
+            id="missing",
+            family="family",
+            size="s",
+            task="detect",
+            weights="missing.pt",
+            onnx_claim="experimental",
+        ),
+        resolve_weights_path=lambda _name: str(weight_path),
+        downloader=lambda path, size: seen.update({"path": path, "size": size}),
+    )
+
+    assert seen == {"path": str(weight_path), "size": "s"}
+
+
+def test_ensure_case_weights_available_skips_existing_file(tmp_path):
+    weight_path = tmp_path / "weights" / "exists.pt"
+    weight_path.parent.mkdir()
+    weight_path.write_bytes(b"weights")
+
+    _ensure_case_weights_available(
+        ParityCase(
+            id="exists",
+            family="family",
+            size="s",
+            task="detect",
+            weights="exists.pt",
+            onnx_claim="experimental",
+        ),
+        resolve_weights_path=lambda _name: str(weight_path),
+        downloader=lambda _path, _size: pytest.fail("download should not run"),
+    )
 
 
 def test_write_summary_counts_unavailable_cases(tmp_path):

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -439,6 +439,22 @@ def test_prepare_pose_data_keeps_existing_pose_yaml(tmp_path):
 
 
 def test_prepare_pose_data_keeps_native_coco_keypoints_yaml(tmp_path):
+    annotation_path = tmp_path / "annotations" / "person_keypoints_val2017.json"
+    annotation_path.parent.mkdir(parents=True)
+    annotation_path.write_text(
+        json.dumps(
+            {
+                "annotations": [],
+                "categories": [
+                    {
+                        "id": 1,
+                        "name": "person",
+                        "keypoints": [f"kpt_{idx}" for idx in range(17)],
+                    }
+                ],
+            }
+        )
+    )
     pose_yaml = tmp_path / "coco-pose.yaml"
     pose_yaml.write_text(
         yaml.safe_dump(
@@ -451,6 +467,99 @@ def test_prepare_pose_data_keeps_native_coco_keypoints_yaml(tmp_path):
     )
 
     assert prepare_pose_data(pose_yaml) == pose_yaml
+
+
+def test_prepare_pose_data_inspects_arbitrary_keypoint_annotation_name(tmp_path):
+    annotation_path = tmp_path / "annotations" / "pose_val.json"
+    annotation_path.parent.mkdir(parents=True)
+    annotation_path.write_text(
+        json.dumps(
+            {
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "keypoints": [0] * 51,
+                        "num_keypoints": 0,
+                    }
+                ],
+                "categories": [{"id": 1, "name": "person"}],
+            }
+        )
+    )
+    pose_yaml = tmp_path / "coco-pose.yaml"
+    pose_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "annotations": {"val": "annotations/pose_val.json"},
+            }
+        )
+    )
+
+    assert prepare_pose_data(pose_yaml) == pose_yaml
+
+
+def test_prepare_pose_data_regenerates_for_box_only_annotation(tmp_path, monkeypatch):
+    import vision_analysis_benchmark.onnx_parity as parity
+
+    annotation_path = tmp_path / "annotations" / "person_keypoints_val2017.json"
+    annotation_path.parent.mkdir(parents=True)
+    annotation_path.write_text(
+        json.dumps(
+            {
+                "annotations": [{"id": 1, "image_id": 1, "category_id": 0}],
+                "categories": [{"id": 0, "name": "person"}],
+            }
+        )
+    )
+    (tmp_path / MINI500_ANNOTATION).write_text(
+        json.dumps({"images": [{"id": 1, "file_name": "a.jpg"}], "annotations": []})
+    )
+    (tmp_path / MINI500_IMAGE_DIR).mkdir(parents=True)
+    full_keypoints = tmp_path / "full_person_keypoints.json"
+    full_keypoints.write_text(
+        json.dumps(
+            {
+                "images": [{"id": 1, "file_name": "a.jpg"}],
+                "annotations": [
+                    {
+                        "id": 10,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "keypoints": [0] * 51,
+                        "num_keypoints": 0,
+                    }
+                ],
+                "categories": [
+                    {
+                        "id": 1,
+                        "name": "person",
+                        "keypoints": [f"kpt_{idx}" for idx in range(17)],
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        parity,
+        "_download_coco_person_keypoints",
+        lambda _dataset_root: full_keypoints,
+    )
+    pose_yaml = tmp_path / "coco-pose.yaml"
+    pose_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "annotations": {"val": "annotations/person_keypoints_val2017.json"},
+            }
+        )
+    )
+
+    assert prepare_pose_data(pose_yaml) == tmp_path / "coco-val2017-mini500-pose.yaml"
 
 
 def test_pose_direct_paths_honor_selected_split(tmp_path):

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import zipfile
 
 import pytest
 import yaml
@@ -248,6 +249,25 @@ def test_safe_hf_dataset_path_returns_target_inside_dest(tmp_path):
 
     assert str(rel) == "images/val2017/frame.jpg"
     assert target == tmp_path.resolve() / "images" / "val2017" / "frame.jpg"
+
+
+def test_download_coco_person_keypoints_recovers_corrupt_zip(tmp_path, monkeypatch):
+    import vision_analysis_benchmark.onnx_parity as parity
+
+    zip_path = tmp_path / "annotations" / "annotations_trainval2017.zip"
+    zip_path.parent.mkdir()
+    zip_path.write_bytes(b"partial")
+
+    def fake_download(_url, target):
+        with zipfile.ZipFile(target, "w") as archive:
+            archive.writestr(parity.COCO_PERSON_KEYPOINTS_MEMBER, "{}")
+
+    monkeypatch.setattr(parity, "_download_atomic", fake_download)
+
+    path = parity._download_coco_person_keypoints(tmp_path)
+
+    assert path == tmp_path / parity.COCO_PERSON_KEYPOINTS_MEMBER
+    assert path.read_text(encoding="utf-8") == "{}"
 
 
 def test_load_onnx_for_parity_uses_exported_metadata_task(tmp_path):

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -21,9 +21,11 @@ from vision_analysis_benchmark.onnx_parity import (
     _preflight_case_weights,
     _safe_hf_dataset_path,
     compare_metrics,
+    download_hf_dataset_snapshot,
     extract_metrics,
     filter_cases,
     metric_keys_for_task,
+    pose_direct_paths,
     prepare_pose_data,
     write_summary,
     write_mini500_yaml,
@@ -434,3 +436,76 @@ def test_prepare_pose_data_keeps_existing_pose_yaml(tmp_path):
     pose_yaml.write_text(yaml.safe_dump({"kpt_shape": [17, 3]}))
 
     assert prepare_pose_data(pose_yaml) == pose_yaml
+
+
+def test_prepare_pose_data_keeps_native_coco_keypoints_yaml(tmp_path):
+    pose_yaml = tmp_path / "coco-pose.yaml"
+    pose_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "annotations": {"val": "annotations/person_keypoints_val2017.json"},
+            }
+        )
+    )
+
+    assert prepare_pose_data(pose_yaml) == pose_yaml
+
+
+def test_pose_direct_paths_honor_selected_split(tmp_path):
+    pose_yaml = tmp_path / "coco-pose.yaml"
+    pose_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "test": "images/test2017",
+                "annotations": {
+                    "val": "annotations/person_keypoints_val2017.json",
+                    "test": "annotations/image_info_test-dev2017.json",
+                },
+            }
+        )
+    )
+
+    annotation_path, image_dir = pose_direct_paths(pose_yaml, split="test")
+
+    assert annotation_path == tmp_path / "annotations" / "image_info_test-dev2017.json"
+    assert image_dir == tmp_path / "images" / "test2017"
+
+
+def test_download_hf_dataset_snapshot_redownloads_unknown_size_partial(
+    tmp_path,
+    monkeypatch,
+):
+    import vision_analysis_benchmark.onnx_parity as parity
+
+    class FakeTreeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return [{"type": "file", "path": "images/val2017/a.jpg"}]
+
+    def fake_get(_url, headers=None, timeout=60):
+        assert headers == {"Accept": "application/json"}
+        assert timeout == 60
+        return FakeTreeResponse()
+
+    seen = {}
+
+    def fake_download(url, target, *, headers=None) -> None:
+        seen.update({"url": url, "headers": headers})
+        target.write_bytes(b"complete")
+
+    target = tmp_path / "images" / "val2017" / "a.jpg"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"partial")
+    monkeypatch.setattr(parity.requests, "get", fake_get)
+    monkeypatch.setattr(parity, "_download_atomic", fake_download)
+
+    download_hf_dataset_snapshot("LibreYOLO/coco-val2017-mini500", tmp_path)
+
+    assert target.read_bytes() == b"complete"
+    assert seen["headers"] == {}

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -454,6 +454,22 @@ def test_prepare_pose_data_keeps_native_coco_keypoints_yaml(tmp_path):
 
 
 def test_pose_direct_paths_honor_selected_split(tmp_path):
+    annotation_path = tmp_path / "annotations" / "person_keypoints_test-dev2017.json"
+    annotation_path.parent.mkdir(parents=True)
+    annotation_path.write_text(
+        json.dumps(
+            {
+                "annotations": [],
+                "categories": [
+                    {
+                        "id": 0,
+                        "name": "person",
+                        "keypoints": [f"kpt_{idx}" for idx in range(17)],
+                    }
+                ],
+            }
+        )
+    )
     pose_yaml = tmp_path / "coco-pose.yaml"
     pose_yaml.write_text(
         yaml.safe_dump(
@@ -463,7 +479,7 @@ def test_pose_direct_paths_honor_selected_split(tmp_path):
                 "test": "images/test2017",
                 "annotations": {
                     "val": "annotations/person_keypoints_val2017.json",
-                    "test": "annotations/image_info_test-dev2017.json",
+                    "test": "annotations/person_keypoints_test-dev2017.json",
                 },
             }
         )
@@ -471,8 +487,41 @@ def test_pose_direct_paths_honor_selected_split(tmp_path):
 
     annotation_path, image_dir = pose_direct_paths(pose_yaml, split="test")
 
-    assert annotation_path == tmp_path / "annotations" / "image_info_test-dev2017.json"
+    assert annotation_path == tmp_path / "annotations" / "person_keypoints_test-dev2017.json"
     assert image_dir == tmp_path / "images" / "test2017"
+
+
+def test_pose_direct_paths_ignores_box_only_coco_annotations(tmp_path):
+    annotation_path = tmp_path / "annotations" / "instances_val2017.json"
+    annotation_path.parent.mkdir(parents=True)
+    annotation_path.write_text(
+        json.dumps(
+            {
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 0,
+                        "bbox": [0, 0, 10, 10],
+                    }
+                ],
+                "categories": [{"id": 0, "name": "person"}],
+            }
+        )
+    )
+    pose_yaml = tmp_path / "pose.yaml"
+    pose_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "annotations": {"val": "annotations/instances_val2017.json"},
+                "kpt_shape": [17, 3],
+            }
+        )
+    )
+
+    assert pose_direct_paths(pose_yaml) == (None, None)
 
 
 def test_download_hf_dataset_snapshot_redownloads_unknown_size_partial(

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -8,6 +8,7 @@ import yaml
 
 from vision_analysis_benchmark.onnx_parity import (
     COCO80_NAMES,
+    CheckpointUnavailableError,
     DEFAULT_CASES,
     MINI500_ANNOTATION,
     MINI500_IMAGE_DIR,
@@ -15,6 +16,8 @@ from vision_analysis_benchmark.onnx_parity import (
     ParityCase,
     _checkpoint_unavailable_reason,
     _ensure_case_weights_available,
+    _load_onnx_for_parity,
+    _preflight_case_weights,
     compare_metrics,
     extract_metrics,
     filter_cases,
@@ -140,6 +143,9 @@ def test_checkpoint_unavailable_reason_is_weight_specific():
     assert _checkpoint_unavailable_reason(
         ValueError("Could not determine download URL for 'missing.pt'.")
     )
+    assert _checkpoint_unavailable_reason(
+        FileNotFoundError("annotations file not found")
+    ) is None
     assert _checkpoint_unavailable_reason(RuntimeError("ONNX export failed")) is None
 
 
@@ -180,6 +186,104 @@ def test_ensure_case_weights_available_skips_existing_file(tmp_path):
         resolve_weights_path=lambda _name: str(weight_path),
         downloader=lambda _path, _size: pytest.fail("download should not run"),
     )
+
+
+def test_preflight_case_weights_raises_unavailable_for_weight_download_failure(monkeypatch):
+    import vision_analysis_benchmark.onnx_parity as parity
+
+    case = ParityCase(
+        id="missing",
+        family="family",
+        size="s",
+        task="detect",
+        weights="missing.pt",
+        onnx_claim="experimental",
+    )
+    monkeypatch.setattr(
+        parity,
+        "_ensure_case_weights_available",
+        lambda _case: (_ for _ in ()).throw(
+            RuntimeError(
+                "Failed to download weights from https://example.test: "
+                "404 Client Error"
+            )
+        ),
+    )
+
+    with pytest.raises(CheckpointUnavailableError, match="Failed to download weights"):
+        _preflight_case_weights(case)
+
+
+def test_preflight_case_weights_does_not_hide_unrelated_file_errors(monkeypatch):
+    import vision_analysis_benchmark.onnx_parity as parity
+
+    case = ParityCase(
+        id="broken-data",
+        family="family",
+        size="s",
+        task="detect",
+        weights="exists.pt",
+        onnx_claim="experimental",
+    )
+    monkeypatch.setattr(
+        parity,
+        "_ensure_case_weights_available",
+        lambda _case: (_ for _ in ()).throw(
+            FileNotFoundError("annotations file not found")
+        ),
+    )
+
+    with pytest.raises(FileNotFoundError, match="annotations file not found"):
+        _preflight_case_weights(case)
+
+
+def test_load_onnx_for_parity_uses_exported_metadata_task(tmp_path):
+    class FakeModel:
+        task = "segment"
+
+    seen = {}
+
+    def fake_loader(path, **kwargs):
+        seen.update({"path": path, "kwargs": kwargs})
+        return FakeModel()
+
+    args = type("Args", (), {"onnx_device": "cuda"})()
+    case = ParityCase(
+        id="seg",
+        family="family",
+        size="s",
+        task="segment",
+        weights="seg.pt",
+        onnx_claim="complete",
+    )
+
+    model = _load_onnx_for_parity(tmp_path / "seg.onnx", case, args, loader=fake_loader)
+
+    assert model.task == "segment"
+    assert seen == {"path": str(tmp_path / "seg.onnx"), "kwargs": {"device": "cuda"}}
+
+
+def test_load_onnx_for_parity_rejects_wrong_exported_task(tmp_path):
+    class FakeModel:
+        task = "detect"
+
+    args = type("Args", (), {"onnx_device": "cpu"})()
+    case = ParityCase(
+        id="seg",
+        family="family",
+        size="s",
+        task="segment",
+        weights="seg.pt",
+        onnx_claim="complete",
+    )
+
+    with pytest.raises(RuntimeError, match="task metadata resolved to 'detect'"):
+        _load_onnx_for_parity(
+            tmp_path / "seg.onnx",
+            case,
+            args,
+            loader=lambda *_args, **_kwargs: FakeModel(),
+        )
 
 
 def test_write_summary_counts_unavailable_cases(tmp_path):

--- a/tests/unit/test_pose_validator.py
+++ b/tests/unit/test_pose_validator.py
@@ -166,6 +166,73 @@ def test_pose_validator_uses_coco_keypoints_annotation_from_yaml(tmp_path):
     assert not (tmp_path / "runs" / "ground_truth_yolo_pose.json").exists()
 
 
+def test_pose_validator_ignores_box_only_coco_annotation_for_pose(tmp_path):
+    images_dir = tmp_path / "images" / "val2017"
+    labels_dir = tmp_path / "labels" / "val2017"
+    annotations_dir = tmp_path / "annotations"
+    images_dir.mkdir(parents=True)
+    labels_dir.mkdir(parents=True)
+    annotations_dir.mkdir(parents=True)
+
+    Image.new("RGB", (320, 240)).save(images_dir / "000000123456.jpg")
+    (labels_dir / "000000123456.txt").write_text(
+        "0 0.5 0.5 0.25 0.5 "
+        "0.4 0.3 2 0.6 0.3 2 0.6 0.7 1 0.4 0.7 0\n"
+    )
+    instances_json = annotations_dir / "instances_val2017.json"
+    instances_json.write_text(
+        json.dumps(
+            {
+                "images": [
+                    {
+                        "id": 123456,
+                        "file_name": "000000123456.jpg",
+                        "width": 320,
+                        "height": 240,
+                    }
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 123456,
+                        "category_id": 0,
+                        "bbox": [0, 0, 100, 100],
+                        "area": 10000,
+                        "iscrowd": 0,
+                    }
+                ],
+                "categories": [{"id": 0, "name": "person"}],
+            }
+        )
+    )
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "annotations": {"val": "annotations/instances_val2017.json"},
+                "nc": 1,
+                "names": {0: "person"},
+                "kpt_shape": [4, 3],
+            }
+        )
+    )
+
+    config = ValidationConfig(
+        data=str(data_yaml),
+        save_dir=str(tmp_path / "runs"),
+        verbose=False,
+    )
+    validator = PoseValidator(_DummyPoseModel(), config=config)
+    validator._setup_paths()
+
+    assert validator._kpts_json == tmp_path / "runs" / "ground_truth_yolo_pose.json"
+    coco = json.loads(validator._kpts_json.read_text())
+    assert coco["images"][0]["file_name"] == str(images_dir / "000000123456.jpg")
+    assert "keypoints" in coco["annotations"][0]
+
+
 def test_pose_validator_maps_contiguous_labels_to_coco_category_ids(tmp_path):
     config = ValidationConfig(
         save_dir=str(tmp_path),

--- a/tests/unit/test_pose_validator.py
+++ b/tests/unit/test_pose_validator.py
@@ -164,3 +164,20 @@ def test_pose_validator_uses_coco_keypoints_annotation_from_yaml(tmp_path):
     assert validator._images_dir == images_dir
     assert validator._image_records[0]["id"] == 123456
     assert not (tmp_path / "runs" / "ground_truth_yolo_pose.json").exists()
+
+
+def test_pose_validator_maps_contiguous_labels_to_coco_category_ids(tmp_path):
+    config = ValidationConfig(
+        save_dir=str(tmp_path),
+        verbose=False,
+        keypoints_json=str(tmp_path / "unused.json"),
+        images_dir=str(tmp_path),
+    )
+    validator = PoseValidator(_DummyPoseModel(), config=config)
+    validator._category_id = 1
+    validator._category_ids = [1, 3]
+
+    assert validator._prediction_category_id(0) == 1
+    assert validator._prediction_category_id(1) == 3
+    assert validator._prediction_category_id(3) == 3
+    assert validator._prediction_category_id(7) == 1

--- a/tests/unit/test_pose_validator.py
+++ b/tests/unit/test_pose_validator.py
@@ -67,6 +67,36 @@ def test_pose_validator_accepts_yolo_pose_yaml(tmp_path):
     assert validator._resolve_oks_sigmas() == [0.25] * 4
 
 
+def test_pose_validator_rejects_missing_yolo_pose_labels(tmp_path):
+    images_dir = tmp_path / "images" / "val"
+    labels_dir = tmp_path / "labels" / "val"
+    images_dir.mkdir(parents=True)
+    labels_dir.mkdir(parents=True)
+    Image.new("RGB", (640, 480)).save(images_dir / "img0.jpg")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val",
+                "nc": 1,
+                "names": {0: "person"},
+                "kpt_shape": [17, 3],
+            }
+        )
+    )
+    config = ValidationConfig(
+        data=str(data_yaml),
+        save_dir=str(tmp_path / "runs"),
+        verbose=False,
+    )
+    validator = PoseValidator(_DummyPoseModel(), config=config)
+
+    with pytest.raises(FileNotFoundError, match="No YOLO pose labels"):
+        validator._setup_paths()
+
+
 def test_pose_validator_zero_predictions_returns_all_keypoint_metrics(tmp_path):
     config = ValidationConfig(
         save_dir=str(tmp_path),

--- a/tests/unit/test_pose_validator.py
+++ b/tests/unit/test_pose_validator.py
@@ -65,3 +65,102 @@ def test_pose_validator_accepts_yolo_pose_yaml(tmp_path):
     assert validator._normalize_skeleton([[1, 2], [3, 4]]) == ((0, 1), (2, 3))
     assert validator._normalize_skeleton([[0, 1], [2, 3]]) == ((0, 1), (2, 3))
     assert validator._resolve_oks_sigmas() == [0.25] * 4
+
+
+def test_pose_validator_zero_predictions_returns_all_keypoint_metrics(tmp_path):
+    config = ValidationConfig(
+        save_dir=str(tmp_path),
+        verbose=False,
+        keypoints_json=str(tmp_path / "unused.json"),
+        images_dir=str(tmp_path),
+    )
+    validator = PoseValidator(_DummyPoseModel(), config=config)
+    validator.save_dir = tmp_path
+    validator._predictions = []
+
+    metrics = validator._evaluate_oks_ap()
+
+    assert metrics == {
+        "metrics/keypoints_mAP50-95": 0.0,
+        "metrics/keypoints_mAP50": 0.0,
+        "metrics/keypoints_mAP75": 0.0,
+        "metrics/keypoints_mAP_M": 0.0,
+        "metrics/keypoints_mAP_L": 0.0,
+        "metrics/keypoints_AR50-95": 0.0,
+        "metrics/keypoints_AR50": 0.0,
+        "metrics/keypoints_AR75": 0.0,
+        "metrics/keypoints_AR_M": 0.0,
+        "metrics/keypoints_AR_L": 0.0,
+    }
+    assert (tmp_path / "predictions.json").exists()
+
+
+def test_pose_validator_uses_coco_keypoints_annotation_from_yaml(tmp_path):
+    images_dir = tmp_path / "images" / "val2017"
+    annotations_dir = tmp_path / "annotations"
+    images_dir.mkdir(parents=True)
+    annotations_dir.mkdir(parents=True)
+    Image.new("RGB", (320, 240)).save(images_dir / "000000123456.jpg")
+
+    keypoints_json = annotations_dir / "person_keypoints_val2017_mini500.json"
+    keypoints_json.write_text(
+        json.dumps(
+            {
+                "images": [
+                    {
+                        "id": 123456,
+                        "file_name": "000000123456.jpg",
+                        "width": 320,
+                        "height": 240,
+                    }
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 123456,
+                        "category_id": 0,
+                        "bbox": [0, 0, 100, 100],
+                        "area": 10000,
+                        "iscrowd": 0,
+                        "num_keypoints": 1,
+                        "keypoints": [50, 60, 2] + [0, 0, 0] * 16,
+                    }
+                ],
+                "categories": [
+                    {
+                        "id": 0,
+                        "name": "person",
+                        "keypoints": [f"kpt_{i}" for i in range(17)],
+                        "skeleton": [],
+                    }
+                ],
+            }
+        )
+    )
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val2017",
+                "annotations": {"val": "annotations/person_keypoints_val2017_mini500.json"},
+                "nc": 1,
+                "names": {0: "person"},
+                "kpt_shape": [17, 3],
+            }
+        )
+    )
+
+    config = ValidationConfig(
+        data=str(data_yaml),
+        save_dir=str(tmp_path / "runs"),
+        verbose=False,
+    )
+    validator = PoseValidator(_DummyPoseModel(), config=config)
+    validator._setup_paths()
+    validator._load_coco_gt()
+
+    assert validator._kpts_json == keypoints_json
+    assert validator._images_dir == images_dir
+    assert validator._image_records[0]["id"] == 123456
+    assert not (tmp_path / "runs" / "ground_truth_yolo_pose.json").exists()

--- a/tests/unit/test_postprocess_package.py
+++ b/tests/unit/test_postprocess_package.py
@@ -183,3 +183,15 @@ def test_ec_postprocess_smoke_lazy_import():
     )
     assert pose["num_detections"] == len(pose["boxes"])
     assert pose["keypoints"].shape[1:] == (17, 3)
+
+    structured_pose = ec.postprocess_pose(
+        {
+            "pred_logits": torch.randn(1, 15, 1, generator=g),
+            "pred_keypoints": torch.rand(1, 15, 17, 2, generator=g),
+        },
+        conf_thres=0.05,
+        original_size=(320, 320),
+        max_det=5,
+    )
+    assert structured_pose["num_detections"] == len(structured_pose["boxes"])
+    assert structured_pose["keypoints"].shape[1:] == (17, 3)

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -134,6 +134,13 @@ def test_rfdetr_detect_size_disambiguates_grouppose_x():
 
     assert LibreRFDETR.detect_size(weights, state_dict=checkpoint) == "x"
     assert LibreRFDETR.detect_size({}, state_dict=checkpoint) == "m"
+    assert (
+        LibreRFDETR.detect_size(
+            {"_kp_active_mask": torch.zeros(0, 0, dtype=torch.bool)},
+            state_dict=checkpoint,
+        )
+        == "m"
+    )
 
 
 @pytest.mark.parametrize("size", ["n", "s", "m", "l", "x"])

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -234,6 +234,25 @@ def test_classic_pose_model_forward_emits_decoded_keypoints():
     assert float(xy.max()) <= 2.0
 
 
+def test_classic_pose_bbox_reparam_keypoints_are_box_relative():
+    class _FixedKeypointHead(torch.nn.Module):
+        def forward(self, hs):
+            raw = torch.tensor([10.0, -10.0, 0.25], dtype=hs.dtype, device=hs.device)
+            return raw.expand(*hs.shape[:-1], 3)
+
+    model = _build_classic_pose_model(num_keypoints=1, nb_classes=1)
+    model.bbox_reparam = True
+    model.keypoint_head = _FixedKeypointHead()
+    hs = torch.zeros(1, 1, 1, 256)
+    reference = torch.tensor([[[[0.5, 0.5, 0.2, 0.4]]]])
+
+    decoded = model._decode_keypoints(hs, reference)
+
+    expected_xy = torch.tensor([0.5999909, 0.3000182])
+    torch.testing.assert_close(decoded[0, 0, 0, 0, :2], expected_xy, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(decoded[0, 0, 0, 0, 2], torch.tensor(0.25))
+
+
 def test_classic_pose_export_preserves_keypoint_batch_axis():
     from libreyolo.models.rfdetr.nn import RFDETRExportWrapper
 

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -1,10 +1,10 @@
-"""Unit tests for RF-DETR GroupPose keypoint support.
+"""Unit tests for RF-DETR pose keypoint support.
 
-These tests target the GroupPose keypoint architecture ported from RF-DETR
-v1.8.0 (the clean-room ``keypoint_head`` MLP / ``_decode_keypoints`` /
-``reinitialize_keypoint_head(int)`` path was removed). The model is built via
+These tests cover both the GroupPose keypoint architecture ported from RF-DETR
+v1.8.0 and the classic ``keypoint_head`` path used by public n/s/m/l pose
+checkpoints. The model is built via
 ``libreyolo.models.rfdetr.nn._make_args`` + ``lwdetr.build_model`` directly so
-we can exercise the GroupPose modules with random weights on CPU (no downloads).
+we can exercise the keypoint modules with random weights on CPU (no downloads).
 
 A tiny size config keeps construction + forward fast while still building every
 GroupPose module:
@@ -72,6 +72,23 @@ def _build_pose_model(num_keypoints_per_class=(0, 17), nb_classes=2) -> torch.nn
     return model
 
 
+def _build_classic_pose_model(num_keypoints=17, nb_classes=1) -> torch.nn.Module:
+    """Build a classic keypoint_head LWDETR with random weights on CPU."""
+    cfg = _small_pose_config()
+    args = _make_args(
+        cfg,
+        pose=True,
+        use_grouppose_keypoints=False,
+        num_keypoints=num_keypoints,
+        nb_classes=nb_classes,
+        device="cpu",
+        segmentation=False,
+    )
+    model = build_model(args)
+    model.eval()
+    return model
+
+
 def _build_detect_model(nb_classes=3) -> torch.nn.Module:
     """Build a plain detection LWDETR (no pose / keypoint flags)."""
     cfg = _small_pose_config()
@@ -85,6 +102,36 @@ def _build_detect_model(nb_classes=3) -> torch.nn.Module:
     model = build_model(args)
     model.eval()
     return model
+
+
+def test_rfdetr_pose_size_table_includes_public_checkpoints():
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+    from libreyolo.models.rfdetr.nn import RFDETR_POSE_CONFIGS
+
+    assert LibreRFDETR.POSE_INPUT_SIZES == {
+        "n": 512,
+        "s": 768,
+        "m": 576,
+        "l": 704,
+        "x": 576,
+    }
+    assert set(RFDETR_POSE_CONFIGS) == {"n", "s", "m", "l", "x"}
+    assert RFDETR_POSE_CONFIGS["x"].grouppose_head is True
+    assert all(
+        not RFDETR_POSE_CONFIGS[size].grouppose_head for size in ("n", "s", "m", "l")
+    )
+
+
+@pytest.mark.parametrize("size", ["n", "s", "m", "l", "x"])
+def test_rfdetr_pose_download_url_for_public_sizes(size):
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    name = f"LibreRFDETR{size}-pose.pt"
+
+    assert LibreRFDETR.get_download_url(name) == (
+        f"https://huggingface.co/LibreYOLO/LibreRFDETR{size}-pose/"
+        f"resolve/main/{name}"
+    )
 
 
 def _random_nested_tensor(batch: int = 1) -> NestedTensor:
@@ -143,11 +190,43 @@ def test_grouppose_keypoint_xy_finite_and_no_vestigial_keypoint_proj():
     assert kp_xy.min() >= -1.0
     assert kp_xy.max() <= 2.0
 
-    # The removed clean-room head exposed ``keypoint_head.keypoint_proj``; the
-    # GroupPose architecture must not carry that vestigial module.
+    # GroupPose must not carry a classic keypoint_head module.
     module_names = {name for name, _ in model.named_modules()}
     assert not any("keypoint_proj" in name for name in module_names)
-    assert not hasattr(model, "keypoint_head")
+    assert getattr(model, "keypoint_head", None) is None
+
+
+def test_classic_pose_model_forward_emits_decoded_keypoints():
+    model = _build_classic_pose_model(num_keypoints=5, nb_classes=1)
+    samples = _random_nested_tensor(batch=1)
+
+    with torch.no_grad():
+        out = model(samples)
+
+    q = _GROUP_DETR
+    assert tuple(out["pred_logits"].shape) == (1, q, 1)
+    assert tuple(out["pred_boxes"].shape) == (1, q, 4)
+    assert tuple(out["pred_keypoints"].shape) == (1, q, 5, 3)
+    xy = out["pred_keypoints"][..., :2]
+    assert torch.isfinite(xy).all()
+    assert float(xy.min()) >= -1.0
+    assert float(xy.max()) <= 2.0
+
+
+def test_classic_pose_export_preserves_keypoint_batch_axis():
+    from libreyolo.models.rfdetr.nn import RFDETRExportWrapper
+
+    model = _build_classic_pose_model(num_keypoints=5, nb_classes=1)
+    wrapper = RFDETRExportWrapper(model).eval()
+    x = torch.rand(1, 3, _RES, _RES)
+
+    with torch.no_grad():
+        boxes, logits, keypoints = wrapper(x)
+
+    q = _GROUP_DETR
+    assert tuple(boxes.shape) == (1, q, 4)
+    assert tuple(logits.shape) == (1, q, 1)
+    assert tuple(keypoints.shape) == (1, q, 5, 3)
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +312,33 @@ def test_grouppose_postprocess_emits_keypoints_with_normalized_visibility():
     assert person_xy.tolist() == pytest.approx([100.0, 50.0])
 
 
+def test_classic_pose_postprocess_keeps_keypoints_without_grouppose_schema():
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    logits = torch.tensor([[[5.0], [4.0]]])
+    boxes = torch.tensor([[[0.5, 0.5, 0.2, 0.4], [0.25, 0.25, 0.1, 0.1]]])
+    keypoints = torch.zeros(1, 2, 2, 3)
+    keypoints[0, 0, :, 0] = torch.tensor([0.25, 0.75])
+    keypoints[0, 0, :, 1] = torch.tensor([0.5, 0.25])
+    keypoints[0, 0, :, 2] = torch.tensor([2.0, -2.0])
+
+    result = postprocess(
+        {"pred_logits": logits, "pred_boxes": boxes, "pred_keypoints": keypoints},
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+        num_keypoints_per_class=None,
+    )[0]
+
+    assert result["labels"].tolist() == [0]
+    assert tuple(result["keypoints"].shape) == (1, 2, 3)
+    assert result["keypoints"][0, :, 0].tolist() == pytest.approx([50.0, 150.0])
+    assert result["keypoints"][0, :, 1].tolist() == pytest.approx([50.0, 25.0])
+    assert result["keypoints"][0, :, 2].tolist() == pytest.approx(
+        [0.880797, 0.119203],
+        rel=1e-5,
+    )
+
+
 # ---------------------------------------------------------------------------
 # 7. Detection path unaffected
 # ---------------------------------------------------------------------------
@@ -245,6 +351,32 @@ def test_detection_model_has_no_keypoint_modules():
     assert model._kp_active_mask.numel() == 0
     module_names = {name for name, _ in model.named_modules()}
     assert not any("keypoint" in name for name in module_names)
+
+
+def test_detection_checkpoint_without_kp_active_mask_loads(monkeypatch):
+    import libreyolo.models.rfdetr.model as rfdetr_model
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    cfg = _small_pose_config()
+    monkeypatch.setitem(rfdetr_model.RFDETR_CONFIGS, "tiny", cfg)
+    monkeypatch.setitem(LibreRFDETR.INPUT_SIZES, "tiny", cfg.resolution)
+    monkeypatch.setitem(LibreRFDETR.TASK_INPUT_SIZES["detect"], "tiny", cfg.resolution)
+
+    source = _build_detect_model(nb_classes=3)
+    state = dict(source.state_dict())
+    assert "_kp_active_mask" in state
+    state.pop("_kp_active_mask")
+
+    model = LibreRFDETR(
+        model_path={"model": state, "task": "detect", "size": "tiny", "nc": 3},
+        size="tiny",
+        task="detect",
+        nb_classes=3,
+        device="cpu",
+    )
+
+    assert model.task == "detect"
+    assert model.model.model._kp_active_mask.numel() == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -21,6 +21,8 @@ GroupPose module:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -109,8 +111,8 @@ def test_rfdetr_pose_size_table_includes_public_checkpoints():
     from libreyolo.models.rfdetr.nn import RFDETR_POSE_CONFIGS
 
     assert LibreRFDETR.POSE_INPUT_SIZES == {
-        "n": 512,
-        "s": 768,
+        "n": 384,
+        "s": 512,
         "m": 576,
         "l": 704,
         "x": 576,
@@ -227,6 +229,48 @@ def test_classic_pose_export_preserves_keypoint_batch_axis():
     assert tuple(boxes.shape) == (1, q, 4)
     assert tuple(logits.shape) == (1, q, 1)
     assert tuple(keypoints.shape) == (1, q, 5, 3)
+
+
+def test_classic_pose_training_model_detected():
+    from libreyolo.models.rfdetr.trainer import _is_classic_pose_training_model
+
+    classic = SimpleNamespace(
+        model=SimpleNamespace(keypoint_head=object(), use_grouppose_keypoints=False)
+    )
+    grouppose = SimpleNamespace(
+        model=SimpleNamespace(keypoint_head=None, use_grouppose_keypoints=True)
+    )
+
+    assert _is_classic_pose_training_model(classic) is True
+    assert _is_classic_pose_training_model(grouppose) is False
+
+
+def test_classic_pose_load_state_dict_reinitializes_keypoint_count(monkeypatch):
+    import libreyolo.models.rfdetr.nn as rfdetr_nn
+
+    cfg = _small_pose_config()
+    monkeypatch.setitem(rfdetr_nn.RFDETR_POSE_CONFIGS, "tiny", cfg)
+    source = rfdetr_nn.LibreRFDETRModel(
+        config="tiny",
+        nb_classes=1,
+        pose=True,
+        device="cpu",
+        num_keypoints=5,
+    )
+    target = rfdetr_nn.LibreRFDETRModel(
+        config="tiny",
+        nb_classes=1,
+        pose=True,
+        device="cpu",
+        num_keypoints=17,
+    )
+
+    target.load_state_dict(source.state_dict(), strict=False)
+
+    assert target.num_keypoints == 5
+    assert target.model.num_keypoints == 5
+    assert target.args.num_keypoints == 5
+    assert target.model.keypoint_head.layers[-1].out_features == 15
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -21,8 +21,6 @@ GroupPose module:
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 
@@ -267,20 +265,6 @@ def test_classic_pose_export_preserves_keypoint_batch_axis():
     assert tuple(boxes.shape) == (1, q, 4)
     assert tuple(logits.shape) == (1, q, 1)
     assert tuple(keypoints.shape) == (1, q, 5, 3)
-
-
-def test_classic_pose_training_model_detected():
-    from libreyolo.models.rfdetr.trainer import _is_classic_pose_training_model
-
-    classic = SimpleNamespace(
-        model=SimpleNamespace(keypoint_head=object(), use_grouppose_keypoints=False)
-    )
-    grouppose = SimpleNamespace(
-        model=SimpleNamespace(keypoint_head=None, use_grouppose_keypoints=True)
-    )
-
-    assert _is_classic_pose_training_model(classic) is True
-    assert _is_classic_pose_training_model(grouppose) is False
 
 
 def test_classic_pose_load_state_dict_reinitializes_keypoint_count(monkeypatch):
@@ -635,7 +619,7 @@ def test_classic_pose_target_trains_nonzero_keypoint_loss():
 
     assert float(losses["loss_keypoints_l1"]) > 0.0
     assert float(losses["loss_keypoints_findable"]) > 0.0
-    assert float(losses["loss_keypoints_visible"]) > 0.0
+    assert float(losses["loss_keypoints_visible"]) == 0.0
     assert float(losses["loss_keypoints_nll"]) == 0.0
     total = sum(losses.values())
     total.backward()
@@ -680,5 +664,89 @@ def test_classic_pose_forward_loss_runs_through_matcher():
 
     assert float(losses["loss_keypoints_l1"]) > 0.0
     assert float(losses["loss_keypoints_findable"]) > 0.0
-    assert float(losses["loss_keypoints_visible"]) > 0.0
+    assert float(losses["loss_keypoints_visible"]) == 0.0
     assert float(losses["loss_keypoints_nll"]) == 0.0
+
+
+def test_train_rfdetr_pose_checkpoint_keeps_size_unset(monkeypatch):
+    import libreyolo.models.rfdetr.model as rfdetr_model
+    from libreyolo.models.rfdetr.trainer import train_rfdetr
+
+    captured = {}
+
+    class _FakeRFDETR:
+        def __init__(
+            self,
+            *,
+            model_path=None,
+            size=None,
+            device="auto",
+            segmentation=False,
+            task=None,
+        ):
+            captured["init"] = {
+                "model_path": model_path,
+                "size": size,
+                "device": device,
+                "segmentation": segmentation,
+                "task": task,
+            }
+
+        def train(self, **kwargs):
+            captured["train"] = kwargs
+            return {"ok": True}
+
+    monkeypatch.setattr(rfdetr_model, "LibreRFDETR", _FakeRFDETR)
+
+    result = train_rfdetr(
+        data="pose.yaml",
+        pose=True,
+        pretrain_weights="LibreRFDETRn-pose.pt",
+        epochs=1,
+    )
+
+    assert result == {"ok": True}
+    assert captured["init"] == {
+        "model_path": "LibreRFDETRn-pose.pt",
+        "size": None,
+        "device": "auto",
+        "segmentation": False,
+        "task": "pose",
+    }
+
+
+def test_train_rfdetr_pose_without_checkpoint_keeps_grouppose_default(monkeypatch):
+    import libreyolo.models.rfdetr.model as rfdetr_model
+    from libreyolo.models.rfdetr.trainer import train_rfdetr
+
+    captured = {}
+
+    class _FakeRFDETR:
+        def __init__(
+            self,
+            *,
+            model_path=None,
+            size=None,
+            device="auto",
+            segmentation=False,
+            task=None,
+        ):
+            captured["init"] = {
+                "model_path": model_path,
+                "size": size,
+                "device": device,
+                "segmentation": segmentation,
+                "task": task,
+            }
+
+        def train(self, **kwargs):
+            captured["train"] = kwargs
+            return {"ok": True}
+
+    monkeypatch.setattr(rfdetr_model, "LibreRFDETR", _FakeRFDETR)
+
+    result = train_rfdetr(data="pose.yaml", pose=True, epochs=1)
+
+    assert result == {"ok": True}
+    assert captured["init"]["size"] == "x"
+    assert captured["init"]["task"] == "pose"

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -570,3 +570,115 @@ def test_grouppose_person_only_target_trains_nonzero_keypoint_loss():
     total = sum(losses.values())
     assert torch.isfinite(total)
     assert float(total) > 0.0
+
+
+def test_classic_pose_criterion_includes_keypoint_losses():
+    from libreyolo.models.rfdetr.lwdetr import build_criterion_and_postprocessors
+
+    args = _make_args(
+        _small_pose_config(),
+        pose=True,
+        use_grouppose_keypoints=False,
+        num_keypoints=5,
+        nb_classes=1,
+        device="cpu",
+        segmentation=False,
+    )
+
+    criterion, _ = build_criterion_and_postprocessors(args)
+
+    assert criterion.use_grouppose_keypoints is False
+    assert "keypoints" in criterion.losses
+    assert criterion.weight_dict["loss_keypoints_l1"] == 1.0
+    assert criterion.weight_dict["loss_keypoints_findable"] == 1.0
+    assert criterion.weight_dict["loss_keypoints_visible"] == 1.0
+    assert "loss_keypoints_nll" not in criterion.weight_dict
+
+
+def test_classic_pose_target_trains_nonzero_keypoint_loss():
+    from libreyolo.models.rfdetr.loss import SetCriterion
+    from libreyolo.models.rfdetr.matcher import HungarianMatcher
+
+    pred_keypoints = torch.tensor(
+        [[[[0.1, 0.2, -2.0], [0.3, 0.4, 2.0]]]],
+        requires_grad=True,
+    )
+    matcher = HungarianMatcher(
+        keypoint_l1_loss_coef=1.0,
+        keypoint_findable_loss_coef=1.0,
+        keypoint_visible_loss_coef=1.0,
+    )
+    criterion = SetCriterion(
+        num_classes=1,
+        matcher=matcher,
+        weight_dict={},
+        focal_alpha=0.25,
+        losses=["keypoints"],
+        group_detr=1,
+        use_grouppose_keypoints=False,
+    )
+    targets = [
+        {
+            "labels": torch.tensor([0]),
+            "boxes": torch.tensor([[0.5, 0.5, 0.4, 0.4]]),
+            "keypoints": torch.tensor([[[0.7, 0.8, 2.0], [0.9, 0.1, 1.0]]]),
+        }
+    ]
+    indices = [(torch.tensor([0]), torch.tensor([0]))]
+
+    losses = criterion.loss_keypoints(
+        {"pred_keypoints": pred_keypoints},
+        targets,
+        indices,
+        num_boxes=1.0,
+    )
+
+    assert float(losses["loss_keypoints_l1"]) > 0.0
+    assert float(losses["loss_keypoints_findable"]) > 0.0
+    assert float(losses["loss_keypoints_visible"]) > 0.0
+    assert float(losses["loss_keypoints_nll"]) == 0.0
+    total = sum(losses.values())
+    total.backward()
+    assert pred_keypoints.grad is not None
+    assert torch.isfinite(pred_keypoints.grad).all()
+    assert float(pred_keypoints.grad.abs().sum()) > 0.0
+
+
+def test_classic_pose_forward_loss_runs_through_matcher():
+    from libreyolo.models.rfdetr.loss import SetCriterion
+    from libreyolo.models.rfdetr.matcher import HungarianMatcher
+
+    criterion = SetCriterion(
+        num_classes=1,
+        matcher=HungarianMatcher(
+            keypoint_l1_loss_coef=1.0,
+            keypoint_findable_loss_coef=1.0,
+            keypoint_visible_loss_coef=1.0,
+        ),
+        weight_dict={},
+        focal_alpha=0.25,
+        losses=["keypoints"],
+        group_detr=1,
+        use_grouppose_keypoints=False,
+    )
+    outputs = {
+        "pred_logits": torch.zeros(1, 2, 1),
+        "pred_boxes": torch.tensor([[[0.5, 0.5, 0.4, 0.4], [0.1, 0.1, 0.2, 0.2]]]),
+        "pred_keypoints": torch.tensor(
+            [[[[0.1, 0.2, -2.0], [0.3, 0.4, 2.0]], [[0.8, 0.8, 1.0], [0.9, 0.9, 1.0]]]]
+        ),
+    }
+    targets = [
+        {
+            "labels": torch.tensor([0]),
+            "boxes": torch.tensor([[0.5, 0.5, 0.4, 0.4]]),
+            "keypoints": torch.tensor([[[0.7, 0.8, 2.0], [0.9, 0.1, 1.0]]]),
+        }
+    ]
+
+    losses = criterion(outputs, targets)
+
+    assert float(losses["loss_keypoints_l1"]) > 0.0
+    assert float(losses["loss_keypoints_findable"]) > 0.0
+    assert float(losses["loss_keypoints_visible"]) > 0.0
+    assert float(losses["loss_keypoints_nll"]) == 0.0

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -124,6 +124,18 @@ def test_rfdetr_pose_size_table_includes_public_checkpoints():
     )
 
 
+def test_rfdetr_detect_size_disambiguates_grouppose_x():
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    weights = {
+        "_kp_active_mask": torch.ones(2, 17, dtype=torch.bool),
+    }
+    checkpoint = {"args": {"resolution": 576}}
+
+    assert LibreRFDETR.detect_size(weights, state_dict=checkpoint) == "x"
+    assert LibreRFDETR.detect_size({}, state_dict=checkpoint) == "m"
+
+
 @pytest.mark.parametrize("size", ["n", "s", "m", "l", "x"])
 def test_rfdetr_pose_download_url_for_public_sizes(size):
     from libreyolo.models.rfdetr.model import LibreRFDETR

--- a/tests/unit/test_yolo9_seg_export.py
+++ b/tests/unit/test_yolo9_seg_export.py
@@ -94,6 +94,48 @@ def test_yolo9_obb_onnx_export_roundtrip(tmp_path):
     assert result.obb is not None
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("onnx") is None
+    or importlib.util.find_spec("onnxruntime") is None,
+    reason="onnx/onnxruntime not installed",
+)
+def test_yolo9_pose_onnx_export_roundtrip(tmp_path):
+    import onnx
+    import onnxruntime as ort
+
+    from libreyolo import LibreYOLO, LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", nb_classes=1, task="pose", device="cpu")
+    out_path = tmp_path / "LibreYOLO9t-pose.onnx"
+    model.export(
+        "onnx",
+        output_path=str(out_path),
+        simplify=False,
+        dynamic=False,
+        imgsz=64,
+        opset=17,
+    )
+
+    proto = onnx.load(str(out_path))
+    output_names = [o.name for o in proto.graph.output]
+    assert output_names == ["predictions", "keypoints"]
+
+    metadata = {p.key: p.value for p in proto.metadata_props}
+    assert metadata.get("model_family") == "yolo9"
+    assert metadata.get("task") == "pose"
+    assert metadata.get("num_keypoints") == "17"
+    assert metadata.get("keypoint_dim") == "3"
+
+    sess = ort.InferenceSession(str(out_path), providers=["CPUExecutionProvider"])
+    outs = sess.run(None, {"images": np.random.randn(1, 3, 64, 64).astype(np.float32)})
+    assert [tuple(out.shape) for out in outs] == [(1, 5, 84), (1, 84, 17, 3)]
+
+    loaded = LibreYOLO(str(out_path), device="cpu")
+    assert loaded.task == "pose"
+    result = loaded.predict(np.zeros((64, 64, 3), dtype=np.uint8), conf=0.99, imgsz=64)
+    assert result.keypoints is not None
+
+
 def test_yolo9_obb_torchscript_export_roundtrip(tmp_path):
     from libreyolo import LibreYOLO, LibreYOLO9
 

--- a/tests/unit/test_yolonas_heuristics.py
+++ b/tests/unit/test_yolonas_heuristics.py
@@ -118,6 +118,9 @@ class TestYOLONASHeuristics:
         [
             "LibreYOLONASn-pose.pt",
             "yolo_nas_pose_n_coco_pose.pth",
+            "yolo_nas_pose_s_coco_pose.pth",
+            "yolo_nas_pose_m_coco_pose.pth",
+            "yolo_nas_pose_l_coco_pose.pth",
             "LibreYOLONASs-pose.pt",
             "LibreYOLONASm-pose.pt",
             "LibreYOLONASl-pose.pt",

--- a/tests/unit/test_yolonas_heuristics.py
+++ b/tests/unit/test_yolonas_heuristics.py
@@ -109,17 +109,37 @@ class TestYOLONASHeuristics:
     def test_get_download_url_returns_none_for_unknown_filename(self):
         assert LibreYOLONAS.get_download_url("unrelated.pt") is None
 
+    @pytest.mark.parametrize("filename", ["LibreYOLONASn.pt", "yolo_nas_n_coco.pth"])
+    def test_get_download_url_returns_none_for_detection_only_n_size(self, filename):
+        assert LibreYOLONAS.get_download_url(filename) is None
+
     @pytest.mark.parametrize(
-        "filename",
+        ("filename", "expected_url"),
         [
-            "LibreYOLONASn.pt",
-            "yolo_nas_n_coco.pth",
-            "LibreYOLONASn-pose.pt",
-            "yolo_nas_pose_n_coco_pose.pth",
+            (
+                "LibreYOLONASn-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_n_coco_pose.pth",
+            ),
+            (
+                "yolo_nas_pose_n_coco_pose.pth",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_n_coco_pose.pth",
+            ),
+            (
+                "LibreYOLONASs-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_s_coco_pose.pth",
+            ),
+            (
+                "LibreYOLONASm-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_m_coco_pose.pth",
+            ),
+            (
+                "LibreYOLONASl-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_l_coco_pose.pth",
+            ),
         ],
     )
-    def test_get_download_url_returns_none_for_pose_only_n_size(self, filename):
-        assert LibreYOLONAS.get_download_url(filename) is None
+    def test_get_download_url_points_to_deci_pose_cdn(self, filename, expected_url):
+        assert LibreYOLONAS.get_download_url(filename) == expected_url
 
 
 class TestYOLONASNativeModel:

--- a/tests/unit/test_yolonas_heuristics.py
+++ b/tests/unit/test_yolonas_heuristics.py
@@ -114,32 +114,17 @@ class TestYOLONASHeuristics:
         assert LibreYOLONAS.get_download_url(filename) is None
 
     @pytest.mark.parametrize(
-        ("filename", "expected_url"),
+        "filename",
         [
-            (
-                "LibreYOLONASn-pose.pt",
-                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_n_coco_pose.pth",
-            ),
-            (
-                "yolo_nas_pose_n_coco_pose.pth",
-                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_n_coco_pose.pth",
-            ),
-            (
-                "LibreYOLONASs-pose.pt",
-                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_s_coco_pose.pth",
-            ),
-            (
-                "LibreYOLONASm-pose.pt",
-                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_m_coco_pose.pth",
-            ),
-            (
-                "LibreYOLONASl-pose.pt",
-                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_l_coco_pose.pth",
-            ),
+            "LibreYOLONASn-pose.pt",
+            "yolo_nas_pose_n_coco_pose.pth",
+            "LibreYOLONASs-pose.pt",
+            "LibreYOLONASm-pose.pt",
+            "LibreYOLONASl-pose.pt",
         ],
     )
-    def test_get_download_url_points_to_deci_pose_cdn(self, filename, expected_url):
-        assert LibreYOLONAS.get_download_url(filename) == expected_url
+    def test_get_download_url_returns_none_for_pose_checkpoints(self, filename):
+        assert LibreYOLONAS.get_download_url(filename) is None
 
 
 class TestYOLONASNativeModel:

--- a/tests/unit/test_yolonas_pose_export.py
+++ b/tests/unit/test_yolonas_pose_export.py
@@ -40,6 +40,7 @@ def test_yolonas_pose_onnx_export_roundtrip(tmp_path):
     assert metadata.get("model_family") == "yolonas"
     assert metadata.get("task") == "pose"
     assert metadata.get("num_keypoints") == "17"
+    assert metadata.get("keypoint_dim") == "3"
 
     sess = ort.InferenceSession(str(out_path), providers=["CPUExecutionProvider"])
     outs = sess.run(None, {"images": np.random.randn(1, 3, 64, 64).astype(np.float32)})

--- a/tests/unit/test_yolonas_pose_export.py
+++ b/tests/unit/test_yolonas_pose_export.py
@@ -1,0 +1,57 @@
+"""Random-weight ONNX export smoke tests for YOLO-NAS pose."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.yolonas]
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("onnx") is None
+    or importlib.util.find_spec("onnxruntime") is None,
+    reason="onnx/onnxruntime not installed",
+)
+def test_yolonas_pose_onnx_export_roundtrip(tmp_path):
+    import onnx
+    import onnxruntime as ort
+
+    from libreyolo import LibreYOLO, LibreYOLONAS
+
+    model = LibreYOLONAS(None, size="n", task="pose", device="cpu")
+    out_path = tmp_path / "LibreYOLONASn-pose.onnx"
+    model.export(
+        "onnx",
+        output_path=str(out_path),
+        simplify=False,
+        dynamic=False,
+        imgsz=64,
+        opset=17,
+    )
+
+    proto = onnx.load(str(out_path))
+    output_names = [o.name for o in proto.graph.output]
+    assert output_names == ["boxes", "scores", "keypoints_xy", "keypoints_conf"]
+
+    metadata = {p.key: p.value for p in proto.metadata_props}
+    assert metadata.get("model_family") == "yolonas"
+    assert metadata.get("task") == "pose"
+    assert metadata.get("num_keypoints") == "17"
+
+    sess = ort.InferenceSession(str(out_path), providers=["CPUExecutionProvider"])
+    outs = sess.run(None, {"images": np.random.randn(1, 3, 64, 64).astype(np.float32)})
+    assert [tuple(out.shape) for out in outs] == [
+        (1, 84, 4),
+        (1, 84, 1),
+        (1, 84, 17, 2),
+        (1, 84, 17),
+    ]
+
+    loaded = LibreYOLO(str(out_path), device="cpu")
+    assert loaded.model_family == "yolonas"
+    assert loaded.task == "pose"
+    result = loaded.predict(np.zeros((64, 64, 3), dtype=np.uint8), conf=0.99, imgsz=64)
+    assert result.keypoints is not None

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -744,20 +744,32 @@ def _is_coco_keypoints_annotation_file(path: Path) -> bool:
     return any("keypoints" in ann and "num_keypoints" in ann for ann in annotations)
 
 
-def _annotation_config_values(config: dict[str, Any]) -> list[Any]:
+def _annotation_config_values(
+    config: dict[str, Any],
+    *,
+    split: str | None = None,
+) -> list[Any]:
     values: list[Any] = []
     if config.get("keypoints_json"):
         values.append(config["keypoints_json"])
     annotations = config.get("annotations") or {}
     if isinstance(annotations, dict):
-        values.extend(annotations.values())
+        if split is None:
+            values.extend(annotations.values())
+        elif annotations.get(split):
+            values.append(annotations[split])
     elif annotations:
         values.append(annotations)
     return values
 
 
-def _has_pose_annotation_config(config: dict[str, Any], root: Path | None = None) -> bool:
-    for value in _annotation_config_values(config):
+def _has_pose_annotation_config(
+    config: dict[str, Any],
+    root: Path | None = None,
+    *,
+    split: str | None = None,
+) -> bool:
+    for value in _annotation_config_values(config, split=split):
         if not value:
             continue
         if root is not None:
@@ -772,13 +784,17 @@ def _has_pose_annotation_config(config: dict[str, Any], root: Path | None = None
     return False
 
 
-def prepare_pose_data(data_yaml: Path) -> Path:
+def prepare_pose_data(data_yaml: Path, *, split: str = "val") -> Path:
     config = yaml.safe_load(data_yaml.read_text(encoding="utf-8")) or {}
     if config.get("kpt_shape"):
         if data_yaml.name == "coco-val2017-mini500-pose.yaml":
             return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
         return data_yaml
-    if _has_pose_annotation_config(config, _dataset_root_from_yaml(data_yaml)):
+    if _has_pose_annotation_config(
+        config,
+        _dataset_root_from_yaml(data_yaml),
+        split=split,
+    ):
         return data_yaml
     return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
 
@@ -1201,7 +1217,7 @@ def main(argv: list[str] | None = None) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     args.data_yaml = prepare_data(args, output_dir)
     args.pose_data_yaml = (
-        prepare_pose_data(args.data_yaml)
+        prepare_pose_data(args.data_yaml, split=args.split)
         if any(case.task == "pose" for case in cases)
         else args.data_yaml
     )

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -183,6 +183,10 @@ class MetricComparison:
     reason: str = ""
 
 
+class CheckpointUnavailableError(RuntimeError):
+    """Raised when a selected parity checkpoint cannot be obtained."""
+
+
 def _checkpoint_unavailable_reason(exc: BaseException) -> str | None:
     """Return a reportable reason when a parity case lacks usable weights."""
     messages: list[str] = []
@@ -194,8 +198,6 @@ def _checkpoint_unavailable_reason(exc: BaseException) -> str | None:
         current = current.__cause__ or current.__context__
 
     text = "\n".join(messages).lower()
-    if isinstance(exc, FileNotFoundError):
-        return str(exc)
     if "model weights file not found" in text:
         return str(exc)
     if "pretrained weights are not available" in text:
@@ -239,6 +241,37 @@ def _ensure_case_weights_available(
     if weights_path.exists():
         return
     downloader(str(weights_path), case.size)
+
+
+def _preflight_case_weights(case: ParityCase) -> None:
+    try:
+        _ensure_case_weights_available(case)
+    except Exception as exc:
+        reason = _checkpoint_unavailable_reason(exc)
+        if reason is not None:
+            raise CheckpointUnavailableError(reason) from exc
+        raise
+
+
+def _load_onnx_for_parity(
+    onnx_path: Path,
+    case: ParityCase,
+    args: argparse.Namespace,
+    *,
+    loader=None,
+):
+    """Load exported ONNX through its own metadata and verify task resolution."""
+    if loader is None:
+        from libreyolo import LibreYOLO as loader
+
+    model = loader(str(onnx_path), device=args.onnx_device)
+    resolved_task = getattr(model, "task", None)
+    if resolved_task != case.task:
+        raise RuntimeError(
+            f"ONNX artifact task metadata resolved to {resolved_task!r}, "
+            f"expected {case.task!r} for parity case {case.id!r}."
+        )
+    return model
 
 
 def _weights(prefix: str, size: str, task: str) -> str:
@@ -735,7 +768,7 @@ def run_case(case: ParityCase, args: argparse.Namespace, output_dir: Path) -> di
     }
     try:
         print(f"[{case.id}] loading PyTorch weights {case.weights}")
-        _ensure_case_weights_available(case)
+        _preflight_case_weights(case)
         pt_model = LibreYOLO(
             case.weights,
             size=case.size,
@@ -771,7 +804,7 @@ def run_case(case: ParityCase, args: argparse.Namespace, output_dir: Path) -> di
         pt_metrics = extract_metrics(pt_metrics_raw, case.task)
 
         print(f"[{case.id}] validating ONNX")
-        onnx_model = LibreYOLO(str(onnx_path), task=case.task, device=args.onnx_device)
+        onnx_model = _load_onnx_for_parity(onnx_path, case, args)
         onnx_metrics_raw = onnx_model.val(
             **_val_kwargs(
                 args,
@@ -800,26 +833,24 @@ def run_case(case: ParityCase, args: argparse.Namespace, output_dir: Path) -> di
                 "comparisons": [asdict(item) for item in comparisons],
             }
         )
+    except CheckpointUnavailableError as exc:
+        record.update(
+            {
+                "status": "unavailable",
+                "error": str(exc),
+                "unavailable_reason": str(exc),
+            }
+        )
+        print(f"[{case.id}] UNAVAILABLE: {exc}", file=sys.stderr)
     except Exception as exc:
-        unavailable_reason = _checkpoint_unavailable_reason(exc)
-        if unavailable_reason is not None:
-            record.update(
-                {
-                    "status": "unavailable",
-                    "error": str(exc),
-                    "unavailable_reason": unavailable_reason,
-                }
-            )
-            print(f"[{case.id}] UNAVAILABLE: {exc}", file=sys.stderr)
-        else:
-            record.update(
-                {
-                    "status": "error",
-                    "error": str(exc),
-                    "traceback": traceback.format_exc(),
-                }
-            )
-            print(f"[{case.id}] ERROR: {exc}", file=sys.stderr)
+        record.update(
+            {
+                "status": "error",
+                "error": str(exc),
+                "traceback": traceback.format_exc(),
+            }
+        )
+        print(f"[{case.id}] ERROR: {exc}", file=sys.stderr)
     finally:
         record["duration_seconds"] = round(time.perf_counter() - started, 3)
         (case_dir / "parity.json").write_text(

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -1,0 +1,1001 @@
+#!/usr/bin/env python3
+"""Run ONNX-vs-PyTorch validation parity checks for LibreYOLO models.
+
+The default matrix covers model families that claim ONNX export support in the
+project support table, limited to detection, instance segmentation, and pose.
+Generated reports are written under ``runs/onnx_parity`` by default.
+
+Example:
+    python vision_analysis_benchmark/onnx_parity.py \
+        --download-mini500 \
+        --families yolo9 rfdetr ec \
+        --tasks detect segment pose \
+        --batch 16 \
+        --device cuda:0
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+import time
+import traceback
+import zipfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import quote
+
+import requests
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+MINI500_DATASET_ID = "LibreYOLO/coco-val2017-mini500"
+MINI500_ANNOTATION = "annotations/instances_val2017_mini500.json"
+MINI500_POSE_ANNOTATION = "annotations/person_keypoints_val2017_mini500.json"
+MINI500_IMAGE_DIR = "images/val2017"
+COCO_ANNOTATIONS_URL = "http://images.cocodataset.org/annotations/annotations_trainval2017.zip"
+COCO_PERSON_KEYPOINTS_MEMBER = "annotations/person_keypoints_val2017.json"
+COCO_POSE_FLIP_IDX = [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
+
+COCO80_NAMES = {
+    0: "person",
+    1: "bicycle",
+    2: "car",
+    3: "motorcycle",
+    4: "airplane",
+    5: "bus",
+    6: "train",
+    7: "truck",
+    8: "boat",
+    9: "traffic light",
+    10: "fire hydrant",
+    11: "stop sign",
+    12: "parking meter",
+    13: "bench",
+    14: "bird",
+    15: "cat",
+    16: "dog",
+    17: "horse",
+    18: "sheep",
+    19: "cow",
+    20: "elephant",
+    21: "bear",
+    22: "zebra",
+    23: "giraffe",
+    24: "backpack",
+    25: "umbrella",
+    26: "handbag",
+    27: "tie",
+    28: "suitcase",
+    29: "frisbee",
+    30: "skis",
+    31: "snowboard",
+    32: "sports ball",
+    33: "kite",
+    34: "baseball bat",
+    35: "baseball glove",
+    36: "skateboard",
+    37: "surfboard",
+    38: "tennis racket",
+    39: "bottle",
+    40: "wine glass",
+    41: "cup",
+    42: "fork",
+    43: "knife",
+    44: "spoon",
+    45: "bowl",
+    46: "banana",
+    47: "apple",
+    48: "sandwich",
+    49: "orange",
+    50: "broccoli",
+    51: "carrot",
+    52: "hot dog",
+    53: "pizza",
+    54: "donut",
+    55: "cake",
+    56: "chair",
+    57: "couch",
+    58: "potted plant",
+    59: "bed",
+    60: "dining table",
+    61: "toilet",
+    62: "tv",
+    63: "laptop",
+    64: "mouse",
+    65: "remote",
+    66: "keyboard",
+    67: "cell phone",
+    68: "microwave",
+    69: "oven",
+    70: "toaster",
+    71: "sink",
+    72: "refrigerator",
+    73: "book",
+    74: "clock",
+    75: "vase",
+    76: "scissors",
+    77: "teddy bear",
+    78: "hair drier",
+    79: "toothbrush",
+}
+
+TASK_SUFFIX = {
+    "detect": "",
+    "segment": "-seg",
+    "pose": "-pose",
+}
+
+DETECT_KEYS = (
+    "metrics/mAP50-95",
+    "metrics/mAP50",
+    "metrics/precision",
+    "metrics/recall",
+)
+SEGMENT_KEYS = (
+    "metrics/mAP50-95(B)",
+    "metrics/mAP50(B)",
+    "metrics/precision(B)",
+    "metrics/recall(B)",
+    "metrics/mAP50-95(M)",
+    "metrics/mAP50(M)",
+    "metrics/precision(M)",
+    "metrics/recall(M)",
+)
+POSE_KEYS = (
+    "metrics/keypoints_mAP50-95",
+    "metrics/keypoints_mAP50",
+    "metrics/keypoints_mAP75",
+    "metrics/keypoints_AR50-95",
+    "metrics/keypoints_AR50",
+    "metrics/keypoints_AR75",
+)
+
+
+@dataclass(frozen=True)
+class ParityCase:
+    id: str
+    family: str
+    size: str
+    task: str
+    weights: str
+    onnx_claim: str
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class MetricComparison:
+    key: str
+    pytorch: float | None
+    onnx: float | None
+    abs_delta: float | None
+    tolerance: float
+    passed: bool
+    reason: str = ""
+
+
+def _weights(prefix: str, size: str, task: str) -> str:
+    return f"{prefix}{size}{TASK_SUFFIX[task]}.pt"
+
+
+def _case(
+    family: str,
+    prefix: str,
+    size: str,
+    task: str,
+    claim: str,
+    notes: str = "",
+) -> ParityCase:
+    suffix = "" if task == "detect" else f"-{task}"
+    return ParityCase(
+        id=f"{family}-{size}{suffix}",
+        family=family,
+        size=size,
+        task=task,
+        weights=_weights(prefix, size, task),
+        onnx_claim=claim,
+        notes=notes,
+    )
+
+
+def build_default_cases() -> list[ParityCase]:
+    cases: list[ParityCase] = []
+
+    def add_many(
+        family: str,
+        prefix: str,
+        sizes: Iterable[str],
+        task: str,
+        claim: str,
+        notes: str = "",
+    ) -> None:
+        cases.extend(_case(family, prefix, size, task, claim, notes) for size in sizes)
+
+    add_many("yolo9", "LibreYOLO9", ("t", "s", "m", "c"), "detect", "complete")
+    add_many(
+        "yolo9",
+        "LibreYOLO9",
+        ("t", "s", "m", "c"),
+        "segment",
+        "complete",
+        "pretrained weights may need to be staged",
+    )
+    add_many(
+        "yolo9",
+        "LibreYOLO9",
+        ("s",),
+        "pose",
+        "complete",
+        "experimental preview checkpoint",
+    )
+
+    add_many("rfdetr", "LibreRFDETR", ("n", "s", "m", "l"), "detect", "complete")
+    add_many(
+        "rfdetr",
+        "LibreRFDETR",
+        ("n", "s", "m", "l", "x", "xx"),
+        "segment",
+        "complete",
+    )
+    add_many(
+        "rfdetr",
+        "LibreRFDETR",
+        ("n", "s", "m", "l", "x"),
+        "pose",
+        "complete",
+        "experimental preview checkpoint",
+    )
+
+    add_many(
+        "yolox",
+        "LibreYOLOX",
+        ("n", "t", "s", "m", "l", "x"),
+        "detect",
+        "experimental",
+    )
+    add_many(
+        "yolo9_e2e",
+        "LibreYOLO9E2E",
+        ("t", "s", "m", "c"),
+        "detect",
+        "experimental",
+    )
+    add_many("yolonas", "LibreYOLONAS", ("s", "m", "l"), "detect", "experimental")
+    add_many(
+        "yolonas",
+        "LibreYOLONAS",
+        ("n", "s", "m", "l"),
+        "pose",
+        "experimental",
+        "pose weights download from Deci CDN with pinned checksums",
+    )
+    add_many("dfine", "LibreDFINE", ("n", "s", "m", "l", "x"), "detect", "experimental")
+    add_many("deim", "LibreDEIM", ("n", "s", "m", "l", "x"), "detect", "experimental")
+    add_many(
+        "deimv2",
+        "LibreDEIMv2",
+        ("atto", "femto", "pico", "n", "s", "m", "l", "x"),
+        "detect",
+        "experimental",
+    )
+    add_many(
+        "rtdetr",
+        "LibreRTDETR",
+        ("r18", "r34", "r50", "r50m", "r101", "l", "x"),
+        "detect",
+        "experimental",
+    )
+    add_many(
+        "rtdetrv2",
+        "LibreRTDETRv2",
+        ("r18", "r34", "r50", "r50m", "r101"),
+        "detect",
+        "experimental",
+    )
+    add_many("rtdetrv4", "LibreRTDETRv4", ("s", "m", "l", "x"), "detect", "experimental")
+    add_many("picodet", "LibrePICODET", ("s", "m", "l"), "detect", "experimental")
+    add_many(
+        "damoyolo",
+        "LibreDAMOYOLO",
+        ("ns", "nm", "nl", "t", "s", "m", "l"),
+        "detect",
+        "experimental",
+    )
+    add_many("rtmdet", "LibreRTMDet", ("t", "s", "m", "l", "x"), "detect", "experimental")
+    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "detect", "experimental")
+    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "segment", "experimental")
+    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "pose", "experimental")
+    return cases
+
+
+DEFAULT_CASES = tuple(build_default_cases())
+
+
+def metric_keys_for_task(task: str) -> tuple[str, ...]:
+    if task == "segment":
+        return SEGMENT_KEYS
+    if task == "pose":
+        return POSE_KEYS
+    return DETECT_KEYS
+
+
+def extract_metrics(metrics: dict[str, Any], task: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for key in metric_keys_for_task(task):
+        value = metrics.get(key)
+        if value is None:
+            continue
+        try:
+            out[key] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def compare_metrics(
+    pytorch: dict[str, float],
+    onnx: dict[str, float],
+    task: str,
+    *,
+    abs_tolerance: float,
+    rel_tolerance: float,
+) -> list[MetricComparison]:
+    comparisons: list[MetricComparison] = []
+    for key in metric_keys_for_task(task):
+        pt_value = pytorch.get(key)
+        onnx_value = onnx.get(key)
+        if pt_value is None or onnx_value is None:
+            comparisons.append(
+                MetricComparison(
+                    key=key,
+                    pytorch=pt_value,
+                    onnx=onnx_value,
+                    abs_delta=None,
+                    tolerance=abs_tolerance,
+                    passed=False,
+                    reason="missing metric",
+                )
+            )
+            continue
+        if not math.isfinite(pt_value) or not math.isfinite(onnx_value):
+            comparisons.append(
+                MetricComparison(
+                    key=key,
+                    pytorch=pt_value,
+                    onnx=onnx_value,
+                    abs_delta=None,
+                    tolerance=abs_tolerance,
+                    passed=False,
+                    reason="non-finite metric",
+                )
+            )
+            continue
+        delta = abs(onnx_value - pt_value)
+        tolerance = max(abs_tolerance, rel_tolerance * abs(pt_value))
+        comparisons.append(
+            MetricComparison(
+                key=key,
+                pytorch=pt_value,
+                onnx=onnx_value,
+                abs_delta=delta,
+                tolerance=tolerance,
+                passed=delta <= tolerance,
+            )
+        )
+    return comparisons
+
+
+def filter_cases(
+    cases: Iterable[ParityCase],
+    *,
+    ids: Iterable[str] | None = None,
+    families: Iterable[str] | None = None,
+    tasks: Iterable[str] | None = None,
+    claims: Iterable[str] | None = None,
+) -> list[ParityCase]:
+    ids_set = {x.strip() for x in ids or [] if x.strip()}
+    family_set = {x.strip() for x in families or [] if x.strip()}
+    task_set = {x.strip() for x in tasks or [] if x.strip()}
+    claim_set = {x.strip() for x in claims or [] if x.strip()}
+
+    selected = []
+    for case in cases:
+        if ids_set and case.id not in ids_set:
+            continue
+        if family_set and case.family not in family_set:
+            continue
+        if task_set and case.task not in task_set:
+            continue
+        if claim_set and case.onnx_claim not in claim_set:
+            continue
+        selected.append(case)
+    return selected
+
+
+def _headers(token: str | None = None) -> dict[str, str]:
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def download_hf_dataset_snapshot(
+    repo_id: str,
+    dest: Path,
+    *,
+    revision: str = "main",
+    token: str | None = None,
+) -> Path:
+    dest.mkdir(parents=True, exist_ok=True)
+    api_url = f"https://huggingface.co/api/datasets/{repo_id}/tree/{revision}?recursive=true"
+    response = requests.get(api_url, headers=_headers(token), timeout=60)
+    response.raise_for_status()
+    files = [item for item in response.json() if item.get("type") == "file"]
+
+    for item in files:
+        rel_path = str(item["path"])
+        target = dest / rel_path
+        expected_size = int(item.get("size") or 0)
+        if target.exists() and (expected_size <= 0 or target.stat().st_size == expected_size):
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        url = (
+            f"https://huggingface.co/datasets/{repo_id}/resolve/"
+            f"{quote(revision)}/{quote(rel_path)}"
+        )
+        download_headers = {}
+        if token:
+            download_headers["Authorization"] = f"Bearer {token}"
+        with requests.get(url, headers=download_headers, stream=True, timeout=60) as r:
+            r.raise_for_status()
+            with open(target, "wb") as f:
+                for chunk in r.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        f.write(chunk)
+    return dest
+
+
+def write_mini500_yaml(dataset_root: Path) -> Path:
+    annotation_path = dataset_root / MINI500_ANNOTATION
+    image_dir = dataset_root / MINI500_IMAGE_DIR
+    if not annotation_path.exists():
+        raise FileNotFoundError(f"Mini500 annotation file not found: {annotation_path}")
+    if not image_dir.is_dir():
+        raise FileNotFoundError(f"Mini500 image directory not found: {image_dir}")
+
+    yaml_path = dataset_root / "coco-val2017-mini500.yaml"
+    config = {
+        "path": str(dataset_root.resolve()),
+        "train": MINI500_IMAGE_DIR,
+        "val": MINI500_IMAGE_DIR,
+        "annotations": {"val": MINI500_ANNOTATION},
+        "nc": 80,
+        "names": COCO80_NAMES,
+    }
+    yaml_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return yaml_path
+
+
+def _download_coco_person_keypoints(dataset_root: Path) -> Path:
+    annotations_dir = dataset_root / "annotations"
+    annotations_dir.mkdir(parents=True, exist_ok=True)
+    target = dataset_root / COCO_PERSON_KEYPOINTS_MEMBER
+    if target.exists():
+        return target
+
+    zip_path = annotations_dir / "annotations_trainval2017.zip"
+    if not zip_path.exists():
+        with requests.get(COCO_ANNOTATIONS_URL, stream=True, timeout=60) as response:
+            response.raise_for_status()
+            with open(zip_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        f.write(chunk)
+
+    with zipfile.ZipFile(zip_path) as archive:
+        archive.extract(COCO_PERSON_KEYPOINTS_MEMBER, path=dataset_root)
+    return target
+
+
+def write_mini500_pose_yaml(
+    dataset_root: Path,
+    *,
+    full_keypoints_path: Path | None = None,
+) -> Path:
+    instance_path = dataset_root / MINI500_ANNOTATION
+    image_dir = dataset_root / MINI500_IMAGE_DIR
+    if not instance_path.exists():
+        raise FileNotFoundError(f"Mini500 annotation file not found: {instance_path}")
+    if not image_dir.is_dir():
+        raise FileNotFoundError(f"Mini500 image directory not found: {image_dir}")
+
+    if full_keypoints_path is None:
+        full_keypoints_path = _download_coco_person_keypoints(dataset_root)
+    if not full_keypoints_path.exists():
+        raise FileNotFoundError(
+            f"COCO person-keypoint annotation file not found: {full_keypoints_path}"
+        )
+
+    instances = json.loads(instance_path.read_text(encoding="utf-8"))
+    keypoints = json.loads(full_keypoints_path.read_text(encoding="utf-8"))
+    image_ids = {int(image["id"]) for image in instances.get("images", [])}
+    person_categories = [
+        category
+        for category in keypoints.get("categories", [])
+        if category.get("name") == "person"
+    ]
+    category = dict(person_categories[0] if person_categories else {"name": "person"})
+    category["id"] = 0
+
+    annotations = []
+    for ann in keypoints.get("annotations", []):
+        if int(ann.get("image_id", -1)) not in image_ids:
+            continue
+        item = dict(ann)
+        item["category_id"] = 0
+        annotations.append(item)
+
+    filtered = {
+        "info": keypoints.get("info", {}),
+        "licenses": keypoints.get("licenses", []),
+        "images": [
+            image
+            for image in keypoints.get("images", [])
+            if int(image.get("id", -1)) in image_ids
+        ],
+        "annotations": annotations,
+        "categories": [category],
+    }
+
+    pose_annotation = dataset_root / MINI500_POSE_ANNOTATION
+    pose_annotation.parent.mkdir(parents=True, exist_ok=True)
+    pose_annotation.write_text(
+        json.dumps(filtered, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+    yaml_path = dataset_root / "coco-val2017-mini500-pose.yaml"
+    config = {
+        "path": str(dataset_root.resolve()),
+        "train": MINI500_IMAGE_DIR,
+        "val": MINI500_IMAGE_DIR,
+        "annotations": {"val": MINI500_POSE_ANNOTATION},
+        "nc": 1,
+        "names": {0: "person"},
+        "kpt_shape": [17, 3],
+        "flip_idx": COCO_POSE_FLIP_IDX,
+    }
+    yaml_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return yaml_path
+
+
+def _dataset_root_from_yaml(data_yaml: Path) -> Path:
+    config = yaml.safe_load(data_yaml.read_text(encoding="utf-8")) or {}
+    root = config.get("path")
+    if root is None:
+        return data_yaml.parent
+    root_path = Path(root)
+    return root_path if root_path.is_absolute() else (data_yaml.parent / root_path)
+
+
+def prepare_pose_data(data_yaml: Path) -> Path:
+    config = yaml.safe_load(data_yaml.read_text(encoding="utf-8")) or {}
+    if config.get("kpt_shape"):
+        if data_yaml.name == "coco-val2017-mini500-pose.yaml":
+            return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
+        return data_yaml
+    return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
+
+
+def pose_direct_paths(data_yaml: Path) -> tuple[Path | None, Path | None]:
+    config = yaml.safe_load(data_yaml.read_text(encoding="utf-8")) or {}
+    root = _dataset_root_from_yaml(data_yaml)
+    annotations = config.get("annotations") or {}
+    annotation_rel = config.get("keypoints_json") or annotations.get("val")
+    images_rel = config.get("images_dir") or config.get("val")
+    if not annotation_rel or not images_rel:
+        return None, None
+    return root / annotation_rel, root / images_rel
+
+
+def prepare_data(args: argparse.Namespace, output_dir: Path) -> Path:
+    if args.data:
+        return Path(args.data)
+    if not args.download_mini500:
+        raise ValueError("Pass --data PATH or --download-mini500.")
+
+    dataset_root = Path(args.dataset_dir or output_dir / "datasets" / "coco-val2017-mini500")
+    download_hf_dataset_snapshot(
+        args.hf_dataset_id,
+        dataset_root,
+        revision=args.hf_revision,
+        token=args.hf_token,
+    )
+    return write_mini500_yaml(dataset_root)
+
+
+def _val_kwargs(
+    args: argparse.Namespace,
+    save_dir: Path,
+    imgsz: int | None,
+    *,
+    data_yaml: Path | None = None,
+    task: str | None = None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "data": str(data_yaml or args.data_yaml),
+        "batch": args.batch,
+        "conf": args.conf,
+        "iou": args.iou,
+        "workers": args.workers,
+        "split": args.split,
+        "augment": False,
+        "save_json": args.save_json,
+        "verbose": args.verbose,
+        "allow_download_scripts": args.allow_download_scripts,
+        "save_dir": str(save_dir),
+        "save_plots": args.save_plots,
+    }
+    if args.val_device:
+        kwargs["device"] = args.val_device
+    if imgsz is not None:
+        kwargs["imgsz"] = imgsz
+    if task == "pose" and getattr(args, "pose_keypoints_json", None):
+        kwargs["keypoints_json"] = str(args.pose_keypoints_json)
+        kwargs["images_dir"] = str(args.pose_images_dir)
+    return kwargs
+
+
+def run_case(case: ParityCase, args: argparse.Namespace, output_dir: Path) -> dict[str, Any]:
+    from libreyolo import LibreYOLO
+
+    started = time.perf_counter()
+    case_dir = output_dir / "cases" / case.id
+    case_dir.mkdir(parents=True, exist_ok=True)
+    export_dir = output_dir / "exports"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    onnx_path = export_dir / f"{case.id}.onnx"
+    imgsz = args.imgsz
+    data_yaml = args.pose_data_yaml if case.task == "pose" else args.data_yaml
+
+    record: dict[str, Any] = {
+        "case": asdict(case),
+        "status": "error",
+        "onnx_path": str(onnx_path),
+        "data": str(data_yaml),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        print(f"[{case.id}] loading PyTorch weights {case.weights}")
+        pt_model = LibreYOLO(
+            case.weights,
+            size=case.size,
+            task=case.task,
+            device=args.device,
+        )
+        if imgsz is None:
+            imgsz = int(pt_model._get_input_size())
+
+        if not args.reuse_exports or not onnx_path.exists():
+            print(f"[{case.id}] exporting ONNX -> {onnx_path}")
+            export_kwargs = {
+                "output_path": str(onnx_path),
+                "simplify": args.simplify,
+                "dynamic": args.dynamic,
+                "opset": args.opset,
+                "imgsz": imgsz,
+            }
+            pt_model.export("onnx", **export_kwargs)
+        else:
+            print(f"[{case.id}] reusing ONNX export {onnx_path}")
+
+        print(f"[{case.id}] validating PyTorch")
+        pt_metrics_raw = pt_model.val(
+            **_val_kwargs(
+                args,
+                case_dir / "pytorch",
+                imgsz,
+                data_yaml=data_yaml,
+                task=case.task,
+            )
+        )
+        pt_metrics = extract_metrics(pt_metrics_raw, case.task)
+
+        print(f"[{case.id}] validating ONNX")
+        onnx_model = LibreYOLO(str(onnx_path), task=case.task, device=args.onnx_device)
+        onnx_metrics_raw = onnx_model.val(
+            **_val_kwargs(
+                args,
+                case_dir / "onnx",
+                imgsz,
+                data_yaml=data_yaml,
+                task=case.task,
+            )
+        )
+        onnx_metrics = extract_metrics(onnx_metrics_raw, case.task)
+
+        comparisons = compare_metrics(
+            pt_metrics,
+            onnx_metrics,
+            case.task,
+            abs_tolerance=args.abs_tolerance,
+            rel_tolerance=args.rel_tolerance,
+        )
+        passed = all(item.passed for item in comparisons)
+        record.update(
+            {
+                "status": "passed" if passed else "failed",
+                "imgsz": imgsz,
+                "pytorch_metrics": pt_metrics,
+                "onnx_metrics": onnx_metrics,
+                "comparisons": [asdict(item) for item in comparisons],
+            }
+        )
+    except Exception as exc:
+        record.update(
+            {
+                "status": "error",
+                "error": str(exc),
+                "traceback": traceback.format_exc(),
+            }
+        )
+        print(f"[{case.id}] ERROR: {exc}", file=sys.stderr)
+    finally:
+        record["duration_seconds"] = round(time.perf_counter() - started, 3)
+        (case_dir / "parity.json").write_text(
+            json.dumps(record, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+    return record
+
+
+def _runtime_report_config(args: argparse.Namespace) -> dict[str, Any]:
+    providers: list[str] = []
+    try:
+        import onnxruntime as ort
+
+        providers = list(ort.get_available_providers())
+    except Exception:
+        providers = []
+
+    return {
+        "data": str(args.data_yaml),
+        "pose_data": str(getattr(args, "pose_data_yaml", "") or ""),
+        "device": args.device,
+        "onnx_device": args.onnx_device,
+        "val_device": args.val_device,
+        "batch": args.batch,
+        "workers": args.workers,
+        "split": args.split,
+        "imgsz": args.imgsz,
+        "conf": args.conf,
+        "iou": args.iou,
+        "opset": args.opset,
+        "simplify": args.simplify,
+        "dynamic": args.dynamic,
+        "abs_tolerance": args.abs_tolerance,
+        "rel_tolerance": args.rel_tolerance,
+        "onnxruntime_providers": providers,
+    }
+
+
+def write_summary(
+    records: list[dict[str, Any]],
+    output_dir: Path,
+    *,
+    run_config: dict[str, Any] | None = None,
+) -> None:
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "run_config": run_config or {},
+        "counts": {
+            "total": len(records),
+            "passed": sum(1 for r in records if r.get("status") == "passed"),
+            "failed": sum(1 for r in records if r.get("status") == "failed"),
+            "error": sum(1 for r in records if r.get("status") == "error"),
+        },
+        "records": records,
+    }
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    csv_path = output_dir / "summary.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "case",
+                "family",
+                "size",
+                "task",
+                "claim",
+                "status",
+                "metric",
+                "pytorch",
+                "onnx",
+                "abs_delta",
+                "tolerance",
+                "reason",
+                "error",
+            ],
+        )
+        writer.writeheader()
+        for record in records:
+            case = record["case"]
+            comparisons = record.get("comparisons") or []
+            if not comparisons:
+                writer.writerow(
+                    {
+                        "case": case["id"],
+                        "family": case["family"],
+                        "size": case["size"],
+                        "task": case["task"],
+                        "claim": case["onnx_claim"],
+                        "status": record.get("status"),
+                        "error": record.get("error", ""),
+                    }
+                )
+                continue
+            for comparison in comparisons:
+                writer.writerow(
+                    {
+                        "case": case["id"],
+                        "family": case["family"],
+                        "size": case["size"],
+                        "task": case["task"],
+                        "claim": case["onnx_claim"],
+                        "status": record.get("status"),
+                        "metric": comparison["key"],
+                        "pytorch": comparison["pytorch"],
+                        "onnx": comparison["onnx"],
+                        "abs_delta": comparison["abs_delta"],
+                        "tolerance": comparison["tolerance"],
+                        "reason": comparison["reason"],
+                        "error": record.get("error", ""),
+                    }
+                )
+
+    md_lines = [
+        "# LibreYOLO ONNX Export Parity",
+        "",
+        f"Generated: {summary['generated_at']}",
+        "",
+        f"Dataset: `{(run_config or {}).get('data', '')}`",
+        f"Devices: PyTorch `{(run_config or {}).get('device', '')}`, "
+        f"ONNX `{(run_config or {}).get('onnx_device', '')}`, "
+        f"validation `{(run_config or {}).get('val_device', '')}`",
+        f"Tolerances: abs `{(run_config or {}).get('abs_tolerance', '')}`, "
+        f"rel `{(run_config or {}).get('rel_tolerance', '')}`",
+        "",
+        "| Case | Task | ONNX claim | Status | Worst metric delta | Notes |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for record in records:
+        case = record["case"]
+        comparisons = record.get("comparisons") or []
+        worst = ""
+        if comparisons:
+            numeric = [c for c in comparisons if c.get("abs_delta") is not None]
+            if numeric:
+                item = max(numeric, key=lambda c: float(c["abs_delta"]))
+                worst = f"{item['key']} = {float(item['abs_delta']):.6g}"
+        notes = case.get("notes") or record.get("error", "")
+        md_lines.append(
+            "| {case} | {task} | {claim} | {status} | {worst} | {notes} |".format(
+                case=case["id"],
+                task=case["task"],
+                claim=case["onnx_claim"],
+                status=record.get("status", ""),
+                worst=worst,
+                notes=str(notes).replace("|", "\\|"),
+            )
+        )
+    (output_dir / "summary.md").write_text("\n".join(md_lines) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", default=None, help="Dataset YAML path.")
+    parser.add_argument(
+        "--download-mini500",
+        action="store_true",
+        help=f"Download {MINI500_DATASET_ID} and generate a local YAML.",
+    )
+    parser.add_argument("--dataset-dir", default=None, help="Local mini500 directory.")
+    parser.add_argument("--hf-dataset-id", default=MINI500_DATASET_ID)
+    parser.add_argument("--hf-revision", default="main")
+    parser.add_argument("--hf-token", default=None)
+    parser.add_argument("--output-dir", default="runs/onnx_parity")
+    parser.add_argument("--case", dest="cases", nargs="*", default=None)
+    parser.add_argument("--families", nargs="*", default=None)
+    parser.add_argument("--tasks", nargs="*", choices=["detect", "segment", "pose"], default=None)
+    parser.add_argument("--claims", nargs="*", choices=["complete", "experimental"], default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--list-cases", action="store_true")
+    parser.add_argument("--device", default="auto", help="Device for PyTorch model load.")
+    parser.add_argument("--onnx-device", default="cpu", help="Device for ONNX Runtime backend.")
+    parser.add_argument("--val-device", default=None, help="Validation dataloader device override.")
+    parser.add_argument("--batch", type=int, default=16)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--split", default="val", choices=["val", "test"])
+    parser.add_argument("--imgsz", type=int, default=None)
+    parser.add_argument("--conf", type=float, default=0.001)
+    parser.add_argument("--iou", type=float, default=0.6)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--simplify", action="store_true")
+    parser.add_argument("--dynamic", action="store_true")
+    parser.add_argument("--reuse-exports", action="store_true")
+    parser.add_argument("--save-json", action="store_true")
+    parser.add_argument("--save-plots", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--allow-download-scripts", action="store_true")
+    parser.add_argument("--abs-tolerance", type=float, default=1e-4)
+    parser.add_argument("--rel-tolerance", type=float, default=1e-3)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    cases = filter_cases(
+        DEFAULT_CASES,
+        ids=args.cases,
+        families=args.families,
+        tasks=args.tasks,
+        claims=args.claims,
+    )
+    if args.limit is not None:
+        cases = cases[: args.limit]
+
+    if args.list_cases:
+        for case in cases:
+            print(
+                f"{case.id:24s} {case.task:8s} {case.onnx_claim:12s} "
+                f"{case.weights} {case.notes}"
+            )
+        return 0
+
+    if not cases:
+        print("No parity cases selected.", file=sys.stderr)
+        return 2
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    args.data_yaml = prepare_data(args, output_dir)
+    args.pose_data_yaml = (
+        prepare_pose_data(args.data_yaml)
+        if any(case.task == "pose" for case in cases)
+        else args.data_yaml
+    )
+    if any(case.task == "pose" for case in cases):
+        args.pose_keypoints_json, args.pose_images_dir = pose_direct_paths(
+            args.pose_data_yaml
+        )
+    else:
+        args.pose_keypoints_json = None
+        args.pose_images_dir = None
+    print(f"Using dataset YAML: {args.data_yaml}")
+    if any(case.task == "pose" for case in cases):
+        print(f"Using pose dataset YAML: {args.pose_data_yaml}")
+    print(f"Selected {len(cases)} parity cases")
+
+    records = [run_case(case, args, output_dir) for case in cases]
+    write_summary(records, output_dir, run_config=_runtime_report_config(args))
+    failing = [r for r in records if r.get("status") != "passed"]
+    print(f"Wrote parity report to {output_dir}")
+    return 1 if failing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -593,6 +593,22 @@ def write_mini500_yaml(dataset_root: Path) -> Path:
     return yaml_path
 
 
+def _download_atomic(url: str, target: Path) -> None:
+    tmp_path = target.with_name(f"{target.name}.tmp")
+    tmp_path.unlink(missing_ok=True)
+    try:
+        with requests.get(url, stream=True, timeout=60) as response:
+            response.raise_for_status()
+            with open(tmp_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        f.write(chunk)
+        tmp_path.replace(target)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def _download_coco_person_keypoints(dataset_root: Path) -> Path:
     annotations_dir = dataset_root / "annotations"
     annotations_dir.mkdir(parents=True, exist_ok=True)
@@ -601,16 +617,17 @@ def _download_coco_person_keypoints(dataset_root: Path) -> Path:
         return target
 
     zip_path = annotations_dir / "annotations_trainval2017.zip"
-    if not zip_path.exists():
-        with requests.get(COCO_ANNOTATIONS_URL, stream=True, timeout=60) as response:
-            response.raise_for_status()
-            with open(zip_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=1024 * 1024):
-                    if chunk:
-                        f.write(chunk)
-
-    with zipfile.ZipFile(zip_path) as archive:
-        archive.extract(COCO_PERSON_KEYPOINTS_MEMBER, path=dataset_root)
+    for attempt in range(2):
+        if not zip_path.exists():
+            _download_atomic(COCO_ANNOTATIONS_URL, zip_path)
+        try:
+            with zipfile.ZipFile(zip_path) as archive:
+                archive.extract(COCO_PERSON_KEYPOINTS_MEMBER, path=dataset_root)
+            break
+        except zipfile.BadZipFile:
+            zip_path.unlink(missing_ok=True)
+            if attempt == 1:
+                raise
     return target
 
 

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -732,6 +732,18 @@ def _looks_like_pose_annotation(value: Any) -> bool:
     return "keypoints" in str(value).lower()
 
 
+def _is_coco_keypoints_annotation_file(path: Path) -> bool:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    categories = data.get("categories") or []
+    if any(cat.get("keypoints") for cat in categories):
+        return True
+    annotations = data.get("annotations") or []
+    return any("keypoints" in ann and "num_keypoints" in ann for ann in annotations)
+
+
 def _has_pose_annotation_config(config: dict[str, Any]) -> bool:
     if config.get("keypoints_json"):
         return True
@@ -768,7 +780,13 @@ def pose_direct_paths(
     images_rel = config.get("images_dir") or config.get(split)
     if not annotation_rel or not images_rel:
         return None, None
-    return _resolve_yaml_path(root, annotation_rel), _resolve_yaml_path(root, images_rel)
+    annotation_path = _resolve_yaml_path(root, annotation_rel)
+    if annotation_path.exists():
+        if not _is_coco_keypoints_annotation_file(annotation_path):
+            return None, None
+    elif not _looks_like_pose_annotation(annotation_rel):
+        return None, None
+    return annotation_path, _resolve_yaml_path(root, images_rel)
 
 
 def prepare_data(args: argparse.Namespace, output_dir: Path) -> Path:

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -183,6 +183,41 @@ class MetricComparison:
     reason: str = ""
 
 
+def _checkpoint_unavailable_reason(exc: BaseException) -> str | None:
+    """Return a reportable reason when a parity case lacks usable weights."""
+    messages: list[str] = []
+    current: BaseException | None = exc
+    while current is not None:
+        message = str(current)
+        if message:
+            messages.append(message)
+        current = current.__cause__ or current.__context__
+
+    text = "\n".join(messages).lower()
+    if isinstance(exc, FileNotFoundError):
+        return str(exc)
+    if "model weights file not found" in text:
+        return str(exc)
+    if "pretrained weights are not available" in text:
+        return str(exc)
+    if "could not determine download url" in text:
+        return str(exc)
+    if "failed to download weights" in text and any(
+        marker in text
+        for marker in (
+            "401 client error",
+            "403 client error",
+            "404 client error",
+            "410 client error",
+            "no such bucket",
+            "repo not found",
+            "repository not found",
+        )
+    ):
+        return str(exc)
+    return None
+
+
 def _weights(prefix: str, size: str, task: str) -> str:
     return f"{prefix}{size}{TASK_SUFFIX[task]}.pt"
 
@@ -742,14 +777,25 @@ def run_case(case: ParityCase, args: argparse.Namespace, output_dir: Path) -> di
             }
         )
     except Exception as exc:
-        record.update(
-            {
-                "status": "error",
-                "error": str(exc),
-                "traceback": traceback.format_exc(),
-            }
-        )
-        print(f"[{case.id}] ERROR: {exc}", file=sys.stderr)
+        unavailable_reason = _checkpoint_unavailable_reason(exc)
+        if unavailable_reason is not None:
+            record.update(
+                {
+                    "status": "unavailable",
+                    "error": str(exc),
+                    "unavailable_reason": unavailable_reason,
+                }
+            )
+            print(f"[{case.id}] UNAVAILABLE: {exc}", file=sys.stderr)
+        else:
+            record.update(
+                {
+                    "status": "error",
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                }
+            )
+            print(f"[{case.id}] ERROR: {exc}", file=sys.stderr)
     finally:
         record["duration_seconds"] = round(time.perf_counter() - started, 3)
         (case_dir / "parity.json").write_text(
@@ -803,6 +849,9 @@ def write_summary(
             "passed": sum(1 for r in records if r.get("status") == "passed"),
             "failed": sum(1 for r in records if r.get("status") == "failed"),
             "error": sum(1 for r in records if r.get("status") == "error"),
+            "unavailable": sum(
+                1 for r in records if r.get("status") == "unavailable"
+            ),
         },
         "records": records,
     }
@@ -878,6 +927,8 @@ def write_summary(
         f"validation `{(run_config or {}).get('val_device', '')}`",
         f"Tolerances: abs `{(run_config or {}).get('abs_tolerance', '')}`, "
         f"rel `{(run_config or {}).get('rel_tolerance', '')}`",
+        "Counts: passed `{passed}`, failed `{failed}`, error `{error}`, "
+        "unavailable `{unavailable}`".format(**summary["counts"]),
         "",
         "| Case | Task | ONNX claim | Status | Worst metric delta | Notes |",
         "|---|---:|---:|---:|---:|---|",
@@ -891,7 +942,14 @@ def write_summary(
             if numeric:
                 item = max(numeric, key=lambda c: float(c["abs_delta"]))
                 worst = f"{item['key']} = {float(item['abs_delta']):.6g}"
-        notes = case.get("notes") or record.get("error", "")
+        if record.get("status") == "unavailable":
+            notes = (
+                record.get("unavailable_reason")
+                or record.get("error", "")
+                or case.get("notes", "")
+            )
+        else:
+            notes = case.get("notes") or record.get("error", "")
         md_lines.append(
             "| {case} | {task} | {claim} | {status} | {worst} | {notes} |".format(
                 case=case["id"],
@@ -941,6 +999,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--save-plots", action="store_true")
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--allow-download-scripts", action="store_true")
+    parser.add_argument(
+        "--fail-on-unavailable",
+        action="store_true",
+        help="Return a nonzero exit code when selected checkpoint weights are unavailable.",
+    )
     parser.add_argument("--abs-tolerance", type=float, default=1e-4)
     parser.add_argument("--rel-tolerance", type=float, default=1e-3)
     return parser.parse_args(argv)
@@ -992,7 +1055,12 @@ def main(argv: list[str] | None = None) -> int:
 
     records = [run_case(case, args, output_dir) for case in cases]
     write_summary(records, output_dir, run_config=_runtime_report_config(args))
-    failing = [r for r in records if r.get("status") != "passed"]
+    failing = [
+        r
+        for r in records
+        if r.get("status") in {"failed", "error"}
+        or (args.fail_on_unavailable and r.get("status") == "unavailable")
+    ]
     print(f"Wrote parity report to {output_dir}")
     return 1 if failing else 0
 

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -26,7 +26,7 @@ import traceback
 import zipfile
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 from urllib.parse import quote
 
@@ -42,7 +42,7 @@ MINI500_DATASET_ID = "LibreYOLO/coco-val2017-mini500"
 MINI500_ANNOTATION = "annotations/instances_val2017_mini500.json"
 MINI500_POSE_ANNOTATION = "annotations/person_keypoints_val2017_mini500.json"
 MINI500_IMAGE_DIR = "images/val2017"
-COCO_ANNOTATIONS_URL = "http://images.cocodataset.org/annotations/annotations_trainval2017.zip"
+COCO_ANNOTATIONS_URL = "https://images.cocodataset.org/annotations/annotations_trainval2017.zip"
 COCO_PERSON_KEYPOINTS_MEMBER = "annotations/person_keypoints_val2017.json"
 COCO_POSE_FLIP_IDX = [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
 
@@ -519,6 +519,23 @@ def _headers(token: str | None = None) -> dict[str, str]:
     return headers
 
 
+def _safe_hf_dataset_path(raw_path: str, dest: Path) -> tuple[PurePosixPath, Path]:
+    raw = str(raw_path)
+    if "\\" in raw or "\x00" in raw:
+        raise ValueError(f"Unsafe Hugging Face dataset path: {raw_path!r}")
+    rel = PurePosixPath(raw)
+    if rel.is_absolute() or any(part in {"..", ""} or ":" in part for part in rel.parts):
+        raise ValueError(f"Unsafe Hugging Face dataset path: {raw_path!r}")
+
+    dest_root = dest.resolve()
+    target = dest_root.joinpath(*rel.parts)
+    try:
+        target.resolve().relative_to(dest_root)
+    except ValueError as exc:
+        raise ValueError(f"Unsafe Hugging Face dataset path: {raw_path!r}") from exc
+    return rel, target
+
+
 def download_hf_dataset_snapshot(
     repo_id: str,
     dest: Path,
@@ -533,8 +550,7 @@ def download_hf_dataset_snapshot(
     files = [item for item in response.json() if item.get("type") == "file"]
 
     for item in files:
-        rel_path = str(item["path"])
-        target = dest / rel_path
+        rel_path, target = _safe_hf_dataset_path(str(item["path"]), dest)
         expected_size = int(item.get("size") or 0)
         if target.exists() and (expected_size <= 0 or target.stat().st_size == expected_size):
             continue
@@ -542,7 +558,7 @@ def download_hf_dataset_snapshot(
         target.parent.mkdir(parents=True, exist_ok=True)
         url = (
             f"https://huggingface.co/datasets/{repo_id}/resolve/"
-            f"{quote(revision)}/{quote(rel_path)}"
+            f"{quote(revision)}/{quote(str(rel_path))}"
         )
         download_headers = {}
         if token:

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -552,7 +552,7 @@ def download_hf_dataset_snapshot(
     for item in files:
         rel_path, target = _safe_hf_dataset_path(str(item["path"]), dest)
         expected_size = int(item.get("size") or 0)
-        if target.exists() and (expected_size <= 0 or target.stat().st_size == expected_size):
+        if target.exists() and expected_size > 0 and target.stat().st_size == expected_size:
             continue
 
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -563,12 +563,13 @@ def download_hf_dataset_snapshot(
         download_headers = {}
         if token:
             download_headers["Authorization"] = f"Bearer {token}"
-        with requests.get(url, headers=download_headers, stream=True, timeout=60) as r:
-            r.raise_for_status()
-            with open(target, "wb") as f:
-                for chunk in r.iter_content(chunk_size=1024 * 1024):
-                    if chunk:
-                        f.write(chunk)
+        _download_atomic(url, target, headers=download_headers)
+        actual_size = target.stat().st_size
+        if expected_size > 0 and actual_size != expected_size:
+            target.unlink(missing_ok=True)
+            raise IOError(
+                f"Downloaded {target} has size {actual_size}, expected {expected_size}."
+            )
     return dest
 
 
@@ -593,11 +594,21 @@ def write_mini500_yaml(dataset_root: Path) -> Path:
     return yaml_path
 
 
-def _download_atomic(url: str, target: Path) -> None:
+def _download_atomic(
+    url: str,
+    target: Path,
+    *,
+    headers: dict[str, str] | None = None,
+) -> None:
     tmp_path = target.with_name(f"{target.name}.tmp")
     tmp_path.unlink(missing_ok=True)
     try:
-        with requests.get(url, stream=True, timeout=60) as response:
+        with requests.get(
+            url,
+            headers=headers or {},
+            stream=True,
+            timeout=60,
+        ) as response:
             response.raise_for_status()
             with open(tmp_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=1024 * 1024):
@@ -712,24 +723,52 @@ def _dataset_root_from_yaml(data_yaml: Path) -> Path:
     return root_path if root_path.is_absolute() else (data_yaml.parent / root_path)
 
 
+def _resolve_yaml_path(root: Path, value: Any) -> Path:
+    path = Path(str(value))
+    return path if path.is_absolute() else root / path
+
+
+def _looks_like_pose_annotation(value: Any) -> bool:
+    return "keypoints" in str(value).lower()
+
+
+def _has_pose_annotation_config(config: dict[str, Any]) -> bool:
+    if config.get("keypoints_json"):
+        return True
+    annotations = config.get("annotations") or {}
+    if isinstance(annotations, dict):
+        return any(_looks_like_pose_annotation(value) for value in annotations.values())
+    return _looks_like_pose_annotation(annotations)
+
+
 def prepare_pose_data(data_yaml: Path) -> Path:
     config = yaml.safe_load(data_yaml.read_text(encoding="utf-8")) or {}
     if config.get("kpt_shape"):
         if data_yaml.name == "coco-val2017-mini500-pose.yaml":
             return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
         return data_yaml
+    if _has_pose_annotation_config(config):
+        return data_yaml
     return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
 
 
-def pose_direct_paths(data_yaml: Path) -> tuple[Path | None, Path | None]:
+def pose_direct_paths(
+    data_yaml: Path,
+    *,
+    split: str = "val",
+) -> tuple[Path | None, Path | None]:
     config = yaml.safe_load(data_yaml.read_text(encoding="utf-8")) or {}
     root = _dataset_root_from_yaml(data_yaml)
     annotations = config.get("annotations") or {}
-    annotation_rel = config.get("keypoints_json") or annotations.get("val")
-    images_rel = config.get("images_dir") or config.get("val")
+    annotation_rel = config.get("keypoints_json")
+    if annotation_rel is None:
+        annotation_rel = (
+            annotations.get(split) if isinstance(annotations, dict) else annotations
+        )
+    images_rel = config.get("images_dir") or config.get(split)
     if not annotation_rel or not images_rel:
         return None, None
-    return root / annotation_rel, root / images_rel
+    return _resolve_yaml_path(root, annotation_rel), _resolve_yaml_path(root, images_rel)
 
 
 def prepare_data(args: argparse.Namespace, output_dir: Path) -> Path:
@@ -1131,7 +1170,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     if any(case.task == "pose" for case in cases):
         args.pose_keypoints_json, args.pose_images_dir = pose_direct_paths(
-            args.pose_data_yaml
+            args.pose_data_yaml,
+            split=args.split,
         )
     else:
         args.pose_keypoints_json = None

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -744,13 +744,32 @@ def _is_coco_keypoints_annotation_file(path: Path) -> bool:
     return any("keypoints" in ann and "num_keypoints" in ann for ann in annotations)
 
 
-def _has_pose_annotation_config(config: dict[str, Any]) -> bool:
+def _annotation_config_values(config: dict[str, Any]) -> list[Any]:
+    values: list[Any] = []
     if config.get("keypoints_json"):
-        return True
+        values.append(config["keypoints_json"])
     annotations = config.get("annotations") or {}
     if isinstance(annotations, dict):
-        return any(_looks_like_pose_annotation(value) for value in annotations.values())
-    return _looks_like_pose_annotation(annotations)
+        values.extend(annotations.values())
+    elif annotations:
+        values.append(annotations)
+    return values
+
+
+def _has_pose_annotation_config(config: dict[str, Any], root: Path | None = None) -> bool:
+    for value in _annotation_config_values(config):
+        if not value:
+            continue
+        if root is not None:
+            annotation_path = _resolve_yaml_path(root, value)
+            if annotation_path.exists():
+                if _is_coco_keypoints_annotation_file(annotation_path):
+                    return True
+                continue
+            continue
+        if _looks_like_pose_annotation(value):
+            return True
+    return False
 
 
 def prepare_pose_data(data_yaml: Path) -> Path:
@@ -759,7 +778,7 @@ def prepare_pose_data(data_yaml: Path) -> Path:
         if data_yaml.name == "coco-val2017-mini500-pose.yaml":
             return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
         return data_yaml
-    if _has_pose_annotation_config(config):
+    if _has_pose_annotation_config(config, _dataset_root_from_yaml(data_yaml)):
         return data_yaml
     return write_mini500_pose_yaml(_dataset_root_from_yaml(data_yaml))
 

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -218,6 +218,29 @@ def _checkpoint_unavailable_reason(exc: BaseException) -> str | None:
     return None
 
 
+def _ensure_case_weights_available(
+    case: ParityCase,
+    *,
+    resolve_weights_path=None,
+    downloader=None,
+) -> None:
+    """Download missing checkpoint weights before model construction.
+
+    The LibreYOLO factory logs auto-download failures and then raises a generic
+    missing-file error. Preflight keeps the original HTTP/download exception
+    attached to the parity record, which matters for unavailable checkpoints.
+    """
+    if resolve_weights_path is None:
+        from libreyolo.models import _resolve_weights_path as resolve_weights_path
+    if downloader is None:
+        from libreyolo.utils.download import download_weights as downloader
+
+    weights_path = Path(resolve_weights_path(case.weights))
+    if weights_path.exists():
+        return
+    downloader(str(weights_path), case.size)
+
+
 def _weights(prefix: str, size: str, task: str) -> str:
     return f"{prefix}{size}{TASK_SUFFIX[task]}.pt"
 
@@ -712,6 +735,7 @@ def run_case(case: ParityCase, args: argparse.Namespace, output_dir: Path) -> di
     }
     try:
         print(f"[{case.id}] loading PyTorch weights {case.weights}")
+        _ensure_case_weights_available(case)
         pt_model = LibreYOLO(
             case.weights,
             size=case.size,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded pose and segmentation support across more model families, including richer keypoint and mask parsing.
  * Pose validation can now generate COCO-style keypoints from YAML dataset configs when annotation JSONs are not provided.
  * Added an ONNX vs PyTorch parity runner CLI with task-aware metric comparisons and reporting.

* **Improvements**
  * Improved pose/segmentation export output wiring and ONNX metadata to better preserve keypoint shapes and schemas.
  * Enhanced backend postprocessing for more accurate candidate selection, scaling, and suppression behaviors.

* **Tests**
  * Added extensive unit coverage for pose/segmentation backends and ONNX roundtrip/export scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->