### PR TITLE
refactor(rfdetr): move classify to the LibreDINOv2 family

### DIFF
--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -36,6 +36,7 @@ separate category, covered in the note below):
 | `deimv2`    | `LibreDEIMv2`   | All-caps acronym + lowercase version |
 | `rtdetr`    | `LibreRTDETR`   | All-caps acronym (hyphen dropped from `RT-DETR`) |
 | `rfdetr`    | `LibreRFDETR`   | All-caps acronym (hyphen dropped from `RF-DETR`) |
+| `dinov2`    | `LibreDINOv2`   | All-caps acronym + lowercase version (DINOv2 backbone) |
 | `picodet`   | `LibrePICODET`  | All-caps (`PicoDet` rendered uppercase) |
 | `ec`     | `LibreEC`    | Short form of EdgeCrafter — used as the family alias for the three sibling upstream models `ECDet`, `ECPose`, `ECSeg` |
 | `l2cs`      | `LibreL2CS`     | All-caps acronym (`L2CS` gaze estimation) — inference-only |
@@ -86,6 +87,7 @@ ships:
 | `deimv2`    | per-cfg (see `SIZE_CONFIGS`) |
 | `rtdetr`    | `r18`, `r34`, `r50`, `r50m`, `r101`, `l`, `x` |
 | `rfdetr`    | `n`, `s`, `m`, `l` |
+| `dinov2`    | `n`, `s`, `m`, `l` (projector width; all sizes share the DINOv2-S encoder) |
 | `picodet`   | `s`, `m`, `l` (320 / 416 / 640 input) |
 | `ec`     | `s`, `m`, `l`, `x` |
 | `l2cs`      | `r18`, `r34`, `r50`, `r101`, `r152` (ResNet backbone depth) |
@@ -151,7 +153,8 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 | `deimv2`    | `("detect",)` (default)             | detect | detect-only |
 | `rtdetr`    | `("detect",)` (default)             | detect | detect-only |
 | `picodet`   | `("detect",)` (default)             | detect | detect-only |
-| `rfdetr`    | `("detect", "segment", "pose", "classify", "obb")` | detect | classify uses 224; seg uses smaller sizes; pose/OBB use detect sizes |
+| `rfdetr`    | `("detect", "segment", "pose", "obb")` | detect | seg uses smaller sizes; pose/OBB use detect sizes |
+| `dinov2`    | `("semantic", "classify")`          | semantic | DINOv2 backbone + task head (semantic dense head at 518 / classify linear probe at 224); NOT the RF-DETR detector |
 | `yolonas`   | `("detect", "pose")`                | detect | pose adds size `n` |
 | `ec`     | `("detect", "pose", "segment")`     | detect | all three tasks |
 | `l2cs`      | `("gaze",)`                         | gaze   | inference-only; two-stage (face detector + gaze head); not trainable in LibreYOLO |
@@ -176,7 +179,6 @@ LibreDEIMx.pt
 LibreDEIMv2s.pt
 LibreRTDETRr50.pt
 LibreRFDETRn.pt
-LibreRFDETRn-cls.pt
 LibrePICODETs.pt
 LibreECs.pt
 ```
@@ -191,12 +193,15 @@ LibreYOLONASs-pose.pt
 LibreYOLONASm-pose.pt
 LibreYOLONASl-pose.pt
 
-# rfdetr - detect + segment + pose + classify + obb
+# rfdetr - detect + segment + pose + obb
 LibreRFDETRn.pt            # detect
 LibreRFDETRn-seg.pt        # segment
 LibreRFDETRx-pose.pt       # pose (preview; only size x ships)
-LibreRFDETRn-cls.pt        # classify
 LibreRFDETRn-obb.pt        # obb
+
+# dinov2 — DINOv2 backbone + task head (NOT the RF-DETR detector)
+LibreDINOv2n.pt            # semantic (default task; dense head at 518)
+LibreDINOv2n-cls.pt        # classify (linear probe at 224)
 
 # ec — detect + pose + segment
 LibreECs.pt             # detect (default)

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -583,11 +583,11 @@ class BaseExporter(ABC):
             nn_model = _RTDETRExportWrapper(nn_model).to(device)
             nn_model.eval()
             dfine_wrapped = True
-        elif family == "rfdetr" and getattr(self.model, "task", None) == "classify":
-            # Classification has no detection decoder; trace the backbone +
-            # linear classifier directly (it returns logits). The detection
-            # export wrapper forwards through ``model.model``, which is None
-            # for classification.
+        elif family == "dinov2" and getattr(self.model, "task", None) == "classify":
+            # Classification (now in the LibreDINOv2 family) has no detection
+            # decoder; trace the backbone + linear classifier directly (it
+            # returns logits). The detection export wrapper forwards through
+            # ``model.model``, which is None for classification.
             nn_model = nn_model.classifier.to(device)
             nn_model.eval()
             # Precompute static DINOv2 positional encodings for the fixed export

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -1,19 +1,27 @@
-"""LibreDINOv2 — DINOv2 backbone + dense decoder for semantic segmentation.
+"""LibreDINOv2 — DINOv2 backbone models for semantic segmentation and classification.
 
-LibreDINOv2 reuses the ``RFDETRSemanticSegmenter`` module from the RF-DETR
-family (DINOv2 encoder + multi-scale projector pyramid + 1x1 dense head) but
-exposes it as its own model family so:
+LibreDINOv2 is the honest home for the tasks that are really "DINOv2 backbone +
+a task head" rather than the RF-DETR detector:
 
-* checkpoints are saved with ``model_family="dinov2"``
-* LibreRFDETR no longer registers ``task="semantic"`` in its supported tasks
-* the factory resolves ``predict.weight + backbone.*`` keys to LibreDINOv2
+* ``semantic`` — reuses ``RFDETRSemanticSegmenter`` (DINOv2 encoder +
+  multi-scale projector pyramid + 1x1 dense head).
+* ``classify`` — reuses ``RFDETRClassifier`` (DINOv2 encoder + projector +
+  global-average-pool + linear head). The DETR decoder/queries are never built;
+  this is a linear probe on the pretrained DINOv2 backbone, not the RF-DETR
+  detector, so it does not belong in the RF-DETR family.
 
-Training delegates to :class:`DINOv2Trainer`, which inherits the semantic
-branches from ``RFDETRTrainer`` and overrides only the family metadata.
+Both expose themselves as the ``dinov2`` family: checkpoints save
+``model_family="dinov2"`` and the factory routes ``backbone.*`` plus
+``predict.*`` (semantic) / ``linear.*`` (classify) keys here. LibreRFDETR no
+longer registers ``semantic`` or ``classify``.
 
-Backward compatibility: checkpoints saved before this split carry
-``model_family="rfdetr"`` and ``task="semantic"``.  :meth:`can_load` accepts
-those keys so the factory can route them here.
+Training delegates to :class:`DINOv2Trainer`, which inherits the semantic and
+classify branches from ``RFDETRTrainer`` and overrides only the family metadata.
+
+Backward compatibility: pre-split semantic checkpoints carry
+``model_family="rfdetr"`` / ``task="semantic"`` and are still accepted.
+Classify is intentionally a clean break — legacy ``LibreRFDETR*-cls``
+checkpoints are not loaded (retrain/republish as ``LibreDINOv2*-cls``).
 """
 
 from __future__ import annotations
@@ -91,6 +99,53 @@ class _DINOv2ModelWrapper(nn.Module):
         return self.segmenter.load_state_dict(state_dict, strict=strict)
 
 
+class _DINOv2ClassifierWrapper(nn.Module):
+    """Exposes ``RFDETRClassifier`` to ``RFDETRTrainer``'s classify path.
+
+    ``RFDETRTrainer.get_freeze_groups`` activates the classify branch when
+    ``self.model.model is None`` and reads ``self.model.classifier`` (backbone +
+    linear head). Mirrors :class:`_DINOv2ModelWrapper` but wraps the linear-probe
+    classifier instead of the dense segmenter. The DETR decoder is never built —
+    this is a DINOv2 backbone + global-average-pool + linear head.
+    """
+
+    def __init__(
+        self,
+        config: str,
+        nb_classes: int,
+        device: str = "cpu",
+    ) -> None:
+        super().__init__()
+        # Lazy import so the outer module-level import stays rfdetr-free.
+        from ..rfdetr.nn import RFDETRClassifier
+
+        # ``model = None`` signals RFDETRTrainer.get_freeze_groups that this is
+        # the linear-head path (uses the classifier freeze layout).
+        self.model: nn.Module | None = None
+        self.classifier = RFDETRClassifier(
+            config=config, nb_classes=nb_classes, device=device
+        )
+        self.nb_classes = nb_classes
+        self.resolution = self.classifier.resolution
+        self.hidden_dim = self.classifier.hidden_dim
+        self.patch_size = self.classifier.patch_size
+        self.num_windows = self.classifier.num_windows
+
+    def forward(self, x: torch.Tensor, targets=None):
+        return self.classifier(x, targets=targets)
+
+    def state_dict(self, *args, **kwargs):
+        return self.classifier.state_dict(*args, **kwargs)
+
+    def load_state_dict(self, state_dict: dict, strict: bool = False):
+        if isinstance(state_dict, dict):
+            if "model" in state_dict and isinstance(state_dict["model"], dict):
+                state_dict = state_dict["model"]
+            elif "state_dict" in state_dict and isinstance(state_dict["state_dict"], dict):
+                state_dict = state_dict["state_dict"]
+        return self.classifier.load_state_dict(state_dict, strict=strict)
+
+
 # ---------------------------------------------------------------------------
 # LibreDINOv2
 # ---------------------------------------------------------------------------
@@ -118,9 +173,12 @@ class LibreDINOv2(BaseModel):
     FILENAME_PREFIX: ClassVar[str] = "LibreDINOv2"
     WEIGHT_EXT: ClassVar[str] = ".pt"
 
-    # All sizes run at the DINOv2-native 518 (37 × 14) resolution.
+    # Semantic runs at the DINOv2-native 518 (37 × 14); classify runs at 224.
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"n": 518, "s": 518, "m": 518, "l": 518}
-    SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("semantic",)
+    TASK_INPUT_SIZES: ClassVar[Dict[str, Dict[str, int]]] = {
+        "classify": {"n": 224, "s": 224, "m": 224, "l": 224},
+    }
+    SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("semantic", "classify")
     DEFAULT_TASK: ClassVar[str] = "semantic"
 
     TRAIN_CONFIG: ClassVar[type] = RFDETRConfig
@@ -137,14 +195,18 @@ class LibreDINOv2(BaseModel):
 
     @classmethod
     def can_load(cls, weights_dict: dict) -> bool:
-        """Match checkpoints whose keys form the backbone + dense-head pattern.
+        """Match LibreDINOv2 checkpoints: backbone + dense head (semantic) or
+        backbone + linear head (classify).
 
-        Also accepts old ``model_family="rfdetr"`` semantic checkpoints for
-        backward compatibility.
+        Semantic also accepts old ``model_family="rfdetr"`` checkpoints for
+        backward compatibility; classify is a clean break (legacy
+        ``LibreRFDETR*-cls`` checkpoints are not matched as new dinov2 weights).
         """
-        return "predict.weight" in weights_dict and any(
-            k.startswith("backbone.") for k in weights_dict
-        )
+        if not any(k.startswith("backbone.") for k in weights_dict):
+            return False
+        is_semantic = "predict.weight" in weights_dict
+        is_classify = "linear.weight" in weights_dict and "predict.weight" not in weights_dict
+        return is_semantic or is_classify
 
     @classmethod
     def detect_size(cls, weights_dict: dict) -> Optional[str]:
@@ -157,6 +219,9 @@ class LibreDINOv2(BaseModel):
         pw = weights_dict.get("predict.weight")
         if pw is not None:
             return int(pw.shape[0])
+        lw = weights_dict.get("linear.weight")
+        if lw is not None:
+            return int(lw.shape[0])
         return None
 
     # =========================================================================
@@ -173,9 +238,9 @@ class LibreDINOv2(BaseModel):
         **kwargs,
     ) -> None:
         resolved_task = normalize_task(task) if task is not None else "semantic"
-        if resolved_task != "semantic":
+        if resolved_task not in ("semantic", "classify"):
             raise ValueError(
-                f"LibreDINOv2 only supports task='semantic'; got {task!r}."
+                f"LibreDINOv2 supports task in ('semantic', 'classify'); got {task!r}."
             )
 
         if isinstance(model_path, dict) and not model_path:
@@ -259,6 +324,12 @@ class LibreDINOv2(BaseModel):
     # =========================================================================
 
     def _init_model(self) -> nn.Module:
+        if self.task == "classify":
+            return _DINOv2ClassifierWrapper(
+                config=self.size,
+                nb_classes=self._model_num_classes,
+                device=str(self.device),
+            )
         return _DINOv2ModelWrapper(
             config=self.size,
             nb_classes=self._model_num_classes,
@@ -268,10 +339,16 @@ class LibreDINOv2(BaseModel):
     def _rebuild_for_new_classes(self, new_nc: int) -> None:
         self.nb_classes = new_nc
         self._model_num_classes = new_nc
-        segmenter = self.model.segmenter
-        in_channels = segmenter.predict.in_channels
-        segmenter.predict = nn.Conv2d(in_channels, new_nc, 1)
-        segmenter.nb_classes = new_nc
+        if self.task == "classify":
+            classifier = self.model.classifier
+            in_features = classifier.linear.in_features
+            classifier.linear = nn.Linear(in_features, new_nc)
+            classifier.nb_classes = new_nc
+        else:
+            segmenter = self.model.segmenter
+            in_channels = segmenter.predict.in_channels
+            segmenter.predict = nn.Conv2d(in_channels, new_nc, 1)
+            segmenter.nb_classes = new_nc
         self.model.nb_classes = new_nc
         self.model.to(self.device)
         self.names = {i: f"class_{i}" for i in range(new_nc)}
@@ -280,14 +357,18 @@ class LibreDINOv2(BaseModel):
         return False
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:
-        segmenter = self.model.segmenter
+        core = self.model.classifier if self.task == "classify" else self.model.segmenter
         layers: Dict[str, nn.Module] = {}
-        backbone = getattr(segmenter, "backbone", None)
+        backbone = getattr(core, "backbone", None)
         if backbone is not None:
             layers["backbone"] = backbone
-        predict = getattr(segmenter, "predict", None)
-        if predict is not None:
-            layers["head"] = predict
+        head = (
+            getattr(core, "linear", None)
+            if self.task == "classify"
+            else getattr(core, "predict", None)
+        )
+        if head is not None:
+            layers["head"] = head
         return layers
 
     @staticmethod
@@ -315,8 +396,15 @@ class LibreDINOv2(BaseModel):
         color_format: str = "auto",
         input_size: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
-        """Stretch-resize to square; the segmenter applies ImageNet norm."""
+        """Stretch-resize to square; the model applies ImageNet norm."""
         effective_res = input_size if input_size is not None else self.input_size
+        if self.task == "classify":
+            from ...data.classify_dataset import build_classify_transforms
+
+            img = ImageLoader.load(image, color_format=color_format)
+            orig_w, orig_h = img.size
+            transform = build_classify_transforms(effective_res, augment=False)
+            return transform(img).unsqueeze(0), img, (orig_w, orig_h), 1.0
         if effective_res % self.semantic_imgsz_divisor:
             raise ValueError(
                 f"LibreDINOv2 semantic imgsz={effective_res} must be divisible "
@@ -341,6 +429,12 @@ class LibreDINOv2(BaseModel):
         max_det: int = 300,
         **kwargs,
     ) -> Dict:
+        if self.task == "classify":
+            logits = output
+            if isinstance(logits, dict):
+                logits = logits.get("logits", logits.get("predictions"))
+            probs = torch.softmax(logits.float(), dim=1)[0]
+            return {"probs": probs.cpu()}
         logits = output
         if isinstance(logits, dict):
             logits = logits.get("semantic_logits", logits.get("predictions"))
@@ -358,7 +452,11 @@ class LibreDINOv2(BaseModel):
     # =========================================================================
 
     def _load_weights(self, model_path: str | dict[str, Any]) -> None:
-        """Load a LibreDINOv2 (or legacy RF-DETR semantic) checkpoint."""
+        """Load a LibreDINOv2 checkpoint.
+
+        Semantic also accepts legacy ``model_family="rfdetr"`` checkpoints;
+        classify is a clean break (see :meth:`_load_classify_weights`).
+        """
         if isinstance(model_path, str):
             if not Path(model_path).exists():
                 from ...utils.download import download_weights
@@ -367,13 +465,16 @@ class LibreDINOv2(BaseModel):
             loaded = load_trusted_torch_file(
                 model_path,
                 map_location="cpu",
-                context="DINOv2 semantic weights",
+                context=f"DINOv2 {self.task} weights",
             )
         else:
             loaded = model_path
 
         if not isinstance(loaded, dict):
             raise TypeError("LibreDINOv2 checkpoints must be dictionaries")
+
+        if self.task == "classify":
+            return self._load_classify_weights(loaded)
 
         # Accept both model_family="dinov2" (new) and "rfdetr" (legacy semantic).
         ckpt_family = loaded.get("model_family", "")
@@ -419,6 +520,54 @@ class LibreDINOv2(BaseModel):
             self.names = self._sanitize_names(ckpt_names, self.nb_classes)
         self.model.to(self.device)
 
+    def _load_classify_weights(self, loaded: dict) -> None:
+        """Load a LibreDINOv2 classification checkpoint.
+
+        Clean break: legacy ``LibreRFDETR*-cls`` checkpoints
+        (``model_family="rfdetr"``) are rejected with a clear message.
+        """
+        ckpt_family = loaded.get("model_family", "")
+        if ckpt_family and ckpt_family != self.FAMILY:
+            raise RuntimeError(
+                f"Checkpoint was trained with model_family='{ckpt_family}', but "
+                f"LibreDINOv2 classification only loads model_family='{self.FAMILY}' "
+                "checkpoints. Legacy LibreRFDETR*-cls weights are not supported — "
+                "retrain/republish as LibreDINOv2*-cls."
+            )
+        ckpt_task = loaded.get("task")
+        if isinstance(ckpt_task, str) and normalize_task(ckpt_task) != "classify":
+            raise RuntimeError(
+                f"Checkpoint was trained for task={normalize_task(ckpt_task)!r}, "
+                "but is being loaded into a LibreDINOv2 classification model."
+            )
+
+        state = self._extract_state(loaded)
+        lw = state.get("linear.weight")
+        if lw is None:
+            raise RuntimeError(
+                "Checkpoint does not look like a LibreDINOv2 classification model "
+                "(no 'linear.weight' classifier head found)."
+            )
+        ckpt_nc = int(lw.shape[0])
+        if ckpt_nc != self.nb_classes:
+            self._rebuild_for_new_classes(ckpt_nc)
+
+        result = self.model.load_state_dict(loaded, strict=False)
+        unexpected = list(getattr(result, "unexpected_keys", []) or [])
+        if any(
+            ("class_embed" in k or "transformer" in k or k.startswith("predict."))
+            for k in unexpected
+        ):
+            raise RuntimeError(
+                "Checkpoint does not look like a LibreDINOv2 classification model "
+                "(weights match a detector or dense head, not backbone + linear)."
+            )
+
+        ckpt_names = loaded.get("names")
+        if ckpt_names is not None:
+            self.names = self._sanitize_names(ckpt_names, self.nb_classes)
+        self.model.to(self.device)
+
     # =========================================================================
     # Training
     # =========================================================================
@@ -434,7 +583,11 @@ class LibreDINOv2(BaseModel):
         resume=None,
         **kwargs,
     ) -> Dict:
-        """Fine-tune LibreDINOv2 for semantic segmentation."""
+        """Fine-tune LibreDINOv2 for semantic segmentation or classification.
+
+        Task is taken from ``self.task``; ``DINOv2Trainer`` (via ``RFDETRTrainer``)
+        routes the classify vs semantic data/loss branches accordingly.
+        """
         from pathlib import Path as _Path
 
         from .trainer import DINOv2Trainer

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -186,25 +186,16 @@ class LibreRFDETR(BaseModel):
     POSE_INPUT_SIZES: ClassVar[dict[str, int]] = {
         "x": 576,
     }
-    # Classification runs the DINOv2 backbone at 224 (divisible by patch_size 14).
-    CLS_INPUT_SIZES: ClassVar[dict[str, int]] = {
-        "n": 224,
-        "s": 224,
-        "m": 224,
-        "l": 224,
-    }
     SUPPORTED_TASKS: ClassVar[tuple[str, ...]] = (
         "detect",
         "segment",
         "pose",
-        "classify",
         "obb",
     )
     TASK_INPUT_SIZES: ClassVar[dict[str, dict[str, int]]] = {
         "detect": INPUT_SIZES,
         "segment": SEG_INPUT_SIZES,
         "pose": POSE_INPUT_SIZES,
-        "classify": CLS_INPUT_SIZES,
         "obb": INPUT_SIZES,
     }
     EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset[str]] = frozenset()
@@ -246,13 +237,8 @@ class LibreRFDETR(BaseModel):
             for k in keys_lower
         ):
             return True
-        # Classification checkpoints carry only the DINOv2 backbone + a linear
-        # head, so they lack the detection/decoder markers above. Recognize the
-        # backbone-plus-linear-head signature so the factory can route them.
-        if "linear.weight" in weights_dict and any(
-            k.startswith("backbone.") for k in weights_dict
-        ):
-            return True
+        # Classification (linear head on the DINOv2 backbone) now lives in the
+        # LibreDINOv2 family, so RF-DETR no longer claims those checkpoints.
         return False
 
     @staticmethod
@@ -340,8 +326,6 @@ class LibreRFDETR(BaseModel):
 
     @classmethod
     def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
-        if "linear.weight" in weights_dict:
-            return int(weights_dict["linear.weight"].shape[0])
         # RF-DETR class_embed has (num_classes + 1) outputs (includes background)
         if "class_embed.bias" in weights_dict:
             detected = int(weights_dict["class_embed.bias"].shape[0]) - 1
@@ -405,13 +389,6 @@ class LibreRFDETR(BaseModel):
             size = "x" if normalize_task(resolved_task) == "pose" else "s"
 
         if isinstance(model_path, dict) and not model_path:
-            weight_source = None
-        elif (
-            normalize_task(resolved_task) == "classify"
-            and model_path is None
-        ):
-            # Classification builds its own pretrained DINOv2 backbone;
-            # the detection checkpoints do not apply.
             weight_source = None
         elif normalize_task(resolved_task) == "pose" and model_path is None:
             weight_source = None
@@ -509,10 +486,6 @@ class LibreRFDETR(BaseModel):
         return getattr(self, "task", "detect") == "pose"
 
     @property
-    def _is_classification(self) -> bool:
-        return self.task == "classify"
-
-    @property
     def _is_obb(self) -> bool:
         """Adapter flag derived from the canonical task state."""
         return self.task == "obb"
@@ -571,8 +544,6 @@ class LibreRFDETR(BaseModel):
             return filename_task
 
         state = _checkpoint_model_state(ckpt) if isinstance(ckpt, dict) else {}
-        if "linear.weight" in state and any(k.startswith("backbone.") for k in state):
-            return "classify"
         if any(k.startswith("segmentation_head") for k in state):
             return "segment"
         # Pose: legacy clean-room keypoint_head.* weights, or the GroupPose
@@ -634,24 +605,12 @@ class LibreRFDETR(BaseModel):
             device=str(self.device),
             segmentation=self._is_segmentation,
             pose=self._is_pose,
-            classification=self._is_classification,
             obb=self._is_obb,
             num_keypoints=self.num_keypoints,
         )
 
     def _rebuild_for_new_classes(self, new_nc: int):
-        """Swap the classifier head (classify) or rebuild the detector head."""
-        if self._is_classification:
-            self.nb_classes = new_nc
-            self._model_num_classes = new_nc
-            classifier = self.model.classifier
-            in_features = classifier.linear.in_features
-            classifier.linear = nn.Linear(in_features, new_nc)
-            classifier.nb_classes = new_nc
-            self.model.nb_classes = new_nc
-            self.model.to(self.device)
-            self.names = {i: f"class_{i}" for i in range(new_nc)}
-            return
+        """Rebuild the detector head for a new class count."""
         super()._rebuild_for_new_classes(new_nc)
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:
@@ -704,13 +663,6 @@ class LibreRFDETR(BaseModel):
         orig_w, orig_h = img.size
         orig_size = (orig_w, orig_h)
 
-        if self._is_classification:
-            from ...data.classify_dataset import build_classify_transforms
-
-            transform = build_classify_transforms(effective_res, augment=False)
-            img_tensor = transform(img).unsqueeze(0)
-            return img_tensor, img, orig_size, 1.0
-
         if self._is_pose:
             # GroupPose keypoint preprocess (adapted from RF-DETR v1.8.0). The
             # official keypoint pipeline is ``Compose([ToTensor, Resize((R, R),
@@ -754,12 +706,6 @@ class LibreRFDETR(BaseModel):
         max_det: int = 300,
         **kwargs,
     ) -> Dict:
-        if self._is_classification:
-            logits = output
-            if isinstance(logits, dict):
-                logits = logits.get("logits", logits.get("predictions"))
-            probs = torch.softmax(logits.float(), dim=1)[0]
-            return {"probs": probs}
         if isinstance(output, tuple):
             tuple_output = output
             output = {"pred_boxes": tuple_output[0], "pred_logits": tuple_output[1]}
@@ -883,64 +829,7 @@ class LibreRFDETR(BaseModel):
     # Weights
     # =========================================================================
 
-    def _load_classify_weights(self, model_path: str | dict[str, Any]) -> None:
-        """Load a LibreYOLO classification checkpoint into the classifier head."""
-        if isinstance(model_path, str):
-            loaded = load_trusted_torch_file(
-                model_path,
-                map_location="cpu",
-                context="RF-DETR classify weights",
-            )
-        else:
-            loaded = model_path
-        if not isinstance(loaded, dict):
-            raise TypeError("RF-DETR classification checkpoints must be dictionaries")
-
-        # Guard against loading a detection/segmentation checkpoint into the
-        # classifier: its keys would silently fail to match (strict=False),
-        # leaving a randomly initialized head that "loads" successfully.
-        ckpt_task = loaded.get("task")
-        if isinstance(ckpt_task, str) and normalize_task(ckpt_task) != "classify":
-            raise RuntimeError(
-                f"Checkpoint was trained for task={normalize_task(ckpt_task)!r}, "
-                "but is being loaded into an RF-DETR classification model. "
-                "Load it with the matching task."
-            )
-
-        ckpt_nc = loaded.get("nc")
-        if ckpt_nc is None:
-            names = loaded.get("names")
-            ckpt_nc = len(names) if names else None
-        if ckpt_nc is None:
-            ckpt_nc = self.detect_nb_classes(_checkpoint_model_state(loaded))
-        if ckpt_nc is not None and ckpt_nc != self.nb_classes:
-            self._rebuild_for_new_classes(int(ckpt_nc))
-
-        # LibreRFDETRModel.load_state_dict (classification branch) unwraps the
-        # checkpoint's "model" payload before loading into the classifier.
-        result = self.model.load_state_dict(loaded, strict=False)
-        missing = list(getattr(result, "missing_keys", []) or [])
-        unexpected = list(getattr(result, "unexpected_keys", []) or [])
-        # The linear head must have been populated; if it is missing (or the
-        # archive is full of detection-only keys), this is not a classifier.
-        if any(k.startswith("linear.") for k in missing) or any(
-            ("class_embed" in k or "transformer" in k or "query" in k)
-            for k in unexpected
-        ):
-            raise RuntimeError(
-                "Checkpoint does not look like an RF-DETR classification model "
-                "(its weights do not match the backbone + linear classifier). "
-                "Load a classification checkpoint or the correct task."
-            )
-
-        ckpt_names = loaded.get("names")
-        if ckpt_names is not None:
-            self.names = self._sanitize_names(ckpt_names, self.nb_classes)
-        self.model.to(self.device)
-
     def _load_weights(self, model_path: str | dict[str, Any]):
-        if self._is_classification:
-            return self._load_classify_weights(model_path)
         try:
             if isinstance(model_path, str):
                 if not Path(model_path).exists():

--- a/tests/unit/test_classification.py
+++ b/tests/unit/test_classification.py
@@ -1,8 +1,10 @@
-"""Image-classification task tests for YOLO9 and RF-DETR.
+"""Image-classification task tests.
 
 Covers the shared classification stack (ImageFolder dataset, collate,
-ClassifyValidator, Results.probs) and the per-family model wiring. All tests
-run on CPU with a tiny synthetic ImageFolder so they need no network or GPU.
+ClassifyValidator, Results.probs) and the LibreDINOv2 model wiring (classify is
+a DINOv2 linear probe, not the RF-DETR detector, so it lives in the dinov2
+family). All tests run on CPU with a tiny synthetic ImageFolder so they need no
+network or GPU.
 """
 
 from __future__ import annotations
@@ -122,16 +124,19 @@ def test_classify_validator_uses_model_name_order(tmp_path):
 @pytest.mark.external_data
 @pytest.mark.network
 @pytest.mark.slow
-def test_rfdetr_classify_forward():
-    """RF-DETR classify build + forward (DINOv2 backbone; random-init if offline)."""
-    from libreyolo import LibreRFDETR
+def test_dinov2_classify_forward():
+    """LibreDINOv2 classify build + forward (DINOv2 backbone; random-init if offline)."""
+    from libreyolo.models.dinov2.model import LibreDINOv2
 
-    m = LibreRFDETR(
+    m = LibreDINOv2(
         model_path=None, size="n", task="classify", nb_classes=4, device="cpu"
     )
     assert m.task == "classify"
     assert m.input_size == 224
-    assert m.model.classification
+    # The classify wrapper exposes the linear-probe classifier and builds no
+    # DETR decoder (model is None signals the non-detection head path).
+    assert m.model.model is None
+    assert m.model.classifier is not None
 
     x = torch.randn(1, 3, 224, 224)
     m.model.train()
@@ -156,8 +161,9 @@ def test_safe_zip_extraction_rejects_path_traversal(tmp_path):
             _safe_extract_zip(zf, tmp_path / "dest")
 
 
-def test_rfdetr_classify_detect_size_uses_metadata():
+def test_dinov2_classify_can_load_and_detect_nb_classes():
     pytest.importorskip("transformers")
+    from libreyolo.models.dinov2.model import LibreDINOv2
     from libreyolo.models.rfdetr.model import LibreRFDETR
 
     weights = {
@@ -166,14 +172,17 @@ def test_rfdetr_classify_detect_size_uses_metadata():
         ),
         "linear.weight": torch.empty(4, 256),
     }
-    checkpoint = {"model_family": "rfdetr", "size": "n", "task": "classify"}
 
-    assert LibreRFDETR.detect_size(weights, state_dict=checkpoint) == "n"
+    # Classify checkpoints (backbone + linear head) belong to LibreDINOv2 now;
+    # RF-DETR must no longer claim them.
+    assert LibreDINOv2.can_load(weights)
+    assert not LibreRFDETR.can_load(weights)
+    assert LibreDINOv2.detect_nb_classes(weights) == 4
 
 
-def test_rfdetr_classify_load_infers_nc_from_linear_weight(monkeypatch, tmp_path):
+def test_dinov2_classify_load_infers_nc_from_linear_weight(monkeypatch, tmp_path):
     pytest.importorskip("transformers")
-    from libreyolo.models.rfdetr.model import LibreRFDETR
+    from libreyolo.models.dinov2.model import LibreDINOv2
 
     class _LoadResult:
         missing_keys = []
@@ -185,11 +194,10 @@ def test_rfdetr_classify_load_infers_nc_from_linear_weight(monkeypatch, tmp_path
             self.linear = torch.nn.Linear(2, nb_classes)
             self.nb_classes = nb_classes
 
-    class _FakeRFDETRModel(torch.nn.Module):
-        classification = True
-
+    class _FakeWrapper(torch.nn.Module):
         def __init__(self):
             super().__init__()
+            self.model = None  # signals the non-detection (linear-head) path
             self.classifier = _FakeClassifier(80)
             self.nb_classes = 80
 
@@ -201,7 +209,7 @@ def test_rfdetr_classify_load_infers_nc_from_linear_weight(monkeypatch, tmp_path
                 raise RuntimeError(f"expected {expected} classifier rows, got {actual}")
             return _LoadResult()
 
-    monkeypatch.setattr(LibreRFDETR, "_init_model", lambda self: _FakeRFDETRModel())
+    monkeypatch.setattr(LibreDINOv2, "_init_model", lambda self: _FakeWrapper())
     path = tmp_path / "best.pt"
     torch.save(
         {
@@ -210,14 +218,14 @@ def test_rfdetr_classify_load_infers_nc_from_linear_weight(monkeypatch, tmp_path
                 "linear.weight": torch.ones(4, 2),
                 "linear.bias": torch.ones(4),
             },
-            "model_family": "rfdetr",
+            "model_family": "dinov2",
             "size": "n",
             "task": "classify",
         },
         path,
     )
 
-    model = LibreRFDETR(str(path), size="n", task="classify", device="cpu")
+    model = LibreDINOv2(str(path), size="n", task="classify", device="cpu")
 
     assert model.nb_classes == 4
     assert model.model.classifier.linear.out_features == 4


### PR DESCRIPTION
RF-DETR "classify" was a DINOv2 linear probe (backbone + global-average-pool
+ linear head; the DETR decoder is never built), not the RF-DETR detector, so it now lives in the LibreDINOv2 family alongside semantic.

- LibreDINOv2.SUPPORTED_TASKS = ("semantic", "classify"); weights are LibreDINOv2<size>-cls.pt and checkpoints save model_family="dinov2".
- LibreRFDETR back to ("detect", "segment", "pose", "obb"); removes all classify wiring (can_load, _load_classify_weights, pre/postprocess, rebuild, init flags, CLS_INPUT_SIZES).
- Clean break: legacy LibreRFDETR*-cls checkpoints no longer load; a clear error directs users to retrain/republish as LibreDINOv2*-cls.
- exporter classify branch keys off family == "dinov2".
- docs/nomenclature.md: classify moved to dinov2 family rows + examples; added the previously-missing dinov2 family/size rows.
- tests: classify model tests retargeted to LibreDINOv2.

Known follow-up: LibreDINOv2.export still raises NotImplementedError, so classify ONNX/TRT export needs wiring.