### PR TITLE
Make release the default branch, keep dev as integration branch

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -2,7 +2,7 @@ name: Install smoke
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, release]
   pull_request:
     branches: [dev, release]
   workflow_dispatch:

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev]
   pull_request:
-    branches: [dev]
+    branches: [dev, release]
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: Unit tests
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, release]
   pull_request:
     branches: [dev, release]
   workflow_dispatch:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev]
   pull_request:
-    branches: [dev]
+    branches: [dev, release]
   workflow_dispatch:
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@
 - Agents may reply with a one-click GitHub URL (no description pre-filled) so
   the human can open the PR or issue themselves.
 - When possible, work in git worktrees
-- The default branch is dev
+- `release` is the default branch that visitors land on and clone; `dev` is the
+  integration branch where all development lands before it is promoted to a release.
 ## Commit policy
 - Do not add LLMs or agent tools as co-authors in commits.
 - Keep commit messages short and factual.
@@ -49,7 +50,9 @@
   evidence.
 
 ## Pull Request (PR) policy
-- The primary development branch is "dev"; "release" is for releases. Generally open PRs to dev, not release.
+- All development PRs target `dev`, never `release`. This holds regardless of
+  which branch GitHub shows as the default: `release` is the public default
+  branch, but it only receives curated release merges, not feature PRs.
 - Before reviewing or changing PRs, read the relevant files under /docs,
   especially documented schemas, contracts, and architecture decisions.
 - Prefer one PR per problem, or per small group of tightly related problems.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,9 @@ is limited. Keep changes focused, tested, and aligned with the project.
 
 ## Before opening a PR
 
+- Base your PR on `dev`, not `release`. `dev` is the integration branch where
+  all development lands; `release` only receives curated release merges. GitHub
+  may default a new PR's base to `release`, so double-check the base is `dev`.
 - For anything non-trivial, open an issue before submitting a PR so we can
   agree on the approach before review time is spent.
 - PRs must link to an issue (for anything non-trivial)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ cd libreyolo
 pip install -e .
 ```
 
+A plain clone checks out `release`, the stable branch whose code matches these
+docs. For the latest unreleased work, switch to the integration branch with
+`git checkout dev`.
+
 ## Flagship models
 
 LibreYOLO recommends these model families because they offer the best balance


### PR DESCRIPTION
Targets the release branch directly (no feature commits) so the CI trigger change is present before the GitHub default is flipped to release: PRs that land on release after the flip run unit tests and install smoke. Also updates AGENTS.md, CONTRIBUTING.md, and README.md to describe release as the public default and dev as the integration branch that all PRs target.