### PR TITLE
Extend YOLO9-grade multi-GPU training support to the rest of the library

### DIFF
--- a/libreyolo/models/convnext/model.py
+++ b/libreyolo/models/convnext/model.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
+from ...training.ddp_spawn import ddp_aware
 from ...training.callbacks import TrainCallbacks
 from ...postprocess.convnext import postprocess as _cnx_postprocess
 from ...utils.image_loader import ImageInput
@@ -174,6 +175,7 @@ class LibreConvNeXt(BaseModel):
 
     # ---- training --------------------------------------------------------
 
+    @ddp_aware()
     def train(
         self,
         data: str,

--- a/libreyolo/models/efficientnetv2/model.py
+++ b/libreyolo/models/efficientnetv2/model.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
+from ...training.ddp_spawn import ddp_aware
 from ...training.callbacks import TrainCallbacks
 from ...postprocess.efficientnetv2 import postprocess as _effv2_postprocess
 from ...utils.image_loader import ImageInput
@@ -179,6 +180,7 @@ class LibreEfficientNetV2(BaseModel):
 
     # ---- training --------------------------------------------------------
 
+    @ddp_aware()
     def train(
         self,
         data: str,

--- a/libreyolo/models/mobilenetv4/model.py
+++ b/libreyolo/models/mobilenetv4/model.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
+from ...training.ddp_spawn import ddp_aware
 from ...training.callbacks import TrainCallbacks
 from ...postprocess.mobilenetv4 import postprocess as _mnv4_postprocess
 from ...utils.image_loader import ImageInput
@@ -179,6 +180,7 @@ class LibreMobileNetV4(BaseModel):
 
     # ---- training --------------------------------------------------------
 
+    @ddp_aware()
     def train(
         self,
         data: str,

--- a/libreyolo/models/nafnet/model.py
+++ b/libreyolo/models/nafnet/model.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 
 from ...postprocess.nafnet import postprocess as _nafnet_postprocess
+from ...training.ddp_spawn import ddp_aware
 from ...utils.image_loader import ImageInput
 from ...utils.serialization import load_untrusted_torch_file
 from ..base import BaseModel
@@ -251,6 +252,7 @@ class LibreNAFNet(BaseModel):
         del conf_thres, iou_thres, max_det, ratio, kwargs
         return {"restored": _nafnet_postprocess(output, original_size)}
 
+    @ddp_aware()
     def train(
         self,
         data: str,

--- a/libreyolo/models/picodet/loss.py
+++ b/libreyolo/models/picodet/loss.py
@@ -141,7 +141,12 @@ class VarifocalLoss(nn.Module):
         )
         if avg_factor is None:
             return self.loss_weight * loss.mean()
-        return self.loss_weight * loss.sum() / max(avg_factor, 1.0)
+        # No clamp here: the caller passes an already-sanitized denominator
+        # (all_reduce_avg_scalar clamps the GLOBAL sum before dividing by
+        # world_size, so a legitimate value can be < 1 under DDP). Re-clamping
+        # to 1 would under-scale sparse/all-background multi-GPU batches by
+        # up to 1/world_size (issue #484).
+        return self.loss_weight * loss.sum() / avg_factor
 
 
 class DistributionFocalLoss(nn.Module):

--- a/libreyolo/models/picodet/loss.py
+++ b/libreyolo/models/picodet/loss.py
@@ -17,9 +17,9 @@ into self-contained PyTorch with no mmcv/mmdet dependency. The pieces:
 Recipe gaps vs Bo's upstream (documented per skill §6):
 - We use SimOTA as upstream does, but the ``iou_weight=6`` cost weight is
   exposed via :class:`PICODETLoss` so it can be tuned. Bo uses 6.
-- ``sync_num_pos`` (DDP averaging of positive-sample counts) is wired
-  via ``torch.distributed`` if available; falls back to local-only
-  count for single-GPU training.
+- ``sync_num_pos`` (DDP averaging of positive-sample counts) maps to
+  :func:`all_reduce_avg_scalar` on the VFL ``avg_factor`` and the box/DFL
+  ``weight_sum``; outside DDP both reduce to the local count.
 """
 
 from __future__ import annotations
@@ -29,6 +29,8 @@ from typing import List, Sequence, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from ...training.distributed import all_reduce_avg_scalar
 
 
 # ---------------------------------------------------------------------------
@@ -519,28 +521,42 @@ class PICODETLoss(nn.Module):
             })
             num_pos_total += int(pos_mask.sum().item())
 
-        # VFL across the whole batch (single call), normalised by total positives.
-        avg_factor = max(num_pos_total, 1)
+        # VFL across the whole batch (single call), normalised by the global
+        # (DDP-reduced) positive count, mirroring upstream PP-PicoDet's
+        # nranks averaging (issue #484). Identical to ``max(num_pos_total, 1)``
+        # outside DDP. Collectives run before the no-positive early return so
+        # every rank reaches them.
+        avg_factor = all_reduce_avg_scalar(
+            num_pos_total, device=bbox_flat.device
+        )
         loss_cls = self.vfl(
             cls_flat.reshape(-1, self.num_classes),
             cls_targets.reshape(-1, self.num_classes),
             avg_factor=avg_factor,
         )
 
+        # Box + DFL: weight each positive by ``weight_targets`` and normalise
+        # by the global (DDP-reduced) sum of weights (Bo's avg_factor
+        # convention). Computed before the early return: it is a collective.
+        all_weights = (
+            torch.cat([r["weight_targets"] for r in pos_records])
+            if pos_records
+            else bbox_flat.new_zeros(0)
+        )
+        weight_sum = all_reduce_avg_scalar(all_weights.sum(), min_value=1e-6)
+
         if not pos_records:
             zero = bbox_flat.new_zeros(())
+            # ``bbox_flat.sum() * 0`` keeps the regression tower in the
+            # autograd graph, so DDP sees the same used-parameter set on
+            # all-background ranks as on ranks with positives.
             return {
-                "total_loss": loss_cls,
+                "total_loss": loss_cls + bbox_flat.sum() * 0.0,
                 "loss_cls": loss_cls.detach(),
                 "loss_bbox": zero,
                 "loss_dfl": zero,
                 "num_pos": 0.0,
             }
-
-        # Box + DFL: weight each positive by ``weight_targets`` and normalise
-        # by the sum of weights across the batch (Bo's avg_factor convention).
-        all_weights = torch.cat([r["weight_targets"] for r in pos_records])
-        weight_sum = all_weights.sum().clamp(min=1e-6)
 
         loss_bbox = bbox_flat.new_zeros(())
         loss_dfl = bbox_flat.new_zeros(())

--- a/libreyolo/models/resnet/model.py
+++ b/libreyolo/models/resnet/model.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
+from ...training.ddp_spawn import ddp_aware
 from ...training.callbacks import TrainCallbacks
 from ...postprocess.resnet import postprocess as _resnet_postprocess
 from ...utils.image_loader import ImageInput
@@ -190,6 +191,7 @@ class LibreResNet(BaseModel):
 
     # ---- training --------------------------------------------------------
 
+    @ddp_aware()
     def train(
         self,
         data: str,

--- a/libreyolo/models/rtmdet/loss.py
+++ b/libreyolo/models/rtmdet/loss.py
@@ -153,7 +153,12 @@ class GIoULoss(nn.Module):
         if avg_factor is None:
             loss = loss.mean()
         else:
-            loss = loss.sum() / max(avg_factor, 1.0)
+            # No clamp here: the caller passes an already-sanitized
+            # denominator (all_reduce_avg_scalar clamps the GLOBAL sum before
+            # dividing by world_size, so a legitimate value can be < 1 under
+            # DDP). Re-clamping to 1 would under-scale low-positive-mass
+            # multi-GPU batches by up to 1/world_size (issue #484).
+            loss = loss.sum() / avg_factor
         return self.loss_weight * loss
 
 
@@ -210,7 +215,9 @@ class QualityFocalLoss(nn.Module):
         if avg_factor is None:
             loss = loss.mean()
         else:
-            loss = loss.sum() / max(avg_factor, 1.0)
+            # No clamp here: see GIoULoss above — the caller's denominator is
+            # already sanitized and may legitimately be < 1 under DDP.
+            loss = loss.sum() / avg_factor
         return self.loss_weight * loss
 
 

--- a/libreyolo/models/rtmdet/loss.py
+++ b/libreyolo/models/rtmdet/loss.py
@@ -27,6 +27,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...training.distributed import all_reduce_avg_scalar
+
 
 _EPS = 1.0e-7
 
@@ -507,7 +509,12 @@ class RTMDetLoss(nn.Module):
 
         bg_class_ind = self.num_classes
         pos_inds = ((labels >= 0) & (labels < bg_class_ind)).nonzero().squeeze(1)
-        avg_factor = max(float(assign_metrics.sum().item()), 1.0)
+        # Global (DDP-reduced) soft positive mass, mirroring upstream mmdet's
+        # ``reduce_mean`` on the cls avg_factor: dividing by the global factor
+        # keeps DDP's gradient averaging equivalent to single-GPU training on
+        # the same global batch (issue #484). Identical to the previous
+        # ``max(sum, 1)`` outside DDP.
+        avg_factor = all_reduce_avg_scalar(assign_metrics.sum())
 
         loss_cls = self.loss_cls(
             cls_preds, (labels, assign_metrics), avg_factor=avg_factor

--- a/libreyolo/models/yolo7/loss.py
+++ b/libreyolo/models/yolo7/loss.py
@@ -36,6 +36,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...training.distributed import all_reduce_avg_scalar
 from ..yolox.loss import IoULoss
 from ..yolox.nn import bboxes_iou
 
@@ -220,7 +221,11 @@ class YOLOv7Loss:
         # Raw match count BEFORE the >=1 normalization clamp, so the reported
         # metric can actually read 0 when SimOTA matched nothing.
         raw_num_fg = num_fg
-        num_fg = max(num_fg, 1)
+        # Global (DDP-reduced) positive count: dividing by the global count
+        # keeps DDP's gradient averaging equivalent to single-GPU training on
+        # the same global batch (issue #484). Identical to the previous
+        # ``max(num_fg, 1)`` outside DDP.
+        num_fg = all_reduce_avg_scalar(num_fg, device=bbox_preds.device)
         loss_iou = self.iou_loss(
             bbox_preds.view(-1, 4)[fg_masks], reg_targets
         ).sum() / num_fg

--- a/libreyolo/models/yolonas/loss.py
+++ b/libreyolo/models/yolonas/loss.py
@@ -16,6 +16,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 
+from ...training.distributed import all_reduce_avg_scalar
 from ...utils.general import cxcywh_to_xyxy
 from .nn import batch_distance2bbox
 
@@ -636,7 +637,12 @@ class PPYoloELoss(nn.Module):
             self._forward_batched(predictions, targets)
         )
 
-        assigned_scores_sum = torch.clamp(assigned_scores_sum, min=1.0)
+        # Global (DDP-reduced) score mass, mirroring upstream SuperGradients'
+        # all_reduce of ``assigned_scores_sum``: dividing by the global sum
+        # keeps DDP's gradient averaging equivalent to single-GPU training on
+        # the same global batch (issue #484). Identical to the previous
+        # ``clamp(min=1)`` outside DDP.
+        assigned_scores_sum = all_reduce_avg_scalar(assigned_scores_sum)
         cls_loss = self.classification_loss_weight * cls_loss_sum / assigned_scores_sum
         iou_loss = self.iou_loss_weight * iou_loss_sum / assigned_scores_sum
         dfl_loss = self.dfl_loss_weight * dfl_loss_sum / assigned_scores_sum
@@ -1168,7 +1174,9 @@ class YoloNASPoseLoss(nn.Module):
                 f"Unknown classification loss type: {self.classification_loss_type}"
             )
 
-        assigned_scores_sum = torch.clip(assigned_scores.sum(), min=1.0)
+        # Global (DDP-reduced) score mass; see the detection loss above
+        # (issue #484). Identical to ``clip(min=1)`` outside DDP.
+        assigned_scores_sum = all_reduce_avg_scalar(assigned_scores.sum())
         loss_cls = loss_cls / assigned_scores_sum
 
         loss_iou, loss_dfl, loss_pose_cls, loss_pose_reg = self._bbox_loss(
@@ -1224,7 +1232,7 @@ class YoloNASPoseLoss(nn.Module):
         area: Tensor,
         sigmas: Tensor,
         assigned_scores: Optional[Tensor] = None,
-        assigned_scores_sum: Optional[Tensor] = None,
+        assigned_scores_sum: Optional[float] = None,
     ) -> Tuple[Tensor, Tensor]:
         sigmas = sigmas.reshape([1, -1, 1])
         area = area.reshape([-1, 1, 1])

--- a/libreyolo/models/yolox/nn.py
+++ b/libreyolo/models/yolox/nn.py
@@ -11,6 +11,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from libreyolo.training.distributed import all_reduce_avg_scalar
+
 
 # =============================================================================
 # Utility functions
@@ -736,7 +738,11 @@ class YOLOXHead(nn.Module):
         if self.use_l1:
             l1_targets = torch.cat(l1_targets, 0)
 
-        num_fg = max(num_fg, 1)
+        # Global (DDP-reduced) positive count: dividing by the global count
+        # keeps DDP's gradient averaging equivalent to single-GPU training on
+        # the same global batch (issue #484). Identical to the previous
+        # ``max(num_fg, 1)`` outside DDP.
+        num_fg = all_reduce_avg_scalar(num_fg, device=outputs.device)
         loss_iou = (
             self.iou_loss(bbox_preds.view(-1, 4)[fg_masks], reg_targets)
         ).sum() / num_fg

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -220,6 +220,9 @@ class TrainConfig:
 class YOLOXConfig(TrainConfig):
     """YOLOX-specific training defaults."""
 
+    # BatchNorm-heavy pure CNN: sync BN stats across ranks under DDP (same
+    # rationale as :class:`YOLO9Config`, issue #484). No-op outside DDP.
+    sync_bn: bool = True
     momentum: float = 0.9
     warmup_epochs: int = 5
     warmup_lr_start: float = 0.0
@@ -240,9 +243,9 @@ class YOLOv7Config(YOLOXConfig):
     v7 is anchor-based but trains through the YOLOX-style pipeline (SimOTA
     assignment + mosaic/mixup), so this subclasses :class:`YOLOXConfig` and
     overrides only the real differences: v5/v7-lineage momentum, a shorter
-    warmup, slower EMA, and ``sync_bn=True`` because v7 is a BatchNorm-heavy
-    pure CNN (same rationale as :class:`YOLO9Config`, issue #484: per-rank BN
-    stats measurably degrade the converged model under DDP).
+    warmup, and slower EMA. ``sync_bn=True`` is inherited from
+    :class:`YOLOXConfig` (v7 is a BatchNorm-heavy pure CNN, same rationale
+    as :class:`YOLO9Config`, issue #484).
 
     Note: unlike YOLOX, the final no-aug epochs run without an L1 refinement
     stage — the v7 SimOTA loss has no raw-offset L1 branch.
@@ -253,7 +256,6 @@ class YOLOv7Config(YOLOXConfig):
     momentum: float = 0.937
     warmup_epochs: int = 3
     ema_decay: float = 0.9999
-    sync_bn: bool = True
 
 
 @dataclass(kw_only=True)
@@ -794,6 +796,9 @@ class ECPoseConfig(ECConfig):
 class YOLONASConfig(TrainConfig):
     """YOLO-NAS-specific training defaults."""
 
+    # BatchNorm-heavy pure CNN: sync BN stats across ranks under DDP (same
+    # rationale as :class:`YOLO9Config`, issue #484). No-op outside DDP.
+    sync_bn: bool = True
     optimizer: str = "adamw"
     lr0: float = 5e-4
     momentum: float = 0.9
@@ -884,6 +889,9 @@ class PICODETConfig(TrainConfig):
     (skill §6: aim for fine-tune parity, not paper parity).
     """
 
+    # BatchNorm-heavy pure CNN: sync BN stats across ranks under DDP (same
+    # rationale as :class:`YOLO9Config`, issue #484). No-op outside DDP.
+    sync_bn: bool = True
     optimizer: str = "sgd"
     lr0: float = 0.1
     momentum: float = 0.9
@@ -932,6 +940,9 @@ class RTMDetConfig(TrainConfig):
     are not validated yet.
     """
 
+    # BatchNorm-heavy pure CNN: sync BN stats across ranks under DDP (same
+    # rationale as :class:`YOLO9Config`, issue #484). No-op outside DDP.
+    sync_bn: bool = True
     optimizer: str = "adamw"
     lr0: float = 0.004
     momentum: float = 0.9  # unused for adamw; kept for TrainConfig compatibility
@@ -961,6 +972,9 @@ class RTMDetConfig(TrainConfig):
 class FOMOConfig(TrainConfig):
     """FOMO point-localizer training defaults."""
 
+    # BatchNorm-heavy pure CNN: sync BN stats across ranks under DDP (same
+    # rationale as :class:`YOLO9Config`, issue #484). No-op outside DDP.
+    sync_bn: bool = True
     optimizer: str = "adam"
     lr0: float = 3e-4
     weight_decay: float = 0.0

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -202,27 +202,6 @@ def unwrap_model(model: nn.Module) -> nn.Module:
 
 
 # =============================================================================
-# EMA buffer broadcast
-# =============================================================================
-
-
-def broadcast_ema_buffers(ema_module: nn.Module, src: int = 0) -> None:
-    """Broadcast all buffers of ``ema_module`` from ``src`` rank to all others.
-
-    Required because EMA is only updated on rank 0. When optimizer steps run
-    per rank, EMA state would diverge if every rank updated it independently.
-    Before validation runs on a non-zero rank, EMA buffers need to be the same
-    as rank 0's.
-    """
-    if not is_distributed():
-        return
-    for buf in ema_module.buffers():
-        dist.broadcast(buf, src=src)
-    for p in ema_module.parameters():
-        dist.broadcast(p.data, src=src)
-
-
-# =============================================================================
 # Loss scaling for DDP
 # =============================================================================
 
@@ -424,7 +403,6 @@ __all__ = [
     "DeviceArg",
     "all_reduce_avg_scalar",
     "barrier",
-    "broadcast_ema_buffers",
     "get_local_rank",
     "get_rank",
     "get_world_size",

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -520,6 +520,38 @@ def test_rtdetr_ddp_2_ranks_cpu_gloo(tmp_path):
         assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
 
 
+def test_classify_and_restore_families_expose_auto_spawn_train():
+    """The classifier families and NAFNet must route multi-GPU device specs
+    through the ``ddp_aware`` auto-spawn wrapper like every other trainable
+    family, so ``model.train(device="0,1")`` works from a plain script.
+    The wrapper's code object lives in ddp_spawn.py; a plain undecorated
+    ``train`` would point at the family's own model.py."""
+    from libreyolo.models.convnext.model import LibreConvNeXt
+    from libreyolo.models.efficientnetv2.model import LibreEfficientNetV2
+    from libreyolo.models.mobilenetv4.model import LibreMobileNetV4
+    from libreyolo.models.nafnet.model import LibreNAFNet
+    from libreyolo.models.resnet.model import LibreResNet
+
+    for cls in (
+        LibreConvNeXt,
+        LibreEfficientNetV2,
+        LibreMobileNetV4,
+        LibreNAFNet,
+        LibreResNet,
+    ):
+        # BaseModel.__init_subclass__ wraps train() again (cfg= support), so
+        # walk the functools.wraps chain and look for the ddp_aware layer.
+        fn = cls.train
+        filenames = []
+        while fn is not None:
+            filenames.append(getattr(fn, "__code__", None) and fn.__code__.co_filename.replace("\\", "/"))
+            fn = getattr(fn, "__wrapped__", None)
+        assert any(f and f.endswith("training/ddp_spawn.py") for f in filenames), (
+            f"{cls.__name__}.train is not wrapped by ddp_aware "
+            f"(wrapper chain: {filenames})"
+        )
+
+
 def test_parse_device_arg_and_wants_distributed():
     """Unit-only sanity checks for the device-argument parser. These run in
     the parent test process and don't need spawn."""

--- a/tests/unit/test_ddp_loss_parity.py
+++ b/tests/unit/test_ddp_loss_parity.py
@@ -399,6 +399,192 @@ def test_yolox_ddp_gradient_matches_single_gpu(tmp_path):
     )
 
 
+# =============================================================================
+# PicoDet / RTMDet parity: these families divide by an avg_factor computed
+# via all_reduce_avg_scalar, then hand it to loss helpers (VFL / QFL / GIoU).
+# A second max(avg_factor, 1) clamp inside those helpers silently destroys
+# the DDP scaling whenever the GLOBAL positive mass is below world_size —
+# the all-background cases here fail at exactly ratio 1/world_size if that
+# downstream clamp ever comes back.
+# =============================================================================
+
+
+def _sparse_gt_lists():
+    """Per-image GT lists: one box on sample 0, all-background on sample 1.
+
+    Exercises the positive-sparse DDP case where one rank contributes zero
+    positives (weight_sum reduction + used-parameter-set consistency)."""
+    return (
+        [torch.tensor([[60.0, 60.0, 140.0, 160.0]]), torch.zeros(0, 4)],
+        [torch.tensor([3]), torch.zeros(0, dtype=torch.long)],
+    )
+
+
+def _background_gt_lists():
+    """All-background GT lists: zero positive mass globally. The decisive
+    case for the downstream-clamp regression: global mass 0 gives a per-rank
+    normalizer of max(0, 1) / world_size = 0.5 < 1."""
+    return (
+        [torch.zeros(0, 4), torch.zeros(0, 4)],
+        [torch.zeros(0, dtype=torch.long), torch.zeros(0, dtype=torch.long)],
+    )
+
+
+def _build_picodet():
+    from libreyolo.models.picodet.loss import PICODETLoss
+    from libreyolo.models.picodet.model import LibrePICODET
+
+    torch.manual_seed(0)
+    wrapper = LibrePICODET(None, size="s", device="cpu")
+    model = wrapper.model
+    model.train()
+    _freeze_batchnorm(model)
+    head = model.head
+    loss_fn = PICODETLoss(
+        num_classes=getattr(head, "num_classes", 80),
+        reg_max=getattr(head, "reg_max", 7),
+        strides=tuple(getattr(head, "strides", (8, 16, 32, 64))),
+    )
+    return model, loss_fn
+
+
+def _build_rtmdet():
+    from libreyolo.models.rtmdet.loss import RTMDetLoss
+    from libreyolo.models.rtmdet.model import LibreRTMDet
+
+    torch.manual_seed(0)
+    wrapper = LibreRTMDet(None, size="t", device="cpu")
+    model = wrapper.model
+    model.train()
+    _freeze_batchnorm(model)
+    head = model.head
+    loss_fn = RTMDetLoss(
+        num_classes=getattr(head, "num_classes", 80),
+        strides=tuple(getattr(head, "strides", (8, 16, 32))),
+    )
+    return model, loss_fn
+
+
+_EXTERNAL_LOSS_BUILDERS = {
+    "picodet": _build_picodet,
+    "rtmdet": _build_rtmdet,
+}
+
+
+def _external_loss_total(model, loss_fn, imgs, gt_boxes, gt_labels):
+    """Same wiring as the family trainers' on_forward: raw model outputs into
+    the external loss module."""
+    cls_scores, bbox_preds = model(imgs)
+    out = loss_fn(cls_scores, bbox_preds, gt_boxes, gt_labels)
+    return out["total_loss"]
+
+
+def _external_imgs():
+    g = torch.Generator().manual_seed(1234)
+    return torch.rand(2, 3, 320, 320, generator=g)
+
+
+def _reference_grad_external(family: str, empty: bool) -> torch.Tensor:
+    model, loss_fn = _EXTERNAL_LOSS_BUILDERS[family]()
+    imgs = _external_imgs()
+    gt_boxes, gt_labels = _background_gt_lists() if empty else _sparse_gt_lists()
+    loss = _external_loss_total(model, loss_fn, imgs, gt_boxes, gt_labels)
+    model.zero_grad(set_to_none=True)
+    loss.backward()
+    return _flat_grad(model)
+
+
+def _external_parity_worker(
+    rank: int, world_size: int, port: int, out_dir: str, family: str, empty: bool
+) -> None:
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        _setup_pg(rank, world_size, port)
+
+        from libreyolo.training.distributed import scale_loss_for_ddp, unwrap_model
+
+        model, loss_fn = _EXTERNAL_LOSS_BUILDERS[family]()
+        ddp_model = nn.parallel.DistributedDataParallel(model)
+
+        imgs = _external_imgs()
+        gt_boxes, gt_labels = _background_gt_lists() if empty else _sparse_gt_lists()
+        loss = _external_loss_total(
+            ddp_model,
+            loss_fn,
+            imgs[rank : rank + 1],
+            gt_boxes[rank : rank + 1],
+            gt_labels[rank : rank + 1],
+        )
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"non-finite loss on rank {rank}: {loss.item()}")
+        loss = scale_loss_for_ddp(loss)
+        model.zero_grad(set_to_none=True)
+        loss.backward()
+
+        flat = _flat_grad(unwrap_model(ddp_model))
+        if rank == 0:
+            torch.save(flat, Path(out_dir) / "ddp_grad.pt")
+        dist.barrier()
+        out_path.write_text(f"ok grad_norm={float(flat.norm().item()):.6f}\n")
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _assert_external_parity(family: str, empty: bool, tmp_path) -> None:
+    ref = _reference_grad_external(family, empty)
+
+    outputs = _spawn_and_check(
+        _external_parity_worker, n_ranks=2, tmp_path=tmp_path, extra_args=(family, empty)
+    )
+    for rank, text in outputs.items():
+        assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
+
+    ddp = torch.load(tmp_path / "ddp_grad.pt", weights_only=False)
+
+    ref_norm = float(ref.norm().item())
+    ddp_norm = float(ddp.norm().item())
+    ratio = ddp_norm / max(ref_norm, 1e-12)
+
+    assert 0.9 < ratio < 1.1, (
+        f"{family} DDP gradient norm is {ratio:.3f}x single-GPU "
+        f"(ref={ref_norm:.4f}, ddp={ddp_norm:.4f}). A ratio near "
+        f"1/world_size (0.5) means an avg_factor is re-clamped to 1 after "
+        f"all_reduce_avg_scalar already sanitized it."
+    )
+    assert torch.allclose(ddp, ref, rtol=2e-3, atol=1e-5), (
+        f"{family} DDP gradient diverged from single-GPU: "
+        f"max_abs_diff={float((ddp - ref).abs().max().item()):.3e}"
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+@pytest.mark.parametrize("family", ["picodet", "rtmdet"])
+def test_external_loss_ddp_gradient_matches_single_gpu_sparse(family, tmp_path):
+    """Positive-sparse global batch: all positives live on rank 0, rank 1 is
+    all background. Checks global-normalizer parity plus DDP used-parameter
+    consistency on the background rank."""
+    _assert_external_parity(family, empty=False, tmp_path=tmp_path)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+@pytest.mark.parametrize("family", ["picodet", "rtmdet"])
+def test_external_loss_ddp_gradient_matches_single_gpu_all_background(family, tmp_path):
+    """All-background global batch (global positive mass 0): the per-rank
+    normalizer is legitimately 0.5 < 1, which a downstream max(avg_factor, 1)
+    clamp destroys, under-scaling the gradient to exactly 1/world_size."""
+    _assert_external_parity(family, empty=True, tmp_path=tmp_path)
+
+
 def _helper_value_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
     """Exercise ``all_reduce_avg_scalar`` itself under a real process group —
     including the non-tensor + ``device=`` form RT-DETR uses, which no other

--- a/tests/unit/test_ddp_loss_parity.py
+++ b/tests/unit/test_ddp_loss_parity.py
@@ -294,6 +294,111 @@ def test_yolo9_ddp_gradient_matches_single_gpu_all_background(tmp_path):
     )
 
 
+# =============================================================================
+# YOLOX parity: local num_fg was the last per-rank normalizer in the SimOTA
+# lineage. yolox/nn.py now reduces it via all_reduce_avg_scalar; this test
+# pins the same single-GPU equivalence the yolo9 tests pin above.
+# =============================================================================
+
+
+def _build_yolox():
+    """Deterministic yolox-t on CPU, train mode, BN frozen (same rationale as
+    ``_build_yolo9``: BN in train mode couples the samples for reasons
+    unrelated to the loss-normalizer math under test)."""
+    from libreyolo import LibreYOLOX
+
+    torch.manual_seed(0)
+    wrapper = LibreYOLOX(None, size="t", device="cpu")
+    model = wrapper.model
+    model.train()
+    _freeze_batchnorm(model)
+    return model
+
+
+def _yolox_global_batch():
+    """Fixed 2-sample batch with [cls, cx, cy, w, h] pixel-space targets (the
+    YOLOX label format). Deterministic so sample ``r`` is byte-identical in the
+    reference run and in rank ``r``'s worker."""
+    g = torch.Generator().manual_seed(1234)
+    imgs = torch.rand(2, 3, 320, 320, generator=g)
+    targets = torch.zeros(2, 8, 5)
+    targets[0, 0] = torch.tensor([0.0, 80.0, 90.0, 60.0, 80.0])
+    targets[0, 1] = torch.tensor([1.0, 200.0, 160.0, 100.0, 120.0])
+    targets[1, 0] = torch.tensor([2.0, 120.0, 100.0, 90.0, 70.0])
+    return imgs, targets
+
+
+def _reference_grad_yolox() -> torch.Tensor:
+    model = _build_yolox()
+    imgs, targets = _yolox_global_batch()
+    out = model(imgs, targets)
+    model.zero_grad(set_to_none=True)
+    out["total_loss"].backward()
+    return _flat_grad(model)
+
+
+def _yolox_parity_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        _setup_pg(rank, world_size, port)
+
+        from libreyolo.training.distributed import scale_loss_for_ddp, unwrap_model
+
+        model = _build_yolox()
+        ddp_model = nn.parallel.DistributedDataParallel(model)
+
+        imgs, targets = _yolox_global_batch()
+        out = ddp_model(imgs[rank : rank + 1], targets[rank : rank + 1])
+        loss = out["total_loss"]
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"non-finite loss on rank {rank}: {loss.item()}")
+        loss = scale_loss_for_ddp(loss)
+        model.zero_grad(set_to_none=True)
+        loss.backward()
+
+        flat = _flat_grad(unwrap_model(ddp_model))
+        if rank == 0:
+            torch.save(flat, Path(out_dir) / "ddp_grad.pt")
+        dist.barrier()
+        out_path.write_text(f"ok grad_norm={float(flat.norm().item()):.6f}\n")
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+def test_yolox_ddp_gradient_matches_single_gpu(tmp_path):
+    """2-rank DDP gradient must match single-GPU on the same global batch.
+    Regresses if yolox's ``num_fg`` goes back to a per-rank ``max(num_fg, 1)``:
+    the norm-ratio band may still pass, but the elementwise check fails."""
+    ref = _reference_grad_yolox()
+
+    outputs = _spawn_and_check(_yolox_parity_worker, n_ranks=2, tmp_path=tmp_path)
+    for rank, text in outputs.items():
+        assert text.startswith("ok "), f"rank {rank} did not finish ok: {text!r}"
+
+    ddp = torch.load(tmp_path / "ddp_grad.pt", weights_only=False)
+
+    ref_norm = float(ref.norm().item())
+    ddp_norm = float(ddp.norm().item())
+    ratio = ddp_norm / max(ref_norm, 1e-12)
+
+    assert 0.9 < ratio < 1.1, (
+        f"DDP gradient norm is {ratio:.3f}x the single-GPU gradient "
+        f"(ref={ref_norm:.4f}, ddp={ddp_norm:.4f})."
+    )
+    assert torch.allclose(ddp, ref, rtol=2e-3, atol=1e-5), (
+        "DDP gradient diverged from single-GPU beyond fp tolerance: "
+        f"max_abs_diff={float((ddp - ref).abs().max().item()):.3e}"
+    )
+
+
 def _helper_value_worker(rank: int, world_size: int, port: int, out_dir: str) -> None:
     """Exercise ``all_reduce_avg_scalar`` itself under a real process group —
     including the non-tensor + ``device=`` form RT-DETR uses, which no other

--- a/tests/unit/test_ddp_syncbn.py
+++ b/tests/unit/test_ddp_syncbn.py
@@ -54,6 +54,32 @@ def test_yolo9_config_enables_sync_bn():
     assert YOLO9PoseConfig().sync_bn is True
 
 
+def test_bn_heavy_cnn_configs_enable_sync_bn():
+    """Every BatchNorm-heavy pure-CNN family must default to SyncBatchNorm
+    under DDP, not only yolo9: per-rank BN stats on a small shard degrade the
+    converged model the same way for all of them (issue #484)."""
+    from libreyolo.training.config import (
+        FOMOConfig,
+        PICODETConfig,
+        RTMDetConfig,
+        YOLONASConfig,
+        YOLONASPoseConfig,
+        YOLOXConfig,
+        YOLOv7Config,
+    )
+
+    for cfg_cls in (
+        FOMOConfig,
+        PICODETConfig,
+        RTMDetConfig,
+        YOLONASConfig,
+        YOLONASPoseConfig,
+        YOLOXConfig,
+        YOLOv7Config,
+    ):
+        assert cfg_cls().sync_bn is True, cfg_cls.__name__
+
+
 # =============================================================================
 # 2. Real-model conversion
 # =============================================================================

--- a/tools/ddp_torchrun_smoke.py
+++ b/tools/ddp_torchrun_smoke.py
@@ -20,7 +20,8 @@ What this covers beyond the existing tests:
     - torchrun env path: has_torchrun_env() → init_distributed() (BaseTrainer.__init__ path)
     - NCCL backend when CUDA available (Gloo fallback on CPU or single-GPU)
     - Multiple training steps
-    - EMA buffer broadcast from rank-0 to all ranks (broadcast_ema_buffers)
+    - EMA cross-rank consistency: every rank updates EMA after DDP-synced
+      steps, so EMA must stay identical on all ranks without any broadcast
     - DistributedSampler: each rank gets distinct indices, set_epoch changes them
     - Checkpoint save on rank-0 + load round-trip into a single-process model
 """
@@ -120,60 +121,88 @@ def run_sampler_test(rank: int, world_size: int) -> None:
 
 
 # ---------------------------------------------------------------------------
-# EMA broadcast test
+# EMA cross-rank consistency test
 # ---------------------------------------------------------------------------
 
 
-def run_ema_broadcast_test(rank: int, world_size: int, device: torch.device) -> None:
-    """Verify broadcast_ema_buffers syncs rank-0's EMA to all other ranks.
+def run_ema_consistency_test(rank: int, world_size: int, device: torch.device) -> None:
+    """Verify EMA stays identical across ranks under the current DDP design.
 
-    Pattern: all ranks create identical EMA, rank-0 modifies it, all call
-    broadcast, then verify values are identical again.
+    BaseTrainer updates EMA on every rank after each optimizer step. Because
+    DDP all-reduces gradients, every rank applies the same parameter update,
+    so the per-rank EMA parameters must remain consistent with no broadcast.
+    (The old ``broadcast_ema_buffers`` helper existed for a rank-0-only EMA
+    design and was removed.)
+
+    Buffers (BN running stats) are only identical across ranks under
+    SyncBatchNorm — yolo9's DDP default — which needs CUDA; on CUDA we
+    convert and check buffers too, on CPU/Gloo we check parameters only.
+
+    Pattern: identical model on all ranks, DDP-wrapped, a few steps with
+    *different* per-rank data, ``ema.update`` on every rank each step, then
+    an all_reduce equality check over the EMA state.
     """
     from libreyolo import LibreYOLO9
-    from libreyolo.training.distributed import broadcast_ema_buffers
+    from libreyolo.training.distributed import unwrap_model
     from libreyolo.training.ema import ModelEMA
 
     torch.manual_seed(42)
     wrapper = LibreYOLO9(None, size="t", device=str(device))
-    wrapper.model.eval()
+    wrapper.model.train()
+    use_sync_bn = device.type == "cuda" and dist.get_backend() == "nccl"
+    if use_sync_bn:
+        wrapper.model = nn.SyncBatchNorm.convert_sync_batchnorm(wrapper.model)
 
-    ema = ModelEMA(wrapper.model)
+    ddp_kwargs: dict = dict(gradient_as_bucket_view=False, static_graph=True)
+    if device.type == "cuda":
+        ddp_kwargs["device_ids"] = [device.index]
+        ddp_kwargs["output_device"] = device.index
+    ddp_model = nn.parallel.DistributedDataParallel(wrapper.model, **ddp_kwargs)
+    optimizer = torch.optim.SGD(
+        unwrap_model(ddp_model).parameters(), lr=0.01, momentum=0.9
+    )
+    ema = ModelEMA(ddp_model)
 
-    # Only rank 0 updates EMA — simulates N training steps on rank-0 only
-    if rank == 0:
-        with torch.no_grad():
-            for p in ema.ema.parameters():
-                p.data.mul_(1.5).add_(0.3)
+    for step in range(3):
+        # Different data per rank — the point is that DDP's gradient
+        # averaging still keeps the models (and therefore EMA) in lockstep.
+        torch.manual_seed(step * 1000 + rank)
+        imgs = torch.randn(1, 3, 320, 320, device=device)
+        targets = torch.zeros(1, 30, 5, device=device)
+        targets[0, 0] = torch.tensor(
+            [float(rank), 160.0, 120.0, 80.0, 60.0], device=device
+        )
+        out = ddp_model(imgs, targets=targets)
+        optimizer.zero_grad(set_to_none=True)
+        out["total_loss"].backward()
+        optimizer.step()
+        ema.update(ddp_model)
 
-    dist.barrier()
-
-    # Before broadcast: verify params differ across ranks (all_reduce sum != local * world)
-    if world_size > 1:
-        any_param = next(iter(ema.ema.parameters()))
-        local = any_param.detach().clone()
-        summed = any_param.detach().clone()
-        dist.all_reduce(summed, op=dist.ReduceOp.SUM)
-        pre_diverged = not torch.allclose(summed, local * world_size, atol=1e-5)
+    # Every rank must now hold identical EMA parameters: for each tensor,
+    # all_reduce(SUM) == local * world_size. Buffers only when SyncBN is on
+    # (without it, BN running stats track each rank's local batches).
+    if use_sync_bn:
+        tensors = list(ema.ema.state_dict().items())
     else:
-        pre_diverged = True  # trivially: single rank, nothing to diverge
-
-    # All ranks call broadcast (collective: rank-0 sends, others receive)
-    broadcast_ema_buffers(ema.ema, src=0)
-
-    # After broadcast: verify all ranks hold rank-0's EMA values.
-    # EMA params have requires_grad=False so _params_match skips them; use
-    # all_reduce directly on all params (no grad involved).
-    for name, p in ema.ema.named_parameters():
-        local = p.data.detach().clone()
-        summed = p.data.detach().clone()
+        tensors = list(ema.ema.named_parameters())
+    checked = 0
+    for name, t in tensors:
+        t = t.data if hasattr(t, "data") else t
+        if not torch.is_floating_point(t):
+            continue
+        local = t.detach().clone()
+        summed = t.detach().clone()
         dist.all_reduce(summed, op=dist.ReduceOp.SUM)
         expected = local * world_size
         if not torch.allclose(summed, expected, atol=1e-5, rtol=1e-4):
             delta = (summed - expected).abs().max().item()
-            raise RuntimeError(f"EMA broadcast failed for param {name!r}: max_abs={delta:.3e}")
+            raise RuntimeError(
+                f"EMA diverged across ranks for {name!r}: max_abs={delta:.3e}"
+            )
+        checked += 1
 
-    _ok(rank, f"EMA broadcast: {'pre-diverged as expected, ' if pre_diverged else ''}post-broadcast synced")
+    scope = "params+buffers (SyncBN)" if use_sync_bn else "params (no SyncBN on CPU)"
+    _ok(rank, f"EMA consistency: identical on all ranks after 3 DDP steps ({checked} tensors, {scope})")
 
 
 # ---------------------------------------------------------------------------
@@ -374,13 +403,13 @@ def main() -> None:
         _log(rank, f"FAIL sampler: {exc}")
         failed.append("sampler")
 
-    # EMA broadcast (uses YOLO9 model, model-agnostic)
+    # EMA cross-rank consistency (uses YOLO9 model, model-agnostic)
     try:
-        run_ema_broadcast_test(rank, world_size, device)
-        passed.append("ema_broadcast")
+        run_ema_consistency_test(rank, world_size, device)
+        passed.append("ema_consistency")
     except Exception as exc:
-        _log(rank, f"FAIL ema_broadcast: {exc}")
-        failed.append("ema_broadcast")
+        _log(rank, f"FAIL ema_consistency: {exc}")
+        failed.append("ema_consistency")
 
     for family in families:
         try:


### PR DESCRIPTION
## What

Brings every trainable family up to the DDP quality bar set for YOLO9 in issue #484. Follow-up to #488/#531/#551.

- **Auto-spawn for classify + restore**: `@ddp_aware()` added to resnet, convnext, efficientnetv2, mobilenetv4, and nafnet `train()`, so `model.train(device="0,1")` works from a plain script (previously torchrun-only for these five).
- **`sync_bn=True` defaults for the remaining BatchNorm-heavy pure CNNs**: yolox (yolo7 now inherits), yolonas det+pose, rtmdet, picodet, fomo. Same rationale as YOLO9Config: per-rank BN stats on a small shard degrade the converged model. Strictly a no-op outside DDP, so single-GPU runs and the open #566 convergence work are unaffected.
- **Global loss normalizers** (exact single-GPU-equivalent DDP gradients, like yolo9's `_global_cls_norm` and DETR `num_boxes`):
  - yolox and yolo7 `num_fg`
  - rtmdet `avg_factor`
  - yolonas `assigned_scores_sum`, det and pose
  - picodet VFL `avg_factor` + box/DFL `weight_sum`; the loss docstring claimed this was already wired, now it is
  - All reductions go through the existing `all_reduce_avg_scalar` (clamp-before-divide), so single-GPU numerics are unchanged.
- **picodet DDP graph consistency**: normalizer collectives moved before the no-positive early return (deadlock risk otherwise), and the all-background path keeps the regression tower in the autograd graph so DDP static_graph sees a consistent used-parameter set.
- **Downstream clamp fix (review round 1)**: picodet `VarifocalLoss` and rtmdet `QualityFocalLoss`/`GIoULoss` re-clamped the already-sanitized `avg_factor` to >= 1, under-scaling sparse and all-background multi-GPU batches by up to 1/world_size. The helpers now honor the caller's sanitized denominator.
- **Cleanup**: removed dead `broadcast_ema_buffers`; `tools/ddp_torchrun_smoke.py` (its one remaining caller) rewritten for the current design: EMA is updated on every rank after DDP-synced steps, so the smoke check verifies cross-rank EMA consistency with no broadcast (params always, buffers too under SyncBN on CUDA).
- **Tests**: yolox 2-rank gradient-parity vs single-GPU; picodet and rtmdet 2-rank parity for positive-sparse and all-background batches (the all-background variants fail at ratio ~0.5 if a downstream clamp returns, verified by temporarily reintroducing one); sync_bn config guard for all BN-heavy families; ddp_aware wiring test for the five new families.

Not touched: DETR families (already all-reduce `num_boxes`; backbone BN under small batch without SyncBN matches their upstream recipes), fomo loss (mean-reduced CE, contract-compliant), inference-only families (no training to distribute).

## How was this tested?

- `tests/unit/test_ddp_loss_parity.py` (incl. 5 new parity tests), `test_ddp_syncbn.py`, `test_ddp_distributed.py`: all pass locally (Windows, CPU/Gloo spawn)
- Family regression sweep (yolox/yolo7/yolonas/rtmdet/picodet/fomo/nafnet/classifiers/config): 515 passed
- `tools/ddp_torchrun_smoke.py` run 2-rank on CPU/Gloo: sampler, ema_consistency, yolo9 all PASS

## Code provenance

All code in this PR is original, written for this PR. No code was ported, adapted, or derived from any third-party repository, in any form.

- The changes extend in-repository mechanisms that already exist on dev: the `all_reduce_avg_scalar` reduction, yolo9's `_global_cls_norm` pattern, the `ddp_aware` decorator, and the `sync_bn` config flag (all from issue #484 work, PRs #488/#531/#551).
- Upstream projects are mentioned in comments only as behavioral references, to document that the DDP normalizer semantics match what each family's original training recipe does (mmdetection's `reduce_mean` on the RTMDet cls avg_factor, Apache-2.0; SuperGradients' all_reduce of `assigned_scores_sum`, Apache-2.0; PP-PicoDet's nranks averaging, Apache-2.0). No source code from those repositories was read, copied, or adapted for this PR; the statements describe publicly documented training behavior. No GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license material was used.