### PR TITLE
Add Depth Anything V2 as the LibreDepthAnythingV2 depth family

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -180,6 +180,32 @@ Used for: ResNet_vd pretrained classification backbones loaded by
           ResNet{18,34,50,101}_vd weights that originate here).
 
 --------------------------------------------------------------------
+Depth Anything V2 (DepthAnything / TikTok)
+--------------------------------------------------------------------
+Source: https://github.com/DepthAnything/Depth-Anything-V2
+License: Apache License 2.0
+Copyright (c) 2024 Depth Anything V2 authors.
+Citation: Yang, L., Kang, B., Huang, Z., Zhao, Z., Xu, X., Feng, J.,
+          and Zhao, H. "Depth Anything V2." NeurIPS 2024.
+Used for: Depth Anything V2 model family (DINOv2 encoder + DPT head)
+          vendored under libreyolo/models/depth_anything/_vendor/
+          (dinov2, dinov2_layers, dpt, util/{blocks,transform}). Bundled
+          verbatim except for added package __init__.py files. The
+          LibreYOLO-side wrapper (libreyolo/models/depth_anything/
+          {model,nn,utils}.py) adds internal ImageNet normalization and
+          the depth-task contract; it does not modify the vendored code.
+
+NOTE - code vs. weights: The Apache-2.0 license covers the Depth
+Anything V2 *source code* vendored above. It does NOT cover the
+pretrained weights, which are split: the Small (ViT-S) checkpoint is
+Apache-2.0, while Base/Large/Giant (ViT-B/L/G) are CC-BY-NC-4.0
+(non-commercial). LibreYOLO therefore does NOT bundle, mirror, or
+auto-download Depth Anything V2 weights. Users obtain official
+checkpoints upstream, convert them with
+weights/convert_depth_anything_v2_weights.py, and are responsible for
+complying with each checkpoint's license.
+
+--------------------------------------------------------------------
 Apache License 2.0 (full text)
 --------------------------------------------------------------------
 The full text of the Apache License, Version 2.0 is available at

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -156,6 +156,7 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 | `ec`     | `("detect", "pose", "segment")`     | detect | all three tasks |
 | `l2cs`      | `("gaze",)`                         | gaze   | inference-only; two-stage (face detector + gaze head); not trainable in LibreYOLO |
 | `fomo`      | `("point",)`                        | point  | point-only localizer model |
+| `depth_anything` | `("depth",)`                   | depth  | Depth Anything V2 (DINOv2 + DPT); sizes `s`/`b`/`l`/`g` all at 518; predict + zero-shot `val`; not trainable in LibreYOLO |
 
 Families that override `SUPPORTED_TASKS` also declare `TASK_INPUT_SIZES` so
 each task can use a different per-size input resolution (relevant for RF-DETR).
@@ -215,6 +216,12 @@ LibreRFDETRn-depth.pt      # depth
 LibreECs.pt             # detect (default)
 LibreECs-pose.pt        # pose
 LibreECs-seg.pt         # segment
+
+# depth_anything — Depth Anything V2 (depth-only)
+LibreDepthAnythingV2s-depth.pt   # ViT-S (Apache-2.0 weights)
+LibreDepthAnythingV2b-depth.pt   # ViT-B (CC-BY-NC-4.0 weights)
+LibreDepthAnythingV2l-depth.pt   # ViT-L (CC-BY-NC-4.0 weights)
+LibreDepthAnythingV2g-depth.pt   # ViT-G (CC-BY-NC-4.0 weights)
 ```
 
 ### Gaze (inference-only)

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -21,6 +21,7 @@ from .models import (
     LibreRTMDet,
     LibreL2CS,
     LibreFOMO,
+    LibreDepthAnythingV2,
 )
 from .utils.results import (
     Results,
@@ -137,6 +138,7 @@ __all__ = [
     "LibreRTMDet",
     "LibreL2CS",
     "LibreFOMO",
+    "LibreDepthAnythingV2",
     # VLM-as-detector tier (optional, requires libreyolo[vlm])
     "LibreVLM",
     "LibreLFM2VL",

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -59,6 +59,9 @@ from .rtdetrv2.model import LibreRTDETRv2  # noqa: E402
 from .rtmdet.model import LibreRTMDet  # noqa: E402
 from .l2cs.model import LibreL2CS  # noqa: E402,F401  (import registers family)
 from .fomo.model import LibreFOMO  # noqa: E402,F401  (import registers family)
+from .depth_anything.model import (  # noqa: E402,F401  (import registers family)
+    LibreDepthAnythingV2,
+)
 
 
 def _ensure_rfdetr():
@@ -603,5 +606,6 @@ __all__ = [
     "LibreRTDETRv2",
     "LibreRTDETRv4",
     "LibreFOMO",
+    "LibreDepthAnythingV2",
     "try_ensure_rfdetr",
 ]

--- a/libreyolo/models/depth_anything/__init__.py
+++ b/libreyolo/models/depth_anything/__init__.py
@@ -1,0 +1,5 @@
+"""Depth Anything V2 monocular-depth family for LibreYOLO."""
+
+from .model import LibreDepthAnythingV2
+
+__all__ = ["LibreDepthAnythingV2"]

--- a/libreyolo/models/depth_anything/_vendor/__init__.py
+++ b/libreyolo/models/depth_anything/_vendor/__init__.py
@@ -1,0 +1,10 @@
+"""Vendored Depth Anything V2 modules (Apache-2.0).
+
+Source: https://github.com/DepthAnything/Depth-Anything-V2 (``depth_anything_v2/``).
+Copyright (c) 2024 Depth Anything V2 authors. Licensed under Apache-2.0.
+
+Bundled verbatim except for the package ``__init__.py`` files added so the
+relative imports resolve inside LibreYOLO. LibreYOLO-side normalization and the
+depth-task wrapper live in the parent package (``nn.py`` / ``model.py``), not
+here. See ``THIRD_PARTY_NOTICES.txt`` at the repository root.
+"""

--- a/libreyolo/models/depth_anything/_vendor/dinov2.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2.py
@@ -1,0 +1,415 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+
+# References:
+#   https://github.com/facebookresearch/dino/blob/main/vision_transformer.py
+#   https://github.com/rwightman/pytorch-image-models/tree/master/timm/models/vision_transformer.py
+
+from functools import partial
+import math
+import logging
+from typing import Sequence, Tuple, Union, Callable
+
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint
+from torch.nn.init import trunc_normal_
+
+from .dinov2_layers import Mlp, PatchEmbed, SwiGLUFFNFused, MemEffAttention, NestedTensorBlock as Block
+
+
+logger = logging.getLogger("dinov2")
+
+
+def named_apply(fn: Callable, module: nn.Module, name="", depth_first=True, include_root=False) -> nn.Module:
+    if not depth_first and include_root:
+        fn(module=module, name=name)
+    for child_name, child_module in module.named_children():
+        child_name = ".".join((name, child_name)) if name else child_name
+        named_apply(fn=fn, module=child_module, name=child_name, depth_first=depth_first, include_root=True)
+    if depth_first and include_root:
+        fn(module=module, name=name)
+    return module
+
+
+class BlockChunk(nn.ModuleList):
+    def forward(self, x):
+        for b in self:
+            x = b(x)
+        return x
+
+
+class DinoVisionTransformer(nn.Module):
+    def __init__(
+        self,
+        img_size=224,
+        patch_size=16,
+        in_chans=3,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        mlp_ratio=4.0,
+        qkv_bias=True,
+        ffn_bias=True,
+        proj_bias=True,
+        drop_path_rate=0.0,
+        drop_path_uniform=False,
+        init_values=None,  # for layerscale: None or 0 => no layerscale
+        embed_layer=PatchEmbed,
+        act_layer=nn.GELU,
+        block_fn=Block,
+        ffn_layer="mlp",
+        block_chunks=1,
+        num_register_tokens=0,
+        interpolate_antialias=False,
+        interpolate_offset=0.1,
+    ):
+        """
+        Args:
+            img_size (int, tuple): input image size
+            patch_size (int, tuple): patch size
+            in_chans (int): number of input channels
+            embed_dim (int): embedding dimension
+            depth (int): depth of transformer
+            num_heads (int): number of attention heads
+            mlp_ratio (int): ratio of mlp hidden dim to embedding dim
+            qkv_bias (bool): enable bias for qkv if True
+            proj_bias (bool): enable bias for proj in attn if True
+            ffn_bias (bool): enable bias for ffn if True
+            drop_path_rate (float): stochastic depth rate
+            drop_path_uniform (bool): apply uniform drop rate across blocks
+            weight_init (str): weight init scheme
+            init_values (float): layer-scale init values
+            embed_layer (nn.Module): patch embedding layer
+            act_layer (nn.Module): MLP activation layer
+            block_fn (nn.Module): transformer block class
+            ffn_layer (str): "mlp", "swiglu", "swiglufused" or "identity"
+            block_chunks: (int) split block sequence into block_chunks units for FSDP wrap
+            num_register_tokens: (int) number of extra cls tokens (so-called "registers")
+            interpolate_antialias: (str) flag to apply anti-aliasing when interpolating positional embeddings
+            interpolate_offset: (float) work-around offset to apply when interpolating positional embeddings
+        """
+        super().__init__()
+        norm_layer = partial(nn.LayerNorm, eps=1e-6)
+
+        self.num_features = self.embed_dim = embed_dim  # num_features for consistency with other models
+        self.num_tokens = 1
+        self.n_blocks = depth
+        self.num_heads = num_heads
+        self.patch_size = patch_size
+        self.num_register_tokens = num_register_tokens
+        self.interpolate_antialias = interpolate_antialias
+        self.interpolate_offset = interpolate_offset
+
+        self.patch_embed = embed_layer(img_size=img_size, patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim)
+        num_patches = self.patch_embed.num_patches
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + self.num_tokens, embed_dim))
+        assert num_register_tokens >= 0
+        self.register_tokens = (
+            nn.Parameter(torch.zeros(1, num_register_tokens, embed_dim)) if num_register_tokens else None
+        )
+
+        if drop_path_uniform is True:
+            dpr = [drop_path_rate] * depth
+        else:
+            dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
+
+        if ffn_layer == "mlp":
+            logger.info("using MLP layer as FFN")
+            ffn_layer = Mlp
+        elif ffn_layer == "swiglufused" or ffn_layer == "swiglu":
+            logger.info("using SwiGLU layer as FFN")
+            ffn_layer = SwiGLUFFNFused
+        elif ffn_layer == "identity":
+            logger.info("using Identity layer as FFN")
+
+            def f(*args, **kwargs):
+                return nn.Identity()
+
+            ffn_layer = f
+        else:
+            raise NotImplementedError
+
+        blocks_list = [
+            block_fn(
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                proj_bias=proj_bias,
+                ffn_bias=ffn_bias,
+                drop_path=dpr[i],
+                norm_layer=norm_layer,
+                act_layer=act_layer,
+                ffn_layer=ffn_layer,
+                init_values=init_values,
+            )
+            for i in range(depth)
+        ]
+        if block_chunks > 0:
+            self.chunked_blocks = True
+            chunked_blocks = []
+            chunksize = depth // block_chunks
+            for i in range(0, depth, chunksize):
+                # this is to keep the block index consistent if we chunk the block list
+                chunked_blocks.append([nn.Identity()] * i + blocks_list[i : i + chunksize])
+            self.blocks = nn.ModuleList([BlockChunk(p) for p in chunked_blocks])
+        else:
+            self.chunked_blocks = False
+            self.blocks = nn.ModuleList(blocks_list)
+
+        self.norm = norm_layer(embed_dim)
+        self.head = nn.Identity()
+
+        self.mask_token = nn.Parameter(torch.zeros(1, embed_dim))
+
+        self.init_weights()
+
+    def init_weights(self):
+        trunc_normal_(self.pos_embed, std=0.02)
+        nn.init.normal_(self.cls_token, std=1e-6)
+        if self.register_tokens is not None:
+            nn.init.normal_(self.register_tokens, std=1e-6)
+        named_apply(init_weights_vit_timm, self)
+
+    def interpolate_pos_encoding(self, x, w, h):
+        previous_dtype = x.dtype
+        npatch = x.shape[1] - 1
+        N = self.pos_embed.shape[1] - 1
+        if npatch == N and w == h:
+            return self.pos_embed
+        pos_embed = self.pos_embed.float()
+        class_pos_embed = pos_embed[:, 0]
+        patch_pos_embed = pos_embed[:, 1:]
+        dim = x.shape[-1]
+        w0 = w // self.patch_size
+        h0 = h // self.patch_size
+        # we add a small number to avoid floating point error in the interpolation
+        # see discussion at https://github.com/facebookresearch/dino/issues/8
+        # DINOv2 with register modify the interpolate_offset from 0.1 to 0.0
+        w0, h0 = w0 + self.interpolate_offset, h0 + self.interpolate_offset
+        # w0, h0 = w0 + 0.1, h0 + 0.1
+        
+        sqrt_N = math.sqrt(N)
+        sx, sy = float(w0) / sqrt_N, float(h0) / sqrt_N
+        patch_pos_embed = nn.functional.interpolate(
+            patch_pos_embed.reshape(1, int(sqrt_N), int(sqrt_N), dim).permute(0, 3, 1, 2),
+            scale_factor=(sx, sy),
+            # (int(w0), int(h0)), # to solve the upsampling shape issue
+            mode="bicubic",
+            antialias=self.interpolate_antialias
+        )
+        
+        assert int(w0) == patch_pos_embed.shape[-2]
+        assert int(h0) == patch_pos_embed.shape[-1]
+        patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
+        return torch.cat((class_pos_embed.unsqueeze(0), patch_pos_embed), dim=1).to(previous_dtype)
+
+    def prepare_tokens_with_masks(self, x, masks=None):
+        B, nc, w, h = x.shape
+        x = self.patch_embed(x)
+        if masks is not None:
+            x = torch.where(masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x)
+
+        x = torch.cat((self.cls_token.expand(x.shape[0], -1, -1), x), dim=1)
+        x = x + self.interpolate_pos_encoding(x, w, h)
+
+        if self.register_tokens is not None:
+            x = torch.cat(
+                (
+                    x[:, :1],
+                    self.register_tokens.expand(x.shape[0], -1, -1),
+                    x[:, 1:],
+                ),
+                dim=1,
+            )
+
+        return x
+
+    def forward_features_list(self, x_list, masks_list):
+        x = [self.prepare_tokens_with_masks(x, masks) for x, masks in zip(x_list, masks_list)]
+        for blk in self.blocks:
+            x = blk(x)
+
+        all_x = x
+        output = []
+        for x, masks in zip(all_x, masks_list):
+            x_norm = self.norm(x)
+            output.append(
+                {
+                    "x_norm_clstoken": x_norm[:, 0],
+                    "x_norm_regtokens": x_norm[:, 1 : self.num_register_tokens + 1],
+                    "x_norm_patchtokens": x_norm[:, self.num_register_tokens + 1 :],
+                    "x_prenorm": x,
+                    "masks": masks,
+                }
+            )
+        return output
+
+    def forward_features(self, x, masks=None):
+        if isinstance(x, list):
+            return self.forward_features_list(x, masks)
+
+        x = self.prepare_tokens_with_masks(x, masks)
+
+        for blk in self.blocks:
+            x = blk(x)
+
+        x_norm = self.norm(x)
+        return {
+            "x_norm_clstoken": x_norm[:, 0],
+            "x_norm_regtokens": x_norm[:, 1 : self.num_register_tokens + 1],
+            "x_norm_patchtokens": x_norm[:, self.num_register_tokens + 1 :],
+            "x_prenorm": x,
+            "masks": masks,
+        }
+
+    def _get_intermediate_layers_not_chunked(self, x, n=1):
+        x = self.prepare_tokens_with_masks(x)
+        # If n is an int, take the n last blocks. If it's a list, take them
+        output, total_block_len = [], len(self.blocks)
+        blocks_to_take = range(total_block_len - n, total_block_len) if isinstance(n, int) else n
+        for i, blk in enumerate(self.blocks):
+            x = blk(x)
+            if i in blocks_to_take:
+                output.append(x)
+        assert len(output) == len(blocks_to_take), f"only {len(output)} / {len(blocks_to_take)} blocks found"
+        return output
+
+    def _get_intermediate_layers_chunked(self, x, n=1):
+        x = self.prepare_tokens_with_masks(x)
+        output, i, total_block_len = [], 0, len(self.blocks[-1])
+        # If n is an int, take the n last blocks. If it's a list, take them
+        blocks_to_take = range(total_block_len - n, total_block_len) if isinstance(n, int) else n
+        for block_chunk in self.blocks:
+            for blk in block_chunk[i:]:  # Passing the nn.Identity()
+                x = blk(x)
+                if i in blocks_to_take:
+                    output.append(x)
+                i += 1
+        assert len(output) == len(blocks_to_take), f"only {len(output)} / {len(blocks_to_take)} blocks found"
+        return output
+
+    def get_intermediate_layers(
+        self,
+        x: torch.Tensor,
+        n: Union[int, Sequence] = 1,  # Layers or n last layers to take
+        reshape: bool = False,
+        return_class_token: bool = False,
+        norm=True
+    ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor]]]:
+        if self.chunked_blocks:
+            outputs = self._get_intermediate_layers_chunked(x, n)
+        else:
+            outputs = self._get_intermediate_layers_not_chunked(x, n)
+        if norm:
+            outputs = [self.norm(out) for out in outputs]
+        class_tokens = [out[:, 0] for out in outputs]
+        outputs = [out[:, 1 + self.num_register_tokens:] for out in outputs]
+        if reshape:
+            B, _, w, h = x.shape
+            outputs = [
+                out.reshape(B, w // self.patch_size, h // self.patch_size, -1).permute(0, 3, 1, 2).contiguous()
+                for out in outputs
+            ]
+        if return_class_token:
+            return tuple(zip(outputs, class_tokens))
+        return tuple(outputs)
+
+    def forward(self, *args, is_training=False, **kwargs):
+        ret = self.forward_features(*args, **kwargs)
+        if is_training:
+            return ret
+        else:
+            return self.head(ret["x_norm_clstoken"])
+
+
+def init_weights_vit_timm(module: nn.Module, name: str = ""):
+    """ViT weight initialization, original timm impl (for reproducibility)"""
+    if isinstance(module, nn.Linear):
+        trunc_normal_(module.weight, std=0.02)
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+
+
+def vit_small(patch_size=16, num_register_tokens=0, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        mlp_ratio=4,
+        block_fn=partial(Block, attn_class=MemEffAttention),
+        num_register_tokens=num_register_tokens,
+        **kwargs,
+    )
+    return model
+
+
+def vit_base(patch_size=16, num_register_tokens=0, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        mlp_ratio=4,
+        block_fn=partial(Block, attn_class=MemEffAttention),
+        num_register_tokens=num_register_tokens,
+        **kwargs,
+    )
+    return model
+
+
+def vit_large(patch_size=16, num_register_tokens=0, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        mlp_ratio=4,
+        block_fn=partial(Block, attn_class=MemEffAttention),
+        num_register_tokens=num_register_tokens,
+        **kwargs,
+    )
+    return model
+
+
+def vit_giant2(patch_size=16, num_register_tokens=0, **kwargs):
+    """
+    Close to ViT-giant, with embed-dim 1536 and 24 heads => embed-dim per head 64
+    """
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1536,
+        depth=40,
+        num_heads=24,
+        mlp_ratio=4,
+        block_fn=partial(Block, attn_class=MemEffAttention),
+        num_register_tokens=num_register_tokens,
+        **kwargs,
+    )
+    return model
+
+
+def DINOv2(model_name):
+    model_zoo = {
+        "vits": vit_small, 
+        "vitb": vit_base, 
+        "vitl": vit_large, 
+        "vitg": vit_giant2
+    }
+    
+    return model_zoo[model_name](
+        img_size=518,
+        patch_size=14,
+        init_values=1.0,
+        ffn_layer="mlp" if model_name != "vitg" else "swiglufused",
+        block_chunks=0,
+        num_register_tokens=0,
+        interpolate_antialias=False,
+        interpolate_offset=0.1
+    )

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/__init__.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .mlp import Mlp
+from .patch_embed import PatchEmbed
+from .swiglu_ffn import SwiGLUFFN, SwiGLUFFNFused
+from .block import NestedTensorBlock
+from .attention import MemEffAttention

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/attention.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/attention.py
@@ -1,0 +1,83 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# References:
+#   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
+#   https://github.com/rwightman/pytorch-image-models/tree/master/timm/models/vision_transformer.py
+
+import logging
+
+from torch import Tensor
+from torch import nn
+
+
+logger = logging.getLogger("dinov2")
+
+
+try:
+    from xformers.ops import memory_efficient_attention, unbind, fmha
+
+    XFORMERS_AVAILABLE = True
+except ImportError:
+    logger.warning("xFormers not available")
+    XFORMERS_AVAILABLE = False
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim, bias=proj_bias)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x: Tensor) -> Tensor:
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
+
+        q, k, v = qkv[0] * self.scale, qkv[1], qkv[2]
+        attn = q @ k.transpose(-2, -1)
+
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+
+class MemEffAttention(Attention):
+    def forward(self, x: Tensor, attn_bias=None) -> Tensor:
+        if not XFORMERS_AVAILABLE:
+            assert attn_bias is None, "xFormers is required for nested tensors usage"
+            return super().forward(x)
+
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads)
+
+        q, k, v = unbind(qkv, 2)
+
+        x = memory_efficient_attention(q, k, v, attn_bias=attn_bias)
+        x = x.reshape([B, N, C])
+
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+        

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/block.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/block.py
@@ -1,0 +1,252 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# References:
+#   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
+#   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/patch_embed.py
+
+import logging
+from typing import Callable, List, Any, Tuple, Dict
+
+import torch
+from torch import nn, Tensor
+
+from .attention import Attention, MemEffAttention
+from .drop_path import DropPath
+from .layer_scale import LayerScale
+from .mlp import Mlp
+
+
+logger = logging.getLogger("dinov2")
+
+
+try:
+    from xformers.ops import fmha
+    from xformers.ops import scaled_index_add, index_select_cat
+
+    XFORMERS_AVAILABLE = True
+except ImportError:
+    logger.warning("xFormers not available")
+    XFORMERS_AVAILABLE = False
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        ffn_bias: bool = True,
+        drop: float = 0.0,
+        attn_drop: float = 0.0,
+        init_values=None,
+        drop_path: float = 0.0,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+        norm_layer: Callable[..., nn.Module] = nn.LayerNorm,
+        attn_class: Callable[..., nn.Module] = Attention,
+        ffn_layer: Callable[..., nn.Module] = Mlp,
+    ) -> None:
+        super().__init__()
+        # print(f"biases: qkv: {qkv_bias}, proj: {proj_bias}, ffn: {ffn_bias}")
+        self.norm1 = norm_layer(dim)
+        self.attn = attn_class(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            proj_bias=proj_bias,
+            attn_drop=attn_drop,
+            proj_drop=drop,
+        )
+        self.ls1 = LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
+        self.drop_path1 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+        self.norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = ffn_layer(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=drop,
+            bias=ffn_bias,
+        )
+        self.ls2 = LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
+        self.drop_path2 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+        self.sample_drop_ratio = drop_path
+
+    def forward(self, x: Tensor) -> Tensor:
+        def attn_residual_func(x: Tensor) -> Tensor:
+            return self.ls1(self.attn(self.norm1(x)))
+
+        def ffn_residual_func(x: Tensor) -> Tensor:
+            return self.ls2(self.mlp(self.norm2(x)))
+
+        if self.training and self.sample_drop_ratio > 0.1:
+            # the overhead is compensated only for a drop path rate larger than 0.1
+            x = drop_add_residual_stochastic_depth(
+                x,
+                residual_func=attn_residual_func,
+                sample_drop_ratio=self.sample_drop_ratio,
+            )
+            x = drop_add_residual_stochastic_depth(
+                x,
+                residual_func=ffn_residual_func,
+                sample_drop_ratio=self.sample_drop_ratio,
+            )
+        elif self.training and self.sample_drop_ratio > 0.0:
+            x = x + self.drop_path1(attn_residual_func(x))
+            x = x + self.drop_path1(ffn_residual_func(x))  # FIXME: drop_path2
+        else:
+            x = x + attn_residual_func(x)
+            x = x + ffn_residual_func(x)
+        return x
+
+
+def drop_add_residual_stochastic_depth(
+    x: Tensor,
+    residual_func: Callable[[Tensor], Tensor],
+    sample_drop_ratio: float = 0.0,
+) -> Tensor:
+    # 1) extract subset using permutation
+    b, n, d = x.shape
+    sample_subset_size = max(int(b * (1 - sample_drop_ratio)), 1)
+    brange = (torch.randperm(b, device=x.device))[:sample_subset_size]
+    x_subset = x[brange]
+
+    # 2) apply residual_func to get residual
+    residual = residual_func(x_subset)
+
+    x_flat = x.flatten(1)
+    residual = residual.flatten(1)
+
+    residual_scale_factor = b / sample_subset_size
+
+    # 3) add the residual
+    x_plus_residual = torch.index_add(x_flat, 0, brange, residual.to(dtype=x.dtype), alpha=residual_scale_factor)
+    return x_plus_residual.view_as(x)
+
+
+def get_branges_scales(x, sample_drop_ratio=0.0):
+    b, n, d = x.shape
+    sample_subset_size = max(int(b * (1 - sample_drop_ratio)), 1)
+    brange = (torch.randperm(b, device=x.device))[:sample_subset_size]
+    residual_scale_factor = b / sample_subset_size
+    return brange, residual_scale_factor
+
+
+def add_residual(x, brange, residual, residual_scale_factor, scaling_vector=None):
+    if scaling_vector is None:
+        x_flat = x.flatten(1)
+        residual = residual.flatten(1)
+        x_plus_residual = torch.index_add(x_flat, 0, brange, residual.to(dtype=x.dtype), alpha=residual_scale_factor)
+    else:
+        x_plus_residual = scaled_index_add(
+            x, brange, residual.to(dtype=x.dtype), scaling=scaling_vector, alpha=residual_scale_factor
+        )
+    return x_plus_residual
+
+
+attn_bias_cache: Dict[Tuple, Any] = {}
+
+
+def get_attn_bias_and_cat(x_list, branges=None):
+    """
+    this will perform the index select, cat the tensors, and provide the attn_bias from cache
+    """
+    batch_sizes = [b.shape[0] for b in branges] if branges is not None else [x.shape[0] for x in x_list]
+    all_shapes = tuple((b, x.shape[1]) for b, x in zip(batch_sizes, x_list))
+    if all_shapes not in attn_bias_cache.keys():
+        seqlens = []
+        for b, x in zip(batch_sizes, x_list):
+            for _ in range(b):
+                seqlens.append(x.shape[1])
+        attn_bias = fmha.BlockDiagonalMask.from_seqlens(seqlens)
+        attn_bias._batch_sizes = batch_sizes
+        attn_bias_cache[all_shapes] = attn_bias
+
+    if branges is not None:
+        cat_tensors = index_select_cat([x.flatten(1) for x in x_list], branges).view(1, -1, x_list[0].shape[-1])
+    else:
+        tensors_bs1 = tuple(x.reshape([1, -1, *x.shape[2:]]) for x in x_list)
+        cat_tensors = torch.cat(tensors_bs1, dim=1)
+
+    return attn_bias_cache[all_shapes], cat_tensors
+
+
+def drop_add_residual_stochastic_depth_list(
+    x_list: List[Tensor],
+    residual_func: Callable[[Tensor, Any], Tensor],
+    sample_drop_ratio: float = 0.0,
+    scaling_vector=None,
+) -> Tensor:
+    # 1) generate random set of indices for dropping samples in the batch
+    branges_scales = [get_branges_scales(x, sample_drop_ratio=sample_drop_ratio) for x in x_list]
+    branges = [s[0] for s in branges_scales]
+    residual_scale_factors = [s[1] for s in branges_scales]
+
+    # 2) get attention bias and index+concat the tensors
+    attn_bias, x_cat = get_attn_bias_and_cat(x_list, branges)
+
+    # 3) apply residual_func to get residual, and split the result
+    residual_list = attn_bias.split(residual_func(x_cat, attn_bias=attn_bias))  # type: ignore
+
+    outputs = []
+    for x, brange, residual, residual_scale_factor in zip(x_list, branges, residual_list, residual_scale_factors):
+        outputs.append(add_residual(x, brange, residual, residual_scale_factor, scaling_vector).view_as(x))
+    return outputs
+
+
+class NestedTensorBlock(Block):
+    def forward_nested(self, x_list: List[Tensor]) -> List[Tensor]:
+        """
+        x_list contains a list of tensors to nest together and run
+        """
+        assert isinstance(self.attn, MemEffAttention)
+
+        if self.training and self.sample_drop_ratio > 0.0:
+
+            def attn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
+                return self.attn(self.norm1(x), attn_bias=attn_bias)
+
+            def ffn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
+                return self.mlp(self.norm2(x))
+
+            x_list = drop_add_residual_stochastic_depth_list(
+                x_list,
+                residual_func=attn_residual_func,
+                sample_drop_ratio=self.sample_drop_ratio,
+                scaling_vector=self.ls1.gamma if isinstance(self.ls1, LayerScale) else None,
+            )
+            x_list = drop_add_residual_stochastic_depth_list(
+                x_list,
+                residual_func=ffn_residual_func,
+                sample_drop_ratio=self.sample_drop_ratio,
+                scaling_vector=self.ls2.gamma if isinstance(self.ls1, LayerScale) else None,
+            )
+            return x_list
+        else:
+
+            def attn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
+                return self.ls1(self.attn(self.norm1(x), attn_bias=attn_bias))
+
+            def ffn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
+                return self.ls2(self.mlp(self.norm2(x)))
+
+            attn_bias, x = get_attn_bias_and_cat(x_list)
+            x = x + attn_residual_func(x, attn_bias=attn_bias)
+            x = x + ffn_residual_func(x)
+            return attn_bias.split(x)
+
+    def forward(self, x_or_x_list):
+        if isinstance(x_or_x_list, Tensor):
+            return super().forward(x_or_x_list)
+        elif isinstance(x_or_x_list, list):
+            assert XFORMERS_AVAILABLE, "Please install xFormers for nested tensors usage"
+            return self.forward_nested(x_or_x_list)
+        else:
+            raise AssertionError

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/drop_path.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/drop_path.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# References:
+#   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
+#   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/drop.py
+
+
+from torch import nn
+
+
+def drop_path(x, drop_prob: float = 0.0, training: bool = False):
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1 - drop_prob
+    shape = (x.shape[0],) + (1,) * (x.ndim - 1)  # work with diff dim tensors, not just 2D ConvNets
+    random_tensor = x.new_empty(shape).bernoulli_(keep_prob)
+    if keep_prob > 0.0:
+        random_tensor.div_(keep_prob)
+    output = x * random_tensor
+    return output
+
+
+class DropPath(nn.Module):
+    """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks)."""
+
+    def __init__(self, drop_prob=None):
+        super(DropPath, self).__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x):
+        return drop_path(x, self.drop_prob, self.training)

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/layer_scale.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/layer_scale.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Modified from: https://github.com/huggingface/pytorch-image-models/blob/main/timm/models/vision_transformer.py#L103-L110
+
+from typing import Union
+
+import torch
+from torch import Tensor
+from torch import nn
+
+
+class LayerScale(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        init_values: Union[float, Tensor] = 1e-5,
+        inplace: bool = False,
+    ) -> None:
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(init_values * torch.ones(dim))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/mlp.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/mlp.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# References:
+#   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
+#   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/mlp.py
+
+
+from typing import Callable, Optional
+
+from torch import Tensor, nn
+
+
+class Mlp(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+        drop: float = 0.0,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features, bias=bias)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features, bias=bias)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/patch_embed.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/patch_embed.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# References:
+#   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
+#   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/patch_embed.py
+
+from typing import Callable, Optional, Tuple, Union
+
+from torch import Tensor
+import torch.nn as nn
+
+
+def make_2tuple(x):
+    if isinstance(x, tuple):
+        assert len(x) == 2
+        return x
+
+    assert isinstance(x, int)
+    return (x, x)
+
+
+class PatchEmbed(nn.Module):
+    """
+    2D image to patch embedding: (B,C,H,W) -> (B,N,D)
+
+    Args:
+        img_size: Image size.
+        patch_size: Patch token size.
+        in_chans: Number of input image channels.
+        embed_dim: Number of linear projection output channels.
+        norm_layer: Normalization layer.
+    """
+
+    def __init__(
+        self,
+        img_size: Union[int, Tuple[int, int]] = 224,
+        patch_size: Union[int, Tuple[int, int]] = 16,
+        in_chans: int = 3,
+        embed_dim: int = 768,
+        norm_layer: Optional[Callable] = None,
+        flatten_embedding: bool = True,
+    ) -> None:
+        super().__init__()
+
+        image_HW = make_2tuple(img_size)
+        patch_HW = make_2tuple(patch_size)
+        patch_grid_size = (
+            image_HW[0] // patch_HW[0],
+            image_HW[1] // patch_HW[1],
+        )
+
+        self.img_size = image_HW
+        self.patch_size = patch_HW
+        self.patches_resolution = patch_grid_size
+        self.num_patches = patch_grid_size[0] * patch_grid_size[1]
+
+        self.in_chans = in_chans
+        self.embed_dim = embed_dim
+
+        self.flatten_embedding = flatten_embedding
+
+        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=patch_HW, stride=patch_HW)
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        _, _, H, W = x.shape
+        patch_H, patch_W = self.patch_size
+
+        assert H % patch_H == 0, f"Input image height {H} is not a multiple of patch height {patch_H}"
+        assert W % patch_W == 0, f"Input image width {W} is not a multiple of patch width: {patch_W}"
+
+        x = self.proj(x)  # B C H W
+        H, W = x.size(2), x.size(3)
+        x = x.flatten(2).transpose(1, 2)  # B HW C
+        x = self.norm(x)
+        if not self.flatten_embedding:
+            x = x.reshape(-1, H, W, self.embed_dim)  # B H W C
+        return x
+
+    def flops(self) -> float:
+        Ho, Wo = self.patches_resolution
+        flops = Ho * Wo * self.embed_dim * self.in_chans * (self.patch_size[0] * self.patch_size[1])
+        if self.norm is not None:
+            flops += Ho * Wo * self.embed_dim
+        return flops

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/swiglu_ffn.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/swiglu_ffn.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Optional
+
+from torch import Tensor, nn
+import torch.nn.functional as F
+
+
+class SwiGLUFFN(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        act_layer: Callable[..., nn.Module] = None,
+        drop: float = 0.0,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.w12 = nn.Linear(in_features, 2 * hidden_features, bias=bias)
+        self.w3 = nn.Linear(hidden_features, out_features, bias=bias)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x12 = self.w12(x)
+        x1, x2 = x12.chunk(2, dim=-1)
+        hidden = F.silu(x1) * x2
+        return self.w3(hidden)
+
+
+try:
+    from xformers.ops import SwiGLU
+
+    XFORMERS_AVAILABLE = True
+except ImportError:
+    SwiGLU = SwiGLUFFN
+    XFORMERS_AVAILABLE = False
+
+
+class SwiGLUFFNFused(SwiGLU):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        act_layer: Callable[..., nn.Module] = None,
+        drop: float = 0.0,
+        bias: bool = True,
+    ) -> None:
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        hidden_features = (int(hidden_features * 2 / 3) + 7) // 8 * 8
+        super().__init__(
+            in_features=in_features,
+            hidden_features=hidden_features,
+            out_features=out_features,
+            bias=bias,
+        )

--- a/libreyolo/models/depth_anything/_vendor/dpt.py
+++ b/libreyolo/models/depth_anything/_vendor/dpt.py
@@ -1,0 +1,221 @@
+import cv2
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchvision.transforms import Compose
+
+from .dinov2 import DINOv2
+from .util.blocks import FeatureFusionBlock, _make_scratch
+from .util.transform import Resize, NormalizeImage, PrepareForNet
+
+
+def _make_fusion_block(features, use_bn, size=None):
+    return FeatureFusionBlock(
+        features,
+        nn.ReLU(False),
+        deconv=False,
+        bn=use_bn,
+        expand=False,
+        align_corners=True,
+        size=size,
+    )
+
+
+class ConvBlock(nn.Module):
+    def __init__(self, in_feature, out_feature):
+        super().__init__()
+        
+        self.conv_block = nn.Sequential(
+            nn.Conv2d(in_feature, out_feature, kernel_size=3, stride=1, padding=1),
+            nn.BatchNorm2d(out_feature),
+            nn.ReLU(True)
+        )
+    
+    def forward(self, x):
+        return self.conv_block(x)
+
+
+class DPTHead(nn.Module):
+    def __init__(
+        self, 
+        in_channels, 
+        features=256, 
+        use_bn=False, 
+        out_channels=[256, 512, 1024, 1024], 
+        use_clstoken=False
+    ):
+        super(DPTHead, self).__init__()
+        
+        self.use_clstoken = use_clstoken
+        
+        self.projects = nn.ModuleList([
+            nn.Conv2d(
+                in_channels=in_channels,
+                out_channels=out_channel,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+            ) for out_channel in out_channels
+        ])
+        
+        self.resize_layers = nn.ModuleList([
+            nn.ConvTranspose2d(
+                in_channels=out_channels[0],
+                out_channels=out_channels[0],
+                kernel_size=4,
+                stride=4,
+                padding=0),
+            nn.ConvTranspose2d(
+                in_channels=out_channels[1],
+                out_channels=out_channels[1],
+                kernel_size=2,
+                stride=2,
+                padding=0),
+            nn.Identity(),
+            nn.Conv2d(
+                in_channels=out_channels[3],
+                out_channels=out_channels[3],
+                kernel_size=3,
+                stride=2,
+                padding=1)
+        ])
+        
+        if use_clstoken:
+            self.readout_projects = nn.ModuleList()
+            for _ in range(len(self.projects)):
+                self.readout_projects.append(
+                    nn.Sequential(
+                        nn.Linear(2 * in_channels, in_channels),
+                        nn.GELU()))
+        
+        self.scratch = _make_scratch(
+            out_channels,
+            features,
+            groups=1,
+            expand=False,
+        )
+        
+        self.scratch.stem_transpose = None
+        
+        self.scratch.refinenet1 = _make_fusion_block(features, use_bn)
+        self.scratch.refinenet2 = _make_fusion_block(features, use_bn)
+        self.scratch.refinenet3 = _make_fusion_block(features, use_bn)
+        self.scratch.refinenet4 = _make_fusion_block(features, use_bn)
+        
+        head_features_1 = features
+        head_features_2 = 32
+        
+        self.scratch.output_conv1 = nn.Conv2d(head_features_1, head_features_1 // 2, kernel_size=3, stride=1, padding=1)
+        self.scratch.output_conv2 = nn.Sequential(
+            nn.Conv2d(head_features_1 // 2, head_features_2, kernel_size=3, stride=1, padding=1),
+            nn.ReLU(True),
+            nn.Conv2d(head_features_2, 1, kernel_size=1, stride=1, padding=0),
+            nn.ReLU(True),
+            nn.Identity(),
+        )
+    
+    def forward(self, out_features, patch_h, patch_w):
+        out = []
+        for i, x in enumerate(out_features):
+            if self.use_clstoken:
+                x, cls_token = x[0], x[1]
+                readout = cls_token.unsqueeze(1).expand_as(x)
+                x = self.readout_projects[i](torch.cat((x, readout), -1))
+            else:
+                x = x[0]
+            
+            x = x.permute(0, 2, 1).reshape((x.shape[0], x.shape[-1], patch_h, patch_w))
+            
+            x = self.projects[i](x)
+            x = self.resize_layers[i](x)
+            
+            out.append(x)
+        
+        layer_1, layer_2, layer_3, layer_4 = out
+        
+        layer_1_rn = self.scratch.layer1_rn(layer_1)
+        layer_2_rn = self.scratch.layer2_rn(layer_2)
+        layer_3_rn = self.scratch.layer3_rn(layer_3)
+        layer_4_rn = self.scratch.layer4_rn(layer_4)
+        
+        path_4 = self.scratch.refinenet4(layer_4_rn, size=layer_3_rn.shape[2:])        
+        path_3 = self.scratch.refinenet3(path_4, layer_3_rn, size=layer_2_rn.shape[2:])
+        path_2 = self.scratch.refinenet2(path_3, layer_2_rn, size=layer_1_rn.shape[2:])
+        path_1 = self.scratch.refinenet1(path_2, layer_1_rn)
+        
+        out = self.scratch.output_conv1(path_1)
+        out = F.interpolate(out, (int(patch_h * 14), int(patch_w * 14)), mode="bilinear", align_corners=True)
+        out = self.scratch.output_conv2(out)
+        
+        return out
+
+
+class DepthAnythingV2(nn.Module):
+    def __init__(
+        self, 
+        encoder='vitl', 
+        features=256, 
+        out_channels=[256, 512, 1024, 1024], 
+        use_bn=False, 
+        use_clstoken=False
+    ):
+        super(DepthAnythingV2, self).__init__()
+        
+        self.intermediate_layer_idx = {
+            'vits': [2, 5, 8, 11],
+            'vitb': [2, 5, 8, 11], 
+            'vitl': [4, 11, 17, 23], 
+            'vitg': [9, 19, 29, 39]
+        }
+        
+        self.encoder = encoder
+        self.pretrained = DINOv2(model_name=encoder)
+        
+        self.depth_head = DPTHead(self.pretrained.embed_dim, features, use_bn, out_channels=out_channels, use_clstoken=use_clstoken)
+    
+    def forward(self, x):
+        patch_h, patch_w = x.shape[-2] // 14, x.shape[-1] // 14
+        
+        features = self.pretrained.get_intermediate_layers(x, self.intermediate_layer_idx[self.encoder], return_class_token=True)
+        
+        depth = self.depth_head(features, patch_h, patch_w)
+        depth = F.relu(depth)
+        
+        return depth.squeeze(1)
+    
+    @torch.no_grad()
+    def infer_image(self, raw_image, input_size=518):
+        image, (h, w) = self.image2tensor(raw_image, input_size)
+        
+        depth = self.forward(image)
+        
+        depth = F.interpolate(depth[:, None], (h, w), mode="bilinear", align_corners=True)[0, 0]
+        
+        return depth.cpu().numpy()
+    
+    def image2tensor(self, raw_image, input_size=518):        
+        transform = Compose([
+            Resize(
+                width=input_size,
+                height=input_size,
+                resize_target=False,
+                keep_aspect_ratio=True,
+                ensure_multiple_of=14,
+                resize_method='lower_bound',
+                image_interpolation_method=cv2.INTER_CUBIC,
+            ),
+            NormalizeImage(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            PrepareForNet(),
+        ])
+        
+        h, w = raw_image.shape[:2]
+        
+        image = cv2.cvtColor(raw_image, cv2.COLOR_BGR2RGB) / 255.0
+        
+        image = transform({'image': image})['image']
+        image = torch.from_numpy(image).unsqueeze(0)
+        
+        DEVICE = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
+        image = image.to(DEVICE)
+        
+        return image, (h, w)

--- a/libreyolo/models/depth_anything/_vendor/util/__init__.py
+++ b/libreyolo/models/depth_anything/_vendor/util/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored Depth Anything V2 utilities (Apache-2.0). See ``_vendor/__init__.py``."""

--- a/libreyolo/models/depth_anything/_vendor/util/blocks.py
+++ b/libreyolo/models/depth_anything/_vendor/util/blocks.py
@@ -1,0 +1,148 @@
+import torch.nn as nn
+
+
+def _make_scratch(in_shape, out_shape, groups=1, expand=False):
+    scratch = nn.Module()
+
+    out_shape1 = out_shape
+    out_shape2 = out_shape
+    out_shape3 = out_shape
+    if len(in_shape) >= 4:
+        out_shape4 = out_shape
+
+    if expand:
+        out_shape1 = out_shape
+        out_shape2 = out_shape * 2
+        out_shape3 = out_shape * 4
+        if len(in_shape) >= 4:
+            out_shape4 = out_shape * 8
+
+    scratch.layer1_rn = nn.Conv2d(in_shape[0], out_shape1, kernel_size=3, stride=1, padding=1, bias=False, groups=groups)
+    scratch.layer2_rn = nn.Conv2d(in_shape[1], out_shape2, kernel_size=3, stride=1, padding=1, bias=False, groups=groups)
+    scratch.layer3_rn = nn.Conv2d(in_shape[2], out_shape3, kernel_size=3, stride=1, padding=1, bias=False, groups=groups)
+    if len(in_shape) >= 4:
+        scratch.layer4_rn = nn.Conv2d(in_shape[3], out_shape4, kernel_size=3, stride=1, padding=1, bias=False, groups=groups)
+
+    return scratch
+
+
+class ResidualConvUnit(nn.Module):
+    """Residual convolution module.
+    """
+
+    def __init__(self, features, activation, bn):
+        """Init.
+
+        Args:
+            features (int): number of features
+        """
+        super().__init__()
+
+        self.bn = bn
+
+        self.groups=1
+
+        self.conv1 = nn.Conv2d(features, features, kernel_size=3, stride=1, padding=1, bias=True, groups=self.groups)
+        
+        self.conv2 = nn.Conv2d(features, features, kernel_size=3, stride=1, padding=1, bias=True, groups=self.groups)
+
+        if self.bn == True:
+            self.bn1 = nn.BatchNorm2d(features)
+            self.bn2 = nn.BatchNorm2d(features)
+
+        self.activation = activation
+
+        self.skip_add = nn.quantized.FloatFunctional()
+
+    def forward(self, x):
+        """Forward pass.
+
+        Args:
+            x (tensor): input
+
+        Returns:
+            tensor: output
+        """
+        
+        out = self.activation(x)
+        out = self.conv1(out)
+        if self.bn == True:
+            out = self.bn1(out)
+       
+        out = self.activation(out)
+        out = self.conv2(out)
+        if self.bn == True:
+            out = self.bn2(out)
+
+        if self.groups > 1:
+            out = self.conv_merge(out)
+
+        return self.skip_add.add(out, x)
+
+
+class FeatureFusionBlock(nn.Module):
+    """Feature fusion block.
+    """
+
+    def __init__(
+        self, 
+        features, 
+        activation, 
+        deconv=False, 
+        bn=False, 
+        expand=False, 
+        align_corners=True,
+        size=None
+    ):
+        """Init.
+        
+        Args:
+            features (int): number of features
+        """
+        super(FeatureFusionBlock, self).__init__()
+
+        self.deconv = deconv
+        self.align_corners = align_corners
+
+        self.groups=1
+
+        self.expand = expand
+        out_features = features
+        if self.expand == True:
+            out_features = features // 2
+        
+        self.out_conv = nn.Conv2d(features, out_features, kernel_size=1, stride=1, padding=0, bias=True, groups=1)
+
+        self.resConfUnit1 = ResidualConvUnit(features, activation, bn)
+        self.resConfUnit2 = ResidualConvUnit(features, activation, bn)
+        
+        self.skip_add = nn.quantized.FloatFunctional()
+
+        self.size=size
+
+    def forward(self, *xs, size=None):
+        """Forward pass.
+
+        Returns:
+            tensor: output
+        """
+        output = xs[0]
+
+        if len(xs) == 2:
+            res = self.resConfUnit1(xs[1])
+            output = self.skip_add.add(output, res)
+
+        output = self.resConfUnit2(output)
+
+        if (size is None) and (self.size is None):
+            modifier = {"scale_factor": 2}
+        elif size is None:
+            modifier = {"size": self.size}
+        else:
+            modifier = {"size": size}
+
+        output = nn.functional.interpolate(output, **modifier, mode="bilinear", align_corners=self.align_corners)
+        
+        output = self.out_conv(output)
+
+        return output

--- a/libreyolo/models/depth_anything/_vendor/util/transform.py
+++ b/libreyolo/models/depth_anything/_vendor/util/transform.py
@@ -1,0 +1,158 @@
+import numpy as np
+import cv2
+
+
+class Resize(object):
+    """Resize sample to given size (width, height).
+    """
+
+    def __init__(
+        self,
+        width,
+        height,
+        resize_target=True,
+        keep_aspect_ratio=False,
+        ensure_multiple_of=1,
+        resize_method="lower_bound",
+        image_interpolation_method=cv2.INTER_AREA,
+    ):
+        """Init.
+
+        Args:
+            width (int): desired output width
+            height (int): desired output height
+            resize_target (bool, optional):
+                True: Resize the full sample (image, mask, target).
+                False: Resize image only.
+                Defaults to True.
+            keep_aspect_ratio (bool, optional):
+                True: Keep the aspect ratio of the input sample.
+                Output sample might not have the given width and height, and
+                resize behaviour depends on the parameter 'resize_method'.
+                Defaults to False.
+            ensure_multiple_of (int, optional):
+                Output width and height is constrained to be multiple of this parameter.
+                Defaults to 1.
+            resize_method (str, optional):
+                "lower_bound": Output will be at least as large as the given size.
+                "upper_bound": Output will be at max as large as the given size. (Output size might be smaller than given size.)
+                "minimal": Scale as least as possible.  (Output size might be smaller than given size.)
+                Defaults to "lower_bound".
+        """
+        self.__width = width
+        self.__height = height
+
+        self.__resize_target = resize_target
+        self.__keep_aspect_ratio = keep_aspect_ratio
+        self.__multiple_of = ensure_multiple_of
+        self.__resize_method = resize_method
+        self.__image_interpolation_method = image_interpolation_method
+
+    def constrain_to_multiple_of(self, x, min_val=0, max_val=None):
+        y = (np.round(x / self.__multiple_of) * self.__multiple_of).astype(int)
+
+        if max_val is not None and y > max_val:
+            y = (np.floor(x / self.__multiple_of) * self.__multiple_of).astype(int)
+
+        if y < min_val:
+            y = (np.ceil(x / self.__multiple_of) * self.__multiple_of).astype(int)
+
+        return y
+
+    def get_size(self, width, height):
+        # determine new height and width
+        scale_height = self.__height / height
+        scale_width = self.__width / width
+
+        if self.__keep_aspect_ratio:
+            if self.__resize_method == "lower_bound":
+                # scale such that output size is lower bound
+                if scale_width > scale_height:
+                    # fit width
+                    scale_height = scale_width
+                else:
+                    # fit height
+                    scale_width = scale_height
+            elif self.__resize_method == "upper_bound":
+                # scale such that output size is upper bound
+                if scale_width < scale_height:
+                    # fit width
+                    scale_height = scale_width
+                else:
+                    # fit height
+                    scale_width = scale_height
+            elif self.__resize_method == "minimal":
+                # scale as least as possbile
+                if abs(1 - scale_width) < abs(1 - scale_height):
+                    # fit width
+                    scale_height = scale_width
+                else:
+                    # fit height
+                    scale_width = scale_height
+            else:
+                raise ValueError(f"resize_method {self.__resize_method} not implemented")
+
+        if self.__resize_method == "lower_bound":
+            new_height = self.constrain_to_multiple_of(scale_height * height, min_val=self.__height)
+            new_width = self.constrain_to_multiple_of(scale_width * width, min_val=self.__width)
+        elif self.__resize_method == "upper_bound":
+            new_height = self.constrain_to_multiple_of(scale_height * height, max_val=self.__height)
+            new_width = self.constrain_to_multiple_of(scale_width * width, max_val=self.__width)
+        elif self.__resize_method == "minimal":
+            new_height = self.constrain_to_multiple_of(scale_height * height)
+            new_width = self.constrain_to_multiple_of(scale_width * width)
+        else:
+            raise ValueError(f"resize_method {self.__resize_method} not implemented")
+
+        return (new_width, new_height)
+
+    def __call__(self, sample):
+        width, height = self.get_size(sample["image"].shape[1], sample["image"].shape[0])
+        
+        # resize sample
+        sample["image"] = cv2.resize(sample["image"], (width, height), interpolation=self.__image_interpolation_method)
+
+        if self.__resize_target:
+            if "depth" in sample:
+                sample["depth"] = cv2.resize(sample["depth"], (width, height), interpolation=cv2.INTER_NEAREST)
+                
+            if "mask" in sample:
+                sample["mask"] = cv2.resize(sample["mask"].astype(np.float32), (width, height), interpolation=cv2.INTER_NEAREST)
+        
+        return sample
+
+
+class NormalizeImage(object):
+    """Normlize image by given mean and std.
+    """
+
+    def __init__(self, mean, std):
+        self.__mean = mean
+        self.__std = std
+
+    def __call__(self, sample):
+        sample["image"] = (sample["image"] - self.__mean) / self.__std
+
+        return sample
+
+
+class PrepareForNet(object):
+    """Prepare sample for usage as network input.
+    """
+
+    def __init__(self):
+        pass
+
+    def __call__(self, sample):
+        image = np.transpose(sample["image"], (2, 0, 1))
+        sample["image"] = np.ascontiguousarray(image).astype(np.float32)
+
+        if "depth" in sample:
+            depth = sample["depth"].astype(np.float32)
+            sample["depth"] = np.ascontiguousarray(depth)
+        
+        if "mask" in sample:
+            sample["mask"] = sample["mask"].astype(np.float32)
+            sample["mask"] = np.ascontiguousarray(sample["mask"])
+        
+        return sample

--- a/libreyolo/models/depth_anything/model.py
+++ b/libreyolo/models/depth_anything/model.py
@@ -54,15 +54,17 @@ class LibreDepthAnythingV2(BaseModel):
 
     # DINOv2 patch grid; the depth dataset and validator enforce divisibility.
     depth_imgsz_divisor = 14
-    # Letterbox keeps the aspect ratio (padded pixels are invalid depth and are
-    # excluded from metrics), closest to DA's native keep-aspect inference.
+    # Validation goes through the shared DepthDataset, which letterboxes to a
+    # fixed square (padded pixels are invalid depth, excluded from metrics).
+    # Note: predict uses DA's native keep-aspect lower-bound resize, so val
+    # metrics on non-square images are a documented approximation of predict.
     depth_resize_mode = "letterbox"
 
     # Keep-aspect preprocessing yields per-image variable sizes, so the stacked
-    # single-forward batched-predict path does not apply. TTA is rejected for
-    # the depth task library-wide.
+    # single-forward batched-predict path does not apply. TTA_ENABLED is left at
+    # its default (True) so predict(augment=True) reaches the depth task's
+    # explicit rejection instead of being silently ignored.
     SUPPORTS_BATCHED_PREDICT = False
-    TTA_ENABLED = False
 
     _SIZE_TO_ENCODER: ClassVar[Dict[str, str]] = {
         "s": "vits",
@@ -127,12 +129,17 @@ class LibreDepthAnythingV2(BaseModel):
             task=task,
             **kwargs,
         )
-        self.names = {0: "depth"}
         self.model.eval()
         # A file path is stored but not loaded by BaseModel; load it here (a raw
         # state_dict passed as ``model_path`` is already loaded by BaseModel).
         if model_path is not None and isinstance(model_path, (str, Path)):
             self._load_weights(str(model_path))
+        # Enforce the single depth slot last, after any loading path. Raw .pth
+        # files loaded via the generic autoconverter would otherwise write
+        # names={0: "class_0"} (build_class_names fallback), violating the
+        # checkpoint schema's {0: "depth"} for this task.
+        self.nb_classes = 1
+        self.names = {0: "depth"}
 
     def _init_model(self) -> nn.Module:
         return LibreDepthAnythingV2Net(self._SIZE_TO_ENCODER[self.size])
@@ -187,11 +194,13 @@ class LibreDepthAnythingV2(BaseModel):
         if isinstance(depth, dict):
             depth = depth.get("depth", depth.get("predictions"))
         orig_w, orig_h = original_size
+        # align_corners=True matches upstream DA infer_image, so converted
+        # checkpoints reproduce upstream depth maps at non-native sizes.
         depth = F.interpolate(
             depth.float(),
             size=(orig_h, orig_w),
             mode="bilinear",
-            align_corners=False,
+            align_corners=True,
         )
         return {"depth": depth[0, 0].cpu()}
 

--- a/libreyolo/models/depth_anything/model.py
+++ b/libreyolo/models/depth_anything/model.py
@@ -1,0 +1,253 @@
+"""LibreYOLO wrapper for Depth Anything V2 monocular depth estimation.
+
+Depth Anything V2 (https://github.com/DepthAnything/Depth-Anything-V2, NeurIPS
+2024) is a DINOv2 encoder + DPT head that predicts a dense relative inverse
+depth map. That is exactly LibreYOLO's ``depth`` task primitive
+(``Results.depth_map``, higher = closer, no metric unit), so this family reuses
+the shared depth dataset, validator, results, and checkpoint schema: ``predict``
+and zero-shot ``val`` (AbsRel / RMSE / delta) work out of the box.
+
+The vendored upstream code is Apache-2.0 (``_vendor/``). Depth Anything V2
+*weights* are split: the Small encoder is Apache-2.0, while Base/Large/Giant are
+CC-BY-NC-4.0 (non-commercial), so LibreYOLO does not redistribute them - convert
+the official checkpoints with ``weights/convert_depth_anything_v2_weights.py``.
+
+Training is out of scope here (see :meth:`LibreDepthAnythingV2.train`).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, ClassVar, Dict, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from PIL import Image
+
+from ...utils.image_loader import ImageInput, ImageLoader
+from ..base.model import BaseModel
+from .nn import LibreDepthAnythingV2Net
+from .utils import preprocess_numpy
+
+logger = logging.getLogger(__name__)
+
+
+class LibreDepthAnythingV2(BaseModel):
+    """Depth Anything V2: image -> dense relative inverse-depth map."""
+
+    FAMILY = "depth_anything"
+    FILENAME_PREFIX = "LibreDepthAnythingV2"
+    WEIGHT_EXT = ".pt"
+    # DA V2 always runs at 518 (37 * 14). Size codes follow the encoder:
+    # s / b / l / g -> ViT-S / B / L / G.
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {
+        "s": 518,
+        "b": 518,
+        "l": 518,
+        "g": 518,
+    }
+    SUPPORTED_TASKS = ("depth",)
+    DEFAULT_TASK = "depth"
+
+    # DINOv2 patch grid; the depth dataset and validator enforce divisibility.
+    depth_imgsz_divisor = 14
+    # Letterbox keeps the aspect ratio (padded pixels are invalid depth and are
+    # excluded from metrics), closest to DA's native keep-aspect inference.
+    depth_resize_mode = "letterbox"
+
+    # Keep-aspect preprocessing yields per-image variable sizes, so the stacked
+    # single-forward batched-predict path does not apply. TTA is rejected for
+    # the depth task library-wide.
+    SUPPORTS_BATCHED_PREDICT = False
+    TTA_ENABLED = False
+
+    _SIZE_TO_ENCODER: ClassVar[Dict[str, str]] = {
+        "s": "vits",
+        "b": "vitb",
+        "l": "vitl",
+        "g": "vitg",
+    }
+    # The DINOv2 cls-token width uniquely identifies the encoder size.
+    _EMBED_DIM_TO_SIZE: ClassVar[Dict[int, str]] = {
+        384: "s",
+        768: "b",
+        1024: "l",
+        1536: "g",
+    }
+
+    _UPSTREAM_URL = "https://github.com/DepthAnything/Depth-Anything-V2"
+
+    # ====================================================================
+    # Checkpoint detection
+    # ====================================================================
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        # DA V2 checkpoints carry the DINOv2 encoder under ``pretrained.*`` and
+        # the DPT head under ``depth_head.*``. RF-DETR's depth head also uses
+        # ``depth_head.*`` but its encoder is ``backbone.*``, so the two never
+        # collide on the encoder prefix.
+        has_encoder = any(k.startswith("pretrained.") for k in weights_dict)
+        has_head = any(k.startswith("depth_head.") for k in weights_dict)
+        return has_encoder and has_head
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        cls_token = weights_dict.get("pretrained.cls_token")
+        if cls_token is not None and getattr(cls_token, "ndim", 0) >= 1:
+            return cls._EMBED_DIM_TO_SIZE.get(int(cls_token.shape[-1]))
+        return None
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        # The single class slot is a schema placeholder; depth has no classes.
+        return 1
+
+    # ====================================================================
+    # Construction
+    # ====================================================================
+
+    def __init__(
+        self,
+        model_path,
+        size: str = "l",
+        nb_classes: int = 1,
+        device: str = "auto",
+        task: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=1,  # always 1 ("depth"); ignore any caller-provided value
+            device=device,
+            task=task,
+            **kwargs,
+        )
+        self.names = {0: "depth"}
+        self.model.eval()
+        # A file path is stored but not loaded by BaseModel; load it here (a raw
+        # state_dict passed as ``model_path`` is already loaded by BaseModel).
+        if model_path is not None and isinstance(model_path, (str, Path)):
+            self._load_weights(str(model_path))
+
+    def _init_model(self) -> nn.Module:
+        return LibreDepthAnythingV2Net(self._SIZE_TO_ENCODER[self.size])
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {
+            "pretrained": self.model.pretrained,
+            "depth_head": self.model.depth_head,
+        }
+
+    # ====================================================================
+    # Inference surface
+    # ====================================================================
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        return preprocess_numpy
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
+        effective_res = (
+            input_size if input_size is not None else self._get_input_size()
+        )
+        if effective_res % self.depth_imgsz_divisor:
+            raise ValueError(
+                f"Depth Anything V2 imgsz={effective_res} must be divisible by "
+                f"{self.depth_imgsz_divisor} (DINOv2 patch grid)."
+            )
+        img = ImageLoader.load(image, color_format=color_format)
+        orig_w, orig_h = img.size
+        chw, ratio = preprocess_numpy(np.asarray(img), effective_res)
+        img_tensor = torch.from_numpy(chw).unsqueeze(0)
+        return img_tensor, img, (orig_w, orig_h), ratio
+
+    def _forward(self, input_tensor: torch.Tensor) -> Any:
+        return self.model(input_tensor)
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        **kwargs,
+    ) -> Dict:
+        depth = output
+        if isinstance(depth, dict):
+            depth = depth.get("depth", depth.get("predictions"))
+        orig_w, orig_h = original_size
+        depth = F.interpolate(
+            depth.float(),
+            size=(orig_h, orig_w),
+            mode="bilinear",
+            align_corners=False,
+        )
+        return {"depth": depth[0, 0].cpu()}
+
+    # ====================================================================
+    # Weights I/O
+    # ====================================================================
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> None:
+        # LibreYOLO does not mirror Depth Anything V2 weights: the strong
+        # checkpoints (Base/Large/Giant) are CC-BY-NC-4.0. Users convert the
+        # official weights with the conversion script.
+        return None
+
+    def _load_weights(self, model_path: str) -> None:
+        path = Path(model_path)
+        if path.exists():
+            super()._load_weights(str(path))
+            return
+        alt = Path("weights") / path.name
+        if alt.exists():
+            super()._load_weights(str(alt))
+            return
+        raise FileNotFoundError(self._weights_help(model_path))
+
+    @classmethod
+    def _weights_help(cls, requested: str) -> str:
+        return (
+            f"Depth Anything V2 weights not found: {requested}\n\n"
+            "LibreYOLO does not redistribute these weights. The Small encoder is\n"
+            "Apache-2.0; Base/Large/Giant are CC-BY-NC-4.0 (non-commercial).\n\n"
+            "To use them:\n"
+            f"  1. Download an official checkpoint from {cls._UPSTREAM_URL}\n"
+            "     (e.g. depth_anything_v2_vitl.pth).\n"
+            "  2. Convert it to a LibreYOLO checkpoint:\n"
+            "       python weights/convert_depth_anything_v2_weights.py \\\n"
+            "         depth_anything_v2_vitl.pth weights/LibreDepthAnythingV2l-depth.pt\n"
+            "  3. Load it: LibreYOLO('weights/LibreDepthAnythingV2l-depth.pt')\n"
+        )
+
+    # ====================================================================
+    # Out of scope
+    # ====================================================================
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Training Depth Anything V2 is out of scope for LibreYOLO. Upstream "
+            "ships no relative-depth training code, and LibreYOLO's depth trainer "
+            "targets the RF-DETR depth head. To train a depth model from scratch, "
+            "use a 'depth'-capable family such as RF-DETR; to fine-tune Depth "
+            f"Anything, train upstream at {self._UPSTREAM_URL} and convert the "
+            "result with weights/convert_depth_anything_v2_weights.py."
+        )
+
+    def export(self, format: str = "onnx", **kwargs) -> str:
+        raise NotImplementedError(
+            "Export is not implemented for Depth Anything V2 yet (depth export is "
+            "out of scope per ADR 0006: depth task contract)."
+        )

--- a/libreyolo/models/depth_anything/nn.py
+++ b/libreyolo/models/depth_anything/nn.py
@@ -51,3 +51,13 @@ class LibreDepthAnythingV2Net(DepthAnythingV2):
         x = (x - self.pixel_mean) / self.pixel_std
         depth = super().forward(x)  # (B, H, W), relative inverse depth (>= 0)
         return depth.unsqueeze(1)
+
+    def infer_image(self, *args, **kwargs):
+        # The vendored DepthAnythingV2.infer_image normalizes ImageNet stats in
+        # its own transform and then calls forward, which would normalize again
+        # here. Route callers through LibreYOLO's predict path instead.
+        raise NotImplementedError(
+            "Use the LibreYOLO predict API (model.predict(...) / model(...)) "
+            "instead of infer_image; the vendored infer_image would double-apply "
+            "ImageNet normalization on top of this wrapper's forward."
+        )

--- a/libreyolo/models/depth_anything/nn.py
+++ b/libreyolo/models/depth_anything/nn.py
@@ -1,0 +1,53 @@
+"""LibreYOLO depth network built on the vendored Depth Anything V2 model."""
+
+from __future__ import annotations
+
+import torch
+
+from ._vendor.dpt import DepthAnythingV2
+
+# Per-encoder DPT configuration, matching upstream ``run.py`` ``model_configs``.
+DEPTH_ANYTHING_V2_CONFIGS: dict[str, dict] = {
+    "vits": {"encoder": "vits", "features": 64, "out_channels": [48, 96, 192, 384]},
+    "vitb": {"encoder": "vitb", "features": 128, "out_channels": [96, 192, 384, 768]},
+    "vitl": {"encoder": "vitl", "features": 256, "out_channels": [256, 512, 1024, 1024]},
+    "vitg": {"encoder": "vitg", "features": 384, "out_channels": [1536, 1536, 1536, 1536]},
+}
+
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+class LibreDepthAnythingV2Net(DepthAnythingV2):
+    """Depth Anything V2 adapted to LibreYOLO's dense-task contract.
+
+    Two changes over the vendored module, both confined to ``forward``:
+
+    - ImageNet normalization happens inside ``forward`` so the network consumes
+      ``[0, 1]`` images, matching ``DepthDataset`` and LibreYOLO's other dense
+      heads (the depth validator feeds raw ``[0, 1]`` batches straight to
+      ``_forward``).
+    - The result is returned as ``(B, 1, H, W)`` relative inverse depth so the
+      depth predict and validation paths consume every family identically.
+
+    The learnable parameters are untouched, so a converted upstream checkpoint
+    (``pretrained.*`` + ``depth_head.*``) loads with ``strict=True``. The
+    normalization buffers are non-persistent and never enter the state dict.
+    """
+
+    def __init__(self, encoder: str = "vitl"):
+        if encoder not in DEPTH_ANYTHING_V2_CONFIGS:
+            raise ValueError(
+                f"Unknown Depth Anything V2 encoder {encoder!r}; "
+                f"expected one of {sorted(DEPTH_ANYTHING_V2_CONFIGS)}."
+            )
+        super().__init__(**DEPTH_ANYTHING_V2_CONFIGS[encoder])
+        mean = torch.tensor(IMAGENET_MEAN).view(1, 3, 1, 1)
+        std = torch.tensor(IMAGENET_STD).view(1, 3, 1, 1)
+        self.register_buffer("pixel_mean", mean, persistent=False)
+        self.register_buffer("pixel_std", std, persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = (x - self.pixel_mean) / self.pixel_std
+        depth = super().forward(x)  # (B, H, W), relative inverse depth (>= 0)
+        return depth.unsqueeze(1)

--- a/libreyolo/models/depth_anything/utils.py
+++ b/libreyolo/models/depth_anything/utils.py
@@ -1,0 +1,36 @@
+"""Preprocessing for the Depth Anything V2 family."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+from ._vendor.util.transform import PrepareForNet, Resize
+
+
+def preprocess_numpy(
+    img_rgb_hwc: np.ndarray, input_size: int = 518
+) -> Tuple[np.ndarray, float]:
+    """Resize an RGB image to Depth Anything V2's native input geometry.
+
+    Reproduces upstream ``infer_image``: keep the aspect ratio and scale the
+    short side up to a multiple of 14 (the DINOv2 patch grid) with cubic
+    interpolation. ImageNet normalization is applied inside the network, so the
+    returned array is a plain ``(3, H, W)`` float32 in ``[0, 1]``. The second
+    return value is the resize ratio (always ``1.0``: depth maps are resized
+    back to the original canvas in ``_postprocess``, not rescaled by ratio).
+    """
+    image = np.asarray(img_rgb_hwc, dtype=np.float32) / 255.0
+    resize = Resize(
+        width=input_size,
+        height=input_size,
+        resize_target=False,
+        keep_aspect_ratio=True,
+        ensure_multiple_of=14,
+        resize_method="lower_bound",
+        image_interpolation_method=cv2.INTER_CUBIC,
+    )
+    sample = PrepareForNet()(resize({"image": image}))
+    return sample["image"], 1.0

--- a/tests/unit/test_depth_anything.py
+++ b/tests/unit/test_depth_anything.py
@@ -86,7 +86,11 @@ class TestPreprocess:
     def test_keep_aspect_multiple_of_14_and_range(self):
         from libreyolo.models.depth_anything.utils import preprocess_numpy
 
-        img = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)
+        # A smooth gradient (real-image-like); cubic resize stays well-behaved.
+        yy, xx = np.mgrid[0:480, 0:640].astype(np.float32)
+        gradient = ((xx / 640.0 + yy / 480.0) * 0.5 * 255.0).astype(np.uint8)
+        img = np.repeat(gradient[:, :, None], 3, axis=2)
+
         chw, ratio = preprocess_numpy(img, input_size=518)
 
         assert chw.dtype == np.float32
@@ -95,7 +99,11 @@ class TestPreprocess:
         assert h % 14 == 0 and w % 14 == 0
         assert h >= 518 and w >= 518  # lower-bound resize
         assert ratio == 1.0
-        assert float(chw.min()) >= 0.0 and float(chw.max()) <= 1.0
+        # Normalized to ~[0, 1] (divided by 255). cv2.INTER_CUBIC can overshoot
+        # the [0, 1] range slightly, so allow a small margin rather than a hard
+        # clamp; the model applies ImageNet normalization next regardless.
+        assert np.isfinite(chw).all()
+        assert chw.min() >= -0.5 and chw.max() <= 1.5
 
 
 # ---------------------------------------------------------------- forward
@@ -156,6 +164,11 @@ class TestForwardAndPredict:
             da_small.train(data="x.yaml")
         with pytest.raises(NotImplementedError):
             da_small.export(format="onnx")
+
+    def test_inherited_infer_image_is_blocked(self, da_small):
+        # The vendored infer_image would double-normalize; it must redirect.
+        with pytest.raises(NotImplementedError, match="predict"):
+            da_small.model.infer_image(np.zeros((10, 10, 3), dtype=np.uint8))
 
 
 # ---------------------------------------------------------------- val + ckpt

--- a/tests/unit/test_depth_anything.py
+++ b/tests/unit/test_depth_anything.py
@@ -96,14 +96,17 @@ class TestPreprocess:
         assert chw.dtype == np.float32
         assert chw.shape[0] == 3
         h, w = chw.shape[1], chw.shape[2]
-        assert h % 14 == 0 and w % 14 == 0
-        assert h >= 518 and w >= 518  # lower-bound resize
+        assert h % 14 == 0
+        assert w % 14 == 0
+        assert h >= 518  # lower-bound resize
+        assert w >= 518
         assert ratio == 1.0
         # Normalized to ~[0, 1] (divided by 255). cv2.INTER_CUBIC can overshoot
         # the [0, 1] range slightly, so allow a small margin rather than a hard
         # clamp; the model applies ImageNet normalization next regardless.
         assert np.isfinite(chw).all()
-        assert chw.min() >= -0.5 and chw.max() <= 1.5
+        assert chw.min() >= -0.5
+        assert chw.max() <= 1.5
 
 
 # ---------------------------------------------------------------- forward
@@ -158,6 +161,13 @@ class TestForwardAndPredict:
         Image.new("RGB", (64, 64), color=(10, 20, 30)).save(img_path)
         with pytest.raises(ValueError, match="divisible by 14"):
             da_small.predict(str(img_path), imgsz=100)
+
+    def test_predict_rejects_augment(self, da_small, tmp_path):
+        # augment must raise, not silently fall through to plain inference.
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (56, 56), color=(10, 20, 30)).save(img_path)
+        with pytest.raises(ValueError, match="augment"):
+            da_small.predict(str(img_path), imgsz=70, augment=True)
 
     def test_train_and_export_out_of_scope(self, da_small):
         with pytest.raises(NotImplementedError):
@@ -230,4 +240,25 @@ def test_checkpoint_round_trip(da_small, tmp_path):
     assert loaded.FAMILY == "depth_anything"
     assert loaded.task == "depth"
     assert loaded.size == "s"
+    assert loaded.names == {0: "depth"}
+
+
+def test_names_forced_to_depth(da_small, tmp_path):
+    """A checkpoint carrying a generic class_0 name is normalized to depth."""
+    from libreyolo import LibreYOLO
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    ckpt = wrap_libreyolo_checkpoint(
+        da_small.model.state_dict(),
+        model_family="depth_anything",
+        size="s",
+        task="depth",
+        nc=1,
+        names={0: "class_0"},  # what the generic autoconverter would write
+        imgsz=518,
+    )
+    ckpt_path = tmp_path / "LibreDepthAnythingV2s-depth.pt"
+    torch.save(ckpt, str(ckpt_path))
+
+    loaded = LibreYOLO(str(ckpt_path), device="cpu")
     assert loaded.names == {0: "depth"}

--- a/tests/unit/test_depth_anything.py
+++ b/tests/unit/test_depth_anything.py
@@ -1,0 +1,220 @@
+"""Unit tests for the Depth Anything V2 family.
+
+The DINOv2 + DPT architecture builds from random init with no network access,
+so a real ViT-S is exercised at a small multiple-of-14 input to keep the tests
+hermetic and fast. Metadata/detection tests need no model build at all.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+import yaml as _yaml
+from PIL import Image
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------- metadata
+
+
+class TestDepthAnythingMetadata:
+    def test_task_and_size_metadata(self):
+        from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+        assert LibreDepthAnythingV2.FAMILY == "depth_anything"
+        assert LibreDepthAnythingV2.SUPPORTED_TASKS == ("depth",)
+        assert LibreDepthAnythingV2.DEFAULT_TASK == "depth"
+        assert LibreDepthAnythingV2.depth_imgsz_divisor == 14
+        assert set(LibreDepthAnythingV2.INPUT_SIZES) == {"s", "b", "l", "g"}
+        assert set(LibreDepthAnythingV2.INPUT_SIZES.values()) == {518}
+
+    def test_registered_in_factory(self):
+        from libreyolo.models import LibreDepthAnythingV2
+        from libreyolo.models.base import BaseModel
+
+        assert LibreDepthAnythingV2 in BaseModel._registry
+
+    def test_can_load_recognizes_da_signature(self):
+        from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+        state = {
+            "pretrained.cls_token": torch.zeros(1, 1, 384),
+            "pretrained.pos_embed": torch.zeros(1, 1370, 384),
+            "depth_head.scratch.output_conv2.0.weight": torch.zeros(1),
+        }
+        assert LibreDepthAnythingV2.can_load(state)
+
+    def test_can_load_rejects_rfdetr_depth_signature(self):
+        from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+        # RF-DETR depth uses backbone.* (not pretrained.*) for the encoder.
+        rfdetr_depth = {
+            "backbone.encoder.proj.weight": torch.zeros(1),
+            "depth_head.weight": torch.zeros(1, 8, 1, 1),
+        }
+        assert not LibreDepthAnythingV2.can_load(rfdetr_depth)
+
+    @pytest.mark.parametrize(
+        "embed_dim,expected",
+        [(384, "s"), (768, "b"), (1024, "l"), (1536, "g")],
+    )
+    def test_detect_size_from_encoder_width(self, embed_dim, expected):
+        from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+        state = {"pretrained.cls_token": torch.zeros(1, 1, embed_dim)}
+        assert LibreDepthAnythingV2.detect_size(state) == expected
+
+    def test_detect_nb_classes_is_one(self):
+        from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+        assert LibreDepthAnythingV2.detect_nb_classes({"pretrained.cls_token": 1}) == 1
+
+    def test_filename_size_and_task_detection(self):
+        from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+        fname = "LibreDepthAnythingV2l-depth.pt"
+        assert LibreDepthAnythingV2.detect_size_from_filename(fname) == "l"
+        assert LibreDepthAnythingV2.detect_task_from_filename(fname) == "depth"
+
+
+# ---------------------------------------------------------------- preprocess
+
+
+class TestPreprocess:
+    def test_keep_aspect_multiple_of_14_and_range(self):
+        from libreyolo.models.depth_anything.utils import preprocess_numpy
+
+        img = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)
+        chw, ratio = preprocess_numpy(img, input_size=518)
+
+        assert chw.dtype == np.float32
+        assert chw.shape[0] == 3
+        h, w = chw.shape[1], chw.shape[2]
+        assert h % 14 == 0 and w % 14 == 0
+        assert h >= 518 and w >= 518  # lower-bound resize
+        assert ratio == 1.0
+        assert float(chw.min()) >= 0.0 and float(chw.max()) <= 1.0
+
+
+# ---------------------------------------------------------------- forward
+
+
+@pytest.fixture(scope="module")
+def da_small():
+    """A random-init ViT-S depth model wrapper on CPU (no weights download)."""
+    from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+    return LibreDepthAnythingV2(model_path=None, size="s", task="depth", device="cpu")
+
+
+class TestForwardAndPredict:
+    def test_net_forward_shape_and_nonneg(self):
+        from libreyolo.models.depth_anything.nn import LibreDepthAnythingV2Net
+
+        net = LibreDepthAnythingV2Net("vits").eval()
+        x = torch.rand(2, 3, 70, 70)  # 70 = 5 * 14
+        with torch.no_grad():
+            out = net(x)
+        assert out.shape == (2, 1, 70, 70)
+        assert float(out.min()) >= 0.0  # relative inverse depth is non-negative
+
+    def test_normalization_buffers_not_in_state_dict(self):
+        from libreyolo.models.depth_anything.nn import LibreDepthAnythingV2Net
+
+        keys = LibreDepthAnythingV2Net("vits").state_dict().keys()
+        assert not any("pixel_mean" in k or "pixel_std" in k for k in keys)
+        assert all(
+            k.startswith("pretrained.") or k.startswith("depth_head.") for k in keys
+        )
+
+    def test_wrapper_metadata(self, da_small):
+        assert da_small.task == "depth"
+        assert da_small.input_size == 518
+        assert da_small.nb_classes == 1
+        assert da_small.names == {0: "depth"}
+
+    def test_predict_returns_depth_map(self, da_small, tmp_path):
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (90, 45), color=(50, 90, 130)).save(img_path)
+
+        result = da_small.predict(str(img_path), imgsz=70)
+
+        assert result.boxes is None
+        assert result.depth_map is not None
+        assert tuple(result.depth_map.data.shape) == (45, 90)
+
+    def test_predict_rejects_non_patch_imgsz(self, da_small, tmp_path):
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (64, 64), color=(10, 20, 30)).save(img_path)
+        with pytest.raises(ValueError, match="divisible by 14"):
+            da_small.predict(str(img_path), imgsz=100)
+
+    def test_train_and_export_out_of_scope(self, da_small):
+        with pytest.raises(NotImplementedError):
+            da_small.train(data="x.yaml")
+        with pytest.raises(NotImplementedError):
+            da_small.export(format="onnx")
+
+
+# ---------------------------------------------------------------- val + ckpt
+
+
+def _make_depth_yaml(root, n_images=4, size=70):
+    for split in ("train", "val"):
+        img_dir = root / "images" / split
+        depth_dir = root / "depths" / split
+        img_dir.mkdir(parents=True, exist_ok=True)
+        depth_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(n_images):
+            arr = np.zeros((size, size, 3), dtype=np.uint8)
+            arr[:, : size // 2] = (200, 40, 40)
+            arr[:, size // 2 :] = (40, 40, 200)
+            Image.fromarray(arr).save(img_dir / f"img{i}.jpg")
+            depth = np.full((size, size), 8.0)
+            depth[:, : size // 2] = 2.0
+            encoded = (depth * 256.0).round().astype(np.uint16)
+            Image.fromarray(encoded).save(depth_dir / f"img{i}.png")
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        _yaml.safe_dump(
+            {"path": str(root), "train": "images/train", "val": "images/val"}
+        )
+    )
+    return yaml_path
+
+
+def test_zero_shot_val_runs(da_small, tmp_path):
+    """Zero-shot eval through the shared DepthValidator yields finite metrics."""
+    yaml_path = _make_depth_yaml(tmp_path)
+    metrics = da_small.val(
+        data=str(yaml_path), imgsz=70, batch=2, workers=0, verbose=False
+    )
+    assert np.isfinite(metrics["metrics/abs_rel"])
+    assert "metrics/delta1" in metrics
+    assert metrics["fitness"] == metrics["metrics/delta1"]
+
+
+def test_checkpoint_round_trip(da_small, tmp_path):
+    """A converted-style checkpoint loads back through the factory as depth."""
+    from libreyolo import LibreYOLO
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    ckpt = wrap_libreyolo_checkpoint(
+        da_small.model.state_dict(),
+        model_family="depth_anything",
+        size="s",
+        task="depth",
+        nc=1,
+        names={0: "depth"},
+        imgsz=518,
+    )
+    ckpt_path = tmp_path / "LibreDepthAnythingV2s-depth.pt"
+    torch.save(ckpt, str(ckpt_path))
+
+    loaded = LibreYOLO(str(ckpt_path), device="cpu")
+    assert loaded.FAMILY == "depth_anything"
+    assert loaded.task == "depth"
+    assert loaded.size == "s"
+    assert loaded.names == {0: "depth"}

--- a/weights/convert_depth_anything_v2_weights.py
+++ b/weights/convert_depth_anything_v2_weights.py
@@ -1,0 +1,134 @@
+"""Convert official Depth Anything V2 weights into LibreYOLO format.
+
+The released relative-depth checkpoints (e.g. ``depth_anything_v2_vitl.pth``)
+ship as a bare state dict whose keys are ``pretrained.*`` (DINOv2 encoder) and
+``depth_head.*`` (DPT head). The architecture is vendored under
+``libreyolo/models/depth_anything/_vendor`` (Apache-2.0), so this script only
+wraps the upstream state dict in the LibreYOLO v1.0 checkpoint schema; the keys
+are unchanged, so the load is 0-missing / 0-unexpected.
+
+Weight licensing: the Small (ViT-S) checkpoint is Apache-2.0; Base/Large/Giant
+(ViT-B/L/G) are CC-BY-NC-4.0 (non-commercial). LibreYOLO does not redistribute
+these weights - you convert your own copy and comply with its license.
+
+Usage::
+
+    python weights/convert_depth_anything_v2_weights.py \
+        depth_anything_v2_vitl.pth weights/LibreDepthAnythingV2l-depth.pt
+
+Size is auto-detected from the encoder width; pass ``--size`` to override. Add
+``--verify`` to load the converted file through the normal LibreYOLO API and run
+a smoke forward pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from _conversion_utils import (
+    add_repo_root_to_path,
+    extract_state_dict,
+    load_checkpoint,
+    save_checkpoint,
+)
+
+# DINOv2 cls-token / embedding width -> LibreYOLO size code (ViT-S/B/L/G).
+_EMBED_DIM_TO_SIZE = {384: "s", 768: "b", 1024: "l", 1536: "g"}
+_IMGSZ = 518
+
+
+def detect_size(state_dict: dict) -> str | None:
+    """Infer the size code from the DINOv2 encoder width."""
+    cls_token = state_dict.get("pretrained.cls_token")
+    if cls_token is not None and getattr(cls_token, "ndim", 0) >= 1:
+        return _EMBED_DIM_TO_SIZE.get(int(cls_token.shape[-1]))
+    return None
+
+
+def convert_weights(
+    input_path: str,
+    output_path: str,
+    *,
+    size: str | None = None,
+) -> dict:
+    print(f"Loading upstream Depth Anything V2 weights from {input_path}")
+    raw = load_checkpoint(input_path)
+    state_dict = extract_state_dict(raw)
+    print(f"Found {len(state_dict)} parameter entries")
+
+    if not any(k.startswith("pretrained.") for k in state_dict) or not any(
+        k.startswith("depth_head.") for k in state_dict
+    ):
+        raise ValueError(
+            "This does not look like a Depth Anything V2 checkpoint "
+            "(expected 'pretrained.*' encoder and 'depth_head.*' head keys)."
+        )
+
+    if size is None:
+        size = detect_size(state_dict)
+        if size is None:
+            raise ValueError(
+                "Could not auto-detect size from the encoder width. "
+                "Pass --size {s,b,l,g} explicitly."
+            )
+        print(f"Auto-detected size: {size}")
+
+    add_repo_root_to_path()
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    libreyolo_ckpt = wrap_libreyolo_checkpoint(
+        state_dict,
+        model_family="depth_anything",
+        size=size,
+        task="depth",
+        nc=1,
+        names={0: "depth"},
+        imgsz=_IMGSZ,
+    )
+
+    save_checkpoint(libreyolo_ckpt, output_path)
+    print(f"Saved LibreYOLO-format checkpoint to {output_path}")
+    return libreyolo_ckpt
+
+
+def verify_conversion(converted_path: str) -> bool:
+    """Load through the normal LibreYOLO API and run a smoke forward pass."""
+    add_repo_root_to_path()
+    from libreyolo import LibreYOLO
+
+    print(f"\nLoading converted weights via LibreYOLO({converted_path})...")
+    m = LibreYOLO(converted_path, device="cpu")
+    print(
+        f"  family={m.FAMILY} size={m.size} task={m.task} "
+        f"nc={m.nb_classes} names={m.names}"
+    )
+
+    m.model.eval()
+    with torch.no_grad():
+        out = m.model(torch.zeros(1, 3, _IMGSZ, _IMGSZ))
+    print(f"  forward pass OK - output shape: {tuple(out.shape)}")
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert Depth Anything V2 weights to LibreYOLO format"
+    )
+    parser.add_argument("input", help="Upstream Depth Anything V2 checkpoint (.pth)")
+    parser.add_argument("output", help="Output LibreYOLO checkpoint (.pt)")
+    parser.add_argument(
+        "--size",
+        default=None,
+        choices=["s", "b", "l", "g"],
+        help="Size code (default: auto-detect from encoder width)",
+    )
+    parser.add_argument(
+        "--verify", action="store_true", help="Verify round-trip after conversion"
+    )
+    args = parser.parse_args()
+
+    convert_weights(args.input, args.output, size=args.size)
+    if args.verify:
+        verify_conversion(args.output)

--- a/weights/convert_depth_anything_v2_weights.py
+++ b/weights/convert_depth_anything_v2_weights.py
@@ -24,6 +24,7 @@ a smoke forward pass.
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 import torch
 
@@ -53,6 +54,18 @@ def convert_weights(
     *,
     size: str | None = None,
 ) -> dict:
+    # Metric checkpoints share the exact same state-dict keys as the relative
+    # ones (the head differs only by a parameter-free Sigmoid * max_depth), so
+    # they cannot be told apart by tensors and would load silently wrong into
+    # the relative ReLU head. Reject by filename - metric depth is out of scope.
+    if "metric" in Path(input_path).name.lower():
+        raise ValueError(
+            f"{input_path} looks like a metric Depth Anything V2 checkpoint. "
+            "LibreYOLO's depth_anything family is relative-depth only; the metric "
+            "head (Sigmoid * max_depth) would load but produce wrong values. "
+            "Metric depth is out of scope."
+        )
+
     print(f"Loading upstream Depth Anything V2 weights from {input_path}")
     raw = load_checkpoint(input_path)
     state_dict = extract_state_dict(raw)


### PR DESCRIPTION
Vendor the Apache-2.0 DINOv2 + DPT model under models/depth_anything/_vendor and add a LibreDepthAnythingV2 family that plugs into the existing depth task contract: predict and zero-shot val work through the shared dataset, validator, results, and checkpoint schema. The wrapper normalizes ImageNet stats inside forward and keeps pretrained.*/depth_head.* keys so converted weights load strict.

Includes weights/convert_depth_anything_v2_weights.py, third-party notice with the code-vs-weights license split, nomenclature docs, and unit tests. Weights are license-gated and not mirrored (Small Apache-2.0; Base/Large/Giant CC-BY-NC-4.0). Training and export are deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Depth Anything V2 monocular depth estimation (depth-only) model with multiple encoder sizes (s/b/l/g) at the required 518 input scale, exposed as a new public model symbol.

* **Documentation**
  * Updated third-party notices with “source code vs. weights” licensing guidance for Depth Anything V2.
  * Expanded nomenclature with the new `depth_anything` family and example checkpoint references.

* **Tests**
  * Added unit tests covering loading, preprocessing, prediction output, and checkpoint round-trips.

* **Chores**
  * Added a script to convert official Depth Anything V2 weights into LibreYOLO format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->