### PR TITLE
Add rfdetr_so family: RF-DETR small-object variant (SSA + PBM)

### DIFF
--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -38,6 +38,7 @@ separate category, covered in the note below). Most are detectors; `eomt` and
 | `deimv2`    | `LibreDEIMv2`   | All-caps acronym + lowercase version |
 | `rtdetr`    | `LibreRTDETR`   | All-caps acronym (hyphen dropped from `RT-DETR`) |
 | `rfdetr`    | `LibreRFDETR`   | All-caps acronym (hyphen dropped from `RF-DETR`) |
+| `rfdetr_so` | `LibreRFDETRSO` | All-caps acronym + variant (SO = small object) |
 | `dinov2`    | `LibreDINOv2`   | All-caps acronym + lowercase version (DINOv2 backbone) |
 | `eomt`      | `LibreEoMT`     | Mixed-case upstream brand preserved (`EoMT`) - semantic-only transformer family |
 | `pidnet`    | `LibrePIDNet`   | All-caps acronym + `Net` brand casing - semantic-only real-time family |
@@ -106,6 +107,7 @@ ships:
 | `deimv2`    | per-cfg (see `SIZE_CONFIGS`) |
 | `rtdetr`    | `r18`, `r34`, `r50`, `r50m`, `r101`, `l`, `x` |
 | `rfdetr`    | `n`, `s`, `m`, `l` |
+| `rfdetr_so` | `s` |
 | `dinov2`    | `n`, `s`, `m`, `l` (projector width; all sizes share the DINOv2-S encoder) |
 | `eomt`      | `l` (EoMT-L, ADE20K semantic checkpoint at 512) |
 | `pidnet`    | `s`, `m`, `l` (PIDNet Small/Medium/Large, Cityscapes checkpoints at 1024) |
@@ -202,6 +204,7 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 | `rtdetr`    | `("detect",)` (default)             | detect | detect-only |
 | `picodet`   | `("detect",)` (default)             | detect | detect-only |
 | `rfdetr`    | `("detect", "segment", "pose", "obb")` | detect | seg uses smaller sizes; pose/OBB use detect sizes |
+| `rfdetr_so` | `("detect",)`                       | detect | detect-only small-object variant (SSA + PBM) |
 | `dinov2`    | `("semantic", "classify")`          | semantic | DINOv2 backbone + task head (semantic dense head at 518 / classify linear probe at 224); NOT the RF-DETR detector |
 | `eomt`      | `("semantic",)`                     | semantic | EoMT-L DINOv2 backbone, ADE20K 150-class semantic checkpoint at 512; DINOv3 variants are excluded |
 | `pidnet`    | `("semantic",)`                     | semantic | real-time PIDNet semantic segmentation; s/m/l at 1024; Cityscapes 19-class checkpoints; inference + `val`; not trainable in LibreYOLO |

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -82,6 +82,7 @@ def __getattr__(name):
 
     _lazy = {
         "LibreRFDETR": (".models.rfdetr.model", "LibreRFDETR"),
+        "LibreRFDETRSO": (".models.rfdetr_so.model", "LibreRFDETRSO"),
         "LibreDINOv2": (".models.dinov2.model", "LibreDINOv2"),
         "LibreEnsemble": (".ensemble", "LibreEnsemble"),
         "ExternalDetector": (".ensemble", "ExternalDetector"),
@@ -120,7 +121,7 @@ def __getattr__(name):
         "load_data_config": (".data", "load_data_config"),
         "check_dataset": (".data", "check_dataset"),
     }
-    if name in ("LibreRFDETR", "LibreDINOv2"):
+    if name in ("LibreRFDETR", "LibreRFDETRSO", "LibreDINOv2"):
         # RF-DETR and DINOv2 share the same transformers dependency check.
         from .models import _ensure_rfdetr
 
@@ -145,6 +146,7 @@ __all__ = [
     "LibreRTDETRv2",
     "LibreRTDETRv4",
     "LibreRFDETR",
+    "LibreRFDETRSO",
     "LibreDFINE",
     "LibreDEIM",
     "LibreDEIMv2",

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -221,6 +221,7 @@ def _is_nms_free_family(model_family: Optional[str]) -> bool:
         "deimv2",
         "ec",
         "rfdetr",
+        "rfdetr_so",
         "rtdetr",
         "rtdetrv2",
         "rtdetrv4",
@@ -392,7 +393,7 @@ class BaseBackend(ABC):
             return yolonas_preprocess_image(
                 image, input_size=effective_imgsz, color_format=color_format
             )
-        elif self.model_family == "rfdetr":
+        elif self.model_family in ("rfdetr", "rfdetr_so"):
             tensor, img, size = self._preprocess_rfdetr(
                 image,
                 effective_imgsz,
@@ -695,7 +696,7 @@ class BaseBackend(ABC):
                 all_outputs, effective_imgsz, orig_w, orig_h, conf, ratio=ratio
             )
             return boxes, scores, cls, None
-        elif self.model_family == "rfdetr":
+        elif self.model_family in ("rfdetr", "rfdetr_so"):
             return self._parse_rfdetr(
                 all_outputs,
                 orig_w,
@@ -2077,6 +2078,7 @@ class BaseBackend(ABC):
             "ec": ECValPreprocessor,
             "picodet": PICODETValPreprocessor,
             "rfdetr": RFDETRValPreprocessor,
+            "rfdetr_so": RFDETRValPreprocessor,
             "rtdetr": RTDETRValPreprocessor,
             "rtdetrv2": RTDETRv2ValPreprocessor,
             "rtdetrv4": DFINEValPreprocessor,

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -76,9 +76,11 @@ from .clip.model import LibreCLIP  # noqa: E402,F401  (import registers family)
 
 
 def _ensure_rfdetr():
-    """Lazily register RF-DETR and LibreDINOv2 if their dependencies are installed."""
-    if any(c.__name__ == "LibreRFDETR" for c in BaseModel._registry) and any(
-        c.__name__ == "LibreDINOv2" for c in BaseModel._registry
+    """Lazily register RF-DETR families and LibreDINOv2 if their dependencies are installed."""
+    if (
+        any(c.__name__ == "LibreRFDETR" for c in BaseModel._registry)
+        and any(c.__name__ == "LibreRFDETRSO" for c in BaseModel._registry)
+        and any(c.__name__ == "LibreDINOv2" for c in BaseModel._registry)
     ):
         return
     import importlib.util
@@ -90,6 +92,10 @@ def _ensure_rfdetr():
             "RF-DETR support requires extra dependencies.\n"
             "Install with: pip install libreyolo[rfdetr]"
         )
+    # NOTE: LibreRFDETRSO must register before LibreRFDETR — SO checkpoints
+    # also match the broad RF-DETR can_load patterns, so the SO discriminator
+    # (backbone.0.ssa_sde / backbone.0.pbm3) must win first.
+    from .rfdetr_so.model import LibreRFDETRSO  # noqa: F401  (import triggers registration)
     from .rfdetr.model import LibreRFDETR  # noqa: F401  (import triggers registration)
     # LibreDINOv2 shares the same transformers dependency (DINOv2 backbone).
     from .dinov2.model import LibreDINOv2  # noqa: F401  (import triggers registration)

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -203,6 +203,10 @@ class LibreRFDETR(BaseModel):
     TRAIN_CONFIG: ClassVar[type[RFDETRConfig]] = RFDETRConfig
     val_preprocessor_class: ClassVar[type[RFDETRValPreprocessor]] = RFDETRValPreprocessor
     TTA_FIXED_SIZE: ClassVar[bool] = True  # fixed square; multi-scale TTA is a no-op
+    # Additional checkpoint model_family values accepted when loading weights
+    # (subclass hook; e.g. rfdetr_so accepts base rfdetr checkpoints, which it
+    # remaps onto its 3-level layout at load time).
+    TRANSFER_COMPATIBLE_FAMILIES: ClassVar[tuple[str, ...]] = ()
 
     # CLI parameters intentionally ignored by native RF-DETR training.
     UNSUPPORTED_TRAIN_PARAMS: ClassVar[set[str]] = {
@@ -227,6 +231,13 @@ class LibreRFDETR(BaseModel):
     @classmethod
     def can_load(cls, weights_dict: dict) -> bool:
         keys_lower = [k.lower() for k in weights_dict]
+        # Explicitly exclude RF-DETR-SO checkpoints (SSA/PBM small-object
+        # modules) so LibreRFDETRSO.can_load wins first in the registry.
+        if any(
+            k.startswith("backbone.0.ssa_sde.") or k.startswith("backbone.0.pbm3.")
+            for k in weights_dict
+        ):
+            return False
         if any(
             "detr" in k
             or "dinov2" in k
@@ -641,6 +652,10 @@ class LibreRFDETR(BaseModel):
     def _strict_loading(self) -> bool:
         return False
 
+    def _trainer_class(self):
+        """Trainer class used by ``train()`` (subclass hook)."""
+        return RFDETRTrainer
+
     # =========================================================================
     # Inference pipeline
     # =========================================================================
@@ -849,7 +864,11 @@ class LibreRFDETR(BaseModel):
                 raise TypeError("RF-DETR checkpoints must be dictionaries")
 
             ckpt_family = loaded.get("model_family", "")
-            if ckpt_family and ckpt_family != self.FAMILY:
+            allowed_families = {
+                self.FAMILY,
+                *getattr(self, "TRANSFER_COMPATIBLE_FAMILIES", ()),
+            }
+            if ckpt_family and ckpt_family not in allowed_families:
                 raise RuntimeError(
                     f"Checkpoint was trained with model_family='{ckpt_family}' "
                     f"but is being loaded into '{self.FAMILY}'."
@@ -1241,7 +1260,7 @@ class LibreRFDETR(BaseModel):
             ) and self._resume_checkpoint_uses_lora(resume_path):
                 train_kwargs["lora"] = True
 
-        trainer = RFDETRTrainer(
+        trainer = self._trainer_class()(
             self.model,
             wrapper_model=self,
             callbacks=callbacks,

--- a/libreyolo/models/rfdetr_so/__init__.py
+++ b/libreyolo/models/rfdetr_so/__init__.py
@@ -1,0 +1,5 @@
+"""RF-DETR-SO (small-object) module for LibreYOLO."""
+
+from .model import LibreRFDETRSO
+
+__all__ = ["LibreRFDETRSO"]

--- a/libreyolo/models/rfdetr_so/backbone.py
+++ b/libreyolo/models/rfdetr_so/backbone.py
@@ -1,0 +1,98 @@
+"""RF-DETR-SO backbone: stock DINOv2 + projector with SSA and PBM on top.
+
+``BackboneSO`` adopts the encoder and multi-scale projector of an
+already-built stock :class:`~libreyolo.models.rfdetr.backbone.Backbone`
+(constructed by ``build_model`` with ``projector_scale=(P3, P4, P5)``) and
+adds the small-object modules:
+
+- an SDE branch on the raw image (stride-4 / stride-8 spatial detail),
+- a 1x1 fusion of the SDE stride-8 map into the projector's P3 level,
+- two parallel bi-fusion (PBM) blocks refining P3 and P4.
+
+Adopting the stock modules by attribute transplant (instead of rebuilding
+them) keeps state-dict keys identical to the base family
+(``backbone.0.encoder.*`` / ``backbone.0.projector.*``), which is what makes
+base RF-DETR checkpoints transfer with a pure key remap.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F  # noqa: N812
+
+from ..rfdetr.backbone import Backbone, ConvX
+from ..rfdetr.tensors import NestedTensor
+from .ssa import BiFusionBlock, SpatialDetailExtractor
+
+
+class BackboneSO(Backbone):
+    """Small-object RF-DETR backbone (3 pyramid levels + SSA + PBM)."""
+
+    def __init__(self, stock: Backbone, hidden_dim: int, ssa_channels: int = 32):
+        # Bypass Backbone.__init__ (it would rebuild the encoder); adopt the
+        # already-constructed modules instead so parameters, freezing state,
+        # and state-dict keys carry over untouched.
+        nn.Module.__init__(self)
+        if stock.cross_attn_projector is not None:
+            raise ValueError("RF-DETR-SO does not support the dual projector")
+        if len(stock.projector_scale) != 3:
+            raise ValueError(
+                "BackboneSO expects a 3-level projector (P3, P4, P5); got "
+                f"{stock.projector_scale}"
+            )
+        self.encoder = stock.encoder
+        self.projector = stock.projector
+        self.projector_scale = stock.projector_scale
+        self.dual_projector = stock.dual_projector
+        self.cross_attn_projector = None
+        self._export = False
+
+        self.ssa_sde = SpatialDetailExtractor(ssa_channels)
+        self.ssa_fuse = ConvX(
+            hidden_dim + self.ssa_sde.out_channels_s8,
+            hidden_dim,
+            kernel=1,
+            layer_norm=True,
+        )
+        self.pbm3 = BiFusionBlock(
+            hidden_dim, shallow_channels=self.ssa_sde.out_channels_s4
+        )
+        self.pbm4 = BiFusionBlock(hidden_dim, shallow_channels=hidden_dim)
+
+    def _forward_features(self, images: torch.Tensor) -> list[torch.Tensor]:
+        v3, v4, v5 = self.projector(self.encoder(images))
+
+        f2, sde3 = self.ssa_sde(images)
+        f3 = self.ssa_fuse(torch.cat([v3, sde3], dim=1))
+
+        # PBM is parallel: both bi-fusion blocks consume the pre-fusion
+        # pyramid (f2/f3/v4/v5), not each other's outputs.
+        p3 = self.pbm3(deep=v4, cur=f3, shallow=f2)
+        p4 = self.pbm4(deep=v5, cur=v4, shallow=f3)
+        return [p3, p4, v5]
+
+    def forward(self, tensor_list: NestedTensor):
+        feats = self._forward_features(tensor_list.tensors)
+        out = []
+        for feat in feats:
+            mask = tensor_list.mask
+            assert mask is not None
+            mask = F.interpolate(mask[None].float(), size=feat.shape[-2:]).to(
+                torch.bool
+            )[0]
+            out.append(NestedTensor(feat, mask))
+        return out
+
+    def forward_export(self, tensors: torch.Tensor):
+        feats = self._forward_features(tensors)
+        out_feats = []
+        out_masks = []
+        for feat in feats:
+            b, _, h, w = feat.shape
+            out_masks.append(
+                torch.zeros((b, h, w), dtype=torch.bool, device=feat.device)
+            )
+            out_feats.append(feat)
+        return out_feats, out_masks
+
+
+__all__ = ["BackboneSO"]

--- a/libreyolo/models/rfdetr_so/config.py
+++ b/libreyolo/models/rfdetr_so/config.py
@@ -1,0 +1,18 @@
+"""Training configuration for native LibreRFDETRSO."""
+
+from dataclasses import dataclass
+
+from ..rfdetr.config import RFDETRConfig
+
+
+@dataclass(kw_only=True)
+class RFDETRSOConfig(RFDETRConfig):
+    """RF-DETR-SO fine-tuning defaults.
+
+    Same recipe as stock RF-DETR, with a one-epoch linear warmup: the
+    freshly initialized SSA/PBM modules and the replicated deformable
+    attention weights benefit from a gentle start.
+    """
+
+    warmup_epochs: int = 1
+    name: str = "rfdetr_so_exp"

--- a/libreyolo/models/rfdetr_so/model.py
+++ b/libreyolo/models/rfdetr_so/model.py
@@ -1,0 +1,105 @@
+"""LibreRFDETRSO inference and training wrapper.
+
+RF-DETR small-object variant (detect only). Compared to stock RF-DETR it
+detects on a 3-level pyramid (strides 8/16/32) and carries the SSA raw-image
+detail branch plus a PBM bi-fusion neck; see ``rfdetr_so/nn.py`` for the
+architecture and the TinyFormer paper grounding.
+
+Loading behavior: RF-DETR-SO checkpoints load as-is. Stock RF-DETR detect
+checkpoints (including the upstream pretrained weights the size config
+points at) are accepted as transfer sources and remapped onto the 3-level
+layout at load time; the SSA/PBM modules and the new projector stages start
+freshly initialized. The DINOv2 encoder is frozen by default
+(``freeze_encoder=False`` unfreezes it for a final polish phase).
+
+Sizes: s (resolution 512).
+"""
+
+from typing import Any, ClassVar
+
+import torch.nn as nn
+
+from ..rfdetr.model import LibreRFDETR
+from .config import RFDETRSOConfig
+from .nn import RFDETRSO_CONFIGS, LibreRFDETRSOModel, is_so_state_dict
+
+
+class LibreRFDETRSO(LibreRFDETR):
+    """RF-DETR-SO: RF-DETR specialized for small objects (SSA + PBM).
+
+    Args:
+        model_path: Path to weights, pre-loaded state_dict, or None (None
+            transfer-initializes from the stock pretrained detect weights).
+        size: Model size variant ("s").
+        nb_classes: Number of classes (default: 80).
+        device: Device for inference.
+        freeze_encoder: Freeze the DINOv2 encoder (default: True).
+
+    Example::
+
+        >>> model = LibreRFDETRSO(None, size="s")
+        >>> model.train(data="coco.yaml", epochs=30)
+    """
+
+    FAMILY: ClassVar[str] = "rfdetr_so"
+    FILENAME_PREFIX: ClassVar[str] = "LibreRFDETRSO"
+    INPUT_SIZES: ClassVar[dict[str, int]] = {"s": 512}
+    SUPPORTED_TASKS: ClassVar[tuple[str, ...]] = ("detect",)
+    TASK_INPUT_SIZES: ClassVar[dict[str, dict[str, int]]] = {"detect": INPUT_SIZES}
+    TRAIN_CONFIG = RFDETRSOConfig
+    # Stock RF-DETR detect checkpoints are valid initialization sources
+    # (remapped by LibreRFDETRSOModel.load_state_dict).
+    TRANSFER_COMPATIBLE_FAMILIES: ClassVar[tuple[str, ...]] = ("rfdetr",)
+
+    # =========================================================================
+    # Registry classmethods
+    # =========================================================================
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        """Match checkpoints that contain the SSA/PBM small-object modules."""
+        return is_so_state_dict(weights_dict)
+
+    @classmethod
+    def detect_size(
+        cls, weights_dict: dict, state_dict: dict | None = None
+    ) -> str | None:
+        size = super().detect_size(weights_dict, state_dict)
+        return size if size in RFDETRSO_CONFIGS else None
+
+    # =========================================================================
+    # Initialization
+    # =========================================================================
+
+    def __init__(
+        self,
+        model_path: str | dict[str, Any] | None = None,
+        size: str | None = None,
+        nb_classes: int = 80,
+        device: str = "auto",
+        freeze_encoder: bool = True,
+        **kwargs,
+    ):
+        self._freeze_encoder = bool(freeze_encoder)
+        kwargs.pop("segmentation", None)
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=nb_classes,
+            device=device,
+            task="detect",
+            **kwargs,
+        )
+
+    def _init_model(self) -> nn.Module:
+        return LibreRFDETRSOModel(
+            config=self.size,
+            nb_classes=self._model_num_classes,
+            device=str(self.device),
+            freeze_encoder=self._freeze_encoder,
+        )
+
+    def _trainer_class(self):
+        from .trainer import RFDETRSOTrainer
+
+        return RFDETRSOTrainer

--- a/libreyolo/models/rfdetr_so/nn.py
+++ b/libreyolo/models/rfdetr_so/nn.py
@@ -1,0 +1,210 @@
+"""Native RF-DETR-SO network assembly for LibreYOLO.
+
+RF-DETR-SO ("small object") is RF-DETR with three architectural changes
+implemented clean-room from the TinyFormer paper (arXiv 2605.25046):
+
+1. a 3-level feature pyramid (``projector_scale=("P3", "P4", "P5")``,
+   strides 8/16/32) instead of the single stride-16 level used by every
+   stock detection size,
+2. an SSA branch: stride-2 convolutions on the raw image whose stride-8
+   output is fused into the P3 level (deconv-upsampled ViT features alone
+   cannot recover detail lost at tokenization),
+3. a PBM neck: two parallel bi-fusion blocks refining P3 and P4 with their
+   neighboring levels before the decoder.
+
+Everything downstream (deformable decoder, two-stage query selection,
+criterion, postprocess) is the stock RF-DETR code path, which is
+level-count agnostic; the decoder's deformable cross-attention simply gets
+``n_levels=3``.
+
+Stock RF-DETR-S detect checkpoints transfer via :func:`remap_stock_state_for_so`:
+the projector's P4 stage shifts from index 0 to index 1, and the decoder's
+deformable-attention ``sampling_offsets`` / ``attention_weights`` tensors get
+their per-level axis replicated from 1 to 3 levels, so every new level starts
+with the sampling pattern the model learned for its single level. New modules
+(SDE, fusion, PBM, projector P3/P5 stages) start fresh.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from ..rfdetr.lwdetr import PostProcess, build_model
+from ..rfdetr.nn import (
+    RFDETR_CONFIGS,
+    RFDETRSizeConfig,
+    LibreRFDETRModel,
+    _make_args,
+    _unwrap_state_dict,
+)
+from .backbone import BackboneSO
+
+RFDETRSO_CONFIGS: dict[str, RFDETRSizeConfig] = {
+    "s": replace(
+        RFDETR_CONFIGS["s"],
+        projector_scale=("P3", "P4", "P5"),
+    ),
+}
+
+# SDE base channel per size (TinyFormer scales this with model capacity).
+SSA_BASE_CHANNELS: dict[str, int] = {"s": 32}
+
+# Index of the P4 (identity-scale) stage inside the 3-level projector.
+_P4_STAGE_INDEX = 1
+
+_PROJECTOR_STAGE_RE = re.compile(
+    r"^(backbone\.0\.projector\.stages(?:_sampling)?)\.0\.(.*)$"
+)
+_SO_KEY_PREFIXES = (
+    "backbone.0.ssa_sde.",
+    "backbone.0.ssa_fuse.",
+    "backbone.0.pbm3.",
+    "backbone.0.pbm4.",
+)
+
+
+def is_so_state_dict(state_dict: dict[str, Any]) -> bool:
+    """Return True when the tensor dict carries RF-DETR-SO module keys."""
+    return any(key.startswith(_SO_KEY_PREFIXES) for key in state_dict)
+
+
+def _expand_deformable_level_axis(
+    tensor: torch.Tensor,
+    n_heads: int,
+    n_points: int,
+    trailing: int,
+    num_levels: int,
+) -> torch.Tensor:
+    """Replicate the per-level axis of a deformable-attention parameter.
+
+    ``sampling_offsets`` tensors factor as (heads, levels, points, 2[, dim]);
+    ``attention_weights`` as (heads, levels, points[, dim]). ``trailing`` is
+    2 for offsets and 1 for weights. Tensors already sized for
+    ``num_levels`` pass through unchanged.
+    """
+    per_level = n_heads * n_points * trailing
+    rows = tensor.shape[0]
+    if rows == per_level * num_levels:
+        return tensor
+    if rows != per_level:
+        return tensor
+    tail = tensor.shape[1:]
+    factored = tensor.reshape(n_heads, 1, n_points * trailing, *tail)
+    expanded = factored.repeat(1, num_levels, *([1] * (factored.dim() - 2)))
+    return expanded.reshape(per_level * num_levels, *tail)
+
+
+def remap_stock_state_for_so(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    ca_nheads: int,
+    dec_n_points: int,
+    num_levels: int = 3,
+) -> dict[str, torch.Tensor]:
+    """Remap a stock (single-level) RF-DETR tensor dict onto the SO layout."""
+    remapped: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        match = _PROJECTOR_STAGE_RE.match(key)
+        if match:
+            key = f"{match.group(1)}.{_P4_STAGE_INDEX}.{match.group(2)}"
+        elif ".cross_attn.sampling_offsets." in key:
+            value = _expand_deformable_level_axis(
+                value, ca_nheads, dec_n_points, 2, num_levels
+            )
+        elif ".cross_attn.attention_weights." in key:
+            value = _expand_deformable_level_axis(
+                value, ca_nheads, dec_n_points, 1, num_levels
+            )
+        remapped[key] = value
+    return remapped
+
+
+class LibreRFDETRSOModel(LibreRFDETRModel):
+    """RF-DETR-SO model built from LibreYOLO-local RF-DETR modules."""
+
+    def __init__(
+        self,
+        config: str = "s",
+        nb_classes: int = 80,
+        device: str = "cpu",
+        freeze_encoder: bool = True,
+    ):
+        # Detection-only variant: build a focused init instead of running the
+        # parent's multi-task constructor against the stock config tables.
+        nn.Module.__init__(self)
+
+        if config not in RFDETRSO_CONFIGS:
+            raise ValueError(
+                f"Invalid RF-DETR-SO size: {config}. "
+                f"Must be one of {sorted(RFDETRSO_CONFIGS)}"
+            )
+
+        self.classification = False
+        self.semantic = False
+        self.segmentation = False
+        self.pose = False
+        self.obb = False
+        self.num_keypoints = 0
+        self.num_keypoints_per_class = []
+
+        self.config_name = config
+        self.config = RFDETRSO_CONFIGS[config]
+        self.nb_classes = nb_classes
+
+        self.args = _make_args(
+            self.config,
+            nb_classes=nb_classes,
+            device=device,
+            segmentation=False,
+        )
+        self.args.freeze_encoder = bool(freeze_encoder)
+
+        self.resolution = self.config.resolution
+        self.hidden_dim = self.config.hidden_dim
+        self.num_queries = self.config.num_queries
+        self.num_select = self.config.num_select
+        self.patch_size = self.config.patch_size
+        self.num_windows = self.config.num_windows
+
+        self.model = build_model(self.args)
+        joiner = self.model.backbone  # Joiner(Backbone, position_embedding)
+        joiner[0] = BackboneSO(
+            joiner[0],
+            hidden_dim=self.hidden_dim,
+            ssa_channels=SSA_BASE_CHANNELS[config],
+        )
+        self.postprocess = PostProcess(num_select=self.num_select)
+
+    def load_state_dict(self, state_dict: dict[str, Any], strict: bool = True):
+        """Load SO checkpoints as-is; remap stock RF-DETR checkpoints first."""
+        tensors = (
+            _unwrap_state_dict(state_dict) if isinstance(state_dict, dict) else {}
+        )
+        if tensors and not is_so_state_dict(tensors):
+            remapped = remap_stock_state_for_so(
+                tensors,
+                ca_nheads=self.args.ca_nheads,
+                dec_n_points=self.args.dec_n_points,
+                num_levels=len(self.config.projector_scale),
+            )
+            wrapped: dict[str, Any] = {"model": remapped}
+            # Preserve the metadata the parent loader consumes.
+            for key in ("args", "num_keypoints"):
+                if isinstance(state_dict, dict) and key in state_dict:
+                    wrapped[key] = state_dict[key]
+            state_dict = wrapped
+        return super().load_state_dict(state_dict, strict=strict)
+
+
+__all__ = [
+    "RFDETRSO_CONFIGS",
+    "SSA_BASE_CHANNELS",
+    "LibreRFDETRSOModel",
+    "is_so_state_dict",
+    "remap_stock_state_for_so",
+]

--- a/libreyolo/models/rfdetr_so/ssa.py
+++ b/libreyolo/models/rfdetr_so/ssa.py
@@ -1,0 +1,88 @@
+"""Spatial modules for RF-DETR-SO: raw-image detail extraction and bi-fusion.
+
+Implemented clean-room from the TinyFormer paper (arXiv 2605.25046):
+
+- ``SpatialDetailExtractor`` (SDE): a short stack of stride-2 convolutions on
+  the raw input image. ViT tokenization destroys high-frequency detail before
+  any pyramid is built; deconv-upsampled ViT features cannot recover it. The
+  SDE re-extracts that detail at strides 4 and 8 so the stride-8 pyramid
+  level carries true high-resolution evidence.
+- ``BiFusionBlock`` (PBM building block): fuses a pyramid level with both of
+  its neighbors in one step. The deeper level enters as an element-wise
+  residual ADD (semantic context); the shallower level enters via a stride-2
+  convolution and channel CONCAT (independent spatial evidence). The paper
+  measured the swapped arrangement to be strictly worse; keep this order.
+
+Both modules reuse the RF-DETR building blocks (``ConvX``, ``C2f``) so their
+export behavior matches the rest of the family.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F  # noqa: N812
+
+from ..rfdetr.backbone import C2f, ConvX, get_norm
+
+
+class SpatialDetailExtractor(nn.Module):
+    """Stride-2 conv stack on the raw image; returns stride-4 and stride-8 maps.
+
+    Channel progression is C -> 2C -> 4C from ``base_channels``. The stride-4
+    output stays a pure spatial prior (never mixed with ViT features); the
+    stride-8 output is fused into the P3 pyramid level.
+    """
+
+    def __init__(self, base_channels: int = 32):
+        super().__init__()
+        c = base_channels
+        self.stage1 = ConvX(3, c, kernel=3, stride=2)  # stride 2
+        self.stage2 = ConvX(c, 2 * c, kernel=3, stride=2)  # stride 4
+        self.stage3 = ConvX(2 * c, 4 * c, kernel=3, stride=2)  # stride 8
+        self.out_channels_s4 = 2 * c
+        self.out_channels_s8 = 4 * c
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        s2 = self.stage1(x)
+        f2 = self.stage2(s2)
+        f3 = self.stage3(f2)
+        return f2, f3
+
+
+class BiFusionBlock(nn.Module):
+    """Parallel bi-fusion of (deeper, current, shallower) pyramid levels.
+
+    ``out = LN(C2f(concat(cur + up2x(1x1(deep)), 3x3s2(shallow))))``
+
+    The C2f + LayerNorm tail mirrors the MultiScaleProjector stages so the
+    decoder sees identically normalized features on every level.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        shallow_channels: int,
+        num_blocks: int = 3,
+        layer_norm: bool = True,
+    ):
+        super().__init__()
+        self.deep_proj = ConvX(hidden_dim, hidden_dim, kernel=1, layer_norm=layer_norm)
+        self.shallow_down = ConvX(
+            shallow_channels, hidden_dim, kernel=3, stride=2, layer_norm=layer_norm
+        )
+        self.fuse = C2f(2 * hidden_dim, hidden_dim, num_blocks, layer_norm=layer_norm)
+        self.norm = get_norm("LN", hidden_dim)
+
+    def forward(
+        self, deep: torch.Tensor, cur: torch.Tensor, shallow: torch.Tensor
+    ) -> torch.Tensor:
+        aligned = cur + F.interpolate(
+            self.deep_proj(deep),
+            size=cur.shape[-2:],
+            mode="bilinear",
+            align_corners=False,
+        )
+        detail = self.shallow_down(shallow)
+        return self.norm(self.fuse(torch.cat([aligned, detail], dim=1)))
+
+
+__all__ = ["SpatialDetailExtractor", "BiFusionBlock"]

--- a/libreyolo/models/rfdetr_so/trainer.py
+++ b/libreyolo/models/rfdetr_so/trainer.py
@@ -1,0 +1,23 @@
+"""RF-DETR-SO trainer."""
+
+from typing import Type
+
+from ...training.config import TrainConfig
+from ..rfdetr.trainer import RFDETRTrainer
+from .config import RFDETRSOConfig
+
+
+class RFDETRSOTrainer(RFDETRTrainer):
+    """Thin trainer subclass for rfdetr_so family metadata and defaults."""
+
+    artifact_model_families = ("rfdetr_so",)
+
+    @classmethod
+    def _config_class(cls) -> Type[TrainConfig]:
+        return RFDETRSOConfig
+
+    def get_model_family(self) -> str:
+        return "rfdetr_so"
+
+    def get_model_tag(self) -> str:
+        return f"LibreRFDETRSO-{self.config.size}"

--- a/tests/unit/test_rfdetr_so.py
+++ b/tests/unit/test_rfdetr_so.py
@@ -1,0 +1,171 @@
+"""Unit tests for the native RF-DETR-SO (small-object) family."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def so_model():
+    from libreyolo import LibreRFDETRSO
+
+    return LibreRFDETRSO(model_path={}, size="s", device="cpu")
+
+
+@pytest.fixture(scope="module")
+def stock_state_dict():
+    from libreyolo import LibreRFDETR
+
+    stock = LibreRFDETR(model_path={}, size="s", device="cpu")
+    return stock.model.state_dict()
+
+
+def test_rfdetr_so_is_registered_and_detects_filename():
+    from libreyolo import LibreRFDETRSO
+    from libreyolo.models.base.model import BaseModel
+
+    assert any(cls.__name__ == "LibreRFDETRSO" for cls in BaseModel._registry)
+    assert LibreRFDETRSO.FAMILY == "rfdetr_so"
+    assert LibreRFDETRSO.SUPPORTED_TASKS == ("detect",)
+    assert LibreRFDETRSO.detect_size_from_filename("LibreRFDETRSOs.pt") == "s"
+
+
+def test_rfdetr_so_filename_does_not_match_base_family():
+    from libreyolo import LibreRFDETR, LibreRFDETRSO
+
+    assert LibreRFDETR.detect_size_from_filename("LibreRFDETRSOs.pt") is None
+    assert LibreRFDETRSO.detect_size_from_filename("LibreRFDETRs.pt") is None
+
+
+def test_rfdetr_so_backbone_produces_three_levels(so_model):
+    """The SO backbone must emit a stride-8/16/32 pyramid (64/32/16 at 512)."""
+    from libreyolo.models.rfdetr.tensors import NestedTensor
+
+    backbone = so_model.model.model.backbone[0]
+    images = torch.zeros(1, 3, 512, 512)
+    mask = torch.zeros(1, 512, 512, dtype=torch.bool)
+    with torch.no_grad():
+        feats = backbone(NestedTensor(images, mask))
+
+    shapes = [tuple(f.tensors.shape) for f in feats]
+    assert shapes == [
+        (1, 256, 64, 64),
+        (1, 256, 32, 32),
+        (1, 256, 16, 16),
+    ]
+
+
+def test_rfdetr_so_eval_forward_shapes(so_model):
+    """Full model forward returns the standard LW-DETR output dict."""
+    so_model.model.eval()
+    with torch.no_grad():
+        out = so_model.model(torch.zeros(1, 3, 512, 512))
+
+    assert "pred_logits" in out and "pred_boxes" in out
+    assert out["pred_boxes"].shape[-1] == 4
+    assert out["pred_logits"].shape[1] == out["pred_boxes"].shape[1]
+
+
+def test_rfdetr_so_encoder_frozen_by_default(so_model):
+    backbone = so_model.model.model.backbone[0]
+    assert all(not p.requires_grad for p in backbone.encoder.parameters())
+    assert any(p.requires_grad for p in backbone.ssa_sde.parameters())
+    assert any(p.requires_grad for p in backbone.projector.parameters())
+
+
+def test_rfdetr_so_can_load_discriminators(so_model, stock_state_dict):
+    from libreyolo import LibreRFDETR, LibreRFDETRSO
+
+    so_sd = so_model.model.state_dict()
+    assert LibreRFDETRSO.can_load(so_sd) is True
+    assert LibreRFDETRSO.can_load(stock_state_dict) is False
+    assert LibreRFDETR.can_load(so_sd) is False
+    assert LibreRFDETR.can_load(stock_state_dict) is True
+
+
+def test_rfdetr_so_transfer_remap_from_stock(so_model, stock_state_dict):
+    """Every stock RF-DETR-S tensor must land in the SO model: the projector
+    P4 stage shifts to index 1, deformable cross-attention expands its level
+    axis 1 -> 3, everything else loads 1:1. Missing keys are exactly the new
+    small-object modules plus the new projector scale stages."""
+    from libreyolo.models.rfdetr_so.nn import remap_stock_state_for_so
+
+    remapped = remap_stock_state_for_so(
+        dict(stock_state_dict),
+        ca_nheads=so_model.model.args.ca_nheads,
+        dec_n_points=so_model.model.args.dec_n_points,
+        num_levels=3,
+    )
+    current = so_model.model.model.state_dict()
+
+    mismatched = [
+        key
+        for key, value in remapped.items()
+        if key not in current or current[key].shape != value.shape
+    ]
+    assert mismatched == []
+
+    # Projector stage remap: P4 tensors now live at index 1, index 0 is new.
+    assert any(k.startswith("backbone.0.projector.stages.1.") for k in remapped)
+    assert not any(k.startswith("backbone.0.projector.stages.0.") for k in remapped)
+
+    # Level-axis expansion happened.
+    offsets_key = next(
+        k for k in remapped if k.endswith("cross_attn.sampling_offsets.weight")
+    )
+    heads = so_model.model.args.ca_nheads
+    points = so_model.model.args.dec_n_points
+    assert remapped[offsets_key].shape[0] == heads * 3 * points * 2
+
+    # Fresh modules receive nothing from the checkpoint.
+    leftover = set(current) - set(remapped)
+    assert any(k.startswith("backbone.0.ssa_sde.") for k in leftover)
+    assert any(k.startswith("backbone.0.pbm3.") for k in leftover)
+    assert any(k.startswith("backbone.0.projector.stages.0.") for k in leftover)
+    assert any(k.startswith("backbone.0.projector.stages.2.") for k in leftover)
+
+
+def test_rfdetr_so_load_state_dict_accepts_stock_checkpoint(
+    so_model, stock_state_dict
+):
+    """End-to-end loader contract: a stock checkpoint loads with strict=False,
+    no unexpected keys, and missing keys limited to the new modules."""
+    missing, unexpected = so_model.model.load_state_dict(
+        {"model": dict(stock_state_dict)}, strict=False
+    )
+    assert unexpected == []
+    allowed_prefixes = (
+        "backbone.0.ssa_sde.",
+        "backbone.0.ssa_fuse.",
+        "backbone.0.pbm3.",
+        "backbone.0.pbm4.",
+        "backbone.0.projector.stages.0.",
+        "backbone.0.projector.stages.2.",
+        "backbone.0.projector.stages_sampling.",
+    )
+    outside = [k for k in missing if not k.startswith(allowed_prefixes)]
+    assert outside == []
+
+
+def test_rfdetr_so_own_checkpoint_roundtrip(so_model):
+    """SO checkpoints must load back without any remap side effects."""
+    sd = so_model.model.state_dict()
+    missing, unexpected = so_model.model.load_state_dict(
+        {"model": dict(sd)}, strict=False
+    )
+    assert missing == []
+    assert unexpected == []
+
+
+def test_rfdetr_so_trainer_metadata():
+    from libreyolo.models.rfdetr_so.config import RFDETRSOConfig
+    from libreyolo.models.rfdetr_so.trainer import RFDETRSOTrainer
+
+    assert RFDETRSOTrainer._config_class() is RFDETRSOConfig
+    assert RFDETRSOTrainer.artifact_model_families == ("rfdetr_so",)
+    cfg = RFDETRSOConfig(size="s")
+    assert cfg.warmup_epochs == 1
+    assert cfg.mosaic_prob == 0.0


### PR DESCRIPTION
New models/rfdetr_so package implementing, clean-room from the TinyFormer paper (arXiv 2605.25046): a 3-level pyramid (projector_scale P3/P4/P5, strides 8/16/32) instead of the single stride-16 level, an SDE raw-image conv branch fused into P3 (SSA), and two parallel bi-fusion blocks (PBM, add-deep / concat-shallow) refining P3 and P4 before the decoder. Size s, DINOv2 encoder frozen by default (freeze_encoder=False unfreezes).

Stock rfdetr detect checkpoints load as transfer sources: the projector P4 stage remaps to index 1 and the decoder deformable cross-attention sampling_offsets / attention_weights replicate their level axis 1 -> 3; SSA/PBM and the new projector stages start fresh.

Shared changes: _trainer_class() hook in LibreRFDETR.train, opt-in TRANSFER_COMPATIBLE_FAMILIES for the checkpoint family guard, SO discriminator exclusion in LibreRFDETR.can_load, rfdetr_so routed through the rfdetr backend preprocess/parse/val-preprocessor paths.

Claude-Session: https://claude.ai/code/session_01WbHHoeK2ZddHLbaFcavVNk