### PR TITLE
Add release and merge-to-dev workflow skills

### DIFF
--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -209,21 +209,28 @@ Present the scoreboard + curated changelog. On explicit "go":
    preflight check 3 told you if there are any). Resolve conflicts on dev;
    the version line auto-merges to the clean release value, so **manually
    set dev back to the next `X.Y.0.dev0`**.
-2. **Bump + PR.** Branch off merged dev, set `pyproject.toml` to clean
-   `X.Y.0`, push, open PR with base `release`. Remember: this PR shows no
-   CI checks by design. Merge with a **merge commit, never squash** (squash
-   collapses the whole cycle's history).
-3. **GitHub release.** Draft it with the changelog so the publish moment is
-   one click:
+2. **Bump + hand over the PR link.** Branch off merged dev, set
+   `pyproject.toml` to clean `X.Y.0`, push, then hand the user the one-click
+   compare URL `https://github.com/LibreYOLO/libreyolo/compare/release...<branch>?expand=1`.
+   Per `AGENTS.md`, the **agent does not open the PR**; the human submits
+   it. Remind them: this PR shows no CI checks by design, and it must be
+   merged with a **merge commit, never squash** (squash collapses the whole
+   cycle's history).
+3. **GitHub release (human action).** Cutting the release is the user's; the
+   agent may prepare a **draft** for them to review and publish, since a
+   draft is not a live PR or comment and publishing it is their click:
 
    ```bash
    gh release create vX.Y.Z -R LibreYOLO/libreyolo --target release \
      --title "LibreYOLO vX.Y.Z" --notes-file changelog.md --draft
    ```
 
-   Publishing the release creates the tag, which fires `publish.yml`.
-4. **Approve "Publish to PyPI"** in the Actions run. This is the only
-   human-required click; do not try to automate it.
+   If unsure whether the user wants even a draft created for them, hand the
+   changelog file and the "new release" URL instead and let them do it.
+   Publishing the release (their action) creates the tag, which fires
+   `publish.yml`.
+4. **Approve "Publish to PyPI"** in the Actions run. This is a
+   human-required click; the agent never approves it.
 
 ## Phase 4: Post-publish verification (do not skip)
 

--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: libreyolo-release
+description: >-
+  Cut a LibreYOLO version release end to end: evidence-backed changelog built
+  by fan-out agents over the release..dev diff, a gate scoreboard (unit CI,
+  GPU e2e on Modal reusing the nightly, weight autodownload probe, wheel
+  smoke, notices sync, docs drift, breaking-change sweep), the branch/tag/PyPI
+  mechanics, post-publish verification, and the handoff to the marketing
+  repo's announcement pipeline. Use whenever the user says "release",
+  "cut vX.Y.Z", "ship a version", "prepare the changelog for the release",
+  or "is dev ready to release?".
+---
+
+# LibreYOLO release
+
+Turn "let's release" into a published PyPI version with a real changelog,
+proven gates, and marketing assets queued, without re-deriving the process
+each time. The engineering source of truth is `RELEASING.md`; this skill
+wraps it with everything that document assumes you already know.
+
+**Golden rule: nothing goes in the changelog without evidence (a commit SHA
+or PR number), and nothing ships without a green scoreboard.** The changelog
+is built before the gates run so that gate failures can be traced back to the
+change that caused them.
+
+## The lay of the land (read once, saves an hour)
+
+- Branches are `dev` and `release`. There is **no `main`**.
+- `pyproject.toml` `version` is the source of truth. `dev` carries
+  `X.Y.0.dev0`; `release` carries the clean `X.Y.0`. The bump commit lives on
+  the release side.
+- CI gotcha: `unit-tests.yml` and `install-smoke.yml` trigger only on
+  push/PR to **`dev`**. A `dev -> release` PR shows **no checks**; the real
+  gate is CI on the dev push. Do not read the empty checks list as green.
+- `publish.yml` fires on `v*` tags, rejects tags not reachable from
+  `release`, and ends in a manual GitHub-Environment approval ("Publish to
+  PyPI"). Trusted Publishing / OIDC; there is no PyPI token anywhere.
+- GPU e2e lives on Modal. `tools/ci/modal_nightly.py` takes `--ref <sha>`,
+  so the same harness that runs the nightly can test the exact release
+  candidate commit.
+- The announcement side (GitHub release body polish, LinkedIn carousel,
+  Reddit GIF post) is the **marketing repo's** `new-version-release` skill
+  (`../marketing/skills/new-version-release/`). This skill produces the
+  facts file and changelog it consumes; do not rebuild its pipelines here.
+
+## Phase 0: Preflight and scoreboard
+
+Create a working directory **outside the repo tree** (scratchpad or
+`~/release-<version>/`) and start `SCOREBOARD.md` in it. Every phase below
+appends one line: `| gate | PASS/FAIL/SKIPPED | evidence link or note |`.
+The scoreboard is the deliverable you show the user before asking for the
+go/no-go; a release with SKIPPED rows needs their explicit sign-off per row.
+
+Preflight checks (all read-only, run in parallel):
+
+```bash
+git fetch upstream --tags
+# 1. What is shipping and from where
+git log -1 upstream/dev --oneline
+grep '^version' pyproject.toml                       # on dev: expect X.Y.0.dev0
+# 2. Last released version = base ref for everything
+git tag --sort=-creatordate | head -5
+# 3. Hotfixes stranded on release that dev never got (MUST be merged back first)
+git log upstream/dev..upstream/release --oneline
+# 4. CI on dev HEAD is actually green
+gh run list -R LibreYOLO/libreyolo --branch dev --limit 10
+# 5. Anything already labeled/queued as release-blocking
+gh pr list -R LibreYOLO/libreyolo --base dev --state open --limit 30
+```
+
+Confirm with the user: version label (`vX.Y.Z`), base tag, and which gates
+to run (default: all except RF5). Then proceed without further check-ins
+until the go/no-go.
+
+## Phase 1: Changelog by fan-out (facts first, prose second)
+
+Range is `vLAST..upstream/dev`. Fan out parallel read-only agents, one lens
+each. Every agent returns **numbered fact entries with evidence**: one-line
+claim + commit SHA or PR number + file path. No pointer, no fact. Uncertain
+items get marked uncertain, never dropped.
+
+Lenses:
+
+1. **New models and tasks**: model families, task types, weight variants
+   added. Check `libreyolo/models/`, registry/config files, `WEIGHT_VARIANTS`,
+   `libreyolo/config/datasets/`, docs pages added.
+2. **Features and API surface**: new CLI commands/flags, new public API
+   (exports in `libreyolo/__init__.py`), export formats, new skills shipped
+   in `skills/`.
+3. **Bug fixes**: every fix, including obscure ones. `git log --grep` for
+   fix/bug plus a pass over merged PRs
+   (`gh pr list -R LibreYOLO/libreyolo --state merged --search "merged:>=<base-date>"`).
+4. **Breaking changes and deprecations**: changed signatures, renamed or
+   removed public names, changed defaults, CLI arg changes. Diff
+   `libreyolo/__init__.py`, `libreyolo/cli/`, and anything in
+   `docs/*_schema.md` between the two refs. This lens decides whether the
+   version is actually a minor or needs louder warnings.
+5. **Training / internals / performance**: trainer, losses, augmentations,
+   postprocess moves, refactors big enough to mention.
+6. **Tests, CI, docs, packaging, licensing**: new test files/counts,
+   workflow changes, dependency changes, NOTICE / THIRD_PARTY_NOTICES
+   entries added or changed.
+7. **People and numbers**: `git shortlog -sn vLAST..upstream/dev`, commit
+   count, files touched, closed issues, PR count.
+
+Merge into `facts.md` (numbered `F1..Fn`, grouped by lens), then write
+`changelog.md` from it:
+
+```markdown
+## LibreYOLO vX.Y.Z
+
+One-paragraph summary, leading with the strongest item.
+
+### New models          (only if any; each with sizes and license posture)
+### Features
+### Improvements
+### Bug fixes           (one line each, plain language)
+### Breaking changes    (only if any; what breaks and what to do instead)
+### Contributors        (everyone, alphabetized, with what they did)
+### Stats               (N commits, N files, +N/-N lines, N new tests)
+
+`pip install --upgrade libreyolo`
+```
+
+Tone: factual, concrete, numbers over adjectives, zero hype. No em dashes.
+Every line traces to a fact id. Show the changelog to the user **now**;
+they curate (a fix can advertise the bug), you never silently drop items.
+
+## Phase 2: Gates
+
+Run these in parallel where possible; append each result to the scoreboard.
+
+### Gate A: unit CI on the exact candidate SHA
+
+Already covered by preflight check 4 if dev HEAD is the candidate. If the
+latest dev run is stale or red, stop here.
+
+### Gate B: GPU e2e on Modal (reuse the nightly, don't reinvent it)
+
+The nightly harness is the canonical GPU gate. Two ways to run it against
+the candidate; prefer the first (no local credentials needed):
+
+```bash
+# 1. Dispatch the existing workflow; force bypasses the tested-SHA cache
+gh workflow run e2e-nightly-dev.yml -R LibreYOLO/libreyolo -f force=true
+gh run watch -R LibreYOLO/libreyolo <run-id>   # ~up to 3h; check step summary
+
+# 2. Or run the Modal app directly (needs MODAL_TOKEN_ID/SECRET in env)
+uvx modal run tools/ci/modal_nightly.py --ref <candidate-sha> --target test_nightly
+```
+
+Both print a `MODAL_NIGHTLY_RESULT {json}` line with `status`, runtime, and
+estimated GPU cost; record status **and cost** on the scoreboard. If the
+last successful nightly already ran on the candidate SHA (check the run's
+step summary for the ref), count it and skip the re-run; that is the whole
+point of reusing the nightly.
+
+For gates beyond the nightly contract (RF5 training benchmark, a heavier
+suite, a specific GPU), use the `launch-serverless-gpu-job` skill
+(Vast / Modal / Beam) instead of hand-rolling anything.
+
+### Gate C: risk-targeted e2e subset (local GPU, optional but cheap)
+
+Map Phase-1 facts to test files: any model family touched in the range gets
+its `tests/e2e/test_<family>*.py` run locally via the
+`libreyolo-run-e2e-tests` skill (one file per process, `-m "e2e and not
+rf5"`). This catches family-specific regressions the general nightly case
+may not exercise. Skip if no local GPU; note it on the scoreboard.
+
+### Gate D: weight autodownload probe
+
+Every weight variant that is new or renamed in the range must actually
+resolve. For each, HEAD-request its Hugging Face URL (or instantiate the
+model with autodownload in a temp cache) and record HTTP 200. A release
+that advertises a model whose weights 404 is the most embarrassing failure
+this project can have; this gate exists because of that.
+
+### Gate E: wheel build + fresh-venv smoke
+
+```bash
+python -m build              # sdist + wheel; MANIFEST.in must keep weights out
+python -m venv /tmp/relsmoke && /tmp/relsmoke/bin/pip install dist/*.whl
+/tmp/relsmoke/bin/python -c "import libreyolo; print(libreyolo.__version__)"
+/tmp/relsmoke/bin/libreyolo --help
+```
+
+Check the sdist/wheel size is sane (no accidentally bundled weights or
+datasets) and the version string matches expectation.
+
+### Gate F: notices and license sync
+
+If Phase-1 lens 1 found new model families or ported code, verify `NOTICE`,
+`THIRD_PARTY_NOTICES.txt`, and `weights/LICENSE_NOTICE.txt` gained the
+matching entries in the same range. A new family with no notices diff is a
+red flag; surface it as a licensing decision for the user, never patch it
+silently.
+
+### Gate G: docs drift
+
+Every headline changelog item should be reachable in docs: repo `docs/`
+and, where relevant, the website repo. List headline facts with no doc
+mention; the user decides whether that blocks or ships as follow-up.
+
+## Phase 3: Go/no-go, then cut it
+
+Present the scoreboard + curated changelog. On explicit "go":
+
+1. **Merge `release` -> `dev` first** (recovers release-only hotfixes;
+   preflight check 3 told you if there are any). Resolve conflicts on dev;
+   the version line auto-merges to the clean release value, so **manually
+   set dev back to the next `X.Y.0.dev0`**.
+2. **Bump + PR.** Branch off merged dev, set `pyproject.toml` to clean
+   `X.Y.0`, push, open PR with base `release`. Remember: this PR shows no
+   CI checks by design. Merge with a **merge commit, never squash** (squash
+   collapses the whole cycle's history).
+3. **GitHub release.** Draft it with the changelog so the publish moment is
+   one click:
+
+   ```bash
+   gh release create vX.Y.Z -R LibreYOLO/libreyolo --target release \
+     --title "LibreYOLO vX.Y.Z" --notes-file changelog.md --draft
+   ```
+
+   Publishing the release creates the tag, which fires `publish.yml`.
+4. **Approve "Publish to PyPI"** in the Actions run. This is the only
+   human-required click; do not try to automate it.
+
+## Phase 4: Post-publish verification (do not skip)
+
+```bash
+# PyPI index catches up within minutes; poll, don't assume
+pip index versions libreyolo
+python -m venv /tmp/pypismoke && /tmp/pypismoke/bin/pip install libreyolo==X.Y.Z
+/tmp/pypismoke/bin/python -c "import libreyolo; assert libreyolo.__version__ == 'X.Y.Z'"
+# GPU e2e against the released branch (manual dispatch only)
+gh workflow run e2e-nightly-release.yml -R LibreYOLO/libreyolo
+```
+
+Append results to the scoreboard. The release is "done" when PyPI installs
+clean and the release nightly is green (or dispatched with the user's OK to
+not wait).
+
+## Phase 5: Marketing handoff
+
+Hand `facts.md` + `changelog.md` to the marketing repo's
+`new-version-release` skill (checkout at `../marketing`). It owns curation
+for the announcement, the GitHub release body polish, the LinkedIn carousel
+pipeline (generate -> audit -> simulator -> final review -> queue), and the
+Reddit GIF post pack. Your facts file matches its expected format (numbered
+facts with evidence), so it can skip its own fact-finding phase and start
+at curation. Never post to social platforms yourself; assets are queued for
+the user to post by hand.
+
+## Anti-patterns
+
+- Writing the changelog from memory or from PR titles alone; titles lie,
+  diffs don't.
+- Treating the empty checks list on the `dev -> release` PR as green.
+- Re-running a 3-hour Modal nightly when the last green run already tested
+  the candidate SHA.
+- Squash-merging the release PR.
+- Bumping the version on dev instead of on the release-PR branch.
+- Skipping Phase 4 because "publish.yml was green" (green publish and a
+  broken install have coexisted before in other projects; verify the
+  artifact users actually get).
+- Fixing a missing license notice yourself instead of surfacing it.
+
+## Related
+
+- `RELEASING.md`: the minimal engineering process this skill wraps.
+- `skills/libreyolo-run-e2e-tests/`: how to run e2e correctly (markers,
+  one-file-per-process rule).
+- `skills/launch-serverless-gpu-job/`: rented/serverless GPUs for gates
+  beyond the nightly contract.
+- `../marketing/skills/new-version-release/`: the announcement pipeline
+  (curation, GitHub release body, LinkedIn carousel, Reddit GIF).
+- `.github/workflows/`: `e2e-nightly-dev.yml`, `e2e-nightly-release.yml`,
+  `publish.yml`, `unit-tests.yml`, `install-smoke.yml`.

--- a/skills/merge-to-dev/SKILL.md
+++ b/skills/merge-to-dev/SKILL.md
@@ -2,21 +2,25 @@
 name: merge-to-dev
 description: >-
   The whole dance for landing code on LibreYOLO's dev branch: branch, commit,
-  push to upstream, hand the user a one-click PR link (or open the PR),
-  then babysit the Greptile bot review until it is happy. Use whenever the
-  user says "put this on dev", "push this to dev", "merge this to dev",
-  "ship this", "open a PR for this", or hands over finished work on
-  LibreYOLO/libreyolo. The user should never have to ask for the PR link;
-  producing it (and handling Greptile) IS the task.
+  push to upstream, then hand the user a one-click compare URL that opens an
+  empty PR form for them to submit (agents must not open the PR themselves),
+  and once they have opened it, babysit the Greptile bot review until it is
+  happy. Use whenever the user says "put this on dev", "push this to dev",
+  "merge this to dev", "ship this", "open a PR for this", or hands over
+  finished work on LibreYOLO/libreyolo. The user should never have to ask for
+  the PR link; producing it is the task.
 ---
 
 # Merge code to dev
 
 There is exactly one way code lands on `dev` in `LibreYOLO/libreyolo`:
-**branch -> commit -> push to upstream -> PR with base `dev`**. Never push
-to `dev` directly, even though the account has admin. When the user says
-"put this on dev", run the entire dance below and end your turn with the
-PR link and the Greptile verdict, not with a question.
+**branch -> commit -> push to upstream -> the human opens a PR with base
+`dev`**. Never push to `dev` directly, even though the account has admin.
+And per `AGENTS.md`, the **agent never opens the PR**: it pushes the branch
+and hands over a one-click compare URL that opens the PR form empty, and the
+human submits it. When the user says "put this on dev", run the dance below
+and end your turn with that link, not with a question and not with a PR you
+opened yourself.
 
 ## Environment gotchas (read first, they bite every session)
 
@@ -62,36 +66,38 @@ PYTHONPATH=. .venv/Scripts/python.exe -m pytest tests/unit/<touched-area> -q
 
 Skills/docs-only changes have no tests to run; say so and move on.
 
-### 3. Push and produce the PR
+### 3. Push and hand over the one-click PR link
 
 ```bash
 git push -u upstream <branch>
 ```
 
-Then either open the PR directly (default when the change is
-self-explanatory):
-
-```bash
-gh pr create -R LibreYOLO/libreyolo --base dev --head <branch> \
-  --title "<title>" --body "<what and why, issue ref like 'Closes #512'>"
-```
-
-or, if the user likes to write the description themselves, give the
-one-click compare URL:
+Then hand the user the one-click compare URL and stop:
 
 ```
 https://github.com/LibreYOLO/libreyolo/compare/dev...<branch>?expand=1
 ```
 
-**Always deliver one of these two without being asked.** "Pushed the
-branch" is not a finished turn; the link is the deliverable. Note: CI
-(`unit-tests.yml`, `install-smoke.yml`) runs on PRs to `dev`, so the PR is
-also what buys you the CI signal.
+**The agent must not open the PR.** `AGENTS.md` is explicit: "Agents must
+not open pull requests"; "Humans handle ... PR creation"; agents "may reply
+with a one-click GitHub URL (no description pre-filled) so the human can
+open the PR." The `?expand=1` compare link opens the PR form empty, which
+is exactly what the policy allows: do not use `gh pr create`, and do not
+pre-fill a description. Draft a suggested title and body in your message
+for the user to copy if they want, but the click is theirs.
 
-### 4. Babysit Greptile
+**Deliver the link without being asked.** "Pushed the branch" is not a
+finished turn; the link is the deliverable. CI (`unit-tests.yml`,
+`install-smoke.yml`) runs once the human opens the PR to `dev`, so their
+click is also what starts the CI signal.
 
-When the PR author is one of the repo admins, the Greptile bot reviews the
-PR automatically a few minutes after it opens (and again after each push).
+### 4. Babysit Greptile (after the human opens the PR)
+
+This step needs a PR to exist, so it starts once the human has opened it
+from your link (or tells you "it's open" / "ship it"). Do not sit polling
+for a PR number before then. When the PR author is one of the repo admins,
+the Greptile bot reviews the PR automatically a few minutes after it opens
+(and again after each push).
 Its reviews are usually good; treat them as a real reviewer, not noise.
 
 Loop until happy:
@@ -109,8 +115,10 @@ Loop until happy:
    - **Right** (real bug, real improvement): fix the code, commit, push.
      The push triggers a re-review; go back to step 1.
    - **Wrong or not applicable**: don't change the code to appease the bot.
-     Reply on the thread with a one-line factual reason so the resolution
-     is recorded, and tell the user in the summary.
+     Put a one-line factual rebuttal in your summary to the user, and let
+     **them** reply on the thread if they want it recorded. `AGENTS.md`:
+     "Agents must not post ... PR comments unless a human explicitly asks."
+     Do not reply on the Greptile thread yourself.
    - **Judgement call** (style, scope): lean toward fixing cheap ones,
      surface expensive ones to the user.
 3. Done when the latest Greptile review has no unaddressed findings and its
@@ -126,10 +134,10 @@ user explicitly says to merge; merging to dev is their click.
 
 ## Common variants
 
-- **"This is for release, not dev"**: same dance with `--base release`,
-  but that only happens during a release cut or hotfix; confirm first.
-  Remember release PRs from dev show no CI checks (workflows trigger on
-  dev only).
+- **"This is for release, not dev"**: same dance, but the compare URL bases
+  on `release` (`compare/release...<branch>?expand=1`); that only happens
+  during a release cut or hotfix, so confirm first. Remember release PRs
+  from dev show no CI checks (workflows trigger on dev only).
 - **Work in a worktree**: same flow; push from the worktree. The branch is
   what matters, not which checkout it sits in.
 - **User says "ship it" on an already-open PR**: skip to step 4; the job
@@ -141,7 +149,11 @@ user explicitly says to merge; merging to dev is their click.
 ## Anti-patterns
 
 - Pushing to `dev` or `release` directly. Never, admin or not.
-- Ending the turn with "want me to open a PR?". Open it or hand the link.
+- Opening the PR yourself with `gh pr create`. `AGENTS.md` forbids it; hand
+  the one-click compare URL and let the human submit.
+- Ending the turn with "want me to open a PR?". Hand the link.
+- Replying on the Greptile thread to rebut a finding. Put the rebuttal in
+  your summary; the human comments if they want to.
 - `git add -A` in the dirty main checkout.
 - Blindly applying every Greptile comment. It's usually right, not always
   right; a wrong "fix" that lands because a bot suggested it is still your

--- a/skills/merge-to-dev/SKILL.md
+++ b/skills/merge-to-dev/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: merge-to-dev
+description: >-
+  The whole dance for landing code on LibreYOLO's dev branch: branch, commit,
+  push to upstream, hand the user a one-click PR link (or open the PR),
+  then babysit the Greptile bot review until it is happy. Use whenever the
+  user says "put this on dev", "push this to dev", "merge this to dev",
+  "ship this", "open a PR for this", or hands over finished work on
+  LibreYOLO/libreyolo. The user should never have to ask for the PR link;
+  producing it (and handling Greptile) IS the task.
+---
+
+# Merge code to dev
+
+There is exactly one way code lands on `dev` in `LibreYOLO/libreyolo`:
+**branch -> commit -> push to upstream -> PR with base `dev`**. Never push
+to `dev` directly, even though the account has admin. When the user says
+"put this on dev", run the entire dance below and end your turn with the
+PR link and the Greptile verdict, not with a question.
+
+## Environment gotchas (read first, they bite every session)
+
+- The repo has **no `main`**; branches are `dev` and `release`. PRs base on
+  `dev` unless the user says otherwise.
+- The `origin` remote is dead. Push to **`upstream`** (LibreYOLO/libreyolo);
+  the account (EHxuban11) has admin there.
+- On this Windows box, `git` and `uv` are not on the PowerShell PATH; use
+  the **Bash** tool for git work.
+- The main checkout's working tree is usually dirty with unrelated
+  experiments. Commit **only the files that belong to this change**; never
+  `git add -A` in the main checkout. If the change is tangled with
+  unrelated edits, stage file by file (or hunks with `git add -p`).
+
+## The dance
+
+### 1. Branch
+
+Branch off up-to-date dev, named `<issue-number>-<short-slug>` when there
+is an issue (repo convention, e.g. `477-add-deblurring`), otherwise a short
+descriptive slug:
+
+```bash
+git fetch upstream
+git switch -c 512-fix-thing upstream/dev
+```
+
+If the work already sits on a correctly-named branch, reuse it. If the work
+sits on the **wrong** branch (someone committed on top of an unrelated
+feature branch), move it: branch from `upstream/dev` and cherry-pick or
+re-stage just the relevant files. Do not open a PR whose diff drags in an
+unrelated feature.
+
+### 2. Commit
+
+Small, plain, imperative subject lines matching repo history ("Fix X",
+"Add Y"). Run the relevant unit tests before pushing when the change
+touches `libreyolo/`:
+
+```bash
+PYTHONPATH=. .venv/Scripts/python.exe -m pytest tests/unit/<touched-area> -q
+```
+
+Skills/docs-only changes have no tests to run; say so and move on.
+
+### 3. Push and produce the PR
+
+```bash
+git push -u upstream <branch>
+```
+
+Then either open the PR directly (default when the change is
+self-explanatory):
+
+```bash
+gh pr create -R LibreYOLO/libreyolo --base dev --head <branch> \
+  --title "<title>" --body "<what and why, issue ref like 'Closes #512'>"
+```
+
+or, if the user likes to write the description themselves, give the
+one-click compare URL:
+
+```
+https://github.com/LibreYOLO/libreyolo/compare/dev...<branch>?expand=1
+```
+
+**Always deliver one of these two without being asked.** "Pushed the
+branch" is not a finished turn; the link is the deliverable. Note: CI
+(`unit-tests.yml`, `install-smoke.yml`) runs on PRs to `dev`, so the PR is
+also what buys you the CI signal.
+
+### 4. Babysit Greptile
+
+When the PR author is one of the repo admins, the Greptile bot reviews the
+PR automatically a few minutes after it opens (and again after each push).
+Its reviews are usually good; treat them as a real reviewer, not noise.
+
+Loop until happy:
+
+1. Wait ~2-3 minutes after opening/pushing, then read everything:
+
+   ```bash
+   gh pr view <n> -R LibreYOLO/libreyolo --json reviews,comments
+   gh api repos/LibreYOLO/libreyolo/pulls/<n>/comments   # inline comments
+   ```
+
+   If nothing from Greptile yet, poll every couple of minutes (up to ~10);
+   don't declare victory on an empty review list.
+2. For each Greptile finding, judge it on the merits:
+   - **Right** (real bug, real improvement): fix the code, commit, push.
+     The push triggers a re-review; go back to step 1.
+   - **Wrong or not applicable**: don't change the code to appease the bot.
+     Reply on the thread with a one-line factual reason so the resolution
+     is recorded, and tell the user in the summary.
+   - **Judgement call** (style, scope): lean toward fixing cheap ones,
+     surface expensive ones to the user.
+3. Done when the latest Greptile review has no unaddressed findings and its
+   summary reads as approving (it scores confidence like "5/5, safe to
+   merge"). Also confirm CI checks are green: `gh pr checks <n>`.
+
+### 5. Report
+
+End the turn with: PR URL, one-line summary of the change, CI status,
+Greptile verdict (score + how many findings were fixed vs rebutted), and
+whether it is ready to merge. **Do not merge the PR yourself** unless the
+user explicitly says to merge; merging to dev is their click.
+
+## Common variants
+
+- **"This is for release, not dev"**: same dance with `--base release`,
+  but that only happens during a release cut or hotfix; confirm first.
+  Remember release PRs from dev show no CI checks (workflows trigger on
+  dev only).
+- **Work in a worktree**: same flow; push from the worktree. The branch is
+  what matters, not which checkout it sits in.
+- **User says "ship it" on an already-open PR**: skip to step 4; the job
+  is Greptile + CI + report.
+- **Fork PRs / external contributors**: Greptile still reviews, but you
+  cannot push to their branch; findings become review comments instead of
+  commits.
+
+## Anti-patterns
+
+- Pushing to `dev` or `release` directly. Never, admin or not.
+- Ending the turn with "want me to open a PR?". Open it or hand the link.
+- `git add -A` in the dirty main checkout.
+- Blindly applying every Greptile comment. It's usually right, not always
+  right; a wrong "fix" that lands because a bot suggested it is still your
+  bug.
+- Marking the dance done before Greptile's re-review of your latest push.
+- Merging without being told.


### PR DESCRIPTION
Two workflow skills for everyday maintainer work on this repo.

- `skills/libreyolo-release`: cut a version end to end (evidence-backed changelog by fan-out over the release..dev diff, a gate scoreboard reusing the Modal nightly, the branch/tag/PyPI mechanics, post-publish verification, and handoff to the marketing repo's announcement pipeline).
- `skills/merge-to-dev`: the branch -> commit -> push -> one-click PR link -> Greptile babysitting loop dance, so 'put this on dev' just happens.

Docs only; no code paths touched.