### PR TITLE
ec-pose: fix decoder depth and person-logit channel

### DIFF
--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1260,7 +1260,9 @@ class BaseBackend(ABC):
 
         scores_per_class = 1.0 / (1.0 + np.exp(-pred_logits.astype(np.float64)))
         scores_per_class = scores_per_class.astype(np.float32)
-        query_scores = scores_per_class[..., 0]
+        # Person class is the LAST logit (index 1 of ECPose's 2-class head); keep
+        # this in lockstep with ``postprocess_pose`` so .pt and ONNX agree.
+        query_scores = scores_per_class[..., -1]
         k = min(max_det, query_scores.size)
         query_idx = np.argpartition(-query_scores, k - 1)[:k]
         query_idx = query_idx[np.argsort(-query_scores[query_idx])]

--- a/libreyolo/models/ec/nn.py
+++ b/libreyolo/models/ec/nn.py
@@ -20,12 +20,16 @@ from .encoder import HybridEncoder
 # Pose-specific per-size diffs (overlay on SIZE_CONFIGS' backbone+encoder).
 # All four sizes share num_classes=2 (DETRPose criterion uses 2 classes:
 # person + bg) and num_keypoints=17 (COCO). Decoder layer counts and
-# dim_feedforward differ per size.
+# dim_feedforward differ per size and must match the published ECPose
+# checkpoints exactly: the pose decoder builds ``dec_num_layers`` decoder
+# layers plus one deep-supervision head (class/pose/lqe) per layer, so an
+# over-count leaves the surplus layers and heads randomly initialized and
+# never restored from the checkpoint.
 POSE_SIZE_OVERRIDES: Dict[str, Dict] = {
     "s": {"dec_num_layers": 3, "dec_dim_feedforward": 512},
     "m": {"dec_num_layers": 4, "dec_dim_feedforward": 512},
-    "l": {"dec_num_layers": 6, "dec_dim_feedforward": 1024},
-    "x": {"dec_num_layers": 6, "dec_dim_feedforward": 2048},
+    "l": {"dec_num_layers": 4, "dec_dim_feedforward": 1024},
+    "x": {"dec_num_layers": 4, "dec_dim_feedforward": 2048},
 }
 
 

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -313,7 +313,10 @@ class ECPoseTrainer(BaseTrainer):
         """``(B, max_labels, 5 + 3K)`` pixel slab -> per-image DETRPose target dicts.
 
         Each dict follows DETRPose's contract:
-          - ``labels``   : (n,) all 0 (person)
+          - ``labels``   : (n,) all 1 (person). ECPose uses a 2-logit class head
+            whose person slot is the LAST logit (index 1); this matches the
+            published checkpoints and the inference person score in
+            ``postprocess_pose`` / ``_parse_ec_pose`` (both read ``[..., -1]``).
           - ``boxes``    : (n,4) xyxy normalized (used by the denoising group)
           - ``keypoints``: (n, 2K + K) = [x1,y1,...,xK,yK | v1,...,vK], normalized
                            xy and binary visibility
@@ -351,7 +354,8 @@ class ECPoseTrainer(BaseTrainer):
             keypoints = torch.cat([kxy.reshape(tv.shape[0], 2 * K), vis], dim=1)
             out.append(
                 {
-                    "labels": torch.zeros(tv.shape[0], dtype=torch.int64, device=self.device),
+                    # person == last logit (index 1) of the 2-class head.
+                    "labels": torch.ones(tv.shape[0], dtype=torch.int64, device=self.device),
                     "boxes": boxes,
                     "keypoints": keypoints,
                     "area": area,

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -333,7 +333,8 @@ class ECPoseTrainer(BaseTrainer):
             if tv.numel() == 0:
                 out.append(
                     {
-                        "labels": torch.zeros(0, dtype=torch.int64, device=self.device),
+                        # person == last logit (index 1) of the 2-class head.
+                        "labels": torch.ones(0, dtype=torch.int64, device=self.device),
                         "boxes": torch.zeros(0, 4, device=self.device),
                         "keypoints": torch.zeros(0, 3 * K, device=self.device),
                         "area": torch.zeros(0, device=self.device),

--- a/libreyolo/postprocess/ec.py
+++ b/libreyolo/postprocess/ec.py
@@ -115,7 +115,11 @@ def postprocess_pose(
         out_logits = out_logits[0]
         out_kpts = out_kpts[0]
 
-    query_scores = out_logits[..., 0].sigmoid()
+    # DETRPose's class head emits ``num_classes`` logits; the published ECPose
+    # COCO checkpoints encode the person class on the LAST logit (index 1 of the
+    # 2-class head) and leave index 0 as an unused background-style slot. Score
+    # the person logit; ``[..., -1]`` also degrades correctly to a 1-logit head.
+    query_scores = out_logits[..., -1].sigmoid()
     scores, query_idx = torch.topk(
         query_scores,
         min(max_det, query_scores.numel()),

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -591,7 +591,8 @@ def test_ec_pose_backend_parses_flattened_keypoints():
         task="pose",
         supported_tasks=("detect", "pose"),
     )
-    logits = np.array([[[10.0, -10.0], [-10.0, -10.0]]], dtype=np.float32)
+    # person is the LAST logit (index 1) of the 2-class ECPose head.
+    logits = np.array([[[-10.0, 10.0], [-10.0, -10.0]]], dtype=np.float32)
     keypoints = np.array(
         [[[0.25, 0.5, 0.75, 0.25], [0.0, 0.0, 0.0, 0.0]]],
         dtype=np.float32,
@@ -616,7 +617,7 @@ def test_ec_pose_backend_uses_exported_boxes_when_present():
         task="pose",
         supported_tasks=("detect", "pose"),
     )
-    logits = np.array([[[10.0, -10.0]]], dtype=np.float32)
+    logits = np.array([[[-10.0, 10.0]]], dtype=np.float32)  # person == last logit
     boxes = np.array([[[0.5, 0.5, 0.8, 0.6]]], dtype=np.float32)
     keypoints = np.array([[[0.45, 0.45, 0.55, 0.55]]], dtype=np.float32)
 
@@ -638,7 +639,7 @@ def test_ec_pose_backend_does_not_clip_keypoints():
         task="pose",
         supported_tasks=("detect", "pose"),
     )
-    logits = np.array([[[10.0, -10.0]]], dtype=np.float32)
+    logits = np.array([[[-10.0, 10.0]]], dtype=np.float32)  # person == last logit
     keypoints = np.array([[[-0.25, 1.25, 0.5, 0.5]]], dtype=np.float32)
 
     boxes, _, _, _, _, parsed_keypoints = backend._parse_outputs(
@@ -724,6 +725,8 @@ def test_ec_pose_backend_scores_person_logit_only():
         task="pose",
         supported_tasks=("detect", "pose"),
     )
+    # Person is the LAST logit (index 1): query 0 wins on its person logit
+    # (10.0) over query 1 (-10.0); query 1's high index-0 logit (9.0) is ignored.
     logits = np.array([[[0.0, 10.0], [9.0, -10.0]]], dtype=np.float32)
     keypoints = np.array(
         [[[0.1, 0.1, 0.2, 0.2], [0.7, 0.7, 0.8, 0.8]]],
@@ -739,7 +742,7 @@ def test_ec_pose_backend_scores_person_logit_only():
     assert classes.tolist() == [0]
     assert masks is None
     assert obb is None
-    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[70.0, 70.0], [80.0, 80.0]])
+    np.testing.assert_allclose(parsed_keypoints[0, :, :2], [[10.0, 10.0], [20.0, 20.0]])
 
 
 def test_ec_pose_backend_does_not_hard_cap_queries_at_sixty():

--- a/tests/unit/test_ec_pose.py
+++ b/tests/unit/test_ec_pose.py
@@ -251,6 +251,9 @@ class TestPoseForwardAndPostprocess:
         np.testing.assert_allclose(det["keypoints"][:, 0, :2], [[10.0, 10.0], [70.0, 70.0]])
 
     def test_postprocess_scores_person_logit_only(self):
+        # Person is the LAST logit (index 1) of the 2-class ECPose head; query 0
+        # wins on its person logit (10.0) over query 1 (-10.0), and the high
+        # index-0 logit on query 1 (9.0) must be ignored.
         raw = {
             "pred_logits": torch.tensor([[[0.0, 10.0], [9.0, -10.0]]]),
             "pred_keypoints": torch.tensor(
@@ -268,7 +271,7 @@ class TestPoseForwardAndPostprocess:
         )
 
         assert det["boxes"].shape == (1, 4)
-        np.testing.assert_allclose(det["keypoints"][0, :, :2], [[70.0, 70.0], [80.0, 80.0]])
+        np.testing.assert_allclose(det["keypoints"][0, :, :2], [[10.0, 10.0], [20.0, 20.0]])
 
     def test_wrapper_postprocess_does_not_hard_cap_queries_at_sixty(self, pose_model):
         raw = {


### PR DESCRIPTION
Two bugs broke LibreEC*-pose inference and ONNX export:

- POSE_SIZE_OVERRIDES built 6 decoder layers for sizes l and x, but the published checkpoints have 4. The surplus layers and their per-layer class/pose/lqe heads stayed randomly initialized (load_state_dict drops them as missing keys), so predictions changed across reloads and the ONNX snapshotted random weights. Set l and x to 4 layers so the checkpoints load with no missing/unexpected keys.

- The pose head emits 2 class logits; the checkpoints place the person score on the last logit (index 1), but postprocess_pose and the ONNX parser read index 0, so confidence was ~0 and no detections survived. Read the last logit in both paths and align the experimental pose trainer's person label.

All four sizes now load deterministically and detect people on parkour.jpg; ONNX matches the .pt within ~1.7px and 3e-4 confidence.