### PR TITLE
Remove classification and YOLOv9-P2 README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,6 @@ model = LibreYOLO("LibreYOLO9t.pt")
 result = model(SAMPLE_IMAGE, save=True)
 ```
 
-Image classification works the same way. Load a pretrained ImageNet-1k
-classifier (`MobileNetV4`, `ConvNeXt`, `EfficientNetV2`, or `ResNet`), then
-predict or fine-tune on your own folder-per-class dataset:
-
-```python
-from libreyolo import LibreYOLO
-
-model = LibreYOLO("LibreResNet50-cls.pt")   # weights auto-download on first use
-result = model("image.jpg")                  # a single image -> one Results
-print(result.probs.top1, float(result.probs.top1conf))  # class index + confidence
-print(result.probs.top5)                     # indices of the 5 most likely classes
-
-# Fine-tune on an ImageFolder dataset (train/ and val/, one sub-folder per
-# class). The classifier head resizes to your class count automatically.
-model.train(data="path/to/dataset", epochs=5)
-```
-
 For the full list of extras and per-backend notes, see the [docs](https://www.libreyolo.com/docs#installation).
 
 To install from source in editable mode (for development or to track unreleased changes):
@@ -130,14 +113,6 @@ hooks via `callbacks=` and built-in experiment loggers via `loggers=`
     <tr><td>L2CS</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
   </tbody>
 </table>
-
-YOLOv9-P2 is a small-object variant of YOLOv9 with an extra stride-4 detection
-scale, built for aerial/tiny-object imagery where objects fall below ~16 px
-(on regular datasets like COCO, prefer stock YOLOv9). A VisDrone-trained
-research preview is available as
-[`LibreYOLO9P2s-visdrone.pt`](https://huggingface.co/LibreYOLO/LibreYOLO9P2s-visdrone)
-(non-commercial license); train your own with
-`LibreYOLO9P2(None, size="s").train(..., pretrained="LibreYOLO9s.pt")`.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,13 +96,6 @@ LibreYOLO 推荐以下模型系列，因为它们在性能上达到最佳平衡�
   </tbody>
 </table>
 
-YOLOv9-P2 是 YOLOv9 的小目标变体，增加了一个 stride-4 检测尺度，专为目标小于约
-16 像素的航拍/微小目标图像设计（常规数据集如 COCO 请使用标准 YOLOv9）。
-基于 VisDrone 训练的研究预览版权重：
-[`LibreYOLO9P2s-visdrone.pt`](https://huggingface.co/LibreYOLO/LibreYOLO9P2s-visdrone)
-（非商业许可证）；也可自行训练：
-`LibreYOLO9P2(None, size="s").train(..., pretrained="LibreYOLO9s.pt")`。
-
 ## 许可证
 
 - **代码：** MIT License


### PR DESCRIPTION
# What does this PR do?

Removes the image-classification usage example and the YOLOv9-P2 research-preview paragraph from the English README. Removes the matching YOLOv9-P2 paragraph from the Chinese README; it did not contain the classification example.

# Provenance declaration (required)

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

# How was this tested?

- Ran `git diff --check`.
- Confirmed the removed classification and YOLOv9-P2 text no longer occurs in either README.