### PR TITLE
Fix PicoDet/RTMDet fine-tune collapse

### DIFF
--- a/libreyolo/models/picodet/loss.py
+++ b/libreyolo/models/picodet/loss.py
@@ -455,7 +455,12 @@ class PICODETLoss(nn.Module):
           GT edges in feature-space, clamped to ``reg_max - eps``.
         """
         device = cls_scores[0].device
-        dtype = cls_scores[0].dtype
+        # Loss math runs in fp32 regardless of autocast: fp16 pixel-space box
+        # areas overflow (640^2 >> fp16 max 65504, NaN GIoU) and the fp32 IoU
+        # scatter into an fp16 VFL target tensor is a dtype crash (issue #566).
+        # The model forward keeps its autocast dtype; only these small
+        # flattened tensors are promoted.
+        dtype = torch.float32
         feat_shapes = [(c.shape[-2], c.shape[-1]) for c in cls_scores]
 
         priors = _generate_priors(feat_shapes, self.strides, device, dtype)
@@ -468,11 +473,11 @@ class PICODETLoss(nn.Module):
         B = cls_scores[0].shape[0]
         cls_flat = torch.cat([
             cs.permute(0, 2, 3, 1).reshape(B, -1, self.num_classes) for cs in cls_scores
-        ], dim=1)
+        ], dim=1).float()
         bbox_flat = torch.cat([
             bp.permute(0, 2, 3, 1).reshape(B, -1, 4 * (self.reg_max + 1))
             for bp in bbox_preds
-        ], dim=1)
+        ], dim=1).float()
 
         decoded = self._batch_decode(bbox_flat, priors, strides_per_prior)
         cls_sigmoid = cls_flat.sigmoid()

--- a/libreyolo/models/rtmdet/loss.py
+++ b/libreyolo/models/rtmdet/loss.py
@@ -454,7 +454,12 @@ class RTMDetLoss(nn.Module):
         gt_labels_list: List[torch.Tensor],
     ) -> dict:
         device = cls_scores[0].device
-        dtype = cls_scores[0].dtype
+        # Loss math runs in fp32 regardless of autocast: fp16 pixel-space box
+        # areas overflow (640^2 >> fp16 max 65504), turning the GIoU term into
+        # NaN on the first batch (issue #566). mmdet keeps loss computation in
+        # fp32 for the same reason. Only these small flattened tensors are
+        # promoted; the model forward keeps its autocast dtype.
+        dtype = torch.float32
         batch_size = cls_scores[0].size(0)
 
         featmap_sizes = [tuple(c.shape[-2:]) for c in cls_scores]
@@ -464,11 +469,11 @@ class RTMDetLoss(nn.Module):
         flat_cls = torch.cat(
             [c.permute(0, 2, 3, 1).reshape(batch_size, -1, self.num_classes) for c in cls_scores],
             dim=1,
-        )
+        ).float()
         flat_dist = torch.cat(
             [r.permute(0, 2, 3, 1).reshape(batch_size, -1, 4) for r in bbox_preds],
             dim=1,
-        )
+        ).float()
         # Decode distances to xyxy boxes
         prior_xy = priors[:, :2]
         decoded_boxes = torch.stack(

--- a/libreyolo/models/rtmdet/nn.py
+++ b/libreyolo/models/rtmdet/nn.py
@@ -436,6 +436,31 @@ class RTMDetSepBNHead(nn.Module):
                     self.cls_convs[n][i].conv = self.cls_convs[0][i].conv
                     self.reg_convs[n][i].conv = self.reg_convs[0][i].conv
 
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        # Mirror mmdet RTMDetSepBNHead.init_weights: Normal(std=0.01) convs,
+        # norms at 1, and the focal prior bias on rtm_cls so a fresh head
+        # scores ~0.01 everywhere instead of ~0.5. Without the prior bias, a
+        # head rebuilt for a new class count fires all priors at once and the
+        # first QFL batch produces a ~1e5x gradient shock that destroys the
+        # pretrained backbone (issue #566). Loading a checkpoint afterwards
+        # overwrites all of this, so published weights are unaffected.
+        import math
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.normal_(m.weight, mean=0.0, std=0.01)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.ones_(m.weight)
+                nn.init.zeros_(m.bias)
+
+        bias_cls = -math.log((1 - 0.01) / 0.01)  # bias_init_with_prob(0.01)
+        for conv in self.rtm_cls:
+            nn.init.constant_(conv.bias, bias_cls)
+
     def forward(self, feats):
         cls_scores = []
         bbox_preds = []

--- a/libreyolo/models/rtmdet/trainer.py
+++ b/libreyolo/models/rtmdet/trainer.py
@@ -13,7 +13,8 @@ fine-tune-from-pretrained path that ``allow_experimental=True`` gates):
   doesn't swap the full pipeline. Acceptable for short fine-tunes; revisit
   for production training.
 - mmdet uses paramwise weight decay (norm_decay_mult=0, bias_decay_mult=0).
-  This trainer uses ``BaseTrainer``'s default param grouping.
+  ``BaseTrainer``'s param grouping now matches: norms and biases carry an
+  explicit ``weight_decay=0.0``.
 """
 
 from __future__ import annotations

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -882,16 +882,23 @@ class PICODETConfig(TrainConfig):
     LibreYOLO v1 cut: SGD + cosine + hflip + ImageNet normalise. Multi-scale
     resize and PhotoMetricDistortion are deferred to a follow-up commit
     (skill §6: aim for fine-tune parity, not paper parity).
+
+    lr0 note (issue #566): Bo's 0.4 is the total LR at total batch 512
+    (4 GPUs x 128 samples), i.e. ~7.8e-4 per image. Copying 0.1 unscaled at
+    the default batch 16 is ~8x that per image and demonstrably destroys a
+    COCO-pretrained model within a few epochs (coco128 fine-tune: 0.40 ->
+    0.14 mAP at 0.1 vs 0.40 -> 0.49 at 0.01). 0.01 matches the upstream
+    per-image rate at the default batch.
     """
 
     optimizer: str = "sgd"
-    lr0: float = 0.1
+    lr0: float = 0.01
     momentum: float = 0.9
     weight_decay: float = 4e-5
 
     scheduler: str = "cos"
     warmup_epochs: int = 1
-    warmup_lr_start: float = 0.01
+    warmup_lr_start: float = 0.001
     no_aug_epochs: int = 0
     min_lr_ratio: float = 0.0
 

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -380,15 +380,19 @@ class BaseTrainer(ABC):
 
         lr = self.effective_lr
         opt_name = self.config.optimizer
+        # BN and bias groups carry an explicit weight_decay=0.0: groups without
+        # the key inherit the optimizer's default, which is 0.01 for AdamW --
+        # silently decaying norm gammas and biases that every upstream recipe
+        # (paramwise norm/bias_decay_mult=0) exempts. No-op for SGD/Adam.
         param_groups = []
         if pg0:
-            param_groups.append({"params": pg0, "lr": lr})
+            param_groups.append({"params": pg0, "lr": lr, "weight_decay": 0.0})
         if pg1:
             param_groups.append(
                 {"params": pg1, "lr": lr, "weight_decay": self.config.weight_decay}
             )
         if pg2:
-            param_groups.append({"params": pg2, "lr": lr})
+            param_groups.append({"params": pg2, "lr": lr, "weight_decay": 0.0})
         if not param_groups:
             raise ValueError(
                 "No trainable parameters remain after layer freezing; "

--- a/tests/unit/test_picodet_train_smoke.py
+++ b/tests/unit/test_picodet_train_smoke.py
@@ -102,3 +102,34 @@ def test_iou_pairwise_correct():
     assert iou.shape == (2, 1)
     assert abs(iou[0, 0].item() - 1.0) < 1e-6
     assert abs(iou[1, 0].item() - 25 / 100) < 1e-6
+
+
+def test_loss_accepts_fp16_predictions():
+    """Under AMP the head emits fp16 while GT boxes stay fp32; the VFL target
+    scatter used to crash with 'Index put requires ... Half/Float' and the
+    pixel-space GIoU could overflow fp16. The loss now promotes its inputs to
+    fp32 (issue #566)."""
+    from libreyolo.models.picodet.loss import PICODETLoss
+
+    torch.manual_seed(0)
+    loss_fn = PICODETLoss(num_classes=3, reg_max=7, strides=(8, 16, 32, 64))
+    sizes = [(40, 40), (20, 20), (10, 10), (5, 5)]
+    cls_scores = [torch.randn(2, 3, h, w).half() for h, w in sizes]
+    bbox_preds = [torch.randn(2, 32, h, w).half() for h, w in sizes]
+    gt_boxes = [torch.tensor([[10.0, 10.0, 300.0, 300.0]]) for _ in range(2)]
+    gt_labels = [torch.tensor([1]) for _ in range(2)]
+
+    out = loss_fn(cls_scores, bbox_preds, gt_boxes, gt_labels)
+    assert torch.isfinite(out["total_loss"])
+    assert out["num_pos"] > 0
+
+
+def test_picodet_config_finetune_lr():
+    """lr0 must stay at the per-image-equivalent fine-tune rate. The old 0.1
+    default (upstream's total-batch-512 rate, unscaled) destroys a pretrained
+    model within epochs (issue #566)."""
+    from libreyolo.training.config import PICODETConfig
+
+    cfg = PICODETConfig()
+    assert cfg.lr0 == 0.01
+    assert cfg.warmup_lr_start <= cfg.lr0 * 0.2

--- a/tests/unit/test_rtmdet.py
+++ b/tests/unit/test_rtmdet.py
@@ -257,3 +257,38 @@ def test_assigner_handles_empty_gt():
     out = assigner(pred_bboxes, pred_scores, priors, gt_labels, gt_bboxes, pad_flag)
     # All priors should be background (label = num_classes)
     assert (out["assigned_labels"] == 80).all()
+
+
+def test_head_init_uses_focal_prior_bias():
+    """A fresh (or rebuilt) head must start with the mmdet focal prior on
+    rtm_cls so all priors score ~0.01, not ~0.5. Without it, the first QFL
+    batch after an nc rebuild produces a ~1e5x loss/gradient shock that
+    destroys the pretrained backbone (issue #566)."""
+    import math
+
+    from libreyolo.models.rtmdet.nn import LibreRTMDetModel
+
+    model = LibreRTMDetModel(size="t", nc=3)
+    expected = -math.log((1 - 0.01) / 0.01)
+    for conv in model.head.rtm_cls:
+        assert torch.allclose(conv.bias, torch.full_like(conv.bias, expected))
+        assert float(conv.weight.std()) < 0.05  # Normal(std=0.01), not kaiming
+
+
+def test_loss_finite_with_fp16_predictions_and_large_boxes():
+    """Loss math must run in fp32: pixel-space box areas overflow fp16
+    (640^2 >> 65504) and turned the GIoU term into NaN under AMP (issue #566)."""
+    from libreyolo.models.rtmdet.loss import RTMDetLoss
+
+    torch.manual_seed(0)
+    loss_fn = RTMDetLoss(num_classes=3, strides=(8, 16, 32))
+    sizes = [(80, 80), (40, 40), (20, 20)]
+    cls_scores = [torch.randn(2, 3, h, w).half() for h, w in sizes]
+    # Large positive distances so decoded boxes span most of a 640 canvas.
+    bbox_preds = [(torch.rand(2, 4, h, w) * 400 + 200).half() for h, w in sizes]
+    gt_boxes = [torch.tensor([[10.0, 10.0, 620.0, 620.0]]) for _ in range(2)]
+    gt_labels = [torch.tensor([1]) for _ in range(2)]
+
+    out = loss_fn(cls_scores, bbox_preds, gt_boxes, gt_labels)
+    assert torch.isfinite(out["total_loss"])
+    assert torch.isfinite(out["loss_bbox"])

--- a/tests/unit/test_trainer_optimizer_groups.py
+++ b/tests/unit/test_trainer_optimizer_groups.py
@@ -1,0 +1,74 @@
+"""BaseTrainer optimizer param-group weight-decay semantics (issue #566)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from libreyolo.training.trainer import BaseTrainer
+
+pytestmark = pytest.mark.unit
+
+
+class TinyTrainer(BaseTrainer):
+    def get_model_family(self) -> str:
+        return "tiny"
+
+    def get_model_tag(self) -> str:
+        return "tiny"
+
+    def create_transforms(self):
+        raise NotImplementedError
+
+    def create_scheduler(self, iters_per_epoch: int):
+        raise NotImplementedError
+
+    def get_loss_components(self, outputs):
+        return {}
+
+
+def _make_trainer(optimizer: str) -> TinyTrainer:
+    trainer = TinyTrainer.__new__(TinyTrainer)
+    trainer.model = nn.Sequential(
+        nn.Conv2d(3, 4, 3, bias=True),
+        nn.BatchNorm2d(4),
+        nn.Conv2d(4, 2, 1, bias=False),
+    )
+    trainer.config = SimpleNamespace(
+        optimizer=optimizer,
+        lr0=1e-3,
+        weight_decay=0.05,
+        momentum=0.9,
+        nesterov=True,
+    )
+    return trainer
+
+
+def test_adamw_norm_and_bias_groups_get_zero_weight_decay():
+    """Param groups without an explicit weight_decay inherit the optimizer
+    default, which is 0.01 for AdamW. Norms and biases must carry an explicit
+    0.0 (upstream paramwise norm/bias_decay_mult=0)."""
+    trainer = _make_trainer("adamw")
+    opt = trainer._setup_optimizer()
+
+    decays = sorted(g["weight_decay"] for g in opt.param_groups)
+    assert decays == [0.0, 0.0, 0.05]
+
+    # The decayed group is the conv/linear weights, not the BN/bias params.
+    bn_weight = trainer.model[1].weight
+    bias = trainer.model[0].bias
+    for group in opt.param_groups:
+        params = {id(p) for p in group["params"]}
+        if id(bn_weight) in params or id(bias) in params:
+            assert group["weight_decay"] == 0.0
+
+
+def test_sgd_groups_unchanged_by_explicit_zero():
+    """SGD's default decay is already 0, so the explicit 0.0 is a no-op."""
+    trainer = _make_trainer("sgd")
+    opt = trainer._setup_optimizer()
+    decays = sorted(g["weight_decay"] for g in opt.param_groups)
+    assert decays == [0.0, 0.0, 0.05]


### PR DESCRIPTION
Fixes #566 (picodet and rtmdet collapsing to ~0 mAP on RF100 fine-tunes, reported in #542).

Root causes were found by line-level comparison against the upstream implementations (Bo396543018/Picodet_Pytorch for PicoDet, open-mmlab/mmdetection for RTMDet, both Apache-2.0) and proven with controlled fine-tune experiments. The loss/assigner ports themselves are faithful; every problem was at the trainer/recipe level.

## Changes

- **RTMDet head init**: the head had no weight init at all. mmdet seeds head convs with Normal(std=0.01) and the cls bias with the focal prior (-4.595); a head rebuilt for a new class count therefore scored ~0.5 everywhere and the first QFL batch produced a ~196,000x loss / ~398,000x gradient shock that destroyed the pretrained backbone. Init now runs in the head constructor (rebuild-safe; checkpoint loading overwrites it).
- **PicoDet lr0 0.1 -> 0.01**: upstream 0.4 is the total LR at total batch 512 (~7.8e-4 per image); 0.1 unscaled at batch 16 is ~8x that and destroys a COCO-pretrained model within epochs (coco128: 0.40 -> 0.14 at 0.1 vs 0.40 -> 0.49 at 0.01).
- **Loss math in fp32 under AMP**: fp16 pixel-space box areas overflow (640^2 >> 65504), turning RTMDet GIoU into NaN on the first batch; PicoDet crashed on an fp32-into-fp16 index_put in the VFL target scatter. Both families shipped amp=True defaults that could not train on CUDA at all.
- **AdamW weight-decay leak**: BaseTrainer BN/bias param groups now carry an explicit weight_decay=0.0 instead of inheriting AdamW default 0.01 (upstream paramwise norm/bias_decay_mult=0).
- Regression tests for each fix (head init prior, fp16-input loss finiteness for both families, lr0 guard, optimizer grouping).

## Validation (pure library defaults, amp on)

| scenario | before | after |
|---|---|---|
| coco128 fine-tune 5 ep, picodet | AMP crash; 0.40 -> 0.14 fp32 | 0.40 -> 0.499 |
| coco128 fine-tune 5 ep, rtmdet | NaN from epoch 1 | 0.526 -> 0.598 |
| nc=80 -> nc=1 rebuild 50 ep, picodet | ~0.03 | 0.486 mAP50-95 / 0.661 mAP50 |
| nc=80 -> nc=1 rebuild 50 ep, rtmdet | ~0.26 (fp32 only) | 0.709 mAP50-95 / 0.863 mAP50 |

Full unit suite: 3085 passed, 50 skipped. The allow_experimental gates stay in place until an RF100-scale rerun.

## Code provenance

All code changes were written for this PR based on inspection of the LibreYOLO codebase and the published upstream references (mmdetection and Bo396543018/Picodet_Pytorch, both Apache-2.0), which were consulted to identify behavioral divergences (weight init constants -4.595/std 0.01 and hyperparameter values). No third-party code was copied, ported, adapted, or derived beyond these published constants.