### PR TITLE
@

### DIFF
--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -203,14 +203,17 @@ def train_cmd(
     # Distillation
     distill_model: str = typer.Option(
         "",
-        help="Teacher checkpoint for knowledge distillation",
+        help="Teacher for knowledge distillation: a detector checkpoint, or a "
+        "foundation-teacher id (e.g. 'dinov2') for backbone feature distillation",
     ),
     dis: Optional[float] = typer.Option(
         None,
         help="Distillation loss weight (default: per-loss-type published default)",
     ),
     distill_loss_type: str = typer.Option(
-        "mgd", help="Distillation feature loss: mgd, cwd"
+        "mgd",
+        help="Distillation feature loss for detector teachers: mgd, cwd "
+        "(foundation teachers always use feat_mse)",
     ),
     # Optimizer
     optimizer: str = typer.Option("sgd", help="Optimizer: sgd, adam, adamw"),

--- a/libreyolo/distillation/__init__.py
+++ b/libreyolo/distillation/__init__.py
@@ -36,16 +36,20 @@ Available loss types:
 """
 
 from .distiller import Distiller
-from .losses import MGDLoss, CWDLoss, DISTILL_LOSSES
+from .losses import MGDLoss, CWDLoss, FeatureMSELoss, DISTILL_LOSSES
 from .hooks import FeatureHookManager
 from .configs import get_distill_config, list_supported
+from .teachers import DINOv2Teacher, is_foundation_teacher
 
 __all__ = [
     "Distiller",
     "MGDLoss",
     "CWDLoss",
+    "FeatureMSELoss",
     "DISTILL_LOSSES",
     "FeatureHookManager",
     "get_distill_config",
     "list_supported",
+    "DINOv2Teacher",
+    "is_foundation_teacher",
 ]

--- a/libreyolo/distillation/distiller.py
+++ b/libreyolo/distillation/distiller.py
@@ -32,13 +32,13 @@ Usage::
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import torch
 import torch.nn as nn
 
 from .hooks import FeatureHookManager
-from .losses import MGDLoss, CWDLoss, DISTILL_LOSSES
+from .losses import MGDLoss, CWDLoss, FeatureMSELoss, DISTILL_LOSSES
 
 logger = logging.getLogger(__name__)
 
@@ -86,16 +86,28 @@ class Distiller(nn.Module):
         mask_ratio: float = 0.65,
         tau: float = 1.0,
         per_scale_weight: Optional[List[float]] = None,
+        teacher_feature_fn: Optional[Callable[[torch.Tensor], List[torch.Tensor]]] = None,
+        normalize: bool = False,
     ):
         super().__init__()
 
         self.loss_type = loss_type.lower()
         self.loss_weight = loss_weight if loss_weight is not None else self._default_weight()
+        self.normalize = normalize
+
+        # A foundation-model teacher (e.g. DINOv2) emits token features that are
+        # not a hookable BCHW module output and lives on a different spatial
+        # grid/stride than the student. Callers pass ``teacher_feature_fn`` to
+        # extract its per-scale feature maps directly; the feature-MSE loss then
+        # resizes them to the student. In that mode we skip teacher hooks and the
+        # stride-equality check (the loss handles spatial mismatch).
+        self.teacher_feature_fn = teacher_feature_fn
+        self._teacher_feats: Optional[List[torch.Tensor]] = None
 
         # Validate configs
         t_strides = teacher_config["strides"]
         s_strides = student_config["strides"]
-        if t_strides != s_strides:
+        if teacher_feature_fn is None and t_strides != s_strides:
             raise ValueError(
                 f"Teacher and student must have matching strides. "
                 f"Teacher: {t_strides}, Student: {s_strides}"
@@ -111,8 +123,14 @@ class Distiller(nn.Module):
         for param in self.teacher.parameters():
             param.requires_grad = False
 
-        # Register hooks on both models
-        self.t_hooks = FeatureHookManager(self.teacher, teacher_config["tap_points"])
+        # Register hooks. The student is always hooked. The teacher is hooked
+        # only when it exposes hookable BCHW features (detector teachers);
+        # foundation teachers deliver features via ``teacher_feature_fn``.
+        self.t_hooks = (
+            FeatureHookManager(self.teacher, teacher_config["tap_points"])
+            if teacher_feature_fn is None
+            else None
+        )
         self.s_hooks = FeatureHookManager(student_model, student_config["tap_points"])
 
         # Per-scale weights
@@ -153,7 +171,7 @@ class Distiller(nn.Module):
 
     def _default_weight(self) -> float:
         """Return sensible default loss weight for the chosen loss type."""
-        defaults = {"mgd": 2e-5, "cwd": 1.0}
+        defaults = {"mgd": 2e-5, "cwd": 1.0, "feat_mse": 1.0}
         if self.loss_type not in defaults:
             raise ValueError(
                 f"No default weight for loss type '{self.loss_type}'. "
@@ -185,6 +203,13 @@ class Distiller(nn.Module):
                 tau=tau,
                 loss_weight=scale_weight,
             )
+        elif self.loss_type == "feat_mse":
+            return FeatureMSELoss(
+                student_channels=student_ch,
+                teacher_channels=teacher_ch,
+                loss_weight=scale_weight,
+                normalize=self.normalize,
+            )
         else:
             raise ValueError(
                 f"Unknown loss type: '{self.loss_type}'. "
@@ -208,6 +233,10 @@ class Distiller(nn.Module):
         Returns:
             Teacher model output (usually ignored — we only need the hooks).
         """
+        if self.teacher_feature_fn is not None:
+            # Foundation teacher: extract features directly and stash them.
+            self._teacher_feats = [f.detach() for f in self.teacher_feature_fn(images)]
+            return None
         return self.teacher(images)
 
     def compute_loss(self) -> torch.Tensor:
@@ -222,13 +251,27 @@ class Distiller(nn.Module):
         Raises:
             RuntimeError: If features haven't been captured yet.
         """
-        t_feats = self.t_hooks.get_feature_list()
+        if self.teacher_feature_fn is not None:
+            if self._teacher_feats is None:
+                raise RuntimeError(
+                    "Teacher features not extracted. "
+                    "Did you call teacher_forward() before compute_loss()?"
+                )
+            t_feats = self._teacher_feats
+        else:
+            t_feats = self.t_hooks.get_feature_list()
         s_feats = self.s_hooks.get_feature_list()
 
         if len(t_feats) != self.num_scales:
-            missing = [
-                p for p in self.t_hooks.tap_points if p not in self.t_hooks.get_features()
-            ]
+            missing = (
+                [
+                    p
+                    for p in self.t_hooks.tap_points
+                    if p not in self.t_hooks.get_features()
+                ]
+                if self.t_hooks is not None
+                else []
+            )
             raise RuntimeError(
                 f"Expected {self.num_scales} teacher features, got {len(t_feats)} "
                 f"(missing tap points: {missing}). "
@@ -259,12 +302,15 @@ class Distiller(nn.Module):
 
     def step(self):
         """Clear captured features. Call at the end of each training step."""
-        self.t_hooks.clear()
+        if self.t_hooks is not None:
+            self.t_hooks.clear()
+        self._teacher_feats = None
         self.s_hooks.clear()
 
     def cleanup(self):
         """Remove all hooks and free resources. Call when training ends."""
-        self.t_hooks.remove()
+        if self.t_hooks is not None:
+            self.t_hooks.remove()
         self.s_hooks.remove()
         logger.info("Distiller cleaned up")
 

--- a/libreyolo/distillation/losses.py
+++ b/libreyolo/distillation/losses.py
@@ -166,8 +166,82 @@ class CWDLoss(nn.Module):
         return self.loss_weight * loss
 
 
+class FeatureMSELoss(nn.Module):
+    """Plain feature-matching MSE loss for foundation-model distillation.
+
+    Aligns the student feature map to the teacher's channel width with a 1x1
+    conv, resizes the teacher's feature grid to the student's spatial size
+    (bilinear), and minimizes the mean-squared error between them. Unlike
+    MGD/CWD this makes no assumption that teacher and student share a spatial
+    resolution or stride, so a single-scale foundation teacher (e.g. a DINOv2
+    ViT with a /14 patch grid) can supervise a convolutional backbone stage.
+
+    This is the classic feature-distillation objective (FitNets, Romero et al.,
+    ICLR 2015): match intermediate student features to a frozen teacher's via
+    a learned projection and an L2 loss. The same objective underlies modern
+    frozen-SSL-teacher recipes that distill a DINOv2 ViT into a smaller student
+    with a plain feature MSE. Implemented from that public description; no
+    third-party distillation source was used.
+
+    Args:
+        student_channels: Channels in the student feature map.
+        teacher_channels: Channels in the teacher feature map.
+        loss_weight: Per-scale multiplier (the global alpha is applied by the
+            Distiller). Default: 1.0.
+        normalize: If True, L2-normalize both feature maps over the channel
+            dimension before the MSE (angle-only matching, scale-invariant).
+            Default: False (plain MSE, matching the zero-hyperparameter recipe).
+
+    Shape:
+        - student_feat: (N, student_channels, Hs, Ws)
+        - teacher_feat: (N, teacher_channels, Ht, Wt)  # Ht/Wt may differ
+        - output: scalar loss
+    """
+
+    def __init__(
+        self,
+        student_channels: int,
+        teacher_channels: int,
+        loss_weight: float = 1.0,
+        normalize: bool = False,
+    ):
+        super().__init__()
+        self.loss_weight = loss_weight
+        self.normalize = normalize
+
+        # 1x1 conv aligning student channels to the teacher width; skipped when
+        # the widths already match.
+        if student_channels != teacher_channels:
+            self.align = nn.Conv2d(student_channels, teacher_channels, kernel_size=1)
+        else:
+            self.align = None
+
+    def forward(
+        self, student_feat: torch.Tensor, teacher_feat: torch.Tensor
+    ) -> torch.Tensor:
+        aligned = self.align(student_feat) if self.align is not None else student_feat
+
+        # Resize the teacher grid to the student's spatial size. The teacher is
+        # single-scale (e.g. DINOv2 /14) and rarely matches the student stride.
+        if aligned.shape[-2:] != teacher_feat.shape[-2:]:
+            teacher_feat = F.interpolate(
+                teacher_feat,
+                size=aligned.shape[-2:],
+                mode="bilinear",
+                align_corners=False,
+            )
+
+        if self.normalize:
+            aligned = F.normalize(aligned, dim=1)
+            teacher_feat = F.normalize(teacher_feat, dim=1)
+
+        loss = F.mse_loss(aligned, teacher_feat)
+        return self.loss_weight * loss
+
+
 # Registry of available loss classes
 DISTILL_LOSSES = {
     "mgd": MGDLoss,
     "cwd": CWDLoss,
+    "feat_mse": FeatureMSELoss,
 }

--- a/libreyolo/distillation/teachers.py
+++ b/libreyolo/distillation/teachers.py
@@ -1,0 +1,133 @@
+"""Foundation-model teachers for feature distillation.
+
+These teachers are *not* LibreYOLO detectors: they are frozen, pretrained
+feature extractors (e.g. a DINOv2 ViT) used to supervise a student backbone
+via a plain feature-MSE loss (see :class:`~libreyolo.distillation.losses.FeatureMSELoss`).
+They plug into :class:`~libreyolo.distillation.distiller.Distiller` through its
+``teacher_feature_fn`` seam rather than forward hooks, because a ViT emits token
+sequences on a single /patch grid instead of hookable multi-scale BCHW maps.
+
+DINOv2 is Apache-2.0 (Meta). The distillation objective (match student features
+to a frozen teacher with an L2 loss) is FitNets (Romero et al., ICLR 2015); this
+adapter is written from that public method, independently of any third-party
+distillation implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+# Friendly aliases -> HuggingFace hub id (all Apache-2.0, facebook/*).
+DINOV2_ALIASES = {
+    "dinov2": "facebook/dinov2-base",
+    "dinov2_vits14": "facebook/dinov2-small",
+    "dinov2_vitb14": "facebook/dinov2-base",
+    "dinov2_vitl14": "facebook/dinov2-large",
+    "dinov2-small": "facebook/dinov2-small",
+    "dinov2-base": "facebook/dinov2-base",
+    "dinov2-large": "facebook/dinov2-large",
+}
+
+# ImageNet-1k normalization DINOv2 was trained with. The student batch arrives
+# in [0, 1] (YOLO9 scales by 1/255 with no mean/std), so we renormalize here.
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+def is_foundation_teacher(identifier: str) -> bool:
+    """True if ``identifier`` names a supported foundation-model teacher."""
+    if not isinstance(identifier, str):
+        return False
+    key = identifier.lower()
+    return key in DINOV2_ALIASES or key.startswith("facebook/dinov2")
+
+
+class DINOv2Teacher(nn.Module):
+    """Frozen DINOv2 ViT teacher that emits a BCHW patch-feature grid.
+
+    Args:
+        identifier: Alias (``"dinov2"``, ``"dinov2_vitb14"``, ...) or a
+            ``facebook/dinov2-*`` hub id.
+        patch_size: ViT patch size (DINOv2 uses 14).
+
+    The teacher is single-scale: its :meth:`get_distill_config` reports one tap
+    at stride ``patch_size`` with ``hidden_size`` channels. Feature extraction
+    goes through :meth:`extract_features`, not forward hooks.
+    """
+
+    def __init__(self, identifier: str = "dinov2", patch_size: int = 14):
+        super().__init__()
+        try:
+            from transformers import Dinov2Model
+        except ImportError as e:  # pragma: no cover - dependency guard
+            raise ImportError(
+                "DINOv2 distillation requires 'transformers'. "
+                "Install with: pip install transformers"
+            ) from e
+
+        hub_id = DINOV2_ALIASES.get(identifier.lower(), identifier)
+        self.hub_id = hub_id
+        self.patch_size = patch_size
+
+        # Load the model directly (NOT via AutoBackbone). Meta/HF DINOv2
+        # `from_pretrained` has silently returned a randomly-initialized model
+        # in some transformers versions; `output_loading_info` lets us verify
+        # the pretrained weights actually landed and fail loudly if not.
+        model, loading_info = Dinov2Model.from_pretrained(
+            hub_id, output_loading_info=True
+        )
+        missing = loading_info.get("missing_keys", [])
+        if missing:
+            raise RuntimeError(
+                f"DINOv2 teacher '{hub_id}' loaded with {len(missing)} missing "
+                f"weight keys (e.g. {missing[:5]}). The backbone would be partly "
+                f"random, so distillation targets would be meaningless. Aborting."
+            )
+
+        self.dino = model.eval()
+        for p in self.dino.parameters():
+            p.requires_grad = False
+
+        self.hidden_size = int(self.dino.config.hidden_size)
+        self.register_buffer(
+            "_mean", torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1), persistent=False
+        )
+        self.register_buffer(
+            "_std", torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1), persistent=False
+        )
+        logger.info(
+            f"DINOv2 teacher ready: {hub_id} "
+            f"(hidden_size={self.hidden_size}, patch={patch_size})"
+        )
+
+    def get_distill_config(self) -> Dict:
+        """Single-scale teacher config: one tap, stride=patch, hidden channels."""
+        return {
+            "tap_points": [],  # unused: features come via extract_features()
+            "channels": [self.hidden_size],
+            "strides": [self.patch_size],
+        }
+
+    @torch.no_grad()
+    def extract_features(self, images: torch.Tensor) -> List[torch.Tensor]:
+        """Return ``[BCHW]`` patch features for a batch of ``[0, 1]`` images.
+
+        The token sequence's last ``Hp*Wp`` entries are the patch tokens
+        (slicing from the end is robust to CLS and register prefix tokens),
+        reshaped to a ``(N, hidden_size, Hp, Wp)`` grid.
+        """
+        images = (images - self._mean) / self._std
+        n, _, h, w = images.shape
+        hp, wp = h // self.patch_size, w // self.patch_size
+
+        out = self.dino(pixel_values=images, interpolate_pos_encoding=True)
+        tokens = out.last_hidden_state  # (N, prefix + Hp*Wp, C)
+        patch_tokens = tokens[:, -(hp * wp):, :]  # drop CLS/register prefixes
+        grid = patch_tokens.reshape(n, hp, wp, self.hidden_size).permute(0, 3, 1, 2)
+        return [grid.contiguous()]

--- a/libreyolo/distillation/teachers.py
+++ b/libreyolo/distillation/teachers.py
@@ -118,13 +118,28 @@ class DINOv2Teacher(nn.Module):
     def extract_features(self, images: torch.Tensor) -> List[torch.Tensor]:
         """Return ``[BCHW]`` patch features for a batch of ``[0, 1]`` images.
 
+        The image is first resized to the nearest multiple of ``patch_size`` so
+        the patch grid covers the *whole* frame. A raw ``h // patch`` grid would
+        crop the trailing ``h % patch`` pixels (e.g. 640 -> 45*14 = 630, a 10 px
+        border), and the loss would then map that partial grid onto the full
+        student feature map, supervising border cells with spatially-shifted
+        targets. Resizing to full coverage keeps teacher and student aligned.
+
         The token sequence's last ``Hp*Wp`` entries are the patch tokens
         (slicing from the end is robust to CLS and register prefix tokens),
         reshaped to a ``(N, hidden_size, Hp, Wp)`` grid.
         """
         images = (images - self._mean) / self._std
         n, _, h, w = images.shape
-        hp, wp = h // self.patch_size, w // self.patch_size
+
+        # Nearest multiple of patch_size on each axis => full-frame coverage.
+        hp = max(1, round(h / self.patch_size))
+        wp = max(1, round(w / self.patch_size))
+        th, tw = hp * self.patch_size, wp * self.patch_size
+        if (th, tw) != (h, w):
+            images = torch.nn.functional.interpolate(
+                images, size=(th, tw), mode="bilinear", align_corners=False
+            )
 
         out = self.dino(pixel_values=images, interpolate_pos_encoding=True)
         tokens = out.last_hidden_state  # (N, prefix + Hp*Wp, C)

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -456,6 +456,24 @@ class LibreYOLO9(BaseModel):
             "strides": [8, 16, 32],
         }
 
+    def get_backbone_distill_config(self) -> Dict:
+        """Single-scale backbone config for foundation-teacher distillation.
+
+        Used when the teacher is a semantic ViT (e.g. DINOv2) rather than a
+        detector: supervision lands on the stride-16 backbone stage (P4,
+        ``backbone.elan3``) instead of the detection-specific neck. The teacher
+        is single-scale, so this returns one tap point.
+        """
+        from .nn import YOLO9_CONFIGS
+
+        cfg = YOLO9_CONFIGS[self.size]
+        p4_channels = cfg["stages"][1][1]  # elan3 (P4) output width
+        return {
+            "tap_points": ["backbone.elan3"],
+            "channels": [p4_channels],
+            "strides": [16],
+        }
+
     @ddp_aware()
     def train(
         self,

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -138,18 +138,23 @@ class TrainConfig:
     # training is unchanged.
     nbs: Optional[int] = None
 
-    # Knowledge distillation. ``distill_model`` is a teacher-checkpoint path;
-    # setting it turns distillation on. ``dis`` is the global distillation loss
-    # weight; left as None it falls back to the selected loss type's published
-    # default (MGD: 2e-5, CWD: 1.0). ``distill_loss_type`` picks the feature
-    # loss ("mgd" or "cwd"); ``distill_mask_ratio`` (MGD) and ``distill_tau``
-    # (CWD) are the per-loss hyper-parameters. Families without a
-    # ``get_distill_config()`` implementation raise a clear error at setup.
+    # Knowledge distillation. ``distill_model`` is a teacher-checkpoint path,
+    # or a foundation-teacher id (e.g. ``"dinov2"``); setting it turns
+    # distillation on. ``dis`` is the global distillation loss weight; left as
+    # None it falls back to the selected loss type's published default (MGD:
+    # 2e-5, CWD: 1.0, feat_mse: 1.0). ``distill_loss_type`` picks the feature
+    # loss ("mgd" or "cwd") for detector teachers; a foundation teacher always
+    # uses "feat_mse" on a single backbone stage. ``distill_mask_ratio`` (MGD)
+    # and ``distill_tau`` (CWD) are the per-loss hyper-parameters;
+    # ``distill_normalize`` L2-normalizes features before the feat_mse loss.
+    # Families without a ``get_distill_config()`` (or, for foundation teachers,
+    # ``get_backbone_distill_config()``) raise a clear error at setup.
     distill_model: Optional[str] = None
     dis: Optional[float] = None
     distill_loss_type: str = "mgd"
     distill_mask_ratio: float = 0.65
     distill_tau: float = 1.0
+    distill_normalize: bool = False
 
     # Checkpointing / output
     project: str = "runs/train"

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -445,7 +445,7 @@ class BaseTrainer(ABC):
             return
 
         from ..distillation import Distiller
-        from ..models import LibreYOLO
+        from ..distillation.teachers import is_foundation_teacher
 
         if self.wrapper_model is None:
             raise ValueError(
@@ -453,27 +453,57 @@ class BaseTrainer(ABC):
                 "wrapper_model set (the student wrapper provides tap points)."
             )
 
-        # Load teacher via the factory (handles family detection, weight loading)
-        logger.info(f"Loading teacher model: {self.config.distill_model}")
-        teacher_wrapper = LibreYOLO(self.config.distill_model)
-        teacher_nn = teacher_wrapper.model.to(self.device)
+        if is_foundation_teacher(self.config.distill_model):
+            # Foundation teacher (e.g. DINOv2): a frozen semantic ViT supervises
+            # a single student backbone stage via feature-MSE. Features come
+            # through the teacher's extract_features(), not forward hooks, and
+            # the loss handles the teacher/student spatial-grid mismatch.
+            from ..distillation.teachers import DINOv2Teacher
 
-        # Get distillation configs from the models themselves. Families that
-        # don't support distillation raise NotImplementedError here with a
-        # message naming the family.
-        teacher_cfg = teacher_wrapper.get_distill_config()
-        student_cfg = self.wrapper_model.get_distill_config()
+            logger.info(f"Loading foundation teacher: {self.config.distill_model}")
+            teacher = DINOv2Teacher(self.config.distill_model).to(self.device)
 
-        self.distiller = Distiller(
-            teacher_model=teacher_nn,
-            student_model=self.model,
-            teacher_config=teacher_cfg,
-            student_config=student_cfg,
-            loss_type=self.config.distill_loss_type,
-            loss_weight=self.config.dis,
-            mask_ratio=self.config.distill_mask_ratio,
-            tau=self.config.distill_tau,
-        )
+            if not hasattr(self.wrapper_model, "get_backbone_distill_config"):
+                family = getattr(self.wrapper_model, "FAMILY", type(self.wrapper_model).__name__)
+                raise NotImplementedError(
+                    f"Foundation-model distillation into the '{family}' family is "
+                    f"not supported yet (no get_backbone_distill_config())."
+                )
+
+            self.distiller = Distiller(
+                teacher_model=teacher,
+                student_model=self.model,
+                teacher_config=teacher.get_distill_config(),
+                student_config=self.wrapper_model.get_backbone_distill_config(),
+                loss_type="feat_mse",
+                loss_weight=self.config.dis,
+                teacher_feature_fn=teacher.extract_features,
+                normalize=getattr(self.config, "distill_normalize", False),
+            )
+        else:
+            from ..models import LibreYOLO
+
+            # Load teacher via the factory (handles family detection, weight loading)
+            logger.info(f"Loading teacher model: {self.config.distill_model}")
+            teacher_wrapper = LibreYOLO(self.config.distill_model)
+            teacher_nn = teacher_wrapper.model.to(self.device)
+
+            # Get distillation configs from the models themselves. Families that
+            # don't support distillation raise NotImplementedError here with a
+            # message naming the family.
+            teacher_cfg = teacher_wrapper.get_distill_config()
+            student_cfg = self.wrapper_model.get_distill_config()
+
+            self.distiller = Distiller(
+                teacher_model=teacher_nn,
+                student_model=self.model,
+                teacher_config=teacher_cfg,
+                student_config=student_cfg,
+                loss_type=self.config.distill_loss_type,
+                loss_weight=self.config.dis,
+                mask_ratio=self.config.distill_mask_ratio,
+                tau=self.config.distill_tau,
+            )
         self.distiller.to(self.device)
 
         # resume() may run before setup() — apply deferred adapter state now.

--- a/tests/unit/test_distillation_dinov2.py
+++ b/tests/unit/test_distillation_dinov2.py
@@ -1,0 +1,168 @@
+"""Unit tests for foundation-model (DINOv2) feature distillation into YOLO9.
+
+These cover the feat_mse loss, the single-scale foundation path through the
+Distiller (via ``teacher_feature_fn``), and the YOLO9 backbone distill config.
+The real DINOv2 teacher needs a network download, so it is not exercised here;
+these tests use a stub teacher feature function.
+"""
+import pytest
+import torch
+import torch.nn as nn
+
+from libreyolo.distillation import Distiller, FeatureMSELoss, is_foundation_teacher
+from libreyolo.distillation.teachers import DINOV2_ALIASES
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Teacher identification
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "ident,expected",
+    [
+        ("dinov2", True),
+        ("dinov2_vitb14", True),
+        ("facebook/dinov2-base", True),
+        ("facebook/dinov2-large", True),
+        ("yolov9c.pt", False),
+        ("runs/train/exp/best.pt", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_foundation_teacher(ident, expected):
+    assert is_foundation_teacher(ident) is expected
+
+
+def test_aliases_all_point_to_facebook_dinov2():
+    for hub_id in DINOV2_ALIASES.values():
+        assert hub_id.startswith("facebook/dinov2")
+
+
+# --------------------------------------------------------------------------- #
+# FeatureMSELoss
+# --------------------------------------------------------------------------- #
+def test_feature_mse_channel_and_spatial_mismatch():
+    """Align (96->768) + bilinear resize (16x16 teacher -> 4x4 student)."""
+    loss_fn = FeatureMSELoss(student_channels=96, teacher_channels=768)
+    assert loss_fn.align is not None
+    s = torch.randn(2, 96, 4, 4, requires_grad=True)
+    t = torch.randn(2, 768, 16, 16)
+    out = loss_fn(s, t)
+    assert out.ndim == 0 and torch.isfinite(out) and out.item() > 0
+    out.backward()
+    assert s.grad is not None and torch.isfinite(s.grad).all()
+
+
+def test_feature_mse_no_align_when_channels_match():
+    loss_fn = FeatureMSELoss(student_channels=256, teacher_channels=256)
+    assert loss_fn.align is None
+    s = torch.randn(1, 256, 8, 8)
+    t = torch.randn(1, 256, 8, 8)
+    assert torch.isfinite(loss_fn(s, t))
+
+
+def test_feature_mse_normalize_option():
+    loss_fn = FeatureMSELoss(64, 64, normalize=True)
+    s = torch.randn(1, 64, 5, 5)
+    t = torch.randn(1, 64, 5, 5)
+    # normalized MSE is bounded (features on the unit sphere)
+    assert 0.0 <= loss_fn(s, t).item() <= 4.0
+
+
+# --------------------------------------------------------------------------- #
+# Distiller foundation path (stub teacher, tiny student)
+# --------------------------------------------------------------------------- #
+class _Backbone(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.elan3 = nn.Conv2d(3, 96, 7, stride=16, padding=3)  # /16 stride
+
+    def forward(self, x):
+        return self.elan3(x)
+
+
+class _TinyStudent(nn.Module):
+    """Minimal stand-in with a ``backbone.elan3`` tap point."""
+
+    def __init__(self):
+        super().__init__()
+        self.backbone = _Backbone()
+
+    def forward(self, x):
+        return self.backbone(x)
+
+
+def _make_foundation_distiller(hidden=768):
+    student = _TinyStudent()
+    teacher_cfg = {"tap_points": [], "channels": [hidden], "strides": [14]}
+    student_cfg = {"tap_points": ["backbone.elan3"], "channels": [96], "strides": [16]}
+
+    def stub_extract(images):
+        n, _, h, w = images.shape
+        return [torch.randn(n, hidden, h // 14, w // 14, device=images.device)]
+
+    distiller = Distiller(
+        teacher_model=nn.Identity(),
+        student_model=student,
+        teacher_config=teacher_cfg,
+        student_config=student_cfg,
+        loss_type="feat_mse",
+        loss_weight=1.0,
+        teacher_feature_fn=stub_extract,
+    )
+    return student, distiller
+
+
+def test_foundation_distiller_builds_single_scale_feat_mse():
+    _, distiller = _make_foundation_distiller()
+    assert distiller.num_scales == 1
+    assert distiller.t_hooks is None  # no teacher hooks in foundation mode
+    assert isinstance(distiller.loss_modules[0], FeatureMSELoss)
+    assert distiller.loss_modules[0].align.in_channels == 96
+    assert distiller.loss_modules[0].align.out_channels == 768
+
+
+def test_foundation_distiller_loss_flows_and_trains_adapter():
+    student, distiller = _make_foundation_distiller()
+    imgs = torch.rand(2, 3, 224, 224)
+    distiller.teacher_forward(imgs)
+    student(imgs)
+    loss = distiller.compute_loss()
+    assert torch.isfinite(loss) and loss.item() > 0
+    loss.backward()
+    grad = distiller.loss_modules[0].align.weight.grad
+    assert grad is not None and torch.isfinite(grad).all()
+
+
+def test_foundation_distiller_step_clears_teacher_feats():
+    student, distiller = _make_foundation_distiller()
+    imgs = torch.rand(1, 3, 112, 112)
+    distiller.teacher_forward(imgs)
+    assert distiller._teacher_feats is not None
+    student(imgs)
+    distiller.compute_loss()
+    distiller.step()
+    assert distiller._teacher_feats is None
+
+
+def test_compute_loss_without_teacher_forward_raises():
+    student, distiller = _make_foundation_distiller()
+    student(torch.rand(1, 3, 112, 112))
+    with pytest.raises(RuntimeError, match="Teacher features not extracted"):
+        distiller.compute_loss()
+
+
+# --------------------------------------------------------------------------- #
+# YOLO9 backbone distill config
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("size,ch", [("t", 96), ("s", 192)])
+def test_yolo9_backbone_distill_config(size, ch):
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9(model_path=None, size=size)
+    cfg = model.get_backbone_distill_config()
+    assert cfg["tap_points"] == ["backbone.elan3"]
+    assert cfg["strides"] == [16]
+    assert cfg["channels"] == [ch]


### PR DESCRIPTION
Add DINOv2 feature distillation into YOLO9

Extends the existing MGD/CWD distillation module to support a frozen foundation-model teacher (DINOv2 ViT) supervising a single YOLO9 backbone stage via a plain feature-MSE loss. Same `libreyolo train --distill-model` API: `--distill-model dinov2` selects the foundation path.

- FeatureMSELoss: 1x1 channel align + bilinear resize of the teacher grid to the student stage + MSE (FitNets, Romero et al. 2015). Handles the teacher/ student stride and spatial-grid mismatch that MGD/CWD cannot.
- DINOv2Teacher: Apache-2.0 DINOv2 (facebook/dinov2-*) loaded via transformers with output_loading_info to fail loudly if pretrained weights do not land (guards the silent-random-backbone failure mode); emits a BCHW patch grid.
- Distiller: teacher_feature_fn seam for non-hookable foundation teachers; stride-equality guard relaxed only on that path.
- LibreYOLO9.get_backbone_distill_config(): single-scale P4 (backbone.elan3, stride 16) tap for semantic-backbone supervision.
- Trainer: foundation-teacher branch in _setup_distillation.

Implemented from the public feature-distillation method; no third-party (AGPL) distillation source was used.

Tests: 18 new unit tests; existing 54 distillation tests still pass. @