### PR TITLE
yolonas: enable pose checkpoint auto-download with pinned SHA-256

### DIFF
--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -98,7 +98,7 @@ class LibreYOLONAS(BaseModel):
             return None
         task = cls.detect_task_from_filename(filename)
         if task == "pose":
-            if size not in cls._SIZE_FROM_HEAD_WIDTH_POSE.values():
+            if size not in cls.POSE_INPUT_SIZES:
                 return None
             return f"{cls._DECI_CDN_BASE}/yolo_nas_pose_{size}_coco_pose.pth"
         if size not in cls.INPUT_SIZES:

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -98,7 +98,9 @@ class LibreYOLONAS(BaseModel):
             return None
         task = cls.detect_task_from_filename(filename)
         if task == "pose":
-            return None
+            if size not in cls._SIZE_FROM_HEAD_WIDTH_POSE.values():
+                return None
+            return f"{cls._DECI_CDN_BASE}/yolo_nas_pose_{size}_coco_pose.pth"
         if size not in cls.INPUT_SIZES:
             return None
         return f"{cls._DECI_CDN_BASE}/yolo_nas_{size}_coco.pth"
@@ -342,6 +344,10 @@ class LibreYOLONAS(BaseModel):
         "yolo_nas_s_coco.pth": "c1b1d9148ab8ae5d5984699547e850955ff9efccaf568c67b3d605acb4bfe1cb",
         "yolo_nas_m_coco.pth": "b194fc7fa196f76161c6356558bedf04fb99a62325a74a36a4bec3ca8ba48250",
         "yolo_nas_l_coco.pth": "91a06beaa1ce1a651d6691e3198061da996eafc8890503238dedacbd4c392a32",
+        "yolo_nas_pose_n_coco_pose.pth": "3544cd4bef7a4930e79c2d9a9ec50167be6fa366be834d52d462393edfc3a64f",
+        "yolo_nas_pose_s_coco_pose.pth": "54f0933cb3760c5f9ba47e901c58d6d114cd206718667a586031bea0ab9ea849",
+        "yolo_nas_pose_m_coco_pose.pth": "6d0f92a589fd2f39a9fb92c42894cca76e81eaf2fcb3a00f1cac2e7089fb91ec",
+        "yolo_nas_pose_l_coco_pose.pth": "d05c55157b3eb917e43d3669cc1e99fbe35a8a93c7883b95b93036a81216c5ab",
     }
 
     @classmethod

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -334,7 +334,7 @@ class LibreYOLONAS(BaseModel):
     def _strict_loading(self) -> bool:
         return False
 
-    # SHA-256 of the official Deci CDN detection checkpoints. Auto-downloaded
+    # SHA-256 of the official Deci CDN checkpoints (detection + pose). Auto-downloaded
     # YOLO-NAS weights are third-party pickles that must be loaded with
     # weights_only=False, so they are verified against these pins before being
     # unpickled; a compromised/tampered CDN object then fails closed instead of

--- a/tests/unit/test_yolonas_heuristics.py
+++ b/tests/unit/test_yolonas_heuristics.py
@@ -114,24 +114,46 @@ class TestYOLONASHeuristics:
         assert LibreYOLONAS.get_download_url(filename) is None
 
     @pytest.mark.parametrize(
-        "filename,expected_cdn_name",
+        ("filename", "expected_url"),
         [
-            ("LibreYOLONASn-pose.pt", "yolo_nas_pose_n_coco_pose.pth"),
-            ("LibreYOLONASs-pose.pt", "yolo_nas_pose_s_coco_pose.pth"),
-            ("LibreYOLONASm-pose.pt", "yolo_nas_pose_m_coco_pose.pth"),
-            ("LibreYOLONASl-pose.pt", "yolo_nas_pose_l_coco_pose.pth"),
-            ("yolo_nas_pose_n_coco_pose.pth", "yolo_nas_pose_n_coco_pose.pth"),
-            ("yolo_nas_pose_s_coco_pose.pth", "yolo_nas_pose_s_coco_pose.pth"),
-            ("yolo_nas_pose_m_coco_pose.pth", "yolo_nas_pose_m_coco_pose.pth"),
-            ("yolo_nas_pose_l_coco_pose.pth", "yolo_nas_pose_l_coco_pose.pth"),
+            (
+                "LibreYOLONASn-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_n_coco_pose.pth",
+            ),
+            (
+                "LibreYOLONASs-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_s_coco_pose.pth",
+            ),
+            (
+                "LibreYOLONASm-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_m_coco_pose.pth",
+            ),
+            (
+                "LibreYOLONASl-pose.pt",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_l_coco_pose.pth",
+            ),
+            (
+                "yolo_nas_pose_n_coco_pose.pth",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_n_coco_pose.pth",
+            ),
+            (
+                "yolo_nas_pose_s_coco_pose.pth",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_s_coco_pose.pth",
+            ),
+            (
+                "yolo_nas_pose_m_coco_pose.pth",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_m_coco_pose.pth",
+            ),
+            (
+                "yolo_nas_pose_l_coco_pose.pth",
+                "https://d2gjn4b69gu75n.cloudfront.net/models/yolo_nas_pose_l_coco_pose.pth",
+            ),
         ],
     )
     def test_get_download_url_returns_cdn_url_for_pose_checkpoints(
-        self, filename, expected_cdn_name
+        self, filename, expected_url
     ):
-        url = LibreYOLONAS.get_download_url(filename)
-        assert url is not None
-        assert url.endswith(expected_cdn_name)
+        assert LibreYOLONAS.get_download_url(filename) == expected_url
 
 
 class TestYOLONASNativeModel:

--- a/tests/unit/test_yolonas_heuristics.py
+++ b/tests/unit/test_yolonas_heuristics.py
@@ -114,20 +114,24 @@ class TestYOLONASHeuristics:
         assert LibreYOLONAS.get_download_url(filename) is None
 
     @pytest.mark.parametrize(
-        "filename",
+        "filename,expected_cdn_name",
         [
-            "LibreYOLONASn-pose.pt",
-            "yolo_nas_pose_n_coco_pose.pth",
-            "yolo_nas_pose_s_coco_pose.pth",
-            "yolo_nas_pose_m_coco_pose.pth",
-            "yolo_nas_pose_l_coco_pose.pth",
-            "LibreYOLONASs-pose.pt",
-            "LibreYOLONASm-pose.pt",
-            "LibreYOLONASl-pose.pt",
+            ("LibreYOLONASn-pose.pt", "yolo_nas_pose_n_coco_pose.pth"),
+            ("LibreYOLONASs-pose.pt", "yolo_nas_pose_s_coco_pose.pth"),
+            ("LibreYOLONASm-pose.pt", "yolo_nas_pose_m_coco_pose.pth"),
+            ("LibreYOLONASl-pose.pt", "yolo_nas_pose_l_coco_pose.pth"),
+            ("yolo_nas_pose_n_coco_pose.pth", "yolo_nas_pose_n_coco_pose.pth"),
+            ("yolo_nas_pose_s_coco_pose.pth", "yolo_nas_pose_s_coco_pose.pth"),
+            ("yolo_nas_pose_m_coco_pose.pth", "yolo_nas_pose_m_coco_pose.pth"),
+            ("yolo_nas_pose_l_coco_pose.pth", "yolo_nas_pose_l_coco_pose.pth"),
         ],
     )
-    def test_get_download_url_returns_none_for_pose_checkpoints(self, filename):
-        assert LibreYOLONAS.get_download_url(filename) is None
+    def test_get_download_url_returns_cdn_url_for_pose_checkpoints(
+        self, filename, expected_cdn_name
+    ):
+        url = LibreYOLONAS.get_download_url(filename)
+        assert url is not None
+        assert url.endswith(expected_cdn_name)
 
 
 class TestYOLONASNativeModel:


### PR DESCRIPTION
## Summary

- All four Deci CDN pose checkpoints (`n`/`s`/`m`/`l`) are publicly live — SHA-256 digests computed fresh from the CDN
- Added the four digests to `_DECI_CHECKPOINT_SHA256` so `verify_downloaded_file` can gate the pickle load
- Re-enabled `get_download_url()` for pose (was unconditionally `return None` since the pinned checksums were missing); now returns the correct CDN URL `yolo_nas_pose_{size}_coco_pose.pth`
- Updated the heuristics test: replaced `test_get_download_url_returns_none_for_pose_checkpoints` with `test_get_download_url_returns_cdn_url_for_pose_checkpoints`, parametrized over all 8 filename variants (4 LibreYOLO names + 4 native Deci names)

Users can now do:

```python
from libreyolo import LibreYOLO
model = LibreYOLO("LibreYOLONASs-pose.pt")  # auto-downloads & verifies on first run
results = model("image.jpg", save=True)
```

Closes #439

## Test plan

- [ ] `pytest tests/unit/test_yolonas_heuristics.py` — 30 passed, 2 skipped (all 8 new pose URL tests green)
- [ ] Smoke-test: `LibreYOLO("LibreYOLONASs-pose.pt")` on a machine without cached weights downloads, verifies checksum, and runs inference