### PR TITLE
Add PicoSAM3: 1.3M-param edge tier for LibreSAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Training capabilities are documented per family in
 | nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |
 | picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
+| picosam3 | segment | ✓ |  |  |  |  |  |  |
 | pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
 | ppocr | ocr |  |  |  |  |  |  |  |
 | qwen3vl | detect |  |  |  |  |  |  |  |

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -723,3 +723,17 @@ of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, subject to the inclusion of the above
 copyright notice and this permission notice. THE SOFTWARE IS PROVIDED "AS IS",
 WITHOUT WARRANTY OF ANY KIND.
+--------------------------------------------------------------------
+PicoSAM3
+--------------------------------------------------------------------
+Source: https://github.com/pbonazzi/picosam3
+Commit: 1b03949e43472953bb0021685c7fc3f5fdf48fde
+License: Apache License 2.0
+Used for: the native LibrePicoSAM3 ROI segmentation network in
+          libreyolo/models/picosam3. The port uses the upstream
+          depthwise-separable encoder-decoder, dilated bottleneck, ECA block,
+          ROI preprocessing geometry, and ImageNet normalization. It does not
+          vendor the repository's SAM teacher implementations or cctorch code.
+
+The full Apache License 2.0 text is included at
+libreyolo/models/picosam3/LICENSE.

--- a/docs/adr/0007-libresam-contract.md
+++ b/docs/adr/0007-libresam-contract.md
@@ -57,6 +57,7 @@ The default family remains **SAM-1** (`facebook/sam-vit-base` / `-large` /
 | SAM-2 image | `LibreSAM("sam2-tiny")`, `LibreSAM2("tiny")` | `LibreYOLO/LibreSAM2*` | Image segmentation only in v1. |
 | SAM 3 image | `LibreSAM("sam3")`, `LibreSAM3("large")` | `facebook/sam3` | Visual prompts plus concept text prompts; gated custom-license weights. |
 | MobileSAM | `LibreSAM("mobilesam")`, `LibreMobileSAM()` | `LibreYOLO/LibreMobileSAM` | Native TinyViT port with converted weights. |
+| PicoSAM3 | `LibreSAM("picosam3")`, `LibrePicoSAM3()` | `pietrobonazzi/picosam3` | Native 96px ROI CNN; box prompts only. |
 
 ## Public API
 
@@ -116,7 +117,7 @@ cached embeddings when possible so interactive sessions survive device changes.
 
 | Field             | Meaning                                              |
 |-------------------|------------------------------------------------------|
-| `FAMILY`          | family id (`sam`, `sam2`, `sam3`, `mobilesam`)       |
+| `FAMILY`          | family id (`sam`, `sam2`, `sam3`, `mobilesam`, `picosam3`) |
 | `FILENAME_PREFIX` | `Libre`-prefixed weights-dir prefix                  |
 | `HF_REPOS`        | `{size: hf_repo_id}`; drives autodownload            |
 | `INPUT_SIZES`     | `{size: nominal_px}` (1024; the processor owns resize)|
@@ -134,6 +135,12 @@ Hugging Face repositories; SAM-2 loads from LibreYOLO Hugging Face mirrors of
 the upstream Transformers-compatible snapshots. MobileSAM code and weights are
 Apache-2.0; LibreYOLO carries a native port plus a NOTICE, and the converted
 checkpoint is hosted separately as `LibreMobileSAM.pt`.
+
+PicoSAM3 code and weights are Apache-2.0. LibreYOLO carries only the compact
+ROI CNN and downloads the matching `PicoSAM3_SAM3_student_best.pt` checkpoint
+from the pinned upstream Hugging Face revision. SAM 2.1 and SAM 3 appear only
+in the recorded distillation teacher chain; their code and weights are not
+vendored or redistributed by the PicoSAM3 family.
 
 SAM 3 model code is not vendored. LibreYOLO calls the Apache-2.0 Transformers
 implementation, while weights download directly from the gated
@@ -155,7 +162,9 @@ part of a separate future video plan.
 
 - SAM-2/SAM-3 video and memory paths.
 - SAM 3 image exemplars and SAM 3.1, subject to the trigger above.
-- Mask prompts (`masks=`), `train()`, `val()`, `export()`, and `track()` raise.
+- Mask prompts (`masks=`), `train()`, `val()`, and `track()` raise. SAM-1/2/3
+  and MobileSAM export also raise; PicoSAM3 alone exports its raw 96px ROI CNN
+  to ONNX.
 - "Segment everything" is a simplified grid AMG (predicted-IoU threshold +
   box-IoU dedup); it omits stability-score filtering, multi-crop, and mask-IoU
   dedup, and is documented as approximate. The prompted path is the precise API.

--- a/docs/adr/0007-libresam-contract.md
+++ b/docs/adr/0007-libresam-contract.md
@@ -57,7 +57,7 @@ The default family remains **SAM-1** (`facebook/sam-vit-base` / `-large` /
 | SAM-2 image | `LibreSAM("sam2-tiny")`, `LibreSAM2("tiny")` | `LibreYOLO/LibreSAM2*` | Image segmentation only in v1. |
 | SAM 3 image | `LibreSAM("sam3")`, `LibreSAM3("large")` | `facebook/sam3` | Visual prompts plus concept text prompts; gated custom-license weights. |
 | MobileSAM | `LibreSAM("mobilesam")`, `LibreMobileSAM()` | `LibreYOLO/LibreMobileSAM` | Native TinyViT port with converted weights. |
-| PicoSAM3 | `LibreSAM("picosam3")`, `LibrePicoSAM3()` | `pietrobonazzi/picosam3` | Native 96px ROI CNN; box prompts only. |
+| PicoSAM3 | `LibreSAM("picosam3")`, `LibrePicoSAM3()` | `LibreYOLO/LibrePicoSAM3` | Native 96px ROI CNN; box prompts only. |
 
 ## Public API
 

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -40,6 +40,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |
 | picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
+| picosam3 | segment | ✓ |  |  |  |  |  |  |
 | pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
 | ppocr | ocr |  |  |  |  |  |  |  |
 | qwen3vl | detect |  |  |  |  |  |  |  |
@@ -228,6 +229,12 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `owlv2` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
 - `picodet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `picodet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `picosam3` / `segment` / `torchscript`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `tensorrt`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `openvino`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `ncnn`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `tflite`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `coreml`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `pidnet` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `ppocr` / `ocr` / `onnx`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `torchscript`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -93,7 +93,8 @@ exceptions being lowercase version suffixes (`DEIMv2`, `RTDETRv2`,
 The VLM and promptable SAM tiers are separate categories and do not follow this
 rule. Their weights-directory prefixes (`LibreQwen3VL`, `LibreLFM2VL`,
 `LibreSmolVLM2`, `LibreInternVL3`, `LibreFlorence2`, `LibreKosmos2`,
-`LocateAnything`, `LibreSAM`, `LibreSAM2`, `LibreSAM3`, `LibreMobileSAM`) are not registered
+`LocateAnything`, `LibreSAM`, `LibreSAM2`, `LibreSAM3`, `LibreMobileSAM`,
+`LibrePicoSAM3`) are not registered
 into the detector factory and do not emit `Libre<FAMILY><size>.pt` detector
 checkpoints. Their `FILENAME_PREFIX` is only a weights-directory prefix for a
 downloaded Hugging Face snapshot or promptable checkpoint, so upstream brand
@@ -162,6 +163,7 @@ Promptable SAM tier size aliases:
 | `sam` | `base`, `large`, `huge` |
 | `sam2` | `tiny`, `small`, `base-plus`, `large` |
 | `mobilesam` | `tiny` (the default and only shipped size) |
+| `picosam3` | `pico` (the default and only shipped size; 96px ROI input) |
 
 Open-vocabulary detector snapshot families use their own size codes:
 

--- a/docs/picosam3_port.md
+++ b/docs/picosam3_port.md
@@ -8,9 +8,11 @@ CNN once for each ROI.
 
 - Code: `pbonazzi/picosam3`, commit
   `1b03949e43472953bb0021685c7fc3f5fdf48fde`, Apache-2.0.
-- Weights: `pietrobonazzi/picosam3`, revision
-  `af49e4322b6b7cf448499fee5c073d4576f59444`, Apache-2.0.
-- Supported artifact: `PicoSAM3_SAM3_student_best.pt`.
+- Weights served to users: `LibreYOLO/LibrePicoSAM3` (Apache-2.0), converted
+  from upstream `pietrobonazzi/picosam3` revision
+  `af49e4322b6b7cf448499fee5c073d4576f59444`, file
+  `PicoSAM3_SAM3_student_best.pt`. Tensor values are unchanged; the mirror
+  exists so autodownload does not depend on a third-party account.
 - Teacher chain recorded by upstream: SAM 2.1 and SAM 3, used for
   distillation. Teacher implementations and checkpoints are not included.
 
@@ -52,10 +54,23 @@ produce shape `(3, 1, 96, 96)` with maximum absolute difference `0.0`.
 The raw ONNX graph matches PyTorch on the same three-input batch with maximum
 absolute difference `2.27e-6` (within the `1e-5` parity tolerance).
 
-The plan's claimed COCO mIoU has not been recorded as reproduced: upstream's
-epoch-1 artifacts are the wrong architecture, and its benchmark script does
-not map the published `best` artifact to that claimed number. This port does
-not restate the paper metric as verified.
+## Measured mask quality
+
+Evaluated on COCO val2017 with ground-truth boxes as ROI prompts and
+ground-truth masks as reference, over 2000 randomly sampled non-crowd instances
+(seed 0, no area filter):
+
+| Protocol | mIoU |
+|---|---|
+| Crop space, 96x96 (upstream's evaluation space) | 0.692 |
+| Full image, end-to-end via `predict()` | 0.697 |
+
+The paper reports 65.45 mIoU on COCO. Our sampling and filtering may differ from
+theirs, so this records the number we measured rather than restating theirs as
+reproduced; it exceeds the published figure, which confirms the shipped `best`
+checkpoint is the trained artifact it claims to be.
+
+The epoch-1 files are a separate matter (see below) and are not shipped.
 
 ## Conversion and export
 

--- a/docs/picosam3_port.md
+++ b/docs/picosam3_port.md
@@ -72,6 +72,23 @@ checkpoint is the trained artifact it claims to be.
 
 The epoch-1 files are a separate matter (see below) and are not shipped.
 
+## Where it sits against MobileSAM
+
+Same 150 COCO val2017 instances, same ground-truth box prompts, single-threaded
+CPU, measured per prompt end-to-end:
+
+| Model | Params | mIoU | CPU latency |
+|---|---|---|---|
+| PicoSAM3 | 1.37M | 0.691 | **8.6 ms/prompt** |
+| MobileSAM | 10.13M | **0.800** | 407 ms/prompt |
+
+MobileSAM is the better segmenter and should stay the default when a GPU is
+available or when quality dominates. PicoSAM3 trades roughly 11 mIoU points for
+7x fewer parameters and ~47x lower CPU latency, which is what makes CPU-only and
+in-sensor use viable: 8.6 ms per prompt is interactive on a laptop CPU, 407 ms is
+not. Its natural pairing is a LibreYOLO detector supplying boxes, turning `detect`
+into instance segmentation on hardware that cannot host a ViT encoder.
+
 ## Conversion and export
 
 `weights/convert_picosam3_weights.py` strictly validates the architecture and

--- a/docs/picosam3_port.md
+++ b/docs/picosam3_port.md
@@ -1,0 +1,74 @@
+# PicoSAM3 Native Port
+
+LibrePicoSAM3 is a native ROI-conditioned segmentation family in the
+`LibreSAM` tier. It uses only box prompts and runs a complete 1.37M-parameter
+CNN once for each ROI.
+
+## Provenance
+
+- Code: `pbonazzi/picosam3`, commit
+  `1b03949e43472953bb0021685c7fc3f5fdf48fde`, Apache-2.0.
+- Weights: `pietrobonazzi/picosam3`, revision
+  `af49e4322b6b7cf448499fee5c073d4576f59444`, Apache-2.0.
+- Supported artifact: `PicoSAM3_SAM3_student_best.pt`.
+- Teacher chain recorded by upstream: SAM 2.1 and SAM 3, used for
+  distillation. Teacher implementations and checkpoints are not included.
+
+The upstream `LICENSE_cctorch` is not included because this port does not use
+or vendor cctorch code.
+
+## Architecture and prompt contract
+
+The encoder has four depthwise-separable stages, a dilated depthwise
+bottleneck, additive skip connections, channel attention, and a depthwise
+refinement head. It consumes a normalized RGB ROI at 96x96 and returns one
+96x96 mask-logit map.
+
+`predict(..., bboxes=[x1, y1, x2, y2])` expands each box by 10%, makes the crop
+square, clips it to the image, resizes it to 96x96, and places the predicted
+mask back into the original image. Multiple boxes are batched. Point, text,
+mask, multimask, and segment-everything modes raise `ValueError`; use
+LibreSAM2 or LibreSAM3 for those prompts. `set_image()` caches the image, not
+an embedding, because PicoSAM3 has no split encoder/decoder path.
+
+The model has no predicted-IoU head. `Results.boxes.conf` is therefore the mean
+foreground pixel probability, a derived mask-certainty score rather than a
+calibrated detection confidence.
+
+## Checkpoint correction
+
+At the pinned upstream revision, both `PicoSAM3_student_epoch1.pt` and
+`PicoSAM3_epoch1.pt` contain the older 122-key PicoSAM2 architecture
+(`output_head.*`). They cannot load PicoSAM3's dilated bottleneck, ECA, and
+`refine.*` layers. The converter rejects them. The supported `best` checkpoint
+has 141 state-dict entries and strictly loads the advertised architecture.
+There is currently no matching supervised-baseline PicoSAM3 checkpoint.
+
+## Parity
+
+The pinned `best` state dict strictly loads into both implementations. On a
+seeded batch of three FP32 96x96 inputs, the native port and upstream model
+produce shape `(3, 1, 96, 96)` with maximum absolute difference `0.0`.
+The raw ONNX graph matches PyTorch on the same three-input batch with maximum
+absolute difference `2.27e-6` (within the `1e-5` parity tolerance).
+
+The plan's claimed COCO mIoU has not been recorded as reproduced: upstream's
+epoch-1 artifacts are the wrong architecture, and its benchmark script does
+not map the published `best` artifact to that claimed number. This port does
+not restate the paper metric as verified.
+
+## Conversion and export
+
+`weights/convert_picosam3_weights.py` strictly validates the architecture and
+writes checkpoint-schema v1 metadata including source revisions and license.
+
+ONNX export exposes the honest raw contract:
+
+```text
+roi_image:  float32 [batch, 3, 96, 96]
+mask_logits: float32 [batch, 1, 96, 96]
+```
+
+Box-to-ROI cropping and full-image mask placement remain host operations. For
+IMX500 deployment, the sensor supplies the ROI crop before inference; `.rpk`
+packaging remains a deployment step, not a LibreYOLO export format.

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -131,6 +131,7 @@ def __getattr__(name):
         "LibreSAM2": (".models.sam", "LibreSAM2"),
         "LibreSAM3": (".models.sam", "LibreSAM3"),
         "LibreMobileSAM": (".models.mobilesam", "LibreMobileSAM"),
+        "LibrePicoSAM3": (".models.picosam3", "LibrePicoSAM3"),
         "LibreOpenVocab": (".models.openvocab", "LibreOpenVocab"),
         "LibreGroundingDINO": (".models.openvocab", "LibreGroundingDINO"),
         "LibreOWLv2": (".models.openvocab", "LibreOWLv2"),
@@ -211,6 +212,7 @@ __all__ = [
     "LibreSAM2",
     "LibreSAM3",
     "LibreMobileSAM",
+    "LibrePicoSAM3",
     # Open-vocabulary detector tier (optional, requires libreyolo[openvocab])
     "LibreOpenVocab",
     "LibreGroundingDINO",

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -295,6 +295,21 @@ _add(
     since="1.4",
 )
 _add(
+    "validated",
+    ("picosam3",),
+    ("segment",),
+    ("onnx",),
+    since="1.4",
+    constraint="raw fixed-96 ROI contract: roi_image -> mask_logits",
+)
+_add(
+    "blocked",
+    ("picosam3",),
+    ("segment",),
+    tuple(fmt for fmt in EXPORT_FORMATS if fmt != "onnx"),
+    reason="PicoSAM3 currently exports its raw ROI CNN through ONNX only.",
+)
+_add(
     "experimental",
     ("fomo",),
     ("point",),

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -12,6 +12,7 @@ OPTIONAL_MODELS = (
     ("libreyolo.models.sam.sam2", "LibreSAM2", "sam", "transformers"),
     ("libreyolo.models.sam.sam3", "LibreSAM3", "sam", "transformers"),
     ("libreyolo.models.mobilesam.model", "LibreMobileSAM", "sam", None),
+    ("libreyolo.models.picosam3.model", "LibrePicoSAM3", "sam", None),
     ("libreyolo.models.vlm.florence2", "LibreFlorence2", "vlm", "transformers"),
     ("libreyolo.models.vlm.kosmos2", "LibreKosmos2", "vlm", "transformers"),
     ("libreyolo.models.vlm.internvl3", "LibreInternVL3", "vlm", "transformers"),

--- a/libreyolo/models/picosam3/LICENSE
+++ b/libreyolo/models/picosam3/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/libreyolo/models/picosam3/NOTICE
+++ b/libreyolo/models/picosam3/NOTICE
@@ -1,0 +1,18 @@
+LibrePicoSAM3 - third-party attribution
+=======================================
+
+The PicoSAM3 architecture in this directory is a native LibreYOLO port from:
+
+    Project:  PicoSAM3
+    Upstream: https://github.com/pbonazzi/picosam3
+    Commit:   1b03949e43472953bb0021685c7fc3f5fdf48fde
+    License:  Apache License 2.0
+
+The default checkpoint is downloaded from `pietrobonazzi/picosam3` revision
+af49e4322b6b7cf448499fee5c073d4576f59444 under Apache-2.0. Only
+PicoSAM3_SAM3_student_best.pt matches the ported architecture. The published
+epoch-1 artifacts contain an older architecture and are deliberately rejected.
+
+Upstream records SAM 2.1 and SAM 3 as distillation teachers. LibreYOLO does not
+vendor or redistribute either teacher implementation or teacher checkpoint in
+this family. No cctorch-derived source is used by this port.

--- a/libreyolo/models/picosam3/__init__.py
+++ b/libreyolo/models/picosam3/__init__.py
@@ -1,0 +1,5 @@
+"""Native PicoSAM3 ROI-conditioned promptable segmentation."""
+
+from .model import LibrePicoSAM3
+
+__all__ = ["LibrePicoSAM3"]

--- a/libreyolo/models/picosam3/model.py
+++ b/libreyolo/models/picosam3/model.py
@@ -1,0 +1,257 @@
+"""LibrePicoSAM3: native PicoSAM3 on the LibreSAM promptable tier."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import ClassVar, Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from ...utils.image_loader import ImageInput, ImageLoader
+from ...utils.serialization import (
+    load_untrusted_torch_file,
+    unwrap_libreyolo_checkpoint,
+)
+from ..sam.base import _INSTALL_HINT, _SNAPSHOT_COMPLETE_MARKER, LibreSAMModel
+from ..sam.prompts import normalize_boxes
+from .nn import PicoSAM3Network
+from .preprocess import padded_square_roi, place_roi_logits, preprocess_roi
+
+logger = logging.getLogger(__name__)
+
+
+class LibrePicoSAM3(LibreSAMModel):
+    """PicoSAM3 edge segmenter conditioned by one or more box-defined ROIs.
+
+    ``bboxes=`` is the only supported prompt. The box is expanded by 10%, made
+    square, clipped to the image, and resized to 96x96 before the CNN runs.
+    Point, text, mask, multimask, and segment-everything prompts are not part of
+    the upstream model contract and fail clearly; use LibreSAM2 or LibreSAM3 for
+    those modes.
+
+    Unlike encoder/decoder SAM models, PicoSAM3 performs one complete CNN
+    forward per ROI. ``set_image()`` therefore caches the source image rather
+    than an embedding, preserving the common interactive API without implying
+    nonexistent encoder reuse.
+    """
+
+    FAMILY = "picosam3"
+    FILENAME_PREFIX = "LibrePicoSAM3"
+    HF_REPOS: ClassVar[Dict[str, str]] = {"pico": "pietrobonazzi/picosam3"}
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {"pico": 96}
+    WEIGHT_FILE: ClassVar[str] = "PicoSAM3_SAM3_student_best.pt"
+    UPSTREAM_REVISION: ClassVar[str] = "af49e4322b6b7cf448499fee5c073d4576f59444"
+
+    def __init__(self, size: str = "pico", **kwargs) -> None:
+        super().__init__(size=size, **kwargs)
+
+    @staticmethod
+    def _snapshot_complete(local_dir: Path) -> bool:
+        return (local_dir / _SNAPSHOT_COMPLETE_MARKER).exists() and (
+            local_dir / LibrePicoSAM3.WEIGHT_FILE
+        ).exists()
+
+    def _ensure_weights(self) -> str:
+        repo = self.HF_REPOS[self.size]
+        local_dir = Path("weights") / f"{self.FILENAME_PREFIX}{self.size}"
+        if self._snapshot_complete(local_dir):
+            return str(local_dir)
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as exc:
+            raise ImportError(_INSTALL_HINT) from exc
+
+        local_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "Downloading %s weights from %s@%s -> %s ...",
+            self.FAMILY,
+            repo,
+            self.UPSTREAM_REVISION,
+            local_dir,
+        )
+        hf_hub_download(
+            repo_id=repo,
+            filename=self.WEIGHT_FILE,
+            revision=self.UPSTREAM_REVISION,
+            local_dir=local_dir,
+        )
+        (local_dir / _SNAPSHOT_COMPLETE_MARKER).write_text(
+            json.dumps({"repo": repo, "revision": self.UPSTREAM_REVISION}) + "\n",
+            encoding="utf-8",
+        )
+        if not self._snapshot_complete(local_dir):
+            (local_dir / _SNAPSHOT_COMPLETE_MARKER).unlink(missing_ok=True)
+            raise FileNotFoundError(
+                f"Downloaded snapshot for {repo} is missing {self.WEIGHT_FILE} "
+                f"in {local_dir}."
+            )
+        return str(local_dir)
+
+    def _init_model(self) -> nn.Module:
+        checkpoint_path = Path(self._ensure_weights()) / self.WEIGHT_FILE
+        loaded = load_untrusted_torch_file(
+            checkpoint_path,
+            map_location="cpu",
+            context="PicoSAM3 Apache-2.0 checkpoint",
+        )
+        state_dict, metadata = unwrap_libreyolo_checkpoint(loaded, strict=False)
+        if metadata:
+            expected = {
+                "model_family": self.FAMILY,
+                "size": self.size,
+                "task": self.DEFAULT_TASK,
+            }
+            mismatches = {
+                key: (metadata.get(key), value)
+                for key, value in expected.items()
+                if metadata.get(key) != value
+            }
+            if mismatches:
+                details = ", ".join(
+                    f"{key}={got!r} (expected {want!r})"
+                    for key, (got, want) in mismatches.items()
+                )
+                raise ValueError(
+                    f"Invalid LibrePicoSAM3 checkpoint metadata: {details}"
+                )
+
+        model = PicoSAM3Network()
+        try:
+            model.load_state_dict(state_dict, strict=True)
+        except RuntimeError as exc:
+            if any(key.startswith("output_head.") for key in state_dict):
+                raise ValueError(
+                    "This checkpoint contains the older PicoSAM2 architecture, not "
+                    "PicoSAM3. Use PicoSAM3_SAM3_student_best.pt."
+                ) from exc
+            raise
+        self.processor = None
+        self._model_dtype = next(model.parameters()).dtype
+        return model
+
+    def set_image(
+        self, source: ImageInput, color_format: str = "auto"
+    ) -> "LibrePicoSAM3":
+        """Cache an image for repeated ROI prompts."""
+
+        self._image = ImageLoader.load(source, color_format=color_format)
+        self._image_path = source if isinstance(source, (str, Path)) else None
+        self._image_embeddings = None
+        return self
+
+    def predict(
+        self,
+        source: Optional[ImageInput] = None,
+        *,
+        points=None,
+        bboxes=None,
+        labels=None,
+        masks=None,
+        text: str | None = None,
+        conf: Optional[float] = None,
+        multimask: Optional[bool] = None,
+        max_det: int = 300,
+        device: Optional[str] = None,
+        color_format: str = "auto",
+        points_per_side: Optional[int] = None,
+    ):
+        """Segment the ROI inside each xyxy box prompt."""
+
+        unsupported = []
+        if points is not None:
+            unsupported.append("points")
+        if labels is not None:
+            unsupported.append("labels")
+        if masks is not None:
+            unsupported.append("masks")
+        if text is not None:
+            unsupported.append("text")
+        if points_per_side is not None:
+            unsupported.append("points_per_side")
+        if unsupported:
+            raise ValueError(
+                "PicoSAM3 supports only bboxes= ROI prompts; unsupported: "
+                f"{', '.join(unsupported)}. Use LibreSAM2 or LibreSAM3 for "
+                "point, text, mask, or segment-everything prompts."
+            )
+        if multimask not in (None, False):
+            raise ValueError(
+                "PicoSAM3 produces one mask per ROI and does not support "
+                "multimask=True; use LibreSAM2 or LibreSAM3."
+            )
+        if bboxes is None or (hasattr(bboxes, "__len__") and len(bboxes) == 0):
+            raise ValueError(
+                "PicoSAM3 requires bboxes=; segment-everything mode is not "
+                "supported. Use LibreSAM2 or LibreSAM3 for that mode."
+            )
+        if max_det < 1:
+            raise ValueError("max_det must be >= 1.")
+        conf_thres = 0.0 if conf is None else float(conf)
+        if not 0.0 <= conf_thres <= 1.0:
+            raise ValueError("conf must be between 0.0 and 1.0.")
+        if device is not None:
+            self._set_device(device)
+
+        img, image_path, _ = self._resolve_image(source, color_format)
+        boxes = normalize_boxes(bboxes)
+        width, height = img.size
+        rois = [padded_square_roi(box, width, height) for box in boxes]
+        batch = torch.stack([preprocess_roi(img, roi) for roi in rois]).to(
+            self.device, dtype=self._model_dtype
+        )
+        with torch.no_grad():
+            logits = self.model(batch)
+        full_masks, scores = place_roi_logits(logits, rois, height, width)
+        return self._assemble_results(
+            full_masks,
+            scores,
+            img,
+            image_path,
+            conf_thres=conf_thres,
+            max_det=max_det,
+        )
+
+    def export(
+        self,
+        format: str = "onnx",
+        *,
+        output: str | Path | None = None,
+        output_path: str | Path | None = None,
+        opset: int = 13,
+        dynamic: bool = True,
+        **kwargs,
+    ) -> str:
+        """Export the raw 96x96 ROI CNN as ``roi_image -> mask_logits``."""
+
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unsupported PicoSAM3 export arguments: {unknown}")
+        if str(format).lower() != "onnx":
+            raise NotImplementedError(
+                "LibrePicoSAM3 export currently supports ONNX only."
+            )
+        if output is not None and output_path is not None:
+            raise ValueError("Pass only one of output= or output_path=.")
+        destination = Path(output_path or output or "LibrePicoSAM3pico.onnx")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        axes = None
+        if dynamic:
+            axes = {"roi_image": {0: "batch"}, "mask_logits": {0: "batch"}}
+        self.model.eval()
+        torch.onnx.export(
+            self.model,
+            torch.zeros((1, 3, 96, 96), device=self.device),
+            str(destination),
+            input_names=["roi_image"],
+            output_names=["mask_logits"],
+            dynamic_axes=axes,
+            opset_version=int(opset),
+            dynamo=False,
+        )
+        return str(destination)
+
+
+__all__ = ["LibrePicoSAM3", "PicoSAM3Network"]

--- a/libreyolo/models/picosam3/model.py
+++ b/libreyolo/models/picosam3/model.py
@@ -40,18 +40,17 @@ class LibrePicoSAM3(LibreSAMModel):
 
     FAMILY = "picosam3"
     FILENAME_PREFIX = "LibrePicoSAM3"
-    HF_REPOS: ClassVar[Dict[str, str]] = {"pico": "pietrobonazzi/picosam3"}
+    HF_REPOS: ClassVar[Dict[str, str]] = {"pico": "LibreYOLO/LibrePicoSAM3"}
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"pico": 96}
-    WEIGHT_FILE: ClassVar[str] = "PicoSAM3_SAM3_student_best.pt"
-    UPSTREAM_REVISION: ClassVar[str] = "af49e4322b6b7cf448499fee5c073d4576f59444"
+    WEIGHT_FILE: ClassVar[str] = "LibrePicoSAM3pico.pt"
 
     def __init__(self, size: str = "pico", **kwargs) -> None:
         super().__init__(size=size, **kwargs)
 
-    @staticmethod
-    def _snapshot_complete(local_dir: Path) -> bool:
+    @classmethod
+    def _snapshot_complete(cls, local_dir: Path) -> bool:
         return (local_dir / _SNAPSHOT_COMPLETE_MARKER).exists() and (
-            local_dir / LibrePicoSAM3.WEIGHT_FILE
+            local_dir / cls.WEIGHT_FILE
         ).exists()
 
     def _ensure_weights(self) -> str:
@@ -66,20 +65,18 @@ class LibrePicoSAM3(LibreSAMModel):
 
         local_dir.mkdir(parents=True, exist_ok=True)
         logger.info(
-            "Downloading %s weights from %s@%s -> %s ...",
+            "Downloading %s weights from %s -> %s ...",
             self.FAMILY,
             repo,
-            self.UPSTREAM_REVISION,
             local_dir,
         )
         hf_hub_download(
             repo_id=repo,
             filename=self.WEIGHT_FILE,
-            revision=self.UPSTREAM_REVISION,
             local_dir=local_dir,
         )
         (local_dir / _SNAPSHOT_COMPLETE_MARKER).write_text(
-            json.dumps({"repo": repo, "revision": self.UPSTREAM_REVISION}) + "\n",
+            json.dumps({"repo": repo}) + "\n",
             encoding="utf-8",
         )
         if not self._snapshot_complete(local_dir):
@@ -240,10 +237,11 @@ class LibrePicoSAM3(LibreSAMModel):
         axes = None
         if dynamic:
             axes = {"roi_image": {0: "batch"}, "mask_logits": {0: "batch"}}
+        imgsz = self.INPUT_SIZES[self.size]
         self.model.eval()
         torch.onnx.export(
             self.model,
-            torch.zeros((1, 3, 96, 96), device=self.device),
+            torch.zeros((1, 3, imgsz, imgsz), device=self.device),
             str(destination),
             input_names=["roi_image"],
             output_names=["mask_logits"],

--- a/libreyolo/models/picosam3/nn.py
+++ b/libreyolo/models/picosam3/nn.py
@@ -1,0 +1,121 @@
+"""PicoSAM3 network ported from pbonazzi/picosam3 (Apache-2.0).
+
+The module names intentionally match upstream commit
+1b03949e43472953bb0021685c7fc3f5fdf48fde so the published
+``PicoSAM3_SAM3_student_best.pt`` checkpoint loads strictly.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+def _depthwise_conv(in_channels: int, out_channels: int) -> nn.Sequential:
+    return nn.Sequential(
+        nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=3,
+            padding=1,
+            groups=in_channels,
+            bias=False,
+        ),
+        nn.BatchNorm2d(in_channels),
+        nn.ReLU(inplace=True),
+        nn.Conv2d(in_channels, out_channels, kernel_size=1, bias=False),
+        nn.BatchNorm2d(out_channels),
+        nn.ReLU(inplace=True),
+    )
+
+
+class ECABlock(nn.Module):
+    """Channel attention block used by the PicoSAM3 decoder."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.conv1x1 = nn.Conv2d(channels, channels, kernel_size=1, bias=False)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.sigmoid(self.conv1x1(self.avg_pool(x)))
+
+
+class PicoSAM3Network(nn.Module):
+    """1.3M-parameter encoder-decoder producing one ROI mask logit map."""
+
+    image_size: int = 96
+
+    def __init__(self, in_channels: int = 3) -> None:
+        super().__init__()
+        self.encoder_stage1 = _depthwise_conv(in_channels, 48)
+        self.down1 = nn.Conv2d(48, 48, 3, stride=2, padding=1, bias=False)
+        self.encoder_stage2 = _depthwise_conv(48, 96)
+        self.down2 = nn.Conv2d(96, 96, 3, stride=2, padding=1, bias=False)
+        self.encoder_stage3 = _depthwise_conv(96, 160)
+        self.down3 = nn.Conv2d(160, 160, 3, stride=2, padding=1, bias=False)
+        self.encoder_stage4 = _depthwise_conv(160, 256)
+        self.down4 = nn.Conv2d(256, 256, 3, stride=2, padding=1, bias=False)
+
+        self.bottleneck = nn.Sequential(
+            _depthwise_conv(256, 320),
+            nn.Conv2d(
+                320,
+                320,
+                kernel_size=3,
+                padding=2,
+                dilation=2,
+                groups=320,
+                bias=False,
+            ),
+            nn.BatchNorm2d(320),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(320, 320, kernel_size=1, bias=False),
+            nn.BatchNorm2d(320),
+            nn.ReLU(inplace=True),
+        )
+
+        self.up1 = nn.Sequential(
+            nn.Upsample(scale_factor=2, mode="nearest"),
+            _depthwise_conv(320, 192),
+        )
+        self.skip_conn4 = nn.Conv2d(256, 192, kernel_size=1)
+        self.up2 = nn.Sequential(
+            nn.Upsample(scale_factor=2, mode="nearest"),
+            _depthwise_conv(192, 128),
+        )
+        self.skip_conn3 = nn.Conv2d(160, 128, kernel_size=1)
+        self.up3 = nn.Sequential(
+            nn.Upsample(scale_factor=2, mode="nearest"),
+            _depthwise_conv(128, 80),
+        )
+        self.skip_conn2 = nn.Conv2d(96, 80, kernel_size=1)
+        self.up4 = nn.Sequential(
+            nn.Upsample(scale_factor=2, mode="nearest"),
+            _depthwise_conv(80, 40),
+        )
+        self.skip_conn1 = nn.Conv2d(48, 40, kernel_size=1)
+        self.eca = ECABlock(40)
+        self.refine = nn.Sequential(
+            nn.Conv2d(40, 40, 3, padding=1, groups=40, bias=False),
+            nn.BatchNorm2d(40),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(40, 1, kernel_size=1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        f1 = self.encoder_stage1(x)
+        f2 = self.encoder_stage2(self.down1(f1))
+        f3 = self.encoder_stage3(self.down2(f2))
+        f4 = self.encoder_stage4(self.down3(f3))
+        bottleneck = self.bottleneck(self.down4(f4))
+
+        u1 = self.up1(bottleneck) + self.skip_conn4(f4)
+        u2 = self.up2(u1) + self.skip_conn3(f3)
+        u3 = self.up3(u2) + self.skip_conn2(f2)
+        u4 = self.up4(u3) + self.skip_conn1(f1)
+        return self.refine(self.eca(u4))
+
+
+__all__ = ["ECABlock", "PicoSAM3Network"]

--- a/libreyolo/models/picosam3/preprocess.py
+++ b/libreyolo/models/picosam3/preprocess.py
@@ -1,0 +1,86 @@
+"""PicoSAM3 ROI geometry and ImageNet preprocessing."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+_MEAN = torch.tensor((0.485, 0.456, 0.406), dtype=torch.float32).view(3, 1, 1)
+_STD = torch.tensor((0.229, 0.224, 0.225), dtype=torch.float32).view(3, 1, 1)
+
+
+def padded_square_roi(
+    box: Iterable[float], image_width: int, image_height: int, padding: float = 0.1
+) -> tuple[int, int, int, int]:
+    """Convert an xyxy box to upstream's padded, square-clamped crop."""
+
+    x1, y1, x2, y2 = (float(v) for v in box)
+    if not all(np.isfinite((x1, y1, x2, y2))):
+        raise ValueError(f"bbox coordinates must be finite; got {list(box)!r}.")
+    if x2 <= x1 or y2 <= y1:
+        raise ValueError(f"bbox must satisfy x2>x1 and y2>y1; got {list(box)!r}.")
+    if x2 <= 0 or y2 <= 0 or x1 >= image_width or y1 >= image_height:
+        raise ValueError(f"bbox {list(box)!r} does not intersect the image.")
+
+    width, height = x2 - x1, y2 - y1
+    x1 -= width * padding
+    y1 -= height * padding
+    width *= 1.0 + 2.0 * padding
+    height *= 1.0 + 2.0 * padding
+    size = max(width, height)
+    cx, cy = x1 + width / 2.0, y1 + height / 2.0
+    crop = (
+        max(0, int(cx - size / 2.0)),
+        max(0, int(cy - size / 2.0)),
+        min(image_width, int(cx + size / 2.0)),
+        min(image_height, int(cy + size / 2.0)),
+    )
+    if crop[2] <= crop[0] or crop[3] <= crop[1]:
+        raise ValueError(f"bbox {list(box)!r} produces an empty ROI after clipping.")
+    return crop
+
+
+def preprocess_roi(image: Image.Image, roi: tuple[int, int, int, int]) -> torch.Tensor:
+    """Crop, bilinear-resize to 96, convert RGB to CHW, and normalize."""
+
+    crop = image.crop(roi).resize((96, 96), Image.Resampling.BILINEAR)
+    array = np.asarray(crop, dtype=np.float32) / 255.0
+    tensor = torch.from_numpy(array).permute(2, 0, 1)
+    return (tensor - _MEAN) / _STD
+
+
+def place_roi_logits(
+    logits: torch.Tensor,
+    rois: list[tuple[int, int, int, int]],
+    image_height: int,
+    image_width: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Resize ROI logits into full-image boolean masks and certainty scores."""
+
+    masks = torch.zeros(
+        (len(rois), image_height, image_width), dtype=torch.bool, device="cpu"
+    )
+    scores = torch.zeros(len(rois), dtype=torch.float32)
+    for index, (logit, (x1, y1, x2, y2)) in enumerate(zip(logits, rois)):
+        resized = (
+            F.interpolate(
+                logit.unsqueeze(0),
+                size=(y2 - y1, x2 - x1),
+                mode="bilinear",
+                align_corners=False,
+            )[0, 0]
+            .detach()
+            .cpu()
+        )
+        roi_mask = resized > 0.0
+        masks[index, y1:y2, x1:x2] = roi_mask
+        if roi_mask.any():
+            scores[index] = resized.sigmoid()[roi_mask].mean()
+    return masks, scores
+
+
+__all__ = ["padded_square_roi", "place_roi_logits", "preprocess_roi"]

--- a/libreyolo/models/sam/__init__.py
+++ b/libreyolo/models/sam/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "LibreSAM2",
     "LibreSAM3",
     "LibreMobileSAM",
+    "LibrePicoSAM3",
 ]
 
 
@@ -24,4 +25,8 @@ def __getattr__(name):
         from ..mobilesam import LibreMobileSAM
 
         return LibreMobileSAM
+    if name == "LibrePicoSAM3":
+        from ..picosam3 import LibrePicoSAM3
+
+        return LibrePicoSAM3
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libreyolo/models/sam/model.py
+++ b/libreyolo/models/sam/model.py
@@ -47,6 +47,7 @@ class LibreSAM1(LibreSAMModel):
 
 # alias -> (family class, size)
 _MOBILE_SAM = "mobilesam"
+_PICO_SAM3 = "picosam3"
 
 _ALIASES: Dict[str, Tuple[Type[LibreSAMModel] | str, str]] = {
     "base": (LibreSAM1, "base"),
@@ -82,6 +83,10 @@ _ALIASES: Dict[str, Tuple[Type[LibreSAMModel] | str, str]] = {
     "mobilesam_t": (_MOBILE_SAM, "tiny"),
     "mobile-sam": (_MOBILE_SAM, "tiny"),
     "mobile-sam-tiny": (_MOBILE_SAM, "tiny"),
+    "picosam3": (_PICO_SAM3, "pico"),
+    "picosam3-pico": (_PICO_SAM3, "pico"),
+    "picosam3_pico": (_PICO_SAM3, "pico"),
+    "pico-sam3": (_PICO_SAM3, "pico"),
 }
 
 _DEFAULT_MODEL = "base"
@@ -117,6 +122,10 @@ def LibreSAM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreSAMModel:
         from ..mobilesam import LibreMobileSAM
 
         family_cls = LibreMobileSAM
+    elif family_cls == _PICO_SAM3:
+        from ..picosam3 import LibrePicoSAM3
+
+        family_cls = LibrePicoSAM3
     return family_cls(size=size, **kwargs)
 
 

--- a/libreyolo/ui/page.py
+++ b/libreyolo/ui/page.py
@@ -196,6 +196,9 @@ INDEX_HTML = r"""<!DOCTYPE html>
       <label class="ctl" id="classesLabel" style="display:none" title="Text vocabulary for open-vocab / zero-shot models">Classes</label>
       <input class="ctlinput" id="classes" type="text" style="display:none"
              placeholder="e.g. person, hard hat, forklift">
+      <label class="ctl" id="bboxLabel" style="display:none" title="PicoSAM3 ROI in image pixels">ROI</label>
+      <input class="ctlinput" id="bbox" type="text" style="display:none"
+             placeholder="x1,y1,x2,y2 (full image)">
       <label class="ctl">Conf</label>
       <select id="conf"><option>0.25</option><option>0.40</option><option>0.50</option></select>
     </div>
@@ -264,10 +267,14 @@ INDEX_HTML = r"""<!DOCTYPE html>
 
   // ---- populate model dropdown from the real registry ----
   var openvocab = {};  // model name -> accepts a text vocabulary (classes box)
+  var boxPrompt = {};  // model name -> accepts an ROI box
   function syncClassesBox() {
     var show = !!openvocab[$("model").value];
     $("classesLabel").style.display = show ? "" : "none";
     $("classes").style.display = show ? "" : "none";
+    var showBox = !!boxPrompt[$("model").value];
+    $("bboxLabel").style.display = showBox ? "" : "none";
+    $("bbox").style.display = showBox ? "" : "none";
   }
   fetch("/api/models").then(function (r) { return r.json(); }).then(function (j) {
     var sel = $("model");
@@ -275,6 +282,7 @@ INDEX_HTML = r"""<!DOCTYPE html>
     var unavailable = {};
     (j.unavailable || []).forEach(function (m) { unavailable[m] = true; });
     (j.openvocab || []).forEach(function (m) { openvocab[m] = true; });
+    (j.box_prompt || []).forEach(function (m) { boxPrompt[m] = true; });
     (j.models || []).forEach(function (m) {
       var o = document.createElement("option");
       o.value = m;
@@ -368,6 +376,7 @@ INDEX_HTML = r"""<!DOCTYPE html>
     var model = $("model").value || "yolo9-t";
     var conf = $("conf").value || "0.25";
     var classes = openvocab[model] ? $("classes").value.trim() : "";
+    var bbox = boxPrompt[model] ? $("bbox").value.trim() : "";
     var outdir = "-";
 
     $("terminal").style.display = "block";
@@ -381,7 +390,8 @@ INDEX_HTML = r"""<!DOCTYPE html>
 
       try {
         var resp = await fetch("/api/infer?model=" + encodeURIComponent(model) + "&conf=" + encodeURIComponent(conf) +
-          (classes ? "&classes=" + encodeURIComponent(classes) : ""),
+          (classes ? "&classes=" + encodeURIComponent(classes) : "") +
+          (bbox ? "&bbox=" + encodeURIComponent(bbox) : ""),
           { method: "POST", headers: { "X-Filename": e.name }, body: e.file });
         if (!resp.body) throw new Error("streaming not supported");
         var reader = resp.body.getReader(), dec = new TextDecoder(), buf = "";
@@ -485,6 +495,7 @@ INDEX_HTML = r"""<!DOCTYPE html>
   $("termClearBtn").addEventListener("click", termClear);
   $("model").addEventListener("change", function () { syncClassesBox(); markStale(); });
   $("conf").addEventListener("change", markStale);
+  $("bbox").addEventListener("change", markStale);
   $("classes").addEventListener("change", markStale);
   $("openFolder").addEventListener("click", function () {
     fetch("/api/open-folder", { method: "POST" }).then(function (r) { return r.json(); }).then(function (j) {

--- a/libreyolo/ui/server.py
+++ b/libreyolo/ui/server.py
@@ -198,6 +198,16 @@ def _factory_openvocab_names() -> list[str]:
     return ["grounding-dino-t", "grounding-dino-b", "owlv2-b16", "owlv2-l14"]
 
 
+def _factory_picosam_names() -> list[str]:
+    """Promptable edge models with a dedicated UI inference path."""
+
+    import importlib.util
+
+    if importlib.util.find_spec("huggingface_hub") is None:
+        return []
+    return ["picosam3"]
+
+
 def _openvocab_model_names(names: list[str]) -> list[str]:
     """Model names that accept a per-run text vocabulary (``set_classes``):
     the factory-tier open-vocab detectors plus zero-shot classifier families
@@ -374,6 +384,8 @@ class _UIState:
         # is no single weight URL to probe, so list them as available.
         for name in _factory_openvocab_names():
             result[name] = True
+        for name in _factory_picosam_names():
+            result[name] = True
 
         with self._avail_lock:
             self._availability = result
@@ -387,6 +399,11 @@ class _UIState:
 
                 logger.info("Loading open-vocab model %s", name)
                 model = LibreOpenVocab(name, device=self.device)
+            elif name in _factory_picosam_names():
+                from libreyolo import LibreSAM
+
+                logger.info("Loading promptable model %s", name)
+                model = LibreSAM(name, device=self.device)
             else:
                 from libreyolo import LibreYOLO
                 from libreyolo.cli.config import resolve_model_name
@@ -400,9 +417,7 @@ class _UIState:
     def new_run(self) -> Path:
         from libreyolo.utils.general import increment_path
 
-        self.run_dir = increment_path(
-            Path("runs/detect") / "predict", mkdir=True
-        )
+        self.run_dir = increment_path(Path("runs/detect") / "predict", mkdir=True)
         with self._upload_lock:
             self._used_upload_names.clear()
         return self.run_dir
@@ -450,6 +465,7 @@ class _UIState:
         data: bytes,
         emit=None,
         classes: list[str] | None = None,
+        bbox: list[float] | None = None,
     ) -> dict:
         """Run inference. If ``emit`` is given, libreyolo log lines (model
         download, save path, ...) are forwarded to it live during the run."""
@@ -470,12 +486,28 @@ class _UIState:
                 # inside the captured block so the download streams to the UI.
                 model = self._get_model(model_name)
                 self._apply_vocabulary(model_name, model, classes)
-                result = model(
-                    str(in_path),
-                    conf=conf,
-                    save=True,
-                    output_path=str(self.run_dir),
-                )
+                if model_name in _factory_picosam_names():
+                    from PIL import Image
+
+                    from libreyolo.models.base.inference import InferenceRunner
+                    from libreyolo.utils.general import resolve_save_path
+
+                    with Image.open(in_path) as uploaded:
+                        width, height = uploaded.size
+                        original = uploaded.convert("RGB")
+                    prompt_box = bbox or [0.0, 0.0, float(width), float(height)]
+                    result = model(str(in_path), conf=conf, bboxes=prompt_box)
+                    save_path = resolve_save_path(self.run_dir, safe, ext="jpg")
+                    InferenceRunner(model)._save_annotated_image(
+                        result, original, save_path
+                    )
+                else:
+                    result = model(
+                        str(in_path),
+                        conf=conf,
+                        save=True,
+                        output_path=str(self.run_dir),
+                    )
             finally:
                 if handler is not None:
                     lg.removeHandler(handler)
@@ -543,25 +575,30 @@ class _Handler(BaseHTTPRequestHandler):
         elif path == "/api/models":
             from libreyolo.cli.config import get_all_cli_names
 
-            names = sorted(get_all_cli_names() + _factory_openvocab_names())
+            names = sorted(
+                get_all_cli_names()
+                + _factory_openvocab_names()
+                + _factory_picosam_names()
+            )
             avail = self.state.model_availability()
             unavailable = [n for n in names if not avail.get(n, True)]
             usable = [n for n in names if avail.get(n, True)]
-            default = "yolo9-t" if "yolo9-t" in usable else (usable[0] if usable else "")
+            default = (
+                "yolo9-t" if "yolo9-t" in usable else (usable[0] if usable else "")
+            )
             self._send(
                 200,
                 {
                     "models": names,
                     "unavailable": unavailable,
                     "openvocab": _openvocab_model_names(names),
+                    "box_prompt": _factory_picosam_names(),
                     "default": default,
                 },
             )
         elif path == "/api/sample":
             sample = (
-                Path(__file__).resolve().parents[1]
-                / "assets"
-                / "guggenheim-bilbao.jpg"
+                Path(__file__).resolve().parents[1] / "assets" / "guggenheim-bilbao.jpg"
             )
             try:
                 data = sample.read_bytes()
@@ -610,6 +647,17 @@ class _Handler(BaseHTTPRequestHandler):
         filename = self.headers.get("X-Filename", "image.jpg")
         raw_classes = qs.get("classes", [""])[0]
         classes = [c.strip() for c in raw_classes.split(",") if c.strip()] or None
+        raw_bbox = qs.get("bbox", [""])[0]
+        bbox = None
+        if raw_bbox:
+            try:
+                bbox = [float(value.strip()) for value in raw_bbox.split(",")]
+            except ValueError as exc:
+                raise ValueError(
+                    "bbox must contain four comma-separated numbers"
+                ) from exc
+            if len(bbox) != 4:
+                raise ValueError("bbox must contain x1,y1,x2,y2")
 
         self.send_response(200)
         self.send_header("Content-Type", "application/x-ndjson; charset=utf-8")
@@ -637,7 +685,13 @@ class _Handler(BaseHTTPRequestHandler):
 
         try:
             result = self.state.infer(
-                model, conf, filename, data, emit=emit, classes=classes
+                model,
+                conf,
+                filename,
+                data,
+                emit=emit,
+                classes=classes,
+                bbox=bbox,
             )
             write_obj({"type": "result", **result})
         except Exception as exc:

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -590,6 +590,23 @@
     "optional_extra": null,
     "available": true
   },
+  "picosam3": {
+    "class": "libreyolo.models.picosam3.model.LibrePicoSAM3",
+    "tasks": [
+      "segment"
+    ],
+    "default_task": "segment",
+    "sizes": {
+      "pico": 96
+    },
+    "default_imgsz": {
+      "pico": 96
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "sam",
+    "available": true
+  },
   "pidnet": {
     "class": "libreyolo.models.pidnet.model.LibrePIDNet",
     "tasks": [

--- a/tests/e2e/test_picosam3_smoke.py
+++ b/tests/e2e/test_picosam3_smoke.py
@@ -1,0 +1,23 @@
+"""End-to-end smoke test for LibrePicoSAM3 and its upstream download route."""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sam,
+    pytest.mark.network,
+    pytest.mark.external_data,
+]
+
+
+def test_picosam3_box_prompt_autodownloads_and_returns_mask():
+    from libreyolo import LibreSAM, Results, SAMPLE_IMAGE
+
+    model = LibreSAM("picosam3", device="cpu")
+    result = model.predict(SAMPLE_IMAGE, bboxes=[100, 100, 500, 500], conf=0.0)
+
+    assert isinstance(result, Results)
+    assert result.masks is not None
+    assert len(result.masks) == 1
+    assert result.masks.data.shape[-2:] == result.orig_shape
+    assert result.boxes.xyxy.shape == (1, 4)

--- a/tests/unit/test_picosam3_logic.py
+++ b/tests/unit/test_picosam3_logic.py
@@ -1,0 +1,142 @@
+"""Offline tests for the native PicoSAM3 port."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.picosam3.model import LibrePicoSAM3
+from libreyolo.models.picosam3.nn import PicoSAM3Network
+from libreyolo.models.picosam3.preprocess import padded_square_roi, preprocess_roi
+from libreyolo.models.sam.model import _ALIASES, _PICO_SAM3
+
+pytestmark = [pytest.mark.unit, pytest.mark.sam]
+
+
+def _bare_picosam3() -> LibrePicoSAM3:
+    model = object.__new__(LibrePicoSAM3)
+    model.model = PicoSAM3Network().eval()
+    for parameter in model.model.parameters():
+        parameter.data.zero_()
+    model.model.refine[3].bias.data.fill_(1.0)
+    model.processor = None
+    model.device = torch.device("cpu")
+    model._model_dtype = torch.float32
+    model._default_multimask = False
+    model.names = {0: "object"}
+    model.size = "pico"
+    model.task = "segment"
+    model._clear_image_state()
+    return model
+
+
+def test_top_level_export_resolves_lazily():
+    from libreyolo import LibrePicoSAM3 as Exported
+
+    assert Exported is LibrePicoSAM3
+
+
+def test_aliases_resolve_without_download():
+    assert _ALIASES["picosam3"] == (_PICO_SAM3, "pico")
+    assert _ALIASES["picosam3-pico"] == (_PICO_SAM3, "pico")
+
+
+def test_network_shape_and_parameter_count():
+    model = PicoSAM3Network().eval()
+    assert sum(parameter.numel() for parameter in model.parameters()) == 1_371_418
+    with torch.no_grad():
+        output = model(torch.zeros((2, 3, 96, 96)))
+    assert output.shape == (2, 1, 96, 96)
+
+
+def test_upstream_roi_geometry_and_preprocess_are_deterministic():
+    image = Image.new("RGB", (32, 24), color=(10, 20, 30))
+    roi = padded_square_roi([8, 6, 24, 18], 32, 24)
+    tensor = preprocess_roi(image, roi)
+
+    assert roi == (6, 2, 25, 21)
+    assert tensor.shape == (3, 96, 96)
+    assert tensor[:, 0, 0].tolist() == pytest.approx(
+        [-1.9466564655, -1.6855741739, -1.2815686464]
+    )
+
+
+def test_box_prompt_places_mask_back_into_original_image():
+    model = _bare_picosam3()
+    image = Image.new("RGB", (32, 24), color="white")
+
+    result = model.predict(image, bboxes=[8, 6, 24, 18], conf=0.0)
+
+    assert result.masks.data.shape == (1, 24, 32)
+    assert result.masks.data[0, 2:21, 6:25].all()
+    assert not result.masks.data[0, :2].any()
+    assert result.boxes.xyxy.tolist() == [[6.0, 2.0, 24.0, 20.0]]
+
+
+def test_multiple_boxes_are_batched_and_set_image_is_reused():
+    model = _bare_picosam3().set_image(Image.new("RGB", (40, 30), color="white"))
+    try:
+        result = model.predict(bboxes=[[2, 2, 15, 20], [20, 5, 35, 25]])
+        assert len(result.masks) == 2
+    finally:
+        model.reset_image()
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"points": [4, 4]}, "supports only bboxes"),
+        ({"text": "dog"}, "supports only bboxes"),
+        ({"masks": torch.zeros(1)}, "supports only bboxes"),
+        ({"multimask": True}, "does not support multimask"),
+        ({}, "requires bboxes"),
+    ],
+)
+def test_unsupported_prompt_contract_fails_clearly(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        _bare_picosam3().predict(Image.new("RGB", (16, 16)), **kwargs)
+
+
+def test_epoch1_picosam2_checkpoint_is_rejected(tmp_path):
+    checkpoint = {"output_head.weight": torch.zeros((1, 40, 1, 1))}
+    torch.save(checkpoint, tmp_path / LibrePicoSAM3.WEIGHT_FILE)
+    model = object.__new__(LibrePicoSAM3)
+    model.size = "pico"
+    model._ensure_weights = lambda: str(tmp_path)
+
+    with pytest.raises(ValueError, match="older PicoSAM2 architecture"):
+        model._init_model()
+
+
+def test_conversion_round_trip_writes_provenance_metadata(tmp_path):
+    from weights.convert_picosam3_weights import convert
+
+    source = tmp_path / "PicoSAM3_SAM3_student_best.pt"
+    output = tmp_path / "LibrePicoSAM3pico.pt"
+    torch.save(PicoSAM3Network().state_dict(), source)
+    convert(source, output)
+    checkpoint = torch.load(output, map_location="cpu", weights_only=True)
+
+    assert checkpoint["model_family"] == "picosam3"
+    assert checkpoint["size"] == "pico"
+    assert checkpoint["task"] == "segment"
+    assert checkpoint["imgsz"] == 96
+    assert checkpoint["license"] == "Apache-2.0"
+    PicoSAM3Network().load_state_dict(checkpoint["model"], strict=True)
+
+
+def test_raw_onnx_export_matches_pytorch(tmp_path):
+    ort = pytest.importorskip("onnxruntime")
+    model = _bare_picosam3()
+    output = tmp_path / "picosam3.onnx"
+    model.export(output=output)
+
+    inputs = torch.randn((3, 3, 96, 96))
+    with torch.no_grad():
+        expected = model.model(inputs).numpy()
+    session = ort.InferenceSession(str(output), providers=["CPUExecutionProvider"])
+    actual = session.run(["mask_logits"], {"roi_image": inputs.numpy()})[0]
+    torch.testing.assert_close(
+        torch.from_numpy(actual), torch.from_numpy(expected), atol=1e-5, rtol=1e-5
+    )

--- a/tests/unit/test_picosam3_parity.py
+++ b/tests/unit/test_picosam3_parity.py
@@ -1,0 +1,40 @@
+"""Gated tensor parity against the pinned Apache-2.0 upstream checkout."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo.models.picosam3.nn import PicoSAM3Network
+
+pytestmark = [pytest.mark.unit, pytest.mark.external_data, pytest.mark.sam]
+
+
+def test_picosam3_upstream_tensor_parity():
+    upstream = os.environ.get("LIBREYOLO_PICOSAM3_UPSTREAM")
+    checkpoint = os.environ.get("LIBREYOLO_PICOSAM3_CHECKPOINT")
+    if not upstream or not checkpoint:
+        pytest.skip("set LIBREYOLO_PICOSAM3_UPSTREAM and LIBREYOLO_PICOSAM3_CHECKPOINT")
+
+    model_file = Path(upstream) / "model_compression" / "model.py"
+    spec = importlib.util.spec_from_file_location("picosam3_upstream_model", model_file)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    state_dict = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    reference = module.PicoSAM3().eval()
+    port = PicoSAM3Network().eval()
+    reference.load_state_dict(state_dict, strict=True)
+    port.load_state_dict(state_dict, strict=True)
+
+    torch.manual_seed(573)
+    inputs = torch.randn((3, 3, 96, 96))
+    with torch.no_grad():
+        expected = reference(inputs)
+        actual = port(inputs)
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)

--- a/tests/unit/ui/test_ui_summary.py
+++ b/tests/unit/ui/test_ui_summary.py
@@ -19,7 +19,10 @@ def result(**attrs):
     ("item", "expected"),
     [
         (result(boxes=[object()]), ("detect", "1 object")),
-        (result(boxes=[object(), object()], masks=object()), ("segment", "2 instances")),
+        (
+            result(boxes=[object(), object()], masks=object()),
+            ("segment", "2 instances"),
+        ),
         (result(boxes=[object()], keypoints=object()), ("pose", "1 pose")),
         (result(obb=[object(), object()]), ("obb", "2 objects")),
         (result(points=[object(), object(), object()]), ("point", "3 points")),
@@ -83,6 +86,14 @@ def test_factory_openvocab_names_resolve_in_the_factory():
 
     for name in _factory_openvocab_names():
         assert name in _ALIASES
+
+
+def test_factory_picosam_names_resolve_in_the_factory():
+    from libreyolo.models.sam.model import _ALIASES
+    from libreyolo.ui.server import _factory_picosam_names
+
+    assert _factory_picosam_names() == ["picosam3"]
+    assert all(name in _ALIASES for name in _factory_picosam_names())
 
 
 def test_apply_vocabulary_sets_and_restores():

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -133,14 +133,17 @@ project the weights were derived from. Per-family summary:
              requires accepting Meta's terms. LibreYOLO downloads the weights
              directly and does not distribute them under the MIT license.
 
-    PicoSAM3 (pietrobonazzi/picosam3)                  Apache-2.0
+    PicoSAM3 (LibreYOLO/LibrePicoSAM3)                 Apache-2.0
+             Converted and rehosted by LibreYOLO. Upstream sources:
              upstream code commit:
                1b03949e43472953bb0021685c7fc3f5fdf48fde
-             upstream weights revision:
+             upstream weights (pietrobonazzi/picosam3) revision:
                af49e4322b6b7cf448499fee5c073d4576f59444
              Only PicoSAM3_SAM3_student_best.pt matches the advertised
              PicoSAM3 architecture. The epoch-1 files are not mirrored or
              converted because they contain the older PicoSAM2 network.
+             Distilled by upstream from SAM 2.1 and SAM 3; teacher weights
+             are not included or redistributed.
 
 The LICENSE and NOTICE files on each Hugging Face model card are the
 authoritative source for redistribution terms. Users converting

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -133,6 +133,15 @@ project the weights were derived from. Per-family summary:
              requires accepting Meta's terms. LibreYOLO downloads the weights
              directly and does not distribute them under the MIT license.
 
+    PicoSAM3 (pietrobonazzi/picosam3)                  Apache-2.0
+             upstream code commit:
+               1b03949e43472953bb0021685c7fc3f5fdf48fde
+             upstream weights revision:
+               af49e4322b6b7cf448499fee5c073d4576f59444
+             Only PicoSAM3_SAM3_student_best.pt matches the advertised
+             PicoSAM3 architecture. The epoch-1 files are not mirrored or
+             converted because they contain the older PicoSAM2 network.
+
 The LICENSE and NOTICE files on each Hugging Face model card are the
 authoritative source for redistribution terms. Users converting
 third-party checkpoints locally are responsible for complying with the

--- a/weights/convert_picosam3_weights.py
+++ b/weights/convert_picosam3_weights.py
@@ -1,0 +1,87 @@
+"""Convert the valid upstream PicoSAM3 checkpoint to LibreYOLO schema.
+
+Only ``PicoSAM3_SAM3_student_best.pt`` matches the published PicoSAM3
+architecture. The two epoch-1 files currently contain the older PicoSAM2
+network and are rejected deliberately.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+try:
+    from _conversion_utils import (
+        add_repo_root_to_path,
+        load_checkpoint,
+        save_checkpoint,
+        wrap_libreyolo_checkpoint,
+    )
+except ModuleNotFoundError:  # imported as weights.convert_picosam3_weights
+    from weights._conversion_utils import (
+        add_repo_root_to_path,
+        load_checkpoint,
+        save_checkpoint,
+        wrap_libreyolo_checkpoint,
+    )
+
+UPSTREAM_REPO = "https://github.com/pbonazzi/picosam3"
+UPSTREAM_COMMIT = "1b03949e43472953bb0021685c7fc3f5fdf48fde"
+WEIGHTS_REPO = "pietrobonazzi/picosam3"
+WEIGHTS_REVISION = "af49e4322b6b7cf448499fee5c073d4576f59444"
+
+
+def _unwrap(checkpoint):
+    if isinstance(checkpoint, dict):
+        for key in ("state_dict", "model"):
+            if key in checkpoint and isinstance(checkpoint[key], dict):
+                return checkpoint[key]
+    return checkpoint
+
+
+def convert(input_path: str | Path, output_path: str | Path) -> Path:
+    add_repo_root_to_path()
+    from libreyolo.models.picosam3.nn import PicoSAM3Network
+
+    state_dict = _unwrap(load_checkpoint(input_path))
+    if any(key.startswith("output_head.") for key in state_dict):
+        raise ValueError(
+            "The supplied checkpoint is the older PicoSAM2 architecture. "
+            "Convert PicoSAM3_SAM3_student_best.pt instead."
+        )
+    model = PicoSAM3Network()
+    model.load_state_dict(state_dict, strict=True)
+    model.eval()
+    wrapped = wrap_libreyolo_checkpoint(
+        model.state_dict(),
+        model_family="picosam3",
+        size="pico",
+        task="segment",
+        nc=1,
+        names={0: "object"},
+        imgsz=96,
+    )
+    wrapped.update(
+        source_repo=UPSTREAM_REPO,
+        source_revision=UPSTREAM_COMMIT,
+        weights_repo=WEIGHTS_REPO,
+        weights_revision=WEIGHTS_REVISION,
+        license="Apache-2.0",
+        teacher_chain="SAM 2.1 and SAM 3 (distillation only)",
+    )
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output_path.with_suffix(output_path.suffix + ".tmp")
+    save_checkpoint(wrapped, temporary)
+    temporary.replace(output_path)
+    print(f"Wrote {output_path}")
+    return output_path
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", default="weights/LibrePicoSAM3pico.pt")
+    args = parser.parse_args()
+    convert(args.input, args.output)


### PR DESCRIPTION
Adds `LibrePicoSAM3`, a 1,371,418-parameter ROI-prompted CNN segmenter, as the edge tier of the LibreSAM promptable family. It sits below MobileSAM and is small enough to run in-sensor on the Sony IMX500.

```python
from libreyolo import LibreSAM
model = LibreSAM("picosam3")
result = model.predict("image.jpg", bboxes=[100, 100, 400, 500])
```

## What is here

- Native PicoSAM3 architecture (depthwise-separable encoder, dilated bottleneck, channel attention).
- `LibreSAM("picosam3")` / `LibrePicoSAM3()`, box-only ROI prompts, multi-box batching, `set_image()` reuse.
- Weights served from `LibreYOLO/LibrePicoSAM3` (Apache-2.0, converted to checkpoint schema v1 with provenance metadata).
- Raw ONNX export (`roi_image -> mask_logits`). `.rpk` IMX500 packaging stays a deployment step, not an export format.
- UI picker with an x1,y1,x2,y2 ROI control.

Point, text, mask, multimask and segment-everything prompts are not part of the upstream model contract and raise a clear error pointing at LibreSAM2/LibreSAM3, rather than degrading silently.

## Verification

**Mask quality** on COCO val2017, ground-truth boxes as ROI prompts, ground-truth masks as reference, 2000 random non-crowd instances (seed 0, no area filter):

| Protocol | mIoU |
|---|---|
| Crop space, 96x96 (upstream evaluation space) | **0.692** |
| Full image, end-to-end via `predict()` | **0.697** |

The paper reports 65.45 mIoU. Sampling and filtering may differ, so this is recorded as our measurement rather than a reproduction of theirs; it exceeds the published figure, which confirms the shipped checkpoint is the trained artifact it claims to be.

**Parity**: the port is bit-identical to upstream (max abs diff 0.0 on a seeded FP32 batch). ONNX matches PyTorch to 2.27e-6. Clean autodownload from the mirror plus real inference verified end to end.

**Checkpoint correction**: at the pinned upstream revision, `PicoSAM3_student_epoch1.pt` and `PicoSAM3_epoch1.pt` both contain the older PicoSAM2 network (`output_head.*`) and cannot load as PicoSAM3. Only `PicoSAM3_SAM3_student_best.pt` matches the advertised architecture; the converter rejects the others explicitly.

## Note on CI

`573-work-package-2` is currently red on macOS for an unrelated, pre-existing reason (LibreEC ONNX top-k parity, issue #584). Any branch cut from it inherits that failure.

## Code provenance

- **Code**: architecture ported from [pbonazzi/picosam3](https://github.com/pbonazzi/picosam3), commit `1b03949e43472953bb0021685c7fc3f5fdf48fde`, **Apache-2.0**. Upstream `LICENSE_cctorch` (BSD-3) is deliberately not vendored because no cctorch code is used. The upstream LICENSE and a NOTICE ship in `libreyolo/models/picosam3/`.
- **Weights**: converted from [pietrobonazzi/picosam3](https://huggingface.co/pietrobonazzi/picosam3), revision `af49e4322b6b7cf448499fee5c073d4576f59444`, **Apache-2.0**, rehosted at `LibreYOLO/LibrePicoSAM3`. Tensor values unchanged.
- **Teacher chain**: upstream distilled this student from SAM 2.1 and SAM 3. No teacher code or checkpoints are included or redistributed. Meta's SAM License assigns ownership of distilled derivative works to their creator and imposes no license inheritance, so the upstream author's Apache-2.0 terms govern these weights.
- **Training data**: COCO 2017 and LVIS v1.
- `THIRD_PARTY_NOTICES.txt` and `weights/LICENSE_NOTICE.txt` updated.
