### PR TITLE
Correct dev version marker to 1.3.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libreyolo"
-version = "1.4.0.dev0"
+version = "1.3.1.dev0"
 description = "Libre YOLO - An open source YOLO library with MIT license."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The next release is the v1.3.0..dev feature range shipped as v1.3.1. Commit 69a50d9b inadvertently bumped the dev marker to 1.4.0.dev0 while fixing unrelated #490 audit findings; restore it to the intended patch marker. The release branch remains the source of truth for the clean version.