### PR TITLE
Add skill for launching serverless / rented GPU jobs

### DIFF
--- a/skills/launch-serverless-gpu-job/SKILL.md
+++ b/skills/launch-serverless-gpu-job/SKILL.md
@@ -47,6 +47,26 @@ Every path here spends real money the moment a GPU spins up.
 - **Pull/persist checkpoints at milestones** (to HF or a volume) so a crash or
   credit-out never loses the model.
 
+## Where to put the data
+
+Decide this before launching — a slow staging path can cost more than the GPU
+time it delays.
+
+- **Dataset → one tar in a Hugging Face dataset repo** (the default). HF's CDN
+  serves ~100 MB/s to every provider, the same recipe works on Vast, Modal and
+  Beam, and a private repo only needs `HF_TOKEN` in the job env. Pack it once
+  (`tar cf mydata.tar mydata/`), upload
+  (`huggingface-cli upload <you>/<name> mydata.tar --repo-type dataset`), and
+  stage it on-box with `hf_hub_download` — `onstart/train.sh.tmpl` does exactly
+  this.
+- **Don't** scp a dataset up from your home connection, and don't pull from slow
+  origins on the box (cocodataset.org throttles one connection to ~2 MB/s; if you
+  must, `aria2c -x16 -s16 -k1M <url>` recovers it).
+- **Checkpoints / results → push back to HF (or a provider Volume) at
+  milestones**, not just at the end — the box is ephemeral, so a crash,
+  preemption, or running out of credit otherwise loses the run. On Vast, also
+  `pull` a local copy before `destroy`.
+
 ---
 
 ## Provider 1 — Vast.ai (rent + drive + destroy)
@@ -114,8 +134,6 @@ $PY $SK audit                                       # end-of-session: is anythin
 - `onstart/train.sh.tmpl` — training template: installs the tools the bare pytorch
   image lacks (git/aria2/unzip + cv2 libs), stages a dataset from HF, runs your
   `TRAIN_CMD`, writes `/root/JOB_DONE`. Fill the `__ALL_CAPS__` placeholders.
-  Fast dataset tip: HF CDN ≈ 100 MB/s; cocodataset.org throttles one connection to
-  ~2 MB/s, so `aria2c -x16 -s16 -k1M <url>` (≈144 MB/s).
 
 ### Vast gotchas (baked into the helper)
 

--- a/skills/launch-serverless-gpu-job/SKILL.md
+++ b/skills/launch-serverless-gpu-job/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: launch-serverless-gpu-job
+description: >-
+  Launch a one-off / batch GPU job (training, evaluation, export, benchmarking)
+  on a rented or serverless GPU when you don't have a local one — or need a
+  bigger/faster card than you have. Covers three providers: Vast.ai (cheap
+  marketplace GPUs you rent + tear down; fully automated here via a helper CLI),
+  Modal (managed serverless, per-second, auto scale-to-zero — what LibreYOLO's
+  own nightly e2e runs on), and Beam (managed serverless, simple decorator). Use
+  whenever someone wants to "run this on a cloud GPU", "train on a rented GPU",
+  "spin up a GPU for a job", "launch on Vast/Modal/Beam", or check what's still
+  billing. NOT for standing inference endpoints / autoscaling serving — this is
+  for batch jobs that start, do work, and stop.
+---
+
+# Launch a serverless / rented GPU job
+
+For running a **batch job** — a training run, a `val` sweep, an export, a
+benchmark — on someone else's GPU and only paying for the run. Three providers,
+one decision up front, then follow that provider's section.
+
+## Pick the provider first
+
+| | **Vast.ai** | **Modal** | **Beam** |
+|---|---|---|---|
+| Model | Marketplace: you rent a raw box, drive it over SSH, **destroy it yourself** | Managed serverless: job is a decorated Python fn, runs on demand | Managed serverless: job is a decorated Python fn |
+| Teardown | **Manual** — a forgotten box bills until destroyed (the main risk) | **Automatic** — scales to zero when the fn returns | **Automatic** — scales to zero |
+| Cost | Cheapest raw $/hr (e.g. RTX 4090 ~$0.35/hr) | Higher $/hr, but per-second and no idle waste | Per-second, autoscale |
+| Best for | Long training on a tight budget; any GPU you can name | Reproducible batch jobs & CI; caching across runs | Quick jobs with a tiny bit of setup |
+| In this repo | helper `scripts/vast_job.py` (full lifecycle) | **already used**: `tools/ci/modal_nightly.py` runs nightly e2e | — |
+| Setup cost | Vast account + API key + 2FA + SSH key | `pip install modal` + `modal token new` | `pip install beam-client` + `beam configure` |
+
+Rule of thumb: **Modal** if you want a job that provisions, runs, and cleans
+itself up with no teardown discipline (and LibreYOLO already has a working
+example). **Vast** when raw $/hr matters and you'll babysit it. **Beam** for a
+quick managed job with a minimal API.
+
+## Universal money safety
+
+Every path here spends real money the moment a GPU spins up.
+
+- **Vast** bills wall-clock until you `destroy`, and a *stopped* box still bills
+  its disk — this is the big trap; use `audit` / `guard` / `destroy` (below).
+- **Modal / Beam** scale to zero when the function returns, so a forgotten box is
+  much less likely — but a hung or infinite-timeout job **still bills**. Always
+  set a `timeout=`, and don't leave an interactive session holding a GPU.
+- **Pull/persist checkpoints at milestones** (to HF or a volume) so a crash or
+  credit-out never loses the model.
+
+---
+
+## Provider 1 — Vast.ai (rent + drive + destroy)
+
+Everything goes through one stdlib-only helper that bakes in the sharp edges
+(2FA-gated ops, transient offers, `-y`-on-destroy, ssh-detach, banner-tolerant
+ssh). Run any Python:
+
+```bash
+export PYTHONUTF8=1                       # avoids Windows console crashes
+PY=python                                 # any python; the helper is stdlib-only
+SK=skills/launch-serverless-gpu-job/scripts/vast_job.py
+$PY $SK <command> ...
+# commands: preflight tfa-login launch wait list cost audit ssh exec tail pull logs guard destroy destroy-all
+```
+
+### One-time setup
+
+```bash
+python -m venv ~/.vast-cli
+~/.vast-cli/Scripts/python -m pip install vastai   # Windows; Linux/mac: ~/.vast-cli/bin/pip
+vastai set api-key <YOUR_KEY>                       # key needs FULL instance permissions
+vastai tfa login --method-type totp -c <6-digit>    # 2FA session, lasts ~7 days
+$PY $SK preflight                                    # expect: authenticated + 2FA active + SSH key
+```
+
+The helper finds the `vastai` binary via `~/.vast-cli` or PATH; override with
+`VAST_BIN=/path/to/vastai`. SSH pubkey defaults to `~/.ssh/id_ed25519.pub`
+(override with `VAST_PUBKEY`).
+
+- `FAIL: no API key` → the **user** runs `vastai set api-key` (never paste a key
+  into chat; rotate any that leaks).
+- `FAIL: instance ops BLOCKED (no 2FA session)` → Vast requires a 2FA session for
+  **all** instance ops; ask the user for a TOTP code and run
+  `$PY $SK tfa-login --code NNNNNN`.
+
+### Launch → drive → tear down
+
+```bash
+$PY $SK launch --gpu RTX_4090 --max-price 0.6 --disk 40 --onstart <file.sh> --label myjob
+$PY $SK wait  <id>                                  # poll to running; prints COLD_START (~30s cached)
+$PY $SK exec  <id> --cmd "cd /root/repo && python train.py" --log /root/train.log
+$PY $SK tail  <id> /root/train.log -n 60            # watch a remote log
+$PY $SK pull  <id> /root/out/best.pt ~/ckpts/       # scp a checkpoint DOWN
+$PY $SK cost                                        # credit + running $/hr + runway
+$PY $SK destroy <id>                                # ALWAYS destroy when done
+$PY $SK audit                                       # end-of-session: is anything still billing?
+```
+
+- `--gpu` is Vast's `gpu_name` with underscores: `RTX_4090`, `RTX_5090`,
+  `RTX_3090`, `A100_SXM4`, `H100_SXM`. Omit for cheapest-of-any; `--gpu-ram 24000`
+  filters VRAM (MB). The helper searches many offers and retries across churn
+  (`no_such_ask ... not available` is normal, not an error).
+- Use **`exec`** (not `ssh`) for anything long-running: it detaches with
+  `</dev/null` so the job survives disconnect; then `tail` the log.
+- **Right-size by $/job, not $/hr.** A tiny model half-idles a 4090; a cheaper
+  card can be cheaper *per epoch* even if slower (watch VRAM).
+- For unattended runs, arm the watchdog in the background:
+  `$PY $SK guard <id> --max-hours 24 --done-file /root/JOB_DONE` (destroys on the
+  done-marker or timeout; best-effort — needs this process alive).
+
+### `onstart` scripts (provided)
+
+- `onstart/probe.sh` — first-launch health/throughput probe (GPU + download speed).
+- `onstart/train.sh.tmpl` — training template: installs the tools the bare pytorch
+  image lacks (git/aria2/unzip + cv2 libs), stages a dataset from HF, runs your
+  `TRAIN_CMD`, writes `/root/JOB_DONE`. Fill the `__ALL_CAPS__` placeholders.
+  Fast dataset tip: HF CDN ≈ 100 MB/s; cocodataset.org throttles one connection to
+  ~2 MB/s, so `aria2c -x16 -s16 -k1M <url>` (≈144 MB/s).
+
+### Vast gotchas (baked into the helper)
+
+1. 2FA session mandatory for instance ops (~7 days); no bypass.
+2. API keys can be permission-scoped (create/list yes; `show instance`/`logs` no)
+   → the helper falls back to SSH for logs.
+3. `destroy` needs `-y` or the raw CLI hangs *while billing*.
+4. Poll `instances-v1`, not `show instance` (often perm-gated).
+5. A **stopped** instance is not free — its disk bills until `destroy`. Run
+   `audit` after any crash/disconnect.
+
+---
+
+## Provider 2 — Modal (managed serverless)
+
+LibreYOLO already runs its **nightly e2e suite on Modal** — read
+`tools/ci/modal_nightly.py` as the canonical, working, in-repo example (it clones
+a ref, installs with `uv`, runs `make test_nightly` on an L4, and caches weights
+in a Modal Volume across runs). Copy that pattern for real jobs.
+
+Setup: `pip install modal` then `modal token new` (opens a browser).
+
+Minimal training job — a self-contained `modal_train.py`:
+
+```python
+import modal
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("git", "libgl1", "libglib2.0-0")     # cv2 system libs
+    .pip_install("libreyolo[rfdetr]")                  # or a git+https / wheel URL
+)
+app = modal.App("libreyolo-train")
+cache = modal.Volume.from_name("libreyolo-cache", create_if_missing=True)
+
+@app.function(gpu="A100", timeout=6 * 60 * 60, volumes={"/cache": cache})
+def train():
+    import os, torch
+    os.environ["HF_HOME"] = "/cache/hf"                # cache weights/datasets across runs
+    assert torch.cuda.is_available()
+    from libreyolo import LibreYOLO9
+    m = LibreYOLO9(None, "t")
+    m.train(data="coco.yaml", epochs=100, project="/cache/runs")
+    cache.commit()                                     # persist the volume
+
+@app.local_entrypoint()
+def main():
+    train.remote()                                     # runs on Modal's GPU
+```
+
+Run it: `modal run modal_train.py`.
+
+- GPU strings: `T4 L4 A10 L40S A100 A100-40GB A100-80GB H100 H200 B200`; multi-GPU
+  `gpu="H100:8"`; fallback preference `gpu=["H100", "A100-80GB"]`.
+- Billing is **per-second** and the container **scales to zero** when `train()`
+  returns — no box to forget. Still set `timeout=` so a hung run can't bill forever.
+- Persist anything you want to keep in the Volume (or push to HF) — the container
+  filesystem is ephemeral.
+
+---
+
+## Provider 3 — Beam (managed serverless)
+
+Setup: `pip install beam-client` then `beam configure` (paste the token from the
+Beam dashboard).
+
+Minimal job — `beam_train.py`:
+
+```python
+from beam import function, Image, Volume
+
+image = (
+    Image(python_version="python3.11")
+    .add_commands(["apt-get update && apt-get install -y libgl1 libglib2.0-0"])
+    .add_python_packages(["libreyolo[rfdetr]"])
+)
+
+@function(
+    gpu="RTX4090",                                     # or "A10G" / "H100"
+    image=image,
+    volumes=[Volume(name="libreyolo-cache", mount_path="./cache")],
+    timeout=86400,                                     # seconds; -1 disables (avoid)
+)
+def train():
+    import os, torch
+    os.environ["HF_HOME"] = "./cache/hf"
+    assert torch.cuda.is_available()
+    from libreyolo import LibreYOLO9
+    LibreYOLO9(None, "t").train(data="coco.yaml", epochs=100, project="./cache/runs")
+
+if __name__ == "__main__":
+    train.remote()                                     # runs on Beam's GPU
+```
+
+Run it: `python beam_train.py` (the `.remote()` call dispatches to Beam).
+
+- GPU menu is smaller than Modal/Vast: `A10G` (24Gi), `RTX4090` (24Gi),
+  `H100` (80Gi); `gpu=["H100","A10G"]` sets preference; multi-GPU via
+  `gpu_count=N` (by request).
+- Managed + autoscale-to-zero like Modal; per-second billing. Persist state to a
+  `Volume` (mounted into the container) or push to HF, since the container is
+  otherwise ephemeral. Keep a real `timeout` (never leave `-1` on a batch job).
+
+> Beam coverage here is intentionally minimal and less battle-tested than the Vast
+> and Modal paths. Verify the current decorator/GPU names against
+> https://docs.beam.cloud if a call is rejected.

--- a/skills/launch-serverless-gpu-job/onstart/probe.sh
+++ b/skills/launch-serverless-gpu-job/onstart/probe.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Probe onstart: report GPU + measure download throughput. Vast captures this
+# script's stdout to /var/log/onstart.log (read it with `vast_job.py logs <id>`).
+# Use this as a first launch to confirm a host is healthy and fast before you
+# commit a long training run to it.
+echo "PROBE_START $(date -u +%FT%TZ)"
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader 2>&1 || echo "nvidia-smi FAILED"
+# NOTE: speed.cloudflare.com/__down returns 403 from datacenter IPs. Use a large
+# public file (HuggingFace CDN) as the throughput probe instead.
+if command -v curl >/dev/null 2>&1; then
+  curl -o /dev/null -sL -w 'DL_RESULT bytes=%{size_download} sec=%{time_total} Bps=%{speed_download}\n' \
+    https://huggingface.co/bert-base-uncased/resolve/main/pytorch_model.bin
+else
+  python - <<'PY'
+import urllib.request, time
+u = "https://huggingface.co/bert-base-uncased/resolve/main/pytorch_model.bin"
+t = time.time(); n = 0; r = urllib.request.urlopen(u, timeout=120)
+while True:
+    b = r.read(1 << 20)
+    if not b: break
+    n += len(b)
+dt = time.time() - t
+print(f"DL_RESULT bytes={n} sec={dt:.2f} MBps={n/1e6/dt:.1f} Mbps={n*8/1e6/dt:.0f}")
+PY
+fi
+echo "PROBE_DONE $(date -u +%FT%TZ)"

--- a/skills/launch-serverless-gpu-job/onstart/train.sh.tmpl
+++ b/skills/launch-serverless-gpu-job/onstart/train.sh.tmpl
@@ -32,7 +32,8 @@ from huggingface_hub import hf_hub_download
 p = hf_hub_download(repo_id="$HF_DATASET_REPO", filename="$HF_DATASET_FILE",
                     repo_type="dataset", local_dir="/tmp/dl", token=os.environ.get("HF_TOKEN"))
 os.makedirs("/tmp/data", exist_ok=True)
-with tarfile.open(p) as t: t.extractall("/tmp/data")
+# filter="data" rejects absolute paths / ../ escapes (tarslip); also guards a malformed tar.
+with tarfile.open(p) as t: t.extractall("/tmp/data", filter="data")
 print("STAGED ->", "/tmp/data")
 PY
 
@@ -42,8 +43,14 @@ PY
 # "cannot import name (unknown location)". Installing the wheel (above) sidesteps this.
 mkdir -p /root/out
 echo "TRAIN: $TRAIN_CMD"
-bash -lc "$TRAIN_CMD" 2>&1 | tee /root/out/train.log
-
-echo "JOB_DONE $(date -u +%FT%TZ)" | tee /root/JOB_DONE
+# Only write JOB_DONE on SUCCESS. pipefail makes the pipeline reflect TRAIN_CMD's status
+# (not tee's), so `guard` never tears the box down on a FAILED run before you inspect it.
+if bash -lc "$TRAIN_CMD" 2>&1 | tee /root/out/train.log; then
+  echo "JOB_DONE $(date -u +%FT%TZ)" | tee /root/JOB_DONE
+else
+  rc=$?
+  echo "JOB_FAILED rc=$rc $(date -u +%FT%TZ)" | tee /root/JOB_FAILED
+  exit "$rc"
+fi
 # push best.pt to HF here if you want it to survive teardown, e.g.:
 #   huggingface-cli upload <you>/<run> /root/out/best.pt best.pt --repo-type model

--- a/skills/launch-serverless-gpu-job/onstart/train.sh.tmpl
+++ b/skills/launch-serverless-gpu-job/onstart/train.sh.tmpl
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Training onstart TEMPLATE. Fill the ALL_CAPS placeholders before use.
+# Stdout -> /var/log/onstart.log (read with `vast_job.py logs <id>`).
+# The launching side polls /root/JOB_DONE and destroys the box (or use `guard`).
+set -uo pipefail
+echo "JOB_START $(date -u +%FT%TZ)"
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+
+# --- 0. tools the bare pytorch image lacks (git/aria2/unzip + cv2 system libs) ---
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq git aria2 unzip libgl1 libglib2.0-0 libxcb1 libxrender1 libxext6 libsm6 2>&1 | tail -2
+
+# --- placeholders ---------------------------------------------------------------
+PIP_INSTALL="__PIP_INSTALL__"            # e.g. 'libreyolo[rfdetr]'  OR a git+https url  OR a .whl url
+HF_DATASET_REPO="__HF_DATASET_REPO__"    # e.g. <you>/coco-yolo  (a single tar; fastest, ~100 MB/s)
+HF_DATASET_FILE="__HF_DATASET_FILE__"    # e.g. coco.tar
+TRAIN_CMD="__TRAIN_CMD__"                # runs from the repo/CWD; writes checkpoints to /root/out
+# HF_TOKEN is injected via `--env '-e HF_TOKEN=...'` (needed for private HF datasets).
+# --------------------------------------------------------------------------------
+
+pip install -q huggingface_hub ${PIP_INSTALL:+"$PIP_INSTALL"} 2>&1 | tail -3
+
+# --- 1. stage the dataset to LOCAL ssd -----------------------------------------
+# Preferred: one tar on HF (fast, one clean source). If instead you pull COCO images
+# from cocodataset.org, use aria2 -x16 (single-connection is throttled to ~2 MB/s):
+#   aria2c -x16 -s16 -k1M -d /root/datasets/coco/images http://images.cocodataset.org/zips/train2017.zip
+echo "STAGE: $HF_DATASET_FILE from $HF_DATASET_REPO ..."
+python - <<PY
+import os, tarfile
+from huggingface_hub import hf_hub_download
+p = hf_hub_download(repo_id="$HF_DATASET_REPO", filename="$HF_DATASET_FILE",
+                    repo_type="dataset", local_dir="/tmp/dl", token=os.environ.get("HF_TOKEN"))
+os.makedirs("/tmp/data", exist_ok=True)
+with tarfile.open(p) as t: t.extractall("/tmp/data")
+print("STAGED ->", "/tmp/data")
+PY
+
+# --- 2. train ------------------------------------------------------------------
+# IMPORTANT: if you run a train script from a cloned repo, run it from INSIDE the repo
+# dir, or `import <pkg>` resolves to the repo folder (namespace pkg) and fails with
+# "cannot import name (unknown location)". Installing the wheel (above) sidesteps this.
+mkdir -p /root/out
+echo "TRAIN: $TRAIN_CMD"
+bash -lc "$TRAIN_CMD" 2>&1 | tee /root/out/train.log
+
+echo "JOB_DONE $(date -u +%FT%TZ)" | tee /root/JOB_DONE
+# push best.pt to HF here if you want it to survive teardown, e.g.:
+#   huggingface-cli upload <you>/<run> /root/out/best.pt best.pt --repo-type model

--- a/skills/launch-serverless-gpu-job/scripts/vast_job.py
+++ b/skills/launch-serverless-gpu-job/scripts/vast_job.py
@@ -331,6 +331,27 @@ def cmd_audit(a):
     return 1
 
 
+def destroy_verified(iid):
+    """Destroy an instance and CONFIRM it's gone. Returns an exit code:
+    0 = confirmed destroyed, 3 = 2FA gone so it could NOT be actioned/verified
+    (may still bill), 1 = command ran but the box is still present. Money safety
+    depends on never reporting success we didn't verify."""
+    rc, out, err = vast("destroy", "instance", str(iid), "-y", timeout=60)
+    if is_2fa_error(out, err):
+        print(f"FAIL: destroy BLOCKED for {iid} (no 2FA session) - IT MAY STILL BE BILLING. "
+              f"Run `tfa-login --code <TOTP>` then `destroy {iid}`.")
+        return 3
+    st = load_state(); st.pop(str(iid), None); save_state(st)
+    inst, ferr = find_instance(iid)
+    if ferr == "NEED_TFA":
+        print(f"WARN: destroy sent for {iid} but can't verify (2FA session gone). "
+              f"Re-run `tfa-login` then `list` to confirm it's gone.")
+        return 3
+    if inst is None:
+        print(f"destroyed {iid}"); return 0
+    print(f"WARN: {iid} STILL PRESENT ({inst.get('actual_status')}) - retry `destroy {iid}`."); return 1
+
+
 def cmd_ssh(a):
     inst = _resolve(a.id)
     out, err, rc = ssh_run(inst, a.cmd or "hostname && nvidia-smi -L", timeout=a.timeout)
@@ -338,7 +359,7 @@ def cmd_ssh(a):
         print(out)
     if err:
         print(err, file=sys.stderr)
-    return 0
+    return rc  # propagate the remote command's status so callers can gate on it
 
 
 def cmd_exec(a):
@@ -347,7 +368,11 @@ def cmd_exec(a):
     # </dev/null is REQUIRED or the ssh channel hangs on the backgrounded process.
     cmd = f"nohup bash -lc {shlex.quote(a.cmd)} </dev/null >{shlex.quote(log)} 2>&1 & echo EXEC_PID $!"
     out, err, rc = ssh_run(inst, cmd, timeout=90)
-    print((out or err).strip(), f"(log: {log}; watch with `tail {a.id} {log}`)")
+    if rc != 0 or "EXEC_PID" not in out:
+        # No background process was started - don't let automation tail a log that never appears.
+        print(f"FAIL: could not start detached job (ssh rc={rc}): {(err or out).strip()[:160]}")
+        return 1
+    print(out.strip(), f"(log: {log}; watch with `tail {a.id} {log}`)")
     return 0
 
 
@@ -398,32 +423,33 @@ def cmd_guard(a):
     while time.time() < deadline:
         inst, err = find_instance(a.id)
         if inst is None:
+            if err == "NEED_TFA":
+                # Can't observe the box, so we can't guarantee teardown - fail loud, don't assume gone.
+                print(f"WARN: 2FA session expired - guard can no longer observe or destroy {a.id}; "
+                      f"IT MAY STILL BE BILLING. Run `tfa-login` then `destroy {a.id}`.", flush=True)
+                return 3
             print("instance already gone"); return 0
         out, _, _ = ssh_run(inst, f"test -f {shlex.quote(a.done_file)} && echo DONE || echo RUN", tries=3)
         if "DONE" in out:
             print("JOB_DONE seen -> destroying", flush=True)
-            vast("destroy", "instance", str(a.id), "-y", timeout=60); return 0
+            return destroy_verified(a.id)
         time.sleep(a.interval)
     print(f"max-hours reached -> destroying {a.id}", flush=True)
-    vast("destroy", "instance", str(a.id), "-y", timeout=60)
-    return 0
+    return destroy_verified(a.id)
 
 
 def cmd_destroy(a):
-    vast("destroy", "instance", str(a.id), "-y", timeout=60)
-    st = load_state(); st.pop(str(a.id), None); save_state(st)
-    inst, _ = find_instance(a.id)
-    print(f"destroyed {a.id}" if inst is None else f"WARN: {a.id} still present ({inst.get('actual_status')})")
-    return 0
+    return destroy_verified(a.id)
 
 
 def cmd_destroy_all(a):
     d, err = list_instances()
     if d is None:
         print("NEED_TFA"); return 3
-    for i in d:
-        vast("destroy", "instance", str(i["id"]), "-y", timeout=60); print(f"destroyed {i['id']}")
+    failed = [i["id"] for i in d if destroy_verified(i["id"]) != 0]
     save_state({})
+    if failed:
+        print(f"WARN: {len(failed)} instance(s) NOT confirmed destroyed: {failed} - run `audit`."); return 1
     return 0
 
 

--- a/skills/launch-serverless-gpu-job/scripts/vast_job.py
+++ b/skills/launch-serverless-gpu-job/scripts/vast_job.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""vast_job.py - Vast.ai GPU job lifecycle helper for the launch-serverless-gpu-job skill.
+
+One helper so renting a GPU, driving a job on it, and tearing it down is a few lines.
+Encodes the edges found running real GPU training jobs on Vast.ai's marketplace:
+2FA-gated instance ops, transient offers, `-y` on destroy, `instances-v1` polling, the
+`</dev/null` ssh-detach trap, and banner-tolerant ssh.
+
+Commands:
+  preflight                          auth + 2FA-session + ssh-key check
+  tfa-login  --code NNNNNN           open a ~7-day 2FA session (required for instance ops)
+  launch     [filters] [--onstart F] search cheapest matching offer(s), create, retry churn
+  wait  <id> [--timeout S]           poll until running; print COLD_START
+  list                               instances (+ $/hr, ssh endpoint)
+  cost                               credit + total running $/hr + runway estimate
+  audit                              hygiene sweep: EVERYTHING that still bills, any state
+                                     (running bills GPU+disk; stopped still bills disk);
+                                     exit 0 only when the account is clean
+  ssh   <id> --cmd "..."             run a command on the box (robust; banners stripped)
+  exec  <id> --cmd "..." [--log P]   start a DETACHED process (survives disconnect)
+  tail  <id> <path> [-n N]           tail a remote log
+  pull  <id> <remote> <local> [-r]   scp a file/dir down (e.g. checkpoints)
+  logs  <id>                         the onstart log (/var/log/onstart.log)
+  guard <id> --max-hours H [--done-file P]   auto-destroy on JOB_DONE marker or timeout
+  destroy <id>                       destroy (always -y; else the CLI hangs while billing)
+  destroy-all                        destroy every running instance
+"""
+import argparse, json, os, shlex, subprocess, sys, time
+
+HOME = os.path.expanduser("~")
+
+
+def _default_vast_bin():
+    """Find the vastai CLI across OSes; fall back to PATH."""
+    for cand in (
+        os.path.join(HOME, ".vast-cli", "Scripts", "vastai.exe"),  # Windows venv
+        os.path.join(HOME, ".vast-cli", "bin", "vastai"),          # Linux/macOS venv
+    ):
+        if os.path.exists(cand):
+            return cand
+    return "vastai"  # rely on PATH (e.g. `pipx install vastai`)
+
+
+VAST = os.environ.get("VAST_BIN", _default_vast_bin())
+STATE = os.path.join(HOME, ".vast-cli", "state.json")
+PUBKEY = os.environ.get("VAST_PUBKEY", os.path.join(HOME, ".ssh", "id_ed25519.pub"))
+os.environ.setdefault("PYTHONUTF8", "1")
+DEFAULT_IMAGE = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime"
+
+_BANNER = ("Welcome to vast.ai", "Have fun!", "authentication fails",
+           "Permanently added", "double check your ssh key")
+_CONN_FAIL = ("Permission denied", "Connection refused", "Connection timed out",
+              "Could not resolve", "kex_exchange", "Connection closed",
+              "Operation timed out", "No route to host", "Connection reset")
+_ATTACHED = set()
+
+
+def vast(*args, timeout=180):
+    r = subprocess.run([VAST, *args], capture_output=True, text=True, timeout=timeout)
+    return r.returncode, r.stdout or "", r.stderr or ""
+
+
+def parse_json_blob(*texts):
+    for t in texts:
+        t = (t or "").strip()
+        if not t:
+            continue
+        try:
+            return json.loads(t)
+        except Exception:
+            for c in ("{", "["):
+                i = t.find(c)
+                if i >= 0:
+                    try:
+                        return json.loads(t[i:])
+                    except Exception:
+                        pass
+    return None
+
+
+def is_2fa_error(*texts):
+    b = " ".join(texts)
+    return "Two Factor Authentication" in b or "requires a 2FA session" in b
+
+
+def load_state():
+    try:
+        return json.load(open(STATE))
+    except Exception:
+        return {}
+
+
+def save_state(s):
+    os.makedirs(os.path.dirname(STATE), exist_ok=True)
+    json.dump(s, open(STATE, "w"), indent=2)
+
+
+def user_credit():
+    _, out, _ = vast("show", "user", "--raw")
+    u = parse_json_blob(out)
+    if not u:
+        return None
+    return (u[0] if isinstance(u, list) else u).get("credit")
+
+
+def list_instances():
+    _, out, err = vast("show", "instances-v1", "--raw")
+    if is_2fa_error(out, err):
+        return None, "NEED_TFA"
+    d = parse_json_blob(out)
+    if isinstance(d, dict):
+        d = d.get("instances") or d.get("results") or []
+    return (d or []), ""
+
+
+def find_instance(iid):
+    d, err = list_instances()
+    if d is None:
+        return None, err
+    for i in d:
+        if str(i.get("id")) == str(iid):
+            return i, ""
+    return None, ""
+
+
+# ---- robust SSH -----------------------------------------------------------
+def _strip(text):
+    return "\n".join(l for l in (text or "").splitlines()
+                     if not any(b in l for b in _BANNER)).strip()
+
+
+def _sshbase(inst):
+    return ["ssh", "-p", str(inst["ssh_port"]),
+            "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "ConnectTimeout=30", "-o", "ServerAliveInterval=15",
+            f"root@{inst['ssh_host']}"]
+
+
+def attach_key(inst):
+    iid = str(inst["id"])
+    if iid in _ATTACHED or not os.path.exists(PUBKEY):
+        return
+    vast("attach", "ssh", iid, open(PUBKEY).read().strip(), timeout=60)
+    _ATTACHED.add(iid)
+
+
+def ssh_run(inst, remote_cmd, timeout=120, tries=6):
+    """Run a command over ssh. Retries ONLY on connection-level failures - NOT on a
+    nonzero exit from the remote command (that is a valid result). Vast's login banner
+    is stripped. Returns (stdout, stderr, returncode)."""
+    attach_key(inst)
+    base = _sshbase(inst)
+    last = ""
+    for k in range(tries):
+        try:
+            r = subprocess.run(base + [remote_cmd], capture_output=True, text=True, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            last = "ssh timeout"; time.sleep(6); continue
+        conn_fail = r.returncode == 255 or any(m in (r.stderr or "") for m in _CONN_FAIL)
+        if conn_fail and k < tries - 1:
+            last = (r.stderr or "").strip(); time.sleep(6); continue
+        return _strip(r.stdout), _strip(r.stderr), r.returncode
+    return "", last, 255
+
+
+def _resolve(iid):
+    inst, err = find_instance(iid)
+    if inst is None:
+        print("NEED_TFA - run tfa-login" if err == "NEED_TFA" else f"instance {iid} not found")
+        sys.exit(3 if err == "NEED_TFA" else 1)
+    return inst
+
+
+# ---- commands -------------------------------------------------------------
+def cmd_preflight(a):
+    import shutil
+    if not (os.path.exists(VAST) or shutil.which(VAST)):
+        print(f"FAIL: vastai not found at {VAST} (set VAST_BIN or add vastai to PATH)"); return 2
+    cr = user_credit()
+    if cr is None:
+        print("FAIL: `show user` returned no JSON - is the API key set? (vastai set api-key <KEY>)"); return 2
+    print(f"OK: authenticated, credit=${cr:.2f}")
+    d, err = list_instances()
+    if d is None:
+        print("FAIL: instance ops BLOCKED (no 2FA session). Run:\n"
+              "  python vast_job.py tfa-login --code <6-digit TOTP>   (session lasts ~7 days)")
+        return 3
+    print(f"OK: 2FA session active. Running instances: {len(d)}")
+    print("OK: SSH key present." if os.path.exists(PUBKEY)
+          else f"WARN: no SSH key at {PUBKEY} - ssh/exec/tail/pull will not work.")
+    return 0
+
+
+def cmd_tfa_login(a):
+    _, out, err = vast("tfa", "login", "--method-type", "totp", "-c", str(a.code))
+    print((out or err).strip())
+    return 0 if "successful" in (out + err).lower() else 1
+
+
+def cmd_launch(a):
+    q = (f"rentable=true verified=true num_gpus={a.num_gpus} direct_port_count>=1 "
+         f"disk_space>={a.disk} inet_down>={a.min_down}")
+    if a.gpu:
+        q += f" gpu_name={a.gpu}"
+    if a.gpu_ram:
+        q += f" gpu_ram>={a.gpu_ram}"
+    _, out, err = vast("search", "offers", q, "-o", "dph+", "--raw")
+    if is_2fa_error(out, err):
+        print("NEED_TFA - run tfa-login first"); return 3
+    offers = [o for o in (parse_json_blob(out) or []) if o.get("dph_total", 1e9) <= a.max_price]
+    offers.sort(key=lambda o: o["dph_total"])
+    if not offers:
+        print(f"FAIL: no offers (gpu={a.gpu or 'any'} max_price={a.max_price} min_down={a.min_down} disk>={a.disk})")
+        return 1
+    print(f"{len(offers)} candidate offers; trying cheapest {min(a.tries, len(offers))}...")
+    for o in offers[:a.tries]:
+        oid = str(o["id"])
+        args = ["create", "instance", oid, "--image", a.image, "--disk", str(a.disk),
+                "--ssh", "--direct", "--cancel-unavail", "--label", a.label]
+        if a.onstart:
+            args += ["--onstart", a.onstart]
+        args += ["--raw"]
+        t0 = time.time()
+        _, out, err = vast(*args)
+        resp = parse_json_blob(out, err) or {}
+        if resp.get("success") and resp.get("new_contract"):
+            iid = resp["new_contract"]
+            st = load_state()
+            st[str(iid)] = {"create_ts": t0, "gpu": o.get("gpu_name"), "dph": o.get("dph_total"),
+                            "label": a.label}
+            save_state(st)
+            print(f"LAUNCHED instance_id={iid} gpu={o.get('gpu_name')} "
+                  f"${o.get('dph_total'):.3f}/hr down={o.get('inet_down')}Mbps")
+            if a.max_hours:
+                print(f"NOTE: run `guard {iid} --max-hours {a.max_hours}` (in the background) to auto-destroy.")
+            return 0
+        msg = (resp.get("msg") or err or out).strip()[:120]
+        if "no_such_ask" in msg or "not available" in msg:
+            print(f"  offer {oid} unavailable, next..."); continue
+        print(f"FAIL: create error on {oid}: {msg}"); return 1
+    print(f"FAIL: all {a.tries} candidates unavailable (marketplace churn); retry."); return 1
+
+
+def cmd_wait(a):
+    ct = load_state().get(str(a.id), {}).get("create_ts")
+    deadline = time.time() + a.timeout
+    last = None
+    while time.time() < deadline:
+        inst, err = find_instance(a.id)
+        if inst is None and err == "NEED_TFA":
+            print("NEED_TFA"); return 3
+        st = inst.get("actual_status") if inst else None
+        if st != last:
+            el = (time.time() - ct) if ct else -1
+            print(f"[{el:5.0f}s] status={st}"); last = st
+        if st == "running":
+            if ct:
+                print(f">>> COLD_START(create->running) = {time.time()-ct:.0f}s")
+            return 0
+        time.sleep(6)
+    print("TIMEOUT: not running"); return 1
+
+
+def cmd_list(a):
+    d, err = list_instances()
+    if d is None:
+        print("NEED_TFA"); return 3
+    if not d:
+        print("no instances"); return 0
+    for i in d:
+        print(f"  id={i.get('id')} {i.get('actual_status')} {i.get('gpu_name')} "
+              f"${i.get('dph_total',0):.3f}/hr {i.get('ssh_host')}:{i.get('ssh_port')} label={i.get('label')}")
+    return 0
+
+
+def cmd_cost(a):
+    cr = user_credit()
+    d, err = list_instances()
+    if d is None:
+        print("NEED_TFA"); return 3
+    total = sum(i.get("dph_total", 0) for i in d)
+    print(f"credit: ${cr:.2f}" if cr is not None else "credit: ?")
+    for i in d:
+        print(f"  id={i.get('id')} {i.get('gpu_name')} ${i.get('dph_total',0):.3f}/hr")
+    line = f"running total: ${total:.3f}/hr"
+    if cr and total:
+        line += f"  (~{cr/total:.1f}h GPU-only runway)"
+    print(line)
+    print("NOTE: Vast also bills disk (~$0.10-0.15/GB/mo) + one-time inbound bandwidth on top.")
+    return 0
+
+
+def cmd_audit(a):
+    """Hygiene sweep: list EVERY instance in ANY state and what it is still billing.
+    A running instance bills GPU + disk; a STOPPED/exited one still bills its disk
+    (~$0.10-0.15/GB/mo) until destroyed. Exit 0 = account clean; exit 1 = something
+    is billing (so scripts/agents can gate on it)."""
+    cr = user_credit()
+    d, err = list_instances()
+    if d is None:
+        print("NEED_TFA"); return 3
+    if not d:
+        print("CLEAN: no instances in any state - nothing billing GPU or disk.")
+        if cr is not None:
+            print(f"credit: ${cr:.2f}")
+        return 0
+    now = time.time()
+    gpu_total, disk_total = 0.0, 0.0
+    for i in d:
+        st = (i.get("actual_status") or i.get("cur_state") or "?").lower()
+        dph = i.get("dph_total") or 0
+        disk = i.get("disk_space") or 0
+        age = f"{(now - i['start_date'])/3600:.1f}h" if i.get("start_date") else "?"
+        disk_total += disk
+        if st == "running":
+            gpu_total += dph
+            note = f"RUNNING: bills ${dph:.3f}/hr GPU + disk"
+        else:
+            note = f"{st.upper()}: GPU off but its {disk:.0f}GB DISK STILL BILLS until destroyed"
+        print(f"  id={i.get('id')} {i.get('gpu_name')} label={i.get('label')} "
+              f"disk={disk:.0f}GB age={age} -> {note}")
+    print(f"TOTAL: ${gpu_total:.3f}/hr GPU + ~${disk_total*0.10:.2f}-{disk_total*0.15:.2f}/mo disk "
+          f"({disk_total:.0f} GB allocated)")
+    if cr is not None:
+        line = f"credit: ${cr:.2f}"
+        if gpu_total:
+            line += f"  (~{cr/gpu_total:.1f}h GPU-only runway)"
+        print(line)
+    print("Anything above is spending money. `destroy <id>` what you don't need - a stopped")
+    print("instance is NOT free. Deeper history: `vastai show invoices-v1` / `show audit-logs`.")
+    return 1
+
+
+def cmd_ssh(a):
+    inst = _resolve(a.id)
+    out, err, rc = ssh_run(inst, a.cmd or "hostname && nvidia-smi -L", timeout=a.timeout)
+    if out:
+        print(out)
+    if err:
+        print(err, file=sys.stderr)
+    return 0
+
+
+def cmd_exec(a):
+    inst = _resolve(a.id)
+    log = a.log or "/root/job.log"
+    # </dev/null is REQUIRED or the ssh channel hangs on the backgrounded process.
+    cmd = f"nohup bash -lc {shlex.quote(a.cmd)} </dev/null >{shlex.quote(log)} 2>&1 & echo EXEC_PID $!"
+    out, err, rc = ssh_run(inst, cmd, timeout=90)
+    print((out or err).strip(), f"(log: {log}; watch with `tail {a.id} {log}`)")
+    return 0
+
+
+def cmd_tail(a):
+    inst = _resolve(a.id)
+    out, err, rc = ssh_run(inst, f"tail -n {a.n} {shlex.quote(a.path)} | tr -d '\\r'", timeout=a.timeout)
+    print(out or err or "(empty)")
+    return 0
+
+
+def cmd_pull(a):
+    inst = _resolve(a.id)
+    attach_key(inst)
+    if not os.path.isdir(a.local):
+        os.makedirs(os.path.dirname(os.path.abspath(a.local)), exist_ok=True)
+    base = ["scp", "-P", str(inst["ssh_port"]), "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null", "-o", "ConnectTimeout=30"]
+    if a.recursive:
+        base.append("-r")
+    src = f"root@{inst['ssh_host']}:{a.remote}"
+    for k in range(4):
+        r = subprocess.run(base + [src, a.local], capture_output=True, text=True)
+        if r.returncode == 0:
+            print(f"pulled {a.remote} -> {a.local}"); return 0
+        if any(m in (r.stderr or "") for m in _CONN_FAIL) and k < 3:
+            time.sleep(6); continue
+        print(f"FAIL: {(r.stderr or '').strip()[:160]}"); return 1
+    return 1
+
+
+def cmd_logs(a):
+    rc, out, err = vast("logs", str(a.id), "--tail", "200")
+    if rc == 0 and "401" not in out and "lacks" not in (out + err):
+        print(out); return 0
+    print("(`vastai logs` unavailable on this key - reading /var/log/onstart.log over SSH)")
+    inst = _resolve(a.id)
+    out, err, rc = ssh_run(inst, "tail -n 200 /var/log/onstart.log 2>/dev/null | tr -d '\\r'")
+    print(out or "(empty)")
+    return 0
+
+
+def cmd_guard(a):
+    """Local watchdog: destroy the instance when <done-file> appears or after --max-hours.
+    Best-effort money safety. NOTE: it needs THIS process alive (run it in the background);
+    it is not a true instance-side self-destruct."""
+    deadline = time.time() + a.max_hours * 3600
+    print(f"guarding {a.id}: destroy on {a.done_file} or after {a.max_hours}h", flush=True)
+    while time.time() < deadline:
+        inst, err = find_instance(a.id)
+        if inst is None:
+            print("instance already gone"); return 0
+        out, _, _ = ssh_run(inst, f"test -f {shlex.quote(a.done_file)} && echo DONE || echo RUN", tries=3)
+        if "DONE" in out:
+            print("JOB_DONE seen -> destroying", flush=True)
+            vast("destroy", "instance", str(a.id), "-y", timeout=60); return 0
+        time.sleep(a.interval)
+    print(f"max-hours reached -> destroying {a.id}", flush=True)
+    vast("destroy", "instance", str(a.id), "-y", timeout=60)
+    return 0
+
+
+def cmd_destroy(a):
+    vast("destroy", "instance", str(a.id), "-y", timeout=60)
+    st = load_state(); st.pop(str(a.id), None); save_state(st)
+    inst, _ = find_instance(a.id)
+    print(f"destroyed {a.id}" if inst is None else f"WARN: {a.id} still present ({inst.get('actual_status')})")
+    return 0
+
+
+def cmd_destroy_all(a):
+    d, err = list_instances()
+    if d is None:
+        print("NEED_TFA"); return 3
+    for i in d:
+        vast("destroy", "instance", str(i["id"]), "-y", timeout=60); print(f"destroyed {i['id']}")
+    save_state({})
+    return 0
+
+
+def main():
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("preflight").set_defaults(fn=cmd_preflight)
+    q = sub.add_parser("tfa-login"); q.add_argument("--code", required=True); q.set_defaults(fn=cmd_tfa_login)
+
+    l = sub.add_parser("launch")
+    l.add_argument("--gpu", default=""); l.add_argument("--gpu-ram", type=int, default=0)
+    l.add_argument("--num-gpus", type=int, default=1); l.add_argument("--max-price", type=float, default=0.6)
+    l.add_argument("--min-down", type=int, default=2000); l.add_argument("--disk", type=int, default=40)
+    l.add_argument("--image", default=DEFAULT_IMAGE); l.add_argument("--onstart", default="")
+    l.add_argument("--label", default="vast-job"); l.add_argument("--tries", type=int, default=8)
+    l.add_argument("--max-hours", type=float, default=0); l.set_defaults(fn=cmd_launch)
+
+    w = sub.add_parser("wait"); w.add_argument("id"); w.add_argument("--timeout", type=int, default=600); w.set_defaults(fn=cmd_wait)
+    sub.add_parser("list").set_defaults(fn=cmd_list)
+    sub.add_parser("cost").set_defaults(fn=cmd_cost)
+    sub.add_parser("audit").set_defaults(fn=cmd_audit)
+    s = sub.add_parser("ssh"); s.add_argument("id"); s.add_argument("--cmd", default=""); s.add_argument("--timeout", type=int, default=120); s.set_defaults(fn=cmd_ssh)
+    e = sub.add_parser("exec"); e.add_argument("id"); e.add_argument("--cmd", required=True); e.add_argument("--log", default=""); e.set_defaults(fn=cmd_exec)
+    t = sub.add_parser("tail"); t.add_argument("id"); t.add_argument("path"); t.add_argument("-n", type=int, default=40); t.add_argument("--timeout", type=int, default=60); t.set_defaults(fn=cmd_tail)
+    pl = sub.add_parser("pull"); pl.add_argument("id"); pl.add_argument("remote"); pl.add_argument("local"); pl.add_argument("-r", "--recursive", action="store_true"); pl.set_defaults(fn=cmd_pull)
+    g = sub.add_parser("logs"); g.add_argument("id"); g.set_defaults(fn=cmd_logs)
+    gu = sub.add_parser("guard"); gu.add_argument("id"); gu.add_argument("--max-hours", type=float, required=True)
+    gu.add_argument("--done-file", dest="done_file", default="/root/JOB_DONE"); gu.add_argument("--interval", type=int, default=300); gu.set_defaults(fn=cmd_guard)
+    d = sub.add_parser("destroy"); d.add_argument("id"); d.set_defaults(fn=cmd_destroy)
+    sub.add_parser("destroy-all").set_defaults(fn=cmd_destroy_all)
+
+    a = p.parse_args()
+    sys.exit(a.fn(a))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A provider-agnostic skill for running one-off batch jobs (train, val, export, benchmark) on a cloud GPU, with three paths:

- Vast.ai: a stdlib-only lifecycle helper (scripts/vast_job.py) that automates rent -> drive over SSH -> destroy, plus onstart probe/train templates. Encodes the sharp edges (2FA-gated ops, transient offers, -y on destroy, ssh-detach, stopped-disk billing).
- Modal: managed serverless, anchored on the in-repo nightly e2e app (tools/ci/modal_nightly.py) plus a minimal modal run example.
- Beam: managed serverless, minimal @function/Image/Volume example.

Leads with a provider-choice table and a universal money-safety section.