### PR TITLE
Add OMDet-Turbo to the open-vocabulary detector tier

### DIFF
--- a/docs/adr/0008-open-vocab-detector-contract.md
+++ b/docs/adr/0008-open-vocab-detector-contract.md
@@ -37,6 +37,10 @@ The first families are:
 
 - `LibreGroundingDINO`, backed by `GroundingDinoForObjectDetection`.
 - `LibreOWLv2`, backed by `Owlv2ForObjectDetection`.
+- `LibreOMDetTurbo`, backed by `OmDetTurboForObjectDetection`. This is the
+  real-time member of the tier; it decouples class embeddings from a task
+  prompt, so post-processing returns labels that map directly to the queried
+  classes and it runs its own NMS. It does not accept `text_threshold=`.
 
 ## Public API
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -84,7 +84,8 @@ casing (CamelCase) is intentionally preserved. See
 [`adr/0007-libresam-contract.md`](adr/0007-libresam-contract.md).
 
 The open-vocabulary detector tier is also separate from the checkpoint factory.
-Its weights-directory prefixes (`LibreGroundingDINO`, `LibreOWLv2`) identify
+Its weights-directory prefixes (`LibreGroundingDINO`, `LibreOWLv2`,
+`LibreOMDetTurbo`) identify
 downloaded Hugging Face snapshots, not `Libre<FAMILY><size>.pt` checkpoints.
 These models are discriminative text-conditioned detectors with calibrated
 scores; they are not VLMs. Upstream brand casing is intentionally preserved.
@@ -133,6 +134,7 @@ Open-vocabulary detector snapshot families use their own size codes:
 |---|---|
 | `grounding_dino` | `t` (Swin-T), `b` (Swin-B) |
 | `owlv2` | `b16` (base patch-16 ensemble), `l14` (large patch-14 ensemble) |
+| `omdet_turbo` | `t` (Swin-T, the only released checkpoint) |
 
 Notes:
 
@@ -302,6 +304,9 @@ weights/LibreGroundingDINOb/
 # owlv2 - Hugging Face snapshot, no .pt checkpoint filename
 weights/LibreOWLv2b16/
 weights/LibreOWLv2l14/
+
+# omdet_turbo - Hugging Face snapshot, no .pt checkpoint filename
+weights/LibreOMDetTurbot/
 ```
 
 ### Gaze (inference-only)

--- a/docs/openvocab_design.md
+++ b/docs/openvocab_design.md
@@ -19,9 +19,17 @@ labels directly.
 |---|---|---|---|
 | `grounding-dino`, `grounding-dino-tiny`, `grounding-dino-base` | Grounding DINO | tiny | Apache-2.0 |
 | `owlv2`, `owlv2-base`, `owlv2-large` | OWLv2 | base-patch16 ensemble | Apache-2.0 |
+| `omdet-turbo`, `omdet`, `omdet-turbo-swin-tiny` | OMDet-Turbo | Swin-T | Apache-2.0 |
 
 The authoritative alias table is `_ALIASES` in
 `libreyolo/models/openvocab/__init__.py`.
+
+OMDet-Turbo is the real-time member of the tier. It is an RT-DETR-based
+open-vocabulary detector that decouples class embeddings from a task prompt,
+which lets it cache text embeddings and run its own NMS in post-processing.
+Because the classes are decoupled, its post-processing returns labels that map
+directly back to the queried class list (no phrase disambiguation like Grounding
+DINO). It does not expose `text_threshold=`.
 
 Weights are loaded from LibreYOLO-owned Hugging Face mirror repositories:
 
@@ -29,6 +37,7 @@ Weights are loaded from LibreYOLO-owned Hugging Face mirror repositories:
 - `LibreYOLO/LibreGroundingDINOb`
 - `LibreYOLO/LibreOWLv2b16`
 - `LibreYOLO/LibreOWLv2l14`
+- `LibreYOLO/LibreOMDetTurbot`
 
 The model cards in those repos record the original upstream source repos.
 

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -116,6 +116,7 @@ def __getattr__(name):
         "LibreOpenVocab": (".models.openvocab", "LibreOpenVocab"),
         "LibreGroundingDINO": (".models.openvocab", "LibreGroundingDINO"),
         "LibreOWLv2": (".models.openvocab", "LibreOWLv2"),
+        "LibreOMDetTurbo": (".models.openvocab", "LibreOMDetTurbo"),
         "DATASETS_DIR": (".data", "DATASETS_DIR"),
         "load_data_config": (".data", "load_data_config"),
         "check_dataset": (".data", "check_dataset"),
@@ -181,6 +182,7 @@ __all__ = [
     "LibreOpenVocab",
     "LibreGroundingDINO",
     "LibreOWLv2",
+    "LibreOMDetTurbo",
     # Results
     "Results",
     "Boxes",

--- a/libreyolo/models/openvocab/__init__.py
+++ b/libreyolo/models/openvocab/__init__.py
@@ -11,6 +11,7 @@ from typing import Dict, Tuple, Type
 
 from .base import LibreOpenVocabDetector
 from .grounding_dino import LibreGroundingDINO
+from .omdet_turbo import LibreOMDetTurbo
 from .owlv2 import LibreOWLv2
 
 _ALIASES: Dict[str, Tuple[Type[LibreOpenVocabDetector], str]] = {
@@ -34,6 +35,12 @@ _ALIASES: Dict[str, Tuple[Type[LibreOpenVocabDetector], str]] = {
     "owl-v2-large": (LibreOWLv2, "l14"),
     "owlv2-l14": (LibreOWLv2, "l14"),
     "owl-v2-l14": (LibreOWLv2, "l14"),
+    "omdet-turbo": (LibreOMDetTurbo, "t"),
+    "omdet": (LibreOMDetTurbo, "t"),
+    "omdetturbo": (LibreOMDetTurbo, "t"),
+    "omdet-turbo-tiny": (LibreOMDetTurbo, "t"),
+    "omdet-turbo-swin-tiny": (LibreOMDetTurbo, "t"),
+    "omdet-turbo-t": (LibreOMDetTurbo, "t"),
 }
 
 _DEFAULT_MODEL = "grounding-dino-tiny"
@@ -59,4 +66,5 @@ __all__ = [
     "LibreOpenVocabDetector",
     "LibreGroundingDINO",
     "LibreOWLv2",
+    "LibreOMDetTurbo",
 ]

--- a/libreyolo/models/openvocab/base.py
+++ b/libreyolo/models/openvocab/base.py
@@ -415,6 +415,46 @@ class LibreOpenVocabDetector(BaseModel):
         }
 
     # ---------------------------------------------------------------------
+    # Label -> class-id mapping (shared by direct-label families)
+    # ---------------------------------------------------------------------
+
+    def _labels_to_class_ids(self, labels: Any) -> torch.Tensor:
+        """Map a processor's per-detection labels to vocabulary class ids.
+
+        Handles both integer query indices and decoded label strings. Unknown
+        or out-of-range labels map to ``-1`` so the caller can drop them.
+        """
+        if isinstance(labels, torch.Tensor):
+            class_ids = labels.detach().cpu().long().reshape(-1)
+        else:
+            values = list(labels)
+            if not values:
+                return torch.zeros((0,), dtype=torch.int64)
+            if all(isinstance(value, (int, float)) for value in values):
+                class_ids = torch.as_tensor(values, dtype=torch.int64).reshape(-1)
+            else:
+                mapped = [self._text_label_to_class_id(str(value)) for value in values]
+                return torch.as_tensor(
+                    [-1 if class_id is None else class_id for class_id in mapped],
+                    dtype=torch.int64,
+                )
+        valid = (class_ids >= 0) & (class_ids < len(self.names))
+        return torch.where(valid, class_ids, torch.full_like(class_ids, -1))
+
+    def _text_label_to_class_id(self, text: str) -> Optional[int]:
+        phrase = _label_tokens(text)
+        matches = []
+        for class_id, name in self.names.items():
+            label = _label_tokens(name)
+            if phrase == label:
+                return class_id
+            if _contains_subsequence(phrase, label) or _contains_subsequence(
+                label, phrase
+            ):
+                matches.append(class_id)
+        return matches[0] if len(matches) == 1 else None
+
+    # ---------------------------------------------------------------------
     # Out of scope for v1
     # ---------------------------------------------------------------------
 

--- a/libreyolo/models/openvocab/omdet_turbo.py
+++ b/libreyolo/models/openvocab/omdet_turbo.py
@@ -1,4 +1,4 @@
-"""OWLv2 open-vocabulary detector adapter."""
+"""OMDet-Turbo open-vocabulary detector adapter."""
 
 from __future__ import annotations
 
@@ -10,43 +10,53 @@ from .base import _INSTALL_HINT
 from .base import LibreOpenVocabDetector
 
 
-class LibreOWLv2(LibreOpenVocabDetector):
-    """OWLv2 zero-shot object detector loaded through ``transformers``."""
+class LibreOMDetTurbo(LibreOpenVocabDetector):
+    """OMDet-Turbo real-time zero-shot detector loaded through ``transformers``.
 
-    FAMILY = "owlv2"
-    FILENAME_PREFIX = "LibreOWLv2"
+    Unlike Grounding DINO, OMDet-Turbo decouples the class embeddings from the
+    task prompt, so its post-processing returns labels that map directly back to
+    the queried class list. There is no phrase-to-class disambiguation. It also
+    runs its own NMS inside ``post_process_grounded_object_detection``.
+    """
+
+    FAMILY = "omdet_turbo"
+    FILENAME_PREFIX = "LibreOMDetTurbo"
     HF_REPOS: ClassVar[Dict[str, str]] = {
-        "b16": "LibreYOLO/LibreOWLv2b16",
-        "l14": "LibreYOLO/LibreOWLv2l14",
+        "t": "LibreYOLO/LibreOMDetTurbot",
     }
     # Informational only: the HF processor owns resizing and predict(imgsz=...)
-    # is rejected by the open-vocab base. Values mirror the published configs.
-    INPUT_SIZES: ClassVar[Dict[str, int]] = {"b16": 960, "l14": 1008}
-    DEFAULT_CONF: ClassVar[float] = 0.1
-    PROMPT_TEMPLATE: ClassVar[str] = "a photo of a {}"
+    # is rejected by the open-vocab base. Mirrors the published config image_size.
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {"t": 640}
+    DEFAULT_CONF: ClassVar[float] = 0.3
+    # OMDet-Turbo applies its own NMS in post-processing (independent of the
+    # LibreYOLO NMS path, which this tier does not run). ``iou=`` is ignored by
+    # the base __call__, so this fixed default owns box suppression.
+    NMS_THRESHOLD: ClassVar[float] = 0.5
+    TASK_TEMPLATE: ClassVar[str] = "Detect {}."
 
     def _load_pretrained(self, snapshot_dir: str):
         try:
-            from transformers import AutoProcessor, Owlv2ForObjectDetection
+            from transformers import AutoProcessor, OmDetTurboForObjectDetection
         except ImportError as exc:
             raise ImportError(_INSTALL_HINT) from exc
-        model = Owlv2ForObjectDetection.from_pretrained(
+        model = OmDetTurboForObjectDetection.from_pretrained(
             snapshot_dir, dtype=self._resolve_dtype()
         )
         processor = AutoProcessor.from_pretrained(snapshot_dir)
         return model, processor
 
-    def _text_labels(self) -> list[list[str]]:
-        labels = []
-        for class_id in range(len(self.names)):
-            name = str(self.names[class_id]).strip().lower()
-            labels.append(self.PROMPT_TEMPLATE.format(name))
-        return [labels]
+    def _class_names(self) -> list[str]:
+        return [str(self.names[class_id]) for class_id in range(len(self.names))]
+
+    def _task_prompt(self, names: list[str]) -> str:
+        return self.TASK_TEMPLATE.format(", ".join(names))
 
     def _build_inputs(self, img: Any) -> Any:
+        names = self._class_names()
         return self.processor(
-            text=self._text_labels(),
             images=img,
+            text=names,
+            task=self._task_prompt(names),
             return_tensors="pt",
         )
 
@@ -61,18 +71,22 @@ class LibreOWLv2(LibreOpenVocabDetector):
         **kwargs,
     ) -> Dict:
         width, height = original_size
+        names = self._class_names()
         results = self.processor.post_process_grounded_object_detection(
             output,
+            text_labels=names,
             threshold=float(conf_thres),
+            nms_threshold=float(self.NMS_THRESHOLD),
             target_sizes=[(height, width)],
-            text_labels=self._text_labels(),
         )
         result = results[0]
         boxes = result.get("boxes", [])
         scores = result.get("scores", [])
-        raw_labels = result.get("labels")
+        raw_labels = result.get("text_labels")
         if raw_labels is None:
-            raw_labels = result.get("text_labels", [])
+            raw_labels = result.get("classes")
+        if raw_labels is None:
+            raw_labels = result.get("labels", [])
 
         class_ids = self._labels_to_class_ids(raw_labels)
         boxes_t = torch.as_tensor(boxes, dtype=torch.float32).reshape(-1, 4)
@@ -96,4 +110,4 @@ class LibreOWLv2(LibreOpenVocabDetector):
         )
 
 
-__all__ = ["LibreOWLv2"]
+__all__ = ["LibreOMDetTurbo"]

--- a/tests/e2e/test_openvocab_inference.py
+++ b/tests/e2e/test_openvocab_inference.py
@@ -49,6 +49,16 @@ def test_owlv2_base_predict_smoke():
     _assert_detection_smoke(result, {0: "person", 1: "dog", 2: "skateboard"})
 
 
+def test_omdet_turbo_predict_smoke():
+    pytest.importorskip("transformers")
+    from libreyolo import LibreOpenVocab
+
+    model = LibreOpenVocab("omdet-turbo", device="cpu")
+    model.set_classes(["person", "dog", "skateboard"])
+    result = model.predict(_sample_image(), conf=0.3)
+    _assert_detection_smoke(result, {0: "person", 1: "dog", 2: "skateboard"})
+
+
 def test_openvocab_val_raises_in_v1():
     pytest.importorskip("transformers")
     from libreyolo import LibreOpenVocab

--- a/tests/smoke/install_surface.py
+++ b/tests/smoke/install_surface.py
@@ -90,11 +90,16 @@ def _check_import_surface(expect_source: str, source_root: Path | None) -> None:
             )
 
     # The open-vocabulary detector tier follows the same lazy-import rule.
-    from libreyolo import LibreGroundingDINO, LibreOpenVocab, LibreOWLv2
+    from libreyolo import (
+        LibreGroundingDINO,
+        LibreOMDetTurbo,
+        LibreOpenVocab,
+        LibreOWLv2,
+    )
 
     if not callable(LibreOpenVocab):
         raise AssertionError("LibreOpenVocab import did not resolve to a callable")
-    for family in (LibreGroundingDINO, LibreOWLv2):
+    for family in (LibreGroundingDINO, LibreOWLv2, LibreOMDetTurbo):
         if not isinstance(family, type):
             raise AssertionError(
                 "Open-vocabulary detector export did not resolve to a class: "

--- a/tests/unit/test_openvocab.py
+++ b/tests/unit/test_openvocab.py
@@ -10,6 +10,7 @@ import torch
 from libreyolo.models.base.model import BaseModel
 from libreyolo.models.openvocab import LibreOpenVocab
 from libreyolo.models.openvocab.grounding_dino import LibreGroundingDINO
+from libreyolo.models.openvocab.omdet_turbo import LibreOMDetTurbo
 from libreyolo.models.openvocab.owlv2 import LibreOWLv2
 
 pytestmark = pytest.mark.unit
@@ -61,6 +62,9 @@ class TestFactoryAliases:
         assert _ALIASES["grounding-dino-base"] == (LibreGroundingDINO, "b")
         assert _ALIASES["owlv2"] == (LibreOWLv2, "b16")
         assert _ALIASES["owl-v2-large"] == (LibreOWLv2, "l14")
+        assert _ALIASES["omdet-turbo"] == (LibreOMDetTurbo, "t")
+        assert _ALIASES["omdet"] == (LibreOMDetTurbo, "t")
+        assert _ALIASES["omdet-turbo-swin-tiny"] == (LibreOMDetTurbo, "t")
 
     def test_unknown_alias_raises_before_loading(self):
         with pytest.raises(ValueError, match="Unknown open-vocabulary detector"):
@@ -117,6 +121,18 @@ class TestCallDefaults:
         m = _bare(LibreOWLv2)
         assert m("image.jpg") == "ok"
         assert captured["conf"] == pytest.approx(0.1)
+
+    def test_omdet_turbo_default_conf_is_injected(self, monkeypatch):
+        captured = {}
+
+        def fake_call(self, source=None, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        monkeypatch.setattr(BaseModel, "__call__", fake_call)
+        m = _bare(LibreOMDetTurbo)
+        assert m("image.jpg") == "ok"
+        assert captured["conf"] == pytest.approx(0.3)
 
     def test_explicit_conf_is_preserved(self, monkeypatch):
         captured = {}
@@ -347,6 +363,81 @@ class TestOWLv2Mapping:
 
         m.processor = Processor()
         det = m._postprocess(object(), 0.1, 0.45, (20, 20))
+        assert det["num_detections"] == 1
+        assert det["classes"].tolist() == [1]
+
+
+class TestOMDetTurboMapping:
+    def test_task_prompt_lists_all_classes(self):
+        m = _bare(LibreOMDetTurbo)
+        m.set_classes(["person", "remote control"])
+        names = m._class_names()
+        assert names == ["person", "remote control"]
+        assert m._task_prompt(names) == "Detect person, remote control."
+
+    def test_build_inputs_passes_classes_and_task_to_processor(self):
+        m = _bare(LibreOMDetTurbo)
+        m.set_classes(["cat", "dog"])
+
+        captured = {}
+
+        class Processor:
+            def __call__(self, *, images, text, task, return_tensors):
+                captured.update(images=images, text=text, task=task, rt=return_tensors)
+                return {"ok": True}
+
+        m.processor = Processor()
+        sentinel = object()
+        out = m._build_inputs(sentinel)
+        assert out == {"ok": True}
+        assert captured["images"] is sentinel
+        assert captured["text"] == ["cat", "dog"]
+        assert captured["task"] == "Detect cat, dog."
+        assert captured["rt"] == "pt"
+
+    def test_postprocess_maps_text_labels_directly(self):
+        m = _bare(LibreOMDetTurbo)
+        m.set_classes(["cat", "dog"])
+
+        class Processor:
+            def post_process_grounded_object_detection(self, *args, **kwargs):
+                return [
+                    {
+                        "boxes": torch.tensor(
+                            [
+                                [1.0, 2.0, 10.0, 12.0],
+                                [3.0, 4.0, 9.0, 11.0],
+                                [0.0, 0.0, 5.0, 5.0],
+                            ]
+                        ),
+                        "scores": torch.tensor([0.9, 0.8, 0.7]),
+                        # "elephant" is not in the vocabulary -> dropped.
+                        "text_labels": ["dog", "cat", "elephant"],
+                    }
+                ]
+
+        m.processor = Processor()
+        det = m._postprocess(object(), 0.3, 0.45, (20, 20))
+        assert det["num_detections"] == 2
+        assert det["classes"].tolist() == [1, 0]
+
+    def test_postprocess_falls_back_to_classes_key(self):
+        m = _bare(LibreOMDetTurbo)
+        m.set_classes(["cat", "dog"])
+
+        class Processor:
+            def post_process_grounded_object_detection(self, *args, **kwargs):
+                # Older transformers used the integer "classes" key.
+                return [
+                    {
+                        "boxes": torch.tensor([[1.0, 2.0, 10.0, 12.0]]),
+                        "scores": torch.tensor([0.9]),
+                        "classes": torch.tensor([1]),
+                    }
+                ]
+
+        m.processor = Processor()
+        det = m._postprocess(object(), 0.3, 0.45, (20, 20))
         assert det["num_detections"] == 1
         assert det["classes"].tolist() == [1]
 


### PR DESCRIPTION
LibreOMDetTurbo joins LibreGroundingDINO and LibreOWLv2 in the LibreOpenVocab tier. It is the real-time member: an RT-DETR-based open-vocabulary detector that decouples class embeddings from a task prompt, so its post-processing returns labels that map directly back to the queried classes (no phrase disambiguation) and it runs its own NMS. Backed by the Apache-2.0 transformers OmDetTurboForObjectDetection; weights mirror from LibreYOLO/LibreOMDetTurbot.

Also promotes the shared label->class-id mappers (_labels_to_class_ids and _text_label_to_class_id) from LibreOWLv2 to the base so both direct-label families reuse them.

Aliases: omdet-turbo, omdet, omdet-turbo-swin-tiny (size t, Swin-T). Adds unit + gated e2e coverage and extends docs/ADR-0008/nomenclature.