### PR TITLE
Fix distributed training and resume contracts

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -195,11 +195,49 @@ flat training/resume fields:
     "train_model": raw_state_dict,
     "ema": ema_state_dict,
     "ema_updates": 12345,
+    "scaler": grad_scaler_state_dict,
+    "scheduler": scheduler_state_dict,  # only when supported
+    "distiller": distillation_adapter_state_dict,
+    "optimizer_step_count": 12000,
+    "patience_counter": 2,
+    "rng_state": rank_zero_rng_state,  # legacy/single-rank compatibility
+    "rng_states_by_rank": [
+        {
+            "python": {...},
+            "numpy": {...},
+            "torch": torch_rng_state,
+            "cuda": local_cuda_rng_state,
+            "train_loader_generator": loader_generator_state,
+        },
+    ],
 }
 ```
 
 `is_ema_weights` declares whether the top-level `model` is EMA-smoothed. When
 EMA is enabled, `train_model`, `ema`, and `ema_updates` preserve resume state.
+`optimizer_step_count` is authoritative even when it is zero; it advances only
+when the optimizer actually applies an update. `patience_counter` counts
+completed validation opportunities without improvement.
+
+New distributed checkpoints store one `rng_states_by_rank` entry per rank.
+Exact RNG replay requires the same world size. If the world size changes, the
+trainer keeps newly seeded per-rank streams. Legacy `rng_state` contains only
+rank-zero state; under DDP it is restored on rank zero only so peer ranks do not
+receive identical dropout and augmentation streams. Seeded loaders run without
+persistent workers so their generator state is resumable at epoch checkpoints.
+
+Resume validates model family, task, and size before applying state. A state
+field that is absent is treated as a legacy omission. State for an enabled
+resume component must load successfully; incompatible state is an error rather
+than a best-effort partial resume. An explicitly disabled EMA, AMP, or
+distillation component warns and discards its saved component state. Current
+explicit training arguments override saved config values. Omitted arguments
+inherit their saved values, except current dataset/model identity, device, and
+security/runtime-only controls. The checkpoint location always defines the
+resumed run directory so logs and checkpoints are not split into a new run.
+`resume()` must run before trainer `setup()` so the model graph and every
+optimizer-dependent component are constructed from one coherent state.
+
 Published inference weights should be lean checkpoints and should not include
 optimizer, epoch, config, loss, or EMA resume state unless intentionally
 distributed as training checkpoints.

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -234,7 +234,10 @@ def train_cmd(
     ),
     # Training
     epochs: int = typer.Option(300, help="Training epochs"),
-    batch: int = typer.Option(16, help="Batch size per device"),
+    batch: int = typer.Option(
+        16,
+        help="Global batch size (must divide the distributed world size)",
+    ),
     imgsz: int = typer.Option(640, help="Training image size"),
     device: str = typer.Option("auto", help="Device: 0, cpu, mps, auto"),
     workers: int = typer.Option(4, help="Dataloader workers"),
@@ -612,6 +615,15 @@ def train_cmd(
             )
     elif not val:
         train_kwargs["eval_interval"] = 0
+
+    from ..aliases import TRAIN_ALIASES
+
+    explicit_train_keys = {
+        TRAIN_ALIASES.get(key, key) for key in user_provided
+    }
+    if "val" in user_provided:
+        explicit_train_keys.add("eval_interval")
+    train_kwargs["_libreyolo_explicit_train_keys"] = sorted(explicit_train_keys)
 
     # Run training
     out.progress(f"Training {model} on {data} for {params['epochs']} epochs...")

--- a/libreyolo/data/__init__.py
+++ b/libreyolo/data/__init__.py
@@ -49,6 +49,14 @@ from .semantic_dataset import (
     resolve_semantic_data,
     semantic_collate_fn,
 )
+from .seeding import (
+    data_seed_for_rank,
+    dataloader_seed_kwargs,
+    distributed_sampler_seed,
+    make_data_generator,
+    normalize_data_seed,
+    seed_data_worker,
+)
 from .utils import (
     DATASETS_DIR,
     check_dataset,
@@ -105,4 +113,10 @@ __all__ = [
     "img2mask_paths",
     "resolve_semantic_data",
     "semantic_collate_fn",
+    "data_seed_for_rank",
+    "dataloader_seed_kwargs",
+    "distributed_sampler_seed",
+    "make_data_generator",
+    "normalize_data_seed",
+    "seed_data_worker",
 ]

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 
 from .cache import ImageCacheMixin
 from .labels import label_row_error, parse_yolo_box_or_segment_label_line
+from .seeding import dataloader_seed_kwargs
 from .obb import (
     canonicalize_xywhr,
     corners_to_xywhr,
@@ -1022,6 +1023,9 @@ def create_dataloader(
     shuffle: bool = True,
     pin_memory: bool = True,
     sampler=None,
+    seed: int | None = None,
+    rank: int = 0,
+    distributed: bool = False,
 ):
     """
     Create a DataLoader for YOLOX training.
@@ -1036,6 +1040,9 @@ def create_dataloader(
         sampler: Optional sampler (e.g. ``DistributedSampler`` for DDP). When
             provided, the sampler's own shuffling takes over and ``shuffle``
             is forced to False to satisfy PyTorch's mutual-exclusion check.
+        seed: Configured training seed. ``None`` keeps ambient-RNG behavior.
+        rank: Global distributed rank used to offset loader/worker streams.
+        distributed: Whether to apply the distributed rank offset.
     """
     try:
         visible_samples = len(sampler) if sampler is not None else len(dataset)
@@ -1051,4 +1058,5 @@ def create_dataloader(
         pin_memory=pin_memory,
         collate_fn=yolox_collate_fn,
         drop_last=drop_last,
+        **dataloader_seed_kwargs(seed, rank=rank, distributed=distributed),
     )

--- a/libreyolo/data/seeding.py
+++ b/libreyolo/data/seeding.py
@@ -1,0 +1,105 @@
+"""Deterministic, rank-aware random seeding for training data loaders."""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+import numpy as np
+import torch
+
+_SEED_MODULUS = 2**63
+
+
+def normalize_data_seed(seed: int) -> int:
+    """Normalize an integer seed to the non-negative range Torch accepts."""
+    try:
+        value = int(seed)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"data-loader seed must be an integer, got {seed!r}") from exc
+    return value % _SEED_MODULUS
+
+
+def data_seed_for_rank(
+    seed: int,
+    *,
+    rank: int = 0,
+    distributed: bool = False,
+) -> int:
+    """Return the configured seed, offset once per distributed rank.
+
+    This mirrors the trainer's rank seed contract: single-process training uses
+    the configured seed unchanged, while distributed rank ``r`` uses
+    ``seed + 1 + r``. The rank offset belongs on the DataLoader generator and
+    worker streams, not on ``DistributedSampler.seed``; sampler ranks must
+    share one permutation before partitioning it.
+    """
+    rank = int(rank)
+    if rank < 0:
+        raise ValueError(f"data-loader rank must be non-negative, got {rank}")
+    base_seed = normalize_data_seed(seed)
+    if not distributed:
+        return base_seed
+    return (base_seed + rank + 1) % _SEED_MODULUS
+
+
+def distributed_sampler_seed(seed: Optional[int]) -> int:
+    """Return the common seed all ranks must pass to DistributedSampler."""
+    return 0 if seed is None or int(seed) < 0 else normalize_data_seed(seed)
+
+
+def make_data_generator(
+    seed: int,
+    *,
+    rank: int = 0,
+    distributed: bool = False,
+) -> torch.Generator:
+    """Build an isolated Torch generator for shuffling and worker base seeds."""
+    generator = torch.Generator()
+    generator.manual_seed(data_seed_for_rank(seed, rank=rank, distributed=distributed))
+    return generator
+
+
+def seed_data_worker(worker_id: int) -> None:
+    """Seed Python, NumPy, and Torch from this DataLoader worker's seed.
+
+    PyTorch assigns ``torch.initial_seed() == base_seed + worker_id`` before
+    calling ``worker_init_fn``. Do not add ``worker_id`` a second time.
+    """
+    del worker_id
+    worker_seed = torch.initial_seed()
+    random.seed(worker_seed)
+    np.random.seed(worker_seed % 2**32)
+    torch.manual_seed(worker_seed)
+
+
+def dataloader_seed_kwargs(
+    seed: Optional[int],
+    *,
+    rank: int = 0,
+    distributed: bool = False,
+) -> dict:
+    """Return deterministic ``generator`` and ``worker_init_fn`` kwargs.
+
+    ``seed=None`` preserves DataLoader's default ambient-RNG behavior.
+    """
+    if seed is None or int(seed) < 0:
+        return {}
+    return {
+        "generator": make_data_generator(
+            seed,
+            rank=rank,
+            distributed=distributed,
+        ),
+        "worker_init_fn": seed_data_worker,
+    }
+
+
+__all__ = [
+    "data_seed_for_rank",
+    "dataloader_seed_kwargs",
+    "distributed_sampler_seed",
+    "make_data_generator",
+    "normalize_data_seed",
+    "seed_data_worker",
+]

--- a/libreyolo/distillation/distiller.py
+++ b/libreyolo/distillation/distiller.py
@@ -26,21 +26,107 @@ Usage::
     student_out = model(images, targets)              # normal forward, hooks capture features
     distill_loss = distiller.compute_loss()
     total_loss = task_loss + distill_loss
-    distiller.step()  # clear features for next iteration
+    distiller.step()  # clear features for the next microbatch
 """
 
 from __future__ import annotations
 
 import logging
+import math
+from collections.abc import Mapping, Sequence
+from numbers import Integral, Real
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
 import torch.nn as nn
 
-from .hooks import FeatureHookManager
+from .hooks import FeatureHookManager, _resolve_module
 from .losses import MGDLoss, CWDLoss, FeatureMSELoss, DISTILL_LOSSES
 
 logger = logging.getLogger(__name__)
+
+
+def _as_sequence(value: Any, name: str) -> list[Any]:
+    """Return a public config sequence as a list, rejecting scalar strings."""
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise TypeError(f"{name} must be a sequence")
+    return list(value)
+
+
+def _positive_ints(values: list[Any], name: str) -> list[int]:
+    """Validate positive integer channel or stride declarations."""
+    result: list[int] = []
+    for index, value in enumerate(values):
+        if isinstance(value, bool) or not isinstance(value, Integral):
+            raise TypeError(f"{name}[{index}] must be a positive integer")
+        if value <= 0:
+            raise ValueError(f"{name}[{index}] must be a positive integer")
+        result.append(int(value))
+    return result
+
+
+def _finite_nonnegative(value: Any, name: str) -> float:
+    """Validate a scalar loss weight and return its floating-point value."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a real number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _validate_config(
+    config: Dict,
+    name: str,
+    *,
+    allow_empty_tap_points: bool,
+) -> dict[str, list[Any]]:
+    """Validate and normalize one model's feature-distillation config."""
+    if not isinstance(config, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+
+    required = ("tap_points", "channels", "strides")
+    missing = [key for key in required if key not in config]
+    if missing:
+        raise ValueError(f"{name} is missing required keys: {missing}")
+
+    tap_points = _as_sequence(config["tap_points"], f"{name}['tap_points']")
+    channels = _positive_ints(
+        _as_sequence(config["channels"], f"{name}['channels']"),
+        f"{name}['channels']",
+    )
+    strides = _positive_ints(
+        _as_sequence(config["strides"], f"{name}['strides']"),
+        f"{name}['strides']",
+    )
+
+    if not strides:
+        raise ValueError(f"{name} must declare at least one feature scale")
+    if len(channels) != len(strides):
+        raise ValueError(
+            f"{name} channels and strides must have matching lengths; "
+            f"got {len(channels)} and {len(strides)}"
+        )
+    valid_tap_counts = {len(strides)}
+    if allow_empty_tap_points:
+        valid_tap_counts.add(0)
+    if len(tap_points) not in valid_tap_counts:
+        qualifier = "zero or " if allow_empty_tap_points else ""
+        raise ValueError(
+            f"{name} tap_points must contain {qualifier}{len(strides)} entries; "
+            f"got {len(tap_points)}"
+        )
+    for index, path in enumerate(tap_points):
+        if not isinstance(path, str) or not path:
+            raise TypeError(f"{name}['tap_points'][{index}] must be a non-empty string")
+
+    return {
+        "tap_points": tap_points,
+        "channels": channels,
+        "strides": strides,
+    }
 
 
 class Distiller(nn.Module):
@@ -58,11 +144,18 @@ class Distiller(nn.Module):
             - channels: list of int channel dimensions
             - strides: list of int spatial strides
         student_config: Dict from ``student.get_distill_config()`` (same format).
-        loss_type: ``"mgd"`` or ``"cwd"`` (default: ``"mgd"``).
-        loss_weight: Global distillation loss weight (alpha). Default: 2e-5 for MGD, 1.0 for CWD.
-        mask_ratio: MGD mask ratio (default: 0.65). Ignored for CWD.
-        tau: CWD temperature (default: 1.0). Ignored for MGD.
-        per_scale_weight: Optional list of per-scale weights. If None, uniform.
+        loss_type: ``"mgd"``, ``"cwd"``, or ``"feat_mse"`` (default: ``"mgd"``).
+        loss_weight: Finite nonnegative global loss weight. Defaults are 2e-5
+            for MGD and 1.0 for CWD/feature MSE.
+        mask_ratio: Finite MGD mask ratio in ``[0, 1)`` (default: 0.65).
+            Ignored for other loss types.
+        tau: Finite positive CWD temperature (default: 1.0). Ignored for other
+            loss types.
+        per_scale_weight: Optional finite nonnegative weight per feature scale.
+            If None, every scale has weight 1.0.
+        teacher_feature_fn: Optional direct teacher feature extractor. This
+            skips teacher hooks and permits teacher/student stride mismatch.
+        normalize: L2-normalize feature-MSE inputs when true.
 
     Example::
 
@@ -91,9 +184,97 @@ class Distiller(nn.Module):
     ):
         super().__init__()
 
+        if not isinstance(teacher_model, nn.Module):
+            raise TypeError("teacher_model must be an nn.Module")
+        if not isinstance(student_model, nn.Module):
+            raise TypeError("student_model must be an nn.Module")
+        if not isinstance(loss_type, str):
+            raise TypeError("loss_type must be a string")
+        if teacher_feature_fn is not None and not callable(teacher_feature_fn):
+            raise TypeError("teacher_feature_fn must be callable or None")
+        if not isinstance(normalize, bool):
+            raise TypeError("normalize must be a bool")
+
         self.loss_type = loss_type.lower()
-        self.loss_weight = loss_weight if loss_weight is not None else self._default_weight()
+        if self.loss_type not in DISTILL_LOSSES:
+            raise ValueError(
+                f"Unknown loss type: '{self.loss_type}'. "
+                f"Available: {list(DISTILL_LOSSES.keys())}"
+            )
+
+        t_config = _validate_config(
+            teacher_config,
+            "teacher_config",
+            allow_empty_tap_points=teacher_feature_fn is not None,
+        )
+        s_config = _validate_config(
+            student_config,
+            "student_config",
+            allow_empty_tap_points=False,
+        )
+        t_strides = t_config["strides"]
+        s_strides = s_config["strides"]
+        if len(t_strides) != len(s_strides):
+            raise ValueError(
+                "Teacher and student must declare the same number of feature scales. "
+                f"Teacher: {len(t_strides)}, Student: {len(s_strides)}"
+            )
+        if teacher_feature_fn is None and t_strides != s_strides:
+            raise ValueError(
+                "Teacher and student must have matching strides. "
+                f"Teacher: {t_strides}, Student: {s_strides}"
+            )
+
+        if self.loss_type == "mgd":
+            if isinstance(mask_ratio, bool) or not isinstance(mask_ratio, Real):
+                raise TypeError("mask_ratio must be a real number")
+            mask_ratio = float(mask_ratio)
+            if not math.isfinite(mask_ratio) or not 0.0 <= mask_ratio < 1.0:
+                raise ValueError(
+                    "mask_ratio must be finite and satisfy 0 <= mask_ratio < 1"
+                )
+        elif self.loss_type == "cwd":
+            if isinstance(tau, bool) or not isinstance(tau, Real):
+                raise TypeError("tau must be a real number")
+            tau = float(tau)
+            if not math.isfinite(tau) or tau <= 0.0:
+                raise ValueError("tau must be finite and greater than zero")
+
+        default_weight = self._default_weight() if loss_weight is None else loss_weight
+        self.loss_weight = _finite_nonnegative(default_weight, "loss_weight")
         self.normalize = normalize
+
+        self.num_scales = len(t_strides)
+        if per_scale_weight is None:
+            self._scale_weights = [1.0] * self.num_scales
+        else:
+            scale_weights = _as_sequence(per_scale_weight, "per_scale_weight")
+            if len(scale_weights) != self.num_scales:
+                raise ValueError(
+                    f"per_scale_weight has {len(scale_weights)} entries, "
+                    f"expected {self.num_scales} (one per feature scale)"
+                )
+            self._scale_weights = [
+                _finite_nonnegative(weight, f"per_scale_weight[{index}]")
+                for index, weight in enumerate(scale_weights)
+            ]
+
+        # Resolve every configured module before freezing the teacher or
+        # registering any hook. A malformed later tap point must not leave
+        # earlier hooks installed on either model.
+        if teacher_feature_fn is None:
+            for path in t_config["tap_points"]:
+                module = _resolve_module(teacher_model, path)
+                if not isinstance(module, nn.Module):
+                    raise TypeError(
+                        f"teacher_config tap point '{path}' does not resolve to an nn.Module"
+                    )
+        for path in s_config["tap_points"]:
+            module = _resolve_module(student_model, path)
+            if not isinstance(module, nn.Module):
+                raise TypeError(
+                    f"student_config tap point '{path}' does not resolve to an nn.Module"
+                )
 
         # A foundation-model teacher (e.g. DINOv2) emits token features that are
         # not a hookable BCHW module output and lives on a different spatial
@@ -104,18 +285,21 @@ class Distiller(nn.Module):
         self.teacher_feature_fn = teacher_feature_fn
         self._teacher_feats: Optional[List[torch.Tensor]] = None
 
-        # Validate configs
-        t_strides = teacher_config["strides"]
-        s_strides = student_config["strides"]
-        if teacher_feature_fn is None and t_strides != s_strides:
-            raise ValueError(
-                f"Teacher and student must have matching strides. "
-                f"Teacher: {t_strides}, Student: {s_strides}"
-            )
+        t_channels = t_config["channels"]
+        s_channels = s_config["channels"]
 
-        self.num_scales = len(t_strides)
-        t_channels = teacher_config["channels"]
-        s_channels = student_config["channels"]
+        # Build every loss module before hooks are installed. Channel and
+        # weight errors therefore cannot leave live forward hooks behind.
+        self.loss_modules = nn.ModuleList()
+        for i in range(self.num_scales):
+            loss_fn = self._build_loss(
+                s_channels[i],
+                t_channels[i],
+                mask_ratio=mask_ratio,
+                tau=tau,
+                scale_weight=self._scale_weights[i],
+            )
+            self.loss_modules.append(loss_fn)
 
         # Freeze teacher
         self.teacher = teacher_model
@@ -127,32 +311,11 @@ class Distiller(nn.Module):
         # only when it exposes hookable BCHW features (detector teachers);
         # foundation teachers deliver features via ``teacher_feature_fn``.
         self.t_hooks = (
-            FeatureHookManager(self.teacher, teacher_config["tap_points"])
+            FeatureHookManager(self.teacher, t_config["tap_points"])
             if teacher_feature_fn is None
             else None
         )
-        self.s_hooks = FeatureHookManager(student_model, student_config["tap_points"])
-
-        # Per-scale weights
-        if per_scale_weight is not None:
-            if len(per_scale_weight) != self.num_scales:
-                raise ValueError(
-                    f"per_scale_weight has {len(per_scale_weight)} entries, "
-                    f"expected {self.num_scales} (one per feature scale)"
-                )
-            self._scale_weights = per_scale_weight
-        else:
-            self._scale_weights = [1.0] * self.num_scales
-
-        # Build loss modules (one per feature scale)
-        self.loss_modules = nn.ModuleList()
-        for i in range(self.num_scales):
-            loss_fn = self._build_loss(
-                s_channels[i], t_channels[i],
-                mask_ratio=mask_ratio, tau=tau,
-                scale_weight=self._scale_weights[i],
-            )
-            self.loss_modules.append(loss_fn)
+        self.s_hooks = FeatureHookManager(student_model, s_config["tap_points"])
 
         # Log configuration
         logger.info("Distiller initialized:")
@@ -300,15 +463,21 @@ class Distiller(nn.Module):
     # Lifecycle
     # =========================================================================
 
-    def step(self):
-        """Clear captured features. Call at the end of each training step."""
+    def step(self) -> None:
+        """Clear features after each microbatch.
+
+        This is feature-lifecycle cleanup, not an optimizer-step transition.
+        Call it for every attempted microbatch, including accumulation
+        microbatches and iterations where AMP skips the optimizer update.
+        """
         if self.t_hooks is not None:
             self.t_hooks.clear()
         self._teacher_feats = None
         self.s_hooks.clear()
 
-    def cleanup(self):
-        """Remove all hooks and free resources. Call when training ends."""
+    def cleanup(self) -> None:
+        """Idempotently clear captured graphs and remove every feature hook."""
+        self.step()
         if self.t_hooks is not None:
             self.t_hooks.remove()
         self.s_hooks.remove()

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
+import random
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -25,6 +26,7 @@ from typing import (
     Union,
 )
 
+import numpy as np
 import torch
 import torch.nn as nn
 from PIL import Image
@@ -86,13 +88,71 @@ def _wrap_train_with_cfg(train_fn: Callable) -> Callable:
 
     @functools.wraps(train_fn)
     def wrapper(self, *args, cfg=None, **user_kwargs):
+        explicit_override = user_kwargs.pop(
+            "_libreyolo_explicit_train_keys",
+            None,
+        )
+
+        def call_train(
+            call_kwargs: Dict[str, Any],
+            explicit_keys: set[str],
+        ):
+            bound = sig.bind_partial(self, *args, **call_kwargs)
+            bound.apply_defaults()
+            seed = bound.arguments.get("seed")
+            variadic_kwargs = bound.arguments.get("kwargs")
+            if seed is None and isinstance(variadic_kwargs, dict):
+                seed = variadic_kwargs.get("seed")
+            if seed is None:
+                config_class = getattr(self, "TRAIN_CONFIG", None)
+                if callable(config_class):
+                    seed = getattr(config_class(), "seed", None)
+            if seed is not None:
+                seed = int(seed)
+                if seed >= 0:
+                    random.seed(seed)
+                    np.random.seed(seed % 2**32)
+                    torch.manual_seed(seed)
+                    if torch.cuda.is_available():
+                        torch.cuda.manual_seed_all(seed)
+
+            aliases = {
+                "batch_size": "batch",
+                "checkpoint_interval": "save_period",
+                "early_stopping_patience": "patience",
+                "img_size": "imgsz",
+                "lr": "lr0",
+                "num_workers": "workers",
+                "use_ema": "ema",
+            }
+            normalized_explicit = {aliases.get(key, key) for key in explicit_keys}
+            missing = object()
+            previous = getattr(self, "_active_train_explicit_keys", missing)
+            self._active_train_explicit_keys = normalized_explicit
+            try:
+                return train_fn(self, *args, **call_kwargs)
+            finally:
+                if previous is missing:
+                    delattr(self, "_active_train_explicit_keys")
+                else:
+                    self._active_train_explicit_keys = previous
+
+        positional_explicit = set(pos_names[: len(args)])
         if cfg is None:
-            return train_fn(self, *args, **user_kwargs)
+            explicit_keys = (
+                set(explicit_override)
+                if explicit_override is not None
+                else positional_explicit | set(user_kwargs)
+            )
+            return call_train(user_kwargs, explicit_keys)
         cfg_kwargs = load_train_cfg(cfg)
         consumed = set(pos_names[: len(args)]) | _WRAPPER_OWNED_CFG_KEYS
         merged = {k: v for k, v in cfg_kwargs.items() if k not in consumed}
         merged.update(user_kwargs)
-        return train_fn(self, *args, **merged)
+        return call_train(
+            merged,
+            positional_explicit | set(cfg_kwargs) | set(user_kwargs),
+        )
 
     wrapper._libreyolo_cfg_wrapped = True  # type: ignore[attr-defined]
     return wrapper
@@ -777,6 +837,47 @@ class BaseModel(ABC):
             raise RuntimeError(
                 f"Failed to load model weights from {model_path}: {e}"
             ) from e
+
+    def _restore_after_training(self, results: Dict[str, Any]) -> Optional[str]:
+        """Load the best available training checkpoint into the live wrapper.
+
+        Validation may not run in a short job, in which case ``best.pt`` does
+        not exist but ``last.pt`` still contains the current EMA weights. This
+        helper makes every wrapper converge on the same best-then-last policy,
+        restores inference mode/device, and records the checkpoint used for a
+        subsequent ``resume=True`` call.
+        """
+        candidates = (
+            results.get("best_checkpoint"),
+            results.get("last_checkpoint"),
+        )
+        checkpoint_path = next(
+            (
+                Path(candidate).expanduser().resolve()
+                for candidate in candidates
+                if candidate and Path(candidate).expanduser().is_file()
+            ),
+            None,
+        )
+        if checkpoint_path is None:
+            move = getattr(self.model, "to", None)
+            if callable(move):
+                move(self.device)
+            evaluate = getattr(self.model, "eval", None)
+            if callable(evaluate):
+                evaluate()
+            self.model_path = None
+            return None
+
+        self._load_weights(str(checkpoint_path))
+        move = getattr(self.model, "to", None)
+        if callable(move):
+            move(self.device)
+        evaluate = getattr(self.model, "eval", None)
+        if callable(evaluate):
+            evaluate()
+        self.model_path = str(checkpoint_path)
+        return self.model_path
 
     def _allow_checkpoint_task_mismatch(self, checkpoint_task: str) -> bool:
         """Return whether a family permits loading a checkpoint from another task."""

--- a/libreyolo/models/convnext/config.py
+++ b/libreyolo/models/convnext/config.py
@@ -22,6 +22,7 @@ class ConvNeXtConfig(TrainConfig):
     epochs: int = 100
     batch: int = 64
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 1e-3
     weight_decay: float = 1e-4
     warmup_epochs: int = 1

--- a/libreyolo/models/convnext/model.py
+++ b/libreyolo/models/convnext/model.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -240,11 +239,8 @@ class LibreConvNeXt(BaseModel):
                     "model = LibreConvNeXt('path/to/last.pt', size='t'); "
                     "model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/convnext/trainer.py
+++ b/libreyolo/models/convnext/trainer.py
@@ -13,7 +13,7 @@ from typing import Dict, Type
 import torch
 import torch.nn.functional as F
 
-from ...training.config import TrainConfig
+from ...training.config import TrainConfig, require_training_choice
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import ConvNeXtConfig
@@ -41,6 +41,12 @@ class ConvNeXtTrainer(BaseTrainer):
         return None, None
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("yoloxwarmcos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/deim/loss.py
+++ b/libreyolo/models/deim/loss.py
@@ -8,8 +8,8 @@ Copyright (c) 2023 lyuwenyu. All Rights Reserved.
 Differences from upstream:
 - ``@register()`` / ``__share__`` / ``__inject__`` stripped — ctor takes
   matcher + weight_dict + losses as plain kwargs.
-- ``misc.dist_utils.{is_dist_available_and_initialized, get_world_size}``
-  inlined as small helpers (LibreYOLO is single-GPU from this module's POV).
+- Upstream distributed count helpers are replaced by LibreYOLO's shared
+  clamp-before-average scalar reduction.
 """
 
 from __future__ import annotations
@@ -17,25 +17,13 @@ from __future__ import annotations
 import copy
 
 import torch
-import torch.distributed
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
 
+from ...training.distributed import all_reduce_avg_scalar
 from .box_ops import box_cxcywh_to_xyxy, box_iou, generalized_box_iou
 from .fdr import bbox2distance
-
-
-def _is_dist_available_and_initialized() -> bool:
-    return torch.distributed.is_available() and torch.distributed.is_initialized()
-
-
-def _get_world_size() -> int:
-    return (
-        torch.distributed.get_world_size()
-        if _is_dist_available_and_initialized()
-        else 1
-    )
 
 
 class DEIMCriterion(nn.Module):
@@ -51,6 +39,10 @@ class DEIMCriterion(nn.Module):
     ``{k: v * weight_dict[k] for k, v in losses.items()}`` for the optimization
     target — this class already applies weights internally.
     """
+
+    @staticmethod
+    def _global_count_normalizer(count: int, device: torch.device) -> float:
+        return all_reduce_avg_scalar(count, device=device, min_value=1.0)
 
     def __init__(
         self,
@@ -388,24 +380,17 @@ class DEIMCriterion(nn.Module):
         indices_go = self._get_go_indices(indices, indices_aux_list)
 
         num_boxes_go = sum(len(x[0]) for x in indices_go)
-        num_boxes_go = torch.as_tensor(
-            [num_boxes_go],
-            dtype=torch.float,
-            device=next(iter(outputs.values())).device,
+        loss_device = next(iter(outputs.values())).device
+        num_boxes_go = self._global_count_normalizer(
+            num_boxes_go,
+            loss_device,
         )
-        if _is_dist_available_and_initialized():
-            torch.distributed.all_reduce(num_boxes_go)
-        num_boxes_go = torch.clamp(num_boxes_go / _get_world_size(), min=1).item()
 
         num_boxes = sum(len(t["labels"]) for t in targets)
-        num_boxes = torch.as_tensor(
-            [num_boxes],
-            dtype=torch.float,
-            device=next(iter(outputs.values())).device,
+        num_boxes = self._global_count_normalizer(
+            num_boxes,
+            loss_device,
         )
-        if _is_dist_available_and_initialized():
-            torch.distributed.all_reduce(num_boxes)
-        num_boxes = torch.clamp(num_boxes / _get_world_size(), min=1).item()
 
         losses = {}
         for loss in self.losses:

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -207,7 +207,7 @@ class LibreDEIM(BaseModel):
         project: str = "runs/train",
         name: str = "deim_exp",
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: bool = False,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
@@ -231,7 +231,7 @@ class LibreDEIM(BaseModel):
             project: Root directory for training runs.
             name: Experiment name.
             exist_ok: If True, overwrite existing experiment directory.
-            resume: If True, resume training from the loaded checkpoint.
+            resume: Checkpoint path, or True to resume the loaded checkpoint.
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
@@ -269,6 +269,18 @@ class LibreDEIM(BaseModel):
             if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreDEIM('path/to/last.pt'); model.train(data=..., resume=True)"
+                )
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = DEIMTrainer(
             model=self.model,
             wrapper_model=self,
@@ -285,7 +297,7 @@ class LibreDEIM(BaseModel):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             patience=patience,
             callbacks=callbacks,
@@ -293,28 +305,11 @@ class LibreDEIM(BaseModel):
             **kwargs,
         )
 
-        if resume:
-            if not self.model_path:
-                raise ValueError(
-                    "resume=True requires a checkpoint. Load one first: "
-                    "model = LibreDEIM('path/to/last.pt'); model.train(data=..., resume=True)"
-                )
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-
-        # The trainer may have forced a different device than the wrapper's
-        # (e.g., MPS-fallback to CPU). Restore the model to the wrapper's
-        # device so subsequent ``model.val()`` / ``model.predict()`` calls
-        # don't hit input/weight device mismatches.
-        self.model.to(self.device)
+        self._restore_after_training(results)
 
         return results
 

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -38,6 +38,8 @@ from torch.amp import autocast
 from tqdm import tqdm
 
 from ...data import (
+    dataloader_seed_kwargs,
+    distributed_sampler_seed,
     get_coco_annotation_file,
     get_coco_image_dir,
     get_img_files,
@@ -45,7 +47,8 @@ from ...data import (
     load_data_config,
 )
 from ...data.dataset import COCODataset, YOLODataset
-from ...training.config import DEIMConfig, TrainConfig
+from ...training.config import DEIMConfig, TrainConfig, require_training_choice
+from ...training.distributed import all_reduce_avg_scalar
 from ...training.scheduler import FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .loss import DEIMCriterion
@@ -77,6 +80,12 @@ class DEIMTrainer(BaseTrainer):
         return preproc, DEIMPassThroughDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("flat_cosine",),
+            family=self.get_model_family(),
+        )
         return FlatCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
@@ -86,6 +95,10 @@ class DEIMTrainer(BaseTrainer):
             no_aug_epochs=self.config.no_aug_epochs,
             min_lr_ratio=self.config.min_lr_ratio,
         )
+
+    def _scale_lr(self, base_lr: float, param_group: dict) -> float:
+        """Apply DEIM's per-group backbone learning-rate multiplier."""
+        return base_lr * param_group.get("lr_mult", 1.0)
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
         # FGL/DDF are emitted only by the aux/dn paths (no main-loss key);
@@ -169,6 +182,12 @@ class DEIMTrainer(BaseTrainer):
         ``backbone_lr_mult=0.5`` matches DEIM's published fine-tune recipe;
         head groups stay at 1.0×.
         """
+        require_training_choice(
+            self.config.optimizer,
+            field="optimizer",
+            supported=("adamw",),
+            family=self.get_model_family(),
+        )
         backbone_wd, backbone_no_wd, head_wd, head_no_wd = [], [], [], []
         for name, p in self.model.named_parameters():
             if not p.requires_grad:
@@ -234,7 +253,9 @@ class DEIMTrainer(BaseTrainer):
                 }
             )
 
-        return torch.optim.AdamW(param_groups, betas=(0.9, 0.999))
+        return torch.optim.AdamW(
+            param_groups, betas=(float(self.config.momentum), 0.999)
+        )
 
     def _targets_to_detr(self, imgs: torch.Tensor, targets: torch.Tensor):
         """Translate padded LibreYOLO labels to DETR target dictionaries."""
@@ -425,14 +446,34 @@ class DEIMTrainer(BaseTrainer):
 
             collate_fn = yolox_collate_fn
 
+        per_rank_batch = self._per_rank_batch_size()
+        sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
+            )
+        visible_samples = len(sampler) if sampler is not None else len(train_dataset)
         self.train_loader = DataLoader(
             train_dataset,
-            batch_size=self.config.batch,
+            batch_size=per_rank_batch,
             num_workers=self.config.workers,
-            shuffle=True,
+            shuffle=sampler is None,
+            sampler=sampler,
             pin_memory=True,
             collate_fn=collate_fn,
-            drop_last=True,
+            drop_last=visible_samples >= per_rank_batch,
+            **dataloader_seed_kwargs(
+                getattr(self.config, "seed", None),
+                rank=self.rank,
+                distributed=self.is_distributed,
+            ),
         )
 
         return train_dataset
@@ -461,11 +502,14 @@ class DEIMTrainer(BaseTrainer):
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
             cf.set_epoch(epoch)
 
-        clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))
+        should_clip = self._should_clip_gradients()
 
         self.model.train()
         self._enforce_frozen_bn_eval()
@@ -500,13 +544,10 @@ class DEIMTrainer(BaseTrainer):
                 )
                 self.optimizer.zero_grad()
                 self.scaler.scale(loss).backward()
-                if clip_max_norm > 0:
+                if should_clip:
                     self.scaler.unscale_(self.optimizer)
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
+                    self._clip_gradients()
+                step_succeeded = self._run_optimizer_step()
             else:
                 outputs = self.on_forward(imgs, targets, polygons=polygons)
                 loss = self._require_finite_training_loss(
@@ -515,14 +556,9 @@ class DEIMTrainer(BaseTrainer):
                 )
                 self.optimizer.zero_grad()
                 loss.backward()
-                if clip_max_norm > 0:
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.optimizer.step()
-
-            if self.ema_model is not None:
-                self.ema_model.update(self.model)
+                if should_clip:
+                    self._clip_gradients()
+                step_succeeded = self._run_optimizer_step()
 
             loss_val = loss.item()
             loss_components = self._scalar_mapping(self.get_loss_components(outputs))
@@ -531,11 +567,9 @@ class DEIMTrainer(BaseTrainer):
                 loss_component_sums[name] = loss_component_sums.get(name, 0.0) + value
             del outputs, loss
 
-            # 3. Per-group LR (scheduler returns one base LR; each group
-            # multiplies by its ``lr_mult``).
-            base_lr = self.lr_scheduler.update_lr(self.current_iter + 1)
-            for pg in self.optimizer.param_groups:
-                pg["lr"] = base_lr * pg.get("lr_mult", 1.0)
+            # 3. EMA, optimizer-step counter, and per-group LR advance only
+            # when GradScaler actually applied the optimizer update.
+            base_lr = self._advance_optimizer_dependent_state(step_succeeded)
             num_batches += 1
 
             postfix = {"loss": f"{loss_val:.4f}", "lr": f"{base_lr:.6f}"}
@@ -549,10 +583,7 @@ class DEIMTrainer(BaseTrainer):
         }
 
         val_metrics = None
-        if (
-            self.config.eval_interval > 0
-            and (epoch + 1) % self.config.eval_interval == 0
-        ):
+        if self._should_validate_epoch(epoch):
             val_metrics = self._validate_epoch(epoch)
 
         return avg_loss, val_metrics, avg_loss_components, self._current_lrs()
@@ -570,11 +601,14 @@ class DEIMTrainer(BaseTrainer):
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
             cf.set_epoch(epoch)
 
-        clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))
+        should_clip = self._should_clip_gradients()
 
         self.model.train()
         self._enforce_frozen_bn_eval()
@@ -590,7 +624,7 @@ class DEIMTrainer(BaseTrainer):
         total_loss = 0.0
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
-        actual_window = accum
+        window_local_samples = 0
         base_lr = self.optimizer.param_groups[0]["lr"]
 
         for batch_idx, batch in enumerate(pbar):
@@ -609,7 +643,11 @@ class DEIMTrainer(BaseTrainer):
 
             if batch_idx % accum == 0:
                 self.optimizer.zero_grad(set_to_none=True)
-                actual_window = min(accum, len(self.train_loader) - batch_idx)
+                window_local_samples = 0
+            batch_samples = int(imgs.shape[0])
+            if batch_samples <= 0:
+                raise ValueError("gradient accumulation received an empty micro-batch")
+            window_local_samples += batch_samples
 
             if self.scaler is not None:
                 with autocast("cuda"):
@@ -618,39 +656,42 @@ class DEIMTrainer(BaseTrainer):
                         outputs["total_loss"],
                         context=f"Epoch {epoch + 1} batch {batch_idx + 1}",
                     )
-                    loss = total_loss_raw / actual_window
+                    loss = total_loss_raw * batch_samples
                 self.scaler.scale(loss).backward()
                 if is_opt_step:
-                    if clip_max_norm > 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
+                    self.scaler.unscale_(self.optimizer)
+                    sample_divisor = all_reduce_avg_scalar(
+                        window_local_samples,
+                        device=self.device,
+                        min_value=1.0,
+                    )
+                    self._normalize_accumulated_gradients(sample_divisor)
+                    if should_clip:
+                        self._clip_gradients()
+                    step_succeeded = self._run_optimizer_step()
             else:
                 outputs = self.on_forward(imgs, targets, polygons=polygons)
                 total_loss_raw = self._require_finite_training_loss(
                     outputs["total_loss"],
                     context=f"Epoch {epoch + 1} batch {batch_idx + 1}",
                 )
-                loss = total_loss_raw / actual_window
+                loss = total_loss_raw * batch_samples
                 loss.backward()
                 if is_opt_step:
-                    if clip_max_norm > 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.optimizer.step()
+                    sample_divisor = all_reduce_avg_scalar(
+                        window_local_samples,
+                        device=self.device,
+                        min_value=1.0,
+                    )
+                    self._normalize_accumulated_gradients(sample_divisor)
+                    if should_clip:
+                        self._clip_gradients()
+                    step_succeeded = self._run_optimizer_step()
 
             if is_opt_step:
-                if self.ema_model is not None:
-                    self.ema_model.update(self.model)
-                # 3. Per-group LR (scheduler returns one base LR; each group
-                # multiplies by its ``lr_mult``).
-                base_lr = self.lr_scheduler.update_lr(opt_step + 1)
-                for pg in self.optimizer.param_groups:
-                    pg["lr"] = base_lr * pg.get("lr_mult", 1.0)
+                # 3. EMA, optimizer-step counter, and per-group LR advance
+                # only after an applied optimizer update.
+                base_lr = self._advance_optimizer_dependent_state(step_succeeded)
 
             loss_val = total_loss_raw.item()
             loss_components = self._scalar_mapping(self.get_loss_components(outputs))
@@ -671,10 +712,7 @@ class DEIMTrainer(BaseTrainer):
         }
 
         val_metrics = None
-        if (
-            self.config.eval_interval > 0
-            and (epoch + 1) % self.config.eval_interval == 0
-        ):
+        if self._should_validate_epoch(epoch):
             val_metrics = self._validate_epoch(epoch)
 
         return avg_loss, val_metrics, avg_loss_components, self._current_lrs()

--- a/libreyolo/models/deimv2/loss.py
+++ b/libreyolo/models/deimv2/loss.py
@@ -16,11 +16,7 @@ import copy
 
 import torch
 
-from ..deim.loss import (
-    DEIMCriterion,
-    _get_world_size,
-    _is_dist_available_and_initialized,
-)
+from ..deim.loss import DEIMCriterion
 
 
 class DEIMv2Criterion(DEIMCriterion):
@@ -57,24 +53,17 @@ class DEIMv2Criterion(DEIMCriterion):
         indices_go = self._get_go_indices(indices, indices_aux_list)
 
         num_boxes_go = sum(len(x[0]) for x in indices_go)
-        num_boxes_go = torch.as_tensor(
-            [num_boxes_go],
-            dtype=torch.float,
-            device=next(iter(outputs.values())).device,
+        loss_device = next(iter(outputs.values())).device
+        num_boxes_go = self._global_count_normalizer(
+            num_boxes_go,
+            loss_device,
         )
-        if _is_dist_available_and_initialized():
-            torch.distributed.all_reduce(num_boxes_go)
-        num_boxes_go = torch.clamp(num_boxes_go / _get_world_size(), min=1).item()
 
         num_boxes = sum(len(t["labels"]) for t in targets)
-        num_boxes = torch.as_tensor(
-            [num_boxes],
-            dtype=torch.float,
-            device=next(iter(outputs.values())).device,
+        num_boxes = self._global_count_normalizer(
+            num_boxes,
+            loss_device,
         )
-        if _is_dist_available_and_initialized():
-            torch.distributed.all_reduce(num_boxes)
-        num_boxes = torch.clamp(num_boxes / _get_world_size(), min=1).item()
 
         losses = {}
         for loss in self.losses:

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -221,7 +221,7 @@ class LibreDEIMv2(BaseModel):
         project: str = "runs/train",
         name: Optional[str] = None,
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: Optional[bool] = None,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
@@ -242,7 +242,7 @@ class LibreDEIMv2(BaseModel):
             project: Root directory for training runs.
             name: Experiment name (None uses the family default).
             exist_ok: If True, overwrite existing experiment directory.
-            resume: If True, resume training from the loaded checkpoint.
+            resume: Checkpoint path, or True to resume the loaded checkpoint.
             amp: Enable automatic mixed precision training (None uses the
                 family default).
             patience: Early stopping patience.
@@ -310,27 +310,27 @@ class LibreDEIMv2(BaseModel):
         }
         trainer_kwargs.update({k: v for k, v in optional.items() if v is not None})
 
-        trainer = DEIMv2Trainer(**trainer_kwargs)
-
+        resume_path = None
         if resume:
-            if not self.model_path:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
                 raise ValueError(
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreDEIMv2('path/to/last.pt'); "
                     "model.train(data=..., resume=True)"
                 )
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
+        trainer_kwargs["resume"] = bool(resume)
+        trainer = DEIMv2Trainer(**trainer_kwargs)
+
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-
-        self.model.to(self.device)
+        self._restore_after_training(results)
 
         return results
 

--- a/libreyolo/models/deimv2/trainer.py
+++ b/libreyolo/models/deimv2/trainer.py
@@ -17,6 +17,7 @@ from ...training.config import (
     DEIMV2_SIZE_DEFAULTS,
     DEIMv2Config,
     TrainConfig,
+    require_training_choice,
 )
 from ..deim.trainer import DEIMTrainer
 from .loss import DEIMv2Criterion
@@ -117,6 +118,12 @@ class DEIMv2Trainer(DEIMTrainer):
         return preproc, DEIMPassThroughDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("flat_cosine",),
+            family=self.get_model_family(),
+        )
         return DEIMv2FlatCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
@@ -173,6 +180,12 @@ class DEIMv2Trainer(DEIMTrainer):
 
     def _setup_optimizer(self) -> torch.optim.Optimizer:
         """AdamW groups matching DEIMv2's HGNetv2/DINOv3 recipes."""
+        require_training_choice(
+            self.config.optimizer,
+            field="optimizer",
+            supported=("adamw",),
+            family=self.get_model_family(),
+        )
         backbone_wd, backbone_no_wd, head_wd, head_no_wd = [], [], [], []
         dino_backbone = self.config.size in DINO_SIZES
 
@@ -235,7 +248,9 @@ class DEIMv2Trainer(DEIMTrainer):
                 }
             )
 
-        return torch.optim.AdamW(param_groups, betas=(0.9, 0.999))
+        return torch.optim.AdamW(
+            param_groups, betas=(float(self.config.momentum), 0.999)
+        )
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         target_list = self._targets_to_detr(imgs, targets)

--- a/libreyolo/models/dfine/loss.py
+++ b/libreyolo/models/dfine/loss.py
@@ -8,8 +8,8 @@ Copyright (c) 2023 lyuwenyu. All Rights Reserved.
 Differences from upstream:
 - ``@register()`` / ``__share__`` / ``__inject__`` stripped — ctor takes
   matcher + weight_dict + losses as plain kwargs.
-- ``misc.dist_utils.{is_dist_available_and_initialized, get_world_size}``
-  inlined as small helpers (LibreYOLO is single-GPU from this module's POV).
+- Upstream distributed count helpers are replaced by LibreYOLO's shared
+  clamp-before-average scalar reduction.
 """
 
 from __future__ import annotations
@@ -17,25 +17,13 @@ from __future__ import annotations
 import copy
 
 import torch
-import torch.distributed
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
 
+from ...training.distributed import all_reduce_avg_scalar
 from .box_ops import box_cxcywh_to_xyxy, box_iou, generalized_box_iou
 from .fdr import bbox2distance
-
-
-def _is_dist_available_and_initialized() -> bool:
-    return torch.distributed.is_available() and torch.distributed.is_initialized()
-
-
-def _get_world_size() -> int:
-    return (
-        torch.distributed.get_world_size()
-        if _is_dist_available_and_initialized()
-        else 1
-    )
 
 
 class DFINECriterion(nn.Module):
@@ -264,8 +252,13 @@ class DFINECriterion(nn.Module):
         return losses
 
     @staticmethod
-    def _cropped_bce_loss(pred_logits, target_masks, boxes, eps=1e-6):
-        del eps
+    def _cropped_bce_loss(
+        pred_logits,
+        target_masks,
+        boxes,
+        normalizer,
+        eps=1e-6,
+    ):
         if pred_logits.shape[0] == 0:
             return pred_logits.sum() * 0.0
 
@@ -287,10 +280,17 @@ class DFINECriterion(nn.Module):
             reduction="none",
         )
         box_area = ((x2 - x1) * (y2 - y1)).flatten().clamp(min=1.0)
-        return (bce * inside).sum(dim=(1, 2)).div(box_area).mean()
+        per_instance = (bce * inside).sum(dim=(1, 2)).div(box_area)
+        return per_instance.sum() / max(float(normalizer), eps)
 
     @staticmethod
-    def _cropped_dice_loss(pred_logits, target_masks, boxes, eps=1e-6):
+    def _cropped_dice_loss(
+        pred_logits,
+        target_masks,
+        boxes,
+        normalizer,
+        eps=1e-6,
+    ):
         if pred_logits.shape[0] == 0:
             return pred_logits.sum() * 0.0
 
@@ -312,10 +312,13 @@ class DFINECriterion(nn.Module):
         target = target.flatten(1)
         inter = (pred * target).sum(dim=1)
         denom = pred.sum(dim=1) + target.sum(dim=1) + eps
-        return (1.0 - (2.0 * inter + eps) / denom).mean()
+        per_instance = 1.0 - (2.0 * inter + eps) / denom
+        return per_instance.sum() / max(float(normalizer), eps)
 
     def loss_masks(self, outputs, targets, indices, num_boxes):
-        del num_boxes
+        # ``num_boxes`` is the globally summed instance count divided by world
+        # size. Dividing each rank's local sum by it composes with DDP's
+        # gradient averaging into the true global per-instance mean.
         if "pred_masks" not in outputs:
             return {}
 
@@ -366,11 +369,17 @@ class DFINECriterion(nn.Module):
         target_sel = torch.cat(target_parts, dim=0)
         target_boxes = torch.cat(box_parts, dim=0)
         return {
-            "loss_mask_bce": self._cropped_bce_loss(pred_sel, target_sel, target_boxes),
+            "loss_mask_bce": self._cropped_bce_loss(
+                pred_sel,
+                target_sel,
+                target_boxes,
+                num_boxes,
+            ),
             "loss_mask_dice": self._cropped_dice_loss(
                 pred_sel,
                 target_sel,
                 target_boxes,
+                num_boxes,
             ),
         }
 
@@ -458,24 +467,19 @@ class DFINECriterion(nn.Module):
         indices_go = self._get_go_indices(indices, indices_aux_list)
 
         num_boxes_go = sum(len(x[0]) for x in indices_go)
-        num_boxes_go = torch.as_tensor(
-            [num_boxes_go],
-            dtype=torch.float,
-            device=next(iter(outputs.values())).device,
+        loss_device = next(iter(outputs.values())).device
+        num_boxes_go = all_reduce_avg_scalar(
+            num_boxes_go,
+            device=loss_device,
+            min_value=1.0,
         )
-        if _is_dist_available_and_initialized():
-            torch.distributed.all_reduce(num_boxes_go)
-        num_boxes_go = torch.clamp(num_boxes_go / _get_world_size(), min=1).item()
 
         num_boxes = sum(len(t["labels"]) for t in targets)
-        num_boxes = torch.as_tensor(
-            [num_boxes],
-            dtype=torch.float,
-            device=next(iter(outputs.values())).device,
+        num_boxes = all_reduce_avg_scalar(
+            num_boxes,
+            device=loss_device,
+            min_value=1.0,
         )
-        if _is_dist_available_and_initialized():
-            torch.distributed.all_reduce(num_boxes)
-        num_boxes = torch.clamp(num_boxes / _get_world_size(), min=1).item()
 
         losses = {}
         for loss in self.losses:

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -301,7 +301,7 @@ class LibreDFINE(BaseModel):
         project: str = "runs/train",
         name: str = "dfine_exp",
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: bool = False,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
@@ -325,7 +325,7 @@ class LibreDFINE(BaseModel):
             project: Root directory for training runs.
             name: Experiment name.
             exist_ok: If True, overwrite existing experiment directory.
-            resume: If True, resume training from the loaded checkpoint.
+            resume: Checkpoint path, or True to resume the loaded checkpoint.
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
@@ -363,6 +363,18 @@ class LibreDFINE(BaseModel):
             if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreDFINE('path/to/last.pt'); model.train(data=..., resume=True)"
+                )
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = DFINETrainer(
             model=self.model,
             wrapper_model=self,
@@ -379,7 +391,7 @@ class LibreDFINE(BaseModel):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             patience=patience,
             callbacks=callbacks,
@@ -387,28 +399,11 @@ class LibreDFINE(BaseModel):
             **kwargs,
         )
 
-        if resume:
-            if not self.model_path:
-                raise ValueError(
-                    "resume=True requires a checkpoint. Load one first: "
-                    "model = LibreDFINE('path/to/last.pt'); model.train(data=..., resume=True)"
-                )
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-
-        # The trainer may have forced a different device than the wrapper's
-        # (e.g., MPS-fallback to CPU). Restore the model to the wrapper's
-        # device so subsequent ``model.val()`` / ``model.predict()`` calls
-        # don't hit input/weight device mismatches.
-        self.model.to(self.device)
+        self._restore_after_training(results)
 
         return results
 

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -40,6 +40,8 @@ from torch.amp import autocast
 from tqdm import tqdm
 
 from ...data import (
+    dataloader_seed_kwargs,
+    distributed_sampler_seed,
     get_coco_annotation_file,
     get_coco_image_dir,
     get_img_files,
@@ -47,7 +49,8 @@ from ...data import (
     load_data_config,
 )
 from ...data.dataset import COCODataset, YOLODataset
-from ...training.config import DFINEConfig, TrainConfig
+from ...training.config import DFINEConfig, TrainConfig, require_training_choice
+from ...training.distributed import all_reduce_avg_scalar
 from ...training.scheduler import FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .loss import DFINECriterion
@@ -98,6 +101,12 @@ class DFINETrainer(BaseTrainer):
         return preproc, DFINEPassThroughDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("flat_cosine",),
+            family=self.get_model_family(),
+        )
         return FlatCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
@@ -107,6 +116,10 @@ class DFINETrainer(BaseTrainer):
             no_aug_epochs=self.config.no_aug_epochs,
             min_lr_ratio=self.config.min_lr_ratio,
         )
+
+    def _scale_lr(self, base_lr: float, param_group: dict) -> float:
+        """Apply D-FINE's per-group backbone learning-rate multiplier."""
+        return base_lr * param_group.get("lr_mult", 1.0)
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
         # FGL/DDF are emitted only by the aux/dn paths (no main-loss key);
@@ -210,6 +223,12 @@ class DFINETrainer(BaseTrainer):
         ``backbone_lr_mult=0.5`` matches D-FINE's published fine-tune recipe;
         head groups stay at 1.0×.
         """
+        require_training_choice(
+            self.config.optimizer,
+            field="optimizer",
+            supported=("adamw",),
+            family=self.get_model_family(),
+        )
         backbone_wd, backbone_no_wd, head_wd, head_no_wd = [], [], [], []
         for name, p in self.model.named_parameters():
             if not p.requires_grad:
@@ -266,7 +285,9 @@ class DFINETrainer(BaseTrainer):
                 }
             )
 
-        return torch.optim.AdamW(param_groups, betas=(0.9, 0.999))
+        return torch.optim.AdamW(
+            param_groups, betas=(float(self.config.momentum), 0.999)
+        )
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         """Forward + loss in one go.
@@ -474,14 +495,34 @@ class DFINETrainer(BaseTrainer):
                 )
             collate_fn = yolox_collate_fn
 
+        per_rank_batch = self._per_rank_batch_size()
+        sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
+            )
+        visible_samples = len(sampler) if sampler is not None else len(train_dataset)
         self.train_loader = DataLoader(
             train_dataset,
-            batch_size=self.config.batch,
+            batch_size=per_rank_batch,
             num_workers=self.config.workers,
-            shuffle=True,
+            shuffle=sampler is None,
+            sampler=sampler,
             pin_memory=True,
             collate_fn=collate_fn,
-            drop_last=True,
+            drop_last=visible_samples >= per_rank_batch,
+            **dataloader_seed_kwargs(
+                getattr(self.config, "seed", None),
+                rank=self.rank,
+                distributed=self.is_distributed,
+            ),
         )
 
         return train_dataset
@@ -510,11 +551,14 @@ class DFINETrainer(BaseTrainer):
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
             cf.set_epoch(epoch)
 
-        clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))
+        should_clip = self._should_clip_gradients()
 
         self.model.train()
         self._enforce_frozen_bn_eval()
@@ -549,13 +593,10 @@ class DFINETrainer(BaseTrainer):
                 )
                 self.optimizer.zero_grad()
                 self.scaler.scale(loss).backward()
-                if clip_max_norm > 0:
+                if should_clip:
                     self.scaler.unscale_(self.optimizer)
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
+                    self._clip_gradients()
+                step_succeeded = self._run_optimizer_step()
             else:
                 outputs = self.on_forward(imgs, targets, polygons=polygons)
                 loss = self._require_finite_training_loss(
@@ -564,14 +605,9 @@ class DFINETrainer(BaseTrainer):
                 )
                 self.optimizer.zero_grad()
                 loss.backward()
-                if clip_max_norm > 0:
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.optimizer.step()
-
-            if self.ema_model is not None:
-                self.ema_model.update(self.model)
+                if should_clip:
+                    self._clip_gradients()
+                step_succeeded = self._run_optimizer_step()
 
             loss_val = loss.item()
             loss_components = self._scalar_mapping(self.get_loss_components(outputs))
@@ -580,11 +616,9 @@ class DFINETrainer(BaseTrainer):
                 loss_component_sums[name] = loss_component_sums.get(name, 0.0) + value
             del outputs, loss
 
-            # 3. Per-group LR (scheduler returns one base LR; each group
-            # multiplies by its ``lr_mult``).
-            base_lr = self.lr_scheduler.update_lr(self.current_iter + 1)
-            for pg in self.optimizer.param_groups:
-                pg["lr"] = base_lr * pg.get("lr_mult", 1.0)
+            # 3. EMA, optimizer-step counter, and per-group LR advance only
+            # when GradScaler actually applied the optimizer update.
+            base_lr = self._advance_optimizer_dependent_state(step_succeeded)
             num_batches += 1
 
             postfix = {"loss": f"{loss_val:.4f}", "lr": f"{base_lr:.6f}"}
@@ -598,10 +632,7 @@ class DFINETrainer(BaseTrainer):
         }
 
         val_metrics = None
-        if (
-            self.config.eval_interval > 0
-            and (epoch + 1) % self.config.eval_interval == 0
-        ):
+        if self._should_validate_epoch(epoch):
             val_metrics = self._validate_epoch(epoch)
 
         return avg_loss, val_metrics, avg_loss_components, self._current_lrs()
@@ -619,11 +650,14 @@ class DFINETrainer(BaseTrainer):
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         cf = getattr(self.train_loader, "collate_fn", None)
         if cf is not None and hasattr(cf, "set_epoch"):
             cf.set_epoch(epoch)
 
-        clip_max_norm = float(getattr(self.config, "clip_max_norm", 0.0))
+        should_clip = self._should_clip_gradients()
 
         self.model.train()
         self._enforce_frozen_bn_eval()
@@ -639,7 +673,7 @@ class DFINETrainer(BaseTrainer):
         total_loss = 0.0
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
-        actual_window = accum
+        window_local_samples = 0
         base_lr = self.optimizer.param_groups[0]["lr"]
 
         for batch_idx, batch in enumerate(pbar):
@@ -658,7 +692,11 @@ class DFINETrainer(BaseTrainer):
 
             if batch_idx % accum == 0:
                 self.optimizer.zero_grad(set_to_none=True)
-                actual_window = min(accum, len(self.train_loader) - batch_idx)
+                window_local_samples = 0
+            batch_samples = int(imgs.shape[0])
+            if batch_samples <= 0:
+                raise ValueError("gradient accumulation received an empty micro-batch")
+            window_local_samples += batch_samples
 
             if self.scaler is not None:
                 with autocast("cuda"):
@@ -667,39 +705,42 @@ class DFINETrainer(BaseTrainer):
                         outputs["total_loss"],
                         context=f"Epoch {epoch + 1} batch {batch_idx + 1}",
                     )
-                    loss = total_loss_raw / actual_window
+                    loss = total_loss_raw * batch_samples
                 self.scaler.scale(loss).backward()
                 if is_opt_step:
-                    if clip_max_norm > 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
+                    self.scaler.unscale_(self.optimizer)
+                    sample_divisor = all_reduce_avg_scalar(
+                        window_local_samples,
+                        device=self.device,
+                        min_value=1.0,
+                    )
+                    self._normalize_accumulated_gradients(sample_divisor)
+                    if should_clip:
+                        self._clip_gradients()
+                    step_succeeded = self._run_optimizer_step()
             else:
                 outputs = self.on_forward(imgs, targets, polygons=polygons)
                 total_loss_raw = self._require_finite_training_loss(
                     outputs["total_loss"],
                     context=f"Epoch {epoch + 1} batch {batch_idx + 1}",
                 )
-                loss = total_loss_raw / actual_window
+                loss = total_loss_raw * batch_samples
                 loss.backward()
                 if is_opt_step:
-                    if clip_max_norm > 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.optimizer.step()
+                    sample_divisor = all_reduce_avg_scalar(
+                        window_local_samples,
+                        device=self.device,
+                        min_value=1.0,
+                    )
+                    self._normalize_accumulated_gradients(sample_divisor)
+                    if should_clip:
+                        self._clip_gradients()
+                    step_succeeded = self._run_optimizer_step()
 
             if is_opt_step:
-                if self.ema_model is not None:
-                    self.ema_model.update(self.model)
-                # 3. Per-group LR (scheduler returns one base LR; each group
-                # multiplies by its ``lr_mult``).
-                base_lr = self.lr_scheduler.update_lr(opt_step + 1)
-                for pg in self.optimizer.param_groups:
-                    pg["lr"] = base_lr * pg.get("lr_mult", 1.0)
+                # 3. EMA, optimizer-step counter, and per-group LR advance
+                # only after an applied optimizer update.
+                base_lr = self._advance_optimizer_dependent_state(step_succeeded)
 
             loss_val = total_loss_raw.item()
             loss_components = self._scalar_mapping(self.get_loss_components(outputs))
@@ -720,10 +761,7 @@ class DFINETrainer(BaseTrainer):
         }
 
         val_metrics = None
-        if (
-            self.config.eval_interval > 0
-            and (epoch + 1) % self.config.eval_interval == 0
-        ):
+        if self._should_validate_epoch(epoch):
             val_metrics = self._validate_epoch(epoch)
 
         return avg_loss, val_metrics, avg_loss_components, self._current_lrs()

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -594,14 +594,15 @@ class LibreDINOv2(BaseModel):
         batch_size: int | None = None,
         lr: float | None = None,
         output_dir: str = "runs/train",
-        resume=None,
+        resume: str | Path | bool | None = None,
         callbacks: TrainCallbacks = None,
         **kwargs,
     ) -> Dict:
         """Fine-tune LibreDINOv2 for semantic segmentation or classification.
 
         Task is taken from ``self.task``; ``DINOv2Trainer`` (via ``RFDETRTrainer``)
-        routes the classify vs semantic data/loss branches accordingly.
+        routes the classify vs semantic data/loss branches accordingly. Pass a
+        checkpoint path, or ``resume=True`` to continue the loaded checkpoint.
         """
         from pathlib import Path as _Path
 
@@ -612,6 +613,7 @@ class LibreDINOv2(BaseModel):
         project = train_kwargs.pop("project", None)
         name = train_kwargs.pop("name", None)
         exist_ok = train_kwargs.pop("exist_ok", True)
+        train_device = train_kwargs.pop("device", self.device)
         batch = train_kwargs.pop("batch", None)
         lr0 = train_kwargs.pop("lr0", None)
         if project is None:
@@ -633,12 +635,25 @@ class LibreDINOv2(BaseModel):
         if resolved_lr0 is None:
             resolved_lr0 = 1e-4
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreDINOv2('path/to/last.pt'); "
+                    "model.train(data=..., resume=True)"
+                )
+            resume_path = _Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = DINOv2Trainer(
             model=self.model,
             wrapper_model=self,
             data=data,
             epochs=epochs,
-            batch_size=resolved_batch,
+            batch=resolved_batch,
             lr0=resolved_lr0,
             imgsz=train_kwargs.pop("imgsz", self.input_size),
             size=self.size,
@@ -646,33 +661,17 @@ class LibreDINOv2(BaseModel):
             project=str(project),
             name=str(name),
             exist_ok=exist_ok,
-            resume=resume,
-            device=str(self.device),
+            resume=bool(resume),
+            device=str(train_device),
             callbacks=callbacks,
             **train_kwargs,
         )
 
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
         result = trainer.train()
         self._restore_after_training(result)
         return result
-
-    def _restore_after_training(self, result: dict) -> None:
-        """Reload the best checkpoint after training completes."""
-        checkpoint = None
-        for key in ("best_checkpoint", "last_checkpoint"):
-            path = result.get(key)
-            if path and Path(path).exists():
-                checkpoint = str(path)
-                break
-        if checkpoint is not None:
-            self.model_path = checkpoint
-            self._load_weights(checkpoint)
-        model = getattr(self, "model", None)
-        device = getattr(self, "device", None)
-        if model is not None and device is not None and hasattr(model, "to"):
-            model.to(device)
-        if model is not None and hasattr(model, "eval"):
-            model.eval()
 
     # =========================================================================
     # Export

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -301,7 +301,7 @@ class LibreEC(BaseModel):
         project: str = "runs/train",
         name: str = "ec_exp",
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: bool = True,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
@@ -403,6 +403,15 @@ class LibreEC(BaseModel):
             if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError("resume=True requires a checkpoint. Load one first.")
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = trainer_cls(
             model=self.model,
             wrapper_model=self,
@@ -419,7 +428,7 @@ class LibreEC(BaseModel):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             patience=patience,
             callbacks=callbacks,
@@ -427,21 +436,11 @@ class LibreEC(BaseModel):
             **kwargs,
         )
 
-        if resume:
-            if not self.model_path:
-                raise ValueError("resume=True requires a checkpoint. Load one first.")
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-
-        self.model.to(self.device)
+        self._restore_after_training(results)
         return results
 
     def _train_pose(
@@ -459,7 +458,7 @@ class LibreEC(BaseModel):
         project: str = "runs/train",
         name: str = "ec_pose_exp",
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: bool = True,
         patience: int = 50,
         callbacks=None,
@@ -560,6 +559,15 @@ class LibreEC(BaseModel):
             if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError("resume=True requires a checkpoint. Load one first.")
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = ECPoseTrainer(
             model=self.model,
             wrapper_model=self,
@@ -579,7 +587,7 @@ class LibreEC(BaseModel):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             patience=patience,
             callbacks=callbacks,
@@ -587,21 +595,11 @@ class LibreEC(BaseModel):
             **kwargs,
         )
 
-        if resume:
-            if not self.model_path:
-                raise ValueError("resume=True requires a checkpoint. Load one first.")
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-
-        self.model.to(self.device)
+        self._restore_after_training(results)
         return results
 
     def _load_weights(self, model_path: str):

--- a/libreyolo/models/ec/pose_loss.py
+++ b/libreyolo/models/ec/pose_loss.py
@@ -30,6 +30,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from scipy.optimize import linear_sum_assignment
 
+from ...training.distributed import all_reduce_avg_scalar
+
 COCO17_OKS_SIGMAS = (
     0.026, 0.025, 0.025, 0.035, 0.035, 0.079, 0.079, 0.072, 0.072,
     0.062, 0.062, 0.107, 0.107, 0.087, 0.087, 0.089, 0.089,
@@ -171,17 +173,13 @@ class PoseHungarianMatcher(nn.Module):
         ]
 
 
-def _is_dist():
-    return torch.distributed.is_available() and torch.distributed.is_initialized()
-
-
-def _world_size():
-    return torch.distributed.get_world_size() if _is_dist() else 1
-
-
 class ECPoseCriterion(nn.Module):
     """DETRPose criterion: VFL classification (OKS-keyed) + keypoint L1 + OKS,
     with GO-LSD union matching, deep supervision, and contrastive denoising."""
+
+    @staticmethod
+    def _global_count_normalizer(count: int, device: torch.device) -> float:
+        return all_reduce_avg_scalar(count, device=device, min_value=1.0)
 
     def __init__(
         self,
@@ -308,17 +306,11 @@ class ECPoseCriterion(nn.Module):
 
     def _num_boxes(self, targets, device):
         n = sum(len(t["labels"]) for t in targets)
-        n = torch.as_tensor([n], dtype=torch.float, device=device)
-        if _is_dist():
-            torch.distributed.all_reduce(n)
-        return torch.clamp(n / _world_size(), min=1).item()
+        return self._global_count_normalizer(n, device)
 
     def _num_index_pairs(self, indices, device):
         n = sum(len(x[0]) for x in indices)
-        n = torch.as_tensor([n], dtype=torch.float, device=device)
-        if _is_dist():
-            torch.distributed.all_reduce(n)
-        return torch.clamp(n / _world_size(), min=1).item()
+        return self._global_count_normalizer(n, device)
 
     def forward(self, outputs, targets):
         device = outputs["pred_logits"].device
@@ -349,9 +341,13 @@ class ECPoseCriterion(nn.Module):
             for loss in self.losses:
                 idx_in = indices_go if loss == "keypoints" else idx_per_layer
                 nb_in = num_boxes_go if loss == "keypoints" else num_boxes
-                l = self.get_loss(loss, out, tgts, idx_in, nb_in)
-                l = {k: v * self.weight_dict[k] for k, v in l.items() if k in self.weight_dict}
-                d.update({k + suffix: v for k, v in l.items()})
+                loss_dict = self.get_loss(loss, out, tgts, idx_in, nb_in)
+                loss_dict = {
+                    k: v * self.weight_dict[k]
+                    for k, v in loss_dict.items()
+                    if k in self.weight_dict
+                }
+                d.update({k + suffix: v for k, v in loss_dict.items()})
             return d
 
         losses = {}
@@ -393,7 +389,11 @@ class ECPoseCriterion(nn.Module):
     def _dn_apply(self, out, targets, dn_pos_idx, dn_nb, suffix):
         d = {}
         for loss in self.losses:
-            l = self.get_loss(loss, out, targets, dn_pos_idx, dn_nb)
-            l = {k: v * self.weight_dict[k] for k, v in l.items() if k in self.weight_dict}
-            d.update({k + suffix: v for k, v in l.items()})
+            loss_dict = self.get_loss(loss, out, targets, dn_pos_idx, dn_nb)
+            loss_dict = {
+                k: v * self.weight_dict[k]
+                for k, v in loss_dict.items()
+                if k in self.weight_dict
+            }
+            d.update({k + suffix: v for k, v in loss_dict.items()})
         return d

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -18,22 +18,23 @@ from __future__ import annotations
 
 import logging
 import os
-import random
 from typing import Dict, Type
 
 import cv2
-import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
 from ...data import (
     YOLOPoseDataset,
+    dataloader_seed_kwargs,
+    distributed_sampler_seed,
     get_img_files,
     img2label_paths,
     load_data_config,
     pose_collate_fn,
+    seed_data_worker,
 )
-from ...training.config import ECPoseConfig, TrainConfig
+from ...training.config import ECPoseConfig, TrainConfig, require_training_choice
 from ...training.scheduler import FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .pose_loss import ECPoseCriterion, PoseHungarianMatcher, default_oks_sigmas
@@ -45,9 +46,7 @@ logger = logging.getLogger(__name__)
 def _pose_worker_init_fn(worker_id: int) -> None:
     cv2.setNumThreads(0)
     torch.set_num_threads(1)
-    seed = (torch.initial_seed() + worker_id) % 2**32
-    random.seed(seed)
-    np.random.seed(seed)
+    seed_data_worker(worker_id)
 
 
 def _set_bn_eval(module: torch.nn.Module) -> None:
@@ -111,6 +110,12 @@ class ECPoseTrainer(BaseTrainer):
         return None, None
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("flat_cosine",),
+            family="ec-pose",
+        )
         return FlatCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
@@ -152,6 +157,12 @@ class ECPoseTrainer(BaseTrainer):
         self.val_loader = None
 
     def _setup_optimizer(self) -> torch.optim.Optimizer:
+        require_training_choice(
+            self.config.optimizer,
+            field="optimizer",
+            supported=("adamw",),
+            family="ec-pose",
+        )
         backbone_wd, backbone_no_wd, head_wd, head_no_wd = [], [], [], []
         for name, p in self.model.named_parameters():
             if not p.requires_grad:
@@ -181,7 +192,9 @@ class ECPoseTrainer(BaseTrainer):
             groups.append({"params": backbone_wd, "lr": lr * bb_mult, "weight_decay": wd, "lr_mult": bb_mult})
         if backbone_no_wd:
             groups.append({"params": backbone_no_wd, "lr": lr * bb_mult, "weight_decay": 0.0, "lr_mult": bb_mult})
-        return torch.optim.AdamW(groups, betas=(0.9, 0.999))
+        return torch.optim.AdamW(
+            groups, betas=(float(self.config.momentum), 0.999)
+        )
 
     def _scale_lr(self, base_lr: float, param_group: dict) -> float:
         return base_lr * float(param_group.get("lr_mult", 1.0))
@@ -239,7 +252,7 @@ class ECPoseTrainer(BaseTrainer):
             to_rgb=True,
         )
         train_ds = self._build_dataset(train_imgs, train_lbls, train_tf)
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         train_sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
@@ -250,17 +263,31 @@ class ECPoseTrainer(BaseTrainer):
                 rank=self.rank,
                 shuffle=True,
                 drop_last=len(train_ds) >= self.world_size,
+                seed=distributed_sampler_seed(getattr(self.config, "seed", None)),
             )
 
         visible_samples = len(train_sampler) if train_sampler is not None else len(train_ds)
         drop_last = visible_samples >= per_rank_batch
-        loader_kwargs = {}
+        worker_kwargs = {}
         if self.config.workers > 0:
-            loader_kwargs.update(
+            deterministic_workers = (
+                getattr(self.config, "seed", None) is not None
+                and int(self.config.seed) >= 0
+            )
+            worker_kwargs.update(
                 worker_init_fn=_pose_worker_init_fn,
-                persistent_workers=self.config.persistent_workers,
+                persistent_workers=(
+                    self.config.persistent_workers and not deterministic_workers
+                ),
                 prefetch_factor=self.config.prefetch_factor,
             )
+        seed_kwargs = dict(
+            seed=getattr(self.config, "seed", None),
+            rank=self.rank,
+            distributed=self.is_distributed,
+        )
+        train_loader_kwargs = dataloader_seed_kwargs(**seed_kwargs)
+        train_loader_kwargs.update(worker_kwargs)
         self.train_loader = DataLoader(
             train_ds,
             batch_size=per_rank_batch,
@@ -270,7 +297,7 @@ class ECPoseTrainer(BaseTrainer):
             pin_memory=self.config.pin_memory,
             drop_last=drop_last,
             collate_fn=pose_collate_fn,
-            **loader_kwargs,
+            **train_loader_kwargs,
         )
 
         val_imgs = cfg.get("val_img_files")
@@ -286,6 +313,8 @@ class ECPoseTrainer(BaseTrainer):
                 self.num_keypoints, imagenet_norm=True, to_rgb=True
             )
             val_ds = self._build_dataset(val_imgs, val_lbls, val_tf)
+            val_loader_kwargs = dataloader_seed_kwargs(**seed_kwargs)
+            val_loader_kwargs.update(worker_kwargs)
             self.val_loader = DataLoader(
                 val_ds,
                 batch_size=per_rank_batch,
@@ -294,7 +323,7 @@ class ECPoseTrainer(BaseTrainer):
                 pin_memory=self.config.pin_memory,
                 drop_last=False,
                 collate_fn=pose_collate_fn,
-                **loader_kwargs,
+                **val_loader_kwargs,
             )
             logger.info("Validation dataset: %d images", len(val_ds))
         else:
@@ -396,16 +425,10 @@ class ECPoseTrainer(BaseTrainer):
             "oks_sigmas": self._resolve_oks_sigmas(),
         }
 
-    def _validate_epoch(self, epoch: int, *, save_plots: bool | None = None):
-        from ...training.distributed import barrier, is_main_process, unwrap_model
-
-        if self.is_distributed and not is_main_process():
-            barrier()
-            return None
+    def _run_validation(self, epoch: int, *, save_plots: bool | None = None):
+        from ...training.distributed import unwrap_model
 
         if getattr(self, "val_loader", None) is None:
-            if self.is_distributed:
-                barrier()
             return None
 
         model = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
@@ -415,43 +438,53 @@ class ECPoseTrainer(BaseTrainer):
         total_loss, num_batches = 0.0, 0
         pose_metrics = None
         try:
-            with torch.no_grad():
-                for batch in self.val_loader:
-                    imgs = batch[0].to(self.device, non_blocking=True)
-                    targets = batch[1].to(self.device, non_blocking=True)
-                    target_list = self._build_pose_targets(targets, imgs)
-                    # The pose decoder only emits aux/enc/dn outputs in train
-                    # mode, but BatchNorm must NOT update running stats from val
-                    # data (no_grad does not stop buffer writes). Run train mode
-                    # for the decoder structure while freezing BN to eval.
-                    model.train()
-                    _set_bn_eval(model)
-                    losses = self.criterion(
-                        model(imgs, targets=target_list), target_list
-                    )
-                    model.eval()
-                    total_loss += float(sum(losses.values()).item())
-                    num_batches += 1
-            pose_metrics = self._run_pose_metric_validation(model, epoch)
+            if not self.is_distributed:
+                with torch.no_grad():
+                    for batch in self.val_loader:
+                        imgs = batch[0].to(self.device, non_blocking=True)
+                        targets = batch[1].to(self.device, non_blocking=True)
+                        target_list = self._build_pose_targets(targets, imgs)
+                        # The pose decoder only emits aux/enc/dn outputs in train
+                        # mode, but BatchNorm must NOT update running stats from val
+                        # data (no_grad does not stop buffer writes). Run train mode
+                        # for the decoder structure while freezing BN to eval.
+                        model.train()
+                        _set_bn_eval(model)
+                        losses = self.criterion(
+                            model(imgs, targets=target_list), target_list
+                        )
+                        model.eval()
+                        total_loss += float(sum(losses.values()).item())
+                        num_batches += 1
+            pose_metrics = self._run_pose_metric_validation(
+                model,
+                epoch,
+                save_plots=save_plots,
+            )
         finally:
             if was_training:
                 model.train()
-            if self.is_distributed:
-                barrier()
 
         avg_loss = total_loss / max(num_batches, 1)
-        metrics = {"loss/val": avg_loss}
+        metrics = {} if self.is_distributed else {"loss/val": avg_loss}
         if pose_metrics:
             metrics.update(self._scalar_mapping(pose_metrics))
             mAP50 = metrics.get("metrics/keypoints_mAP50")
             mAP50_95 = metrics.get("metrics/keypoints_mAP50-95")
-            logger.info(
-                "Validation - loss/val: %.4f, keypoints_mAP50: %.4f, "
-                "keypoints_mAP50-95: %.4f",
-                avg_loss,
-                mAP50 if mAP50 is not None else 0.0,
-                mAP50_95 if mAP50_95 is not None else 0.0,
-            )
+            if self.is_distributed:
+                logger.info(
+                    "Validation - keypoints_mAP50: %.4f, keypoints_mAP50-95: %.4f",
+                    mAP50 if mAP50 is not None else 0.0,
+                    mAP50_95 if mAP50_95 is not None else 0.0,
+                )
+            else:
+                logger.info(
+                    "Validation - loss/val: %.4f, keypoints_mAP50: %.4f, "
+                    "keypoints_mAP50-95: %.4f",
+                    avg_loss,
+                    mAP50 if mAP50 is not None else 0.0,
+                    mAP50_95 if mAP50_95 is not None else 0.0,
+                )
             return {
                 "best_metric": mAP50_95 if mAP50_95 is not None else 0.0,
                 "best_metric_key": self.best_metric_key,
@@ -459,6 +492,13 @@ class ECPoseTrainer(BaseTrainer):
                 "mAP50_95": mAP50_95,
                 "metrics": metrics,
             }
+
+        if self.is_distributed:
+            logger.warning(
+                "Skipping EC pose validation loss under DDP because the criterion "
+                "uses training collectives; pose metrics were unavailable"
+            )
+            return None
 
         logger.info("Validation - loss/val: %.4f", avg_loss)
         return {
@@ -469,17 +509,29 @@ class ECPoseTrainer(BaseTrainer):
             "metrics": metrics,
         }
 
-    def _run_pose_metric_validation(self, eval_model, epoch: int):
+    def _run_pose_metric_validation(
+        self,
+        eval_model,
+        epoch: int,
+        *,
+        save_plots: bool | None = None,
+    ):
         if self.wrapper_model is None:
             logger.warning("Skipping pose mAP validation: wrapper_model is missing")
             return None
         try:
             from libreyolo.validation import PoseValidator, ValidationConfig
 
+            should_save_plots = (
+                bool(save_plots)
+                if save_plots is not None
+                else bool(getattr(self.config, "save_plots", False))
+                and self._is_final_epoch(epoch)
+            )
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
-                batch_size=self.config.batch,
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,
                 iou_thres=0.65,
@@ -489,7 +541,8 @@ class ECPoseTrainer(BaseTrainer):
                 num_workers=self.config.workers,
                 allow_download_scripts=self.config.allow_download_scripts,
                 oks_sigmas=self._resolve_oks_sigmas(),
-                save_dir=str(self.save_dir / "val"),
+                save_plots=should_save_plots,
+                save_dir=str(self.save_dir / "val") if should_save_plots else None,
             )
             original_model = self.wrapper_model.model
             self.wrapper_model.model = eval_model

--- a/libreyolo/models/ec/seg_trainer.py
+++ b/libreyolo/models/ec/seg_trainer.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Type
 
 import torch
 
-from ...training.config import ECSegConfig, TrainConfig
+from ...training.config import ECSegConfig, TrainConfig, require_training_choice
 from ...training.scheduler import FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from ..rfdetr.seg_transforms import RFDETRSegPassThroughDataset, RFDETRSegTransform
@@ -75,6 +75,12 @@ class ECSegTrainer(BaseTrainer):
         return preproc, RFDETRSegPassThroughDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("flat_cosine",),
+            family="ec-segment",
+        )
         return FlatCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
@@ -126,6 +132,12 @@ class ECSegTrainer(BaseTrainer):
 
     def _setup_optimizer(self) -> torch.optim.Optimizer:
         """AdamW with {backbone, head} x {wd, no-wd} groups (EC recipe)."""
+        require_training_choice(
+            self.config.optimizer,
+            field="optimizer",
+            supported=("adamw",),
+            family="ec-segment",
+        )
         backbone_wd, backbone_no_wd, head_wd, head_no_wd = [], [], [], []
         for name, p in self.model.named_parameters():
             if not p.requires_grad:
@@ -159,7 +171,9 @@ class ECSegTrainer(BaseTrainer):
             groups.append({"params": backbone_wd, "lr": lr * bb_mult, "weight_decay": wd, "lr_mult": bb_mult})
         if backbone_no_wd:
             groups.append({"params": backbone_no_wd, "lr": lr * bb_mult, "weight_decay": 0.0, "lr_mult": bb_mult})
-        return torch.optim.AdamW(groups, betas=(0.9, 0.999))
+        return torch.optim.AdamW(
+            groups, betas=(float(self.config.momentum), 0.999)
+        )
 
     def _scale_lr(self, base_lr: float, param_group: dict) -> float:
         return base_lr * float(param_group.get("lr_mult", 1.0))

--- a/libreyolo/models/efficientnetv2/config.py
+++ b/libreyolo/models/efficientnetv2/config.py
@@ -22,6 +22,7 @@ class EfficientNetV2Config(TrainConfig):
     epochs: int = 100
     batch: int = 64
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 1e-3
     weight_decay: float = 1e-4
     warmup_epochs: int = 1

--- a/libreyolo/models/efficientnetv2/model.py
+++ b/libreyolo/models/efficientnetv2/model.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -245,11 +244,8 @@ class LibreEfficientNetV2(BaseModel):
                     "model = LibreEfficientNetV2('path/to/last.pt', size='b0'); "
                     "model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/efficientnetv2/trainer.py
+++ b/libreyolo/models/efficientnetv2/trainer.py
@@ -13,7 +13,7 @@ from typing import Dict, Type
 import torch
 import torch.nn.functional as F
 
-from ...training.config import TrainConfig
+from ...training.config import TrainConfig, require_training_choice
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import EfficientNetV2Config
@@ -41,6 +41,12 @@ class EfficientNetV2Trainer(BaseTrainer):
         return None, None
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("yoloxwarmcos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/fomo/model.py
+++ b/libreyolo/models/fomo/model.py
@@ -245,19 +245,8 @@ class LibreFOMO(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreFOMO('path/to/last.pt'); model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-
-        reload_path = None
-        for key in ("best_checkpoint", "last_checkpoint"):
-            path = results.get(key)
-            if path and Path(path).exists():
-                reload_path = str(path)
-                break
-
-        if reload_path:
-            self._load_weights(reload_path)
-
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/fomo/trainer.py
+++ b/libreyolo/models/fomo/trainer.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, Optional, Type
 import torch
 from torch.utils.data import DataLoader
 
-from ...training.config import FOMOConfig, TrainConfig
+from ...data import dataloader_seed_kwargs, distributed_sampler_seed
+from ...training.config import FOMOConfig, TrainConfig, require_training_choice
 from ...training.trainer import BaseTrainer
 from ...training.distributed import (
     is_main_process,
@@ -61,7 +62,7 @@ class FOMOTrainer(BaseTrainer):
 
         self._val_dataset = val_dataset
 
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
@@ -70,7 +71,8 @@ class FOMOTrainer(BaseTrainer):
                 num_replicas=self.world_size,
                 rank=self.rank,
                 shuffle=True,
-                drop_last=True,
+                drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(getattr(self.config, "seed", None)),
             )
 
         self.train_loader = DataLoader(
@@ -81,6 +83,11 @@ class FOMOTrainer(BaseTrainer):
             pin_memory=self.device.type == "cuda",
             sampler=sampler,
             drop_last=False,
+            **dataloader_seed_kwargs(
+                getattr(self.config, "seed", None),
+                rank=self.rank,
+                distributed=self.is_distributed,
+            ),
         )
 
         if is_main_process():
@@ -96,7 +103,12 @@ class FOMOTrainer(BaseTrainer):
         return train_dataset
 
     def create_scheduler(self, iters_per_epoch: int):
-        sched_type = getattr(self.config, "scheduler", "cosine")
+        sched_type = require_training_choice(
+            getattr(self.config, "scheduler", "cosine"),
+            field="scheduler",
+            supported=("cos", "cosine", "flat_cosine", "linear", "constant"),
+            family=self.get_model_family(),
+        )
 
         if sched_type in ("cosine", "cos"):
             from ...training.scheduler import CosineAnnealingScheduler
@@ -129,7 +141,7 @@ class FOMOTrainer(BaseTrainer):
                 warmup_lr_start=getattr(self.config, "warmup_lr_start", 0.0001),
                 min_lr_ratio=getattr(self.config, "min_lr_ratio", 0.01),
             )
-        
+
         from ...training.scheduler import ConstantLRScheduler
         return ConstantLRScheduler(
             lr=self.effective_lr,
@@ -180,7 +192,7 @@ class FOMOTrainer(BaseTrainer):
 
             val_config = ValidationConfig(
                 data=self.config.data,
-                batch_size=self.config.batch,
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,
                 iou_thres=0.65,

--- a/libreyolo/models/mobilenetv4/config.py
+++ b/libreyolo/models/mobilenetv4/config.py
@@ -22,6 +22,7 @@ class MobileNetV4Config(TrainConfig):
     epochs: int = 100
     batch: int = 64
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 1e-3
     weight_decay: float = 1e-4
     warmup_epochs: int = 1

--- a/libreyolo/models/mobilenetv4/model.py
+++ b/libreyolo/models/mobilenetv4/model.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -245,11 +244,8 @@ class LibreMobileNetV4(BaseModel):
                     "model = LibreMobileNetV4('path/to/last.pt', size='s'); "
                     "model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/mobilenetv4/trainer.py
+++ b/libreyolo/models/mobilenetv4/trainer.py
@@ -13,7 +13,7 @@ from typing import Dict, Type
 import torch
 import torch.nn.functional as F
 
-from ...training.config import TrainConfig
+from ...training.config import TrainConfig, require_training_choice
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import MobileNetV4Config
@@ -41,6 +41,12 @@ class MobileNetV4Trainer(BaseTrainer):
         return None, None
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("yoloxwarmcos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/nafnet/config.py
+++ b/libreyolo/models/nafnet/config.py
@@ -21,6 +21,7 @@ class NAFNetConfig(TrainConfig):
     epochs: int = 100
     batch: int = 16
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 1e-3
     weight_decay: float = 0.0
     warmup_epochs: int = 0

--- a/libreyolo/models/nafnet/model.py
+++ b/libreyolo/models/nafnet/model.py
@@ -314,13 +314,10 @@ class LibreNAFNet(BaseModel):
                     "model = LibreNAFNet('path/to/last.pt', size='s'); "
                     "model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
+        self._restore_after_training(results)
         return results
 
 

--- a/libreyolo/models/nafnet/trainer.py
+++ b/libreyolo/models/nafnet/trainer.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Type
 
 import torch
 
-from ...training.config import TrainConfig
+from ...training.config import TrainConfig, require_training_choice
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import NAFNetConfig
@@ -71,6 +71,12 @@ class NAFNetTrainer(BaseTrainer):
             self._restore_inference_pooling()
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("yoloxwarmcos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/picodet/model.py
+++ b/libreyolo/models/picodet/model.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -289,11 +288,8 @@ class LibrePICODET(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibrePICODET('path/to/last.pt'); model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/picodet/trainer.py
+++ b/libreyolo/models/picodet/trainer.py
@@ -30,7 +30,7 @@ from ...data.augment.boxes import xyxy2cxcywh
 from ...data.augment.color import augment_hsv
 from ...data.augment.geometry import mirror
 from ...training.augment import MosaicMixupDataset
-from ...training.config import PICODETConfig, TrainConfig
+from ...training.config import PICODETConfig, TrainConfig, require_training_choice
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from .loss import PICODETLoss
@@ -134,6 +134,12 @@ class PICODETTrainer(BaseTrainer):
         return preproc, MosaicMixupDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("cos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/resnet/config.py
+++ b/libreyolo/models/resnet/config.py
@@ -20,6 +20,7 @@ class ResNetConfig(TrainConfig):
     epochs: int = 100
     batch: int = 64
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 1e-3
     weight_decay: float = 1e-4
     warmup_epochs: int = 1

--- a/libreyolo/models/resnet/model.py
+++ b/libreyolo/models/resnet/model.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -256,11 +255,8 @@ class LibreResNet(BaseModel):
                     "model = LibreResNet('path/to/last.pt', size='50'); "
                     "model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/resnet/trainer.py
+++ b/libreyolo/models/resnet/trainer.py
@@ -12,7 +12,7 @@ from typing import Dict, Type
 import torch
 import torch.nn.functional as F
 
-from ...training.config import TrainConfig
+from ...training.config import TrainConfig, require_training_choice
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from .config import ResNetConfig
@@ -39,6 +39,12 @@ class ResNetTrainer(BaseTrainer):
         return None, None
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("yoloxwarmcos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/rfdetr/config.py
+++ b/libreyolo/models/rfdetr/config.py
@@ -32,6 +32,7 @@ class RFDETRConfig(TrainConfig):
 
     patience: int = 0
     optimizer: str = "adamw"
+    momentum: float = 0.9
     scheduler: str = "step"
     mosaic_prob: float = 0.0
     mixup_prob: float = 0.0

--- a/libreyolo/models/rfdetr/loss.py
+++ b/libreyolo/models/rfdetr/loss.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import nn
 
+from ...training.distributed import all_reduce_avg_scalar
 from .keypoints import compute_l1_keypoint_loss, map_labels_to_keypoint_schema
 from .segmentation import (
     calculate_uncertainty,
@@ -90,16 +91,6 @@ def accuracy(output: torch.Tensor, target: torch.Tensor, topk=(1,)):
         correct_k = correct[:k].view(-1).float().sum(0)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res
-
-
-def is_dist_avail_and_initialized() -> bool:
-    return torch.distributed.is_available() and torch.distributed.is_initialized()
-
-
-def get_world_size() -> int:
-    if not is_dist_avail_and_initialized():
-        return 1
-    return torch.distributed.get_world_size()
 
 
 def sigmoid_focal_loss(inputs, targets, num_boxes, alpha: float = 0.25, gamma: float = 2):
@@ -207,6 +198,10 @@ class SetCriterion(nn.Module):
         1) we compute hungarian assignment between ground truth boxes and the outputs of the model
         2) we supervise each pair of matched ground-truth / prediction (supervise class and box)
     """
+
+    @staticmethod
+    def _global_count_normalizer(count: int, device: torch.device) -> float:
+        return all_reduce_avg_scalar(count, device=device, min_value=1.0)
 
     def __init__(
         self,
@@ -655,10 +650,10 @@ class SetCriterion(nn.Module):
         num_boxes = sum(len(t["labels"]) for t in targets)
         if not self.sum_group_losses:
             num_boxes = num_boxes * group_detr
-        num_boxes = torch.as_tensor([num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device)
-        if is_dist_avail_and_initialized():
-            torch.distributed.all_reduce(num_boxes)
-        num_boxes = torch.clamp(num_boxes / get_world_size(), min=1).item()
+        num_boxes = self._global_count_normalizer(
+            num_boxes,
+            next(iter(outputs.values())).device,
+        )
 
         # Compute all the requested losses
         losses = {}

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -1127,26 +1127,6 @@ class LibreRFDETR(BaseModel):
         """
         return super().val(*args, workers=workers, **kwargs)
 
-    def _restore_after_training(self, result: dict) -> None:
-        """Reload the saved checkpoint and leave real torch models in eval mode."""
-        checkpoint = None
-        for key in ("best_checkpoint", "last_checkpoint"):
-            path = result.get(key)
-            if path and Path(path).exists():
-                checkpoint = str(path)
-                break
-
-        if checkpoint is not None:
-            self.model_path = checkpoint
-            self._load_weights(checkpoint)
-
-        model = getattr(self, "model", None)
-        device = getattr(self, "device", None)
-        if model is not None and device is not None and hasattr(model, "to"):
-            model.to(device)
-        if model is not None and hasattr(model, "eval"):
-            model.eval()
-
     def _resume_checkpoint_uses_lora(self, resume_path: str | Path) -> bool:
         """Return True when a resume checkpoint needs a LoRA-wrapped graph."""
         path = Path(resume_path)
@@ -1285,6 +1265,7 @@ class LibreRFDETR(BaseModel):
                 "project": str(project),
                 "name": str(name),
                 "exist_ok": exist_ok,
+                "resume": bool(resume),
                 "size": self.size,
                 "num_classes": self.nb_classes,
             }
@@ -1311,7 +1292,16 @@ class LibreRFDETR(BaseModel):
 
         resume_path = None
         if resume:
-            resume_path = run_dir / "weights" / "last.pt" if resume is True else resume
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreRFDETR('path/to/last.pt'); "
+                    "model.train(data=..., resume=True)"
+                )
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
             if not train_kwargs.get(
                 "lora", False
             ) and self._resume_checkpoint_uses_lora(resume_path):
@@ -1324,8 +1314,7 @@ class LibreRFDETR(BaseModel):
             loggers=loggers,
             **train_kwargs,
         )
-        if resume:
-            trainer.setup()
+        if resume_path is not None:
             trainer.resume(str(resume_path))
         result = trainer.train()
         result["output_dir"] = result.get("save_dir", str(run_dir))

--- a/libreyolo/models/rfdetr/nn.py
+++ b/libreyolo/models/rfdetr/nn.py
@@ -11,9 +11,33 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F  # noqa: N812
 
+from ...training.distributed import all_reduce_avg_scalar
 from .backbone import build_backbone
 from .lwdetr import LWDETR, MLP, PostProcess, build_criterion_and_postprocessors, build_model
 from .tensors import NestedTensor
+
+
+def _semantic_cross_entropy(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    *,
+    ignore_index: int,
+) -> torch.Tensor:
+    """Semantic CE normalized by the global valid-pixel count under DDP."""
+    targets = targets.long()
+    valid_pixels = (targets != ignore_index).sum()
+    valid_pixels_per_rank = all_reduce_avg_scalar(
+        valid_pixels,
+        device=logits.device,
+        min_value=1.0,
+    )
+    local_loss_sum = F.cross_entropy(
+        logits,
+        targets,
+        ignore_index=ignore_index,
+        reduction="sum",
+    )
+    return local_loss_sum / valid_pixels_per_rank
 
 
 @dataclass(frozen=True)
@@ -626,15 +650,11 @@ class RFDETRSemanticSegmenter(nn.Module):
             logits = F.interpolate(
                 logits, size=targets.shape[-2:], mode="bilinear", align_corners=False
             )
-            targets = targets.long()
-            if bool((targets != self.IGNORE_INDEX).any()):
-                loss = F.cross_entropy(
-                    logits, targets, ignore_index=self.IGNORE_INDEX
-                )
-            else:
-                # cross_entropy returns NaN when every pixel is ignored; emit
-                # a graph-connected zero so the optimizer step stays sane.
-                loss = logits.sum() * 0.0
+            loss = _semantic_cross_entropy(
+                logits,
+                targets,
+                ignore_index=self.IGNORE_INDEX,
+            )
             return {"total_loss": loss, "sem": loss}
 
         return F.interpolate(

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -9,20 +9,22 @@ from types import SimpleNamespace
 from typing import Dict, List, Optional, Type
 
 import cv2
-import numpy as np
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from ...data import (
     YOLOPoseDataset,
+    dataloader_seed_kwargs,
     default_oks_sigmas,
+    distributed_sampler_seed,
     get_img_files,
     img2label_paths,
     load_data_config,
     pose_collate_fn,
+    seed_data_worker,
 )
-from ...training.config import TrainConfig
+from ...training.config import TrainConfig, require_training_choice
 from ...training.distributed import is_main_process, unwrap_model
 from ...training.freezing import FreezeGroup
 from ...training.scheduler import BaseScheduler, CosineAnnealingScheduler, FlatCosineScheduler
@@ -44,9 +46,7 @@ logger = logging.getLogger(__name__)
 def _pose_worker_init_fn(worker_id: int) -> None:
     cv2.setNumThreads(0)
     torch.set_num_threads(1)
-    seed = (torch.initial_seed() + worker_id) % 2**32
-    random.seed(seed)
-    np.random.seed(seed)
+    seed_data_worker(worker_id)
 
 
 class RFDETRStepScheduler(BaseScheduler):
@@ -302,7 +302,12 @@ class RFDETRTrainer(BaseTrainer):
         return preproc, DFINEPassThroughDataset
 
     def create_scheduler(self, iters_per_epoch: int):
-        scheduler = str(getattr(self.config, "scheduler", "step")).lower()
+        scheduler = require_training_choice(
+            getattr(self.config, "scheduler", "step"),
+            field="scheduler",
+            supported=("step", "cosine", "flat_cosine"),
+            family=self.get_model_family(),
+        )
         if scheduler == "step":
             return RFDETRStepScheduler(
                 lr=self.effective_lr,
@@ -475,7 +480,7 @@ class RFDETRTrainer(BaseTrainer):
         )
         train_ds = self._build_pose_dataset(train_imgs, train_lbls, train_tf)
 
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
@@ -486,15 +491,30 @@ class RFDETRTrainer(BaseTrainer):
                 rank=self.rank,
                 shuffle=True,
                 drop_last=len(train_ds) >= self.world_size,
+                seed=distributed_sampler_seed(getattr(self.config, "seed", None)),
             )
 
-        loader_kwargs = {}
+        worker_kwargs = {}
         if self.config.workers > 0:
-            loader_kwargs.update(
+            deterministic_workers = (
+                getattr(self.config, "seed", None) is not None
+                and int(self.config.seed) >= 0
+            )
+            worker_kwargs.update(
                 worker_init_fn=_pose_worker_init_fn,
-                persistent_workers=self.config.persistent_workers,
+                persistent_workers=(
+                    self.config.persistent_workers and not deterministic_workers
+                ),
                 prefetch_factor=self.config.prefetch_factor,
             )
+        seed_kwargs = dict(
+            seed=getattr(self.config, "seed", None),
+            rank=self.rank,
+            distributed=self.is_distributed,
+        )
+        train_loader_kwargs = dataloader_seed_kwargs(**seed_kwargs)
+        train_loader_kwargs.update(worker_kwargs)
+        visible_samples = len(sampler) if sampler is not None else len(train_ds)
 
         self.train_loader = DataLoader(
             train_ds,
@@ -503,9 +523,9 @@ class RFDETRTrainer(BaseTrainer):
             sampler=sampler,
             num_workers=self.config.workers,
             pin_memory=self.config.pin_memory,
-            drop_last=len(train_ds) >= per_rank_batch,
+            drop_last=visible_samples >= per_rank_batch,
             collate_fn=pose_collate_fn,
-            **loader_kwargs,
+            **train_loader_kwargs,
         )
 
         val_imgs = cfg.get("val_img_files")
@@ -528,6 +548,8 @@ class RFDETRTrainer(BaseTrainer):
                 crop_resize_prob=0.0,
             )
             val_ds = self._build_pose_dataset(val_imgs, val_lbls, val_tf)
+            val_loader_kwargs = dataloader_seed_kwargs(**seed_kwargs)
+            val_loader_kwargs.update(worker_kwargs)
             self.val_loader = DataLoader(
                 val_ds,
                 batch_size=per_rank_batch,
@@ -536,7 +558,7 @@ class RFDETRTrainer(BaseTrainer):
                 pin_memory=self.config.pin_memory,
                 drop_last=False,
                 collate_fn=pose_collate_fn,
-                **loader_kwargs,
+                **val_loader_kwargs,
             )
             if is_main_process():
                 logger.info("Validation dataset: %d images", len(val_ds))
@@ -653,6 +675,13 @@ class RFDETRTrainer(BaseTrainer):
                 self.wrapper_model.keypoint_dim = self.config.keypoint_dim
 
     def _setup_optimizer(self) -> torch.optim.Optimizer:
+        require_training_choice(
+            self.config.optimizer,
+            field="optimizer",
+            supported=("adamw",),
+            family=self.get_model_family(),
+        )
+        betas = (float(self.config.momentum), 0.999)
         if getattr(getattr(self, "wrapper_model", None), "task", "detect") in (
             "classify",
             "semantic",
@@ -674,14 +703,14 @@ class RFDETRTrainer(BaseTrainer):
                 groups.append({"params": decay, "weight_decay": self.config.weight_decay})
             if no_decay:
                 groups.append({"params": no_decay, "weight_decay": 0.0})
-            return torch.optim.AdamW(groups, lr=self.effective_lr, betas=(0.9, 0.999))
+            return torch.optim.AdamW(groups, lr=self.effective_lr, betas=betas)
         upstream_groups = self._setup_upstream_optimizer_groups()
         if upstream_groups:
             return torch.optim.AdamW(
                 upstream_groups,
                 lr=self.effective_lr,
                 weight_decay=self.config.weight_decay,
-                betas=(0.9, 0.999),
+                betas=betas,
             )
 
         backbone_wd, backbone_no_wd, head_wd, head_no_wd = [], [], [], []
@@ -716,7 +745,7 @@ class RFDETRTrainer(BaseTrainer):
                 "No trainable parameters remain after layer freezing; "
                 "reduce the freeze value or choose a narrower selector."
             )
-        return torch.optim.AdamW(groups, betas=(0.9, 0.999))
+        return torch.optim.AdamW(groups, betas=betas)
 
     def _setup_upstream_optimizer_groups(self) -> list[dict]:
         core_model = getattr(self.model, "model", self.model)
@@ -1032,7 +1061,7 @@ class RFDETRTrainer(BaseTrainer):
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
-                batch_size=self.config.batch,
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,
                 iou_thres=0.65,

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
@@ -591,18 +590,8 @@ class LibreRTDETR(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreRTDETR('path/to/last.pt'); model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
-
-        # Restore wrapper-side device after possible MPS->CPU trainer fallback
-        # (no-op if the trainer didn't change device). Matches the D-FINE
-        # pattern; safe for v1 since trainer there doesn't fall back.
-        self.model.to(self.device)
-
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -86,7 +86,7 @@ class LibreRTDETRv4(LibreDFINE):
         project: str = "runs/train",
         name: str = _TRAIN_DEFAULTS.name,
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: bool = False,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
@@ -107,7 +107,7 @@ class LibreRTDETRv4(LibreDFINE):
             project: Root directory for training runs.
             name: Experiment name.
             exist_ok: If True, overwrite existing experiment directory.
-            resume: If True, resume training from the loaded checkpoint.
+            resume: Checkpoint path, or True to resume the loaded checkpoint.
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
@@ -145,6 +145,19 @@ class LibreRTDETRv4(LibreDFINE):
             if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreRTDETRv4('path/to/last.pt'); "
+                    "model.train(data=..., resume=True)"
+                )
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = RTDETRv4Trainer(
             model=self.model,
             wrapper_model=self,
@@ -161,7 +174,7 @@ class LibreRTDETRv4(LibreDFINE):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             patience=patience,
             callbacks=callbacks,
@@ -169,23 +182,10 @@ class LibreRTDETRv4(LibreDFINE):
             **kwargs,
         )
 
-        if resume:
-            if not self.model_path:
-                raise ValueError(
-                    "resume=True requires a checkpoint. Load one first: "
-                    "model = LibreRTDETRv4('path/to/last.pt'); model.train(data=..., resume=True)"
-                )
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-
-        self.model.to(self.device)
+        self._restore_after_training(results)
 
         return results

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -11,7 +11,6 @@ mmdetection checkpoints.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -370,11 +369,8 @@ class LibreRTMDet(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreRTMDet('path/to/last.pt'); model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/rtmdet/trainer.py
+++ b/libreyolo/models/rtmdet/trainer.py
@@ -25,7 +25,7 @@ import numpy as np
 import torch
 
 from ...training.augment import MosaicMixupDataset, TrainTransform
-from ...training.config import RTMDetConfig, TrainConfig
+from ...training.config import RTMDetConfig, TrainConfig, require_training_choice
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
 from .loss import RTMDetLoss
@@ -80,6 +80,12 @@ class RTMDetTrainer(BaseTrainer):
         return preproc, MosaicMixupDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("cos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/segformer/model.py
+++ b/libreyolo/models/segformer/model.py
@@ -425,7 +425,7 @@ class LibreSegformer(BaseModel):
         project: str = "runs/train",
         name: str = "segformer_exp",
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: bool = True,
         callbacks: TrainCallbacks = None,
         loggers=None,
@@ -438,6 +438,19 @@ class LibreSegformer(BaseModel):
         carry none of the upstream non-commercial restriction.
         """
         from .trainer import SegformerTrainer
+
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreSegformer('path/to/last.pt'); "
+                    "model.train(data=..., resume=True)"
+                )
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
 
         train_kwargs = dict(
             data=data,
@@ -452,7 +465,7 @@ class LibreSegformer(BaseModel):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             **kwargs,
         )
@@ -466,22 +479,11 @@ class LibreSegformer(BaseModel):
             loggers=loggers,
             **train_kwargs,
         )
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
         result = trainer.train()
         self._restore_after_training(result)
         return result
-
-    def _restore_after_training(self, result: dict) -> None:
-        checkpoint = None
-        for key in ("best_checkpoint", "last_checkpoint"):
-            path = result.get(key)
-            if path and Path(path).exists():
-                checkpoint = str(path)
-                break
-        if checkpoint is not None:
-            self.model_path = checkpoint
-            self._load_weights(checkpoint)
-        self.model.to(self.device)
-        self.model.eval()
 
     def export(self, format: str = "onnx", **kwargs) -> str:
         raise NotImplementedError("Export is not implemented for LibreSegformer yet.")

--- a/libreyolo/models/segformer/nn.py
+++ b/libreyolo/models/segformer/nn.py
@@ -26,6 +26,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...training.distributed import all_reduce_avg_scalar
+
 IGNORE_INDEX = 255
 # Every LayerNorm in the Apache-2.0 reference implementation is built as
 # ``nn.LayerNorm(dim)``, i.e. with PyTorch's default eps. The ``layer_norm_eps``
@@ -41,6 +43,29 @@ HIDDEN_DROPOUT_PROB = 0.0
 CLASSIFIER_DROPOUT_PROB = 0.1
 # Std of the normal init for Linear/Conv weights (reference: initializer_range).
 INITIALIZER_RANGE = 0.02
+
+
+def _semantic_cross_entropy(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    *,
+    ignore_index: int,
+) -> torch.Tensor:
+    """Semantic CE normalized by the global valid-pixel count under DDP."""
+    targets = targets.long()
+    valid_pixels = (targets != ignore_index).sum()
+    valid_pixels_per_rank = all_reduce_avg_scalar(
+        valid_pixels,
+        device=logits.device,
+        min_value=1.0,
+    )
+    local_loss_sum = F.cross_entropy(
+        logits,
+        targets,
+        ignore_index=ignore_index,
+        reduction="sum",
+    )
+    return local_loss_sum / valid_pixels_per_rank
 
 
 @dataclass(frozen=True)
@@ -400,13 +425,11 @@ class LibreSegformerNet(nn.Module):
 
         if self.training and targets is not None:
             logits = F.interpolate(logits, size=targets.shape[-2:], mode="bilinear", align_corners=False)
-            targets = targets.long()
-            if bool((targets != self.IGNORE_INDEX).any()):
-                loss = F.cross_entropy(logits, targets, ignore_index=self.IGNORE_INDEX)
-            else:
-                # cross_entropy returns NaN when every pixel is ignored; emit a
-                # graph-connected zero so the optimizer step stays sane.
-                loss = logits.sum() * 0.0
+            loss = _semantic_cross_entropy(
+                logits,
+                targets,
+                ignore_index=self.IGNORE_INDEX,
+            )
             return {"total_loss": loss, "sem": loss}
 
         return F.interpolate(logits, size=(h, w), mode="bilinear", align_corners=False)

--- a/libreyolo/models/segformer/trainer.py
+++ b/libreyolo/models/segformer/trainer.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Tuple, Type
 
 import torch
 
-from ...training.config import SegformerConfig, TrainConfig
+from ...training.config import SegformerConfig, TrainConfig, require_training_choice
 from ...training.distributed import is_main_process, unwrap_model
 from ...training.scheduler import FlatCosineScheduler, LinearLRScheduler
 from ...training.trainer import BaseTrainer
@@ -52,6 +52,12 @@ class SegformerTrainer(BaseTrainer):
         Frozen params (``requires_grad=False``) are skipped, so layer-freeze
         config still works.
         """
+        require_training_choice(
+            self.config.optimizer,
+            field="optimizer",
+            supported=("adamw",),
+            family=self.get_model_family(),
+        )
         base_lr = self.effective_lr
         wd = self.config.weight_decay
         head_lr_mult = float(getattr(self.config, "head_lr_mult", 10.0))
@@ -85,7 +91,11 @@ class SegformerTrainer(BaseTrainer):
             for (lr_mult, group_wd), params in buckets.items()
         ]
 
-        optimizer = torch.optim.AdamW(param_groups, lr=base_lr)
+        optimizer = torch.optim.AdamW(
+            param_groups,
+            lr=base_lr,
+            betas=(float(self.config.momentum), 0.999),
+        )
         if is_main_process():
             logger.info("SegFormer optimizer: AdamW, backbone base lr=%s", base_lr)
             for (lr_mult, group_wd), params in buckets.items():
@@ -114,7 +124,12 @@ class SegformerTrainer(BaseTrainer):
         )
 
     def create_scheduler(self, iters_per_epoch: int):
-        scheduler_name = str(self.config.scheduler).lower()
+        scheduler_name = require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("linear", "cosine", "flat_cosine", "cos"),
+            family=self.get_model_family(),
+        )
         if scheduler_name == "linear":
             return LinearLRScheduler(
                 lr=self.effective_lr,

--- a/libreyolo/models/yolo7/model.py
+++ b/libreyolo/models/yolo7/model.py
@@ -17,8 +17,6 @@ from typing import Any, Dict, Optional, Tuple
 import torch
 import torch.nn as nn
 from libreyolo.training.ddp_spawn import ddp_aware
-from PIL import Image
-
 from ...training.callbacks import TrainCallbacks
 from ...training.config import YOLOv7Config
 from ...utils.image_loader import ImageInput
@@ -287,13 +285,8 @@ class LibreYOLO7(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreYOLO('last.pt'); model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
-
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -286,21 +286,6 @@ class LibreYOLO9(BaseModel):
 
         self._rebuild_for_new_classes(new_nc)
 
-    def _restore_after_training(self, results: dict) -> None:
-        """Reload the saved checkpoint and leave the model ready for inference."""
-        checkpoint = None
-        for key in ("best_checkpoint", "last_checkpoint"):
-            path = results.get(key)
-            if path and Path(path).exists():
-                checkpoint = str(path)
-                break
-
-        if checkpoint is not None:
-            self.model_path = checkpoint
-            self._load_weights(checkpoint)
-
-        self.model.to(self.device).eval()
-
     def _align_class_towers_for_transfer(self, state_dict: dict) -> None:
         """Match COCO-width class towers before partial transfer loading."""
         hidden_key = "head.cv3.0.0.conv.weight"
@@ -681,7 +666,6 @@ class LibreYOLO9(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreYOLO9('path/to/last.pt', size='t'); model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()

--- a/libreyolo/models/yolo9_e2e/model.py
+++ b/libreyolo/models/yolo9_e2e/model.py
@@ -12,7 +12,6 @@ Sizes: t / s / m / c (same backbone configs as yolo9).
 """
 
 import re
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -279,15 +278,10 @@ class LibreYOLO9E2E(LibreYOLO9):
                     "model = LibreYOLO9E2E('path/to/last.pt', size='t'); "
                     "model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
-
+        self._restore_after_training(results)
         return results
 
 

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -527,7 +527,7 @@ class LibreYOLONAS(BaseModel):
         project: str = "runs/train",
         name: Optional[str] = None,
         exist_ok: bool = False,
-        resume: bool = False,
+        resume: str | Path | bool = False,
         amp: Optional[bool] = None,
         patience: int = 50,
         callbacks: TrainCallbacks = None,
@@ -549,7 +549,7 @@ class LibreYOLONAS(BaseModel):
             project: Root directory for training runs.
             name: Experiment name (None uses the task default).
             exist_ok: If True, overwrite existing experiment directory.
-            resume: If True, resume training from the loaded checkpoint.
+            resume: Checkpoint path, or True to resume the loaded checkpoint.
             amp: Enable automatic mixed precision training (None uses the
                 task default).
             patience: Early stopping patience.
@@ -623,6 +623,19 @@ class LibreYOLONAS(BaseModel):
             if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreYOLONAS('path/to/last.pt'); "
+                    "model.train(data=..., resume=True)"
+                )
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = YOLONASTrainer(
             model=self.model,
             wrapper_model=self,
@@ -640,7 +653,7 @@ class LibreYOLONAS(BaseModel):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             patience=patience,
             callbacks=callbacks,
@@ -648,23 +661,11 @@ class LibreYOLONAS(BaseModel):
             **kwargs,
         )
 
-        if resume:
-            if not self.model_path:
-                raise ValueError(
-                    "resume=True requires a checkpoint. Load one first: "
-                    "model = LibreYOLONAS('path/to/last.pt'); model.train(data=..., resume=True)"
-                )
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-            self.model.eval()
+        self._restore_after_training(results)
 
         return results
 
@@ -683,7 +684,7 @@ class LibreYOLONAS(BaseModel):
         project: str,
         name: str,
         exist_ok: bool,
-        resume: bool,
+        resume: str | Path | bool,
         amp: bool,
         patience: int,
         callbacks=None,
@@ -768,6 +769,19 @@ class LibreYOLONAS(BaseModel):
             if str(device).lower() not in ("cpu", "mps") and torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
 
+        resume_path = None
+        if resume:
+            checkpoint = self.model_path if resume is True else resume
+            if checkpoint is None:
+                raise ValueError(
+                    "resume=True requires a checkpoint. Load one first: "
+                    "model = LibreYOLONAS('path/to/last.pt', task='pose'); "
+                    "model.train(data=..., resume=True)"
+                )
+            resume_path = Path(checkpoint).expanduser()
+            if not resume_path.is_file():
+                raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+
         trainer = YOLONASPoseTrainer(
             model=self.model,
             wrapper_model=self,
@@ -787,7 +801,7 @@ class LibreYOLONAS(BaseModel):
             project=project,
             name=name,
             exist_ok=exist_ok,
-            resume=resume,
+            resume=bool(resume),
             amp=amp,
             patience=patience,
             callbacks=callbacks,
@@ -795,23 +809,10 @@ class LibreYOLONAS(BaseModel):
             **kwargs,
         )
 
-        if resume:
-            if not self.model_path:
-                raise ValueError(
-                    "resume=True requires a checkpoint. Load one first: "
-                    "model = LibreYOLONAS('path/to/last.pt', task='pose'); "
-                    "model.train(data=..., resume=True)"
-                )
-            trainer.setup()
-            trainer.resume(str(self.model_path))
-            return trainer.train()
+        if resume_path is not None:
+            trainer.resume(str(resume_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self.model_path = best_ckpt
-            self._load_weights(best_ckpt)
-            self.model.eval()
+        self._restore_after_training(results)
 
         return results

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -12,23 +12,29 @@ with validation loss as the fallback signal.
 from __future__ import annotations
 
 import logging
-import random
 from typing import Dict, Type
 
 import cv2
-import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
 from ...data import (
     YOLOPoseDataset,
+    dataloader_seed_kwargs,
     default_oks_sigmas,
+    distributed_sampler_seed,
     get_img_files,
     img2label_paths,
     load_data_config,
     pose_collate_fn,
+    seed_data_worker,
 )
-from ...training.config import TrainConfig, YOLONASPoseConfig
+from ...training.config import (
+    TrainConfig,
+    YOLONASPoseConfig,
+    require_training_choice,
+)
+from ...training.distributed import unwrap_model
 from ...training.scheduler import CosineAnnealingScheduler
 from ...training.trainer import BaseTrainer
 from .loss import YoloNASPoseLoss
@@ -39,9 +45,7 @@ logger = logging.getLogger(__name__)
 def _pose_worker_init_fn(worker_id: int) -> None:
     cv2.setNumThreads(0)
     torch.set_num_threads(1)
-    seed = (torch.initial_seed() + worker_id) % 2**32
-    random.seed(seed)
-    np.random.seed(seed)
+    seed_data_worker(worker_id)
 
 
 class YOLONASPoseTrainer(BaseTrainer):
@@ -74,6 +78,12 @@ class YOLONASPoseTrainer(BaseTrainer):
         return None, None
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("cos",),
+            family="yolonas-pose",
+        )
         return CosineAnnealingScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,
@@ -161,23 +171,51 @@ class YOLONASPoseTrainer(BaseTrainer):
             affine_interpolation=self.config.affine_interpolation,
         )
         train_ds = self._build_dataset(train_imgs, train_lbls, train_tf)
-        drop_last = len(train_ds) >= self.config.batch
-        loader_kwargs = {}
+        per_rank_batch = self._per_rank_batch_size()
+        sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            sampler = DistributedSampler(
+                train_ds,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_ds) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
+            )
+        visible_samples = len(sampler) if sampler is not None else len(train_ds)
+        drop_last = visible_samples >= per_rank_batch
+        worker_kwargs = {}
         if self.config.workers > 0:
-            loader_kwargs.update(
+            deterministic_workers = (
+                getattr(self.config, "seed", None) is not None
+                and int(self.config.seed) >= 0
+            )
+            worker_kwargs.update(
                 worker_init_fn=_pose_worker_init_fn,
-                persistent_workers=self.config.persistent_workers,
+                persistent_workers=(
+                    self.config.persistent_workers and not deterministic_workers
+                ),
                 prefetch_factor=self.config.prefetch_factor,
             )
+        seed_kwargs = dict(
+            seed=getattr(self.config, "seed", None),
+            rank=self.rank,
+            distributed=self.is_distributed,
+        )
+        train_loader_kwargs = dataloader_seed_kwargs(**seed_kwargs)
+        train_loader_kwargs.update(worker_kwargs)
         self.train_loader = DataLoader(
             train_ds,
-            batch_size=self.config.batch,
-            shuffle=True,
+            batch_size=per_rank_batch,
+            shuffle=sampler is None,
+            sampler=sampler,
             num_workers=self.config.workers,
             pin_memory=self.config.pin_memory,
             drop_last=drop_last,
             collate_fn=pose_collate_fn,
-            **loader_kwargs,
+            **train_loader_kwargs,
         )
 
         val_imgs = cfg.get("val_img_files")
@@ -192,15 +230,17 @@ class YOLONASPoseTrainer(BaseTrainer):
             val_ds = self._build_dataset(
                 val_imgs, val_lbls, YOLONASPoseValTransform(self.num_keypoints)
             )
+            val_loader_kwargs = dataloader_seed_kwargs(**seed_kwargs)
+            val_loader_kwargs.update(worker_kwargs)
             self.val_loader = DataLoader(
                 val_ds,
-                batch_size=self.config.batch,
+                batch_size=per_rank_batch,
                 shuffle=False,
                 num_workers=self.config.workers,
                 pin_memory=self.config.pin_memory,
                 drop_last=False,
                 collate_fn=pose_collate_fn,
-                **loader_kwargs,
+                **val_loader_kwargs,
             )
             logger.info("Validation dataset: %d images", len(val_ds))
         else:
@@ -238,43 +278,55 @@ class YOLONASPoseTrainer(BaseTrainer):
             "pose_reg": log_losses[4],
         }
 
-    def _validate_epoch(self, epoch: int):
+    def _run_validation(self, epoch: int, *, save_plots: bool | None = None):
         if getattr(self, "val_loader", None) is None:
             return None
 
-        model = self.ema_model.ema if self.ema_model else self.model
+        model = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
         was_training = model.training
         model.eval()
 
         total_loss, num_batches = 0.0, 0
         pose_metrics = None
         try:
-            with torch.no_grad():
-                for batch in self.val_loader:
-                    imgs = batch[0].to(self.device, non_blocking=True)
-                    targets = batch[1].to(self.device, non_blocking=True)
-                    loss, _ = self.loss_fn(model(imgs), targets)
-                    total_loss += float(loss.item())
-                    num_batches += 1
+            if not self.is_distributed:
+                with torch.no_grad():
+                    for batch in self.val_loader:
+                        imgs = batch[0].to(self.device, non_blocking=True)
+                        targets = batch[1].to(self.device, non_blocking=True)
+                        loss, _ = self.loss_fn(model(imgs), targets)
+                        total_loss += float(loss.item())
+                        num_batches += 1
 
-            pose_metrics = self._run_pose_metric_validation(model, epoch)
+            pose_metrics = self._run_pose_metric_validation(
+                model,
+                epoch,
+                save_plots=save_plots,
+            )
         finally:
             if was_training:
                 model.train()
 
         avg_loss = total_loss / max(num_batches, 1)
-        metrics = {"loss/val": avg_loss}
+        metrics = {} if self.is_distributed else {"loss/val": avg_loss}
         if pose_metrics:
             metrics.update(self._scalar_mapping(pose_metrics))
             mAP50 = metrics.get("metrics/keypoints_mAP50")
             mAP50_95 = metrics.get("metrics/keypoints_mAP50-95")
-            logger.info(
-                "Validation - loss/val: %.4f, keypoints_mAP50: %.4f, "
-                "keypoints_mAP50-95: %.4f",
-                avg_loss,
-                mAP50 if mAP50 is not None else 0.0,
-                mAP50_95 if mAP50_95 is not None else 0.0,
-            )
+            if self.is_distributed:
+                logger.info(
+                    "Validation - keypoints_mAP50: %.4f, keypoints_mAP50-95: %.4f",
+                    mAP50 if mAP50 is not None else 0.0,
+                    mAP50_95 if mAP50_95 is not None else 0.0,
+                )
+            else:
+                logger.info(
+                    "Validation - loss/val: %.4f, keypoints_mAP50: %.4f, "
+                    "keypoints_mAP50-95: %.4f",
+                    avg_loss,
+                    mAP50 if mAP50 is not None else 0.0,
+                    mAP50_95 if mAP50_95 is not None else 0.0,
+                )
             return {
                 "best_metric": mAP50_95 if mAP50_95 is not None else 0.0,
                 "best_metric_key": self.best_metric_key,
@@ -282,6 +334,13 @@ class YOLONASPoseTrainer(BaseTrainer):
                 "mAP50_95": mAP50_95,
                 "metrics": metrics,
             }
+
+        if self.is_distributed:
+            logger.warning(
+                "Skipping YOLO-NAS pose validation loss under DDP because the "
+                "criterion uses training collectives; pose metrics were unavailable"
+            )
+            return None
 
         logger.info("Validation - loss/val: %.4f", avg_loss)
         return {
@@ -293,7 +352,11 @@ class YOLONASPoseTrainer(BaseTrainer):
         }
 
     def _run_pose_metric_validation(
-        self, eval_model: torch.nn.Module, epoch: int
+        self,
+        eval_model: torch.nn.Module,
+        epoch: int,
+        *,
+        save_plots: bool | None = None,
     ) -> Dict[str, float] | None:
         if self.wrapper_model is None:
             logger.warning("Skipping pose mAP validation: wrapper_model is missing")
@@ -302,10 +365,16 @@ class YOLONASPoseTrainer(BaseTrainer):
         try:
             from libreyolo.validation import PoseValidator, ValidationConfig
 
+            should_save_plots = (
+                bool(save_plots)
+                if save_plots is not None
+                else bool(getattr(self.config, "save_plots", False))
+                and self._is_final_epoch(epoch)
+            )
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
-                batch_size=self.config.batch,
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,
                 iou_thres=0.65,
@@ -315,7 +384,8 @@ class YOLONASPoseTrainer(BaseTrainer):
                 num_workers=self.config.workers,
                 allow_download_scripts=self.config.allow_download_scripts,
                 oks_sigmas=self._resolve_oks_sigmas(),
-                save_dir=str(self.save_dir / "val"),
+                save_plots=should_save_plots,
+                save_dir=str(self.save_dir / "val") if should_save_plots else None,
             )
 
             original_model = self.wrapper_model.model

--- a/libreyolo/models/yolonas/trainer.py
+++ b/libreyolo/models/yolonas/trainer.py
@@ -6,7 +6,7 @@ from typing import Dict, Type
 
 import torch
 
-from ...training.config import TrainConfig, YOLONASConfig
+from ...training.config import TrainConfig, YOLONASConfig, require_training_choice
 from ...training.scheduler import CosineAnnealingScheduler
 from ...training.trainer import BaseTrainer
 from .loss import PPYoloELoss
@@ -36,6 +36,12 @@ class YOLONASTrainer(BaseTrainer):
         return preproc, YOLONASAffineMixupDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("cos",),
+            family=self.get_model_family(),
+        )
         return CosineAnnealingScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -1,6 +1,5 @@
 """LibreYOLOX implementation for LibreYOLO."""
 
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -309,13 +308,8 @@ class LibreYOLOX(BaseModel):
                     "resume=True requires a checkpoint. Load one first: "
                     "model = LibreYOLOX('path/to/last.pt'); model.train(data=..., resume=True)"
                 )
-            trainer.setup()
             trainer.resume(str(self.model_path))
 
         results = trainer.train()
-
-        best_ckpt = results.get("best_checkpoint")
-        if best_ckpt and Path(best_ckpt).exists():
-            self._load_weights(best_ckpt)
-
+        self._restore_after_training(results)
         return results

--- a/libreyolo/models/yolox/trainer.py
+++ b/libreyolo/models/yolox/trainer.py
@@ -9,7 +9,11 @@ import torch
 from typing import Dict, Type
 
 from libreyolo.training.trainer import BaseTrainer
-from libreyolo.training.config import TrainConfig, YOLOXConfig
+from libreyolo.training.config import (
+    TrainConfig,
+    YOLOXConfig,
+    require_training_choice,
+)
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.augment import TrainTransform, MosaicMixupDataset
 
@@ -37,6 +41,12 @@ class YOLOXTrainer(BaseTrainer):
         return preproc, MosaicMixupDataset
 
     def create_scheduler(self, iters_per_epoch: int):
+        require_training_choice(
+            self.config.scheduler,
+            field="scheduler",
+            supported=("yoloxwarmcos",),
+            family=self.get_model_family(),
+        )
         return WarmupCosineScheduler(
             lr=self.effective_lr,
             iters_per_epoch=iters_per_epoch,

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -10,6 +10,24 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+def require_training_choice(
+    value: str,
+    *,
+    field: str,
+    supported: Tuple[str, ...],
+    family: str,
+) -> str:
+    """Normalize a family-local training choice or reject it explicitly."""
+    normalized = str(value).strip().lower()
+    if normalized not in supported:
+        choices = ", ".join(repr(choice) for choice in supported)
+        raise ValueError(
+            f"{family} does not support {field}={value!r}; supported values: "
+            f"{choices}."
+        )
+    return normalized
+
+
 def load_train_cfg(path) -> dict:
     """Load a training-config yaml as a dict suitable for ``model.train(**out)``.
 
@@ -337,6 +355,7 @@ class DFINEConfig(TrainConfig):
     """
 
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 2e-4
     weight_decay: float = 1e-4
 
@@ -389,6 +408,7 @@ class DEIMConfig(TrainConfig):
     """
 
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 4e-4
     weight_decay: float = 1e-4
 
@@ -613,6 +633,7 @@ class DEIMv2Config(TrainConfig):
     """
 
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 5e-4
     weight_decay: float = 1e-4
 
@@ -678,6 +699,7 @@ class ECConfig(TrainConfig):
     """
 
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 5e-4
     weight_decay: float = 1e-4
 
@@ -956,7 +978,7 @@ class RTMDetConfig(TrainConfig):
     sync_bn: bool = True
     optimizer: str = "adamw"
     lr0: float = 0.004
-    momentum: float = 0.9  # unused for adamw; kept for TrainConfig compatibility
+    momentum: float = 0.9  # AdamW beta1 (and SGD momentum when selected)
     weight_decay: float = 0.05
 
     scheduler: str = "cos"
@@ -994,6 +1016,7 @@ class SegformerConfig(TrainConfig):
     """
 
     optimizer: str = "adamw"
+    momentum: float = 0.9
     lr0: float = 6e-5
     weight_decay: float = 0.01
     # Decode-head LR multiplier over the backbone base LR (mmseg SegFormer uses
@@ -1037,6 +1060,7 @@ class FOMOConfig(TrainConfig):
     # rationale as :class:`YOLO9Config`, issue #484). No-op outside DDP.
     sync_bn: bool = True
     optimizer: str = "adam"
+    momentum: float = 0.9
     lr0: float = 3e-4
     weight_decay: float = 0.0
 

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -257,18 +257,22 @@ def spawn_for_model(
     last = result.get("last_checkpoint")
     ckpt = next((p for p in (best, last) if p and Path(p).exists()), None)
     if ckpt:
-        if hasattr(model_instance, "model_path"):
-            model_instance.model_path = ckpt
-        model_instance._load_weights(ckpt)
-        if hasattr(model_instance, "model"):
-            first_device = devices[0] if devices else 0
-            target = (
-                torch.device("cuda", first_device)
-                if torch.cuda.is_available()
-                else torch.device("cpu")
-            )
+        first_device = devices[0] if devices else 0
+        target = (
+            torch.device("cuda", first_device)
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        model_instance.device = target
+        restore = getattr(model_instance, "_restore_after_training", None)
+        if callable(restore):
+            restore(result)
+        else:
+            resolved_checkpoint = str(Path(ckpt).expanduser().resolve())
+            if hasattr(model_instance, "model_path"):
+                model_instance.model_path = resolved_checkpoint
+            model_instance._load_weights(resolved_checkpoint)
             model_instance.model.to(target).eval()
-            model_instance.device = target
     elif _model_moved:
         model_instance.model.to(_original_device)
         torch.cuda.empty_cache()
@@ -329,6 +333,18 @@ def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
                     # Guard not satisfied — fall through so the function body
                     # raises its validation error cleanly on the main process.
                     return train_fn(self, *args, **kwargs)
+                if batch_key != "batch" and train_kw.get("batch") is not None:
+                    alias_batch = train_kw.pop("batch")
+                    named_batch = train_kw.get(batch_key)
+                    if named_batch is not None and named_batch != alias_batch:
+                        raise ValueError(
+                            f"Conflicting batch values: {batch_key}={named_batch} "
+                            f"and batch={alias_batch}"
+                        )
+                    train_kw[batch_key] = alias_batch
+                train_kw["_libreyolo_explicit_train_keys"] = sorted(
+                    getattr(self, "_active_train_explicit_keys", ())
+                )
                 return spawn_for_model(self, train_kw, len(devices), devices=devices, batch_key=batch_key)
 
             return train_fn(self, *args, **kwargs)

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -13,15 +13,49 @@ no-op.
 from __future__ import annotations
 
 import os
+import pickle
 import socket
+import traceback
 from datetime import timedelta
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, TypeVar, Union
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 
 DeviceArg = Union[str, int, List[int], None]
+PhaseResult = TypeVar("PhaseResult")
+
+
+class RankZeroPhaseError(RuntimeError):
+    """A rank-zero-only phase failed and the failure was shared with all ranks.
+
+    ``root_exception_type``, ``root_exception_message``, and
+    ``rank_zero_traceback`` describe the original exception on rank 0. On rank
+    0, the original exception is also retained as ``__cause__`` by
+    :func:`run_rank_zero_phase`.
+    """
+
+    def __init__(
+        self,
+        phase: str,
+        root_exception_type: str,
+        root_exception_message: str,
+        rank_zero_traceback: str,
+        failure_stage: str = "execution",
+    ) -> None:
+        self.phase = phase
+        self.root_exception_type = root_exception_type
+        self.root_exception_message = root_exception_message
+        self.rank_zero_traceback = rank_zero_traceback
+        self.failure_stage = failure_stage
+        cause = root_exception_type
+        if root_exception_message:
+            cause = f"{cause}: {root_exception_message}"
+        super().__init__(
+            f"Rank-zero phase {phase!r} failed during {failure_stage} "
+            f"on rank 0 with {cause}"
+        )
 
 
 # =============================================================================
@@ -65,6 +99,149 @@ def barrier() -> None:
         dist.barrier()
 
 
+def _phase_name(phase: str) -> str:
+    """Validate and normalize a rank-zero phase label."""
+    if not isinstance(phase, str):
+        raise TypeError(f"phase must be a string, got {type(phase).__name__}")
+    name = phase.strip()
+    if not name:
+        raise ValueError("phase must be a non-empty string")
+    return name
+
+
+def _exception_type_name(exc: BaseException) -> str:
+    """Return a stable, readable type name for a serialized exception."""
+    cls = type(exc)
+    if cls.__module__ == "builtins":
+        return cls.__qualname__
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _failure_payload(phase: str, stage: str, exc: BaseException) -> bytes:
+    """Serialize exception metadata without requiring the exception to pickle."""
+    try:
+        message = str(exc)
+    except BaseException:
+        message = "<exception message could not be rendered>"
+    try:
+        formatted_traceback = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+    except BaseException:
+        formatted_traceback = "<rank-zero traceback could not be rendered>"
+    outcome = {
+        "ok": False,
+        "phase": phase,
+        "failure_stage": stage,
+        "root_exception_type": _exception_type_name(exc),
+        "root_exception_message": message,
+        "rank_zero_traceback": formatted_traceback,
+    }
+    return pickle.dumps(outcome, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _collective_device() -> torch.device:
+    """Choose storage accepted by the active collective backend."""
+    backend = str(dist.get_backend()).lower()
+    if "nccl" in backend:
+        return torch.device("cuda", torch.cuda.current_device())
+    return torch.device("cpu")
+
+
+def _broadcast_bytes_from_rank_zero(payload: Optional[bytes]) -> bytes:
+    """Broadcast a variable-length byte payload from rank 0."""
+    device = _collective_device()
+    size = torch.tensor(
+        [len(payload) if payload is not None else 0],
+        dtype=torch.int64,
+        device=device,
+    )
+    dist.broadcast(size, src=0)
+    payload_size = int(size.item())
+    if payload_size <= 0:
+        raise RuntimeError("rank-zero phase produced an empty collective payload")
+
+    if get_rank() == 0:
+        data = torch.tensor(bytearray(payload or b""), dtype=torch.uint8, device=device)
+    else:
+        data = torch.empty(payload_size, dtype=torch.uint8, device=device)
+    dist.broadcast(data, src=0)
+    return bytes(data.cpu().tolist())
+
+
+def run_rank_zero_phase(
+    phase: str,
+    function: Callable[[], PhaseResult],
+) -> PhaseResult:
+    """Run one callable on rank 0 and share its result or failure with all ranks.
+
+    Every rank must call this collective in the same order. Rank 0 executes
+    ``function``; the other ranks never call it. A successful, pickleable
+    return value is broadcast and returned on every rank. If the callable
+    raises, or its result cannot be serialized, every rank raises the same
+    :class:`RankZeroPhaseError` after receiving the rank-zero exception type,
+    message, and traceback. Rank 0 chains the original exception as the error's
+    cause.
+
+    Outside distributed mode, this calls ``function`` directly and preserves
+    its normal return value and exception behavior.
+
+    Args:
+        phase: Short name used to identify the setup, validation, checkpoint,
+            callback, or other rank-zero-only phase in failures.
+        function: Zero-argument callable to execute on rank 0.
+
+    Returns:
+        The callable's return value on every rank.
+
+    Raises:
+        RankZeroPhaseError: The rank-zero callable failed or returned a value
+            that could not be serialized while distributed is initialized.
+    """
+    if not is_distributed():
+        _phase_name(phase)
+        return function()
+
+    wire_payload: Optional[bytes] = None
+    root_exception: Optional[BaseException] = None
+    if get_rank() == 0:
+        try:
+            name = _phase_name(phase)
+        except BaseException as exc:
+            root_exception = exc
+            wire_payload = _failure_payload("<invalid phase>", "phase validation", exc)
+        else:
+            try:
+                value = function()
+            except BaseException as exc:
+                root_exception = exc
+                wire_payload = _failure_payload(name, "execution", exc)
+            else:
+                try:
+                    outcome = {"ok": True, "phase": name, "value": value}
+                    wire_payload = pickle.dumps(
+                        outcome, protocol=pickle.HIGHEST_PROTOCOL
+                    )
+                except BaseException as exc:
+                    root_exception = exc
+                    wire_payload = _failure_payload(name, "result serialization", exc)
+
+    outcome = pickle.loads(_broadcast_bytes_from_rank_zero(wire_payload))
+    if outcome["ok"]:
+        return outcome["value"]
+
+    error = RankZeroPhaseError(
+        phase=outcome["phase"],
+        root_exception_type=outcome["root_exception_type"],
+        root_exception_message=outcome["root_exception_message"],
+        rank_zero_traceback=outcome["rank_zero_traceback"],
+        failure_stage=outcome["failure_stage"],
+    )
+    if root_exception is not None:
+        raise error from root_exception
+    raise error
+
+
 # =============================================================================
 # Device argument parsing
 # =============================================================================
@@ -91,7 +268,11 @@ def parse_device_arg(device: DeviceArg) -> List[int]:
     if s in ("", "auto", "cpu", "mps"):
         return []
     if "," in s:
-        return [int(x.strip()) for x in s.split(",") if x.strip().lstrip("-").isdigit() and int(x.strip()) >= 0]
+        return [
+            int(x.strip())
+            for x in s.split(",")
+            if x.strip().lstrip("-").isdigit() and int(x.strip()) >= 0
+        ]
     if s.startswith("cuda:"):
         s = s.split(":", 1)[1]
     if s.lstrip("-").isdigit():
@@ -160,7 +341,11 @@ def init_distributed(timeout_seconds: int = 10800) -> None:
     # so wrap defensively and omit the kwarg on failure.
     try:
         pg_sig = inspect.signature(dist.init_process_group)
-        if "device_id" in pg_sig.parameters and backend == "nccl" and torch.cuda.is_available():
+        if (
+            "device_id" in pg_sig.parameters
+            and backend == "nccl"
+            and torch.cuda.is_available()
+        ):
             init_kwargs["device_id"] = torch.device("cuda", local_rank)
     except (TypeError, ValueError):
         pass
@@ -401,6 +586,7 @@ def spawn_ddp_train(
 
 __all__ = [
     "DeviceArg",
+    "RankZeroPhaseError",
     "all_reduce_avg_scalar",
     "barrier",
     "get_local_rank",
@@ -411,6 +597,7 @@ __all__ = [
     "is_distributed",
     "is_main_process",
     "parse_device_arg",
+    "run_rank_zero_phase",
     "scale_loss_for_ddp",
     "seed_for_rank",
     "shutdown_distributed",

--- a/libreyolo/training/ema.py
+++ b/libreyolo/training/ema.py
@@ -18,6 +18,34 @@ def is_parallel(model):
     return isinstance(model, parallel_type)
 
 
+def _strided_storage_signature(tensor: torch.Tensor):
+    """Return the storage and exact layout identity for a strided tensor."""
+    storage = tensor.untyped_storage()
+    layout = (
+        storage,
+        tensor.storage_offset(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.device,
+        tensor.is_conj(),
+        tensor.is_neg(),
+    )
+    return layout, storage
+
+
+def _tensor_alias_signature(tensor: torch.Tensor):
+    """Identify exact aliases while keeping different storage views distinct."""
+    if tensor.layout != torch.strided:
+        # State-dict wrappers for uncommon layouts do not expose a general
+        # storage-region contract. Keep them independent rather than risk
+        # merging tensors that merely look alike.
+        return (tensor.layout, id(tensor)), ()
+
+    layout, storage = _strided_storage_signature(tensor)
+    return (torch.strided, layout), (storage,)
+
+
 class ModelEMA:
     """Model Exponential Moving Average.
 
@@ -43,13 +71,39 @@ class ModelEMA:
             msd = (
                 model.module.state_dict() if is_parallel(model) else model.state_dict()
             )
-            # EMA update: v = d*v + (1-d)*model[k] for every float tensor.
+            # EMA update: v = d*v + (1-d)*model[k] for every unique float
+            # tensor layout. state_dict() retains every alias path, so updating
+            # each key would apply the decay repeatedly to shared tensors.
             ema_vals, model_vals = [], []
+            seen_layouts = set()
+            storage_counts = {}
             for k, v in self.ema.state_dict().items():
                 if v.dtype.is_floating_point:
+                    layout, storages = _tensor_alias_signature(v)
+                    if layout in seen_layouts:
+                        continue
+                    seen_layouts.add(layout)
                     ema_vals.append(v)
                     model_vals.append(msd[k])
-            if ema_vals and ema_vals[0].is_cuda:
+                    for storage in set(storages):
+                        storage_counts[storage] = storage_counts.get(storage, 0) + 1
+            has_overlapping_views = any(count > 1 for count in storage_counts.values())
+            if has_overlapping_views:
+                raise RuntimeError(
+                    "ModelEMA does not support distinct state-dict tensor views "
+                    "that share storage; make the views independent or exact aliases"
+                )
+            if (
+                ema_vals
+                and all(
+                    v.is_cuda
+                    and v.layout == torch.strided
+                    and mv.layout == torch.strided
+                    and v.device == mv.device
+                    and v.dtype == mv.dtype
+                    for v, mv in zip(ema_vals, model_vals)
+                )
+            ):
                 # CUDA / ROCm: fuse the ~N per-parameter mul_/add_ launches into
                 # two multi-tensor _foreach_ calls — a large win when the step is
                 # launch-bound. Numerically identical (~1e-7).

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -626,8 +626,10 @@ class BaseTrainer(ABC):
             if getattr(self, "_resume_distiller_state", None) is not None:
                 logger.warning(
                     "Resume checkpoint contains distiller state, but distillation "
-                    "is disabled"
+                    "is disabled; discarding distiller state and any distillation-"
+                    "specific optimizer slots"
                 )
+                self._discard_resume_distiller_optimizer_state = True
                 self._resume_distiller_state = None
             return
 
@@ -1555,7 +1557,10 @@ class BaseTrainer(ABC):
         # _initialize_scheduler_lr() sets the correct LR on top.
         if getattr(self, "_resume_optimizer_state", None) is not None:
             try:
-                self.optimizer.load_state_dict(self._resume_optimizer_state)
+                optimizer_state = self._optimizer_state_for_resume(
+                    self._resume_optimizer_state
+                )
+                self.optimizer.load_state_dict(optimizer_state)
                 logger.info("Optimizer state restored from resume checkpoint")
             except Exception as e:
                 raise RuntimeError(f"Cannot resume optimizer state: {e}") from e
@@ -2735,8 +2740,40 @@ class BaseTrainer(ABC):
     ) -> Optional[Dict[str, Any]]:
         return run_rank_zero_phase(
             f"validation epoch {epoch + 1}",
-            lambda: self._run_validation(epoch, save_plots=save_plots),
+            lambda: self._run_rank_zero_validation(
+                epoch,
+                save_plots=save_plots,
+            ),
         )
+
+    def _run_rank_zero_validation(
+        self, epoch: int, *, save_plots: bool | None = None
+    ) -> Optional[Dict[str, Any]]:
+        """Validate without entering DDP forward collectives on rank zero."""
+        original_model = self.model
+        if not isinstance(original_model, nn.parallel.DistributedDataParallel):
+            return self._run_validation(epoch, save_plots=save_plots)
+
+        validation_model = unwrap_model(original_model)
+        was_training = validation_model.training
+        wrapper = getattr(self, "wrapper_model", None)
+        original_wrapper_model = getattr(wrapper, "model", None)
+        replace_wrapper_model = (
+            wrapper is not None and original_wrapper_model is original_model
+        )
+
+        self.model = validation_model
+        if replace_wrapper_model:
+            wrapper.model = validation_model
+        try:
+            return self._run_validation(epoch, save_plots=save_plots)
+        finally:
+            try:
+                validation_model.train(was_training)
+            finally:
+                self.model = original_model
+                if replace_wrapper_model:
+                    wrapper.model = original_wrapper_model
 
     def _run_validation(
         self, epoch: int, *, save_plots: bool | None = None
@@ -3396,6 +3433,108 @@ class BaseTrainer(ABC):
                 f"Cannot resume: model architecture mismatch - {exc}"
             ) from exc
 
+    def _optimizer_state_for_resume(
+        self,
+        optimizer_state: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        """Remove only disabled-distillation slots from a saved optimizer state."""
+        if not getattr(self, "_discard_resume_distiller_optimizer_state", False):
+            return optimizer_state
+
+        saved_groups = optimizer_state.get("param_groups")
+        saved_slots = optimizer_state.get("state")
+        if not isinstance(saved_groups, (list, tuple)) or not isinstance(
+            saved_slots, Mapping
+        ):
+            raise RuntimeError(
+                "disabled distillation cannot be removed from a malformed "
+                "optimizer state"
+            )
+
+        current_groups = self.optimizer.param_groups
+        current_group_count = len(current_groups)
+        if len(saved_groups) < current_group_count:
+            raise RuntimeError(
+                "disabled distillation cannot be removed safely: checkpoint has "
+                f"{len(saved_groups)} optimizer groups, but the current model has "
+                f"{current_group_count}"
+            )
+        if len(saved_groups) == current_group_count:
+            return optimizer_state
+
+        model_groups = saved_groups[:current_group_count]
+        for index, (saved_group, current_group) in enumerate(
+            zip(model_groups, current_groups)
+        ):
+            if not isinstance(saved_group, Mapping) or not isinstance(
+                current_group, Mapping
+            ):
+                raise RuntimeError(
+                    "disabled distillation cannot be removed from malformed "
+                    f"optimizer group {index}"
+                )
+            saved_params = saved_group.get("params")
+            current_params = current_group.get("params")
+            if not isinstance(saved_params, (list, tuple)) or not isinstance(
+                current_params, (list, tuple)
+            ):
+                raise RuntimeError(
+                    "disabled distillation cannot be removed from malformed "
+                    f"optimizer group {index}"
+                )
+            if len(saved_params) != len(current_params):
+                raise RuntimeError(
+                    "disabled distillation cannot be removed safely: model "
+                    f"optimizer group {index} has {len(saved_params)} saved "
+                    f"parameters and {len(current_params)} current parameters"
+                )
+
+        retained_param_ids = {
+            param_id for group in model_groups for param_id in group["params"]
+        }
+        discarded_groups = saved_groups[current_group_count:]
+        for index, discarded_group in enumerate(
+            discarded_groups,
+            start=current_group_count,
+        ):
+            if not isinstance(discarded_group, Mapping) or not isinstance(
+                discarded_group.get("params"), (list, tuple)
+            ):
+                raise RuntimeError(
+                    "disabled distillation cannot be removed from malformed "
+                    f"optimizer group {index}"
+                )
+        discarded_param_ids = {
+            param_id for group in discarded_groups for param_id in group["params"]
+        }
+        if retained_param_ids & discarded_param_ids:
+            raise RuntimeError(
+                "disabled distillation cannot be removed safely: optimizer "
+                "parameter ids overlap model and distiller groups"
+            )
+        unexpected_slots = set(saved_slots) - (
+            retained_param_ids | discarded_param_ids
+        )
+        if unexpected_slots:
+            raise RuntimeError(
+                "disabled distillation cannot be removed safely: optimizer state "
+                "contains slots outside its parameter groups"
+            )
+
+        filtered_state = dict(optimizer_state)
+        filtered_state["param_groups"] = [dict(group) for group in model_groups]
+        filtered_state["state"] = {
+            param_id: slot
+            for param_id, slot in saved_slots.items()
+            if param_id in retained_param_ids
+        }
+        logger.info(
+            "Discarded %d distillation optimizer group(s); retained %d model group(s)",
+            len(discarded_groups),
+            current_group_count,
+        )
+        return filtered_state
+
     def _restore_checkpoint_config(self, checkpoint: Mapping[str, Any]) -> None:
         """Restore saved run settings while preserving explicit runtime choices.
 
@@ -3565,6 +3704,11 @@ class BaseTrainer(ABC):
         self._validate_resume_identity(checkpoint)
         self._restore_checkpoint_config(checkpoint)
 
+        if "distiller" in checkpoint and not getattr(
+            self.config, "distill_model", None
+        ):
+            self._discard_resume_distiller_optimizer_state = True
+
         model_state = checkpoint.get("train_model", checkpoint["model"])
         self._prepare_resume_model_architecture(checkpoint, model_state)
         if getattr(self, "_is_setup", False):
@@ -3597,7 +3741,10 @@ class BaseTrainer(ABC):
         if "optimizer" in checkpoint:
             if self.optimizer is not None:
                 try:
-                    self.optimizer.load_state_dict(checkpoint["optimizer"])
+                    optimizer_state = self._optimizer_state_for_resume(
+                        checkpoint["optimizer"]
+                    )
+                    self.optimizer.load_state_dict(optimizer_state)
                     logger.info("Optimizer state restored")
                 except Exception as e:
                     raise RuntimeError(f"Cannot resume optimizer state: {e}") from e

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import math
 import os
+import random
 import shutil
 import sys
 import time
@@ -17,6 +18,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type
 
+import numpy as np
 import torch
 import torch.nn as nn
 from torch.amp import GradScaler, autocast
@@ -34,7 +36,7 @@ from .callbacks import (
 from .config import TrainConfig
 from .loggers import resolve_loggers
 from .distributed import (
-    barrier,
+    all_reduce_avg_scalar,
     get_local_rank,
     get_rank,
     get_world_size,
@@ -43,6 +45,7 @@ from .distributed import (
     is_distributed,
     is_main_process,
     parse_device_arg,
+    run_rank_zero_phase,
     scale_loss_for_ddp,
     seed_for_rank,
     unwrap_model,
@@ -52,6 +55,8 @@ from .ema import ModelEMA
 from .freezing import FreezeGroup, apply_freeze, default_freeze_groups
 from ..data.dataset import YOLODataset, COCODataset, create_dataloader
 from ..data import (
+    dataloader_seed_kwargs,
+    distributed_sampler_seed,
     get_coco_annotation_file,
     get_coco_image_dir,
     get_img_files,
@@ -59,6 +64,7 @@ from ..data import (
     load_data_config,
     resolve_default_coco_image_dir,
 )
+from ..tasks import normalize_task
 from ..utils.serialization import (
     REQUIRED_CHECKPOINT_METADATA_KEYS,
     SCHEMA_VERSION,
@@ -217,6 +223,16 @@ class BaseTrainer(ABC):
         self.config = self._config_class().from_kwargs(**kwargs)
         self.model = model
         self.wrapper_model = wrapper_model
+        wrapper_explicit_keys = (
+            getattr(wrapper_model, "_active_train_explicit_keys", None)
+            if wrapper_model is not None
+            else None
+        )
+        self._explicit_train_config_keys = frozenset(
+            kwargs.keys()
+            if wrapper_explicit_keys is None
+            else wrapper_explicit_keys
+        )
         self.callbacks = TrainCallbackList(callbacks)
         for logger_callback in resolve_loggers(loggers):
             self.callbacks.append(logger_callback)
@@ -243,9 +259,17 @@ class BaseTrainer(ABC):
         self.world_size = get_world_size()
         self.is_distributed = is_distributed()
 
-        # Per-rank seed so dataloader/aug RNG differs across ranks.
-        if self.is_distributed and getattr(self.config, "seed", None) is not None:
-            seed = seed_for_rank(int(self.config.seed))
+        # Seed every trainer, with a rank offset under DDP so Python, NumPy,
+        # Torch, CUDA, samplers, and workers can derive one coherent stream.
+        configured_seed = getattr(self.config, "seed", None)
+        if configured_seed is not None and int(configured_seed) >= 0:
+            seed = (
+                seed_for_rank(int(configured_seed))
+                if self.is_distributed
+                else int(configured_seed)
+            )
+            random.seed(seed)
+            np.random.seed(seed % 2**32)
             torch.manual_seed(seed)
             if torch.cuda.is_available():
                 torch.cuda.manual_seed_all(seed)
@@ -257,6 +281,8 @@ class BaseTrainer(ABC):
         self.start_epoch = 0
         self.current_epoch = 0
         self.current_iter = 0
+        self.optimizer_step_count = 0
+        self._optimizer_step_count_restored = False
 
         # Metric tracking
         self.best_mAP50_95 = 0.0
@@ -326,6 +352,24 @@ class BaseTrainer(ABC):
         if self._accum_steps > 1:
             steps = max(1, math.ceil(steps / self._accum_steps))
         return steps
+
+    def _per_rank_batch_size(self) -> int:
+        """Resolve the exact local batch represented by the global config."""
+        batch = int(self.config.batch)
+        world_size = max(int(getattr(self, "world_size", 1)), 1)
+        if batch <= 0:
+            raise ValueError(f"batch must be positive after setup, got {batch}")
+        if world_size > 1 and batch % world_size != 0:
+            raise ValueError(
+                f"Global batch={batch} must be divisible by world_size={world_size}; "
+                "choose a divisible batch so DDP does not silently change it"
+            )
+        per_rank_batch = batch // world_size
+        if per_rank_batch <= 0:
+            raise ValueError(
+                f"Global batch={batch} is smaller than world_size={world_size}"
+            )
+        return per_rank_batch
 
     @property
     def input_size(self) -> Tuple[int, int]:
@@ -532,9 +576,17 @@ class BaseTrainer(ABC):
                 nesterov=self.config.nesterov,
             )
         elif opt_name == "adam":
-            optimizer = torch.optim.Adam(param_groups, lr=lr)
+            optimizer = torch.optim.Adam(
+                param_groups,
+                lr=lr,
+                betas=(self.config.momentum, 0.999),
+            )
         elif opt_name == "adamw":
-            optimizer = torch.optim.AdamW(param_groups, lr=lr)
+            optimizer = torch.optim.AdamW(
+                param_groups,
+                lr=lr,
+                betas=(self.config.momentum, 0.999),
+            )
         else:
             raise ValueError(f"Unknown optimizer: {opt_name}")
 
@@ -571,6 +623,12 @@ class BaseTrainer(ABC):
     def _setup_distillation(self):
         """Set up knowledge distillation when ``config.distill_model`` is set."""
         if not getattr(self.config, "distill_model", None):
+            if getattr(self, "_resume_distiller_state", None) is not None:
+                logger.warning(
+                    "Resume checkpoint contains distiller state, but distillation "
+                    "is disabled"
+                )
+                self._resume_distiller_state = None
             return
 
         from ..distillation import Distiller
@@ -642,18 +700,43 @@ class BaseTrainer(ABC):
                 self.distiller.loss_modules.load_state_dict(deferred_state)
                 logger.info("Distiller adapter state restored from resume checkpoint")
             except Exception as e:
-                logger.warning(f"Could not load deferred distiller state: {e}")
+                raise RuntimeError(f"Cannot resume distiller state: {e}") from e
             finally:
                 self._resume_distiller_state = None
 
         # Add distiller's learnable params (align/generation convs) to optimizer
-        distill_params = list(self.distiller.loss_modules.parameters())
-        if distill_params:
+        distill_decay = []
+        distill_no_decay = []
+        for name, param in self.distiller.loss_modules.named_parameters():
+            if not param.requires_grad:
+                continue
+            if param.ndim <= 1 or name.endswith(".bias"):
+                distill_no_decay.append(param)
+            else:
+                distill_decay.append(param)
+        if distill_decay:
             self.optimizer.add_param_group(
-                {"params": distill_params, "lr": self.effective_lr}
+                {
+                    "params": distill_decay,
+                    "lr": self.effective_lr,
+                    "weight_decay": self.config.weight_decay,
+                }
             )
+        if distill_no_decay:
+            self.optimizer.add_param_group(
+                {
+                    "params": distill_no_decay,
+                    "lr": self.effective_lr,
+                    "weight_decay": 0.0,
+                }
+            )
+        distill_param_count = len(distill_decay) + len(distill_no_decay)
+        if distill_param_count:
             logger.info(
-                f"Added {len(distill_params)} distillation params to optimizer"
+                "Added %d distillation params to optimizer (%d decay, %d no-decay)",
+                distill_param_count,
+                len(distill_decay),
+                len(distill_no_decay),
             )
 
     def _sync_distiller_grads(self):
@@ -675,6 +758,12 @@ class BaseTrainer(ABC):
                 param.grad /= world_size
 
     def _get_save_dir(self) -> Path:
+        resume_save_dir = getattr(self, "_resume_save_dir", None)
+        if resume_save_dir is not None:
+            save_dir = Path(resume_save_dir)
+            save_dir.mkdir(parents=True, exist_ok=True)
+            return save_dir
+
         project = Path(self.config.project)
         name = self.config.name
 
@@ -865,7 +954,7 @@ class BaseTrainer(ABC):
 
         # ``batch`` is the global batch under DDP. Each rank's loader is built
         # with ``batch // world_size``.
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
@@ -876,6 +965,7 @@ class BaseTrainer(ABC):
                 rank=self.rank,
                 shuffle=True,
                 drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
             )
 
         self.train_loader = create_dataloader(
@@ -885,6 +975,9 @@ class BaseTrainer(ABC):
             shuffle=True,
             pin_memory=self.device.type == "cuda",
             sampler=sampler,
+            seed=self.config.seed,
+            rank=self.rank,
+            distributed=self.is_distributed,
         )
 
         if is_main_process():
@@ -961,7 +1054,7 @@ class BaseTrainer(ABC):
             cutmix=getattr(self.config, "cutmix", 0.0),
         )
 
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         if per_rank_batch < 2:
             raise ValueError(
                 "Classification training needs an effective per-rank batch size >= 2 "
@@ -980,6 +1073,7 @@ class BaseTrainer(ABC):
                 rank=self.rank,
                 shuffle=True,
                 drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
             )
 
         # Under DDP each rank only sees ``len(sampler)`` samples, so base the
@@ -999,6 +1093,11 @@ class BaseTrainer(ABC):
             pin_memory=self.device.type == "cuda",
             collate_fn=collate_fn,
             drop_last=visible_samples >= per_rank_batch,
+            **dataloader_seed_kwargs(
+                self.config.seed,
+                rank=self.rank,
+                distributed=self.is_distributed,
+            ),
         )
 
         if is_main_process():
@@ -1085,7 +1184,7 @@ class BaseTrainer(ABC):
             wrapper.nb_classes = num_classes
             wrapper.names = dict(train_dataset.names)
 
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
@@ -1096,6 +1195,7 @@ class BaseTrainer(ABC):
                 rank=self.rank,
                 shuffle=True,
                 drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
             )
 
         try:
@@ -1111,6 +1211,11 @@ class BaseTrainer(ABC):
             pin_memory=self.device.type == "cuda",
             collate_fn=semantic_collate_fn,
             drop_last=visible_samples >= per_rank_batch,
+            **dataloader_seed_kwargs(
+                self.config.seed,
+                rank=self.rank,
+                distributed=self.is_distributed,
+            ),
         )
 
         if is_main_process():
@@ -1164,7 +1269,7 @@ class BaseTrainer(ABC):
             self.wrapper_model.nb_classes = 1
             self.wrapper_model.names = {0: "depth"}
 
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
@@ -1175,6 +1280,7 @@ class BaseTrainer(ABC):
                 rank=self.rank,
                 shuffle=True,
                 drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
             )
 
         try:
@@ -1190,6 +1296,11 @@ class BaseTrainer(ABC):
             pin_memory=self.device.type == "cuda",
             collate_fn=depth_collate_fn,
             drop_last=visible_samples >= per_rank_batch,
+            **dataloader_seed_kwargs(
+                self.config.seed,
+                rank=self.rank,
+                distributed=self.is_distributed,
+            ),
         )
 
         if is_main_process():
@@ -1231,7 +1342,7 @@ class BaseTrainer(ABC):
             self.wrapper_model.nb_classes = 1
             self.wrapper_model.names = {0: "image"}
 
-        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        per_rank_batch = self._per_rank_batch_size()
         sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
@@ -1242,6 +1353,7 @@ class BaseTrainer(ABC):
                 rank=self.rank,
                 shuffle=True,
                 drop_last=len(train_dataset) >= self.world_size,
+                seed=distributed_sampler_seed(self.config.seed),
             )
 
         try:
@@ -1257,6 +1369,11 @@ class BaseTrainer(ABC):
             pin_memory=self.device.type == "cuda",
             collate_fn=restore_collate_fn,
             drop_last=visible_samples >= per_rank_batch,
+            **dataloader_seed_kwargs(
+                self.config.seed,
+                rank=self.rank,
+                distributed=self.is_distributed,
+            ),
         )
 
         if is_main_process():
@@ -1383,7 +1500,7 @@ class BaseTrainer(ABC):
         # converged model (issue #484). Warn (do not silently change behavior)
         # so users of BatchNorm families can enable sync_bn.
         if self.is_distributed and not getattr(self.config, "sync_bn", False):
-            per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+            per_rank_batch = self._per_rank_batch_size()
             has_batchnorm = any(
                 isinstance(m, nn.modules.batchnorm._BatchNorm)
                 for m in self.model.modules()
@@ -1400,10 +1517,38 @@ class BaseTrainer(ABC):
                 )
 
         self._setup_data()
+        if self.train_loader is None or len(self.train_loader) == 0:
+            raise ValueError(
+                "Training dataloader has zero batches; reduce batch size, add "
+                "training samples, or reduce world_size"
+            )
+        deferred_model_state = getattr(self, "_resume_model_state", None)
+        if deferred_model_state is not None:
+            self._load_resume_model_state(deferred_model_state)
+            self._resume_model_state = None
         self._apply_freeze_config()
         self.optimizer = self._setup_optimizer()
         self._setup_distillation()
         self.lr_scheduler = self.create_scheduler(self._scheduler_steps_per_epoch())
+
+        deferred_scheduler_state = getattr(self, "_resume_scheduler_state", None)
+        if deferred_scheduler_state is not None:
+            load_scheduler_state = getattr(self.lr_scheduler, "load_state_dict", None)
+            if callable(load_scheduler_state):
+                try:
+                    load_scheduler_state(deferred_scheduler_state)
+                    logger.info("Scheduler state restored from resume checkpoint")
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Cannot resume scheduler state: {exc}"
+                    ) from exc
+            else:
+                raise RuntimeError(
+                    "Cannot resume scheduler state: "
+                    f"{type(self.lr_scheduler).__name__} does not support "
+                    "load_state_dict()"
+                )
+            self._resume_scheduler_state = None
 
         # resume() may be called before setup() when the optimizer doesn't exist
         # yet. Apply the deferred state now so momentum buffers are restored before
@@ -1413,7 +1558,7 @@ class BaseTrainer(ABC):
                 self.optimizer.load_state_dict(self._resume_optimizer_state)
                 logger.info("Optimizer state restored from resume checkpoint")
             except Exception as e:
-                logger.warning(f"Could not load deferred optimizer state: {e}")
+                raise RuntimeError(f"Cannot resume optimizer state: {e}") from e
             finally:
                 self._resume_optimizer_state = None
 
@@ -1454,31 +1599,56 @@ class BaseTrainer(ABC):
                     ema_tau,
                 )
 
-        # Save-dir creation, config dump, and TB writer all live on rank 0.
-        # The resolved name (which may include an auto-increment suffix when
-        # exist_ok=False and a previous run exists) is broadcast to other
-        # ranks so every rank's ``self.save_dir`` agrees and event-level
-        # paths emitted by callbacks are consistent.
-        if is_main_process():
-            self.save_dir = self._get_save_dir()
-            self.config.to_yaml(self.save_dir / "train_config.yaml")
-            logger.info(f"Saving to: {self.save_dir}")
+        deferred_ema_state = getattr(self, "_resume_ema_state", None)
+        if deferred_ema_state is not None:
+            if self.ema_model is None:
+                logger.warning(
+                    "Resume checkpoint contains EMA state, but EMA is disabled"
+                )
+            else:
+                try:
+                    self.ema_model.ema.load_state_dict(deferred_ema_state)
+                    self.ema_model.updates = int(
+                        getattr(self, "_resume_ema_updates", 0)
+                    )
+                    logger.info("EMA state restored from resume checkpoint")
+                except Exception as exc:
+                    raise RuntimeError(f"Cannot resume EMA state: {exc}") from exc
+            self._resume_ema_state = None
+            self._resume_ema_updates = None
+
+        deferred_scaler_state = getattr(self, "_resume_scaler_state", None)
+        if deferred_scaler_state is not None:
+            if self.scaler is None:
+                logger.warning(
+                    "Resume checkpoint contains GradScaler state, but AMP is disabled"
+                )
+            else:
+                try:
+                    self.scaler.load_state_dict(deferred_scaler_state)
+                    logger.info("GradScaler state restored from resume checkpoint")
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Cannot resume GradScaler state: {exc}"
+                    ) from exc
+            self._resume_scaler_state = None
+
+        # Create and persist the output location once. All ranks receive either
+        # the resolved path or the rank-zero failure, avoiding a peer hang when
+        # filesystem setup fails.
+        def setup_output_dir() -> str:
+            save_dir = self._get_save_dir()
+            self.config.to_yaml(save_dir / "train_config.yaml")
+            logger.info(f"Saving to: {save_dir}")
             logger.info(
                 f"Tip: watch this run live in your browser with "
-                f"`libreyolo monitor {self.save_dir}`"
+                f"`libreyolo monitor {save_dir}`"
             )
-        else:
-            self.save_dir = Path(self.config.project) / self.config.name
+            return str(save_dir)
 
-        if self.is_distributed:
-            import torch.distributed as _dist
-
-            container = [str(self.save_dir)] if is_main_process() else [None]
-            _dist.broadcast_object_list(container, src=0)
-            self.save_dir = Path(container[0])
-
-        # Wait for rank 0 to finish dir creation before any rank proceeds.
-        barrier()
+        self.save_dir = Path(
+            run_rank_zero_phase("training output setup", setup_output_dir)
+        )
 
         # Optional training-step profiler (opt-in via config.profile). Built on
         # the main process; emits the breakdown + Chrome trace into save_dir.
@@ -1521,6 +1691,15 @@ class BaseTrainer(ABC):
                         "workers": self.config.workers,
                     },
                 )
+
+        deferred_rng_state = getattr(self, "_resume_rng_state", None)
+        if deferred_rng_state is not None:
+            try:
+                self._restore_rng_state(deferred_rng_state)
+                logger.info("RNG state restored from resume checkpoint")
+            except Exception as exc:
+                raise RuntimeError(f"Cannot resume RNG state: {exc}") from exc
+            self._resume_rng_state = None
 
         self._is_setup = True
 
@@ -1577,12 +1756,13 @@ class BaseTrainer(ABC):
                 logger.info(f"Learning rate: {self.effective_lr}")
 
             start_event = self._build_train_start_event()
-            # Artifact + user callbacks fire on rank 0 only — they write
-            # files (results.json, TensorBoard, etc.) that would race on
-            # shared paths otherwise.
-            if is_main_process():
+            # Callbacks execute on rank 0 because they may write shared files.
+            # Every rank joins the phase so user callback failures propagate.
+            def on_train_start() -> None:
                 self._dispatch_artifact_callbacks("on_train_start", start_event)
                 self.callbacks.on_train_start(start_event)
+
+            run_rank_zero_phase("on_train_start callback", on_train_start)
 
             no_aug_start = self.config.epochs - self.config.no_aug_epochs
             if self.config.no_aug_epochs > 0 and self.start_epoch > no_aug_start:
@@ -1641,26 +1821,17 @@ class BaseTrainer(ABC):
                     epoch_seconds=epoch_seconds,
                 )
                 self.epoch_events.append(event)
-                if is_main_process():
+                def on_train_epoch_end() -> None:
                     self._dispatch_artifact_callbacks("on_train_epoch_end", event)
                     self.callbacks.on_train_epoch_end(event)
 
-                # Early-stop decision lives on rank 0 only (patience_counter
-                # is updated from val_metrics, which only rank 0 receives).
-                # We broadcast the stop flag so every rank exits the loop in
-                # lockstep — otherwise non-rank-0 ranks proceed into the
-                # next epoch's collective backward() and deadlock.
-                # Patience is measured in EPOCHS since the last metric
-                # improvement. ``best_epoch`` is the 1-based epoch of the best
-                # result, so this stays meaningful even when validation only
-                # runs on an interval (unlike counting discrete val events).
-                epochs_since_best = (
-                    (epoch + 1) - self.best_epoch if self.best_epoch else 0
-                )
+                run_rank_zero_phase("on_train_epoch_end callback", on_train_epoch_end)
+
+                # Patience counts completed validation opportunities. With an
+                # eval interval, unevaluated epochs must not consume patience.
                 should_stop = (
                     self.config.patience > 0
-                    and self.best_epoch > 0
-                    and epochs_since_best >= self.config.patience
+                    and self.patience_counter >= self.config.patience
                 )
                 if self.is_distributed:
                     import torch.distributed as _dist
@@ -1677,15 +1848,13 @@ class BaseTrainer(ABC):
                     if is_main_process():
                         logger.info(
                             f"Early stopping triggered after {epoch + 1} epochs "
-                            f"(patience={self.config.patience}, no improvement for {epochs_since_best} epochs)"
+                            f"(patience={self.config.patience}, no improvement for "
+                            f"{self.patience_counter} validation opportunities)"
                         )
                     break
 
                 if getattr(self, "_stop_training", False):
                     break
-
-            if getattr(self, "distiller", None) is not None:
-                self.distiller.cleanup()
 
             total_time = time.time() - start_time
             if is_main_process():
@@ -1702,21 +1871,32 @@ class BaseTrainer(ABC):
 
             results = self._build_train_results()
             end_event = self._build_train_end_event(total_time, results)
-            if is_main_process():
+            def on_train_end() -> None:
                 self._dispatch_artifact_callbacks("on_train_end", end_event)
                 self.callbacks.on_train_end(end_event)
+
+            run_rank_zero_phase("on_train_end callback", on_train_end)
             return results
 
         except BaseException as exc:
             elapsed_seconds = time.time() - start_time
             exception_event = self._build_train_exception_event(exc, elapsed_seconds)
-            if is_main_process():
+            def on_train_exception() -> None:
                 self._dispatch_artifact_callbacks("on_train_exception", exception_event)
                 try:
                     self.callbacks.on_train_exception(exception_event)
                 except Exception:
                     logger.exception("Training exception callback failed")
+
+            run_rank_zero_phase("on_train_exception callback", on_train_exception)
             raise
+        finally:
+            distiller = getattr(self, "distiller", None)
+            if distiller is not None:
+                try:
+                    distiller.cleanup()
+                except Exception:
+                    logger.exception("Distillation cleanup failed")
 
     def _dispatch_artifact_callbacks(self, method_name: str, event) -> None:
         try:
@@ -2071,8 +2251,61 @@ class BaseTrainer(ABC):
     def _initialize_scheduler_lr(self) -> None:
         if self.optimizer is None or self.lr_scheduler is None:
             return
-        init_iter = getattr(self, "start_epoch", 0) * self._scheduler_steps_per_epoch()
+        init_iter = int(getattr(self, "optimizer_step_count", 0))
+        if not getattr(self, "_optimizer_step_count_restored", False):
+            init_iter = (
+                getattr(self, "start_epoch", 0)
+                * self._scheduler_steps_per_epoch()
+            )
+            self.optimizer_step_count = init_iter
         self._set_optimizer_lr(self.lr_scheduler.update_lr(init_iter))
+
+    def _run_optimizer_step(self) -> bool:
+        """Step the optimizer and report whether AMP actually applied it."""
+        if self.scaler is None:
+            self.optimizer.step()
+            return True
+
+        get_scale = getattr(self.scaler, "get_scale", None)
+        scale_before = float(get_scale()) if callable(get_scale) else None
+        self.scaler.step(self.optimizer)
+        self.scaler.update()
+        if scale_before is None:
+            # Lightweight test/custom scalers may not expose scale state. Their
+            # step contract has no observable skip signal, so preserve legacy
+            # behavior and treat the call as successful.
+            return True
+        scale_after = float(get_scale())
+        return scale_after >= scale_before
+
+    def _advance_optimizer_dependent_state(self, step_succeeded: bool) -> float:
+        """Advance counters, EMA, and LR only after a real optimizer update."""
+        if not step_succeeded:
+            return float(self.optimizer.param_groups[0].get("lr", 0.0))
+        self.optimizer_step_count = int(
+            getattr(self, "optimizer_step_count", 0)
+        ) + 1
+        if getattr(self, "ema_model", None) is not None:
+            self.ema_model.update(self.model)
+        if getattr(self, "lr_scheduler", None) is not None:
+            lr = self.lr_scheduler.update_lr(self.optimizer_step_count)
+            self._set_optimizer_lr(lr)
+            return float(lr)
+        return float(self.optimizer.param_groups[0].get("lr", 0.0))
+
+    def _normalize_accumulated_gradients(self, divisor: float) -> None:
+        """Normalize a sample-summed accumulation window exactly once."""
+        if not math.isfinite(divisor) or divisor <= 0:
+            raise ValueError(
+                f"gradient accumulation divisor must be finite and positive, got {divisor!r}"
+            )
+        seen: set[int] = set()
+        for group in self.optimizer.param_groups:
+            for param in group.get("params", ()):
+                if param.grad is None or id(param) in seen:
+                    continue
+                seen.add(id(param))
+                param.grad.div_(divisor)
 
     def _gradient_clip_parameters(self) -> List[torch.nn.Parameter]:
         if self.optimizer is None:
@@ -2134,6 +2367,7 @@ class BaseTrainer(ABC):
         total_loss = 0.0
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
+        lr = float(self.optimizer.param_groups[0].get("lr", 0.0))
 
         # getattr: test doubles may bypass BaseTrainer.__init__, same as _profiler.
         distiller = getattr(self, "distiller", None)
@@ -2195,8 +2429,7 @@ class BaseTrainer(ABC):
                         self.scaler.unscale_(self.optimizer)
                         self._clip_gradients()
                 with self._prof_phase("optimizer"):
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
+                    step_succeeded = self._run_optimizer_step()
             else:
                 with self._prof_phase("forward"):
                     outputs = self.on_forward(imgs, targets, polygons=polygons)
@@ -2216,14 +2449,12 @@ class BaseTrainer(ABC):
                     self._sync_distiller_grads()
                     self._clip_gradients()
                 with self._prof_phase("optimizer"):
-                    self.optimizer.step()
+                    step_succeeded = self._run_optimizer_step()
 
             if distiller is not None:
                 distiller.step()
 
-            # EMA
-            if self.ema_model is not None:
-                self.ema_model.update(self.model)
+            lr = self._advance_optimizer_dependent_state(step_succeeded)
 
             # Logging captures the pre-scale value so single-GPU and DDP
             # report identical magnitudes (single-GPU semantics). ``.item()``
@@ -2238,9 +2469,6 @@ class BaseTrainer(ABC):
 
             del outputs, loss
 
-            # LR update
-            lr = self.lr_scheduler.update_lr(self.current_iter + 1)
-            self._set_optimizer_lr(lr)
             num_batches += 1
 
             # Progress bar
@@ -2287,11 +2515,14 @@ class BaseTrainer(ABC):
     ) -> Tuple[float, Optional[Dict[str, Any]], Dict[str, float], Dict[str, float]]:
         """``_train_epoch`` variant with gradient accumulation enabled.
 
-        Accumulates gradients over ``accum`` micro-batches before each optimizer
-        step. The micro-batch loss is divided by the accumulation window so the
-        summed gradient equals the mean over the effective batch; the optimizer
-        step, gradient clipping, EMA update and LR scheduler each advance once
-        per optimizer step. Reached only when ``_accum_steps > 1``.
+        Weights each already-reduced micro-batch loss by its image count, then
+        divides once by the local/global window sample count. This makes short
+        or variable-size windows exact for per-image-mean losses and prevents a
+        one-image tail batch from weighing as much as a full batch. Losses that
+        normalize separate terms by positives, boxes, or pixels cannot in
+        general be recomposed exactly without unreduced numerator metadata;
+        equal-size production windows retain their established semantics.
+        Optimizer, clipping, EMA, and LR advance once per successful update.
         """
         self.model.train()
         self._enforce_frozen_bn_eval()
@@ -2314,7 +2545,7 @@ class BaseTrainer(ABC):
         total_loss = 0.0
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
-        actual_window = accum
+        window_local_samples = 0
         lr = self.optimizer.param_groups[0]["lr"]
 
         # getattr: test doubles may bypass BaseTrainer.__init__, same as _profiler.
@@ -2346,7 +2577,11 @@ class BaseTrainer(ABC):
 
             if batch_idx % accum == 0:
                 self.optimizer.zero_grad(set_to_none=True)
-                actual_window = min(accum, len(self.train_loader) - batch_idx)
+                window_local_samples = 0
+            batch_samples = int(imgs.shape[0])
+            if batch_samples <= 0:
+                raise ValueError("gradient accumulation received an empty micro-batch")
+            window_local_samples += batch_samples
 
             # Teacher forward (no-grad). Under AMP it runs in autocast too, so
             # the frozen teacher doesn't pay full-precision compute each step.
@@ -2359,10 +2594,9 @@ class BaseTrainer(ABC):
 
             # Forward + backward. Gradients accumulate across the window; the
             # optimizer step, clipping, EMA and LR update fire only on the
-            # window boundary (``is_opt_step``). The division by the window
-            # keeps mean semantics across micro-batches; under DDP no further
-            # rescaling is needed (losses are mean-normalized, so DDP's
-            # gradient averaging is already correct — see scale_loss_for_ddp).
+            # window boundary (``is_opt_step``). Image-count weighting corrects
+            # per-image-mean losses and partial batches; DDP's gradient average
+            # is paired with the global average sample count below.
             if self.scaler is not None:
                 with self._prof_phase("forward"):
                     with autocast("cuda"):
@@ -2376,18 +2610,23 @@ class BaseTrainer(ABC):
                             total_loss_raw,
                             context=f"Epoch {epoch + 1} batch {batch_idx + 1}",
                         )
-                        loss = total_loss_raw / actual_window
+                        loss = total_loss_raw * batch_samples
                 loss = scale_loss_for_ddp(loss)
                 with self._prof_phase("backward"):
                     self.scaler.scale(loss).backward()
                 if is_opt_step:
                     with self._prof_phase("optimizer"):
                         self._sync_distiller_grads()
+                        self.scaler.unscale_(self.optimizer)
+                        sample_divisor = all_reduce_avg_scalar(
+                            window_local_samples,
+                            device=self.device,
+                            min_value=1.0,
+                        )
+                        self._normalize_accumulated_gradients(sample_divisor)
                         if self._should_clip_gradients():
-                            self.scaler.unscale_(self.optimizer)
                             self._clip_gradients()
-                        self.scaler.step(self.optimizer)
-                        self.scaler.update()
+                        step_succeeded = self._run_optimizer_step()
             else:
                 with self._prof_phase("forward"):
                     outputs = self.on_forward(imgs, targets, polygons=polygons)
@@ -2400,26 +2639,27 @@ class BaseTrainer(ABC):
                         total_loss_raw,
                         context=f"Epoch {epoch + 1} batch {batch_idx + 1}",
                     )
-                    loss = total_loss_raw / actual_window
+                    loss = total_loss_raw * batch_samples
                 loss = scale_loss_for_ddp(loss)
                 with self._prof_phase("backward"):
                     loss.backward()
                 if is_opt_step:
                     with self._prof_phase("optimizer"):
                         self._sync_distiller_grads()
+                        sample_divisor = all_reduce_avg_scalar(
+                            window_local_samples,
+                            device=self.device,
+                            min_value=1.0,
+                        )
+                        self._normalize_accumulated_gradients(sample_divisor)
                         self._clip_gradients()
-                        self.optimizer.step()
+                        step_succeeded = self._run_optimizer_step()
 
             if distiller is not None:
                 distiller.step()
 
             if is_opt_step:
-                # EMA
-                if self.ema_model is not None:
-                    self.ema_model.update(self.model)
-                # LR update
-                lr = self.lr_scheduler.update_lr(opt_step + 1)
-                self._set_optimizer_lr(lr)
+                lr = self._advance_optimizer_dependent_state(step_succeeded)
 
             # Logging uses the raw pre-scale value (single-GPU semantics).
             loss_val = float(total_loss_raw.detach().item())
@@ -2493,17 +2733,10 @@ class BaseTrainer(ABC):
     def _validate_epoch(
         self, epoch: int, *, save_plots: bool | None = None
     ) -> Optional[Dict[str, Any]]:
-        # First-cut policy: validation runs on rank 0 only. Non-zero ranks
-        # barrier-wait so the next epoch's set_epoch fires in lockstep.
-        # Rank 0 barriers once at the bottom regardless of outcome.
-        if self.is_distributed and not is_main_process():
-            barrier()
-            return None
-        try:
-            return self._run_validation(epoch, save_plots=save_plots)
-        finally:
-            if self.is_distributed:
-                barrier()
+        return run_rank_zero_phase(
+            f"validation epoch {epoch + 1}",
+            lambda: self._run_validation(epoch, save_plots=save_plots),
+        )
 
     def _run_validation(
         self, epoch: int, *, save_plots: bool | None = None
@@ -2543,7 +2776,7 @@ class BaseTrainer(ABC):
 
             val_config = ValidationConfig(
                 data=self.config.data,
-                batch_size=max(1, self.config.batch // max(getattr(self, "world_size", 1), 1)),
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,
                 iou_thres=0.65,
@@ -2637,7 +2870,7 @@ class BaseTrainer(ABC):
             logger.info(f"Running classification validation for epoch {epoch + 1}")
             val_config = ValidationConfig(
                 data=self.config.data,
-                batch_size=max(1, self.config.batch // max(getattr(self, "world_size", 1), 1)),
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 device=str(self.device),
                 half=self.config.amp and self.device.type == "cuda",
@@ -2694,7 +2927,7 @@ class BaseTrainer(ABC):
             logger.info(f"Running semantic validation for epoch {epoch + 1}")
             val_config = ValidationConfig(
                 data=self.config.data,
-                batch_size=max(1, self.config.batch // max(getattr(self, "world_size", 1), 1)),
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 device=str(self.device),
                 half=self.config.amp and self.device.type == "cuda",
@@ -2751,7 +2984,7 @@ class BaseTrainer(ABC):
             logger.info(f"Running depth validation for epoch {epoch + 1}")
             val_config = ValidationConfig(
                 data=self.config.data,
-                batch_size=max(1, self.config.batch // max(getattr(self, "world_size", 1), 1)),
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 device=str(self.device),
                 half=self.config.amp and self.device.type == "cuda",
@@ -2809,7 +3042,7 @@ class BaseTrainer(ABC):
             logger.info(f"Running restore validation for epoch {epoch + 1}")
             val_config = ValidationConfig(
                 data=self.config.data,
-                batch_size=max(1, self.config.batch // max(getattr(self, "world_size", 1), 1)),
+                batch_size=self._per_rank_batch_size(),
                 imgsz=self.config.imgsz,
                 device=str(self.device),
                 half=self.config.amp and self.device.type == "cuda",
@@ -2856,6 +3089,97 @@ class BaseTrainer(ABC):
     # Checkpointing
     # =========================================================================
 
+    def _capture_rng_state(self) -> Dict[str, Any]:
+        """Capture weights-only-safe RNG state for the current rank."""
+        python_version, python_keys, python_gauss = random.getstate()
+        numpy_state = np.random.get_state()
+        state: Dict[str, Any] = {
+            "python": {
+                "version": int(python_version),
+                "keys": torch.tensor(python_keys, dtype=torch.int64),
+                "gauss": python_gauss,
+            },
+            "numpy": {
+                "keys": torch.from_numpy(
+                    numpy_state[1].astype("int64", copy=True)
+                ),
+                "pos": int(numpy_state[2]),
+                "has_gauss": int(numpy_state[3]),
+                "cached_gaussian": float(numpy_state[4]),
+            },
+            "torch": torch.get_rng_state(),
+        }
+        loader_generator = getattr(
+            getattr(self, "train_loader", None), "generator", None
+        )
+        if loader_generator is not None:
+            state["train_loader_generator"] = loader_generator.get_state()
+        if torch.cuda.is_available() and self.device.type == "cuda":
+            state["cuda"] = torch.cuda.get_rng_state(self.device)
+        return state
+
+    def _gather_rng_states(self) -> List[Dict[str, Any]]:
+        """Gather each rank's independent RNG stream before a checkpoint."""
+        local_state = self._capture_rng_state()
+        if not is_distributed():
+            return [local_state]
+
+        import torch.distributed as _dist
+
+        gathered: List[Optional[Dict[str, Any]]] = [None] * get_world_size()
+        _dist.all_gather_object(gathered, local_state)
+        if any(state is None for state in gathered):
+            raise RuntimeError("distributed RNG-state gather returned an empty rank")
+        return [state for state in gathered if state is not None]
+
+    def _restore_rng_state(self, rng_state: Dict[str, Any]) -> None:
+        """Restore one rank's Python, NumPy, Torch, and CUDA RNG streams."""
+        python_state = rng_state.get("python")
+        if python_state is not None:
+            random.setstate(
+                (
+                    int(python_state["version"]),
+                    tuple(int(value) for value in python_state["keys"].tolist()),
+                    python_state.get("gauss"),
+                )
+            )
+
+        numpy_state = rng_state.get("numpy")
+        if numpy_state is not None:
+            np.random.set_state(
+                (
+                    "MT19937",
+                    numpy_state["keys"].cpu().numpy().astype("uint32"),
+                    int(numpy_state["pos"]),
+                    int(numpy_state["has_gauss"]),
+                    float(numpy_state["cached_gaussian"]),
+                )
+            )
+
+        torch_state = rng_state.get("torch")
+        if torch_state is not None:
+            torch.set_rng_state(torch_state.cpu())
+
+        loader_state = rng_state.get("train_loader_generator")
+        loader_generator = getattr(
+            getattr(self, "train_loader", None), "generator", None
+        )
+        if loader_state is not None and loader_generator is not None:
+            loader_generator.set_state(loader_state.cpu())
+
+        cuda_state = rng_state.get("cuda")
+        if (
+            cuda_state is not None
+            and torch.cuda.is_available()
+            and self.device.type == "cuda"
+        ):
+            if isinstance(cuda_state, (list, tuple)):
+                # Backward compatibility with checkpoints that captured every
+                # visible CUDA device from a single process.
+                torch.cuda.set_rng_state_all([state.cpu() for state in cuda_state])
+            else:
+                torch.cuda.set_rng_state(cuda_state.cpu(), self.device)
+
     def _save_checkpoint(
         self,
         epoch: int,
@@ -2868,12 +3192,28 @@ class BaseTrainer(ABC):
             raise ValueError(f"Checkpoint loss must be finite, got {loss!r}.")
         loss = loss_value
 
+        rng_states_by_rank = self._gather_rng_states()
+        return run_rank_zero_phase(
+            f"checkpoint epoch {epoch + 1}",
+            lambda: self._write_checkpoint(
+                epoch,
+                loss,
+                val_metrics=val_metrics,
+                is_best=is_best,
+                rng_states_by_rank=rng_states_by_rank,
+            ),
+        )
+
+    def _write_checkpoint(
+        self,
+        epoch: int,
+        loss: float,
+        val_metrics: Optional[Dict[str, Any]] = None,
+        is_best: Optional[bool] = None,
+        rng_states_by_rank: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
         if is_best is None:
             is_best = self._update_best_state(epoch, val_metrics)
-
-        # Only rank 0 writes checkpoint files. Other ranks skip silently.
-        if not is_main_process():
-            return
 
         # Always unwrap DDP/compile wrappers before reading state_dict so the
         # checkpoint is interchangeable with single-GPU runs.
@@ -2941,6 +3281,15 @@ class BaseTrainer(ABC):
         )
         checkpoint["best_metric"] = self.best_mAP50_95
         checkpoint["best_metric_name"] = checkpoint["best_metric_key"]
+        checkpoint["optimizer_step_count"] = int(
+            getattr(self, "optimizer_step_count", 0)
+        )
+        checkpoint["patience_counter"] = int(getattr(self, "patience_counter", 0))
+        scheduler_state_dict = getattr(
+            getattr(self, "lr_scheduler", None), "state_dict", None
+        )
+        if callable(scheduler_state_dict):
+            checkpoint["scheduler"] = scheduler_state_dict()
         if self.ema_model is not None:
             checkpoint["train_model"] = raw_model.state_dict()
             checkpoint["ema"] = self.ema_model.ema.state_dict()
@@ -2958,25 +3307,10 @@ class BaseTrainer(ABC):
                 checkpoint["scaler"] = self.scaler.state_dict()
             except Exception:
                 logger.warning("Could not capture GradScaler state for checkpoint")
-        rng_state: Dict[str, Any] = {"torch": torch.get_rng_state()}
-        if torch.cuda.is_available():
-            rng_state["cuda"] = torch.cuda.get_rng_state_all()
-        try:
-            import numpy as _np
-
-            # Store numpy's MT19937 state in a ``weights_only=True``-safe form
-            # (a torch tensor + primitives). The raw ``get_state()`` tuple holds
-            # a numpy ndarray, which the repo's safe checkpoint loader rejects.
-            _keys, _pos, _has_gauss, _cached = _np.random.get_state()[1:]
-            rng_state["numpy"] = {
-                "keys": torch.from_numpy(_keys.astype("int64", copy=True)),
-                "pos": int(_pos),
-                "has_gauss": int(_has_gauss),
-                "cached_gaussian": float(_cached),
-            }
-        except Exception:
-            pass
-        checkpoint["rng_state"] = rng_state
+        if rng_states_by_rank is None:
+            rng_states_by_rank = [self._capture_rng_state()]
+        checkpoint["rng_states_by_rank"] = rng_states_by_rank
+        checkpoint["rng_state"] = rng_states_by_rank[0]
 
         validate_checkpoint_metadata(checkpoint, strict=True)
 
@@ -3009,9 +3343,199 @@ class BaseTrainer(ABC):
     def _checkpoint_extra_metadata(self) -> Dict[str, Any]:
         return {}
 
+    def _prepare_resume_model_architecture(
+        self,
+        checkpoint: Mapping[str, Any],
+        model_state: Mapping[str, Any],
+    ) -> None:
+        """Rebuild checkpoint-dependent wrapper structure before setup/load."""
+        wrapper = self.wrapper_model
+        if wrapper is None:
+            return
+        checkpoint_nc = checkpoint.get("nc")
+        checkpoint_names = checkpoint.get("names")
+        if checkpoint_nc is None and checkpoint_names is not None:
+            checkpoint_nc = len(checkpoint_names)
+        if checkpoint_nc is None:
+            return
+        checkpoint_nc = int(checkpoint_nc)
+        current_nc = getattr(wrapper, "nb_classes", None)
+        if current_nc is None or int(current_nc) != checkpoint_nc:
+            if getattr(self, "_is_setup", False):
+                raise RuntimeError(
+                    "Cannot resume checkpoint with nc="
+                    f"{checkpoint_nc} after setup() built a {current_nc}-class "
+                    "training graph; create a new trainer and resume before setup()"
+                )
+            rebuild = getattr(wrapper, "_rebuild_for_checkpoint_classes", None)
+            if not callable(rebuild):
+                raise RuntimeError(
+                    "Cannot resume checkpoint with nc="
+                    f"{checkpoint_nc}: wrapper cannot rebuild its class head"
+                )
+            rebuild(checkpoint_nc, model_state)
+            self.model = wrapper.model.to(self.device)
+            wrapper.device = self.device
+        wrapper.nb_classes = checkpoint_nc
+        self.config.num_classes = checkpoint_nc
+        self.num_classes = checkpoint_nc
+        if checkpoint_names is not None:
+            sanitize_names = getattr(wrapper, "_sanitize_names", None)
+            wrapper.names = (
+                sanitize_names(checkpoint_names, checkpoint_nc)
+                if callable(sanitize_names)
+                else build_class_names(checkpoint_nc)
+            )
+
+    def _load_resume_model_state(self, model_state: Mapping[str, Any]) -> None:
+        """Strictly restore training weights after architecture preparation."""
+        try:
+            unwrap_model(self.model).load_state_dict(model_state)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Cannot resume: model architecture mismatch - {exc}"
+            ) from exc
+
+    def _restore_checkpoint_config(self, checkpoint: Mapping[str, Any]) -> None:
+        """Restore saved run settings while preserving explicit runtime choices.
+
+        Arguments explicitly supplied by the current invocation override saved
+        values, including when the supplied value equals the family default.
+        Omitted values inherit the saved value. Dataset/model identity, device,
+        and security/runtime-only controls stay authoritative from the current
+        invocation. The checkpoint path defines the resumed run directory.
+        """
+        saved_config = checkpoint.get("config")
+        if not isinstance(saved_config, Mapping) or getattr(
+            self, "_is_setup", False
+        ):
+            return
+
+        config_class = self._config_class()
+        current = self.config.to_dict()
+        explicit_keys = getattr(self, "_explicit_train_config_keys", ())
+        optimizer_state_keys = {"momentum", "nesterov", "optimizer", "weight_decay"}
+        if "optimizer" in checkpoint:
+            for key in optimizer_state_keys & set(explicit_keys):
+                if key in saved_config and current.get(key) != saved_config[key]:
+                    raise RuntimeError(
+                        f"Cannot resume with {key}={current.get(key)!r}: checkpoint "
+                        f"optimizer state requires {key}={saved_config[key]!r}"
+                    )
+        protected = {
+            "allow_download_scripts",
+            "data",
+            "data_dir",
+            "device",
+            "exist_ok",
+            "name",
+            "num_classes",
+            "profile",
+            "profile_open",
+            "profile_then_stop",
+            "project",
+            "resume",
+            "size",
+        }
+        restored = []
+        for key, saved_value in saved_config.items():
+            if key in protected or key not in current:
+                continue
+            if key in explicit_keys:
+                continue
+            if current[key] != saved_value:
+                current[key] = saved_value
+                restored.append(key)
+
+        if restored:
+            self.config = config_class.from_kwargs(**current)
+            logger.info(
+                "Restored checkpoint training config values: %s",
+                ", ".join(sorted(restored)),
+            )
+
+    def _validate_resume_identity(self, checkpoint: Mapping[str, Any]) -> None:
+        """Reject a resume checkpoint for a different model identity."""
+        expected = {
+            "model_family": str(self.get_model_family()).lower(),
+            "task": normalize_task(
+                getattr(getattr(self, "wrapper_model", None), "task", "detect")
+            ),
+        }
+        current_size = getattr(self.config, "size", None)
+        if current_size is not None:
+            expected["size"] = str(current_size).lower()
+        for key, expected_value in expected.items():
+            actual = checkpoint.get(key)
+            if actual is None:
+                continue
+            actual_value = (
+                normalize_task(actual)
+                if key == "task"
+                else str(actual).strip().lower()
+            )
+            if actual_value != expected_value:
+                raise RuntimeError(
+                    f"Cannot resume: checkpoint {key}={actual!r} does not match "
+                    f"current {key}={expected_value!r}"
+                )
+
+    @staticmethod
+    def _validate_resume_runtime_states(checkpoint: Mapping[str, Any]) -> None:
+        """Reject malformed component states before they can look absent."""
+        for key in ("optimizer", "scheduler", "distiller", "ema", "scaler"):
+            if key in checkpoint and not isinstance(checkpoint[key], Mapping):
+                raise RuntimeError(
+                    f"Cannot resume {key} state: expected a mapping, got "
+                    f"{type(checkpoint[key]).__name__}"
+                )
+
+        if "rng_state" in checkpoint and not isinstance(
+            checkpoint["rng_state"], Mapping
+        ):
+            raise RuntimeError(
+                "Cannot resume RNG state: expected a mapping, got "
+                f"{type(checkpoint['rng_state']).__name__}"
+            )
+
+        if "rng_states_by_rank" in checkpoint:
+            rank_states = checkpoint["rng_states_by_rank"]
+            if (
+                not isinstance(rank_states, (list, tuple))
+                or not rank_states
+                or not all(isinstance(state, Mapping) for state in rank_states)
+            ):
+                raise RuntimeError(
+                    "Cannot resume per-rank RNG state: expected a non-empty "
+                    "sequence of mappings"
+                )
+
     def resume(self, checkpoint_path: str):
-        if not Path(checkpoint_path).exists():
+        checkpoint_path = Path(checkpoint_path).expanduser().resolve()
+        if not checkpoint_path.exists():
             raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint_path}")
+        if getattr(self, "_is_setup", False):
+            raise RuntimeError(
+                "resume() must be called before setup(); create a new trainer "
+                "for this checkpoint so model, optimizer, scheduler, EMA, AMP, "
+                "and distillation state are rebuilt coherently"
+            )
+
+        # Continue writing into the interrupted run instead of auto-incrementing
+        # a sibling directory (for example exp -> exp2). Standard checkpoints
+        # live under <run>/weights; custom checkpoint locations resume beside
+        # the checkpoint itself.
+        self._resume_save_dir = (
+            checkpoint_path.parent.parent
+            if checkpoint_path.parent.name == "weights"
+            else checkpoint_path.parent
+        )
+        self.config.project = str(self._resume_save_dir.parent)
+        self.config.name = self._resume_save_dir.name
+        self.config.exist_ok = True
+        if getattr(self, "_is_setup", False):
+            self._resume_save_dir.mkdir(parents=True, exist_ok=True)
+            self.save_dir = self._resume_save_dir
 
         logger.info(f"Resuming from {checkpoint_path}")
         checkpoint = load_trusted_torch_file(
@@ -3031,15 +3555,44 @@ class BaseTrainer(ABC):
                 SCHEMA_VERSION,
             )
 
-        try:
-            model_state = checkpoint.get("train_model", checkpoint["model"])
-            # Checkpoint state dict is always unwrapped — feed it to the
-            # unwrapped module so the DDP "module." prefix doesn't trip us.
-            unwrap_model(self.model).load_state_dict(model_state)
-        except Exception as e:
-            raise RuntimeError(f"Cannot resume: model architecture mismatch - {e}")
+        if "epoch" not in checkpoint:
+            raise RuntimeError(
+                "Cannot resume: checkpoint has no training epoch/resume state. "
+                "Load it as pretrained weights and use resume=False instead."
+            )
+
+        self._validate_resume_runtime_states(checkpoint)
+        self._validate_resume_identity(checkpoint)
+        self._restore_checkpoint_config(checkpoint)
+
+        model_state = checkpoint.get("train_model", checkpoint["model"])
+        self._prepare_resume_model_architecture(checkpoint, model_state)
+        if getattr(self, "_is_setup", False):
+            self._load_resume_model_state(model_state)
+        else:
+            # setup() may still rebuild dataset-dependent heads or inject LoRA.
+            # Load only after those structural phases and before optimizer setup.
+            self._resume_model_state = model_state
 
         self.start_epoch = checkpoint["epoch"] + 1
+        default_step_count = 0
+        if self.train_loader is not None:
+            default_step_count = self.start_epoch * self._scheduler_steps_per_epoch()
+        has_step_count = "optimizer_step_count" in checkpoint
+        raw_step_count = checkpoint.get("optimizer_step_count", default_step_count)
+        try:
+            self.optimizer_step_count = int(raw_step_count)
+            if self.optimizer_step_count < 0:
+                raise ValueError
+            self._optimizer_step_count_restored = has_step_count
+        except (TypeError, ValueError):
+            if has_step_count:
+                raise RuntimeError(
+                    "Cannot resume: invalid optimizer_step_count="
+                    f"{raw_step_count!r}"
+                )
+            self.optimizer_step_count = default_step_count
+            self._optimizer_step_count_restored = False
 
         if "optimizer" in checkpoint:
             if self.optimizer is not None:
@@ -3047,11 +3600,26 @@ class BaseTrainer(ABC):
                     self.optimizer.load_state_dict(checkpoint["optimizer"])
                     logger.info("Optimizer state restored")
                 except Exception as e:
-                    logger.warning(f"Could not load optimizer state: {e}")
+                    raise RuntimeError(f"Cannot resume optimizer state: {e}") from e
             else:
                 # setup() hasn't run yet — defer until the optimizer exists.
                 self._resume_optimizer_state = checkpoint["optimizer"]
                 logger.info("Optimizer state deferred until after setup()")
+
+        if "scheduler" in checkpoint:
+            load_scheduler_state = getattr(
+                getattr(self, "lr_scheduler", None), "load_state_dict", None
+            )
+            if callable(load_scheduler_state):
+                try:
+                    load_scheduler_state(checkpoint["scheduler"])
+                    logger.info("Scheduler state restored")
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Cannot resume scheduler state: {exc}"
+                    ) from exc
+            else:
+                self._resume_scheduler_state = checkpoint["scheduler"]
 
         if "distiller" in checkpoint:
             if self.distiller is not None:
@@ -3059,16 +3627,18 @@ class BaseTrainer(ABC):
                     self.distiller.loss_modules.load_state_dict(checkpoint["distiller"])
                     logger.info("Distiller adapter state restored")
                 except Exception as e:
-                    logger.warning(f"Could not load distiller state: {e}")
+                    raise RuntimeError(f"Cannot resume distiller state: {e}") from e
             else:
                 # setup() hasn't run yet — defer until the distiller exists.
                 self._resume_distiller_state = checkpoint["distiller"]
                 logger.info("Distiller state deferred until after setup()")
 
+        metric_tracking_compatible = True
         if "best_metric_value" in checkpoint or "best_mAP50_95" in checkpoint:
             checkpoint_metric_key = checkpoint.get("best_metric_key", "metrics/mAP50-95")
             current_metric_key = getattr(self, "best_metric_key", "metrics/mAP50-95")
             if checkpoint_metric_key != current_metric_key:
+                metric_tracking_compatible = False
                 logger.warning(
                     "Checkpoint best metric key %s differs from current key %s. "
                     "Resetting best metric tracking for this run.",
@@ -3111,61 +3681,80 @@ class BaseTrainer(ABC):
             self.best_mAP50 = 0.0
             self.best_epoch = 0
 
-        if self.ema_model and "ema_updates" in checkpoint:
-            if "ema" in checkpoint:
+        if "ema" in checkpoint:
+            if self.ema_model is not None:
                 try:
                     self.ema_model.ema.load_state_dict(checkpoint["ema"])
+                    self.ema_model.updates = int(checkpoint.get("ema_updates", 0))
                     logger.info("EMA weights restored")
                 except Exception as e:
-                    logger.warning(f"Could not load EMA weights: {e}")
-            self.ema_model.updates = checkpoint["ema_updates"]
-            logger.info(f"EMA updates restored: {self.ema_model.updates}")
+                    raise RuntimeError(f"Cannot resume EMA state: {e}") from e
+            else:
+                self._resume_ema_state = checkpoint["ema"]
+                self._resume_ema_updates = int(checkpoint.get("ema_updates", 0))
+                logger.info("EMA state deferred until after setup()")
 
-        # Restore AMP + RNG state when present (backward-compatible: pre-v1.3
-        # checkpoints lack these keys and simply skip this block).
-        if "scaler" in checkpoint and self.scaler is not None:
-            try:
-                self.scaler.load_state_dict(checkpoint["scaler"])
-                logger.info("GradScaler state restored")
-            except Exception as e:
-                logger.warning(f"Could not load GradScaler state: {e}")
+        if "scaler" in checkpoint:
+            if self.scaler is not None:
+                try:
+                    self.scaler.load_state_dict(checkpoint["scaler"])
+                    logger.info("GradScaler state restored")
+                except Exception as e:
+                    raise RuntimeError(f"Cannot resume GradScaler state: {e}") from e
+            else:
+                self._resume_scaler_state = checkpoint["scaler"]
+                logger.info("GradScaler state deferred until after setup()")
 
-        rng_state = checkpoint.get("rng_state")
+        rank_rng_states = checkpoint.get("rng_states_by_rank")
+        if rank_rng_states:
+            current_world_size = get_world_size()
+            if len(rank_rng_states) != current_world_size:
+                logger.warning(
+                    "Checkpoint has RNG state for %d ranks, but current world_size "
+                    "is %d; keeping newly seeded per-rank RNG streams",
+                    len(rank_rng_states),
+                    current_world_size,
+                )
+                rng_state = None
+            else:
+                rng_state = rank_rng_states[get_rank()]
+        else:
+            rng_state = checkpoint.get("rng_state")
+            if rng_state and is_distributed():
+                logger.warning(
+                    "Legacy checkpoint has only rank-zero RNG state; exact "
+                    "per-rank RNG replay is unavailable"
+                )
+                if get_rank() != 0:
+                    rng_state = None
         if rng_state:
-            try:
-                torch_state = rng_state.get("torch")
-                if torch_state is not None:
-                    # map_location may have moved the byte tensor to GPU; the
-                    # RNG setters require CPU ByteTensors.
-                    torch.set_rng_state(torch_state.cpu())
-                cuda_state = rng_state.get("cuda")
-                if cuda_state is not None and torch.cuda.is_available():
-                    torch.cuda.set_rng_state_all([s.cpu() for s in cuda_state])
-                np_state = rng_state.get("numpy")
-                if np_state is not None:
-                    import numpy as _np
+            if getattr(self, "_is_setup", False):
+                try:
+                    self._restore_rng_state(rng_state)
+                    logger.info("RNG state restored")
+                except Exception as e:
+                    raise RuntimeError(f"Cannot resume RNG state: {e}") from e
+            else:
+                # setup() constructs loaders, schedulers, EMA, and AMP objects;
+                # restore afterward so setup-time random draws do not perturb
+                # the resumed stream.
+                self._resume_rng_state = rng_state
+                logger.info("RNG state deferred until after setup()")
 
-                    _np.random.set_state(
-                        (
-                            "MT19937",
-                            np_state["keys"].cpu().numpy().astype("uint32"),
-                            int(np_state["pos"]),
-                            int(np_state["has_gauss"]),
-                            float(np_state["cached_gaussian"]),
-                        )
-                    )
-                logger.info("RNG state restored")
-            except Exception as e:
-                logger.warning(f"Could not restore RNG state: {e}")
-
-        self.patience_counter = 0
+        raw_patience = checkpoint.get("patience_counter", 0)
+        try:
+            self.patience_counter = int(raw_patience)
+            if self.patience_counter < 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            if "patience_counter" in checkpoint:
+                raise RuntimeError(
+                    f"Cannot resume: invalid patience_counter={raw_patience!r}"
+                )
+            self.patience_counter = 0
+        if not metric_tracking_compatible:
+            self.patience_counter = 0
         logger.info(
             f"Resumed from epoch {self.start_epoch} "
             f"(will train to epoch {self.config.epochs})"
         )
-
-        # setup() may have already run (immediate path: setup → resume). Re-sync
-        # the LR now that start_epoch is known — _initialize_scheduler_lr() is
-        # idempotent and fast-forwards to the correct schedule position.
-        if self.lr_scheduler is not None and self.train_loader is not None:
-            self._initialize_scheduler_lr()

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -280,6 +280,49 @@ def test_train_rfdetr_actual_call_uses_reported_defaults(monkeypatch, tmp_path):
     assert data["epochs_completed"] == 100
 
 
+def test_train_passes_explicit_keys_and_maps_val_to_eval_interval(
+    monkeypatch, tmp_path
+):
+    app = _make_app()
+    captured = {}
+
+    class _YOLO9Like:
+        FAMILY = "yolo9"
+        device = "cpu"
+
+        def train(self, data, **kwargs):
+            captured["data"] = data
+            captured["kwargs"] = kwargs
+            return {"output_dir": str(tmp_path / "exp")}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda out, model, model_path, device: _YOLO9Like(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "data=dummy.yaml",
+            "model=LibreYOLO9t.pt",
+            "mosaic=1.0",
+            "val=false",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["data"] == "dummy.yaml"
+    kwargs = captured["kwargs"]
+    assert kwargs["mosaic_prob"] == 1.0
+    assert kwargs["eval_interval"] == 0
+    explicit_keys = set(kwargs["_libreyolo_explicit_train_keys"])
+    assert "mosaic_prob" in explicit_keys
+    assert "eval_interval" in explicit_keys
+
+
 def test_train_rfdetr_scheduler_override_reaches_trainer(monkeypatch, tmp_path):
     app = _make_app()
     captured = {}

--- a/tests/unit/test_data_seeding.py
+++ b/tests/unit/test_data_seeding.py
@@ -1,0 +1,155 @@
+"""Deterministic data-loader, worker, and distributed-sampler seeding."""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import pytest
+import torch
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.distributed import DistributedSampler
+
+from libreyolo.data.dataset import create_dataloader
+from libreyolo.data.seeding import (
+    data_seed_for_rank,
+    dataloader_seed_kwargs,
+    distributed_sampler_seed,
+    seed_data_worker,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _RandomDataset(Dataset):
+    def __len__(self) -> int:
+        return 12
+
+    def __getitem__(self, index: int):
+        return (
+            index,
+            random.randrange(2**31),
+            int(np.random.randint(0, 2**31)),
+            int(torch.randint(0, 2**31, ()).item()),
+        )
+
+
+class _YoloDataset(Dataset):
+    def __len__(self) -> int:
+        return 16
+
+    def __getitem__(self, index: int):
+        return (
+            np.full((3, 2, 2), index, dtype=np.float32),
+            np.zeros((1, 5), dtype=np.float32),
+            (2, 2),
+            index,
+        )
+
+
+def _collect_worker_stream(seed: int, *, rank: int = 0, distributed: bool = False):
+    loader = DataLoader(
+        _RandomDataset(),
+        batch_size=1,
+        shuffle=True,
+        num_workers=2,
+        **dataloader_seed_kwargs(seed, rank=rank, distributed=distributed),
+    )
+    return [tuple(int(value.item()) for value in batch) for batch in loader]
+
+
+def test_worker_streams_reproduce_for_same_seed_and_diverge_by_rank_and_seed():
+    first = _collect_worker_stream(41, rank=0, distributed=True)
+    repeated = _collect_worker_stream(41, rank=0, distributed=True)
+    other_rank = _collect_worker_stream(41, rank=1, distributed=True)
+    other_seed = _collect_worker_stream(42, rank=0, distributed=True)
+
+    assert first == repeated
+    assert first != other_rank
+    assert first != other_seed
+
+    # Compare values by dataset index as well as shuffled order. This proves
+    # Python, NumPy, and Torch worker streams changed, not merely the sampler.
+    first_by_index = {row[0]: row[1:] for row in first}
+    rank_by_index = {row[0]: row[1:] for row in other_rank}
+    seed_by_index = {row[0]: row[1:] for row in other_seed}
+    assert first_by_index != rank_by_index
+    assert first_by_index != seed_by_index
+
+
+def test_create_dataloader_preserves_contract_and_uses_rank_generator():
+    loader = create_dataloader(
+        _YoloDataset(),
+        batch_size=4,
+        num_workers=0,
+        shuffle=True,
+        pin_memory=False,
+        seed=17,
+        rank=2,
+        distributed=True,
+    )
+
+    assert loader.batch_size == 4
+    assert loader.drop_last is True
+    assert loader.worker_init_fn is seed_data_worker
+    assert loader.generator.initial_seed() == data_seed_for_rank(
+        17, rank=2, distributed=True
+    )
+
+    ambient_loader = create_dataloader(
+        _YoloDataset(),
+        batch_size=4,
+        num_workers=0,
+        pin_memory=False,
+        seed=None,
+    )
+    assert ambient_loader.generator is None
+    assert ambient_loader.worker_init_fn is None
+
+
+def test_distributed_sampler_uses_common_seed_and_partitions_one_permutation():
+    dataset = list(range(12))
+    seed = distributed_sampler_seed(73)
+    samplers = [
+        DistributedSampler(
+            dataset,
+            num_replicas=2,
+            rank=rank,
+            shuffle=True,
+            seed=seed,
+            drop_last=False,
+        )
+        for rank in range(2)
+    ]
+    for sampler in samplers:
+        sampler.set_epoch(4)
+
+    partitions = [list(sampler) for sampler in samplers]
+    assert set(partitions[0]).isdisjoint(partitions[1])
+    assert sorted(partitions[0] + partitions[1]) == dataset
+
+    repeated = DistributedSampler(
+        dataset,
+        num_replicas=2,
+        rank=0,
+        shuffle=True,
+        seed=distributed_sampler_seed(73),
+        drop_last=False,
+    )
+    repeated.set_epoch(4)
+    changed = DistributedSampler(
+        dataset,
+        num_replicas=2,
+        rank=0,
+        shuffle=True,
+        seed=distributed_sampler_seed(74),
+        drop_last=False,
+    )
+    changed.set_epoch(4)
+
+    assert list(repeated) == partitions[0]
+    assert list(changed) != partitions[0]
+    assert distributed_sampler_seed(73) == distributed_sampler_seed(73)
+    assert data_seed_for_rank(73, rank=0, distributed=True) != data_seed_for_rank(
+        73, rank=1, distributed=True
+    )

--- a/tests/unit/test_ddp_count_normalization.py
+++ b/tests/unit/test_ddp_count_normalization.py
@@ -1,0 +1,240 @@
+"""CPU/Gloo regressions for globally count-normalized DDP losses."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import socket
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+pytestmark = pytest.mark.unit
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _distributed_average(value: torch.Tensor) -> float:
+    reduced = value.detach().clone()
+    dist.all_reduce(reduced)
+    return float((reduced / dist.get_world_size()).item())
+
+
+def _semantic_case(rank: int, loss_function) -> dict[str, float]:
+    logits = torch.tensor(
+        [[[[2.0, 0.0, -1.0, 3.0]], [[0.0, 1.0, 2.0, -2.0]]]],
+        requires_grad=True,
+    )
+    if rank == 0:
+        targets = torch.full((1, 1, 4), 255, dtype=torch.long)
+    else:
+        targets = torch.tensor([[[0, 1, 1, 0]]], dtype=torch.long)
+
+    loss = loss_function(logits, targets, ignore_index=255)
+    local_sum = F.cross_entropy(
+        logits,
+        targets,
+        ignore_index=255,
+        reduction="sum",
+    ).detach()
+    local_count = (targets != 255).sum().to(dtype=torch.float32)
+    global_sum = local_sum.clone()
+    global_count = local_count.clone()
+    dist.all_reduce(global_sum)
+    dist.all_reduce(global_count)
+    expected = float((global_sum / global_count).item())
+    averaged = _distributed_average(loss)
+
+    loss.backward()
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+    return {"averaged": averaged, "expected": expected}
+
+
+def _dfine_mask_case(rank: int) -> dict[str, float]:
+    from libreyolo.models.dfine.loss import DFINECriterion
+    from libreyolo.training.distributed import all_reduce_avg_scalar
+
+    instance_count = 1 if rank == 0 else 3
+    logit_value = -3.0 if rank == 0 else 3.0
+    pred_masks = torch.full(
+        (1, instance_count, 2, 2),
+        logit_value,
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+    target_masks = torch.ones(instance_count, 2, 2)
+    targets = [
+        {
+            "labels": torch.zeros(instance_count, dtype=torch.long),
+            "boxes": torch.tensor(
+                [[0.5, 0.5, 1.0, 1.0]] * instance_count,
+                dtype=torch.float32,
+            ),
+            "masks": target_masks,
+        }
+    ]
+    matched = torch.arange(instance_count, dtype=torch.long)
+    indices = [(matched, matched)]
+    normalizer = all_reduce_avg_scalar(
+        instance_count,
+        device=pred_masks.device,
+        min_value=1.0,
+    )
+
+    criterion = DFINECriterion(
+        matcher=None,
+        weight_dict={},
+        losses=["masks"],
+        num_classes=1,
+    )
+    losses = criterion.loss_masks(
+        {"pred_masks": pred_masks},
+        targets,
+        indices,
+        normalizer,
+    )
+
+    bce_per_instance = F.binary_cross_entropy_with_logits(
+        pred_masks[0],
+        target_masks,
+        reduction="none",
+    ).mean(dim=(1, 2))
+    probabilities = pred_masks[0].sigmoid().flatten(1)
+    target_flat = target_masks.flatten(1)
+    intersection = (probabilities * target_flat).sum(dim=1)
+    denominator = probabilities.sum(dim=1) + target_flat.sum(dim=1) + 1e-6
+    dice_per_instance = 1.0 - (2.0 * intersection + 1e-6) / denominator
+
+    local_bce_sum = bce_per_instance.sum().detach()
+    local_dice_sum = dice_per_instance.sum().detach()
+    global_bce_sum = local_bce_sum.clone()
+    global_dice_sum = local_dice_sum.clone()
+    global_count = torch.tensor(float(instance_count))
+    dist.all_reduce(global_bce_sum)
+    dist.all_reduce(global_dice_sum)
+    dist.all_reduce(global_count)
+
+    result = {
+        "bce_averaged": _distributed_average(losses["loss_mask_bce"]),
+        "bce_expected": float((global_bce_sum / global_count).item()),
+        "dice_averaged": _distributed_average(losses["loss_mask_dice"]),
+        "dice_expected": float((global_dice_sum / global_count).item()),
+        "normalizer": normalizer,
+    }
+    (losses["loss_mask_bce"] + losses["loss_mask_dice"]).backward()
+    assert pred_masks.grad is not None
+    assert torch.isfinite(pred_masks.grad).all()
+    return result
+
+
+def _sparse_count_normalizer_case(rank: int) -> dict[str, float]:
+    from libreyolo.models.deim.loss import DEIMCriterion
+    from libreyolo.models.ec.pose_loss import ECPoseCriterion
+    from libreyolo.models.rfdetr.loss import SetCriterion
+
+    local_count = rank
+    device = torch.device("cpu")
+    ec_criterion = ECPoseCriterion.__new__(ECPoseCriterion)
+    targets = [{"labels": torch.zeros(local_count, dtype=torch.long)}]
+    matched = torch.arange(local_count, dtype=torch.long)
+    indices = [(matched, matched)]
+
+    return {
+        "deim": DEIMCriterion._global_count_normalizer(local_count, device),
+        # DEIMv2 inherits this exact normalization seam and calls it from its
+        # own forward without importing the restricted backbone package here.
+        "deimv2": DEIMCriterion._global_count_normalizer(local_count, device),
+        "rfdetr": SetCriterion._global_count_normalizer(local_count, device),
+        "ec": ec_criterion._global_count_normalizer(local_count, device),
+        "ec_boxes": ec_criterion._num_boxes(targets, device),
+        "ec_indices": ec_criterion._num_index_pairs(indices, device),
+    }
+
+
+def _count_normalization_worker(
+    rank: int,
+    world_size: int,
+    port: int,
+    output_dir: str,
+) -> None:
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        from libreyolo.models.rfdetr.nn import (
+            _semantic_cross_entropy as dinov2_semantic_loss,
+        )
+        from libreyolo.models.segformer.nn import (
+            _semantic_cross_entropy as segformer_semantic_loss,
+        )
+
+        record = {
+            "dinov2": _semantic_case(rank, dinov2_semantic_loss),
+            "segformer": _semantic_case(rank, segformer_semantic_loss),
+            "dfine_masks": _dfine_mask_case(rank),
+            "sparse_counts": _sparse_count_normalizer_case(rank),
+        }
+        (Path(output_dir) / f"rank-{rank}.json").write_text(
+            json.dumps(record, sort_keys=True),
+            encoding="utf-8",
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize(("count", "expected"), [(0, 1.0), (1, 1.0), (3, 3.0)])
+def test_sparse_count_normalizers_preserve_single_process_behavior(count, expected):
+    from libreyolo.models.deim.loss import DEIMCriterion
+    from libreyolo.models.ec.pose_loss import ECPoseCriterion
+    from libreyolo.models.rfdetr.loss import SetCriterion
+
+    device = torch.device("cpu")
+    assert DEIMCriterion._global_count_normalizer(count, device) == expected
+    assert SetCriterion._global_count_normalizer(count, device) == expected
+    assert ECPoseCriterion._global_count_normalizer(count, device) == expected
+
+
+def test_ddp_losses_match_true_global_count_weighted_means(tmp_path):
+    world_size = 2
+    mp.spawn(
+        _count_normalization_worker,
+        args=(world_size, _free_port(), str(tmp_path)),
+        nprocs=world_size,
+        join=True,
+    )
+
+    records = [
+        json.loads((tmp_path / f"rank-{rank}.json").read_text(encoding="utf-8"))
+        for rank in range(world_size)
+    ]
+    assert records[0] == records[1]
+    for family in ("dinov2", "segformer"):
+        assert records[0][family]["averaged"] == pytest.approx(
+            records[0][family]["expected"], abs=1e-6
+        )
+
+    mask_result = records[0]["dfine_masks"]
+    assert mask_result["normalizer"] == pytest.approx(2.0)
+    assert mask_result["bce_averaged"] == pytest.approx(
+        mask_result["bce_expected"], abs=1e-6
+    )
+    assert mask_result["dice_averaged"] == pytest.approx(
+        mask_result["dice_expected"], abs=1e-6
+    )
+
+    for normalizer in records[0]["sparse_counts"].values():
+        assert normalizer == pytest.approx(0.5)

--- a/tests/unit/test_ddp_count_normalization.py
+++ b/tests/unit/test_ddp_count_normalization.py
@@ -172,7 +172,7 @@ def _count_normalization_worker(
         init_method=f"tcp://127.0.0.1:{port}",
         rank=rank,
         world_size=world_size,
-        timeout=timedelta(seconds=30),
+        timeout=timedelta(minutes=2),
     )
     try:
         from libreyolo.models.rfdetr.nn import (

--- a/tests/unit/test_ddp_distributed.py
+++ b/tests/unit/test_ddp_distributed.py
@@ -573,6 +573,66 @@ def test_parse_device_arg_and_wants_distributed():
     assert not wants_distributed("auto")
 
 
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("libreyolo.models.rfdetr.model", "LibreRFDETR"),
+        ("libreyolo.models.dinov2.model", "LibreDINOv2"),
+    ],
+)
+def test_alias_batch_is_normalized_before_rfdetr_family_spawn(
+    monkeypatch, module_name, class_name
+):
+    """RF-DETR-family wrappers must resolve ``batch`` before AutoBatch runs."""
+    module = __import__(module_name, fromlist=[class_name])
+    wrapper_class = getattr(module, class_name)
+    model = object.__new__(wrapper_class)
+    spawned = []
+
+    def fake_spawn(model_instance, train_kw, nprocs, *, devices, batch_key):
+        spawned.append(
+            {
+                "model": model_instance,
+                "train_kw": train_kw,
+                "nprocs": nprocs,
+                "devices": devices,
+                "batch_key": batch_key,
+            }
+        )
+        return {"spawned": True}
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        "libreyolo.training.distributed.has_torchrun_env", lambda: False
+    )
+    monkeypatch.setattr(
+        "libreyolo.training.ddp_spawn.spawn_for_model", fake_spawn
+    )
+
+    result = wrapper_class.train(
+        model,
+        "data.yaml",
+        batch=-1,
+        device="0,1",
+    )
+
+    assert result == {"spawned": True}
+    assert len(spawned) == 1
+    assert spawned[0]["train_kw"]["batch_size"] == -1
+    assert "batch" not in spawned[0]["train_kw"]
+    assert spawned[0]["batch_key"] == "batch_size"
+
+    with pytest.raises(ValueError, match="Conflicting batch values"):
+        wrapper_class.train(
+            model,
+            "data.yaml",
+            batch_size=8,
+            batch=-1,
+            device="0,1",
+        )
+    assert len(spawned) == 1
+
+
 def test_syncbn_weights_land_in_no_weight_decay_group():
     """Regression: SyncBatchNorm is a sibling of BatchNorm2d (both subclass
     ``_BatchNorm``), not a subclass of it. An ``isinstance(v, nn.BatchNorm2d)``
@@ -1210,3 +1270,103 @@ def test_spawn_for_model_writes_flat_state_dict(tmp_path):
     assert all(isinstance(v, torch.Tensor) for v in obj.values()), (
         "all values in the bootstrap state dict must be tensors"
     )
+
+
+def test_spawn_for_model_restores_with_shared_wrapper_helper(monkeypatch, tmp_path):
+    """The parent wrapper should use the same best-then-last restore contract."""
+    import json
+
+    from libreyolo.training.ddp_spawn import spawn_for_model
+
+    checkpoint = tmp_path / "best.pt"
+    checkpoint.touch()
+
+    class _Wrapper:
+        def __init__(self):
+            self.model = nn.Linear(4, 2)
+            self.model_path = None
+            self.device = torch.device("cpu")
+            self.restore_calls = []
+
+        def _restore_after_training(self, result):
+            self.restore_calls.append((result, self.device))
+
+    model_instance = _Wrapper()
+
+    def fake_spawn(worker_fn, spawn_args, nprocs, result_path, **kwargs):
+        Path(result_path).write_text(
+            json.dumps({"best_checkpoint": str(checkpoint)})
+        )
+
+    monkeypatch.setattr(
+        "libreyolo.training.distributed.spawn_ddp_train", fake_spawn
+    )
+    monkeypatch.setattr(
+        "libreyolo.training.ddp_spawn._build_init_kw", lambda model: {}
+    )
+    monkeypatch.setattr(
+        "libreyolo.training.ddp_spawn._filter_picklable", lambda kwargs: kwargs
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    result = spawn_for_model(
+        model_instance,
+        train_kw={},
+        nprocs=2,
+        devices=[0, 1],
+    )
+
+    assert result == {"best_checkpoint": str(checkpoint)}
+    assert model_instance.restore_calls == [(result, torch.device("cpu"))]
+
+
+def test_spawn_for_model_fallback_uses_absolute_checkpoint(
+    monkeypatch, tmp_path
+):
+    """Legacy wrappers without the shared helper still receive an absolute path."""
+    import json
+
+    from libreyolo.training.ddp_spawn import spawn_for_model
+
+    checkpoint = tmp_path / "last.pt"
+    checkpoint.touch()
+    monkeypatch.chdir(tmp_path)
+
+    class _LegacyWrapper:
+        def __init__(self):
+            self.model = nn.Linear(4, 2)
+            self.model_path = None
+            self.device = torch.device("cpu")
+            self.loaded_paths = []
+
+        def _load_weights(self, path):
+            self.loaded_paths.append(path)
+
+    model_instance = _LegacyWrapper()
+
+    def fake_spawn(worker_fn, spawn_args, nprocs, result_path, **kwargs):
+        Path(result_path).write_text(json.dumps({"last_checkpoint": "last.pt"}))
+
+    monkeypatch.setattr(
+        "libreyolo.training.distributed.spawn_ddp_train", fake_spawn
+    )
+    monkeypatch.setattr(
+        "libreyolo.training.ddp_spawn._build_init_kw", lambda model: {}
+    )
+    monkeypatch.setattr(
+        "libreyolo.training.ddp_spawn._filter_picklable", lambda kwargs: kwargs
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    result = spawn_for_model(
+        model_instance,
+        train_kw={},
+        nprocs=2,
+        devices=[0, 1],
+    )
+
+    expected = str(checkpoint.resolve())
+    assert result == {"last_checkpoint": "last.pt"}
+    assert model_instance.model_path == expected
+    assert model_instance.loaded_paths == [expected]
+    assert model_instance.model.training is False

--- a/tests/unit/test_dfine_deim_amp_step_gating.py
+++ b/tests/unit/test_dfine_deim_amp_step_gating.py
@@ -1,0 +1,219 @@
+"""AMP optimizer-step gating for D-FINE and DEIM trainer overrides."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+
+class _Loader:
+    def __init__(self, num_batches: int):
+        self.dataset = SimpleNamespace()
+        self.collate_fn = None
+        self._batches = [
+            (
+                torch.zeros(1, 1),
+                torch.zeros(1, 1, 5),
+                ((1, 1),),
+                (index,),
+            )
+            for index in range(num_batches)
+        ]
+
+    def __iter__(self):
+        return iter(self._batches)
+
+    def __len__(self) -> int:
+        return len(self._batches)
+
+
+class _VariableLoader(_Loader):
+    def __init__(self):
+        self.dataset = SimpleNamespace()
+        self.collate_fn = None
+        self._batches = [
+            (
+                torch.ones(4, 1),
+                torch.zeros(4, 1, 5),
+                ((1, 1),) * 4,
+                tuple(range(4)),
+            ),
+            (
+                torch.full((1, 1), 10.0),
+                torch.zeros(1, 1, 5),
+                ((1, 1),),
+                (4,),
+            ),
+        ]
+
+
+class _Progress:
+    def __init__(self, iterable):
+        self.iterable = iterable
+
+    def __iter__(self):
+        return iter(self.iterable)
+
+    def set_postfix(self, values) -> None:
+        del values
+
+
+class _SequencedScaler:
+    """Minimal GradScaler double: skip one step, then apply one step."""
+
+    def __init__(self):
+        self._scale = 8.0
+        self._outcomes = iter((False, True))
+        self._last_step_succeeded = False
+        self.optimizer_steps = 0
+        self.update_calls = 0
+
+    def scale(self, loss):
+        return loss
+
+    def get_scale(self) -> float:
+        return self._scale
+
+    def unscale_(self, optimizer) -> None:
+        del optimizer
+
+    def step(self, optimizer) -> None:
+        self._last_step_succeeded = next(self._outcomes)
+        if self._last_step_succeeded:
+            optimizer.step()
+            self.optimizer_steps += 1
+
+    def update(self) -> None:
+        self.update_calls += 1
+        if not self._last_step_succeeded:
+            self._scale /= 2.0
+
+
+class _EMA:
+    def __init__(self):
+        self.updates = 0
+
+    def update(self, model) -> None:
+        del model
+        self.updates += 1
+
+
+class _Scheduler:
+    def __init__(self):
+        self.calls: list[int] = []
+
+    def update_lr(self, step: int) -> float:
+        self.calls.append(step)
+        return 0.05
+
+
+@pytest.mark.parametrize("family", ["dfine", "deim"])
+@pytest.mark.parametrize("accum_steps", [1, 2])
+def test_amp_skip_does_not_advance_optimizer_dependent_state(
+    family,
+    accum_steps,
+    monkeypatch,
+):
+    module = importlib.import_module(f"libreyolo.models.{family}.trainer")
+    trainer_class = getattr(module, f"{family.upper()}Trainer")
+    monkeypatch.setattr(
+        module,
+        "autocast",
+        lambda *args, **kwargs: contextlib.nullcontext(),
+    )
+    monkeypatch.setattr(
+        module,
+        "tqdm",
+        lambda iterable, **kwargs: _Progress(iterable),
+    )
+
+    trainer = trainer_class.__new__(trainer_class)
+    trainer.config = SimpleNamespace(
+        epochs=1,
+        clip_max_norm=0.0,
+        eval_interval=-1,
+        batch=1,
+        nbs=accum_steps,
+    )
+    trainer.device = torch.device("cpu")
+    trainer.model = torch.nn.Linear(1, 1, bias=False)
+    with torch.no_grad():
+        trainer.model.weight.fill_(1.0)
+    trainer.optimizer = torch.optim.SGD(
+        [
+            {
+                "params": trainer.model.parameters(),
+                "lr": 0.2,
+                "lr_mult": 0.5,
+            }
+        ],
+        lr=0.2,
+    )
+    trainer.scaler = _SequencedScaler()
+    trainer.ema_model = _EMA()
+    trainer.lr_scheduler = _Scheduler()
+    trainer.optimizer_step_count = 0
+    trainer._frozen_bn_modules = []
+    trainer.train_loader = _Loader(num_batches=2 if accum_steps == 1 else 4)
+    trainer.get_loss_components = lambda outputs: {}
+    trainer.on_forward = lambda imgs, targets, polygons=None: {
+        "total_loss": trainer.model.weight.sum()
+    }
+
+    _, val_metrics, loss_components, lrs = trainer_class._train_epoch(trainer, 0)
+
+    assert val_metrics is None
+    assert loss_components == {}
+    assert trainer.scaler.update_calls == 2
+    assert trainer.scaler.optimizer_steps == 1
+    assert trainer.optimizer_step_count == 1
+    assert trainer.ema_model.updates == 1
+    assert trainer.lr_scheduler.calls == [1]
+    assert trainer.model.weight.item() == pytest.approx(0.8)
+    assert lrs == {"group0": pytest.approx(0.025)}
+
+
+@pytest.mark.parametrize("family", ["dfine", "deim"])
+def test_variable_microbatches_are_sample_weighted(family, monkeypatch):
+    module = importlib.import_module(f"libreyolo.models.{family}.trainer")
+    trainer_class = getattr(module, f"{family.upper()}Trainer")
+    monkeypatch.setattr(
+        module,
+        "tqdm",
+        lambda iterable, **kwargs: _Progress(iterable),
+    )
+
+    trainer = trainer_class.__new__(trainer_class)
+    trainer.config = SimpleNamespace(
+        epochs=1,
+        clip_max_norm=0.0,
+        eval_interval=-1,
+        batch=1,
+        nbs=2,
+    )
+    trainer.device = torch.device("cpu")
+    trainer.model = torch.nn.Linear(1, 1, bias=False)
+    with torch.no_grad():
+        trainer.model.weight.fill_(1.0)
+    trainer.optimizer = torch.optim.SGD(trainer.model.parameters(), lr=0.1)
+    trainer.scaler = None
+    trainer.ema_model = None
+    trainer.lr_scheduler = _Scheduler()
+    trainer.optimizer_step_count = 0
+    trainer._frozen_bn_modules = []
+    trainer.train_loader = _VariableLoader()
+    trainer.get_loss_components = lambda outputs: {}
+    trainer.on_forward = lambda imgs, targets, polygons=None: {
+        "total_loss": trainer.model(imgs).mean()
+    }
+
+    trainer_class._train_epoch(trainer, 0)
+
+    # Combined gradient is (4 * 1 + 1 * 10) / 5 = 2.8.
+    assert trainer.model.weight.item() == pytest.approx(0.72)

--- a/tests/unit/test_distillation.py
+++ b/tests/unit/test_distillation.py
@@ -6,6 +6,8 @@ hooks, losses, channel adaptation, and the full distiller pipeline work
 correctly without requiring real YOLO weights.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn as nn
@@ -14,8 +16,21 @@ from libreyolo.distillation.hooks import FeatureHookManager, _resolve_module
 from libreyolo.distillation.losses import MGDLoss, CWDLoss
 from libreyolo.distillation.distiller import Distiller
 from libreyolo.distillation.configs import get_distill_config, list_supported
+from libreyolo.training.trainer import BaseTrainer
 
 pytestmark = pytest.mark.unit
+
+
+def test_disabled_distillation_discards_deferred_resume_state(caplog):
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(distill_model=None),
+        _resume_distiller_state={"adapter.weight": torch.ones(1)},
+    )
+
+    BaseTrainer._setup_distillation(trainer)
+
+    assert trainer._resume_distiller_state is None
+    assert "distillation is disabled" in caplog.text
 
 
 # =============================================================================
@@ -304,6 +319,26 @@ class TestDistiller:
         )
         return distiller, teacher, student
 
+    @staticmethod
+    def _single_scale_components():
+        teacher = DummyModel(channels=(8, 8, 8))
+        student = DummyModel(channels=(8, 8, 8))
+        teacher_config = {
+            "tap_points": ["neck.p3"],
+            "channels": [8],
+            "strides": [8],
+        }
+        student_config = {
+            "tap_points": ["neck.p3"],
+            "channels": [8],
+            "strides": [8],
+        }
+        return teacher, student, teacher_config, student_config
+
+    @staticmethod
+    def _forward_hook_count(model):
+        return sum(len(module._forward_hooks) for module in model.modules())
+
     def test_mgd_pipeline(self):
         distiller, teacher, student = self._make_distiller("mgd")
         x = torch.randn(2, 3, 16, 16)
@@ -345,6 +380,145 @@ class TestDistiller:
                 student_config={"tap_points": ["neck.p3"], "channels": [64], "strides": [16]},
             )
 
+    @pytest.mark.parametrize(
+        "tau",
+        [0.0, -1.0, float("nan"), float("inf"), float("-inf")],
+    )
+    def test_invalid_cwd_tau_is_rejected_before_side_effects(self, tau):
+        teacher, student, teacher_config, student_config = self._single_scale_components()
+        teacher.train()
+
+        with pytest.raises(ValueError, match="tau"):
+            Distiller(
+                teacher_model=teacher,
+                student_model=student,
+                teacher_config=teacher_config,
+                student_config=student_config,
+                loss_type="cwd",
+                tau=tau,
+            )
+
+        assert teacher.training
+        assert all(parameter.requires_grad for parameter in teacher.parameters())
+        assert self._forward_hook_count(teacher) == 0
+        assert self._forward_hook_count(student) == 0
+
+    @pytest.mark.parametrize(
+        "mask_ratio",
+        [-0.1, 1.0, 1.1, float("nan"), float("inf"), float("-inf")],
+    )
+    def test_invalid_mgd_mask_ratio_is_rejected_before_side_effects(self, mask_ratio):
+        teacher, student, teacher_config, student_config = self._single_scale_components()
+        teacher.train()
+
+        with pytest.raises(ValueError, match="mask_ratio"):
+            Distiller(
+                teacher_model=teacher,
+                student_model=student,
+                teacher_config=teacher_config,
+                student_config=student_config,
+                loss_type="mgd",
+                mask_ratio=mask_ratio,
+            )
+
+        assert teacher.training
+        assert all(parameter.requires_grad for parameter in teacher.parameters())
+        assert self._forward_hook_count(teacher) == 0
+        assert self._forward_hook_count(student) == 0
+
+    @pytest.mark.parametrize(
+        ("argument", "value"),
+        [
+            ("loss_weight", -0.1),
+            ("loss_weight", float("nan")),
+            ("loss_weight", float("inf")),
+            ("per_scale_weight", [-0.1]),
+            ("per_scale_weight", [float("nan")]),
+            ("per_scale_weight", [float("inf")]),
+        ],
+    )
+    def test_invalid_weights_are_rejected_before_hooks(self, argument, value):
+        teacher, student, teacher_config, student_config = self._single_scale_components()
+
+        with pytest.raises(ValueError, match=argument):
+            Distiller(
+                teacher_model=teacher,
+                student_model=student,
+                teacher_config=teacher_config,
+                student_config=student_config,
+                **{argument: value},
+            )
+
+        assert self._forward_hook_count(teacher) == 0
+        assert self._forward_hook_count(student) == 0
+
+    @pytest.mark.parametrize(
+        ("config_name", "field", "value"),
+        [
+            ("teacher_config", "channels", []),
+            ("student_config", "tap_points", []),
+        ],
+    )
+    def test_misaligned_config_lengths_are_rejected_before_hooks(
+        self, config_name, field, value
+    ):
+        teacher, student, teacher_config, student_config = self._single_scale_components()
+        configs = {
+            "teacher_config": teacher_config,
+            "student_config": student_config,
+        }
+        configs[config_name][field] = value
+
+        with pytest.raises(ValueError, match=config_name):
+            Distiller(
+                teacher_model=teacher,
+                student_model=student,
+                **configs,
+            )
+
+        assert self._forward_hook_count(teacher) == 0
+        assert self._forward_hook_count(student) == 0
+
+    def test_all_tap_points_are_resolved_before_hooks_are_installed(self):
+        teacher, student, teacher_config, student_config = self._single_scale_components()
+        teacher_config = {
+            "tap_points": ["neck.p3", "neck.p4"],
+            "channels": [8, 8],
+            "strides": [8, 16],
+        }
+        student_config = {
+            "tap_points": ["neck.p3", "neck.missing"],
+            "channels": [8, 8],
+            "strides": [8, 16],
+        }
+
+        with pytest.raises(AttributeError, match="neck.missing"):
+            Distiller(
+                teacher_model=teacher,
+                student_model=student,
+                teacher_config=teacher_config,
+                student_config=student_config,
+            )
+
+        assert self._forward_hook_count(teacher) == 0
+        assert self._forward_hook_count(student) == 0
+
+    def test_unknown_loss_is_rejected_before_hooks_are_installed(self):
+        teacher, student, teacher_config, student_config = self._single_scale_components()
+
+        with pytest.raises(ValueError, match="Unknown loss type"):
+            Distiller(
+                teacher_model=teacher,
+                student_model=student,
+                teacher_config=teacher_config,
+                student_config=student_config,
+                loss_type="unknown",
+                loss_weight=1.0,
+            )
+
+        assert self._forward_hook_count(teacher) == 0
+        assert self._forward_hook_count(student) == 0
+
     def test_compute_loss_without_forward_raises(self):
         distiller, _, _ = self._make_distiller()
         with pytest.raises(RuntimeError, match="Expected"):
@@ -356,11 +530,38 @@ class TestDistiller:
 
         distiller.teacher_forward(x)
         student(x)
+        assert distiller.s_hooks.get_feature_list()[0].grad_fn is not None
         distiller.cleanup()
 
-        # After cleanup, hooks should be removed
+        assert distiller._teacher_feats is None
+        assert len(distiller.t_hooks.get_feature_list()) == 0
+        assert len(distiller.s_hooks.get_feature_list()) == 0
+        assert self._forward_hook_count(teacher) == 0
+        assert self._forward_hook_count(student) == 0
+
+        # Later forwards must not repopulate released feature references.
         student(x)
         assert len(distiller.s_hooks.get_feature_list()) == 0
+
+    def test_step_clears_microbatch_features_without_invalidating_loss(self):
+        teacher, student, teacher_config, student_config = self._single_scale_components()
+        distiller = Distiller(
+            teacher_model=teacher,
+            student_model=student,
+            teacher_config=teacher_config,
+            student_config=student_config,
+        )
+        x = torch.randn(1, 3, 8, 8)
+
+        distiller.teacher_forward(x)
+        student(x)
+        loss = distiller.compute_loss()
+        distiller.step()
+
+        assert len(distiller.t_hooks.get_feature_list()) == 0
+        assert len(distiller.s_hooks.get_feature_list()) == 0
+        loss.backward()
+        assert student.neck.p3.weight.grad is not None
 
     def test_multiple_steps(self):
         distiller, teacher, student = self._make_distiller()

--- a/tests/unit/test_distillation_dinov2.py
+++ b/tests/unit/test_distillation_dinov2.py
@@ -147,6 +147,21 @@ def test_foundation_distiller_step_clears_teacher_feats():
     assert distiller._teacher_feats is None
 
 
+def test_foundation_distiller_cleanup_clears_features_and_is_idempotent():
+    student, distiller = _make_foundation_distiller()
+    imgs = torch.rand(1, 3, 112, 112)
+    distiller.teacher_forward(imgs)
+    student(imgs)
+
+    assert distiller._teacher_feats is not None
+    assert distiller.s_hooks.get_feature_list()[0].grad_fn is not None
+    distiller.cleanup()
+    distiller.cleanup()
+
+    assert distiller._teacher_feats is None
+    assert distiller.s_hooks.get_feature_list() == []
+
+
 def test_compute_loss_without_teacher_forward_raises():
     student, distiller = _make_foundation_distiller()
     student(torch.rand(1, 3, 112, 112))

--- a/tests/unit/test_distributed_rank_zero_phase.py
+++ b/tests/unit/test_distributed_rank_zero_phase.py
@@ -116,6 +116,99 @@ def _rank_zero_phase_worker(
         dist.destroy_process_group()
 
 
+def _rank_zero_validation_worker(
+    rank: int,
+    world_size: int,
+    port: int,
+    output_dir: str,
+) -> None:
+    """Prove rank-zero validation bypasses the live DDP forward wrapper."""
+    output = Path(output_dir)
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        from libreyolo.training.trainer import BaseTrainer
+
+        class _BufferModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 1, bias=False)
+                self.register_buffer("offset", torch.tensor([0.5]))
+
+            def forward(self, inputs):
+                return self.linear(inputs) + self.offset
+
+        torch.manual_seed(7)
+        ddp_model = torch.nn.parallel.DistributedDataParallel(_BufferModel())
+        ddp_model.train()
+
+        class _Wrapper:
+            def __init__(self, model):
+                self.model = model
+
+        class _ValidationProbe:
+            _validate_epoch = BaseTrainer._validate_epoch
+            _run_rank_zero_validation = BaseTrainer._run_rank_zero_validation
+
+            def _run_validation(self, epoch, *, save_plots=None):
+                del epoch, save_plots
+                if isinstance(
+                    self.model,
+                    torch.nn.parallel.DistributedDataParallel,
+                ):
+                    raise AssertionError("rank-zero validation entered DDP.forward")
+                if self.model is not ddp_model.module:
+                    raise AssertionError("validation did not receive the DDP module")
+                if self.wrapper_model.model is not self.model:
+                    raise AssertionError("wrapper still references the DDP model")
+                self.model.eval()
+                with torch.no_grad():
+                    prediction = self.model(torch.ones(1, 2))
+                (output / f"validation-called-rank-{rank}").write_text(
+                    "complete",
+                    encoding="utf-8",
+                )
+                return {
+                    "owner": rank,
+                    "prediction": float(prediction.item()),
+                }
+
+        trainer = _ValidationProbe()
+        trainer.model = ddp_model
+        trainer.wrapper_model = _Wrapper(ddp_model)
+        result = trainer._validate_epoch(0)
+
+        restored = (
+            trainer.model is ddp_model
+            and trainer.wrapper_model.model is ddp_model
+            and trainer.model.training
+            and trainer.model.module.training
+        )
+        with torch.no_grad():
+            post_validation = ddp_model(torch.ones(1, 2))
+        collective = torch.tensor(1, dtype=torch.int64)
+        dist.all_reduce(collective)
+        (output / f"validation-rank-{rank}.json").write_text(
+            json.dumps(
+                {
+                    "result": result,
+                    "restored": restored,
+                    "post_validation": float(post_validation.item()),
+                    "collective": int(collective.item()),
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+    finally:
+        dist.destroy_process_group()
+
+
 def test_rank_zero_phase_preserves_non_distributed_behavior():
     from libreyolo.training.distributed import run_rank_zero_phase
 
@@ -181,3 +274,32 @@ def test_rank_zero_phase_broadcasts_success_and_failure_on_cpu_gloo(tmp_path):
     assert "local object" in serialization_failures[0]["root_message"].lower()
     assert all(record["reached_after_failure"] == world_size for record in records)
     assert all(record["recovered"] == "recovered" for record in records)
+
+
+def test_rank_zero_validation_unwraps_ddp_on_cpu_gloo(tmp_path):
+    world_size = 2
+    mp.spawn(
+        _rank_zero_validation_worker,
+        args=(world_size, _free_port(), str(tmp_path)),
+        nprocs=world_size,
+        join=True,
+    )
+
+    records = [
+        json.loads(
+            (tmp_path / f"validation-rank-{rank}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for rank in range(world_size)
+    ]
+    assert records[0]["result"] == records[1]["result"]
+    assert records[0]["result"]["owner"] == 0
+    assert all(record["restored"] for record in records)
+    assert all(record["collective"] == world_size for record in records)
+    assert records[0]["post_validation"] == pytest.approx(
+        records[1]["post_validation"]
+    )
+    assert sorted(
+        path.name for path in tmp_path.glob("validation-called-rank-*")
+    ) == ["validation-called-rank-0"]

--- a/tests/unit/test_distributed_rank_zero_phase.py
+++ b/tests/unit/test_distributed_rank_zero_phase.py
@@ -1,0 +1,183 @@
+"""Collective-safety tests for rank-zero-only training phases."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import socket
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+pytestmark = pytest.mark.unit
+
+
+def _free_port() -> int:
+    socket_pair = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    with contextlib.closing(socket_pair) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _rank_zero_phase_worker(
+    rank: int,
+    world_size: int,
+    port: int,
+    output_dir: str,
+) -> None:
+    """Exercise success, root failure, and serialization failure on Gloo."""
+    output = Path(output_dir)
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        from libreyolo.training.distributed import (
+            RankZeroPhaseError,
+            run_rank_zero_phase,
+        )
+
+        def successful_phase() -> dict:
+            (output / f"success-called-rank-{rank}").write_text(
+                "complete", encoding="utf-8"
+            )
+            return {"owner": rank, "items": [1, 2, 3]}
+
+        success = run_rank_zero_phase("setup", successful_phase)
+        marker_complete = (output / "success-called-rank-0").read_text(
+            encoding="utf-8"
+        ) == "complete"
+
+        def failing_phase() -> None:
+            (output / f"failure-called-rank-{rank}").write_text(
+                "called", encoding="utf-8"
+            )
+            raise ValueError("rank zero exploded")
+
+        try:
+            run_rank_zero_phase("validation", failing_phase)
+        except RankZeroPhaseError as exc:
+            failure = {
+                "type": type(exc).__name__,
+                "message": str(exc),
+                "phase": exc.phase,
+                "failure_stage": exc.failure_stage,
+                "root_type": exc.root_exception_type,
+                "root_message": exc.root_exception_message,
+                "traceback": exc.rank_zero_traceback,
+                "cause_type": type(exc.__cause__).__name__
+                if exc.__cause__ is not None
+                else None,
+            }
+        else:
+            raise AssertionError("rank-zero failure was not propagated")
+
+        # A collective after the error proves every rank received the outcome
+        # and remained in a usable, synchronized process group.
+        reached_after_failure = torch.tensor(1, dtype=torch.int64)
+        dist.all_reduce(reached_after_failure)
+
+        def unserializable_phase():
+            return lambda: None
+
+        try:
+            run_rank_zero_phase("checkpoint", unserializable_phase)
+        except RankZeroPhaseError as exc:
+            serialization_failure = {
+                "message": str(exc),
+                "phase": exc.phase,
+                "failure_stage": exc.failure_stage,
+                "root_type": exc.root_exception_type,
+                "root_message": exc.root_exception_message,
+            }
+        else:
+            raise AssertionError("unserializable rank-zero result was accepted")
+
+        recovered = run_rank_zero_phase("callback", lambda: "recovered")
+        record = {
+            "success": success,
+            "marker_complete": marker_complete,
+            "failure": failure,
+            "serialization_failure": serialization_failure,
+            "reached_after_failure": int(reached_after_failure.item()),
+            "recovered": recovered,
+        }
+        (output / f"rank-{rank}.json").write_text(
+            json.dumps(record, sort_keys=True), encoding="utf-8"
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_rank_zero_phase_preserves_non_distributed_behavior():
+    from libreyolo.training.distributed import run_rank_zero_phase
+
+    calls: list[str] = []
+    result = run_rank_zero_phase("setup", lambda: calls.append("called") or 42)
+
+    assert result == 42
+    assert calls == ["called"]
+
+    root_error = ValueError("local failure")
+    with pytest.raises(ValueError) as caught:
+        run_rank_zero_phase("validation", lambda: (_ for _ in ()).throw(root_error))
+    assert caught.value is root_error
+
+
+def test_rank_zero_phase_broadcasts_success_and_failure_on_cpu_gloo(tmp_path):
+    world_size = 2
+    mp.spawn(
+        _rank_zero_phase_worker,
+        args=(world_size, _free_port(), str(tmp_path)),
+        nprocs=world_size,
+        join=True,
+    )
+
+    records = [
+        json.loads((tmp_path / f"rank-{rank}.json").read_text(encoding="utf-8"))
+        for rank in range(world_size)
+    ]
+    assert (
+        records[0]["success"]
+        == records[1]["success"]
+        == {
+            "owner": 0,
+            "items": [1, 2, 3],
+        }
+    )
+    assert all(record["marker_complete"] for record in records)
+    assert sorted(path.name for path in tmp_path.glob("success-called-rank-*")) == [
+        "success-called-rank-0"
+    ]
+    assert sorted(path.name for path in tmp_path.glob("failure-called-rank-*")) == [
+        "failure-called-rank-0"
+    ]
+
+    failures = [record["failure"] for record in records]
+    assert failures[0]["message"] == failures[1]["message"]
+    assert failures[0]["phase"] == failures[1]["phase"] == "validation"
+    assert failures[0]["failure_stage"] == failures[1]["failure_stage"] == "execution"
+    assert failures[0]["root_type"] == failures[1]["root_type"] == "ValueError"
+    assert (
+        failures[0]["root_message"]
+        == failures[1]["root_message"]
+        == "rank zero exploded"
+    )
+    assert "ValueError: rank zero exploded" in failures[0]["traceback"]
+    assert failures[0]["cause_type"] == "ValueError"
+    assert failures[1]["cause_type"] is None
+
+    serialization_failures = [record["serialization_failure"] for record in records]
+    assert serialization_failures[0] == serialization_failures[1]
+    assert serialization_failures[0]["phase"] == "checkpoint"
+    assert serialization_failures[0]["failure_stage"] == "result serialization"
+    assert "local object" in serialization_failures[0]["root_message"].lower()
+    assert all(record["reached_after_failure"] == world_size for record in records)
+    assert all(record["recovered"] == "recovered" for record in records)

--- a/tests/unit/test_distributed_rank_zero_phase.py
+++ b/tests/unit/test_distributed_rank_zero_phase.py
@@ -36,7 +36,7 @@ def _rank_zero_phase_worker(
         init_method=f"tcp://127.0.0.1:{port}",
         rank=rank,
         world_size=world_size,
-        timeout=timedelta(seconds=30),
+        timeout=timedelta(minutes=2),
     )
     try:
         from libreyolo.training.distributed import (
@@ -129,7 +129,7 @@ def _rank_zero_validation_worker(
         init_method=f"tcp://127.0.0.1:{port}",
         rank=rank,
         world_size=world_size,
-        timeout=timedelta(seconds=30),
+        timeout=timedelta(minutes=2),
     )
     try:
         from libreyolo.training.trainer import BaseTrainer
@@ -287,9 +287,7 @@ def test_rank_zero_validation_unwraps_ddp_on_cpu_gloo(tmp_path):
 
     records = [
         json.loads(
-            (tmp_path / f"validation-rank-{rank}.json").read_text(
-                encoding="utf-8"
-            )
+            (tmp_path / f"validation-rank-{rank}.json").read_text(encoding="utf-8")
         )
         for rank in range(world_size)
     ]
@@ -297,9 +295,7 @@ def test_rank_zero_validation_unwraps_ddp_on_cpu_gloo(tmp_path):
     assert records[0]["result"]["owner"] == 0
     assert all(record["restored"] for record in records)
     assert all(record["collective"] == world_size for record in records)
-    assert records[0]["post_validation"] == pytest.approx(
-        records[1]["post_validation"]
-    )
-    assert sorted(
-        path.name for path in tmp_path.glob("validation-called-rank-*")
-    ) == ["validation-called-rank-0"]
+    assert records[0]["post_validation"] == pytest.approx(records[1]["post_validation"])
+    assert sorted(path.name for path in tmp_path.glob("validation-called-rank-*")) == [
+        "validation-called-rank-0"
+    ]

--- a/tests/unit/test_ema.py
+++ b/tests/unit/test_ema.py
@@ -96,7 +96,9 @@ def test_model_ema_updates_shared_parameter_once(device, dtype):
     assert torch.equal(restored.first.weight, ema.ema.first.weight)
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda", "mps"])
+# PyTorch deep-copies distinct MPS tensor views with clone(), so the EMA
+# destination tensors no longer overlap and are safe to update.
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 def test_model_ema_rejects_distinct_overlapping_views(device):
     _require_device(device)
     model = _OverlappingBuffers(device)

--- a/tests/unit/test_ema.py
+++ b/tests/unit/test_ema.py
@@ -1,12 +1,37 @@
 import math
 
 import pytest
+import torch
 import torch.nn as nn
 
 from libreyolo.training.ema import ModelEMA
 
 
 pytestmark = pytest.mark.unit
+
+
+class _SharedLinear(nn.Module):
+    def __init__(self):
+        super().__init__()
+        shared = nn.Linear(2, 2, bias=False)
+        self.first = shared
+        self.second = shared
+
+
+class _OverlappingBuffers(nn.Module):
+    def __init__(self, device):
+        super().__init__()
+        base = torch.ones(4, device=device)
+        self.register_buffer("base", base)
+        self.register_buffer("exact_alias", base.view_as(base))
+        self.register_buffer("tail", base[1:])
+
+
+def _require_device(device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if device == "mps" and not torch.backends.mps.is_available():
+        pytest.skip("MPS is not available")
 
 
 def test_model_ema_uses_configurable_tau():
@@ -34,3 +59,73 @@ def test_model_ema_tau_zero_uses_constant_decay():
     ema.set_decay(0.9, ramp=True)
 
     assert ema.decay(1) == pytest.approx(0.9)
+
+
+@pytest.mark.parametrize(
+    ("device", "dtype"),
+    [
+        pytest.param("cpu", torch.float32, id="cpu-float32"),
+        pytest.param("cpu", torch.float64, id="cpu-float64"),
+        pytest.param("cuda", torch.float32, id="cuda-float32"),
+        pytest.param("cuda", torch.float64, id="cuda-float64"),
+        pytest.param("mps", torch.float32, id="mps-float32"),
+    ],
+)
+def test_model_ema_updates_shared_parameter_once(device, dtype):
+    _require_device(device)
+
+    model = _SharedLinear().to(device=device, dtype=dtype)
+    with torch.no_grad():
+        model.first.weight.fill_(1.0)
+    ema = ModelEMA(model, decay=0.5, tau=0)
+    with torch.no_grad():
+        ema.ema.first.weight.zero_()
+
+    ema.update(model)
+
+    assert ema.ema.first.weight is ema.ema.second.weight
+    assert set(ema.ema.state_dict()) == {"first.weight", "second.weight"}
+    assert ema.ema.first.weight.device.type == device
+    assert ema.ema.first.weight.dtype == dtype
+    assert torch.allclose(
+        ema.ema.first.weight, torch.full_like(ema.ema.first.weight, 0.5)
+    )
+    restored = _SharedLinear().to(device=device, dtype=dtype)
+    restored.load_state_dict(ema.ema.state_dict())
+    assert restored.first.weight is restored.second.weight
+    assert torch.equal(restored.first.weight, ema.ema.first.weight)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda", "mps"])
+def test_model_ema_rejects_distinct_overlapping_views(device):
+    _require_device(device)
+    model = _OverlappingBuffers(device)
+    ema = ModelEMA(model, decay=0.5, tau=0)
+    ema.ema.base.zero_()
+
+    with pytest.raises(RuntimeError, match="share storage"):
+        ema.update(model)
+
+
+def test_model_ema_updates_rtmdet_shared_head_once():
+    from libreyolo.models.rtmdet.nn import RTMDetSepBNHead
+
+    model = RTMDetSepBNHead(
+        num_classes=2,
+        in_channels=4,
+        feat_channels=4,
+        stacked_convs=1,
+        share_conv=True,
+    )
+    shared_weight = model.cls_convs[0][0].conv.weight
+    with torch.no_grad():
+        shared_weight.fill_(1.0)
+    ema = ModelEMA(model, decay=0.5, tau=0)
+    with torch.no_grad():
+        ema.ema.cls_convs[0][0].conv.weight.zero_()
+
+    ema.update(model)
+
+    weights = [ema.ema.cls_convs[level][0].conv.weight for level in range(3)]
+    assert weights[0] is weights[1] is weights[2]
+    assert torch.allclose(weights[0], torch.full_like(weights[0], 0.5))

--- a/tests/unit/test_fomo_trainer_smoke.py
+++ b/tests/unit/test_fomo_trainer_smoke.py
@@ -11,7 +11,7 @@ import torch
 pytestmark = [pytest.mark.unit, pytest.mark.fomo]
 
 
-def _make_random_fomo(size: str = "s", nc: int = 1) -> "LibreFOMO":
+def _make_random_fomo(size: str = "s", nc: int = 1) -> Any:
     from libreyolo.models.fomo.model import LibreFOMO
 
     return LibreFOMO(model_path=None, size=size, nb_classes=nc, device="cpu")
@@ -54,7 +54,7 @@ class TestLibreFOMOTrainerSmoke:
             
         monkeypatch.setattr(model, "_load_weights", mock_load_weights)
         
-        results = model.train("dummy.yaml", allow_experimental=True)
+        model.train("dummy.yaml", allow_experimental=True)
         assert loaded_path == str(dummy_ckpt)
 
     def test_train_resume_raises_when_no_checkpoint(self) -> None:
@@ -84,8 +84,10 @@ class TestLibreFOMOTrainerSmoke:
 
         monkeypatch.setattr("libreyolo.models.fomo.trainer.FOMOTrainer", DummyTrainer)
 
-        results = model.train("dummy.yaml", allow_experimental=True, resume=True)
-        assert setup_called is True
+        model.train("dummy.yaml", allow_experimental=True, resume=True)
+        # Resume must happen before setup so the original run directory and
+        # deferred optimizer/EMA/scaler/RNG state are restored coherently.
+        assert setup_called is False
         assert resume_called_with == str(dummy_ckpt)
 
     def test_train_seeds_rngs(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_grad_accum.py
+++ b/tests/unit/test_grad_accum.py
@@ -2,11 +2,12 @@
 
 Two families of tests:
 
-1. Gradient equivalence — the core mathematical claim: accumulating N
-   mini-batches of size B (``nbs`` set so ``round(nbs / batch) == N``) must
-   produce the same parameter gradients as a single forward pass over a full
-   batch of size N*B (given mean loss reduction and the ``loss / accum``
-   scaling in the loop).
+1. Gradient equivalence for per-image-mean losses: accumulating N mini-batches
+   must produce the same parameter gradients as a single forward pass over
+   their combined samples, including unequal or partial batches. Detection
+   terms normalized by positives or boxes retain their established equal-size
+   window semantics; exact unequal-window recomposition would require each
+   criterion to expose its unreduced numerator and denominator.
 
 2. Trainer wiring — that ``optimizer.step()`` and ``zero_grad()`` fire at the
    right frequency when ``_train_epoch_accum`` runs with accum > 1.
@@ -144,6 +145,34 @@ def _hash_state_dict(model: nn.Module) -> str:
 
 
 @_requires_libreyolo
+def test_variable_microbatch_sizes_match_one_combined_batch():
+    """A [4, 1] accumulation window weights samples, not micro-batches."""
+    torch.manual_seed(2027)
+    first = torch.randn(4, 8)
+    second = torch.randn(1, 8)
+    combined = torch.cat((first, second))
+
+    accumulated_model = _TinyModel()
+    combined_model = copy.deepcopy(accumulated_model)
+    combined_optimizer = torch.optim.SGD(combined_model.parameters(), lr=0.01)
+    combined_optimizer.zero_grad(set_to_none=True)
+    combined_model(combined).mean().backward()
+    combined_optimizer.step()
+
+    trainer = _make_trainer(accumulated_model, accum=2, num_batches=2)
+    trainer.train_loader = [
+        (first, torch.zeros(4, 5), [{}] * 4, list(range(4))),
+        (second, torch.zeros(1, 5), [{}], [4]),
+    ]
+    trainer._train_epoch(0)
+
+    for actual, expected in zip(
+        accumulated_model.parameters(), combined_model.parameters()
+    ):
+        torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+@_requires_libreyolo
 def test_base_effective_lr_is_absolute_under_accumulation():
     trainer = _make_trainer(_TinyModel(), accum=4)
     trainer.config.lr0 = 0.123
@@ -151,6 +180,19 @@ def test_base_effective_lr_is_absolute_under_accumulation():
 
     assert trainer._accum_steps == 4
     assert trainer.effective_lr == pytest.approx(0.123)
+
+
+@_requires_libreyolo
+def test_global_batch_must_divide_world_size_exactly():
+    trainer = _make_trainer(_TinyModel())
+    trainer.config.batch = 10
+    trainer.world_size = 4
+
+    with pytest.raises(ValueError, match="divisible"):
+        trainer._per_rank_batch_size()
+
+    trainer.config.batch = 12
+    assert trainer._per_rank_batch_size() == 3
 
 
 # =========================================================================
@@ -711,6 +753,60 @@ class _FakeEMA:
         self.updates += 1
 
 
+class _OverflowThenStepScaler(_FakeScaler):
+    """Skip the first optimizer step, then apply the second one."""
+
+    def __init__(self):
+        super().__init__()
+        self._scale = 8.0
+        self._outcomes = iter((False, True))
+        self._last_step_succeeded = False
+
+    def get_scale(self):
+        return self._scale
+
+    def step(self, optimizer):
+        self.step_calls += 1
+        self._last_step_succeeded = next(self._outcomes)
+        if self._last_step_succeeded:
+            optimizer.step()
+
+    def update(self):
+        super().update()
+        if not self._last_step_succeeded:
+            self._scale /= 2.0
+
+
+class _RecordingScheduler:
+    def __init__(self):
+        self.calls = []
+
+    def update_lr(self, step):
+        self.calls.append(step)
+        return 0.01
+
+
+@_requires_libreyolo
+@pytest.mark.parametrize("accum", [1, 2])
+def test_amp_overflow_does_not_advance_base_optimizer_state(accum):
+    trainer = _make_trainer(
+        _TinyModel(),
+        accum=accum,
+        num_batches=2 if accum == 1 else 4,
+    )
+    trainer.scaler = _OverflowThenStepScaler()
+    trainer.ema_model = _FakeEMA()
+    trainer.lr_scheduler = _RecordingScheduler()
+
+    trainer._train_epoch(0)
+
+    assert trainer.scaler.step_calls == 2
+    assert trainer.scaler.update_calls == 2
+    assert trainer.optimizer_step_count == 1
+    assert trainer.ema_model.updates == 1
+    assert trainer.lr_scheduler.calls == [1]
+
+
 @_requires_libreyolo
 def test_amp_accum_steps_once_per_window():
     """AMP path: scaler.step/update fire once per window; scale fires every batch."""
@@ -1070,9 +1166,118 @@ def test_resume_checkpoint_preserves_nbs_and_optimizer_step_iter(tmp_path):
     resumed.resume(str(checkpoint_path))
     assert resumed.start_epoch == 1
     assert resumed.config.nbs == 4
+    assert resumed._get_save_dir() == trainer.save_dir
 
     resumed._train_epoch(resumed.start_epoch)
     assert resumed.current_iter == 3
+
+
+@_requires_libreyolo
+def test_rng_capture_restore_covers_python_numpy_and_torch():
+    import random
+
+    import numpy as np
+
+    trainer = _make_trainer(_TinyModel())
+    loader_generator = torch.Generator().manual_seed(31)
+    trainer.train_loader = type(
+        "_LoaderState", (), {"generator": loader_generator}
+    )()
+    random.seed(19)
+    np.random.seed(23)
+    torch.manual_seed(29)
+    captured = trainer._capture_rng_state()
+    expected = (
+        random.random(),
+        np.random.random(),
+        torch.rand(3),
+        torch.rand(3, generator=loader_generator),
+    )
+
+    random.seed(101)
+    np.random.seed(103)
+    torch.manual_seed(107)
+    trainer._restore_rng_state(captured)
+    actual = (
+        random.random(),
+        np.random.random(),
+        torch.rand(3),
+        torch.rand(3, generator=loader_generator),
+    )
+
+    assert actual[0] == expected[0]
+    assert actual[1] == expected[1]
+    torch.testing.assert_close(actual[2], expected[2])
+    torch.testing.assert_close(actual[3], expected[3])
+
+
+@_requires_libreyolo
+def test_resume_defers_runtime_state_until_setup(tmp_path):
+    from libreyolo.training.ema import ModelEMA
+
+    class _StatefulScaler:
+        def state_dict(self):
+            return {"scale": 32.0, "growth_tracker": 7}
+
+    trainer = _make_trainer(_TinyModel(), accum=2, num_batches=3)
+    trainer.save_dir = tmp_path / "first"
+    trainer.save_dir.mkdir()
+    trainer.ema_model = ModelEMA(trainer.model, decay=0.9)
+    trainer.ema_model.updates = 11
+    trainer.scaler = _StatefulScaler()
+    trainer.optimizer_step_count = 17
+    trainer.patience_counter = 2
+    trainer.config.momentum = 0.81
+    trainer._save_checkpoint(epoch=3, loss=1.0, is_best=True)
+    checkpoint_path = trainer.save_dir / "weights" / "last.pt"
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+    assert checkpoint["optimizer_step_count"] == 17
+    assert checkpoint["patience_counter"] == 2
+    assert len(checkpoint["rng_states_by_rank"]) == 1
+    assert "python" in checkpoint["rng_states_by_rank"][0]
+
+    resumed = _make_trainer(_TinyModel(), accum=2, num_batches=3)
+    resumed.config.epochs = 99
+    resumed.resume(str(checkpoint_path))
+
+    assert resumed.start_epoch == 4
+    assert resumed.optimizer_step_count == 17
+    assert resumed.patience_counter == 2
+    assert resumed.config.momentum == pytest.approx(0.81)
+    assert resumed.config.epochs == 99
+    assert resumed._resume_ema_updates == 11
+    assert resumed._resume_scaler_state == {
+        "scale": 32.0,
+        "growth_tracker": 7,
+    }
+    assert resumed._resume_rng_state is not None
+
+
+@_requires_libreyolo
+def test_resume_preserves_explicit_default_valued_config():
+    trainer = _make_trainer(_TinyModel())
+    trainer.config.epochs = 300
+    trainer._explicit_train_config_keys = frozenset({"epochs"})
+
+    trainer._restore_checkpoint_config({"config": {"epochs": 100}})
+
+    assert trainer.config.epochs == 300
+
+
+@_requires_libreyolo
+def test_restored_zero_optimizer_steps_does_not_fast_forward_scheduler():
+    trainer = _make_trainer(_TinyModel(), accum=1, num_batches=4)
+    scheduler = _RecordingScheduler()
+    trainer.lr_scheduler = scheduler
+    trainer.start_epoch = 3
+    trainer.optimizer_step_count = 0
+    trainer._optimizer_step_count_restored = True
+
+    trainer._initialize_scheduler_lr()
+
+    assert scheduler.calls == [0]
+    assert trainer.optimizer_step_count == 0
 
 
 @_requires_libreyolo

--- a/tests/unit/test_pose_ddp_validation.py
+++ b/tests/unit/test_pose_ddp_validation.py
@@ -1,0 +1,36 @@
+"""Rank-zero pose validation must not enter training-loss collectives."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.ec.pose_trainer import ECPoseTrainer
+from libreyolo.models.yolonas.pose_trainer import YOLONASPoseTrainer
+
+pytestmark = pytest.mark.unit
+
+
+class _ForbiddenLoader:
+    def __iter__(self):
+        raise AssertionError("DDP rank-zero validation iterated the loss loader")
+
+
+@pytest.mark.parametrize("trainer_class", [YOLONASPoseTrainer, ECPoseTrainer])
+def test_ddp_pose_validation_skips_collective_loss(trainer_class):
+    trainer = trainer_class.__new__(trainer_class)
+    trainer.is_distributed = True
+    trainer.val_loader = _ForbiddenLoader()
+    trainer.model = torch.nn.Identity()
+    trainer.ema_model = None
+    trainer.best_metric_key = "metrics/keypoints_mAP50-95"
+    trainer._run_pose_metric_validation = lambda *args, **kwargs: {
+        "metrics/keypoints_mAP50": 0.6,
+        "metrics/keypoints_mAP50-95": 0.4,
+    }
+
+    result = trainer_class._run_validation(trainer, 0)
+
+    assert result["mAP50"] == pytest.approx(0.6)
+    assert result["mAP50_95"] == pytest.approx(0.4)
+    assert "loss/val" not in result["metrics"]

--- a/tests/unit/test_resume_state_contracts.py
+++ b/tests/unit/test_resume_state_contracts.py
@@ -1,0 +1,209 @@
+"""Strict resume ordering and checkpoint identity contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo.training.trainer import BaseTrainer
+
+pytestmark = pytest.mark.unit
+
+
+class _Scheduler:
+    def update_lr(self, step: int) -> float:
+        del step
+        return 0.01
+
+
+class _ResumeTrainer(BaseTrainer):
+    def get_model_family(self) -> str:
+        return "resume-test"
+
+    def get_model_tag(self) -> str:
+        return "resume-test"
+
+    def create_transforms(self):
+        return None, None
+
+    def create_scheduler(self, iters_per_epoch):
+        del iters_per_epoch
+        return _Scheduler()
+
+    def get_loss_components(self, outputs):
+        del outputs
+        return {}
+
+    def on_forward(self, imgs, targets, polygons=None):
+        del targets, polygons
+        return {"total_loss": self.model(imgs).mean()}
+
+    def on_setup(self):
+        self.events.append("on_setup")
+
+    def _setup_data(self):
+        self.events.append("data")
+        self.model = torch.nn.Linear(2, 1, bias=False)
+        self.train_loader = [object()]
+
+    def _setup_optimizer(self):
+        self.events.append("optimizer")
+        torch.testing.assert_close(
+            self.model.weight,
+            self.expected_weight,
+        )
+        return torch.optim.SGD(self.model.parameters(), lr=0.01)
+
+
+def _trainer(tmp_path: Path) -> _ResumeTrainer:
+    trainer = _ResumeTrainer(
+        model=torch.nn.Linear(1, 1, bias=False),
+        device="cpu",
+        amp=False,
+        ema=False,
+        data=None,
+        project=str(tmp_path),
+        name="run",
+        exist_ok=True,
+    )
+    trainer.events = []
+    return trainer
+
+
+def test_resume_defers_model_load_until_after_architecture_setup(tmp_path):
+    expected_weight = torch.tensor([[2.0, 3.0]])
+    checkpoint = tmp_path / "last.pt"
+    torch.save(
+        {
+            "model": {"weight": expected_weight.clone()},
+            "epoch": 0,
+        },
+        checkpoint,
+    )
+    trainer = _trainer(tmp_path)
+    trainer.expected_weight = expected_weight
+
+    trainer.resume(str(checkpoint))
+
+    assert trainer.model.weight.shape == (1, 1)
+    assert trainer._resume_model_state is not None
+    trainer.setup()
+    assert trainer.events == ["on_setup", "data", "optimizer"]
+    torch.testing.assert_close(trainer.model.weight, expected_weight)
+
+
+@pytest.mark.parametrize(
+    ("field", "wrong_value"),
+    [
+        ("model_family", "another-family"),
+        ("size", "m"),
+        ("task", "segment"),
+    ],
+)
+def test_resume_rejects_checkpoint_identity_mismatch(
+    tmp_path,
+    field,
+    wrong_value,
+):
+    checkpoint = tmp_path / "wrong.pt"
+    payload = {
+        "model": {"weight": torch.ones(1, 1)},
+        "epoch": 0,
+        "model_family": "resume-test",
+        "size": "s",
+        "task": "detect",
+    }
+    payload[field] = wrong_value
+    torch.save(
+        payload,
+        checkpoint,
+    )
+    trainer = _trainer(tmp_path)
+
+    with pytest.raises(RuntimeError, match=field):
+        trainer.resume(str(checkpoint))
+
+
+def test_resume_rejects_inference_only_checkpoint(tmp_path):
+    checkpoint = tmp_path / "inference.pt"
+    torch.save({"model": {"weight": torch.ones(1, 1)}}, checkpoint)
+    trainer = _trainer(tmp_path)
+
+    with pytest.raises(RuntimeError, match="no training epoch"):
+        trainer.resume(str(checkpoint))
+
+
+@pytest.mark.parametrize(
+    "state_name",
+    ["optimizer", "scheduler", "distiller", "ema", "scaler"],
+)
+def test_resume_rejects_null_component_state(tmp_path, state_name):
+    checkpoint = tmp_path / f"null-{state_name}.pt"
+    torch.save(
+        {
+            "model": {"weight": torch.ones(1, 1)},
+            "epoch": 0,
+            state_name: None,
+        },
+        checkpoint,
+    )
+    trainer = _trainer(tmp_path)
+
+    with pytest.raises(RuntimeError, match=rf"{state_name} state"):
+        trainer.resume(str(checkpoint))
+
+
+def test_resume_rejects_every_checkpoint_after_setup(tmp_path):
+    checkpoint = tmp_path / "different-nc.pt"
+    torch.save(
+        {
+            "model": {"weight": torch.ones(2, 1)},
+            "epoch": 0,
+            "nc": 2,
+        },
+        checkpoint,
+    )
+    trainer = _trainer(tmp_path)
+
+    class _Wrapper:
+        task = "detect"
+        nb_classes = 1
+
+        def __init__(self, model):
+            self.model = model
+            self.rebuild_calls = 0
+
+        def _rebuild_for_checkpoint_classes(self, nc, model_state):
+            del nc, model_state
+            self.rebuild_calls += 1
+
+    wrapper = _Wrapper(trainer.model)
+    trainer.wrapper_model = wrapper
+    trainer._is_setup = True
+    original_model = trainer.model
+
+    with pytest.raises(RuntimeError, match=r"before setup\(\)"):
+        trainer.resume(str(checkpoint))
+
+    assert trainer.model is original_model
+    assert wrapper.model is original_model
+    assert wrapper.rebuild_calls == 0
+
+
+def test_omitted_recipe_value_inherits_checkpoint_config(tmp_path):
+    trainer = _trainer(tmp_path)
+    trainer.config.lr0 = 0.005
+    trainer._explicit_train_config_keys = frozenset()
+
+    trainer._restore_checkpoint_config(
+        {
+            "config": {
+                **trainer.config.to_dict(),
+                "lr0": 0.000123,
+            }
+        }
+    )
+
+    assert trainer.config.lr0 == pytest.approx(0.000123)

--- a/tests/unit/test_resume_state_contracts.py
+++ b/tests/unit/test_resume_state_contracts.py
@@ -13,9 +13,18 @@ pytestmark = pytest.mark.unit
 
 
 class _Scheduler:
+    def __init__(self):
+        self.position = 0
+
     def update_lr(self, step: int) -> float:
         del step
         return 0.01
+
+    def state_dict(self):
+        return {"position": self.position}
+
+    def load_state_dict(self, state):
+        self.position = int(state["position"])
 
 
 class _ResumeTrainer(BaseTrainer):
@@ -92,6 +101,127 @@ def test_resume_defers_model_load_until_after_architecture_setup(tmp_path):
     trainer.setup()
     assert trainer.events == ["on_setup", "data", "optimizer"]
     torch.testing.assert_close(trainer.model.weight, expected_weight)
+
+
+def test_resume_with_distillation_disabled_keeps_student_optimizer_state(
+    tmp_path,
+    caplog,
+):
+    source_model = torch.nn.Linear(2, 1, bias=False)
+    adapter_weight = torch.nn.Parameter(torch.tensor([[3.0]]))
+    adapter_bias = torch.nn.Parameter(torch.tensor([4.0]))
+    optimizer = torch.optim.SGD(
+        [
+            {"params": list(source_model.parameters()), "lr": 0.07},
+            {"params": [adapter_weight], "lr": 0.03},
+            {"params": [adapter_bias], "lr": 0.03},
+        ],
+        momentum=0.9,
+    )
+    source_model.weight.grad = torch.tensor([[2.0, 4.0]])
+    adapter_weight.grad = torch.tensor([[5.0]])
+    adapter_bias.grad = torch.tensor([6.0])
+    optimizer.step()
+    optimizer_state = optimizer.state_dict()
+    student_param_id = optimizer_state["param_groups"][0]["params"][0]
+    expected_momentum = optimizer_state["state"][student_param_id][
+        "momentum_buffer"
+    ].clone()
+    expected_ema_weight = torch.tensor([[7.0, 11.0]])
+
+    trainer = _ResumeTrainer(
+        model=torch.nn.Linear(1, 1, bias=False),
+        device="cpu",
+        amp=False,
+        ema=True,
+        distill_model=None,
+        data=None,
+        project=str(tmp_path),
+        name="run",
+        exist_ok=True,
+    )
+    trainer.events = []
+    saved_config = trainer.config.to_dict()
+    saved_config["distill_model"] = "teacher.pt"
+    checkpoint = tmp_path / "distilled.pt"
+    torch.save(
+        {
+            "model": source_model.state_dict(),
+            "epoch": 2,
+            "optimizer": optimizer_state,
+            "optimizer_step_count": 13,
+            "scheduler": {"position": 13},
+            "distiller": {
+                "adapter.weight": adapter_weight.detach().clone(),
+                "adapter.bias": adapter_bias.detach().clone(),
+            },
+            "ema": {"weight": expected_ema_weight.clone()},
+            "ema_updates": 9,
+            "config": saved_config,
+        },
+        checkpoint,
+    )
+    trainer.expected_weight = source_model.weight.detach().clone()
+
+    trainer.resume(str(checkpoint))
+    trainer.setup()
+
+    assert trainer.distiller is None
+    assert len(trainer.optimizer.param_groups) == 1
+    assert len(trainer.optimizer.state) == 1
+    assert trainer.optimizer.param_groups[0]["momentum"] == pytest.approx(0.9)
+    torch.testing.assert_close(
+        trainer.optimizer.state[trainer.model.weight]["momentum_buffer"],
+        expected_momentum,
+    )
+    assert trainer.optimizer_step_count == 13
+    assert trainer.lr_scheduler.position == 13
+    assert trainer.ema_model.updates == 9
+    torch.testing.assert_close(trainer.ema_model.ema.weight, expected_ema_weight)
+    assert "distillation is disabled" in caplog.text
+
+
+def test_disabled_distillation_rejects_ambiguous_optimizer_topology(tmp_path):
+    current_param = torch.nn.Parameter(torch.ones(1))
+    trainer = _trainer(tmp_path)
+    trainer.optimizer = torch.optim.SGD([current_param], lr=0.01)
+    trainer._discard_resume_distiller_optimizer_state = True
+
+    model_param_a = torch.nn.Parameter(torch.ones(1))
+    model_param_b = torch.nn.Parameter(torch.ones(1))
+    distiller_param = torch.nn.Parameter(torch.ones(1))
+    saved_optimizer = torch.optim.SGD(
+        [
+            {"params": [model_param_a, model_param_b]},
+            {"params": [distiller_param]},
+        ],
+        lr=0.01,
+    ).state_dict()
+
+    with pytest.raises(RuntimeError, match="model optimizer group 0"):
+        trainer._optimizer_state_for_resume(saved_optimizer)
+
+
+def test_resume_inherits_saved_distillation_when_not_explicitly_disabled(tmp_path):
+    trainer = _trainer(tmp_path)
+    saved_config = trainer.config.to_dict()
+    saved_config["distill_model"] = "teacher.pt"
+    checkpoint = tmp_path / "distilled.pt"
+    torch.save(
+        {
+            "model": trainer.model.state_dict(),
+            "epoch": 0,
+            "distiller": {"adapter.weight": torch.ones(1)},
+            "config": saved_config,
+        },
+        checkpoint,
+    )
+
+    trainer.resume(str(checkpoint))
+
+    assert trainer.config.distill_model == "teacher.pt"
+    assert trainer._resume_distiller_state is not None
+    assert not getattr(trainer, "_discard_resume_distiller_optimizer_state", False)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_rfdetr_lr_contract.py
+++ b/tests/unit/test_rfdetr_lr_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import torch.nn as nn
 
 pytestmark = pytest.mark.unit
 
@@ -10,7 +11,8 @@ rfdetr_trainer = pytest.importorskip("libreyolo.models.rfdetr.trainer")
 
 def _make_wrapper():
     wrapper = rfdetr_model.LibreRFDETR.__new__(rfdetr_model.LibreRFDETR)
-    wrapper.model = object()
+    wrapper.model = nn.Identity()
+    wrapper.device = "cpu"
     wrapper.size = "n"
     wrapper.nb_classes = 2
     wrapper.input_size = 560
@@ -106,14 +108,13 @@ def test_rfdetr_train_honors_explicit_run_kwargs(monkeypatch, tmp_path):
 def test_rfdetr_train_resolves_resume_paths(monkeypatch, tmp_path, resume_arg):
     captured = _install_dummy_trainer(monkeypatch, {"save_dir": str(tmp_path / "exp")})
     checkpoint_path = tmp_path / "resume.pt"
+    checkpoint_path.touch()
     resume = checkpoint_path if resume_arg == "explicit" else True
-    expected = (
-        tmp_path / "project" / "custom" / "weights" / "last.pt"
-        if resume is True
-        else checkpoint_path
-    )
+    wrapper = _make_wrapper()
+    wrapper.model_path = checkpoint_path
+    wrapper._resume_checkpoint_uses_lora = lambda _path: False
 
-    _make_wrapper().train(
+    wrapper.train(
         data="data.yaml",
         output_dir=str(tmp_path / "ignored"),
         project=str(tmp_path / "project"),
@@ -121,8 +122,9 @@ def test_rfdetr_train_resolves_resume_paths(monkeypatch, tmp_path, resume_arg):
         resume=resume,
     )
 
-    assert captured["setup"] is True
-    assert captured["resume"] == str(expected)
+    assert "setup" not in captured
+    assert captured["resume"] == str(checkpoint_path)
+    assert captured["kwargs"]["resume"] is True
 
 
 def test_rfdetr_train_rejects_conflicting_lr_aliases(tmp_path):

--- a/tests/unit/test_rfdetr_seg_trainer_smoke.py
+++ b/tests/unit/test_rfdetr_seg_trainer_smoke.py
@@ -75,7 +75,6 @@ def test_setup_syncs_wrapper_device_to_trainer_device():
         with (
             patch.object(trainer, "_setup_data", side_effect=lambda: setattr(trainer, "train_loader", fake_loader)),
             patch.object(trainer, "_setup_optimizer", return_value=torch.optim.SGD(trainer.model.parameters(), lr=1e-4)),
-            patch("libreyolo.training.trainer.barrier"),
             patch.object(trainer, "_get_save_dir", return_value=Path(tmp)),
         ):
             trainer.setup()

--- a/tests/unit/test_train_callbacks.py
+++ b/tests/unit/test_train_callbacks.py
@@ -247,6 +247,46 @@ class CallbackTrainer(DummyTrainer):
         )
 
 
+class IntervalValidationTrainer(CallbackTrainer):
+    """Expose validation metrics every second epoch for patience testing."""
+
+    def _train_epoch(self, epoch: int):
+        val_metrics = None
+        if (epoch + 1) % 2 == 0:
+            metric = 0.7 if epoch == 1 else 0.5
+            val_metrics = {
+                "mAP50": metric,
+                "mAP50_95": metric,
+                "best_metric": metric,
+                "best_metric_key": "metrics/mAP50-95",
+                "metrics": {"metrics/mAP50-95": metric},
+            }
+        return 1.0, val_metrics, {}, {"group0": 0.01}
+
+
+def test_early_stopping_patience_counts_validation_opportunities(tmp_path):
+    trainer = IntervalValidationTrainer(
+        model=nn.Linear(1, 1),
+        data=None,
+        device="cpu",
+        ema=False,
+        epochs=8,
+        patience=2,
+        eval_interval=2,
+        save_period=10,
+    )
+    trainer._test_save_dir = tmp_path
+    trainer.saved_checkpoints = []
+
+    trainer.train()
+
+    # Best at epoch 2, then two non-improving validations at epochs 4 and 6.
+    # Unevaluated epochs 3 and 5 do not consume patience.
+    assert len(trainer.saved_checkpoints) == 6
+    assert trainer.best_epoch == 2
+    assert trainer.patience_counter == 2
+
+
 def test_train_emits_epoch_callback_after_best_update_and_checkpoint(tmp_path):
     received = []
     lifecycle = []

--- a/tests/unit/test_train_cfg.py
+++ b/tests/unit/test_train_cfg.py
@@ -1,6 +1,10 @@
 """Tests for ``model.train(cfg=...)`` yaml loading."""
 
+import random
+
+import numpy as np
 import pytest
+import torch
 
 from libreyolo.models.base.model import _wrap_train_with_cfg
 from libreyolo.training.config import load_train_cfg
@@ -85,6 +89,116 @@ def test_wrapper_no_cfg_passes_through(tmp_path):
     assert captured["data"] == "data.yaml"
     assert captured["epochs"] == 42
     assert captured["batch"] == 8  # default
+
+
+def test_wrapper_applies_seed_before_family_train_body():
+    def train(self, data, *, seed=31):
+        del self, data
+        return random.random(), np.random.random(), torch.rand(2)
+
+    wrapped = _wrap_train_with_cfg(train)
+    random.seed(1)
+    np.random.seed(2)
+    torch.manual_seed(3)
+    first = wrapped(_FakeWrapper(), "data.yaml", seed=41)
+    random.seed(101)
+    np.random.seed(102)
+    torch.manual_seed(103)
+    second = wrapped(_FakeWrapper(), "data.yaml", seed=41)
+
+    assert first[0] == second[0]
+    assert first[1] == second[1]
+    torch.testing.assert_close(first[2], second[2])
+
+
+def test_wrapper_uses_family_seed_when_train_signature_omits_it():
+    class _Defaults:
+        seed = 47
+
+    class _Wrapper:
+        TRAIN_CONFIG = _Defaults
+
+    def train(self, data, **kwargs):
+        del self, data, kwargs
+        return random.random(), np.random.random(), torch.rand(2)
+
+    wrapped = _wrap_train_with_cfg(train)
+    random.seed(1)
+    np.random.seed(2)
+    torch.manual_seed(3)
+    first = wrapped(_Wrapper(), "data.yaml")
+    random.seed(101)
+    np.random.seed(102)
+    torch.manual_seed(103)
+    second = wrapped(_Wrapper(), "data.yaml")
+
+    assert first[0] == second[0]
+    assert first[1] == second[1]
+    torch.testing.assert_close(first[2], second[2])
+
+
+def test_hidden_explicit_keys_survive_ddp_default_materialization(monkeypatch):
+    """The worker payload is metadata, not a family ``train`` kwarg.
+
+    DDP materializes signature defaults before spawning. The hidden payload
+    must remain authoritative so explicit values that happen to equal those
+    defaults are still recognized after the worker re-enters the base wrapper.
+    """
+    from libreyolo.training.ddp_spawn import ddp_aware
+
+    captured = {}
+
+    def train(
+        self,
+        data,
+        *,
+        batch_size=4,
+        use_ema=True,
+        device="auto",
+        **kwargs,
+    ):
+        raise AssertionError("multi-device training should spawn before the body")
+
+    def fake_spawn(model_instance, train_kw, nprocs, *, devices, batch_key):
+        captured.update(
+            model=model_instance,
+            train_kw=train_kw,
+            nprocs=nprocs,
+            devices=devices,
+            batch_key=batch_key,
+        )
+        return {"spawned": True}
+
+    wrapped = _wrap_train_with_cfg(ddp_aware(batch_key="batch_size")(train))
+    model = _FakeWrapper()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        "libreyolo.training.distributed.has_torchrun_env", lambda: False
+    )
+    monkeypatch.setattr(
+        "libreyolo.training.ddp_spawn.spawn_for_model", fake_spawn
+    )
+
+    result = wrapped(
+        model,
+        "data.yaml",
+        batch_size=4,
+        use_ema=True,
+        device="0,1",
+        _libreyolo_explicit_train_keys=["batch_size", "use_ema"],
+    )
+
+    assert result == {"spawned": True}
+    assert captured["train_kw"]["batch_size"] == 4
+    assert captured["train_kw"]["use_ema"] is True
+    assert captured["train_kw"]["_libreyolo_explicit_train_keys"] == [
+        "batch",
+        "ema",
+    ]
+    assert captured["nprocs"] == 2
+    assert captured["devices"] == [0, 1]
+    assert captured["batch_key"] == "batch_size"
+    assert not hasattr(model, "_active_train_explicit_keys")
 
 
 def test_wrapper_loads_cfg_yaml(tmp_path):

--- a/tests/unit/test_training_control_contracts.py
+++ b/tests/unit/test_training_control_contracts.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch.nn as nn
+
+from libreyolo.training.config import require_training_choice
+
+
+pytestmark = pytest.mark.unit
+
+
+def _trainer(module_name: str, class_name: str):
+    return getattr(importlib.import_module(module_name), class_name)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "requested"),
+    [
+        ("libreyolo.models.yolox.trainer", "YOLOXTrainer", "constant"),
+        ("libreyolo.models.yolo7.trainer", "YOLOv7Trainer", "constant"),
+        ("libreyolo.models.convnext.trainer", "ConvNeXtTrainer", "constant"),
+        (
+            "libreyolo.models.efficientnetv2.trainer",
+            "EfficientNetV2Trainer",
+            "constant",
+        ),
+        (
+            "libreyolo.models.mobilenetv4.trainer",
+            "MobileNetV4Trainer",
+            "constant",
+        ),
+        ("libreyolo.models.resnet.trainer", "ResNetTrainer", "constant"),
+        ("libreyolo.models.nafnet.trainer", "NAFNetTrainer", "constant"),
+        ("libreyolo.models.picodet.trainer", "PICODETTrainer", "constant"),
+        ("libreyolo.models.rtmdet.trainer", "RTMDetTrainer", "constant"),
+        ("libreyolo.models.yolonas.trainer", "YOLONASTrainer", "constant"),
+        (
+            "libreyolo.models.yolonas.pose_trainer",
+            "YOLONASPoseTrainer",
+            "constant",
+        ),
+        ("libreyolo.models.dfine.trainer", "DFINETrainer", "constant"),
+        ("libreyolo.models.deim.trainer", "DEIMTrainer", "constant"),
+        ("libreyolo.models.ec.seg_trainer", "ECSegTrainer", "constant"),
+        ("libreyolo.models.ec.pose_trainer", "ECPoseTrainer", "constant"),
+        ("libreyolo.models.fomo.trainer", "FOMOTrainer", "typo"),
+        ("libreyolo.models.rfdetr.trainer", "RFDETRTrainer", "typo"),
+        ("libreyolo.models.segformer.trainer", "SegformerTrainer", "typo"),
+    ],
+)
+def test_family_scheduler_rejects_unimplemented_choice(
+    module_name, class_name, requested
+):
+    trainer_cls = _trainer(module_name, class_name)
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = trainer_cls._config_class()(scheduler=requested)
+
+    with pytest.raises(ValueError, match="does not support scheduler"):
+        trainer.create_scheduler(iters_per_epoch=2)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "scheduler_class"),
+    [
+        (
+            "libreyolo.models.yolox.trainer",
+            "YOLOXTrainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.yolo7.trainer",
+            "YOLOv7Trainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.convnext.trainer",
+            "ConvNeXtTrainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.efficientnetv2.trainer",
+            "EfficientNetV2Trainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.mobilenetv4.trainer",
+            "MobileNetV4Trainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.resnet.trainer",
+            "ResNetTrainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.nafnet.trainer",
+            "NAFNetTrainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.picodet.trainer",
+            "PICODETTrainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.rtmdet.trainer",
+            "RTMDetTrainer",
+            "WarmupCosineScheduler",
+        ),
+        (
+            "libreyolo.models.yolonas.trainer",
+            "YOLONASTrainer",
+            "CosineAnnealingScheduler",
+        ),
+        (
+            "libreyolo.models.yolonas.pose_trainer",
+            "YOLONASPoseTrainer",
+            "CosineAnnealingScheduler",
+        ),
+        (
+            "libreyolo.models.dfine.trainer",
+            "DFINETrainer",
+            "FlatCosineScheduler",
+        ),
+        (
+            "libreyolo.models.deim.trainer",
+            "DEIMTrainer",
+            "FlatCosineScheduler",
+        ),
+        (
+            "libreyolo.models.ec.seg_trainer",
+            "ECSegTrainer",
+            "FlatCosineScheduler",
+        ),
+        (
+            "libreyolo.models.ec.pose_trainer",
+            "ECPoseTrainer",
+            "FlatCosineScheduler",
+        ),
+        (
+            "libreyolo.models.fomo.trainer",
+            "FOMOTrainer",
+            "CosineAnnealingScheduler",
+        ),
+        (
+            "libreyolo.models.rfdetr.trainer",
+            "RFDETRTrainer",
+            "RFDETRStepScheduler",
+        ),
+        (
+            "libreyolo.models.segformer.trainer",
+            "SegformerTrainer",
+            "LinearLRScheduler",
+        ),
+    ],
+)
+def test_family_scheduler_keeps_recipe_default(
+    module_name, class_name, scheduler_class
+):
+    trainer_cls = _trainer(module_name, class_name)
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = trainer_cls._config_class()()
+
+    scheduler = trainer.create_scheduler(iters_per_epoch=2)
+
+    assert type(scheduler).__name__ == scheduler_class
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "requested", "scheduler_class"),
+    [
+        (
+            "libreyolo.models.fomo.trainer",
+            "FOMOTrainer",
+            "constant",
+            "ConstantLRScheduler",
+        ),
+        (
+            "libreyolo.models.rfdetr.trainer",
+            "RFDETRTrainer",
+            "cosine",
+            "CosineAnnealingScheduler",
+        ),
+        (
+            "libreyolo.models.rfdetr.trainer",
+            "RFDETRTrainer",
+            "flat_cosine",
+            "FlatCosineScheduler",
+        ),
+    ],
+)
+def test_family_scheduler_honors_implemented_nondefault(
+    module_name, class_name, requested, scheduler_class
+):
+    trainer_cls = _trainer(module_name, class_name)
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = trainer_cls._config_class()(scheduler=requested)
+
+    scheduler = trainer.create_scheduler(iters_per_epoch=2)
+
+    assert type(scheduler).__name__ == scheduler_class
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("libreyolo.models.dfine.trainer", "DFINETrainer"),
+        ("libreyolo.models.deim.trainer", "DEIMTrainer"),
+        ("libreyolo.models.ec.trainer", "ECTrainer"),
+        ("libreyolo.models.ec.seg_trainer", "ECSegTrainer"),
+        ("libreyolo.models.ec.pose_trainer", "ECPoseTrainer"),
+        ("libreyolo.models.rtdetrv4.trainer", "RTDETRv4Trainer"),
+        ("libreyolo.models.rfdetr.trainer", "RFDETRTrainer"),
+        ("libreyolo.models.dinov2.trainer", "DINOv2Trainer"),
+        ("libreyolo.models.segformer.trainer", "SegformerTrainer"),
+    ],
+)
+def test_recipe_specific_optimizer_rejects_unimplemented_choice(
+    module_name, class_name
+):
+    trainer_cls = _trainer(module_name, class_name)
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = trainer_cls._config_class()(optimizer="sgd")
+
+    with pytest.raises(ValueError, match="does not support optimizer"):
+        trainer._setup_optimizer()
+
+
+class _GroupedModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Linear(2, 2)
+        self.head = nn.Linear(2, 2)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("libreyolo.models.dfine.trainer", "DFINETrainer"),
+        ("libreyolo.models.deim.trainer", "DEIMTrainer"),
+        ("libreyolo.models.ec.seg_trainer", "ECSegTrainer"),
+        ("libreyolo.models.ec.pose_trainer", "ECPoseTrainer"),
+    ],
+)
+def test_detr_recipe_optimizer_honors_configured_beta1(module_name, class_name):
+    trainer_cls = _trainer(module_name, class_name)
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = trainer_cls._config_class()(momentum=0.42)
+    trainer.model = _GroupedModel()
+
+    optimizer = trainer._setup_optimizer()
+
+    assert optimizer.defaults["betas"] == pytest.approx((0.42, 0.999))
+
+
+def test_rfdetr_optimizer_honors_configured_beta1():
+    trainer_cls = _trainer("libreyolo.models.rfdetr.trainer", "RFDETRTrainer")
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = trainer_cls._config_class()(momentum=0.42)
+    trainer.model = _GroupedModel()
+    trainer.wrapper_model = SimpleNamespace(task="classify")
+
+    optimizer = trainer._setup_optimizer()
+
+    assert optimizer.defaults["betas"] == pytest.approx((0.42, 0.999))
+
+
+def test_segformer_optimizer_honors_configured_beta1():
+    trainer_cls = _trainer("libreyolo.models.segformer.trainer", "SegformerTrainer")
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = trainer_cls._config_class()(momentum=0.42)
+    trainer.model = _GroupedModel()
+
+    optimizer = trainer._setup_optimizer()
+
+    assert optimizer.defaults["betas"] == pytest.approx((0.42, 0.999))
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("libreyolo.training.config", "DFINEConfig"),
+        ("libreyolo.training.config", "DEIMConfig"),
+        ("libreyolo.training.config", "DEIMv2Config"),
+        ("libreyolo.training.config", "ECConfig"),
+        ("libreyolo.training.config", "SegformerConfig"),
+        ("libreyolo.training.config", "FOMOConfig"),
+        ("libreyolo.models.convnext.config", "ConvNeXtConfig"),
+        ("libreyolo.models.efficientnetv2.config", "EfficientNetV2Config"),
+        ("libreyolo.models.mobilenetv4.config", "MobileNetV4Config"),
+        ("libreyolo.models.resnet.config", "ResNetConfig"),
+        ("libreyolo.models.nafnet.config", "NAFNetConfig"),
+        ("libreyolo.models.rfdetr.config", "RFDETRConfig"),
+    ],
+)
+def test_adam_family_defaults_keep_beta1_point_nine(module_name, class_name):
+    config_cls = getattr(importlib.import_module(module_name), class_name)
+    assert config_cls().momentum == pytest.approx(0.9)
+
+
+def test_training_choice_normalizes_case_and_whitespace():
+    assert (
+        require_training_choice(
+            " Flat_Cosine ",
+            field="scheduler",
+            supported=("flat_cosine",),
+            family="test",
+        )
+        == "flat_cosine"
+    )

--- a/tests/unit/test_wrapper_resume_contracts.py
+++ b/tests/unit/test_wrapper_resume_contracts.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+
+_CASES = [
+    (
+        "dfine",
+        "libreyolo.models.dfine.model",
+        "LibreDFINE",
+        "libreyolo.models.dfine.trainer",
+        "DFINETrainer",
+    ),
+    (
+        "deim",
+        "libreyolo.models.deim.model",
+        "LibreDEIM",
+        "libreyolo.models.deim.trainer",
+        "DEIMTrainer",
+    ),
+    (
+        "deimv2",
+        "libreyolo.models.deimv2.model",
+        "LibreDEIMv2",
+        "libreyolo.models.deimv2.trainer",
+        "DEIMv2Trainer",
+    ),
+    (
+        "ec",
+        "libreyolo.models.ec.model",
+        "LibreEC",
+        "libreyolo.models.ec.trainer",
+        "ECTrainer",
+    ),
+    (
+        "rtdetrv4",
+        "libreyolo.models.rtdetrv4.model",
+        "LibreRTDETRv4",
+        "libreyolo.models.rtdetrv4.trainer",
+        "RTDETRv4Trainer",
+    ),
+    (
+        "yolonas",
+        "libreyolo.models.yolonas.model",
+        "LibreYOLONAS",
+        "libreyolo.models.yolonas.trainer",
+        "YOLONASTrainer",
+    ),
+    (
+        "segformer",
+        "libreyolo.models.segformer.model",
+        "LibreSegformer",
+        "libreyolo.models.segformer.trainer",
+        "SegformerTrainer",
+    ),
+    (
+        "dinov2",
+        "libreyolo.models.dinov2.model",
+        "LibreDINOv2",
+        "libreyolo.models.dinov2.trainer",
+        "DINOv2Trainer",
+    ),
+    (
+        "rfdetr",
+        "libreyolo.models.rfdetr.model",
+        "LibreRFDETR",
+        "libreyolo.models.rfdetr.model",
+        "RFDETRTrainer",
+    ),
+]
+
+
+class _TrackingModel:
+    def __init__(self):
+        self.to_calls = []
+        self.eval_calls = 0
+
+    def to(self, device):
+        self.to_calls.append(device)
+        return self
+
+    def eval(self):
+        self.eval_calls += 1
+        return self
+
+
+def _make_wrapper(model_module, wrapper_name, model_path):
+    wrapper_cls = getattr(model_module, wrapper_name)
+    wrapper = wrapper_cls.__new__(wrapper_cls)
+    wrapper.model = _TrackingModel()
+    wrapper.model_path = str(model_path) if model_path is not None else None
+    wrapper.device = torch.device("cpu")
+    wrapper.size = "s"
+    wrapper.nb_classes = 2
+    wrapper.input_size = 640
+    wrapper.task = "detect"
+    wrapper.names = {0: "zero", 1: "one"}
+    loaded = []
+    wrapper._load_weights = lambda path: loaded.append(path)
+    if wrapper_name == "LibreRFDETR":
+        wrapper._resume_checkpoint_uses_lora = lambda _path: False
+    return wrapper, loaded
+
+
+def _install_trainer(monkeypatch, module_name, trainer_name, result):
+    trainer_module = importlib.import_module(module_name)
+    events = []
+    captured = {}
+
+    class _DummyTrainer:
+        def __init__(self, *args, **kwargs):
+            captured["kwargs"] = kwargs
+            events.append("init")
+
+        def setup(self):
+            events.append("setup")
+
+        def resume(self, checkpoint_path):
+            captured["resume"] = checkpoint_path
+            events.append("resume")
+
+        def train(self):
+            events.append("train")
+            return dict(result)
+
+    monkeypatch.setattr(trainer_module, trainer_name, _DummyTrainer)
+    return events, captured
+
+
+@pytest.mark.parametrize(
+    ("family", "model_module_name", "wrapper_name", "trainer_module", "trainer_name"),
+    _CASES,
+    ids=[case[0] for case in _CASES],
+)
+@pytest.mark.parametrize("resume_kind", ["loaded", "explicit"])
+@pytest.mark.parametrize("saved_kind", ["best", "last"])
+def test_wrapper_resume_runs_training_and_restores_checkpoint(
+    monkeypatch,
+    tmp_path,
+    family,
+    model_module_name,
+    wrapper_name,
+    trainer_module,
+    trainer_name,
+    resume_kind,
+    saved_kind,
+):
+    data_module = importlib.import_module("libreyolo.data")
+    monkeypatch.setattr(
+        data_module,
+        "load_data_config",
+        lambda *_args, **_kwargs: {
+            "yaml_file": "data.yaml",
+            "nc": 2,
+        },
+    )
+
+    loaded_checkpoint = tmp_path / f"{family}-loaded.pt"
+    explicit_checkpoint = tmp_path / f"{family}-explicit.pt"
+    best_checkpoint = tmp_path / f"{family}-best.pt"
+    last_checkpoint = tmp_path / f"{family}-last.pt"
+    loaded_checkpoint.touch()
+    explicit_checkpoint.touch()
+    best_checkpoint.touch()
+    last_checkpoint.touch()
+
+    model_module = importlib.import_module(model_module_name)
+    wrapper, loaded_paths = _make_wrapper(
+        model_module,
+        wrapper_name,
+        loaded_checkpoint,
+    )
+    events, captured = _install_trainer(
+        monkeypatch,
+        trainer_module,
+        trainer_name,
+        {
+            "best_checkpoint": (
+                str(best_checkpoint) if saved_kind == "best" else None
+            ),
+            "last_checkpoint": str(last_checkpoint),
+        },
+    )
+
+    resume = True if resume_kind == "loaded" else explicit_checkpoint
+    expected_resume = loaded_checkpoint if resume is True else explicit_checkpoint
+    kwargs = {"allow_experimental": True} if family == "ec" else {}
+    wrapper.train("data.yaml", resume=resume, **kwargs)
+
+    assert events == ["init", "resume", "train"]
+    assert captured["resume"] == str(expected_resume)
+    assert captured["kwargs"]["resume"] is True
+    expected_saved = best_checkpoint if saved_kind == "best" else last_checkpoint
+    assert wrapper.model_path == str(expected_saved.resolve())
+    assert loaded_paths == [str(expected_saved.resolve())]
+    assert wrapper.model.to_calls[-1] == wrapper.device
+    assert wrapper.model.eval_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("family", "model_module_name", "wrapper_name", "trainer_module", "trainer_name"),
+    _CASES,
+    ids=[case[0] for case in _CASES],
+)
+def test_wrapper_resume_true_requires_loaded_checkpoint(
+    monkeypatch,
+    family,
+    model_module_name,
+    wrapper_name,
+    trainer_module,
+    trainer_name,
+):
+    data_module = importlib.import_module("libreyolo.data")
+    monkeypatch.setattr(
+        data_module,
+        "load_data_config",
+        lambda *_args, **_kwargs: {
+            "yaml_file": "data.yaml",
+            "nc": 2,
+        },
+    )
+    model_module = importlib.import_module(model_module_name)
+    wrapper, _ = _make_wrapper(model_module, wrapper_name, None)
+    events, _ = _install_trainer(
+        monkeypatch,
+        trainer_module,
+        trainer_name,
+        {},
+    )
+
+    kwargs = {"allow_experimental": True} if family == "ec" else {}
+    with pytest.raises(ValueError, match="resume=True requires a checkpoint"):
+        wrapper.train("data.yaml", resume=True, **kwargs)
+
+    assert events == []
+
+
+@pytest.mark.parametrize("family", ["ec", "yolonas"])
+@pytest.mark.parametrize("resume_kind", ["loaded", "explicit"])
+def test_pose_wrapper_resume_runs_training_and_restores_last_checkpoint(
+    monkeypatch,
+    tmp_path,
+    family,
+    resume_kind,
+):
+    if family == "ec":
+        model_module_name = "libreyolo.models.ec.model"
+        wrapper_name = "LibreEC"
+        trainer_module = "libreyolo.models.ec.pose_trainer"
+        trainer_name = "ECPoseTrainer"
+        data_config = {
+            "yaml_file": "data.yaml",
+            "nc": 1,
+            "names": ["person"],
+            "kpt_shape": [17, 3],
+        }
+    else:
+        model_module_name = "libreyolo.models.yolonas.model"
+        wrapper_name = "LibreYOLONAS"
+        trainer_module = "libreyolo.models.yolonas.pose_trainer"
+        trainer_name = "YOLONASPoseTrainer"
+        data_config = {
+            "yaml_file": "data.yaml",
+            "nc": 2,
+            "names": ["zero", "one"],
+            "kpt_shape": [17, 3],
+        }
+
+    data_module = importlib.import_module("libreyolo.data")
+    monkeypatch.setattr(
+        data_module,
+        "load_data_config",
+        lambda *_args, **_kwargs: data_config,
+    )
+
+    loaded_checkpoint = tmp_path / f"{family}-pose-loaded.pt"
+    explicit_checkpoint = tmp_path / f"{family}-pose-explicit.pt"
+    last_checkpoint = tmp_path / f"{family}-pose-last.pt"
+    loaded_checkpoint.touch()
+    explicit_checkpoint.touch()
+    last_checkpoint.touch()
+
+    model_module = importlib.import_module(model_module_name)
+    wrapper, loaded_paths = _make_wrapper(
+        model_module,
+        wrapper_name,
+        loaded_checkpoint,
+    )
+    wrapper.task = "pose"
+    wrapper.num_keypoints = 17
+    if family == "ec":
+        wrapper.nb_classes = 1
+        wrapper.names = {0: "person"}
+    events, captured = _install_trainer(
+        monkeypatch,
+        trainer_module,
+        trainer_name,
+        {
+            "best_checkpoint": None,
+            "last_checkpoint": str(last_checkpoint),
+        },
+    )
+
+    resume = True if resume_kind == "loaded" else explicit_checkpoint
+    expected_resume = loaded_checkpoint if resume is True else explicit_checkpoint
+    kwargs = {"allow_experimental": True} if family == "ec" else {}
+    wrapper.train("data.yaml", resume=resume, **kwargs)
+
+    assert events == ["init", "resume", "train"]
+    assert captured["resume"] == str(expected_resume)
+    assert captured["kwargs"]["resume"] is True
+    assert wrapper.model_path == str(last_checkpoint)
+    assert loaded_paths == [str(last_checkpoint)]
+    assert wrapper.model.eval_calls == 1


### PR DESCRIPTION
# What does this PR do?

Fixes the distributed-training, optimizer-update, and resume correctness findings tracked in #591.

- Makes gradient accumulation sample-weighted, including partial windows, and advances scheduler, EMA, and optimizer-step state only when an optimizer update is applied.
- Correctly gates AMP-overflow behavior and normalizes sparse DETR-family losses from true global counts.
- Makes rank-zero-only distributed phases share results or failures with every rank and adds deterministic rank-aware data-loader seeding.
- Validates checkpoint identity before resume and restores model, optimizer, scaler, scheduler, distiller, EMA, RNG, patience, and optimizer-step state after architecture setup.
- Preserves explicit current-run overrides and rejects unsupported optimizer or scheduler choices instead of silently ignoring them.
- Fixes CLI/config propagation, callback ordering, zero-valued best metrics, and validation-based early-stopping accounting.

# Provenance declaration (required)

## Code provenance

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

# How was this tested?

- Exact head `95c3e90a8b878cd32c3ef5c598a13870bbefe0f3`: [Unit tests](https://github.com/LibreYOLO/libreyolo/actions/runs/29212074248) passed on all required platforms: Windows 3,924 passed / 105 skipped / 4 expected failures; macOS 3,922 passed / 105 skipped / 6 expected failures; Linux 3,923 passed / 106 skipped / 4 expected failures.
- [Install smoke](https://github.com/LibreYOLO/libreyolo/actions/runs/29212075097) passed all 8 wheel, sdist, editable, and PyPI jobs across Linux, Windows, and macOS.
- Focused local regression tests for the macOS findings passed: 17 passed, 1 platform skip. The broader training regression selection passed before the CI-only harness correction: 574 passed, 5 skipped.
- Ruff and `git diff --check` passed. Greptile reviewed the exact head at 5/5 with no blocking finding.
- The first exact-head macOS run exposed a 30-second spawned-process test timeout and an invalid MPS deepcopy assumption; both test harness issues were corrected and the complete replacement matrix above passed.