### PR TITLE
Add regression tests for the PR #550 fixes

### DIFF
--- a/libreyolo/models/nafnet/model.py
+++ b/libreyolo/models/nafnet/model.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 
 from ...postprocess.nafnet import postprocess as _nafnet_postprocess
 from ...utils.image_loader import ImageInput
+from ...utils.serialization import load_untrusted_torch_file
 from ..base import BaseModel
 from .config import NAFNetConfig
 from .nn import NAFNetLocal
@@ -176,7 +177,9 @@ class LibreNAFNet(BaseModel):
                 # Safe peek: weights_only=True forbids pickle code execution.
                 # This only needs the tensor state dict to infer the block
                 # layout; anything unloadable falls back to the default config.
-                loaded = torch.load(str(path), map_location="cpu", weights_only=True)
+                loaded = load_untrusted_torch_file(
+                    str(path), map_location="cpu", context="NAFNet arch peek"
+                )
                 state_dict = loaded.get("model", loaded) if isinstance(loaded, dict) else None
             else:
                 return None

--- a/tests/unit/test_classification.py
+++ b/tests/unit/test_classification.py
@@ -331,6 +331,17 @@ def test_erasing_appended_after_normalize():
     assert names.index("RandomErasing") > names.index("Normalize")
 
 
+def test_square_resize_with_augment_raises():
+    """square_resize is a val-only transform; the augment branch used to return
+    first and ignore it silently."""
+    from libreyolo.data.classify_dataset import build_classify_transforms
+
+    with pytest.raises(ValueError, match="square_resize"):
+        build_classify_transforms(224, True, square_resize=True)
+    # The val pipeline still honours it.
+    assert build_classify_transforms(224, False, square_resize=True) is not None
+
+
 def test_val_pipeline_ignores_augment_knobs():
     from libreyolo.data.classify_dataset import build_classify_transforms
 

--- a/tests/unit/test_yolo1.py
+++ b/tests/unit/test_yolo1.py
@@ -220,6 +220,23 @@ def test_postprocess_recovers_single_detection():
     assert (x1 + x2) / 2 == pytest.approx(50.0, abs=1.0)
 
 
+def test_decode_detection_rejects_batched_input():
+    # The guard must be a raised ValueError, not a bare ``assert``: ``python -O``
+    # strips asserts, and the decoder would then reshape a multi-image tensor and
+    # return image 0's detections for the whole batch.
+    spec = _det_spec(side=1, num=1, nc=1, sqrt=False)
+    preds = torch.zeros(2, 6)
+    with pytest.raises(ValueError, match="batch size 1"):
+        decode_detection(preds, spec, input_size=100)
+
+
+def test_libreyolo1_does_not_claim_batched_predict():
+    # The dense FC head is single-image. Inheriting BaseModel's True would send a
+    # stacked chunk down the batched predict path and duplicate image 0's boxes.
+    assert BaseModel.SUPPORTS_BATCHED_PREDICT is True
+    assert LibreYOLO1.SUPPORTS_BATCHED_PREDICT is False
+
+
 # ---------------------------------------------------------------------------
 # family registry discrimination
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the post-merge audit of #549 / #550.

## What this PR does

**1. Regression tests for the three fixes in #550**, which shipped with no test
coverage and could silently revert:

- `LibreYOLO1.SUPPORTS_BATCHED_PREDICT` is `False`. The dense FC head is
  single-image; inheriting `BaseModel`'s `True` sent a stacked chunk down the
  batched predict path and duplicated image 0's boxes across the batch.
- `decode_detection` raises `ValueError` on a batched tensor. The original guard
  was a bare `assert b == 1`, which `python -O` strips.
- `build_classify_transforms` raises on `square_resize=True` with `augment=True`
  instead of silently ignoring it.

Both `ValueError` guards are also exercised under `python -O`, so the tests fail
if either regresses back to a bare `assert`.

**2. NAFNet arch peek** now routes through
`libreyolo/utils/serialization.load_untrusted_torch_file` instead of an inline
`torch.load(..., weights_only=True)`, matching every other load in the codebase.
This was a Greptile P2 on #550 that posted 41 seconds after that PR merged, so it
was never seen. It is not a security regression, `weights_only=True` was already
set; this restores the single serialization entry point.

No behavior change beyond the NAFNet load path.

## Code provenance

All code in this PR is original, written for LibreYOLO. Nothing is ported,
adapted, or derived from any third-party project, so no notice files change.

The tests exercise LibreYOLO's own public API (`LibreYOLO1`, `decode_detection`,
`build_classify_transforms`). The NAFNet change swaps one internal call for an
existing internal LibreYOLO helper.

## How this was tested

- Full PR gate on this branch:
  `LIBREYOLO_PR_GATE=1 pytest tests/unit -m "unit and not external_data and not network"`
  -> **2989 passed, 19 skipped, 0 failed**.
- Same gate on dev tip `b6f8facf` for comparison: 2986 passed, 19 skipped, 0 failed.
  The 3 new tests are the delta.
- Both guards re-run under `python -O -m pytest` (asserts stripped): both still raise.
- `ruff check` clean on all changed files.
