### PR TITLE
Enable SyncBatchNorm for YOLO9 under DDP

### DIFF
--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -62,9 +62,10 @@ class TrainConfig:
     #   - "cpu", "mps", "0", "cuda:0", 0 → single device
     #   - [0, 1] or "0,1" → multi-GPU, requires torchrun launch
     device: Union[str, int, List[int]] = "auto"
-    # SyncBatchNorm across ranks under DDP. Off here; per-family configs
-    # override (yolo9 defaults True per upstream MultimediaTechLab). No-op
-    # when not distributed.
+    # SyncBatchNorm across ranks under DDP. Off here; BatchNorm-heavy CNN
+    # families (e.g. yolo9) override to True so BN statistics are computed
+    # across the global batch instead of each rank's small shard. No-op when
+    # not distributed.
     sync_bn: bool = False
 
     # Optimizer
@@ -222,7 +223,11 @@ class YOLO9Config(TrainConfig):
     name: str = "yolo9_exp"
     workers: int = 8
     mask_downsample_ratio: int = 4
-    sync_bn: bool = False
+    # YOLO9 is BatchNorm-heavy. Under multi-GPU DDP the per-rank batch is
+    # ``batch // world_size``; without SyncBatchNorm each rank's BN running
+    # statistics track only its own small shard, which measurably degrades the
+    # converged model versus single-GPU (issue #484). Sync BN across ranks.
+    sync_bn: bool = True
     # Per-image ground-truth cap in the train transforms. Dense datasets
     # (e.g. aerial imagery) exceed the historical 100-box default; boxes
     # beyond the cap are silently dropped, so raise it for such data.

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1177,6 +1177,28 @@ class BaseTrainer(ABC):
             if is_main_process():
                 logger.info("AutoBatch: resolved global batch size = %d", self.config.batch)
 
+        # BN statistics quality under DDP: with SyncBatchNorm off, each rank's
+        # BatchNorm tracks only its own per-rank shard (batch // world_size).
+        # A small per-rank batch produces noisy running stats and degrades the
+        # converged model (issue #484). Warn (do not silently change behavior)
+        # so users of BatchNorm families can enable sync_bn.
+        if self.is_distributed and not getattr(self.config, "sync_bn", False):
+            per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+            has_batchnorm = any(
+                isinstance(m, nn.modules.batchnorm._BatchNorm)
+                for m in self.model.modules()
+            )
+            if has_batchnorm and per_rank_batch < 16 and is_main_process():
+                logger.warning(
+                    "DDP per-rank batch is %d (global batch %d / world_size %d) "
+                    "and sync_bn is disabled; BatchNorm running statistics are "
+                    "computed per rank on this small shard, which can reduce "
+                    "accuracy versus single-GPU. Consider setting sync_bn=True.",
+                    per_rank_batch,
+                    self.config.batch,
+                    self.world_size,
+                )
+
         self._setup_data()
         self._apply_freeze_config()
         self.optimizer = self._setup_optimizer()

--- a/tests/unit/test_ddp_syncbn.py
+++ b/tests/unit/test_ddp_syncbn.py
@@ -1,0 +1,180 @@
+"""SyncBatchNorm under DDP for YOLO9 (issue #484, residual multi-GPU gap).
+
+After the loss-scaling fix (``test_ddp_loss_parity.py``), YOLO9 multi-GPU
+training still trailed single-GPU by a few points of mAP. The cause is
+BatchNorm: the global batch is split across ranks (``batch // world_size``),
+so with SyncBatchNorm off each rank's BN running statistics track only its own
+small shard, and only rank 0's shard-derived buffers are validated and saved.
+YOLO9 is BatchNorm-heavy, so this measurably degrades the converged model.
+
+The fix is ``YOLO9Config.sync_bn = True`` (plus a trainer warning for any
+BatchNorm family left with sync_bn off at a small per-rank batch). These tests:
+
+1. Guard the config default so it can never silently regress to False again.
+2. Verify the real YOLO9 model's BatchNorm converts to SyncBatchNorm, i.e. the
+   conversion the trainer runs under DDP actually reaches every BN layer.
+3. Demonstrate, over 2 gloo ranks, the per-rank running-stat divergence that
+   SyncBatchNorm removes.
+
+SyncBatchNorm's forward requires GPU modules, so the identical-stats end state
+cannot be exercised on CPU; tests 1-2 lock in the config + conversion, test 3
+documents the mechanism on CPU. Gloo/CPU only, no GPU required.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+
+pytestmark = pytest.mark.unit
+
+
+# =============================================================================
+# 1. Config guard
+# =============================================================================
+
+
+def test_yolo9_config_enables_sync_bn():
+    """YOLO9 (and its pose subclass) must enable SyncBatchNorm; the base config
+    must keep it off. Guards against the config silently disagreeing with its
+    documented intent again (issue #484)."""
+    from libreyolo.training.config import TrainConfig, YOLO9Config, YOLO9PoseConfig
+
+    assert TrainConfig().sync_bn is False
+    assert YOLO9Config().sync_bn is True
+    assert YOLO9PoseConfig().sync_bn is True
+
+
+# =============================================================================
+# 2. Real-model conversion
+# =============================================================================
+
+
+def test_yolo9_batchnorm_converts_to_syncbatchnorm():
+    """The conversion the trainer performs under DDP
+    (``nn.SyncBatchNorm.convert_sync_batchnorm``) must reach every BatchNorm in
+    a real YOLO9 model — no BN layer left as a plain per-rank module."""
+    from libreyolo import LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", device="cpu").model
+
+    n_bn_before = sum(
+        isinstance(m, nn.modules.batchnorm._BatchNorm) for m in model.modules()
+    )
+    assert n_bn_before > 0, "YOLO9-t is expected to contain BatchNorm layers"
+
+    converted = nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+    n_sync = sum(isinstance(m, nn.SyncBatchNorm) for m in converted.modules())
+    n_plain_left = sum(
+        isinstance(m, nn.modules.batchnorm._BatchNorm)
+        and not isinstance(m, nn.SyncBatchNorm)
+        for m in converted.modules()
+    )
+    assert n_sync == n_bn_before
+    assert n_plain_left == 0
+
+
+# =============================================================================
+# 3. Per-rank BN divergence (the mechanism SyncBatchNorm removes)
+# =============================================================================
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _setup_pg(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+
+
+def _build_bn_model() -> nn.Sequential:
+    """Deterministic conv+BN, identical initial weights in every process."""
+    torch.manual_seed(0)
+    return nn.Sequential(nn.Conv2d(3, 4, 3, padding=1), nn.BatchNorm2d(4))
+
+
+def _bn_divergence_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+    """One rank: forward its OWN data through DDP-wrapped plain BatchNorm, then
+    save the BN running_mean. With sync_bn off each rank updates running stats
+    from its local shard only, so the saved buffers differ across ranks."""
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        _setup_pg(rank, world_size, port)
+
+        model = _build_bn_model()
+        ddp_model = nn.parallel.DistributedDataParallel(model)
+        ddp_model.train()
+
+        # Different, deterministic data per rank → different local BN stats.
+        g = torch.Generator().manual_seed(100 + rank)
+        x = torch.rand(4, 3, 8, 8, generator=g)
+        ddp_model(x)
+
+        running_mean = model[1].running_mean.detach().clone()
+        torch.save(running_mean, Path(out_dir) / f"running_mean_{rank}.pt")
+        dist.barrier()
+        out_path.write_text("ok\n")
+    except Exception as exc:  # pragma: no cover - surfaced via the parent assert
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+def test_ddp_batchnorm_running_stats_diverge_per_rank(tmp_path):
+    """Plain BatchNorm under 2-rank DDP: each rank's running_mean reflects only
+    its own shard, so the buffers differ across ranks. This is the degradation
+    (issue #484) that ``sync_bn=True`` removes by computing BN statistics over
+    the global batch."""
+    port = _free_port()
+    out_dir = str(tmp_path)
+    try:
+        mp.spawn(
+            _bn_divergence_worker,
+            args=(2, port, out_dir),
+            nprocs=2,
+            join=True,
+        )
+    except Exception as exc:
+        outputs = {
+            r: (tmp_path / f"rank_{r}.txt").read_text()
+            if (tmp_path / f"rank_{r}.txt").exists()
+            else "<no output>"
+            for r in range(2)
+        }
+        raise AssertionError(f"spawn failed: {exc}\nper-rank outputs: {outputs}") from exc
+
+    for r in range(2):
+        text = (tmp_path / f"rank_{r}.txt").read_text()
+        assert text.startswith("ok"), f"rank {r} did not finish ok: {text!r}"
+
+    rm0 = torch.load(tmp_path / "running_mean_0.pt", weights_only=False)
+    rm1 = torch.load(tmp_path / "running_mean_1.pt", weights_only=False)
+
+    assert not torch.allclose(rm0, rm1), (
+        "BatchNorm running_mean is identical across ranks, but with sync_bn off "
+        "each rank should track only its own shard. If this ever passes, the "
+        "per-rank BN divergence this test documents has changed."
+    )


### PR DESCRIPTION
Multi-GPU training splits the global batch across ranks, so with SyncBatchNorm off each rank's BatchNorm tracked only its own shard and only rank 0's buffers were validated and saved, degrading the converged model versus single-GPU (issue #484). Default YOLO9Config.sync_bn to True, and warn when any BatchNorm family trains under DDP with a small per-rank batch and sync_bn disabled.