### PR TITLE
Fix LibreFOMO release gaps: validator dispatch, exports, and docs

### DIFF
--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -160,7 +160,7 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 
 Families that override `SUPPORTED_TASKS` also declare `TASK_INPUT_SIZES` so
 each task can use a different per-size input resolution (relevant for RF-DETR).
-LibreFOMO supports and ships `point` weights natively, using `SUPPORTED_TASKS = ("point",)`. Other point-localization families must opt into `SUPPORTED_TASKS = ("point",)` or an equivalent multi-task tuple.
+LibreFOMO uses `SUPPORTED_TASKS = ("point",)`. No pretrained weights are auto-downloadable for this family; see `libreyolo/models/fomo/model.py`. Other point-localization families must opt into `SUPPORTED_TASKS = ("point",)` or an equivalent multi-task tuple.
 
 ## Examples by family + task
 
@@ -234,7 +234,13 @@ LibreL2CSr50.pt           # L2CS gaze estimation (ResNet-50, Gaze360 weights)
 
 ```text
 LibreFOMOs-point.pt       # FOMO point-localizer (size s, point task)
+LibreFOMOm-point.pt       # FOMO point-localizer (size m, point task)
+LibreFOMOl-point.pt       # FOMO point-localizer (size l, point task)
 ```
+
+These are the canonical filenames for LibreFOMO checkpoints. Pretrained weights
+are not currently auto-downloadable; pass a local checkpoint path or train from
+scratch. See `libreyolo/models/fomo/model.py` for details.
 
 `gaze` is L2CS's only task, so — like `detect` for the detection families —
 it carries no suffix in the canonical filename; `-gaze` is accepted but

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -116,6 +116,7 @@ class BaseModel(ABC):
     TASK_INPUT_SIZES: ClassVar[dict[str, dict[str, int]]] = {}
     TRAIN_CONFIG: ClassVar[Optional[type[TrainConfig]]] = None
     val_preprocessor_class = StandardValPreprocessor
+    validator_class: ClassVar[Optional[type]] = None
     EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset[str]] = frozenset()
 
     # Batched-predict policy: True when ``_preprocess`` yields stackable
@@ -1200,7 +1201,9 @@ class BaseModel(ABC):
                 "is out of scope for LibreYOLO. Evaluate upstream at "
                 "https://github.com/Ahmednull/L2CS-Net."
             )
-        if self.task == "pose":
+        if self.validator_class is not None:
+            validator_cls = self.validator_class
+        elif self.task == "pose":
             validator_cls = PoseValidator
         elif self.task == "point":
             validator_cls = PointValidator

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -104,6 +104,7 @@ class BaseModel(ABC):
         INPUT_SIZES: Mapping of size code to input resolution.
         TRAIN_CONFIG: TrainConfig subclass with family-specific defaults.
         val_preprocessor_class: Preprocessor class for validation.
+        validator_class: Override the validator used by val(); defaults to task-based dispatch.
     """
 
     # Class-level model metadata — subclasses override these

--- a/libreyolo/models/fomo/model.py
+++ b/libreyolo/models/fomo/model.py
@@ -15,6 +15,7 @@ from .utils import postprocess as postprocess_fomo
 from ...training.config import FOMOConfig
 from ...training.ddp_spawn import ddp_aware
 from ...validation.preprocessors import FOMOValPreprocessor
+from ...validation.fomo_validator import FOMOValidator
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class LibreFOMO(BaseModel):
     DEFAULT_TASK = "point"
     TRAIN_CONFIG = FOMOConfig
     val_preprocessor_class = FOMOValPreprocessor
+    validator_class = FOMOValidator
 
     TTA_ENABLED = False
 

--- a/libreyolo/validation/__init__.py
+++ b/libreyolo/validation/__init__.py
@@ -9,6 +9,7 @@ from .pose_validator import PoseValidator
 from .point_validator import PointValidator
 from .depth_validator import DepthValidator
 from .semantic_validator import SemanticValidator
+from .fomo_validator import FOMOValidator
 from .val_plotter import ValPlotter, ConfusionMatrix
 
 __all__ = [
@@ -19,6 +20,7 @@ __all__ = [
     "OBBValidator",
     "PoseValidator",
     "PointValidator",
+    "FOMOValidator",
     "DepthValidator",
     "SemanticValidator",
     "COCOEvaluator",

--- a/libreyolo/validation/fomo_validator.py
+++ b/libreyolo/validation/fomo_validator.py
@@ -171,8 +171,8 @@ class FOMOValidator(PointValidator):
             self.val_loss_total += float(loss_out["total_loss"].item())
             self.batch_count += 1
 
-        logits_cpu = logits.detach().cpu()
         from ..models.fomo.utils import decode_points_from_logits
+        logits_cpu = logits.detach().cpu()
         targets_cpu = grid_targets.detach().cpu()
         for threshold in self.conf_thresholds:
             for nms_radius in self.nms_radii:

--- a/libreyolo/validation/fomo_validator.py
+++ b/libreyolo/validation/fomo_validator.py
@@ -9,8 +9,6 @@ import torch
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 
-from ..models.fomo.loss import FOMOLoss
-from ..models.fomo.utils import decode_points_from_logits
 from .point_validator import PointValidator
 
 __all__ = ["FOMOValidator"]
@@ -37,6 +35,7 @@ class FOMOValidator(PointValidator):
         self.nms_radii = nms_radii
         self.distance_tolerance = distance_tolerance
 
+        from ..models.fomo.loss import FOMOLoss
         self.val_loss_fn = FOMOLoss(
             num_classes=self.nc,
             fg_weight=self.fg_weight,
@@ -173,6 +172,7 @@ class FOMOValidator(PointValidator):
             self.batch_count += 1
 
         logits_cpu = logits.detach().cpu()
+        from ..models.fomo.utils import decode_points_from_logits
         targets_cpu = grid_targets.detach().cpu()
         for threshold in self.conf_thresholds:
             for nms_radius in self.nms_radii:


### PR DESCRIPTION
- Add `validator_class` hook to BaseModel so families can declare their own validator class; `val()` prefers it over the task-based dispatch.
- Set `LibreFOMO.validator_class = FOMOValidator` so `model.val()` uses FOMOValidator (with grid-level F1/P/R metrics) instead of the generic PointValidator.
- Make the models.fomo imports in fomo_validator.py lazy to break the validation ↔ models.fomo circular import that the above exposes.
- Export FOMOValidator from libreyolo.validation package.
- Fix nomenclature.md: remove the false "ships weights natively" claim; expand the point filename examples with m/l sizes; note no weights are auto-downloadable.
- Fix pre-existing test bug: threshold=0.25 causes all zero-logit cells to fire (softmax=0.5 > 0.25), producing 35 spurious FPs. Test now uses threshold=0.99 so only the explicitly boosted cell fires.