### PR TITLE
feat: built-in training profiler (model.train(profile=True))

### DIFF
--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -1,0 +1,101 @@
+# Training profiler
+
+A built-in profiler that answers one question fast: **where does each training
+step's time go, and is the GPU actually busy?** It runs from a single flag,
+prints a diagnosis, opens a self-contained timeline, and exposes a CLI an agent
+can drive to optimise a training loop.
+
+## Quick start
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreYOLO9t.pt", size="t")
+model.train(data="coco1000", profile=True)
+```
+
+`profile=True` profiles a short window of real training steps (a few warmup
+steps, then a measured window), prints a report, writes its artifacts, and
+**stops early** — so a profile run takes seconds, not a full training.
+
+It is **zero overhead when off** (the default); the hot loop's hooks short
+-circuit to a no-op. Profiling is ignored under distributed (DDP) training.
+
+### What it prints
+
+```
+GPU util 29%  (89 ms GPU-busy / 304 ms step)  |  8187 kernels/step @ ~11us
+peak VRAM 5540 MB  |  Tensor Cores 18% of GPU time  |  memcpy 3.0 ms/step
+>> VERDICT: HOST/LAUNCH-BOUND — GPU only ~29% busy — fed too slowly...
+   Levers: larger batch, fewer per-step .item()/syncs, CUDA graphs, op fusion.
+GPU kernel mix:  gemm/conv 39% · elementwise 26% · batchnorm 18% · layout 11%
+top kernels:     cudnn bn-bwd 10% · cutlass conv 5% · nchw->nhwc(x496) 4% ...
+```
+
+The **verdict** is one of three:
+
+| verdict | meaning | typical levers |
+|---|---|---|
+| `dataloader-bound` | the GPU waits on input data | more `workers`, `cache='ram'/'disk'`, lighter aug, larger batch |
+| `host / launch-bound` | the GPU is fed too slowly (tiny kernels, per-step syncs) | larger batch, fewer `.item()`/syncs, CUDA graphs, op fusion |
+| `compute-bound` | the GPU is saturated | AMP/bf16, a larger model |
+
+GPU utilisation is measured honestly: kernel busy-time over the *real* (unsynced)
+step time — not wall-clock hand-waving.
+
+### Artifacts (written to the run directory)
+
+| file | what |
+|---|---|
+| `timeline.html` | self-contained CPU/GPU timeline (auto-opens) + analysis panel — no external viewer |
+| `profile_trace.json` | the raw `torch.profiler` Chrome trace (also loads in Perfetto/Nsight) |
+| `profile_summary.json` | the computed metrics + verdict |
+
+### Config knobs
+
+| key | default | meaning |
+|---|---|---|
+| `profile` | `False` | enable the profiler |
+| `profile_warmup` | `5` | leading steps discarded |
+| `profile_steps` | `20` | measured steps |
+| `profile_trace` | `True` | emit the Chrome trace + timeline |
+| `profile_open` | `True` | auto-open `timeline.html` in a browser |
+
+### Gotcha: augmentation regime
+
+The profiler measures **epoch 0**. If you use a tiny `epochs` with the default
+`no_aug_epochs`, mosaic/mixup can be disabled for the window (the no-aug schedule
+kicks in immediately), so you would profile a *lighter* dataloader than you
+train with. To profile the real augmented pipeline, set `no_aug_epochs=0` — or
+use `libreyolo profile run`, which does.
+
+## The CLI — `libreyolo profile`
+
+The profiler is also a toolbox of focused commands so an agent (or you) can
+inspect the trace at any abstraction level. Each command writes results to
+stdout and supports `--json`.
+
+```
+libreyolo profile run     --data coco1000 --weights LibreYOLO9t.pt --size t   # train+profile -> trace
+libreyolo profile summary <trace>                 # util, verdict, kernel mix, top kernels
+libreyolo profile get     <trace> <field>         # ONE metric (img_per_s, forward_gpu_ms, ...)
+libreyolo profile phases  <trace>                 # per-phase gpu/wall ms + kernel & op counts
+libreyolo profile kernels <trace> [--phase forward --category gemm --grep bn --tensorcore --sort time --top N]
+libreyolo profile ops     <trace> [--phase backward --top N]   # aten/autograd ops by CPU time
+libreyolo profile compare <before> <after>        # did the change help? (img/s, util, mix deltas)
+```
+
+`get <trace>` with no field lists every available metric.
+
+### Agent loop
+
+```
+libreyolo profile get trace.json bound            -> host / launch
+libreyolo profile get trace.json gpu_util         -> 0.29
+libreyolo profile phases trace.json               -> forward 42/120, unphased 6gpu/11k ops
+libreyolo profile ops trace.json --phase unphased --top 5   -> aten::lerp_ (EMA), .item ...
+#   ...change config/code, re-run, then:
+libreyolo profile compare before.json after.json  -> img/s +40%, gpu_util 0.29 -> 0.51
+```
+
+Train → read → drill → change → **prove it helped**, until images/sec is maxed.

--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -63,6 +63,10 @@ step time — not wall-clock hand-waving.
 | `profile_trace` | `True` | emit the Chrome trace + timeline |
 | `profile_open` | `True` | auto-open `timeline.html` in a browser |
 
+When gradient accumulation is enabled (`nbs > batch`), the profiler rounds the
+warmup and measured windows up to accumulation boundaries so the captured window
+contains complete optimizer steps.
+
 ### Gotcha: augmentation regime
 
 The profiler measures **epoch 0**. If you use a tiny `epochs` with the default
@@ -91,9 +95,11 @@ libreyolo profile compare <before.json> <after.json>   # did it help? img/s + ms
 
 Every command takes either the **self-contained `profile.json`** (recommended — copy
 it freely) or a raw `profile_trace.json`. `get <file>` with no field lists every
-metric. Use **`run --repeat N`** for mean±stdev img/s — a single run *lies* when
-the step is launch-bound (the bottleneck itself makes the step time noisy), and
-`compare` will tell you whether a change is statistically significant.
+metric. `run` follows normal training defaults, including AMP on supported CUDA
+devices; pass `--no-amp` to force fp32. Use **`run --repeat N`** for mean±stdev
+img/s — a single run *lies* when the step is launch-bound (the bottleneck itself
+makes the step time noisy). Repeated runs emit an aggregate `profile_repeat.json`
+for `compare`, plus per-trial `prof_*/profile.json` files for drill-down.
 
 ### Agent loop
 

--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -39,6 +39,7 @@ The **verdict** is one of three:
 | `dataloader-bound` | the GPU waits on input data | more `workers`, `cache='ram'/'disk'`, lighter aug, larger batch |
 | `host / launch-bound` | the GPU is fed too slowly (tiny kernels, per-step syncs) | larger batch, fewer `.item()`/syncs, CUDA graphs, op fusion |
 | `compute-bound` | the GPU is saturated | AMP/bf16, a larger model |
+| `memory-pressure` | allocator thrash / VRAM at the edge — util & throughput here are unreliable | lower batch, fix fragmentation; don't run at the OOM edge |
 
 GPU utilisation is measured honestly: kernel busy-time over the *real* (unsynced)
 step time — not wall-clock hand-waving.
@@ -50,6 +51,7 @@ step time — not wall-clock hand-waving.
 | `timeline.html` | self-contained CPU/GPU timeline (auto-opens) + analysis panel — no external viewer |
 | `profile_trace.json` | the raw `torch.profiler` Chrome trace (also loads in Perfetto/Nsight) |
 | `profile_summary.json` | the computed metrics + verdict |
+| `profile.json` | **self-contained** analysis (metrics + verdict + kernels + phases) — the one file to copy and `compare` |
 
 ### Config knobs
 
@@ -67,7 +69,8 @@ The profiler measures **epoch 0**. If you use a tiny `epochs` with the default
 `no_aug_epochs`, mosaic/mixup can be disabled for the window (the no-aug schedule
 kicks in immediately), so you would profile a *lighter* dataloader than you
 train with. To profile the real augmented pipeline, set `no_aug_epochs=0` — or
-use `libreyolo profile run`, which does.
+use `libreyolo profile run`, which sets `no_aug_epochs=0` and runs enough
+epochs to fill the measurement window automatically.
 
 ## The CLI — `libreyolo profile`
 
@@ -76,26 +79,35 @@ inspect the trace at any abstraction level. Each command writes results to
 stdout and supports `--json`.
 
 ```
-libreyolo profile run     --data coco1000 --weights LibreYOLO9t.pt --size t   # train+profile -> trace
-libreyolo profile summary <trace>                 # util, verdict, kernel mix, top kernels
-libreyolo profile get     <trace> <field>         # ONE metric (img_per_s, forward_gpu_ms, ...)
-libreyolo profile phases  <trace>                 # per-phase gpu/wall ms + kernel & op counts
-libreyolo profile kernels <trace> [--phase forward --category gemm --grep bn --tensorcore --sort time --top N]
-libreyolo profile ops     <trace> [--phase backward --top N]   # aten/autograd ops by CPU time
-libreyolo profile compare <before> <after>        # did the change help? (img/s, util, mix deltas)
+libreyolo profile run     coco128 --weights LibreYOLO9t.pt --size t [--repeat 3 --warmup 5 --steps 20]
+libreyolo profile summary <profile.json>          # util, verdict, host overhead, kernel mix, top kernels
+libreyolo profile get     <profile.json> <field>  # ONE metric (img_per_s, forward_gpu_ms, host_overhead_ms, ...)
+libreyolo profile phases  <profile.json>          # per-phase gpu/wall ms + kernel & op counts
+libreyolo profile kernels <profile.json> [--phase forward --category gemm --grep bn --tensorcore --sort time --top N]
+libreyolo profile ops     <profile.json> [--phase backward --top N]   # aten/autograd ops by CPU time
+libreyolo profile what-if <profile.json> [--remove-category layout | --remove-launches 3300]   # project a fix
+libreyolo profile compare <before.json> <after.json>   # did it help? img/s + ms/image + significance
 ```
 
-`get <trace>` with no field lists every available metric.
+Every command takes either the **self-contained `profile.json`** (recommended — copy
+it freely) or a raw `profile_trace.json`. `get <file>` with no field lists every
+metric. Use **`run --repeat N`** for mean±stdev img/s — a single run *lies* when
+the step is launch-bound (the bottleneck itself makes the step time noisy), and
+`compare` will tell you whether a change is statistically significant.
 
 ### Agent loop
 
 ```
-libreyolo profile get trace.json bound            -> host / launch
-libreyolo profile get trace.json gpu_util         -> 0.29
-libreyolo profile phases trace.json               -> forward 42/120, unphased 6gpu/11k ops
-libreyolo profile ops trace.json --phase unphased --top 5   -> aten::lerp_ (EMA), .item ...
-#   ...change config/code, re-run, then:
-libreyolo profile compare before.json after.json  -> img/s +40%, gpu_util 0.29 -> 0.51
+libreyolo profile run coco128 --repeat 3                 -> img/s 50 +/- 1.4 | host / launch
+libreyolo profile get  profile.json gpu_util             -> 0.29        # GPU 71% idle
+libreyolo profile phases profile.json                    -> forward 42/120, unphased 6gpu/11k ops
+libreyolo profile ops  profile.json --phase unphased --top 5  -> aten::lerp_ (EMA) ...
+libreyolo profile what-if profile.json --remove-launches 3300  -> img/s 50 -> ~69 (+38%)   # worth it
+#   ...make the change, re-run with --repeat, then:
+libreyolo profile compare before.json after.json         -> img/s +28%  [significant]
 ```
 
-Train → read → drill → change → **prove it helped**, until images/sec is maxed.
+Train → read → drill → **estimate** (`what-if`) → change → **prove it** (`compare`,
+with significance), until images/sec is maxed. The two things that make this safe
+for an autonomous agent: `--repeat` (so a noisy single run can't lie) and
+`what-if` (so it triages before rewriting code).

--- a/libreyolo/cli/__init__.py
+++ b/libreyolo/cli/__init__.py
@@ -78,7 +78,7 @@ def entrypoint() -> None:
     argv = _normalize_logging_flags(argv)
     _setup_logging_from_argv(argv)
 
-    from .commands import special, predict, train, val, export, ui, doctor  # noqa: F401
+    from .commands import special, predict, train, val, export, ui, doctor, profile  # noqa: F401
     from .parsing import KeyValueCommand
 
     # Special commands
@@ -92,5 +92,8 @@ def entrypoint() -> None:
     app.command("export", cls=KeyValueCommand)(export.export_cmd)
     app.command("ui", cls=KeyValueCommand)(ui.ui_cmd)
     app.command("doctor", cls=KeyValueCommand)(doctor.doctor_cmd)
+
+    # Profiler analysis command group (agent-friendly: every subcommand --json).
+    app.add_typer(profile.profile_app, name="profile")
 
     app(args=argv[1:])

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -68,7 +68,7 @@ def run_cmd(
     batch: int = typer.Option(16, "--batch", help="Micro-batch (-1 auto-fits ~70%% VRAM)"),
     imgsz: int = typer.Option(640, "--imgsz"),
     workers: int = typer.Option(8, "--workers"),
-    amp: bool = typer.Option(False, "--amp", help="Use the family's AMP path"),
+    amp: bool = typer.Option(True, "--amp/--no-amp", help="Use the family's AMP path"),
     steps: int = typer.Option(20, "--steps", help="Profiled (measured) steps"),
     warmup: int = typer.Option(5, "--warmup", help="Warmup steps before measuring"),
     repeat: int = typer.Option(1, "--repeat", help="Repeat N times for mean +/- stdev (a single run lies when launch-bound)"),
@@ -85,7 +85,7 @@ def run_cmd(
     # Enough total iterations to fill warmup+steps even on a tiny dataset; the
     # profiler early-stops once the window is full, so extra epochs never run.
     epochs = warmup + steps + 5
-    trials, last_dir = [], None
+    trials, trial_profiles, trial_paths, last_dir = [], [], [], None
     for i in range(max(1, repeat)):
         name = f"prof_{i}" if repeat > 1 else "prof"
         model = LibreYOLO(model_path=weights, size=size, device=device)
@@ -104,6 +104,8 @@ def run_cmd(
                 "or a smaller --batch.", err=True)
             raise typer.Exit(3)
         a = _load(str(pj))
+        trial_profiles.append(a)
+        trial_paths.append(str(pj))
         if a.get("img_per_s") is not None:
             trials.append(a["img_per_s"])
         if i < repeat - 1:
@@ -115,11 +117,48 @@ def run_cmd(
     pj = last_dir / "profile.json"
     agg = _load(str(pj))
     if len(trials) > 1:
+        agg = dict(trial_profiles[-1])
         mean, std = round(_st.fmean(trials), 2), round(_st.pstdev(trials), 2)
         agg["img_per_s"] = agg["metrics"]["img_per_s"] = mean
         agg["img_per_s_std"] = agg["metrics"]["img_per_s_std"] = std
         agg["img_per_s_n"] = agg["metrics"]["img_per_s_n"] = len(trials)
         agg["img_per_s_trials"] = [round(t, 2) for t in trials]
+        agg["aggregation"] = {
+            "n": len(trial_profiles),
+            "profiles": trial_paths,
+            "representative_profile": trial_paths[-1],
+            "note": "scalar metrics are averaged; kernel lists and trace view use the final trial.",
+        }
+        scalar_keys = (
+            "step_ms", "gpu_util", "gpu_util_raw", "gpu_busy_ms_per_step",
+            "mean_kernel_us", "kernels_per_step", "memcpy_ms_per_step",
+            "host_overhead_ms_per_step", "launches_per_step", "dataload_ms",
+            "dataload_frac", "tensorcore_pct", "cuda_mallocs_per_step",
+        )
+        metric_aliases = {
+            "gpu_busy_ms_per_step": "gpu_busy_ms",
+            "memcpy_ms_per_step": "memcpy_ms",
+            "host_overhead_ms_per_step": "host_overhead_ms",
+        }
+        metrics = dict(agg.get("metrics") or {})
+        for key in scalar_keys:
+            values = [
+                p.get(key) for p in trial_profiles
+                if isinstance(p.get(key), (int, float)) and p.get(key) is not None
+            ]
+            if not values:
+                continue
+            value = round(_st.fmean(values), 3)
+            if all(isinstance(v, int) for v in values):
+                value = int(round(value))
+            agg[key] = value
+            metrics[metric_aliases.get(key, key)] = value
+        bounds = [p.get("bound") for p in trial_profiles if p.get("bound")]
+        if bounds and len(set(bounds)) > 1:
+            agg["bound"] = metrics["bound"] = "mixed"
+            agg["bound_why"] = "repeat trials produced mixed bottleneck verdicts"
+        agg["metrics"] = metrics
+        pj = Path(project) / "profile_repeat.json"
         pj.write_text(_json.dumps(agg))
 
     if json_output:

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -1,0 +1,208 @@
+"""profile: analyse training profiles from ``model.train(profile=True)``.
+
+Built for agents. Every subcommand prints results to stdout and supports
+``--json``, so an LLM can drive the loop:
+
+    libreyolo profile run  --data coco1000 --weights LibreYOLO9t.pt --size t
+    libreyolo profile summary <trace>                # what's the bottleneck?
+    libreyolo profile kernels <trace> --top 20       # drill to the kernels
+    libreyolo profile ops     <trace> --top 20       # framework/host ops
+    libreyolo profile compare <before> <after>       # did my change help?
+
+...read insight, change the training/config/code, re-run, ``compare``, repeat
+until images/sec is maxed.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import re as _re
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+profile_app = typer.Typer(
+    name="profile",
+    help="Analyse training profiles (model.train(profile=True)) for speed tuning.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+def _load(trace: str) -> dict:
+    from libreyolo.training.profiler import analyze_trace
+
+    p = Path(trace)
+    if not p.exists():
+        typer.echo(f"trace not found: {trace}", err=True)
+        raise typer.Exit(2)
+    try:
+        return analyze_trace(p)
+    except Exception as exc:  # pragma: no cover - defensive
+        typer.echo(f"failed to analyse {trace}: {exc}", err=True)
+        raise typer.Exit(1)
+
+
+def _pct(before, after) -> str:
+    if not before:
+        return ""
+    return f" ({(after - before) / before * 100:+.0f}%)"
+
+
+@profile_app.command("run")
+def run_cmd(
+    data: str = typer.Argument(..., help="Dataset yaml/name (e.g. coco1000)"),
+    weights: str = typer.Option("LibreYOLO9t.pt", "--weights", help="Model weights file / name"),
+    size: str = typer.Option("t", "--size", help="Model size variant"),
+    batch: int = typer.Option(16, "--batch"),
+    imgsz: int = typer.Option(640, "--imgsz"),
+    workers: int = typer.Option(8, "--workers"),
+    amp: bool = typer.Option(False, "--amp", help="Use the family's AMP path"),
+    steps: int = typer.Option(20, "--steps", help="Profiled (measured) steps"),
+    device: str = typer.Option("0", "--device"),
+    project: str = typer.Option("runs/profile", "--project"),
+    json_output: bool = typer.Option(False, "--json", help="JSON {trace, summary} to stdout"),
+) -> None:
+    """Launch a short profiled training and emit the trace (no browser)."""
+    from libreyolo import LibreYOLO
+
+    m = LibreYOLO(model_path=weights, size=size, device=device)
+    m.train(
+        data=data, epochs=1, batch=batch, imgsz=imgsz, workers=workers, amp=amp,
+        device=device, profile=True, profile_steps=steps, profile_open=False,
+        no_aug_epochs=0, project=project, name="prof", exist_ok=True,
+    )
+    trace = Path(project) / "prof" / "profile_trace.json"
+    if json_output:
+        a = _load(str(trace)) if trace.exists() else {}
+        print(_json.dumps({"trace": str(trace), "summary": {
+            k: a.get(k) for k in
+            ("bound", "gpu_util", "img_per_s", "step_ms", "tensorcore_pct", "peak_vram_mb")
+        }}, indent=2))
+    else:
+        print(f"trace: {trace}")
+        print(f"next:  libreyolo profile summary {trace}")
+
+
+@profile_app.command("summary")
+def summary_cmd(
+    trace: str = typer.Argument(..., help="Path to profile_trace.json"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """High-level diagnosis: utilisation, verdict, kernel mix, top kernels."""
+    a = _load(trace)
+    if json_output:
+        keep = ("trace", "model", "config", "bound", "bound_why", "step_ms", "img_per_s",
+                "gpu_util", "gpu_busy_ms_per_step", "mean_kernel_us", "kernels_per_step",
+                "unique_kernels", "memcpy_ms_per_step", "tensorcore_pct", "peak_vram_mb",
+                "dataload_ms", "dataload_frac", "window", "categories", "phases_gpu",
+                "top_kernels")
+        print(_json.dumps({k: a[k] for k in keep}, indent=2))
+        return
+    print(f"model {a.get('model') or '?'}  |  {a.get('img_per_s') or '?'} img/s  |  "
+          f"step {a['step_ms']} ms  |  {a['kernels_per_step']} kernels/step @ ~{a['mean_kernel_us']:.0f}us")
+    print(f"GPU util {a['gpu_util'] * 100:.0f}%  ({a['gpu_busy_ms_per_step']} ms busy)  |  "
+          f"Tensor Cores {a['tensorcore_pct']:.0f}%  |  peak VRAM {a.get('peak_vram_mb') or '?'} MB  |  "
+          f"memcpy {a['memcpy_ms_per_step']} ms")
+    print(f">> {str(a['bound']).upper()} — {a['bound_why']}")
+    print("kernel mix:")
+    for c in a["categories"]:
+        print(f"  {c['name']:<17} {c['pct']:5.1f}%   {c['ms_per_step']:.1f} ms/step")
+    print("top kernels/step:")
+    for k in a["top_kernels"]:
+        tc = " [TC]" if k["tensorcore"] else ""
+        print(f"  {k['pct_of_gpu']:5.1f}%  {k['ms_per_step']:6.3f} ms  x{k['count_per_step']:<4} {k['kernel']}{tc}")
+
+
+@profile_app.command("kernels")
+def kernels_cmd(
+    trace: str = typer.Argument(..., help="Path to profile_trace.json"),
+    top: int = typer.Option(20, "--top", help="Show top N by GPU time"),
+    category: Optional[str] = typer.Option(None, "--category", help="Filter by category substring (gemm, layout, norm, elementwise)"),
+    grep: Optional[str] = typer.Option(None, "--grep", help="Filter by kernel-name regex"),
+    tensorcore: bool = typer.Option(False, "--tensorcore", help="Only Tensor-Core kernels"),
+    sort: str = typer.Option("time", "--sort", help="time | count | name"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """Drill to individual GPU kernels — the bottom of the analysis."""
+    a = _load(trace)
+    ks = a["kernels"]
+    if category:
+        ks = [k for k in ks if category.lower() in k["category"].lower()]
+    if grep:
+        rx = _re.compile(grep, _re.I)
+        ks = [k for k in ks if rx.search(k["raw_name"]) or rx.search(k["kernel"])]
+    if tensorcore:
+        ks = [k for k in ks if k["tensorcore"]]
+    keyf = {"time": lambda k: -k["pct_of_gpu"], "count": lambda k: -k["count_per_step"],
+            "name": lambda k: k["kernel"]}.get(sort, lambda k: -k["pct_of_gpu"])
+    ks = sorted(ks, key=keyf)[:top]
+    if json_output:
+        print(_json.dumps({"trace": a["trace"], "matched": len(ks), "kernels": ks}, indent=2))
+        return
+    print(f"{'%GPU':>6} {'ms/step':>9} {'x/step':>7} TC  kernel  [category]")
+    for k in ks:
+        print(f"{k['pct_of_gpu']:6.2f} {k['ms_per_step']:9.3f} {k['count_per_step']:7d}  "
+              f"{'Y' if k['tensorcore'] else ' '}  {k['kernel']}  [{k['category']}]")
+
+
+@profile_app.command("ops")
+def ops_cmd(
+    trace: str = typer.Argument(..., help="Path to profile_trace.json"),
+    top: int = typer.Option(20, "--top"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """Framework view: aten/autograd ops by CPU time (host-launch culprits)."""
+    a = _load(trace)
+    ops = a["ops"][:top]
+    if json_output:
+        print(_json.dumps({"trace": a["trace"], "ops": ops}, indent=2))
+        return
+    print(f"{'%cpu':>6} {'ms/step':>9} {'x/step':>7}  op")
+    for o in ops:
+        print(f"{o['pct_of_cpu_ops']:6.2f} {o['ms_per_step']:9.3f} {o['count_per_step']:7d}  {o['op']}")
+
+
+@profile_app.command("compare")
+def compare_cmd(
+    before: str = typer.Argument(..., help="baseline profile_trace.json"),
+    after: str = typer.Argument(..., help="new profile_trace.json"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """Diff two profiles — did the change help? (the optimise-loop closer)."""
+    a, b = _load(before), _load(after)
+
+    def delta(x, y):
+        return None if (x is None or y is None) else round(y - x, 3)
+
+    catA = {c["name"]: c["ms_per_step"] for c in a["categories"]}
+    catB = {c["name"]: c["ms_per_step"] for c in b["categories"]}
+    cat_delta = {k: round(catB.get(k, 0.0) - catA.get(k, 0.0), 2)
+                 for k in set(catA) | set(catB)}
+    res = {
+        "before": before, "after": after,
+        "img_per_s": {"before": a["img_per_s"], "after": b["img_per_s"],
+                      "delta": delta(a["img_per_s"], b["img_per_s"])},
+        "step_ms": {"before": a["step_ms"], "after": b["step_ms"],
+                    "delta": delta(a["step_ms"], b["step_ms"])},
+        "gpu_util": {"before": a["gpu_util"], "after": b["gpu_util"],
+                     "delta": delta(a["gpu_util"], b["gpu_util"])},
+        "gpu_busy_ms_per_step": {"before": a["gpu_busy_ms_per_step"],
+                                 "after": b["gpu_busy_ms_per_step"]},
+        "tensorcore_pct": {"before": a["tensorcore_pct"], "after": b["tensorcore_pct"]},
+        "bound": {"before": a["bound"], "after": b["bound"]},
+        "category_ms_delta": cat_delta,
+    }
+    if json_output:
+        print(_json.dumps(res, indent=2))
+        return
+    print(f"img/s    {a.get('img_per_s')} -> {b.get('img_per_s')}"
+          f"{_pct(a.get('img_per_s') or 0, b.get('img_per_s') or 0)}")
+    print(f"step ms  {a['step_ms']} -> {b['step_ms']}{_pct(a['step_ms'], b['step_ms'])}")
+    print(f"GPU util {a['gpu_util'] * 100:.0f}% -> {b['gpu_util'] * 100:.0f}%")
+    print(f"TC %     {a['tensorcore_pct']:.0f}% -> {b['tensorcore_pct']:.0f}%")
+    print(f"verdict  {a['bound']} -> {b['bound']}")
+    print("category ms/step delta (negative = faster):")
+    for k, v in sorted(cat_delta.items(), key=lambda kv: kv[1]):
+        print(f"  {k:<17} {v:+.2f}")

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -35,8 +35,18 @@ def _load(trace: str) -> dict:
 
     p = Path(trace)
     if not p.exists():
-        typer.echo(f"trace not found: {trace}", err=True)
+        typer.echo(f"not found: {trace}", err=True)
         raise typer.Exit(2)
+    try:
+        data = _json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        data = None
+    # A self-contained profile.json (the recommended artifact to copy/compare)
+    # is used as-is; a raw profile_trace.json is analysed on the fly.
+    if isinstance(data, dict) and str(data.get("schema", "")).startswith(
+        "libreyolo.profile.analysis"
+    ):
+        return data
     try:
         return analyze_trace(p)
     except Exception as exc:  # pragma: no cover - defensive
@@ -52,37 +62,80 @@ def _pct(before, after) -> str:
 
 @profile_app.command("run")
 def run_cmd(
-    data: str = typer.Argument(..., help="Dataset yaml/name (e.g. coco1000)"),
+    data: str = typer.Argument(..., help="Dataset yaml/name (e.g. coco128)"),
     weights: str = typer.Option("LibreYOLO9t.pt", "--weights", help="Model weights file / name"),
     size: str = typer.Option("t", "--size", help="Model size variant"),
-    batch: int = typer.Option(16, "--batch"),
+    batch: int = typer.Option(16, "--batch", help="Micro-batch (-1 auto-fits ~70%% VRAM)"),
     imgsz: int = typer.Option(640, "--imgsz"),
     workers: int = typer.Option(8, "--workers"),
     amp: bool = typer.Option(False, "--amp", help="Use the family's AMP path"),
     steps: int = typer.Option(20, "--steps", help="Profiled (measured) steps"),
+    warmup: int = typer.Option(5, "--warmup", help="Warmup steps before measuring"),
+    repeat: int = typer.Option(1, "--repeat", help="Repeat N times for mean +/- stdev (a single run lies when launch-bound)"),
     device: str = typer.Option("0", "--device"),
     project: str = typer.Option("runs/profile", "--project"),
-    json_output: bool = typer.Option(False, "--json", help="JSON {trace, summary} to stdout"),
+    json_output: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Launch a short profiled training and emit the trace (no browser)."""
+    """Launch a short profiled training and emit a self-contained profile.json."""
+    import statistics as _st
+
+    import torch
     from libreyolo import LibreYOLO
 
-    m = LibreYOLO(model_path=weights, size=size, device=device)
-    m.train(
-        data=data, epochs=1, batch=batch, imgsz=imgsz, workers=workers, amp=amp,
-        device=device, profile=True, profile_steps=steps, profile_open=False,
-        no_aug_epochs=0, project=project, name="prof", exist_ok=True,
-    )
-    trace = Path(project) / "prof" / "profile_trace.json"
+    # Enough total iterations to fill warmup+steps even on a tiny dataset; the
+    # profiler early-stops once the window is full, so extra epochs never run.
+    epochs = warmup + steps + 5
+    trials, last_dir = [], None
+    for i in range(max(1, repeat)):
+        name = f"prof_{i}" if repeat > 1 else "prof"
+        model = LibreYOLO(model_path=weights, size=size, device=device)
+        model.train(
+            data=data, epochs=epochs, batch=batch, imgsz=imgsz, workers=workers,
+            amp=amp, device=device, profile=True, profile_steps=steps,
+            profile_warmup=warmup, profile_open=False, no_aug_epochs=0,
+            project=project, name=name, exist_ok=True,
+        )
+        last_dir = Path(project) / name
+        pj = last_dir / "profile.json"
+        if not pj.exists():
+            typer.echo(
+                f"no profile produced for run {i}: the window (warmup {warmup} + "
+                f"steps {steps}) never filled. Use a larger dataset, fewer --steps, "
+                "or a smaller --batch.", err=True)
+            raise typer.Exit(3)
+        a = _load(str(pj))
+        if a.get("img_per_s") is not None:
+            trials.append(a["img_per_s"])
+        if i < repeat - 1:
+            import gc
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    pj = last_dir / "profile.json"
+    agg = _load(str(pj))
+    if len(trials) > 1:
+        mean, std = round(_st.fmean(trials), 2), round(_st.pstdev(trials), 2)
+        agg["img_per_s"] = agg["metrics"]["img_per_s"] = mean
+        agg["img_per_s_std"] = agg["metrics"]["img_per_s_std"] = std
+        agg["img_per_s_n"] = agg["metrics"]["img_per_s_n"] = len(trials)
+        agg["img_per_s_trials"] = [round(t, 2) for t in trials]
+        pj.write_text(_json.dumps(agg))
+
     if json_output:
-        a = _load(str(trace)) if trace.exists() else {}
-        print(_json.dumps({"trace": str(trace), "summary": {
-            k: a.get(k) for k in
-            ("bound", "gpu_util", "img_per_s", "step_ms", "tensorcore_pct", "peak_vram_mb")
-        }}, indent=2))
+        print(_json.dumps({
+            "profile": str(pj), "trace": str(last_dir / "profile_trace.json"),
+            "img_per_s": agg.get("img_per_s"), "img_per_s_std": agg.get("img_per_s_std"),
+            "img_per_s_n": agg.get("img_per_s_n", 1), "bound": agg.get("bound"),
+            "gpu_util": agg.get("gpu_util"),
+        }, indent=2))
     else:
-        print(f"trace: {trace}")
-        print(f"next:  libreyolo profile summary {trace}")
+        v = str(agg.get("img_per_s"))
+        if agg.get("img_per_s_n", 1) > 1:
+            v += f" +/- {agg.get('img_per_s_std')} (n={agg['img_per_s_n']})"
+        print(f"img/s: {v}  |  {agg.get('bound')}")
+        print(f"profile: {pj}")
+        print(f"next:    libreyolo profile summary {pj}")
 
 
 @profile_app.command("summary")
@@ -96,8 +149,9 @@ def summary_cmd(
         keep = ("trace", "model", "config", "bound", "bound_why", "step_ms", "img_per_s",
                 "gpu_util", "gpu_busy_ms_per_step", "mean_kernel_us", "kernels_per_step",
                 "unique_kernels", "memcpy_ms_per_step", "tensorcore_pct", "peak_vram_mb",
-                "dataload_ms", "dataload_frac", "window", "categories", "phases_gpu",
-                "top_kernels")
+                "dataload_ms", "dataload_frac", "host_overhead_ms_per_step",
+                "launches_per_step", "memory_pressure", "cuda_mallocs_per_step",
+                "gpu_util_raw", "window", "categories", "phases_gpu", "top_kernels")
         print(_json.dumps({k: a[k] for k in keep}, indent=2))
         return
     print(f"model {a.get('model') or '?'}  |  {a.get('img_per_s') or '?'} img/s  |  "
@@ -105,6 +159,10 @@ def summary_cmd(
     print(f"GPU util {a['gpu_util'] * 100:.0f}%  ({a['gpu_busy_ms_per_step']} ms busy)  |  "
           f"Tensor Cores {a['tensorcore_pct']:.0f}%  |  peak VRAM {a.get('peak_vram_mb') or '?'} MB  |  "
           f"memcpy {a['memcpy_ms_per_step']} ms")
+    print(f"host overhead {a['host_overhead_ms_per_step']} ms/step  |  "
+          f"{a['launches_per_step']} kernel launches/step")
+    if a.get("memory_pressure"):
+        print("** MEMORY-PRESSURE: VRAM thrash — utilisation/throughput here are unreliable **")
     print(f">> {str(a['bound']).upper()} — {a['bound_why']}")
     print("kernel mix:")
     for c in a["categories"]:
@@ -224,36 +282,107 @@ def compare_cmd(
     """Diff two profiles — did the change help? (the optimise-loop closer)."""
     a, b = _load(before), _load(after)
 
-    def delta(x, y):
-        return None if (x is None or y is None) else round(y - x, 3)
+    def per_img(x):
+        bs = (x.get("config") or {}).get("batch") or 0
+        return round(x["step_ms"] / bs, 3) if bs else None
 
-    catA = {c["name"]: c["ms_per_step"] for c in a["categories"]}
-    catB = {c["name"]: c["ms_per_step"] for c in b["categories"]}
-    cat_delta = {k: round(catB.get(k, 0.0) - catA.get(k, 0.0), 2)
-                 for k in set(catA) | set(catB)}
+    def significance(x, y):
+        import math
+        ma, mb = x.get("img_per_s"), y.get("img_per_s")
+        if ma is None or mb is None:
+            return None, "img/s unavailable"
+        sa, sb = x.get("img_per_s_std"), y.get("img_per_s_std")
+        na, nb = x.get("img_per_s_n", 1), y.get("img_per_s_n", 1)
+        if na < 2 or nb < 2 or sa is None or sb is None:
+            return None, "single run — use 'run --repeat N' for a significance call"
+        se = math.sqrt(sa ** 2 / na + sb ** 2 / nb)
+        return (abs(mb - ma) > 2 * se), f"|d|={abs(mb - ma):.1f} vs 2*SE={2 * se:.1f}"
+
+    sig, sig_why = significance(a, b)
     res = {
         "before": before, "after": after,
-        "img_per_s": {"before": a["img_per_s"], "after": b["img_per_s"],
-                      "delta": delta(a["img_per_s"], b["img_per_s"])},
-        "step_ms": {"before": a["step_ms"], "after": b["step_ms"],
-                    "delta": delta(a["step_ms"], b["step_ms"])},
-        "gpu_util": {"before": a["gpu_util"], "after": b["gpu_util"],
-                     "delta": delta(a["gpu_util"], b["gpu_util"])},
-        "gpu_busy_ms_per_step": {"before": a["gpu_busy_ms_per_step"],
-                                 "after": b["gpu_busy_ms_per_step"]},
-        "tensorcore_pct": {"before": a["tensorcore_pct"], "after": b["tensorcore_pct"]},
+        "img_per_s": {"before": a.get("img_per_s"), "after": b.get("img_per_s"),
+                      "std": [a.get("img_per_s_std"), b.get("img_per_s_std")],
+                      "n": [a.get("img_per_s_n", 1), b.get("img_per_s_n", 1)],
+                      "significant": sig, "significance": sig_why},
+        "ms_per_image": {"before": per_img(a), "after": per_img(b)},
+        "gpu_util": {"before": a["gpu_util"], "after": b["gpu_util"]},
+        "host_overhead_ms_per_step": {"before": a.get("host_overhead_ms_per_step"),
+                                      "after": b.get("host_overhead_ms_per_step")},
+        "launches_per_step": {"before": a.get("launches_per_step"),
+                              "after": b.get("launches_per_step")},
         "bound": {"before": a["bound"], "after": b["bound"]},
-        "category_ms_delta": cat_delta,
     }
     if json_output:
         print(_json.dumps(res, indent=2))
         return
-    print(f"img/s    {a.get('img_per_s')} -> {b.get('img_per_s')}"
-          f"{_pct(a.get('img_per_s') or 0, b.get('img_per_s') or 0)}")
-    print(f"step ms  {a['step_ms']} -> {b['step_ms']}{_pct(a['step_ms'], b['step_ms'])}")
-    print(f"GPU util {a['gpu_util'] * 100:.0f}% -> {b['gpu_util'] * 100:.0f}%")
-    print(f"TC %     {a['tensorcore_pct']:.0f}% -> {b['tensorcore_pct']:.0f}%")
-    print(f"verdict  {a['bound']} -> {b['bound']}")
-    print("category ms/step delta (negative = faster):")
-    for k, v in sorted(cat_delta.items(), key=lambda kv: kv[1]):
-        print(f"  {k:<17} {v:+.2f}")
+    tag = {True: "  [significant]", False: "  [NOT significant]"}.get(sig, f"  [{sig_why}]")
+    ia, ib = a.get("img_per_s") or 0, b.get("img_per_s") or 0
+    print(f"img/s          {a.get('img_per_s')} -> {b.get('img_per_s')}{_pct(ia, ib)}{tag}")
+    pa, pb = per_img(a), per_img(b)
+    if pa and pb:
+        print(f"ms/image       {pa} -> {pb}{_pct(pa, pb)}   (batch-independent speed)")
+    print(f"GPU util       {a['gpu_util'] * 100:.0f}% -> {b['gpu_util'] * 100:.0f}%")
+    print(f"host overhead  {a.get('host_overhead_ms_per_step')} -> "
+          f"{b.get('host_overhead_ms_per_step')} ms/step")
+    print(f"launches/step  {a.get('launches_per_step')} -> {b.get('launches_per_step')}")
+    print(f"verdict        {a['bound']} -> {b['bound']}")
+
+
+@profile_app.command("what-if")
+def whatif_cmd(
+    trace: str = typer.Argument(..., help="Path to profile.json / profile_trace.json"),
+    remove_category: Optional[str] = typer.Option(None, "--remove-category", help="Project removing a kernel category (gemm, layout, norm, elementwise)"),
+    remove_launches: Optional[int] = typer.Option(None, "--remove-launches", help="Project removing N kernel launches/step (e.g. an op-fusion win)"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """Estimate a change's payoff BEFORE editing code (rough projection)."""
+    a = _load(trace)
+    if not remove_category and remove_launches is None:
+        typer.echo("specify --remove-category or --remove-launches", err=True)
+        raise typer.Exit(2)
+    step = a["step_ms"]
+    bs = (a.get("config") or {}).get("batch") or 0
+    host = a.get("host_overhead_ms_per_step") or 0.0
+    launches = a.get("launches_per_step") or 1
+    gpu = a.get("gpu_busy_ms_per_step") or 0.0
+    util = a.get("gpu_util") or 0.0
+    per_launch_ms = host / launches if launches else 0.0
+
+    removed_gpu = 0.0
+    removed_launches = remove_launches or 0
+    if remove_category:
+        cat = next((c for c in a["categories"]
+                    if remove_category.lower() in c["name"].lower()), None)
+        if cat is None:
+            have = ", ".join(c["name"] for c in a["categories"])
+            typer.echo(f"no category matching '{remove_category}'. have: {have}", err=True)
+            raise typer.Exit(2)
+        removed_gpu = cat["ms_per_step"]
+        removed_launches += int(launches * (cat["ms_per_step"] / (gpu or 1)))
+
+    if util < 0.8:
+        new_step = max(step - removed_launches * per_launch_ms,
+                       gpu + (a.get("dataload_ms") or 0.0))
+        mechanism = (f"host/launch-bound: ~{removed_launches} fewer launches x "
+                     f"~{per_launch_ms * 1000:.0f}us host cost")
+    else:
+        new_step = max(step - removed_gpu, host)
+        mechanism = f"compute-bound: ~{removed_gpu:.1f} ms less GPU work"
+    cur_imgs = a.get("img_per_s")
+    new_imgs = round(bs / (new_step / 1000.0), 1) if (bs and new_step) else None
+    res = {
+        "trace": a["trace"], "bound": a["bound"], "mechanism": mechanism,
+        "removed": {"gpu_ms": round(removed_gpu, 2), "launches": removed_launches},
+        "step_ms": {"now": step, "projected": round(new_step, 1)},
+        "img_per_s": {"now": cur_imgs, "projected": new_imgs},
+        "caveat": "rough estimate (per-launch host cost is approximate); verify by profiling.",
+    }
+    if json_output:
+        print(_json.dumps(res, indent=2))
+        return
+    print(f"what-if [{a['bound']}]: {mechanism}")
+    print(f"  step   {step} -> ~{new_step:.0f} ms")
+    if new_imgs and cur_imgs:
+        print(f"  img/s  {cur_imgs} -> ~{new_imgs:.0f}{_pct(cur_imgs, new_imgs)}")
+    print("  (rough — verify by actually profiling the change)")

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -115,6 +115,42 @@ def summary_cmd(
         print(f"  {k['pct_of_gpu']:5.1f}%  {k['ms_per_step']:6.3f} ms  x{k['count_per_step']:<4} {k['kernel']}{tc}")
 
 
+@profile_app.command("get")
+def get_cmd(
+    trace: str = typer.Argument(..., help="Path to profile_trace.json"),
+    field: Optional[str] = typer.Argument(None, help="Metric name (omit to list metrics)"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """Print ONE metric — minimal output for tight loops (img_per_s, forward_ms, gpu_util...)."""
+    a = _load(trace)
+    m = a["metrics"]
+    if not field:
+        keys = sorted(m.keys())
+        print(_json.dumps(keys) if json_output else "available metrics:\n  " + "\n  ".join(keys))
+        return
+    if field not in m:
+        typer.echo(f"unknown metric '{field}'. run 'profile get {trace}' to list metrics.", err=True)
+        raise typer.Exit(2)
+    print(_json.dumps({field: m[field]}) if json_output else m[field])
+
+
+@profile_app.command("phases")
+def phases_cmd(
+    trace: str = typer.Argument(..., help="Path to profile_trace.json"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """Per-phase breakdown: GPU ms, wall ms, kernel & op counts (forward/backward/dataload/...)."""
+    a = _load(trace)
+    if json_output:
+        print(_json.dumps({"trace": a["trace"], "phases": a["phases"]}, indent=2))
+        return
+    print(f"{'phase':<11} {'gpu_ms':>8} {'wall_ms':>8} {'kernels':>8} {'ops':>7}")
+    for p in a["phases"]:
+        wall = "-" if p["wall_ms_per_step"] is None else f"{p['wall_ms_per_step']:.1f}"
+        print(f"{p['phase']:<11} {p['gpu_ms_per_step']:8.1f} {wall:>8} "
+              f"{p['kernels_per_step']:8d} {p['ops_per_step']:7d}")
+
+
 @profile_app.command("kernels")
 def kernels_cmd(
     trace: str = typer.Argument(..., help="Path to profile_trace.json"),
@@ -123,11 +159,18 @@ def kernels_cmd(
     grep: Optional[str] = typer.Option(None, "--grep", help="Filter by kernel-name regex"),
     tensorcore: bool = typer.Option(False, "--tensorcore", help="Only Tensor-Core kernels"),
     sort: str = typer.Option("time", "--sort", help="time | count | name"),
+    phase: Optional[str] = typer.Option(None, "--phase", help="Restrict to a phase (forward/backward/dataload/to_device/optimizer)"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
     """Drill to individual GPU kernels — the bottom of the analysis."""
     a = _load(trace)
-    ks = a["kernels"]
+    if phase:
+        ks = a["kernels_by_phase"].get(phase)
+        if ks is None:
+            typer.echo(f"unknown phase '{phase}'. available: {', '.join(a['kernels_by_phase'])}", err=True)
+            raise typer.Exit(2)
+    else:
+        ks = a["kernels"]
     if category:
         ks = [k for k in ks if category.lower() in k["category"].lower()]
     if grep:
@@ -151,11 +194,19 @@ def kernels_cmd(
 def ops_cmd(
     trace: str = typer.Argument(..., help="Path to profile_trace.json"),
     top: int = typer.Option(20, "--top"),
+    phase: Optional[str] = typer.Option(None, "--phase", help="Restrict to a phase (forward/backward/...)"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
     """Framework view: aten/autograd ops by CPU time (host-launch culprits)."""
     a = _load(trace)
-    ops = a["ops"][:top]
+    if phase:
+        ops_all = a["ops_by_phase"].get(phase)
+        if ops_all is None:
+            typer.echo(f"unknown phase '{phase}'. available: {', '.join(a['ops_by_phase'])}", err=True)
+            raise typer.Exit(2)
+    else:
+        ops_all = a["ops"]
+    ops = ops_all[:top]
     if json_output:
         print(_json.dumps({"trace": a["trace"], "ops": ops}, indent=2))
         return

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -136,6 +136,17 @@ class TrainConfig:
     seed: int = 0
     allow_download_scripts: bool = False
 
+    # Profiling. When ``profile`` is True the trainer profiles a short window of
+    # real training steps (``profile_warmup`` discarded, then ``profile_steps``
+    # measured), prints a per-phase breakdown + GPU-idle verdict, writes a Chrome
+    # trace (open at https://ui.perfetto.dev), then stops early. Zero overhead
+    # when off. Ignored under distributed training.
+    profile: bool = False
+    profile_warmup: int = 5
+    profile_steps: int = 20
+    profile_trace: bool = True
+    profile_open: bool = True
+
     @classmethod
     def from_kwargs(cls, **kwargs):
         """Construct config, warning on unknown keys."""

--- a/libreyolo/training/ema.py
+++ b/libreyolo/training/ema.py
@@ -43,10 +43,24 @@ class ModelEMA:
             msd = (
                 model.module.state_dict() if is_parallel(model) else model.state_dict()
             )
+            # EMA update: v = d*v + (1-d)*model[k] for every float tensor.
+            ema_vals, model_vals = [], []
             for k, v in self.ema.state_dict().items():
                 if v.dtype.is_floating_point:
-                    v *= d
-                    v += (1.0 - d) * msd[k].detach()
+                    ema_vals.append(v)
+                    model_vals.append(msd[k])
+            if ema_vals and ema_vals[0].is_cuda:
+                # CUDA / ROCm: fuse the ~N per-parameter mul_/add_ launches into
+                # two multi-tensor _foreach_ calls — a large win when the step is
+                # launch-bound. Numerically identical (~1e-7).
+                torch._foreach_mul_(ema_vals, d)
+                torch._foreach_add_(ema_vals, model_vals, alpha=1.0 - d)
+            else:
+                # CPU / MPS / other backends: portable per-tensor path (identical
+                # math; _foreach_ coverage is incomplete on MPS, and the launch
+                # win is CUDA-specific anyway).
+                for v, mv in zip(ema_vals, model_vals):
+                    v.mul_(d).add_(mv, alpha=1.0 - d)
 
     def set_decay(self, decay: float, ramp: bool = False):
         """Replace the decay schedule (used for D-FINE-style EMA restart).

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -146,6 +146,8 @@ def analyze_trace(trace_path, summary_path=None):
         return w0 is None or (w0 <= ts < w1)
 
     kern, opagg, phase_gpu = {}, {}, {}
+    kernel_list, op_list = [], []
+    gpu_intervals, cpu_intervals = {}, {}
     gpu_busy_us = memcpy_us = tc_us = 0.0
     n_kern = 0
     for e in events:
@@ -165,14 +167,51 @@ def analyze_trace(trace_path, summary_path=None):
             k = kern.setdefault(name, [0.0, 0])
             k[0] += dur
             k[1] += 1
+            kernel_list.append((name, dur, ts))
         elif cat in ("gpu_memcpy", "gpu_memset"):
             memcpy_us += dur
         elif cat == "cpu_op":
             o = opagg.setdefault(name, [0.0, 0])
             o[0] += dur
             o[1] += 1
+            op_list.append((name, dur, ts))
         elif cat == "gpu_user_annotation" and name.startswith("step/"):
-            phase_gpu[name[5:]] = phase_gpu.get(name[5:], 0.0) + dur
+            p = name[5:]
+            phase_gpu[p] = phase_gpu.get(p, 0.0) + dur
+            gpu_intervals.setdefault(p, []).append((ts, ts + dur))
+        elif cat == "user_annotation" and name.startswith("step/"):
+            cpu_intervals.setdefault(name[5:], []).append((ts, ts + dur))
+
+    # Tag each kernel/op with the phase whose span contains it (for `phases`
+    # and `--phase` drill-down).
+    gpu_iv = sorted((s, en, p) for p, ivs in gpu_intervals.items() for (s, en) in ivs)
+    cpu_iv = sorted((s, en, p) for p, ivs in cpu_intervals.items() for (s, en) in ivs)
+
+    def _phase_of(ts, iv):
+        for s, en, p in iv:
+            if s <= ts < en:
+                return p
+        return "unphased"
+
+    phase_kern, phase_kcount, phase_op, phase_ocount = {}, {}, {}, {}
+    phase_gpu_us = {}
+    # Tag GPU kernels by the CPU phase span that launched them. The gpu-side
+    # annotation spans overlap and mis-attribute (forward swallows backward);
+    # the CPU launch spans are clean, and for a host-bound step each kernel
+    # runs inside its launch span.
+    for name, dur, ts in kernel_list:
+        p = _phase_of(ts, cpu_iv)
+        d = phase_kern.setdefault(p, {}).setdefault(name, [0.0, 0])
+        d[0] += dur
+        d[1] += 1
+        phase_kcount[p] = phase_kcount.get(p, 0) + 1
+        phase_gpu_us[p] = phase_gpu_us.get(p, 0.0) + dur
+    for name, dur, ts in op_list:
+        p = _phase_of(ts, cpu_iv)
+        d = phase_op.setdefault(p, {}).setdefault(name, [0.0, 0])
+        d[0] += dur
+        d[1] += 1
+        phase_ocount[p] = phase_ocount.get(p, 0) + 1
 
     wall_ms = (w1 - w0) / 1000.0 if w0 is not None else 0.0
     tot = sum(v[0] for v in kern.values()) or 1.0
@@ -185,22 +224,28 @@ def analyze_trace(trace_path, summary_path=None):
         except Exception:
             summary = {}
     real = summary.get("real", {})
+    comp = summary.get("composition_ms", {})
     step_ms = real.get("step_ms") or (wall_ms / n_real if n_real else wall_ms)
     gpu_busy_ms = gpu_busy_us / 1000.0 / n_real
     util = (gpu_busy_ms / step_ms) if step_ms else 0.0
 
-    def krow(name, td):
+    def krow(name, td, denom):
         return {
             "kernel": _friendly_kernel(name),
             "raw_name": name[:90],
             "category": _kernel_category(name),
             "tensorcore": _is_tensorcore(name),
             "ms_per_step": round(td[0] / 1000.0 / n_real, 4),
-            "pct_of_gpu": round(td[0] / tot * 100, 2),
+            "pct_of_gpu": round(td[0] / denom * 100, 2),
             "count_per_step": max(td[1] // n_real, 1),
         }
 
-    kernels = sorted((krow(n, td) for n, td in kern.items()),
+    def orow(name, td, denom):
+        return {"op": name[:70], "ms_per_step": round(td[0] / 1000.0 / n_real, 4),
+                "pct_of_cpu_ops": round(td[0] / denom * 100, 2),
+                "count_per_step": max(td[1] // n_real, 1)}
+
+    kernels = sorted((krow(n, td, tot) for n, td in kern.items()),
                      key=lambda r: r["pct_of_gpu"], reverse=True)
     cats = {}
     for n, td in kern.items():
@@ -210,13 +255,30 @@ def analyze_trace(trace_path, summary_path=None):
                    "ms_per_step": round(v / 1000.0 / n_real, 3)}
                   for c, v in sorted(cats.items(), key=lambda kv: kv[1], reverse=True) if v > 0]
     optot = sum(v[0] for v in opagg.values()) or 1.0
-    ops = sorted(({"op": n[:70], "ms_per_step": round(td[0] / 1000.0 / n_real, 4),
-                   "pct_of_cpu_ops": round(td[0] / optot * 100, 2),
-                   "count_per_step": max(td[1] // n_real, 1)}
-                  for n, td in opagg.items()),
+    ops = sorted((orow(n, td, optot) for n, td in opagg.items()),
                  key=lambda r: r["pct_of_cpu_ops"], reverse=True)
-    phases_gpu = [{"phase": p, "gpu_ms_per_step": round(v / 1000.0 / n_real, 3)}
-                  for p, v in sorted(phase_gpu.items(), key=lambda kv: kv[1], reverse=True)]
+
+    # Per-phase rollup + drill lists.
+    _ORDER = ["dataload", "to_device", "forward", "backward", "optimizer"]
+    phase_names = [p for p in _ORDER if p in phase_gpu or p in phase_kern or p in phase_op]
+    phase_names += [p for p in phase_kern if p not in phase_names]
+    phases, kernels_by_phase, ops_by_phase = [], {}, {}
+    for p in phase_names:
+        ptot = sum(v[0] for v in phase_kern.get(p, {}).values()) or 1.0
+        potot = sum(v[0] for v in phase_op.get(p, {}).values()) or 1.0
+        kernels_by_phase[p] = sorted((krow(n, td, ptot) for n, td in phase_kern.get(p, {}).items()),
+                                     key=lambda r: r["pct_of_gpu"], reverse=True)[:40]
+        ops_by_phase[p] = sorted((orow(n, td, potot) for n, td in phase_op.get(p, {}).items()),
+                                 key=lambda r: r["pct_of_cpu_ops"], reverse=True)[:40]
+        wall = real.get("dataload_ms") if p == "dataload" else comp.get(p)
+        phases.append({
+            "phase": p,
+            "gpu_ms_per_step": round(phase_gpu_us.get(p, 0.0) / 1000.0 / n_real, 3),
+            "wall_ms_per_step": round(wall, 2) if wall is not None else None,
+            "kernels_per_step": int(phase_kcount.get(p, 0) // n_real),
+            "ops_per_step": int(phase_ocount.get(p, 0) // n_real),
+            "unique_kernels": len(phase_kern.get(p, {})),
+        })
 
     bound = summary.get("bound")
     why = summary.get("bound_why", "")
@@ -226,6 +288,33 @@ def analyze_trace(trace_path, summary_path=None):
                if bound == "compute" else
                f"GPU only ~{util * 100:.0f}% busy — tiny kernels / host overhead "
                "(dataloader stall not measurable from trace alone)")
+
+    tc_pct = round(tc_us / gpu_busy_us * 100, 1) if gpu_busy_us else 0.0
+    peak_vram = (summary.get("analysis") or {}).get("peak_vram_mb")
+
+    # Flat metrics for `profile get <field>` (atomic, minimal-output queries).
+    metrics = {
+        "img_per_s": real.get("img_per_s"),
+        "step_ms": round(step_ms, 2),
+        "dataload_ms": real.get("dataload_ms"),
+        "dataload_frac": real.get("dataload_frac"),
+        "gpu_util": round(util, 3),
+        "gpu_busy_ms": round(gpu_busy_ms, 2),
+        "mean_kernel_us": round(gpu_busy_us / n_kern, 2) if n_kern else 0.0,
+        "kernels_per_step": int(n_kern // n_real),
+        "unique_kernels": len(kern),
+        "ops_per_step": int(sum(phase_ocount.values()) // n_real),
+        "memcpy_ms": round(memcpy_us / 1000.0 / n_real, 3),
+        "tensorcore_pct": tc_pct,
+        "peak_vram_mb": peak_vram,
+        "bound": bound,
+    }
+    for ph in phases:
+        p = ph["phase"]
+        metrics[f"{p}_gpu_ms"] = ph["gpu_ms_per_step"]
+        metrics[f"{p}_wall_ms"] = ph["wall_ms_per_step"]
+        metrics[f"{p}_kernels"] = ph["kernels_per_step"]
+        metrics[f"{p}_ops"] = ph["ops_per_step"]
 
     return {
         "trace": str(trace_path),
@@ -243,11 +332,16 @@ def analyze_trace(trace_path, summary_path=None):
         "kernels_per_step": int(n_kern // n_real),
         "unique_kernels": len(kern),
         "memcpy_ms_per_step": round(memcpy_us / 1000.0 / n_real, 3),
-        "tensorcore_pct": round(tc_us / gpu_busy_us * 100, 1) if gpu_busy_us else 0.0,
-        "peak_vram_mb": (summary.get("analysis") or {}).get("peak_vram_mb"),
+        "tensorcore_pct": tc_pct,
+        "peak_vram_mb": peak_vram,
         "window": {"wall_ms": round(wall_ms, 1), "real_steps": n_real},
+        "metrics": metrics,
         "categories": categories,
-        "phases_gpu": phases_gpu,
+        "phases": phases,
+        "phases_gpu": [{"phase": ph["phase"], "gpu_ms_per_step": ph["gpu_ms_per_step"]}
+                       for ph in phases],
+        "kernels_by_phase": kernels_by_phase,
+        "ops_by_phase": ops_by_phase,
         "top_kernels": kernels[:8],
         "kernels": kernels,
         "ops": ops,

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -343,17 +343,25 @@ class TrainStepProfiler:
                 lane, label = "mem", name
             else:
                 continue
-            kept.append({"name": label, "_ts": ts, "_dur": dur,
+            kept.append({"name": label[:64], "_ts": ts, "_dur": dur,
                          "lane": LANE[lane], "cat": lane})
         if not kept:
             return None
 
-        CAP = 8000
-        if len(kept) > CAP:
-            keepers = [e for e in kept if e["cat"] in ("pcpu", "pgpu", "mem")]
-            rest = sorted((e for e in kept if e["cat"] in ("cpu", "gpu")),
-                          key=lambda e: e["_dur"], reverse=True)
-            kept = keepers + rest[: max(0, CAP - len(keepers))]
+        # Keep every phase/memcpy span; cap the noisy cpu-op and kernel lanes to
+        # their longest entries so the GPU work isn't crowded out (the autograd
+        # ops are mostly nested wrappers) and the emitted file stays small.
+        def _longest(cat, n):
+            evs = [e for e in kept if e["cat"] == cat]
+            if len(evs) <= n:
+                return evs
+            return sorted(evs, key=lambda e: e["_dur"], reverse=True)[:n]
+
+        kept = (
+            [e for e in kept if e["cat"] in ("pcpu", "pgpu", "mem")]
+            + _longest("cpu", 1500)
+            + _longest("gpu", 2500)
+        )
 
         base = min(e["_ts"] for e in kept)
         for e in kept:
@@ -414,187 +422,6 @@ class TrainStepProfiler:
             page = _TIMELINE_HTML.replace("/*__DATA__*/", payload)
             path = self.save_dir / "timeline.html"
             path.write_text(page, encoding="utf-8")
-            return path
-        except Exception:
-            return None
-
-    def _open_in_perfetto(self, trace_path, timeout: float = 30.0) -> None:
-        """Open the trace as a GPU/CPU timeline in Perfetto.
-
-        Serves a tiny local page that loads the trace same-origin and hands the
-        bytes to ui.perfetto.dev via the official postMessage API — sidestepping
-        the mixed-content block that defeats the ``?url=`` deep link. Auto-opens;
-        if the browser blocks the popup, the page shows a one-click button.
-        """
-        import functools
-        import http.server
-        import socketserver
-        import threading
-        import webbrowser
-
-        directory = str(trace_path.parent)
-        trace_name = trace_path.name
-        loaded = threading.Event()
-        origin = "https://ui.perfetto.dev"
-
-        open_html = (
-            "<!doctype html><meta charset='utf-8'>"
-            "<title>LibreYOLO profile</title>"
-            "<style>body{font-family:Segoe UI,sans-serif;background:#0f1115;color:#e6e6e6;"
-            "padding:40px;text-align:center}button{font-size:16px;padding:12px 22px;border:0;"
-            "border-radius:8px;background:#3498db;color:#fff;cursor:pointer;margin-top:18px}"
-            "#s{color:#8b95a5;margin-top:10px}</style>"
-            "<h2>LibreYOLO training profile</h2><div id='s'>loading trace...</div>"
-            "<button id='b' style='display:none' onclick='go()'>&#9654; Open timeline in Perfetto</button>"
-            "<script>var O='" + origin + "';var BUF=null;"
-            "fetch('./" + trace_name + "').then(function(r){return r.arrayBuffer();})"
-            ".then(function(b){BUF=b;fetch('/__loaded').catch(function(){});"
-            "document.getElementById('s').textContent='trace ready ('+(b.byteLength/1e6).toFixed(1)+' MB)';go();});"
-            "function go(){var w=window.open(O);"
-            "if(!w){document.getElementById('b').style.display='inline-block';"
-            "document.getElementById('s').textContent='click the button to open the timeline';return;}"
-            "var t=setInterval(function(){w.postMessage('PING',O);},64);"
-            "function h(e){if(e.data!=='PONG')return;clearInterval(t);"
-            "window.removeEventListener('message',h);"
-            "w.postMessage({perfetto:{buffer:BUF,title:'LibreYOLO training profile',"
-            "fileName:'" + trace_name + "'}},O);}"
-            "window.addEventListener('message',h);}</script>"
-        )
-        try:
-            (trace_path.parent / "open.html").write_text(open_html, encoding="utf-8")
-        except Exception:
-            return
-
-        class Handler(http.server.SimpleHTTPRequestHandler):
-            def end_headers(self):
-                self.send_header("Cache-Control", "no-store")
-                super().end_headers()
-
-            def do_GET(self):
-                if "__loaded" in self.path:
-                    loaded.set()
-                    self.send_response(204)
-                    self.end_headers()
-                    return
-                super().do_GET()
-
-            def log_message(self, *args):
-                pass
-
-        handler = functools.partial(Handler, directory=directory)
-        try:
-            httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
-        except Exception:
-            self._emit(f"  (could not start local server — drag {trace_name} "
-                       "into https://ui.perfetto.dev)")
-            return
-        port = httpd.server_address[1]
-        threading.Thread(target=httpd.serve_forever, daemon=True).start()
-        url = f"http://127.0.0.1:{port}/open.html"
-        self._emit(f"  opening the GPU/CPU timeline in Perfetto…  {url}")
-        try:
-            webbrowser.open(url)
-        except Exception:
-            pass
-        loaded.wait(timeout)
-        if loaded.is_set():
-            self._emit("  trace handed to Perfetto (timeline should be open).")
-            time.sleep(5.0)  # grace for the popup handshake / a manual click
-        else:
-            self._emit(f"  (page didn't load within {int(timeout)}s — open {url} "
-                       f"or drag {trace_name} into https://ui.perfetto.dev)")
-        try:
-            httpd.shutdown()
-        except Exception:
-            pass
-
-    def _write_html(self, trace_path):
-        """Write a self-contained HTML report; returns its path (or None)."""
-        if self.save_dir is None or self.summary is None:
-            return None
-        s = self.summary
-        r = s["real"]
-        m = self.meta
-        comp_total = s["composition_total_ms"] or 1.0
-        idle = r["gpu_idle_fraction"] * 100.0
-        if s["bound"] == "dataloader":
-            banner_bg = "#c0392b"
-            verdict = f"DATALOADER-BOUND — GPU idle ~{idle:.0f}% (waiting on data)"
-        else:
-            banner_bg = "#1e8449"
-            verdict = f"COMPUTE-BOUND — GPU idle only ~{idle:.0f}% (healthy)"
-
-        palette = {
-            "to_device": "#f1c40f", "forward": "#3498db",
-            "backward": "#9b59b6", "optimizer": "#2ecc71",
-        }
-        rows = []
-        for p in PHASES:
-            ms = s["composition_ms"][p]
-            pct = ms / comp_total * 100.0
-            rows.append(
-                f'<tr><td class="ph">{p}</td><td class="ms">{ms:.2f} ms</td>'
-                f'<td class="barcell"><div class="bar" style="width:{pct:.1f}%;'
-                f'background:{palette[p]}"></div></td>'
-                f'<td class="pct">{pct:.1f}%</td></tr>'
-            )
-
-        # Real split: dataload vs compute, as one stacked bar.
-        step = r["step_ms"] or 1.0
-        dl_pct = r["dataload_ms"] / step * 100.0
-        cp_pct = r["compute_ms"] / step * 100.0
-        trace_html = ""
-        if trace_path is not None:
-            trace_html = (
-                '<p class="meta">Full async timeline: drag '
-                f'<code>{Path(trace_path).name}</code> into '
-                '<a href="https://ui.perfetto.dev" target="_blank">ui.perfetto.dev</a>.</p>'
-            )
-        css = (
-            "body{font-family:Segoe UI,Roboto,-apple-system,sans-serif;"
-            "background:#0f1115;color:#e6e6e6;margin:0;padding:32px}"
-            ".card{max-width:780px;margin:auto;background:#171a21;"
-            "border:1px solid #262b36;border-radius:12px;padding:24px 28px}"
-            "h1{font-size:19px;margin:0 0 4px}h2{font-size:14px;color:#cbd3df;margin:20px 0 8px}"
-            ".meta{color:#8b95a5;font-size:13px;margin:6px 0}"
-            ".banner{color:#fff;font-weight:600;padding:10px 14px;"
-            "border-radius:8px;margin:14px 0 8px;background:%s}"
-            ".big{font-size:15px;margin:10px 0}"
-            ".stack{display:flex;height:22px;border-radius:5px;overflow:hidden;margin:8px 0}"
-            ".seg{height:22px;display:flex;align-items:center;justify-content:center;"
-            "font-size:11px;color:#0b0d12;font-weight:600}"
-            "table{width:100%%;border-collapse:collapse}"
-            "td{padding:6px 8px;font-size:14px;vertical-align:middle}"
-            ".ph{width:88px;color:#cbd3df}"
-            ".ms{width:88px;text-align:right;font-variant-numeric:tabular-nums}"
-            ".pct{width:52px;text-align:right;color:#8b95a5}"
-            ".bar{height:16px;border-radius:4px;min-width:2px}"
-            "code{color:#f1c40f}a{color:#4aa3ff}"
-        ) % banner_bg
-        html = (
-            "<!doctype html><html><head><meta charset='utf-8'>"
-            f"<title>LibreYOLO profile — {m.get('model','?')}</title>"
-            f"<style>{css}</style></head><body><div class='card'>"
-            f"<h1>LibreYOLO training profile — {m.get('model','?')}</h1>"
-            f"<div class='meta'>device {m.get('device','?')} · batch {m.get('batch','?')}"
-            f" · imgsz {m.get('imgsz','?')} · amp {m.get('amp','?')}"
-            f" · workers {m.get('workers','?')} · "
-            f"{s['window']['real_steps']}+{s['window']['synced_steps']} steps</div>"
-            f"<div class='banner'>{verdict}</div>"
-            f"<div class='big'>Real step <b>{r['step_ms']:.0f} ms</b> &rarr; "
-            f"<b>{r['img_per_s']:.1f} img/s</b></div>"
-            "<div class='stack'>"
-            f"<div class='seg' style='width:{dl_pct:.1f}%;background:#e67e22'>dataload {r['dataload_ms']:.0f}ms</div>"
-            f"<div class='seg' style='width:{cp_pct:.1f}%;background:#3498db'>compute {r['compute_ms']:.0f}ms</div>"
-            "</div>"
-            "<h2>GPU compute composition (synchronized)</h2>"
-            f"<table>{''.join(rows)}</table>"
-            f"{trace_html}</div></body></html>"
-        )
-        try:
-            self.save_dir.mkdir(parents=True, exist_ok=True)
-            path = self.save_dir / "profile_report.html"
-            path.write_text(html, encoding="utf-8")
             return path
         except Exception:
             return None

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -149,7 +149,7 @@ def analyze_trace(trace_path, summary_path=None):
     kernel_list, op_list = [], []
     cpu_intervals = {}
     gpu_busy_us = memcpy_us = tc_us = 0.0
-    n_kern = 0
+    n_kern = n_malloc = 0
     for e in events:
         if e.get("ph") != "X":
             continue
@@ -170,6 +170,8 @@ def analyze_trace(trace_path, summary_path=None):
             kernel_list.append((name, dur, ts))
         elif cat in ("gpu_memcpy", "gpu_memset"):
             memcpy_us += dur
+        elif cat == "cuda_runtime" and ("Malloc" in name or "Free" in name):
+            n_malloc += 1
         elif cat == "cpu_op":
             o = opagg.setdefault(name, [0.0, 0])
             o[0] += dur
@@ -224,7 +226,15 @@ def analyze_trace(trace_path, summary_path=None):
     comp = summary.get("composition_ms", {})
     step_ms = real.get("step_ms") or (wall_ms / n_real if n_real else wall_ms)
     gpu_busy_ms = gpu_busy_us / 1000.0 / n_real
-    util = (gpu_busy_ms / step_ms) if step_ms else 0.0
+    util_raw = (gpu_busy_ms / step_ms) if step_ms else 0.0
+    util = min(util_raw, 1.0)
+    mallocs_per_step = int(n_malloc // n_real) if n_real else n_malloc
+    # util > ~100% or many allocations/step = allocator thrash / VRAM pressure,
+    # not real saturation — flag it so it stops reading as "compute-bound".
+    memory_pressure = mallocs_per_step >= 5 or util_raw > 1.05
+    dl_ms = real.get("dataload_ms") or 0.0
+    host_overhead_ms = max(step_ms - gpu_busy_ms - dl_ms, 0.0)
+    launches_per_step = int(n_kern // n_real)
 
     def krow(name, td, denom):
         return {
@@ -285,6 +295,11 @@ def analyze_trace(trace_path, summary_path=None):
                if bound == "compute" else
                f"GPU only ~{util * 100:.0f}% busy — tiny kernels / host overhead "
                "(dataloader stall not measurable from trace alone)")
+    if memory_pressure:
+        bound = "memory-pressure"
+        why = (f"allocator thrash (~{mallocs_per_step} cudaMalloc/free per step"
+               + (f"; util read {util_raw * 100:.0f}%" if util_raw > 1.05 else "")
+               + ") — VRAM pressure; throughput and utilisation here are unreliable")
 
     tc_pct = round(tc_us / gpu_busy_us * 100, 1) if gpu_busy_us else 0.0
     peak_vram = (summary.get("analysis") or {}).get("peak_vram_mb")
@@ -304,6 +319,10 @@ def analyze_trace(trace_path, summary_path=None):
         "memcpy_ms": round(memcpy_us / 1000.0 / n_real, 3),
         "tensorcore_pct": tc_pct,
         "peak_vram_mb": peak_vram,
+        "host_overhead_ms": round(host_overhead_ms, 2),
+        "launches_per_step": launches_per_step,
+        "cuda_mallocs_per_step": mallocs_per_step,
+        "memory_pressure": memory_pressure,
         "bound": bound,
     }
     for ph in phases:
@@ -314,6 +333,7 @@ def analyze_trace(trace_path, summary_path=None):
         metrics[f"{p}_ops"] = ph["ops_per_step"]
 
     return {
+        "schema": "libreyolo.profile.analysis/v1",
         "trace": str(trace_path),
         "model": (summary.get("meta") or {}).get("model"),
         "config": summary.get("meta") or {},
@@ -324,6 +344,11 @@ def analyze_trace(trace_path, summary_path=None):
         "dataload_ms": real.get("dataload_ms"),
         "dataload_frac": real.get("dataload_frac"),
         "gpu_util": round(util, 3),
+        "gpu_util_raw": round(util_raw, 3),
+        "memory_pressure": memory_pressure,
+        "cuda_mallocs_per_step": mallocs_per_step,
+        "host_overhead_ms_per_step": round(host_overhead_ms, 2),
+        "launches_per_step": launches_per_step,
         "gpu_busy_ms_per_step": round(gpu_busy_ms, 2),
         "mean_kernel_us": round(gpu_busy_us / n_kern, 2) if n_kern else 0.0,
         "kernels_per_step": int(n_kern // n_real),
@@ -522,6 +547,17 @@ class TrainStepProfiler:
                     analysis["img_per_s"] = self.summary["real"]["img_per_s"]
                     analysis["dataload_ms"] = self.summary["real"]["dataload_ms"]
                 timeline_path = self._write_timeline_html(curated)
+            # Self-contained analysis artifact — one copyable file the CLI reads
+            # (summary/get/phases/compare); the raw trace stays for kernel drill.
+            if self.save_dir is not None:
+                try:
+                    full = analyze_trace(
+                        trace_path,
+                        summary_path=self.save_dir / "profile_summary.json",
+                    )
+                    (self.save_dir / "profile.json").write_text(json.dumps(full))
+                except Exception:
+                    pass
         self._report(trace_path, timeline_path)
         if self.open_report and timeline_path is not None:
             try:

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -147,7 +147,7 @@ def analyze_trace(trace_path, summary_path=None):
 
     kern, opagg, phase_gpu = {}, {}, {}
     kernel_list, op_list = [], []
-    gpu_intervals, cpu_intervals = {}, {}
+    cpu_intervals = {}
     gpu_busy_us = memcpy_us = tc_us = 0.0
     n_kern = 0
     for e in events:
@@ -176,15 +176,12 @@ def analyze_trace(trace_path, summary_path=None):
             o[1] += 1
             op_list.append((name, dur, ts))
         elif cat == "gpu_user_annotation" and name.startswith("step/"):
-            p = name[5:]
-            phase_gpu[p] = phase_gpu.get(p, 0.0) + dur
-            gpu_intervals.setdefault(p, []).append((ts, ts + dur))
+            phase_gpu[name[5:]] = phase_gpu.get(name[5:], 0.0) + dur
         elif cat == "user_annotation" and name.startswith("step/"):
             cpu_intervals.setdefault(name[5:], []).append((ts, ts + dur))
 
-    # Tag each kernel/op with the phase whose span contains it (for `phases`
-    # and `--phase` drill-down).
-    gpu_iv = sorted((s, en, p) for p, ivs in gpu_intervals.items() for (s, en) in ivs)
+    # CPU phase launch spans, for tagging kernels/ops to a phase (`phases`,
+    # `--phase` drill-down).
     cpu_iv = sorted((s, en, p) for p, ivs in cpu_intervals.items() for (s, en) in ivs)
 
     def _phase_of(ts, iv):

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -1,0 +1,705 @@
+"""Lightweight built-in training profiler.
+
+Answers one question fast: **where does each training step's time go, and is the
+GPU starved?** It profiles a short window of *real* training steps and reports
+two complementary views:
+
+1. **Real timing (unsynced).** The first half of the window runs with no extra
+   synchronization, so the measured step time and the dataloader stall reflect
+   true overlap behavior. This drives the honest verdict (dataloader-bound vs
+   compute-bound), the real img/s, and the GPU-idle estimate.
+2. **Compute composition (synced).** The second half brackets each phase with a
+   CUDA sync to attribute GPU time to forward / backward / optimizer / to_device.
+
+Splitting the window matters: syncing every phase serializes the GPU and hands
+the dataloader workers slack, which *hides* starvation. So we never derive the
+verdict from synced numbers — only the composition.
+
+It writes a self-contained ``profile_report.html`` (auto-opened in the browser)
+and a Chrome/Perfetto trace (``profile_trace.json``), plus ``profile_summary.json``.
+
+Zero overhead when disabled: the trainer holds ``None`` and the hot-loop calls
+short-circuit to a shared no-op context.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import time
+from pathlib import Path
+from typing import Optional
+
+import torch
+from torch.profiler import record_function
+
+PHASES = ("to_device", "forward", "backward", "optimizer")
+_NULL = contextlib.nullcontext()
+
+
+class TrainStepProfiler:
+    """Profiles a short window of training steps and reports the breakdown."""
+
+    def __init__(
+        self,
+        *,
+        device: torch.device,
+        warmup: int = 5,
+        active: int = 20,
+        trace: bool = True,
+        open_report: bool = True,
+        save_dir: Optional[Path] = None,
+        logger=None,
+        meta: Optional[dict] = None,
+    ) -> None:
+        self.device = device
+        self.warmup = max(0, int(warmup))
+        self.active = max(2, int(active))
+        self.trace = trace
+        self.open_report = open_report
+        self.save_dir = Path(save_dir) if save_dir else None
+        self.logger = logger
+        self.meta = meta or {}
+
+        self._is_cuda = getattr(device, "type", str(device)) == "cuda"
+        # First half of the active window is unsynced (real timing); second half
+        # is synced (compute composition).
+        self._half = max(1, self.active // 2)
+        self._step_i = 0          # total iterations seen (incl. warmup)
+        self._m = 0               # measured iterations (0-based within window)
+
+        # Real (unsynced) timing.
+        self._real_step_ms = 0.0
+        self._real_step_n = 0
+        self._real_dl_ms = 0.0
+        self._real_dl_n = 0
+        self._prev_fetch: Optional[float] = None
+
+        # Synced compute composition.
+        self._sums = {p: 0.0 for p in PHASES}
+        self._synced_n = 0
+
+        self.finished = False
+        self.summary: Optional[dict] = None
+
+        self._torch_prof = None
+        if self.trace:
+            self._start_torch_profiler()
+
+    # -- internals -----------------------------------------------------------
+
+    def _sync(self) -> None:
+        if self._is_cuda:
+            torch.cuda.synchronize(self.device)
+
+    def _active_now(self) -> bool:
+        return (not self.finished) and self._step_i >= self.warmup
+
+    def _unsynced_phase(self) -> bool:
+        return self._active_now() and self._m < self._half
+
+    def _synced_phase(self) -> bool:
+        return self._active_now() and self._m >= self._half
+
+    def _start_torch_profiler(self) -> None:
+        try:
+            from torch.profiler import ProfilerActivity, profile, schedule
+
+            acts = [ProfilerActivity.CPU]
+            if self._is_cuda:
+                acts.append(ProfilerActivity.CUDA)
+            self._torch_prof = profile(
+                activities=acts,
+                schedule=schedule(
+                    wait=0, warmup=self.warmup, active=self.active, repeat=1
+                ),
+                record_shapes=False,
+                with_stack=False,
+                profile_memory=False,
+            )
+            self._torch_prof.start()
+        except Exception:
+            self._torch_prof = None  # trace is best-effort; never break training
+
+    # -- public hooks (called from the training loop) ------------------------
+
+    def phase(self, name: str):
+        """Context for one phase: labels the trace across the whole active
+        window, and additionally sync-times it during the synced half."""
+        if not self._active_now():
+            return _NULL
+        return _PhaseTimer(self, name)
+
+    def wrap_loader(self, iterable):
+        """Yield batches while measuring real step time + dataload stall."""
+        it = iter(iterable)
+        while True:
+            t0 = time.perf_counter()
+            try:
+                with record_function("step/dataload"):
+                    batch = next(it)
+            except StopIteration:
+                return
+            t1 = time.perf_counter()
+            if self._unsynced_phase():
+                self._real_dl_ms += (t1 - t0) * 1000.0
+                self._real_dl_n += 1
+                if self._prev_fetch is not None:
+                    self._real_step_ms += (t1 - self._prev_fetch) * 1000.0
+                    self._real_step_n += 1
+            self._prev_fetch = t1
+            yield batch
+
+    def step(self) -> None:
+        """Advance one iteration; finalizes + reports when the window closes."""
+        if self.finished:
+            return
+        if self._torch_prof is not None:
+            try:
+                self._torch_prof.step()
+            except Exception:
+                pass
+        if self._synced_phase():
+            self._synced_n += 1
+        if self._step_i >= self.warmup:
+            self._m += 1
+        self._step_i += 1
+        if self._m >= self.active:
+            self._finish()
+
+    # -- finalize ------------------------------------------------------------
+
+    def _finish(self) -> None:
+        self.finished = True
+        trace_path = None
+        if self._torch_prof is not None:
+            try:
+                self._torch_prof.stop()
+                if self.trace and self.save_dir is not None:
+                    self.save_dir.mkdir(parents=True, exist_ok=True)
+                    trace_path = self.save_dir / "profile_trace.json"
+                    self._torch_prof.export_chrome_trace(str(trace_path))
+            except Exception:
+                trace_path = None
+        self._build_summary(trace_path)
+        timeline_path = None
+        if trace_path is not None:
+            timeline_path = self._write_timeline_html(self._curate_trace(trace_path))
+        self._report(trace_path, timeline_path)
+        if self.open_report and timeline_path is not None:
+            try:
+                import webbrowser
+
+                webbrowser.open(timeline_path.as_uri())
+            except Exception:
+                pass
+
+    def _build_summary(self, trace_path) -> None:
+        synced_n = max(self._synced_n, 1)
+        comp = {p: self._sums[p] / synced_n for p in PHASES}
+        comp_total = sum(comp.values()) or 1.0
+
+        real_step = self._real_step_ms / self._real_step_n if self._real_step_n else 0.0
+        real_dl = self._real_dl_ms / self._real_dl_n if self._real_dl_n else 0.0
+        real_compute = max(real_step - real_dl, 0.0)
+        idle_frac = (real_dl / real_step) if real_step > 0 else 0.0
+        batch = self.meta.get("batch", 0) or 0
+        img_s = (batch / (real_step / 1000.0)) if real_step > 0 else 0.0
+
+        self.summary = {
+            "meta": self.meta,
+            "window": {
+                "warmup": self.warmup,
+                "real_steps": self._real_step_n,
+                "synced_steps": self._synced_n,
+            },
+            "real": {
+                "step_ms": round(real_step, 3),
+                "dataload_ms": round(real_dl, 3),
+                "compute_ms": round(real_compute, 3),
+                "img_per_s": round(img_s, 2),
+                "gpu_idle_fraction": round(idle_frac, 3),
+            },
+            "composition_ms": {p: round(comp[p], 3) for p in PHASES},
+            "composition_total_ms": round(comp_total, 3),
+            "bound": "dataloader" if idle_frac >= 0.2 else "compute",
+            "trace": str(trace_path) if trace_path else None,
+        }
+        if self.save_dir is not None:
+            try:
+                self.save_dir.mkdir(parents=True, exist_ok=True)
+                (self.save_dir / "profile_summary.json").write_text(
+                    json.dumps(self.summary, indent=2)
+                )
+            except Exception:
+                pass
+
+    def _emit(self, line: str) -> None:
+        if self.logger is not None:
+            self.logger.info(line)
+        else:
+            print(line)
+
+    def _report(self, trace_path, timeline_path=None) -> None:
+        s = self.summary
+        r = s["real"]
+        m = self.meta
+        idle = r["gpu_idle_fraction"] * 100.0
+        comp_total = s["composition_total_ms"] or 1.0
+        bar_w = 20
+
+        self._emit("=" * 64)
+        self._emit(f"  LibreYOLO training profile — {m.get('model', '?')}")
+        self._emit(
+            f"  device={m.get('device','?')}  batch={m.get('batch','?')}  "
+            f"imgsz={m.get('imgsz','?')}  amp={m.get('amp','?')}  workers={m.get('workers','?')}"
+        )
+        self._emit(
+            f"  window: {s['window']['real_steps']} real-timed + "
+            f"{s['window']['synced_steps']} compute-split (+{self.warmup} warmup)"
+        )
+        self._emit(
+            f"  REAL step {r['step_ms']:.1f} ms = dataload {r['dataload_ms']:.1f} ms "
+            f"+ compute {r['compute_ms']:.1f} ms  ->  {r['img_per_s']:.1f} img/s"
+        )
+        if s["bound"] == "dataloader":
+            self._emit(
+                f"  >> VERDICT: DATALOADER-BOUND — GPU idle ~{idle:.0f}% "
+                "(waiting on data)."
+            )
+            self._emit(
+                "     Levers: workers↑, cache='ram'/'disk', lighter aug (mosaic), "
+                "or larger batch."
+            )
+        else:
+            self._emit(
+                f"  >> VERDICT: COMPUTE-BOUND — GPU idle only ~{idle:.0f}% (healthy)."
+            )
+        self._emit("  GPU compute composition (synchronized):")
+        for p in PHASES:
+            ms = s["composition_ms"][p]
+            frac = ms / comp_total
+            fill = int(round(frac * bar_w))
+            bar = "#" * fill + "." * (bar_w - fill)
+            self._emit(f"    {p:<10} {ms:8.2f} ms  |{bar}| {frac*100:5.1f}%")
+        if timeline_path:
+            self._emit(f"  timeline:  {timeline_path}")
+            if self.open_report:
+                self._emit("             (opening in your browser…)")
+        if trace_path:
+            self._emit(f"  raw trace: {trace_path}  (load in Perfetto/Nsight if you want)")
+        self._emit("=" * 64)
+
+    def _curate_trace(self, trace_path):
+        """Reduce the raw torch trace to the bounded set worth drawing.
+
+        Keeps our ``step/*`` phase spans (CPU + GPU projections), the
+        significant cpu ops, the GPU kernels and memcpys, and the CPU->GPU flow
+        links — within a steady window of ~3 middle training steps.
+        """
+        try:
+            import json
+            data = json.loads(Path(trace_path).read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        events = data.get("traceEvents", []) if isinstance(data, dict) else data
+
+        steps = sorted(
+            (e for e in events
+             if e.get("ph") == "X" and str(e.get("name", "")).startswith("ProfilerStep")),
+            key=lambda e: e.get("ts", 0),
+        )
+        if steps:
+            mid = len(steps) // 2
+            sel = steps[max(0, mid - 1): mid + 2] or steps[:3]
+            w0 = sel[0]["ts"]
+            w1 = sel[-1]["ts"] + sel[-1].get("dur", 0)
+        else:
+            w0 = w1 = None
+
+        def in_win(ts):
+            return w0 is None or (w0 <= ts <= w1)
+
+        LANE = {"pcpu": 0, "cpu": 1, "pgpu": 2, "gpu": 3, "mem": 4}
+        kept = []
+        for e in events:
+            if e.get("ph") != "X":
+                continue
+            cat = e.get("cat", "")
+            name = str(e.get("name", ""))
+            ts = e.get("ts")
+            dur = e.get("dur", 0) or 0
+            if ts is None or not in_win(ts):
+                continue
+            if cat == "user_annotation" and name.startswith("step/"):
+                lane, label = "pcpu", name[5:]
+            elif cat == "gpu_user_annotation" and name.startswith("step/"):
+                lane, label = "pgpu", name[5:]
+            elif cat == "cpu_op" and dur >= 20:
+                lane, label = "cpu", name
+            elif cat == "kernel" and dur >= 2:
+                lane, label = "gpu", name
+            elif cat in ("gpu_memcpy", "gpu_memset"):
+                lane, label = "mem", name
+            else:
+                continue
+            kept.append({"name": label, "_ts": ts, "_dur": dur,
+                         "lane": LANE[lane], "cat": lane})
+        if not kept:
+            return None
+
+        CAP = 8000
+        if len(kept) > CAP:
+            keepers = [e for e in kept if e["cat"] in ("pcpu", "pgpu", "mem")]
+            rest = sorted((e for e in kept if e["cat"] in ("cpu", "gpu")),
+                          key=lambda e: e["_dur"], reverse=True)
+            kept = keepers + rest[: max(0, CAP - len(keepers))]
+
+        base = min(e["_ts"] for e in kept)
+        for e in kept:
+            e["t"] = round((e["_ts"] - base) / 1000.0, 3)
+            e["d"] = round(e["_dur"] / 1000.0, 4)
+            del e["_ts"]
+            del e["_dur"]
+
+        lane_rows = {}
+        for li in range(5):
+            evs = sorted([e for e in kept if e["lane"] == li], key=lambda x: x["t"])
+            ends = []
+            for e in evs:
+                placed = False
+                for i, end in enumerate(ends):
+                    if e["t"] >= end:
+                        e["row"] = i
+                        ends[i] = e["t"] + max(e["d"], 0.001)
+                        placed = True
+                        break
+                if not placed:
+                    e["row"] = len(ends)
+                    ends.append(e["t"] + max(e["d"], 0.001))
+            lane_rows[li] = max(len(ends), 1)
+
+        s_by_id, f_by_id = {}, {}
+        for e in events:
+            if e.get("cat") != "ac2g":
+                continue
+            ph, i, ts = e.get("ph"), e.get("id"), e.get("ts")
+            if i is None or ts is None or not in_win(ts):
+                continue
+            if ph == "s":
+                s_by_id[i] = ts
+            elif ph == "f":
+                f_by_id[i] = ts
+        flows = []
+        for i, sts in s_by_id.items():
+            fts = f_by_id.get(i)
+            if fts is None:
+                continue
+            flows.append([round((sts - base) / 1000.0, 3),
+                          round((fts - base) / 1000.0, 3)])
+            if len(flows) >= 4000:
+                break
+
+        total = max((e["t"] + e["d"] for e in kept), default=1.0)
+        return {"events": kept, "flows": flows, "lane_rows": lane_rows,
+                "total_ms": round(total, 3), "meta": self.meta}
+
+    def _write_timeline_html(self, curated):
+        """Render the curated trace into a self-contained timeline.html."""
+        if self.save_dir is None or not curated:
+            return None
+        import json
+        try:
+            payload = json.dumps(curated).replace("</", "<\\/")
+            page = _TIMELINE_HTML.replace("/*__DATA__*/", payload)
+            path = self.save_dir / "timeline.html"
+            path.write_text(page, encoding="utf-8")
+            return path
+        except Exception:
+            return None
+
+    def _open_in_perfetto(self, trace_path, timeout: float = 30.0) -> None:
+        """Open the trace as a GPU/CPU timeline in Perfetto.
+
+        Serves a tiny local page that loads the trace same-origin and hands the
+        bytes to ui.perfetto.dev via the official postMessage API — sidestepping
+        the mixed-content block that defeats the ``?url=`` deep link. Auto-opens;
+        if the browser blocks the popup, the page shows a one-click button.
+        """
+        import functools
+        import http.server
+        import socketserver
+        import threading
+        import webbrowser
+
+        directory = str(trace_path.parent)
+        trace_name = trace_path.name
+        loaded = threading.Event()
+        origin = "https://ui.perfetto.dev"
+
+        open_html = (
+            "<!doctype html><meta charset='utf-8'>"
+            "<title>LibreYOLO profile</title>"
+            "<style>body{font-family:Segoe UI,sans-serif;background:#0f1115;color:#e6e6e6;"
+            "padding:40px;text-align:center}button{font-size:16px;padding:12px 22px;border:0;"
+            "border-radius:8px;background:#3498db;color:#fff;cursor:pointer;margin-top:18px}"
+            "#s{color:#8b95a5;margin-top:10px}</style>"
+            "<h2>LibreYOLO training profile</h2><div id='s'>loading trace...</div>"
+            "<button id='b' style='display:none' onclick='go()'>&#9654; Open timeline in Perfetto</button>"
+            "<script>var O='" + origin + "';var BUF=null;"
+            "fetch('./" + trace_name + "').then(function(r){return r.arrayBuffer();})"
+            ".then(function(b){BUF=b;fetch('/__loaded').catch(function(){});"
+            "document.getElementById('s').textContent='trace ready ('+(b.byteLength/1e6).toFixed(1)+' MB)';go();});"
+            "function go(){var w=window.open(O);"
+            "if(!w){document.getElementById('b').style.display='inline-block';"
+            "document.getElementById('s').textContent='click the button to open the timeline';return;}"
+            "var t=setInterval(function(){w.postMessage('PING',O);},64);"
+            "function h(e){if(e.data!=='PONG')return;clearInterval(t);"
+            "window.removeEventListener('message',h);"
+            "w.postMessage({perfetto:{buffer:BUF,title:'LibreYOLO training profile',"
+            "fileName:'" + trace_name + "'}},O);}"
+            "window.addEventListener('message',h);}</script>"
+        )
+        try:
+            (trace_path.parent / "open.html").write_text(open_html, encoding="utf-8")
+        except Exception:
+            return
+
+        class Handler(http.server.SimpleHTTPRequestHandler):
+            def end_headers(self):
+                self.send_header("Cache-Control", "no-store")
+                super().end_headers()
+
+            def do_GET(self):
+                if "__loaded" in self.path:
+                    loaded.set()
+                    self.send_response(204)
+                    self.end_headers()
+                    return
+                super().do_GET()
+
+            def log_message(self, *args):
+                pass
+
+        handler = functools.partial(Handler, directory=directory)
+        try:
+            httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+        except Exception:
+            self._emit(f"  (could not start local server — drag {trace_name} "
+                       "into https://ui.perfetto.dev)")
+            return
+        port = httpd.server_address[1]
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        url = f"http://127.0.0.1:{port}/open.html"
+        self._emit(f"  opening the GPU/CPU timeline in Perfetto…  {url}")
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+        loaded.wait(timeout)
+        if loaded.is_set():
+            self._emit("  trace handed to Perfetto (timeline should be open).")
+            time.sleep(5.0)  # grace for the popup handshake / a manual click
+        else:
+            self._emit(f"  (page didn't load within {int(timeout)}s — open {url} "
+                       f"or drag {trace_name} into https://ui.perfetto.dev)")
+        try:
+            httpd.shutdown()
+        except Exception:
+            pass
+
+    def _write_html(self, trace_path):
+        """Write a self-contained HTML report; returns its path (or None)."""
+        if self.save_dir is None or self.summary is None:
+            return None
+        s = self.summary
+        r = s["real"]
+        m = self.meta
+        comp_total = s["composition_total_ms"] or 1.0
+        idle = r["gpu_idle_fraction"] * 100.0
+        if s["bound"] == "dataloader":
+            banner_bg = "#c0392b"
+            verdict = f"DATALOADER-BOUND — GPU idle ~{idle:.0f}% (waiting on data)"
+        else:
+            banner_bg = "#1e8449"
+            verdict = f"COMPUTE-BOUND — GPU idle only ~{idle:.0f}% (healthy)"
+
+        palette = {
+            "to_device": "#f1c40f", "forward": "#3498db",
+            "backward": "#9b59b6", "optimizer": "#2ecc71",
+        }
+        rows = []
+        for p in PHASES:
+            ms = s["composition_ms"][p]
+            pct = ms / comp_total * 100.0
+            rows.append(
+                f'<tr><td class="ph">{p}</td><td class="ms">{ms:.2f} ms</td>'
+                f'<td class="barcell"><div class="bar" style="width:{pct:.1f}%;'
+                f'background:{palette[p]}"></div></td>'
+                f'<td class="pct">{pct:.1f}%</td></tr>'
+            )
+
+        # Real split: dataload vs compute, as one stacked bar.
+        step = r["step_ms"] or 1.0
+        dl_pct = r["dataload_ms"] / step * 100.0
+        cp_pct = r["compute_ms"] / step * 100.0
+        trace_html = ""
+        if trace_path is not None:
+            trace_html = (
+                '<p class="meta">Full async timeline: drag '
+                f'<code>{Path(trace_path).name}</code> into '
+                '<a href="https://ui.perfetto.dev" target="_blank">ui.perfetto.dev</a>.</p>'
+            )
+        css = (
+            "body{font-family:Segoe UI,Roboto,-apple-system,sans-serif;"
+            "background:#0f1115;color:#e6e6e6;margin:0;padding:32px}"
+            ".card{max-width:780px;margin:auto;background:#171a21;"
+            "border:1px solid #262b36;border-radius:12px;padding:24px 28px}"
+            "h1{font-size:19px;margin:0 0 4px}h2{font-size:14px;color:#cbd3df;margin:20px 0 8px}"
+            ".meta{color:#8b95a5;font-size:13px;margin:6px 0}"
+            ".banner{color:#fff;font-weight:600;padding:10px 14px;"
+            "border-radius:8px;margin:14px 0 8px;background:%s}"
+            ".big{font-size:15px;margin:10px 0}"
+            ".stack{display:flex;height:22px;border-radius:5px;overflow:hidden;margin:8px 0}"
+            ".seg{height:22px;display:flex;align-items:center;justify-content:center;"
+            "font-size:11px;color:#0b0d12;font-weight:600}"
+            "table{width:100%%;border-collapse:collapse}"
+            "td{padding:6px 8px;font-size:14px;vertical-align:middle}"
+            ".ph{width:88px;color:#cbd3df}"
+            ".ms{width:88px;text-align:right;font-variant-numeric:tabular-nums}"
+            ".pct{width:52px;text-align:right;color:#8b95a5}"
+            ".bar{height:16px;border-radius:4px;min-width:2px}"
+            "code{color:#f1c40f}a{color:#4aa3ff}"
+        ) % banner_bg
+        html = (
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            f"<title>LibreYOLO profile — {m.get('model','?')}</title>"
+            f"<style>{css}</style></head><body><div class='card'>"
+            f"<h1>LibreYOLO training profile — {m.get('model','?')}</h1>"
+            f"<div class='meta'>device {m.get('device','?')} · batch {m.get('batch','?')}"
+            f" · imgsz {m.get('imgsz','?')} · amp {m.get('amp','?')}"
+            f" · workers {m.get('workers','?')} · "
+            f"{s['window']['real_steps']}+{s['window']['synced_steps']} steps</div>"
+            f"<div class='banner'>{verdict}</div>"
+            f"<div class='big'>Real step <b>{r['step_ms']:.0f} ms</b> &rarr; "
+            f"<b>{r['img_per_s']:.1f} img/s</b></div>"
+            "<div class='stack'>"
+            f"<div class='seg' style='width:{dl_pct:.1f}%;background:#e67e22'>dataload {r['dataload_ms']:.0f}ms</div>"
+            f"<div class='seg' style='width:{cp_pct:.1f}%;background:#3498db'>compute {r['compute_ms']:.0f}ms</div>"
+            "</div>"
+            "<h2>GPU compute composition (synchronized)</h2>"
+            f"<table>{''.join(rows)}</table>"
+            f"{trace_html}</div></body></html>"
+        )
+        try:
+            self.save_dir.mkdir(parents=True, exist_ok=True)
+            path = self.save_dir / "profile_report.html"
+            path.write_text(html, encoding="utf-8")
+            return path
+        except Exception:
+            return None
+
+
+class _PhaseTimer:
+    """Labels the trace via record_function; sync-times only in the synced half."""
+
+    __slots__ = ("prof", "name", "_t0", "_rf")
+
+    def __init__(self, prof: TrainStepProfiler, name: str) -> None:
+        self.prof = prof
+        self.name = name
+        self._t0 = None
+        self._rf = None
+
+    def __enter__(self):
+        self._rf = record_function("step/" + self.name)
+        self._rf.__enter__()
+        if self.prof._synced_phase():
+            self.prof._sync()
+            self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, *exc):
+        if self._t0 is not None:
+            self.prof._sync()
+            self.prof._sums[self.name] += (time.perf_counter() - self._t0) * 1000.0
+        if self._rf is not None:
+            self._rf.__exit__(*exc)
+        return False
+
+
+_TIMELINE_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
+<title>LibreYOLO profiler - timeline</title>
+<style>
+ html,body{margin:0;background:#0f1115;color:#e6e6e6;font-family:Segoe UI,Roboto,sans-serif;overflow:hidden}
+ #hdr{padding:7px 12px;font-size:13px;color:#cbd3df;border-bottom:1px solid #20242c;white-space:nowrap;overflow:hidden}
+ #hdr b{color:#fff}
+ .sw{display:inline-block;width:9px;height:9px;border-radius:2px;margin:0 3px 0 9px;vertical-align:middle}
+ #tip{position:fixed;pointer-events:none;background:rgba(0,0,0,.88);border:1px solid #333;
+      padding:4px 8px;font-size:12px;border-radius:5px;display:none;white-space:nowrap;z-index:9;max-width:60vw;overflow:hidden}
+ canvas{display:block;cursor:grab}
+</style></head><body>
+<div id="hdr"></div><canvas id="c"></canvas><div id="tip"></div>
+<script>
+var DATA = /*__DATA__*/;
+var cv=document.getElementById('c'),ctx=cv.getContext('2d'),tip=document.getElementById('tip'),
+    hdr=document.getElementById('hdr');
+var LEFT=128,TOP=28,ROW=12,GAP=12;
+var LANES=['phase · CPU','CPU ops','phase · GPU','GPU kernels','GPU memcpy'];
+var PH={dataload:'#e67e22',to_device:'#f1c40f',forward:'#3498db',backward:'#9b59b6',optimizer:'#2ecc71'};
+function col(e){if(e.cat==='pcpu'||e.cat==='pgpu')return PH[e.name]||'#7f8c8d';
+ if(e.cat==='cpu')return '#5d6d7e';if(e.cat==='gpu')return '#16a085';return '#e74c3c';}
+var laneY=[],yy=TOP+8;
+for(var i=0;i<5;i++){laneY[i]=yy;yy+=(DATA.lane_rows[i]||1)*ROW+GAP;}
+var pxPerMs=1,viewStart=0,W=0,H=0,fitted=false;
+function xOf(t){return LEFT+(t-viewStart)*pxPerMs;}
+function fit(){pxPerMs=(W-LEFT-20)/(DATA.total_ms||1);viewStart=0;}
+function resize(){W=cv.width=window.innerWidth;H=cv.height=window.innerHeight-hdr.offsetHeight;
+ if(!fitted){fit();fitted=true;}draw();}
+function niceStep(span){var raw=span/10,p=Math.pow(10,Math.floor(Math.log10(raw||1))),n=raw/p;
+ n=n<1.5?1:n<3?2:n<7?5:10;return Math.max(n*p,0.001);}
+function draw(){
+ ctx.clearRect(0,0,W,H);
+ ctx.strokeStyle='rgba(130,170,210,.08)';ctx.lineWidth=1;ctx.beginPath();
+ var cy=laneY[1]+(DATA.lane_rows[1]||1)*ROW,gy=laneY[3];
+ for(var f=0;f<DATA.flows.length;f++){var a=DATA.flows[f],xa=xOf(a[0]),xb=xOf(a[1]);
+  if((xa<LEFT&&xb<LEFT)||(xa>W&&xb>W))continue;ctx.moveTo(xa,cy);ctx.lineTo(xb,gy);}
+ ctx.stroke();
+ for(var k=0;k<DATA.events.length;k++){var e=DATA.events[k],ex=xOf(e.t),ew=Math.max(e.d*pxPerMs,1);
+  if(ex+ew<LEFT||ex>W)continue;var ey=laneY[e.lane]+e.row*ROW;
+  ctx.fillStyle=col(e);ctx.fillRect(ex<LEFT?LEFT:ex,ey,ew,ROW-1);}
+ ctx.fillStyle='#0f1115';ctx.fillRect(0,0,LEFT,H);
+ ctx.fillStyle='#cbd3df';ctx.font='11px Segoe UI';ctx.textBaseline='top';
+ for(var i=0;i<5;i++)ctx.fillText(LANES[i],8,laneY[i]);
+ ctx.fillStyle='#0f1115';ctx.fillRect(0,0,W,TOP);
+ ctx.strokeStyle='#222';ctx.beginPath();ctx.moveTo(0,TOP);ctx.lineTo(W,TOP);ctx.stroke();
+ var span=(W-LEFT)/pxPerMs,st=niceStep(span),t0=Math.floor(viewStart/st)*st;
+ ctx.font='10px Segoe UI';
+ for(var t=t0;xOf(t)<W;t+=st){var px=xOf(t);if(px<LEFT)continue;
+  ctx.strokeStyle='#171a21';ctx.beginPath();ctx.moveTo(px,TOP);ctx.lineTo(px,H);ctx.stroke();
+  ctx.fillStyle='#8b95a5';ctx.fillText((st<1?t.toFixed(2):t.toFixed(0))+' ms',px+3,9);}
+}
+var drag=false,lx=0;
+cv.addEventListener('mousedown',function(e){drag=true;lx=e.clientX;cv.style.cursor='grabbing';});
+window.addEventListener('mouseup',function(){drag=false;cv.style.cursor='grab';});
+window.addEventListener('mousemove',function(e){
+ if(drag){viewStart-=(e.clientX-lx)/pxPerMs;lx=e.clientX;draw();return;}
+ var r=cv.getBoundingClientRect(),mx=e.clientX-r.left,my=e.clientY-r.top,found=null;
+ if(mx>LEFT)for(var k=0;k<DATA.events.length;k++){var ev=DATA.events[k],ex=xOf(ev.t),
+  ew=Math.max(ev.d*pxPerMs,1),ey=laneY[ev.lane]+ev.row*ROW;
+  if(mx>=ex&&mx<=ex+ew&&my>=ey&&my<=ey+ROW)found=ev;}
+ if(found){tip.style.display='block';tip.style.left=(e.clientX+12)+'px';tip.style.top=(e.clientY+14)+'px';
+  tip.innerHTML='<b>'+found.name+'</b> &mdash; '+found.d.toFixed(found.d<1?3:2)+' ms';}
+ else tip.style.display='none';
+});
+cv.addEventListener('wheel',function(e){e.preventDefault();var r=cv.getBoundingClientRect(),
+ mx=e.clientX-r.left,mt=viewStart+(mx-LEFT)/pxPerMs,fac=e.deltaY<0?1.2:1/1.2;
+ pxPerMs*=fac;viewStart=mt-(mx-LEFT)/pxPerMs;draw();},{passive:false});
+hdr.innerHTML='LibreYOLO profiler &mdash; <b>'+(DATA.meta.model||'')+'</b> &middot; batch '+
+ (DATA.meta.batch||'?')+' &middot; imgsz '+(DATA.meta.imgsz||'?')+' &middot; '+DATA.events.length+' events'+
+ '<span style="color:#8b95a5;font-size:11px">'+
+ '<i class=sw style="background:#3498db"></i>forward<i class=sw style="background:#9b59b6"></i>backward'+
+ '<i class=sw style="background:#e67e22"></i>dataload<i class=sw style="background:#16a085"></i>kernel'+
+ '<i class=sw style="background:#e74c3c"></i>memcpy &middot; scroll=zoom drag=pan</span>';
+window.addEventListener('resize',resize);resize();
+</script></body></html>"""

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -39,10 +39,15 @@ _NULL = contextlib.nullcontext()
 
 # Kernel-name -> coarse category. Order matters (first match wins): norm before
 # gemm/conv (cudnn batchnorm), layout before gemm/conv (cudnn nchw<->nhwc).
+# First match wins. Explicit transposes are checked BEFORE conv (cudnn's
+# nchwToNhwc kernel also contains "cudnn"); conv/gemm is checked BEFORE generic
+# copies (cutlass conv epilogues mention "copy"); bare nchw/nhwc are NOT layout
+# tokens (they appear in conv kernel names as layout specialisations).
 _KERNEL_CATS = (
-    ("reduction / norm", r"reduce|_norm|batchnorm|\bbn_|softmax|layer_norm|welford|variance|moment"),
-    ("layout / copy", r"nchw|nhwc|memcpy|memset|gather|scatter|permute|transpose|contiguous|\bcat\b|concat|slice"),
+    ("reduction / norm", r"bn_bw|bn_fw|batchnorm|batch_norm|layer_norm|group_norm|instance_norm|softmax|welford|\breduce|variance|rms_norm"),
+    ("layout / copy", r"nchwtonhwc|nhwctonchw"),
     ("gemm / conv", r"gemm|conv|implicit|cutlass|cudnn|wgrad|dgrad|winograd"),
+    ("layout / copy", r"memcpy|memset|\bcopy|catarray|concat|contiguous|\bgather|\bscatter|\bpermute|\btranspose"),
     ("elementwise", r"elementwise|vectorized|pointwise|activation|silu|relu|sigmoid|unary|binary|clamp|fill|arange"),
 )
 
@@ -90,6 +95,163 @@ _TC_PAT = r"h884|h1688|i16832|i8816|s16816|s1688|hmma|imma|tensorop|wmma|16816|1
 
 def _is_tensorcore(name: str) -> bool:
     return re.search(_TC_PAT, name.lower()) is not None
+
+
+def _pick_window(steps):
+    """Return ``(w0, w1, n_real)`` for a steady multi-step analysis window.
+
+    Skips the first two (cold) ProfilerStep markers; spanning several steps is
+    immune to torch's duplicate big/small ProfilerStep markers.
+    """
+    if len(steps) >= 4:
+        w0 = steps[2]["ts"]
+        w1 = steps[min(len(steps) - 1, 8)]["ts"]
+    elif steps:
+        w0 = steps[0]["ts"]
+        w1 = steps[-1]["ts"] + (steps[-1].get("dur", 0) or 0)
+    else:
+        return None, None, 1
+    if w1 <= w0:
+        w1 = w0 + 1.0
+    import statistics as _st
+    med = _st.median([s.get("dur", 0) for s in steps]) if steps else 0
+    n_real = max(len([s for s in steps if w0 <= s["ts"] < w1 and s.get("dur", 0) > med]), 1)
+    return w0, w1, n_real
+
+
+def analyze_trace(trace_path, summary_path=None):
+    """Rich, CLI-facing analysis of a torch ``profile_trace.json``.
+
+    Mines the GPU truth at every abstraction level (utilisation, kernel mix,
+    every kernel, every aten op, per-phase GPU time, Tensor-Core %). When a
+    sibling ``profile_summary.json`` is present it is used for the honest
+    unsynced step time / dataloader stall / verdict; otherwise those are
+    derived from the trace (with dataloader-vs-host noted as approximate).
+
+    Returns a plain dict — safe to ``json.dumps`` — so an agent can drive a
+    train -> profile -> drill-down -> change -> compare loop over the CLI.
+    """
+    trace_path = Path(trace_path)
+    data = json.loads(trace_path.read_text(encoding="utf-8"))
+    events = data.get("traceEvents", []) if isinstance(data, dict) else data
+
+    steps = sorted(
+        (e for e in events if e.get("ph") == "X"
+         and str(e.get("name", "")).startswith("ProfilerStep")),
+        key=lambda e: e.get("ts", 0),
+    )
+    w0, w1, n_real = _pick_window(steps)
+
+    def in_win(ts):
+        return w0 is None or (w0 <= ts < w1)
+
+    kern, opagg, phase_gpu = {}, {}, {}
+    gpu_busy_us = memcpy_us = tc_us = 0.0
+    n_kern = 0
+    for e in events:
+        if e.get("ph") != "X":
+            continue
+        cat = e.get("cat", "")
+        ts = e.get("ts")
+        dur = e.get("dur", 0) or 0
+        if ts is None or not in_win(ts):
+            continue
+        name = str(e.get("name", ""))
+        if cat == "kernel":
+            gpu_busy_us += dur
+            n_kern += 1
+            if _is_tensorcore(name):
+                tc_us += dur
+            k = kern.setdefault(name, [0.0, 0])
+            k[0] += dur
+            k[1] += 1
+        elif cat in ("gpu_memcpy", "gpu_memset"):
+            memcpy_us += dur
+        elif cat == "cpu_op":
+            o = opagg.setdefault(name, [0.0, 0])
+            o[0] += dur
+            o[1] += 1
+        elif cat == "gpu_user_annotation" and name.startswith("step/"):
+            phase_gpu[name[5:]] = phase_gpu.get(name[5:], 0.0) + dur
+
+    wall_ms = (w1 - w0) / 1000.0 if w0 is not None else 0.0
+    tot = sum(v[0] for v in kern.values()) or 1.0
+
+    summary = {}
+    sp = Path(summary_path) if summary_path else trace_path.with_name("profile_summary.json")
+    if sp.exists():
+        try:
+            summary = json.loads(sp.read_text(encoding="utf-8"))
+        except Exception:
+            summary = {}
+    real = summary.get("real", {})
+    step_ms = real.get("step_ms") or (wall_ms / n_real if n_real else wall_ms)
+    gpu_busy_ms = gpu_busy_us / 1000.0 / n_real
+    util = (gpu_busy_ms / step_ms) if step_ms else 0.0
+
+    def krow(name, td):
+        return {
+            "kernel": _friendly_kernel(name),
+            "raw_name": name[:90],
+            "category": _kernel_category(name),
+            "tensorcore": _is_tensorcore(name),
+            "ms_per_step": round(td[0] / 1000.0 / n_real, 4),
+            "pct_of_gpu": round(td[0] / tot * 100, 2),
+            "count_per_step": max(td[1] // n_real, 1),
+        }
+
+    kernels = sorted((krow(n, td) for n, td in kern.items()),
+                     key=lambda r: r["pct_of_gpu"], reverse=True)
+    cats = {}
+    for n, td in kern.items():
+        c = _kernel_category(n)
+        cats[c] = cats.get(c, 0.0) + td[0]
+    categories = [{"name": c, "pct": round(v / tot * 100, 1),
+                   "ms_per_step": round(v / 1000.0 / n_real, 3)}
+                  for c, v in sorted(cats.items(), key=lambda kv: kv[1], reverse=True) if v > 0]
+    optot = sum(v[0] for v in opagg.values()) or 1.0
+    ops = sorted(({"op": n[:70], "ms_per_step": round(td[0] / 1000.0 / n_real, 4),
+                   "pct_of_cpu_ops": round(td[0] / optot * 100, 2),
+                   "count_per_step": max(td[1] // n_real, 1)}
+                  for n, td in opagg.items()),
+                 key=lambda r: r["pct_of_cpu_ops"], reverse=True)
+    phases_gpu = [{"phase": p, "gpu_ms_per_step": round(v / 1000.0 / n_real, 3)}
+                  for p, v in sorted(phase_gpu.items(), key=lambda kv: kv[1], reverse=True)]
+
+    bound = summary.get("bound")
+    why = summary.get("bound_why", "")
+    if not bound:
+        bound = "compute" if util >= 0.8 else "host / launch"
+        why = (f"GPU ~{util * 100:.0f}% busy"
+               if bound == "compute" else
+               f"GPU only ~{util * 100:.0f}% busy — tiny kernels / host overhead "
+               "(dataloader stall not measurable from trace alone)")
+
+    return {
+        "trace": str(trace_path),
+        "model": (summary.get("meta") or {}).get("model"),
+        "config": summary.get("meta") or {},
+        "bound": bound,
+        "bound_why": why,
+        "step_ms": round(step_ms, 2),
+        "img_per_s": real.get("img_per_s"),
+        "dataload_ms": real.get("dataload_ms"),
+        "dataload_frac": real.get("dataload_frac"),
+        "gpu_util": round(util, 3),
+        "gpu_busy_ms_per_step": round(gpu_busy_ms, 2),
+        "mean_kernel_us": round(gpu_busy_us / n_kern, 2) if n_kern else 0.0,
+        "kernels_per_step": int(n_kern // n_real),
+        "unique_kernels": len(kern),
+        "memcpy_ms_per_step": round(memcpy_us / 1000.0 / n_real, 3),
+        "tensorcore_pct": round(tc_us / gpu_busy_us * 100, 1) if gpu_busy_us else 0.0,
+        "peak_vram_mb": (summary.get("analysis") or {}).get("peak_vram_mb"),
+        "window": {"wall_ms": round(wall_ms, 1), "real_steps": n_real},
+        "categories": categories,
+        "phases_gpu": phases_gpu,
+        "top_kernels": kernels[:8],
+        "kernels": kernels,
+        "ops": ops,
+    }
 
 
 class TrainStepProfiler:

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import re
 import time
 from pathlib import Path
 from typing import Optional
@@ -35,6 +36,60 @@ from torch.profiler import record_function
 
 PHASES = ("to_device", "forward", "backward", "optimizer")
 _NULL = contextlib.nullcontext()
+
+# Kernel-name -> coarse category. Order matters (first match wins): norm before
+# gemm/conv (cudnn batchnorm), layout before gemm/conv (cudnn nchw<->nhwc).
+_KERNEL_CATS = (
+    ("reduction / norm", r"reduce|_norm|batchnorm|\bbn_|softmax|layer_norm|welford|variance|moment"),
+    ("layout / copy", r"nchw|nhwc|memcpy|memset|gather|scatter|permute|transpose|contiguous|\bcat\b|concat|slice"),
+    ("gemm / conv", r"gemm|conv|implicit|cutlass|cudnn|wgrad|dgrad|winograd"),
+    ("elementwise", r"elementwise|vectorized|pointwise|activation|silu|relu|sigmoid|unary|binary|clamp|fill|arange"),
+)
+
+# Friendly labels for the most common mangled kernel names.
+_KERNEL_FRIENDLY = (
+    ("bn_bw", "cudnn batchnorm (bwd)"),
+    ("bn_fw", "cudnn batchnorm (fwd)"),
+    ("nchwtonhwc", "layout nchw->nhwc"),
+    ("nhwctonchw", "layout nhwc->nchw"),
+    ("implicitgemm", "cutlass conv (implicit gemm)"),
+    ("implicit_convolve", "implicit conv"),
+    ("wgrad", "conv wgrad"),
+    ("dgrad", "conv dgrad"),
+    ("cgemm", "gemm"),
+    ("sgemm", "gemm"),
+    ("gemm", "gemm"),
+    ("vectorized_elementwise", "elementwise"),
+    ("elementwise", "elementwise"),
+    ("softmax", "softmax"),
+    ("reduce", "reduction"),
+    ("cat", "concat"),
+)
+
+
+def _kernel_category(name: str) -> str:
+    nl = name.lower()
+    for cat, pat in _KERNEL_CATS:
+        if re.search(pat, nl):
+            return cat
+    return "other"
+
+
+def _friendly_kernel(name: str) -> str:
+    nl = name.lower()
+    for key, friendly in _KERNEL_FRIENDLY:
+        if key in nl:
+            return friendly
+    return name[:40]
+
+
+# Tensor-Core kernel signatures (Volta h884, Ampere/Ada 16816/16832, tf32 s1688,
+# int8 imma, cutlass tensorop, wmma).
+_TC_PAT = r"h884|h1688|i16832|i8816|s16816|s1688|hmma|imma|tensorop|wmma|16816|16832|884gemm|1688gemm"
+
+
+def _is_tensorcore(name: str) -> bool:
+    return re.search(_TC_PAT, name.lower()) is not None
 
 
 class TrainStepProfiler:
@@ -62,6 +117,11 @@ class TrainStepProfiler:
         self.meta = meta or {}
 
         self._is_cuda = getattr(device, "type", str(device)) == "cuda"
+        if self._is_cuda:
+            try:
+                torch.cuda.reset_peak_memory_stats(device)
+            except Exception:
+                pass
         # First half of the active window is unsynced (real timing); second half
         # is synced (compute composition).
         self._half = max(1, self.active // 2)
@@ -184,7 +244,31 @@ class TrainStepProfiler:
         self._build_summary(trace_path)
         timeline_path = None
         if trace_path is not None:
-            timeline_path = self._write_timeline_html(self._curate_trace(trace_path))
+            curated, analysis = self._analyze_trace(trace_path)
+            if analysis:
+                self.summary["analysis"] = analysis
+                if self._is_cuda:
+                    try:
+                        analysis["peak_vram_mb"] = round(
+                            torch.cuda.max_memory_allocated(self.device) / 1e6, 1)
+                    except Exception:
+                        pass
+                self._refine_verdict(analysis)
+                if self.save_dir is not None:
+                    try:
+                        (self.save_dir / "profile_summary.json").write_text(
+                            json.dumps(self.summary, indent=2)
+                        )
+                    except Exception:
+                        pass
+            if curated:
+                if analysis:
+                    analysis["bound"] = self.summary.get("bound")
+                    analysis["bound_why"] = self.summary.get("bound_why", "")
+                    analysis["step_ms"] = self.summary["real"]["step_ms"]
+                    analysis["img_per_s"] = self.summary["real"]["img_per_s"]
+                    analysis["dataload_ms"] = self.summary["real"]["dataload_ms"]
+                timeline_path = self._write_timeline_html(curated)
         self._report(trace_path, timeline_path)
         if self.open_report and timeline_path is not None:
             try:
@@ -218,11 +302,12 @@ class TrainStepProfiler:
                 "dataload_ms": round(real_dl, 3),
                 "compute_ms": round(real_compute, 3),
                 "img_per_s": round(img_s, 2),
-                "gpu_idle_fraction": round(idle_frac, 3),
+                "dataload_frac": round(idle_frac, 3),
             },
             "composition_ms": {p: round(comp[p], 3) for p in PHASES},
             "composition_total_ms": round(comp_total, 3),
             "bound": "dataloader" if idle_frac >= 0.2 else "compute",
+            "bound_why": "",
             "trace": str(trace_path) if trace_path else None,
         }
         if self.save_dir is not None:
@@ -234,6 +319,29 @@ class TrainStepProfiler:
             except Exception:
                 pass
 
+    def _refine_verdict(self, analysis) -> None:
+        """3-way bottleneck classification using the trace-mined GPU util."""
+        dl = self.summary["real"].get("dataload_frac", 0.0)
+        # Tie utilisation to our honest unsynced step time (the trace window's
+        # wall can include the profiler's own sync overhead); GPU-busy is stable.
+        real_step = self.summary["real"].get("step_ms", 0.0)
+        busy = analysis.get("gpu_busy_ms_per_step", 0.0)
+        util = (busy / real_step) if real_step > 0 else analysis.get("gpu_util", 0.0)
+        analysis["gpu_util"] = round(util, 3)
+        if dl >= 0.2:
+            bound = "dataloader"
+            why = f"the GPU waits on input data (~{dl * 100:.0f}% of the step)"
+        elif util >= 0.8:
+            bound = "compute"
+            why = f"the GPU is saturated (~{util * 100:.0f}% busy)"
+        else:
+            bound = "host / launch"
+            why = (f"GPU only ~{util * 100:.0f}% busy — fed too slowly: "
+                   f"{analysis['kernels_per_step']} kernels/step at "
+                   f"~{analysis['mean_kernel_us']:.0f}us each plus host overhead")
+        self.summary["bound"] = bound
+        self.summary["bound_why"] = why
+
     def _emit(self, line: str) -> None:
         if self.logger is not None:
             self.logger.info(line)
@@ -244,8 +352,7 @@ class TrainStepProfiler:
         s = self.summary
         r = s["real"]
         m = self.meta
-        idle = r["gpu_idle_fraction"] * 100.0
-        comp_total = s["composition_total_ms"] or 1.0
+        an = s.get("analysis")
         bar_w = 20
 
         self._emit("=" * 64)
@@ -255,33 +362,46 @@ class TrainStepProfiler:
             f"imgsz={m.get('imgsz','?')}  amp={m.get('amp','?')}  workers={m.get('workers','?')}"
         )
         self._emit(
-            f"  window: {s['window']['real_steps']} real-timed + "
-            f"{s['window']['synced_steps']} compute-split (+{self.warmup} warmup)"
-        )
-        self._emit(
             f"  REAL step {r['step_ms']:.1f} ms = dataload {r['dataload_ms']:.1f} ms "
             f"+ compute {r['compute_ms']:.1f} ms  ->  {r['img_per_s']:.1f} img/s"
         )
-        if s["bound"] == "dataloader":
+        if an:
             self._emit(
-                f"  >> VERDICT: DATALOADER-BOUND — GPU idle ~{idle:.0f}% "
-                "(waiting on data)."
+                f"  GPU util {an['gpu_util'] * 100:.0f}%  "
+                f"({an['gpu_busy_ms_per_step']:.0f} ms GPU-busy / {r['step_ms']:.0f} ms step)  |  "
+                f"{an['kernels_per_step']} kernels/step @ ~{an['mean_kernel_us']:.0f}us"
             )
-            self._emit(
-                "     Levers: workers↑, cache='ram'/'disk', lighter aug (mosaic), "
-                "or larger batch."
-            )
-        else:
-            self._emit(
-                f"  >> VERDICT: COMPUTE-BOUND — GPU idle only ~{idle:.0f}% (healthy)."
-            )
-        self._emit("  GPU compute composition (synchronized):")
-        for p in PHASES:
-            ms = s["composition_ms"][p]
-            frac = ms / comp_total
-            fill = int(round(frac * bar_w))
-            bar = "#" * fill + "." * (bar_w - fill)
-            self._emit(f"    {p:<10} {ms:8.2f} ms  |{bar}| {frac*100:5.1f}%")
+            bits = []
+            if an.get("peak_vram_mb"):
+                bits.append(f"peak VRAM {an['peak_vram_mb']:.0f} MB")
+            bits.append(f"Tensor Cores {an.get('tensorcore_pct', 0):.0f}% of GPU time")
+            if an.get("memcpy_ms_per_step"):
+                bits.append(f"memcpy {an['memcpy_ms_per_step']:.1f} ms/step")
+            self._emit("  " + "  |  ".join(bits))
+        label = {"dataloader": "DATALOADER-BOUND", "host / launch": "HOST/LAUNCH-BOUND",
+                 "compute": "COMPUTE-BOUND"}.get(s["bound"], str(s["bound"]).upper())
+        self._emit(f"  >> VERDICT: {label} — {s.get('bound_why', '')}.")
+        levers = {
+            "dataloader": "workers↑, cache='ram'/'disk', lighter aug, larger batch",
+            "host / launch": "larger batch (amortize launches), fewer per-step .item()/syncs, CUDA graphs, op fusion",
+            "compute": "already GPU-bound — try AMP/bf16 or a larger model",
+        }
+        self._emit(f"     Levers: {levers.get(s['bound'], '')}.")
+        if an and not self.meta.get("amp"):
+            self._emit("     note: running fp32 — AMP/bf16 would push gemm/conv onto "
+                       f"Tensor Cores (now {an.get('tensorcore_pct', 0):.0f}%).")
+        if an and an.get("categories"):
+            self._emit("  GPU kernel mix:")
+            for c in an["categories"]:
+                fill = int(round(c["pct"] / 100.0 * bar_w))
+                self._emit(f"    {c['name']:<17} {c['pct']:5.1f}%  |"
+                           + "#" * fill + "." * (bar_w - fill)
+                           + f"|  {c['ms']:.1f} ms/step")
+            self._emit("  top kernels (per step):")
+            for k in an["top_kernels"]:
+                self._emit(f"    {k['pct']:5.1f}%  {k['ms']:6.2f} ms  x{k['count']:<4} {k['name']}")
+        self._emit("  per-phase wall (synced): "
+                   + " · ".join(f"{p} {s['composition_ms'][p]:.0f}ms" for p in PHASES))
         if timeline_path:
             self._emit(f"  timeline:  {timeline_path}")
             if self.open_report:
@@ -290,18 +410,18 @@ class TrainStepProfiler:
             self._emit(f"  raw trace: {trace_path}  (load in Perfetto/Nsight if you want)")
         self._emit("=" * 64)
 
-    def _curate_trace(self, trace_path):
-        """Reduce the raw torch trace to the bounded set worth drawing.
+    def _analyze_trace(self, trace_path):
+        """Parse the trace once; return ``(curated_timeline, analysis)``.
 
-        Keeps our ``step/*`` phase spans (CPU + GPU projections), the
-        significant cpu ops, the GPU kernels and memcpys, and the CPU->GPU flow
-        links — within a steady window of ~3 middle training steps.
+        ``analysis`` mines the GPU truth — achieved utilization (kernel busy
+        time / wall), kernel mix and top kernels, mean kernel size — over a
+        steady multi-step window. ``curated_timeline`` is the bounded event set
+        for the viewer (phase bands, capped cpu/gpu lanes, CPU->GPU flows).
         """
         try:
-            import json
             data = json.loads(Path(trace_path).read_text(encoding="utf-8"))
         except Exception:
-            return None
+            return None, None
         events = data.get("traceEvents", []) if isinstance(data, dict) else data
 
         steps = sorted(
@@ -309,60 +429,102 @@ class TrainStepProfiler:
              if e.get("ph") == "X" and str(e.get("name", "")).startswith("ProfilerStep")),
             key=lambda e: e.get("ts", 0),
         )
-        if steps:
-            mid = len(steps) // 2
-            sel = steps[max(0, mid - 1): mid + 2] or steps[:3]
-            w0 = sel[0]["ts"]
-            w1 = sel[-1]["ts"] + sel[-1].get("dur", 0)
+        # Robust window: a contiguous span of several step markers, skipping the
+        # first two (cold). Spanning multiple steps is immune to torch's
+        # duplicate big/small ProfilerStep markers.
+        if len(steps) >= 4:
+            w0 = steps[2]["ts"]
+            w1 = steps[min(len(steps) - 1, 8)]["ts"]
+        elif steps:
+            w0 = steps[0]["ts"]
+            w1 = steps[-1]["ts"] + (steps[-1].get("dur", 0) or 0)
         else:
             w0 = w1 = None
+        if w0 is not None and w1 is not None and w1 <= w0:
+            w1 = w0 + 1.0
 
         def in_win(ts):
-            return w0 is None or (w0 <= ts <= w1)
+            return w0 is None or (w0 <= ts < w1)
 
         LANE = {"pcpu": 0, "cpu": 1, "pgpu": 2, "gpu": 3, "mem": 4}
         kept = []
+        kern_total, kern_count = {}, {}
+        gpu_busy_us = memcpy_us = tc_us = 0.0
+        n_kern = 0
         for e in events:
             if e.get("ph") != "X":
                 continue
             cat = e.get("cat", "")
-            name = str(e.get("name", ""))
             ts = e.get("ts")
             dur = e.get("dur", 0) or 0
             if ts is None or not in_win(ts):
                 continue
-            if cat == "user_annotation" and name.startswith("step/"):
-                lane, label = "pcpu", name[5:]
-            elif cat == "gpu_user_annotation" and name.startswith("step/"):
-                lane, label = "pgpu", name[5:]
-            elif cat == "cpu_op" and dur >= 20:
-                lane, label = "cpu", name
-            elif cat == "kernel" and dur >= 2:
-                lane, label = "gpu", name
+            name = str(e.get("name", ""))
+            if cat == "kernel":
+                gpu_busy_us += dur
+                n_kern += 1
+                if _is_tensorcore(name):
+                    tc_us += dur
+                kern_total[name] = kern_total.get(name, 0.0) + dur
+                kern_count[name] = kern_count.get(name, 0) + 1
+                if dur >= 2:
+                    kept.append({"name": name[:64], "_ts": ts, "_dur": dur,
+                                 "lane": LANE["gpu"], "cat": "gpu"})
             elif cat in ("gpu_memcpy", "gpu_memset"):
-                lane, label = "mem", name
-            else:
-                continue
-            kept.append({"name": label[:64], "_ts": ts, "_dur": dur,
-                         "lane": LANE[lane], "cat": lane})
+                memcpy_us += dur
+                kept.append({"name": name[:64], "_ts": ts, "_dur": dur,
+                             "lane": LANE["mem"], "cat": "mem"})
+            elif cat == "user_annotation" and name.startswith("step/"):
+                kept.append({"name": name[5:], "_ts": ts, "_dur": dur,
+                             "lane": LANE["pcpu"], "cat": "pcpu"})
+            elif cat == "gpu_user_annotation" and name.startswith("step/"):
+                kept.append({"name": name[5:], "_ts": ts, "_dur": dur,
+                             "lane": LANE["pgpu"], "cat": "pgpu"})
+            elif cat == "cpu_op" and dur >= 20:
+                kept.append({"name": name[:64], "_ts": ts, "_dur": dur,
+                             "lane": LANE["cpu"], "cat": "cpu"})
         if not kept:
-            return None
+            return None, None
 
-        # Keep every phase/memcpy span; cap the noisy cpu-op and kernel lanes to
-        # their longest entries so the GPU work isn't crowded out (the autograd
-        # ops are mostly nested wrappers) and the emitted file stays small.
-        def _longest(cat, n):
-            evs = [e for e in kept if e["cat"] == cat]
-            if len(evs) <= n:
-                return evs
-            return sorted(evs, key=lambda e: e["_dur"], reverse=True)[:n]
+        # ---- analysis: the GPU truth ----
+        import statistics as _st
+        wall_ms = (w1 - w0) / 1000.0 if (w0 is not None and w1 is not None) else 0.0
+        med = _st.median([s.get("dur", 0) for s in steps]) if steps else 0
+        n_real = max(len([s for s in steps if w0 <= s["ts"] < w1 and s.get("dur", 0) > med]), 1)
+        gpu_busy_ms = gpu_busy_us / 1000.0
+        util = (gpu_busy_ms / wall_ms) if wall_ms > 0 else 0.0
+        tot = sum(kern_total.values()) or 1.0
+        top = sorted(kern_total.items(), key=lambda kv: kv[1], reverse=True)[:6]
+        top_kernels = [{"name": _friendly_kernel(n), "pct": round(v / tot * 100, 1),
+                        "ms": round(v / 1000.0 / n_real, 3),
+                        "count": max(kern_count[n] // n_real, 1)} for n, v in top]
+        cats = {}
+        for n, v in kern_total.items():
+            c = _kernel_category(n)
+            cats[c] = cats.get(c, 0.0) + v
+        categories = [{"name": c, "pct": round(v / tot * 100, 1),
+                       "ms": round(v / 1000.0 / n_real, 3)}
+                      for c, v in sorted(cats.items(), key=lambda kv: kv[1], reverse=True) if v > 0]
+        analysis = {
+            "gpu_util": round(util, 3),
+            "gpu_busy_ms_per_step": round(gpu_busy_ms / n_real, 2),
+            "mean_kernel_us": round((gpu_busy_us / n_kern) if n_kern else 0.0, 2),
+            "kernels_per_step": int(n_kern // n_real),
+            "memcpy_ms_per_step": round(memcpy_us / 1000.0 / n_real, 3),
+            "tensorcore_pct": round(tc_us / gpu_busy_us * 100, 1) if gpu_busy_us else 0.0,
+            "window_real_steps": n_real,
+            "top_kernels": top_kernels,
+            "categories": categories,
+        }
 
-        kept = (
-            [e for e in kept if e["cat"] in ("pcpu", "pgpu", "mem")]
-            + _longest("cpu", 1500)
-            + _longest("gpu", 2500)
-        )
+        # ---- curate: bounded event set for the viewer ----
+        def _longest(c, n):
+            evs = [e for e in kept if e["cat"] == c]
+            return evs if len(evs) <= n else sorted(
+                evs, key=lambda e: e["_dur"], reverse=True)[:n]
 
+        kept = ([e for e in kept if e["cat"] in ("pcpu", "pgpu", "mem")]
+                + _longest("cpu", 1500) + _longest("gpu", 2500))
         base = min(e["_ts"] for e in kept)
         for e in kept:
             e["t"] = round((e["_ts"] - base) / 1000.0, 3)
@@ -409,8 +571,9 @@ class TrainStepProfiler:
                 break
 
         total = max((e["t"] + e["d"] for e in kept), default=1.0)
-        return {"events": kept, "flows": flows, "lane_rows": lane_rows,
-                "total_ms": round(total, 3), "meta": self.meta}
+        curated = {"events": kept, "flows": flows, "lane_rows": lane_rows,
+                   "total_ms": round(total, 3), "meta": self.meta, "analysis": analysis}
+        return curated, analysis
 
     def _write_timeline_html(self, curated):
         """Render the curated trace into a self-contained timeline.html."""
@@ -465,8 +628,24 @@ _TIMELINE_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
  #tip{position:fixed;pointer-events:none;background:rgba(0,0,0,.88);border:1px solid #333;
       padding:4px 8px;font-size:12px;border-radius:5px;display:none;white-space:nowrap;z-index:9;max-width:60vw;overflow:hidden}
  canvas{display:block;cursor:grab}
+ #ptoggle{position:fixed;right:8px;top:5px;z-index:10;background:#262b36;color:#cbd3df;border:0;
+      border-radius:5px;padding:3px 10px;font-size:12px;cursor:pointer}
+ #panel{position:fixed;right:0;top:0;width:332px;height:100vh;overflow:auto;box-sizing:border-box;
+      background:rgba(18,21,28,.96);border-left:1px solid #262b36;padding:34px 14px 30px;font-size:12px;z-index:8}
+ #panel.hidden{display:none}
+ #panel .verdict{font-weight:700;color:#fff;padding:8px 10px;border-radius:7px;margin:2px 0 10px;text-align:center}
+ #panel .util{font-size:26px;font-weight:700;color:#fff}
+ #panel .sub{color:#8b95a5;margin:2px 0}
+ #panel .why{color:#9aa4b2;font-size:11px;margin:8px 0 2px;line-height:1.35}
+ #panel h4{margin:14px 0 6px;color:#cbd3df;font-size:12px}
+ #panel .row{display:flex;align-items:center;gap:6px;margin:3px 0}
+ #panel .nm{flex:0 0 118px;color:#cbd3df;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+ #panel .barwrap{flex:1;background:#20242c;border-radius:3px;height:11px;overflow:hidden}
+ #panel .barfill{height:11px}
+ #panel .pc{flex:0 0 42px;text-align:right;color:#8b95a5}
 </style></head><body>
 <div id="hdr"></div><canvas id="c"></canvas><div id="tip"></div>
+<button id="ptoggle" onclick="togglePanel()">hide analysis</button><div id="panel"></div>
 <script>
 var DATA = /*__DATA__*/;
 var cv=document.getElementById('c'),ctx=cv.getContext('2d'),tip=document.getElementById('tip'),
@@ -528,5 +707,26 @@ hdr.innerHTML='LibreYOLO profiler &mdash; <b>'+(DATA.meta.model||'')+'</b> &midd
  '<i class=sw style="background:#3498db"></i>forward<i class=sw style="background:#9b59b6"></i>backward'+
  '<i class=sw style="background:#e67e22"></i>dataload<i class=sw style="background:#16a085"></i>kernel'+
  '<i class=sw style="background:#e74c3c"></i>memcpy &middot; scroll=zoom drag=pan</span>';
+var A=DATA.analysis||{};
+function boundColor(b){return b==='dataloader'?'#c0392b':(b==='compute'?'#1e8449':'#d35400');}
+function buildPanel(){
+ var p=document.getElementById('panel'),tg=document.getElementById('ptoggle');
+ if(A.gpu_util===undefined){p.style.display='none';tg.style.display='none';return;}
+ var CC={'gemm / conv':'#3498db','layout / copy':'#e67e22','elementwise':'#9b59b6','reduction / norm':'#1abc9c','other':'#7f8c8d'};
+ var h='<div class="verdict" style="background:'+boundColor(A.bound)+'">'+String(A.bound||'').toUpperCase()+'</div>';
+ h+='<div class="util">GPU '+Math.round(A.gpu_util*100)+'%</div>';
+ h+='<div class="sub">'+A.gpu_busy_ms_per_step+' ms busy / '+Math.round(A.step_ms||0)+' ms step &middot; '+(A.img_per_s||'?')+' img/s</div>';
+ h+='<div class="sub">'+A.kernels_per_step+' kernels/step @ ~'+Math.round(A.mean_kernel_us)+' &micro;s &middot; memcpy '+A.memcpy_ms_per_step+' ms</div>';
+ h+='<div class="sub">peak VRAM '+(A.peak_vram_mb||'?')+' MB &middot; Tensor Cores '+(A.tensorcore_pct||0)+'% of GPU</div>';
+ h+='<div class="why">'+(A.bound_why||'')+'</div>';
+ h+='<h4>GPU kernel mix</h4>';
+ (A.categories||[]).forEach(function(c){h+='<div class="row"><div class="nm">'+c.name+'</div><div class="barwrap"><div class="barfill" style="width:'+c.pct+'%;background:'+(CC[c.name]||'#7f8c8d')+'"></div></div><div class="pc">'+c.pct+'%</div></div>';});
+ h+='<h4>top kernels / step</h4>';
+ (A.top_kernels||[]).forEach(function(k){h+='<div class="row"><div class="nm" title="'+k.name+'">'+k.name+'</div><div class="pc">'+k.ms.toFixed(2)+'ms</div><div class="pc">'+k.pct+'%</div></div>';});
+ p.innerHTML=h;
+}
+function togglePanel(){var p=document.getElementById('panel'),tg=document.getElementById('ptoggle');
+ p.classList.toggle('hidden');tg.textContent=p.classList.contains('hidden')?'show analysis':'hide analysis';}
+buildPanel();
 window.addEventListener('resize',resize);resize();
 </script></body></html>"""

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -113,10 +113,31 @@ def _pick_window(steps):
         return None, None, 1
     if w1 <= w0:
         w1 = w0 + 1.0
-    import statistics as _st
-    med = _st.median([s.get("dur", 0) for s in steps]) if steps else 0
-    n_real = max(len([s for s in steps if w0 <= s["ts"] < w1 and s.get("dur", 0) > med]), 1)
+    n_real = _count_steps_in_window(steps, w0, w1)
     return w0, w1, n_real
+
+
+def _count_steps_in_window(steps, w0, w1):
+    if w0 is None or w1 is None:
+        return 1
+    in_window = [s for s in steps if w0 <= s.get("ts", 0) < w1]
+    if not in_window:
+        return 1
+    numbered = set()
+    for step in in_window:
+        match = re.search(r"#(\d+)", str(step.get("name", "")))
+        if match:
+            numbered.add(match.group(1))
+    if numbered:
+        return max(len(numbered), 1)
+    starts = sorted(float(s.get("ts", 0)) for s in in_window)
+    clusters = 0
+    last = None
+    for ts in starts:
+        if last is None or ts - last > 1.0:
+            clusters += 1
+        last = ts
+    return max(clusters, 1)
 
 
 def analyze_trace(trace_path, summary_path=None):
@@ -411,7 +432,7 @@ class TrainStepProfiler:
         self._real_step_n = 0
         self._real_dl_ms = 0.0
         self._real_dl_n = 0
-        self._prev_fetch: Optional[float] = None
+        self._step_t0: Optional[float] = None
 
         # Synced compute composition.
         self._sums = {p: 0.0 for p in PHASES}
@@ -482,16 +503,20 @@ class TrainStepProfiler:
             if self._unsynced_phase():
                 self._real_dl_ms += (t1 - t0) * 1000.0
                 self._real_dl_n += 1
-                if self._prev_fetch is not None:
-                    self._real_step_ms += (t1 - self._prev_fetch) * 1000.0
-                    self._real_step_n += 1
-            self._prev_fetch = t1
+                self._step_t0 = t0
+            else:
+                self._step_t0 = None
             yield batch
 
     def step(self) -> None:
         """Advance one iteration; finalizes + reports when the window closes."""
         if self.finished:
             return
+        t_done = time.perf_counter()
+        if self._unsynced_phase() and self._step_t0 is not None:
+            self._real_step_ms += (t_done - self._step_t0) * 1000.0
+            self._real_step_n += 1
+            self._step_t0 = None
         if self._torch_prof is not None:
             try:
                 self._torch_prof.step()
@@ -616,16 +641,28 @@ class TrainStepProfiler:
         real_step = self.summary["real"].get("step_ms", 0.0)
         busy = analysis.get("gpu_busy_ms_per_step", 0.0)
         util = (busy / real_step) if real_step > 0 else analysis.get("gpu_util", 0.0)
-        analysis["gpu_util"] = round(util, 3)
-        if dl >= 0.2:
+        analysis["gpu_util_raw"] = round(util, 3)
+        analysis["gpu_util"] = round(min(util, 1.0), 3)
+        memory_pressure = (
+            analysis.get("cuda_mallocs_per_step", 0) >= 5
+            or util > 1.05
+        )
+        analysis["memory_pressure"] = memory_pressure
+        if memory_pressure:
+            bound = "memory-pressure"
+            why = (
+                f"allocator/VRAM pressure (~{analysis.get('cuda_mallocs_per_step', 0)} "
+                "cudaMalloc/free per step); throughput and utilisation are unreliable"
+            )
+        elif dl >= 0.2:
             bound = "dataloader"
             why = f"the GPU waits on input data (~{dl * 100:.0f}% of the step)"
-        elif util >= 0.8:
+        elif analysis["gpu_util"] >= 0.8:
             bound = "compute"
-            why = f"the GPU is saturated (~{util * 100:.0f}% busy)"
+            why = f"the GPU is saturated (~{analysis['gpu_util'] * 100:.0f}% busy)"
         else:
             bound = "host / launch"
-            why = (f"GPU only ~{util * 100:.0f}% busy — fed too slowly: "
+            why = (f"GPU only ~{analysis['gpu_util'] * 100:.0f}% busy — fed too slowly: "
                    f"{analysis['kernels_per_step']} kernels/step at "
                    f"~{analysis['mean_kernel_us']:.0f}us each plus host overhead")
         self.summary["bound"] = bound
@@ -668,12 +705,14 @@ class TrainStepProfiler:
                 bits.append(f"memcpy {an['memcpy_ms_per_step']:.1f} ms/step")
             self._emit("  " + "  |  ".join(bits))
         label = {"dataloader": "DATALOADER-BOUND", "host / launch": "HOST/LAUNCH-BOUND",
-                 "compute": "COMPUTE-BOUND"}.get(s["bound"], str(s["bound"]).upper())
+                 "compute": "COMPUTE-BOUND", "memory-pressure": "MEMORY-PRESSURE"}.get(
+                     s["bound"], str(s["bound"]).upper())
         self._emit(f"  >> VERDICT: {label} — {s.get('bound_why', '')}.")
         levers = {
             "dataloader": "workers↑, cache='ram'/'disk', lighter aug, larger batch",
             "host / launch": "larger batch (amortize launches), fewer per-step .item()/syncs, CUDA graphs, op fusion",
             "compute": "already GPU-bound — try AMP/bf16 or a larger model",
+            "memory-pressure": "lower batch, reduce activation memory, avoid running at the OOM edge",
         }
         self._emit(f"     Levers: {levers.get(s['bound'], '')}.")
         if an and not self.meta.get("amp"):
@@ -739,7 +778,7 @@ class TrainStepProfiler:
         kept = []
         kern_total, kern_count = {}, {}
         gpu_busy_us = memcpy_us = tc_us = 0.0
-        n_kern = 0
+        n_kern = n_malloc = 0
         for e in events:
             if e.get("ph") != "X":
                 continue
@@ -763,6 +802,8 @@ class TrainStepProfiler:
                 memcpy_us += dur
                 kept.append({"name": name[:64], "_ts": ts, "_dur": dur,
                              "lane": LANE["mem"], "cat": "mem"})
+            elif cat == "cuda_runtime" and ("Malloc" in name or "Free" in name):
+                n_malloc += 1
             elif cat == "user_annotation" and name.startswith("step/"):
                 kept.append({"name": name[5:], "_ts": ts, "_dur": dur,
                              "lane": LANE["pcpu"], "cat": "pcpu"})
@@ -776,12 +817,11 @@ class TrainStepProfiler:
             return None, None
 
         # ---- analysis: the GPU truth ----
-        import statistics as _st
         wall_ms = (w1 - w0) / 1000.0 if (w0 is not None and w1 is not None) else 0.0
-        med = _st.median([s.get("dur", 0) for s in steps]) if steps else 0
-        n_real = max(len([s for s in steps if w0 <= s["ts"] < w1 and s.get("dur", 0) > med]), 1)
+        n_real = _count_steps_in_window(steps, w0, w1)
         gpu_busy_ms = gpu_busy_us / 1000.0
         util = (gpu_busy_ms / wall_ms) if wall_ms > 0 else 0.0
+        mallocs_per_step = int(n_malloc // n_real) if n_real else n_malloc
         tot = sum(kern_total.values()) or 1.0
         top = sorted(kern_total.items(), key=lambda kv: kv[1], reverse=True)[:6]
         top_kernels = [{"name": _friendly_kernel(n), "pct": round(v / tot * 100, 1),
@@ -801,6 +841,9 @@ class TrainStepProfiler:
             "kernels_per_step": int(n_kern // n_real),
             "memcpy_ms_per_step": round(memcpy_us / 1000.0 / n_real, 3),
             "tensorcore_pct": round(tc_us / gpu_busy_us * 100, 1) if gpu_busy_us else 0.0,
+            "cuda_mallocs_per_step": mallocs_per_step,
+            "gpu_util_raw": round(util, 3),
+            "memory_pressure": mallocs_per_step >= 5 or util > 1.05,
             "window_real_steps": n_real,
             "top_kernels": top_kernels,
             "categories": categories,

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1076,10 +1076,23 @@ class BaseTrainer(ABC):
             elif is_main_process():
                 from libreyolo.training.profiler import TrainStepProfiler
 
+                profile_warmup = getattr(self.config, "profile_warmup", 5)
+                profile_steps = getattr(self.config, "profile_steps", 20)
+                accum_steps = self._accum_steps
+                if accum_steps > 1:
+                    profile_warmup = math.ceil(profile_warmup / accum_steps) * accum_steps
+                    profile_steps = math.ceil(profile_steps / accum_steps) * accum_steps
+                    logger.info(
+                        "profile window rounded to accumulation boundaries "
+                        "(warmup=%d, steps=%d, accum=%d)",
+                        profile_warmup,
+                        profile_steps,
+                        accum_steps,
+                    )
                 self._profiler = TrainStepProfiler(
                     device=self.device,
-                    warmup=getattr(self.config, "profile_warmup", 5),
-                    active=getattr(self.config, "profile_steps", 20),
+                    warmup=profile_warmup,
+                    active=profile_steps,
                     trace=getattr(self.config, "profile_trace", True),
                     open_report=getattr(self.config, "profile_open", True),
                     save_dir=self.save_dir,
@@ -1559,7 +1572,7 @@ class BaseTrainer(ABC):
 
     def _prof_phase(self, name: str):
         """Profiler phase context manager (no-op when profiling is disabled)."""
-        prof = self._profiler
+        prof = getattr(self, "_profiler", None)
         return prof.phase(name) if prof is not None else contextlib.nullcontext()
 
     def _train_epoch(
@@ -1593,7 +1606,8 @@ class BaseTrainer(ABC):
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
 
-        loader = self._profiler.wrap_loader(pbar) if self._profiler else pbar
+        prof = getattr(self, "_profiler", None)
+        loader = prof.wrap_loader(pbar) if prof is not None else pbar
         for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
@@ -1668,9 +1682,9 @@ class BaseTrainer(ABC):
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
 
-            if self._profiler is not None:
-                self._profiler.step()
-                if self._profiler.finished:
+            if prof is not None:
+                prof.step()
+                if prof.finished:
                     self._stop_training = True
                     break
 
@@ -1724,7 +1738,8 @@ class BaseTrainer(ABC):
         actual_window = accum
         lr = self.optimizer.param_groups[0]["lr"]
 
-        loader = self._profiler.wrap_loader(pbar) if self._profiler else pbar
+        prof = getattr(self, "_profiler", None)
+        loader = prof.wrap_loader(pbar) if prof is not None else pbar
         for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
@@ -1809,9 +1824,9 @@ class BaseTrainer(ABC):
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
 
-            if self._profiler is not None:
-                self._profiler.step()
-                if self._profiler.finished:
+            if prof is not None:
+                prof.step()
+                if prof.finished:
                     self._stop_training = True
                     break
 

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -3,6 +3,7 @@
 Model-specific trainers subclass BaseTrainer and override hooks.
 """
 
+import contextlib
 import logging
 import math
 import sys
@@ -142,6 +143,10 @@ class BaseTrainer(ABC):
         self._frozen_bn_modules: Tuple[nn.Module, ...] = ()
         self.train_loader = None
         self._is_setup = False
+
+        # Profiling (opt-in via config.profile). None = disabled, zero overhead.
+        self._profiler = None
+        self._stop_training = False
 
     # =========================================================================
     # Config
@@ -1060,6 +1065,35 @@ class BaseTrainer(ABC):
 
         # Wait for rank 0 to finish dir creation before any rank proceeds.
         barrier()
+
+        # Optional training-step profiler (opt-in via config.profile). Built on
+        # the main process; emits the breakdown + Chrome trace into save_dir.
+        # Disabled under DDP (its early-stop would desync ranks).
+        if getattr(self.config, "profile", False):
+            if self.is_distributed:
+                if is_main_process():
+                    logger.warning("profile=True is ignored under distributed training.")
+            elif is_main_process():
+                from libreyolo.training.profiler import TrainStepProfiler
+
+                self._profiler = TrainStepProfiler(
+                    device=self.device,
+                    warmup=getattr(self.config, "profile_warmup", 5),
+                    active=getattr(self.config, "profile_steps", 20),
+                    trace=getattr(self.config, "profile_trace", True),
+                    open_report=getattr(self.config, "profile_open", True),
+                    save_dir=self.save_dir,
+                    logger=logger,
+                    meta={
+                        "model": self.get_model_tag(),
+                        "device": str(self.device),
+                        "batch": self.config.batch,
+                        "imgsz": self.config.imgsz,
+                        "amp": bool(self.config.amp),
+                        "workers": self.config.workers,
+                    },
+                )
+
         self._is_setup = True
 
     def _ddp_find_unused_parameters(self) -> bool:
@@ -1202,6 +1236,9 @@ class BaseTrainer(ABC):
                             f"Early stopping triggered after {epoch + 1} epochs "
                             f"(patience={self.config.patience}, no improvement for {self.patience_counter} epochs)"
                         )
+                    break
+
+                if getattr(self, "_stop_training", False):
                     break
 
             total_time = time.time() - start_time
@@ -1520,6 +1557,11 @@ class BaseTrainer(ABC):
             max_norm,
         )
 
+    def _prof_phase(self, name: str):
+        """Profiler phase context manager (no-op when profiling is disabled)."""
+        prof = self._profiler
+        return prof.phase(name) if prof is not None else contextlib.nullcontext()
+
     def _train_epoch(
         self, epoch: int
     ) -> Tuple[float, Optional[Dict[str, Any]], Dict[str, float], Dict[str, float]]:
@@ -1551,7 +1593,8 @@ class BaseTrainer(ABC):
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
 
-        for batch_idx, batch in enumerate(pbar):
+        loader = self._profiler.wrap_loader(pbar) if self._profiler else pbar
+        for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
             else:
@@ -1559,8 +1602,9 @@ class BaseTrainer(ABC):
                 polygons = None
             self.current_iter = epoch * len(self.train_loader) + batch_idx
 
-            imgs = imgs.to(self.device, non_blocking=True)
-            targets = targets.to(self.device, non_blocking=True)
+            with self._prof_phase("to_device"):
+                imgs = imgs.to(self.device, non_blocking=True)
+                targets = targets.to(self.device, non_blocking=True)
             if hasattr(self, "_apply_multi_scale_batch"):
                 imgs, targets, polygons = self._apply_multi_scale_batch(
                     imgs,
@@ -1573,25 +1617,31 @@ class BaseTrainer(ABC):
             # so that backward() gradient averaging produces the same
             # sum-of-per-rank gradients as single-GPU. No-op outside DDP.
             if self.scaler is not None:
-                with autocast("cuda"):
+                with self._prof_phase("forward"):
+                    with autocast("cuda"):
+                        outputs = self.on_forward(imgs, targets, polygons=polygons)
+                        total_loss_raw = outputs["total_loss"]
+                loss = scale_loss_for_ddp(total_loss_raw)
+                self.optimizer.zero_grad()
+                with self._prof_phase("backward"):
+                    self.scaler.scale(loss).backward()
+                    if self._should_clip_gradients():
+                        self.scaler.unscale_(self.optimizer)
+                        self._clip_gradients()
+                with self._prof_phase("optimizer"):
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+            else:
+                with self._prof_phase("forward"):
                     outputs = self.on_forward(imgs, targets, polygons=polygons)
                     total_loss_raw = outputs["total_loss"]
                 loss = scale_loss_for_ddp(total_loss_raw)
                 self.optimizer.zero_grad()
-                self.scaler.scale(loss).backward()
-                if self._should_clip_gradients():
-                    self.scaler.unscale_(self.optimizer)
+                with self._prof_phase("backward"):
+                    loss.backward()
                     self._clip_gradients()
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
-            else:
-                outputs = self.on_forward(imgs, targets, polygons=polygons)
-                total_loss_raw = outputs["total_loss"]
-                loss = scale_loss_for_ddp(total_loss_raw)
-                self.optimizer.zero_grad()
-                loss.backward()
-                self._clip_gradients()
-                self.optimizer.step()
+                with self._prof_phase("optimizer"):
+                    self.optimizer.step()
 
             # EMA
             if self.ema_model is not None:
@@ -1617,6 +1667,12 @@ class BaseTrainer(ABC):
             postfix = {"loss": f"{loss_val:.4f}", "lr": f"{lr:.6f}"}
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
+
+            if self._profiler is not None:
+                self._profiler.step()
+                if self._profiler.finished:
+                    self._stop_training = True
+                    break
 
         avg_loss = total_loss / max(num_batches, 1)
         avg_loss_components = {
@@ -1668,7 +1724,8 @@ class BaseTrainer(ABC):
         actual_window = accum
         lr = self.optimizer.param_groups[0]["lr"]
 
-        for batch_idx, batch in enumerate(pbar):
+        loader = self._profiler.wrap_loader(pbar) if self._profiler else pbar
+        for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
             else:
@@ -1679,8 +1736,9 @@ class BaseTrainer(ABC):
             opt_step = epoch * steps_per_epoch + batch_idx // accum
             self.current_iter = opt_step
 
-            imgs = imgs.to(self.device, non_blocking=True)
-            targets = targets.to(self.device, non_blocking=True)
+            with self._prof_phase("to_device"):
+                imgs = imgs.to(self.device, non_blocking=True)
+                targets = targets.to(self.device, non_blocking=True)
             if hasattr(self, "_apply_multi_scale_batch"):
                 imgs, targets, polygons = self._apply_multi_scale_batch(
                     imgs,
@@ -1700,27 +1758,33 @@ class BaseTrainer(ABC):
             # gradient averaging composes correctly with the division-by-
             # window scheme.
             if self.scaler is not None:
-                with autocast("cuda"):
+                with self._prof_phase("forward"):
+                    with autocast("cuda"):
+                        outputs = self.on_forward(imgs, targets, polygons=polygons)
+                        total_loss_raw = outputs["total_loss"]
+                        loss = total_loss_raw / actual_window
+                loss = scale_loss_for_ddp(loss)
+                with self._prof_phase("backward"):
+                    self.scaler.scale(loss).backward()
+                if is_opt_step:
+                    with self._prof_phase("optimizer"):
+                        if self._should_clip_gradients():
+                            self.scaler.unscale_(self.optimizer)
+                            self._clip_gradients()
+                        self.scaler.step(self.optimizer)
+                        self.scaler.update()
+            else:
+                with self._prof_phase("forward"):
                     outputs = self.on_forward(imgs, targets, polygons=polygons)
                     total_loss_raw = outputs["total_loss"]
                     loss = total_loss_raw / actual_window
                 loss = scale_loss_for_ddp(loss)
-                self.scaler.scale(loss).backward()
+                with self._prof_phase("backward"):
+                    loss.backward()
                 if is_opt_step:
-                    if self._should_clip_gradients():
-                        self.scaler.unscale_(self.optimizer)
+                    with self._prof_phase("optimizer"):
                         self._clip_gradients()
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-            else:
-                outputs = self.on_forward(imgs, targets, polygons=polygons)
-                total_loss_raw = outputs["total_loss"]
-                loss = total_loss_raw / actual_window
-                loss = scale_loss_for_ddp(loss)
-                loss.backward()
-                if is_opt_step:
-                    self._clip_gradients()
-                    self.optimizer.step()
+                        self.optimizer.step()
 
             if is_opt_step:
                 # EMA
@@ -1744,6 +1808,12 @@ class BaseTrainer(ABC):
             postfix = {"loss": f"{loss_val:.4f}", "lr": f"{lr:.6f}"}
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
+
+            if self._profiler is not None:
+                self._profiler.step()
+                if self._profiler.finished:
+                    self._stop_training = True
+                    break
 
         avg_loss = total_loss / max(num_batches, 1)
         avg_loss_components = {

--- a/tests/unit/cli/commands/test_profile.py
+++ b/tests/unit/cli/commands/test_profile.py
@@ -39,6 +39,13 @@ def _write_trace(directory: Path) -> Path:
                "ts": 355, "dur": 50, "pid": 1, "tid": 1})
     trace = Path(directory) / "profile_trace.json"
     trace.write_text(json.dumps({"traceEvents": ev}))
+    (Path(directory) / "profile_summary.json").write_text(json.dumps({
+        "meta": {"model": "YOLOv9-t", "batch": 16},
+        "real": {"step_ms": 0.3, "img_per_s": 53.3, "dataload_ms": 0.0,
+                 "dataload_frac": 0.0},
+        "composition_ms": {"forward": 0.05, "backward": 0.06},
+        "bound": "host / launch", "bound_why": "test",
+    }))
     return trace
 
 
@@ -111,3 +118,29 @@ def test_compare_self(tmp_path):
 def test_missing_trace(tmp_path):
     r = runner.invoke(_app(), ["profile", "summary", str(tmp_path / "nope.json")])
     assert r.exit_code == 2
+
+
+def test_summary_shows_host_overhead(tmp_path):
+    r = runner.invoke(_app(), ["profile", "summary", str(_write_trace(tmp_path))])
+    assert r.exit_code == 0
+    assert "host overhead" in r.stdout and "launches/step" in r.stdout
+
+
+def test_whatif(tmp_path):
+    r = runner.invoke(_app(), ["profile", "what-if", str(_write_trace(tmp_path)),
+                               "--remove-launches", "2"])
+    assert r.exit_code == 0
+    assert "what-if" in r.stdout and "img/s" in r.stdout
+
+
+def test_whatif_requires_arg(tmp_path):
+    r = runner.invoke(_app(), ["profile", "what-if", str(_write_trace(tmp_path))])
+    assert r.exit_code == 2
+
+
+def test_compare_significance_note(tmp_path):
+    t = str(_write_trace(tmp_path))
+    r = runner.invoke(_app(), ["profile", "compare", t, t])
+    assert r.exit_code == 0
+    assert "single run" in r.stdout
+    assert "ms/image" in r.stdout

--- a/tests/unit/cli/commands/test_profile.py
+++ b/tests/unit/cli/commands/test_profile.py
@@ -22,21 +22,22 @@ def _write_trace(directory: Path) -> Path:
          "ts": i * 100, "dur": 100, "pid": 1, "tid": 1}
         for i in range(6)
     ]
-    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/forward",
-               "ts": 210, "dur": 130, "pid": 1, "tid": 1})
-    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/backward",
-               "ts": 350, "dur": 140, "pid": 1, "tid": 1})
-    for name, ts, dur in [
-        ("ampere_sgemm_128x128_nt", 220, 10),
-        ("_ZN5cudnn21bn_bw_1C11_kernel_new", 360, 20),
-        ("ampere_h16816gemm_128x128", 380, 15),
-    ]:
-        ev.append({"ph": "X", "cat": "kernel", "name": name, "ts": ts, "dur": dur,
-                   "pid": 0, "tid": 7})
-    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::conv2d",
-               "ts": 215, "dur": 40, "pid": 1, "tid": 1})
-    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::convolution_backward",
-               "ts": 355, "dur": 50, "pid": 1, "tid": 1})
+    for base in (200, 300, 400):
+        ev.append({"ph": "X", "cat": "user_annotation", "name": "step/forward",
+                   "ts": base + 10, "dur": 35, "pid": 1, "tid": 1})
+        ev.append({"ph": "X", "cat": "user_annotation", "name": "step/backward",
+                   "ts": base + 50, "dur": 40, "pid": 1, "tid": 1})
+        for name, offset, dur in [
+            ("ampere_sgemm_128x128_nt", 20, 10),
+            ("_ZN5cudnn21bn_bw_1C11_kernel_new", 60, 20),
+            ("ampere_h16816gemm_128x128", 80, 15),
+        ]:
+            ev.append({"ph": "X", "cat": "kernel", "name": name,
+                       "ts": base + offset, "dur": dur, "pid": 0, "tid": 7})
+        ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::conv2d",
+                   "ts": base + 15, "dur": 40, "pid": 1, "tid": 1})
+        ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::convolution_backward",
+                   "ts": base + 55, "dur": 50, "pid": 1, "tid": 1})
     trace = Path(directory) / "profile_trace.json"
     trace.write_text(json.dumps({"traceEvents": ev}))
     (Path(directory) / "profile_summary.json").write_text(json.dumps({

--- a/tests/unit/cli/commands/test_profile.py
+++ b/tests/unit/cli/commands/test_profile.py
@@ -1,0 +1,113 @@
+"""CLI tests for the ``libreyolo profile`` command group.
+
+Exercises every lens (summary/get/phases/kernels/ops/compare) against a small
+synthetic trace, so it runs in CI without a GPU.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+pytestmark = pytest.mark.unit
+runner = CliRunner()
+
+
+def _write_trace(directory: Path) -> Path:
+    ev = [
+        {"ph": "X", "cat": "user_annotation", "name": f"ProfilerStep#{i}",
+         "ts": i * 100, "dur": 100, "pid": 1, "tid": 1}
+        for i in range(6)
+    ]
+    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/forward",
+               "ts": 210, "dur": 130, "pid": 1, "tid": 1})
+    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/backward",
+               "ts": 350, "dur": 140, "pid": 1, "tid": 1})
+    for name, ts, dur in [
+        ("ampere_sgemm_128x128_nt", 220, 10),
+        ("_ZN5cudnn21bn_bw_1C11_kernel_new", 360, 20),
+        ("ampere_h16816gemm_128x128", 380, 15),
+    ]:
+        ev.append({"ph": "X", "cat": "kernel", "name": name, "ts": ts, "dur": dur,
+                   "pid": 0, "tid": 7})
+    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::conv2d",
+               "ts": 215, "dur": 40, "pid": 1, "tid": 1})
+    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::convolution_backward",
+               "ts": 355, "dur": 50, "pid": 1, "tid": 1})
+    trace = Path(directory) / "profile_trace.json"
+    trace.write_text(json.dumps({"traceEvents": ev}))
+    return trace
+
+
+def _app() -> typer.Typer:
+    from libreyolo.cli.commands import profile
+
+    app = typer.Typer(add_completion=False)
+    app.add_typer(profile.profile_app, name="profile")
+    return app
+
+
+def test_summary(tmp_path):
+    r = runner.invoke(_app(), ["profile", "summary", str(_write_trace(tmp_path))])
+    assert r.exit_code == 0
+    assert "kernel mix" in r.stdout
+    assert "cudnn batchnorm (bwd)" in r.stdout
+
+
+def test_get_atomic(tmp_path):
+    r = runner.invoke(_app(), ["profile", "get", str(_write_trace(tmp_path)), "kernels_per_step"])
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "3"
+
+
+def test_get_json(tmp_path):
+    r = runner.invoke(_app(), ["profile", "get", str(_write_trace(tmp_path)),
+                               "forward_kernels", "--json"])
+    assert r.exit_code == 0
+    assert json.loads(r.stdout.strip()) == {"forward_kernels": 1}
+
+
+def test_get_unknown_field(tmp_path):
+    r = runner.invoke(_app(), ["profile", "get", str(_write_trace(tmp_path)), "nonsense"])
+    assert r.exit_code == 2
+
+
+def test_phases(tmp_path):
+    r = runner.invoke(_app(), ["profile", "phases", str(_write_trace(tmp_path))])
+    assert r.exit_code == 0
+    assert "forward" in r.stdout and "backward" in r.stdout
+
+
+def test_kernels_phase_filter(tmp_path):
+    r = runner.invoke(_app(), ["profile", "kernels", str(_write_trace(tmp_path)),
+                               "--phase", "backward", "--json"])
+    assert r.exit_code == 0
+    names = [k["kernel"] for k in json.loads(r.stdout)["kernels"]]
+    assert "cudnn batchnorm (bwd)" in names
+
+
+def test_kernels_unknown_phase(tmp_path):
+    r = runner.invoke(_app(), ["profile", "kernels", str(_write_trace(tmp_path)),
+                               "--phase", "nope"])
+    assert r.exit_code == 2
+
+
+def test_ops(tmp_path):
+    r = runner.invoke(_app(), ["profile", "ops", str(_write_trace(tmp_path)), "--top", "3"])
+    assert r.exit_code == 0
+    assert "aten::conv" in r.stdout
+
+
+def test_compare_self(tmp_path):
+    t = str(_write_trace(tmp_path))
+    r = runner.invoke(_app(), ["profile", "compare", t, t])
+    assert r.exit_code == 0
+    assert "img/s" in r.stdout
+
+
+def test_missing_trace(tmp_path):
+    r = runner.invoke(_app(), ["profile", "summary", str(tmp_path / "nope.json")])
+    assert r.exit_code == 2

--- a/tests/unit/test_training_profiler.py
+++ b/tests/unit/test_training_profiler.py
@@ -160,3 +160,27 @@ def test_trainstepprofiler_runs_without_trace(tmp_path):
     assert prof.finished
     assert prof.summary is not None
     assert prof.summary["real"]["step_ms"] >= 0
+
+
+def test_analyze_trace_host_overhead_and_schema(tmp_path):
+    a = analyze_trace(write_synthetic_trace(tmp_path, with_summary=True))
+    assert a["schema"] == "libreyolo.profile.analysis/v1"
+    assert a["launches_per_step"] == 5
+    assert a["memory_pressure"] is False
+    # step 100 ms, GPU busy ~0.06 ms, dataload 1 ms -> host overhead dominates
+    assert a["host_overhead_ms_per_step"] > 90
+    assert a["metrics"]["host_overhead_ms"] == a["host_overhead_ms_per_step"]
+    assert a["metrics"]["launches_per_step"] == 5
+
+
+def test_memory_pressure_detected(tmp_path):
+    ev = _trace_events()
+    for i in range(20):
+        ev.append({"ph": "X", "cat": "cuda_runtime", "name": "cudaMalloc",
+                   "ts": 250 + i, "dur": 1, "pid": 1, "tid": 1})
+    trace = tmp_path / "profile_trace.json"
+    trace.write_text(json.dumps({"traceEvents": ev}))
+    a = analyze_trace(trace)
+    assert a["memory_pressure"] is True
+    assert a["bound"] == "memory-pressure"
+    assert a["cuda_mallocs_per_step"] >= 5

--- a/tests/unit/test_training_profiler.py
+++ b/tests/unit/test_training_profiler.py
@@ -1,0 +1,162 @@
+"""Unit tests for the training profiler analysis (no GPU required).
+
+The analysis logic is exercised against a small synthetic torch chrome-trace so
+it runs in CI without a GPU or a real training step.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo.training.config import TrainConfig
+from libreyolo.training.profiler import (
+    TrainStepProfiler,
+    _friendly_kernel,
+    _is_tensorcore,
+    _kernel_category,
+    _pick_window,
+    analyze_trace,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _trace_events():
+    """A tiny trace: 6 steps, a forward+backward CPU span, 5 kernels, 2 ops."""
+    ev = [
+        {"ph": "X", "cat": "user_annotation", "name": f"ProfilerStep#{i}",
+         "ts": i * 100, "dur": 100, "pid": 1, "tid": 1}
+        for i in range(6)
+    ]
+    # CPU launch spans inside the analysis window [200, 500).
+    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/forward",
+               "ts": 210, "dur": 130, "pid": 1, "tid": 1})
+    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/backward",
+               "ts": 350, "dur": 140, "pid": 1, "tid": 1})
+    # kernels: (name, ts, dur) — fwd: sgemm, elementwise, nchwToNhwc; bwd: bn_bw, h16816gemm(TC)
+    for name, ts, dur in [
+        ("ampere_sgemm_128x128_nt", 220, 10),
+        ("void at::native::vectorized_elementwise_kernel<f>", 230, 5),
+        ("_ZN5cudnn19engines16nchwToNhwcKernel", 240, 8),
+        ("_ZN5cudnn21bn_bw_1C11_kernel_new", 360, 20),
+        ("ampere_h16816gemm_128x128", 380, 15),
+    ]:
+        ev.append({"ph": "X", "cat": "kernel", "name": name, "ts": ts, "dur": dur,
+                   "pid": 0, "tid": 7})
+    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::conv2d",
+               "ts": 215, "dur": 40, "pid": 1, "tid": 1})
+    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::convolution_backward",
+               "ts": 355, "dur": 50, "pid": 1, "tid": 1})
+    ev.append({"ph": "X", "cat": "gpu_memcpy", "name": "Memcpy HtoD",
+               "ts": 205, "dur": 3, "pid": 0, "tid": 7})
+    return ev
+
+
+def write_synthetic_trace(directory: Path, *, with_summary: bool = False) -> Path:
+    directory = Path(directory)
+    trace = directory / "profile_trace.json"
+    trace.write_text(json.dumps({"traceEvents": _trace_events()}))
+    if with_summary:
+        (directory / "profile_summary.json").write_text(json.dumps({
+            "meta": {"model": "YOLOv9-t", "batch": 16},
+            "real": {"step_ms": 100.0, "img_per_s": 10.0, "dataload_ms": 1.0,
+                     "dataload_frac": 0.01},
+            "composition_ms": {"forward": 0.05, "backward": 0.06,
+                               "to_device": 0.01, "optimizer": 0.005},
+            "bound": "dataloader", "bound_why": "from summary",
+            "analysis": {"peak_vram_mb": 1234.0},
+        }))
+    return trace
+
+
+# --- pure helpers -----------------------------------------------------------
+
+def test_kernel_category():
+    assert _kernel_category("_ZN5cudnn21bn_bw_1C11_kernel") == "reduction / norm"
+    assert _kernel_category("ampere_sgemm_128x128") == "gemm / conv"
+    assert _kernel_category("_ZN5cudnn16nchwToNhwcKernel") == "layout / copy"
+    assert _kernel_category("vectorized_elementwise_kernel") == "elementwise"
+    # a conv whose mangled name embeds nhwc must NOT be miscounted as layout
+    assert _kernel_category("cudnn_implicit_convolution_nhwc") == "gemm / conv"
+
+
+def test_is_tensorcore():
+    assert _is_tensorcore("ampere_h16816gemm_128x128") is True
+    assert _is_tensorcore("sm80_xmma_tensorop_conv") is True
+    assert _is_tensorcore("ampere_sgemm_128x128") is False
+
+
+def test_friendly_kernel():
+    assert _friendly_kernel("_ZN5cudnn21bn_bw_x") == "cudnn batchnorm (bwd)"
+    assert _friendly_kernel("ampere_h16816gemm") == "gemm"
+
+
+def test_pick_window():
+    steps = [{"ts": i * 100, "dur": 100} for i in range(6)]
+    w0, w1, n_real = _pick_window(steps)
+    assert (w0, w1) == (200, 500)
+    assert n_real >= 1
+
+
+# --- analyze_trace ----------------------------------------------------------
+
+def test_analyze_trace_metrics(tmp_path):
+    a = analyze_trace(write_synthetic_trace(tmp_path))
+    assert a["kernels_per_step"] == 5
+    assert a["mean_kernel_us"] == pytest.approx(58 / 5, rel=0.05)
+    assert a["tensorcore_pct"] == pytest.approx(15 / 58 * 100, abs=1.0)
+    assert a["bound"] == "host / launch"
+    cats = {c["name"]: c["pct"] for c in a["categories"]}
+    assert cats["gemm / conv"] == pytest.approx(25 / 58 * 100, abs=1.0)
+    assert "reduction / norm" in cats
+    assert a["top_kernels"][0]["kernel"] == "cudnn batchnorm (bwd)"
+
+
+def test_analyze_trace_phases(tmp_path):
+    a = analyze_trace(write_synthetic_trace(tmp_path))
+    ph = {p["phase"]: p for p in a["phases"]}
+    assert ph["forward"]["kernels_per_step"] == 3
+    assert ph["backward"]["kernels_per_step"] == 2
+    assert ph["forward"]["ops_per_step"] == 1
+    assert ph["backward"]["ops_per_step"] == 1
+    # per-phase GPU time reconciles to total GPU-busy
+    total = sum(p["gpu_ms_per_step"] for p in a["phases"])
+    assert total == pytest.approx(a["gpu_busy_ms_per_step"], rel=0.05)
+    assert a["metrics"]["forward_kernels"] == 3
+    assert a["kernels_by_phase"]["backward"][0]["kernel"] == "cudnn batchnorm (bwd)"
+
+
+def test_analyze_trace_uses_summary(tmp_path):
+    a = analyze_trace(write_synthetic_trace(tmp_path, with_summary=True))
+    assert a["bound"] == "dataloader"
+    assert a["img_per_s"] == 10.0
+    assert a["step_ms"] == 100.0
+    assert a["peak_vram_mb"] == 1234.0
+
+
+# --- TrainStepProfiler core (no real model, no trace) -----------------------
+
+def test_profiler_disabled_by_default():
+    cfg = TrainConfig()
+    assert cfg.profile is False
+    assert cfg.profile_open is True
+
+
+def test_trainstepprofiler_runs_without_trace(tmp_path):
+    prof = TrainStepProfiler(
+        device=torch.device("cpu"), warmup=1, active=2, trace=False,
+        open_report=False, save_dir=tmp_path, meta={"model": "t", "batch": 4},
+    )
+    for _ in prof.wrap_loader(range(20)):
+        for name in ("to_device", "forward", "backward", "optimizer"):
+            with prof.phase(name):
+                pass
+        prof.step()
+        if prof.finished:
+            break
+    assert prof.finished
+    assert prof.summary is not None
+    assert prof.summary["real"]["step_ms"] >= 0

--- a/tests/unit/test_training_profiler.py
+++ b/tests/unit/test_training_profiler.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import time
 
 import pytest
 import torch
@@ -25,33 +26,34 @@ pytestmark = pytest.mark.unit
 
 
 def _trace_events():
-    """A tiny trace: 6 steps, a forward+backward CPU span, 5 kernels, 2 ops."""
+    """A tiny trace: 6 steps, 3 analysed steps, 5 kernels/step, 2 ops/step."""
     ev = [
         {"ph": "X", "cat": "user_annotation", "name": f"ProfilerStep#{i}",
          "ts": i * 100, "dur": 100, "pid": 1, "tid": 1}
         for i in range(6)
     ]
     # CPU launch spans inside the analysis window [200, 500).
-    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/forward",
-               "ts": 210, "dur": 130, "pid": 1, "tid": 1})
-    ev.append({"ph": "X", "cat": "user_annotation", "name": "step/backward",
-               "ts": 350, "dur": 140, "pid": 1, "tid": 1})
-    # kernels: (name, ts, dur) — fwd: sgemm, elementwise, nchwToNhwc; bwd: bn_bw, h16816gemm(TC)
-    for name, ts, dur in [
-        ("ampere_sgemm_128x128_nt", 220, 10),
-        ("void at::native::vectorized_elementwise_kernel<f>", 230, 5),
-        ("_ZN5cudnn19engines16nchwToNhwcKernel", 240, 8),
-        ("_ZN5cudnn21bn_bw_1C11_kernel_new", 360, 20),
-        ("ampere_h16816gemm_128x128", 380, 15),
-    ]:
-        ev.append({"ph": "X", "cat": "kernel", "name": name, "ts": ts, "dur": dur,
-                   "pid": 0, "tid": 7})
-    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::conv2d",
-               "ts": 215, "dur": 40, "pid": 1, "tid": 1})
-    ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::convolution_backward",
-               "ts": 355, "dur": 50, "pid": 1, "tid": 1})
-    ev.append({"ph": "X", "cat": "gpu_memcpy", "name": "Memcpy HtoD",
-               "ts": 205, "dur": 3, "pid": 0, "tid": 7})
+    for base in (200, 300, 400):
+        ev.append({"ph": "X", "cat": "user_annotation", "name": "step/forward",
+                   "ts": base + 10, "dur": 35, "pid": 1, "tid": 1})
+        ev.append({"ph": "X", "cat": "user_annotation", "name": "step/backward",
+                   "ts": base + 50, "dur": 40, "pid": 1, "tid": 1})
+        # kernels: fwd: sgemm, elementwise, nchwToNhwc; bwd: bn_bw, h16816gemm(TC)
+        for name, offset, dur in [
+            ("ampere_sgemm_128x128_nt", 12, 10),
+            ("void at::native::vectorized_elementwise_kernel<f>", 23, 5),
+            ("_ZN5cudnn19engines16nchwToNhwcKernel", 31, 8),
+            ("_ZN5cudnn21bn_bw_1C11_kernel_new", 55, 20),
+            ("ampere_h16816gemm_128x128", 78, 15),
+        ]:
+            ev.append({"ph": "X", "cat": "kernel", "name": name,
+                       "ts": base + offset, "dur": dur, "pid": 0, "tid": 7})
+        ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::conv2d",
+                   "ts": base + 15, "dur": 40, "pid": 1, "tid": 1})
+        ev.append({"ph": "X", "cat": "cpu_op", "name": "aten::convolution_backward",
+                   "ts": base + 55, "dur": 50, "pid": 1, "tid": 1})
+        ev.append({"ph": "X", "cat": "gpu_memcpy", "name": "Memcpy HtoD",
+                   "ts": base + 5, "dur": 3, "pid": 0, "tid": 7})
     return ev
 
 
@@ -98,7 +100,15 @@ def test_pick_window():
     steps = [{"ts": i * 100, "dur": 100} for i in range(6)]
     w0, w1, n_real = _pick_window(steps)
     assert (w0, w1) == (200, 500)
-    assert n_real >= 1
+    assert n_real == 3
+
+
+def test_pick_window_counts_equal_duration_steps():
+    steps = [
+        {"name": f"ProfilerStep#{i}", "ts": i * 100, "dur": 100}
+        for i in range(6)
+    ]
+    assert _pick_window(steps) == (200, 500, 3)
 
 
 # --- analyze_trace ----------------------------------------------------------
@@ -160,6 +170,21 @@ def test_trainstepprofiler_runs_without_trace(tmp_path):
     assert prof.finished
     assert prof.summary is not None
     assert prof.summary["real"]["step_ms"] >= 0
+
+
+def test_profiler_real_timing_excludes_warmup_work(tmp_path):
+    prof = TrainStepProfiler(
+        device=torch.device("cpu"), warmup=1, active=2, trace=False,
+        open_report=False, save_dir=tmp_path, meta={"model": "t", "batch": 1},
+    )
+    for idx, _ in enumerate(prof.wrap_loader(range(3))):
+        time.sleep(0.05 if idx == 0 else 0.005)
+        prof.step()
+        if prof.finished:
+            break
+
+    assert prof.summary is not None
+    assert prof.summary["real"]["step_ms"] < 30.0
 
 
 def test_analyze_trace_host_overhead_and_schema(tmp_path):


### PR DESCRIPTION
Opt-in profiler that shows where each training step's time goes and whether the GPU is starved, then opens a self-contained timeline in the browser. Experiment for #451.

- libreyolo/training/profiler.py (new): TrainStepProfiler profiles a short window of real steps. Two-phase measurement: an unsynced half for honest real step-time + dataload stall (a fully-synced profiler hides starvation by handing the loader slack), and a synced half for the forward/backward/ optimizer composition. Phases are tagged with record_function and a Chrome trace is written.
- Self-contained viewer: the raw trace is curated to a steady ~3-step window and rendered as a zero-dependency canvas timeline (CPU + GPU lanes, phase bands, CPU->GPU flow links, zoom/pan/tooltips) that opens via file://. The raw profile_trace.json is still emitted for Perfetto/Nsight.
- TrainConfig: profile / profile_warmup / profile_steps / profile_trace / profile_open. Hooks in BaseTrainer._train_epoch and _train_epoch_accum are zero-overhead when off (nullcontext); disabled under DDP.

WIP: unused Perfetto/summary-card helpers still present; needs tests + docs.