### PR TITLE
Implement the panoptic task: COCO-panoptic dataset and Panoptic Quality

### DIFF
--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -109,36 +109,80 @@ Canonical loader: `libreyolo.data.SemanticDataset`.
 
 ## panoptic
 
-> SCAFFOLD (issue #555): the `panoptic` task is registered and its validator is
-> wired, but the dataset loader below is **not implemented yet**. This section
-> is the contract a contributor implements against; there is no canonical
-> `PanopticDataset` on disk yet.
+Panoptic segmentation pairs each image with a dense segment-id map and a
+per-image list describing each segment. LibreYOLO adopts the **COCO-panoptic
+format** verbatim (`Panoptic Segmentation`, Kirillov et al., CVPR 2019); no
+LibreYOLO-specific panoptic format exists, and none is needed.
 
-Panoptic segmentation pairs each image with a dense single-channel segment-id
-map and a per-image list describing each segment. The intended contract follows
-the COCO-panoptic format:
+### Segment-id PNG
 
-- A PNG per image whose pixel value (or RGB-encoded value) is a **segment id**.
-  Every pixel belongs to exactly one segment; there is no overlap.
-- A JSON `segments_info` list, one entry per segment id present in the image:
-  `{"id": int, "category_id": int, "iscrowd": 0|1, "area": int}`. `category_id`
-  indexes the dataset `names`.
+One RGB PNG per image, same resolution as the image, where each pixel's colour
+encodes the id of the segment it belongs to:
 
-thing-vs-stuff is a **per-category** property, not a per-segment one: as in
-COCO-panoptic, GT `segments_info` entries do **not** carry an `isthing` field;
-the split lives on the category metadata (each category is a "thing" or
-"stuff"). The prediction result payload
-(`libreyolo.utils.results.PanopticSegmentation`) uses the same convention and
-may optionally denormalize `isthing` onto each predicted segment for
-convenience. Deriving thing/stuff from `category_id` is therefore the
-producer's responsibility (the model's `_postprocess_predictions` and
-`PanopticValidator`), so the two surfaces stay consistent.
+```text
+segment_id = R + 256 * G + 256 * 256 * B
+```
 
-Validation uses Panoptic Quality (PQ = SQ x RQ), matching predicted to
-ground-truth segments of the same category at IoU > 0.5. See
-`libreyolo/validation/panoptic_validator.py` for the metric plug points.
+Every pixel belongs to exactly one segment; segments never overlap. Segment id
+`0` (RGB black) is **VOID**: unlabeled pixels, excluded from the metric.
 
-Canonical loader: *(to be added — `libreyolo.data.PanopticDataset`)*.
+### Annotations JSON
+
+```json
+{
+  "images":      [{"id": 139, "file_name": "000000000139.jpg", ...}],
+  "annotations": [{"image_id": 139, "file_name": "000000000139.png",
+                   "segments_info": [
+                     {"id": 3226956, "category_id": 1, "area": 2840,
+                      "bbox": [413, 158, 53, 138], "iscrowd": 0}]}],
+  "categories":  [{"id": 1, "name": "person", "isthing": 1, "supercategory": "person"}]
+}
+```
+
+- `annotations[].file_name` names the segment-id PNG inside `panoptic_dir`.
+- `segments_info[].id` matches a value in the PNG.
+- `iscrowd` marks group regions: they are never false negatives, and a
+  prediction mostly covering one is not a false positive.
+- **thing-vs-stuff is a per-category property.** `isthing` lives on
+  `categories`, never on `segments_info`. The prediction payload
+  (`libreyolo.utils.results.PanopticSegmentation`) may denormalize `isthing`
+  onto each predicted segment for convenience; the category metadata stays the
+  source of truth.
+
+### Class ids
+
+COCO-panoptic `category_id`s are the dataset's raw ids and are typically
+non-contiguous (COCO runs 1..200 with gaps). LibreYOLO models predict
+contiguous `0..nc-1`. Raw ids are remapped through the YAML `names` **by
+category name**, the same rule the native COCO-JSON detect loader follows: when
+`names` is present, it defines the label ids. A JSON category absent from
+`names` is an error, not a silent drop, because it would otherwise score as a
+permanent false negative.
+
+### YAML
+
+```yaml
+path: coco
+val: images/val2017
+annotations:
+  val: annotations/panoptic_val2017.json
+panoptic_dir:
+  val: annotations/panoptic_val2017   # the segment-id PNGs
+names: {0: person, 1: bicycle, ..., 132: rug-merged}
+```
+
+`annotations` and `panoptic_dir` accept either a single path or a per-split
+mapping.
+
+### Validation
+
+Panoptic Quality (`PQ = SQ x RQ`), computed at the ground-truth resolution and
+averaged over the categories that appear, then split into `PQ_things` /
+`PQ_stuff`. Matching is unique: a predicted and a ground-truth segment of the
+same category match iff IoU > 0.5. See
+`libreyolo/validation/panoptic_quality.py`.
+
+Canonical loader: `libreyolo.data.PanopticDataset`.
 
 ## depth
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -211,9 +211,10 @@ non-overlapping label, unifying `semantic` "stuff" (amorphous regions) with
 scored with Panoptic Quality (PQ = SQ x RQ) rather than mIoU or mask mAP. The
 canonical suffix is the full word `-panoptic` (not an abbreviation), so
 `LibreEoMTs-panoptic.pt` is a first-class panoptic checkpoint, not a `segment`
-checkpoint in disguise. NOTE (issue #555): the task, its `Results` slot, and
-the `PanopticValidator` dispatch are scaffolded; the model postprocess, the PQ
-metric, and the COCO-panoptic dataset loader are not implemented yet.
+checkpoint in disguise. Ground truth follows the COCO-panoptic format
+(`PanopticDataset`) and `model.val()` reports PQ / SQ / RQ split into things and
+stuff. NOTE (issue #555): the per-family panoptic postprocess is what a model
+family must still provide; a family without it raises from `_postprocess`.
 
 `depth` is the task for dense monocular depth estimation. Models expose
 `Results.depth_map`, a float `(H, W)` relative inverse-depth map on the

--- a/libreyolo/data/__init__.py
+++ b/libreyolo/data/__init__.py
@@ -38,6 +38,11 @@ from .restore_dataset import (
     resolve_restore_data,
     restore_collate_fn,
 )
+from .panoptic_dataset import (
+    PanopticDataset,
+    panoptic_collate_fn,
+    resolve_panoptic_data,
+)
 from .semantic_dataset import (
     SemanticDataset,
     img2mask_paths,
@@ -94,6 +99,9 @@ __all__ = [
     "resolve_restore_data",
     "restore_collate_fn",
     "SemanticDataset",
+    "PanopticDataset",
+    "panoptic_collate_fn",
+    "resolve_panoptic_data",
     "img2mask_paths",
     "resolve_semantic_data",
     "semantic_collate_fn",

--- a/libreyolo/data/panoptic_dataset.py
+++ b/libreyolo/data/panoptic_dataset.py
@@ -1,0 +1,234 @@
+"""COCO-panoptic dataset for the ``panoptic`` task.
+
+Panoptic ground truth is the COCO-panoptic format (`Panoptic Segmentation`,
+Kirillov et al., CVPR 2019): one PNG per image whose RGB encodes a **segment
+id**, plus a JSON file listing, per image, the segments present.
+
+The PNG encoding is a data-format fact, not a choice::
+
+    segment_id = R + 256 * G + 256 * 256 * B
+
+Segment id ``0`` (RGB black) is VOID: unlabeled pixels that neither reward nor
+penalize a prediction.
+
+Category ids in the JSON are the dataset's raw ids and are typically
+non-contiguous (COCO panoptic runs 1..200 with gaps). LibreYOLO models predict
+contiguous ``0..nc-1`` class indices, so raw ids are remapped through the YAML
+``names`` by category **name**, matching the rule the native COCO-JSON detect
+loader already follows: when ``names`` is present, it defines the label ids.
+
+thing-vs-stuff is a per-category property carried on the JSON ``categories``
+entries (``isthing``), never on individual segments. See
+``docs/dataset_schema.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from .utils import load_data_config
+
+logger = logging.getLogger(__name__)
+
+# COCO panoptic reserves segment id 0 (RGB black) for unlabeled pixels.
+VOID_SEGMENT_ID = 0
+
+
+def rgb2id(color: np.ndarray) -> np.ndarray:
+    """Decode a COCO-panoptic RGB PNG into a 2-D segment-id map.
+
+    ``segment_id = R + 256 * G + 256 * 256 * B``.
+    """
+    if color.ndim != 3 or color.shape[2] < 3:
+        raise ValueError(
+            f"Panoptic PNG must be an (H, W, 3) RGB image, got shape {color.shape}."
+        )
+    color = color[:, :, :3].astype(np.uint32)
+    return color[:, :, 0] + 256 * color[:, :, 1] + 256 * 256 * color[:, :, 2]
+
+
+def resolve_panoptic_data(data: str | Path, allow_scripts: bool = False) -> Dict:
+    """Load and sanity-check a panoptic dataset YAML config."""
+    config = load_data_config(str(data), allow_scripts=allow_scripts)
+    if not config.get("names"):
+        raise ValueError(f"Panoptic dataset config {data!r} must define class names.")
+    if not config.get("annotations"):
+        raise ValueError(
+            f"Panoptic dataset config {data!r} must define 'annotations' mapping "
+            "each split to its COCO-panoptic JSON file."
+        )
+    if not config.get("panoptic_dir"):
+        raise ValueError(
+            f"Panoptic dataset config {data!r} must define 'panoptic_dir', the "
+            "directory holding the segment-id PNGs."
+        )
+    return config
+
+
+def _split_value(value, split: str) -> str:
+    """Accept either a single path or a per-split mapping."""
+    if isinstance(value, dict):
+        if split not in value:
+            raise ValueError(f"No '{split}' entry in {value!r}.")
+        return str(value[split])
+    return str(value)
+
+
+class PanopticDataset(Dataset):
+    """COCO-panoptic dataset yielding ``(img_path, seg_map, segments_info, info)``.
+
+    Images are returned as paths, not tensors: panoptic evaluation runs at the
+    original image resolution, and each model family owns its own preprocessing
+    geometry (EoMT pads COCO inputs, splits ADE20K ones). The validator asks the
+    model to preprocess, so the dataset never has to guess.
+    """
+
+    def __init__(self, data_config: Dict, split: str = "val"):
+        self.split = split
+
+        root = Path(data_config.get("path") or ".")
+
+        split_value = data_config.get(split)
+        if not split_value:
+            raise ValueError(f"Panoptic dataset config has no '{split}' split.")
+        self.img_root = self._resolve(root, split_value)
+
+        ann_path = self._resolve(root, _split_value(data_config["annotations"], split))
+        self.panoptic_dir = self._resolve(
+            root, _split_value(data_config["panoptic_dir"], split)
+        )
+        if not ann_path.is_file():
+            raise FileNotFoundError(f"Panoptic annotations JSON not found: {ann_path}")
+        if not self.panoptic_dir.is_dir():
+            raise NotADirectoryError(
+                f"Panoptic PNG directory not found: {self.panoptic_dir}"
+            )
+
+        names = data_config.get("names") or {}
+        if isinstance(names, list):
+            names = {index: name for index, name in enumerate(names)}
+        self.names: Dict[int, str] = {int(k): str(v) for k, v in names.items()}
+        self.nc = int(data_config.get("nc") or len(self.names))
+        if self.nc != len(self.names):
+            raise ValueError(f"nc={self.nc} does not match {len(self.names)} names.")
+
+        with open(ann_path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+
+        self.category_id_to_train_id, self.thing_train_ids = self._build_category_map(
+            payload.get("categories") or []
+        )
+
+        images_by_id = {img["id"]: img for img in payload.get("images") or []}
+        self.items: List[Tuple[Path, Path, List[dict]]] = []
+        for ann in payload.get("annotations") or []:
+            png_path = self.panoptic_dir / ann["file_name"]
+            image_entry = images_by_id.get(ann["image_id"])
+            if image_entry is None:
+                raise ValueError(
+                    f"Annotation references image_id={ann['image_id']} which is "
+                    f"absent from the 'images' list in {ann_path}."
+                )
+            img_path = self.img_root / image_entry["file_name"]
+            self.items.append((img_path, png_path, ann.get("segments_info") or []))
+
+        if not self.items:
+            raise ValueError(f"No panoptic annotations found in {ann_path}.")
+
+    @staticmethod
+    def _resolve(root: Path, value: str) -> Path:
+        candidate = Path(value)
+        return candidate if candidate.is_absolute() else root / candidate
+
+    def _build_category_map(self, categories: List[dict]) -> Tuple[Dict[int, int], set]:
+        """Map raw COCO category ids onto contiguous train ids via YAML ``names``.
+
+        Raises rather than silently dropping: a category the model cannot name
+        would otherwise be scored as a permanent false negative.
+        """
+        if not categories:
+            raise ValueError("Panoptic JSON has no 'categories' list.")
+        name_to_train_id = {name: idx for idx, name in self.names.items()}
+        mapping: Dict[int, int] = {}
+        thing_train_ids: set = set()
+        for entry in categories:
+            name = str(entry["name"])
+            if name not in name_to_train_id:
+                raise ValueError(
+                    f"Panoptic category {name!r} (id={entry['id']}) is missing from "
+                    "the dataset YAML 'names'. Category names define the label ids."
+                )
+            train_id = name_to_train_id[name]
+            mapping[int(entry["id"])] = train_id
+            if int(entry.get("isthing", 0)) == 1:
+                thing_train_ids.add(train_id)
+        return mapping, thing_train_ids
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __getitem__(self, index: int):
+        img_path, png_path, raw_segments = self.items[index]
+
+        with Image.open(png_path) as handle:
+            seg_map = rgb2id(np.asarray(handle.convert("RGB")))
+
+        segments_info: List[dict] = []
+        for segment in raw_segments:
+            raw_category = int(segment["category_id"])
+            if raw_category not in self.category_id_to_train_id:
+                raise ValueError(
+                    f"{png_path.name}: segment category_id={raw_category} is not in "
+                    "the JSON 'categories' list."
+                )
+            segments_info.append(
+                {
+                    "id": int(segment["id"]),
+                    "category_id": self.category_id_to_train_id[raw_category],
+                    "iscrowd": int(segment.get("iscrowd", 0)),
+                    "area": int(segment.get("area", 0)),
+                }
+            )
+
+        info = {
+            "img_path": str(img_path),
+            "panoptic_path": str(png_path),
+            "height": int(seg_map.shape[0]),
+            "width": int(seg_map.shape[1]),
+        }
+        return (
+            str(img_path),
+            torch.from_numpy(seg_map.astype(np.int64)),
+            segments_info,
+            info,
+        )
+
+
+def panoptic_collate_fn(batch):
+    """Collate panoptic samples, keeping per-image structure intact.
+
+    Segment maps have per-image resolutions and variable-length ``segments_info``,
+    so nothing is stacked. Panoptic validation runs one image at a time.
+    """
+    img_paths = [item[0] for item in batch]
+    seg_maps = [item[1] for item in batch]
+    segments_infos = [item[2] for item in batch]
+    infos = [item[3] for item in batch]
+    return img_paths, seg_maps, segments_infos, infos
+
+
+__all__ = [
+    "VOID_SEGMENT_ID",
+    "PanopticDataset",
+    "panoptic_collate_fn",
+    "resolve_panoptic_data",
+    "rgb2id",
+]

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -51,6 +51,7 @@ from ...utils.results import (
     Masks,
     Matte,
     OBB,
+    PanopticSegmentation,
     Points,
     Probs,
     Results,
@@ -674,6 +675,27 @@ class InferenceRunner:
                 path=str(image_path) if image_path else None,
                 names=self.model.names,
                 semantic_mask=SemanticMask(semantic_t.long(), (orig_h, orig_w)),
+            )
+
+        # Panoptic: a dense non-overlapping segment-id map plus segments_info.
+        panoptic_data = detections.get("panoptic")
+        if panoptic_data is not None:
+            orig_w, orig_h = original_size
+            panoptic_t = (
+                panoptic_data
+                if isinstance(panoptic_data, torch.Tensor)
+                else torch.as_tensor(panoptic_data)
+            )
+            return Results(
+                boxes=None,
+                orig_shape=(orig_h, orig_w),
+                path=str(image_path) if image_path else None,
+                names=self.model.names,
+                panoptic=PanopticSegmentation(
+                    panoptic_t.long(),
+                    detections.get("segments_info") or [],
+                    (orig_h, orig_w),
+                ),
             )
 
         # Depth: a dense relative inverse-depth map, no boxes.

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -487,12 +487,11 @@ class PanopticSegmentation(_TensorPayload):
     on the producer (a model's ``_postprocess_predictions`` /
     ``PanopticValidator``), not on downstream consumers.
 
-    SCAFFOLD (issue #555): this defines the API contract only. No model family
-    populates a :class:`Results` ``panoptic`` slot yet, and no drawing/summary
-    path consumes it. A family with panoptic weights (e.g. ``eomt``) plugs its
-    panoptic postprocess in by constructing this payload; :class:`Results.plot`
-    and :meth:`Results.summary` panoptic rendering are follow-up work. The
-    matching evaluation plug point is ``PanopticValidator`` (Panoptic Quality).
+    ``predict`` populates this slot whenever a model family's ``_postprocess``
+    returns a ``panoptic`` segment-id map plus ``segments_info``; evaluation is
+    ``PanopticValidator`` (Panoptic Quality) over a ``PanopticDataset``.
+    NOTE (issue #555): :class:`Results.plot` and :meth:`Results.summary` do not
+    render panoptic output yet.
     """
 
     IGNORE_INDEX = 0  # COCO panoptic convention: segment id 0 is unlabeled/void.

--- a/libreyolo/validation/__init__.py
+++ b/libreyolo/validation/__init__.py
@@ -12,6 +12,7 @@ from .depth_validator import DepthValidator
 from .restore_validator import RestoreValidator
 from .matte_validator import MatteValidator
 from .semantic_validator import SemanticValidator
+from .panoptic_quality import PanopticQuality
 from .panoptic_validator import PanopticValidator
 from .fomo_validator import FOMOValidator
 from .val_plotter import ValPlotter, ConfusionMatrix
@@ -31,6 +32,7 @@ __all__ = [
     "MatteValidator",
     "SemanticValidator",
     "PanopticValidator",
+    "PanopticQuality",
     "COCOEvaluator",
     "ValPlotter",
     "ConfusionMatrix",

--- a/libreyolo/validation/panoptic_quality.py
+++ b/libreyolo/validation/panoptic_quality.py
@@ -115,6 +115,13 @@ class PanopticQuality:
         gt_flat = gt_map.reshape(-1).astype(np.int64)
         pred_flat = pred_map.reshape(-1).astype(np.int64)
 
+        # Pairs are packed as gt * _OFFSET + pred for a single bincount, so an id
+        # at or above _OFFSET would unpack as a different segment and silently
+        # misattribute intersections. COCO ids fit in 24 bits; model output is
+        # not bounds-checked anywhere else.
+        self._check_id_range(gt_flat, "ground-truth")
+        self._check_id_range(pred_flat, "predicted")
+
         gt_areas = self._areas(gt_flat)
         pred_areas = self._areas(pred_flat)
         intersections = self._pair_areas(gt_flat, pred_flat)
@@ -155,10 +162,15 @@ class PanopticQuality:
                 matched_pred.add(pred_id)
 
         # --- false negatives: unmatched GT, crowd never counts ----------------
-        crowd_by_category: Dict[int, int] = {}
+        # A category may carry more than one crowd region in an image, so collect
+        # them all: keeping only the last would under-count the ignored area and
+        # turn a legitimately-excused prediction into a false positive.
+        crowd_by_category: Dict[int, List[int]] = {}
         for gt_id, gt_segment in gt_by_id.items():
             if int(gt_segment.get("iscrowd", 0)) == 1:
-                crowd_by_category[int(gt_segment["category_id"])] = gt_id
+                crowd_by_category.setdefault(
+                    int(gt_segment["category_id"]), []
+                ).append(gt_id)
                 continue
             if gt_id in matched_gt:
                 continue
@@ -172,12 +184,22 @@ class PanopticQuality:
             if pred_area == 0:
                 continue
             ignored = intersections.get((VOID_SEGMENT_ID, pred_id), 0)
-            crowd_id = crowd_by_category.get(int(pred_segment["category_id"]))
-            if crowd_id is not None:
+            for crowd_id in crowd_by_category.get(int(pred_segment["category_id"]), ()):
                 ignored += intersections.get((crowd_id, pred_id), 0)
             if ignored / pred_area > PQ_IOU_THRESHOLD:
                 continue  # removed; does not count as a false positive
             self._stat(int(pred_segment["category_id"])).fp += 1
+
+    @staticmethod
+    def _check_id_range(flat: np.ndarray, which: str) -> None:
+        if flat.size == 0:
+            return
+        if flat.min() < 0 or flat.max() >= _OFFSET:
+            raise ValueError(
+                f"{which} segment ids must lie in [0, {_OFFSET}); got "
+                f"[{int(flat.min())}, {int(flat.max())}]. Ids are packed pairwise "
+                "for the intersection histogram."
+            )
 
     @staticmethod
     def _areas(flat: np.ndarray) -> Dict[int, int]:

--- a/libreyolo/validation/panoptic_quality.py
+++ b/libreyolo/validation/panoptic_quality.py
@@ -1,0 +1,226 @@
+"""Panoptic Quality (PQ) metric.
+
+Implemented from the metric definition in *Panoptic Segmentation*
+(Kirillov, He, Girshick, Rother, Dollar; CVPR 2019, arXiv:1801.00868), which
+specifies both the formula and the evaluation rules for void and group regions.
+
+PQ, for one category::
+
+    PQ = sum_{(p,g) in TP} IoU(p, g) / (|TP| + 0.5 * |FP| + 0.5 * |FN|)
+       = SQ * RQ
+
+where ``SQ = sum IoU / |TP|`` (the average IoU of matched segments) and
+``RQ = |TP| / (|TP| + 0.5|FP| + 0.5|FN|)`` (the F1 score).
+
+Matching rule (paper, Theorem 1): a predicted and a ground-truth segment of the
+**same category** match iff their IoU is strictly greater than 0.5. Because
+panoptic segments do not overlap, such a match is provably unique, so no greedy
+tie-breaking is needed.
+
+Void handling (paper, "void labels"):
+
+1. During matching, predicted pixels that are void in the ground truth are
+   removed from the prediction and do not affect the IoU.
+2. After matching, an unmatched predicted segment whose void fraction exceeds
+   the matching threshold is removed and does not count as a false positive.
+
+Group (crowd) handling (paper, "group labels"):
+
+1. During matching, group regions are not used.
+2. After matching, an unmatched predicted segment whose overlap with a group of
+   the same class exceeds the matching threshold is removed and does not count
+   as a false positive.
+
+Ground-truth crowd segments therefore never become false negatives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence, Set
+
+import numpy as np
+
+# Segments match iff IoU strictly exceeds this. Fixed by the metric definition:
+# above 0.5 the match is unique (Theorem 1).
+PQ_IOU_THRESHOLD = 0.5
+
+# Void/unlabeled segment id, shared with the COCO-panoptic PNG encoding.
+VOID_SEGMENT_ID = 0
+
+# Pairs (gt_id, pred_id) are packed into one integer for a single bincount.
+_OFFSET = 1 << 32
+
+
+@dataclass
+class CategoryStat:
+    """Accumulators for one category, summed over images."""
+
+    iou: float = 0.0
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+
+    def pq_sq_rq(self) -> tuple[float, float, float]:
+        denominator = self.tp + 0.5 * self.fp + 0.5 * self.fn
+        if denominator == 0:
+            return 0.0, 0.0, 0.0
+        sq = self.iou / self.tp if self.tp else 0.0
+        rq = self.tp / denominator
+        return sq * rq, sq, rq
+
+    @property
+    def seen(self) -> bool:
+        """Whether the category appeared in the ground truth or a prediction."""
+        return (self.tp + self.fp + self.fn) > 0
+
+
+@dataclass
+class PanopticQuality:
+    """Streaming Panoptic Quality accumulator.
+
+    ``thing_class_ids`` splits the per-category results into PQ_things and
+    PQ_stuff. It is a property of the label set, not of individual segments.
+    """
+
+    thing_class_ids: Set[int] = field(default_factory=set)
+    stats: Dict[int, CategoryStat] = field(default_factory=dict)
+
+    def _stat(self, category_id: int) -> CategoryStat:
+        return self.stats.setdefault(category_id, CategoryStat())
+
+    def update(
+        self,
+        gt_map: np.ndarray,
+        gt_segments: Sequence[dict],
+        pred_map: np.ndarray,
+        pred_segments: Sequence[dict],
+    ) -> None:
+        """Accumulate one image.
+
+        ``gt_map`` / ``pred_map`` are ``(H, W)`` segment-id maps; id
+        ``VOID_SEGMENT_ID`` is void. Each entry of ``gt_segments`` needs
+        ``id``, ``category_id`` and ``iscrowd``; ``pred_segments`` needs ``id``
+        and ``category_id``.
+        """
+        if gt_map.shape != pred_map.shape:
+            raise ValueError(
+                f"gt_map {gt_map.shape} and pred_map {pred_map.shape} must match. "
+                "Panoptic Quality is computed at the ground-truth resolution."
+            )
+
+        gt_by_id = {int(s["id"]): s for s in gt_segments}
+        pred_by_id = {int(s["id"]): s for s in pred_segments}
+
+        gt_flat = gt_map.reshape(-1).astype(np.int64)
+        pred_flat = pred_map.reshape(-1).astype(np.int64)
+
+        gt_areas = self._areas(gt_flat)
+        pred_areas = self._areas(pred_flat)
+        intersections = self._pair_areas(gt_flat, pred_flat)
+
+        matched_gt: Set[int] = set()
+        matched_pred: Set[int] = set()
+
+        # --- matching: same category, IoU > 0.5, crowd excluded ---------------
+        for (gt_id, pred_id), inter in intersections.items():
+            if gt_id == VOID_SEGMENT_ID or pred_id == VOID_SEGMENT_ID:
+                continue
+            gt_segment = gt_by_id.get(gt_id)
+            pred_segment = pred_by_id.get(pred_id)
+            if gt_segment is None or pred_segment is None:
+                continue
+            if int(gt_segment.get("iscrowd", 0)) == 1:
+                continue  # rule: group regions are not used during matching
+            if int(gt_segment["category_id"]) != int(pred_segment["category_id"]):
+                continue
+
+            # Void GT pixels inside the prediction are removed from it, so they
+            # neither count toward the union nor penalize the IoU.
+            void_inside_pred = intersections.get((VOID_SEGMENT_ID, pred_id), 0)
+            union = (
+                gt_areas.get(gt_id, 0)
+                + pred_areas.get(pred_id, 0)
+                - inter
+                - void_inside_pred
+            )
+            if union <= 0:
+                continue
+            iou = inter / union
+            if iou > PQ_IOU_THRESHOLD:
+                stat = self._stat(int(gt_segment["category_id"]))
+                stat.tp += 1
+                stat.iou += iou
+                matched_gt.add(gt_id)
+                matched_pred.add(pred_id)
+
+        # --- false negatives: unmatched GT, crowd never counts ----------------
+        crowd_by_category: Dict[int, int] = {}
+        for gt_id, gt_segment in gt_by_id.items():
+            if int(gt_segment.get("iscrowd", 0)) == 1:
+                crowd_by_category[int(gt_segment["category_id"])] = gt_id
+                continue
+            if gt_id in matched_gt:
+                continue
+            self._stat(int(gt_segment["category_id"])).fn += 1
+
+        # --- false positives: unmatched predictions, minus void/crowd ---------
+        for pred_id, pred_segment in pred_by_id.items():
+            if pred_id in matched_pred:
+                continue
+            pred_area = pred_areas.get(pred_id, 0)
+            if pred_area == 0:
+                continue
+            ignored = intersections.get((VOID_SEGMENT_ID, pred_id), 0)
+            crowd_id = crowd_by_category.get(int(pred_segment["category_id"]))
+            if crowd_id is not None:
+                ignored += intersections.get((crowd_id, pred_id), 0)
+            if ignored / pred_area > PQ_IOU_THRESHOLD:
+                continue  # removed; does not count as a false positive
+            self._stat(int(pred_segment["category_id"])).fp += 1
+
+    @staticmethod
+    def _areas(flat: np.ndarray) -> Dict[int, int]:
+        ids, counts = np.unique(flat, return_counts=True)
+        return {int(i): int(c) for i, c in zip(ids, counts)}
+
+    @staticmethod
+    def _pair_areas(gt_flat: np.ndarray, pred_flat: np.ndarray) -> Dict[tuple, int]:
+        packed = gt_flat * _OFFSET + pred_flat
+        keys, counts = np.unique(packed, return_counts=True)
+        return {
+            (int(k // _OFFSET), int(k % _OFFSET)): int(c) for k, c in zip(keys, counts)
+        }
+
+    def compute(self) -> Dict[str, float]:
+        """Average per-category PQ/SQ/RQ over categories that were seen."""
+        overall = self._average(self.stats.keys())
+        things = self._average(i for i in self.stats if i in self.thing_class_ids)
+        stuff = self._average(i for i in self.stats if i not in self.thing_class_ids)
+        return {
+            "metrics/PQ": overall["pq"],
+            "metrics/SQ": overall["sq"],
+            "metrics/RQ": overall["rq"],
+            "metrics/PQ_things": things["pq"],
+            "metrics/PQ_stuff": stuff["pq"],
+            "metrics/categories": overall["n"],
+            "fitness": overall["pq"],
+        }
+
+    def _average(self, category_ids: Iterable[int]) -> Dict[str, float]:
+        seen: List[CategoryStat] = [
+            self.stats[i] for i in category_ids if self.stats[i].seen
+        ]
+        if not seen:
+            return {"pq": 0.0, "sq": 0.0, "rq": 0.0, "n": 0}
+        triples = [stat.pq_sq_rq() for stat in seen]
+        count = len(triples)
+        return {
+            "pq": sum(t[0] for t in triples) / count,
+            "sq": sum(t[1] for t in triples) / count,
+            "rq": sum(t[2] for t in triples) / count,
+            "n": count,
+        }
+
+
+__all__ = ["CategoryStat", "PanopticQuality", "PQ_IOU_THRESHOLD", "VOID_SEGMENT_ID"]

--- a/libreyolo/validation/panoptic_validator.py
+++ b/libreyolo/validation/panoptic_validator.py
@@ -1,34 +1,18 @@
 """Panoptic-segmentation validator for LibreYOLO.
 
-SCAFFOLD (issue #555): this file defines the validator's public shape only.
-The actual Panoptic Quality (PQ) computation and the COCO-panoptic
-ground-truth loader are NOT implemented here yet. A contributor porting a
-panoptic model family (e.g. ``eomt``) plugs the real logic in by filling the
-methods below; the ``val()`` dispatch, the ``panoptic`` task, and the
-:class:`~libreyolo.utils.results.PanopticSegmentation` result payload are
-already wired so this validator is reachable via ``model.val(...)`` once the
-model produces panoptic output.
+Scores a panoptic model with Panoptic Quality (PQ = SQ x RQ) over a
+COCO-panoptic split, reusing the :class:`BaseValidator` template
+(setup -> iterate -> finalize).
 
-What "done" looks like for whoever finishes this:
+Panoptic Quality is defined at the ground-truth resolution, and each model
+family owns its own preprocessing geometry (EoMT pads COCO inputs but splits
+ADE20K ones into sliding windows). So this validator delegates both ends to the
+model: :meth:`_preprocess_batch` calls the family's ``_preprocess`` and
+:meth:`_postprocess_predictions` calls its ``_postprocess``, which returns a
+segment-id map already resized onto the original canvas. Images are therefore
+processed one at a time.
 
-* ``_setup_dataloader`` builds a COCO-panoptic split. The GT contract is a PNG
-  whose RGB encodes a per-pixel segment id, plus a JSON ``segments_info`` list
-  (``id``, ``category_id``, ``iscrowd``, ``area``). See ``docs/dataset_schema.md``
-  (panoptic section) for the label spec to implement against.
-* ``_postprocess_predictions`` decodes raw model output into, per image, a
-  ``(H, W)`` segment-id map + ``segments_info`` (the same contract as
-  :class:`PanopticSegmentation`). The model's own panoptic postprocess (merge
-  thing-instances + stuff-regions into one non-overlapping map) lives on the
-  model family, not here.
-* ``_update_metrics`` accumulates, per category, the matched-IoU sum and the
-  TP / FP / FN counts using the standard PQ matching rule (a predicted segment
-  matches a GT segment of the same category iff IoU > 0.5; the match is unique).
-* ``_compute_metrics`` reduces those accumulators to Panoptic Quality::
-
-      PQ = (sum of matched IoU / TP) * (TP / (TP + 0.5*FP + 0.5*FN))
-         = SQ * RQ
-
-  reported overall and split into PQ_things / PQ_stuff, with ``fitness`` = PQ.
+The metric itself lives in :mod:`libreyolo.validation.panoptic_quality`.
 """
 
 from __future__ import annotations
@@ -38,68 +22,121 @@ from typing import Any, Dict
 
 from torch.utils.data import DataLoader
 
+from ..data.panoptic_dataset import (
+    PanopticDataset,
+    panoptic_collate_fn,
+    resolve_panoptic_data,
+)
 from .base import BaseValidator
+from .panoptic_quality import PQ_IOU_THRESHOLD, PanopticQuality
 
 logger = logging.getLogger(__name__)
 
-# Panoptic Quality matching threshold: a predicted segment matches a
-# ground-truth segment of the same category iff their IoU strictly exceeds
-# this value. Fixed by the panoptic-segmentation metric definition.
-PQ_IOU_THRESHOLD = 0.5
-
-_NOT_IMPLEMENTED = (
-    "Panoptic validation (Panoptic Quality) is not implemented yet. This is "
-    "scaffolding from issue #555: the task, the val() dispatch, and the "
-    "PanopticSegmentation result payload exist, but the PQ metric and the "
-    "COCO-panoptic dataset loader still need to be filled in. See the module "
-    "docstring in libreyolo/validation/panoptic_validator.py for the contract."
-)
-
 
 class PanopticValidator(BaseValidator):
-    """Panoptic Quality (PQ = SQ x RQ) validator for the ``panoptic`` task.
-
-    SCAFFOLD: every hook raises :class:`NotImplementedError` until the PQ
-    metric and COCO-panoptic loader are implemented. The class is intentionally
-    importable and dispatchable so downstream wiring can be tested before the
-    metric lands.
-    """
+    """Panoptic Quality (PQ = SQ x RQ) validator for the ``panoptic`` task."""
 
     task = "panoptic"
 
+    # Populated by _setup_dataloader; defaulted so _init_metrics is never a
+    # surprise AttributeError when the hooks are exercised out of order.
+    _thing_class_ids: set = frozenset()
+
     def _setup_dataloader(self) -> DataLoader:
-        # TODO(#555): build a COCO-panoptic split (PNG segment-id map + JSON
-        # segments_info). Mirror SemanticValidator._setup_dataloader for the
-        # data-resolution / class-count-check structure.
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        if not self.config.data:
+            raise ValueError("Panoptic validation requires data= (a dataset YAML).")
+        data_config = resolve_panoptic_data(
+            self.config.data,
+            allow_scripts=getattr(self.config, "allow_download_scripts", False),
+        )
+        split = self.config.split or "val"
+        dataset = PanopticDataset(data_config, split=split)
+
+        model_nc = getattr(self.model, "nb_classes", None)
+        if model_nc is not None and int(model_nc) != dataset.nc:
+            raise ValueError(
+                f"Panoptic dataset has {dataset.nc} classes but the model predicts "
+                f"{int(model_nc)}. Use a matching dataset/checkpoint."
+            )
+
+        # A thing/stuff split that disagrees with the checkpoint would not crash;
+        # it would quietly mis-partition PQ_things / PQ_stuff. Fail loudly instead.
+        model_things = getattr(self.model, "thing_class_ids", None)
+        if model_things and set(int(i) for i in model_things) != dataset.thing_train_ids:
+            raise ValueError(
+                "The checkpoint's thing_class_ids disagree with the dataset's "
+                "'isthing' categories. PQ_things / PQ_stuff would be mis-split. "
+                "Check that the dataset YAML 'names' order matches the checkpoint."
+            )
+
+        self._thing_class_ids = dataset.thing_train_ids
+        self._class_names = dict(dataset.names)
+
+        if self.config.batch_size != 1:
+            logger.info(
+                "Panoptic validation runs one image at a time (batch_size=%d ignored); "
+                "segment maps have per-image resolutions.",
+                self.config.batch_size,
+            )
+        return DataLoader(
+            dataset,
+            batch_size=1,
+            shuffle=False,
+            num_workers=self.config.num_workers,
+            pin_memory=False,
+            collate_fn=panoptic_collate_fn,
+        )
 
     def _init_metrics(self) -> None:
-        # TODO(#555): allocate per-category accumulators: matched-IoU sum and
-        # TP / FP / FN counts.
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        self._pq = PanopticQuality(thing_class_ids=set(self._thing_class_ids))
 
     def _preprocess_batch(self, batch: Any) -> tuple:
-        # TODO(#555): unpack (images, panoptic_targets, segments_info, img_info).
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        img_paths, seg_maps, segments_infos, infos = batch
+        # Let the model apply its own resize/pad/split geometry.
+        tensor, _, original_size, _ = self.model._preprocess(img_paths[0])
+        self._original_size = original_size
+        # The 4-tuple carries segments_info in the img_ids slot.
+        return tensor, seg_maps, infos, segments_infos
 
     def _postprocess_predictions(self, preds: Any, batch: Any) -> Any:
-        # TODO(#555): decode raw model output into per-image (segment-id map,
-        # segments_info). The model family's panoptic postprocess does the
-        # non-overlapping thing+stuff merge; this method only adapts its output
-        # to the metric's expected shape.
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        """Ask the model for a segment-id map on the original image canvas."""
+        detections = self.model._postprocess(
+            preds,
+            self.config.conf_thres,
+            self.config.iou_thres,
+            self._original_size,
+        )
+        if not isinstance(detections, dict) or "panoptic" not in detections:
+            raise ValueError(
+                f"{type(self.model).__name__}._postprocess did not return a "
+                "'panoptic' segment-id map. Does this family implement the "
+                "panoptic task?"
+            )
+        return detections
 
     def _update_metrics(
         self, preds: Any, targets: Any, img_info: Any, img_ids: Any = None
     ) -> None:
-        # TODO(#555): match predicted vs GT segments per category with
-        # IoU > PQ_IOU_THRESHOLD and accumulate TP/FP/FN + matched IoU.
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        gt_map = targets[0].numpy()
+        gt_segments = img_ids[0]
+        pred_map = preds["panoptic"].cpu().numpy()
+        pred_segments = preds.get("segments_info") or []
+        self._pq.update(gt_map, gt_segments, pred_map, pred_segments)
 
     def _compute_metrics(self) -> Dict[str, float]:
-        # TODO(#555): reduce accumulators to PQ / SQ / RQ (+ things/stuff split)
-        # and return {"metrics/PQ": ..., "fitness": PQ, ...}.
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        return self._pq.compute()
+
+    def _print_results(self, metrics: Dict[str, float]) -> None:
+        logger.info("=" * 50)
+        logger.info("LibreYOLO Panoptic Segmentation Validation Results")
+        logger.info("=" * 50)
+        logger.info("  PQ:         %.4f", metrics.get("metrics/PQ", 0.0))
+        logger.info("  SQ:         %.4f", metrics.get("metrics/SQ", 0.0))
+        logger.info("  RQ:         %.4f", metrics.get("metrics/RQ", 0.0))
+        logger.info("  PQ things:  %.4f", metrics.get("metrics/PQ_things", 0.0))
+        logger.info("  PQ stuff:   %.4f", metrics.get("metrics/PQ_stuff", 0.0))
+        logger.info("  categories: %d", int(metrics.get("metrics/categories", 0)))
+        logger.info("=" * 50)
 
 
 __all__ = ["PanopticValidator", "PQ_IOU_THRESHOLD"]

--- a/libreyolo/validation/panoptic_validator.py
+++ b/libreyolo/validation/panoptic_validator.py
@@ -61,8 +61,12 @@ class PanopticValidator(BaseValidator):
 
         # A thing/stuff split that disagrees with the checkpoint would not crash;
         # it would quietly mis-partition PQ_things / PQ_stuff. Fail loudly instead.
+        # `is not None` distinguishes "checkpoint carries no split" (skip) from
+        # "checkpoint says every category is stuff" (an assertion to honour).
         model_things = getattr(self.model, "thing_class_ids", None)
-        if model_things and set(int(i) for i in model_things) != dataset.thing_train_ids:
+        if model_things is not None and (
+            set(int(i) for i in model_things) != dataset.thing_train_ids
+        ):
             raise ValueError(
                 "The checkpoint's thing_class_ids disagree with the dataset's "
                 "'isthing' categories. PQ_things / PQ_stuff would be mis-split. "

--- a/tests/unit/test_panoptic_dataset.py
+++ b/tests/unit/test_panoptic_dataset.py
@@ -1,0 +1,133 @@
+"""Tests for the COCO-panoptic dataset loader (issue #555)."""
+
+import json
+
+import numpy as np
+import pytest
+import yaml
+from PIL import Image
+
+from libreyolo.data.panoptic_dataset import (
+    VOID_SEGMENT_ID,
+    PanopticDataset,
+    panoptic_collate_fn,
+    resolve_panoptic_data,
+    rgb2id,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _id2rgb(segment_id: int) -> tuple:
+    """Inverse of the COCO encoding, for building fixtures."""
+    return (segment_id % 256, (segment_id // 256) % 256, segment_id // 65536)
+
+
+def _build_dataset(tmp_path, *, names=None, categories=None, segments=None):
+    root = tmp_path / "ds"
+    (root / "images").mkdir(parents=True)
+    (root / "panoptic").mkdir(parents=True)
+
+    Image.new("RGB", (4, 2), (10, 20, 30)).save(root / "images" / "a.jpg")
+
+    # Left half segment id 1, right half id 3226956, plus one void column.
+    seg = np.zeros((2, 4, 3), dtype=np.uint8)
+    seg[:, 0:2] = _id2rgb(1)
+    seg[:, 2:3] = _id2rgb(3226956)
+    # column 3 stays (0,0,0) -> VOID
+    Image.fromarray(seg).save(root / "panoptic" / "a.png")
+
+    categories = categories or [
+        {"id": 1, "name": "person", "isthing": 1},
+        {"id": 92, "name": "sky", "isthing": 0},
+    ]
+    segments = segments or [
+        {"id": 1, "category_id": 1, "area": 4, "iscrowd": 0},
+        {"id": 3226956, "category_id": 92, "area": 2, "iscrowd": 1},
+    ]
+    ann = {
+        "images": [{"id": 7, "file_name": "a.jpg"}],
+        "annotations": [
+            {"image_id": 7, "file_name": "a.png", "segments_info": segments}
+        ],
+        "categories": categories,
+    }
+    (root / "panoptic.json").write_text(json.dumps(ann), encoding="utf-8")
+
+    cfg = {
+        "path": str(root),
+        "val": "images",
+        "annotations": {"val": "panoptic.json"},
+        "panoptic_dir": {"val": "panoptic"},
+        "names": names if names is not None else {0: "person", 1: "sky"},
+    }
+    yaml_path = tmp_path / "panoptic.yaml"
+    yaml_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return yaml_path
+
+
+def test_rgb2id_matches_the_coco_encoding():
+    # id = R + 256*G + 256*256*B
+    rgb = np.array([[[76, 61, 49]]], dtype=np.uint8)
+    assert int(rgb2id(rgb)[0, 0]) == 76 + 256 * 61 + 65536 * 49 == 3226956
+    assert int(rgb2id(np.zeros((1, 1, 3), dtype=np.uint8))[0, 0]) == VOID_SEGMENT_ID
+
+
+def test_rgb2id_rejects_non_rgb():
+    with pytest.raises(ValueError, match=r"\(H, W, 3\)"):
+        rgb2id(np.zeros((2, 2), dtype=np.uint8))
+
+
+def test_rgb2id_does_not_overflow_uint8_arithmetic():
+    """Naive uint8 math would wrap; ids must survive as full integers."""
+    rgb = np.array([[[255, 255, 255]]], dtype=np.uint8)
+    assert int(rgb2id(rgb)[0, 0]) == 255 + 256 * 255 + 65536 * 255
+
+
+def test_dataset_loads_segment_map_and_remaps_categories(tmp_path):
+    dataset = PanopticDataset(resolve_panoptic_data(_build_dataset(tmp_path)), "val")
+    assert len(dataset) == 1
+    # 'person'(raw 1) -> train 0, 'sky'(raw 92) -> train 1; things = {0}
+    assert dataset.category_id_to_train_id == {1: 0, 92: 1}
+    assert dataset.thing_train_ids == {0}
+    assert dataset.nc == 2
+
+    img_path, seg_map, segments_info, info = dataset[0]
+    assert img_path.endswith("a.jpg")
+    assert tuple(seg_map.shape) == (2, 4)
+    assert seg_map[0, 0].item() == 1
+    assert seg_map[0, 2].item() == 3226956
+    assert seg_map[0, 3].item() == VOID_SEGMENT_ID
+    assert info["height"] == 2 and info["width"] == 4
+
+    by_id = {s["id"]: s for s in segments_info}
+    assert by_id[1]["category_id"] == 0 and by_id[1]["iscrowd"] == 0
+    assert by_id[3226956]["category_id"] == 1
+    assert by_id[3226956]["iscrowd"] == 1  # crowd flag survives
+
+
+def test_dataset_rejects_category_missing_from_names(tmp_path):
+    """A category the model cannot name would score as a permanent false negative."""
+    yaml_path = _build_dataset(tmp_path, names={0: "person"})  # 'sky' missing
+    with pytest.raises(ValueError, match="missing from the dataset YAML"):
+        PanopticDataset(resolve_panoptic_data(yaml_path), "val")
+
+
+def test_resolve_requires_annotations_and_panoptic_dir(tmp_path):
+    cfg = {"val": "images", "names": {0: "person"}}
+    p = tmp_path / "bad.yaml"
+    p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    with pytest.raises(ValueError, match="annotations"):
+        resolve_panoptic_data(p)
+
+    cfg["annotations"] = {"val": "x.json"}
+    p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    with pytest.raises(ValueError, match="panoptic_dir"):
+        resolve_panoptic_data(p)
+
+
+def test_collate_keeps_per_image_structure(tmp_path):
+    dataset = PanopticDataset(resolve_panoptic_data(_build_dataset(tmp_path)), "val")
+    paths, maps, infos, meta = panoptic_collate_fn([dataset[0]])
+    assert len(paths) == len(maps) == len(infos) == len(meta) == 1
+    assert tuple(maps[0].shape) == (2, 4)  # not stacked, not resized

--- a/tests/unit/test_panoptic_quality.py
+++ b/tests/unit/test_panoptic_quality.py
@@ -1,0 +1,179 @@
+"""Tests for the Panoptic Quality metric (issue #555).
+
+The rules under test come from the metric definition in *Panoptic Segmentation*
+(Kirillov et al., CVPR 2019): unique matching at IoU > 0.5, void pixels removed
+from predictions before the IoU, crowd regions never counted as false
+negatives, and predictions mostly covering void/crowd removed before counting
+false positives.
+"""
+
+import numpy as np
+import pytest
+
+from libreyolo.validation.panoptic_quality import PanopticQuality
+
+pytestmark = pytest.mark.unit
+
+
+def _gt(id_, cat, crowd=0):
+    return {"id": id_, "category_id": cat, "iscrowd": crowd}
+
+
+def _pred(id_, cat):
+    return {"id": id_, "category_id": cat}
+
+
+def test_perfect_prediction_scores_pq_one():
+    gt = np.array([[1, 1], [2, 2]])
+    pred = np.array([[1, 1], [2, 2]])
+    pq = PanopticQuality(thing_class_ids={0})
+    pq.update(gt, [_gt(1, 0), _gt(2, 5)], pred, [_pred(1, 0), _pred(2, 5)])
+    m = pq.compute()
+    assert m["metrics/PQ"] == pytest.approx(1.0)
+    assert m["metrics/SQ"] == pytest.approx(1.0)
+    assert m["metrics/RQ"] == pytest.approx(1.0)
+    assert m["metrics/PQ_things"] == pytest.approx(1.0)  # category 0
+    assert m["metrics/PQ_stuff"] == pytest.approx(1.0)   # category 5
+    assert m["fitness"] == pytest.approx(1.0)
+
+
+def test_segment_ids_need_not_agree_only_categories_and_overlap():
+    """Predicted ids are independent of GT ids; matching is by category + IoU."""
+    gt = np.array([[7, 7], [7, 7]])
+    pred = np.array([[99, 99], [99, 99]])
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(7, 3)], pred, [_pred(99, 3)])
+    assert pq.compute()["metrics/PQ"] == pytest.approx(1.0)
+
+
+def test_wrong_category_is_fp_plus_fn_not_a_match():
+    gt = np.ones((2, 2), dtype=np.int64)
+    pred = np.ones((2, 2), dtype=np.int64)
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0)], pred, [_pred(1, 1)])
+    m = pq.compute()
+    assert pq.stats[0].fn == 1 and pq.stats[1].fp == 1
+    assert pq.stats[0].tp == 0 and pq.stats[1].tp == 0
+    assert m["metrics/PQ"] == pytest.approx(0.0)
+
+
+def test_iou_at_or_below_half_does_not_match():
+    """IoU exactly 0.5 must NOT match; the rule is strictly greater than 0.5."""
+    gt = np.array([[1, 1, 0, 0]])          # gt area 2
+    pred = np.array([[2, 0, 0, 0]])        # pred area 1, intersection 1
+    # union = 2 + 1 - 1 = 2 -> IoU = 0.5 exactly
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0)], pred, [_pred(2, 0)])
+    assert pq.stats[0].tp == 0
+    assert pq.stats[0].fn == 1
+    assert pq.stats[0].fp == 1
+
+
+def test_iou_above_half_matches_and_sq_is_the_iou():
+    # No void anywhere: pixel 4 belongs to a different-category gt segment, so
+    # the void rule cannot inflate the IoU.
+    gt = np.array([[1, 1, 1, 9]])            # seg 1 (cat 0) area 3, seg 9 (cat 1)
+    pred = np.array([[2, 2, 2, 2]])          # pred area 4, intersection 3
+    # union = 3 + 4 - 3 = 4 -> IoU = 0.75 > 0.5
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0), _gt(9, 1)], pred, [_pred(2, 0)])
+    assert pq.stats[0].tp == 1
+    assert pq.stats[0].iou == pytest.approx(0.75)
+    # SQ for the matched category is its mean matched IoU.
+    assert pq.stats[0].pq_sq_rq()[1] == pytest.approx(0.75)
+    assert pq.stats[0].pq_sq_rq()[2] == pytest.approx(1.0)  # RQ: 1 tp, no fp/fn
+    assert pq.stats[1].fn == 1  # the other gt segment was missed
+
+
+def test_void_pixels_are_removed_from_the_prediction_before_iou():
+    """Void GT under a prediction must not shrink its IoU (paper, void rule 1)."""
+    gt = np.array([[1, 1, 0, 0]])           # ids 1,1,void,void ; gt area 2
+    pred = np.array([[2, 2, 2, 2]])         # covers everything; pred area 4
+    # Without the void rule: union = 2 + 4 - 2 = 4 -> IoU 0.5 -> no match.
+    # With it: subtract the 2 void px inside pred -> union 2 -> IoU 1.0 -> match.
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0)], pred, [_pred(2, 0)])
+    assert pq.stats[0].tp == 1
+    assert pq.compute()["metrics/SQ"] == pytest.approx(1.0)
+
+
+def test_crowd_gt_is_never_a_false_negative():
+    gt = np.array([[1, 1]])
+    pred = np.zeros((1, 2), dtype=np.int64)  # predicted nothing
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0, crowd=1)], pred, [])
+    assert pq.stats == {}  # category never even instantiated
+    assert pq.compute()["metrics/categories"] == 0
+
+
+def test_unmatched_prediction_over_void_is_not_a_false_positive():
+    """Paper, void rule 2: >50% void overlap removes the prediction."""
+    gt = np.array([[0, 0, 0, 1]])            # 3 void px, 1 gt px
+    pred = np.array([[5, 5, 5, 0]])          # pred area 3, all on void
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0)], pred, [_pred(5, 1)])
+    assert 1 not in pq.stats or pq.stats[1].fp == 0   # removed, not a FP
+    assert pq.stats[0].fn == 1                        # gt segment still missed
+
+
+def test_unmatched_prediction_over_crowd_of_same_class_is_not_a_false_positive():
+    """Paper, group rule 2: same-class crowd overlap removes the prediction."""
+    gt = np.array([[1, 1, 1, 1]])
+    pred = np.array([[5, 5, 5, 5]])
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0, crowd=1)], pred, [_pred(5, 0)])
+    assert 0 not in pq.stats or pq.stats[0].fp == 0
+
+
+def test_crowd_of_a_different_class_does_not_excuse_a_false_positive():
+    gt = np.array([[1, 1, 1, 1]])
+    pred = np.array([[5, 5, 5, 5]])
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0, crowd=1)], pred, [_pred(5, 7)])  # class 7 != 0
+    assert pq.stats[7].fp == 1
+
+
+def test_things_and_stuff_are_averaged_separately():
+    gt = np.array([[1, 1], [2, 2]])
+    pred = np.array([[1, 1], [0, 0]])  # thing matched, stuff missed
+    pq = PanopticQuality(thing_class_ids={0})
+    pq.update(gt, [_gt(1, 0), _gt(2, 5)], pred, [_pred(1, 0)])
+    m = pq.compute()
+    assert m["metrics/PQ_things"] == pytest.approx(1.0)
+    assert m["metrics/PQ_stuff"] == pytest.approx(0.0)
+    assert m["metrics/PQ"] == pytest.approx(0.5)  # mean over both categories
+    assert m["metrics/categories"] == 2
+
+
+def test_only_seen_categories_are_averaged():
+    """A category absent from both GT and prediction must not drag PQ down."""
+    gt = np.ones((2, 2), dtype=np.int64)
+    pred = np.ones((2, 2), dtype=np.int64)
+    pq = PanopticQuality(thing_class_ids={0, 1, 2, 3})
+    pq.update(gt, [_gt(1, 0)], pred, [_pred(1, 0)])
+    m = pq.compute()
+    assert m["metrics/categories"] == 1
+    assert m["metrics/PQ"] == pytest.approx(1.0)
+
+
+def test_accumulates_across_images():
+    pq = PanopticQuality()
+    perfect = np.ones((2, 2), dtype=np.int64)
+    pq.update(perfect, [_gt(1, 0)], perfect, [_pred(1, 0)])
+    pq.update(perfect, [_gt(1, 0)], np.zeros((2, 2), dtype=np.int64), [])
+    assert pq.stats[0].tp == 1 and pq.stats[0].fn == 1
+    # PQ = 1.0 / (1 + 0.5*0 + 0.5*1) = 0.6667
+    assert pq.compute()["metrics/PQ"] == pytest.approx(2 / 3)
+
+
+def test_shape_mismatch_is_rejected():
+    pq = PanopticQuality()
+    with pytest.raises(ValueError, match="ground-truth resolution"):
+        pq.update(np.zeros((2, 2)), [], np.zeros((3, 3)), [])
+
+
+def test_empty_prediction_and_empty_gt_gives_zero_not_nan():
+    pq = PanopticQuality()
+    pq.update(np.zeros((2, 2), dtype=np.int64), [], np.zeros((2, 2), dtype=np.int64), [])
+    m = pq.compute()
+    assert m["metrics/PQ"] == 0.0 and m["metrics/categories"] == 0

--- a/tests/unit/test_panoptic_quality.py
+++ b/tests/unit/test_panoptic_quality.py
@@ -177,3 +177,59 @@ def test_empty_prediction_and_empty_gt_gives_zero_not_nan():
     pq.update(np.zeros((2, 2), dtype=np.int64), [], np.zeros((2, 2), dtype=np.int64), [])
     m = pq.compute()
     assert m["metrics/PQ"] == 0.0 and m["metrics/categories"] == 0
+
+
+# --- regressions from code review -------------------------------------------
+
+
+def test_multiple_crowd_regions_of_one_category_all_excuse_a_prediction():
+    """Two crowd segments of the same class must both count toward the ignored area.
+
+    Keeping only one would under-count the overlap and turn an excused
+    prediction into a false positive, silently lowering PQ.
+    """
+    # Two crowd regions of category 0 (ids 1 and 2), 2 px each, and a 6 px
+    # prediction spanning both. No void anywhere: id 9 is a real segment.
+    #   both crowds counted -> ignored 4/6 = 0.667 > 0.5 -> excused
+    #   only one counted    -> ignored 2/6 = 0.333       -> false positive
+    # So this fixture fails if the crowd bookkeeping keeps just one segment.
+    gt = np.array([[1, 1, 2, 2, 9, 9]])
+    pred = np.array([[5, 5, 5, 5, 5, 5]])
+    pq = PanopticQuality()
+    pq.update(
+        gt,
+        [_gt(1, 0, crowd=1), _gt(2, 0, crowd=1), _gt(9, 7)],
+        pred,
+        [_pred(5, 0)],
+    )
+    assert 0 not in pq.stats or pq.stats[0].fp == 0
+    assert pq.stats[7].fn == 1  # the real segment was still missed
+
+
+def test_single_crowd_region_still_excuses_only_up_to_its_own_area():
+    """Sanity guard for the fix above: a small crowd must not excuse everything."""
+    gt = np.array([[1, 9, 9, 9, 9, 9]])   # 1 crowd px, rest a real gt segment
+    pred = np.array([[5, 5, 5, 5, 5, 5]])  # pred area 6, only 1 px on crowd
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(1, 0, crowd=1), _gt(9, 7)], pred, [_pred(5, 0)])
+    assert pq.stats[0].fp == 1  # 1/6 overlap is far below the 0.5 threshold
+
+
+def test_segment_ids_at_or_above_the_packing_offset_are_rejected():
+    """Ids >= 2**32 would unpack as a different segment and corrupt PQ."""
+    pq = PanopticQuality()
+    huge = np.array([[1 << 32]], dtype=np.int64)
+    ok = np.array([[1]], dtype=np.int64)
+    with pytest.raises(ValueError, match="predicted segment ids"):
+        pq.update(ok, [_gt(1, 0)], huge, [_pred(1 << 32, 0)])
+    with pytest.raises(ValueError, match="ground-truth segment ids"):
+        pq.update(huge, [_gt(1 << 32, 0)], ok, [_pred(1, 0)])
+
+
+def test_max_coco_segment_id_is_accepted():
+    """The largest id the COCO PNG encoding can produce must still work."""
+    max_coco_id = 255 + 256 * 255 + 65536 * 255  # 16777215, fits in 24 bits
+    gt = np.full((1, 2), max_coco_id, dtype=np.int64)
+    pq = PanopticQuality()
+    pq.update(gt, [_gt(max_coco_id, 0)], gt, [_pred(max_coco_id, 0)])
+    assert pq.compute()["metrics/PQ"] == pytest.approx(1.0)

--- a/tests/unit/test_panoptic_scaffold.py
+++ b/tests/unit/test_panoptic_scaffold.py
@@ -104,7 +104,10 @@ def test_results_panoptic_slot_roundtrips():
     assert result[0].panoptic.data.shape == (3, 3)
 
 
-def test_panoptic_validator_importable_but_unimplemented():
+def test_panoptic_validator_computes_pq():
+    """The validator is no longer a stub: its metric hooks accumulate PQ."""
+    import numpy as np
+
     from libreyolo.validation import PanopticValidator, ValidationConfig
 
     assert PanopticValidator.task == "panoptic"
@@ -115,11 +118,37 @@ def test_panoptic_validator_importable_but_unimplemented():
 
     config = ValidationConfig(data="dummy.yaml", device="cpu")
     validator = PanopticValidator(model=_StubModel(), config=config)
-    # Every metric hook is scaffolding and must fail loudly until implemented.
-    with pytest.raises(NotImplementedError):
-        validator._init_metrics()
-    with pytest.raises(NotImplementedError):
-        validator._compute_metrics()
+
+    validator._init_metrics()
+    perfect = np.ones((2, 2), dtype=np.int64)
+    validator._pq.update(
+        perfect,
+        [{"id": 1, "category_id": 0, "iscrowd": 0}],
+        perfect,
+        [{"id": 1, "category_id": 0}],
+    )
+    metrics = validator._compute_metrics()
+    assert metrics["metrics/PQ"] == 1.0
+    assert metrics["fitness"] == 1.0
+
+
+def test_panoptic_postprocess_without_family_support_fails_loudly():
+    """A family that does not implement panoptic must not silently score zero."""
+    from libreyolo.validation import PanopticValidator, ValidationConfig
+
+    class _NoPanopticModel:
+        task = "panoptic"
+        nb_classes = 133
+
+        def _postprocess(self, *args, **kwargs):
+            return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
+
+    validator = PanopticValidator(
+        model=_NoPanopticModel(), config=ValidationConfig(data="d.yaml", device="cpu")
+    )
+    validator._original_size = (4, 4)
+    with pytest.raises(ValueError, match="panoptic"):
+        validator._postprocess_predictions(preds=None, batch=None)
 
 
 def test_panoptic_validator_exported_from_package():

--- a/tests/unit/test_panoptic_scaffold.py
+++ b/tests/unit/test_panoptic_scaffold.py
@@ -1,9 +1,8 @@
-"""Tests for the panoptic-segmentation task scaffolding (issue #555).
+"""Tests for the panoptic-segmentation task surface (issue #555).
 
-These cover the API surface only: task registration, the PanopticSegmentation
-result payload, and that PanopticValidator is importable/dispatchable but its
-metric hooks are still unimplemented. The PQ metric and COCO-panoptic loader
-are intentionally not tested here because they are not implemented yet.
+Task registration, the PanopticSegmentation result payload, and the
+PanopticValidator's wiring and loud-failure paths. The PQ metric itself is
+covered in test_panoptic_quality.py and the loader in test_panoptic_dataset.py.
 """
 
 import numpy as np
@@ -156,3 +155,34 @@ def test_panoptic_validator_exported_from_package():
 
     assert hasattr(libreyolo, "PanopticValidator")
     assert hasattr(libreyolo, "PanopticSegmentation")
+
+
+def test_empty_thing_class_ids_still_enforces_agreement(monkeypatch, tmp_path):
+    """`thing_class_ids = set()` means 'all stuff', not 'no opinion'.
+
+    A falsy guard would skip the check and quietly mis-split PQ_things/PQ_stuff.
+    """
+    import pytest as _pytest
+
+    from libreyolo.validation import PanopticValidator, ValidationConfig
+    from libreyolo.validation import panoptic_validator as pv
+
+    class _AllStuffModel:
+        task = "panoptic"
+        nb_classes = 2
+        thing_class_ids: set = set()
+
+    class _Dataset:
+        nc = 2
+        thing_train_ids = {0}  # dataset says category 0 IS a thing
+        names = {0: "person", 1: "sky"}
+
+    monkeypatch.setattr(pv, "resolve_panoptic_data", lambda *a, **k: {})
+    monkeypatch.setattr(pv, "PanopticDataset", lambda *a, **k: _Dataset())
+
+    validator = PanopticValidator(
+        model=_AllStuffModel(),
+        config=ValidationConfig(data=str(tmp_path / "d.yaml"), device="cpu"),
+    )
+    with _pytest.raises(ValueError, match="thing_class_ids"):
+        validator._setup_dataloader()


### PR DESCRIPTION
## Summary

PR #557 registered the `panoptic` task and stubbed its API surface. This fills the three holes it deliberately left, so `panoptic` becomes a finished task that a model family can plug into.

Before this PR, on `dev`:

| piece | status |
|---|---|
| `panoptic` task registered | present (#557) |
| `Results.panoptic` ever populated | **no** — `_build_results` had no `panoptic` branch |
| `PanopticValidator` | **7 `NotImplementedError`** |
| `PanopticDataset` | **did not exist** |

## What's included

- **`data/panoptic_dataset.py`** — `PanopticDataset` over the **COCO-panoptic format**, adopted verbatim. There is no YOLO panoptic format, and none is needed: every major panoptic dataset (COCO, Cityscapes, ADE20K, Mapillary) already ships in this format.
  - Segment-id PNG: `segment_id = R + 256*G + 256*256*B`, id `0` = VOID.
  - Raw `category_id`s are non-contiguous (COCO runs 1..200 with gaps). They are remapped onto contiguous train ids **through the YAML `names`, by category name** — the rule the native COCO-JSON detect loader already follows. A JSON category absent from `names` **raises**, because silently dropping it scores as a permanent false negative.
- **`validation/panoptic_quality.py`** — streaming `PQ = SQ x RQ`, split into `PQ_things` / `PQ_stuff`.
- **`validation/panoptic_validator.py`** — replaces the stub. PQ is defined at ground-truth resolution and each family owns its own input geometry (EoMT pads COCO inputs but splits ADE20K ones), so the validator delegates `_preprocess` / `_postprocess` to the model and evaluates one image at a time.
- **`models/base/inference.py`** — populate `Results.panoptic`. The slot existed; nothing ever filled it.
- **Docs** — `dataset_schema.md` pins the encoding, adds the missing `bbox` field, documents the category remap and the YAML keys. `nomenclature.md` narrows the #555 caveat.

## Failing loudly instead of silently

Two mistakes here produce plausible-looking but wrong PQ rather than a crash, so both are hard errors:

- A model family whose `_postprocess` returns no `panoptic` map.
- A checkpoint whose `thing_class_ids` disagree with the dataset's `isthing` categories — this would mis-split `PQ_things` / `PQ_stuff` without ever raising.

## Still not included

- The **per-family panoptic postprocess** (the thing+stuff merge). That is what a model family provides; see #553 for `eomt`.
- `Results.plot` / `Results.summary` panoptic rendering.

## Test plan

- [x] `pytest tests/unit/test_panoptic_quality.py tests/unit/test_panoptic_dataset.py tests/unit/test_panoptic_scaffold.py` — 37 passed
- [x] `pytest tests/unit` — **3011 passed, 50 skipped, 0 failures**, in both deterministic and randomized order

22 new tests cover each PQ rule (unique matching at IoU > 0.5, void removal, crowd never a false negative, void/crowd false-positive removal), the `rgb2id` encoding including uint8 overflow, and the dataset's category remap / crowd / void handling.

## Code provenance

All code in this PR is **original, written for LibreYOLO**. Nothing is ported, copied, adapted, or derived from any third-party source.

The `PanopticQuality` metric is implemented from the **published metric definition** in *Panoptic Segmentation* (Kirillov, He, Girshick, Rother, Dollar; CVPR 2019, [arXiv:1801.00868](https://arxiv.org/abs/1801.00868)), which specifies the `PQ = SQ x RQ` formula, the unique-matching theorem at IoU > 0.5, the two void rules, and the two group/crowd rules. The paper is the source; the implementation is ours.

**`cocodataset/panopticapi` was deliberately NOT used as a source.** That repository ships **no license file** and GitHub reports no license for it, which makes it unknown-license and therefore unusable here in any form, including a rewrite or renamed adaptation. It is not vendored, not imported, and not a dependency.

The COCO-panoptic **file format** (the `R + 256*G + 65536*B` segment-id encoding and the annotations JSON schema) is a data-format specification, not copyrightable expression; LibreYOLO reads and writes it natively.
