### PR TITLE
Clarify licensing and provenance policy for agents and contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Write your PR description however you like. Structure it your own way.
+Only the "Code provenance" section below is required (CI checks it exists and
+is filled). Everything else is up to you.
+-->
+
+## Code provenance
+
+<!--
+Required. Replace this comment with a statement of where the code in this PR
+comes from. Use whatever wording and structure you prefer, as long as the
+provenance is clear. Cover, as applicable:
+  - original code written for this PR, and/or
+  - code ported, adapted, or derived from a third party: the upstream
+    repository, the commit or version, and its license.
+Only permissively licensed sources are acceptable (MIT, Apache-2.0, BSD, or
+similar). GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license
+code is not accepted, in any form (including rewrites or renamed adaptations).
+-->

--- a/.github/workflows/provenance-check.yml
+++ b/.github/workflows/provenance-check.yml
@@ -1,0 +1,52 @@
+name: provenance-check
+
+# Fails a PR whose description has no filled-in "Code provenance" section.
+# This is the deterministic gate; it only checks the section EXISTS and is not
+# empty. Judging whether the stated provenance is adequate for the diff is left
+# to the reviewer (human / Greptile). Re-runs when the description is edited.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  provenance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const lines = body.split(/\r?\n/);
+            // find a heading whose text is "code provenance" (any heading level)
+            const headingRe = /^\s*#{1,6}\s*code provenance\s*$/i;
+            const idx = lines.findIndex(l => headingRe.test(l));
+            if (idx === -1) {
+              core.setFailed(
+                "PR description has no 'Code provenance' section. Add a " +
+                "'## Code provenance' heading and state where the code came " +
+                "from (see the PR template)."
+              );
+              return;
+            }
+            // collect lines until the next heading (or end of body)
+            const section = [];
+            for (let i = idx + 1; i < lines.length; i++) {
+              if (/^\s*#{1,6}\s+\S/.test(lines[i])) break;
+              section.push(lines[i]);
+            }
+            // strip HTML comments (the template placeholder) and whitespace
+            const content = section.join("\n").replace(/<!--[\s\S]*?-->/g, "").trim();
+            if (content.length === 0) {
+              core.setFailed(
+                "The 'Code provenance' section is empty. State the provenance " +
+                "of the code in this PR: original, or the upstream repository, " +
+                "commit, and license for any ported/adapted code."
+              );
+              return;
+            }
+            core.info("Code provenance section present and non-empty.");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@
   value is being genuinely MIT; one license violation endangers the project.
 - LibreYOLO faithfully respects open-source licenses.
 - Agents must not copy, adapt, paraphrase, or derive code from any third-party
-  project unless that project is explicitly licensed under MIT, Apache-2.0, or
-  a similarly permissive license compatible with LibreYOLO's licensing
+  project unless that project is explicitly licensed under MIT, Apache-2.0,
+  BSD, or a similarly permissive license compatible with LibreYOLO's licensing
   requirements. Unknown or missing license means incompatible.
 - Never rewrite, rename, or restructure incompatibly-licensed code to obscure
   its origin. A GPL function with new variable names is still a derivative

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,31 @@
 # Agent Instructions
 
+## Licensing policy (read this first)
+
+- This is the most important policy in this repository. LibreYOLO's entire
+  value is being genuinely MIT; one license violation endangers the project.
+- LibreYOLO faithfully respects open-source licenses.
+- Agents must not copy, adapt, paraphrase, or derive code from any third-party
+  project unless that project is explicitly licensed under MIT, Apache-2.0, or
+  a similarly permissive license compatible with LibreYOLO's licensing
+  requirements. Unknown or missing license means incompatible.
+- Never rewrite, rename, or restructure incompatibly-licensed code to obscure
+  its origin. A GPL function with new variable names is still a derivative
+  work. The only acceptable remedies are re-derivation from a genuinely clean
+  source with documented provenance, or removal. That choice belongs to the
+  maintainer: surface it, never pick silently.
+- If an agent may have been exposed to, influenced by, or contaminated by code
+  under GPL, AGPL, LGPL, proprietary, unknown, or otherwise incompatible terms,
+  the agent must immediately stop work on the affected area, flag the
+  contamination risk to the developer, and avoid contributing the affected
+  code. Flagging is never the wrong move; quiet contribution always is.
+- Ported or adapted code must state its upstream: repository, commit, and
+  license, in the PR description and the notice files.
+- See `skills/libreyolo-license-audit/` for the audit discipline and the
+  notice surfaces.
+
+## Agent conduct
+
 - Agents must not open GitHub issues.
 - Agents must not open pull requests.
 - Agents must not post issue comments or PR comments unless a human explicitly
@@ -53,17 +79,6 @@
   documentation; depth belongs in `/docs` or on the website.
 - Style: no em dashes, no decorative or AI-flavored characters, no fluff.
 - The detailed editing contract lives in `skills/libreyolo-update-readme/`.
-
-## Licensing policy
-
-- LibreYOLO faithfully respects open-source licenses.
-- Agents must not copy, adapt, paraphrase, or derive code from any third-party
-  project unless that project is explicitly licensed under MIT or Apache-2.0
-  and is compatible with LibreYOLO's licensing requirements.
-- If an agent may have been exposed to, influenced by, or contaminated by code
-  under GPL, AGPL, LGPL, proprietary, unknown, or otherwise incompatible terms,
-  the agent must immediately flag the contamination risk to the developer and
-  avoid contributing the affected code.
 
 ## Review guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,27 @@ LibreYOLO is an MIT-licensed computer vision library focused on YOLO-style
 training and inference. Contributions are welcome, but maintainer review time
 is limited. Keep changes focused, tested, and aligned with the project.
 
+## Licensing and provenance (non-negotiable)
+
+LibreYOLO is MIT. That only stays true if every contribution is clean:
+
+- Only submit code you wrote yourself, or code from a source explicitly
+  licensed under MIT, Apache-2.0, BSD, or a similarly permissive license.
+- Code derived from GPL, AGPL, LGPL, non-commercial, proprietary, or
+  unknown-license sources is not accepted in any form. This includes
+  rewrites, paraphrases, renamed variables, and "inspired by" adaptations:
+  a derivative work stays a derivative work no matter how it is reworded.
+- If your PR ports or adapts third-party code, declare it in the PR
+  description: upstream repository, commit, and license. Ported code
+  without a provenance declaration will not be merged.
+- New ported code must update the notice files (`THIRD_PARTY_NOTICES.txt`
+  and the per-family `NOTICE` convention under `libreyolo/models/`).
+- By submitting a contribution you certify that you have the right to submit
+  it under the MIT license, in the sense of the Developer Certificate of
+  Origin (developercertificate.org).
+- Licensing doubts are blocking, not nits. If you are unsure whether a
+  source is compatible, ask in the issue before writing code.
+
 ## Before opening a PR
 
 - For anything non-trivial, open an issue before submitting a PR so we can

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ LibreYOLO is MIT. That only stays true if every contribution is clean:
   and the per-family `NOTICE` convention under `libreyolo/models/`).
 - By submitting a contribution you certify that you have the right to submit
   it under the MIT license, in the sense of the Developer Certificate of
-  Origin (developercertificate.org).
+  Origin (<https://developercertificate.org>).
 - Licensing doubts are blocking, not nits. If you are unsure whether a
   source is compatible, ask in the issue before writing code.
 


### PR DESCRIPTION
Expand the licensing guidance in AGENTS.md and add a licensing and provenance section to CONTRIBUTING.md, so contributors know that only permissively licensed code is accepted and that ported code must declare its upstream.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enforces the project's licensing and provenance policy by adding human-facing guidance to `CONTRIBUTING.md`, agent-facing guidance to `AGENTS.md`, a PR template with a required "Code provenance" section, and a CI workflow that blocks merging when that section is absent or unfilled.

- **AGENTS.md**: Licensing policy moved to the top of the file and expanded with BSD, a "stop work on contaminated areas" conduct rule, and a pointer to the existing `skills/libreyolo-license-audit/` skill.
- **CONTRIBUTING.md**: New "Licensing and provenance" section covering accepted licenses, derivative-work restrictions, provenance declaration requirements, notice-file updates, and a DCO certification line.
- **`.github/pull_request_template.md` + `provenance-check.yml`**: PR template seeds the required section; the workflow parses the PR body, strips HTML placeholder comments, and fails the check if the section is missing or empty.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are documentation and CI policy only, with no effect on library code paths.

All four changed files are documentation or GitHub configuration. The workflow logic correctly handles null bodies, CRLF line endings, and HTML-comment placeholders. Referenced paths exist in the repo. License lists and DCO URL are consistent across all files.

.github/workflows/provenance-check.yml — the action is pinned to a tag rather than a commit SHA, worth addressing given the project's supply-chain focus.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/pull_request_template.md | New PR template with a required "Code provenance" section; content and format match the workflow's heading regex exactly. |
| .github/workflows/provenance-check.yml | New CI workflow that validates the PR body contains a non-empty "Code provenance" section; logic is correct but the action is pinned to a tag rather than a SHA. |
| AGENTS.md | Licensing policy section promoted to top of file, expanded with BSD, "stop work" conduct, and reference to the existing audit skill; no issues found. |
| CONTRIBUTING.md | New "Licensing and provenance" section added; BSD, DCO link, and notice-file requirements are all consistent with AGENTS.md and the PR template. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened / edited / pushed] --> B{provenance-check workflow}
    B --> C{Heading found?\n'## Code provenance'}
    C -- No --> D[Fail: section missing]
    C -- Yes --> E[Collect lines until next heading]
    E --> F[Strip HTML comments]
    F --> G{Content non-empty?}
    G -- No --> H[Fail: section empty]
    G -- Yes --> I[Pass: provenance declared]
    I --> J[Human / Greptile reviewer judges adequacy]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR opened / edited / pushed] --> B{provenance-check workflow}
    B --> C{Heading found?\n'## Code provenance'}
    C -- No --> D[Fail: section missing]
    C -- Yes --> E[Collect lines until next heading]
    E --> F[Strip HTML comments]
    F --> G{Content non-empty?}
    G -- No --> H[Fail: section empty]
    G -- Yes --> I[Pass: provenance declared]
    I --> J[Human / Greptile reviewer judges adequacy]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review: align license l..."](https://github.com/libreyolo/libreyolo/commit/2d9062c3e73c80c5d306724c70826a7955c79a94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42707699)</sub>

<!-- /greptile_comment -->