### PR TITLE
Accept litert as an alias for the tflite export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install libreyolo
 
 # Add an extra in brackets when you need one (comma-separate to combine),
 # e.g. pip install "libreyolo[rfdetr,onnx]":
-#   export:    onnx, tensorrt, openvino, ncnn, tflite, coreml
+#   export:    onnx, tensorrt, openvino, ncnn, tflite (alias: litert), coreml
 #   models:    rfdetr, vlm, sam, openvocab, clip, gaze
 #   training:  lora, plots, tensorboard, mlflow, wandb
 #   or all:    pip install "libreyolo[all]"
@@ -108,7 +108,7 @@ hooks via `callbacks=` and built-in experiment loggers via `loggers=`
       <th>TensorRT</th>
       <th>OpenVINO</th>
       <th>NCNN</th>
-      <th>TFLite</th>
+      <th>TFLite (LiteRT)</th>
     </tr>
   </thead>
   <tbody>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ LibreYOLO 推荐以下模型系列，因为它们在性能上达到最佳平衡�
       <th>TensorRT</th>
       <th>OpenVINO</th>
       <th>NCNN</th>
-      <th>TFLite</th>
+      <th>TFLite (LiteRT)</th>
     </tr>
   </thead>
   <tbody>

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -60,10 +60,12 @@ def export_cmd(
     """Export a model to a deployment format."""
     out = OutputHandler(json_mode=json_output, quiet=quiet)
 
-    # Resolve format alias
+    # Resolve format aliases (engine -> tensorrt, litert -> tflite) so JSON
+    # output and messages always report the canonical format name.
+    from libreyolo.export.exporter import BaseExporter
+
     fmt = format.lower()
-    if fmt == "engine":
-        fmt = "tensorrt"
+    fmt = BaseExporter._aliases.get(fmt, fmt)
 
     if half and int8:
         out.warning("Both half and int8 were requested. Using INT8 precision.")

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -19,7 +19,7 @@ def export_cmd(
     model: str = typer.Option(..., help="Model weights (.pt)"),
     format: str = typer.Option(
         "onnx",
-        help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite, coreml",
+        help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite (alias: litert), coreml",
     ),
     imgsz: Optional[str] = typer.Option(None, help="Input image size (e.g. 640 or 640,480)"),
     batch: int = typer.Option(1, help="Export batch size"),

--- a/libreyolo/cli/commands/special.py
+++ b/libreyolo/cli/commands/special.py
@@ -247,8 +247,13 @@ def formats_cmd(
             "fp16": cls.supports_fp16,
             "requires_onnx": cls.requires_onnx,
         }
-        if name == "tensorrt":
-            info["aliases"] = ["engine"]
+        aliases = sorted(
+            alias
+            for alias, target in BaseExporter._aliases.items()
+            if target == name
+        )
+        if aliases:
+            info["aliases"] = aliases
         formats.append(info)
 
     out = _get_output(json_output, quiet)

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -197,7 +197,9 @@ class BaseExporter(ABC):
 
     # Alternate names accepted by create(). "litert" is Google's current name
     # for TensorFlow Lite; the format and .tflite suffix are unchanged.
-    _aliases: dict[str, str] = {"litert": "tflite"}
+    # The CLI and the `libreyolo formats` listing derive from this mapping,
+    # so aliases live here and nowhere else.
+    _aliases: dict[str, str] = {"engine": "tensorrt", "litert": "tflite"}
 
     # Class attributes (overridden by each subclass)
     format_name: str  # e.g. "onnx"

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -195,6 +195,10 @@ class BaseExporter(ABC):
 
     _registry: dict[str, type["BaseExporter"]] = {}
 
+    # Alternate names accepted by create(). "litert" is Google's current name
+    # for TensorFlow Lite; the format and .tflite suffix are unchanged.
+    _aliases: dict[str, str] = {"litert": "tflite"}
+
     # Class attributes (overridden by each subclass)
     format_name: str  # e.g. "onnx"
     suffix: str  # e.g. ".onnx"
@@ -220,6 +224,7 @@ class BaseExporter(ABC):
     def create(cls, format: str, model) -> "BaseExporter":
         """Look up *format* in the registry and return an exporter instance."""
         key = format.lower()
+        key = cls._aliases.get(key, key)
         if key not in cls._registry:
             valid = ", ".join(sorted(cls._registry))
             raise ValueError(

--- a/libreyolo/export/tflite.py
+++ b/libreyolo/export/tflite.py
@@ -1,4 +1,9 @@
-"""TensorFlow Lite export implementation via onnx2tf."""
+"""TensorFlow Lite (LiteRT) export implementation via onnx2tf.
+
+LiteRT is Google's current name for TensorFlow Lite. The output is a standard
+``.tflite`` FlatBuffer that runs on LiteRT's Interpreter and CompiledModel
+APIs (``pip install ai-edge-litert`` on the target device).
+"""
 
 from __future__ import annotations
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1155,7 +1155,8 @@ class BaseModel(ABC):
 
         Args:
             format: Target format ("onnx", "torchscript", "tensorrt",
-                "openvino", "ncnn", "tflite").
+                "openvino", "ncnn", "tflite"). "litert" is accepted as an
+                alias for "tflite" (LiteRT is TensorFlow Lite's new name).
             **kwargs: Format-specific parameters forwarded to the exporter.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,11 @@ tflite = [
     # Required for RF-DETR onnxsim preprocessing step.
     "onnx-simplifier>=0.4.36",
 ]
+# LiteRT is Google's current name for TensorFlow Lite; same export path,
+# same .tflite output. Separate extra so both names install.
+litert = [
+    "libreyolo[tflite]",
+]
 # Intentionally empty: all tracking dependencies (e.g. scipy) are core deps,
 # so `libreyolo[tracking]` installs nothing extra. Kept for a stable extra name.
 tracking = []

--- a/skills/use-libreyolo/SKILL.md
+++ b/skills/use-libreyolo/SKILL.md
@@ -37,7 +37,8 @@ libreyolo checks      # verify install, CUDA/MPS, and optional export backends
 
 The base install is lightweight. Some features need **optional extras** —
 install them as `libreyolo[extra]` (or `libreyolo[all]`). Available extras:
-`onnx`, `rfdetr`, `eomt`, `tensorrt`, `openvino`, `ncnn`, `tflite`, `coreml`,
+`onnx`, `rfdetr`, `eomt`, `tensorrt`, `openvino`, `ncnn`, `tflite` (alias
+`litert`; LiteRT is TensorFlow Lite's new name), `coreml`,
 `tracking`, `gaze`, `rtdetr`, `vlm`, `sam`, `openvocab`, `clip`, `label`,
 `plots`, `lora`, `tensorboard`, `mlflow`, `wandb`, `all`. `libreyolo checks`
 reports which are present.

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -938,6 +938,12 @@ class TestExporterValidation:
             )
             assert Path(path).exists()
 
+    def test_litert_alias_resolves_to_tflite(self):
+        wrapper = _make_wrapper()
+        exporter = BaseExporter.create("litert", wrapper)
+        assert exporter.format_name == "tflite"
+        assert exporter.suffix == ".tflite"
+
 
 class TestOutputPathGeneration:
     def test_auto_path_torchscript(self):


### PR DESCRIPTION
Google renamed TensorFlow Lite to LiteRT in September 2024 ([announcement](https://developers.googleblog.com/tensorflow-lite-is-now-litert/)); the `.tflite` file format and runtime APIs are unchanged. This PR makes both names work in LibreYOLO so users searching for either one find the same path:

- `BaseExporter.create()` accepts `litert` as an alias for `tflite` (`model.export(format="litert")` and `libreyolo export format=litert` both work).
- New `libreyolo[litert]` extra that installs `libreyolo[tflite]`.
- Docs/help wording: format labelled "TFLite (LiteRT)" in the README tables, CLI help, `export()` docstring, `use-libreyolo` skill, and the `tflite.py` module docstring (which now also points to `ai-edge-litert` as the runtime package).

No behavior change for existing users: `format="tflite"` stays canonical and the output suffix stays `.tflite`.

Tests: `tests/unit/test_export.py` gains `test_litert_alias_resolves_to_tflite`; the full file passes locally (111 passed, Python 3.12.13, torch 2.11).

## Code provenance

All changes are original code and documentation written for this PR (a dict lookup alias, a pyproject extra, wording edits). No third-party code was ported, adapted, or referenced.