### PR TITLE
Fix RF100 benchmark issues

### DIFF
--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -533,6 +533,16 @@ class BaseExporter(ABC):
                     "Depth export imgsz must be divisible by the network "
                     f"stride {divisor}, got {imgsz}."
                 )
+        if model_name == "rfdetr":
+            from ..models.rfdetr.imgsz import resolve_patch_window, validate_imgsz
+
+            patch_size, num_windows = resolve_patch_window(self.model.model)
+            imgsz = validate_imgsz(
+                imgsz,
+                patch_size=patch_size,
+                num_windows=num_windows,
+                name="RF-DETR export imgsz",
+            )
         if _is_rectangular_imgsz(imgsz) and model_name in _FIXED_SQUARE_EXPORT_FAMILIES:
             raise NotImplementedError(
                 f"Rectangular imgsz export is not supported for {model_name}: "

--- a/libreyolo/models/picodet/loss.py
+++ b/libreyolo/models/picodet/loss.py
@@ -238,8 +238,12 @@ class SimOTAAssigner:
 
         # Assignment is no-grad bookkeeping. Keep raw BCE out of CUDA autocast:
         # PyTorch treats probability BCE as unsafe under AMP, while the actual
-        # trainable VFL path below already uses BCE-with-logits.
-        with torch.amp.autocast(valid_cls_pred.device.type, enabled=False):
+        # trainable VFL path below already uses BCE-with-logits. Hardcoding
+        # "cuda" matches the YOLOX/YOLOv7 SimOTA guards: BaseTrainer only ever
+        # enables autocast for CUDA, a disabled "cuda" context is host-safe on
+        # CPU/MPS, and device-generic device_type crashes on MPS with torch
+        # 2.4.x.
+        with torch.amp.autocast("cuda", enabled=False):
             gt_onehot = F.one_hot(
                 gt_labels.long(),
                 num_classes=cls_pred.shape[1],

--- a/libreyolo/models/picodet/loss.py
+++ b/libreyolo/models/picodet/loss.py
@@ -236,17 +236,22 @@ class SimOTAAssigner:
         pairwise_ious = bbox_iou_xyxy(valid_decoded, gt_bboxes)
         iou_cost = -torch.log(pairwise_ious + 1e-8)
 
-        # Classification cost: BCE between predicted scores and one-hot GT.
-        gt_onehot = F.one_hot(gt_labels.long(), num_classes=cls_pred.shape[1]).float()
-        gt_onehot = gt_onehot.unsqueeze(0).repeat(valid_decoded.shape[0], 1, 1)
-        cls_pred_expanded = (
-            valid_cls_pred.unsqueeze(1).repeat(1, num_gts, 1)
-        )
-        cls_cost = F.binary_cross_entropy(
-            cls_pred_expanded.clamp(1e-7, 1 - 1e-7),
-            gt_onehot,
-            reduction="none",
-        ).sum(dim=-1)
+        # Assignment is no-grad bookkeeping. Keep raw BCE out of CUDA autocast:
+        # PyTorch treats probability BCE as unsafe under AMP, while the actual
+        # trainable VFL path below already uses BCE-with-logits.
+        with torch.amp.autocast(valid_cls_pred.device.type, enabled=False):
+            gt_onehot = F.one_hot(
+                gt_labels.long(),
+                num_classes=cls_pred.shape[1],
+            ).float()
+            gt_onehot = gt_onehot.unsqueeze(0).repeat(valid_decoded.shape[0], 1, 1)
+            cls_pred_expanded = valid_cls_pred.float().unsqueeze(1).repeat(1, num_gts, 1)
+            cls_cost = F.binary_cross_entropy(
+                cls_pred_expanded.clamp(1e-7, 1 - 1e-7),
+                gt_onehot,
+                reduction="none",
+            ).sum(dim=-1)
+        cls_cost = cls_cost.to(iou_cost.dtype)
 
         cost = (
             self.cls_weight * cls_cost

--- a/libreyolo/models/rfdetr/imgsz.py
+++ b/libreyolo/models/rfdetr/imgsz.py
@@ -9,9 +9,14 @@ def resolve_patch_window(
     model: Any,
     *,
     default_patch_size: int = 16,
-    default_num_windows: int = 4,
+    default_num_windows: int = 2,
 ) -> tuple[int, int]:
-    """Return ``(patch_size, num_windows)`` from common wrapper shapes."""
+    """Return ``(patch_size, num_windows)`` from common wrapper shapes.
+
+    Real RF-DETR modules always expose ``patch_size``/``num_windows``; the
+    defaults only cover wrappers that hide them and mirror every detection
+    size config (patch 16 x 2 windows, block 32).
+    """
 
     candidates = []
     current = model
@@ -64,7 +69,7 @@ def _validate_one(
 
 
 def validate_imgsz(
-    imgsz: int | tuple[int, int],
+    imgsz: int | tuple[int, int] | list[int],
     *,
     patch_size: int,
     num_windows: int,
@@ -72,9 +77,9 @@ def validate_imgsz(
 ) -> int | tuple[int, int]:
     """Validate RF-DETR spatial divisibility and return normalized ints."""
 
-    if isinstance(imgsz, tuple):
+    if isinstance(imgsz, (tuple, list)):
         if len(imgsz) != 2:
-            raise ValueError(f"{name} tuple must be (height, width), got {imgsz}.")
+            raise ValueError(f"{name} must be (height, width), got {imgsz}.")
         h = _validate_one(
             imgsz[0],
             name=f"{name} height",

--- a/libreyolo/models/rfdetr/imgsz.py
+++ b/libreyolo/models/rfdetr/imgsz.py
@@ -1,0 +1,96 @@
+"""RF-DETR image-size validation helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def resolve_patch_window(
+    model: Any,
+    *,
+    default_patch_size: int = 16,
+    default_num_windows: int = 4,
+) -> tuple[int, int]:
+    """Return ``(patch_size, num_windows)`` from common wrapper shapes."""
+
+    candidates = []
+    current = model
+    for _ in range(4):
+        if current is None or current in candidates:
+            break
+        candidates.append(current)
+        current = getattr(current, "module", None) or getattr(current, "model", None)
+
+    patch_size = default_patch_size
+    num_windows = default_num_windows
+    for candidate in candidates:
+        if hasattr(candidate, "patch_size") or hasattr(candidate, "num_windows"):
+            patch_size = int(getattr(candidate, "patch_size", patch_size))
+            num_windows = int(getattr(candidate, "num_windows", num_windows))
+            break
+    return patch_size, num_windows
+
+
+def _suggest_sizes(value: int, block_size: int) -> str:
+    lo = (value // block_size) * block_size
+    hi = lo + block_size
+    choices = [str(size) for size in (lo, hi) if size > 0]
+    if not choices:
+        choices = [str(block_size)]
+    if len(choices) == 1:
+        return choices[0]
+    return f"{choices[0]} or {choices[1]}"
+
+
+def _validate_one(
+    value: int,
+    *,
+    name: str,
+    patch_size: int,
+    num_windows: int,
+) -> int:
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}.")
+
+    block_size = int(patch_size) * int(num_windows)
+    if value % block_size != 0:
+        raise ValueError(
+            f"{name}={value} is not divisible by {block_size} "
+            f"(patch_size={patch_size} x num_windows={num_windows}). "
+            f"Use {_suggest_sizes(value, block_size)}."
+        )
+    return value
+
+
+def validate_imgsz(
+    imgsz: int | tuple[int, int],
+    *,
+    patch_size: int,
+    num_windows: int,
+    name: str = "imgsz",
+) -> int | tuple[int, int]:
+    """Validate RF-DETR spatial divisibility and return normalized ints."""
+
+    if isinstance(imgsz, tuple):
+        if len(imgsz) != 2:
+            raise ValueError(f"{name} tuple must be (height, width), got {imgsz}.")
+        h = _validate_one(
+            imgsz[0],
+            name=f"{name} height",
+            patch_size=patch_size,
+            num_windows=num_windows,
+        )
+        w = _validate_one(
+            imgsz[1],
+            name=f"{name} width",
+            patch_size=patch_size,
+            num_windows=num_windows,
+        )
+        return h, w
+    return _validate_one(
+        imgsz,
+        name=name,
+        patch_size=patch_size,
+        num_windows=num_windows,
+    )

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -681,11 +681,15 @@ class LibreRFDETR(BaseModel):
         input_size: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
         """Preprocess: resize + ImageNet normalization (no letterbox)."""
+        # Only user-supplied overrides need checking: the construction-time
+        # self.input_size is always a valid native size, and this runs on the
+        # per-image hot path.
+        if input_size is not None:
+            input_size = self._validate_imgsz(
+                input_size,
+                name="RF-DETR inference imgsz",
+            )
         effective_res = input_size if input_size is not None else self.input_size
-        effective_res = self._validate_imgsz(
-            effective_res,
-            name="RF-DETR inference imgsz",
-        )
 
         img = ImageLoader.load(image, color_format=color_format)
         orig_w, orig_h = img.size
@@ -1085,19 +1089,12 @@ class LibreRFDETR(BaseModel):
         return super().export(format, opset=opset, **kwargs)
 
     def val(self, *args, workers: int = 0, **kwargs) -> Dict:
-        """Run RF-DETR validation with a Windows-safe worker default."""
-        if "imgsz" in kwargs and kwargs["imgsz"] is not None:
-            kwargs["imgsz"] = self._validate_imgsz(
-                kwargs["imgsz"],
-                name="RF-DETR validation imgsz",
-            )
-        elif len(args) >= 3 and args[2] is not None:
-            args = list(args)
-            args[2] = self._validate_imgsz(
-                args[2],
-                name="RF-DETR validation imgsz",
-            )
-            args = tuple(args)
+        """Run RF-DETR validation with a Windows-safe worker default.
+
+        No imgsz check here: every validator routes the effective imgsz
+        through ``_get_val_preprocessor``, which validates, and inspecting
+        positional args would hardcode the base signature's parameter order.
+        """
         return super().val(*args, workers=workers, **kwargs)
 
     def _restore_after_training(self, result: dict) -> None:

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -21,6 +21,7 @@ from .nn import (
     RFDETR_SEG_CONFIGS,
 )
 from .config import RFDETRConfig
+from .imgsz import resolve_patch_window, validate_imgsz
 from ...postprocess.rfdetr import postprocess
 from .utils import IMAGENET_MEAN, IMAGENET_STD, preprocess_numpy
 from .trainer import RFDETRTrainer
@@ -651,6 +652,28 @@ class LibreRFDETR(BaseModel):
 
         return preprocess_numpy
 
+    def _validate_imgsz(
+        self,
+        imgsz: int | tuple[int, int],
+        *,
+        name: str = "imgsz",
+    ) -> int | tuple[int, int]:
+        patch_size, num_windows = resolve_patch_window(self.model)
+        return validate_imgsz(
+            imgsz,
+            patch_size=patch_size,
+            num_windows=num_windows,
+            name=name,
+        )
+
+    def _get_val_preprocessor(self, img_size: int | None = None):
+        if img_size is not None:
+            img_size = self._validate_imgsz(
+                img_size,
+                name="RF-DETR validation imgsz",
+            )
+        return super()._get_val_preprocessor(img_size=img_size)
+
     def _preprocess(
         self,
         image: ImageInput,
@@ -659,6 +682,10 @@ class LibreRFDETR(BaseModel):
     ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
         """Preprocess: resize + ImageNet normalization (no letterbox)."""
         effective_res = input_size if input_size is not None else self.input_size
+        effective_res = self._validate_imgsz(
+            effective_res,
+            name="RF-DETR inference imgsz",
+        )
 
         img = ImageLoader.load(image, color_format=color_format)
         orig_w, orig_h = img.size
@@ -1050,10 +1077,27 @@ class LibreRFDETR(BaseModel):
 
     def export(self, format: str = "onnx", *, opset: int = 17, **kwargs) -> str:
         """Export model. RF-DETR requires opset >= 17 for LayerNormalization."""
+        if kwargs.get("imgsz") is not None:
+            kwargs["imgsz"] = self._validate_imgsz(
+                kwargs["imgsz"],
+                name="RF-DETR export imgsz",
+            )
         return super().export(format, opset=opset, **kwargs)
 
     def val(self, *args, workers: int = 0, **kwargs) -> Dict:
         """Run RF-DETR validation with a Windows-safe worker default."""
+        if "imgsz" in kwargs and kwargs["imgsz"] is not None:
+            kwargs["imgsz"] = self._validate_imgsz(
+                kwargs["imgsz"],
+                name="RF-DETR validation imgsz",
+            )
+        elif len(args) >= 3 and args[2] is not None:
+            args = list(args)
+            args[2] = self._validate_imgsz(
+                args[2],
+                name="RF-DETR validation imgsz",
+            )
+            args = tuple(args)
         return super().val(*args, workers=workers, **kwargs)
 
     def _restore_after_training(self, result: dict) -> None:
@@ -1221,6 +1265,11 @@ class LibreRFDETR(BaseModel):
         train_kwargs.update(pose_train_metadata)
         if train_kwargs.get("imgsz") is None:
             train_kwargs["imgsz"] = self.input_size
+        else:
+            train_kwargs["imgsz"] = self._validate_imgsz(
+                train_kwargs["imgsz"],
+                name="RF-DETR train imgsz",
+            )
 
         aliases = {
             "num_workers": "workers",

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -28,6 +28,7 @@ from ...training.freezing import FreezeGroup
 from ...training.scheduler import BaseScheduler, CosineAnnealingScheduler, FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import RFDETRConfig
+from .imgsz import validate_imgsz
 from ..dfine.transforms import DFINEPassThroughDataset
 from .pose_transforms import RFDETRPoseTransform
 from .seg_transforms import (
@@ -246,19 +247,16 @@ class RFDETRTrainer(BaseTrainer):
         return getattr(getattr(self, "wrapper_model", None), "task", "detect") == "segment"
 
     def create_transforms(self):
-        patch_size = int(getattr(self.model, "patch_size", 16))
-        num_windows = int(getattr(self.model, "num_windows", 4))
-        block_size = patch_size * num_windows
+        raw = unwrap_model(self.model)
+        patch_size = int(getattr(raw, "patch_size", 16))
+        num_windows = int(getattr(raw, "num_windows", 4))
         # Validation always uses the literal imgsz, so divisibility is required
         # regardless of multi_scale mode.
-        if self.config.imgsz % block_size != 0:
-            lo = (self.config.imgsz // block_size) * block_size
-            hi = lo + block_size
-            raise ValueError(
-                f"imgsz={self.config.imgsz} is not divisible by {block_size} "
-                f"(patch_size={patch_size} x num_windows={num_windows}). "
-                f"Use {lo} or {hi}."
-            )
+        validate_imgsz(
+            self.config.imgsz,
+            patch_size=patch_size,
+            num_windows=num_windows,
+        )
         task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
         if task == "segment":
             preproc = RFDETRSegTransform(
@@ -456,17 +454,14 @@ class RFDETRTrainer(BaseTrainer):
         if not train_imgs:
             raise FileNotFoundError("No training images found for RF-DETR pose training")
 
-        patch_size = int(getattr(self.model, "patch_size", 16))
-        num_windows = int(getattr(self.model, "num_windows", 4))
-        block_size = patch_size * num_windows
-        if self.config.imgsz % block_size != 0:
-            lo = (self.config.imgsz // block_size) * block_size
-            hi = lo + block_size
-            raise ValueError(
-                f"imgsz={self.config.imgsz} is not divisible by {block_size} "
-                f"(patch_size={patch_size} x num_windows={num_windows}). "
-                f"Use {lo} or {hi}."
-            )
+        raw = unwrap_model(self.model)
+        patch_size = int(getattr(raw, "patch_size", 16))
+        num_windows = int(getattr(raw, "num_windows", 4))
+        validate_imgsz(
+            self.config.imgsz,
+            patch_size=patch_size,
+            num_windows=num_windows,
+        )
         train_tf = RFDETRPoseTransform(
             self.config.num_keypoints,
             flip_idx=flip_idx,

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -28,7 +28,7 @@ from ...training.freezing import FreezeGroup
 from ...training.scheduler import BaseScheduler, CosineAnnealingScheduler, FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import RFDETRConfig
-from .imgsz import validate_imgsz
+from .imgsz import resolve_patch_window, validate_imgsz
 from ..dfine.transforms import DFINEPassThroughDataset
 from .pose_transforms import RFDETRPoseTransform
 from .seg_transforms import (
@@ -248,8 +248,7 @@ class RFDETRTrainer(BaseTrainer):
 
     def create_transforms(self):
         raw = unwrap_model(self.model)
-        patch_size = int(getattr(raw, "patch_size", 16))
-        num_windows = int(getattr(raw, "num_windows", 4))
+        patch_size, num_windows = resolve_patch_window(raw)
         # Validation always uses the literal imgsz, so divisibility is required
         # regardless of multi_scale mode.
         validate_imgsz(
@@ -335,8 +334,7 @@ class RFDETRTrainer(BaseTrainer):
         if not self.config.multi_scale or self.config.do_random_resize_via_padding:
             return []
         raw = unwrap_model(self.model)
-        patch_size = int(getattr(raw, "patch_size", 16))
-        num_windows = int(getattr(raw, "num_windows", 4))
+        patch_size, num_windows = resolve_patch_window(raw)
         return compute_multi_scale_scales(
             self.config.imgsz,
             self.config.expanded_scales,
@@ -455,8 +453,7 @@ class RFDETRTrainer(BaseTrainer):
             raise FileNotFoundError("No training images found for RF-DETR pose training")
 
         raw = unwrap_model(self.model)
-        patch_size = int(getattr(raw, "patch_size", 16))
-        num_windows = int(getattr(raw, "num_windows", 4))
+        patch_size, num_windows = resolve_patch_window(raw)
         validate_imgsz(
             self.config.imgsz,
             patch_size=patch_size,

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -656,11 +656,16 @@ class DEIMv2Config(TrainConfig):
 class ECConfig(TrainConfig):
     """EC-specific training defaults (experimental).
 
-    Fine-tune defaults follow upstream EdgeCrafter's published recipe (S/M):
+    Fine-tune defaults keep the optimizer/scheduler/loss shape from
+    EdgeCrafter's published recipe (S/M):
     AdamW with backbone-LR multiplier 0.05 (≈2.5e-5 vs head 5e-4), no-decay
     on norms/biases, FlatCosine schedule with quadratic warmup, EMA 0.9999,
-    Mosaic+Mixup until ~mid-training, all strong augs disabled past
-    ``stop_epoch``. Loss = MAL + L1 + GIoU + FGL + DDF.
+    Loss = MAL + L1 + GIoU + FGL + DDF.
+
+    The current LibreYOLO detection trainer uses a per-image D-FINE-style
+    pass-through transform with ImageNet normalization. Mosaic/MixUp and the
+    strong color/geometric knobs are disabled here so the public config matches
+    the effective training path.
 
     Training has NOT been validated on a real fine-tune run — ship as
     experimental.
@@ -676,12 +681,12 @@ class ECConfig(TrainConfig):
     no_aug_epochs: int = 4
     min_lr_ratio: float = 0.5  # EC's lr_gamma in upstream
 
-    mosaic_prob: float = 0.75
-    mixup_prob: float = 0.75
-    hsv_prob: float = 0.5
+    mosaic_prob: float = 0.0
+    mixup_prob: float = 0.0
+    hsv_prob: float = 0.0
     flip_prob: float = 0.5
-    degrees: float = 10.0
-    translate: float = 0.1
+    degrees: float = 0.0
+    translate: float = 0.0
     mosaic_scale: Tuple[float, float] = (0.5, 1.5)
     mixup_scale: Tuple[float, float] = (0.5, 1.5)
     shear: float = 0.0
@@ -920,11 +925,11 @@ class RTMDetConfig(TrainConfig):
     - DynamicSoftLabelAssigner (topk=13)
     - QualityFocalLoss (beta=2.0, weight=1.0) + GIoULoss (weight=2.0)
 
-    Status: training is NOT yet implemented in LibreYOLO. This config exists so
-    callers can introspect intended hyperparameters. ``LibreRTMDet.train()``
-    raises ``NotImplementedError`` until the follow-up PR lands the loss,
-    DynamicSoftLabelAssigner, MlvlPointGenerator,
-    and the 2-stage pipeline-switch hook.
+    Status: training is implemented but experimental. ``LibreRTMDet.train()``
+    requires ``allow_experimental=True`` because small-dataset fine-tune
+    convergence, from-scratch paper parity, multi-GPU behavior, cached
+    Mosaic/MixUp throughput, and the strict upstream two-stage pipeline switch
+    are not validated yet.
     """
 
     optimizer: str = "adamw"

--- a/tests/e2e/configs/rfdetr.yaml
+++ b/tests/e2e/configs/rfdetr.yaml
@@ -3,10 +3,10 @@ model_type: rfdetr
 
 # Size-specific defaults
 sizes:
-  n: {imgsz: 560, lr0: 0.001, weights: LibreRFDETRn.pt}
-  s: {imgsz: 560, lr0: 0.001, weights: LibreRFDETRs.pt}
-  m: {imgsz: 560, lr0: 0.001, weights: LibreRFDETRm.pt}
-  l: {imgsz: 560, lr0: 0.001, weights: LibreRFDETRl.pt}
+  n: {imgsz: 544, lr0: 0.001, weights: LibreRFDETRn.pt}
+  s: {imgsz: 544, lr0: 0.001, weights: LibreRFDETRs.pt}
+  m: {imgsz: 544, lr0: 0.001, weights: LibreRFDETRm.pt}
+  l: {imgsz: 544, lr0: 0.001, weights: LibreRFDETRl.pt}
 
 # Training
 epochs: 100
@@ -17,7 +17,7 @@ weight_decay: 0.0001
 nesterov: true
 
 # Scheduler
-scheduler: yoloxwarmcos
+scheduler: step
 warmup_epochs: 5
 warmup_lr_start: 0.0
 no_aug_epochs: 15

--- a/tests/e2e/configs/yolo9.yaml
+++ b/tests/e2e/configs/yolo9.yaml
@@ -17,7 +17,7 @@ weight_decay: 0.0005
 nesterov: true
 
 # Scheduler
-scheduler: yoloxwarmcos
+scheduler: linear
 warmup_epochs: 5
 warmup_lr_start: 0.0
 no_aug_epochs: 15

--- a/tests/unit/test_ec_training_fixes.py
+++ b/tests/unit/test_ec_training_fixes.py
@@ -20,6 +20,19 @@ pytestmark = pytest.mark.unit
 CKPT_PATH = Path("weights/LibreECs.pt")
 
 
+def test_ec_detection_config_matches_pass_through_augment_path():
+    """EC detect training currently uses DFINEPassThroughDataset, not mosaic."""
+    from libreyolo.training.config import ECConfig
+
+    cfg = ECConfig()
+    assert cfg.mosaic_prob == 0.0
+    assert cfg.mixup_prob == 0.0
+    assert cfg.hsv_prob == 0.0
+    assert cfg.degrees == 0.0
+    assert cfg.translate == 0.0
+    assert cfg.flip_prob == 0.5
+
+
 def test_imagenet_norm_applied_when_flag_true():
     """DFINETrainTransform(imagenet_norm=True) shifts the image distribution
     to roughly mean 0, std ~1; without the flag it stays in [0, 1]."""

--- a/tests/unit/test_picodet_train_smoke.py
+++ b/tests/unit/test_picodet_train_smoke.py
@@ -55,6 +55,37 @@ def test_simota_handles_empty_gt():
     assert pos.sum() == 0
 
 
+def test_simota_bce_cost_disables_autocast(monkeypatch):
+    """Raw probability BCE must not run inside AMP autocast."""
+    from libreyolo.models.picodet import loss as loss_module
+
+    a = SimOTAAssigner()
+    priors = torch.tensor(
+        [[5.0, 5.0, 8.0, 8.0], [20.0, 20.0, 8.0, 8.0]],
+        dtype=torch.float32,
+    )
+    decoded = torch.tensor(
+        [[0.0, 0.0, 10.0, 10.0], [16.0, 16.0, 24.0, 24.0]],
+        dtype=torch.float32,
+    )
+    cls_pred = torch.full((2, 80), 0.5, dtype=torch.float32)
+    gt_boxes = torch.tensor([[0.0, 0.0, 10.0, 10.0]], dtype=torch.float32)
+    gt_labels = torch.tensor([3], dtype=torch.long)
+    seen = {}
+    real_bce = loss_module.F.binary_cross_entropy
+
+    def wrapped_bce(*args, **kwargs):
+        seen["cpu_autocast"] = torch.is_autocast_enabled("cpu")
+        return real_bce(*args, **kwargs)
+
+    monkeypatch.setattr(loss_module.F, "binary_cross_entropy", wrapped_bce)
+
+    with torch.amp.autocast("cpu"):
+        a.assign(priors, decoded, cls_pred, gt_boxes, gt_labels)
+
+    assert seen["cpu_autocast"] is False
+
+
 def test_iou_pairwise_correct():
     a = torch.tensor([[0, 0, 10, 10], [0, 0, 5, 5]], dtype=torch.float32)
     b = torch.tensor([[0, 0, 10, 10]], dtype=torch.float32)

--- a/tests/unit/test_picodet_train_smoke.py
+++ b/tests/unit/test_picodet_train_smoke.py
@@ -58,8 +58,9 @@ def test_simota_handles_empty_gt():
 def test_simota_bce_cost_disables_autocast(monkeypatch):
     """Raw probability BCE must not run inside CUDA AMP autocast.
 
-    Entering a "cuda" autocast context only flips thread-local state, so this
-    exercises the guard even on CUDA-less hosts.
+    ``torch.amp.autocast("cuda")`` refuses to enable on CUDA-less hosts (CI),
+    so set the thread-local flag directly to simulate an active CUDA autocast
+    region; the guard's disabled "cuda" context must still flip it off.
     """
     from libreyolo.models.picodet import loss as loss_module
 
@@ -84,9 +85,12 @@ def test_simota_bce_cost_disables_autocast(monkeypatch):
 
     monkeypatch.setattr(loss_module.F, "binary_cross_entropy", wrapped_bce)
 
-    with torch.amp.autocast("cuda"):
+    torch.set_autocast_enabled("cuda", True)
+    try:
         assert torch.is_autocast_enabled("cuda")
         a.assign(priors, decoded, cls_pred, gt_boxes, gt_labels)
+    finally:
+        torch.set_autocast_enabled("cuda", False)
 
     assert seen["cuda_autocast"] is False
 

--- a/tests/unit/test_picodet_train_smoke.py
+++ b/tests/unit/test_picodet_train_smoke.py
@@ -56,7 +56,11 @@ def test_simota_handles_empty_gt():
 
 
 def test_simota_bce_cost_disables_autocast(monkeypatch):
-    """Raw probability BCE must not run inside AMP autocast."""
+    """Raw probability BCE must not run inside CUDA AMP autocast.
+
+    Entering a "cuda" autocast context only flips thread-local state, so this
+    exercises the guard even on CUDA-less hosts.
+    """
     from libreyolo.models.picodet import loss as loss_module
 
     a = SimOTAAssigner()
@@ -75,15 +79,16 @@ def test_simota_bce_cost_disables_autocast(monkeypatch):
     real_bce = loss_module.F.binary_cross_entropy
 
     def wrapped_bce(*args, **kwargs):
-        seen["cpu_autocast"] = torch.is_autocast_enabled("cpu")
+        seen["cuda_autocast"] = torch.is_autocast_enabled("cuda")
         return real_bce(*args, **kwargs)
 
     monkeypatch.setattr(loss_module.F, "binary_cross_entropy", wrapped_bce)
 
-    with torch.amp.autocast("cpu"):
+    with torch.amp.autocast("cuda"):
+        assert torch.is_autocast_enabled("cuda")
         a.assign(priors, decoded, cls_pred, gt_boxes, gt_labels)
 
-    assert seen["cpu_autocast"] is False
+    assert seen["cuda_autocast"] is False
 
 
 def test_iou_pairwise_correct():

--- a/tests/unit/test_rfdetr_imgsz_override.py
+++ b/tests/unit/test_rfdetr_imgsz_override.py
@@ -7,6 +7,7 @@ pytestmark = pytest.mark.unit
 
 rfdetr_model = pytest.importorskip("libreyolo.models.rfdetr.model")
 rfdetr_trainer = pytest.importorskip("libreyolo.models.rfdetr.trainer")
+from libreyolo.models.rfdetr.imgsz import validate_imgsz  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -15,10 +16,16 @@ rfdetr_trainer = pytest.importorskip("libreyolo.models.rfdetr.trainer")
 
 def _make_wrapper(input_size: int = 504) -> rfdetr_model.LibreRFDETR:
     wrapper = rfdetr_model.LibreRFDETR.__new__(rfdetr_model.LibreRFDETR)
-    wrapper.model = object()
+
+    class _FakeModel:
+        patch_size = 6
+        num_windows = 4  # block_size = 24
+
+    wrapper.model = _FakeModel()
     wrapper.size = "l"
     wrapper.nb_classes = 80
     wrapper.input_size = input_size
+    wrapper.task = "detect"
     return wrapper
 
 
@@ -105,6 +112,48 @@ def test_imgsz_none_falls_back_to_model_default(monkeypatch, tmp_path):
     assert captured["kwargs"]["imgsz"] == 504
 
 
+def test_train_rejects_invalid_explicit_imgsz():
+    """train(imgsz=500) fails before constructing the trainer."""
+    wrapper = _make_wrapper(input_size=504)
+    with pytest.raises(ValueError, match="RF-DETR train imgsz=500 is not divisible by 24"):
+        wrapper.train(data="data.yaml", imgsz=500)
+
+
+def test_inference_rejects_invalid_imgsz_before_loading_image():
+    """predict/preprocess paths fail early with the shared RF-DETR message."""
+    wrapper = _make_wrapper(input_size=504)
+    with pytest.raises(
+        ValueError,
+        match="RF-DETR inference imgsz=500 is not divisible by 24",
+    ):
+        wrapper._preprocess("missing.jpg", input_size=500)
+
+
+def test_val_preprocessor_rejects_invalid_imgsz():
+    """Validation preprocessor creation validates the RF-DETR block size."""
+    wrapper = _make_wrapper(input_size=504)
+    with pytest.raises(
+        ValueError,
+        match="RF-DETR validation imgsz=500 is not divisible by 24",
+    ):
+        wrapper._get_val_preprocessor(img_size=500)
+
+
+def test_export_rejects_invalid_imgsz_before_exporter(monkeypatch):
+    """export(imgsz=500) fails before backend exporter setup."""
+    wrapper = _make_wrapper(input_size=504)
+
+    def _should_not_run(*args, **kwargs):
+        raise AssertionError("BaseModel.export should not run")
+
+    monkeypatch.setattr(rfdetr_model.BaseModel, "export", _should_not_run)
+    with pytest.raises(
+        ValueError,
+        match="RF-DETR export imgsz=500 is not divisible by 24",
+    ):
+        wrapper.export(imgsz=500)
+
+
 # ---------------------------------------------------------------------------
 # create_transforms() divisibility validation
 # ---------------------------------------------------------------------------
@@ -121,3 +170,9 @@ def test_imgsz_not_divisible_raises_with_multi_scale_too():
     trainer = _make_trainer(imgsz=500, multi_scale=True)
     with pytest.raises(ValueError, match="not divisible by 24"):
         trainer.create_transforms()
+
+
+def test_validator_suggests_adjacent_valid_sizes():
+    """The shared message points users to nearby RF-DETR-valid square sizes."""
+    with pytest.raises(ValueError, match="Use 544 or 576"):
+        validate_imgsz(560, patch_size=16, num_windows=2)

--- a/tests/unit/test_rfdetr_imgsz_override.py
+++ b/tests/unit/test_rfdetr_imgsz_override.py
@@ -176,3 +176,21 @@ def test_validator_suggests_adjacent_valid_sizes():
     """The shared message points users to nearby RF-DETR-valid square sizes."""
     with pytest.raises(ValueError, match="Use 544 or 576"):
         validate_imgsz(560, patch_size=16, num_windows=2)
+
+
+def test_validator_accepts_list_imgsz():
+    """CLI/config plumbing may hand a [h, w] list instead of a tuple."""
+    assert validate_imgsz([544, 576], patch_size=16, num_windows=2) == (544, 576)
+
+
+def test_resolve_patch_window_fallback_matches_detection_block():
+    """Models without the attrs (mocks, exotic wrappers) fall back to the
+    detection block of 32 (patch 16 x 2 windows), so real-world-valid sizes
+    such as 544 are never rejected by a guessed block of 64."""
+    from libreyolo.models.rfdetr.imgsz import resolve_patch_window
+
+    class _Bare:
+        pass
+
+    assert resolve_patch_window(_Bare()) == (16, 2)
+    validate_imgsz(544, patch_size=16, num_windows=2)

--- a/tests/unit/test_rtmdet.py
+++ b/tests/unit/test_rtmdet.py
@@ -163,6 +163,16 @@ def test_train_gated_without_allow_experimental():
         m.train(data="coco128.yaml", epochs=1)
 
 
+def test_config_docstring_matches_experimental_training_status():
+    """RTMDet config docs should not claim training is unimplemented."""
+    from libreyolo.training.config import RTMDetConfig
+
+    doc = RTMDetConfig.__doc__ or ""
+    assert "implemented but experimental" in doc
+    assert "NOT yet implemented" not in doc
+    assert "NotImplementedError" not in doc
+
+
 def test_trainer_filters_targets_by_width_and_height():
     """Zero-height boxes are padding/invalid; cy=0 is still a valid coordinate."""
     from libreyolo.models.rtmdet.trainer import RTMDetTrainer


### PR DESCRIPTION
Fixes several low-risk issues surfaced by the RF100 benchmark thread (issue #542).

- fixes stale e2e scheduler/imgsz config for YOLO9 and RF-DETR (`yoloxwarmcos` is not accepted by either trainer; RF-DETR imgsz 560 is not divisible by its block of 32)
- centralizes RF-DETR image-size validation (train/val/predict/export now fail early with nearby valid sizes, e.g. "Use 544 or 576"); the fallback block used when a wrapper hides `patch_size`/`num_windows` matches the real detection configs (16 x 2 = 32)
- aligns EC detection defaults with its no-mosaic training path (the mosaic/color/geometric knobs were never consumed by the EC trainer)
- keeps PicoDet SimOTA probability BCE outside CUDA autocast, matching the existing YOLOX/YOLOv7 SimOTA guards
- updates stale RTMDet training-status docs (training exists behind `allow_experimental=True`)

The Volta/V100 PyTorch wheel caveat from the issue is intentionally not documented here; it will be covered outside this repo.

Validation: full unit suite green locally after rebasing onto dev, including the exporter tests that failed on the previous revision.

## Code provenance

All code and documentation changes in this PR were written specifically for this PR based on the RF100 benchmark findings in issue #542 and inspection of the LibreYOLO codebase. No third-party code was copied, ported, adapted, or derived
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses several low-severity issues surfaced by the RF100 benchmark, touching RF-DETR image-size validation, PicoDet AMP safety, EC/RTMDet config correctness, and stale YAML scheduler/imgsz values.

- **RF-DETR imgsz validation centralized**: A new `libreyolo/models/rfdetr/imgsz.py` module provides `resolve_patch_window()` and `validate_imgsz()`, wired into `_preprocess`, `_get_val_preprocessor`, `export`, `val`, and `train` on `LibreRFDETR`; `trainer.py` switches from bare `getattr(self.model, ...)` to `unwrap_model()`, removing duplicated inline block-size checks.
- **PicoDet SimOTA BCE guarded from AMP**: Probability BCE is now computed inside `torch.amp.autocast(device_type, enabled=False)` with `.float()` cast on input and `.to(iou_cost.dtype)` afterward to restore the outer dtype.
- **Config/YAML corrections**: `ECConfig` augmentation defaults zeroed to match the actual pass-through training path; `RTMDetConfig` docstring updated; RF-DETR e2e imgsz corrected from 560 to 544 and scheduler from `yoloxwarmcos` to `step`; YOLO9 scheduler corrected to `linear`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are narrowly scoped bug fixes with matching unit tests and no alterations to shared training logic outside the affected models.

Each fix is self-contained: the new imgsz validation module is pure Python with no side effects, the AMP guard in PicoDet loss is proven by the new autocast smoke test, the ECConfig default changes are regression-guarded, and the YAML corrections align configs with the actual validated training paths. No regressions were identified across the 12 changed files.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/rfdetr/imgsz.py | New centralized RF-DETR image-size validation module with resolve_patch_window(), validate_imgsz(), and suggestion helpers; well-structured and handles both scalar and tuple imgsz inputs. |
| libreyolo/models/rfdetr/model.py | Adds _validate_imgsz() wrapper and hooks it into _preprocess, _get_val_preprocessor, export, val, and train; prior review threads already cover the positional-args branch in val() and hot-path validation in _preprocess(). |
| libreyolo/models/rfdetr/trainer.py | Switches from bare getattr on self.model to unwrap_model() before reading patch_size/num_windows; delegates block-size validation to centralized validate_imgsz(), removing duplicated inline logic. |
| libreyolo/models/picodet/loss.py | Wraps probability BCE in torch.amp.autocast(device_type, enabled=False) to prevent AMP from running an unsafe op, followed by .to(iou_cost.dtype) to match the outer dtype. |
| libreyolo/export/exporter.py | Adds RF-DETR block-size validation into the base exporter, consistent with the NAFNet and DEIMv2 checks already present. |
| libreyolo/training/config.py | Resets ECConfig augmentation defaults to 0.0 to match the actual D-FINE pass-through training path; updates RTMDetConfig docstring from not implemented to implemented but experimental. |
| tests/e2e/configs/rfdetr.yaml | Corrects imgsz from 560 to 544 and switches scheduler from yoloxwarmcos to step. |
| tests/unit/test_rfdetr_imgsz_override.py | Expands coverage with a _FakeModel exposing patch_size/num_windows and adds tests for all new validation entry points. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User calls train/val/export/_preprocess] --> B{entry point}
    B -->|train| C[LibreRFDETR.train]
    B -->|val| D[LibreRFDETR.val]
    B -->|export| E[LibreRFDETR.export]
    B -->|_preprocess| F[LibreRFDETR._preprocess]
    C --> H[_validate_imgsz]
    D --> H
    E --> H
    F --> H
    H --> I[resolve_patch_window - imgsz.py]
    I --> J{attrs found on model?}
    J -->|yes| K[use model patch_size/num_windows]
    J -->|no| L[use defaults 16x4]
    K --> M[validate_imgsz - imgsz.py]
    L --> M
    M -->|invalid| N[ValueError + nearby valid sizes]
    M -->|valid| O[proceed to super call]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User calls train/val/export/_preprocess] --> B{entry point}
    B -->|train| C[LibreRFDETR.train]
    B -->|val| D[LibreRFDETR.val]
    B -->|export| E[LibreRFDETR.export]
    B -->|_preprocess| F[LibreRFDETR._preprocess]
    C --> H[_validate_imgsz]
    D --> H
    E --> H
    F --> H
    H --> I[resolve_patch_window - imgsz.py]
    I --> J{attrs found on model?}
    J -->|yes| K[use model patch_size/num_windows]
    J -->|no| L[use defaults 16x4]
    K --> M[validate_imgsz - imgsz.py]
    L --> M
    M -->|invalid| N[ValueError + nearby valid sizes]
    M -->|valid| O[proceed to super call]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix RF100 benchmark issues"](https://github.com/libreyolo/libreyolo/commit/acfba8829301764efe1aded431315caf41eda455) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42737640)</sub>

<!-- /greptile_comment -->
