### PR TITLE
fix(rfdetr): load real DINOv2 weights for classify (silent random backbone)

### DIFF
--- a/libreyolo/models/rfdetr/backbone.py
+++ b/libreyolo/models/rfdetr/backbone.py
@@ -529,17 +529,53 @@ class DinoV2(nn.Module):
                 window_block_indexes=window_block_indexes,
                 gradient_checkpointing=gradient_checkpointing,
             )
-            self.encoder = (
-                WindowedDinov2WithRegistersBackbone.from_pretrained(
-                    name,
-                    config=windowed_dino_config,
-                )
-                if load_dinov2_weights
-                else WindowedDinov2WithRegistersBackbone(windowed_dino_config)
-            )
+            self.encoder = WindowedDinov2WithRegistersBackbone(windowed_dino_config)
+            if load_dinov2_weights:
+                # NOTE: WindowedDinov2WithRegistersBackbone.from_pretrained(...) silently
+                # no-ops the weight transfer under recent Transformers releases: the class
+                # inherits base_model_prefix="dinov2_with_registers" but attaches its
+                # submodules directly (self.embeddings/self.encoder/self.layernorm), so the
+                # loader's prefix reconciliation fails to populate any weights while still
+                # reporting success. That leaves the ViT randomly initialized. We copy the
+                # reference DINOv2 state dict explicitly and verify the transfer took effect.
+                self._load_pretrained_dinov2(name)
 
         self._out_feature_channels = [size_to_width[size]] * len(out_feature_indexes)
         self._export = False
+
+    def _load_pretrained_dinov2(self, name):
+        """Explicitly copy pretrained DINOv2 weights into the windowed backbone.
+
+        The windowed backbone's state-dict keys (embeddings.*, encoder.*, layernorm.*)
+        match the reference DINOv2 checkpoint exactly, so a direct shape-checked copy is
+        robust across Transformers versions. Raises if the transfer fails to land, so a
+        silently-random backbone can never ship again.
+        """
+        from transformers import AutoModel
+
+        ref_sd = AutoModel.from_pretrained(name).state_dict()
+        tgt_sd = self.encoder.state_dict()
+        new_sd, matched, skipped = {}, 0, 0
+        for k, v in tgt_sd.items():
+            if k in ref_sd and ref_sd[k].shape == v.shape:
+                new_sd[k] = ref_sd[k]
+                matched += 1
+            else:
+                new_sd[k] = v
+                skipped += 1
+        self.encoder.load_state_dict(new_sd, strict=False)
+
+        pe_std = self.encoder.embeddings.patch_embeddings.projection.weight.std().item()
+        if matched == 0 or pe_std > 0.015:
+            raise RuntimeError(
+                f"DINOv2 pretrained transfer failed for '{name}' "
+                f"(matched={matched}, skipped={skipped}, patch_embed std={pe_std:.4f}). "
+                "The backbone would train from random init."
+            )
+        logger.info(
+            f"Loaded pretrained DINOv2 weights from '{name}' "
+            f"(matched={matched}, skipped={skipped}, patch_embed std={pe_std:.4f})."
+        )
 
     def export(self):
         if self._export:


### PR DESCRIPTION
## Problem

RF-DETR classify trains on a **randomly-initialized** DINOv2 backbone. `WindowedDinov2WithRegistersBackbone.from_pretrained(...)` silently no-ops the weight transfer under Transformers 5.x: the class inherits `base_model_prefix="dinov2_with_registers"` but attaches its submodules directly (`embeddings`/`encoder`/`layernorm`), so prefix reconciliation populates nothing while still reporting `Loading weights: 100% 223/223`. The ViT is left random.

Detection/pose **hide** this bug because they overwrite the whole model with a full RF-DETR checkpoint. Classify has no such checkpoint (`weight_source=None` → `load_dinov2_weights=True`), so the random init is exposed — this is why RF-DETR classify stalled near random-backbone accuracy (~81% top-1 on imagenette).

## Fix

Replace the `from_pretrained` no-op in `DinoV2.__init__` with an explicit, shape-checked state-dict transfer (`_load_pretrained_dinov2`): copy the reference DINOv2 state dict into the windowed backbone (223/223 tensors match), and **raise** if the transfer fails to land (`matched == 0` or `patch_embed std > 0.015`) so a silently-random backbone can never ship again.

## Empirical verification

Built `LibreRFDETR(task="classify")` and measured the patch-embed projection weight std:

| | `patch_embed` std | meaning |
|---|---|---|
| before (current dev) | **0.0200** | == `initializer_range` → random |
| after (this PR) | **0.0070** | `matched=223, skipped=0` → genuine `facebook/dinov2-small` |

## Scope

Single-file change (`backbone.py`), touches only the `load_dinov2_weights=True` path. No behaviour change for detection/pose (they overwrite the backbone anyway).

Part of #431. This is the backbone fix only; the production-grade classify pieces (label smoothing, archive datasets, task-aware configs) are a separate follow-up that needs manual re-application onto the post-#436 classify implementation, so #431 stays open.