### PR TITLE
Add SAM 3 image inference

### DIFF
--- a/docs/adr/0007-libresam-contract.md
+++ b/docs/adr/0007-libresam-contract.md
@@ -55,6 +55,7 @@ The default family remains **SAM-1** (`facebook/sam-vit-base` / `-large` /
 |---|---|---|---|
 | SAM-1 | `LibreSAM("base")`, `LibreSAM1("base")` | `facebook/sam-vit-*` | Default promptable family. |
 | SAM-2 image | `LibreSAM("sam2-tiny")`, `LibreSAM2("tiny")` | `LibreYOLO/LibreSAM2*` | Image segmentation only in v1. |
+| SAM 3 image | `LibreSAM("sam3")`, `LibreSAM3("large")` | `facebook/sam3` | Visual prompts plus concept text prompts; gated custom-license weights. |
 | MobileSAM | `LibreSAM("mobilesam")`, `LibreMobileSAM()` | `LibreYOLO/LibreMobileSAM` | Native TinyViT port with converted weights. |
 
 ## Public API
@@ -77,6 +78,9 @@ a = model.predict(points=[500, 375], labels=[1])           # ...prompt cheaply
 b = model.predict(bboxes=[100, 100, 200, 200])
 model.reset_image()
 
+sam3 = LibreSAM("sam3")
+r = sam3.predict("img.jpg", text="yellow school bus")  # all matching instances
+
 r.masks.xy        # polygons
 r.boxes.xyxy      # tight boxes derived from masks
 ```
@@ -90,6 +94,14 @@ r.boxes.xyxy      # tight boxes derived from masks
   confidence). `None` keeps all in the prompted path and applies the family grid
   threshold in "segment everything"; `0.0` disables filtering in either mode.
 - `device=` on `predict` moves the model and invalidates the cached embedding.
+- SAM 3 visual prompts follow the same contract through `Sam3TrackerModel`.
+  Its `text=` extension instead performs Promptable Concept Segmentation through
+  a lazily loaded `Sam3Model`; text is mutually exclusive with points and boxes.
+  `conf` is the PCS detection score on this path, and returned `names` maps class
+  `0` to the requested concept. A text call with `source=None` re-encodes the
+  cached image because tracker and PCS encoder caches are not shared.
+- The image-exemplar name `exemplars=` is reserved for a future PCS extension;
+  exemplar prompts are not implemented.
 
 ## Internal Contract
 
@@ -102,7 +114,7 @@ cached embeddings when possible so interactive sessions survive device changes.
 
 | Field             | Meaning                                              |
 |-------------------|------------------------------------------------------|
-| `FAMILY`          | family id (`sam`, `sam2`, `mobilesam`)               |
+| `FAMILY`          | family id (`sam`, `sam2`, `sam3`, `mobilesam`)       |
 | `FILENAME_PREFIX` | `Libre`-prefixed weights-dir prefix                  |
 | `HF_REPOS`        | `{size: hf_repo_id}`; drives autodownload            |
 | `INPUT_SIZES`     | `{size: nominal_px}` (1024; the processor owns resize)|
@@ -121,14 +133,26 @@ the upstream Transformers-compatible snapshots. MobileSAM code and weights are
 Apache-2.0; LibreYOLO carries a native port plus a NOTICE, and the converted
 checkpoint is hosted separately as `LibreMobileSAM.pt`.
 
-SAM-3's custom "SAM License" is gated (download requires accepting Meta's
-terms) and would follow the existing LibreVLM license-notice pattern when added;
-the tier must not vendor SAM-licensed modeling code.
+SAM 3 model code is not vendored. LibreYOLO calls the Apache-2.0 Transformers
+implementation, while weights download directly from the gated
+`facebook/sam3` repository. Users must accept Meta's custom SAM License and
+authenticate with Hugging Face. The weights are not MIT or Apache-2.0 and are
+not redistributed by LibreYOLO. Loading logs a license notice before download.
+The SAM 3 and tracker classes first shipped in Transformers 5.0.0; LibreYOLO's
+`sam` extra already has the stricter `transformers>=5.3.0` floor.
+
+SAM 3.1 is explicitly deferred. Its custom-license implementation cannot be
+vendored into this MIT repository, and Transformers does not yet support the
+3.1 checkpoint. The implementation keeps `HF_REPOS` keyed per size so a future
+checkpoint can be added cheaply. The exact trigger is Transformers gaining SAM
+3.1 image-model support; then add the repo/alias, rerun parity and smoke tests,
+and evaluate whether image checkpoint outputs change. Object Multiplex remains
+part of a separate future video plan.
 
 ## Out Of Scope (v1)
 
-- SAM-2 video/memory and SAM-3 (concept/open-vocab seg, gated). Both slot onto
-  this same tier later.
+- SAM-2/SAM-3 video and memory paths.
+- SAM 3 image exemplars and SAM 3.1, subject to the trigger above.
 - Mask prompts (`masks=`), `train()`, `val()`, `export()`, and `track()` raise.
 - "Segment everything" is a simplified grid AMG (predicted-IoU threshold +
   box-IoU dedup); it omits stability-score filtering, multi-crop, and mask-IoU

--- a/docs/adr/0007-libresam-contract.md
+++ b/docs/adr/0007-libresam-contract.md
@@ -98,8 +98,10 @@ r.boxes.xyxy      # tight boxes derived from masks
   Its `text=` extension instead performs Promptable Concept Segmentation through
   a lazily loaded `Sam3Model`; text is mutually exclusive with points and boxes.
   `conf` is the PCS detection score on this path, and returned `names` maps class
-  `0` to the requested concept. A text call with `source=None` re-encodes the
-  cached image because tracker and PCS encoder caches are not shared.
+  `0` to the requested concept. `conf=None` uses the processor's standard 0.3
+  PCS score threshold, while explicit `conf=0.0` keeps all candidates. A text
+  call with `source=None` re-encodes the cached image because tracker and PCS
+  encoder caches are not shared.
 - The image-exemplar name `exemplars=` is reserved for a future PCS extension;
   exemplar prompts are not implemented.
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -90,7 +90,7 @@ exceptions being lowercase version suffixes (`DEIMv2`, `RTDETRv2`,
 The VLM and promptable SAM tiers are separate categories and do not follow this
 rule. Their weights-directory prefixes (`LibreQwen3VL`, `LibreLFM2VL`,
 `LibreSmolVLM2`, `LibreInternVL3`, `LibreFlorence2`, `LibreKosmos2`,
-`LocateAnything`, `LibreSAM`, `LibreSAM2`, `LibreMobileSAM`) are not registered
+`LocateAnything`, `LibreSAM`, `LibreSAM2`, `LibreSAM3`, `LibreMobileSAM`) are not registered
 into the detector factory and do not emit `Libre<FAMILY><size>.pt` detector
 checkpoints. Their `FILENAME_PREFIX` is only a weights-directory prefix for a
 downloaded Hugging Face snapshot or promptable checkpoint, so upstream brand

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -125,6 +125,7 @@ def __getattr__(name):
         "LibreSAM": (".models.sam", "LibreSAM"),
         "LibreSAM1": (".models.sam", "LibreSAM1"),
         "LibreSAM2": (".models.sam", "LibreSAM2"),
+        "LibreSAM3": (".models.sam", "LibreSAM3"),
         "LibreMobileSAM": (".models.mobilesam", "LibreMobileSAM"),
         "LibreOpenVocab": (".models.openvocab", "LibreOpenVocab"),
         "LibreGroundingDINO": (".models.openvocab", "LibreGroundingDINO"),
@@ -201,6 +202,7 @@ __all__ = [
     "LibreSAM",
     "LibreSAM1",
     "LibreSAM2",
+    "LibreSAM3",
     "LibreMobileSAM",
     # Open-vocabulary detector tier (optional, requires libreyolo[openvocab])
     "LibreOpenVocab",

--- a/libreyolo/models/sam/__init__.py
+++ b/libreyolo/models/sam/__init__.py
@@ -7,9 +7,16 @@ See ``model.py`` for the ``LibreSAM(...)`` factory and ``base.py`` for the
 from __future__ import annotations
 
 from .base import LibreSAMModel
-from .model import LibreSAM, LibreSAM1, LibreSAM2
+from .model import LibreSAM, LibreSAM1, LibreSAM2, LibreSAM3
 
-__all__ = ["LibreSAM", "LibreSAMModel", "LibreSAM1", "LibreSAM2", "LibreMobileSAM"]
+__all__ = [
+    "LibreSAM",
+    "LibreSAMModel",
+    "LibreSAM1",
+    "LibreSAM2",
+    "LibreSAM3",
+    "LibreMobileSAM",
+]
 
 
 def __getattr__(name):

--- a/libreyolo/models/sam/base.py
+++ b/libreyolo/models/sam/base.py
@@ -281,6 +281,7 @@ class LibreSAMModel(BaseModel):
         bboxes=None,
         labels=None,
         masks=None,
+        text: str | None = None,
         conf: Optional[float] = None,
         multimask: Optional[bool] = None,
         max_det: int = 300,
@@ -302,6 +303,8 @@ class LibreSAMModel(BaseModel):
             bboxes: ``[x1, y1, x2, y2]`` or a list of them (one mask per box).
             labels: Point labels, ``1`` positive / ``0`` negative (default all
                 positive), shaped to match ``points``.
+            text: Concept prompt. Text prompts require SAM 3; spatial-prompt
+                families raise ``NotImplementedError``.
             conf: Drop masks whose *predicted IoU* (mask-quality score, not a
                 detection confidence) is below this. ``None`` keeps all in the
                 prompted path and applies the family's grid threshold in
@@ -317,6 +320,10 @@ class LibreSAMModel(BaseModel):
                 ``DEFAULT_POINTS_PER_SIDE``; on CPU the default of 32 runs
                 ~1024 decoder passes and is slow — lower it for interactivity).
         """
+        if text is not None:
+            raise NotImplementedError(
+                "Text prompts require SAM 3; load LibreSAM('sam3')."
+            )
         if masks is not None:
             raise NotImplementedError(
                 "Mask prompts are not supported in LibreSAM v1; use points= or bboxes=."
@@ -489,7 +496,7 @@ class LibreSAMModel(BaseModel):
         return sel.bool(), conf.float()
 
     def _assemble_results(
-        self, masks, conf, img, image_path, *, conf_thres, max_det
+        self, masks, conf, img, image_path, *, conf_thres, max_det, names=None
     ) -> Results:
         from torchvision.ops import masks_to_boxes
 
@@ -508,7 +515,7 @@ class LibreSAMModel(BaseModel):
             masks, conf = masks[top], conf[top]
 
         if masks.shape[0] == 0:
-            return self._empty_results(orig_shape, image_path)
+            return self._empty_results(orig_shape, image_path, names=names)
 
         boxes = masks_to_boxes(masks.float())
         cls = torch.zeros(masks.shape[0], dtype=torch.float32)
@@ -516,11 +523,11 @@ class LibreSAMModel(BaseModel):
             boxes=Boxes(boxes, conf, cls),
             orig_shape=orig_shape,
             path=str(image_path) if image_path else None,
-            names=self.names,
+            names=self.names if names is None else names,
             masks=Masks(masks, orig_shape),
         )
 
-    def _empty_results(self, orig_shape, image_path) -> Results:
+    def _empty_results(self, orig_shape, image_path, *, names=None) -> Results:
         return Results(
             boxes=Boxes(
                 torch.zeros((0, 4), dtype=torch.float32),
@@ -529,7 +536,7 @@ class LibreSAMModel(BaseModel):
             ),
             orig_shape=orig_shape,
             path=str(image_path) if image_path else None,
-            names=self.names,
+            names=self.names if names is None else names,
         )
 
     def _segment_everything(

--- a/libreyolo/models/sam/model.py
+++ b/libreyolo/models/sam/model.py
@@ -29,6 +29,7 @@ from typing import Dict, Tuple, Type
 
 from .base import LibreSAMModel
 from .sam2 import LibreSAM2
+from .sam3 import LibreSAM3
 
 
 class LibreSAM1(LibreSAMModel):
@@ -73,6 +74,9 @@ _ALIASES: Dict[str, Tuple[Type[LibreSAMModel] | str, str]] = {
     "sam2_s": (LibreSAM2, "small"),
     "sam2_bp": (LibreSAM2, "base-plus"),
     "sam2_l": (LibreSAM2, "large"),
+    "sam3": (LibreSAM3, "large"),
+    "sam-3": (LibreSAM3, "large"),
+    "sam3-large": (LibreSAM3, "large"),
     "mobilesam": (_MOBILE_SAM, "tiny"),
     "mobilesam-tiny": (_MOBILE_SAM, "tiny"),
     "mobilesam_t": (_MOBILE_SAM, "tiny"),
@@ -91,6 +95,7 @@ def LibreSAM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreSAMModel:
             (also ``"sam_b"``/``"sam_l"``/``"sam_h"``, or ``"b"``/``"l"``/``"h"``).
             SAM-2 aliases use an explicit prefix, for example
             ``"sam2-tiny"`` / ``"sam2_t"``.
+            SAM 3 uses ``"sam3"`` / ``"sam-3"`` / ``"sam3-large"``.
             MobileSAM aliases resolve to its single ``"tiny"`` size.
         **kwargs: Forwarded to the family constructor: ``device``, and
             ``multimask`` (when True, ``predict`` returns all of SAM's ambiguity
@@ -115,4 +120,4 @@ def LibreSAM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreSAMModel:
     return family_cls(size=size, **kwargs)
 
 
-__all__ = ["LibreSAM", "LibreSAM1", "LibreSAM2"]
+__all__ = ["LibreSAM", "LibreSAM1", "LibreSAM2", "LibreSAM3"]

--- a/libreyolo/models/sam/sam3.py
+++ b/libreyolo/models/sam/sam3.py
@@ -1,0 +1,214 @@
+"""SAM 3 image segmentation adapter for the LibreSAM tier.
+
+Visual prompts use Transformers' tracker model and keep the existing
+encode-once LibreSAM contract. Concept text prompts lazily load the separate
+PCS model from the same gated checkpoint snapshot.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar, Dict
+
+import torch
+
+from .base import _INSTALL_HINT, _is_empty_prompt, LibreSAMModel
+
+logger = logging.getLogger(__name__)
+
+_GATED_REPO = "facebook/sam3"
+_GATED_HELP = (
+    "SAM 3 weights are gated. Visit https://huggingface.co/facebook/sam3, "
+    "accept the terms, then run `hf auth login` (or set HF_TOKEN) and retry."
+)
+
+
+def _http_status(exc: BaseException) -> int | None:
+    """Best-effort HTTP status extraction without depending on Hub internals."""
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if status is None:
+        status = getattr(exc, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+class LibreSAM3(LibreSAMModel):
+    """SAM 3 visual and concept-prompted image segmenter.
+
+    The visual path uses ``Sam3TrackerModel``. The first ``text=`` call loads a
+    separate ``Sam3Model`` instance, which increases peak RAM/VRAM because the
+    two Transformers models do not share their instantiated encoder weights.
+    """
+
+    FAMILY = "sam3"
+    FILENAME_PREFIX = "LibreSAM3"
+    HF_REPOS: ClassVar[Dict[str, str]] = {"large": _GATED_REPO}
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {"large": 1008}
+    _LICENSE_NOTICE_SHOWN: ClassVar[bool] = False
+    _LICENSE_NOTICE: ClassVar[str] = (
+        "SAM 3 weights are provided by Meta under the custom SAM License, not "
+        "LibreYOLO's MIT license. Use is subject to the terms accepted at "
+        "https://huggingface.co/facebook/sam3."
+    )
+    SNAPSHOT_IGNORE_PATTERNS: ClassVar[tuple[str, ...]] = (
+        *LibreSAMModel.SNAPSHOT_IGNORE_PATTERNS,
+        "*.pt",
+    )
+
+    def __init__(self, size: str = "large", **kwargs):
+        super().__init__(size=size, **kwargs)
+        self._pcs_model = None
+        self._pcs_processor = None
+
+    def _ensure_weights(self) -> str:
+        if not type(self)._LICENSE_NOTICE_SHOWN:
+            type(self)._LICENSE_NOTICE_SHOWN = True
+            logger.warning(self._LICENSE_NOTICE)
+        try:
+            return super()._ensure_weights()
+        except Exception as exc:
+            if _http_status(exc) in (401, 403):
+                raise RuntimeError(_GATED_HELP) from exc
+            raise
+
+    def _load_pretrained(self, snapshot_dir: str) -> tuple:
+        try:
+            from transformers import Sam3TrackerModel, Sam3TrackerProcessor
+        except ImportError as exc:
+            raise ImportError(_INSTALL_HINT) from exc
+        object.__setattr__(self, "_snapshot_dir", snapshot_dir)
+        model = Sam3TrackerModel.from_pretrained(
+            snapshot_dir, dtype=self._resolve_dtype()
+        )
+        processor = Sam3TrackerProcessor.from_pretrained(snapshot_dir)
+        return model, processor
+
+    def _load_pcs(self):
+        if self._pcs_model is not None:
+            return self._pcs_model, self._pcs_processor
+        try:
+            from transformers import Sam3Model, Sam3Processor
+        except ImportError as exc:
+            raise ImportError(_INSTALL_HINT) from exc
+        model = Sam3Model.from_pretrained(
+            self._snapshot_dir, dtype=self._resolve_dtype()
+        ).to(self.device)
+        model.eval()
+        self._pcs_model = model
+        self._pcs_processor = Sam3Processor.from_pretrained(self._snapshot_dir)
+        return self._pcs_model, self._pcs_processor
+
+    def _set_device(self, device: str) -> "LibreSAM3":
+        super()._set_device(device)
+        if self._pcs_model is not None:
+            self._pcs_model.to(self.device)
+        return self
+
+    def _move_embeddings(self, embeddings, device: torch.device):
+        """SAM 3 tracker caches a list of vision feature tensors."""
+        if isinstance(embeddings, list):
+            return [embedding.to(device) for embedding in embeddings]
+        return super()._move_embeddings(embeddings, device)
+
+    def _post_process_masks(self, pred_masks, enc):
+        """SAM 3 tracker uses original sizes without a reshaped-size argument."""
+        fn = getattr(self.processor, "post_process_masks", None)
+        if fn is None:
+            fn = self.processor.image_processor.post_process_masks
+        return fn(pred_masks.cpu(), enc["original_sizes"])
+
+    @staticmethod
+    def _move_pcs_inputs(inputs: Any, device: torch.device) -> Any:
+        if hasattr(inputs, "to"):
+            return inputs.to(device)
+        if isinstance(inputs, dict):
+            return {
+                key: value.to(device) if hasattr(value, "to") else value
+                for key, value in inputs.items()
+            }
+        return inputs
+
+    def predict(
+        self,
+        source=None,
+        *,
+        points=None,
+        bboxes=None,
+        labels=None,
+        masks=None,
+        text: str | None = None,
+        conf=None,
+        multimask=None,
+        max_det: int = 300,
+        device=None,
+        color_format: str = "auto",
+        points_per_side=None,
+    ):
+        """Segment with spatial prompts or find all instances matching ``text``.
+
+        On the text path, ``conf`` is the PCS detection score. On the visual
+        path it remains the predicted mask-IoU score. Text is mutually exclusive
+        with points, boxes, labels, masks, and segment-everything controls.
+        """
+        if text is None:
+            return super().predict(
+                source,
+                points=points,
+                bboxes=bboxes,
+                labels=labels,
+                masks=masks,
+                text=None,
+                conf=conf,
+                multimask=multimask,
+                max_det=max_det,
+                device=device,
+                color_format=color_format,
+                points_per_side=points_per_side,
+            )
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("text must be a non-empty concept string.")
+        if not _is_empty_prompt(points) or not _is_empty_prompt(bboxes):
+            raise ValueError("text prompts cannot be combined with points or bboxes.")
+        if labels is not None or masks is not None:
+            raise ValueError("text prompts cannot be combined with labels or masks.")
+        if points_per_side is not None:
+            raise ValueError("points_per_side only applies to segment-everything mode.")
+        if multimask not in (None, False):
+            raise ValueError("multimask only applies to visual prompts.")
+        if device is not None:
+            self._set_device(device)
+
+        img, image_path, _ = self._resolve_image(source, color_format)
+        model, processor = self._load_pcs()
+        inputs = processor(images=img, text=text.strip(), return_tensors="pt")
+        inputs = self._move_pcs_inputs(inputs, self.device)
+        with torch.no_grad():
+            outputs = model(**inputs)
+        target_sizes = inputs["original_sizes"].detach().cpu().tolist()
+        processed = processor.post_process_instance_segmentation(
+            outputs,
+            threshold=0.0,
+            mask_threshold=0.5,
+            target_sizes=target_sizes,
+        )[0]
+        result_masks = torch.as_tensor(processed["masks"]).detach().cpu().bool()
+        scores = torch.as_tensor(processed["scores"]).detach().cpu().float()
+        conf_thres = 0.0 if conf is None else float(conf)
+        return self._assemble_results(
+            result_masks,
+            scores,
+            img,
+            image_path,
+            conf_thres=conf_thres,
+            max_det=max_det,
+            names={0: text.strip()},
+        )
+
+    def track(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreSAM3 supports image inference only; SAM 3 video models are "
+            "outside the LibreSAM image contract."
+        )
+
+
+__all__ = ["LibreSAM3"]

--- a/libreyolo/models/sam/sam3.py
+++ b/libreyolo/models/sam/sam3.py
@@ -44,6 +44,7 @@ class LibreSAM3(LibreSAMModel):
     FILENAME_PREFIX = "LibreSAM3"
     HF_REPOS: ClassVar[Dict[str, str]] = {"large": _GATED_REPO}
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"large": 1008}
+    DEFAULT_PCS_SCORE_THRESH: ClassVar[float] = 0.3
     _LICENSE_NOTICE_SHOWN: ClassVar[bool] = False
     _LICENSE_NOTICE: ClassVar[str] = (
         "SAM 3 weights are provided by Meta under the custom SAM License, not "
@@ -76,7 +77,7 @@ class LibreSAM3(LibreSAMModel):
             from transformers import Sam3TrackerModel, Sam3TrackerProcessor
         except ImportError as exc:
             raise ImportError(_INSTALL_HINT) from exc
-        object.__setattr__(self, "_snapshot_dir", snapshot_dir)
+        self._snapshot_dir = snapshot_dir
         model = Sam3TrackerModel.from_pretrained(
             snapshot_dir, dtype=self._resolve_dtype()
         )
@@ -100,8 +101,9 @@ class LibreSAM3(LibreSAMModel):
 
     def _set_device(self, device: str) -> "LibreSAM3":
         super()._set_device(device)
-        if self._pcs_model is not None:
-            self._pcs_model.to(self.device)
+        pcs_model = getattr(self, "_pcs_model", None)
+        if pcs_model is not None:
+            pcs_model.to(self.device)
         return self
 
     def _move_embeddings(self, embeddings, device: torch.device):
@@ -146,9 +148,11 @@ class LibreSAM3(LibreSAMModel):
     ):
         """Segment with spatial prompts or find all instances matching ``text``.
 
-        On the text path, ``conf`` is the PCS detection score. On the visual
-        path it remains the predicted mask-IoU score. Text is mutually exclusive
-        with points, boxes, labels, masks, and segment-everything controls.
+        On the text path, ``conf`` is the PCS detection score; ``None`` uses
+        ``DEFAULT_PCS_SCORE_THRESH`` (0.3), while an explicit ``0.0`` keeps all
+        candidates. On the visual path it remains the predicted mask-IoU score.
+        Text is mutually exclusive with points, boxes, labels, masks, and
+        segment-everything controls.
         """
         if text is None:
             return super().predict(
@@ -187,13 +191,17 @@ class LibreSAM3(LibreSAMModel):
         target_sizes = inputs["original_sizes"].detach().cpu().tolist()
         processed = processor.post_process_instance_segmentation(
             outputs,
+            # Keep candidates here so the shared Results assembly owns both
+            # the default/explicit threshold semantics and max_det ordering.
             threshold=0.0,
             mask_threshold=0.5,
             target_sizes=target_sizes,
         )[0]
         result_masks = torch.as_tensor(processed["masks"]).detach().cpu().bool()
         scores = torch.as_tensor(processed["scores"]).detach().cpu().float()
-        conf_thres = 0.0 if conf is None else float(conf)
+        conf_thres = (
+            self.DEFAULT_PCS_SCORE_THRESH if conf is None else float(conf)
+        )
         return self._assemble_results(
             result_masks,
             scores,

--- a/skills/use-libreyolo-zero-shot/SKILL.md
+++ b/skills/use-libreyolo-zero-shot/SKILL.md
@@ -100,6 +100,10 @@ model.reset_image()
   Meta's custom SAM License, not MIT or Apache-2.0. Accept its terms and run
   `hf auth login` (or set `HF_TOKEN`) before first use. The first `text=` call
   lazily loads a second model instance and therefore raises peak RAM/VRAM.
+  In a reference CPU/fp32 run at the native 1008 px frame, RSS was 3.0 GB after
+  visual inference and 5.9 GB with both models resident, with a 9.0 GB peak
+  while loading/running the first text prompt. An 8 GB host may exhaust memory
+  on the text path even when visual prompting works comfortably.
 - `text=` returns every instance matching the concept and cannot be combined
   with points or boxes. Its `conf` is a PCS detection score; visual-prompt
   `conf` remains predicted mask IoU. Text prompts default to `conf=0.3`; pass

--- a/skills/use-libreyolo-zero-shot/SKILL.md
+++ b/skills/use-libreyolo-zero-shot/SKILL.md
@@ -102,8 +102,9 @@ model.reset_image()
   lazily loads a second model instance and therefore raises peak RAM/VRAM.
 - `text=` returns every instance matching the concept and cannot be combined
   with points or boxes. Its `conf` is a PCS detection score; visual-prompt
-  `conf` remains predicted mask IoU. Image exemplars are reserved but not yet
-  implemented.
+  `conf` remains predicted mask IoU. Text prompts default to `conf=0.3`; pass
+  `conf=0.0` explicitly to keep all candidates. Image exemplars are reserved
+  but not yet implemented.
 - Interactive loops: always `set_image` once, then prompt; re-passing the
   image per predict re-encodes and dominates latency.
 - Prompt coordinates are pixels on the original image. Multiple points with

--- a/skills/use-libreyolo-zero-shot/SKILL.md
+++ b/skills/use-libreyolo-zero-shot/SKILL.md
@@ -3,7 +3,8 @@ name: use-libreyolo-zero-shot
 description: >-
   Use LibreYOLO's zero-shot and promptable tiers: open-vocabulary detection
   with text vocabularies (LibreOpenVocab: Grounding DINO, OWLv2), promptable
-  segmentation with points/boxes (LibreSAM: SAM-1, SAM-2, MobileSAM),
+  segmentation with points/boxes or concept text (LibreSAM: SAM-1, SAM-2,
+  SAM 3, MobileSAM),
   zero-shot classification (LibreCLIP / LibreSigLIP2 set_classes), and VLM-as-detector
   (LibreVLM). Use when someone wants to detect arbitrary text-described
   classes without training ("find the forklifts", custom vocabulary),
@@ -25,7 +26,7 @@ directory, not a `Libre*<size>.pt` checkpoint).
 | You want | Tier | Install |
 |---|---|---|
 | Boxes for classes described in text | `LibreOpenVocab` | `libreyolo[openvocab]` |
-| Mask from a click / box, or segment-everything | `LibreSAM` | `libreyolo[sam]` |
+| Mask from a click / box / concept text, or segment-everything | `LibreSAM` | `libreyolo[sam]` |
 | Whole-image label from your own label set | `LibreCLIP` / `LibreSigLIP2` | `libreyolo[clip]` / `libreyolo[siglip2]` |
 | Ask an instruction-following model to find things (slow, flexible) | `LibreVLM` | `libreyolo[vlm]` |
 
@@ -82,6 +83,9 @@ r = model.predict("img.jpg", bboxes=[100, 100, 200, 200])
 r = model.predict("img.jpg")                        # segment everything (slow)
 r.masks.xy; r.boxes.xyxy                            # boxes derived from masks
 
+sam3 = LibreSAM("sam3")
+matches = sam3.predict("img.jpg", text="yellow school bus", conf=0.3)
+
 model.set_image("img.jpg")                          # encode once (the expensive part)...
 a = model.predict(points=[500, 375], labels=[1])    # ...prompt many, cheap
 model.reset_image()
@@ -89,8 +93,17 @@ model.reset_image()
 
 - Family pick: `LibreSAM("base"/"large"/"huge")` = SAM-1; `LibreSAM2`
   aliases for SAM-2 (better masks, video-capable lineage);
+  `LibreSAM("sam3")` = SAM 3 visual prompts plus concept `text=` prompts;
   `LibreMobileSAM` (tiny encoder, edge/CPU-friendly, same prompt API).
   The alias table in `libreyolo/models/sam/model.py` is authoritative.
+- SAM 3 weights come directly from the gated `facebook/sam3` repository under
+  Meta's custom SAM License, not MIT or Apache-2.0. Accept its terms and run
+  `hf auth login` (or set `HF_TOKEN`) before first use. The first `text=` call
+  lazily loads a second model instance and therefore raises peak RAM/VRAM.
+- `text=` returns every instance matching the concept and cannot be combined
+  with points or boxes. Its `conf` is a PCS detection score; visual-prompt
+  `conf` remains predicted mask IoU. Image exemplars are reserved but not yet
+  implemented.
 - Interactive loops: always `set_image` once, then prompt; re-passing the
   image per predict re-encodes and dominates latency.
 - Prompt coordinates are pixels on the original image. Multiple points with

--- a/skills/use-libreyolo/SKILL.md
+++ b/skills/use-libreyolo/SKILL.md
@@ -172,7 +172,8 @@ as the source of truth. By tier:
   ImageFolder root (or a known name/`.zip` URL) with `model.train(data=...)`.
 - **Zero-shot / promptable tiers** (need `[openvocab]` / `[sam]` / `[clip]` / `[siglip2]`
   / `[vlm]`): `LibreOpenVocab` (text-vocabulary detection), `LibreSAM` /
-  `LibreSAM2` / `LibreMobileSAM` (point/box-prompted masks), `LibreCLIP` / `LibreSigLIP2`
+  `LibreSAM2` / `LibreSAM3` / `LibreMobileSAM` (point/box-prompted masks;
+  SAM 3 also accepts concept `text=` prompts), `LibreCLIP` / `LibreSigLIP2`
   (zero-shot classify), and the `LibreVLM` family (vision-language
   detection). For the exact model aliases in each tier, use `libreyolo
   models` and the dedicated guide `skills/use-libreyolo-zero-shot/`.

--- a/tests/e2e/test_sam3_smoke.py
+++ b/tests/e2e/test_sam3_smoke.py
@@ -1,8 +1,7 @@
 """Authenticated end-to-end smoke coverage for SAM 3 image inference."""
 
-import os
-
 import pytest
+from huggingface_hub import get_token
 
 pytestmark = [
     pytest.mark.e2e,
@@ -13,9 +12,9 @@ pytestmark = [
 
 pytest.importorskip("transformers", reason="LibreSAM3 requires the 'sam' extra")
 
-if not os.environ.get("HF_TOKEN"):
+if get_token() is None:
     pytest.skip(
-        "SAM 3 is gated; accept its terms and set HF_TOKEN to run this smoke test",
+        "SAM 3 is gated; accept its terms and authenticate with Hugging Face",
         allow_module_level=True,
     )
 

--- a/tests/e2e/test_sam3_smoke.py
+++ b/tests/e2e/test_sam3_smoke.py
@@ -1,0 +1,62 @@
+"""Authenticated end-to-end smoke coverage for SAM 3 image inference."""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sam,
+    pytest.mark.network,
+    pytest.mark.external_data,
+]
+
+pytest.importorskip("transformers", reason="LibreSAM3 requires the 'sam' extra")
+
+if not os.environ.get("HF_TOKEN"):
+    pytest.skip(
+        "SAM 3 is gated; accept its terms and set HF_TOKEN to run this smoke test",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def sam3_model():
+    from libreyolo import LibreSAM3
+
+    return LibreSAM3(device="cpu")
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        {"points": [640, 360], "labels": [1]},
+        {"bboxes": [100, 100, 500, 500]},
+    ],
+)
+def test_sam3_visual_prompt_returns_mask(sam3_model, prompt):
+    from libreyolo import Results, SAMPLE_IMAGE
+
+    result = sam3_model.predict(SAMPLE_IMAGE, **prompt)
+    assert isinstance(result, Results)
+    assert result.masks is not None
+    assert len(result.masks) >= 1
+    assert result.masks.data.shape[-2:] == result.orig_shape
+
+
+def test_sam3_segment_everything_runs(sam3_model):
+    from libreyolo import SAMPLE_IMAGE
+
+    result = sam3_model.predict(SAMPLE_IMAGE, points_per_side=4)
+    assert result.masks is not None
+    assert len(result.masks) == len(result.boxes)
+
+
+def test_sam3_text_prompt_returns_scored_instances(sam3_model):
+    from libreyolo import SAMPLE_IMAGE
+
+    result = sam3_model.predict(SAMPLE_IMAGE, text="person", conf=0.2, max_det=10)
+    assert result.masks is not None
+    assert 1 <= len(result.masks) <= 10
+    assert result.names == {0: "person"}
+    assert result.masks.data.shape[-2:] == result.orig_shape

--- a/tests/unit/test_sam3_logic.py
+++ b/tests/unit/test_sam3_logic.py
@@ -1,0 +1,171 @@
+"""Offline coverage for the LibreSAM3 adapter."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.sam.model import LibreSAM1, _ALIASES
+from libreyolo.models.sam.sam3 import LibreSAM3
+
+pytestmark = [pytest.mark.unit, pytest.mark.sam]
+
+
+class _PCSProcessor:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, *, images, text, return_tensors):
+        self.calls += 1
+        assert images.size == (10, 8)
+        assert text == "person"
+        assert return_tensors == "pt"
+        return {
+            "pixel_values": torch.zeros((1, 3, 4, 4)),
+            "input_ids": torch.ones((1, 2), dtype=torch.long),
+            "original_sizes": torch.tensor([[8, 10]]),
+        }
+
+    def post_process_instance_segmentation(self, outputs, **kwargs):
+        assert outputs.ok
+        assert kwargs == {
+            "threshold": 0.0,
+            "mask_threshold": 0.5,
+            "target_sizes": [[8, 10]],
+        }
+        masks = torch.zeros((3, 8, 10), dtype=torch.bool)
+        masks[0, :2, :2] = True
+        masks[1, 2:5, 2:5] = True
+        masks[2, 5:8, 5:10] = True
+        return [{"masks": masks, "scores": torch.tensor([0.2, 0.9, 0.7])}]
+
+
+class _PCSModel(torch.nn.Module):
+    def forward(self, **inputs):
+        assert inputs["pixel_values"].device.type == "cpu"
+        return SimpleNamespace(ok=True)
+
+
+def _bare_sam3():
+    model = object.__new__(LibreSAM3)
+    model.model = torch.nn.Identity()
+    model.processor = SimpleNamespace()
+    model.device = torch.device("cpu")
+    model._model_dtype = torch.float32
+    model._default_multimask = False
+    model.names = {0: "object"}
+    model.size = "large"
+    model.task = "segment"
+    model._snapshot_dir = "unused"
+    model._pcs_model = _PCSModel()
+    model._pcs_processor = _PCSProcessor()
+    model._clear_image_state()
+    return model
+
+
+def test_aliases_resolve_to_sam3_without_download():
+    assert _ALIASES["sam3"] == (LibreSAM3, "large")
+    assert _ALIASES["sam-3"] == (LibreSAM3, "large")
+    assert _ALIASES["sam3-large"] == (LibreSAM3, "large")
+
+
+def test_sam3_repo_and_input_frame_are_per_size():
+    assert LibreSAM3.HF_REPOS == {"large": "facebook/sam3"}
+    assert LibreSAM3.INPUT_SIZES == {"large": 1008}
+    assert "*.pt" in LibreSAM3.SNAPSHOT_IGNORE_PATTERNS
+
+
+def test_move_embeddings_maps_tracker_feature_list():
+    model = object.__new__(LibreSAM3)
+    embeddings = [torch.zeros(1), torch.ones(1)]
+    moved = model._move_embeddings(embeddings, torch.device("cpu"))
+    assert isinstance(moved, list)
+    assert [item.device.type for item in moved] == ["cpu", "cpu"]
+
+
+def test_non_sam3_text_prompt_fails_loudly():
+    model = object.__new__(LibreSAM1)
+    with pytest.raises(NotImplementedError, match=r"LibreSAM\('sam3'\)"):
+        model.predict(Image.new("RGB", (4, 4)), text="person")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"points": [1, 1]},
+        {"bboxes": [0, 0, 2, 2]},
+        {"labels": [1]},
+        {"masks": torch.zeros((2, 2))},
+    ],
+)
+def test_text_and_visual_prompts_are_mutually_exclusive(kwargs):
+    with pytest.raises(ValueError, match="cannot be combined"):
+        _bare_sam3().predict(Image.new("RGB", (10, 8)), text="person", **kwargs)
+
+
+def test_text_path_filters_by_score_caps_and_sets_concept_name():
+    model = _bare_sam3()
+    result = model.predict(
+        Image.new("RGB", (10, 8)), text=" person ", conf=0.5, max_det=1
+    )
+    assert len(result.masks) == 1
+    assert float(result.boxes.conf[0]) == pytest.approx(0.9)
+    assert result.names == {0: "person"}
+    assert model.names == {0: "object"}
+
+
+def test_lazy_loader_instantiates_pcs_once(monkeypatch):
+    model = _bare_sam3()
+    model._pcs_model = None
+    model._pcs_processor = None
+    created = {"models": 0, "processors": 0}
+
+    class ModelFactory:
+        @classmethod
+        def from_pretrained(cls, path, dtype):
+            created["models"] += 1
+            return _PCSModel()
+
+    class ProcessorFactory:
+        @classmethod
+        def from_pretrained(cls, path):
+            created["processors"] += 1
+            return _PCSProcessor()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(Sam3Model=ModelFactory, Sam3Processor=ProcessorFactory),
+    )
+    assert model._load_pcs() == model._load_pcs()
+    assert created == {"models": 1, "processors": 1}
+
+
+def test_gated_download_error_is_actionable(monkeypatch, tmp_path):
+    class Forbidden(Exception):
+        response = SimpleNamespace(status_code=403)
+
+    model = object.__new__(LibreSAM3)
+    model.size = "large"
+    model.FILENAME_PREFIX = "TestSAM3"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(
+            snapshot_download=lambda *args, **kwargs: (_ for _ in ()).throw(
+                Forbidden()
+            )
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace())
+    with pytest.raises(RuntimeError) as caught:
+        model._ensure_weights()
+    message = str(caught.value)
+    assert "accept the terms" in message
+    assert "HF_TOKEN" in message
+    assert "https://huggingface.co/facebook/sam3" in message

--- a/tests/unit/test_sam3_logic.py
+++ b/tests/unit/test_sam3_logic.py
@@ -76,6 +76,7 @@ def test_aliases_resolve_to_sam3_without_download():
 def test_sam3_repo_and_input_frame_are_per_size():
     assert LibreSAM3.HF_REPOS == {"large": "facebook/sam3"}
     assert LibreSAM3.INPUT_SIZES == {"large": 1008}
+    assert LibreSAM3.DEFAULT_PCS_SCORE_THRESH == 0.3
     assert "*.pt" in LibreSAM3.SNAPSHOT_IGNORE_PATTERNS
 
 
@@ -116,6 +117,19 @@ def test_text_path_filters_by_score_caps_and_sets_concept_name():
     assert float(result.boxes.conf[0]) == pytest.approx(0.9)
     assert result.names == {0: "person"}
     assert model.names == {0: "object"}
+
+
+def test_text_path_default_score_threshold_and_explicit_keep_all():
+    model = _bare_sam3()
+    image = Image.new("RGB", (10, 8))
+
+    default = model.predict(image, text="person")
+    keep_all = model.predict(image, text="person", conf=0.0)
+
+    assert [float(score) for score in default.boxes.conf] == pytest.approx([0.9, 0.7])
+    assert [float(score) for score in keep_all.boxes.conf] == pytest.approx(
+        [0.2, 0.9, 0.7]
+    )
 
 
 def test_lazy_loader_instantiates_pcs_once(monkeypatch):

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -104,6 +104,11 @@ project the weights were derived from. Per-family summary:
                maintainer can host them once the tag is confirmed. Users may
                still convert BiRefNet_lite locally at their own discretion.
 
+    SAM 3    (facebook/sam3 snapshot; not rehosted)   custom SAM License
+             upstream: facebook/sam3 on Hugging Face. Access is gated and
+             requires accepting Meta's terms. LibreYOLO downloads the weights
+             directly and does not distribute them under the MIT license.
+
 The LICENSE and NOTICE files on each Hugging Face model card are the
 authoritative source for redistribution terms. Users converting
 third-party checkpoints locally are responsible for complying with the


### PR DESCRIPTION
## What does this PR do?

Adds SAM 3 image inference to the LibreSAM tier for work package #573.

- Uses `Sam3TrackerModel` for the existing point, box, and segment-everything contract.
- Adds mutually exclusive `text=` concept prompts through a lazily loaded `Sam3Model`.
- Adds `sam3`, `sam-3`, and `sam3-large` aliases plus package exports.
- Handles the gated `facebook/sam3` download with actionable authentication guidance and a custom-license notice.
- Defaults PCS filtering to `conf=0.3`; explicit `conf=0.0` keeps all candidates.
- Documents the PCS/PVS split, SAM 3.1 deferral trigger, licensing, and measured memory use.
- Adds offline logic coverage and authenticated end-to-end smoke coverage.

SAM 3.1 remains deferred until Hugging Face Transformers supports its image checkpoint.

## Code provenance

All LibreYOLO adapter, factory, result-assembly, testing, and documentation changes in this PR are original code written for LibreYOLO.

The adapter calls the Apache-2.0-licensed Hugging Face Transformers SAM 3 APIs. No Meta SAM source code is copied, adapted, or vendored. Model weights download directly from the gated `facebook/sam3` repository and remain subject to Meta's custom SAM License; LibreYOLO does not redistribute them.

## How was this tested?

- `75 passed` across the focused SAM unit suite.
- Ruff and `git diff --check` pass.
- Explicit merge-tree check against `573-work-package-2` is conflict-free.
- Real gated CPU/fp32 e2e smoke: all 4 tests passed in 3m32s, covering point, box, segment-everything, and text prompts.
- Text inference found 4 `person` instances in the sample image and returned `{0: person}` names.
- CPU/fp32 memory at 1008 px: 3.0 GB RSS after visual inference; 5.9 GB RSS with both models resident; 9.0 GB peak during the first text call.

Transformers emits an expected `sam3_video` to `sam3_tracker` model-type warning when loading the shared official checkpoint. This matches the documented `Sam3TrackerModel.from_pretrained(facebook/sam3)` path and inference succeeds.