### PR TITLE
Revive YOLO9 instance segmentation (task='segment')

### DIFF
--- a/libreyolo/models/yolo9/loss.py
+++ b/libreyolo/models/yolo9/loss.py
@@ -672,3 +672,250 @@ class YOLO9Loss:
 
         return loss_dict
 
+
+def _crop_mask_loss(loss: Tensor, boxes_xyxy: Tensor) -> Tensor:
+    """Zero the per-pixel mask loss outside each positive's matched box.
+
+    YOLACT crops predicted masks to the detection box; at train time we crop
+    the loss instead so gradients only flow for pixels inside the box.
+
+    Args:
+        loss: (n, h, w) per-pixel loss for n positive instances.
+        boxes_xyxy: (n, 4) boxes in prototype-grid coordinates.
+    """
+    n, h, w = loss.shape
+    if n == 0:
+        return loss
+
+    x1, y1, x2, y2 = boxes_xyxy.unbind(dim=1)
+    rows = torch.arange(h, device=loss.device, dtype=loss.dtype)[None, :, None]
+    cols = torch.arange(w, device=loss.device, dtype=loss.dtype)[None, None, :]
+    keep = (
+        (cols >= x1[:, None, None])
+        & (cols < x2[:, None, None])
+        & (rows >= y1[:, None, None])
+        & (rows < y2[:, None, None])
+    )
+    return loss * keep
+
+
+class YOLO9SegmentationLoss(YOLO9Loss):
+    """YOLO9 detection loss plus YOLACT-style prototype-mask loss.
+
+    Reuses the detection assignment and box/DFL/class losses from
+    :class:`YOLO9Loss`, then adds a per-positive mask BCE between the predicted
+    mask (``coeffs @ proto``) and the ground-truth instance mask, cropped to
+    the matched box and normalized by box area (as in YOLACT / the YOLOv8-seg
+    recipe, both public).
+    """
+
+    def __init__(
+        self,
+        *args,
+        num_masks: int = 32,
+        mask_weight: float = 2.5,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.num_masks = num_masks
+        self.mask_weight = mask_weight
+
+    def _normalize_masks(self, masks, targets: Tensor, size: Tuple[int, int]) -> Tensor:
+        """Coerce the GT masks to ``(B, N, mask_h, mask_w)`` at prototype size."""
+        if masks is None:
+            raise ValueError(
+                "YOLO9 segmentation training requires per-instance masks. "
+                "Use YOLO segmentation labels or COCO segmentations."
+            )
+
+        if isinstance(masks, Tensor):
+            mask_tensor = masks.to(device=targets.device, dtype=targets.dtype)
+        else:
+            stacked = []
+            for item in masks:
+                if isinstance(item, Tensor):
+                    stacked.append(item)
+                else:
+                    stacked.append(torch.as_tensor(item))
+            mask_tensor = torch.stack(stacked, dim=0).to(
+                device=targets.device, dtype=targets.dtype
+            )
+
+        if mask_tensor.ndim == 3:
+            mask_tensor = mask_tensor.unsqueeze(0)
+        if tuple(mask_tensor.shape[-2:]) != tuple(size):
+            b, n, _, _ = mask_tensor.shape
+            mask_tensor = F.interpolate(
+                mask_tensor.reshape(b * n, 1, *mask_tensor.shape[-2:]),
+                size=size,
+                mode="nearest",
+            ).reshape(b, n, *size)
+        return mask_tensor
+
+    def _single_mask_loss(
+        self,
+        gt_masks: Tensor,
+        pred_coeffs: Tensor,
+        proto: Tensor,
+        boxes_xyxy: Tensor,
+        areas: Tensor,
+    ) -> Tensor:
+        if pred_coeffs.numel() == 0:
+            return proto.sum() * 0.0
+
+        c, h, w = proto.shape
+        pred_masks = (pred_coeffs @ proto.reshape(c, -1)).reshape(-1, h, w)
+        loss = F.binary_cross_entropy_with_logits(
+            pred_masks, gt_masks, reduction="none"
+        )
+        cropped = _crop_mask_loss(loss, boxes_xyxy)
+        return (cropped.mean(dim=(1, 2)) / areas.clamp_min(1e-6)).mean()
+
+    def __call__(
+        self,
+        predictions: List[Tensor],
+        targets: Tensor,
+        mask_coeffs: Tensor,
+        proto: Tensor,
+        masks=None,
+    ) -> Dict[str, Tensor]:
+        if self.vec2box is None:
+            raise RuntimeError("Vec2Box not initialized. Call update_anchors() first.")
+
+        preds_cls, preds_anc, preds_box = self.vec2box(predictions)
+
+        bsz = targets.shape[0]
+        img_w, img_h = self.vec2box.image_size
+        scale = torch.tensor(
+            [1, img_w, img_h, img_w, img_h],
+            device=targets.device,
+            dtype=targets.dtype,
+        )
+        targets_scaled = targets * scale
+
+        align_targets, valid_masks, matched_indices = self.matcher(
+            targets_scaled,
+            (preds_cls.detach(), preds_box.detach()),
+            return_indices=True,
+        )
+        targets_cls, targets_bbox = torch.split(
+            align_targets, (self.num_classes, 4), dim=-1
+        )
+
+        preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
+        targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
+
+        cls_norm = self._global_cls_norm(targets_cls)
+        box_norm = targets_cls.sum(-1)[valid_masks]
+
+        loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)
+        if valid_masks.any():
+            loss_box = self.box_loss(
+                preds_box_norm, targets_bbox_norm, valid_masks, box_norm, cls_norm
+            )
+            anchors_norm = (self.vec2box.anchor_grid / self.vec2box.scaler[:, None])[None]
+            loss_dfl = self.dfl_loss(
+                preds_anc,
+                targets_bbox_norm,
+                anchors_norm,
+                valid_masks,
+                box_norm,
+                cls_norm,
+            )
+        else:
+            loss_box = preds_box_norm.sum() * 0.0
+            loss_dfl = preds_anc.sum() * 0.0
+
+        # ---- Prototype mask loss -------------------------------------------
+        mask_h, mask_w = proto.shape[-2:]
+        gt_masks = self._normalize_masks(masks, targets, (mask_h, mask_w))
+        num_gt_masks = gt_masks.shape[1]
+        coeffs = mask_coeffs.permute(0, 2, 1).contiguous()  # (B, anchors, nm)
+
+        loss_mask = proto.sum() * 0.0
+        for batch_idx in range(bsz):
+            positives = valid_masks[batch_idx]
+            if not positives.any():
+                continue
+
+            target_idx = matched_indices[batch_idx][positives].long()
+
+            # Fix (issue #432 era): DO NOT clamp out-of-range matches onto the
+            # last mask — that silently trains a positive against a *different*
+            # instance's silhouette (mosaic concatenates 4 images, so the label
+            # count can exceed the rasterized-mask buffer). Drop those positives
+            # instead of corrupting the loss.
+            in_range = (target_idx >= 0) & (target_idx < num_gt_masks)
+            if not in_range.any():
+                continue
+            target_idx = target_idx[in_range]
+
+            matched_masks = gt_masks[batch_idx][target_idx]
+
+            # Fix: skip empty GT masks (padding rows and the mosaic
+            # empty-polygon placeholders rasterize to all-zeros; supervising
+            # them teaches the model to erase real objects).
+            nonempty = matched_masks.flatten(1).any(dim=1)
+            if not nonempty.any():
+                continue
+            keep = in_range.clone()
+            keep[in_range] = nonempty
+            matched_masks = matched_masks[nonempty]
+
+            matched_boxes = targets_bbox[batch_idx][positives][keep]
+            scale_boxes = matched_boxes / torch.tensor(
+                [img_w, img_h, img_w, img_h],
+                device=targets.device,
+                dtype=targets.dtype,
+            )
+            mask_boxes = scale_boxes * torch.tensor(
+                [mask_w, mask_h, mask_w, mask_h],
+                device=targets.device,
+                dtype=targets.dtype,
+            )
+            areas = (
+                (scale_boxes[:, 2] - scale_boxes[:, 0]).clamp_min(0)
+                * (scale_boxes[:, 3] - scale_boxes[:, 1]).clamp_min(0)
+            )
+
+            loss_mask = loss_mask + self._single_mask_loss(
+                matched_masks,
+                coeffs[batch_idx][positives][keep],
+                proto[batch_idx],
+                mask_boxes,
+                areas,
+            )
+
+        loss_box_weighted = self.box_weight * loss_box
+        loss_dfl_weighted = self.dfl_weight * loss_dfl
+        loss_cls_weighted = self.cls_weight * loss_cls
+        loss_mask_weighted = self.mask_weight * loss_mask / max(bsz, 1)
+
+        total_loss = (
+            loss_box_weighted
+            + loss_dfl_weighted
+            + loss_cls_weighted
+            + loss_mask_weighted
+        )
+
+        return {
+            "total_loss": total_loss,
+            "box_loss": loss_box_weighted,
+            "dfl_loss": loss_dfl_weighted,
+            "cls_loss": loss_cls_weighted,
+            "seg_loss": loss_mask_weighted,
+            "box": loss_box_weighted.item()
+            if isinstance(loss_box_weighted, Tensor)
+            else loss_box_weighted,
+            "dfl": loss_dfl_weighted.item()
+            if isinstance(loss_dfl_weighted, Tensor)
+            else loss_dfl_weighted,
+            "cls": loss_cls_weighted.item()
+            if isinstance(loss_cls_weighted, Tensor)
+            else loss_cls_weighted,
+            "seg": loss_mask_weighted.item()
+            if isinstance(loss_mask_weighted, Tensor)
+            else loss_mask_weighted,
+            "num_fg": valid_masks.sum().item() / max(bsz, 1),
+        }
+

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -50,9 +50,10 @@ class LibreYOLO9(BaseModel):
     FAMILY = "yolo9"
     FILENAME_PREFIX = "LibreYOLO9"
     INPUT_SIZES = {"t": 640, "s": 640, "m": 640, "c": 640}
-    SUPPORTED_TASKS = ("detect",)
+    SUPPORTED_TASKS = ("detect", "segment")
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,
+        "segment": INPUT_SIZES,
     }
     EXPERIMENTAL_WEIGHT_FILENAMES: frozenset = frozenset()
     TRAIN_CONFIG = YOLO9Config
@@ -132,6 +133,8 @@ class LibreYOLO9(BaseModel):
     @classmethod
     def detect_checkpoint_task(cls, weights_dict: dict) -> Optional[str]:
         """Infer YOLO9 task from task-specific head branches."""
+        if any(key.startswith("head.proto") for key in weights_dict):
+            return "segment"
         return None
 
     # =========================================================================
@@ -169,6 +172,7 @@ class LibreYOLO9(BaseModel):
             config=self.size,
             reg_max=self.reg_max,
             nb_classes=self.nb_classes,
+            task=self.task,
         )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:

--- a/libreyolo/models/yolo9/nn.py
+++ b/libreyolo/models/yolo9/nn.py
@@ -714,6 +714,108 @@ class DDetect(nn.Module):
         )
 
 
+class MaskProto(nn.Module):
+    """Prototype-mask branch for YOLO9 instance segmentation.
+
+    YOLACT-style prototype generator (Bolya et al., ICCV 2019, "YOLACT:
+    Real-time Instance Segmentation"): a small conv stack over the highest-
+    resolution neck feature (P3) that emits ``c_out`` prototype masks at
+    2x the P3 resolution. Per-instance masks are recovered downstream as a
+    linear combination of these prototypes with the head's mask coefficients.
+    """
+
+    def __init__(self, c1, c_mid=256, c_out=32):
+        super().__init__()
+        self.cv1 = Conv(c1, c_mid, 3)
+        self.up = nn.Upsample(scale_factor=2, mode="nearest")
+        self.cv2 = Conv(c_mid, c_mid, 3)
+        self.cv3 = Conv(c_mid, c_out, 1)
+
+    def forward(self, x):
+        return self.cv3(self.cv2(self.up(self.cv1(x))))
+
+
+class DDetectSeg(DDetect):
+    """YOLO9 detection head plus YOLACT-style prototype mask prediction.
+
+    Extends :class:`DDetect` with a :class:`MaskProto` prototype branch on the
+    P3 feature and a per-scale mask-coefficient tower (``cv4``). Detection is
+    unchanged and reuses the base towers/decode; segmentation adds ``nm`` mask
+    coefficients per anchor whose linear combination with the prototypes yields
+    the instance masks.
+
+    Checkpoint-format contract: the extra branches live at ``proto`` and
+    ``cv4`` — the presence of ``head.proto.*`` keys is what marks a checkpoint
+    as ``task='segment'`` (see ``model.py``).
+    """
+
+    def __init__(
+        self,
+        nc=80,
+        ch=(),
+        reg_max=16,
+        stride=(),
+        use_group=True,
+        num_masks=32,
+        proto_channels=256,
+    ):
+        super().__init__(
+            nc=nc, ch=ch, reg_max=reg_max, stride=stride, use_group=use_group
+        )
+        self.nm = num_masks
+        self.proto = MaskProto(ch[0], proto_channels, self.nm)
+        self._seg_loss_fn = None
+
+        # Mask-coefficient tower per scale (YOLACT prediction head), mirroring
+        # the box/class tower widths: a quarter of P3 channels, floored at nm.
+        c4 = max(ch[0] // 4, self.nm)
+        self.cv4 = nn.ModuleList(
+            nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nm, 1))
+            for x in ch
+        )
+
+    def _get_seg_loss_fn(self, device):
+        if self._seg_loss_fn is None:
+            from .loss import YOLO9SegmentationLoss
+
+            self._seg_loss_fn = YOLO9SegmentationLoss(
+                num_classes=self.nc,
+                reg_max=self.reg_max,
+                strides=self.stride.tolist(),
+                image_size=None,
+                device=device,
+                num_masks=self.nm,
+            )
+        return self._seg_loss_fn
+
+    def forward(self, x, targets=None, img_size=None, masks=None):
+        features = list(x)
+        proto = self.proto(features[0])
+        batch_size = proto.shape[0]
+        mask_coeffs = torch.cat(
+            [
+                self.cv4[i](features[i]).view(batch_size, self.nm, -1)
+                for i in range(self.nl)
+            ],
+            dim=2,
+        )
+
+        det_outputs = super().forward(features, targets=None, img_size=img_size)
+
+        if self.training:
+            if targets is not None:
+                loss_fn = self._get_seg_loss_fn(proto.device)
+                if img_size is not None:
+                    loss_fn.update_anchors(list(img_size))
+                return loss_fn(det_outputs, targets, mask_coeffs, proto, masks)
+            return det_outputs, mask_coeffs, proto
+
+        predictions, raw_outputs = det_outputs
+        if self.export:
+            return predictions, proto, mask_coeffs
+        return predictions, raw_outputs, proto, mask_coeffs
+
+
 # =============================================================================
 # Model Architecture Definitions
 # =============================================================================
@@ -1011,6 +1113,9 @@ class LibreYOLO9Model(nn.Module):
         reg_max=16,
         nb_classes=80,
         img_size=640,
+        task="detect",
+        num_masks=32,
+        proto_channels=256,
     ):
         """
         Initialize YOLOv9 model.
@@ -1020,6 +1125,10 @@ class LibreYOLO9Model(nn.Module):
             reg_max: Regression max value for DFL
             nb_classes: Number of classes
             img_size: Input image size
+            task: 'detect' (default) or 'segment' for YOLACT-style instance
+                segmentation, which swaps in the :class:`DDetectSeg` head.
+            num_masks: Number of prototype masks / mask coefficients (segment).
+            proto_channels: Hidden channels of the prototype branch (segment).
         """
         super().__init__()
 
@@ -1032,6 +1141,7 @@ class LibreYOLO9Model(nn.Module):
         self.nc = nb_classes
         self.reg_max = reg_max
         self.img_size = img_size
+        self.task = task
 
         cfg = YOLO9_CONFIGS[config]
 
@@ -1040,14 +1150,24 @@ class LibreYOLO9Model(nn.Module):
 
         # Detection head - use exact channels from config
         head_channels = cfg["head_channels"]
-        self.head = DDetect(
-            nc=nb_classes,
-            ch=head_channels,
-            reg_max=reg_max,
-            stride=(8, 16, 32),
-        )
+        if task == "segment":
+            self.head = DDetectSeg(
+                nc=nb_classes,
+                ch=head_channels,
+                reg_max=reg_max,
+                stride=(8, 16, 32),
+                num_masks=num_masks,
+                proto_channels=proto_channels,
+            )
+        else:
+            self.head = DDetect(
+                nc=nb_classes,
+                ch=head_channels,
+                reg_max=reg_max,
+                stride=(8, 16, 32),
+            )
 
-    def forward(self, x, targets=None):
+    def forward(self, x, targets=None, masks=None):
         """
         Forward pass through backbone, neck, and detection head.
 
@@ -1055,12 +1175,15 @@ class LibreYOLO9Model(nn.Module):
             x: Input tensor [B, 3, H, W]
             targets: Optional ground truth [B, max_targets, 5] with [class, x1, y1, x2, y2] normalized
                     Only used during training to compute loss.
+            masks: Optional per-instance GT masks for segmentation training.
 
         Returns:
             Training with targets: Dict with loss values (total_loss, box_loss, dfl_loss, cls_loss)
             Training without targets: Raw predictions (list of tensors)
             Inference: Dict with decoded predictions and features
         """
+        is_segment = self.task == "segment"
+
         # Backbone
         p3, p4, p5 = self.backbone(x)
 
@@ -1071,6 +1194,10 @@ class LibreYOLO9Model(nn.Module):
         if self.training and targets is not None:
             # Pass image size for anchor generation
             img_size = (x.shape[3], x.shape[2])  # (W, H)
+            if is_segment:
+                return self.head(
+                    [n3, n4, n5], targets=targets, img_size=img_size, masks=masks
+                )
             return self.head([n3, n4, n5], targets=targets, img_size=img_size)
 
         # Normal forward (training without targets or inference)
@@ -1080,7 +1207,23 @@ class LibreYOLO9Model(nn.Module):
             # Return raw outputs for loss calculation
             return output
 
-        # Inference mode
+        if is_segment:
+            # Export: DDetectSeg returns (predictions, proto, mask_coeffs).
+            if self.head.export:
+                return output
+            # DDetectSeg inference returns (y, raw_outputs, proto, mask_coeffs)
+            y, x_list, proto, mask_coeffs = output
+            return {
+                "predictions": y,
+                "raw_outputs": x_list,
+                "proto": proto,
+                "mask_coeffs": mask_coeffs,
+                "x8": {"features": n3},
+                "x16": {"features": n4},
+                "x32": {"features": n5},
+            }
+
+        # Inference mode (detect)
         y, x_list = output
 
         # Export mode: return only the prediction tensor for ONNX/TorchScript

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -104,11 +104,16 @@ class YOLO9Trainer(BaseTrainer):
         def _scalar(v):
             return v.item() if isinstance(v, torch.Tensor) else v
 
-        return {
+        components = {
             "box": _scalar(outputs.get("box", 0)),
             "cls": _scalar(outputs.get("cls", 0)),
             "dfl": _scalar(outputs.get("dfl", 0)),
         }
+        if "seg" in outputs:
+            components["seg"] = _scalar(outputs.get("seg", 0))
+        return components
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
+        if getattr(self.model, "task", "detect") == "segment":
+            return self.model(imgs, targets=targets, masks=polygons)
         return self.model(imgs, targets=targets)

--- a/tests/unit/test_segmentation.py
+++ b/tests/unit/test_segmentation.py
@@ -251,8 +251,10 @@ class TestFactorySegDetection:
         assert LibreYOLOX.get_download_url("LibreYOLOXs-seg.pt") is None
         assert LibreYOLO9.detect_size_from_filename("LibreYOLO9s.pt") == "s"
         assert LibreYOLO9.detect_task_from_filename("LibreYOLO9s.pt") is None
-        # YOLO9 is detect-only; legacy -seg filenames no longer match.
-        assert LibreYOLO9.detect_size_from_filename("LibreYOLO9s-seg.pt") is None
+        # YOLO9 supports instance segmentation, so -seg filenames resolve to
+        # size 's' and task 'segment' (as with the other seg-capable families).
+        assert LibreYOLO9.detect_size_from_filename("LibreYOLO9s-seg.pt") == "s"
+        assert LibreYOLO9.detect_task_from_filename("LibreYOLO9s-seg.pt") == "segment"
 
 
 class TestPolygonLabelParsing:

--- a/tests/unit/test_yolo9_seg.py
+++ b/tests/unit/test_yolo9_seg.py
@@ -1,0 +1,125 @@
+"""Unit tests for YOLO9 instance segmentation (task='segment').
+
+Covers the YOLACT-style head (MaskProto + DDetectSeg), the segmentation loss,
+the two mask/label-alignment bug fixes, checkpoint task detection, and the
+predict path producing masks.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.models.yolo9.model import LibreYOLO9
+from libreyolo.models.yolo9.nn import DDetectSeg, LibreYOLO9Model
+
+pytestmark = pytest.mark.unit
+
+
+def _build(nc=2, imgsz=160, size="t"):
+    model = LibreYOLO9Model(config=size, nb_classes=nc, img_size=imgsz, task="segment")
+    return model
+
+
+def test_segment_head_is_ddetectseg():
+    model = _build()
+    assert isinstance(model.head, DDetectSeg)
+    assert model.head.nm == 32
+    assert model.task == "segment"
+
+
+def test_inference_forward_returns_proto_and_coeffs():
+    model = _build(imgsz=160)
+    model.eval()
+    with torch.no_grad():
+        out = model(torch.rand(1, 3, 160, 160))
+    assert set(("predictions", "proto", "mask_coeffs")).issubset(out.keys())
+    # proto at input/4, one coeff vector per anchor
+    assert out["proto"].shape[-2:] == (40, 40)
+    assert out["mask_coeffs"].shape[1] == model.head.nm
+
+
+def test_training_loss_has_seg_component_and_backprops():
+    model = _build(nc=1, imgsz=160)
+    model.train()
+    x = torch.full((1, 3, 160, 160), 0.1)
+    x[:, :, 40:120, 40:120] = 0.9
+    targets = torch.zeros(1, 1, 5)
+    targets[0, 0] = torch.tensor([0, 0.25, 0.25, 0.75, 0.75])
+    masks = torch.zeros(1, 1, 40, 40)
+    masks[0, 0, 10:30, 10:30] = 1.0
+
+    ld = model(x, targets=targets, masks=masks)
+    assert "seg_loss" in ld and "seg" in ld
+    assert torch.isfinite(ld["total_loss"])
+    ld["total_loss"].backward()
+    # seg gradients reach the prototype branch and the coeff tower
+    assert model.head.proto.cv3.conv.weight.grad.abs().sum() > 0
+    assert model.head.cv4[0][-1].weight.grad.abs().sum() > 0
+
+
+def test_overfit_one_sample_drives_seg_loss_down():
+    torch.manual_seed(0)
+    model = _build(nc=1, imgsz=160)
+    model.train()
+    x = torch.full((1, 3, 160, 160), 0.1)
+    x[:, :, 40:120, 40:120] = 0.9
+    targets = torch.zeros(1, 1, 5)
+    targets[0, 0] = torch.tensor([0, 0.25, 0.25, 0.75, 0.75])
+    masks = torch.zeros(1, 1, 40, 40)
+    masks[0, 0, 10:30, 10:30] = 1.0
+
+    opt = torch.optim.AdamW(model.parameters(), lr=5e-3)
+    first = last = None
+    for step in range(60):
+        opt.zero_grad()
+        ld = model(x, targets=targets, masks=masks)
+        ld["total_loss"].backward()
+        opt.step()
+        if step == 0:
+            first = ld["seg"]
+        last = ld["seg"]
+    assert last < first * 0.5, f"seg loss did not fall: {first} -> {last}"
+
+
+def test_padding_and_empty_masks_are_skipped():
+    """Bug fixes: padding rows (out-of-range / empty masks) must not corrupt
+    the loss (no clamp-to-last-mask, no supervising blank masks)."""
+    model = _build(nc=1, imgsz=160)
+    model.train()
+    x = torch.rand(1, 3, 160, 160)
+    # 1 real target + 2 padding rows (class 0, zero box, empty mask)
+    targets = torch.zeros(1, 3, 5)
+    targets[0, 0] = torch.tensor([0, 0.3, 0.3, 0.7, 0.7])
+    masks = torch.zeros(1, 3, 40, 40)
+    masks[0, 0, 12:28, 12:28] = 1.0  # only the real target has a mask
+    ld = model(x, targets=targets, masks=masks)
+    assert torch.isfinite(ld["total_loss"])
+    ld["total_loss"].backward()  # must not raise / NaN
+
+
+def test_checkpoint_task_detection_and_roundtrip():
+    m = LibreYOLO9(model_path=None, size="t", nb_classes=2, task="segment", device="cpu")
+    sd = m.model.state_dict()
+    assert any(k.startswith("head.proto") for k in sd)
+    assert LibreYOLO9.detect_checkpoint_task(sd) == "segment"
+
+    m2 = LibreYOLO9(model_path=None, size="t", nb_classes=2, task="segment", device="cpu")
+    missing, unexpected = m2.model.load_state_dict(sd, strict=False)
+    assert list(unexpected) == []
+
+
+def test_predict_path_exposes_masks_attr():
+    m = LibreYOLO9(model_path=None, size="t", nb_classes=2, task="segment", device="cpu")
+    m.model.eval()
+    img = (np.random.rand(192, 256, 3) * 255).astype(np.uint8)
+    results = m(img, conf=0.001)
+    r = results[0] if isinstance(results, list) else results
+    assert hasattr(r, "masks")  # populated only when detections survive NMS
+
+
+def test_detect_task_still_default_and_unaffected():
+    m = LibreYOLO9(model_path=None, size="t", nb_classes=2, device="cpu")
+    assert m.task == "detect"
+    from libreyolo.models.yolo9.nn import DDetect
+
+    assert type(m.model.head) is DDetect  # not the seg subclass


### PR DESCRIPTION
Restores the YOLACT-style instance-segmentation head that was removed in 0d5fe2ba, grafted onto current dev (post head-provenance rework, unified augment, postprocess centralization), plus two correctness fixes to the mask loss that capped mask quality on the old code.

- nn.py: MaskProto prototype branch + DDetectSeg head (subclass of DDetect, adds cv4 mask-coeff towers + proto on P3); LibreYOLO9Model is now task-aware and threads masks (train) / proto+coeffs (infer, export).
- loss.py: YOLO9SegmentationLoss (reuses detection assignment + box/DFL/cls, adds per-positive box-cropped mask BCE normalized by box area). Inherits the #484 DDP-aware cls normalizer.
    * Fix: do NOT clamp out-of-range matched indices onto the last mask (mosaic concatenates 4 images, so label count can exceed the mask buffer — clamping silently trained a positive against a different instance's silhouette). Drop those positives instead.
    * Fix: skip empty GT masks (padding rows + mosaic empty-polygon placeholders rasterize to all-zeros; supervising them taught the model to erase real objects).
- model.py: SUPPORTED_TASKS += segment, TASK_INPUT_SIZES, _init_model passes task, detect_checkpoint_task infers 'segment' from head.proto.* keys.
- trainer.py: on_forward passes masks=polygons for segment; seg loss component surfaced.
- postprocess/yolo9.py already carried the full mask decode path through the removal, so no changes were needed there.

Verified: seg head/loss forward+backward, overfit-one-sample drives seg loss to ~0 with grads reaching proto+cv4, predict produces masks, checkpoint task round-trips, detection export/ONNX unaffected. New tests in test_yolo9_seg.py; full yolo9+segmentation suite green (270 passed).

Follow-up: mosaic still skips random_affine on the segment path (masks would misalign) — extending affine to warp polygons is the highest-value remaining training improvement (the seg half of #432).