### PR TITLE
Add RTMDet-Ins instance segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ hooks via `callbacks=` and built-in experiment loggers via `loggers=`
     <tr><td>RT-DETRv2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>RT-DETRv4</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>PicoDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>RTMDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>RTMDet</td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>EC</td><td>✓</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>MobileNetV4</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>ConvNeXt</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -133,12 +133,15 @@ Used for: RepConv fuse / re-parameterization logic
 mmdetection (OpenMMLab)
 --------------------------------------------------------------------
 Source: https://github.com/open-mmlab/mmdetection
+Commit: cfd5d3a985b0249de009b67d04f37263e11cdf3d
 License: Apache License 2.0
 Copyright (c) OpenMMLab. All rights reserved.
 Used for: RTMDet model family (libreyolo/models/rtmdet/): architecture
-          port in nn.py; QualityFocalLoss, GIoULoss,
+          port in nn.py, including the RTMDet-Ins head and mask decoder;
+          QualityFocalLoss, GIoULoss,
           DynamicSoftLabelAssigner and MlvlPointGenerator in loss.py.
-          Published RTMDet COCO weights were trained with mmdetection.
+          Published RTMDet and RTMDet-Ins COCO weights were trained with
+          mmdetection.
 
 --------------------------------------------------------------------
 PicoDet (PaddleDetection / Picodet_Pytorch)

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -264,7 +264,7 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 | `rtdetr`    | `("detect",)` (default)             | detect | detect-only |
 | `rtdetrv2`  | `("detect",)` (default)             | detect | detect-only |
 | `rtdetrv4`  | `("detect",)` (default)             | detect | detect-only |
-| `rtmdet`    | `("detect",)` (default)             | detect | detect-only; training is gated experimental (`allow_experimental=True`) |
+| `rtmdet`    | `("detect", "segment")` (default: detect) | detect | RTMDet-Ins uses `-seg`; detect training is gated experimental, segment training is not implemented |
 | `picodet`   | `("detect",)` (default)             | detect | detect-only |
 | `rfdetr`    | `("detect", "segment", "pose", "obb")` | detect | seg uses smaller sizes; pose/OBB use detect sizes |
 | `dinov2`    | `("semantic", "classify")`          | semantic | DINOv2 backbone + task head (semantic dense head at 518 / classify linear probe at 224); NOT the RF-DETR detector |

--- a/libreyolo/models/rtmdet/NOTICE
+++ b/libreyolo/models/rtmdet/NOTICE
@@ -1,0 +1,20 @@
+LibreRTMDet third-party attribution
+====================================
+
+The RTMDet detection and RTMDet-Ins instance-segmentation architecture,
+dynamic mask decoder, and official COCO checkpoints originate from:
+
+    Repository: https://github.com/open-mmlab/mmdetection
+    Commit:     cfd5d3a985b0249de009b67d04f37263e11cdf3d
+    Files:      mmdet/models/dense_heads/rtmdet_head.py
+                mmdet/models/dense_heads/rtmdet_ins_head.py
+                mmdet/configs/rtmdet/
+    License:    Apache License 2.0
+    Copyright:  Copyright (c) OpenMMLab. All rights reserved.
+
+LibreYOLO's module names follow the Apache-2.0 upstream so official state
+dictionaries load through a syntactic bbox_head-to-head rename. No code from
+the separately licensed mmyolo project was consulted or used for this port.
+
+Official RTMDet-Ins COCO mask AP references at 640 pixels are 35.4, 38.7,
+42.1, 43.7, and 44.6 for tiny, small, medium, large, and extra-large.

--- a/libreyolo/models/rtmdet/__init__.py
+++ b/libreyolo/models/rtmdet/__init__.py
@@ -1,4 +1,4 @@
-"""LibreRTMDet family: CSPNeXt + CSPNeXtPAFPN + RTMDetSepBNHead, point-based YOLO-grid detector."""
+"""LibreRTMDet detection and RTMDet-Ins instance-segmentation family."""
 
 from .model import LibreRTMDet
 

--- a/libreyolo/models/rtmdet/convert.py
+++ b/libreyolo/models/rtmdet/convert.py
@@ -1,4 +1,4 @@
-"""Upstream RTMDet checkpoint key remapping.
+"""Upstream RTMDet and RTMDet-Ins checkpoint key remapping.
 
 Upstream mm-series RTMDet checkpoints name the detection head ``bbox_head``
 where LibreRTMDet uses ``head``, and carry normalization constants under
@@ -20,7 +20,11 @@ DROP_PREFIXES = ("data_preprocessor.",)
 
 
 def is_upstream_state_dict(state_dict: dict) -> bool:
-    """True for mm-series ``bbox_head`` naming (vs LibreRTMDet's ``head``)."""
+    """True for mm-series ``bbox_head`` naming (vs LibreRTMDet's ``head``).
+
+    This covers both detection heads and RTMDet-Ins heads carrying
+    ``rtm_kernel`` and ``mask_head`` tensors.
+    """
     return any(
         k.startswith("bbox_head.") and ("rtm_cls" in k or "rtm_reg" in k)
         for k in state_dict

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -1,11 +1,12 @@
 """LibreRTMDet: BaseModel subclass wiring RTMDet into the LibreYOLO factory.
 
 Port of RTMDet (Lyu et al., 2022) from open-mmlab/mmdetection
-(Apache-2.0). Sizes: t / s / m / l / x. Detection-only in the first PR;
-RTMDet-Ins (segmentation) lands as a follow-up.
+(Apache-2.0). Sizes: t / s / m / l / x. Supports detection and RTMDet-Ins
+instance segmentation inference and validation.
 
-Training is wired but experimental: ``model.train(..., allow_experimental=True)``.
-Inference is bit-equivalent to upstream mmdet on the same checkpoint.
+Detection training is wired but experimental via ``allow_experimental=True``.
+RTMDet-Ins training is not implemented. Inference is compatible with official
+mmdetection checkpoints.
 """
 
 from __future__ import annotations
@@ -32,7 +33,7 @@ _TRAIN_DEFAULTS = RTMDetConfig()
 
 
 class LibreRTMDet(BaseModel):
-    """RTMDet detector (CSPNeXt backbone + CSPNeXtPAFPN neck + decoupled SepBN head).
+    """RTMDet detection and RTMDet-Ins instance segmentation.
 
     Args:
         model_path: path to a LibreRTMDet weight file, or None for a fresh model.
@@ -44,13 +45,19 @@ class LibreRTMDet(BaseModel):
 
         >>> model = LibreYOLO("LibreRTMDett.pt")
         >>> result = model("image.jpg", save=True)
+        >>> segmenter = LibreYOLO("LibreRTMDett-seg.pt")
+        >>> masks = segmenter("image.jpg")[0].masks
     """
 
     FAMILY = "rtmdet"
     FILENAME_PREFIX = "LibreRTMDet"
     INPUT_SIZES = {"t": 640, "s": 640, "m": 640, "l": 640, "x": 640}
-    SUPPORTED_TASKS = ("detect",)
+    SUPPORTED_TASKS = ("detect", "segment")
     DEFAULT_TASK = "detect"
+    TASK_INPUT_SIZES = {
+        "detect": INPUT_SIZES,
+        "segment": INPUT_SIZES,
+    }
     TRAIN_CONFIG = RTMDetConfig
     val_preprocessor_class = RTMDetValPreprocessor
 
@@ -63,9 +70,7 @@ class LibreRTMDet(BaseModel):
         # `rtm_cls` / `rtm_reg` are unique to RTMDet (no other family in the
         # registry uses these prefixes). Both `bbox_head.rtm_cls` (upstream)
         # and `head.rtm_cls` (LibreRTMDet checkpoints) match.
-        return any(
-            "rtm_cls" in k or "rtm_reg" in k for k in weights_dict
-        )
+        return any("rtm_cls" in k or "rtm_reg" in k for k in weights_dict)
 
     @classmethod
     def detect_size(cls, weights_dict: dict) -> Optional[str]:
@@ -82,6 +87,12 @@ class LibreRTMDet(BaseModel):
         for key in ("head.rtm_cls.0.weight", "bbox_head.rtm_cls.0.weight"):
             if key in weights_dict:
                 return int(weights_dict[key].shape[0])
+        return None
+
+    @classmethod
+    def detect_checkpoint_task(cls, weights_dict: dict) -> Optional[str]:
+        if any("rtm_kernel" in key or ".mask_head." in key for key in weights_dict):
+            return "segment"
         return None
 
     @classmethod
@@ -103,6 +114,7 @@ class LibreRTMDet(BaseModel):
         size: str = "s",
         nb_classes: int = 80,
         device: str = "auto",
+        task: str | None = None,
         **kwargs,
     ):
         super().__init__(
@@ -110,6 +122,7 @@ class LibreRTMDet(BaseModel):
             size=size,
             nb_classes=nb_classes,
             device=device,
+            task=task,
             **kwargs,
         )
         if isinstance(model_path, str):
@@ -120,14 +133,43 @@ class LibreRTMDet(BaseModel):
     # =========================================================================
 
     def _init_model(self) -> nn.Module:
-        return LibreRTMDetModel(size=self.size, nc=self.nb_classes)
+        return LibreRTMDetModel(
+            size=self.size,
+            nc=self.nb_classes,
+            enable_mask_head=self.task == "segment",
+        )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:
-        return {
+        layers = {
             "backbone": self.model.backbone,
             "neck": self.model.neck,
             "head": self.model.head,
         }
+        if self.task == "segment":
+            layers["mask_head"] = self.model.head.mask_head
+        return layers
+
+    @property
+    def _is_segmentation(self) -> bool:
+        return self.task == "segment"
+
+    def _validate_loaded_state_dict_for_task(
+        self,
+        state_dict: dict,
+        checkpoint: dict | None = None,
+    ) -> None:
+        detected_task = self.detect_checkpoint_task(state_dict)
+        if detected_task == "segment" and self.task != "segment":
+            raise RuntimeError(
+                "RTMDet-Ins segmentation checkpoints must be loaded with "
+                "task='segment' or a '-seg' filename suffix."
+            )
+        if self.task == "segment" and detected_task is None:
+            raise RuntimeError(
+                "This RTMDet checkpoint has no instance-segmentation mask head, "
+                "but the model was initialized for task='segment'. Use an "
+                "RTMDet-Ins '-seg' checkpoint."
+            )
 
     def _strict_loading(self) -> bool:
         # share_conv aliasing means the saved state_dict has fewer keys than the
@@ -239,6 +281,11 @@ class LibreRTMDet(BaseModel):
                 ('tensorboard', 'mlflow', 'wandb'), a configured logger
                 instance, or an iterable mixing both.
         """
+        if self.task == "segment":
+            raise NotImplementedError(
+                "RTMDet-Ins training is not implemented yet. Instance "
+                "segmentation currently supports inference and validation."
+            )
         if not allow_experimental:
             raise RuntimeError(
                 "RTMDet training is experimental. The loss + assigner follow "
@@ -261,7 +308,9 @@ class LibreRTMDet(BaseModel):
 
         try:
             data_config = load_data_config(
-                data, autodownload=True, allow_scripts=allow_download_scripts,
+                data,
+                autodownload=True,
+                allow_scripts=allow_download_scripts,
             )
             data = data_config.get("yaml_file", data)
         except Exception as e:

--- a/libreyolo/models/rtmdet/nn.py
+++ b/libreyolo/models/rtmdet/nn.py
@@ -24,6 +24,7 @@ from typing import Sequence, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 # IMPORTANT: the mmdet RTMDet config sets ``norm_cfg=dict(type='SyncBN')`` and
 # does NOT pass ``momentum`` / ``eps``. SyncBN therefore uses PyTorch defaults,
@@ -207,7 +208,10 @@ class SPPBottleneck(nn.Module):
         mid_channels = in_channels // 2
         self.conv1 = ConvBNAct(in_channels, mid_channels, 1)
         self.poolings = nn.ModuleList(
-            [nn.MaxPool2d(kernel_size=ks, stride=1, padding=ks // 2) for ks in kernel_sizes]
+            [
+                nn.MaxPool2d(kernel_size=ks, stride=1, padding=ks // 2)
+                for ks in kernel_sizes
+            ]
         )
         conv2_channels = mid_channels * (len(kernel_sizes) + 1)
         self.conv2 = ConvBNAct(conv2_channels, out_channels, 1)
@@ -306,7 +310,9 @@ class CSPNeXtPAFPN(nn.Module):
         self.reduce_layers = nn.ModuleList()
         self.top_down_blocks = nn.ModuleList()
         for idx in range(n - 1, 0, -1):
-            self.reduce_layers.append(ConvBNAct(self.in_channels[idx], self.in_channels[idx - 1], 1))
+            self.reduce_layers.append(
+                ConvBNAct(self.in_channels[idx], self.in_channels[idx - 1], 1)
+            )
             self.top_down_blocks.append(
                 CSPLayer(
                     self.in_channels[idx - 1] * 2,
@@ -322,7 +328,11 @@ class CSPNeXtPAFPN(nn.Module):
         self.downsamples = nn.ModuleList()
         self.bottom_up_blocks = nn.ModuleList()
         for idx in range(n - 1):
-            self.downsamples.append(ConvBNAct(self.in_channels[idx], self.in_channels[idx], 3, stride=2, padding=1))
+            self.downsamples.append(
+                ConvBNAct(
+                    self.in_channels[idx], self.in_channels[idx], 3, stride=2, padding=1
+                )
+            )
             self.bottom_up_blocks.append(
                 CSPLayer(
                     self.in_channels[idx] * 2,
@@ -335,7 +345,10 @@ class CSPNeXtPAFPN(nn.Module):
             )
 
         self.out_convs = nn.ModuleList(
-            [ConvBNAct(self.in_channels[i], out_channels, 3, padding=1) for i in range(n)]
+            [
+                ConvBNAct(self.in_channels[i], out_channels, 3, padding=1)
+                for i in range(n)
+            ]
         )
 
     def forward(self, inputs: Tuple[torch.Tensor, ...]) -> Tuple[torch.Tensor, ...]:
@@ -350,7 +363,9 @@ class CSPNeXtPAFPN(nn.Module):
             feat_high = self.reduce_layers[i](feat_high)
             inner_outs[0] = feat_high
             upsample_feat = self.upsample(feat_high)
-            inner_out = self.top_down_blocks[i](torch.cat([upsample_feat, feat_low], dim=1))
+            inner_out = self.top_down_blocks[i](
+                torch.cat([upsample_feat, feat_low], dim=1)
+            )
             inner_outs.insert(0, inner_out)
 
         # bottom-up
@@ -359,7 +374,9 @@ class CSPNeXtPAFPN(nn.Module):
             feat_low = outs[-1]
             feat_high = inner_outs[idx + 1]
             downsample_feat = self.downsamples[idx](feat_low)
-            out = self.bottom_up_blocks[idx](torch.cat([downsample_feat, feat_high], dim=1))
+            out = self.bottom_up_blocks[idx](
+                torch.cat([downsample_feat, feat_high], dim=1)
+            )
             outs.append(out)
 
         # final 3x3 convs to out_channels
@@ -417,17 +434,27 @@ class RTMDetSepBNHead(nn.Module):
             reg_per_level = nn.ModuleList()
             for i in range(stacked_convs):
                 chn = in_channels if i == 0 else feat_channels
-                cls_per_level.append(ConvBNAct(chn, feat_channels, 3, stride=1, padding=1))
-                reg_per_level.append(ConvBNAct(chn, feat_channels, 3, stride=1, padding=1))
+                cls_per_level.append(
+                    ConvBNAct(chn, feat_channels, 3, stride=1, padding=1)
+                )
+                reg_per_level.append(
+                    ConvBNAct(chn, feat_channels, 3, stride=1, padding=1)
+                )
             self.cls_convs.append(cls_per_level)
             self.reg_convs.append(reg_per_level)
 
         pad = pred_kernel_size // 2
         self.rtm_cls = nn.ModuleList(
-            [nn.Conv2d(feat_channels, num_classes, pred_kernel_size, padding=pad) for _ in range(n_levels)]
+            [
+                nn.Conv2d(feat_channels, num_classes, pred_kernel_size, padding=pad)
+                for _ in range(n_levels)
+            ]
         )
         self.rtm_reg = nn.ModuleList(
-            [nn.Conv2d(feat_channels, 4, pred_kernel_size, padding=pad) for _ in range(n_levels)]
+            [
+                nn.Conv2d(feat_channels, 4, pred_kernel_size, padding=pad)
+                for _ in range(n_levels)
+            ]
         )
 
         if share_conv:
@@ -511,6 +538,198 @@ class RTMDetSepBNHead(nn.Module):
         return tuple(cls_scores), tuple(bbox_preds)
 
 
+class MaskFeatModule(nn.Module):
+    """Fuse the three FPN levels into the stride-8 RTMDet-Ins mask feature."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        feat_channels: int,
+        num_levels: int = 3,
+        num_prototypes: int = 8,
+        stacked_convs: int = 4,
+    ):
+        super().__init__()
+        self.num_levels = num_levels
+        self.fusion_conv = nn.Conv2d(num_levels * in_channels, in_channels, 1)
+        convs = []
+        for i in range(stacked_convs):
+            in_c = in_channels if i == 0 else feat_channels
+            convs.append(ConvBNAct(in_c, feat_channels, 3, padding=1))
+        self.stacked_convs = nn.Sequential(*convs)
+        self.projection = nn.Conv2d(feat_channels, num_prototypes, 1)
+
+    def forward(self, features: Tuple[torch.Tensor, ...]) -> torch.Tensor:
+        size = features[0].shape[-2:]
+        fused = [features[0]]
+        for feature in features[1 : self.num_levels]:
+            fused.append(F.interpolate(feature, size=size, mode="bilinear"))
+        return self.projection(
+            self.stacked_convs(self.fusion_conv(torch.cat(fused, dim=1)))
+        )
+
+
+class RTMDetInsSepBNHead(nn.Module):
+    """RTMDet-Ins box, class, dynamic-kernel, and mask-feature head.
+
+    The module layout follows open-mmlab/mmdetection's Apache-2.0
+    ``RTMDetInsSepBNHead`` so official checkpoints need only the syntactic
+    ``bbox_head`` to ``head`` key rename.
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        in_channels: int,
+        feat_channels: int,
+        strides: Sequence[int] = (8, 16, 32),
+        stacked_convs: int = 2,
+        share_conv: bool = True,
+        pred_kernel_size: int = 1,
+        num_prototypes: int = 8,
+        num_dyconvs: int = 3,
+        dyconv_channels: int = 8,
+    ):
+        super().__init__()
+        self.num_classes = num_classes
+        self.in_channels = in_channels
+        self.feat_channels = feat_channels
+        self.strides = list(strides)
+        self.stacked_convs = stacked_convs
+        self.share_conv = share_conv
+        self.pred_kernel_size = pred_kernel_size
+        self.num_prototypes = num_prototypes
+        self.num_dyconvs = num_dyconvs
+        self.dyconv_channels = dyconv_channels
+        self.export: bool = False
+
+        weight_nums = []
+        bias_nums = []
+        for i in range(num_dyconvs):
+            if i == 0:
+                weight_nums.append((num_prototypes + 2) * dyconv_channels)
+                bias_nums.append(dyconv_channels)
+            elif i == num_dyconvs - 1:
+                weight_nums.append(dyconv_channels)
+                bias_nums.append(1)
+            else:
+                weight_nums.append(dyconv_channels * dyconv_channels)
+                bias_nums.append(dyconv_channels)
+        self.weight_nums = weight_nums
+        self.bias_nums = bias_nums
+        self.num_gen_params = sum(weight_nums) + sum(bias_nums)
+
+        n_levels = len(self.strides)
+        self.cls_convs = nn.ModuleList()
+        self.reg_convs = nn.ModuleList()
+        self.kernel_convs = nn.ModuleList()
+        for _ in range(n_levels):
+            cls_per_level = nn.ModuleList()
+            kernel_per_level = nn.ModuleList()
+            for i in range(stacked_convs):
+                chn = in_channels if i == 0 else feat_channels
+                cls_per_level.append(
+                    ConvBNAct(chn, feat_channels, 3, stride=1, padding=1)
+                )
+                kernel_per_level.append(
+                    ConvBNAct(chn, feat_channels, 3, stride=1, padding=1)
+                )
+            self.cls_convs.append(cls_per_level)
+            # The published RTMDet-Ins head intentionally uses the same tower
+            # modules for classification and regression.
+            self.reg_convs.append(cls_per_level)
+            self.kernel_convs.append(kernel_per_level)
+
+        pad = pred_kernel_size // 2
+        self.rtm_cls = nn.ModuleList(
+            [
+                nn.Conv2d(feat_channels, num_classes, pred_kernel_size, padding=pad)
+                for _ in range(n_levels)
+            ]
+        )
+        self.rtm_reg = nn.ModuleList(
+            [
+                nn.Conv2d(feat_channels, 4, pred_kernel_size, padding=pad)
+                for _ in range(n_levels)
+            ]
+        )
+        self.rtm_kernel = nn.ModuleList(
+            [
+                nn.Conv2d(
+                    feat_channels,
+                    self.num_gen_params,
+                    pred_kernel_size,
+                    padding=pad,
+                )
+                for _ in range(n_levels)
+            ]
+        )
+
+        if share_conv:
+            for n in range(1, n_levels):
+                for i in range(stacked_convs):
+                    self.cls_convs[n][i].conv = self.cls_convs[0][i].conv
+                    self.reg_convs[n][i].conv = self.reg_convs[0][i].conv
+
+        self.mask_head = MaskFeatModule(
+            in_channels=in_channels,
+            feat_channels=feat_channels,
+            num_levels=n_levels,
+            num_prototypes=num_prototypes,
+            stacked_convs=4,
+        )
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        import math
+
+        for module in self.modules():
+            if isinstance(module, nn.Conv2d):
+                nn.init.normal_(module.weight, mean=0.0, std=0.01)
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+            elif isinstance(module, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.ones_(module.weight)
+                nn.init.zeros_(module.bias)
+        bias_cls = -math.log((1 - 0.01) / 0.01)
+        for cls_conv, reg_conv in zip(self.rtm_cls, self.rtm_reg):
+            nn.init.constant_(cls_conv.bias, bias_cls)
+            nn.init.constant_(reg_conv.bias, 1.0)
+
+    def forward(self, feats):
+        if self.export:
+            raise NotImplementedError(
+                "RTMDet-Ins export is not supported yet; use native PyTorch "
+                "inference for task='segment'."
+            )
+
+        mask_feat = self.mask_head(feats)
+        cls_scores = []
+        bbox_preds = []
+        kernel_preds = []
+        for idx, feat in enumerate(feats):
+            cls_feat = feat
+            reg_feat = feat
+            kernel_feat = feat
+            for layer in self.cls_convs[idx]:
+                cls_feat = layer(cls_feat)
+            for layer in self.reg_convs[idx]:
+                reg_feat = layer(reg_feat)
+            for layer in self.kernel_convs[idx]:
+                kernel_feat = layer(kernel_feat)
+
+            cls_scores.append(self.rtm_cls[idx](cls_feat))
+            bbox_preds.append(F.relu(self.rtm_reg[idx](reg_feat)) * self.strides[idx])
+            kernel_preds.append(self.rtm_kernel[idx](kernel_feat))
+
+        return (
+            tuple(cls_scores),
+            tuple(bbox_preds),
+            tuple(kernel_preds),
+            mask_feat,
+        )
+
+
 # =============================================================================
 # Per-size table and assembly
 # =============================================================================
@@ -526,15 +745,18 @@ _SIZE_CONFIG = {
 
 
 class LibreRTMDetModel(nn.Module):
-    """Top-level RTMDet detection model: backbone + neck + head."""
+    """Top-level RTMDet detection or instance-segmentation model."""
 
-    def __init__(self, size: str = "s", nc: int = 80):
+    def __init__(self, size: str = "s", nc: int = 80, enable_mask_head: bool = False):
         super().__init__()
         if size not in _SIZE_CONFIG:
-            raise ValueError(f"Unknown RTMDet size {size!r}. Must be one of {list(_SIZE_CONFIG)}.")
+            raise ValueError(
+                f"Unknown RTMDet size {size!r}. Must be one of {list(_SIZE_CONFIG)}."
+            )
         deepen, widen, neck_in, neck_out, num_csp, exp_on_reg = _SIZE_CONFIG[size]
         self.size = size
         self.nc = nc
+        self.enable_mask_head = enable_mask_head
 
         self.backbone = CSPNeXt(
             deepen_factor=deepen,
@@ -549,16 +771,19 @@ class LibreRTMDetModel(nn.Module):
             num_csp_blocks=num_csp,
             expand_ratio=0.5,
         )
-        self.head = RTMDetSepBNHead(
+        head_cls = RTMDetInsSepBNHead if enable_mask_head else RTMDetSepBNHead
+        head_kwargs = dict(
             num_classes=nc,
             in_channels=neck_out,
             feat_channels=neck_out,
             strides=(8, 16, 32),
             stacked_convs=2,
             share_conv=True,
-            exp_on_reg=exp_on_reg,
             pred_kernel_size=1,
         )
+        if not enable_mask_head:
+            head_kwargs["exp_on_reg"] = exp_on_reg
+        self.head = head_cls(**head_kwargs)
 
     def forward(self, x: torch.Tensor):
         feats = self.backbone(x)

--- a/libreyolo/models/rtmdet/nn.py
+++ b/libreyolo/models/rtmdet/nn.py
@@ -723,6 +723,9 @@ class RTMDetInsSepBNHead(nn.Module):
                 kernel_feat = layer(kernel_feat)
 
             cls_scores.append(self.rtm_cls[idx](cls_feat))
+            # Unlike the separate detection head, the official RTMDet-Ins
+            # head uses relu(raw) * stride for every size, including m/l/x.
+            # The exp_on_reg entries in _SIZE_CONFIG apply only to detection.
             bbox_preds.append(F.relu(self.rtm_reg[idx](reg_feat)) * self.strides[idx])
             kernel_preds.append(self.rtm_kernel[idx](kernel_feat))
 

--- a/libreyolo/models/rtmdet/nn.py
+++ b/libreyolo/models/rtmdet/nn.py
@@ -563,7 +563,11 @@ class MaskFeatModule(nn.Module):
         size = features[0].shape[-2:]
         fused = [features[0]]
         for feature in features[1 : self.num_levels]:
-            fused.append(F.interpolate(feature, size=size, mode="bilinear"))
+            fused.append(
+                F.interpolate(
+                    feature, size=size, mode="bilinear", align_corners=False
+                )
+            )
         return self.projection(
             self.stacked_convs(self.fusion_conv(torch.cat(fused, dim=1)))
         )

--- a/libreyolo/postprocess/rtmdet.py
+++ b/libreyolo/postprocess/rtmdet.py
@@ -75,6 +75,8 @@ def postprocess(
     Returns boxes in original-image coordinates (after letterbox inverse).
     """
     if len(outputs) == 4:
+        # RTMDet-Ins uses nms_pre=1000 in every official COCO size config,
+        # while RTMDet detection uses 30000. Preserve a smaller caller value.
         return _postprocess_segment(
             outputs,
             conf_thres=conf_thres,
@@ -350,7 +352,10 @@ def _postprocess_segment(
 
     mask_logits = _decode_masks(mask_feats[0], kernels, priors)
     mask_logits = F.interpolate(
-        mask_logits.unsqueeze(0), scale_factor=8, mode="bilinear"
+        mask_logits.unsqueeze(0),
+        scale_factor=8,
+        mode="bilinear",
+        align_corners=False,
     )
     if original_size is not None:
         orig_w, orig_h = original_size

--- a/libreyolo/postprocess/rtmdet.py
+++ b/libreyolo/postprocess/rtmdet.py
@@ -11,16 +11,18 @@ everything here for backward compatibility.
 
 from __future__ import annotations
 
+import contextlib
+import math
 from typing import List, Tuple
 
 import torch
+import torch.nn.functional as F
+import torchvision.ops
 
 from .common import postprocess_detections
 
 
-def _make_grid_priors(
-    feats: List[torch.Tensor], strides: List[int]
-) -> torch.Tensor:
+def _make_grid_priors(feats: List[torch.Tensor], strides: List[int]) -> torch.Tensor:
     """Build (N, 2) grid of pixel-space prior points for all FPN levels.
 
     Matches mmdet's ``MlvlPointGenerator(offset=0)`` as configured in the
@@ -54,7 +56,7 @@ def _distance2bbox(points: torch.Tensor, distance: torch.Tensor) -> torch.Tensor
 
 
 def postprocess(
-    outputs: Tuple[Tuple[torch.Tensor, ...], Tuple[torch.Tensor, ...]],
+    outputs: tuple,
     conf_thres: float = 0.25,
     iou_thres: float = 0.65,
     input_size: int = 640,
@@ -72,6 +74,19 @@ def postprocess(
 
     Returns boxes in original-image coordinates (after letterbox inverse).
     """
+    if len(outputs) == 4:
+        return _postprocess_segment(
+            outputs,
+            conf_thres=conf_thres,
+            iou_thres=iou_thres,
+            input_size=input_size,
+            original_size=original_size,
+            ratio=ratio,
+            max_det=max_det,
+            strides=strides,
+            nms_pre=min(nms_pre, 1000),
+        )
+
     cls_scores, bbox_preds = outputs
 
     # Match mmdet's ``_predict_by_feat_single`` (mmdetection/mmdet/models/dense_heads/
@@ -88,20 +103,20 @@ def postprocess(
     for cls, reg, stride in zip(cls_scores, bbox_preds, strides):
         b, c, h, w = cls.shape
         scores_lvl = cls[0].permute(1, 2, 0).reshape(-1, c).sigmoid()  # (H*W, C)
-        dist_lvl = reg[0].permute(1, 2, 0).reshape(-1, 4)               # (H*W, 4)
+        dist_lvl = reg[0].permute(1, 2, 0).reshape(-1, 4)  # (H*W, 4)
 
         # Build priors for this level only (offset=0, cell corners).
         device, dtype = scores_lvl.device, scores_lvl.dtype
         sx = torch.arange(w, device=device, dtype=dtype) * stride
         sy = torch.arange(h, device=device, dtype=dtype) * stride
         yy, xx = torch.meshgrid(sy, sx, indexing="ij")
-        points_lvl = torch.stack([xx, yy], dim=-1).reshape(-1, 2)       # (H*W, 2)
+        points_lvl = torch.stack([xx, yy], dim=-1).reshape(-1, 2)  # (H*W, 2)
 
         valid_mask = scores_lvl > conf_thres
         if not valid_mask.any():
             continue
-        valid_idxs = torch.nonzero(valid_mask, as_tuple=False)           # (M, 2)
-        flat_scores = scores_lvl[valid_mask]                             # (M,)
+        valid_idxs = torch.nonzero(valid_mask, as_tuple=False)  # (M, 2)
+        flat_scores = scores_lvl[valid_mask]  # (M,)
 
         num_topk = min(nms_pre, flat_scores.numel())
         sorted_scores, sort_idxs = flat_scores.sort(descending=True)
@@ -161,3 +176,200 @@ def postprocess(
         max_det=max_det,
         letterbox=False,
     )
+
+
+def _empty_segment_result(
+    original_size: Tuple[int, int] | None,
+    input_size: int,
+) -> dict:
+    if original_size is None:
+        h = w = input_size
+    else:
+        w, h = original_size
+    return {
+        "boxes": torch.empty((0, 4), dtype=torch.float32),
+        "scores": torch.empty(0, dtype=torch.float32),
+        "classes": torch.empty(0, dtype=torch.int64),
+        "masks": torch.empty((0, h, w), dtype=torch.bool),
+        "num_detections": 0,
+    }
+
+
+def _parse_dynamic_params(
+    kernels: torch.Tensor,
+    weight_nums: Tuple[int, ...] = (80, 64, 8),
+    bias_nums: Tuple[int, ...] = (8, 8, 1),
+    dyconv_channels: int = 8,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Split the 169 RTMDet-Ins parameters into grouped 1x1 convolutions."""
+    num_inst = kernels.shape[0]
+    pieces = list(torch.split(kernels, weight_nums + bias_nums, dim=1))
+    weights = pieces[: len(weight_nums)]
+    biases = pieces[len(weight_nums) :]
+    for i in range(len(weights)):
+        if i < len(weights) - 1:
+            weights[i] = weights[i].reshape(num_inst * dyconv_channels, -1, 1, 1)
+            biases[i] = biases[i].reshape(num_inst * dyconv_channels)
+        else:
+            weights[i] = weights[i].reshape(num_inst, -1, 1, 1)
+            biases[i] = biases[i].reshape(num_inst)
+    return weights, biases
+
+
+def _decode_masks(
+    mask_feat: torch.Tensor,
+    kernels: torch.Tensor,
+    priors: torch.Tensor,
+) -> torch.Tensor:
+    """Apply the per-instance dynamic convolution network in fp32."""
+    num_inst = priors.shape[0]
+    h, w = mask_feat.shape[-2:]
+    if num_inst == 0:
+        return mask_feat.new_empty((0, h, w), dtype=torch.float32)
+
+    device_type = mask_feat.device.type
+    autocast = (
+        torch.autocast(device_type=device_type, enabled=False)
+        if device_type in {"cpu", "cuda"}
+        else contextlib.nullcontext()
+    )
+    with autocast:
+        mask_feat = mask_feat.float()
+        kernels = kernels.float()
+        priors = priors.float()
+
+        xs = torch.arange(w, device=mask_feat.device, dtype=torch.float32) * 8
+        ys = torch.arange(h, device=mask_feat.device, dtype=torch.float32) * 8
+        yy, xx = torch.meshgrid(ys, xs, indexing="ij")
+        coords = torch.stack((xx, yy), dim=-1).reshape(1, -1, 2)
+        points = priors[:, :2].reshape(-1, 1, 2)
+        relative = (points - coords).permute(0, 2, 1)
+        relative = relative / (priors[:, 2].reshape(-1, 1, 1) * 8)
+        relative = relative.reshape(num_inst, 2, h, w)
+
+        dynamic_input = torch.cat(
+            (relative, mask_feat.unsqueeze(0).repeat(num_inst, 1, 1, 1)),
+            dim=1,
+        ).reshape(1, -1, h, w)
+        weights, biases = _parse_dynamic_params(kernels)
+        for i, (weight, bias) in enumerate(zip(weights, biases)):
+            dynamic_input = F.conv2d(dynamic_input, weight, bias=bias, groups=num_inst)
+            if i < len(weights) - 1:
+                dynamic_input = F.relu(dynamic_input)
+        return dynamic_input.reshape(num_inst, h, w)
+
+
+def _postprocess_segment(
+    outputs: tuple,
+    *,
+    conf_thres: float,
+    iou_thres: float,
+    input_size: int,
+    original_size: Tuple[int, int] | None,
+    ratio: float,
+    max_det: int,
+    strides: Tuple[int, ...],
+    nms_pre: int,
+) -> dict:
+    """Decode RTMDet-Ins boxes, run NMS, then decode survivor masks."""
+    cls_scores, bbox_preds, kernel_preds, mask_feats = outputs
+    scores_all = []
+    classes_all = []
+    distances_all = []
+    priors_all = []
+    kernels_all = []
+
+    for cls, reg, kernel, stride in zip(cls_scores, bbox_preds, kernel_preds, strides):
+        _, num_classes, h, w = cls.shape
+        scores = cls[0].permute(1, 2, 0).reshape(-1, num_classes).sigmoid()
+        distances = reg[0].permute(1, 2, 0).reshape(-1, 4)
+        kernels = kernel[0].permute(1, 2, 0).reshape(-1, kernel.shape[1])
+
+        xs = torch.arange(w, device=cls.device, dtype=cls.dtype) * stride
+        ys = torch.arange(h, device=cls.device, dtype=cls.dtype) * stride
+        yy, xx = torch.meshgrid(ys, xs, indexing="ij")
+        points = torch.stack((xx, yy), dim=-1).reshape(-1, 2)
+        strides_lvl = torch.full_like(points, stride)
+        priors = torch.cat((points, strides_lvl), dim=1)
+
+        valid = scores > conf_thres
+        if not valid.any():
+            continue
+        pairs = torch.nonzero(valid, as_tuple=False)
+        values = scores[valid]
+        count = min(nms_pre, values.numel())
+        values, order = values.sort(descending=True)
+        pairs = pairs[order[:count]]
+        loc_idx = pairs[:, 0]
+
+        scores_all.append(values[:count])
+        classes_all.append(pairs[:, 1])
+        distances_all.append(distances[loc_idx])
+        priors_all.append(priors[loc_idx])
+        kernels_all.append(kernels[loc_idx])
+
+    if not scores_all:
+        return _empty_segment_result(original_size, input_size)
+
+    scores = torch.cat(scores_all)
+    classes = torch.cat(classes_all)
+    distances = torch.cat(distances_all)
+    priors = torch.cat(priors_all)
+    kernels = torch.cat(kernels_all)
+    boxes = _distance2bbox(priors[:, :2], distances)
+    boxes[:, [0, 2]].clamp_(0, input_size)
+    boxes[:, [1, 3]].clamp_(0, input_size)
+
+    finite = (
+        torch.isfinite(boxes).all(dim=1)
+        & torch.isfinite(scores)
+        & torch.isfinite(kernels).all(dim=1)
+    )
+    widths = boxes[:, 2] - boxes[:, 0]
+    heights = boxes[:, 3] - boxes[:, 1]
+    valid = finite & (widths > 0) & (heights > 0)
+    if not valid.all():
+        boxes = boxes[valid]
+        scores = scores[valid]
+        classes = classes[valid]
+        priors = priors[valid]
+        kernels = kernels[valid]
+    if boxes.numel() == 0:
+        return _empty_segment_result(original_size, input_size)
+
+    boxes = boxes.float()
+    scores = scores.float()
+    keep = torchvision.ops.batched_nms(boxes, scores, classes, iou_thres)
+    # The official RTMDet-Ins COCO recipe keeps at most 100 masks.
+    keep = keep[: min(max_det, 100)]
+    boxes = boxes[keep]
+    scores = scores[keep]
+    classes = classes[keep]
+    priors = priors[keep]
+    kernels = kernels[keep]
+
+    mask_logits = _decode_masks(mask_feats[0], kernels, priors)
+    mask_logits = F.interpolate(
+        mask_logits.unsqueeze(0), scale_factor=8, mode="bilinear"
+    )
+    if original_size is not None:
+        orig_w, orig_h = original_size
+        resized = math.ceil(mask_logits.shape[-1] / ratio)
+        mask_logits = F.interpolate(
+            mask_logits,
+            size=(resized, resized),
+            mode="bilinear",
+            align_corners=False,
+        )[..., :orig_h, :orig_w]
+        boxes = boxes / ratio
+        boxes[:, [0, 2]].clamp_(0, orig_w)
+        boxes[:, [1, 3]].clamp_(0, orig_h)
+
+    masks = mask_logits.sigmoid().squeeze(0) > 0.5
+    return {
+        "boxes": boxes.detach().cpu(),
+        "scores": scores.detach().cpu(),
+        "classes": classes.detach().cpu(),
+        "masks": masks.detach().cpu(),
+        "num_detections": int(boxes.shape[0]),
+    }

--- a/tests/unit/test_autoconvert_families.py
+++ b/tests/unit/test_autoconvert_families.py
@@ -108,6 +108,17 @@ def _rtmdet_s_upstream():
     }
 
 
+def _rtmdet_ins_s_upstream():
+    sd = _rtmdet_s_upstream()
+    sd.update(
+        {
+            "bbox_head.rtm_kernel.0.weight": torch.zeros(169, 128, 1, 1),
+            "bbox_head.mask_head.projection.weight": torch.zeros(8, 128, 1, 1),
+        }
+    )
+    return sd
+
+
 def _rtdetr_r18_upstream(v2: bool = False):
     sd = {
         "backbone.res_layers.0.blocks.0.conv1.weight": torch.zeros(4, 4, 3, 3),
@@ -188,6 +199,7 @@ CASES = [
     ("yolonas-pose", lambda: _yolonas_s(pose=True), _wrap_ema_net, "yolo_nas_pose_s_coco.pth", "yolonas", "LibreYOLONAS", "s", "pose", 1),
     ("picodet", _picodet_s_upstream, _wrap_state_dict, "picodet_s_320.pth", "picodet", "LibrePICODET", "s", "detect", 80),
     ("rtmdet", _rtmdet_s_upstream, _wrap_ema_state_dict, "rtmdet_s_coco.pth", "rtmdet", "LibreRTMDet", "s", "detect", 80),
+    ("rtmdet-ins", _rtmdet_ins_s_upstream, _wrap_ema_state_dict, "rtmdet-ins_s_coco.pth", "rtmdet", "LibreRTMDet", "s", "segment", 80),
     ("rtdetr-r18", _rtdetr_r18_upstream, _wrap_ema_module, "rtdetr_r18vd_coco.pth", "rtdetr", "LibreRTDETR", "r18", "detect", 80),
     ("rtdetrv2-r18", lambda: _rtdetr_r18_upstream(v2=True), _wrap_ema_module, "rtdetrv2_r18vd_120e_coco.pth", "rtdetrv2", "LibreRTDETRv2", "r18", "detect", 80),
     ("rtdetr-hgnetv2-l", _rtdetr_hgnetv2_l_upstream, _wrap_ema_module, "rtdetrv2_hgnetv2_l_6x_coco.pth", "rtdetr", "LibreRTDETR", "l", "detect", 80),

--- a/tests/unit/test_rtmdet_ins.py
+++ b/tests/unit/test_rtmdet_ins.py
@@ -51,6 +51,14 @@ def test_rtmdet_ins_forward_shapes_and_tower_aliasing():
     assert mask_feat.shape == (1, 8, 8, 8)
 
 
+@pytest.mark.parametrize("size", ["t", "s", "m", "l", "x"])
+def test_rtmdet_ins_all_sizes_use_upstream_relu_box_decode(size):
+    """RTMDet-Ins never uses detection's m/l/x exponential box decode."""
+    model = LibreRTMDetModel(size=size, nc=1, enable_mask_head=True)
+    assert isinstance(model.head, RTMDetInsSepBNHead)
+    assert not hasattr(model.head, "exp_on_reg")
+
+
 def test_rtmdet_ins_postprocess_decodes_masks_after_nms():
     cls = tuple(torch.full((1, 1, size, size), -20.0) for size in (2, 1, 1))
     reg = tuple(torch.full((1, 4, size, size), 4.0) for size in (2, 1, 1))

--- a/tests/unit/test_rtmdet_ins.py
+++ b/tests/unit/test_rtmdet_ins.py
@@ -1,0 +1,140 @@
+"""RTMDet-Ins instance-segmentation unit tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo import LibreRTMDet, LibreYOLO
+from libreyolo.models.rtmdet.nn import LibreRTMDetModel, RTMDetInsSepBNHead
+from libreyolo.models.rtmdet.utils import postprocess
+from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+
+pytestmark = pytest.mark.unit
+
+
+def _minimal_state(*, segment: bool) -> dict:
+    state = {
+        "backbone.stem.0.conv.weight": torch.zeros(12, 3, 3, 3),
+        "head.rtm_cls.0.weight": torch.zeros(2, 96, 1, 1),
+        "head.rtm_reg.0.weight": torch.zeros(4, 96, 1, 1),
+    }
+    if segment:
+        state["head.rtm_kernel.0.weight"] = torch.zeros(169, 96, 1, 1)
+        state["head.mask_head.projection.weight"] = torch.zeros(8, 96, 1, 1)
+    return state
+
+
+def test_rtmdet_ins_suffix_task_and_download_url():
+    assert LibreRTMDet.SUPPORTED_TASKS == ("detect", "segment")
+    assert LibreRTMDet.detect_task_from_filename("LibreRTMDetm-seg.pt") == "segment"
+    assert LibreRTMDet.detect_checkpoint_task(_minimal_state(segment=True)) == "segment"
+    assert LibreRTMDet.get_download_url("LibreRTMDetm-seg.pt") == (
+        "https://huggingface.co/LibreYOLO/LibreRTMDetm-seg/resolve/main/"
+        "LibreRTMDetm-seg.pt"
+    )
+
+
+def test_rtmdet_ins_forward_shapes_and_tower_aliasing():
+    model = LibreRTMDetModel(size="t", nc=3, enable_mask_head=True).eval()
+    assert isinstance(model.head, RTMDetInsSepBNHead)
+    assert model.head.num_gen_params == 169
+    for level in range(3):
+        assert model.head.reg_convs[level] is model.head.cls_convs[level]
+
+    with torch.no_grad():
+        cls, reg, kernels, mask_feat = model(torch.zeros(1, 3, 64, 64))
+    assert [item.shape[-2:] for item in cls] == [(8, 8), (4, 4), (2, 2)]
+    assert [item.shape[1] for item in reg] == [4, 4, 4]
+    assert [item.shape[1] for item in kernels] == [169, 169, 169]
+    assert mask_feat.shape == (1, 8, 8, 8)
+
+
+def test_rtmdet_ins_postprocess_decodes_masks_after_nms():
+    cls = tuple(torch.full((1, 1, size, size), -20.0) for size in (2, 1, 1))
+    reg = tuple(torch.full((1, 4, size, size), 4.0) for size in (2, 1, 1))
+    kernels = tuple(torch.zeros(1, 169, size, size) for size in (2, 1, 1))
+    cls[0][0, 0, 1, 1] = 10.0
+    # The final generated parameter is the output-layer bias. A positive value
+    # makes the survivor mask unambiguously foreground after sigmoid.
+    kernels[0][0, -1, 1, 1] = 10.0
+    mask_feat = torch.zeros(1, 8, 2, 2, dtype=torch.float16)
+
+    result = postprocess(
+        (cls, reg, kernels, mask_feat),
+        conf_thres=0.25,
+        iou_thres=0.6,
+        input_size=16,
+        original_size=(24, 12),
+        ratio=2 / 3,
+        max_det=100,
+    )
+
+    assert result["num_detections"] == 1
+    assert result["masks"].dtype == torch.bool
+    assert result["masks"].shape == (1, 12, 24)
+    assert result["masks"].all()
+
+
+def test_rtmdet_ins_factory_resolves_segment_checkpoint(tmp_path):
+    checkpoint = wrap_libreyolo_checkpoint(
+        _minimal_state(segment=True),
+        model_family="rtmdet",
+        size="t",
+        task="segment",
+        nc=2,
+    )
+    path = tmp_path / "LibreRTMDett-seg.pt"
+    torch.save(checkpoint, path)
+
+    model = LibreYOLO(str(path), device="cpu")
+    assert isinstance(model, LibreRTMDet)
+    assert model.task == "segment"
+    assert isinstance(model.model.head, RTMDetInsSepBNHead)
+
+
+def test_rtmdet_ins_rejects_seg_checkpoint_for_default_task(tmp_path):
+    checkpoint = wrap_libreyolo_checkpoint(
+        _minimal_state(segment=True),
+        model_family="rtmdet",
+        size="t",
+        task="segment",
+        nc=2,
+    )
+    path = tmp_path / "seg-checkpoint.pt"
+    torch.save(checkpoint, path)
+
+    with pytest.raises(RuntimeError, match="task='segment'"):
+        LibreRTMDet(str(path), size="t", nb_classes=2, device="cpu")
+
+
+def test_rtmdet_ins_rejects_detect_checkpoint_for_segment_task(tmp_path):
+    checkpoint = wrap_libreyolo_checkpoint(
+        _minimal_state(segment=False),
+        model_family="rtmdet",
+        size="t",
+        task="detect",
+        nc=2,
+    )
+    path = tmp_path / "detect-checkpoint.pt"
+    torch.save(checkpoint, path)
+
+    with pytest.raises(RuntimeError, match="task='detect'"):
+        LibreRTMDet(
+            str(path),
+            size="t",
+            nb_classes=2,
+            device="cpu",
+            task="segment",
+        )
+
+
+def test_rtmdet_ins_training_and_export_are_explicitly_unsupported():
+    wrapper = LibreRTMDet(None, size="t", nb_classes=2, device="cpu", task="segment")
+    with pytest.raises(NotImplementedError, match="training"):
+        wrapper.train(data="unused.yaml", allow_experimental=True)
+
+    wrapper.model.head.export = True
+    with pytest.raises(NotImplementedError, match="export"):
+        wrapper.model(torch.zeros(1, 3, 64, 64))

--- a/weights/convert_rtmdet_weights.py
+++ b/weights/convert_rtmdet_weights.py
@@ -1,10 +1,14 @@
-"""Convert open-mmlab RTMDet checkpoints to LibreRTMDet.
+"""Convert open-mmlab RTMDet and RTMDet-Ins checkpoints to LibreRTMDet.
 
 Usage::
 
     python weights/convert_rtmdet_weights.py \\
         /path/to/rtmdet_tiny_8xb32-300e_coco_*.pth \\
         weights/LibreRTMDett.pt --size t
+
+    python weights/convert_rtmdet_weights.py \
+        /path/to/rtmdet-ins_tiny_8xb32-300e_coco_*.pth \
+        weights/LibreRTMDett-seg.pt --size t --task segment
 
 The upstream `.pth` is mmengine-pickled and contains EMA weights. We:
 
@@ -28,6 +32,7 @@ import sys
 import types
 from pathlib import Path
 from typing import Any
+
 
 # Stub mmengine/mmcv before torch.load so unpickling succeeds without the
 # upstream packages installed.
@@ -87,7 +92,9 @@ def _select_state_dict(ckpt: dict) -> dict:
     if "ema_state_dict" in ckpt:
         sd = ckpt["ema_state_dict"]
         # mmengine ExpMomentumEMA prefixes module params with "module."
-        return {k[len("module.") :]: v for k, v in sd.items() if k.startswith("module.")}
+        return {
+            k[len("module.") :]: v for k, v in sd.items() if k.startswith("module.")
+        }
     if "state_dict" in ckpt:
         return ckpt["state_dict"]
     return ckpt
@@ -98,6 +105,7 @@ def convert(
     output_path: str | Path,
     size: str,
     nc: int = 80,
+    task: str | None = None,
 ) -> Path:
     print(f"[convert_rtmdet] loading {input_path}")
     ckpt: Any = torch.load(input_path, map_location="cpu", weights_only=False)
@@ -107,12 +115,27 @@ def convert(
     raw_sd = _select_state_dict(ckpt)
     print(f"[convert_rtmdet] source has {len(raw_sd)} parameters")
 
+    detected_task = (
+        "segment"
+        if any("rtm_kernel" in key or ".mask_head." in key for key in raw_sd)
+        else "detect"
+    )
+    if task is None:
+        task = detected_task
+    elif task != detected_task:
+        raise RuntimeError(
+            f"Requested task={task!r}, but checkpoint tensors identify "
+            f"task={detected_task!r}."
+        )
+
     libre_sd = _remap_keys(raw_sd)
 
     # Sanity: build a fresh model and check what loads cleanly.
-    model = LibreRTMDetModel(size=size, nc=nc)
+    model = LibreRTMDetModel(size=size, nc=nc, enable_mask_head=task == "segment")
     incompat = model.load_state_dict(libre_sd, strict=False)
-    missing = [k for k in incompat.missing_keys if not k.endswith("num_batches_tracked")]
+    missing = [
+        k for k in incompat.missing_keys if not k.endswith("num_batches_tracked")
+    ]
     unexpected = [
         k for k in incompat.unexpected_keys if not k.endswith("num_batches_tracked")
     ]
@@ -121,7 +144,9 @@ def convert(
         for k in missing[:10]:
             print(f"    - {k}")
     if unexpected:
-        print(f"[convert_rtmdet] WARNING: {len(unexpected)} unexpected keys (showing 10):")
+        print(
+            f"[convert_rtmdet] WARNING: {len(unexpected)} unexpected keys (showing 10):"
+        )
         for k in unexpected[:10]:
             print(f"    + {k}")
     if not missing and not unexpected:
@@ -134,8 +159,8 @@ def convert(
         model_family="rtmdet",
         size=size,
         nc=nc,
-        task="detect",
-        supported_tasks=("detect",),
+        task=task,
+        supported_tasks=("detect", "segment"),
         default_task="detect",
     )
 
@@ -158,9 +183,21 @@ def main():
         help="model size",
     )
     parser.add_argument("--nc", type=int, default=80, help="number of classes")
+    parser.add_argument(
+        "--task",
+        choices=["detect", "segment"],
+        default=None,
+        help="checkpoint task (auto-detected when omitted)",
+    )
     args = parser.parse_args()
 
-    convert(args.input, args.output, size=args.size, nc=args.nc)
+    convert(
+        args.input,
+        args.output,
+        size=args.size,
+        nc=args.nc,
+        task=args.task,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Adds RTMDet-Ins instance-segmentation inference and validation for RTMDet tiny, small, medium, large, and extra-large checkpoints.

The change adds the official dynamic-kernel mask head and stride-8 mask feature fusion, decodes masks only after NMS in fp32, maps masks back through RTMDet letterbox preprocessing, wires `task=segment` through checkpoint detection and validation, extends raw upstream checkpoint conversion, and rejects detect/segment checkpoint mismatches. Detection behavior remains unchanged. RTMDet-Ins training and export are explicitly unsupported in this first version.

## Code provenance

The RTMDet-Ins architecture and mask decoding behavior are ported from `open-mmlab/mmdetection` at commit `cfd5d3a985b0249de009b67d04f37263e11cdf3d`, licensed Apache-2.0. Integration, task guards, conversion plumbing, tests, and documentation were written for this PR. No mmyolo code was consulted or used.

| Ported component | Upstream file | Commit | License |
| --- | --- | --- | --- |
| RTMDet-Ins SepBN head and mask feature module | `mmdet/models/dense_heads/rtmdet_ins_head.py` | `cfd5d3a985b0249de009b67d04f37263e11cdf3d` | Apache-2.0 |
| RTMDet-Ins inference mask decoder and COCO configuration | `mmdet/models/dense_heads/rtmdet_ins_head.py`, `mmdet/configs/rtmdet/` | `cfd5d3a985b0249de009b67d04f37263e11cdf3d` | Apache-2.0 |

Attribution is recorded in `libreyolo/models/rtmdet/NOTICE` and `THIRD_PARTY_NOTICES.txt`.

## How was this tested?

- `pytest tests/unit/test_rtmdet_ins.py tests/unit/test_rtmdet.py tests/unit/test_autoconvert_families.py tests/unit/test_tasks.py tests/unit/test_postprocess_package.py -m unit -q`: 95 passed.
- Post-review RTMDet regression rerun: 31 passed.
- Ruff checks and `git diff --check`: passed.
- Official RTMDet-Ins tiny checkpoint: all 546 tensors loaded with zero missing or unexpected keys; dynamic parameter count is 169.
- Raw official `.pth` auto-conversion through `LibreYOLO(path)`: passed and resolved family `rtmdet`, size `t`, task `segment`.
- Native CUDA sample inference: produced one mask at the original `852x1280` image resolution.
- Greptile local pre-review against `origin/dev`: 5/5, no review comments; its style observations were addressed in commit `69239de2`.

The repository-wide unit gate was attempted, but the Windows process crashed inside ONNX Runtime during the unrelated DEIMv2 export roundtrip at 23% with a native access violation. Full COCO mask validation was also attempted with the official tiny checkpoint, but mask resizing and RLE evaluation did not complete within the 30-minute local command ceiling, so no mask mAP is claimed here.
