### PR TITLE
Pre-fill the Code provenance section in the merge-to-dev handoff URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,12 @@
   asks for it.
 - Humans handle issue creation, PR creation, review submission, and final merge
   decisions.
-- Agents may reply with a one-click GitHub URL (no description pre-filled) so
-  the human can open the PR or issue themselves.
+- Agents may reply with a one-click GitHub URL so the human can open the PR or
+  issue themselves, and should pre-fill it. For a PR, pre-fill the title and a
+  description that includes the required `## Code provenance` section (see
+  `.github/pull_request_template.md` and the `merge-to-dev` skill); for an
+  issue, the `libreyolo-report-issue` skill already does this. Pre-filling the
+  handoff URL is expected; opening the PR itself (e.g. `gh pr create`) is not.
 - When possible, work in git worktrees
 - The default branch is dev
 
@@ -103,8 +107,11 @@
 - Keep PRs to the least code needed to solve the stated problem.
 - Do not mention other computer vision libraries in PR titles or descriptions
   unless the comparison is necessary to explain compatibility or API behavior.
-- Encourage humans to write PR titles and descriptions in their own words so the
-  history is easier for reviewers and future readers to follow.
+- The agent pre-fills a draft PR title and description (including the required
+  `## Code provenance` section); the human edits it into their own words before
+  submitting, so the history stays easy for reviewers and future readers to
+  follow. The provenance section must be accurate for the actual diff, never a
+  placeholder, or the `provenance-check` CI gate fails.
 
 ## General library constraints
 - Generally every user facing API (Python, yamls, etc) has to follow the de-facto YOLO CLI/API conventions

--- a/skills/merge-to-dev/SKILL.md
+++ b/skills/merge-to-dev/SKILL.md
@@ -2,8 +2,9 @@
 name: merge-to-dev
 description: >-
   The whole dance for landing code on LibreYOLO's dev branch: branch, commit,
-  push to upstream, then hand the user a one-click compare URL that opens an
-  empty PR form for them to submit (agents must not open the PR themselves),
+  push to upstream, then hand the user a one-click compare URL that pre-fills
+  the PR title and description (including the required Code provenance section)
+  for them to review and submit (agents must not open the PR themselves),
   and once they have opened it, babysit the Greptile bot review until it is
   happy. Use whenever the user says "put this on dev", "push this to dev",
   "merge this to dev", "ship this", "open a PR for this", or hands over
@@ -17,8 +18,9 @@ There is exactly one way code lands on `dev` in `LibreYOLO/libreyolo`:
 **branch -> commit -> push to upstream -> the human opens a PR with base
 `dev`**. Never push to `dev` directly, even though the account has admin.
 And per `AGENTS.md`, the **agent never opens the PR**: it pushes the branch
-and hands over a one-click compare URL that opens the PR form empty, and the
-human submits it. When the user says "put this on dev", run the dance below
+and hands over a one-click compare URL that pre-fills the PR title and
+description (with the required Code provenance section), and the human reviews
+and submits it. When the user says "put this on dev", run the dance below
 and end your turn with that link, not with a question and not with a PR you
 opened yourself.
 
@@ -87,19 +89,44 @@ git push -u "$REMOTE" <branch>
 The compare URL below is a github.com URL, so it is unaffected by which
 remote name you pushed through.
 
-Then hand the user the one-click compare URL and stop:
+Then build the handoff URL with the **title and description pre-filled** and
+hand it over. A bare `compare/...?expand=1` link is not enough: for a
+single-commit branch GitHub fills the body from the commit message, and the
+required provenance section comes up blank. GitHub honours `title` and `body`
+query params on the compare page, so pre-fill them yourself and the human
+lands on a PR form already filled in.
 
-```
-https://github.com/LibreYOLO/libreyolo/compare/dev...<branch>?expand=1
+Write the body the way `.github/pull_request_template.md` asks: a normal
+description in whatever shape fits the change, plus, **required, a
+`## Code provenance` section**. The `provenance-check` CI gate fails the PR
+if that section is missing or empty, so it is the one part you must always
+include. Keep it short, factual prose, matching the repo's house style, no
+checkboxes and no tables:
+
+- First-party only: a `## Code provenance` heading followed by one line, e.g.
+  "Original code written for this PR; bug fixes to LibreYOLO's own first-party
+  code, no third-party code ported, adapted, or introduced; no
+  GPL/AGPL/LGPL/non-commercial/unknown-license material involved."
+- Ported or adapted code: name the upstream repository, the commit or version,
+  and its license (permissive only: MIT, Apache-2.0, BSD, or similar), and
+  update the notice files.
+
+Write the description to a scratch `body.md` (so multi-line content survives),
+then URL-encode title and body and print the link (same mechanism the
+`libreyolo-report-issue` skill uses for issues):
+
+```bash
+python -c "import urllib.parse,sys; print('https://github.com/LibreYOLO/libreyolo/compare/dev...'+sys.argv[1]+'?expand=1&title='+urllib.parse.quote(sys.argv[2])+'&body='+urllib.parse.quote(sys.argv[3]))" <branch> "<title>" "$(cat body.md)"
 ```
 
-**The agent must not open the PR.** `AGENTS.md` is explicit: "Agents must
-not open pull requests"; "Humans handle ... PR creation"; agents "may reply
-with a one-click GitHub URL (no description pre-filled) so the human can
-open the PR." The `?expand=1` compare link opens the PR form empty, which
-is exactly what the policy allows: do not use `gh pr create`, and do not
-pre-fill a description. Draft a suggested title and body in your message
-for the user to copy if they want, but the click is theirs.
+Hand the user that single pre-filled link and stop.
+
+**Pre-filling the URL is allowed; opening the PR is not.** `AGENTS.md`:
+"Agents must not open pull requests"; "Humans handle ... PR creation." So
+never run `gh pr create`; hand the pre-filled compare URL and let the human
+review, edit the prose into their own words, and submit. The `## Code
+provenance` section is the accurate part you own; never leave it blank or the
+CI gate fails.
 
 **Deliver the link without being asked.** "Pushed the branch" is not a
 finished turn; the link is the deliverable. CI (`unit-tests.yml`,
@@ -183,6 +210,11 @@ merging to dev is their click.
 - Pushing to `dev` or `release` directly. Never, admin or not.
 - Opening the PR yourself with `gh pr create`. `AGENTS.md` forbids it; hand
   the one-click compare URL and let the human submit.
+- Handing a bare `?expand=1` link with no `&body=`. It leaves the required
+  `## Code provenance` section blank, so the `provenance-check` CI gate fails.
+- Padding the description with checkbox lists or a provenance table. The
+  template is free-form prose; only a filled `## Code provenance` section is
+  required. Keep it simple.
 - Ending the turn with "want me to open a PR?". Hand the link.
 - Replying on the Greptile thread to rebut a finding. Put the rebuttal in
   your summary; the human comments if they want to.


### PR DESCRIPTION
Fixes the gap left after #547: the PR template and provenance-check CI gate require a filled Code provenance section, but the merge-to-dev skill still handed a bare compare link and called the form empty.

- merge-to-dev skill now pre-fills the PR title and description (with a plain-prose Code provenance section) via the compare URL title/body query params, so the handoff already passes the gate. No checkboxes, no table.
- AGENTS.md reverses the old "no description pre-filled" and "humans write their own descriptions" lines to match: agents pre-fill the URL, humans still open and submit.

## Code provenance

Original code written for this PR; documentation and skill edits to LibreYOLO's own first-party files (AGENTS.md, skills/merge-to-dev/SKILL.md). No third-party code is ported, adapted, or introduced. No GPL/AGPL/LGPL/non-commercial/unknown-license material involved

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR closes the gap left by #547 by teaching the `merge-to-dev` skill to build a GitHub compare URL pre-filled with a PR title and a `## Code provenance` description block (using `urllib.parse.quote`), so the handoff already satisfies the `provenance-check` CI gate when the human opens it. `AGENTS.md` is updated in parallel to make pre-filling the URL the stated expectation rather than the old "bare link, humans write their own descriptions."

- `AGENTS.md`: agent-conduct and PR-policy sections now explicitly require agents to pre-fill the compare URL (title + Code provenance); the human edits and submits.
- `skills/merge-to-dev/SKILL.md`: replaces the bare `?expand=1` link with a Python one-liner that URL-encodes title and body, documents first-party vs ported provenance prose, and adds two new anti-patterns (bare link, checkbox padding).
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the dev PR path; the release PR variant needs a small follow-up fix before that path is reliable.

The dev PR workflow is correctly updated end-to-end and the new anti-patterns are clear. The one gap is that the Common Variants release-PR entry still shows a bare URL without title/body params, which directly contradicts the new anti-pattern rule and would produce a provenance-check failure for any release PR handed off using that section as the template. The provenance-check workflow has no branch filter, so it fires on release PRs too.

skills/merge-to-dev/SKILL.md — the Common Variants release-PR section needs to show the pre-filled URL command with release as the base, and the no-CI claim should be scoped to unit-tests/install-smoke only.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Updated agent conduct and PR policy sections to say agents should pre-fill the compare URL (title + Code provenance description) rather than handing a bare link; wording is clear and internally consistent. |
| skills/merge-to-dev/SKILL.md | Adds the pre-filled URL mechanism with a Python one-liner and new anti-patterns. The main path (dev PRs) is correct, but the Common Variants release-PR path still shows a bare ?expand=1 URL that contradicts the new anti-pattern and would fail provenance-check CI. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent
    participant Git/GitHub
    participant Human
    participant CI

    Agent->>Git/GitHub: git push -u $REMOTE branch
    Agent->>Agent: "Write body.md (description + ## Code provenance)"
    Agent->>Agent: python urllib.parse.quote(title, body)
    Agent->>Human: Hand pre-filled compare URL (title + body params)
    Human->>GitHub: Opens PR from compare URL (form pre-filled)
    GitHub->>CI: Triggers provenance-check (all PRs)
    GitHub->>CI: Triggers unit-tests / install-smoke (dev PRs only)
    CI-->>Human: provenance-check passes (section present and non-empty)
    CI-->>Human: unit-tests / install-smoke results
    Human->>Agent: Its open
    Agent->>GitHub: Poll gh pr view reviews and comments
    Agent->>Agent: Evaluate Greptile findings
    Agent-->>Human: Report PR URL CI status Greptile verdict
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent
    participant Git/GitHub
    participant Human
    participant CI

    Agent->>Git/GitHub: git push -u $REMOTE branch
    Agent->>Agent: "Write body.md (description + ## Code provenance)"
    Agent->>Agent: python urllib.parse.quote(title, body)
    Agent->>Human: Hand pre-filled compare URL (title + body params)
    Human->>GitHub: Opens PR from compare URL (form pre-filled)
    GitHub->>CI: Triggers provenance-check (all PRs)
    GitHub->>CI: Triggers unit-tests / install-smoke (dev PRs only)
    CI-->>Human: provenance-check passes (section present and non-empty)
    CI-->>Human: unit-tests / install-smoke results
    Human->>Agent: Its open
    Agent->>GitHub: Poll gh pr view reviews and comments
    Agent->>Agent: Evaluate Greptile findings
    Agent-->>Human: Report PR URL CI status Greptile verdict
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `skills/merge-to-dev/SKILL.md`, line 193-198 ([link](https://github.com/libreyolo/libreyolo/blob/f2a80a016f632b62a17ff80b9412693afee0182f/skills/merge-to-dev/SKILL.md#L193-L198)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Release variant still shows a bare URL, contradicting the new anti-pattern**

   The "Common variants" section for release PRs says "same dance" but then shows `compare/release...<branch>?expand=1` with no `&title=` or `&body=` params — exactly the pattern the new anti-pattern rule forbids. The `provenance-check.yml` workflow has no `branches` filter, so it fires on ALL pull requests including release-base ones; a bare URL handed for a release PR will still fail that gate. On top of that, the Python command added in this PR hardcodes `dev` as the base, so an agent following the variant literally could produce a URL with the wrong base and no provenance body. The release variant should either show the adapted Python command (changing `dev` to `release`) or explicitly state that the same pre-filled URL mechanism applies, and the "no CI" claim should carve out `provenance-check`.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20skills%2Fmerge-to-dev%2FSKILL.md%0ALine%3A%20193-198%0A%0AComment%3A%0A**Release%20variant%20still%20shows%20a%20bare%20URL%2C%20contradicting%20the%20new%20anti-pattern**%0A%0AThe%20%22Common%20variants%22%20section%20for%20release%20PRs%20says%20%22same%20dance%22%20but%20then%20shows%20%60compare%2Frelease...%3Cbranch%3E%3Fexpand%3D1%60%20with%20no%20%60%26title%3D%60%20or%20%60%26body%3D%60%20params%20%E2%80%94%20exactly%20the%20pattern%20the%20new%20anti-pattern%20rule%20forbids.%20The%20%60provenance-check.yml%60%20workflow%20has%20no%20%60branches%60%20filter%2C%20so%20it%20fires%20on%20ALL%20pull%20requests%20including%20release-base%20ones%3B%20a%20bare%20URL%20handed%20for%20a%20release%20PR%20will%20still%20fail%20that%20gate.%20On%20top%20of%20that%2C%20the%20Python%20command%20added%20in%20this%20PR%20hardcodes%20%60dev%60%20as%20the%20base%2C%20so%20an%20agent%20following%20the%20variant%20literally%20could%20produce%20a%20URL%20with%20the%20wrong%20base%20and%20no%20provenance%20body.%20The%20release%20variant%20should%20either%20show%20the%20adapted%20Python%20command%20%28changing%20%60dev%60%20to%20%60release%60%29%20or%20explicitly%20state%20that%20the%20same%20pre-filled%20URL%20mechanism%20applies%2C%20and%20the%20%22no%20CI%22%20claim%20should%20carve%20out%20%60provenance-check%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22enforce-pr-template%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22enforce-pr-template%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20skills%2Fmerge-to-dev%2FSKILL.md%0ALine%3A%20193-198%0A%0AComment%3A%0A**Release%20variant%20still%20shows%20a%20bare%20URL%2C%20contradicting%20the%20new%20anti-pattern**%0A%0AThe%20%22Common%20variants%22%20section%20for%20release%20PRs%20says%20%22same%20dance%22%20but%20then%20shows%20%60compare%2Frelease...%3Cbranch%3E%3Fexpand%3D1%60%20with%20no%20%60%26title%3D%60%20or%20%60%26body%3D%60%20params%20%E2%80%94%20exactly%20the%20pattern%20the%20new%20anti-pattern%20rule%20forbids.%20The%20%60provenance-check.yml%60%20workflow%20has%20no%20%60branches%60%20filter%2C%20so%20it%20fires%20on%20ALL%20pull%20requests%20including%20release-base%20ones%3B%20a%20bare%20URL%20handed%20for%20a%20release%20PR%20will%20still%20fail%20that%20gate.%20On%20top%20of%20that%2C%20the%20Python%20command%20added%20in%20this%20PR%20hardcodes%20%60dev%60%20as%20the%20base%2C%20so%20an%20agent%20following%20the%20variant%20literally%20could%20produce%20a%20URL%20with%20the%20wrong%20base%20and%20no%20provenance%20body.%20The%20release%20variant%20should%20either%20show%20the%20adapted%20Python%20command%20%28changing%20%60dev%60%20to%20%60release%60%29%20or%20explicitly%20state%20that%20the%20same%20pre-filled%20URL%20mechanism%20applies%2C%20and%20the%20%22no%20CI%22%20claim%20should%20carve%20out%20%60provenance-check%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=libreyolo%2Flibreyolo&pr=554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Askills%2Fmerge-to-dev%2FSKILL.md%3A193-198%0A**Release%20variant%20still%20shows%20a%20bare%20URL%2C%20contradicting%20the%20new%20anti-pattern**%0A%0AThe%20%22Common%20variants%22%20section%20for%20release%20PRs%20says%20%22same%20dance%22%20but%20then%20shows%20%60compare%2Frelease...%3Cbranch%3E%3Fexpand%3D1%60%20with%20no%20%60%26title%3D%60%20or%20%60%26body%3D%60%20params%20%E2%80%94%20exactly%20the%20pattern%20the%20new%20anti-pattern%20rule%20forbids.%20The%20%60provenance-check.yml%60%20workflow%20has%20no%20%60branches%60%20filter%2C%20so%20it%20fires%20on%20ALL%20pull%20requests%20including%20release-base%20ones%3B%20a%20bare%20URL%20handed%20for%20a%20release%20PR%20will%20still%20fail%20that%20gate.%20On%20top%20of%20that%2C%20the%20Python%20command%20added%20in%20this%20PR%20hardcodes%20%60dev%60%20as%20the%20base%2C%20so%20an%20agent%20following%20the%20variant%20literally%20could%20produce%20a%20URL%20with%20the%20wrong%20base%20and%20no%20provenance%20body.%20The%20release%20variant%20should%20either%20show%20the%20adapted%20Python%20command%20%28changing%20%60dev%60%20to%20%60release%60%29%20or%20explicitly%20state%20that%20the%20same%20pre-filled%20URL%20mechanism%20applies%2C%20and%20the%20%22no%20CI%22%20claim%20should%20carve%20out%20%60provenance-check%60.%0A%0A&pr=554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22enforce-pr-template%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22enforce-pr-template%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Askills%2Fmerge-to-dev%2FSKILL.md%3A193-198%0A**Release%20variant%20still%20shows%20a%20bare%20URL%2C%20contradicting%20the%20new%20anti-pattern**%0A%0AThe%20%22Common%20variants%22%20section%20for%20release%20PRs%20says%20%22same%20dance%22%20but%20then%20shows%20%60compare%2Frelease...%3Cbranch%3E%3Fexpand%3D1%60%20with%20no%20%60%26title%3D%60%20or%20%60%26body%3D%60%20params%20%E2%80%94%20exactly%20the%20pattern%20the%20new%20anti-pattern%20rule%20forbids.%20The%20%60provenance-check.yml%60%20workflow%20has%20no%20%60branches%60%20filter%2C%20so%20it%20fires%20on%20ALL%20pull%20requests%20including%20release-base%20ones%3B%20a%20bare%20URL%20handed%20for%20a%20release%20PR%20will%20still%20fail%20that%20gate.%20On%20top%20of%20that%2C%20the%20Python%20command%20added%20in%20this%20PR%20hardcodes%20%60dev%60%20as%20the%20base%2C%20so%20an%20agent%20following%20the%20variant%20literally%20could%20produce%20a%20URL%20with%20the%20wrong%20base%20and%20no%20provenance%20body.%20The%20release%20variant%20should%20either%20show%20the%20adapted%20Python%20command%20%28changing%20%60dev%60%20to%20%60release%60%29%20or%20explicitly%20state%20that%20the%20same%20pre-filled%20URL%20mechanism%20applies%2C%20and%20the%20%22no%20CI%22%20claim%20should%20carve%20out%20%60provenance-check%60.%0A%0A&repo=libreyolo%2Flibreyolo&pr=554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Teach merge-to-dev to pre-fill the Code ..."](https://github.com/libreyolo/libreyolo/commit/f2a80a016f632b62a17ff80b9412693afee0182f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42856780)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/libreyolo/github/LibreYOLO/libreyolo/-/custom-context?memory=73e9ce7a-9a60-4fcf-b36b-54facf36715d))

<!-- /greptile_comment -->