### PR TITLE
fix: classify probs corrupted by Results indexing (+ doc corrections)

### DIFF
--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -144,14 +144,14 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 | Family    | `SUPPORTED_TASKS`                   | Default | Notes |
 |---|---|---|---|
 | `yolox`     | `("detect",)` (default)             | detect | detect-only |
-| `yolo9`     | `("detect", "segment", "semantic", "pose", "classify", "obb")` | detect | native grid, classifier, and dense-decoder heads |
+| `yolo9`     | `("detect",)`                       | detect | detect-only (non-detect flagship variants removed in #436) |
 | `yolo9_e2e` | `("detect",)` (default)             | detect | detect-only |
 | `dfine`     | `("detect",)` (default)             | detect | detect-only |
 | `deim`      | `("detect",)` (default)             | detect | detect-only |
 | `deimv2`    | `("detect",)` (default)             | detect | detect-only |
 | `rtdetr`    | `("detect",)` (default)             | detect | detect-only |
 | `picodet`   | `("detect",)` (default)             | detect | detect-only |
-| `rfdetr`    | `("detect", "segment", "semantic", "pose", "classify", "obb", "depth")` | detect | classify uses 224; semantic/depth use 518; seg uses smaller sizes; pose/OBB use detect sizes |
+| `rfdetr`    | `("detect", "segment", "pose", "classify", "obb")` | detect | classify uses 224; seg uses smaller sizes; pose/OBB use detect sizes |
 | `yolonas`   | `("detect", "pose")`                | detect | pose adds size `n` |
 | `ec`     | `("detect", "pose", "segment")`     | detect | all three tasks |
 | `l2cs`      | `("gaze",)`                         | gaze   | inference-only; two-stage (face detector + gaze head); not trainable in LibreYOLO |
@@ -169,10 +169,6 @@ LibreFOMO uses `SUPPORTED_TASKS = ("point",)`. No pretrained weights are auto-do
 ```text
 LibreYOLOXn.pt
 LibreYOLO9s.pt
-LibreYOLO9t-seg.pt
-LibreYOLO9t-pose.pt
-LibreYOLO9t-cls.pt
-LibreYOLO9t-obb.pt
 LibreYOLO9E2Es.pt
 LibreYOLONASm.pt
 LibreDFINEl.pt
@@ -195,22 +191,12 @@ LibreYOLONASs-pose.pt
 LibreYOLONASm-pose.pt
 LibreYOLONASl-pose.pt
 
-# yolo9 - detect + segment + semantic + pose + classify + obb
-LibreYOLO9t.pt             # detect (default)
-LibreYOLO9t-seg.pt         # segment
-LibreYOLO9t-sem.pt         # semantic
-LibreYOLO9t-pose.pt        # pose
-LibreYOLO9t-cls.pt         # classify
-LibreYOLO9t-obb.pt         # obb
-
-# rfdetr - detect + segment + semantic + pose + classify + obb + depth
+# rfdetr - detect + segment + pose + classify + obb
 LibreRFDETRn.pt            # detect
 LibreRFDETRn-seg.pt        # segment
-LibreRFDETRn-sem.pt        # semantic
 LibreRFDETRx-pose.pt       # pose (preview; only size x ships)
 LibreRFDETRn-cls.pt        # classify
 LibreRFDETRn-obb.pt        # obb
-LibreRFDETRn-depth.pt      # depth
 
 # ec — detect + pose + segment
 LibreECs.pt             # detect (default)

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -412,6 +412,12 @@ class Probs(_TensorPayload):
             return self.data[torch.tensor(indices, device=self.data.device)]
         return self.data[indices]
 
+    def __getitem__(self, idx):
+        # A classification probability vector is whole-image, not per-detection;
+        # keep it intact so shared Results slicing (e.g. ``result[0]``) cannot
+        # truncate it to a single class. Mirrors SemanticMask/DepthMap.
+        return self.__class__(self.data, self.orig_shape)
+
 
 class SemanticMask(_TensorPayload):
     """Dense semantic segmentation map for a single image.

--- a/skills/use-libreyolo/SKILL.md
+++ b/skills/use-libreyolo/SKILL.md
@@ -80,11 +80,13 @@ Run `libreyolo formats` for each format's extension and FP16/INT8 support.
 
 ## Reading results
 
-`predict`/`track` return `Results` objects (one per image, or a generator when
-streaming). Read them programmatically rather than re-parsing saved files:
+`predict`/`track` return a single `Results` for a single image, or a `list` of
+`Results` for multiple inputs (a directory, a list, or video frames). Index the
+list, not a single `Results` — indexing a `Results` selects one detection.
+Read them programmatically rather than re-parsing saved files:
 
 ```python
-r = model("img.jpg")[0]
+r = model("img.jpg")          # one Results (single image); use model([...])  / a dir for a list
 len(r)              # number of detections
 r.boxes.xyxy        # (N, 4) boxes; also .xywh, .conf, .cls, .id (tracking)
 r.masks             # segmentation masks (segment task)

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -253,6 +253,26 @@ class TestResults:
         assert result.probs.top5conf.tolist() == pytest.approx([0.7, 0.2, 0.1])
         assert result.summary()[0]["name"] == "b"
 
+    def test_classify_probs_survive_result_indexing(self):
+        # Regression: indexing a classification Results (the universal
+        # ``results[0]`` idiom, and what predict() of a single image invites)
+        # must NOT slice the whole-image probs vector down to one class.
+        probs = Probs(torch.tensor([0.1, 0.7, 0.2]))
+        result = Results(
+            boxes=None,
+            orig_shape=(1, 1),
+            probs=probs,
+            names={0: "a", 1: "b", 2: "c"},
+        )
+
+        indexed = result[0]
+
+        assert indexed.probs.data.shape == (3,)
+        assert indexed.probs.top1 == 1
+        assert indexed.probs.top1conf.item() == pytest.approx(0.7)
+        # Probs payload indexing is itself a no-op (mirrors SemanticMask/DepthMap).
+        assert probs[0].data.shape == (3,)
+
     def test_depth_map_result_ignores_nonfinite_summary_values(self):
         depth = DepthMap(torch.tensor([[1.0, float("nan")], [float("inf"), 3.0]]))
         result = Results(


### PR DESCRIPTION
## Why

Found during heavy QA of RF-DETR classification for the v1.3.0 release.

**Release-critical bug:** `model("img.jpg")[0].probs` silently returned the **wrong class** for every image. A single-image `predict()` returns one `Results`, and indexing a `Results` (`[0]`) slices every payload via the inherited `_TensorPayload.__getitem__` — including the whole-image classification probability vector, truncating `[num_classes]` → `[1]`. `argmax` then always returned class 0, with no error. Our own `skills/use-libreyolo/SKILL.md` documents exactly this idiom, so users following the docs got wrong classifications.

The model weights are fine — only the access path was broken (empirically: `res.probs.top1` correct = 1 @ conf 0.94, `res[0].probs.top1` wrong = 0 @ 0.009).

## Fix

`SemanticMask` and `DepthMap` (also whole-image payloads) already guard against this with a no-op `__getitem__`. `Probs` was simply missing the same override. This PR adds `Probs.__getitem__` returning an intact copy (mirroring them) plus a regression test (`test_classify_probs_survive_result_indexing`); the existing `test_classify_probs_result` only exercised `result.probs` directly, never `result[0]`.

## Docs (verified against current `SUPPORTED_TASKS`)

- `nomenclature.md`: `yolo9` is detect-only and `rfdetr` no longer supports `semantic`/`depth` (post-#436); removed the stale `LibreYOLO9t-{seg,pose,cls,obb}` and `LibreRFDETR{n-sem,n-depth}` examples.
- `use-libreyolo/SKILL.md`: corrected the `model("img.jpg")[0]` idiom (single image → one `Results`; index the list only for multiple inputs).

## Validation

- `tests/unit/{test_results,test_classification,test_segmentation}` + CLI predict tests pass; broader `Results` blast radius (422 unit tests) green.
- Verified on real models: classify `res[0].probs` full vector + correct top1; semantic `res[0].semantic_mask` intact; detection `res[0]` still slices to one box.

## Not in this PR (follow-up, non-blocking)

- **Fine-tune recipe gap:** a fresh classify fine-tune with the default recipe plateaus ~0.93 on imagenette vs the shipped 0.976. Decide: port the production recipe, or document the default ceiling. Practical guidance today: fine-tune *from* the shipped `-cls` checkpoint (transfer reached 0.955 in 5 epochs).

https://claude.ai/code/session_01XHy3Sr3RNgYJrdMW9k7db2