### PR TITLE
Add multi-class keypoints to YOLO-NAS pose

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -41,6 +41,11 @@ Required field meanings:
 
 Pose checkpoints additionally include:
 
+- `nc` / `names`: pose is usually single-class (`nc: 1`, `person`), but the
+  YOLO-NAS pose head also supports multi-class pose with a single shared
+  keypoint skeleton (one `kpt_shape` for every class); `nc` and `names` then
+  describe the classes as in detection. Runtime pose exports emit `scores` with
+  shape `[batch, anchors, nc]`.
 - `num_keypoints`: positive integer keypoint count used by the pose head.
 - `keypoint_dim`: pose label dimension from the dataset contract, either `2`
   for `x,y` labels or `3` for `x,y,visibility` labels. Model outputs always

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -1196,16 +1196,28 @@ class BaseBackend(ABC):
     ):
         """Parse YOLO-NAS pose: boxes, scores, keypoint xy, keypoint confidence."""
         boxes = all_outputs[0][0]
-        scores = all_outputs[1][0].squeeze(-1)
+        scores = all_outputs[1][0]
         keypoints_xy = all_outputs[2][0]
         keypoints_conf = all_outputs[3][0]
+
+        # scores: [A, nc]. Single-class pose keeps the historical squeeze;
+        # multi-class pose takes the top-scoring class per anchor.
+        if scores.ndim > 1 and scores.shape[-1] > 1:
+            class_ids_full = scores.argmax(axis=-1).astype(np.int64)
+            scores = scores.max(axis=-1)
+        else:
+            scores = scores.squeeze(-1)
+            class_ids_full = None
 
         mask = scores >= conf
         boxes = boxes[mask].astype(np.float32, copy=True)
         max_scores = scores[mask].astype(np.float32, copy=False)
         keypoints_xy = keypoints_xy[mask].astype(np.float32, copy=True)
         keypoints_conf = keypoints_conf[mask].astype(np.float32, copy=False)
-        class_ids = np.zeros((max_scores.shape[0],), dtype=np.int64)
+        if class_ids_full is not None:
+            class_ids = class_ids_full[mask]
+        else:
+            class_ids = np.zeros((max_scores.shape[0],), dtype=np.int64)
 
         if len(boxes) == 0:
             keypoints = np.zeros((0, keypoints_xy.shape[-2], 3), dtype=np.float32)

--- a/libreyolo/data/pose_dataset.py
+++ b/libreyolo/data/pose_dataset.py
@@ -29,7 +29,10 @@ logger = logging.getLogger(__name__)
 
 
 def parse_yolo_pose_label_line(
-    parts: Sequence[str], num_keypoints: int, keypoint_dim: int = 3
+    parts: Sequence[str],
+    num_keypoints: int,
+    keypoint_dim: int = 3,
+    num_classes: Optional[int] = None,
 ):
     """Parse one YOLO pose label line into ``(cls, bbox, keypoints)``.
 
@@ -39,6 +42,10 @@ def parse_yolo_pose_label_line(
         keypoint_dim: Number of values per keypoint in the label file. YOLO pose
             YAML uses ``kpt_shape: [K, 2]`` for xy-only labels and
             ``kpt_shape: [K, 3]`` for xyv labels.
+        num_classes: If given, reject class ids outside ``[0, num_classes)``.
+            Single-class pose is class-agnostic (the loss trains class 0
+            regardless of the label column), so callers pass this for
+            multi-class datasets only.
 
     Returns:
         Tuple of ``(cls_id: int, bbox: (4,) cxcywh float32,
@@ -46,7 +53,9 @@ def parse_yolo_pose_label_line(
         labels are promoted to xyv with visibility ``2``.
 
     Raises:
-        ValueError: If the line does not have exactly ``5 + keypoint_dim*K`` fields.
+        ValueError: If the line does not have exactly ``5 + keypoint_dim*K``
+            fields, or if ``num_classes`` is given and the class id falls
+            outside ``[0, num_classes)``.
     """
     if keypoint_dim not in (2, 3):
         raise ValueError(f"Unsupported keypoint_dim {keypoint_dim}; expected 2 or 3")
@@ -57,6 +66,10 @@ def parse_yolo_pose_label_line(
             f"label, got {len(parts)}"
         )
     cls_id = int(float(parts[0]))
+    if num_classes is not None and not 0 <= cls_id < num_classes:
+        raise ValueError(
+            f"Pose class id {cls_id} out of range [0, {num_classes - 1}]"
+        )
     bbox = np.array(parts[1:5], dtype=np.float32)
     keypoints = np.array(parts[5:], dtype=np.float32).reshape(
         num_keypoints, keypoint_dim
@@ -84,13 +97,17 @@ class YOLOPoseDataset(Dataset):
         preproc=None,
         keypoint_dim: int = 3,
         decode_scale: int = 1,
+        num_classes: Optional[int] = None,
     ):
         if num_keypoints < 1:
             raise ValueError(f"num_keypoints must be >= 1, got {num_keypoints}")
         if keypoint_dim not in (2, 3):
             raise ValueError(f"keypoint_dim must be 2 or 3, got {keypoint_dim}")
+        if num_classes is not None and num_classes < 1:
+            raise ValueError(f"num_classes must be >= 1, got {num_classes}")
 
         self.num_keypoints = num_keypoints
+        self.num_classes = num_classes
         self.keypoint_dim = keypoint_dim
         self.img_size = img_size
         self._input_dim = img_size
@@ -128,6 +145,7 @@ class YOLOPoseDataset(Dataset):
     def _load_all_labels(self) -> List[Tuple[np.ndarray, np.ndarray, np.ndarray]]:
         labels = []
         bad_lines = 0
+        bad_class_lines = 0
         for label_file in self.label_files:
             cls_list, box_list, kpt_list = [], [], []
             if label_file.exists():
@@ -142,6 +160,11 @@ class YOLOPoseDataset(Dataset):
                             )
                         except ValueError:
                             bad_lines += 1
+                            continue
+                        if self.num_classes is not None and not (
+                            0 <= cls_id < self.num_classes
+                        ):
+                            bad_class_lines += 1
                             continue
                         cls_list.append(cls_id)
                         box_list.append(bbox)
@@ -168,6 +191,14 @@ class YOLOPoseDataset(Dataset):
                 "that does not match %d keypoints",
                 bad_lines,
                 self.num_keypoints,
+            )
+        if bad_class_lines:
+            logger.warning(
+                "YOLOPoseDataset: skipped %d label line(s) with a class id "
+                "outside [0, %d]; check for 1-indexed class ids or a wrong "
+                "nc in the dataset yaml",
+                bad_class_lines,
+                self.num_classes - 1,
             )
         return labels
 

--- a/libreyolo/models/yolonas/loss.py
+++ b/libreyolo/models/yolonas/loss.py
@@ -1042,6 +1042,7 @@ class YoloNASPoseLoss(nn.Module):
         bbox_assigned_beta: float = 6.0,
         assigner_multiply_by_pose_oks: bool = True,
         rescale_pose_loss_with_assigned_score: bool = True,
+        num_classes: int = 1,
     ):
         super().__init__()
         self.classification_loss_type = classification_loss_type
@@ -1050,7 +1051,9 @@ class YoloNASPoseLoss(nn.Module):
         self.iou_loss_weight = iou_loss_weight
         self.iou_loss = {"giou": GIoULoss, "ciou": CIoULoss}[regression_iou_loss_type]()
         self.num_keypoints = len(oks_sigmas)
-        self.num_classes = 1  # pose estimation is single-class
+        # Class count for the box/objectness branch. 1 for classic single-class
+        # (person) pose; > 1 for multi-class pose with a shared keypoint skeleton.
+        self.num_classes = num_classes
         self.register_buffer("oks_sigmas", torch.as_tensor(oks_sigmas, dtype=torch.float32))
         self.pose_cls_loss_weight = pose_cls_loss_weight
         self.pose_reg_loss_weight = pose_reg_loss_weight
@@ -1101,7 +1104,9 @@ class YoloNASPoseLoss(nn.Module):
         t = targets[:, :n_max]
         gt_bbox = cxcywh_to_xyxy(t[..., 1:5])
         pad_gt_mask = ((t[..., 3] > 0) & (t[..., 4] > 0)).unsqueeze(-1).float()
-        gt_class = torch.zeros(batch_size, n_max, 1, dtype=torch.long, device=device)
+        # Real class ids from the targets (column 0). For single-class pose
+        # these are all 0; for multi-class pose they select the gt's class.
+        gt_class = t[..., 0:1].long()
         gt_poses = t[..., 5:].reshape(batch_size, n_max, self.num_keypoints, 3)
         gt_crowd = torch.zeros(batch_size, n_max, 1, device=device)
         return {

--- a/libreyolo/models/yolonas/loss.py
+++ b/libreyolo/models/yolonas/loss.py
@@ -1104,9 +1104,16 @@ class YoloNASPoseLoss(nn.Module):
         t = targets[:, :n_max]
         gt_bbox = cxcywh_to_xyxy(t[..., 1:5])
         pad_gt_mask = ((t[..., 3] > 0) & (t[..., 4] > 0)).unsqueeze(-1).float()
-        # Real class ids from the targets (column 0). For single-class pose
-        # these are all 0; for multi-class pose they select the gt's class.
-        gt_class = t[..., 0:1].long()
+        if self.num_classes == 1:
+            # Historical single-class pose contract: the label class column is
+            # category-agnostic and every GT trains class 0. Forwarding a raw
+            # non-zero id (e.g. COCO person=1) would collide with the assigner's
+            # background index and silently drop that GT's supervision.
+            gt_class = torch.zeros(batch_size, n_max, 1, dtype=torch.long, device=device)
+        else:
+            # Multi-class pose: real class ids from the targets (column 0),
+            # validated against nc at data-load time (YOLOPoseDataset).
+            gt_class = t[..., 0:1].long()
         gt_poses = t[..., 5:].reshape(batch_size, n_max, self.num_keypoints, 3)
         gt_crowd = torch.zeros(batch_size, n_max, 1, device=device)
         return {

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -124,9 +124,14 @@ class LibreYOLONAS(BaseModel):
         if tensor is None or tensor.ndim == 0:
             return None
         if cls.is_pose_state_dict(weights_dict):
-            # Pose has 1 detection class (person); the cls head's extra
-            # channels are per-keypoint visibility logits.
-            return 1
+            # The pose cls head fuses num_classes class scores with K
+            # per-keypoint visibility logits: out_channels == num_classes + K.
+            # Recover the class count by subtracting K (from pose_pred). A
+            # single-class COCO checkpoint yields (1 + 17) - 17 = 1.
+            num_keypoints = cls.detect_num_keypoints(weights_dict)
+            if num_keypoints is None:
+                return 1
+            return max(1, int(tensor.shape[0]) - int(num_keypoints))
         return int(tensor.shape[0])
 
     @classmethod
@@ -165,8 +170,6 @@ class LibreYOLONAS(BaseModel):
         task: str | None = None,
         **kwargs,
     ):
-        # For pose, override classes to single-class person detection regardless
-        # of how many classes the user passed (which defaults to 80 for COCO).
         resolved_task = normalize_task(task) if task is not None else None
         self.reg_max = reg_max
         # Default keypoint count; overridden from checkpoint metadata/state
@@ -179,7 +182,14 @@ class LibreYOLONAS(BaseModel):
                 ckpt_k = self.detect_num_keypoints(model_path)
                 if ckpt_k is not None:
                     self.num_keypoints = ckpt_k
-        if resolved_task == "pose":
+                # Recover the class count from the state dict so a multi-class
+                # pose checkpoint builds the right head width.
+                ckpt_nc = self.detect_nb_classes(model_path)
+                nb_classes = ckpt_nc if ckpt_nc is not None else 1
+        elif resolved_task == "pose":
+            # Fresh model or file path: default to single-class (person) pose.
+            # A file path's real class count is resolved in _load_weights;
+            # training resolves it from the dataset yaml.
             nb_classes = 1
         super().__init__(
             model_path=model_path,
@@ -190,7 +200,12 @@ class LibreYOLONAS(BaseModel):
             **kwargs,
         )
         if self.task == "pose":
-            self.names = {0: "person"}
+            # Placeholder names; overridden by checkpoint metadata in
+            # _load_weights or by the dataset yaml at train() time.
+            if self.nb_classes == 1:
+                self.names = {0: "person"}
+            else:
+                self.names = {i: str(i) for i in range(self.nb_classes)}
         if isinstance(model_path, str):
             self._load_weights(model_path)
 
@@ -199,6 +214,7 @@ class LibreYOLONAS(BaseModel):
             return LibreYOLONASPoseModel(
                 config=self.size,
                 num_keypoints=self.num_keypoints,
+                num_classes=self.nb_classes,
                 reg_max=self.reg_max,
             )
         return LibreYOLONASModel(
@@ -223,11 +239,13 @@ class LibreYOLONAS(BaseModel):
         }
 
     def _rebuild_for_new_classes(self, new_nb_classes: int):
-        if self.task == "pose":
-            # Pose head has fixed single-class detection; classes are not
-            # configurable at load time.
-            return
         self.nb_classes = new_nb_classes
+        if self.task == "pose":
+            # Rebuild the pose head's class channels; the per-keypoint
+            # visibility channels and the rest of the model are preserved.
+            self.model.replace_num_classes(new_nb_classes)
+            self.model.to(self.device)
+            return
         self.model.nc = new_nb_classes
         self.model.heads.replace_num_classes(new_nb_classes)
         self.model.to(self.device)
@@ -427,6 +445,12 @@ class LibreYOLONAS(BaseModel):
                 ckpt_k = self.detect_num_keypoints(state_dict)
                 if ckpt_k is not None and ckpt_k != self.num_keypoints:
                     self._rebuild_for_new_keypoints(ckpt_k)
+                # Match the class count from the state-dict shapes, covering
+                # bare pose checkpoints that carry no ``nc`` metadata (the
+                # metadata path below is a no-op when they already agree).
+                ckpt_nc = self.detect_nb_classes(state_dict)
+                if ckpt_nc is not None and ckpt_nc != self.nb_classes:
+                    self._rebuild_for_new_classes(ckpt_nc)
 
             if isinstance(loaded, dict):
                 ckpt_family = loaded.get("model_family", "")
@@ -663,12 +687,17 @@ class LibreYOLONAS(BaseModel):
                 f"(got {keypoint_dim})."
             )
 
-        # Pose is single-class; carry the dataset's class name into checkpoints.
+        # Resolve the class count from the dataset yaml. Multi-class pose uses a
+        # single shared keypoint skeleton (one kpt_shape for every class), so nc
+        # only affects the class/box branch, not the keypoints.
+        yaml_nc = data_config.get("nc")
         yaml_names = data_config.get("names")
-        if yaml_names is not None:
-            if isinstance(yaml_names, list):
-                yaml_names = {i: n for i, n in enumerate(yaml_names)}
-            self.names = self._sanitize_names(yaml_names, 1)
+        if yaml_nc is None and yaml_names is not None:
+            yaml_nc = len(yaml_names)
+
+        # Rebuild the pose head for the dataset's keypoint count first, then its
+        # class count (both touch cls_pred; this order carries the freshly sized
+        # visibility channels through the class rebuild).
         if num_keypoints != self.num_keypoints:
             logger.info(
                 "Rebuilding YOLO-NAS pose head for %d keypoints (was %d)",
@@ -676,6 +705,19 @@ class LibreYOLONAS(BaseModel):
                 self.num_keypoints,
             )
             self._rebuild_for_new_keypoints(num_keypoints)
+        if yaml_nc is not None and int(yaml_nc) != self.nb_classes:
+            logger.info(
+                "Rebuilding YOLO-NAS pose head for %d classes (was %d)",
+                int(yaml_nc),
+                self.nb_classes,
+            )
+            self._rebuild_for_new_classes(int(yaml_nc))
+
+        # Carry the dataset's class names into checkpoints.
+        if yaml_names is not None:
+            if isinstance(yaml_names, list):
+                yaml_names = {i: n for i, n in enumerate(yaml_names)}
+            self.names = self._sanitize_names(yaml_names, self.nb_classes)
 
         if self.size in {"m", "l"}:
             kwargs.setdefault("dfl_loss_weight", 0.5)
@@ -696,7 +738,7 @@ class LibreYOLONAS(BaseModel):
             model=self.model,
             wrapper_model=self,
             size=self.size,
-            num_classes=1,
+            num_classes=self.nb_classes,
             num_keypoints=num_keypoints,
             keypoint_dim=keypoint_dim,
             data=data,

--- a/libreyolo/models/yolonas/nn.py
+++ b/libreyolo/models/yolonas/nn.py
@@ -1324,12 +1324,14 @@ class YoloNASPoseDFLHead(nn.Module):
         num_keypoints: int,
         stride: int,
         reg_max: int = 16,
+        num_classes: int = 1,
     ):
         super().__init__()
         bbox_inter = width_multiplier(bbox_inter_channels, width_mult, 8)
         pose_inter = width_multiplier(pose_inter_channels, width_mult, 8)
 
         self.num_keypoints = num_keypoints
+        self.num_classes = num_classes
         self.stride = stride
         self.reg_max = reg_max
         self.prior_prob = 1e-2
@@ -1355,8 +1357,10 @@ class YoloNASPoseDFLHead(nn.Module):
             *[pose_block(pose_inter, pose_inter) for _ in range(pose_regression_blocks)]
         )
 
-        # pose_conf_in_class_head=True: cls outputs 1 (objectness) + K (visibility).
-        self.cls_pred = nn.Conv2d(bbox_inter, 1 + num_keypoints, 1, 1, 0)
+        # pose_conf_in_class_head=True: cls outputs num_classes class scores + K
+        # (per-keypoint visibility). For single-class pose num_classes == 1, the
+        # historical objectness channel.
+        self.cls_pred = nn.Conv2d(bbox_inter, num_classes + num_keypoints, 1, 1, 0)
         self.reg_pred = nn.Conv2d(bbox_inter, 4 * (reg_max + 1), 1, 1, 0)
         self.pose_pred = nn.Conv2d(pose_inter, 2 * num_keypoints, 1, 1, 0)
 
@@ -1373,22 +1377,45 @@ class YoloNASPoseDFLHead(nn.Module):
         """Rebuild the keypoint-dependent layers for a new keypoint count.
 
         Used when fine-tuning a COCO (17-keypoint) checkpoint onto a dataset
-        with a different number of keypoints. The objectness channel of
-        ``cls_pred`` is preserved; the per-keypoint visibility channels and
-        ``pose_pred`` are reinitialised.
+        with a different number of keypoints. The class channels of ``cls_pred``
+        are preserved; the per-keypoint visibility channels and ``pose_pred``
+        are reinitialised.
         """
+        nc = self.num_classes
         old_cls = self.cls_pred
-        new_cls = nn.Conv2d(old_cls.in_channels, 1 + num_keypoints, 1, 1, 0)
+        new_cls = nn.Conv2d(old_cls.in_channels, nc + num_keypoints, 1, 1, 0)
         prior_bias = -math.log((1 - self.prior_prob) / self.prior_prob)
         torch.nn.init.constant_(new_cls.bias, prior_bias)
         with torch.no_grad():
-            new_cls.weight[0:1].copy_(old_cls.weight[0:1])
-            new_cls.bias[0:1].copy_(old_cls.bias[0:1])
+            new_cls.weight[:nc].copy_(old_cls.weight[:nc])
+            new_cls.bias[:nc].copy_(old_cls.bias[:nc])
         self.cls_pred = new_cls
         self.pose_pred = nn.Conv2d(
             self.pose_pred.in_channels, 2 * num_keypoints, 1, 1, 0
         )
         self.num_keypoints = num_keypoints
+
+    def replace_num_classes(self, num_classes: int):
+        """Rebuild the class channels of ``cls_pred`` for a new class count.
+
+        Used when fine-tuning a single-class (COCO person) checkpoint onto a
+        multi-class pose dataset. The per-keypoint visibility channels are
+        preserved; the class channels are reinitialised with the prior bias.
+        """
+        old_cls = self.cls_pred
+        old_nc = self.num_classes
+        new_cls = nn.Conv2d(
+            old_cls.in_channels, num_classes + self.num_keypoints, 1, 1, 0
+        )
+        prior_bias = -math.log((1 - self.prior_prob) / self.prior_prob)
+        torch.nn.init.constant_(new_cls.bias, prior_bias)
+        with torch.no_grad():
+            # Preserve the K visibility channels: old ``[old_nc:]`` -> new
+            # ``[num_classes:]`` (class channels are left freshly initialised).
+            new_cls.weight[num_classes:].copy_(old_cls.weight[old_nc:])
+            new_cls.bias[num_classes:].copy_(old_cls.bias[old_nc:])
+        self.cls_pred = new_cls
+        self.num_classes = num_classes
 
     def forward(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         x = self.stem(x)
@@ -1403,9 +1430,9 @@ class YoloNASPoseDFLHead(nn.Module):
         pose_feat = self.reg_dropout_rate(self.pose_convs(pose_features))
         pose_output = self.pose_pred(pose_feat)
 
-        # Split objectness and per-keypoint visibility from cls head.
-        pose_logits = cls_output[:, 1:, :, :]
-        cls_output = cls_output[:, 0:1, :, :]
+        # Split class scores and per-keypoint visibility from cls head.
+        pose_logits = cls_output[:, self.num_classes :, :, :]
+        cls_output = cls_output[:, : self.num_classes, :, :]
         pose_regression = pose_output.reshape(
             (pose_output.size(0), self.num_keypoints, 2, pose_output.size(2), pose_output.size(3))
         )
@@ -1428,6 +1455,7 @@ class YoloNASPoseNDFLHeads(nn.Module):
         self,
         in_channels: Tuple[int, int, int],
         num_keypoints: int = 17,
+        num_classes: int = 1,
         width_mult: float = 1.0,
         reg_max: int = 16,
         grid_cell_offset: float = 0.5,
@@ -1438,6 +1466,7 @@ class YoloNASPoseNDFLHeads(nn.Module):
         super().__init__()
         self.in_channels = tuple(in_channels)
         self.num_keypoints = num_keypoints
+        self.num_classes = num_classes
         self.reg_max = reg_max
         self.grid_cell_offset = grid_cell_offset
         self.compensate_grid_cell_offset = compensate_grid_cell_offset
@@ -1458,6 +1487,7 @@ class YoloNASPoseNDFLHeads(nn.Module):
                 num_keypoints=num_keypoints,
                 stride=stride,
                 reg_max=reg_max,
+                num_classes=num_classes,
             )
             setattr(self, f"head{i + 1}", head)
 
@@ -1468,6 +1498,12 @@ class YoloNASPoseNDFLHeads(nn.Module):
         for i in range(self.num_heads):
             getattr(self, f"head{i + 1}").replace_num_keypoints(num_keypoints)
         self.num_keypoints = num_keypoints
+
+    def replace_num_classes(self, num_classes: int):
+        """Rebuild every per-stride head for a new class count."""
+        for i in range(self.num_heads):
+            getattr(self, f"head{i + 1}").replace_num_classes(num_classes)
+        self.num_classes = num_classes
 
     @torch.jit.ignore
     def cache_anchors(self, input_size: Tuple[int, int]):
@@ -1532,7 +1568,7 @@ class YoloNASPoseNDFLHeads(nn.Module):
             pose_logits_list.append(torch.permute(pose_logits.flatten(2), [0, 2, 1]))
 
         cls_score_list = torch.cat(cls_score_list, dim=-1)
-        cls_score_list = torch.permute(cls_score_list, [0, 2, 1])  # [B, A, 1] logits
+        cls_score_list = torch.permute(cls_score_list, [0, 2, 1])  # [B, A, nc] logits
         reg_dist_reduced_list = torch.cat(reg_dist_reduced_list, dim=1)  # [B, A, 4]
         reg_distri_list = torch.cat(reg_distri_list, dim=1)  # [B, A, 4*(reg_max+1)]
         pose_regression_list = torch.cat(pose_regression_list, dim=1)  # [B, A, K, 2]
@@ -1577,7 +1613,7 @@ class YoloNASPoseNDFLHeads(nn.Module):
             )
         )
         raw_predictions = (
-            cls_score_list,        # [B, A, 1] classification logits
+            cls_score_list,        # [B, A, nc] classification logits
             reg_distri_list,       # [B, A, 4*(reg_max+1)] raw DFL distribution
             pose_regression_list,  # [B, A, K, 2] decoded pose coords (image px)
             pose_logits_list,      # [B, A, K] keypoint visibility logits
@@ -1601,6 +1637,7 @@ class LibreYOLONASPoseModel(nn.Module):
         self,
         config: str = "s",
         num_keypoints: int = 17,
+        num_classes: int = 1,
         in_channels: int = 3,
         reg_max: int = 16,
         eval_size: Optional[Tuple[int, int]] = None,
@@ -1615,6 +1652,7 @@ class LibreYOLONASPoseModel(nn.Module):
         variant = _VARIANT_CONFIGS[config]
         self.config = config
         self.num_keypoints = num_keypoints
+        self.num_classes = num_classes
         self.reg_max = reg_max
 
         self.backbone = YoloNASBackbone(variant, in_channels=in_channels)
@@ -1622,6 +1660,7 @@ class LibreYOLONASPoseModel(nn.Module):
         self.heads = YoloNASPoseNDFLHeads(
             in_channels=tuple(self.neck.out_channels),
             num_keypoints=num_keypoints,
+            num_classes=num_classes,
             width_mult=variant["head_width_mult"],
             reg_max=reg_max,
             eval_size=eval_size,
@@ -1642,6 +1681,11 @@ class LibreYOLONASPoseModel(nn.Module):
         """Rebuild the pose head for a new keypoint count (fine-tuning hook)."""
         self.heads.replace_num_keypoints(num_keypoints)
         self.num_keypoints = num_keypoints
+
+    def replace_num_classes(self, num_classes: int):
+        """Rebuild the pose head for a new class count (fine-tuning hook)."""
+        self.heads.replace_num_classes(num_classes)
+        self.num_classes = num_classes
 
     def prep_model_for_conversion(
         self, input_size=None, full_fusion: bool = False, **kwargs

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -97,6 +97,7 @@ class YOLONASPoseTrainer(BaseTrainer):
     def on_setup(self):
         self.loss_fn = YoloNASPoseLoss(
             oks_sigmas=self._resolve_oks_sigmas(),
+            num_classes=self.config.num_classes,
             classification_loss_type=self.config.classification_loss_type,
             regression_iou_loss_type=self.config.regression_iou_loss_type,
             classification_loss_weight=self.config.classification_loss_weight,
@@ -132,7 +133,7 @@ class YOLONASPoseTrainer(BaseTrainer):
         cfg = load_data_config(
             self.config.data, allow_scripts=self.config.allow_download_scripts
         )
-        self.num_classes = 1
+        self.num_classes = self.config.num_classes
         flip_idx = cfg.get("flip_idx")
 
         train_imgs = cfg.get("train_img_files")

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -116,6 +116,10 @@ class YOLONASPoseTrainer(BaseTrainer):
         self.val_loader = None
 
     def _build_dataset(self, img_files, label_files, preproc) -> YOLOPoseDataset:
+        # Validate label class ids only for multi-class pose. Single-class pose
+        # is class-agnostic by contract (the loss trains class 0 regardless of
+        # the label column), so any historical labels keep loading.
+        nc = self.config.num_classes
         return YOLOPoseDataset(
             img_files=img_files,
             num_keypoints=self.num_keypoints,
@@ -124,6 +128,7 @@ class YOLONASPoseTrainer(BaseTrainer):
             preproc=preproc,
             keypoint_dim=self.config.keypoint_dim,
             decode_scale=self.config.decode_scale,
+            num_classes=nc if nc and nc > 1 else None,
         )
 
     def _setup_data(self):

--- a/libreyolo/postprocess/yolonas.py
+++ b/libreyolo/postprocess/yolonas.py
@@ -205,7 +205,15 @@ def postprocess_pose(
         pose_xy = pose_xy[0]
         pose_conf = pose_conf[0]
 
-    scores = scores.squeeze(-1)
+    # scores: [A, nc]. Single-class pose keeps the exact historical path
+    # (class-agnostic NMS, all-zero classes); multi-class pose takes the
+    # highest-scoring class per anchor and runs per-class NMS.
+    multiclass = scores.shape[-1] > 1
+    if multiclass:
+        scores, class_ids = scores.max(dim=-1)
+    else:
+        scores = scores.squeeze(-1)
+        class_ids = None
     # `>=` matches super-gradients' YoloNASPosePostPredictionCallback boundary.
     mask = scores >= conf_thres
     if not mask.any():
@@ -221,6 +229,8 @@ def postprocess_pose(
     scores = scores[mask].float()
     pose_xy = pose_xy[mask].float()
     pose_conf = pose_conf[mask].float()
+    if class_ids is not None:
+        class_ids = class_ids[mask]
 
     if pre_nms_max_predictions and scores.numel() > pre_nms_max_predictions:
         topk = scores.topk(pre_nms_max_predictions)
@@ -228,6 +238,8 @@ def postprocess_pose(
         bboxes = bboxes[topk.indices]
         pose_xy = pose_xy[topk.indices]
         pose_conf = pose_conf[topk.indices]
+        if class_ids is not None:
+            class_ids = class_ids[topk.indices]
 
     if original_size is not None:
         if letterbox:
@@ -258,6 +270,8 @@ def postprocess_pose(
             scores = scores[valid]
             pose_xy = pose_xy[valid]
             pose_conf = pose_conf[valid]
+            if class_ids is not None:
+                class_ids = class_ids[valid]
 
     if bboxes.numel() == 0:
         return {
@@ -268,7 +282,10 @@ def postprocess_pose(
             "keypoints": torch.zeros((0, pose_xy.shape[-2], 3)),
         }
 
-    keep = torchvision.ops.nms(bboxes, scores, iou_thres)
+    if class_ids is not None:
+        keep = torchvision.ops.batched_nms(bboxes, scores, class_ids, iou_thres)
+    else:
+        keep = torchvision.ops.nms(bboxes, scores, iou_thres)
     if keep.numel() > post_nms_max_predictions:
         keep = keep[:post_nms_max_predictions]
 
@@ -277,7 +294,10 @@ def postprocess_pose(
     pose_xy = pose_xy[keep].cpu()
     pose_conf = pose_conf[keep].cpu()
     keypoints = torch.cat([pose_xy, pose_conf.unsqueeze(-1)], dim=-1)
-    classes = torch.zeros(scores.shape[0], dtype=torch.long)
+    if class_ids is not None:
+        classes = class_ids[keep].cpu().long()
+    else:
+        classes = torch.zeros(scores.shape[0], dtype=torch.long)
 
     return {
         "boxes": bboxes,

--- a/libreyolo/validation/pose_validator.py
+++ b/libreyolo/validation/pose_validator.py
@@ -592,13 +592,30 @@ class PoseValidator(BaseValidator):
                 gt_keypoints_arr = (
                     np.stack(gt_keypoints) if gt_keypoints else None
                 )
-                gt_classes = np.zeros(len(anns), int)
+                category_ids = getattr(self, "_category_ids", []) or []
+                if len(category_ids) > 1:
+                    # Multi-class pose: label GT/predictions by class in the plot.
+                    cat_to_idx = {int(c): i for i, c in enumerate(category_ids)}
+                    gt_classes = np.array(
+                        [cat_to_idx.get(int(a.get("category_id", 0)), 0) for a in anns],
+                        dtype=int,
+                    )
+                    names = getattr(self.model, "names", None)
+                    class_names = (
+                        [str(names.get(i, i)) for i in range(len(category_ids))]
+                        if isinstance(names, dict)
+                        else names
+                    )
+                else:
+                    # Single-class pose is visually category-agnostic.
+                    gt_classes = np.zeros(len(anns), int)
+                    class_names = None
                 _safe(
                     ValPlotter.plot_val_sample,
                     img_bgr,
                     gt_boxes, gt_classes,
                     sample["pred_boxes"], sample["pred_classes"], sample["pred_scores"],
-                    None,  # class_names — poses are category-agnostic visually
+                    class_names,
                     samples_dir / f"val_sample_{idx:02d}.jpg",
                     gt_keypoints=gt_keypoints_arr,
                     pred_keypoints=sample.get("pred_keypoints"),

--- a/tests/e2e/test_yolonas_multiclass_pose_training.py
+++ b/tests/e2e/test_yolonas_multiclass_pose_training.py
@@ -1,0 +1,146 @@
+"""E2E overfit gate for YOLO-NAS multi-class (shared-skeleton) pose (issue #484).
+
+Fine-tunes ``yolonas-pose-n`` from the pretrained COCO pose checkpoint on a tiny
+synthetic 2-class, 1-keypoint dataset (circle vs square, each with a single
+center keypoint) and asserts the model:
+
+1. writes a multi-class pose checkpoint (``nc=2`` + names + ``num_keypoints=1``)
+   that reloads into a fresh model with an auto-rebuilt head, and
+2. actually discriminates the two classes on the val split.
+
+Follows the tier-0 overfit-gate precedent: a small, deterministic synthetic
+dataset the model must clearly overfit, with an assertion on class
+discrimination (not just mAP, which can pass with class collapse).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+import torch
+import yaml
+
+from .conftest import cuda_cleanup, requires_cuda
+
+pytestmark = [pytest.mark.e2e, pytest.mark.yolonas, pytest.mark.slow]
+
+
+def _make_dataset(root: Path, n_per_class: int = 40, size: int = 320, seed: int = 0) -> str:
+    """Circle (class 0) vs square (class 1); each has one center keypoint.
+
+    kpt_shape [1, 2] mirrors the meter-reading use case from issue #484.
+    """
+    rng = np.random.default_rng(seed)
+    for split in ("train", "val"):
+        img_dir = root / "images" / split
+        lbl_dir = root / "labels" / split
+        img_dir.mkdir(parents=True, exist_ok=True)
+        lbl_dir.mkdir(parents=True, exist_ok=True)
+        npc = n_per_class if split == "train" else max(6, n_per_class // 3)
+        idx = 0
+        for cls in (0, 1):
+            for _ in range(npc):
+                img = np.full((size, size, 3), 40, dtype=np.uint8)
+                r = int(rng.integers(size // 8, size // 6))
+                cx = int(rng.integers(r + 4, size - r - 4))
+                cy = int(rng.integers(r + 4, size - r - 4))
+                color = (0, 200, 255) if cls == 0 else (255, 120, 0)
+                if cls == 0:
+                    cv2.circle(img, (cx, cy), r, color, -1)
+                else:
+                    cv2.rectangle(img, (cx - r, cy - r), (cx + r, cy + r), color, -1)
+                img = cv2.GaussianBlur(img, (3, 3), 0)
+                name = f"{split}_{cls}_{idx:03d}"
+                cv2.imwrite(str(img_dir / f"{name}.jpg"), img)
+                bw = bh = (2 * r + 6) / size
+                ncx, ncy = cx / size, cy / size
+                (lbl_dir / f"{name}.txt").write_text(
+                    f"{cls} {ncx:.6f} {ncy:.6f} {bw:.6f} {bh:.6f} {ncx:.6f} {ncy:.6f}\n"
+                )
+                idx += 1
+
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(root),
+                "train": "images/train",
+                "val": "images/val",
+                "names": {0: "circle", 1: "square"},
+                "nc": 2,
+                "kpt_shape": [1, 2],
+            }
+        )
+    )
+    return str(yaml_path)
+
+
+@requires_cuda
+def test_yolonas_multiclass_pose_overfit(tmp_path):
+    from libreyolo.models.yolonas.model import LibreYOLONAS
+
+    data = _make_dataset(tmp_path)
+
+    model = LibreYOLONAS("yolo_nas_pose_n_coco_pose.pth", size="n", task="pose")
+    try:
+        results = model.train(
+            data=data,
+            epochs=40,
+            batch=16,
+            imgsz=320,
+            device="0",
+            workers=0,
+            seed=0,
+            project=str(tmp_path / "runs"),
+            name="mc_pose",
+            exist_ok=True,
+            optimizer="AdamW",
+            lr0=2e-3,
+        )
+        best = results.get("best_checkpoint")
+        assert best and Path(best).exists(), "no best checkpoint written"
+
+        # 1. Checkpoint carries multi-class pose metadata.
+        ckpt = torch.load(best, map_location="cpu", weights_only=False)
+        assert ckpt["task"] == "pose"
+        assert ckpt["nc"] == 2, f"expected nc=2, got {ckpt['nc']}"
+        assert set(ckpt["names"].values()) == {"circle", "square"}
+        assert ckpt["num_keypoints"] == 1, ckpt["num_keypoints"]
+        assert ckpt["model_family"] == "yolonas"
+
+        # 2. Reload into a fresh model: head auto-rebuilt to nc=2, K=1.
+        del model
+        cuda_cleanup()
+        fresh = LibreYOLONAS(best, size="n", task="pose", device="0")
+        assert fresh.nb_classes == 2
+        assert fresh.num_keypoints == 1
+        assert fresh.model.num_classes == 2
+
+        # 3. Class discrimination on the val split (the point of the test:
+        #    mAP alone can pass under class collapse).
+        val_imgs = sorted((tmp_path / "images" / "val").glob("*.jpg"))
+        correct = total = 0
+        for img in val_imgs:
+            true_cls = 0 if "_0_" in img.name else 1
+            out = fresh.predict(str(img), conf=0.3)
+            r0 = out[0] if isinstance(out, list) else out
+            if len(r0.boxes) == 0:
+                continue
+            top = int(torch.as_tensor(r0.boxes.conf).argmax())
+            pred_cls = int(r0.boxes.cls[top])
+            total += 1
+            correct += int(pred_cls == true_cls)
+            # every detection also carries the single keypoint
+            assert r0.keypoints is not None and r0.keypoints.xy.shape[-2] == 1
+
+        assert total >= 0.5 * len(val_imgs), (
+            f"model detected only {total}/{len(val_imgs)} val objects; "
+            "fine-tune did not converge"
+        )
+        acc = correct / max(total, 1)
+        assert acc >= 0.9, f"class-discrimination accuracy {acc:.2f} < 0.9"
+    finally:
+        cuda_cleanup()

--- a/tests/unit/test_autoconvert_families.py
+++ b/tests/unit/test_autoconvert_families.py
@@ -82,6 +82,10 @@ def _yolonas_s(pose: bool = False):
         "heads.head1.reg_pred.weight": torch.zeros(68, 64, 1, 1),
     }
     if pose:
+        # Pose fuses the class scores and K per-keypoint visibility logits into
+        # one head: cls_pred out_channels == num_classes + K. Single-class
+        # (person) COCO pose is 1 + 17 = 18, not the 80-class detection width.
+        sd["heads.head1.cls_pred.weight"] = torch.zeros(1 + 17, 64, 1, 1)
         sd["heads.head1.pose_pred.weight"] = torch.zeros(34, 64, 1, 1)
     return sd
 

--- a/tests/unit/test_yolonas_multiclass_pose.py
+++ b/tests/unit/test_yolonas_multiclass_pose.py
@@ -269,3 +269,65 @@ class TestBackendParser:
             effective_imgsz=320, orig_w=320, orig_h=320, conf=0.5, ratio=1.0,
         )
         assert class_ids.tolist() == [0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Class-id safety (Greptile P1 on PR #530 + label range validation)
+# ---------------------------------------------------------------------------
+
+
+class TestClassIdSafety:
+    def test_single_class_nonzero_label_ids_train_class_zero(self):
+        # Historical contract: single-class pose ignores the label class column.
+        # A raw id of 1 (e.g. COCO person=1) must NOT reach the assigner, whose
+        # background index is also 1 — that would silently drop the GT.
+        loss_fn = YoloNASPoseLoss(oks_sigmas=[0.1], num_classes=1)
+        targets = torch.zeros(1, 2, 5 + 3 * 1)
+        targets[0, 0] = torch.tensor([1, 160, 160, 80, 80, 160, 160, 2])
+        targets[0, 1] = torch.tensor([1, 60, 60, 40, 40, 60, 60, 2])
+        tgt = loss_fn._unpack_padded_targets(targets)
+        assert tgt["gt_class"].unique().tolist() == [0]
+
+    def test_multiclass_gt_class_passes_through(self):
+        loss_fn = YoloNASPoseLoss(oks_sigmas=[0.1], num_classes=3)
+        targets = torch.zeros(1, 2, 5 + 3 * 1)
+        targets[0, 0] = torch.tensor([2, 160, 160, 80, 80, 160, 160, 2])
+        targets[0, 1] = torch.tensor([0, 60, 60, 40, 40, 60, 60, 2])
+        tgt = loss_fn._unpack_padded_targets(targets)
+        assert tgt["gt_class"][0, :, 0].tolist() == [2, 0]
+
+    def test_parser_rejects_out_of_range_class(self):
+        from libreyolo.data.pose_dataset import parse_yolo_pose_label_line
+
+        line = "2 0.5 0.5 0.2 0.2 0.5 0.5 2".split()
+        # id == nc and negatives are rejected when num_classes is given
+        with pytest.raises(ValueError, match="out of range"):
+            parse_yolo_pose_label_line(line, 1, 3, num_classes=2)
+        with pytest.raises(ValueError, match="out of range"):
+            parse_yolo_pose_label_line(
+                "-1 0.5 0.5 0.2 0.2 0.5 0.5 2".split(), 1, 3, num_classes=2
+            )
+        # in-range id passes; without num_classes stays lenient
+        cls_id, _, _ = parse_yolo_pose_label_line(line, 1, 3, num_classes=3)
+        assert cls_id == 2
+        cls_id, _, _ = parse_yolo_pose_label_line(line, 1, 3)
+        assert cls_id == 2
+
+    def test_dataset_skips_out_of_range_class_lines(self, tmp_path):
+        from libreyolo.data.pose_dataset import YOLOPoseDataset
+
+        img = tmp_path / "im.jpg"
+        img.write_bytes(b"")  # labels load at init; the image is never opened
+        lbl = tmp_path / "im.txt"
+        lbl.write_text(
+            "0 0.5 0.5 0.2 0.2 0.5 0.5 2\n"
+            "5 0.3 0.3 0.1 0.1 0.3 0.3 2\n"  # out of range for nc=2
+            "1 0.7 0.7 0.1 0.1 0.7 0.7 2\n"
+        )
+        ds = YOLOPoseDataset(
+            [img], num_keypoints=1, label_files=[lbl], num_classes=2
+        )
+        assert ds.labels[0][1].tolist() == [0.0, 1.0]
+        # without num_classes the historical leniency is preserved
+        ds = YOLOPoseDataset([img], num_keypoints=1, label_files=[lbl])
+        assert ds.labels[0][1].tolist() == [0.0, 5.0, 1.0]

--- a/tests/unit/test_yolonas_multiclass_pose.py
+++ b/tests/unit/test_yolonas_multiclass_pose.py
@@ -1,0 +1,271 @@
+"""Multi-class (shared-skeleton) keypoint support for YOLO-NAS pose (issue #484).
+
+The user's meter-reading case needs one keypoint per object while classifying the
+object into several types. YOLO-NAS pose gains ``num_classes`` on the class/box
+branch; the single shared keypoint skeleton is unchanged. Single-class pose stays
+byte-identical. These tests cover the nc > 1 additions:
+
+- head width and the train/eval output shapes
+- ``replace_num_classes`` / ``replace_num_keypoints`` rebuild round-trips
+- the loss + assigner routing score mass to the correct class column
+- shape-based class-count detection (multi-class and legacy single-class)
+- ``postprocess_pose`` (argmax + per-class NMS; single-class parity)
+- the ONNX backend parser
+"""
+
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.backends.base import BaseBackend
+from libreyolo.models.yolonas.loss import YoloNASPoseLoss
+from libreyolo.models.yolonas.model import LibreYOLONAS
+from libreyolo.models.yolonas.nn import LibreYOLONASPoseModel
+from libreyolo.postprocess.yolonas import postprocess_pose
+
+pytestmark = [pytest.mark.unit, pytest.mark.yolonas]
+
+
+def _decoded(out):
+    """Head forward returns (decoded, raw) unless tracing; unwrap the decoded 4-tuple."""
+    if isinstance(out, tuple) and len(out) == 2 and isinstance(out[0], tuple):
+        return out[0]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Head width + rebuild round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestMultiClassPoseHead:
+    def test_single_class_default_unchanged(self):
+        m = LibreYOLONASPoseModel(config="n", num_keypoints=17)
+        assert m.num_classes == 1
+        # fused cls head: num_classes (1) + K visibility channels
+        assert m.heads.head1.cls_pred.out_channels == 1 + 17
+
+    def test_multiclass_head_widths(self):
+        m = LibreYOLONASPoseModel(config="n", num_keypoints=1, num_classes=3)
+        assert m.heads.head1.cls_pred.out_channels == 3 + 1
+        assert m.heads.head2.cls_pred.out_channels == 3 + 1
+        assert m.heads.head3.cls_pred.out_channels == 3 + 1
+
+    def test_eval_output_shapes(self):
+        m = LibreYOLONASPoseModel(config="n", num_keypoints=1, num_classes=3).eval()
+        with torch.no_grad():
+            bboxes, scores, pose_xy, pose_scores = _decoded(m(torch.rand(2, 3, 320, 320)))
+        assert bboxes.shape[0] == 2 and bboxes.shape[-1] == 4
+        assert scores.shape[-1] == 3
+        assert pose_xy.shape[-2:] == (1, 2)  # [B, A, K=1, 2]
+        assert pose_scores.shape[-1] == 1
+
+    def test_train_raw_shapes(self):
+        m = LibreYOLONASPoseModel(config="n", num_keypoints=1, num_classes=3).train()
+        _, raw = m(torch.rand(2, 3, 320, 320))
+        cls_logits, _reg, pose_coords, pose_logits = raw[0], raw[1], raw[2], raw[3]
+        assert cls_logits.shape[-1] == 3
+        assert pose_coords.shape[-2:] == (1, 2)
+        assert pose_logits.shape[-1] == 1
+
+    def test_replace_num_classes_preserves_visibility(self):
+        m = LibreYOLONASPoseModel(config="n", num_keypoints=2, num_classes=1)
+        vis_before = m.heads.head1.cls_pred.weight[1:].clone()  # K=2 visibility rows
+        m.replace_num_classes(5)
+        assert m.num_classes == 5
+        assert m.heads.head1.cls_pred.out_channels == 5 + 2
+        vis_after = m.heads.head1.cls_pred.weight[5:].clone()
+        assert torch.allclose(vis_before, vis_after)
+
+    def test_keypoints_then_classes_rebuild(self):
+        # COCO-style start (nc=1, K=17), fine-tune to a 1-keypoint, 4-class dataset.
+        m = LibreYOLONASPoseModel(config="n", num_keypoints=17, num_classes=1)
+        m.replace_num_keypoints(1)
+        vis_before = m.heads.head1.cls_pred.weight[1:].clone()  # freshly sized vis
+        m.replace_num_classes(4)
+        assert m.heads.head1.cls_pred.out_channels == 4 + 1
+        vis_after = m.heads.head1.cls_pred.weight[4:].clone()
+        assert torch.allclose(vis_before, vis_after)
+        m.eval()
+        with torch.no_grad():
+            _, scores, pose_xy, _ = _decoded(m(torch.rand(1, 3, 320, 320)))
+        assert scores.shape[-1] == 4
+        assert pose_xy.shape[-2:] == (1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Loss + assigner class routing
+# ---------------------------------------------------------------------------
+
+
+class TestMultiClassPoseLoss:
+    def test_loss_finite_and_assigner_routes_classes(self):
+        torch.manual_seed(0)
+        nc, K = 3, 1
+        model = LibreYOLONASPoseModel(config="n", num_keypoints=K, num_classes=nc).train()
+        loss_fn = YoloNASPoseLoss(oks_sigmas=[0.1] * K, num_classes=nc)
+
+        targets = torch.zeros(2, 2, 5 + 3 * K)
+        targets[0, 0] = torch.tensor([2, 160, 160, 80, 80, 160, 160, 2])  # class 2
+        targets[1, 0] = torch.tensor([0, 100, 100, 60, 60, 100, 100, 2])  # class 0
+        targets[1, 1] = torch.tensor([1, 220, 220, 60, 60, 220, 220, 2])  # class 1
+
+        out = model(torch.rand(2, 3, 320, 320))
+        loss, logs = loss_fn(out, targets)
+        assert torch.isfinite(loss)
+        loss.backward()  # gradients flow
+
+        # The assigner one-hot must land in the gt's class column.
+        tgt = loss_fn._unpack_padded_targets(targets)
+        assert tgt["gt_class"][0, 0, 0].item() == 2
+        _, preds = out
+        (pred_scores, pred_distri, pred_pose_coords, _pl, _a, anchor_points,
+         _nal, stride_tensor) = preds
+        pred_bboxes, _ = loss_fn._bbox_decode(anchor_points / stride_tensor, pred_distri)
+        ar = loss_fn.assigner(
+            pred_scores=pred_scores.detach().sigmoid(),
+            pred_bboxes=pred_bboxes.detach() * stride_tensor,
+            pred_pose_coords=pred_pose_coords.detach(),
+            anchor_points=anchor_points,
+            gt_labels=tgt["gt_class"], gt_bboxes=tgt["gt_bbox"],
+            gt_poses=tgt["gt_poses"], gt_crowd=tgt["gt_crowd"],
+            pad_gt_mask=tgt["pad_gt_mask"], bg_index=nc,
+        )
+        sc = ar.assigned_scores  # [B, A, nc]
+        pos0 = sc[0].sum(dim=-1) > 0
+        assert sc[0][pos0].argmax(dim=-1).unique().tolist() == [2]
+        pos1 = sc[1].sum(dim=-1) > 0
+        assert sorted(sc[1][pos1].argmax(dim=-1).unique().tolist()) == [0, 1]
+
+    def test_single_class_default(self):
+        loss_fn = YoloNASPoseLoss(oks_sigmas=[0.1])
+        assert loss_fn.num_classes == 1
+
+
+# ---------------------------------------------------------------------------
+# Shape-based class-count detection (backward compatible)
+# ---------------------------------------------------------------------------
+
+
+class TestShapeBasedClassDetection:
+    @staticmethod
+    def _state_dict(nc, K):
+        return {
+            "heads.head1.cls_pred.weight": torch.zeros(nc + K, 8, 1, 1),
+            "heads.head1.pose_pred.weight": torch.zeros(2 * K, 8, 1, 1),
+        }
+
+    def test_legacy_single_class_checkpoint(self):
+        sd = self._state_dict(nc=1, K=17)  # cls_pred out = 18
+        assert LibreYOLONAS.is_pose_state_dict(sd)
+        assert LibreYOLONAS.detect_num_keypoints(sd) == 17
+        assert LibreYOLONAS.detect_nb_classes(sd) == 1
+
+    def test_multiclass_checkpoint(self):
+        sd = self._state_dict(nc=17, K=1)  # cls_pred out = 18, pose_pred out = 2
+        assert LibreYOLONAS.detect_num_keypoints(sd) == 1
+        assert LibreYOLONAS.detect_nb_classes(sd) == 17
+
+
+# ---------------------------------------------------------------------------
+# postprocess_pose
+# ---------------------------------------------------------------------------
+
+
+def _pose_output(scores):
+    """Build a head-style output dict with two well-separated boxes."""
+    a = scores.shape[0]
+    boxes = torch.zeros(a, 4)
+    boxes[0] = torch.tensor([10.0, 10.0, 40.0, 40.0])
+    if a > 1:
+        boxes[1] = torch.tensor([200.0, 200.0, 240.0, 240.0])
+    pose_xy = torch.zeros(a, 1, 2)
+    pose_conf = torch.ones(a, 1)
+    return {"boxes": boxes, "scores": scores, "keypoints_xy": pose_xy, "keypoints_conf": pose_conf}
+
+
+class TestPostprocessPose:
+    def test_single_class_classes_all_zero(self):
+        scores = torch.tensor([[0.9], [0.8]])  # [A, 1]
+        res = postprocess_pose(_pose_output(scores), conf_thres=0.5)
+        assert res["num_detections"] == 2
+        assert res["classes"].tolist() == [0, 0]
+
+    def test_multiclass_argmax_classes(self):
+        scores = torch.tensor([[0.1, 0.9, 0.2], [0.8, 0.1, 0.1]])  # [A, 3]
+        res = postprocess_pose(_pose_output(scores), conf_thres=0.5)
+        assert res["num_detections"] == 2
+        # box 0 -> class 1 (0.9), box 1 -> class 0 (0.8); ordered by score
+        assert sorted(res["classes"].tolist()) == [0, 1]
+
+    def test_per_class_nms_keeps_overlapping_different_classes(self):
+        # Two identical boxes, different top class -> both survive under batched_nms.
+        out = {
+            "boxes": torch.tensor([[10.0, 10, 40, 40], [10.0, 10, 40, 40]]),
+            "scores": torch.tensor([[0.1, 0.9], [0.8, 0.1]]),
+            "keypoints_xy": torch.zeros(2, 1, 2),
+            "keypoints_conf": torch.ones(2, 1),
+        }
+        res = postprocess_pose(out, conf_thres=0.5, iou_thres=0.5)
+        assert res["num_detections"] == 2
+        assert sorted(res["classes"].tolist()) == [0, 1]
+
+    def test_per_class_nms_suppresses_same_class(self):
+        out = {
+            "boxes": torch.tensor([[10.0, 10, 40, 40], [11.0, 11, 41, 41]]),
+            "scores": torch.tensor([[0.1, 0.9], [0.1, 0.8]]),  # both top class 1
+            "keypoints_xy": torch.zeros(2, 1, 2),
+            "keypoints_conf": torch.ones(2, 1),
+        }
+        res = postprocess_pose(out, conf_thres=0.5, iou_thres=0.5)
+        assert res["num_detections"] == 1
+        assert res["classes"].tolist() == [1]
+
+
+# ---------------------------------------------------------------------------
+# ONNX backend parser
+# ---------------------------------------------------------------------------
+
+
+class TestBackendParser:
+    def test_parse_multiclass_scores(self):
+        a = 3
+        boxes = np.zeros((1, a, 4), np.float32)
+        boxes[0, 0] = [10, 10, 40, 40]
+        boxes[0, 1] = [200, 200, 240, 240]
+        boxes[0, 2] = [50, 50, 60, 60]
+        scores = np.zeros((1, a, 3), np.float32)
+        scores[0, 0] = [0.1, 0.9, 0.2]   # class 1
+        scores[0, 1] = [0.8, 0.1, 0.1]   # class 0
+        scores[0, 2] = [0.0, 0.0, 0.0]   # below conf
+        kpxy = np.zeros((1, a, 1, 2), np.float32)
+        kpconf = np.ones((1, a, 1), np.float32)
+
+        dummy = types.SimpleNamespace()
+        boxes_o, scores_o, class_ids, _m, _extra, keypoints = (
+            BaseBackend._parse_yolonas_pose(
+                dummy, [boxes, scores, kpxy, kpconf],
+                effective_imgsz=320, orig_w=320, orig_h=320, conf=0.5, ratio=1.0,
+            )
+        )
+        assert set(class_ids.tolist()) == {0, 1}
+        assert keypoints.shape[-2:] == (1, 3)
+
+    def test_parse_single_class_scores(self):
+        a = 2
+        boxes = np.zeros((1, a, 4), np.float32)
+        boxes[0, 0] = [10, 10, 40, 40]
+        boxes[0, 1] = [200, 200, 240, 240]
+        scores = np.array([[[0.9], [0.8]]], np.float32)  # [1, A, 1]
+        kpxy = np.zeros((1, a, 1, 2), np.float32)
+        kpconf = np.ones((1, a, 1), np.float32)
+        dummy = types.SimpleNamespace()
+        _b, scores_o, class_ids, _m, _e, _k = BaseBackend._parse_yolonas_pose(
+            dummy, [boxes, scores, kpxy, kpconf],
+            effective_imgsz=320, orig_w=320, orig_h=320, conf=0.5, ratio=1.0,
+        )
+        assert class_ids.tolist() == [0, 0]


### PR DESCRIPTION
Extend the YOLO-NAS pose head, loss, and trainer to support multiple classes that share a single keypoint skeleton (issue #484): detect and classify each object while predicting the same set of keypoints. The fused class head widens from 1 + K to num_classes + K channels; the task-aligned assigner and the per-category OKS validation were already class-generic.

Single-class (person) pose is unchanged: the postprocess and ONNX-backend paths keep the exact class-agnostic behavior when nc == 1, and the class count is recovered from tensor shapes so existing single-class checkpoints keep loading. Multi-class training resolves nc/names from the dataset yaml, carries them in the checkpoint, and rebuilds the head (class channels reinitialised, keypoint visibility channels preserved) when fine-tuning a single-class checkpoint.

Verified end to end on a synthetic 2-class, 1-keypoint dataset: fine-tuning the COCO pose checkpoint reaches 100% class discrimination, and the checkpoint round-trips through save/reload and ONNX export.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the YOLO-NAS pose head, loss, and trainer to support multiple object classes that share a single keypoint skeleton.

- **Head widening**: `cls_pred` output channels grow from `1 + K` to `num_classes + K`; forward pass splits at `[:nc]`/`[nc:]` for class logits and visibility logits. Single-class pose (nc=1) is byte-identical to the old path.
- **Backward compatibility**: `_unpack_padded_targets` forces `gt_class=0` when `num_classes==1`, fixing the previously reported COCO person=1 background-index collision. Shape-based class-count detection enables seamless reload of old single-class checkpoints.
- **Multi-class inference**: `postprocess_pose` and the ONNX backend use argmax-over-classes then `batched_nms`, allowing overlapping boxes of different classes to survive NMS.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-class pose behavior is preserved byte-for-byte and the multi-class additions are well-guarded at every layer.

The critical backward-compatibility risk (COCO person=1 colliding with the assigner background index) identified in previous review rounds is definitively fixed. Shape-based nc recovery is unambiguous, state-dict loading rebuilds the head before applying weights, and the multi-class NMS/argmax/dataset-validation paths are covered by both unit and E2E tests.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/yolonas/nn.py | cls_pred widened to num_classes+K; replace_num_classes added, preserves visibility channels and reinitialises class channels; forward split updated from hard-coded [:1]/[1:] to [:nc]/[nc:]. |
| libreyolo/models/yolonas/loss.py | num_classes param added to YoloNASPoseLoss; _unpack_padded_targets forces gt_class=0 for nc==1 and passes real class ids for nc>1. |
| libreyolo/models/yolonas/model.py | _rebuild_for_new_classes now handles pose; _load_weights adds shape-based nc detection before metadata path; train() rebuilds keypoints then classes in correct order. |
| libreyolo/postprocess/yolonas.py | Branches on scores.shape[-1]>1; multi-class path uses argmax+batched_nms; class_ids propagated through all filters. |
| libreyolo/backends/base.py | _parse_yolonas_pose handles [A,nc] scores: argmax for multi-class, squeeze for single-class. |
| libreyolo/data/pose_dataset.py | num_classes added; class range validation scoped to nc>1 preserving single-class leniency. |
| libreyolo/models/yolonas/pose_trainer.py | num_classes passed to loss and dataset; _setup_data reads from config instead of hardcoding 1. |
| tests/unit/test_yolonas_multiclass_pose.py | Covers head widths, rebuild round-trips, loss/assigner routing, shape detection, NMS paths, ONNX backend, and class-id safety. |
| tests/e2e/test_yolonas_multiclass_pose_training.py | E2E overfit gate: fine-tunes on synthetic 2-class 1-keypoint dataset, asserts 90% class discrimination and checkpoint round-trip. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Guard pose class ids against assigner ba..."](https://github.com/libreyolo/libreyolo/commit/af5ae648cb49037efb10a0c7e86cbbe3058f87e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42029629)</sub>

<!-- /greptile_comment -->