### PR TITLE
Profiler: profile=True keeps training; profile_then_stop for benchmark mode

### DIFF
--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -20,8 +20,16 @@ model.train(data="coco1000", profile=True)
 ```
 
 `profile=True` profiles a short window of real training steps (a few warmup
-steps, then a measured window), prints a report, writes its artifacts, and
-**stops early** — so a profile run takes seconds, not a full training.
+steps, then a measured window), prints a report, writes its artifacts, and then
+**keeps training**: the hooks are dropped once the window closes, so the rest
+of the run pays nothing. It is safe to combine with a real (or resumed)
+training run.
+
+To profile *without* training to the end, pass `profile_then_stop=True`: the
+run stops right after the window, so it takes seconds instead of a full
+training. This is what `libreyolo profile run` uses. A stopped run is
+benchmark-only: the partial epoch is neither validated nor checkpointed, and
+the log says so instead of reporting a completed training.
 
 It is **zero overhead when off** (the default); the hot loop's hooks short
 -circuit to a no-op. Profiling is ignored under distributed (DDP) training.
@@ -62,7 +70,8 @@ step time — not wall-clock hand-waving.
 
 | key | default | meaning |
 |---|---|---|
-| `profile` | `False` | enable the profiler |
+| `profile` | `False` | enable the profiler (training continues after the window) |
+| `profile_then_stop` | `False` | stop the run right after the profile window (benchmark mode; no checkpoint for the partial epoch) |
 | `profile_warmup` | `5` | leading steps discarded |
 | `profile_steps` | `20` | measured steps |
 | `profile_trace` | `True` | emit the Chrome trace + timeline |

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -99,8 +99,9 @@ def run_cmd(
     import torch
     from libreyolo import LibreYOLO
 
-    # Enough total iterations to fill warmup+steps even on a tiny dataset; the
-    # profiler early-stops once the window is full, so extra epochs never run.
+    # Enough total iterations to fill warmup+steps even on a tiny dataset;
+    # profile_then_stop ends the run once the window is full, so extra epochs
+    # never run.
     epochs = warmup + steps + 5
     trials, trial_profiles, trial_paths, last_dir = [], [], [], None
     for i in range(max(1, repeat)):
@@ -108,7 +109,8 @@ def run_cmd(
         model = LibreYOLO(model_path=weights, size=size, device=device)
         model.train(
             data=data, epochs=epochs, batch=batch, imgsz=imgsz, workers=workers,
-            amp=amp, device=device, profile=True, profile_steps=steps,
+            amp=amp, device=device, profile=True, profile_then_stop=True,
+            profile_steps=steps,
             profile_warmup=warmup, profile_open=False, no_aug_epochs=0,
             project=project, name=name, exist_ok=True,
         )

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -179,9 +179,13 @@ class TrainConfig:
     # Profiling. When ``profile`` is True the trainer profiles a short window of
     # real training steps (``profile_warmup`` discarded, then ``profile_steps``
     # measured), prints a per-phase breakdown + GPU-idle verdict, writes a Chrome
-    # trace (open at https://ui.perfetto.dev), then stops early. Zero overhead
-    # when off. Ignored under distributed training.
+    # trace (open at https://ui.perfetto.dev), then drops the hooks and KEEPS
+    # TRAINING. ``profile_then_stop`` instead stops the run right after the
+    # window (benchmark mode, what ``libreyolo profile run`` uses); the partial
+    # epoch is then neither validated nor checkpointed, so it cannot poison a
+    # later resume. Zero overhead when off. Ignored under distributed training.
     profile: bool = False
+    profile_then_stop: bool = False
     profile_warmup: int = 5
     profile_steps: int = 20
     profile_trace: bool = True

--- a/libreyolo/training/profiler.py
+++ b/libreyolo/training/profiler.py
@@ -496,6 +496,11 @@ class TrainStepProfiler:
         """Yield batches while measuring real step time + dataload stall."""
         it = iter(iterable)
         while True:
+            if self.finished:
+                # Window closed but training continues: get out of the way so
+                # the rest of the epoch pays no per-batch instrumentation.
+                yield from it
+                return
             t0 = time.perf_counter()
             try:
                 with record_function("step/dataload"):

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1339,7 +1339,8 @@ class BaseTrainer(ABC):
 
         # Optional training-step profiler (opt-in via config.profile). Built on
         # the main process; emits the breakdown + Chrome trace into save_dir.
-        # Disabled under DDP (its early-stop would desync ranks).
+        # Disabled under DDP (rank-0-only syncs, and the profile_then_stop
+        # early stop would desync ranks).
         if getattr(self.config, "profile", False):
             if self.is_distributed:
                 if is_main_process():
@@ -1465,14 +1466,24 @@ class BaseTrainer(ABC):
                 self.final_loss = epoch_loss
                 self.epoch_losses.append(epoch_loss)
 
-                is_best = self._update_best_state(epoch, val_metrics)
+                profile_truncated = bool(getattr(self, "_stop_training", False))
+                is_best = (
+                    False
+                    if profile_truncated
+                    else self._update_best_state(epoch, val_metrics)
+                )
                 # Write ``last.pt`` every epoch so a crash never costs more than
                 # a single epoch. ``best.pt`` (is_best) and periodic
                 # ``epoch_N.pt`` (save_period) stay gated inside
-                # _save_checkpoint, so those are unaffected.
-                self._save_checkpoint(
-                    epoch, epoch_loss, val_metrics, is_best=is_best
-                )
+                # _save_checkpoint, so those are unaffected. A profile-only run
+                # (profile_then_stop) truncated the epoch after the profile
+                # window, so no checkpoint is written for it: stamping the
+                # partial epoch as complete would make a later resume skip the
+                # rest of it.
+                if not profile_truncated:
+                    self._save_checkpoint(
+                        epoch, epoch_loss, val_metrics, is_best=is_best
+                    )
 
                 event = self._build_train_epoch_event(
                     epoch=epoch,
@@ -1532,7 +1543,16 @@ class BaseTrainer(ABC):
 
             total_time = time.time() - start_time
             if is_main_process():
-                logger.info(f"Training complete in {total_time / 3600:.2f} hours")
+                if getattr(self, "_stop_training", False):
+                    logger.info(
+                        "Profile-only run (profile_then_stop=True): training "
+                        f"stopped after the profile window in {total_time:.1f}s; "
+                        "the partial epoch was not validated or checkpointed"
+                    )
+                else:
+                    logger.info(
+                        f"Training complete in {total_time / 3600:.2f} hours"
+                    )
 
             results = self._build_train_results()
             end_event = self._build_train_end_event(total_time, results)
@@ -1990,8 +2010,17 @@ class BaseTrainer(ABC):
             if prof is not None:
                 prof.step()
                 if prof.finished:
-                    self._stop_training = True
-                    break
+                    if getattr(self.config, "profile_then_stop", False):
+                        self._stop_training = True
+                        break
+                    # Window closed: drop the hooks so the rest of the run
+                    # pays nothing, and keep training.
+                    logger.info(
+                        "Profile window complete; training continues "
+                        "(profile_then_stop=True stops here instead)"
+                    )
+                    self._profiler = None
+                    prof = None
 
         avg_loss = total_loss / max(num_batches, 1)
         avg_loss_components = {
@@ -2001,9 +2030,13 @@ class BaseTrainer(ABC):
         if is_main_process():
             logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
 
-        # Validation
+        # Validation. A profile-only run (profile_then_stop) truncated the
+        # epoch, so validating the barely-trained weights would waste time and
+        # could poison the best-metric state.
         val_metrics = None
-        if self._should_validate_epoch(epoch):
+        if not getattr(self, "_stop_training", False) and self._should_validate_epoch(
+            epoch
+        ):
             val_metrics = self._validate_epoch(epoch)
 
         return avg_loss, val_metrics, avg_loss_components, self._current_lrs()
@@ -2159,8 +2192,17 @@ class BaseTrainer(ABC):
             if prof is not None:
                 prof.step()
                 if prof.finished:
-                    self._stop_training = True
-                    break
+                    if getattr(self.config, "profile_then_stop", False):
+                        self._stop_training = True
+                        break
+                    # Window closed: drop the hooks so the rest of the run
+                    # pays nothing, and keep training.
+                    logger.info(
+                        "Profile window complete; training continues "
+                        "(profile_then_stop=True stops here instead)"
+                    )
+                    self._profiler = None
+                    prof = None
 
         avg_loss = total_loss / max(num_batches, 1)
         avg_loss_components = {
@@ -2170,9 +2212,13 @@ class BaseTrainer(ABC):
         if is_main_process():
             logger.info(f"Epoch {epoch + 1} - Average loss: {avg_loss:.4f}")
 
-        # Validation
+        # Validation. A profile-only run (profile_then_stop) truncated the
+        # epoch, so validating the barely-trained weights would waste time and
+        # could poison the best-metric state.
         val_metrics = None
-        if self._should_validate_epoch(epoch):
+        if not getattr(self, "_stop_training", False) and self._should_validate_epoch(
+            epoch
+        ):
             val_metrics = self._validate_epoch(epoch)
 
         return avg_loss, val_metrics, avg_loss_components, self._current_lrs()

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1421,6 +1421,9 @@ class BaseTrainer(ABC):
 
     def train(self) -> Dict:
         start_time = time.time()
+        # May be stale from a previous profile_then_stop run on this instance;
+        # a leftover True would silently truncate this run's first epoch.
+        self._stop_training = False
         try:
             self.setup()
 

--- a/skills/libreyolo-profiling/SKILL.md
+++ b/skills/libreyolo-profiling/SKILL.md
@@ -43,6 +43,10 @@ libreyolo profile run <data> --weights LibreYOLO9t.pt --size t --repeat 3 --json
 ```
 
 - `<data>` is a dataset yaml/name (e.g. `coco128`). `--batch -1` auto-fits ~70% VRAM.
+- `profile run` stops right after the profile window (it passes
+  `profile_then_stop=True`). In contrast, `model.train(..., profile=True)`
+  profiles the window and then **keeps training**, so it is safe on a real or
+  resumed run.
 - **Always `--repeat 3`+** — a single run *lies* when launch-bound; `--repeat`
   gives mean ± stdev and is what makes a later `compare` significant. The
   aggregate is `runs/profile/profile_repeat.json` — use **that** path (not a

--- a/tests/unit/test_training_profiler.py
+++ b/tests/unit/test_training_profiler.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import time
+from types import SimpleNamespace
 
 import pytest
 import torch
+from torch import nn
 
 from libreyolo.training.config import TrainConfig
+from libreyolo.training.trainer import BaseTrainer
 from libreyolo.training.profiler import (
     TrainStepProfiler,
     _friendly_kernel,
@@ -152,6 +155,7 @@ def test_analyze_trace_uses_summary(tmp_path):
 def test_profiler_disabled_by_default():
     cfg = TrainConfig()
     assert cfg.profile is False
+    assert cfg.profile_then_stop is False
     assert cfg.profile_open is True
 
 
@@ -203,6 +207,121 @@ def test_analyze_trace_host_overhead_and_schema(tmp_path):
     assert a["host_overhead_ms_per_step"] > 90
     assert a["metrics"]["host_overhead_ms"] == a["host_overhead_ms_per_step"]
     assert a["metrics"]["launches_per_step"] == 5
+
+
+def test_wrap_loader_passes_through_after_finish(tmp_path):
+    """Once the window closes, wrap_loader keeps yielding untouched batches."""
+    prof = TrainStepProfiler(
+        device=torch.device("cpu"), warmup=1, active=1, trace=False,
+        open_report=False, save_dir=tmp_path, meta={"model": "t", "batch": 1},
+    )
+    seen = []
+    for item in prof.wrap_loader(range(10)):
+        seen.append(item)
+        prof.step()
+    assert prof.finished
+    assert seen == list(range(10))
+
+
+# --- trainer integration: profile window vs. the training loop --------------
+
+class _ProfTrainer(BaseTrainer):
+    def get_model_family(self) -> str:
+        return "tiny"
+
+    def get_model_tag(self) -> str:
+        return "tiny"
+
+    def create_transforms(self):
+        raise NotImplementedError
+
+    def create_scheduler(self, iters_per_epoch: int):
+        raise NotImplementedError
+
+    def get_loss_components(self, outputs):
+        return {}
+
+
+class _Loader:
+    def __init__(self, num_batches):
+        self.dataset = SimpleNamespace()
+        self.num_batches = num_batches
+
+    def __iter__(self):
+        for _ in range(self.num_batches):
+            yield torch.zeros(1, 1), torch.zeros(1, 1), (None,), (0,)
+
+    def __len__(self):
+        return self.num_batches
+
+
+def _build_profiled_trainer(tmp_path, *, num_batches, **config_overrides):
+    """Bare-bones trainer (bypasses __init__, like test_trainer_grad_clip) with
+    a live CPU profiler whose window closes after 3 steps (warmup 1 + measured
+    2, since active is clamped to >= 2).
+    """
+    trainer = _ProfTrainer.__new__(_ProfTrainer)
+    trainer.model = nn.Linear(1, 1, bias=False)
+    param = next(trainer.model.parameters())
+    trainer.train_loader = _Loader(num_batches)
+    trainer.config = SimpleNamespace(
+        epochs=1,
+        batch=1,
+        log_interval=999,
+        eval_interval=-1,
+        clip_max_norm=None,
+        **config_overrides,
+    )
+    trainer.device = torch.device("cpu")
+    trainer.optimizer = torch.optim.SGD([param], lr=0.1)
+    trainer.scaler = None
+    trainer.ema_model = None
+    trainer.lr_scheduler = SimpleNamespace(update_lr=lambda _: 0.1)
+    trainer.wrapper_model = SimpleNamespace(task="detect")
+    trainer._stop_training = False
+
+    forwards = []
+
+    def on_forward(imgs, targets, polygons=None):
+        forwards.append(1)
+        return {"total_loss": (param * 0).sum() + 1.0}
+
+    trainer.on_forward = on_forward
+    trainer._profiler = TrainStepProfiler(
+        device=torch.device("cpu"), warmup=1, active=1, trace=False,
+        open_report=False, save_dir=tmp_path, meta={"model": "t", "batch": 1},
+    )
+    return trainer, forwards
+
+
+def test_profile_window_close_keeps_training(tmp_path):
+    """Default profile=True: the window closes and the epoch keeps training."""
+    trainer, forwards = _build_profiled_trainer(tmp_path, num_batches=6)
+
+    _ProfTrainer._train_epoch(trainer, 0)
+
+    assert trainer._profiler is None  # hooks dropped after the window
+    assert trainer._stop_training is False
+    assert len(forwards) == 6  # every batch still trained
+
+
+def test_profile_then_stop_truncates_without_validation(tmp_path):
+    """profile_then_stop=True: stop right after the window; the partial epoch
+    must not be validated (train() skips its checkpoint for the same reason)."""
+    trainer, forwards = _build_profiled_trainer(
+        tmp_path, num_batches=6, profile_then_stop=True
+    )
+    validated = []
+    trainer._should_validate_epoch = lambda epoch: True
+    trainer._validate_epoch = lambda epoch, **kw: validated.append(epoch)
+
+    _, val_metrics, _, _ = _ProfTrainer._train_epoch(trainer, 0)
+
+    assert trainer._stop_training is True
+    # Window only: warmup 1 + measured 2 (active is clamped to >= 2).
+    assert len(forwards) == 3
+    assert validated == []
+    assert val_metrics is None
 
 
 def test_memory_pressure_detected(tmp_path):


### PR DESCRIPTION
## Summary
- `model.train(..., profile=True)` no longer truncates the run: the profiler drops its hooks once the window closes and training continues at full speed. `wrap_loader` also gets out of the way after the window, so the rest of the run pays no per-batch instrumentation.
- The old stop-after-window behavior is now opt-in via `profile_then_stop=True`. `libreyolo profile run` passes it, so the CLI benchmark flow is unchanged.
- A stopped run now logs "Profile-only run (profile_then_stop=True): training stopped after the profile window" instead of "Training complete", and the partial epoch is neither validated nor checkpointed.
- Docs (`docs/profiler.md`), the `TrainConfig` comment, and the `libreyolo-profiling` skill updated to match.

## Why
`profile=True` on a long (or resumed) run profiled ~25 steps, then exited with code 0, logged "Training complete in 0.02 hours", and wrote `last.pt` stamped with the partial epoch as complete; a later resume (`start_epoch = ckpt[9 then silently skipped the rest of that epoch while the LR schedule advanced. Validation on the barely-trained epoch could also update `best.pt`. The knob looked observabilitye a benchmark harness, and the run outcome was indistinguishable from a real completion.

## Testing
- New unit tests in `tests/unit/test_training_profiler.py`: continue mo0and clears the hooks; `profile_then_stop` truncates after the window and skips validation; `wrap_loader` passes batches through untouched after the window; config default is off.
- Suites green: test_training_profiler, test_trainer_grad_clip, test_grad_accum, cli test_profile, test_training_artifacts, test_trainer_validation_plots, test_layer_freezing, test_ddp_distributed, test_autoba E2E on coco8/CPU: `profile=True` completes all epochs (`last.pt` epoch stamp 1); `profile_then_stop=True` stops after the window, logs the profile-only line, andeted epoch is checkpointed (epoch stamp 0).

## Code provenance
All changes writte from scratch for thsting LibreYOLO profiler/trainer code (MIT). No external code consulted or copied.