### PR TITLE
Add PatchCore anomaly detection

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -677,3 +677,17 @@ of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, subject to the inclusion of the above
 copyright notice and this permission notice. THE SOFTWARE IS PROVIDED "AS IS",
 WITHOUT WARRANTY OF ANY KIND.
+
+--------------------------------------------------------------------
+PatchCore (Amazon Science)
+--------------------------------------------------------------------
+Source: https://github.com/amazon-science/patchcore-inspection
+Commit: fcaa92f124fb1ad74a7acf56726decd4b27cbcad
+License: Apache License 2.0
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Used for: LibrePatchCore visual anomaly detection
+          (libreyolo/models/patchcore and libreyolo/postprocess/patchcore.py),
+          including frozen multi-scale feature aggregation, greedy coreset
+          sampling, nearest-neighbor scoring, and anomaly-map generation.
+          LibreYOLO adds its native anomaly task, checkpoint, dataset,
+          validation, visualization, and CLI contracts.

--- a/docs/adr/0011-anomaly-task-contract.md
+++ b/docs/adr/0011-anomaly-task-contract.md
@@ -1,0 +1,41 @@
+# ADR 0011: Anomaly Task Contract
+
+## Status
+
+Accepted.
+
+## Context
+
+One-class visual anomaly detection does not emit object instances. A model is
+fitted for one product or scene using normal images, then produces an
+image-level deviation score and a dense localization heatmap.
+
+## Decision
+
+LibreYOLO defines the canonical `anomaly` task. A result exposes:
+
+- `anomaly_score`: a float image score, higher means more anomalous;
+- `anomaly_map`: a float `(H, W)` map on the original image canvas;
+- `is_anomalous`: the score compared with the checkpoint threshold, or `None`
+  when no calibrated threshold is available.
+
+Anomaly checkpoints use `task: "anomaly"`, `nc: 1`, and
+`names: {0: "anomaly"}` for checkpoint-schema compatibility. Training is a
+family-defined fit operation and need not use gradients or epochs.
+
+The dataset contract follows the category-local `train/good`, `test/good`,
+`test/<defect>`, and optional `ground_truth/<defect>` directory layout.
+Validation reports image AUROC and maximum F1, plus pixel equivalents when
+masks exist.
+
+Tracking, tiled inference, test-time augmentation, and export are rejected
+until anomaly-specific contracts exist for them.
+
+## Consequences
+
+- Results do not fabricate boxes.
+- A fitted checkpoint is category-specific, not a universal detector.
+- Thresholds are checkpoint metadata and may be overridden through the public
+  prediction threshold argument.
+- Benchmark datasets and derived artifacts remain subject to their own data
+  licenses and are never implicitly redistributed.

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -32,8 +32,8 @@ Required field meanings:
   `dfine`, or `ec`.
 - `size`: model variant within the family, such as `t`, `s`, `r18`, or `atto`.
 - `task`: canonical task, one of `detect`, `segment`, `semantic`, `panoptic`,
-  `pose`, `classify`, `gaze`, `obb`, `point`, `depth`, `restore`, `matte`, or
-  `ocr`.
+  `pose`, `classify`, `gaze`, `obb`, `point`, `depth`, `restore`, `matte`,
+  `ocr`, or `anomaly`.
 - `nc`: positive integer class count.
 - `names`: `dict[int, str]` with keys in `0..nc-1`. Official checkpoints
   should write every key. Readers may pad missing keys with `class_i` labels for
@@ -61,6 +61,14 @@ Pose checkpoints additionally include:
 Depth checkpoints use the task string `depth`, `nc: 1`, and
 `names: {0: "depth"}`. The single class-like slot exists only for checkpoint
 schema compatibility; depth predictions are dense float maps, not classes.
+
+Anomaly checkpoints use `task: "anomaly"`, `nc: 1`, and
+`names: {0: "anomaly"}`. LibrePatchCore checkpoints store the category memory
+bank and calibration state in `model`; the frozen stock feature extractor is
+restored from torchvision. Flat metadata includes `backbone`,
+`feature_layers`, `coreset_percent`, `calibrated_threshold`, and
+`calibration_split`. A checkpoint is category-specific, not a universal
+anomaly model.
 
 Restore checkpoints use the task string `restore`, `nc: 1`, and
 `names: {0: "image"}`. The single class-like slot exists only for checkpoint

--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -322,6 +322,37 @@ The class-like YAML fields are schema placeholders: use `nc: 1` and
 Validation is inference-only in v1 (OCR training is out of scope). Canonical
 sample resolver: `libreyolo.data.ocr_dataset.resolve_ocr_samples`.
 
+## anomaly
+
+Visual anomaly detection uses one category per dataset root. Fitting consumes
+only normal images from `train/good`; any folder below `test/` whose name is not
+`good` is an anomalous defect class:
+
+```text
+category_root/
+  train/good/*.png
+  test/good/*.png
+  test/<defect_type>/*.png
+  ground_truth/<defect_type>/*_mask.png   # optional
+```
+
+Pass the category root directly as `data=`, or use a YAML containing `path` and
+an optional `category` subdirectory:
+
+```yaml
+path: /datasets/visa
+category: pcb1
+```
+
+Masks are optional. Validation always reports image AUROC and maximum F1. It
+also reports pixel AUROC and maximum pixel F1 when defect masks are present.
+Mask filenames use the image stem plus `_mask.png`; a same-stem `.png` is also
+accepted. LibrePatchCore calibrates its prediction threshold from `test/good`
+when that split exists, otherwise from `train/good`.
+
+No benchmark data is bundled or downloaded. Datasets with non-commercial terms
+must remain user-local and must not be mirrored by the project.
+
 ## pose
 
 YAML adds:

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -68,6 +68,7 @@ instance, and panoptic segmentation; the `mobilenetv4` / `convnext` /
 | `zipdepth`  | `LibreZipDepth` | CamelCase preserved (`ZipDepth` brand casing); depth-only lightweight CNN (speed/edge tier) |
 | `birefnet`  | `LibreBiRefNet` | CamelCase preserved (Bilateral Reference); matte-only background-removal family |
 | `ppocr`     | `LibrePPOCR`    | All-caps acronym (PP-OCR brand, hyphen dropped); ocr-only two-stage text detection + recognition family |
+| `patchcore` | `LibrePatchCore` | Upstream brand casing preserved; anomaly-only memory-bank family |
 
 Casing rules observed in the table:
 
@@ -152,6 +153,7 @@ ships:
 | `zipdepth`  | `b` (base, GPU/CPU convex upsampling), `bnpu` (base capacity with the separately trained unfold-free upsampling head for NPU/edge compilers); both at short-side 384 |
 | `birefnet`  | `t` (BiRefNet_lite, Swin-T tier), `l` (BiRefNet general, Swin-L tier); both at fixed 1024 |
 | `ppocr`     | `t` (PP-OCRv5 mobile det + mobile rec, CPU tier), `l` (PP-OCRv5 server det + server rec, quality tier); detection long side 960 |
+| `patchcore` | `b` (WideResNet-50-2 backbone at 224) |
 | `clip`      | `b32`, `b16`, `l14` (ViT patch size baked in, all at 224) |
 | `siglip2`   | `b16` (base patch-16 at 256), `so400m` (shape-optimized 400M patch-14 at 384) |
 
@@ -197,6 +199,7 @@ From `libreyolo/tasks.py`:
 | `restore`     | `-restore` |
 | `matte`       | `-matte` |
 | `ocr`         | `-ocr` |
+| `anomaly`     | `-anomaly` |
 
 The factory accepts selected upstream-style aliases (`detection`, `det`,
 `segmentation`, `keypoints`, `cls`, …) at the API boundary; only the canonical
@@ -257,6 +260,12 @@ Detection quads are genuine polygons (rotated text) and do not populate
 aliases `text`, `text-recognition`, and `text_recognition` resolve to `ocr` at
 the API boundary.
 
+`anomaly` is one-class visual anomaly detection. Models expose
+`Results.anomaly_score`, `Results.anomaly_map`, and `Results.is_anomalous`.
+Canonical checkpoints require the `-anomaly` suffix. Public aliases
+`anomaly-detection`, `anomaly_detection`, and `ad` normalize to `anomaly`.
+Each fitted checkpoint belongs to one inspected category.
+
 Dataset and label contracts are documented in
 [`dataset_schema.md`](dataset_schema.md). A task is supported by a model family
 only when it appears in that family's `SUPPORTED_TASKS`.
@@ -296,6 +305,7 @@ only when it appears in that family's `SUPPORTED_TASKS`.
 | `nafnet`    | `("restore",)`                      | restore | NAFNet RGB restoration; sizes `s`/`l`; native predict runs at original resolution with reflect padding; paired PSNR/SSIM train+val; fixed-resolution ONNX v1. Published denoise weights: `LibreNAFNetl-restore-sidd.pt` (SIDD width-64, bit-exact conversion, upstream PSNR 40.3045 dB) |
 | `birefnet`  | `("matte",)`                        | matte  | BiRefNet background removal; sizes `t` (lite)/`l` (general), both fixed 1024; predict + `cutout` + transparent-PNG save + zero-shot `val` (MAE/S-measure); inference-only in v1; fixed-resolution ONNX (opset 19 DeformConv) |
 | `ppocr`     | `("ocr",)`                          | ocr    | PP-OCRv5 two-stage text detection + recognition (zh/zh-TW/en/ja/pinyin, one dictionary); sizes `t` (mobile)/`l` (server); one composite checkpoint bundles det.* and rec.* plus the charset; predict + `val` (hmean / e2e F1 / 1-NED); inference-only; export unsupported (two-network pipeline) |
+| `patchcore` | `("anomaly",)`                      | anomaly | training-free fit on `train/good`; category-specific memory bank; predict + image/pixel AUROC validation; export deferred |
 | `realesrgan` | `("restore",)`                     | restore | Real-ESRGAN super-resolution; sizes `x4`/`x2`/`x4t`; native predict at original resolution, `Results.restored` is `restore_scale` x the input; optional seam-free tiling (`predict(..., tile=512)`); inference + PSNR/SSIM `val` only (no training); dynamic-H/W ONNX |
 | `swinir`    | `("restore",)`                     | restore | SwinIR transformer super-resolution; sizes `s`/`m`/`l`, all 4x; native predict at original resolution with window padding; optional tiled inference; inference + PSNR/SSIM `val` only (no training); fixed-resolution ONNX |
 | `mobilenetv4` | `("classify",)`                | classify | MobileNetV4-conv image classifier; s/m/l at 224/224/256; predict + top-1/top-5 `val` + CE fine-tune train + ONNX |
@@ -401,6 +411,9 @@ LibreBiRefNetl-matte.pt          # BiRefNet general (Swin-L tier), MIT weights
 # ppocr — PP-OCRv5 text detection + recognition (ocr-only)
 LibrePPOCRt-ocr.pt               # mobile det + mobile rec (CPU tier), Apache-2.0 weights
 LibrePPOCRl-ocr.pt               # server det + server rec (quality tier), Apache-2.0 weights
+
+# patchcore - category-specific anomaly detector created by model.train(data=...)
+LibrePatchCoreb-anomaly.pt
 ```
 
 ### Zero-shot / open-vocabulary classify (inference-only)

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -43,6 +43,7 @@ from .models import (
     LibreCLIP,
     LibreSigLIP2,
     LibrePPOCR,
+    LibrePatchCore,
 )
 from .utils.results import (
     Results,
@@ -59,6 +60,7 @@ from .utils.results import (
     RestoredImage,
     Matte,
     OCRRegions,
+    AnomalyMap,
 )
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
@@ -113,6 +115,7 @@ def __getattr__(name):
         "SemanticValidator": (".validation", "SemanticValidator"),
         "PanopticValidator": (".validation", "PanopticValidator"),
         "DepthValidator": (".validation", "DepthValidator"),
+        "AnomalyValidator": (".validation", "AnomalyValidator"),
         "ValidationConfig": (".validation", "ValidationConfig"),
         "ByteTracker": (".tracking", "ByteTracker"),
         "TrackConfig": (".tracking", "TrackConfig"),
@@ -195,6 +198,7 @@ __all__ = [
     "LibreCLIP",
     "LibreSigLIP2",
     "LibrePPOCR",
+    "LibrePatchCore",
     "LibreDINOv2",
     # VLM-as-detector tier (optional, requires libreyolo[vlm])
     "LibreVLM",
@@ -230,6 +234,7 @@ __all__ = [
     "RestoredImage",
     "Matte",
     "OCRRegions",
+    "AnomalyMap",
     # Assets
     "SAMPLE_IMAGE",
     # Tracking

--- a/libreyolo/cli/commands/predict.py
+++ b/libreyolo/cli/commands/predict.py
@@ -344,6 +344,17 @@ def predict_cmd(
                     f"depth min={depth_map.min:.4g} "
                     f"max={depth_map.max:.4g} mean={depth_map.mean:.4g}"
                 )
+            elif getattr(r, "anomaly_map", None) is not None:
+                anomaly_map = r.anomaly_map
+                result_data["anomaly"] = {
+                    "score": round(float(r.anomaly_score), 6),
+                    "is_anomalous": r.is_anomalous,
+                    "map_shape": list(anomaly_map.data.shape),
+                    "map_min": round(float(anomaly_map.min), 6),
+                    "map_max": round(float(anomaly_map.max), 6),
+                }
+                decision = "anomalous" if r.is_anomalous is True else "good" if r.is_anomalous is False else "uncalibrated"
+                summary = f"{decision} score={r.anomaly_score:.6g}"
             else:
                 summary = "(no detections)"
 

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -49,12 +49,14 @@ def _create_explicit_task_train_model(
     Create the requested architecture first so task-specific heads exist before
     training.
     """
-    if family not in {"yolo9", "rfdetr", "dfine"} or resume:
+    if family not in {"yolo9", "rfdetr", "dfine", "patchcore"} or resume:
         return None
 
     from libreyolo.tasks import normalize_task
 
-    if family == "yolo9":
+    if family == "patchcore":
+        from libreyolo.models.patchcore.model import LibrePatchCore as model_cls
+    elif family == "yolo9":
         from libreyolo.models.yolo9.model import LibreYOLO9 as model_cls
     elif family == "dfine":
         from libreyolo.models.dfine.model import LibreDFINE as model_cls
@@ -65,6 +67,11 @@ def _create_explicit_task_train_model(
     train_task = normalize_task(task) if task is not None else filename_task
     if train_task is None:
         return None
+    if family == "patchcore":
+        if _model_ref_exists(model_path):
+            return None
+        size = model_cls.detect_size_from_filename(Path(model_path).name)
+        return model_cls(None, size=size or "b", task="anomaly", device=device)
     if family == "dfine" and train_task != "segment":
         return None
     if task is None and filename_task == train_task and _model_ref_exists(model_path):
@@ -229,7 +236,7 @@ def train_cmd(
         None,
         help=(
             "Explicit task override: detect, segment, semantic, pose, classify, "
-            "gaze, obb, point, depth"
+            "gaze, obb, point, depth, restore, matte, anomaly"
         ),
     ),
     # Training
@@ -245,6 +252,10 @@ def train_cmd(
     resume: str = typer.Option("", help="Resume training: true, or path to checkpoint"),
     amp: bool = typer.Option(True, help="Automatic Mixed Precision"),
     pretrained: bool = typer.Option(True, help="Use pretrained weights"),
+    coreset: Optional[float] = typer.Option(
+        None,
+        help="PatchCore memory-bank percentage, from 1 to 25",
+    ),
     lora: bool = typer.Option(
         False,
         "--lora",
@@ -394,7 +405,7 @@ def train_cmd(
             out, model=model, model_path=model_path, device=device
         )
         family = get_loaded_model_family(loaded_model)
-    if loaded_model is None:
+    if loaded_model is None and not (dry_run and family == "patchcore"):
         loaded_model = _create_explicit_task_train_model(
             family=family,
             model_path=model_path,
@@ -495,6 +506,7 @@ def train_cmd(
         "save_period": save_period,
         "log_interval": log_interval,
         "allow_download_scripts": allow_download_scripts,
+        "coreset": coreset,
     }
     if family:
         params = apply_family_defaults(

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -426,6 +426,11 @@ def build_family_train_kwargs(
     user_provided: set[str] | None = None,
 ) -> dict[str, Any]:
     """Build train kwargs, translating family-specific CLI/API mismatches."""
+    if family == "patchcore":
+        kwargs = build_train_kwargs(params)
+        if params.get("coreset") is not None:
+            kwargs["coreset"] = params["coreset"]
+        return kwargs
     if family == "rfdetr":
         return _build_rfdetr_train_kwargs(
             params, model_path=model_path, user_provided=user_provided

--- a/libreyolo/data/anomaly_dataset.py
+++ b/libreyolo/data/anomaly_dataset.py
@@ -1,0 +1,74 @@
+"""MVTec-style category dataset resolution for anomaly detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+IMAGE_EXTENSIONS = frozenset({".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"})
+
+
+def _image_files(directory: Path) -> list[Path]:
+    if not directory.is_dir():
+        return []
+    return sorted(
+        path for path in directory.rglob("*")
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+    )
+
+
+def resolve_anomaly_root(data: str | Path) -> Path:
+    data_path = Path(data)
+    if data_path.is_dir():
+        return data_path.resolve()
+    if data_path.is_file() and data_path.suffix.lower() in {".yaml", ".yml"}:
+        import yaml
+
+        with data_path.open("r", encoding="utf-8") as stream:
+            config = yaml.safe_load(stream) or {}
+        root = Path(config.get("path", data_path.parent))
+        if not root.is_absolute():
+            root = (data_path.parent / root).resolve()
+        category = config.get("category")
+        return (root / str(category)).resolve() if category else root.resolve()
+    raise ValueError(f"Anomaly data must be a category directory or YAML, got {data!r}.")
+
+
+def resolve_good_training_images(data: str | Path) -> list[Path]:
+    root = resolve_anomaly_root(data)
+    images = _image_files(root / "train" / "good")
+    if not images:
+        raise ValueError(f"No good training images found under {root / 'train' / 'good'}.")
+    return images
+
+
+def resolve_anomaly_test_samples(
+    data: str | Path,
+) -> list[tuple[Path, int, Path | None]]:
+    root = resolve_anomaly_root(data)
+    test_root = root / "test"
+    if not test_root.is_dir():
+        raise ValueError(f"Anomaly test directory not found: {test_root}.")
+    samples: list[tuple[Path, int, Path | None]] = []
+    for defect_dir in sorted(path for path in test_root.iterdir() if path.is_dir()):
+        label = 0 if defect_dir.name.lower() == "good" else 1
+        for image_path in _image_files(defect_dir):
+            mask_path = None
+            if label:
+                gt_dir = root / "ground_truth" / defect_dir.name
+                candidates = (
+                    gt_dir / f"{image_path.stem}_mask.png",
+                    gt_dir / f"{image_path.stem}.png",
+                )
+                mask_path = next((path for path in candidates if path.is_file()), None)
+            samples.append((image_path, label, mask_path))
+    if not samples:
+        raise ValueError(f"No anomaly test images found under {test_root}.")
+    return samples
+
+
+__all__ = [
+    "IMAGE_EXTENSIONS",
+    "resolve_anomaly_root",
+    "resolve_anomaly_test_samples",
+    "resolve_good_training_images",
+]

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -77,6 +77,7 @@ from .depth_anything3.model import (  # noqa: E402,F401  (import registers famil
 )
 from .nafnet.model import LibreNAFNet  # noqa: E402,F401  (restore-only)
 from .birefnet.model import LibreBiRefNet  # noqa: E402,F401  (matte-only; can_load keyed on squeeze_module+gdt_convs_attn+ipt_blk)
+from .patchcore.model import LibrePatchCore  # noqa: E402,F401  (anomaly-only; memory-bank fingerprint)
 from .realesrgan.model import LibreRealESRGAN  # noqa: E402,F401  (restore/super-resolution; RRDBNet+SRVGG keys are unique)
 from .swinir.model import LibreSwinIR  # noqa: E402,F401  (restore/super-resolution; RSTB keys are unique)
 from .eomt.model import LibreEoMT  # noqa: E402,F401  (semantic-only; EoMT query/mask keys are unique)
@@ -653,6 +654,7 @@ __all__ = [
     "LibreYOLO9",
     "LibreYOLO9E2E",
     "LibreYOLO9P2",
+    "LibrePatchCore",
     "LibreYOLONAS",
     "LibreDFINE",
     "LibreDEIM",

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -28,6 +28,7 @@ from torchvision.ops import batched_nms
 
 from ...postprocess.slicing import slice_batch_outputs
 from ...utils.drawing import (
+    draw_anomaly_map,
     draw_boxes,
     draw_keypoints,
     draw_masks,
@@ -47,6 +48,7 @@ from ...utils.general import (
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.predict_args import normalize_predict_kwargs
 from ...utils.results import (
+    AnomalyMap,
     Boxes,
     DepthMap,
     Keypoints,
@@ -541,6 +543,11 @@ class InferenceRunner:
             annotated_img.save(save_path)
             log_saved_result(result, save_path)
             return
+        if result.boxes is None and getattr(result, "anomaly_map", None) is not None:
+            annotated_img = draw_anomaly_map(original_img, result.anomaly_map.array)
+            annotated_img.save(save_path)
+            log_saved_result(result, save_path)
+            return
         if result.boxes is None and getattr(result, "restored", None) is not None:
             result.restored.save(save_path)
             log_saved_result(result, save_path)
@@ -723,6 +730,24 @@ class InferenceRunner:
                 depth_data
                 if isinstance(depth_data, torch.Tensor)
                 else torch.as_tensor(depth_data)
+            )
+
+        anomaly_data = detections.get("anomaly_map")
+        if anomaly_data is not None:
+            orig_w, orig_h = original_size
+            anomaly_t = (
+                anomaly_data
+                if isinstance(anomaly_data, torch.Tensor)
+                else torch.as_tensor(anomaly_data)
+            )
+            return Results(
+                boxes=None,
+                orig_shape=(orig_h, orig_w),
+                path=str(image_path) if image_path else None,
+                names=self.model.names,
+                anomaly_map=AnomalyMap(anomaly_t.float(), (orig_h, orig_w)),
+                anomaly_score=float(detections["anomaly_score"]),
+                is_anomalous=detections.get("is_anomalous"),
             )
             return Results(
                 boxes=None,
@@ -1107,6 +1132,10 @@ class InferenceRunner:
             raise ValueError(
                 "Tiled inference does not support depth maps yet. "
                 "Use non-tiled inference for depth models."
+            )
+        if getattr(self.model, "task", "detect") == "anomaly":
+            raise ValueError(
+                "Tiled inference does not support anomaly maps. Use non-tiled inference."
             )
 
         if getattr(self.model, "_is_segmentation", False):

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1074,6 +1074,10 @@ class BaseModel(ABC):
             raise NotImplementedError(
                 "Tracking does not support OCR models yet. Use predict()."
             )
+        if task == "anomaly":
+            raise NotImplementedError(
+                "Tracking does not support anomaly maps. Use predict()."
+            )
 
         from ...tracking import (
             ByteTracker,
@@ -1230,6 +1234,7 @@ class BaseModel(ABC):
             MatteValidator,
             OBBValidator,
             OCRValidator,
+            AnomalyValidator,
             PanopticValidator,
             PointValidator,
             PoseValidator,
@@ -1288,6 +1293,10 @@ class BaseModel(ABC):
                 "Augmented validation does not support OCR models yet. "
                 "Use augment=False for OCR models."
             )
+        if augment and self.task == "anomaly":
+            raise ValueError(
+                "Augmented validation does not support anomaly models. Use augment=False."
+            )
 
         config = ValidationConfig(
             data=data,
@@ -1331,6 +1340,8 @@ class BaseModel(ABC):
             validator_cls = MatteValidator
         elif self.task == "ocr":
             validator_cls = OCRValidator
+        elif self.task == "anomaly":
+            validator_cls = AnomalyValidator
         elif self.task == "classify":
             validator_cls = ClassifyValidator
         elif self.task == "obb":

--- a/libreyolo/models/patchcore/NOTICE
+++ b/libreyolo/models/patchcore/NOTICE
@@ -1,0 +1,20 @@
+LibrePatchCore third-party attribution
+======================================
+
+LibrePatchCore is derived from the official PatchCore implementation:
+
+    Repository: https://github.com/amazon-science/patchcore-inspection
+    Commit:     fcaa92f124fb1ad74a7acf56726decd4b27cbcad
+    License:    Apache License 2.0
+    Copyright:  Amazon.com, Inc. or its affiliates
+
+The LibreYOLO implementation provides native task, dataset, checkpoint,
+validation, visualization, and CLI integration. It uses torchvision's
+WideResNet-50-2 implementation and ImageNet pretrained weights through the
+installed torchvision dependency. torchvision is BSD-3-Clause licensed.
+
+Apache License 2.0:
+https://www.apache.org/licenses/LICENSE-2.0
+
+BSD 3-Clause License:
+https://github.com/pytorch/vision/blob/main/LICENSE

--- a/libreyolo/models/patchcore/__init__.py
+++ b/libreyolo/models/patchcore/__init__.py
@@ -1,0 +1,5 @@
+"""LibrePatchCore anomaly-detection family."""
+
+from .model import LibrePatchCore
+
+__all__ = ["LibrePatchCore"]

--- a/libreyolo/models/patchcore/config.py
+++ b/libreyolo/models/patchcore/config.py
@@ -1,0 +1,25 @@
+"""Training-free fit configuration for LibrePatchCore."""
+
+from dataclasses import dataclass
+
+from ...training.config import TrainConfig
+
+
+@dataclass(kw_only=True)
+class PatchCoreConfig(TrainConfig):
+    size: str = "b"
+    num_classes: int = 1
+    imgsz: int = 224
+    epochs: int = 0
+    batch: int = 8
+    device: str = "auto"
+    workers: int = 4
+    project: str = "runs/anomaly/train"
+    name: str = "patchcore"
+    coreset: float = 10.0
+    projection_dim: int = 128
+    reweight_neighbors: int = 9
+    query_chunk_size: int = 2048
+
+
+__all__ = ["PatchCoreConfig"]

--- a/libreyolo/models/patchcore/model.py
+++ b/libreyolo/models/patchcore/model.py
@@ -1,0 +1,293 @@
+"""LibrePatchCore training-free visual anomaly detector."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, ClassVar, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from ...postprocess.patchcore import postprocess as patchcore_postprocess
+from ...utils.general import increment_path
+from ...utils.image_loader import ImageInput
+from ...utils.serialization import load_untrusted_torch_file, wrap_libreyolo_checkpoint
+from ..base import BaseModel
+from .config import PatchCoreConfig
+from .nn import PatchCoreNet, greedy_coreset
+from .utils import (
+    iter_preprocessed_batches,
+    preprocess_image,
+    preprocess_numpy,
+    resolve_anomaly_test_samples,
+    resolve_good_training_images,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LibrePatchCore(BaseModel):
+    """PatchCore anomaly detection with a frozen WideResNet-50-2 backbone."""
+
+    FAMILY = "patchcore"
+    FILENAME_PREFIX = "LibrePatchCore"
+    INPUT_SIZES: ClassVar[dict[str, int]] = {"b": 224}
+    SUPPORTED_TASKS = ("anomaly",)
+    DEFAULT_TASK = "anomaly"
+    REQUIRE_TASK_SUFFIX = True
+    TRAIN_CONFIG = PatchCoreConfig
+    TTA_ENABLED = False
+    SUPPORTS_BATCHED_PREDICT = True
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        bank = weights_dict.get("memory_bank")
+        return (
+            isinstance(bank, torch.Tensor)
+            and bank.ndim == 2
+            and bank.shape[1] == 1536
+            and "anomaly_threshold" in weights_dict
+            and "fitted" in weights_dict
+        )
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        return "b" if cls.can_load(weights_dict) else None
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        return 1 if cls.can_load(weights_dict) else None
+
+    @classmethod
+    def detect_checkpoint_task(cls, state_dict: dict) -> Optional[str]:
+        return "anomaly" if cls.can_load(state_dict) else None
+
+    @classmethod
+    def format_weight_filename(cls, size_code: str) -> str:
+        return f"{cls.FILENAME_PREFIX}{size_code}-anomaly{cls.WEIGHT_EXT}"
+
+    def __init__(
+        self,
+        model_path=None,
+        size: str = "b",
+        nb_classes: int = 1,
+        device: str = "auto",
+        task: str | None = None,
+        pretrained: bool = True,
+        reweight_neighbors: int = 9,
+        query_chunk_size: int = 2048,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=1,
+            device=device,
+            task=task,
+            pretrained=pretrained,
+            reweight_neighbors=reweight_neighbors,
+            query_chunk_size=query_chunk_size,
+            **kwargs,
+        )
+        if model_path is not None and isinstance(model_path, (str, Path)):
+            self._load_weights(str(model_path))
+            self._load_patchcore_metadata(str(model_path))
+        self.nb_classes = 1
+        self.names = {0: "anomaly"}
+
+    def _init_model(self) -> nn.Module:
+        use_pretrained = bool(getattr(self, "pretrained", True)) and not bool(
+            getattr(self, "_in_rebuild", False)
+        )
+        return PatchCoreNet(
+            pretrained=use_pretrained,
+            reweight_neighbors=int(getattr(self, "reweight_neighbors", 9)),
+            query_chunk_size=int(getattr(self, "query_chunk_size", 2048)),
+        )
+
+    def _prepare_state_dict(self, state_dict: dict) -> dict:
+        bank = state_dict.get("memory_bank")
+        if isinstance(bank, torch.Tensor) and bank.ndim == 2:
+            self.model.memory_bank = torch.empty_like(bank)
+        return state_dict
+
+    def _strict_loading(self) -> bool:
+        # Category checkpoints intentionally omit the frozen torchvision
+        # backbone. It is restored from torchvision when the wrapper is built.
+        return False
+
+    def _load_patchcore_metadata(self, model_path: str) -> None:
+        checkpoint = load_untrusted_torch_file(
+            model_path, map_location="cpu", context="PatchCore metadata"
+        )
+        if not isinstance(checkpoint, dict):
+            return
+        self.backbone_id = str(checkpoint.get("backbone", "wide_resnet50_2"))
+        self.feature_layers = tuple(checkpoint.get("feature_layers", ("layer2", "layer3")))
+        self.model.reweight_neighbors = int(checkpoint.get("reweight_neighbors", 9))
+        self.model.query_chunk_size = int(checkpoint.get("query_chunk_size", 2048))
+
+    @property
+    def threshold(self) -> float | None:
+        value = float(self.model.anomaly_threshold.detach().cpu())
+        return value if torch.isfinite(torch.tensor(value)) else None
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {"backbone": self.model.backbone, "layer2": self.model.backbone.layer2, "layer3": self.model.backbone.layer3}
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        return preprocess_numpy
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, Any, Tuple[int, int], float]:
+        return preprocess_image(
+            image, input_size=input_size or self.input_size, color_format=color_format
+        )
+
+    def _forward(self, input_tensor: torch.Tensor) -> Any:
+        return self.model(input_tensor.float())
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        del iou_thres, max_det, ratio, kwargs
+        threshold = self.threshold
+        if conf_thres is not None and conf_thres != 0.25:
+            threshold = float(conf_thres)
+        return patchcore_postprocess(
+            output, original_size=original_size, threshold=threshold, sigma=4.0
+        )
+
+    def _extract_dataset_features(self, images: list[Path], batch: int) -> torch.Tensor:
+        features: list[torch.Tensor] = []
+        self.model.eval()
+        with torch.no_grad():
+            for tensors in iter_preprocessed_batches(images, batch, self.input_size):
+                grid = self.model.extract_features(tensors.to(self.device).float())
+                features.append(grid.reshape(-1, grid.shape[-1]).cpu())
+        return torch.cat(features, dim=0)
+
+    def _calibrate_threshold(self, images: list[Path], batch: int) -> float:
+        scores: list[torch.Tensor] = []
+        self.model.eval()
+        with torch.no_grad():
+            for tensors in iter_preprocessed_batches(images, batch, self.input_size):
+                output = self.model(tensors.to(self.device).float())
+                scores.append(output["image_scores"].detach().cpu())
+        return float(torch.cat(scores).max())
+
+    def train(
+        self,
+        data: str,
+        *,
+        batch: int = 8,
+        imgsz: int | None = None,
+        device: str = "",
+        workers: int = 4,
+        seed: int = 0,
+        project: str = "runs/anomaly/train",
+        name: str = "patchcore",
+        exist_ok: bool = False,
+        coreset: float = 10.0,
+        projection_dim: int = 128,
+        reweight_neighbors: int = 9,
+        query_chunk_size: int = 2048,
+        epochs: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Fit the memory bank from good images; no optimizer or epochs are used."""
+        del workers, kwargs
+        if int(os.environ.get("WORLD_SIZE", "1")) != 1:
+            raise RuntimeError("LibrePatchCore fit is single-process only; DDP is not supported.")
+        if epochs not in (None, 0, 1):
+            logger.warning("LibrePatchCore is training-free; epochs=%s is ignored.", epochs)
+        if imgsz is not None and int(imgsz) != self.input_size:
+            raise ValueError(f"LibrePatchCoreb uses imgsz={self.input_size}; got {imgsz}.")
+        if device and str(device).lower() not in {"auto", ""}:
+            self.device = torch.device(f"cuda:{device}" if str(device).isdigit() else device)
+            self.model.to(self.device)
+        if batch < 1:
+            raise ValueError("batch must be at least 1.")
+        self.model.reweight_neighbors = int(reweight_neighbors)
+        self.model.query_chunk_size = int(query_chunk_size)
+
+        train_images = resolve_good_training_images(data)
+        features = self._extract_dataset_features(train_images, batch)
+        bank = greedy_coreset(
+            features, percent=float(coreset), projection_dim=int(projection_dim), seed=int(seed)
+        )
+        self.model.set_memory_bank(bank.to(self.device), float(coreset))
+
+        try:
+            good_test = [
+                path for path, label, _ in resolve_anomaly_test_samples(data) if label == 0
+            ]
+        except ValueError:
+            good_test = []
+        calibration_images = good_test or train_images
+        threshold = self._calibrate_threshold(calibration_images, batch)
+        self.model.anomaly_threshold.fill_(threshold)
+
+        save_dir = increment_path(Path(project) / name, exist_ok=exist_ok)
+        weights_dir = save_dir / "weights"
+        weights_dir.mkdir(parents=True, exist_ok=True)
+        checkpoint = wrap_libreyolo_checkpoint(
+            {
+                key: value.detach().cpu()
+                for key, value in self.model.state_dict().items()
+                if not key.startswith("backbone.")
+            },
+            model_family=self.FAMILY,
+            size=self.size,
+            task=self.task,
+            nc=1,
+            names={0: "anomaly"},
+            imgsz=self.input_size,
+            backbone="wide_resnet50_2",
+            backbone_weights="torchvision:Wide_ResNet50_2_Weights.IMAGENET1K_V2",
+            feature_layers=["layer2", "layer3"],
+            coreset_percent=float(coreset),
+            projection_dim=int(projection_dim),
+            reweight_neighbors=int(reweight_neighbors),
+            query_chunk_size=int(query_chunk_size),
+            calibrated_threshold=threshold,
+            calibration_split="test/good" if good_test else "train/good",
+            training_images=len(train_images),
+        )
+        best_path = weights_dir / "best.pt"
+        last_path = weights_dir / "last.pt"
+        torch.save(checkpoint, best_path)
+        torch.save(checkpoint, last_path)
+        self.model_path = str(best_path)
+        self.model.eval()
+        return {
+            "save_dir": str(save_dir),
+            "best_checkpoint": str(best_path),
+            "last_checkpoint": str(last_path),
+            "memory_bank_size": int(bank.shape[0]),
+            "training_patches": int(features.shape[0]),
+            "threshold": threshold,
+        }
+
+    def export(self, format: str = "onnx", **kwargs) -> str:
+        del format, kwargs
+        raise NotImplementedError(
+            "LibrePatchCore export is not supported in v1 because its dynamic memory bank and kNN search have no runtime contract."
+        )
+
+
+__all__ = ["LibrePatchCore"]

--- a/libreyolo/models/patchcore/nn.py
+++ b/libreyolo/models/patchcore/nn.py
@@ -1,0 +1,149 @@
+"""Frozen feature extractor, coreset sampling, and nearest-neighbor scoring."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class PatchCoreNet(nn.Module):
+    """WideResNet feature memory used by PatchCore."""
+
+    def __init__(
+        self,
+        *,
+        pretrained: bool = True,
+        reweight_neighbors: int = 9,
+        query_chunk_size: int = 2048,
+    ) -> None:
+        super().__init__()
+        from torchvision.models import Wide_ResNet50_2_Weights, wide_resnet50_2
+
+        weights = Wide_ResNet50_2_Weights.IMAGENET1K_V2 if pretrained else None
+        self.backbone = wide_resnet50_2(weights=weights)
+        self.backbone.fc = nn.Identity()
+        for parameter in self.backbone.parameters():
+            parameter.requires_grad_(False)
+        self.backbone.eval()
+
+        self.register_buffer("memory_bank", torch.empty(0, 1536), persistent=True)
+        self.register_buffer("anomaly_threshold", torch.tensor(float("nan")), persistent=True)
+        self.register_buffer("coreset_percent", torch.tensor(10.0), persistent=True)
+        self.register_buffer("fitted", torch.tensor(False), persistent=True)
+        self.reweight_neighbors = int(reweight_neighbors)
+        self.query_chunk_size = int(query_chunk_size)
+
+    def train(self, mode: bool = True):
+        super().train(mode)
+        self.backbone.eval()
+        return self
+
+    def extract_features(self, images: torch.Tensor) -> torch.Tensor:
+        """Return locally aggregated patch features as ``(B, H, W, C)``."""
+        x = self.backbone.conv1(images)
+        x = self.backbone.bn1(x)
+        x = self.backbone.relu(x)
+        x = self.backbone.maxpool(x)
+        x = self.backbone.layer1(x)
+        layer2 = self.backbone.layer2(x)
+        layer3 = self.backbone.layer3(layer2)
+        layer2 = F.avg_pool2d(layer2, kernel_size=3, stride=1, padding=1)
+        layer3 = F.avg_pool2d(layer3, kernel_size=3, stride=1, padding=1)
+        layer3 = F.interpolate(layer3, size=layer2.shape[-2:], mode="bilinear", align_corners=False)
+        features = torch.cat((layer2, layer3), dim=1)
+        return features.permute(0, 2, 3, 1).contiguous()
+
+    def set_memory_bank(self, bank: torch.Tensor, coreset_percent: float) -> None:
+        if bank.ndim != 2 or bank.shape[1] != 1536 or bank.shape[0] == 0:
+            raise ValueError(f"Expected a non-empty (N, 1536) memory bank, got {tuple(bank.shape)}.")
+        self.memory_bank = bank.detach().float().to(self.memory_bank.device)
+        self.coreset_percent.fill_(float(coreset_percent))
+        self.fitted.fill_(True)
+
+    def nearest_distances(self, queries: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if not bool(self.fitted) or self.memory_bank.numel() == 0:
+            raise RuntimeError("LibrePatchCore is not fitted. Run model.train(data=...) first.")
+        queries = queries.float()
+        bank = self.memory_bank.float()
+        distances: list[torch.Tensor] = []
+        indices: list[torch.Tensor] = []
+        for start in range(0, len(queries), self.query_chunk_size):
+            chunk = queries[start : start + self.query_chunk_size]
+            values, nearest = torch.cdist(chunk, bank).min(dim=1)
+            distances.append(values)
+            indices.append(nearest)
+        return torch.cat(distances), torch.cat(indices)
+
+    def _image_score(
+        self, queries: torch.Tensor, patch_distances: torch.Tensor, nearest: torch.Tensor
+    ) -> torch.Tensor:
+        max_index = int(patch_distances.argmax())
+        raw_score = patch_distances[max_index]
+        count = min(self.reweight_neighbors, int(self.memory_bank.shape[0]))
+        if count <= 1:
+            return raw_score
+        support_index = int(nearest[max_index])
+        support = self.memory_bank[support_index : support_index + 1].float()
+        _, neighbor_indices = torch.cdist(support, self.memory_bank.float()).topk(
+            count, largest=False, dim=1
+        )
+        neighbor_features = self.memory_bank[neighbor_indices[0]].float()
+        neighbor_distances = torch.linalg.vector_norm(
+            neighbor_features - queries[max_index].float(), dim=1
+        )
+        weights = torch.softmax(neighbor_distances, dim=0)
+        return raw_score * (1.0 - weights[0])
+
+    def forward(self, images: torch.Tensor) -> dict[str, torch.Tensor]:
+        feature_grid = self.extract_features(images)
+        batch, height, width, channels = feature_grid.shape
+        maps: list[torch.Tensor] = []
+        scores: list[torch.Tensor] = []
+        for features in feature_grid.reshape(batch, height * width, channels):
+            distances, nearest = self.nearest_distances(features)
+            maps.append(distances.reshape(height, width))
+            scores.append(self._image_score(features, distances, nearest))
+        return {"patch_scores": torch.stack(maps), "image_scores": torch.stack(scores)}
+
+
+def greedy_coreset(
+    features: torch.Tensor,
+    *,
+    percent: float = 10.0,
+    projection_dim: int = 128,
+    seed: int = 0,
+) -> torch.Tensor:
+    """Deterministic projected farthest-first coreset selection."""
+    if features.ndim != 2 or len(features) == 0:
+        raise ValueError("Coreset features must be a non-empty 2D tensor.")
+    if not 1.0 <= percent <= 25.0:
+        raise ValueError(f"coreset must be in [1, 25] percent, got {percent}.")
+    count = max(1, int(math.ceil(len(features) * percent / 100.0)))
+    if count >= len(features):
+        return features.detach().float()
+
+    source = features.detach().float().cpu()
+    dim = min(int(projection_dim), int(source.shape[1]))
+    generator = torch.Generator(device="cpu").manual_seed(int(seed))
+    projection = torch.randn(source.shape[1], dim, generator=generator) / math.sqrt(dim)
+    projected = source @ projection
+
+    centroid = projected.mean(dim=0, keepdim=True)
+    first = int(torch.linalg.vector_norm(projected - centroid, dim=1).argmax())
+    selected = torch.empty(count, dtype=torch.long)
+    selected[0] = first
+    min_distances = torch.linalg.vector_norm(projected - projected[first], dim=1)
+    min_distances[first] = -1
+    for index in range(1, count):
+        chosen = int(min_distances.argmax())
+        selected[index] = chosen
+        distance = torch.linalg.vector_norm(projected - projected[chosen], dim=1)
+        min_distances = torch.minimum(min_distances, distance)
+        min_distances[selected[: index + 1]] = -1
+    return source[selected]
+
+
+__all__ = ["PatchCoreNet", "greedy_coreset"]

--- a/libreyolo/models/patchcore/utils.py
+++ b/libreyolo/models/patchcore/utils.py
@@ -1,0 +1,75 @@
+"""Image preprocessing and dataset helpers for LibrePatchCore."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import torch
+from PIL import Image
+
+from ...utils.image_loader import ImageInput, ImageLoader
+from ...data.anomaly_dataset import (
+    resolve_anomaly_root,
+    resolve_anomaly_test_samples,
+    resolve_good_training_images,
+)
+
+IMAGENET_MEAN = np.asarray((0.485, 0.456, 0.406), dtype=np.float32)
+IMAGENET_STD = np.asarray((0.229, 0.224, 0.225), dtype=np.float32)
+
+
+def preprocess_numpy(image_rgb_hwc: np.ndarray, input_size: int = 224) -> tuple[np.ndarray, float]:
+    """Resize, center-crop, and ImageNet-normalize an RGB image."""
+    image = Image.fromarray(np.asarray(image_rgb_hwc, dtype=np.uint8), mode="RGB")
+    width, height = image.size
+    resize_short = int(round(input_size / 0.875))
+    scale = resize_short / min(width, height)
+    resized = image.resize(
+        (max(input_size, int(round(width * scale))), max(input_size, int(round(height * scale)))),
+        Image.Resampling.BILINEAR,
+    )
+    left = (resized.width - input_size) // 2
+    top = (resized.height - input_size) // 2
+    crop = resized.crop((left, top, left + input_size, top + input_size))
+    array = np.asarray(crop, dtype=np.float32) / 255.0
+    array = (array - IMAGENET_MEAN) / IMAGENET_STD
+    return np.ascontiguousarray(array.transpose(2, 0, 1)), 1.0
+
+
+def preprocess_image(
+    image: ImageInput,
+    *,
+    input_size: int = 224,
+    color_format: str = "auto",
+) -> tuple[torch.Tensor, Image.Image, tuple[int, int], float]:
+    original = ImageLoader.load(image, color_format=color_format)
+    if not isinstance(original, Image.Image):
+        original = Image.fromarray(np.asarray(original)).convert("RGB")
+    original = original.convert("RGB")
+    chw, ratio = preprocess_numpy(np.asarray(original), input_size)
+    return torch.from_numpy(chw).unsqueeze(0), original, original.size, ratio
+
+
+def iter_preprocessed_batches(
+    paths: Iterable, batch_size: int, input_size: int
+) -> Iterable[torch.Tensor]:
+    batch: list[torch.Tensor] = []
+    for path in paths:
+        tensor, _, _, _ = preprocess_image(str(path), input_size=input_size)
+        batch.append(tensor)
+        if len(batch) == batch_size:
+            yield torch.cat(batch, dim=0)
+            batch = []
+    if batch:
+        yield torch.cat(batch, dim=0)
+
+
+__all__ = [
+    "iter_preprocessed_batches",
+    "preprocess_image",
+    "preprocess_numpy",
+    "resolve_anomaly_root",
+    "resolve_anomaly_test_samples",
+    "resolve_good_training_images",
+]

--- a/libreyolo/postprocess/patchcore.py
+++ b/libreyolo/postprocess/patchcore.py
@@ -1,0 +1,40 @@
+"""PatchCore anomaly-map postprocessing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+def postprocess(
+    output: dict[str, torch.Tensor],
+    *,
+    original_size: tuple[int, int],
+    threshold: float | None,
+    sigma: float = 4.0,
+) -> dict[str, Any]:
+    """Upsample and smooth one PatchCore score map to the original canvas."""
+    width, height = original_size
+    patch_scores = output["patch_scores"]
+    image_scores = output["image_scores"]
+    if patch_scores.ndim == 2:
+        patch_scores = patch_scores.unsqueeze(0)
+    anomaly_map = F.interpolate(
+        patch_scores[:, None].float(), size=(height, width), mode="bilinear", align_corners=False
+    )[0, 0].detach().cpu().numpy()
+    if sigma > 0:
+        from scipy.ndimage import gaussian_filter
+
+        anomaly_map = gaussian_filter(anomaly_map, sigma=float(sigma))
+    score = float(image_scores.reshape(-1)[0].detach().cpu())
+    return {
+        "anomaly_score": score,
+        "anomaly_map": np.asarray(anomaly_map, dtype=np.float32),
+        "is_anomalous": None if threshold is None else bool(score > threshold),
+    }
+
+
+__all__ = ["postprocess"]

--- a/libreyolo/tasks.py
+++ b/libreyolo/tasks.py
@@ -21,6 +21,7 @@ TaskType = Literal[
     "restore",
     "matte",
     "ocr",
+    "anomaly",
 ]
 TASKS = (
     "detect",
@@ -36,6 +37,7 @@ TASKS = (
     "restore",
     "matte",
     "ocr",
+    "anomaly",
 )
 
 TASK_ALIASES = {
@@ -91,6 +93,10 @@ TASK_ALIASES = {
     "text": "ocr",
     "text-recognition": "ocr",
     "text_recognition": "ocr",
+    "anomaly": "anomaly",
+    "anomaly-detection": "anomaly",
+    "anomaly_detection": "anomaly",
+    "ad": "anomaly",
 }
 
 TASK_TO_SUFFIX = {
@@ -106,6 +112,7 @@ TASK_TO_SUFFIX = {
     "restore": "restore",
     "matte": "matte",
     "ocr": "ocr",
+    "anomaly": "anomaly",
 }
 
 SUFFIX_TO_TASK = {v: k for k, v in TASK_TO_SUFFIX.items()}

--- a/libreyolo/ui/server.py
+++ b/libreyolo/ui/server.py
@@ -90,6 +90,12 @@ def _summarize_result(result) -> tuple[str, str]:
     if getattr(result, "depth_map", None) is not None:
         return "depth", "depth map"
 
+    if getattr(result, "anomaly_map", None) is not None:
+        score = float(getattr(result, "anomaly_score", 0.0) or 0.0)
+        decision = getattr(result, "is_anomalous", None)
+        label = "anomalous" if decision is True else "good" if decision is False else "scored"
+        return "anomaly", f"{label} {score:.3f}"
+
     if getattr(result, "restored", None) is not None:
         scale = getattr(result, "restore_scale", 1)
         label = f"upscaled x{scale}" if scale and scale != 1 else "restored"

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -598,6 +598,32 @@ def draw_depth_map(
     return result
 
 
+def draw_anomaly_map(
+    img: Image.Image,
+    anomaly_map: np.ndarray,
+    alpha: float = 0.55,
+) -> Image.Image:
+    """Overlay an anomaly heatmap, with high scores rendered in warm colors."""
+    scores = np.asarray(anomaly_map, dtype=np.float32)
+    if scores.shape[:2] != (img.height, img.width):
+        scores = np.asarray(
+            Image.fromarray(scores, mode="F").resize(img.size, Image.BILINEAR),
+            dtype=np.float32,
+        )
+    finite = np.isfinite(scores)
+    normalized = np.zeros_like(scores, dtype=np.float32)
+    if finite.any():
+        values = scores[finite]
+        lo, hi = float(values.min()), float(values.max())
+        if hi > lo:
+            normalized[finite] = (values - lo) / (hi - lo)
+    indices = ((1.0 - normalized) * 255).round().astype(np.uint8)
+    colored = _depth_colormap_lut()[indices]
+    colored[~finite] = 0
+    heatmap = Image.fromarray(colored, mode="RGB")
+    return Image.blend(img.convert("RGB"), heatmap, float(alpha))
+
+
 def _checkerboard(
     height: int,
     width: int,

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -610,6 +610,44 @@ class DepthMap(_TensorPayload):
         )
 
 
+class AnomalyMap(_TensorPayload):
+    """Dense float anomaly heatmap for a single image."""
+
+    def __init__(self, data: TensorLike, orig_shape: Tuple[int, int] | None = None):
+        if data.ndim != 2:
+            raise ValueError(
+                f"expected (H, W) anomaly map but got shape {tuple(data.shape)}"
+            )
+        if orig_shape is None:
+            orig_shape = (int(data.shape[0]), int(data.shape[1]))
+        super().__init__(data, orig_shape)
+
+    @property
+    def array(self) -> np.ndarray:
+        return np.asarray(_numpy(self.data), dtype=np.float32)
+
+    @property
+    def min(self) -> float:
+        return float(self.array.min()) if self.array.size else 0.0
+
+    @property
+    def max(self) -> float:
+        return float(self.array.max()) if self.array.size else 0.0
+
+    @property
+    def mean(self) -> float:
+        return float(self.array.mean()) if self.array.size else 0.0
+
+    def __getitem__(self, idx):
+        return self.__class__(self.data, self.orig_shape)
+
+    def __len__(self) -> int:
+        return 1
+
+    def __repr__(self) -> str:
+        return f"AnomalyMap(shape={tuple(self.data.shape)}, orig_shape={self.orig_shape})"
+
+
 class RestoredImage(_TensorPayload):
     """Dense restored RGB image for a single input.
 
@@ -1026,6 +1064,7 @@ class Results:
         "semantic_mask",
         "panoptic",
         "depth_map",
+        "anomaly_map",
         "restored",
         "matte",
         "ocr",
@@ -1046,6 +1085,9 @@ class Results:
         semantic_mask: Optional[SemanticMask] = None,
         panoptic: Optional[PanopticSegmentation] = None,
         depth_map: Optional[DepthMap] = None,
+        anomaly_map: Optional[AnomalyMap] = None,
+        anomaly_score: Optional[float] = None,
+        is_anomalous: Optional[bool] = None,
         restored: Optional[RestoredImage] = None,
         matte: Optional[Matte] = None,
         ocr: Optional[OCRRegions] = None,
@@ -1062,6 +1104,8 @@ class Results:
             points = Points(points.data, orig_shape)
         if depth_map is not None and depth_map.orig_shape is None:
             depth_map = DepthMap(depth_map.data, orig_shape)
+        if anomaly_map is not None and anomaly_map.orig_shape is None:
+            anomaly_map = AnomalyMap(anomaly_map.data, orig_shape)
         if restored is not None and restored.orig_shape is None:
             restored = RestoredImage(restored.data, orig_shape)
         if matte is not None and matte.orig_shape is None:
@@ -1079,6 +1123,9 @@ class Results:
         self.semantic_mask = semantic_mask
         self.panoptic = panoptic
         self.depth_map = depth_map
+        self.anomaly_map = anomaly_map
+        self.anomaly_score = None if anomaly_score is None else float(anomaly_score)
+        self.is_anomalous = None if is_anomalous is None else bool(is_anomalous)
         self.restored = restored
         self.matte = matte
         self.ocr = ocr
@@ -1108,6 +1155,9 @@ class Results:
             "semantic_mask": self.semantic_mask,
             "panoptic": self.panoptic,
             "depth_map": self.depth_map,
+            "anomaly_map": self.anomaly_map,
+            "anomaly_score": self.anomaly_score,
+            "is_anomalous": self.is_anomalous,
             "restored": self.restored,
             "matte": self.matte,
             "ocr": self.ocr,
@@ -1166,6 +1216,9 @@ class Results:
         semantic_mask: Optional[SemanticMask] = None,
         panoptic: Optional[PanopticSegmentation] = None,
         depth_map: Optional[DepthMap] = None,
+        anomaly_map: Optional[AnomalyMap] = None,
+        anomaly_score: Optional[float] = None,
+        is_anomalous: Optional[bool] = None,
         restored: Optional[RestoredImage] = None,
         matte: Optional[Matte] = None,
         ocr: Optional[OCRRegions] = None,
@@ -1192,6 +1245,12 @@ class Results:
             self.panoptic = panoptic
         if depth_map is not None:
             self.depth_map = depth_map
+        if anomaly_map is not None:
+            self.anomaly_map = anomaly_map
+        if anomaly_score is not None:
+            self.anomaly_score = float(anomaly_score)
+        if is_anomalous is not None:
+            self.is_anomalous = bool(is_anomalous)
         if restored is not None:
             self.restored = restored
         if matte is not None:
@@ -1249,18 +1308,34 @@ class Results:
             rgb = np.asarray(Image.fromarray(rgb.astype(np.uint8)).resize((w, h), Image.BILINEAR))
         return rgb.astype(np.uint8)
 
-    def save(self, path: str, image: Any = None) -> str:
-        """Save a matte result as a transparent-background RGBA PNG cutout.
+    def plot(self, image: Any = None):
+        """Render a task-aware result preview for dense anomaly results."""
+        if self.anomaly_map is None:
+            raise NotImplementedError(
+                "Results.plot() is currently implemented for anomaly results. "
+                "Use predict(save=True) for other task previews."
+            )
+        from PIL import Image
+        from .drawing import draw_anomaly_map
 
-        Returns the written path. Requires the source image (via ``image`` or
-        ``self.path``).
-        """
+        h, w = self.anomaly_map.array.shape
+        source = Image.fromarray(self._source_rgb(image, (h, w)), mode="RGB")
+        return draw_anomaly_map(source, self.anomaly_map.array)
+
+    def save(self, path: str, image: Any = None) -> str:
+        """Save a matte cutout or an anomaly heatmap preview."""
         from PIL import Image
 
+        if self.anomaly_map is not None:
+            out = Path(path)
+            if out.parent and str(out.parent) not in (".", ""):
+                out.parent.mkdir(parents=True, exist_ok=True)
+            self.plot(image=image).save(out)
+            return str(out)
         if self.matte is None:
             raise NotImplementedError(
-                "Results.save() writes a transparent-PNG cutout and is defined for "
-                "matte results only. Use result.plot()/CLI --save for other tasks."
+                "Results.save() is defined for matte and anomaly results. "
+                "Use predict(save=True) for other tasks."
             )
         rgba = self.cutout(image=image)
         out = Path(path)
@@ -1268,6 +1343,18 @@ class Results:
             out.parent.mkdir(parents=True, exist_ok=True)
         Image.fromarray(rgba, mode="RGBA").save(out)
         return str(out)
+
+    def verbose(self) -> str:
+        """Return a concise human-readable result summary."""
+        if self.anomaly_map is not None:
+            decision = (
+                "anomalous" if self.is_anomalous is True
+                else "good" if self.is_anomalous is False
+                else "uncalibrated"
+            )
+            return f"{decision}, anomaly_score {float(self.anomaly_score or 0.0):.5g}"
+        rows = self.summary()
+        return ", ".join(str(row) for row in rows)
 
     def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, Any]]:
         if self.boxes is None:
@@ -1332,6 +1419,16 @@ class Results:
                         "min": round(self.depth_map.min, decimals),
                         "max": round(self.depth_map.max, decimals),
                         "mean": round(self.depth_map.mean, decimals),
+                    }
+                ]
+            if self.anomaly_map is not None:
+                return [
+                    {
+                        "name": "anomaly",
+                        "score": round(float(self.anomaly_score or 0.0), decimals),
+                        "is_anomalous": self.is_anomalous,
+                        "map_min": round(self.anomaly_map.min, decimals),
+                        "map_max": round(self.anomaly_map.max, decimals),
                     }
                 ]
             if self.restored is not None:
@@ -1446,6 +1543,8 @@ class Results:
             return 1
         if self.depth_map is not None:
             return 1
+        if self.anomaly_map is not None:
+            return 1
         if self.restored is not None:
             return 1
         if self.matte is not None:
@@ -1470,6 +1569,10 @@ class Results:
             parts.append(f"panoptic={self.panoptic}")
         if self.depth_map is not None:
             parts.append(f"depth_map={self.depth_map}")
+        if self.anomaly_map is not None:
+            parts.append(f"anomaly_score={self.anomaly_score:.5g}" if self.anomaly_score is not None else "anomaly_score=None")
+            parts.append(f"is_anomalous={self.is_anomalous}")
+            parts.append(f"anomaly_map={self.anomaly_map}")
         if self.restored is not None:
             parts.append(f"restored={self.restored}")
             if self.restore_scale != 1:

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -306,6 +306,7 @@ def run_video_inference(
     from tqdm import tqdm
 
     from .drawing import (
+        draw_anomaly_map,
         draw_boxes,
         draw_depth_map,
         draw_keypoints,
@@ -389,6 +390,13 @@ def run_video_inference(
                         if isinstance(depth_np, torch.Tensor):
                             depth_np = depth_np.cpu().numpy()
                         annotated_pil = draw_depth_map(pil_img, depth_np)
+                    elif (
+                        result.boxes is None
+                        and getattr(result, "anomaly_map", None) is not None
+                    ):
+                        annotated_pil = draw_anomaly_map(
+                            pil_img, result.anomaly_map.array
+                        )
                     elif len(result) > 0:
                         annotated_pil = pil_img
                         if result.masks is not None:

--- a/libreyolo/validation/__init__.py
+++ b/libreyolo/validation/__init__.py
@@ -12,6 +12,7 @@ from .depth_validator import DepthValidator
 from .restore_validator import RestoreValidator
 from .matte_validator import MatteValidator
 from .ocr_validator import OCRValidator
+from .anomaly_validator import AnomalyValidator
 from .semantic_validator import SemanticValidator
 from .panoptic_quality import PanopticQuality
 from .panoptic_validator import PanopticValidator
@@ -32,6 +33,7 @@ __all__ = [
     "RestoreValidator",
     "MatteValidator",
     "OCRValidator",
+    "AnomalyValidator",
     "SemanticValidator",
     "PanopticValidator",
     "PanopticQuality",

--- a/libreyolo/validation/anomaly_validator.py
+++ b/libreyolo/validation/anomaly_validator.py
@@ -1,0 +1,122 @@
+"""Image- and pixel-level validation for visual anomaly detection."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+import numpy as np
+from PIL import Image
+
+from ..data.anomaly_dataset import resolve_anomaly_test_samples
+
+logger = logging.getLogger(__name__)
+
+
+def binary_auroc(labels, scores) -> float:
+    """Compute binary AUROC with average ranks for tied scores."""
+    labels = np.asarray(labels, dtype=np.uint8).reshape(-1)
+    scores = np.asarray(scores, dtype=np.float64).reshape(-1)
+    if labels.shape != scores.shape:
+        raise ValueError("labels and scores must have identical shapes.")
+    positives = int(labels.sum())
+    negatives = int(len(labels) - positives)
+    if positives == 0 or negatives == 0:
+        raise ValueError("AUROC requires at least one normal and one anomalous sample.")
+    order = np.argsort(scores, kind="mergesort")
+    sorted_scores = scores[order]
+    ranks = np.empty(len(scores), dtype=np.float64)
+    start = 0
+    while start < len(scores):
+        end = start + 1
+        while end < len(scores) and sorted_scores[end] == sorted_scores[start]:
+            end += 1
+        ranks[order[start:end]] = (start + 1 + end) / 2.0
+        start = end
+    positive_rank_sum = float(ranks[labels == 1].sum())
+    return (positive_rank_sum - positives * (positives + 1) / 2.0) / (positives * negatives)
+
+
+def best_f1(labels, scores) -> tuple[float, float]:
+    """Return maximum binary F1 and the corresponding inclusive threshold."""
+    labels = np.asarray(labels, dtype=np.uint8).reshape(-1)
+    scores = np.asarray(scores, dtype=np.float64).reshape(-1)
+    if not len(labels) or labels.sum() == 0:
+        return 0.0, float("inf")
+    order = np.argsort(-scores, kind="mergesort")
+    sorted_labels = labels[order]
+    sorted_scores = scores[order]
+    tp = np.cumsum(sorted_labels)
+    fp = np.cumsum(1 - sorted_labels)
+    fn = int(labels.sum()) - tp
+    f1 = 2.0 * tp / np.maximum(2.0 * tp + fp + fn, 1)
+    best = int(np.argmax(f1))
+    return float(f1[best]), float(sorted_scores[best])
+
+
+def _load_mask(path, shape: tuple[int, int]) -> np.ndarray:
+    mask = Image.open(path).convert("L")
+    if mask.size != (shape[1], shape[0]):
+        mask = mask.resize((shape[1], shape[0]), Image.Resampling.NEAREST)
+    return np.asarray(mask, dtype=np.uint8) > 0
+
+
+class AnomalyValidator:
+    """AUROC and best-F1 validator for an MVTec-style test split."""
+
+    task = "anomaly"
+
+    def __init__(self, model, config, **kwargs):
+        self.model = model
+        self.config = config
+
+    def __call__(self, **kwargs) -> Dict[str, float]:
+        if not self.config.data:
+            raise ValueError("Anomaly validation requires data= pointing to a category root or YAML.")
+        samples = resolve_anomaly_test_samples(self.config.data)
+        image_labels: list[int] = []
+        image_scores: list[float] = []
+        pixel_labels: list[np.ndarray] = []
+        pixel_scores: list[np.ndarray] = []
+        have_defect_mask = False
+
+        for image_path, label, mask_path in samples:
+            result = self.model.predict(str(image_path), verbose=False)[0]
+            if result.anomaly_map is None or result.anomaly_score is None:
+                raise ValueError(f"Model returned no anomaly result for {image_path}.")
+            score_map = result.anomaly_map.array
+            image_labels.append(label)
+            image_scores.append(float(result.anomaly_score))
+            if label == 0:
+                pixel_labels.append(np.zeros(score_map.shape, dtype=np.uint8).reshape(-1))
+                pixel_scores.append(score_map.reshape(-1))
+            elif mask_path is not None:
+                have_defect_mask = True
+                pixel_labels.append(_load_mask(mask_path, score_map.shape).astype(np.uint8).reshape(-1))
+                pixel_scores.append(score_map.reshape(-1))
+
+        image_auc = binary_auroc(image_labels, image_scores)
+        image_f1, image_threshold = best_f1(image_labels, image_scores)
+        metrics: Dict[str, float] = {
+            "metrics/image_AUROC": float(image_auc),
+            "metrics/image_F1_max": float(image_f1),
+            "metrics/image_F1_threshold": float(image_threshold),
+            "fitness": float(image_auc),
+        }
+        if have_defect_mask and pixel_labels:
+            labels = np.concatenate(pixel_labels)
+            scores = np.concatenate(pixel_scores)
+            metrics["metrics/pixel_AUROC"] = float(binary_auroc(labels, scores))
+            pixel_f1, pixel_threshold = best_f1(labels, scores)
+            metrics["metrics/pixel_F1_max"] = float(pixel_f1)
+            metrics["metrics/pixel_F1_threshold"] = float(pixel_threshold)
+        if getattr(self.config, "verbose", True):
+            logger.info(
+                "Anomaly validation: image AUROC %.4f, image F1-max %.4f",
+                image_auc,
+                image_f1,
+            )
+        return metrics
+
+
+__all__ = ["AnomalyValidator", "best_f1", "binary_auroc"]

--- a/skills/use-libreyolo/SKILL.md
+++ b/skills/use-libreyolo/SKILL.md
@@ -3,7 +3,7 @@ name: use-libreyolo
 description: >-
   Use LibreYOLO as a computer vision library: run inference, train, validate,
   export, and track with object-detection / segmentation (and pose, classify,
-  gaze, OBB, semantic, depth, point, restore) models on your own images and
+  gaze, OBB, semantic, depth, point, restore, anomaly) models on your own images and
   video. This is the
   guide for *using* the `libreyolo` pip package — not for contributing to or
   developing it. Use whenever someone wants to detect, segment, or track with a
@@ -140,11 +140,12 @@ handles every run under the root (`?run=` in the URL selects one).
 ## Supported tasks
 
 `detect` (suffixless default), `segment`, `semantic`, `pose`, `classify`,
-`gaze`, `obb`, `point`, `depth`, `restore`, `matte`, `ocr`. Detection — plus
+`gaze`, `obb`, `point`, `depth`, `restore`, `matte`, `ocr`, `anomaly`. Detection — plus
 **RF-DETR segmentation** — is the heavily-tested core; other task/family
 combinations vary in maturity, so check the README compatibility table before
 relying on one. Task outputs land on matching `Results` fields
-(`r.semantic_mask`, `r.depth_map`, `r.restored`, `r.points`, `r.matte`, …).
+(`r.semantic_mask`, `r.depth_map`, `r.restored`, `r.points`, `r.matte`,
+`r.anomaly_map`, …).
 Matte adds `r.cutout()` (RGBA) and a transparent-PNG `r.save()`.
 
 OCR reads located text (zh/zh-TW/en/ja/pinyin with one model):
@@ -170,6 +171,7 @@ as the source of truth. By tier:
   recipe).
 - **Specialized:** L2CS (gaze), DepthAnything3 (recommended depth quality
   default), DepthAnythingV2 and ZipDepth (depth alternatives), FOMO (point),
+  PatchCore (anomaly, training-free fit on good images),
   NAFNet (restore: deblur/denoise; denoise ships as
   `LibreYOLO("LibreNAFNetl-restore-sidd.pt")`), RealESRGAN (restore:
   super-resolution, `x4`/`x2`/`x4t`; `r.restored` is `r.restore_scale` x the

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -47,6 +47,25 @@ def test_train_dry_run_uses_rtdetr_defaults():
     assert data["resolved_config"]["scheduler"] == "constant"
 
 
+def test_train_dry_run_uses_patchcore_fit_defaults_without_loading_weights():
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        [
+            "data=category",
+            "model=patchcore-b",
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_family"] == "patchcore"
+    assert data["resolved_config"]["epochs"] == 0
+    assert data["resolved_config"]["batch"] == 8
+    assert data["resolved_config"]["imgsz"] == 224
+
+
 def test_train_dry_run_uses_rtdetr_defaults_for_weight_filename():
     """Dry-run detects family defaults from supported weight filenames."""
     app = _make_app()

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -45,6 +45,10 @@ class TestResolveModelName:
         assert resolve_model_name("rfdetr-x-seg") == "LibreRFDETRx-seg.pt"
         assert resolve_model_name("rfdetr-xx-seg") == "LibreRFDETRxx-seg.pt"
 
+    def test_patchcore_size_includes_required_task_suffix(self):
+        assert resolve_model_name("patchcore-b") == "LibrePatchCoreb-anomaly.pt"
+        assert is_known_weight_filename("LibrePatchCoreb-anomaly.pt") is True
+
     def test_case_insensitive(self):
         assert resolve_model_name("YOLOX-S") == "LibreYOLOXs.pt"
         assert resolve_model_name("Yolo9-T") == "LibreYOLO9t.pt"

--- a/tests/unit/test_patchcore_anomaly.py
+++ b/tests/unit/test_patchcore_anomaly.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.data.anomaly_dataset import (
+    resolve_anomaly_test_samples,
+    resolve_good_training_images,
+)
+from libreyolo.models.patchcore.model import LibrePatchCore
+from libreyolo.models.patchcore.nn import PatchCoreNet, greedy_coreset
+from libreyolo.postprocess.patchcore import postprocess
+from libreyolo.utils.drawing import draw_anomaly_map
+from libreyolo.utils.results import AnomalyMap, Results
+from libreyolo.validation.anomaly_validator import best_f1, binary_auroc
+
+
+def test_anomaly_results_contract_and_rendering(tmp_path):
+    heatmap = np.arange(24, dtype=np.float32).reshape(4, 6)
+    result = Results(
+        boxes=None,
+        orig_shape=(4, 6),
+        anomaly_map=AnomalyMap(heatmap),
+        anomaly_score=2.5,
+        is_anomalous=True,
+        path=str(tmp_path / "source.png"),
+    )
+    Image.new("RGB", (6, 4), "gray").save(result.path)
+    assert len(result) == 1
+    assert result.anomaly_map.array.dtype == np.float32
+    assert result.summary() == [
+        {
+            "name": "anomaly",
+            "score": 2.5,
+            "is_anomalous": True,
+            "map_min": 0.0,
+            "map_max": 23.0,
+        }
+    ]
+    assert json.loads(result.to_json())[0]["is_anomalous"] is True
+    rendered = draw_anomaly_map(Image.new("RGB", (6, 4), "gray"), heatmap)
+    assert rendered.size == (6, 4)
+    assert result.plot().size == (6, 4)
+    assert "anomalous" in result.verbose()
+    assert result.save(tmp_path / "anomaly.png") == str(tmp_path / "anomaly.png")
+
+
+def test_anomaly_dataset_layout_and_optional_mask(tmp_path):
+    for relative in (
+        "train/good/train.png",
+        "test/good/good.png",
+        "test/crack/bad.png",
+        "ground_truth/crack/bad_mask.png",
+    ):
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("L" if "mask" in relative else "RGB", (8, 8), 255).save(path)
+    assert [path.name for path in resolve_good_training_images(tmp_path)] == ["train.png"]
+    samples = resolve_anomaly_test_samples(tmp_path)
+    assert [(path.parent.name, label) for path, label, _ in samples] == [
+        ("crack", 1),
+        ("good", 0),
+    ]
+    assert samples[0][2].name == "bad_mask.png"
+    assert samples[1][2] is None
+
+
+def test_anomaly_metrics_and_ties():
+    assert binary_auroc([0, 0, 1, 1], [0.1, 0.2, 0.8, 0.9]) == 1.0
+    assert binary_auroc([0, 1], [0.5, 0.5]) == 0.5
+    f1, threshold = best_f1([0, 0, 1, 1], [0.1, 0.2, 0.8, 0.9])
+    assert f1 == 1.0
+    assert threshold == 0.8
+
+
+def test_greedy_coreset_is_deterministic_and_bounded():
+    features = torch.arange(100 * 12, dtype=torch.float32).reshape(100, 12)
+    first = greedy_coreset(features, percent=10, projection_dim=4, seed=7)
+    second = greedy_coreset(features, percent=10, projection_dim=4, seed=7)
+    assert first.shape == (10, 12)
+    assert torch.equal(first, second)
+    with pytest.raises(ValueError, match=r"\[1, 25\]"):
+        greedy_coreset(features, percent=0.5)
+
+
+def test_patchcore_nearest_neighbor_scoring_without_backbone():
+    net = PatchCoreNet.__new__(PatchCoreNet)
+    torch.nn.Module.__init__(net)
+    net.register_buffer("memory_bank", torch.tensor([[0.0, 0.0], [2.0, 0.0], [0.0, 2.0]]))
+    net.register_buffer("fitted", torch.tensor(True))
+    net.reweight_neighbors = 3
+    net.query_chunk_size = 2
+    queries = torch.tensor([[0.1, 0.0], [1.8, 0.0], [3.0, 3.0]])
+    distances, indices = net.nearest_distances(queries)
+    assert distances.tolist() == pytest.approx([0.1, 0.2, np.sqrt(10.0)], rel=1e-5)
+    assert indices.tolist() == [0, 1, 1]
+    assert float(net._image_score(queries, distances, indices)) > 0
+
+
+def test_patchcore_postprocess_and_checkpoint_fingerprint():
+    output = {
+        "patch_scores": torch.tensor([[0.0, 1.0], [2.0, 3.0]]),
+        "image_scores": torch.tensor(2.75),
+    }
+    parsed = postprocess(output, original_size=(10, 8), threshold=2.0, sigma=0)
+    assert parsed["anomaly_map"].shape == (8, 10)
+    assert parsed["anomaly_score"] == pytest.approx(2.75)
+    assert parsed["is_anomalous"] is True
+    state = {
+        "memory_bank": torch.empty(3, 1536),
+        "anomaly_threshold": torch.tensor(1.0),
+        "fitted": torch.tensor(True),
+    }
+    assert LibrePatchCore.can_load(state)
+    assert LibrePatchCore.detect_size(state) == "b"

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -64,6 +64,13 @@ def test_normalize_matte_task_aliases():
     assert normalize_task("dis") == "matte"
 
 
+def test_normalize_anomaly_task_aliases():
+    assert normalize_task("anomaly") == "anomaly"
+    assert normalize_task("anomaly-detection") == "anomaly"
+    assert normalize_task("anomaly_detection") == "anomaly"
+    assert normalize_task("ad") == "anomaly"
+
+
 def test_task_type_literal_is_public():
     assert set(TaskType.__args__) == {
         "detect",
@@ -79,6 +86,7 @@ def test_task_type_literal_is_public():
         "restore",
         "matte",
         "ocr",
+        "anomaly",
     }
 
 
@@ -123,11 +131,13 @@ def test_task_suffix_helpers():
     assert suffix_to_task("-depth") == "depth"
     assert suffix_to_task("-restore") == "restore"
     assert suffix_to_task("-matte") == "matte"
+    assert suffix_to_task("-anomaly") == "anomaly"
     assert task_to_suffix("obb") == "obb"
     assert task_to_suffix("point") == "point"
     assert task_to_suffix("depth") == "depth"
     assert task_to_suffix("restore") == "restore"
     assert task_to_suffix("matte") == "matte"
+    assert task_to_suffix("anomaly") == "anomaly"
     assert task_to_suffix("semantic") == "sem"
     assert suffix_to_task("-unknown") is None
 

--- a/tests/unit/ui/test_ui_summary.py
+++ b/tests/unit/ui/test_ui_summary.py
@@ -34,6 +34,10 @@ def result(**attrs):
         (result(restored=object(), restore_scale=4), ("restore", "upscaled x4")),
         (result(restored=object(), restore_scale=1), ("restore", "restored")),
         (result(matte=object()), ("matte", "alpha matte")),
+        (
+            result(anomaly_map=object(), anomaly_score=1.25, is_anomalous=True),
+            ("anomaly", "anomalous 1.250"),
+        ),
         (result(gaze=[object(), object()]), ("gaze", "2 gaze")),
         (result(), ("detect", "0 objects")),
     ],


### PR DESCRIPTION
Adds the anomaly task and LibrePatchCore, a training-free visual anomaly detector fitted from `train/good` images. The change includes MVTec-style category data resolution, lean memory-bank checkpoints with calibrated thresholds, image and pixel AUROC/F1 validation, Results/CLI/UI visualization, task contracts, and focused tests. EfficientAD remains deferred and is not included.

Testing:
- 129 focused unit and CLI tests passed after rebasing onto `573-work-package-2`.
- 28 PPOCR overlap tests passed after resolving the shared task/results conflicts.
- Ruff and `git diff --check` passed.
- Synthetic CPU fit, checkpoint reload, and defect prediction passed with the real WideResNet execution path.
- The broader unit run reached 22% before an unrelated native ONNX Runtime access violation in `tests/unit/test_deimv2_export.py:77` terminated the process.

## Code provenance

LibrePatchCore is derived from `amazon-science/patchcore-inspection` at commit `fcaa92f124fb1ad74a7acf56726decd4b27cbcad`, licensed Apache-2.0. The anomaly task, dataset, checkpoint, validation, CLI, and UI integration is original code written for this PR. The frozen WideResNet-50-2 backbone is loaded through the BSD-3-Clause torchvision dependency. No GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license code was used.