### PR TITLE
Fix multi-GPU LR (incl. RT-DETR), mixup label-drop, background augmentation, and pose crash (#484)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -39,7 +39,7 @@ evidence-based, and scoped to the PR under review.
 - Per-rank loaders divide global batch.
 - Python multi-GPU training auto-spawns DDP.
 - Torchrun owns rank and device environment.
-- DDP loss scales by world size.
+- DDP losses are globally normalized; gradient averaging needs no world-size scaling.
 - Rank zero owns side effects.
 - Autobatch returns rank-divisible global batches.
 - Unit tests prove CPU-safe API behavior.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -39,7 +39,7 @@ evidence-based, and scoped to the PR under review.
 - Per-rank loaders divide global batch.
 - Python multi-GPU training auto-spawns DDP.
 - Torchrun owns rank and device environment.
-- DDP losses are globally normalized; gradient averaging needs no world-size scaling.
+- DDP losses are mean-normalized (locally, or global-sum/world_size); gradient averaging needs no world-size scaling.
 - Rank zero owns side effects.
 - Autobatch returns rank-divisible global batches.
 - Unit tests prove CPU-safe API behavior.

--- a/libreyolo/data/augment/pose.py
+++ b/libreyolo/data/augment/pose.py
@@ -149,7 +149,7 @@ def build_target(
     target[:n, 1:5] = bboxes_px[:n]
     # Reshape the first ``n`` (capped) instances, not ``len(kpts_px)``: when an
     # image has more instances than ``max_labels`` the two differ and the old
-    # ``reshape(len(kpts_px), -1)`` raised a shape error (n*K*3 elements can't
-    # fill len(kpts_px) rows).
+    # ``reshape(len(kpts_px), -1)`` either raised a shape error or, when the
+    # element counts happened to divide, silently mis-broadcast coordinates.
     target[:n, 5:] = kpts_px[:n].reshape(n, -1)
     return target

--- a/libreyolo/data/augment/pose.py
+++ b/libreyolo/data/augment/pose.py
@@ -147,5 +147,9 @@ def build_target(
 
     target[:n, 0] = cls[:n]
     target[:n, 1:5] = bboxes_px[:n]
-    target[:n, 5:] = kpts_px[:n].reshape(len(kpts_px), -1)[:n]
+    # Reshape the first ``n`` (capped) instances, not ``len(kpts_px)``: when an
+    # image has more instances than ``max_labels`` the two differ and the old
+    # ``reshape(len(kpts_px), -1)`` raised a shape error (n*K*3 elements can't
+    # fill len(kpts_px) rows).
+    target[:n, 5:] = kpts_px[:n].reshape(n, -1)
     return target

--- a/libreyolo/data/augment/yolo9.py
+++ b/libreyolo/data/augment/yolo9.py
@@ -101,6 +101,19 @@ class YOLO9TrainTransform:
             padded_labels = np.zeros((self.max_labels, label_dim), dtype=np.float32)
             # Fill class with -1 to indicate padding (empty slots)
             padded_labels[:, 0] = -1
+            # Background images get the same photometric/flip augmentation as
+            # labeled images (no label sync needed — there are no labels). The
+            # old early return skipped HSV and flips entirely, so on
+            # background-heavy datasets most of the training data was never
+            # augmented and the model could memorize the exact negatives
+            # (issue #484). Same op order and RNG-draw pattern as the labeled
+            # path below.
+            if random.random() < self.hsv_prob:
+                augment_hsv(image)
+            if random.random() < self.flip_prob:
+                image = image[:, ::-1]
+            if random.random() < self.vertical_flip_prob:
+                image = image[::-1, :]
             image, _ = preproc(image, input_dim)
             if return_masks:
                 return (

--- a/libreyolo/data/augment/yolo9.py
+++ b/libreyolo/data/augment/yolo9.py
@@ -464,28 +464,44 @@ class YOLO9MosaicMixupDataset:
         return img, labels, (input_h, input_w), idx
 
     def _mixup(self, img, labels):
-        """Apply mixup augmentation."""
-        # Get another random image
-        idx2 = random.randint(0, len(self.dataset) - 1)
-        img2, labels2, _, _ = self._get_normal_item(idx2)
+        """Apply mixup augmentation.
 
-        # Mix images
+        Both ``labels`` and the second image's labels arrive already padded to
+        ``max_labels`` rows with class ``-1`` marking empty slots (that is what
+        ``YOLO9TrainTransform`` emits). Vstacking the second image's rows after
+        this full block and truncating to ``max_labels`` would keep only the
+        first image's block and silently drop every object from the second
+        image — they land at rows >= max_labels — turning ~50%-opacity objects
+        into unlabeled ghosts the loss punishes as background (issue #484).
+
+        Fix: strip padding from both images, concatenate the *real* objects,
+        then re-pad. Mirrors the shared YOLOX mixup, which merges labels before
+        padding.
+        """
+        # Get another random image (mixup only runs on the non-segment path,
+        # so _get_normal_item returns (img, label, ...); ignore the tail).
+        idx2 = random.randint(0, len(self.dataset) - 1)
+        img2, labels2, *_ = self._get_normal_item(idx2)
+
+        # Mix images (beta(32, 32) ≈ 0.5, so both images are ~equally visible
+        # and both label sets must be kept).
         r = np.random.beta(32.0, 32.0)
         img = (img * r + img2 * (1 - r)).astype(img.dtype)
 
-        # Concatenate labels (from both images)
-        if labels2 is not None and len(labels2) > 0 and labels2[0, 0] >= 0:
-            # Filter padding from labels2
-            mask = labels2[:, 0] >= 0
-            labels2 = labels2[mask]
-            if len(labels2) > 0:
-                # Concatenate and truncate
-                all_labels = np.vstack([labels, labels2])
-                max_labels = (
-                    self.preproc.max_labels
-                    if hasattr(self.preproc, "max_labels")
-                    else 100
-                )
-                labels = all_labels[:max_labels]
+        max_labels = getattr(self.preproc, "max_labels", 100)
+        label_dim = labels.shape[1]
 
-        return img, labels
+        # Drop padding (class == -1) from both, then merge the real objects.
+        real1 = labels[labels[:, 0] >= 0]
+        if labels2 is not None and len(labels2) > 0:
+            real2 = labels2[labels2[:, 0] >= 0]
+        else:
+            real2 = np.zeros((0, label_dim), dtype=labels.dtype)
+        merged = np.vstack([real1, real2])[:max_labels]
+
+        # Re-pad to max_labels with class = -1 (matches YOLO9TrainTransform).
+        padded = np.zeros((max_labels, label_dim), dtype=labels.dtype)
+        padded[:, 0] = -1
+        padded[: len(merged)] = merged
+
+        return img, padded

--- a/libreyolo/models/rtdetr/loss.py
+++ b/libreyolo/models/rtdetr/loss.py
@@ -13,10 +13,11 @@ Reference: https://github.com/lyuwenyu/RT-DETR
 """
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
+
+from libreyolo.training.distributed import all_reduce_avg_scalar
 
 try:
     from scipy.optimize import linear_sum_assignment
@@ -313,16 +314,16 @@ class SetCriterion(nn.Module):
         indices = self.matcher(outputs_without_aux, targets)
 
         # Compute number of target boxes for normalization.
-        # Under DDP, all-reduce so every rank divides by the global count,
-        # not just its own per-rank batch. Without this, losses would be
-        # scaled by per-rank box counts, which diverge from single-GPU semantics.
-        num_boxes = sum(len(t["labels"]) for t in targets)
-        num_boxes = torch.as_tensor(
-            [num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device
+        # Under DDP, all-reduce and divide by world_size (the average per-rank
+        # count) so DDP's gradient averaging reproduces single-GPU semantics —
+        # the same reduction every other DETR family uses. The previous code
+        # summed WITHOUT dividing, which was only correct in combination with
+        # the (removed) x world_size loss scaling; keeping it would under-scale
+        # RT-DETR's multi-GPU gradients by 1/world_size (issue #484).
+        num_boxes = all_reduce_avg_scalar(
+            sum(len(t["labels"]) for t in targets),
+            device=next(iter(outputs.values())).device,
         )
-        if dist.is_available() and dist.is_initialized():
-            dist.all_reduce(num_boxes, op=dist.ReduceOp.SUM)
-        num_boxes = torch.clamp(num_boxes, min=1).item()
 
         # Compute all requested losses
         losses = {}

--- a/libreyolo/models/yolo9/loss.py
+++ b/libreyolo/models/yolo9/loss.py
@@ -563,6 +563,17 @@ class YOLO9Loss:
         if self.vec2box is None or self.vec2box.image_size != image_size:
             self._init_vec2box(image_size)
 
+    @staticmethod
+    def _global_cls_norm(targets_cls: Tensor) -> float:
+        """Global (DDP-reduced) positive count for loss normalization.
+
+        Multi-GPU training must divide by the global count so DDP's gradient
+        averaging matches single-GPU on the same global batch (issue #484).
+        Identical to ``max(targets_cls.sum(), 1)`` outside DDP. Shared by all
+        yolo9 task losses so the normalizer contract lives in one place.
+        """
+        return all_reduce_avg_scalar(targets_cls.sum())
+
     def __call__(
         self, predictions: List[Tensor], targets: Tensor
     ) -> Tuple[Tensor, Dict[str, float]]:
@@ -608,10 +619,7 @@ class YOLO9Loss:
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
         # Compute normalization factors
-        # Global (DDP-reduced) positive count so multi-GPU training matches
-        # single-GPU on the same global batch (issue #484). Identical to
-        # ``max(targets_cls.sum(), 1)`` outside DDP.
-        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
+        cls_norm = self._global_cls_norm(targets_cls)
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         # Compute losses
@@ -736,10 +744,7 @@ class YOLO9OBBLoss(YOLO9Loss):
         preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
-        # Global (DDP-reduced) positive count so multi-GPU training matches
-        # single-GPU on the same global batch (issue #484). Identical to
-        # ``max(targets_cls.sum(), 1)`` outside DDP.
-        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
+        cls_norm = self._global_cls_norm(targets_cls)
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)
@@ -922,10 +927,7 @@ class YOLO9SegmentationLoss(YOLO9Loss):
         preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
-        # Global (DDP-reduced) positive count so multi-GPU training matches
-        # single-GPU on the same global batch (issue #484). Identical to
-        # ``max(targets_cls.sum(), 1)`` outside DDP.
-        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
+        cls_norm = self._global_cls_norm(targets_cls)
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)
@@ -1171,10 +1173,7 @@ class YOLO9PoseLoss(YOLO9Loss):
         preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
-        # Global (DDP-reduced) positive count so multi-GPU training matches
-        # single-GPU on the same global batch (issue #484). Identical to
-        # ``max(targets_cls.sum(), 1)`` outside DDP.
-        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
+        cls_norm = self._global_cls_norm(targets_cls)
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)

--- a/libreyolo/models/yolo9/loss.py
+++ b/libreyolo/models/yolo9/loss.py
@@ -12,6 +12,7 @@ from torch import Tensor, nn
 from torch.nn import BCEWithLogitsLoss
 
 from libreyolo.data import default_oks_sigmas
+from libreyolo.training.distributed import all_reduce_avg_scalar
 from libreyolo.utils.box_ops import compute_iou as calculate_iou
 
 
@@ -607,7 +608,10 @@ class YOLO9Loss:
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
         # Compute normalization factors
-        cls_norm = max(targets_cls.sum(), 1)
+        # Global (DDP-reduced) positive count so multi-GPU training matches
+        # single-GPU on the same global batch (issue #484). Identical to
+        # ``max(targets_cls.sum(), 1)`` outside DDP.
+        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         # Compute losses
@@ -732,7 +736,10 @@ class YOLO9OBBLoss(YOLO9Loss):
         preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
-        cls_norm = max(targets_cls.sum(), 1)
+        # Global (DDP-reduced) positive count so multi-GPU training matches
+        # single-GPU on the same global batch (issue #484). Identical to
+        # ``max(targets_cls.sum(), 1)`` outside DDP.
+        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)
@@ -915,7 +922,10 @@ class YOLO9SegmentationLoss(YOLO9Loss):
         preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
-        cls_norm = max(targets_cls.sum(), 1)
+        # Global (DDP-reduced) positive count so multi-GPU training matches
+        # single-GPU on the same global batch (issue #484). Identical to
+        # ``max(targets_cls.sum(), 1)`` outside DDP.
+        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)
@@ -1161,7 +1171,10 @@ class YOLO9PoseLoss(YOLO9Loss):
         preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
         targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
 
-        cls_norm = max(targets_cls.sum(), 1)
+        # Global (DDP-reduced) positive count so multi-GPU training matches
+        # single-GPU on the same global batch (issue #484). Identical to
+        # ``max(targets_cls.sum(), 1)`` outside DDP.
+        cls_norm = all_reduce_avg_scalar(targets_cls.sum())
         box_norm = targets_cls.sum(-1)[valid_masks]
 
         loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -245,13 +245,24 @@ def all_reduce_avg_scalar(
 
     Outside DDP this is just ``max(value, min_value)`` — single-GPU behavior is
     unchanged (identical numeric value to the previous ``max(sum, 1)``).
+
+    This is a COLLECTIVE under DDP: every rank must reach it or the callers
+    deadlock. Only call it from code that runs symmetrically on all ranks
+    (the training loss); never from rank-0-only paths like validation.
     """
     if isinstance(value, torch.Tensor):
+        # .sum() materializes a fresh tensor even for 0-dim input, so the
+        # in-place all_reduce below cannot touch the caller's storage.
         v = value.detach().float().sum().reshape(())
     else:
         v = torch.as_tensor(float(value), dtype=torch.float32, device=device)
     if is_distributed():
-        v = v.clone()
+        if v.device.type == "cpu" and dist.get_backend() == "nccl":
+            raise ValueError(
+                "all_reduce_avg_scalar got a CPU scalar under the NCCL "
+                "backend; pass device= (or a tensor already on the right "
+                "GPU) so the collective can run."
+            )
         dist.all_reduce(v)
         v = v / float(get_world_size())
     return float(v.clamp_min(min_value).item())
@@ -269,6 +280,13 @@ def scale_loss_for_ddp(loss: torch.Tensor) -> torch.Tensor:
     over-counts by ~N and inflates the effective learning rate — this was the
     root cause of the multi-GPU accuracy gap in issue #484 (4-GPU trained at
     ~4× LR vs single-GPU).
+
+    This is a CONTRACT each family's loss must satisfy, not a given: a loss
+    that normalizes by a globally-summed count WITHOUT dividing by world_size
+    (as RT-DETR's ``num_boxes`` did before #484 fixed it) under-scales by 1/N
+    once the identity is in place. New families must either use a local
+    normalizer or the ``all_reduce_avg_scalar`` reduction (global sum /
+    world_size) — never a bare global sum.
 
     Kept as the single, documented seam where a *genuinely sum-reduced* loss
     (no normalizer) could opt back into ``loss * world_size``. No family
@@ -397,6 +415,7 @@ def spawn_ddp_train(
 
 __all__ = [
     "DeviceArg",
+    "all_reduce_avg_scalar",
     "barrier",
     "broadcast_ema_buffers",
     "get_local_rank",

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -240,8 +240,14 @@ def all_reduce_avg_scalar(
     single-GPU training on the same global batch: with each rank dividing by
     ``global_count / world_size`` and DDP averaging the gradients, the two
     cancel to reproduce the single-GPU gradient exactly (see
-    ``scale_loss_for_ddp``). The result is clamped to ``min_value`` to avoid
-    division by zero on all-background batches.
+    ``scale_loss_for_ddp``).
+
+    The global sum is clamped to ``min_value`` BEFORE dividing by world_size.
+    Clamping after the divide (the upstream-DETR order) breaks exactness
+    whenever the global positive mass is below world_size: an all-background
+    batch would train at exactly 1/world_size gradient — worst on the
+    background-heavy datasets from issue #484. Clamp-first keeps the
+    single-GPU-equivalence exact for every batch, including empty ones.
 
     Outside DDP this is just ``max(value, min_value)`` — single-GPU behavior is
     unchanged (identical numeric value to the previous ``max(sum, 1)``).
@@ -264,7 +270,8 @@ def all_reduce_avg_scalar(
                 "GPU) so the collective can run."
             )
         dist.all_reduce(v)
-        v = v / float(get_world_size())
+        v = v.clamp_min(min_value) / float(get_world_size())
+        return float(v.item())
     return float(v.clamp_min(min_value).item())
 
 

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -227,26 +227,54 @@ def broadcast_ema_buffers(ema_module: nn.Module, src: int = 0) -> None:
 # =============================================================================
 
 
-def scale_loss_for_ddp(loss: torch.Tensor) -> torch.Tensor:
-    """Multiply loss by world_size so DDP gradient averaging composes correctly.
+def all_reduce_avg_scalar(
+    value: Union[float, torch.Tensor],
+    *,
+    device: Optional[torch.device] = None,
+    min_value: float = 1.0,
+) -> float:
+    """Average a per-rank scalar count across ranks: ``sum`` then ``/ world_size``.
 
-    DDP all-reduces gradients during ``backward()`` and divides by world_size
-    (an average). For sum-style losses we want the final gradient to be
-    ``sum_r dL_r/dθ``, not ``mean_r dL_r/dθ``. Pre-multiplying by world_size
-    cancels DDP's 1/N averaging exactly:
+    Mirrors the DETR ``num_boxes`` reduction. A mean/ratio-normalized loss must
+    divide by the *global* count of positives to be numerically equivalent to
+    single-GPU training on the same global batch: with each rank dividing by
+    ``global_count / world_size`` and DDP averaging the gradients, the two
+    cancel to reproduce the single-GPU gradient exactly (see
+    ``scale_loss_for_ddp``). The result is clamped to ``min_value`` to avoid
+    division by zero on all-background batches.
 
-        per-rank grad after backward = N * dL_r/dθ
-        DDP-averaged grad            = (1/N) * sum_r (N * dL_r/dθ) = sum_r dL_r/dθ
-
-    For mean-normalized losses (yolo9's cls_norm, DETR's num_boxes) the
-    result diverges slightly from single-GPU semantics. That divergence comes
-    from each rank using its own local normalizer.
-
-    No-op outside DDP.
+    Outside DDP this is just ``max(value, min_value)`` — single-GPU behavior is
+    unchanged (identical numeric value to the previous ``max(sum, 1)``).
     """
-    if not is_distributed():
-        return loss
-    return loss * float(get_world_size())
+    if isinstance(value, torch.Tensor):
+        v = value.detach().float().sum().reshape(())
+    else:
+        v = torch.as_tensor(float(value), dtype=torch.float32, device=device)
+    if is_distributed():
+        v = v.clone()
+        dist.all_reduce(v)
+        v = v / float(get_world_size())
+    return float(v.clamp_min(min_value).item())
+
+
+def scale_loss_for_ddp(loss: torch.Tensor) -> torch.Tensor:
+    """Pass the loss through unchanged — DDP needs no per-loss rescaling here.
+
+    DDP all-reduces gradients during ``backward()`` and **averages** them
+    (divides by world_size). Every LibreYOLO loss is mean/ratio-normalized:
+    each rank already produces a "full-batch magnitude" gradient (normalized by
+    a per-positive / per-box count — globally reduced for yolo9's ``cls_norm``
+    and the DETR ``num_boxes``), so DDP's averaging composes them into the
+    single-GPU-equivalent gradient. Multiplying by world_size on top of that
+    over-counts by ~N and inflates the effective learning rate — this was the
+    root cause of the multi-GPU accuracy gap in issue #484 (4-GPU trained at
+    ~4× LR vs single-GPU).
+
+    Kept as the single, documented seam where a *genuinely sum-reduced* loss
+    (no normalizer) could opt back into ``loss * world_size``. No family
+    currently uses one, so this is the identity in every case, DDP or not.
+    """
+    return loss
 
 
 # =============================================================================

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1709,9 +1709,10 @@ class BaseTrainer(ABC):
                     step=self.current_iter,
                 )
 
-            # Forward + backward. Under DDP we multiply loss by world_size
-            # so that backward() gradient averaging produces the same
-            # sum-of-per-rank gradients as single-GPU. No-op outside DDP.
+            # Forward + backward. Under DDP the loss needs no rescaling:
+            # every family's loss is mean/ratio-normalized, so DDP's gradient
+            # averaging already composes the per-rank gradients into the
+            # single-GPU-equivalent gradient (see scale_loss_for_ddp, #484).
             if self.scaler is not None:
                 with self._prof_phase("forward"):
                     with autocast("cuda"):
@@ -1850,10 +1851,10 @@ class BaseTrainer(ABC):
 
             # Forward + backward. Gradients accumulate across the window; the
             # optimizer step, clipping, EMA and LR update fire only on the
-            # window boundary (``is_opt_step``). Under DDP we additionally
-            # multiply the per-micro-batch loss by world_size so DDP's
-            # gradient averaging composes correctly with the division-by-
-            # window scheme.
+            # window boundary (``is_opt_step``). The division by the window
+            # keeps mean semantics across micro-batches; under DDP no further
+            # rescaling is needed (losses are mean-normalized, so DDP's
+            # gradient averaging is already correct — see scale_loss_for_ddp).
             if self.scaler is not None:
                 with self._prof_phase("forward"):
                     with autocast("cuda"):

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -2,8 +2,10 @@
 
 Spawns 2 child processes using ``torch.multiprocessing.spawn`` and exercises
 the full BaseTrainer DDP path: process group init, DDP model wrap, per-rank
-forward, ``loss * world_size`` backward, optimizer step, parameter sync check
-across ranks, and checkpoint round-trip.
+forward, backward, optimizer step, parameter sync check across ranks, and
+checkpoint round-trip. (Loss is passed through ``scale_loss_for_ddp``, which is
+the identity — every LibreYOLO loss is mean/ratio-normalized, so DDP's gradient
+averaging already yields single-GPU-equivalent gradients; see issue #484.)
 
 Two backend tiers:
 

--- a/tests/unit/test_ddp_loss_parity.py
+++ b/tests/unit/test_ddp_loss_parity.py
@@ -1,0 +1,267 @@
+"""DDP↔single-GPU numerical parity tests (issue #484, complaint #3).
+
+The existing ``test_ddp_distributed.py`` smoke tests only assert that all
+ranks hold *identical* parameters after a step — which is true regardless of
+loss scaling, because DDP always all-reduces gradients. They do **not** check
+that N-rank training produces the **same** gradient as single-GPU training on
+the same global batch. That equivalence is exactly what the ``× world_size``
+loss scaling used to break: every LibreYOLO loss is mean/ratio-normalized, so
+DDP's built-in gradient averaging already yields single-GPU-equivalent
+gradients; pre-multiplying by ``world_size`` over-counted by ~N and inflated
+the effective learning rate — the root cause of the multi-GPU accuracy gap in
+issue #484.
+
+Method: build the *same* deterministic model and a fixed 2-sample global
+batch. Compute the reference gradient once, single-process, over the whole
+batch (``batch=2``). Then spawn 2 gloo ranks, give rank ``r`` sample ``r``
+(``batch=1`` each), run forward → ``scale_loss_for_ddp`` → backward (DDP
+averages the grads), and compare rank 0's synced gradient to the reference.
+
+Correct behavior ⇒ ``‖g_ddp‖ / ‖g_ref‖ ≈ 1``. The old ``× world_size`` bug
+makes the ratio ≈ ``world_size`` (≈ 2 here). BatchNorm is frozen (running
+stats) so the loss is separable across the batch and the only cross-sample
+coupling is the (globally reduced) classification normalizer — which is what
+makes the parity exact rather than merely approximate.
+
+Gloo/CPU only — no GPU required. ~20-40s.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+
+pytestmark = pytest.mark.unit
+
+
+# =============================================================================
+# Shared deterministic model + batch (module-level so spawn() can pickle refs)
+# =============================================================================
+
+
+def _freeze_batchnorm(model: nn.Module) -> None:
+    """Put every BatchNorm into eval() so it uses fixed running stats.
+
+    In train mode BN normalizes over the batch, coupling the two samples and
+    making the per-sample loss non-separable — which would make single-vs-DDP
+    gradients differ for a reason unrelated to loss scaling. Freezing BN
+    isolates the loss-normalization math we're actually testing. The detection
+    head stays in train mode (raw outputs for the loss path).
+    """
+    for mod in model.modules():
+        if isinstance(mod, nn.modules.batchnorm._BatchNorm):
+            mod.eval()
+
+
+def _build_yolo9():
+    """Deterministic yolo9-t on CPU, train mode, BN frozen. Identical weights
+    in every process because the seed and constructor are fixed."""
+    from libreyolo import LibreYOLO9
+
+    torch.manual_seed(0)
+    wrapper = LibreYOLO9(None, size="t", device="cpu")
+    model = wrapper.model
+    model.train()
+    _freeze_batchnorm(model)
+    return model
+
+
+def _global_batch():
+    """Fixed 2-sample batch: images plus normalized [cls, x1, y1, x2, y2] boxes.
+
+    Deterministic so sample ``r`` is byte-identical in the reference run and in
+    rank ``r``'s worker. Padding rows are all-zero (a degenerate box that
+    matches no anchor, contributing nothing to the loss)."""
+    g = torch.Generator().manual_seed(1234)
+    imgs = torch.rand(2, 3, 320, 320, generator=g)
+    targets = torch.zeros(2, 8, 5)
+    targets[0, 0] = torch.tensor([0.0, 0.20, 0.20, 0.50, 0.60])
+    targets[0, 1] = torch.tensor([1.0, 0.55, 0.50, 0.80, 0.85])
+    targets[1, 0] = torch.tensor([2.0, 0.10, 0.15, 0.45, 0.50])
+    return imgs, targets
+
+
+def _flat_grad(model: nn.Module) -> torch.Tensor:
+    """Concatenate all parameter gradients in named-parameter order.
+
+    None grads become zeros so the vector layout is identical across runs
+    (the same params are used in the reference and DDP runs)."""
+    parts = []
+    for _name, p in model.named_parameters():
+        if p.grad is None:
+            parts.append(torch.zeros_like(p).reshape(-1))
+        else:
+            parts.append(p.grad.detach().reshape(-1))
+    return torch.cat(parts)
+
+
+def _reference_grad() -> torch.Tensor:
+    """Single-process gradient over the full 2-sample batch — the ground truth
+    that DDP over 2 ranks must reproduce."""
+    model = _build_yolo9()
+    imgs, targets = _global_batch()
+    out = model(imgs, targets=targets)
+    model.zero_grad(set_to_none=True)
+    out["total_loss"].backward()
+    return _flat_grad(model)
+
+
+# =============================================================================
+# DDP worker
+# =============================================================================
+
+
+def _setup_pg(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+
+
+def _yolo9_parity_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+    """One rank: forward its own sample, DDP-averaged backward, rank 0 saves the
+    synced gradient for the parent to compare against the reference."""
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        _setup_pg(rank, world_size, port)
+
+        from libreyolo.training.distributed import scale_loss_for_ddp, unwrap_model
+
+        model = _build_yolo9()
+        ddp_model = nn.parallel.DistributedDataParallel(model)
+
+        imgs, targets = _global_batch()
+        my_img = imgs[rank : rank + 1]
+        my_tgt = targets[rank : rank + 1]
+
+        out = ddp_model(my_img, targets=my_tgt)
+        loss = out["total_loss"]
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"non-finite loss on rank {rank}: {loss.item()}")
+        loss = scale_loss_for_ddp(loss)
+        model.zero_grad(set_to_none=True)
+        loss.backward()
+
+        flat = _flat_grad(unwrap_model(ddp_model))
+        if rank == 0:
+            torch.save(flat, Path(out_dir) / "ddp_grad.pt")
+        dist.barrier()
+        out_path.write_text(
+            f"ok grad_norm={float(flat.norm().item()):.6f}\n"
+        )
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _spawn_and_check(worker, n_ranks: int, tmp_path) -> dict:
+    port = _free_port()
+    out_dir = str(tmp_path)
+    try:
+        mp.spawn(worker, args=(n_ranks, port, out_dir), nprocs=n_ranks, join=True)
+    except Exception as exc:
+        outputs = {
+            rank: (tmp_path / f"rank_{rank}.txt").read_text()
+            if (tmp_path / f"rank_{rank}.txt").exists()
+            else "<no output>"
+            for rank in range(n_ranks)
+        }
+        raise AssertionError(
+            f"spawn failed: {exc}\nper-rank outputs: {outputs}"
+        ) from exc
+    return {
+        rank: (tmp_path / f"rank_{rank}.txt").read_text() for rank in range(n_ranks)
+    }
+
+
+# =============================================================================
+# Test
+# =============================================================================
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+def test_yolo9_ddp_gradient_matches_single_gpu(tmp_path):
+    """2-rank DDP gradient must match single-GPU gradient on the same global
+    batch. Fails with ratio ≈ world_size if the ``× world_size`` loss-scaling
+    bug (issue #484) is present."""
+    ref = _reference_grad()
+
+    outputs = _spawn_and_check(_yolo9_parity_worker, n_ranks=2, tmp_path=tmp_path)
+    for rank, text in outputs.items():
+        assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
+
+    ddp = torch.load(tmp_path / "ddp_grad.pt", weights_only=False)
+
+    ref_norm = float(ref.norm().item())
+    ddp_norm = float(ddp.norm().item())
+    ratio = ddp_norm / max(ref_norm, 1e-12)
+
+    assert 0.9 < ratio < 1.1, (
+        f"DDP gradient norm is {ratio:.3f}× the single-GPU gradient "
+        f"(ref={ref_norm:.4f}, ddp={ddp_norm:.4f}). A ratio near world_size (2) "
+        f"means the loss is being multiplied by world_size — the issue #484 "
+        f"multi-GPU learning-rate bug."
+    )
+    assert torch.allclose(ddp, ref, rtol=2e-3, atol=1e-5), (
+        "DDP gradient diverged from single-GPU beyond fp tolerance: "
+        f"max_abs_diff={float((ddp - ref).abs().max().item()):.3e}"
+    )
+
+
+# =============================================================================
+# Deterministic unit tests for the reduction primitives (no spawn needed).
+# These pin single-GPU behavior so the DDP fix cannot regress it, and prove the
+# loss is no longer multiplied by world_size — the shared mechanism every
+# normalized-loss family (yolo9, YOLOX, DETR num_boxes, …) relies on.
+# =============================================================================
+
+
+def test_scale_loss_for_ddp_is_identity():
+    """The DDP loss scaler must pass the loss through untouched (no
+    ``× world_size``). Returned tensor is the same object."""
+    from libreyolo.training.distributed import scale_loss_for_ddp
+
+    loss = torch.tensor(3.14159)
+    assert scale_loss_for_ddp(loss) is loss
+
+
+def test_all_reduce_avg_scalar_single_process_matches_legacy_max():
+    """Outside DDP, ``all_reduce_avg_scalar`` must equal the old
+    ``max(sum, 1)`` normalizer exactly, so single-GPU yolo9 loss values are
+    unchanged. Accepts tensor, python float, and int inputs; clamps to 1."""
+    from libreyolo.training.distributed import all_reduce_avg_scalar
+
+    assert all_reduce_avg_scalar(torch.tensor(5.0)) == 5.0
+    assert all_reduce_avg_scalar(torch.tensor(0.0)) == 1.0  # clamp to min 1
+    assert all_reduce_avg_scalar(0.0) == 1.0
+    assert all_reduce_avg_scalar(7) == 7.0
+    # A multi-element tensor is summed (matches ``targets_cls.sum()`` usage).
+    assert all_reduce_avg_scalar(torch.tensor([1.0, 2.0, 3.0])) == 6.0

--- a/tests/unit/test_ddp_loss_parity.py
+++ b/tests/unit/test_ddp_loss_parity.py
@@ -90,6 +90,18 @@ def _global_batch():
     return imgs, targets
 
 
+def _empty_global_batch():
+    """All-background 2-sample batch: zero positive mass on every rank.
+
+    Exercises the normalizer clamp: with clamp-after-divide DDP would train
+    this batch at exactly 1/world_size gradient (measured ratio 0.5000 during
+    review); clamp-before-divide keeps it exact."""
+    g = torch.Generator().manual_seed(4321)
+    imgs = torch.rand(2, 3, 320, 320, generator=g)
+    targets = torch.zeros(2, 8, 5)
+    return imgs, targets
+
+
 def _flat_grad(model: nn.Module) -> torch.Tensor:
     """Concatenate all parameter gradients in named-parameter order.
 
@@ -104,11 +116,11 @@ def _flat_grad(model: nn.Module) -> torch.Tensor:
     return torch.cat(parts)
 
 
-def _reference_grad() -> torch.Tensor:
+def _reference_grad(empty: bool = False) -> torch.Tensor:
     """Single-process gradient over the full 2-sample batch — the ground truth
     that DDP over 2 ranks must reproduce."""
     model = _build_yolo9()
-    imgs, targets = _global_batch()
+    imgs, targets = _empty_global_batch() if empty else _global_batch()
     out = model(imgs, targets=targets)
     model.zero_grad(set_to_none=True)
     out["total_loss"].backward()
@@ -129,7 +141,9 @@ def _setup_pg(rank: int, world_size: int, port: int) -> None:
     dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
 
 
-def _yolo9_parity_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+def _yolo9_parity_worker(
+    rank: int, world_size: int, port: int, out_dir: str, empty: bool = False
+) -> None:
     """One rank: forward its own sample, DDP-averaged backward, rank 0 saves the
     synced gradient for the parent to compare against the reference."""
     out_path = Path(out_dir) / f"rank_{rank}.txt"
@@ -141,7 +155,7 @@ def _yolo9_parity_worker(rank: int, world_size: int, port: int, out_dir: str) ->
         model = _build_yolo9()
         ddp_model = nn.parallel.DistributedDataParallel(model)
 
-        imgs, targets = _global_batch()
+        imgs, targets = _empty_global_batch() if empty else _global_batch()
         my_img = imgs[rank : rank + 1]
         my_tgt = targets[rank : rank + 1]
 
@@ -179,11 +193,16 @@ def _free_port() -> int:
         return int(s.getsockname()[1])
 
 
-def _spawn_and_check(worker, n_ranks: int, tmp_path) -> dict:
+def _spawn_and_check(worker, n_ranks: int, tmp_path, extra_args: tuple = ()) -> dict:
     port = _free_port()
     out_dir = str(tmp_path)
     try:
-        mp.spawn(worker, args=(n_ranks, port, out_dir), nprocs=n_ranks, join=True)
+        mp.spawn(
+            worker,
+            args=(n_ranks, port, out_dir) + extra_args,
+            nprocs=n_ranks,
+            join=True,
+        )
     except Exception as exc:
         outputs = {
             rank: (tmp_path / f"rank_{rank}.txt").read_text()
@@ -230,10 +249,98 @@ def test_yolo9_ddp_gradient_matches_single_gpu(tmp_path):
         f"means the loss is being multiplied by world_size — the issue #484 "
         f"multi-GPU learning-rate bug."
     )
+    # The elementwise allclose is the LOAD-BEARING assertion: a local (not
+    # globally-reduced) cls_norm passes the norm-ratio band above (~0.98) but
+    # fails here decisively (max_abs_diff ~1e-1). Do not loosen the tolerance.
     assert torch.allclose(ddp, ref, rtol=2e-3, atol=1e-5), (
         "DDP gradient diverged from single-GPU beyond fp tolerance: "
         f"max_abs_diff={float((ddp - ref).abs().max().item()):.3e}"
     )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+def test_yolo9_ddp_gradient_matches_single_gpu_all_background(tmp_path):
+    """Same parity check on an all-background global batch (zero positive
+    mass). Pins the clamp-BEFORE-divide order in ``all_reduce_avg_scalar``:
+    with clamp-after-divide, every rank's normalizer clamps to 1 instead of
+    sharing global ``max(sum,1)/world_size``, and DDP trains the batch at
+    exactly 1/world_size gradient (measured ratio 0.5000 during review) —
+    worst exactly on the background-heavy datasets from issue #484."""
+    ref = _reference_grad(empty=True)
+
+    outputs = _spawn_and_check(
+        _yolo9_parity_worker, n_ranks=2, tmp_path=tmp_path, extra_args=(True,)
+    )
+    for rank, text in outputs.items():
+        assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
+
+    ddp = torch.load(tmp_path / "ddp_grad.pt", weights_only=False)
+
+    ref_norm = float(ref.norm().item())
+    ddp_norm = float(ddp.norm().item())
+    ratio = ddp_norm / max(ref_norm, 1e-12)
+
+    assert 0.9 < ratio < 1.1, (
+        f"all-background DDP gradient is {ratio:.3f}× single-GPU "
+        f"(ref={ref_norm:.4f}, ddp={ddp_norm:.4f}). A ratio near "
+        f"1/world_size (0.5) means the normalizer clamps after dividing."
+    )
+    assert torch.allclose(ddp, ref, rtol=2e-3, atol=1e-5), (
+        "all-background DDP gradient diverged from single-GPU: "
+        f"max_abs_diff={float((ddp - ref).abs().max().item()):.3e}"
+    )
+
+
+def _helper_value_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+    """Exercise ``all_reduce_avg_scalar`` itself under a real process group —
+    including the non-tensor + ``device=`` form RT-DETR uses, which no other
+    test runs distributed."""
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        _setup_pg(rank, world_size, port)
+
+        from libreyolo.training.distributed import all_reduce_avg_scalar
+
+        # Python-scalar branch (the RT-DETR num_boxes form): ranks contribute
+        # 3 and 5 → both must see max(8, 1) / 2 = 4.
+        got_scalar = all_reduce_avg_scalar(3.0 if rank == 0 else 5.0)
+        # Tensor branch (the yolo9 cls_norm form): same values as tensors.
+        got_tensor = all_reduce_avg_scalar(torch.tensor(3.0 if rank == 0 else 5.0))
+        # Zero global mass: clamp the GLOBAL sum first → max(0, 1) / 2 = 0.5.
+        # (Clamp-after-divide would return 1.0 and break all-background parity.)
+        got_zero = all_reduce_avg_scalar(torch.tensor(0.0))
+
+        if got_scalar != 4.0:
+            raise RuntimeError(f"scalar branch: expected 4.0, got {got_scalar}")
+        if got_tensor != 4.0:
+            raise RuntimeError(f"tensor branch: expected 4.0, got {got_tensor}")
+        if got_zero != 0.5:
+            raise RuntimeError(f"zero-mass: expected 0.5, got {got_zero}")
+
+        out_path.write_text("ok\n")
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+def test_all_reduce_avg_scalar_2_ranks(tmp_path):
+    """Distributed values of the reduction helper: global-sum / world_size with
+    the clamp applied to the global sum. Covers the python-scalar + ``device=``
+    branch that RT-DETR's ``num_boxes`` uses (previously only exercised
+    single-process)."""
+    outputs = _spawn_and_check(_helper_value_worker, n_ranks=2, tmp_path=tmp_path)
+    for rank, text in outputs.items():
+        assert text.startswith("ok"), f"rank {rank} did not finish ok: {text!r}"
 
 
 # =============================================================================

--- a/tests/unit/test_pose_build_target.py
+++ b/tests/unit/test_pose_build_target.py
@@ -1,0 +1,53 @@
+"""Regression test for the pose ``build_target`` reshape crash.
+
+When an image has more keypoint instances than ``max_labels``, the capped row
+count ``n`` differs from ``len(kpts_px)``. The old
+``kpts_px[:n].reshape(len(kpts_px), -1)`` then raised a numpy shape error
+(``n * K * 3`` elements cannot fill ``len(kpts_px)`` rows), crashing pose
+training on any crowded image. This pins the fix.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from libreyolo.data.augment.pose import build_target
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_instances(m, k):
+    cls = np.zeros(m, dtype=np.float32)
+    # [x, y, w, h] with w*h > 1 so the keep-filter passes.
+    bboxes_px = np.tile(np.array([10.0, 10.0, 20.0, 20.0], dtype=np.float32), (m, 1))
+    kpts_px = np.zeros((m, k, 3), dtype=np.float32)
+    kpts_px[..., 0] = 5.0
+    kpts_px[..., 1] = 5.0
+    kpts_px[..., 2] = 2.0  # visible → keep-filter passes
+    return cls, bboxes_px, kpts_px
+
+
+def test_build_target_caps_instances_over_max_labels_without_crashing():
+    k, max_labels = 5, 10
+    m = max_labels + 5  # more instances than slots
+    cls, bboxes_px, kpts_px = _valid_instances(m, k)
+
+    target = build_target(cls, bboxes_px, kpts_px, num_keypoints=k, max_labels=max_labels)
+
+    assert target.shape == (max_labels, 5 + 3 * k)
+    # Every slot is filled (all instances valid, capped at max_labels).
+    assert int((target[:, 3] > 0).sum()) == max_labels
+    # Keypoints made it into the tail columns.
+    assert np.any(target[:, 5:] > 0)
+
+
+def test_build_target_normal_case_unaffected():
+    k, max_labels = 5, 20
+    m = 3  # fewer instances than slots
+    cls, bboxes_px, kpts_px = _valid_instances(m, k)
+
+    target = build_target(cls, bboxes_px, kpts_px, num_keypoints=k, max_labels=max_labels)
+
+    assert target.shape == (max_labels, 5 + 3 * k)
+    assert int((target[:, 3] > 0).sum()) == m

--- a/tests/unit/test_yolo9_background_augment.py
+++ b/tests/unit/test_yolo9_background_augment.py
@@ -1,0 +1,93 @@
+"""Regression tests: background (empty-label) images must be augmented too.
+
+``YOLO9TrainTransform`` used to early-return on images with no labels,
+skipping HSV and flips entirely. On background-heavy datasets (the issue #484
+reporter's is >80% background) most of the training data was therefore never
+augmented: the model saw the exact same negative images every epoch while
+labeled images varied. Backgrounds must get the same photometric/flip
+augmentation as labeled images — there are no labels to keep in sync, so only
+the image changes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from libreyolo.data.augment.yolo9 import YOLO9TrainTransform, preproc
+
+pytestmark = pytest.mark.unit
+
+_EMPTY = np.zeros((0, 5), dtype=np.float32)
+
+
+def _asymmetric_image(h=48, w=64):
+    """Left half dark, right half bright — any flip is detectable."""
+    img = np.zeros((h, w, 3), dtype=np.uint8)
+    img[:, w // 2 :] = 200
+    return img
+
+
+def test_background_image_is_horizontally_flipped():
+    """flip_prob=1 must flip an empty-label image (old code returned it
+    unflipped)."""
+    t = YOLO9TrainTransform(
+        max_labels=10, flip_prob=1.0, vertical_flip_prob=0.0, hsv_prob=0.0
+    )
+    img = _asymmetric_image()
+
+    out, labels = t(img.copy(), _EMPTY, (48, 64))
+    expected, _ = preproc(img[:, ::-1], (48, 64))
+
+    assert np.array_equal(out, expected), (
+        "empty-label image was not flipped — background images are skipping "
+        "augmentation (issue #484)"
+    )
+    # Labels stay an all-padding block.
+    assert labels.shape == (10, 5)
+    assert np.all(labels[:, 0] == -1)
+
+
+def test_background_image_gets_hsv_augmentation():
+    """hsv_prob=1 must alter the pixels of an empty-label image."""
+    t = YOLO9TrainTransform(
+        max_labels=10, flip_prob=0.0, vertical_flip_prob=0.0, hsv_prob=1.0
+    )
+    img = _asymmetric_image()
+
+    out, _ = t(img.copy(), _EMPTY, (48, 64))
+    unaugmented, _ = preproc(img, (48, 64))
+
+    assert not np.array_equal(out, unaugmented), (
+        "empty-label image pixels unchanged with hsv_prob=1 — HSV skipped "
+        "on the background path"
+    )
+
+
+def test_background_image_unchanged_when_augs_disabled():
+    """With all probabilities 0 the empty path must reduce to plain
+    letterbox preprocessing — pinning that the fix adds no unconditional
+    behavior change."""
+    t = YOLO9TrainTransform(
+        max_labels=10, flip_prob=0.0, vertical_flip_prob=0.0, hsv_prob=0.0
+    )
+    img = _asymmetric_image()
+
+    out, _ = t(img.copy(), _EMPTY, (48, 64))
+    expected, _ = preproc(img, (48, 64))
+
+    assert np.array_equal(out, expected)
+
+
+def test_background_image_with_segments_returns_empty_masks():
+    """The mask variant of the empty path still returns all-zero masks."""
+    t = YOLO9TrainTransform(
+        max_labels=10, flip_prob=1.0, vertical_flip_prob=0.0, hsv_prob=1.0
+    )
+    img = _asymmetric_image()
+
+    out, labels, masks = t(img.copy(), _EMPTY, (48, 64), segments=[])
+
+    assert masks.shape == (10, 48 // 4, 64 // 4)
+    assert not masks.any()
+    assert np.all(labels[:, 0] == -1)

--- a/tests/unit/test_yolo9_mixup_regression.py
+++ b/tests/unit/test_yolo9_mixup_regression.py
@@ -1,0 +1,106 @@
+"""Regression test for the YOLO9 mixup label-drop bug (issue #484, complaint #2).
+
+``YOLO9MosaicMixupDataset._mixup`` used to vstack the second image's labels
+onto the already-padded ``(max_labels, 5)`` block of the first image and then
+truncate back to ``max_labels`` — which kept only the first image's block and
+silently dropped every object from the second image. Those ~50%-opacity
+objects then trained as unlabeled background, poisoning the model whenever
+mixup was enabled.
+
+The check is semantic and platform-independent (rather than a byte-exact
+golden fixture, which would depend on the beta-distribution RNG and the
+platform): after mixup, labels from *both* images must be present.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from libreyolo.data.augment.yolo9 import (
+    YOLO9MosaicMixupDataset,
+    YOLO9TrainTransform,
+)
+
+pytestmark = pytest.mark.unit
+
+_B_CLASS = 7  # the "second image" always contributes exactly this class
+
+
+class _StubBDataset:
+    """Every image is a single box of class ``_B_CLASS`` — so whatever the
+    second image contributes to a mixup is unambiguous."""
+
+    def __init__(self, img_size=(64, 64)):
+        self.img_size = img_size
+
+    def __len__(self):
+        return 4
+
+    def _label(self):
+        # [x1, y1, x2, y2, class] in pixel coords (YOLO9TrainTransform input).
+        return np.array([[8.0, 8.0, 40.0, 40.0, float(_B_CLASS)]], dtype=np.float32)
+
+    def load_anno(self, idx):
+        return self._label()
+
+    def pull_item(self, idx):
+        img = np.full((self.img_size[0], self.img_size[1], 3), 120, dtype=np.uint8)
+        return img, self._label(), (img.shape[0], img.shape[1]), idx
+
+
+def _make_dataset():
+    preproc = YOLO9TrainTransform(max_labels=50, flip_prob=0.0, hsv_prob=0.0)
+    return YOLO9MosaicMixupDataset(
+        _StubBDataset(),
+        img_size=(64, 64),
+        mosaic=True,
+        preproc=preproc,
+        enable_mixup=True,
+        mosaic_prob=1.0,
+        mixup_prob=1.0,
+    )
+
+
+def test_mixup_keeps_labels_from_both_images():
+    """The first image's object (class 3) AND the second image's object
+    (class ``_B_CLASS``) must both survive the mix."""
+    ds = _make_dataset()
+
+    a_class = 3.0
+    # First image's labels as YOLO9TrainTransform emits them: padded to
+    # max_labels rows, real rows front-packed, padding class = -1,
+    # boxes normalized [class, x1, y1, x2, y2].
+    labels = np.zeros((50, 5), dtype=np.float32)
+    labels[:, 0] = -1
+    labels[0] = [a_class, 0.10, 0.10, 0.50, 0.50]
+    img = np.zeros((3, 64, 64), dtype=np.float32)
+
+    _mixed_img, out = ds._mixup(img, labels)
+
+    real = out[out[:, 0] >= 0]
+    classes = set(np.round(real[:, 0]).astype(int).tolist())
+
+    assert int(a_class) in classes, "first image's label was dropped by mixup"
+    assert _B_CLASS in classes, (
+        "second image's label was dropped by mixup — the issue #484 "
+        "label-drop bug (its objects would train as unlabeled background)"
+    )
+
+
+def test_mixup_output_is_padded_to_max_labels():
+    """The result must still be a ``(max_labels, 5)`` block with class = -1
+    padding, so the collate/loss path is unchanged."""
+    ds = _make_dataset()
+
+    labels = np.zeros((50, 5), dtype=np.float32)
+    labels[:, 0] = -1
+    labels[0] = [3.0, 0.10, 0.10, 0.50, 0.50]
+    img = np.zeros((3, 64, 64), dtype=np.float32)
+
+    _mixed_img, out = ds._mixup(img, labels)
+
+    assert out.shape == (50, 5)
+    # Exactly two real objects (one per image); the rest padding class = -1.
+    assert int((out[:, 0] >= 0).sum()) == 2
+    assert np.all(out[out[:, 0] < 0][:, 0] == -1)


### PR DESCRIPTION
Fixes the training-correctness bugs reported in #484, plus one regression caught by review during the work (RT-DETR DDP normalization). Status per reported problem is at the bottom.

## 1. Multi-GPU trained at ~N× effective LR (#484 point 3)

`scale_loss_for_ddp` multiplied every loss by `world_size`. That is only correct for a *pure-sum* loss, but **every** LibreYOLO loss is mean/ratio-normalized (yolo9 `cls_norm`, YOLOX `num_fg`, RTMDet/PicoDet `avg_factor`, YOLO-NAS `assigned_scores_sum`, the DETR families' `num_boxes`, classification `cross_entropy`, NAFNet per-pixel mean). DDP already **averages** gradients across ranks, so a normalized per-rank loss already composes to the single-GPU-equivalent gradient; the extra `× world_size` over-counted by ~N and inflated the effective learning rate. A 4-GPU run effectively trained at ~4× LR — matching the reporter's 4-GPU mAP 0.585 vs 1-GPU 0.814.

**Fix**
- `scale_loss_for_ddp` is now the identity (kept as the documented seam where a genuinely sum-reduced loss could opt back in; none currently exists). Its docstring now states the per-family normalizer contract explicitly.
- yolo9's `cls_norm` is globally reduced via a new `all_reduce_avg_scalar` helper (mirrors the DETR `num_boxes` reduction), through a single shared `YOLO9Loss._global_cls_norm` used by all four task losses, so multi-GPU matches single-GPU exactly (up to fp reassociation, ~4e-6). Single-GPU numerics are unchanged (`all_reduce_avg_scalar` == the old `max(sum, 1)` outside DDP).

**Proof** — new `tests/unit/test_ddp_loss_parity.py` compares the 2-rank gloo gradient to the single-GPU gradient on the *same global batch*. Ratio was **1.96 ≈ world_size** before, **1.00 / elementwise `allclose`** after.

### RT-DETR: review-caught inversion, fixed here

RT-DETR's `num_boxes` all-reduced the global count but — unlike D-FINE/DEIM/DEIMv2/RF-DETR — **never divided by world_size**. Under the old `× world_size` scaling the two errors cancelled and RT-DETR multi-GPU was accidentally correct; with the identity alone it would have trained at ~1/N effective LR. RT-DETR now uses the same `all_reduce_avg_scalar` reduction as everything else, restoring exact single-GPU equivalence. (Single-GPU numerics unchanged.)

The remaining local-normalizer families (YOLOX, RTMDet, PicoDet, YOLO-NAS) go from ~N× error to approximately-correct; making their normalizers globally reduced for bit-exact parity — and migrating the DETR families' inline reductions onto the shared helper — is a follow-up.

## 2. YOLO9 mixup dropped the second image's labels (#484 point 2)

`_mixup` vstacked the second image's labels onto the first image's already-padded `(max_labels, 5)` block and truncated back to `max_labels`, keeping only the first block — so every object from the second image (blended in at ~50% opacity) was dropped and trained as unlabeled background. Fix: strip padding from both, merge the real objects, re-pad (mirrors the shared YOLOX mixup). Regression test added.

## 3. Background images were never augmented (#484 point 1)

`YOLO9TrainTransform` early-returned on empty-label images, skipping HSV and flips entirely. On the reporter's dataset (>80% background) most of the training data was therefore never augmented: the model saw the exact same negatives every epoch while labeled images varied. The empty path now applies the same photometric/flip ops (no label sync needed). No golden parity fixture pins the yolo9 empty path and the labeled path is untouched — all 44 augment parity fixtures still pass. (The YOLOX-family empty path is intentionally left as-is: that family's contract is byte-parity with upstream YOLOX, which also skips.)

Honest scoping: we found **no single smoking-gun** for the reported −12% on background-heavy data. Three defects that plausibly compound with it are now fixed (mosaic geometric augmentation — #467, already on dev; mixup label-drop and background-augmentation skip — this PR). The reporter should retrain on dev and report back; if a gap remains, it gets its own investigation.

## 4. Pose `build_target` crash on crowded images

`reshape(len(kpts_px), -1)` used the uncapped instance count; when an image had more instances than `max_labels` the element count could not fill `len(kpts_px)` rows and numpy raised, crashing pose training. Fix: reshape the capped `n` instances. Regression test added. (Pre-existing; surfaced by Greptile on #483.)

## Status vs #484's four reported problems

| # | Reported problem | Status |
|---|---|---|
| 1 | Background-heavy dataset trains ~12% worse | Three compounding defects fixed (#467 on dev + points 2 & 3 above); no single root cause confirmed — retest requested |
| 2 | Mosaic/mixup stalls training | Mosaic fixed by #467 (dev); mixup label-drop fixed here |
| 3 | Single vs multi-GPU accuracy gap | Fixed here (yolo9 bit-exact, proven by gradient-parity test; DETR families corrected; RT-DETR normalizer fixed) |
| 4 | Multi-class keypoints | **Not in this PR** — investigated: all three pose families (RF-DETR/GroupPose, YOLO-NAS, EC) enforce nc=1 at head, loss, loader contract, and checkpoint schema, and both upstreams are person-only, so there is no low-risk plumbing path. Tracked as a feature request. |

## Behavior changes (release notes)

- Existing multi-GPU users were effectively training at ~N× LR. After this fix, N-GPU matches 1-GPU at the configured LR — the global batch is fixed and split across ranks, so no linear-LR-scaling rule applies. Users who previously compensated with a lowered LR should use the configured value. Gradient-clipping thresholds tuned on old multi-GPU runs now act on ~N×-smaller gradient norms; AMP's GradScaler re-adapts automatically within a few hundred steps when resuming old checkpoints.
- Background images now receive HSV/flip augmentation during YOLO9 training. Seeded runs consume the RNG stream differently than pre-fix versions (backgrounds now draw augmentation randomness), so per-sample augmentations are not reproducible *across* library versions — seeded runs within a version are unaffected.
- REVIEW.md's "DDP loss scales by world size" axiom updated to the new contract.

## Review pass

An 8-angle review (line-by-line, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) ran over this PR before final push. It caught the RT-DETR inversion (fixed above) and drove: the shared `_global_cls_norm` method (was 4× copy-paste), a guard raising a clear error if the helper receives a CPU scalar under NCCL (was a latent hang), removal of a redundant `clone()`, and the REVIEW.md axiom update. Known accepted trade-offs, documented in code: the yolo9 loss now contains a collective (must run on all ranks — same property the DETR criteria already have), and the background/labeled augmentation blocks are kept separate with matching op order.


## Second review round (two independent agents on the final state)

A DDP-numerics specialist re-derived the gradient algebra for **every** training path and confirmed the PR's math (yolo9 exact to 3.9e-6 empirically, with negative controls: reinstating `× world_size` → ratio 2.000007; a local `cls_norm` → max diff 9.4e-2). It also confirmed DEIM/D-FINE never had the ×N bug (their trainers bypass the scaling seam), so this PR unifies a previously inconsistent framework.

An adversarial reviewer then found one real, measured defect in the new helper: it clamped the normalizer **after** dividing by world_size (the upstream-DETR order), so any global batch with positive mass below world_size — all-background batches above all — trained at ~mass/N gradient under DDP (measured ratio 0.5000 at 2 ranks). Fixed in the final commit by clamping the **global sum first**; parity is now exact for every batch including empty ones (a deliberate, documented deviation from the upstream-DETR clamp order). Two tests pin it: an all-background 2-rank gradient-parity test, and a 2-rank value test for `all_reduce_avg_scalar` covering the python-scalar + `device=` branch RT-DETR uses.


## Third review round (post dev-merge: merge audit + adversarial agent + Codex)

After merging dev (distillation #485, profiler #497) into the branch, three more independent reviews ran on the final state:

- **Merge audit: clean.** The merged `trainer.py` differs from dev's by comments only; all 11 PR files byte-identical to the branch parent. Bonus: dev's `_sync_distiller_grads` *averages* adapter grads — consistent with the identity scaling here (it was inconsistent with the old ×N), so the two PRs fix each other's interaction.
- **Adversarial agent:** found the HSV background test was flaky (~1/3 failure — `augment_hsv`'s draws are legitimately a visible no-op on an achromatic image). Replaced with a deterministic spy on the empty-label path. Also empirically verified RT-DETR fractional `num_boxes` DDP parity to 1.2e-7 including the denoising path, and that the all-background parity test cannot false-pass.
- **Codex (gpt-5.5, xhigh): one High finding, correct.** RF-DETR and EC pose still clamped their inline `num_boxes` *after* dividing by world_size; since both route through the shared trainer loop, removing the ×N compensation regressed their all-background corner to 1/world_size gradient. Both now use `all_reduce_avg_scalar` (clamp the global sum, then divide) — same fix as yolo9/RT-DETR. DEIM/D-FINE/DEIMv2 are intentionally untouched: they bypass `scale_loss_for_ddp` with their own epoch loops, so their pre-existing corner behavior is unchanged by this PR and stays a follow-up.

## Tests

- `test_ddp_loss_parity.py` — spawn gradient parity on a positive-rich batch AND an all-background batch, a 2-rank distributed value test for the reduction helper, plus single-process reduction-primitive tests.
- `test_yolo9_mixup_regression.py`, `test_yolo9_background_augment.py`, `test_pose_build_target.py`.
- Existing `test_ddp_distributed.py` DDP smoke tests still green (incl. RT-DETR's, which exercises the fixed `num_boxes` reduction under a real process group); stale ×world_size comments refreshed.
- Full unit suite green locally and on CI.
