### PR TITLE
Fix D-FINE eval dynamic sizes

### DIFF
--- a/libreyolo/models/dfine/decoder.py
+++ b/libreyolo/models/dfine/decoder.py
@@ -39,6 +39,9 @@ from .ms_deform import (
 )
 
 
+EVAL_CONSTANT_CACHE_LIMIT = 16
+
+
 class MLP(nn.Module):
     def __init__(self, input_dim, hidden_dim, output_dim, num_layers, act="relu"):
         super().__init__()
@@ -492,7 +495,7 @@ class DFINETransformer(nn.Module):
         self.eval_spatial_size = eval_spatial_size
         self.aux_loss = aux_loss
         self.reg_max = reg_max
-        self._anchor_cache = {}
+        self._anchor_cache = OrderedDict()
 
         assert query_select_method in ("default", "one2many", "agnostic")
         assert cross_attn_method in ("default", "discrete")
@@ -745,23 +748,29 @@ class DFINETransformer(nn.Module):
     def _spatial_shape_key(spatial_shapes):
         return tuple((int(h), int(w)) for h, w in spatial_shapes)
 
-    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
-        key = self._spatial_shape_key(spatial_shapes)
-        if key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
-            return (
-                self.anchors.to(device=memory.device, dtype=memory.dtype),
-                self.valid_mask.to(device=memory.device),
-            )
+    def _cache_anchors(self, key, anchors, valid_mask):
+        self._anchor_cache[key] = (anchors, valid_mask)
+        self._anchor_cache.move_to_end(key)
+        while len(self._anchor_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._anchor_cache.popitem(last=False)
 
+    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
+        shape_key = self._spatial_shape_key(spatial_shapes)
+        key = (shape_key, memory.device, memory.dtype)
         cached = self._anchor_cache.get(key)
         if cached is None:
-            cached = self._generate_anchors(spatial_shapes)
-            self._anchor_cache[key] = cached
-        anchors, valid_mask = cached
-        return (
-            anchors.to(device=memory.device, dtype=memory.dtype),
-            valid_mask.to(device=memory.device),
-        )
+            if shape_key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
+                anchors = self.anchors.to(device=memory.device, dtype=memory.dtype)
+                valid_mask = self.valid_mask.to(device=memory.device)
+            else:
+                anchors, valid_mask = self._generate_anchors(
+                    spatial_shapes, dtype=memory.dtype, device=memory.device
+                )
+            self._cache_anchors(key, anchors, valid_mask)
+        else:
+            self._anchor_cache.move_to_end(key)
+            anchors, valid_mask = cached
+        return anchors, valid_mask
 
     def _get_decoder_input(
         self,

--- a/libreyolo/models/dfine/decoder.py
+++ b/libreyolo/models/dfine/decoder.py
@@ -492,6 +492,7 @@ class DFINETransformer(nn.Module):
         self.eval_spatial_size = eval_spatial_size
         self.aux_loss = aux_loss
         self.reg_max = reg_max
+        self._anchor_cache = {}
 
         assert query_select_method in ("default", "one2many", "agnostic")
         assert cross_attn_method in ("default", "discrete")
@@ -592,6 +593,14 @@ class DFINETransformer(nn.Module):
             anchors, valid_mask = self._generate_anchors()
             self.register_buffer("anchors", anchors)
             self.register_buffer("valid_mask", valid_mask)
+            self._eval_spatial_shape_key = self._spatial_shape_key(
+                [
+                    [int(self.eval_spatial_size[0] / s), int(self.eval_spatial_size[1] / s)]
+                    for s in self.feat_strides
+                ]
+            )
+        else:
+            self._eval_spatial_shape_key = None
 
         self._reset_parameters(feat_channels)
 
@@ -732,6 +741,28 @@ class DFINETransformer(nn.Module):
 
         return anchors, valid_mask
 
+    @staticmethod
+    def _spatial_shape_key(spatial_shapes):
+        return tuple((int(h), int(w)) for h, w in spatial_shapes)
+
+    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
+        key = self._spatial_shape_key(spatial_shapes)
+        if key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
+            return (
+                self.anchors.to(device=memory.device, dtype=memory.dtype),
+                self.valid_mask.to(device=memory.device),
+            )
+
+        cached = self._anchor_cache.get(key)
+        if cached is None:
+            cached = self._generate_anchors(spatial_shapes)
+            self._anchor_cache[key] = cached
+        anchors, valid_mask = cached
+        return (
+            anchors.to(device=memory.device, dtype=memory.dtype),
+            valid_mask.to(device=memory.device),
+        )
+
     def _get_decoder_input(
         self,
         memory: torch.Tensor,
@@ -741,11 +772,12 @@ class DFINETransformer(nn.Module):
     ):
         if self.training or self.eval_spatial_size is None:
             anchors, valid_mask = self._generate_anchors(
-                spatial_shapes, device=memory.device
+                spatial_shapes, dtype=memory.dtype, device=memory.device
             )
         else:
-            anchors = self.anchors
-            valid_mask = self.valid_mask
+            anchors, valid_mask = self._get_anchors_for_spatial_shapes(
+                spatial_shapes, memory
+            )
         if memory.shape[0] > 1:
             anchors = anchors.repeat(memory.shape[0], 1, 1)
 

--- a/libreyolo/models/dfine/encoder.py
+++ b/libreyolo/models/dfine/encoder.py
@@ -20,6 +20,9 @@ import torch.nn.functional as F
 from .ms_deform import get_activation
 
 
+EVAL_CONSTANT_CACHE_LIMIT = 16
+
+
 class ConvNormLayer_fuse(nn.Module):
     def __init__(
         self,
@@ -356,7 +359,7 @@ class HybridEncoder(nn.Module):
         self.num_encoder_layers = num_encoder_layers
         self.pe_temperature = pe_temperature
         self.eval_spatial_size = eval_spatial_size
-        self._pos_embed_cache = {}
+        self._pos_embed_cache = OrderedDict()
         self.out_channels = [hidden_dim for _ in range(len(self.in_channels))]
         self.out_strides = self.feat_strides
 
@@ -439,13 +442,16 @@ class HybridEncoder(nn.Module):
                     self.pe_temperature,
                 )
                 setattr(self, f"pos_embed{idx}", pos_embed)
-                self._pos_embed_cache[
+                self._cache_pos_embed(
                     (
                         idx,
                         self.eval_spatial_size[0] // stride,
                         self.eval_spatial_size[1] // stride,
-                    )
-                ] = pos_embed
+                        pos_embed.device,
+                        pos_embed.dtype,
+                    ),
+                    pos_embed,
+                )
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.0):
@@ -466,15 +472,26 @@ class HybridEncoder(nn.Module):
             [out_w.sin(), out_w.cos(), out_h.sin(), out_h.cos()], dim=1
         )[None, :, :]
 
+    def _cache_pos_embed(self, key, pos_embed):
+        self._pos_embed_cache[key] = pos_embed
+        self._pos_embed_cache.move_to_end(key)
+        while len(self._pos_embed_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._pos_embed_cache.popitem(last=False)
+
     def _get_pos_embed(self, enc_ind, h, w, src_flatten):
-        key = (enc_ind, h, w)
+        key = (enc_ind, h, w, src_flatten.device, src_flatten.dtype)
         pos_embed = self._pos_embed_cache.get(key)
         if pos_embed is None:
-            pos_embed = self.build_2d_sincos_position_embedding(
-                w, h, self.hidden_dim, self.pe_temperature
-            )
-            self._pos_embed_cache[key] = pos_embed
-        return pos_embed.to(device=src_flatten.device, dtype=src_flatten.dtype)
+            base = getattr(self, f"pos_embed{enc_ind}", None)
+            if base is None or base.shape[1] != h * w:
+                base = self.build_2d_sincos_position_embedding(
+                    w, h, self.hidden_dim, self.pe_temperature
+                )
+            pos_embed = base.to(device=src_flatten.device, dtype=src_flatten.dtype)
+            self._cache_pos_embed(key, pos_embed)
+        else:
+            self._pos_embed_cache.move_to_end(key)
+        return pos_embed
 
     def forward(self, feats):
         assert len(feats) == len(self.in_channels)

--- a/libreyolo/models/dfine/encoder.py
+++ b/libreyolo/models/dfine/encoder.py
@@ -356,6 +356,7 @@ class HybridEncoder(nn.Module):
         self.num_encoder_layers = num_encoder_layers
         self.pe_temperature = pe_temperature
         self.eval_spatial_size = eval_spatial_size
+        self._pos_embed_cache = {}
         self.out_channels = [hidden_dim for _ in range(len(self.in_channels))]
         self.out_strides = self.feat_strides
 
@@ -438,6 +439,13 @@ class HybridEncoder(nn.Module):
                     self.pe_temperature,
                 )
                 setattr(self, f"pos_embed{idx}", pos_embed)
+                self._pos_embed_cache[
+                    (
+                        idx,
+                        self.eval_spatial_size[0] // stride,
+                        self.eval_spatial_size[1] // stride,
+                    )
+                ] = pos_embed
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.0):
@@ -458,6 +466,16 @@ class HybridEncoder(nn.Module):
             [out_w.sin(), out_w.cos(), out_h.sin(), out_h.cos()], dim=1
         )[None, :, :]
 
+    def _get_pos_embed(self, enc_ind, h, w, src_flatten):
+        key = (enc_ind, h, w)
+        pos_embed = self._pos_embed_cache.get(key)
+        if pos_embed is None:
+            pos_embed = self.build_2d_sincos_position_embedding(
+                w, h, self.hidden_dim, self.pe_temperature
+            )
+            self._pos_embed_cache[key] = pos_embed
+        return pos_embed.to(device=src_flatten.device, dtype=src_flatten.dtype)
+
     def forward(self, feats):
         assert len(feats) == len(self.in_channels)
         proj_feats = [self.input_proj[i](feat) for i, feat in enumerate(feats)]
@@ -469,11 +487,9 @@ class HybridEncoder(nn.Module):
                 if self.training or self.eval_spatial_size is None:
                     pos_embed = self.build_2d_sincos_position_embedding(
                         w, h, self.hidden_dim, self.pe_temperature
-                    ).to(src_flatten.device)
+                    ).to(device=src_flatten.device, dtype=src_flatten.dtype)
                 else:
-                    pos_embed = getattr(self, f"pos_embed{enc_ind}", None).to(
-                        src_flatten.device
-                    )
+                    pos_embed = self._get_pos_embed(enc_ind, h, w, src_flatten)
 
                 memory = self.encoder[i](src_flatten, pos_embed=pos_embed)
                 proj_feats[enc_ind] = (

--- a/tests/unit/test_dfine_endtoend_shapes.py
+++ b/tests/unit/test_dfine_endtoend_shapes.py
@@ -13,7 +13,7 @@ import torch
 from libreyolo.models.dfine.backbone import HGNetv2
 from libreyolo.models.dfine.decoder import DFINETransformer
 from libreyolo.models.dfine.encoder import HybridEncoder
-from libreyolo.models.dfine.nn import SIZE_CONFIGS
+from libreyolo.models.dfine.nn import LibreDFINEModel, SIZE_CONFIGS
 
 pytestmark = pytest.mark.unit
 
@@ -70,3 +70,18 @@ def test_full_pipeline_random_weights(size):
     assert out["pred_boxes"].shape == (1, 300, 4)
     # Boxes should be in [0, 1] after sigmoid.
     assert (out["pred_boxes"] >= 0).all() and (out["pred_boxes"] <= 1).all()
+
+
+def test_eval_forward_accepts_runtime_size_different_from_eval_spatial_size():
+    """Eval must rebuild fixed-size encoder/decoder constants for runtime imgsz."""
+    model = LibreDFINEModel(
+        "n", nb_classes=2, eval_spatial_size=(640, 640)
+    ).eval()
+
+    x = torch.randn(1, 3, 320, 320)
+    with torch.no_grad():
+        out = model(x)
+
+    assert set(out.keys()) == {"pred_logits", "pred_boxes"}
+    assert out["pred_logits"].shape == (1, 300, 2)
+    assert out["pred_boxes"].shape == (1, 300, 4)

--- a/tests/unit/test_dfine_endtoend_shapes.py
+++ b/tests/unit/test_dfine_endtoend_shapes.py
@@ -11,8 +11,14 @@ import pytest
 import torch
 
 from libreyolo.models.dfine.backbone import HGNetv2
-from libreyolo.models.dfine.decoder import DFINETransformer
-from libreyolo.models.dfine.encoder import HybridEncoder
+from libreyolo.models.dfine.decoder import (
+    DFINETransformer,
+    EVAL_CONSTANT_CACHE_LIMIT as DECODER_CACHE_LIMIT,
+)
+from libreyolo.models.dfine.encoder import (
+    HybridEncoder,
+    EVAL_CONSTANT_CACHE_LIMIT as ENCODER_CACHE_LIMIT,
+)
 from libreyolo.models.dfine.nn import LibreDFINEModel, SIZE_CONFIGS
 
 pytestmark = pytest.mark.unit
@@ -85,3 +91,61 @@ def test_eval_forward_accepts_runtime_size_different_from_eval_spatial_size():
     assert set(out.keys()) == {"pred_logits", "pred_boxes"}
     assert out["pred_logits"].shape == (1, 300, 2)
     assert out["pred_boxes"].shape == (1, 300, 4)
+
+
+def test_eval_pos_embed_cache_is_bounded_and_reuses_moved_tensor():
+    encoder = HybridEncoder(
+        in_channels=(16,),
+        feat_strides=(16,),
+        hidden_dim=16,
+        nhead=4,
+        dim_feedforward=32,
+        use_encoder_idx=(0,),
+        eval_spatial_size=(64, 64),
+    )
+    src_flatten = torch.empty(1, 25, 16)
+
+    first = encoder._get_pos_embed(0, 5, 5, src_flatten)
+    second = encoder._get_pos_embed(0, 5, 5, src_flatten)
+
+    assert first.data_ptr() == second.data_ptr()
+
+    for size in range(6, 6 + ENCODER_CACHE_LIMIT + 4):
+        src_flatten = torch.empty(1, size * size, 16)
+        encoder._get_pos_embed(0, size, size, src_flatten)
+
+    assert len(encoder._pos_embed_cache) <= ENCODER_CACHE_LIMIT
+
+
+def test_eval_anchor_cache_is_bounded_and_reuses_moved_tensors():
+    decoder = DFINETransformer(
+        num_classes=2,
+        hidden_dim=16,
+        num_queries=4,
+        feat_channels=(16,),
+        feat_strides=(16,),
+        num_levels=1,
+        num_points=2,
+        nhead=4,
+        num_layers=1,
+        dim_feedforward=32,
+        eval_spatial_size=(64, 64),
+        reg_max=4,
+    )
+    memory = torch.empty(1, 25, 16)
+
+    first_anchors, first_mask = decoder._get_anchors_for_spatial_shapes(
+        [[5, 5]], memory
+    )
+    second_anchors, second_mask = decoder._get_anchors_for_spatial_shapes(
+        [[5, 5]], memory
+    )
+
+    assert first_anchors.data_ptr() == second_anchors.data_ptr()
+    assert first_mask.data_ptr() == second_mask.data_ptr()
+
+    for size in range(6, 6 + DECODER_CACHE_LIMIT + 4):
+        memory = torch.empty(1, size * size, 16)
+        decoder._get_anchors_for_spatial_shapes([[size, size]], memory)
+
+    assert len(decoder._anchor_cache) <= DECODER_CACHE_LIMIT


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes D-FINE evaluation correctness when the runtime image size differs from the `eval_spatial_size` configured at model initialization. Previously, the encoder and decoder unconditionally reused statically precomputed constants (positional embeddings and anchors) that were sized for `eval_spatial_size`, producing silent shape mismatches at any other resolution. The fix introduces an LRU cache (bounded to 16 entries via `EVAL_CONSTANT_CACHE_LIMIT`) in both components so non-standard sizes are computed on demand, cached for efficiency, and kept bounded in memory.

- **Encoder (`HybridEncoder`)**: `_get_pos_embed` replaces the raw attribute lookup, regenerating and caching the 2-D sin-cos embedding whenever `(enc_ind, h, w, device, dtype)` is a cache miss. The dtype is also propagated correctly for FP16 inference.
- **Decoder (`DFINETransformer`)**: `_get_anchors_for_spatial_shapes` wraps `_generate_anchors`, preferring the precomputed `self.anchors` buffer at the standard eval size, falling back to regeneration otherwise, and caching both. The training path retains direct `_generate_anchors` calls with no caching overhead.
- **Tests**: Three new unit tests cover runtime-size acceptance, cache-hit identity (via `data_ptr`), and LRU eviction.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change corrects a silent shape mismatch at non-standard eval sizes without touching the training path or model weights.

Both encoder and decoder caches are keyed by (shape, device, dtype), so multi-device and mixed-precision cases are handled correctly. The training path is unchanged. The LRU eviction logic and dtype propagation fixes are verified by the new unit tests.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/dfine/decoder.py | Introduces LRU anchor cache (`_anchor_cache`) keyed by `(shape_key, device, dtype)`, `_eval_spatial_shape_key` for fast-path detection, dtype propagation fix to `_generate_anchors`, and `EVAL_CONSTANT_CACHE_LIMIT` constant. Logic is correct; valid_mask broadcasts correctly for batch > 1. |
| libreyolo/models/dfine/encoder.py | Introduces LRU pos-embed cache (`_pos_embed_cache`) keyed by `(enc_ind, h, w, device, dtype)`, `_get_pos_embed` helper, and propagates dtype through the training-path `build_2d_sincos_position_embedding` call. Pre-populates cache at init for eval_spatial_size (CPU float32 key); harmless but evictable. Logic is correct. |
| tests/unit/test_dfine_endtoend_shapes.py | Adds three targeted unit tests: end-to-end acceptance at a non-standard size, cache-hit identity via `data_ptr`, and LRU eviction for both encoder and decoder caches. Tests are well-structured and cover the new code paths. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["forward(feats) / _get_decoder_input(memory, spatial_shapes)"] --> B{training or\neval_spatial_size is None?}
    B -- Yes --> C["_generate_anchors / build_2d_sincos_position_embedding\n(no caching, dtype+device from input)"]
    B -- No --> D["_get_anchors_for_spatial_shapes /\n_get_pos_embed\n(cache lookup: shape+device+dtype key)"]
    D --> E{Cache hit?}
    E -- Yes --> F["move_to_end(key)\nreturn cached tensor"]
    E -- No --> G{shape_key ==\n_eval_spatial_shape_key?}
    G -- Yes --> H["Use precomputed self.anchors buffer\n(or pos_embed{idx} attribute)\n.to(device, dtype)"]
    G -- No --> I["_generate_anchors /\nbuild_2d_sincos_position_embedding\n(regenerate for dynamic size)"]
    H --> J["_cache_anchors / _cache_pos_embed\n(LRU evict if > EVAL_CONSTANT_CACHE_LIMIT=16)"]
    I --> J
    J --> K["return anchors+valid_mask / pos_embed"]
    F --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["forward(feats) / _get_decoder_input(memory, spatial_shapes)"] --> B{training or\neval_spatial_size is None?}
    B -- Yes --> C["_generate_anchors / build_2d_sincos_position_embedding\n(no caching, dtype+device from input)"]
    B -- No --> D["_get_anchors_for_spatial_shapes /\n_get_pos_embed\n(cache lookup: shape+device+dtype key)"]
    D --> E{Cache hit?}
    E -- Yes --> F["move_to_end(key)\nreturn cached tensor"]
    E -- No --> G{shape_key ==\n_eval_spatial_shape_key?}
    G -- Yes --> H["Use precomputed self.anchors buffer\n(or pos_embed{idx} attribute)\n.to(device, dtype)"]
    G -- No --> I["_generate_anchors /\nbuild_2d_sincos_position_embedding\n(regenerate for dynamic size)"]
    H --> J["_cache_anchors / _cache_pos_embed\n(LRU evict if > EVAL_CONSTANT_CACHE_LIMIT=16)"]
    I --> J
    J --> K["return anchors+valid_mask / pos_embed"]
    F --> K
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Bound D-FINE eval caches"](https://github.com/libreyolo/libreyolo/commit/43c42953543ccffb384935379142a644e43f584c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42637238)</sub>

<!-- /greptile_comment -->