### PR TITLE
fix(l2cs): correct swapped pitch/yaw in gaze inference

### DIFF
--- a/libreyolo/models/l2cs/inference.py
+++ b/libreyolo/models/l2cs/inference.py
@@ -269,11 +269,15 @@ class GazeInferenceRunner:
         device = self.model.device
         batch = preprocess_face_crops(crops, device=device)
         with torch.no_grad():
-            # L2CS.forward returns (fc_yaw_gaze, fc_pitch_gaze). Despite the
-            # layer names, upstream training (L2CS-Net train.py) supervises
-            # fc_yaw_gaze on pitch labels and fc_pitch_gaze on yaw labels, so
-            # forward position 0 is the pitch head and position 1 the yaw head.
-            pitch_logits, yaw_logits = self.model.model(batch)
+            # L2CS.forward returns (fc_yaw_gaze(x), fc_pitch_gaze(x)) in that
+            # order, and the head names are honest: fc_yaw_gaze predicts yaw,
+            # fc_pitch_gaze predicts pitch. Verified empirically with a
+            # horizontal-flip symmetry test on the Gaze360 checkpoint — only the
+            # fc_yaw_gaze output negates under mirroring, which is the defining
+            # property of yaw. (An earlier version unpacked these swapped, which
+            # made the rendered gaze arrow point vertically regardless of the
+            # true horizontal gaze direction.)
+            yaw_logits, pitch_logits = self.model.model(batch)
         angles = bin_logits_to_angles(
             yaw_logits,
             pitch_logits,

--- a/libreyolo/models/l2cs/nn.py
+++ b/libreyolo/models/l2cs/nn.py
@@ -94,11 +94,12 @@ class L2CS(nn.Module):
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """Return the raw head outputs ``(fc_yaw_gaze(x), fc_pitch_gaze(x))``.
 
-        Each has shape ``(B, num_bins)``. NOTE: per upstream L2CS-Net training
-        (``train.py``), ``fc_yaw_gaze`` is supervised on pitch labels and
-        ``fc_pitch_gaze`` on yaw labels — the head names are swapped relative
-        to the angle each one actually predicts. Callers that need
-        ``(pitch, yaw)`` must account for this; see
+        Each has shape ``(B, num_bins)``. The head names are honest:
+        ``fc_yaw_gaze`` predicts yaw and ``fc_pitch_gaze`` predicts pitch
+        (confirmed empirically by a horizontal-flip symmetry test on the
+        Gaze360 checkpoint — only the ``fc_yaw_gaze`` output negates under
+        mirroring). Callers that need ``(pitch, yaw)`` should therefore read
+        position 0 as yaw and position 1 as pitch; see
         ``GazeInferenceRunner._run_gaze``.
         """
         x = self.conv1(x)


### PR DESCRIPTION
L2CS.forward returns (yaw_logits, pitch_logits), but GazeInferenceRunner unpacked them as (pitch, yaw), flipping the two gaze axes. Rendered gaze arrows always pointed nearly vertical regardless of the true horizontal gaze.

Swap the unpack order so bin_logits_to_angles receives yaw and pitch in the correct slots, and fix the misleading comment/docstring that claimed the head names were intentionally swapped.

Verified with a horizontal-flip symmetry test on the Gaze360 checkpoint: fc_yaw_gaze negates under mirroring (yaw), fc_pitch_gaze does not (pitch). After the fix, gaze arrows track horizontal gaze correctly.