### PR TITLE
Fix review findings in new model families (batch guard + safe NAFNet peek)

### DIFF
--- a/libreyolo/models/nafnet/model.py
+++ b/libreyolo/models/nafnet/model.py
@@ -173,7 +173,10 @@ class LibreNAFNet(BaseModel):
                     path = Path(cls._resolve_weights_path(str(model_path)))
                 if not path.exists():
                     return None
-                loaded = torch.load(str(path), map_location="cpu", weights_only=False)
+                # Safe peek: weights_only=True forbids pickle code execution.
+                # This only needs the tensor state dict to infer the block
+                # layout; anything unloadable falls back to the default config.
+                loaded = torch.load(str(path), map_location="cpu", weights_only=True)
                 state_dict = loaded.get("model", loaded) if isinstance(loaded, dict) else None
             else:
                 return None

--- a/libreyolo/models/yolo1/model.py
+++ b/libreyolo/models/yolo1/model.py
@@ -59,6 +59,10 @@ VOC_NAMES: tuple[str, ...] = (
 
 class LibreYOLO1(DarknetFamily):
     FAMILY = "yolo1"
+    # The fully-connected head decodes a single fixed-448 image at a time; the
+    # decoder rejects batch > 1. Force the inference runner to loop per image
+    # for list inputs instead of attempting a real batch.
+    SUPPORTS_BATCHED_PREDICT = False
     FILENAME_PREFIX = "LibreYOLO1"
     INPUT_SIZES = {"t": 448, "b": 448}
 

--- a/libreyolo/postprocess/darknet_yolo.py
+++ b/libreyolo/postprocess/darknet_yolo.py
@@ -116,7 +116,11 @@ def decode_detection(
     anchor decoders so the shared NMS + letterbox-inverse path is reused.
     """
     b = output.shape[0]
-    assert b == 1, "darknet detection decode expects batch size 1"
+    if b != 1:
+        raise ValueError(
+            f"darknet detection decode expects batch size 1, got {b}. "
+            "This head does not support batched inference."
+        )
     s = spec.side
     n = spec.boxes_per_cell
     nc = spec.num_classes


### PR DESCRIPTION
Follow-up to #549 (the new-model bundle, now merged). Fixes the three review findings Greptile raised on that PR, which merged before they were applied. All three are small and confirmed.

## What changed
1. **`libreyolo/postprocess/darknet_yolo.py`** - the YOLOv1 decode guarded batch size with a bare `assert b == 1`, which `python -O`/`-OO` strips, silently folding a multi-image batch into one flat vector and returning garbage boxes. Replaced with a `ValueError` (verified it raises under `-O`).
2. **`libreyolo/models/yolo1/model.py`** - `LibreYOLO1` inherited `SUPPORTS_BATCHED_PREDICT = True` but its fully-connected head decodes one fixed-448 image at a time. Set it to `False` so `predict([...])` loops per image instead of attempting a real batch.
3. **`libreyolo/models/nafnet/model.py`** - the block-layout arch-peek used `torch.load(weights_only=False)`, which allows arbitrary code execution from a malicious `.pt`. Changed to `weights_only=True` (the peek only needs the tensor state dict; anything unloadable still falls back to the default config).

## Verification
- `test_yolo1.py` + `test_nafnet_restore.py`: 43 passed, 1 skipped (NAFNet still loads under the safe peek; YOLOv1 unaffected).
- Direct check: `decode_detection` on a batch-2 input raises `ValueError` even under `python -O`.

## Code provenance
Original code written for this PR. These are bug fixes to LibreYOLO's own first-party code (`postprocess/darknet_yolo.py`, `models/yolo1/model.py`, `models/nafnet/model.py`); no third-party code is ported, adapted, or introduced. No GPL/AGPL/LGPL/non-commercial/unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies three targeted bug fixes to the new-model bundle from #549, addressing findings raised in that PR's review before it merged. All changes are confined to their respective model files with no shared-code blast radius.

- **`darknet_yolo.py`**: Replaces `assert b == 1` in `decode_detection` with a `ValueError`, making the batch guard survive `python -O`/`-OO` and providing a descriptive message with the actual batch size.
- **`yolo1/model.py`**: Sets `SUPPORTS_BATCHED_PREDICT = False` on `LibreYOLO1` so the inference runner loops per image instead of constructing a real batch for the fixed-448 FC head.
- **`nafnet/model.py`**: Switches `_peek_arch_config` from `weights_only=False` to `weights_only=True`, eliminating arbitrary code execution risk from a malicious `.pt` file during the pre-build arch inspection; failures fall back gracefully to the default config via the existing `except Exception` handler.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all three fixes address real issues with minimal risk of regression.

The batch-guard and SUPPORTS_BATCHED_PREDICT changes are clean and tightly scoped. The NAFNet peek security fix is correct in intent, but the inline torch.load call bypasses the centralized load_untrusted_torch_file helper that handles old-PyTorch gracefully; on an affected PyTorch version the peek silently fails, the model is built with the wrong default config, and the subsequent weight load then fails with a cryptic shape mismatch. The fallback is safe in all modern environments.

libreyolo/models/nafnet/model.py — the inline torch.load in _peek_arch_config should route through load_untrusted_torch_file for version-safe behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/postprocess/darknet_yolo.py | Replaces the bare `assert b == 1` with a `ValueError`; the guard is now optimizer-safe and includes a clear message with the actual batch size. |
| libreyolo/models/yolo1/model.py | Adds `SUPPORTS_BATCHED_PREDICT = False` to `LibreYOLO1`, correctly preventing the inference runner from constructing a real batch for the fixed-448 FC head. |
| libreyolo/models/nafnet/model.py | Switches `_peek_arch_config` from `weights_only=False` to `weights_only=True`; the security intent is correct but the inline `torch.load` bypasses the centralized `load_untrusted_torch_file` helper that handles old-PyTorch version checks. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["predict(images)"] --> B{SUPPORTS_BATCHED_PREDICT?}
    B -- "True (YOLOv2/v3/v4/NAFNet)" --> C["batch forward pass"]
    B -- "False (YOLOv1 — new)" --> D["loop: one image at a time"]
    D --> E["decode_detection(output)\nbatch=1 enforced by ValueError"]
    C --> F{spec.kind}
    F -- "anchor/region" --> G["decode_head (v2/v3/v4)"]
    F -- "detection" --> E
    E --> H["NMS + postprocess"]
    G --> H

    subgraph NAFNet load
        I["_peek_arch_config(path)"]
        I --> J["torch.load\nweights_only=True ✓"]
        J -- "success" --> K["infer_nafnet_config\n→ _arch_config"]
        J -- "exception" --> L["log warning\n→ default config"]
        K --> M["_init_model with inferred layout"]
        L --> M
        M --> N["_load_weights via\nload_untrusted_torch_file"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["predict(images)"] --> B{SUPPORTS_BATCHED_PREDICT?}
    B -- "True (YOLOv2/v3/v4/NAFNet)" --> C["batch forward pass"]
    B -- "False (YOLOv1 — new)" --> D["loop: one image at a time"]
    D --> E["decode_detection(output)\nbatch=1 enforced by ValueError"]
    C --> F{spec.kind}
    F -- "anchor/region" --> G["decode_head (v2/v3/v4)"]
    F -- "detection" --> E
    E --> H["NMS + postprocess"]
    G --> H

    subgraph NAFNet load
        I["_peek_arch_config(path)"]
        I --> J["torch.load\nweights_only=True ✓"]
        J -- "success" --> K["infer_nafnet_config\n→ _arch_config"]
        J -- "exception" --> L["log warning\n→ default config"]
        K --> M["_init_model with inferred layout"]
        L --> M
        M --> N["_load_weights via\nload_untrusted_torch_file"]
    end
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibreyolo%2Fmodels%2Fnafnet%2Fmodel.py%3A176-179%0AThe%20peek%20now%20uses%20an%20inline%20%60torch.load%60%20with%20%60weights_only%3DTrue%60%2C%20but%20the%20rest%20of%20the%20codebase%20%28including%20the%20base%20%60_load_weights%60%29%20routes%20all%20trusted%2Funtrusted%20loads%20through%20%60load_untrusted_torch_file%60%20in%20%60libreyolo%2Futils%2Fserialization.py%60.%20That%20helper%20handles%20the%20version%20check%20%28%60_supports_weights_only%60%29%20gracefully%3A%20on%20older%20PyTorch%20that%20doesn't%20accept%20the%20flag%2C%20it%20raises%20a%20descriptive%20%60RuntimeError%60%20rather%20than%20leaking%20a%20bare%20%60TypeError%60%20through%20the%20%60except%20Exception%60%20catch.%20The%20current%20inline%20call%20would%20silently%20swallow%20that%20error%2C%20fall%20back%20to%20%60None%60%2C%20build%20the%20model%20with%20the%20wrong%20default%20config%2C%20and%20then%20fail%20at%20weight-load%20time%20with%20a%20cryptic%20shape%20mismatch%20instead%20of%20a%20clear%20%22upgrade%20PyTorch%22%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Safe%20peek%3A%20weights_only%3DTrue%20forbids%20pickle%20code%20execution.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20This%20only%20needs%20the%20tensor%20state%20dict%20to%20infer%20the%20block%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20layout%3B%20anything%20unloadable%20falls%20back%20to%20the%20default%20config.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20from%20...utils.serialization%20import%20load_untrusted_torch_file%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20loaded%20%3D%20load_untrusted_torch_file%28str%28path%29%2C%20map_location%3D%22cpu%22%2C%20context%3D%22NAFNet%20arch%20peek%22%29%0A%60%60%60%0A%0A&pr=550&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22fix-newmodel-review-findings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-newmodel-review-findings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibreyolo%2Fmodels%2Fnafnet%2Fmodel.py%3A176-179%0AThe%20peek%20now%20uses%20an%20inline%20%60torch.load%60%20with%20%60weights_only%3DTrue%60%2C%20but%20the%20rest%20of%20the%20codebase%20%28including%20the%20base%20%60_load_weights%60%29%20routes%20all%20trusted%2Funtrusted%20loads%20through%20%60load_untrusted_torch_file%60%20in%20%60libreyolo%2Futils%2Fserialization.py%60.%20That%20helper%20handles%20the%20version%20check%20%28%60_supports_weights_only%60%29%20gracefully%3A%20on%20older%20PyTorch%20that%20doesn't%20accept%20the%20flag%2C%20it%20raises%20a%20descriptive%20%60RuntimeError%60%20rather%20than%20leaking%20a%20bare%20%60TypeError%60%20through%20the%20%60except%20Exception%60%20catch.%20The%20current%20inline%20call%20would%20silently%20swallow%20that%20error%2C%20fall%20back%20to%20%60None%60%2C%20build%20the%20model%20with%20the%20wrong%20default%20config%2C%20and%20then%20fail%20at%20weight-load%20time%20with%20a%20cryptic%20shape%20mismatch%20instead%20of%20a%20clear%20%22upgrade%20PyTorch%22%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20Safe%20peek%3A%20weights_only%3DTrue%20forbids%20pickle%20code%20execution.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20This%20only%20needs%20the%20tensor%20state%20dict%20to%20infer%20the%20block%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20layout%3B%20anything%20unloadable%20falls%20back%20to%20the%20default%20config.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20from%20...utils.serialization%20import%20load_untrusted_torch_file%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20loaded%20%3D%20load_untrusted_torch_file%28str%28path%29%2C%20map_location%3D%22cpu%22%2C%20context%3D%22NAFNet%20arch%20peek%22%29%0A%60%60%60%0A%0A&repo=libreyolo%2Flibreyolo&pr=550&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix review findings in new model familie..."](https://github.com/libreyolo/libreyolo/commit/afe5b559cc6316be21ad410c463c7d9553a3029b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42729942)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->