### PR TITLE
Unify model capability and input-size contracts

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -38,7 +38,13 @@ Required field meanings:
 - `names`: `dict[int, str]` with keys in `0..nc-1`. Official checkpoints
   should write every key. Readers may pad missing keys with `class_i` labels for
   legacy sparse mappings, but out-of-range keys are invalid.
-- `imgsz`: positive integer square input resolution.
+- `imgsz`: positive integer square input resolution. Native v1 writers and
+  readers validate it against the selected family's fixed-canvas, minimum-size, stride, or patch
+  grid contract before loading weights. A valid value becomes the runtime
+  default for dynamic families. Fixed-canvas families reject a mismatch unless
+  the family explicitly opts into separately published native resolutions
+  (currently EoMT's 1280 COCO instance variant). Legacy/raw state dictionaries
+  do not override the constructed default.
 
 Pose checkpoints additionally include:
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -2,9 +2,12 @@
 
 This document catalogs the model-naming conventions **currently in use** in
 the LibreYOLO repository. It is descriptive — it records what is there today,
-not a proposal. Sources of truth are the `FAMILY` and `FILENAME_PREFIX`
-class constants in `libreyolo/models/<family>/model.py` and the
-task-resolution rules in [`libreyolo/tasks.py`](../libreyolo/tasks.py).
+not a proposal. The public identity source of truth is
+[`libreyolo/models/manifest.py`](../libreyolo/models/manifest.py), together
+with the task-resolution rules in
+[`libreyolo/tasks.py`](../libreyolo/tasks.py). Family-class `FAMILY` and
+`FILENAME_PREFIX` constants remain runtime compatibility metadata and must
+agree with the manifest.
 
 ## Filename schema
 
@@ -316,9 +319,8 @@ LibreFOMO uses `SUPPORTED_TASKS = ("point",)`. No pretrained weights are auto-do
 are converted from NVIDIA's ADE20K checkpoints, whose license permits
 redistribution (with the license attached) but restricts use to research or
 evaluation only. LibreYOLO hosts them and prints that restriction before each
-download, exactly as it does for the VisDrone research-preview weights. They are
-not covered by LibreYOLO's permissive license; train from scratch for
-unrestricted use. See `libreyolo/models/segformer/NOTICE`.
+download. They are not covered by LibreYOLO's permissive license; train from
+scratch for unrestricted use. See `libreyolo/models/segformer/NOTICE`.
 
 ## Examples by family + task
 
@@ -520,6 +522,24 @@ number, which sits a hair below the test-size figure. Each family threads its
 `crop_pct`/`interpolation` through `predict()`, `val()`, and exported-backend
 inference so all three agree.
 
+## Runtime input-size contract
+
+The task-and-size entry selects the model's native square canvas. Public
+`imgsz` overrides are validated before source loading, dataset setup, training,
+or exporter construction:
+
+- fixed-canvas families accept only the instance's native resolution;
+- dynamic convolutional families may require a declared stride divisor and
+  minimum canvas;
+- patch-transformer families require their patch-grid divisor; and
+- rectangular exports validate the height and width independently.
+
+A validated native v1 checkpoint `imgsz` becomes the default canvas for a
+dynamic family. Fixed-canvas families reject conflicting checkpoint metadata
+unless they explicitly publish multiple native resolutions; EoMT's 1280 COCO
+instance variant is the current opt-in case. Legacy/raw state dictionaries do
+not change the constructed runtime default.
+
 ## Resolution precedence
 
 When loading via `LibreYOLO("...")`, the task is resolved with this priority
@@ -535,7 +555,13 @@ Official LibreYOLO v1.0 checkpoints must carry `task` metadata; see
 legacy compatibility path for old LibreYOLO checkpoints, not the standard for
 new artifacts.
 
-## Filename regex
+## Filename identity and legacy regex
+
+`libreyolo.models.manifest` is the source of truth for public canonical
+filenames, aliases, family/task/size combinations, variants, and publication
+routes. Public resolution requires an exact manifest identity (matched
+case-insensitively); impossible combinations are rejected rather than inferred
+through a permissive pattern.
 
 `BaseModel._filename_regex` builds the canonical pattern as:
 
@@ -544,12 +570,15 @@ new artifacts.
 ```
 
 with `task_suffixes` derived from `SUPPORTED_TASKS` via
-`libreyolo.tasks.task_suffix_pattern`. This is the single source of truth for
-parsing a filename back into `(family, size, task, variant)`.
+`libreyolo.tasks.task_suffix_pattern`. Class regexes remain a compatibility
+parser for legacy, upstream, and third-party filenames outside the public
+manifest; they do not advertise or authorize a public artifact.
 
 The `variant` group only exists for families that declare `WEIGHT_VARIANTS`, a
 dataset suffix for published checkpoints trained on a non-default dataset.
-Example: `yolo9_p2` declares `("visdrone",)`, so `LibreYOLO9P2s-visdrone.pt`
-resolves the Hugging Face repo `LibreYOLO/LibreYOLO9P2s-visdrone` (a research
-preview under VisDrone's CC BY-NC-SA license, announced by a download notice).
+Example: `yolo9_p2` recognizes the local filename
+`LibreYOLO9P2s-visdrone.pt`, but neither the base P2 checkpoint nor the
+VisDrone variant has a public auto-download route. The variant remains gated
+by VisDrone's CC BY-NC-SA terms; users must supply a checkpoint they are
+authorized to use.
 Plain COCO-default weights never carry a variant suffix.

--- a/libreyolo/cli/commands/special.py
+++ b/libreyolo/cli/commands/special.py
@@ -163,20 +163,9 @@ def models_cmd(
 ) -> None:
     """List available model families and sizes."""
     from libreyolo.models.inventory import collect_model_inventory
-    from libreyolo.tasks import task_to_suffix
 
     families = []
     for family, metadata in collect_model_inventory().items():
-        cli_names = []
-        task_sizes = metadata["task_sizes"] or {
-            metadata["default_task"]: metadata["default_imgsz"]
-        }
-        for task, sizes in task_sizes.items():
-            suffix = task_to_suffix(task)
-            for size in sizes:
-                name = f"{family}-{size}" + (f"-{suffix}" if suffix else "")
-                if name not in cli_names:
-                    cli_names.append(name)
         extra = metadata["optional_extra"]
         families.append(
             {
@@ -186,10 +175,17 @@ def models_cmd(
                 "task_sizes": metadata["task_sizes"],
                 "tasks": metadata["tasks"],
                 "default_task": metadata["default_task"],
-                "cli_names": cli_names,
+                "cli_names": metadata["cli_names"],
+                "downloadable_cli_names": metadata["downloadable_cli_names"],
+                "local_only_cli_names": metadata["local_only_cli_names"],
                 "available": metadata["available"],
                 "optional_extra": extra,
                 "install_hint": f"pip install libreyolo[{extra}]" if extra else None,
+                "factory": metadata["factory"],
+                "public_entrypoint": metadata["public_entrypoint"],
+                "factory_default_model": metadata["factory_default_model"],
+                "generic_cli": metadata["generic_cli"],
+                "artifacts": metadata["artifacts"],
             }
         )
 
@@ -204,7 +200,37 @@ def models_cmd(
                 f"    Tasks: {', '.join(f['tasks'])} (default: {f['default_task']})"
             )
             lines.append(f"    Sizes: {', '.join(f['sizes'])}")
-            lines.append(f"    Names: {', '.join(f['cli_names'])}")
+            if f["cli_names"]:
+                lines.append(f"    Names: {', '.join(f['cli_names'])}")
+                if f["downloadable_cli_names"]:
+                    lines.append(
+                        "    Auto-download: " + ", ".join(f["downloadable_cli_names"])
+                    )
+                if f["local_only_cli_names"]:
+                    lines.append(
+                        "    Local checkpoint required: "
+                        + ", ".join(f["local_only_cli_names"])
+                    )
+            else:
+                model_states = sorted(
+                    {
+                        (artifact["factory_model"], artifact["publication"])
+                        for artifact in f["artifacts"]
+                        if artifact["factory_model"] is not None
+                    }
+                )
+                lines.append(
+                    f"    API: {f['public_entrypoint']} (separate {f['factory']} factory)"
+                )
+                lines.append(
+                    "    Models: "
+                    + ", ".join(
+                        f"{model} [{publication}]"
+                        for model, publication in model_states
+                    )
+                )
+                if f["factory_default_model"] is not None:
+                    lines.append(f"    Default: {f['factory_default_model']}")
             imgsz_str = ", ".join(f"{s}={v}" for s, v in f["default_imgsz"].items())
             lines.append(f"    Input: {imgsz_str}")
             if not f["available"] and f["install_hint"]:
@@ -270,9 +296,7 @@ def formats_cmd(
             "requires_onnx": cls.requires_onnx,
         }
         aliases = sorted(
-            alias
-            for alias, target in BaseExporter._aliases.items()
-            if target == name
+            alias for alias, target in BaseExporter._aliases.items() if target == name
         )
         if aliases:
             info["aliases"] = aliases

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -9,7 +9,14 @@ from dataclasses import MISSING, fields
 from pathlib import Path
 from typing import Any, Optional
 
-from libreyolo.tasks import task_to_suffix
+from libreyolo.models.manifest import (
+    CLI_MODEL_ALIASES,
+    FactoryKind,
+    get_family_spec,
+    load_family_class,
+    match_weight_filename,
+    resolve_cli_model,
+)
 
 
 def get_unsupported_train_params(family: str | None) -> set[str]:
@@ -27,71 +34,16 @@ def get_unsupported_train_params(family: str | None) -> set[str]:
 # Model name resolution
 # =========================================================================
 
-# Maps CLI model names (e.g. "yolox-s") to weight filenames (e.g. "LibreYOLOXs.pt").
-_CLI_NAME_TO_WEIGHTS: dict[str, str] = {}
-
-
-def _weight_filename_for_cli(cls, size_code: str) -> str:
-    formatter = getattr(cls, "format_weight_filename", None)
-    if callable(formatter):
-        return formatter(size_code)
-    return f"{cls.FILENAME_PREFIX}{size_code}{cls.WEIGHT_EXT}"
-
-
-def _task_sizes_for_cli(cls, task: str) -> dict[str, int]:
-    task_sizes = getattr(cls, "TASK_INPUT_SIZES", {}) or {}
-    return task_sizes.get(task) or cls.INPUT_SIZES
-
-
-def _register_cli_names_for_class(cls) -> None:
-    default_task = getattr(cls, "DEFAULT_TASK", "detect")
-    for size_code in _task_sizes_for_cli(cls, default_task):
-        cli_name = f"{cls.FAMILY}-{size_code}"
-        _CLI_NAME_TO_WEIGHTS[cli_name] = _weight_filename_for_cli(cls, size_code)
-
-    for task in getattr(cls, "SUPPORTED_TASKS", ("detect",)):
-        if task == default_task:
-            continue
-        suffix = task_to_suffix(task)
-        if suffix is None:
-            continue
-        for size_code in _task_sizes_for_cli(cls, task):
-            cli_name = f"{cls.FAMILY}-{size_code}-{suffix}"
-            weight_name = f"{cls.FILENAME_PREFIX}{size_code}-{suffix}{cls.WEIGHT_EXT}"
-            _CLI_NAME_TO_WEIGHTS[cli_name] = weight_name
-
-
-def _build_name_map() -> None:
-    """Populate CLI name → weight filename mapping from model registry."""
-    if _CLI_NAME_TO_WEIGHTS:
-        return
-    from libreyolo.models.base.model import BaseModel
-
-    for cls in BaseModel._registry:
-        _register_cli_names_for_class(cls)
-
-    # Also try RF-DETR (lazily registered)
-    from libreyolo.models import try_ensure_rfdetr
-
-    rfcls = try_ensure_rfdetr()
-    if rfcls is not None:
-        _register_cli_names_for_class(rfcls)
-
 
 def get_all_cli_names() -> list[str]:
     """Return all valid CLI model names (e.g. ['yolox-n', 'yolox-s', ...])."""
-    _build_name_map()
-    return list(_CLI_NAME_TO_WEIGHTS.keys())
+    return list(CLI_MODEL_ALIASES)
 
 
 def is_known_weight_filename(model: str) -> bool:
     """Return whether a path or filename matches a known packaged weight name."""
-    _build_name_map()
-    filename = Path(model).name.lower()
-    return any(
-        Path(weight).name.lower() == filename
-        for weight in _CLI_NAME_TO_WEIGHTS.values()
-    )
+    artifact = match_weight_filename(model)
+    return artifact is not None and artifact.factory is FactoryKind.CHECKPOINT
 
 
 def resolve_model_name(model: str) -> str:
@@ -100,18 +52,16 @@ def resolve_model_name(model: str) -> str:
     ``yolox-s`` → ``LibreYOLOXs.pt``
     ``best.pt`` → ``best.pt`` (unchanged)
     """
-    _build_name_map()
-    return _CLI_NAME_TO_WEIGHTS.get(model.lower(), model)
+    artifact = resolve_cli_model(model)
+    if artifact is None or artifact.canonical_filename is None:
+        return model
+    return artifact.canonical_filename
 
 
 def detect_family_from_name(model_name: str) -> Optional[str]:
     """Detect model family from a CLI model name like 'yolox-s' or 'yolo9-m'."""
-    _build_name_map()
-    lower = model_name.lower()
-    resolved = _CLI_NAME_TO_WEIGHTS.get(lower)
-    if resolved is not None:
-        return detect_family_from_weight_filename(resolved)
-    return None
+    artifact = resolve_cli_model(model_name)
+    return artifact.family if artifact is not None else None
 
 
 def _iter_model_classes():
@@ -132,7 +82,19 @@ def _iter_model_classes():
 
 def detect_family_from_weight_filename(model: str) -> Optional[str]:
     """Detect model family from a known LibreYOLO weight filename or path."""
+    artifact = match_weight_filename(model)
+    if artifact is not None and artifact.factory is FactoryKind.CHECKPOINT:
+        return artifact.family
+
+    # Preserve upstream/legacy filename recognition for complete checkpoint
+    # filenames only. Public aliases never enter the mutable registry fallback.
     filename = Path(model).name
+    if Path(filename).suffix.lower() not in {".pt", ".pth", ".safetensors"}:
+        return None
+    if filename.casefold().startswith("libre"):
+        # A Libre-prefixed public filename must be an exact manifest entry;
+        # do not let permissive legacy regexes accept impossible task/size pairs.
+        return None
     for cls in _iter_model_classes():
         if cls.detect_size_from_filename(filename) is not None:
             return cls.FAMILY
@@ -170,8 +132,10 @@ def detect_family_from_checkpoint(model_path: str) -> Optional[str]:
 
     if isinstance(checkpoint, dict):
         family = checkpoint.get("model_family")
-        if isinstance(family, str) and family:
-            return family
+        if isinstance(family, str):
+            family_spec = get_family_spec(family)
+            if family_spec is not None:
+                return family_spec.family
 
     state = _unwrap_checkpoint_state(checkpoint)
     if not isinstance(state, dict):
@@ -226,23 +190,27 @@ def detect_family_from_model_ref(
 
 
 def get_train_config_class(family: str) -> type:
-    """Look up the TrainConfig subclass for a model family from the registry.
+    """Look up the TrainConfig subclass for an exact model family.
 
     Returns the base TrainConfig if the family has no specific config.
     """
     from libreyolo.models.base.model import BaseModel
     from libreyolo.training.config import TrainConfig
 
+    family_spec = get_family_spec(family)
+    if family_spec is not None and family_spec.factory is FactoryKind.CHECKPOINT:
+        try:
+            model_class = load_family_class(family_spec)
+        except (ImportError, ModuleNotFoundError):
+            model_class = None
+        train_config = getattr(model_class, "TRAIN_CONFIG", None)
+        if train_config is not None:
+            return train_config
+
+    # Compatibility for third-party BaseModel subclasses outside the manifest.
     for cls in BaseModel._registry:
         if cls.FAMILY == family and cls.TRAIN_CONFIG is not None:
             return cls.TRAIN_CONFIG
-
-    # Check RF-DETR (lazily registered)
-    from libreyolo.models import try_ensure_rfdetr
-
-    rfcls = try_ensure_rfdetr()
-    if rfcls is not None and rfcls.FAMILY == family and rfcls.TRAIN_CONFIG is not None:
-        return rfcls.TRAIN_CONFIG
 
     return TrainConfig
 

--- a/libreyolo/data/depth_dataset.py
+++ b/libreyolo/data/depth_dataset.py
@@ -202,9 +202,10 @@ class DepthDataset(Dataset):
         augment: bool = False,
         resize_mode: str = "letterbox",
     ):
-        if resize_mode not in ("letterbox", "stretch"):
+        if resize_mode not in ("letterbox", "stretch", "native"):
             raise ValueError(
-                f"resize_mode must be 'letterbox' or 'stretch', got {resize_mode!r}"
+                "resize_mode must be 'letterbox', 'stretch', or 'native', "
+                f"got {resize_mode!r}"
             )
         self.split = split
         self.imgsz = int(imgsz)
@@ -278,6 +279,8 @@ class DepthDataset(Dataset):
     ) -> Tuple[np.ndarray, np.ndarray, float, Tuple[int, int]]:
         """Resize image (bilinear) and depth (nearest) and pad to imgsz."""
         h0, w0 = img.shape[:2]
+        if self.resize_mode == "native":
+            return img, depth, 1.0, (0, 0)
         if self.resize_mode == "stretch":
             new_w = new_h = self.imgsz
             ratio = 1.0

--- a/libreyolo/data/semantic_dataset.py
+++ b/libreyolo/data/semantic_dataset.py
@@ -194,9 +194,10 @@ class SemanticDataset(Dataset):
         hsv_prob: float = 0.5,
         crop_cat_max_ratio: float = 0.75,
     ):
-        if resize_mode not in ("letterbox", "stretch", "resize_crop"):
+        if resize_mode not in ("letterbox", "stretch", "resize_crop", "native"):
             raise ValueError(
-                f"resize_mode must be 'letterbox', 'stretch', or 'resize_crop', got {resize_mode!r}"
+                "resize_mode must be 'letterbox', 'stretch', 'resize_crop', "
+                f"or 'native', got {resize_mode!r}"
             )
         self.split = split
         self.imgsz = int(imgsz)
@@ -294,6 +295,8 @@ class SemanticDataset(Dataset):
     ) -> Tuple[np.ndarray, np.ndarray, float, Tuple[int, int]]:
         """Resize image (bilinear) and mask (nearest) and pad/crop to imgsz."""
         h0, w0 = img.shape[:2]
+        if self.resize_mode == "native":
+            return img, mask, 1.0, (0, 0)
         if self.resize_mode == "stretch":
             new_w = new_h = self.imgsz
             ratio = 1.0

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -541,16 +541,34 @@ class BaseExporter(ABC):
     def _resolve_params(self, output_path, imgsz, device, half, int8):
         native_imgsz = self.model._get_input_size()
         model_name = self.model._get_model_name()
+        validate_input_size = getattr(
+            type(self.model),
+            "_validate_input_size",
+            None,
+        )
+
+        def validate_dimension(value):
+            if callable(validate_input_size):
+                return validate_input_size(
+                    self.model,
+                    value,
+                    context="export",
+                )
+            return int(value)
+
         if imgsz is None:
+            native_imgsz = validate_dimension(native_imgsz)
             imgsz = (native_imgsz, native_imgsz)
         elif isinstance(imgsz, tuple):
             if len(imgsz) != 2:
                 raise ValueError(f"imgsz tuple must be (height, width), got {imgsz}")
-            imgsz = (int(imgsz[0]), int(imgsz[1]))
+            imgsz = (
+                validate_dimension(imgsz[0]),
+                validate_dimension(imgsz[1]),
+            )
         else:
-            imgsz = (int(imgsz), int(imgsz))
-        if imgsz[0] <= 0 or imgsz[1] <= 0:
-            raise ValueError(f"imgsz values must be positive, got {imgsz}.")
+            imgsz = validate_dimension(imgsz)
+            imgsz = (imgsz, imgsz)
         if model_name == "deimv2" and imgsz != (
             int(native_imgsz),
             int(native_imgsz),

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -10,10 +10,17 @@ All model families register here via ``__init_subclass__``. Adding a new model m
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from .base import BaseModel
-from ..tasks import resolve_task
+from .manifest import (
+    FactoryKind,
+    get_family_spec,
+    load_family_class,
+    match_weight_filename,
+)
+from ..tasks import normalize_task, resolve_task
 from ..utils.download import download_weights
 from ..utils.logging import ensure_default_logging
 from ..utils.serialization import (
@@ -98,6 +105,7 @@ from .clip.model import LibreCLIP  # noqa: E402,F401  (import registers family)
 # vision_model.embeddings.patch_embedding + text_model.head, so order does not
 # matter. NB: SigLIP carries logit_bias, which CLIP lacks.
 from .siglip2.model import LibreSigLIP2  # noqa: E402,F401  (import registers family)
+
 # PP-OCRv5 text detection + recognition pipeline. can_load is uniquely keyed
 # on the composite det.*/rec.* checkpoint layout, so order does not matter.
 from .ppocr.model import LibrePPOCR  # noqa: E402,F401  (import registers family)
@@ -141,10 +149,13 @@ def try_ensure_rfdetr():
 # =============================================================================
 
 
-def _resolve_weights_path(model_path: str) -> str:
+def _resolve_weights_path(model_path: str | os.PathLike[str]) -> str:
     """Resolve bare filenames to weights/ directory."""
+    model_path = os.fspath(model_path)
     path = Path(model_path)
-    if path.parent == Path(".") and not model_path.startswith(("./", "../")):
+    if path.parent == Path(".") and not model_path.startswith(
+        ("./", "../", ".\\", "..\\")
+    ):
         weights_path = Path("weights") / path.name
         if weights_path.exists():
             return str(weights_path)
@@ -225,7 +236,7 @@ def _has_any_libreyolo_metadata(loaded: object) -> bool:
 
 
 def LibreYOLO(
-    model_path: str,
+    model_path: str | os.PathLike[str],
     size: str | None = None,
     reg_max: int = 16,
     nb_classes: int | None = None,
@@ -253,31 +264,34 @@ def LibreYOLO(
         Model instance (LibreYOLOX, LibreYOLO9, LibreRFDETR, or inference backend).
     """
     ensure_default_logging()
+    requested_size = size
     model_path = _resolve_weights_path(model_path)
+    model_suffix = Path(model_path).suffix.casefold()
+    filename_artifact = match_weight_filename(model_path)
 
     # Non-PyTorch formats: delegate to inference backends
-    if model_path.endswith(".onnx"):
+    if model_suffix == ".onnx":
         from ..backends.onnx import OnnxBackend
 
         return OnnxBackend(
             model_path, nb_classes=nb_classes or 80, device=device, task=task
         )
 
-    if model_path.endswith(".torchscript"):
+    if model_suffix == ".torchscript":
         from ..backends.torchscript import TorchScriptBackend
 
         return TorchScriptBackend(
             model_path, nb_classes=nb_classes, device=device, task=task
         )
 
-    if model_path.endswith(".tflite"):
+    if model_suffix == ".tflite":
         from ..backends.tflite import TFLiteBackend
 
         return TFLiteBackend(
             model_path, nb_classes=nb_classes, device=device, task=task
         )
 
-    if model_path.endswith((".engine", ".tensorrt")):
+    if model_suffix in {".engine", ".tensorrt"}:
         from ..backends.tensorrt import TensorRTBackend
 
         return TensorRTBackend(
@@ -291,7 +305,7 @@ def LibreYOLO(
             model_path, nb_classes=nb_classes, device=device, task=task
         )
 
-    if Path(model_path).is_dir() and Path(model_path).suffix == ".mlpackage":
+    if Path(model_path).is_dir() and model_suffix == ".mlpackage":
         from ..backends.coreml import CoreMLBackend
 
         return CoreMLBackend(
@@ -312,7 +326,28 @@ def LibreYOLO(
                 model_path, nb_classes=nb_classes, device=device, task=task
             )
 
-    if task is not None:
+    if filename_artifact is not None:
+        if filename_artifact.factory is not FactoryKind.CHECKPOINT:
+            family_spec = get_family_spec(filename_artifact.family)
+            entrypoint = family_spec.public_entrypoint if family_spec else "its factory"
+            raise ValueError(
+                f"{Path(model_path).name!r} belongs to the separate {entrypoint} "
+                "model tier and cannot be loaded through LibreYOLO()."
+            )
+        if not Path(model_path).exists():
+            if size is not None and str(size).lower() != filename_artifact.size:
+                raise ValueError(
+                    f"Explicit size {size!r} conflicts with canonical filename "
+                    f"size {filename_artifact.size!r}."
+                )
+            explicit_task = normalize_task(task) if task is not None else None
+            if explicit_task is not None and explicit_task != filename_artifact.task:
+                raise ValueError(
+                    f"Explicit task {explicit_task!r} is not supported by the "
+                    f"canonical artifact for task {filename_artifact.task!r}."
+                )
+            size = filename_artifact.size
+    elif task is not None:
         filename = Path(model_path).name
         for cls in BaseModel._registry:
             if cls.detect_size_from_filename(filename) is not None:
@@ -326,30 +361,12 @@ def LibreYOLO(
     # Download if missing
     if not Path(model_path).exists():
         if size is None:
-            for cls in BaseModel._registry:
-                detected = cls.detect_size_from_filename(Path(model_path).name)
-                if detected is not None:
-                    size = detected
-                    logger.debug("Detected size '%s' from filename", size)
-                    break
-            # Try RF-DETR (may not be registered yet — cheap check)
-            if size is None:
-                try:
-                    _ensure_rfdetr()
-                    for cls in BaseModel._registry:
-                        detected = cls.detect_size_from_filename(Path(model_path).name)
-                        if detected is not None:
-                            size = detected
-                            logger.debug("Detected size '%s' from filename", size)
-                            break
-                except ModuleNotFoundError:
-                    pass
-            if size is None:
-                raise ValueError(
-                    f"Model weights file not found: {model_path}\n"
-                    f"Cannot auto-download: unable to determine size from filename.\n"
-                    f"Please specify size explicitly or provide a valid weights file path."
-                )
+            raise ValueError(
+                f"Model weights file not found: {model_path}\n"
+                "Cannot auto-download: the filename is not a canonical public "
+                "model artifact.\n"
+                "Use a generic CLI model name or provide a valid weights file path."
+            )
 
         download_error = None
         try:
@@ -366,7 +383,7 @@ def LibreYOLO(
 
     # Load weights once
     try:
-        if Path(model_path).suffix == ".safetensors":
+        if model_suffix == ".safetensors":
             try:
                 from safetensors.torch import load_file as load_safetensors_file
             except ImportError as e:
@@ -403,6 +420,17 @@ def LibreYOLO(
     metadata_errors = validate_checkpoint_metadata(loaded, strict=False)
     has_v1_metadata = not metadata_errors
     has_partial_metadata = _has_any_libreyolo_metadata(loaded)
+    if has_v1_metadata:
+        checkpoint_size = str(loaded["size"]).casefold()
+        if (
+            requested_size is not None
+            and str(requested_size).casefold() != checkpoint_size
+        ):
+            raise ValueError(
+                f"Explicit size {requested_size!r} conflicts with checkpoint "
+                f"metadata size {checkpoint_size!r}."
+            )
+        size = checkpoint_size
     is_legacy_libreyolo = (
         not has_v1_metadata
         and isinstance(loaded, dict)
@@ -478,9 +506,30 @@ def LibreYOLO(
         else None
     )
     if metadata_family:
-        cls = _find_registered_family(metadata_family)
+        family_spec = get_family_spec(metadata_family)
+        if (
+            family_spec is not None
+            and family_spec.factory is not FactoryKind.CHECKPOINT
+        ):
+            raise ValueError(
+                f"Checkpoint metadata family {metadata_family!r} belongs to the "
+                f"separate {family_spec.public_entrypoint} model tier and cannot "
+                "be loaded through LibreYOLO()."
+            )
+        cls = (
+            load_family_class(family_spec)
+            if family_spec is not None and family_spec.factory is FactoryKind.CHECKPOINT
+            else _find_registered_family(metadata_family)
+        )
         if cls is not None and cls.can_load(weights_dict):
             matched_cls = cls
+
+    if matched_cls is None and filename_artifact is not None:
+        family_spec = get_family_spec(filename_artifact.family)
+        if family_spec is not None and family_spec.factory is FactoryKind.CHECKPOINT:
+            cls = load_family_class(family_spec)
+            if cls.can_load(weights_dict):
+                matched_cls = cls
 
     if matched_cls is None:
         filename = Path(model_path).name
@@ -559,13 +608,13 @@ def LibreYOLO(
     # the fresh model init too early. This matters for YOLO9-t where the class
     # branch width depends on COCO-vs-custom ``nc`` during construction.
     if nb_classes is None:
-        if matched_cls.FAMILY in ("rfdetr", "dinov2", "eomt"):
-            # Transformer dense heads build to the checkpoint's class width.
-            # The 80 default below is a YOLO9-family convention that would
-            # mis-size the head for a metadata-wrapped checkpoint.
+        if matched_cls.FAMILY in ("rfdetr", "dinov2", "eomt", "yolo1"):
+            # Dense transformer heads and fixed-width YOLO1 build to the
+            # checkpoint's class width.  The generic 80-class default would
+            # mis-size these models before their loaders can inspect metadata.
             nb_classes = matched_cls.detect_nb_classes(weights_dict)
             if nb_classes is None:
-                nb_classes = 80
+                nb_classes = 20 if matched_cls.FAMILY == "yolo1" else 80
         elif has_metadata:
             nb_classes = 80
         else:

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -200,17 +200,6 @@ class InferenceRunner:
             vid_stride=vid_stride,
             overlap_ratio=overlap_ratio,
         )
-        if device is not None:
-            self._set_device(device)
-
-        if output_file_format is not None:
-            output_file_format = output_file_format.lower().lstrip(".")
-            if output_file_format not in ("jpg", "jpeg", "png", "webp"):
-                raise ValueError(
-                    f"Invalid output_file_format: {output_file_format}. "
-                    "Must be one of: 'jpg', 'png', 'webp'"
-                )
-            
         if tiling and augment:
             raise ValueError(
                 "tiling and augment cannot be used together. "
@@ -223,6 +212,35 @@ class InferenceRunner:
                 "Test-time augmentation does not support point-task models yet. "
                 "Use augment=False for point models."
             )
+        effective_imgsz = imgsz if imgsz is not None else self.model._get_input_size()
+        validate_input_size = getattr(
+            type(self.model),
+            "_validate_predict_input_size",
+            None,
+        )
+        imgsz = (
+            validate_input_size(
+                self.model,
+                effective_imgsz,
+            )
+            if callable(validate_input_size)
+            else effective_imgsz
+        )
+        if tiling and isinstance(imgsz, tuple):
+            raise ValueError(
+                "Tiled inference requires a square imgsz; got rectangular "
+                f"imgsz={imgsz}. Use a scalar canvas or disable tiling."
+            )
+        if device is not None:
+            self._set_device(device)
+
+        if output_file_format is not None:
+            output_file_format = output_file_format.lower().lstrip(".")
+            if output_file_format not in ("jpg", "jpeg", "png", "webp"):
+                raise ValueError(
+                    f"Invalid output_file_format: {output_file_format}. "
+                    "Must be one of: 'jpg', 'png', 'webp'"
+                )
 
         # A four-dimensional in-memory source is an image batch, not a single
         # image. Expand it in source order so no item is silently discarded by

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -751,7 +751,7 @@ class BaseModel(ABC):
         # Exact public identities are owned by the static manifest.  In
         # particular, do not synthesize a plausible URL for a known
         # config-only or otherwise unpublished checkpoint.
-        from ..manifest import match_weight_filename
+        from ..manifest import get_artifact_spec, match_weight_filename
 
         artifact = match_weight_filename(filename)
         if artifact is not None:
@@ -764,10 +764,28 @@ class BaseModel(ABC):
         size = cls.detect_size_from_filename(filename)
         if size is None:
             return None
-        task = cls.detect_task_from_filename(filename)
+        task = cls.detect_task_from_filename(filename) or cls.DEFAULT_TASK
+        variant = cls.detect_variant_from_filename(filename)
+
+        # A permissive legacy filename regex must not bypass a fail-closed
+        # publication declaration.  For example, adding an arbitrary prefix to
+        # a config-only canonical filename makes ``match_weight_filename`` miss,
+        # while ``detect_size_from_filename`` still recognizes the embedded
+        # model name.  Resolve the parsed identity through the manifest before
+        # retaining the compatibility URL fallback.
+        declared = get_artifact_spec(
+            cls.FAMILY,
+            size,
+            task,
+            variant=variant,
+        )
+        if declared is not None:
+            if declared.download_kind != "hf":
+                return None
+            return declared.download_url
+
         task_suffix = task_to_suffix(task)
         suffix = f"-{task_suffix}" if task_suffix else ""
-        variant = cls.detect_variant_from_filename(filename)
         variant_suffix = f"-{variant}" if variant else ""
         name = f"{cls.FILENAME_PREFIX}{size}{suffix}{variant_suffix}"
         return f"https://huggingface.co/LibreYOLO/{name}/resolve/main/{name}{cls.WEIGHT_EXT}"

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -12,6 +12,7 @@ import logging
 import random
 import re
 from abc import ABC, abstractmethod
+from numbers import Integral
 from pathlib import Path
 from typing import (
     Any,
@@ -99,8 +100,26 @@ def _wrap_train_with_cfg(train_fn: Callable) -> Callable:
         ):
             bound = sig.bind_partial(self, *args, **call_kwargs)
             bound.apply_defaults()
-            seed = bound.arguments.get("seed")
+            imgsz = bound.arguments.get("imgsz")
             variadic_kwargs = bound.arguments.get("kwargs")
+            if imgsz is None and isinstance(variadic_kwargs, dict):
+                imgsz = variadic_kwargs.get("imgsz")
+            if imgsz is not None:
+                validate_input_size = getattr(
+                    type(self),
+                    "_validate_input_size",
+                    None,
+                )
+                validated = (
+                    validate_input_size(self, imgsz, context="train")
+                    if callable(validate_input_size)
+                    else imgsz
+                )
+                if "imgsz" in call_kwargs:
+                    call_kwargs = dict(call_kwargs)
+                    call_kwargs["imgsz"] = validated
+
+            seed = bound.arguments.get("seed")
             if seed is None and isinstance(variadic_kwargs, dict):
                 seed = variadic_kwargs.get("seed")
             if seed is None:
@@ -184,6 +203,17 @@ class BaseModel(ABC):
     # classify-only family requires ``-cls``); detect families leave it optional.
     REQUIRE_TASK_SUFFIX: ClassVar[bool] = False
     TASK_INPUT_SIZES: ClassVar[dict[str, dict[str, int]]] = {}
+    # User-facing input-size constraints. Fixed families accept only the
+    # instance-native canvas; dynamic families may declare a stride/divisor and
+    # minimum safe canvas. Family-local semantic/depth divisor attributes are
+    # also honored for backward compatibility.
+    INPUT_SIZE_FIXED: ClassVar[bool] = False
+    INPUT_SIZE_DIVISOR: ClassVar[int | None] = None
+    INPUT_SIZE_MIN: ClassVar[int] = 1
+    SUPPORTS_RECTANGULAR_INPUT: ClassVar[bool] = False
+    # Rare fixed-canvas families with separately published native resolutions
+    # may let validated checkpoint metadata replace the construction default.
+    CHECKPOINT_INPUT_SIZE_OVERRIDE: ClassVar[bool] = False
     TRAIN_CONFIG: ClassVar[Optional[type[TrainConfig]]] = None
     val_preprocessor_class = StandardValPreprocessor
     validator_class: ClassVar[Optional[type]] = None
@@ -417,6 +447,116 @@ class BaseModel(ABC):
     def _get_input_size(self) -> int:
         return self.input_size
 
+    def _validate_input_size(
+        self,
+        imgsz: Any,
+        *,
+        context: str,
+        allow_fixed_override: bool = False,
+    ) -> int:
+        """Validate one square runtime canvas before any expensive work."""
+        family = self.FAMILY or type(self).__name__
+        if isinstance(imgsz, bool) or not isinstance(imgsz, Integral):
+            raise ValueError(
+                f"{family} {context} imgsz must be a positive integer, got "
+                f"{imgsz!r}"
+            )
+        value = int(imgsz)
+        if value <= 0:
+            raise ValueError(
+                f"{family} {context} imgsz must be a positive integer, got "
+                f"{value}"
+            )
+
+        native = int(self._get_input_size())
+        if self.INPUT_SIZE_FIXED and value != native and not allow_fixed_override:
+            raise ValueError(
+                f"{family} only supports imgsz={native}; {context} requires "
+                f"imgsz={native}, got {value}"
+            )
+
+        minimum = int(getattr(self, "INPUT_SIZE_MIN", 1) or 1)
+        if value < minimum:
+            raise ValueError(
+                f"{family} {context} imgsz must be at least {minimum}; got {value}"
+            )
+
+        divisor = getattr(self, "INPUT_SIZE_DIVISOR", None)
+        if divisor is None:
+            if getattr(self, "task", None) == "semantic":
+                divisor = getattr(self, "semantic_imgsz_divisor", None)
+            elif getattr(self, "task", None) == "depth":
+                divisor = getattr(self, "depth_imgsz_divisor", None)
+        divisor = int(divisor or 1)
+        if divisor <= 0:
+            raise RuntimeError(
+                f"{family} declares invalid INPUT_SIZE_DIVISOR={divisor}"
+            )
+        if value % divisor:
+            raise ValueError(
+                f"{family} {context} imgsz={value} must be divisible by "
+                f"{divisor}"
+            )
+        return value
+
+    def _validate_predict_input_size(self, imgsz: Any) -> int | tuple[int, int]:
+        """Validate scalar or rectangular prediction canvas dimensions."""
+        if isinstance(imgsz, (list, tuple)):
+            if len(imgsz) != 2:
+                raise ValueError(
+                    f"{self.FAMILY or type(self).__name__} inference imgsz must "
+                    f"be an integer or (height, width), got {imgsz!r}"
+                )
+            height = self._validate_input_size(imgsz[0], context="inference")
+            width = self._validate_input_size(imgsz[1], context="inference")
+            if height == width:
+                return height
+            if not self.SUPPORTS_RECTANGULAR_INPUT:
+                raise ValueError(
+                    f"{self.FAMILY or type(self).__name__} inference does not "
+                    f"support rectangular imgsz={(height, width)}"
+                )
+            return height, width
+        return self._validate_input_size(imgsz, context="inference")
+
+    def _validate_export_input_size(self, imgsz: Any) -> int | tuple[int, int]:
+        """Validate export dimensions before exporter construction."""
+        if isinstance(imgsz, (list, tuple)):
+            if len(imgsz) != 2:
+                raise ValueError(
+                    f"{self.FAMILY or type(self).__name__} export imgsz must be "
+                    f"an integer or (height, width), got {imgsz!r}"
+                )
+            return (
+                self._validate_input_size(imgsz[0], context="export"),
+                self._validate_input_size(imgsz[1], context="export"),
+            )
+        return self._validate_input_size(imgsz, context="export")
+
+    def _apply_checkpoint_input_size(
+        self,
+        checkpoint: dict,
+        *,
+        is_native_v1: bool,
+    ) -> None:
+        """Adopt validated native checkpoint canvas metadata when supported."""
+        if not is_native_v1 or "imgsz" not in checkpoint:
+            return
+        raw_imgsz = checkpoint["imgsz"]
+        allow_fixed_override = bool(self.CHECKPOINT_INPUT_SIZE_OVERRIDE)
+        try:
+            validated = self._validate_input_size(
+                raw_imgsz,
+                context="checkpoint",
+                allow_fixed_override=allow_fixed_override,
+            )
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Cannot use checkpoint imgsz={raw_imgsz!r} for "
+                f"{self.FAMILY or type(self).__name__}: {exc}"
+            ) from exc
+        self.input_size = validated
+
     def _strict_loading(self) -> bool:
         """Return whether legacy raw checkpoints require exact loading."""
         return True
@@ -608,6 +748,19 @@ class BaseModel(ABC):
     @classmethod
     def get_download_url(cls, filename: str) -> Optional[str]:
         """Return the Hugging Face download URL for the given weight filename."""
+        # Exact public identities are owned by the static manifest.  In
+        # particular, do not synthesize a plausible URL for a known
+        # config-only or otherwise unpublished checkpoint.
+        from ..manifest import match_weight_filename
+
+        artifact = match_weight_filename(filename)
+        if artifact is not None:
+            if artifact.family != cls.FAMILY or artifact.download_kind != "hf":
+                return None
+            return artifact.download_url
+
+        # Preserve the historical convention for compatible third-party or
+        # locally published filenames that are not part of the public catalog.
         size = cls.detect_size_from_filename(filename)
         if size is None:
             return None
@@ -755,6 +908,11 @@ class BaseModel(ABC):
                     f"but this model was initialized for task='{self.task}'. "
                     "Pass the matching task or use the correct checkpoint."
                 )
+
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
 
         ckpt_nc = self._normalize_checkpoint_nc(loaded.get("nc"))
         ckpt_names = loaded.get("names")
@@ -991,6 +1149,8 @@ class BaseModel(ABC):
         orig_w, orig_h = img_pil.size
 
         scales = (1.0,) if self.TTA_FIXED_SIZE else self.TTA_SCALES
+        postprocess_kwargs = dict(kwargs)
+        postprocess_kwargs["input_size"] = effective_imgsz
 
         aug_dets = []
         for scale in scales:
@@ -1013,7 +1173,13 @@ class BaseModel(ABC):
                 with torch.no_grad():
                     raw = self._forward(tensor.to(self.device))
                 det = self._postprocess(
-                    raw, conf, iou, orig_size, max_det=max_det, ratio=ratio, **kwargs
+                    raw,
+                    conf,
+                    iou,
+                    orig_size,
+                    max_det=max_det,
+                    ratio=ratio,
+                    **postprocess_kwargs,
                 )
                 aug_dets.append((det, orig_size, is_flipped, scale))
 
@@ -1405,6 +1571,9 @@ class BaseModel(ABC):
         """
         from libreyolo.export import BaseExporter
 
+        if kwargs.get("imgsz") is not None:
+            kwargs["imgsz"] = self._validate_export_input_size(kwargs["imgsz"])
+
         return BaseExporter.create(format, self)(**kwargs)
 
     def val(
@@ -1463,6 +1632,9 @@ class BaseModel(ABC):
 
         if imgsz is None:
             imgsz = self._get_input_size()
+        validate_input_size = getattr(type(self), "_validate_input_size", None)
+        if callable(validate_input_size):
+            imgsz = validate_input_size(self, imgsz, context="validation")
         if plots is not None and "save_plots" not in kwargs:
             kwargs["save_plots"] = plots
         if augment and self.task == "obb":

--- a/libreyolo/models/birefnet/model.py
+++ b/libreyolo/models/birefnet/model.py
@@ -38,6 +38,7 @@ class LibreBiRefNet(BaseModel):
     FILENAME_PREFIX = "LibreBiRefNet"
     WEIGHT_EXT = ".pt"
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"t": 1024, "l": 1024}
+    INPUT_SIZE_FIXED = True
     SUPPORTED_TASKS = ("matte",)
     DEFAULT_TASK = "matte"
     REQUIRE_TASK_SUFFIX = True

--- a/libreyolo/models/clip/model.py
+++ b/libreyolo/models/clip/model.py
@@ -62,6 +62,7 @@ class LibreCLIP(BaseModel):
     INPUT_SIZES: ClassVar[Dict[str, int]] = {
         size: cfg.image_size for size, cfg in CLIP_CONFIGS.items()
     }
+    INPUT_SIZE_FIXED: ClassVar[bool] = True
     SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("classify",)
     DEFAULT_TASK: ClassVar[str] = "classify"
     TRAIN_CONFIG = None
@@ -336,7 +337,7 @@ class LibreCLIP(BaseModel):
 
         if not isinstance(loaded, dict):
             raise TypeError("LibreCLIP checkpoints must be dictionaries.")
-        loaded, _is_native_v1 = self._parse_checkpoint_metadata(
+        loaded, is_native_v1 = self._parse_checkpoint_metadata(
             loaded,
             context="LibreCLIP checkpoint",
         )
@@ -352,6 +353,11 @@ class LibreCLIP(BaseModel):
             raise RuntimeError(
                 f"Checkpoint task={normalize_task(ckpt_task)!r} is not 'classify'."
             )
+
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
 
         state = self._extract_state(loaded)
         if "logit_scale" not in state or "text_projection" not in state:
@@ -385,6 +391,11 @@ class LibreCLIP(BaseModel):
         """
         from ...data.classify_dataset import get_class_names, resolve_classify_data
 
+        requested_imgsz = kwargs.get("imgsz")
+        kwargs["imgsz"] = self._validate_input_size(
+            self._get_input_size() if requested_imgsz is None else requested_imgsz,
+            context="validation",
+        )
         if data is None:
             raise ValueError("LibreCLIP.val() requires data= (an ImageFolder root).")
         root = resolve_classify_data(data)
@@ -423,6 +434,11 @@ class LibreCLIP(BaseModel):
                 "(frozen-class) is supported. Open-vocabulary export (two towers "
                 "+ tokenizer) is out of scope for v1."
             )
+        requested_imgsz = kwargs.get("imgsz")
+        kwargs["imgsz"] = self._validate_input_size(
+            self._get_input_size() if requested_imgsz is None else requested_imgsz,
+            context="export",
+        )
         if self._text_embeds is None:
             raise RuntimeError("No classes set; call set_classes() before export().")
 

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -32,6 +32,7 @@ class LibreDEIM(BaseModel):
     FAMILY = "deim"
     FILENAME_PREFIX = "LibreDEIM"
     INPUT_SIZES = {"n": 640, "s": 640, "m": 640, "l": 640, "x": 640}
+    INPUT_SIZE_FIXED = True
     TRAIN_CONFIG = DEIMConfig
     val_preprocessor_class = DEIMValPreprocessor
     TTA_FIXED_SIZE = True  # resizes to a fixed square; multi-scale TTA is a no-op
@@ -343,6 +344,10 @@ class LibreDEIM(BaseModel):
                         f"Checkpoint was trained for task={normalize_task(ckpt_task)!r} "
                         f"but this model was initialized for task={self.task!r}."
                     )
+                self._apply_checkpoint_input_size(
+                    loaded,
+                    is_native_v1=is_native_v1,
+                )
                 ckpt_names = loaded.get("names")
                 ckpt_nc = self._normalize_checkpoint_nc(loaded.get("nc"))
                 if ckpt_nc is None and ckpt_names is not None:

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -40,6 +40,7 @@ class LibreDEIMv2(BaseModel):
     FAMILY = "deimv2"
     FILENAME_PREFIX = "LibreDEIMv2"
     INPUT_SIZES = {size: int(cfg["input_size"]) for size, cfg in SIZE_CONFIGS.items()}
+    INPUT_SIZE_FIXED = True
     TRAIN_CONFIG = DEIMv2Config
     val_preprocessor_class = DEIMv2ValPreprocessor
     TTA_FIXED_SIZE = True  # fixed decoder anchors require a fixed size; multi-scale TTA is invalid
@@ -408,6 +409,10 @@ class LibreDEIMv2(BaseModel):
                 f"Checkpoint was trained for task={normalize_task(ckpt_task)!r}, "
                 "but DEIMv2 is detection-only."
             )
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
         ckpt_nc = self._normalize_checkpoint_nc(loaded.get("nc"))
         if ckpt_nc is None:
             ckpt_nc = self._normalize_checkpoint_nc(

--- a/libreyolo/models/depth_anything/model.py
+++ b/libreyolo/models/depth_anything/model.py
@@ -54,11 +54,9 @@ class LibreDepthAnythingV2(BaseModel):
 
     # DINOv2 patch grid; the depth dataset and validator enforce divisibility.
     depth_imgsz_divisor = 14
-    # Validation goes through the shared DepthDataset, which letterboxes to a
-    # fixed square (padded pixels are invalid depth, excluded from metrics).
-    # Note: predict uses DA's native keep-aspect lower-bound resize, so val
-    # metrics on non-square images are a documented approximation of predict.
-    depth_resize_mode = "letterbox"
+    # Validation delegates to the same keep-aspect lower-bound preprocess and
+    # original-canvas postprocess used by predict.
+    depth_resize_mode = "native"
 
     # Keep-aspect preprocessing yields per-image variable sizes, so the stacked
     # single-forward batched-predict path does not apply. TTA_ENABLED is left at

--- a/libreyolo/models/depth_anything3/model.py
+++ b/libreyolo/models/depth_anything3/model.py
@@ -42,7 +42,7 @@ class LibreDepthAnything3(BaseModel):
     REQUIRE_TASK_SUFFIX = True
 
     depth_imgsz_divisor = 14
-    depth_resize_mode = "letterbox"
+    depth_resize_mode = "native"
     SUPPORTS_BATCHED_PREDICT = False
 
     _UPSTREAM_URL = "https://github.com/ByteDance-Seed/Depth-Anything-3"

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -41,6 +41,8 @@ class LibreDFINE(BaseModel):
     FAMILY = "dfine"
     FILENAME_PREFIX = "LibreDFINE"
     INPUT_SIZES = {"n": 640, "s": 640, "m": 640, "l": 640, "x": 640}
+    INPUT_SIZE_DIVISOR = 32
+    INPUT_SIZE_MIN = 128
     SUPPORTED_TASKS = ("detect", "segment")
     DEFAULT_TASK = "detect"
     TASK_INPUT_SIZES = {
@@ -449,6 +451,10 @@ class LibreDFINE(BaseModel):
                             f"but this model was initialized for task='{self.task}'. "
                             "Pass the matching task."
                         )
+                self._apply_checkpoint_input_size(
+                    loaded,
+                    is_native_v1=is_native_v1,
+                )
                 ckpt_names = loaded.get("names")
                 ckpt_nc = self._normalize_checkpoint_nc(loaded.get("nc"))
                 if ckpt_nc is None and ckpt_names is not None:

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -180,6 +180,7 @@ class LibreDINOv2(BaseModel):
 
     # Semantic runs at the DINOv2-native 518 (37 × 14); classify runs at 224.
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"n": 518, "s": 518, "m": 518, "l": 518}
+    INPUT_SIZE_DIVISOR: ClassVar[int] = 14
     TASK_INPUT_SIZES: ClassVar[Dict[str, Dict[str, int]]] = {
         "classify": {"n": 224, "s": 224, "m": 224, "l": 224},
     }
@@ -481,13 +482,16 @@ class LibreDINOv2(BaseModel):
 
         if not isinstance(loaded, dict):
             raise TypeError("LibreDINOv2 checkpoints must be dictionaries")
-        loaded, _is_native_v1 = self._parse_checkpoint_metadata(
+        loaded, is_native_v1 = self._parse_checkpoint_metadata(
             loaded,
             context=f"DINOv2 {self.task} checkpoint",
         )
 
         if self.task == "classify":
-            return self._load_classify_weights(loaded)
+            return self._load_classify_weights(
+                loaded,
+                is_native_v1=is_native_v1,
+            )
 
         # Accept both model_family="dinov2" (new) and "rfdetr" (legacy semantic).
         ckpt_family = loaded.get("model_family", "")
@@ -503,6 +507,11 @@ class LibreDINOv2(BaseModel):
                 f"Checkpoint was trained for task={normalize_task(ckpt_task)!r}, "
                 "but is being loaded into a LibreDINOv2 semantic model."
             )
+
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
 
         # Detect and rebuild for checkpoint class count.
         state = self._extract_state(loaded)
@@ -532,7 +541,12 @@ class LibreDINOv2(BaseModel):
             self.names = self._sanitize_names(ckpt_names, self.nb_classes)
         self.model.to(self.device).eval()
 
-    def _load_classify_weights(self, loaded: dict) -> None:
+    def _load_classify_weights(
+        self,
+        loaded: dict,
+        *,
+        is_native_v1: bool,
+    ) -> None:
         """Load a LibreDINOv2 classification checkpoint.
 
         Clean break: legacy ``LibreRFDETR*-cls`` checkpoints
@@ -552,6 +566,11 @@ class LibreDINOv2(BaseModel):
                 f"Checkpoint was trained for task={normalize_task(ckpt_task)!r}, "
                 "but is being loaded into a LibreDINOv2 classification model."
             )
+
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
 
         state = self._extract_state(loaded)
         lw = state.get("linear.weight")

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -29,6 +29,7 @@ class LibreEC(BaseModel):
     FAMILY = "ec"
     FILENAME_PREFIX = "LibreEC"
     INPUT_SIZES = {"s": 640, "m": 640, "l": 640, "x": 640}
+    INPUT_SIZE_FIXED = True
     POSE_INPUT_SIZES = {"s": 640, "m": 640, "l": 640, "x": 640}
     SEG_INPUT_SIZES = {"s": 640, "m": 640, "l": 640, "x": 640}
     SUPPORTED_TASKS = ("detect", "pose", "segment")
@@ -642,6 +643,10 @@ class LibreEC(BaseModel):
                         f"Checkpoint was trained with model_family='{ckpt_family}' "
                         f"but is being loaded into '{own_family}'."
                     )
+                self._apply_checkpoint_input_size(
+                    loaded,
+                    is_native_v1=is_native_v1,
+                )
                 ckpt_names = loaded.get("names")
                 ckpt_nc = self._normalize_checkpoint_nc(loaded.get("nc"))
                 if ckpt_nc is None and ckpt_names is not None:

--- a/libreyolo/models/eomt/model.py
+++ b/libreyolo/models/eomt/model.py
@@ -6,6 +6,7 @@ import logging
 import math
 import sys
 import time
+from functools import wraps
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
@@ -27,10 +28,23 @@ from ...utils.serialization import (
     inspect_load_state_dict_result,
     load_untrusted_torch_file,
 )
+from ...validation.base import validation_model_state
+from ...validation.preprocessors import BaseValPreprocessor
 from ..base.model import BaseModel
 from .nn import LibreEoMTNet, normalize_eomt_state_dict
 
 logger = logging.getLogger(__name__)
+
+
+def _transactional_validation(method):
+    """Restore EoMT's live device and mixed module modes after custom val."""
+
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with validation_model_state(self, self.device):
+            return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 def _extract_state(loaded: dict[str, Any]) -> dict[str, Any]:
@@ -42,6 +56,93 @@ def _extract_state(loaded: dict[str, Any]) -> dict[str, Any]:
 
 def _eomt_keys(weights_dict: dict[str, Any]) -> set[str]:
     return set(normalize_eomt_state_dict(weights_dict))
+
+
+def _eomt_coco_content_size(orig_h: int, orig_w: int, size: int) -> Tuple[int, int]:
+    """Return EoMT's aspect-preserving COCO content size."""
+    min_o, max_o = float(min(orig_h, orig_w)), float(max(orig_h, orig_w))
+    target = size
+    raw: Optional[float] = None
+    if max_o / min_o * size > size:
+        raw = size * min_o / max_o
+        target = int(round(raw))
+    if (orig_h <= orig_w and orig_h == target) or (
+        orig_w <= orig_h and orig_w == target
+    ):
+        return orig_h, orig_w
+    if orig_w < orig_h:
+        out_w = target
+        out_h = (
+            int(raw * orig_h / orig_w)
+            if raw is not None
+            else int(size * orig_h / orig_w)
+        )
+    else:
+        out_h = target
+        out_w = (
+            int(raw * orig_w / orig_h)
+            if raw is not None
+            else int(size * orig_w / orig_h)
+        )
+    return out_h, out_w
+
+
+def _preprocess_eomt_coco_pil(
+    img: Image.Image, input_size: int
+) -> tuple[torch.Tensor, Tuple[int, int]]:
+    """Resize and zero-pad one COCO image using EoMT's native geometry."""
+    orig_w, orig_h = img.size
+    content_h, content_w = _eomt_coco_content_size(orig_h, orig_w, input_size)
+    resized = TVF.resize(
+        TVF.pil_to_tensor(img).unsqueeze(0),
+        [content_h, content_w],
+        interpolation=InterpolationMode.BILINEAR,
+        antialias=True,
+    )[0].float()
+    resized.div_(255.0)
+    canvas = torch.zeros((3, input_size, input_size), dtype=resized.dtype)
+    canvas[:, :content_h, :content_w] = resized
+    return canvas.unsqueeze(0), (content_h, content_w)
+
+
+class _EoMTCOCOValPreprocessor(BaseValPreprocessor):
+    """Use EoMT's native COCO resize/pad helper for instance validation."""
+
+    @property
+    def normalize(self) -> bool:
+        return True
+
+    @property
+    def uses_letterbox(self) -> bool:
+        return True
+
+    @property
+    def wants_unresized_image(self) -> bool:
+        return True
+
+    def __call__(
+        self, img: np.ndarray, targets: np.ndarray, input_size: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        target_h, target_w = input_size
+        if target_h != target_w:
+            raise ValueError(
+                "EoMT COCO validation requires a square input canvas, got "
+                f"{input_size}."
+            )
+        orig_h, orig_w = img.shape[:2]
+        rgb = np.ascontiguousarray(img[:, :, ::-1])
+        tensor, (content_h, content_w) = _preprocess_eomt_coco_pil(
+            Image.fromarray(rgb), target_h
+        )
+
+        padded_targets = np.zeros((self.max_labels, 5), dtype=np.float32)
+        if len(targets) > 0:
+            targets = np.asarray(targets, dtype=np.float32).copy()
+            n = min(len(targets), self.max_labels)
+            targets[:n, [0, 2]] *= content_w / orig_w
+            targets[:n, [1, 3]] *= content_h / orig_h
+            padded_targets[:n] = targets[:n]
+        return tensor[0].numpy(), padded_targets
 
 
 class LibreEoMT(BaseModel):
@@ -77,6 +178,9 @@ class LibreEoMT(BaseModel):
     _EMBED_DIM_TO_SIZE: ClassVar[Dict[int, str]] = {384: "s", 768: "b", 1024: "l"}
     _UPSTREAM_URL: ClassVar[str] = "https://github.com/tue-mps/eomt"
     SUPPORTS_BATCHED_PREDICT: ClassVar[bool] = False
+    INPUT_SIZE_FIXED: ClassVar[bool] = True
+    INPUT_SIZE_DIVISOR: ClassVar[int] = 16
+    CHECKPOINT_INPUT_SIZE_OVERRIDE: ClassVar[bool] = True
 
     @classmethod
     def can_load(cls, weights_dict: dict) -> bool:
@@ -240,6 +344,10 @@ class LibreEoMT(BaseModel):
                 layers[name] = module
         return layers
 
+    def _get_val_preprocessor(self, img_size: int | None = None):
+        effective = self._get_input_size() if img_size is None else int(img_size)
+        return _EoMTCOCOValPreprocessor((effective, effective))
+
     @staticmethod
     def _get_preprocess_numpy():
         import cv2
@@ -358,31 +466,7 @@ class LibreEoMT(BaseModel):
         EoMT image processor uses for the COCO checkpoints, where both
         ``shortest_edge`` and ``longest_edge`` equal the model resolution.
         """
-        min_o, max_o = float(min(orig_h, orig_w)), float(max(orig_h, orig_w))
-        target = size
-        raw: Optional[float] = None
-        if max_o / min_o * size > size:
-            raw = size * min_o / max_o
-            target = int(round(raw))
-        if (orig_h <= orig_w and orig_h == target) or (
-            orig_w <= orig_h and orig_w == target
-        ):
-            return orig_h, orig_w
-        if orig_w < orig_h:
-            out_w = target
-            out_h = (
-                int(raw * orig_h / orig_w)
-                if raw is not None
-                else int(size * orig_h / orig_w)
-            )
-        else:
-            out_h = target
-            out_w = (
-                int(raw * orig_w / orig_h)
-                if raw is not None
-                else int(size * orig_w / orig_h)
-            )
-        return out_h, out_w
+        return _eomt_coco_content_size(orig_h, orig_w, size)
 
     def _preprocess_pil_pad(
         self,
@@ -395,18 +479,7 @@ class LibreEoMT(BaseModel):
         normalizes afterwards, so the padded region lands on ``-mean/std``,
         which is exactly what the upstream processor produces.
         """
-        orig_w, orig_h = img.size
-        content_h, content_w = self._coco_content_size(orig_h, orig_w, input_size)
-        resized = TVF.resize(
-            TVF.pil_to_tensor(img).unsqueeze(0),
-            [content_h, content_w],
-            interpolation=InterpolationMode.BILINEAR,
-            antialias=True,
-        )[0].float()
-        resized.div_(255.0)
-        canvas = torch.zeros((3, input_size, input_size), dtype=resized.dtype)
-        canvas[:, :content_h, :content_w] = resized
-        return canvas.unsqueeze(0), (content_h, content_w)
+        return _preprocess_eomt_coco_pil(img, input_size)
 
     def _preprocess(
         self,
@@ -441,12 +514,10 @@ class LibreEoMT(BaseModel):
             )
             self._last_eomt_resized_shape = resized_shape
             self._last_eomt_patch_offsets = patch_offsets
-            self._last_eomt_content_size = None
         else:
-            img_tensor, content_size = self._preprocess_pil_pad(img, effective_res)
+            img_tensor, _ = self._preprocess_pil_pad(img, effective_res)
             self._last_eomt_resized_shape = None
             self._last_eomt_patch_offsets = None
-            self._last_eomt_content_size = content_size
 
         return img_tensor, img, (orig_w, orig_h), 1.0
 
@@ -461,10 +532,16 @@ class LibreEoMT(BaseModel):
         matching the upstream post-process.
         """
         orig_w, orig_h = original_size
-        content = getattr(self, "_last_eomt_content_size", None)
-        if content is not None:
-            content_h, content_w = content
-            mask_logits = mask_logits[:, :content_h, :content_w]
+        canvas_h, canvas_w = mask_logits.shape[-2:]
+        if canvas_h != canvas_w:
+            raise ValueError(
+                "EoMT COCO mask logits must use a square padded canvas, got "
+                f"{(canvas_h, canvas_w)}."
+            )
+        content_h, content_w = self._coco_content_size(
+            orig_h, orig_w, int(canvas_h)
+        )
+        mask_logits = mask_logits[:, :content_h, :content_w]
         return F.interpolate(
             mask_logits.unsqueeze(0),
             size=(orig_h, orig_w),
@@ -864,13 +941,42 @@ class LibreEoMT(BaseModel):
         if ckpt_num_queries is not None and ckpt_num_queries != self.num_queries:
             self._rebuild_for_new_queries(ckpt_num_queries)
 
-        # State-dict detection is authoritative: position embeddings encode the
-        # native resolution and cannot be wrong. Metadata imgsz is a hint only.
-        ckpt_imgsz = self.detect_image_size(state)
-        if ckpt_imgsz is None:
-            ckpt_imgsz = loaded.get("imgsz") if isinstance(loaded, dict) else None
-        if ckpt_imgsz is not None and int(ckpt_imgsz) != self.input_size:
-            self._rebuild_for_new_image_size(int(ckpt_imgsz))
+        # Position embeddings encode the graph resolution. Native metadata is
+        # part of the same strict contract, so disagreement means the
+        # checkpoint is internally inconsistent rather than a reason to trust
+        # one source silently.
+        state_imgsz = self.detect_image_size(state)
+        metadata_imgsz = loaded.get("imgsz")
+        if metadata_imgsz is not None:
+            try:
+                metadata_imgsz = self._validate_input_size(
+                    metadata_imgsz,
+                    context="checkpoint",
+                    allow_fixed_override=True,
+                )
+            except ValueError as exc:
+                raise RuntimeError(
+                    "Cannot use checkpoint imgsz="
+                    f"{loaded.get('imgsz')!r} for eomt: {exc}"
+                ) from exc
+        if state_imgsz is not None:
+            state_imgsz = self._validate_input_size(
+                state_imgsz,
+                context="checkpoint state",
+                allow_fixed_override=True,
+            )
+        if (
+            metadata_imgsz is not None
+            and state_imgsz is not None
+            and metadata_imgsz != state_imgsz
+        ):
+            raise RuntimeError(
+                f"EoMT checkpoint metadata imgsz={metadata_imgsz} conflicts "
+                f"with state-derived imgsz={state_imgsz}."
+            )
+        ckpt_imgsz = state_imgsz if state_imgsz is not None else metadata_imgsz
+        if ckpt_imgsz is not None and ckpt_imgsz != self.input_size:
+            self._rebuild_for_new_image_size(ckpt_imgsz)
 
         policy = self._checkpoint_load_policy(loaded, self.task)
         target_state = self.model.state_dict()
@@ -934,6 +1040,7 @@ class LibreEoMT(BaseModel):
             "LibreEoMT instance and panoptic export need query-mask runtime contracts."
         )
 
+    @_transactional_validation
     def val(
         self,
         data: str | None = None,
@@ -1033,13 +1140,10 @@ class LibreEoMT(BaseModel):
                 "Augmented validation does not support semantic segmentation yet. "
                 "Use augment=False for semantic models."
             )
-        effective_imgsz = self.input_size if imgsz is None else int(imgsz)
-        if effective_imgsz != self.input_size:
-            raise ValueError(
-                f"LibreEoMT validation requires imgsz={self.input_size}; got "
-                f"imgsz={effective_imgsz}. The EoMT checkpoint uses fixed "
-                "position embeddings."
-            )
+        effective_imgsz = self._validate_input_size(
+            self.input_size if imgsz is None else imgsz,
+            context="validation",
+        )
 
         from ...data.semantic_dataset import (
             _apply_label_mapping,

--- a/libreyolo/models/fomo/model.py
+++ b/libreyolo/models/fomo/model.py
@@ -35,6 +35,7 @@ class LibreFOMO(BaseModel):
     WEIGHT_EXT = ".pt"
 
     INPUT_SIZES: ClassVar[Dict[str, int]] = {k: int(v["imgsz"]) for k, v in CONFIGS.items()}
+    INPUT_SIZE_FIXED = True
 
     SUPPORTED_TASKS = ("point",)
     DEFAULT_TASK = "point"

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -1,122 +1,94 @@
-"""Model-family inventory used by CLI and generated export documentation."""
+"""Deterministic model-family inventory for CLI and generated documentation."""
 
 from __future__ import annotations
 
-import ast
-import importlib
 import importlib.util
-import inspect
-import textwrap
 
-
-OPTIONAL_MODELS = (
-    ("libreyolo.models.sam.model", "LibreSAM1", "sam", "transformers"),
-    ("libreyolo.models.sam.sam2", "LibreSAM2", "sam", "transformers"),
-    ("libreyolo.models.sam.sam3", "LibreSAM3", "sam", "transformers"),
-    ("libreyolo.models.mobilesam.model", "LibreMobileSAM", "sam", None),
-    ("libreyolo.models.picosam3.model", "LibrePicoSAM3", "sam", None),
-    ("libreyolo.models.vlm.florence2", "LibreFlorence2", "vlm", "transformers"),
-    ("libreyolo.models.vlm.kosmos2", "LibreKosmos2", "vlm", "transformers"),
-    ("libreyolo.models.vlm.internvl3", "LibreInternVL3", "vlm", "transformers"),
-    ("libreyolo.models.vlm.lfm2", "LibreLFM2VL", "vlm", "transformers"),
-    (
-        "libreyolo.models.vlm.locateanything",
-        "LibreLocateAnything",
-        "vlm",
-        "transformers",
-    ),
-    ("libreyolo.models.vlm.qwen3vl", "LibreQwen3VL", "vlm", "transformers"),
-    ("libreyolo.models.vlm.smolvlm", "LibreSmolVLM2", "vlm", "transformers"),
-    (
-        "libreyolo.models.openvocab.grounding_dino",
-        "LibreGroundingDINO",
-        "openvocab",
-        "transformers",
-    ),
-    ("libreyolo.models.openvocab.owlv2", "LibreOWLv2", "openvocab", "transformers"),
+from .manifest import (
+    ARTIFACT_BY_KEY,
+    CLI_MODEL_ALIASES,
+    FACTORY_DEFAULT_MODELS,
+    FactoryKind,
+    iter_family_specs,
 )
 
 
-def _export_override(cls, base_cls) -> str:
-    """Classify a family's ``export``: ``none``, ``custom``, or ``blocked``.
-
-    ``blocked`` means every path raises. A family that exports some formats
-    and raises for the rest (PicoSAM3 ships ONNX only) is ``custom``, so walk
-    the AST for an actual export call instead of matching source text: the
-    old ``"export_" not in source`` check missed ``torch.onnx.export``.
-    """
-    if cls.export is base_cls.export:
-        return "none"
-    tree = ast.parse(textwrap.dedent(inspect.getsource(cls.export)))
-    raises_not_implemented = False
-    performs_export = False
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Raise):
-            raised = node.exc
-            if isinstance(raised, ast.Call):
-                raised = raised.func
-            if isinstance(raised, ast.Name) and raised.id == "NotImplementedError":
-                raises_not_implemented = True
-        elif isinstance(node, ast.Call):
-            called = node.func
-            name = ""
-            if isinstance(called, ast.Attribute):
-                name = called.attr
-            elif isinstance(called, ast.Name):
-                name = called.id
-            if "export" in name.lower():
-                performs_export = True
-    if raises_not_implemented and not performs_export:
-        return "blocked"
-    return "custom"
+def _is_available(dependencies: tuple[str, ...]) -> bool:
+    return all(importlib.util.find_spec(name) is not None for name in dependencies)
 
 
 def collect_model_inventory() -> dict[str, dict]:
-    """Return eager and lazy family metadata without constructing models."""
-    from libreyolo.models import try_ensure_rfdetr
-    from libreyolo.models.base.model import BaseModel
-
-    optional: dict[str, tuple[str, bool]] = {}
-    try_ensure_rfdetr()
-    classes = list(BaseModel._registry)
-    if any(cls.FAMILY == "rfdetr" for cls in BaseModel._registry):
-        optional["rfdetr"] = ("rfdetr", True)
-        optional["dinov2"] = ("rfdetr", True)
-
-    for module_name, class_name, extra, requirement in OPTIONAL_MODELS:
-        available = (
-            requirement is None or importlib.util.find_spec(requirement) is not None
-        )
-        try:
-            cls = getattr(importlib.import_module(module_name), class_name)
-        except (ImportError, ModuleNotFoundError):
-            continue
-        optional[cls.FAMILY] = (extra, available)
-        if cls not in classes:
-            classes.append(cls)
-
+    """Return the complete public inventory without importing model modules."""
     inventory: dict[str, dict] = {}
-    for cls in classes:
-        family = str(getattr(cls, "FAMILY", ""))
-        if not family:
-            continue
-        extra, available = optional.get(family, (None, True))
-        task_sizes = {task: dict(sizes) for task, sizes in cls.TASK_INPUT_SIZES.items()}
-        all_sizes = dict(cls.INPUT_SIZES)
+    for family in iter_family_specs():
+        task_sizes = {
+            task.task: {size.code: size.native_imgsz for size in task.sizes}
+            for task in family.tasks
+        }
+        default_imgsz = dict(task_sizes[family.default_task])
+        # Retain the legacy flattened mapping for report consumers.  Task-aware
+        # consumers must use task_sizes because the same size code can have a
+        # different native resolution for another task.
+        all_sizes = dict(default_imgsz)
         for sizes in task_sizes.values():
             all_sizes.update(sizes)
-        inventory[family] = {
-            "class": f"{cls.__module__}.{cls.__name__}",
-            "tasks": list(cls.SUPPORTED_TASKS),
-            "default_task": cls.DEFAULT_TASK,
+
+        artifacts = []
+        for key, artifact in ARTIFACT_BY_KEY.items():
+            if key[0] != family.family:
+                continue
+            artifacts.append(
+                {
+                    "size": artifact.size,
+                    "task": artifact.task,
+                    "variant": artifact.variant,
+                    "imgsz": artifact.native_imgsz,
+                    "filename": artifact.canonical_filename,
+                    "publication": artifact.publication.value,
+                    "downloadable": artifact.downloadable,
+                    "download_kind": artifact.download_kind,
+                    "download_url": artifact.download_url,
+                    "aliases": list(artifact.aliases),
+                    "factory_model": artifact.factory_model,
+                    "invocation": artifact.invocation,
+                    "repository": artifact.repository,
+                    "revision": artifact.revision,
+                }
+            )
+
+        cli_names = sorted(
+            alias
+            for alias, artifact in CLI_MODEL_ALIASES.items()
+            if artifact.family == family.family
+        )
+        downloadable_cli_names = sorted(
+            alias
+            for alias, artifact in CLI_MODEL_ALIASES.items()
+            if artifact.family == family.family and artifact.downloadable
+        )
+        inventory[family.family] = {
+            "class": family.class_path,
+            "tasks": [task.task for task in family.tasks],
+            "default_task": family.default_task,
             "sizes": all_sizes,
-            "default_imgsz": dict(cls.INPUT_SIZES),
+            "default_imgsz": default_imgsz,
             "task_sizes": task_sizes,
-            "export_override": _export_override(cls, BaseModel),
-            "optional_extra": extra,
-            "available": available,
+            "export_override": family.export_override,
+            "optional_extra": family.optional_extra,
+            "available": _is_available(family.dependencies),
+            "factory": family.factory.value,
+            "public_entrypoint": family.public_entrypoint,
+            "factory_default_model": FACTORY_DEFAULT_MODELS.get(family.factory),
+            "generic_cli": family.factory is FactoryKind.CHECKPOINT,
+            "cli_names": cli_names,
+            "downloadable_cli_names": downloadable_cli_names,
+            "local_only_cli_names": sorted(
+                set(cli_names) - set(downloadable_cli_names)
+            ),
+            "artifacts": artifacts,
+            "dependencies": list(family.dependencies),
         }
     return dict(sorted(inventory.items()))
 
 
-__all__ = ["OPTIONAL_MODELS", "collect_model_inventory"]
+__all__ = ["collect_model_inventory"]

--- a/libreyolo/models/l2cs/inference.py
+++ b/libreyolo/models/l2cs/inference.py
@@ -64,11 +64,16 @@ class GazeInferenceRunner:
         show: bool = False,
         output_file_format: Optional[str] = None,
         device: Optional[str] = None,
+        imgsz: Optional[int] = None,
         # Rejected with a clear message so detection-shaped kwargs fail loudly
         augment: bool = False,
         tiling: bool = False,
         **_: object,
     ) -> Union[Results, List[Results], Generator[Results, None, None]]:
+        effective_imgsz = (
+            self.model._get_input_size() if imgsz is None else imgsz
+        )
+        self.model._validate_predict_input_size(effective_imgsz)
         if augment:
             raise ValueError(
                 "TTA (augment=True) is not meaningful for gaze inference; "

--- a/libreyolo/models/l2cs/model.py
+++ b/libreyolo/models/l2cs/model.py
@@ -39,6 +39,7 @@ class LibreL2CS(BaseModel):
         "r101": 448,
         "r152": 448,
     }
+    INPUT_SIZE_FIXED = True
     SUPPORTED_TASKS = ("gaze",)
     DEFAULT_TASK = "gaze"
     NUM_BINS = 90

--- a/libreyolo/models/manifest.py
+++ b/libreyolo/models/manifest.py
@@ -1,0 +1,1502 @@
+"""Immutable public model identity and publication manifest.
+
+The runtime class registry remains the compatibility mechanism for sniffing
+metadata-less state dictionaries.  Public discovery must not depend on which
+optional model modules happened to be imported first, so CLI aliases,
+canonical filenames, task/size validation, and download routing use this
+declarative manifest instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Iterator
+
+from ..tasks import normalize_task, task_to_suffix
+
+
+class FactoryKind(str, Enum):
+    """Public constructor that owns a model family."""
+
+    CHECKPOINT = "libreyolo"
+    SAM = "sam"
+    VLM = "vlm"
+    OPENVOCAB = "openvocab"
+
+
+class PublicationState(str, Enum):
+    """Declared checkpoint/snapshot availability, independent of architecture support."""
+
+    PUBLISHED = "published"
+    DIRECT = "direct"
+    GATED = "gated"
+    CONFIG_ONLY = "config_only"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class SizeSpec:
+    """One valid size and its native input resolution for a task."""
+
+    code: str
+    native_imgsz: int
+    publication: PublicationState = PublicationState.PUBLISHED
+
+
+@dataclass(frozen=True, slots=True)
+class TaskSpec:
+    """One canonical task and all architecture-supported sizes."""
+
+    task: str
+    sizes: tuple[SizeSpec, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class VariantSpec:
+    """An explicitly named published/configured checkpoint variant."""
+
+    name: str
+    task: str
+    sizes: tuple[str, ...]
+    publication: PublicationState
+    native_imgsz: int | None = None
+    download_kind: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FactoryModelSpec:
+    """One model identifier accepted by a sibling public factory."""
+
+    size: str
+    model: str
+    aliases: tuple[str, ...]
+    repository: str
+    revision: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FamilySpec:
+    """Stable public identity for one model family."""
+
+    family: str
+    class_path: str
+    filename_prefix: str
+    default_task: str
+    tasks: tuple[TaskSpec, ...]
+    factory: FactoryKind = FactoryKind.CHECKPOINT
+    optional_extra: str | None = None
+    dependencies: tuple[str, ...] = ()
+    export_override: str = "none"
+    weight_ext: str = ".pt"
+    suffixless_tasks: tuple[str, ...] = ()
+    download_kind: str = "hf"
+    variants: tuple[VariantSpec, ...] = ()
+    factory_models: tuple[FactoryModelSpec, ...] = ()
+
+    @property
+    def public_entrypoint(self) -> str:
+        return {
+            FactoryKind.CHECKPOINT: "LibreYOLO",
+            FactoryKind.SAM: "LibreSAM",
+            FactoryKind.VLM: "LibreVLM",
+            FactoryKind.OPENVOCAB: "LibreOpenVocab",
+        }[self.factory]
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactSpec:
+    """One valid family/task/size checkpoint or snapshot identity."""
+
+    family: str
+    size: str
+    task: str
+    native_imgsz: int
+    factory: FactoryKind
+    canonical_filename: str | None
+    publication: PublicationState
+    download_kind: str
+    download_url: str | None
+    variant: str | None = None
+    aliases: tuple[str, ...] = ()
+    factory_model: str | None = None
+    repository: str | None = None
+    revision: str | None = None
+
+    @property
+    def downloadable(self) -> bool:
+        return self.download_kind in {"hf", "family", "snapshot"}
+
+    @property
+    def invocation(self) -> str:
+        entrypoint = {
+            FactoryKind.CHECKPOINT: "LibreYOLO",
+            FactoryKind.SAM: "LibreSAM",
+            FactoryKind.VLM: "LibreVLM",
+            FactoryKind.OPENVOCAB: "LibreOpenVocab",
+        }[self.factory]
+        model = self.canonical_filename or self.factory_model
+        return f"{entrypoint}({model!r})" if model is not None else f"{entrypoint}()"
+
+
+def _task(
+    task: str,
+    sizes: tuple[tuple[str, int], ...],
+    *,
+    publication: PublicationState = PublicationState.PUBLISHED,
+    overrides: tuple[tuple[str, PublicationState], ...] = (),
+) -> TaskSpec:
+    override_map = dict(overrides)
+    return TaskSpec(
+        task=task,
+        sizes=tuple(
+            SizeSpec(code, imgsz, override_map.get(code, publication))
+            for code, imgsz in sizes
+        ),
+    )
+
+
+def _family(
+    family: str,
+    class_path: str,
+    prefix: str,
+    default_task: str,
+    tasks: tuple[TaskSpec, ...],
+    *,
+    factory: FactoryKind = FactoryKind.CHECKPOINT,
+    optional_extra: str | None = None,
+    dependency: str | None = None,
+    dependencies: tuple[str, ...] = (),
+    export_override: str = "none",
+    suffixless_tasks: tuple[str, ...] = (),
+    download_kind: str = "hf",
+    variants: tuple[VariantSpec, ...] = (),
+    factory_models: tuple[FactoryModelSpec, ...] = (),
+) -> FamilySpec:
+    return FamilySpec(
+        family=family,
+        class_path=class_path,
+        filename_prefix=prefix,
+        default_task=default_task,
+        tasks=tasks,
+        factory=factory,
+        optional_extra=optional_extra,
+        dependencies=((dependency,) if dependency is not None else ()) + dependencies,
+        export_override=export_override,
+        suffixless_tasks=suffixless_tasks,
+        download_kind=download_kind,
+        variants=variants,
+        factory_models=factory_models,
+    )
+
+
+def _factory_model(
+    size: str,
+    model: str,
+    aliases: tuple[str, ...],
+    repository: str,
+    *,
+    revision: str | None = None,
+) -> FactoryModelSpec:
+    return FactoryModelSpec(
+        size=size,
+        model=model,
+        aliases=aliases,
+        repository=repository,
+        revision=revision,
+    )
+
+
+# This tuple is deliberately static.  Do not populate it by importing model
+# modules: doing so recreates the initialization-order bug this manifest fixes.
+MODEL_FAMILIES: tuple[FamilySpec, ...] = (
+    _family(
+        "birefnet",
+        "libreyolo.models.birefnet.model.LibreBiRefNet",
+        "LibreBiRefNet",
+        "matte",
+        (
+            _task(
+                "matte",
+                (("t", 1024), ("l", 1024)),
+                overrides=(("t", PublicationState.CONFIG_ONLY),),
+            ),
+        ),
+    ),
+    _family(
+        "clip",
+        "libreyolo.models.clip.model.LibreCLIP",
+        "LibreCLIP",
+        "classify",
+        (
+            _task(
+                "classify",
+                (("b32", 224), ("b16", 224), ("l14", 224)),
+                overrides=(("l14", PublicationState.CONFIG_ONLY),),
+            ),
+        ),
+        optional_extra="clip",
+        dependencies=("regex", "ftfy"),
+        export_override="custom",
+    ),
+    _family(
+        "convnext",
+        "libreyolo.models.convnext.model.LibreConvNeXt",
+        "LibreConvNeXt",
+        "classify",
+        (_task("classify", (("t", 224), ("s", 224), ("b", 224))),),
+    ),
+    _family(
+        "deim",
+        "libreyolo.models.deim.model.LibreDEIM",
+        "LibreDEIM",
+        "detect",
+        (
+            _task(
+                "detect", (("n", 640), ("s", 640), ("m", 640), ("l", 640), ("x", 640))
+            ),
+        ),
+    ),
+    _family(
+        "deimv2",
+        "libreyolo.models.deimv2.model.LibreDEIMv2",
+        "LibreDEIMv2",
+        "detect",
+        (
+            _task(
+                "detect",
+                (
+                    ("atto", 320),
+                    ("femto", 416),
+                    ("pico", 640),
+                    ("n", 640),
+                    ("s", 640),
+                    ("m", 640),
+                    ("l", 640),
+                    ("x", 640),
+                ),
+            ),
+        ),
+    ),
+    _family(
+        "depth_anything",
+        "libreyolo.models.depth_anything.model.LibreDepthAnythingV2",
+        "LibreDepthAnythingV2",
+        "depth",
+        (
+            _task(
+                "depth",
+                (("s", 518), ("b", 518), ("l", 518), ("g", 518)),
+                overrides=(
+                    ("b", PublicationState.CONFIG_ONLY),
+                    ("l", PublicationState.CONFIG_ONLY),
+                    ("g", PublicationState.CONFIG_ONLY),
+                ),
+            ),
+        ),
+        export_override="custom",
+    ),
+    _family(
+        "depth_anything3",
+        "libreyolo.models.depth_anything3.model.LibreDepthAnything3",
+        "LibreDepthAnything3",
+        "depth",
+        (_task("depth", (("l", 504),)),),
+        export_override="blocked",
+    ),
+    _family(
+        "dfine",
+        "libreyolo.models.dfine.model.LibreDFINE",
+        "LibreDFINE",
+        "detect",
+        (
+            _task(
+                "detect", (("n", 640), ("s", 640), ("m", 640), ("l", 640), ("x", 640))
+            ),
+            _task(
+                "segment", (("n", 640), ("s", 640), ("m", 640), ("l", 640), ("x", 640))
+            ),
+        ),
+    ),
+    _family(
+        "dinov2",
+        "libreyolo.models.dinov2.model.LibreDINOv2",
+        "LibreDINOv2",
+        "semantic",
+        (
+            _task(
+                "semantic",
+                (("n", 518), ("s", 518), ("m", 518), ("l", 518)),
+                publication=PublicationState.UNKNOWN,
+            ),
+            _task(
+                "classify",
+                (("n", 224), ("s", 224), ("m", 224), ("l", 224)),
+                publication=PublicationState.UNKNOWN,
+            ),
+        ),
+        optional_extra="rfdetr",
+        dependency="transformers",
+        export_override="custom",
+        suffixless_tasks=("semantic",),
+    ),
+    _family(
+        "ec",
+        "libreyolo.models.ec.model.LibreEC",
+        "LibreEC",
+        "detect",
+        (
+            _task("detect", (("s", 640), ("m", 640), ("l", 640), ("x", 640))),
+            _task("pose", (("s", 640), ("m", 640), ("l", 640), ("x", 640))),
+            _task("segment", (("s", 640), ("m", 640), ("l", 640), ("x", 640))),
+        ),
+    ),
+    _family(
+        "efficientnetv2",
+        "libreyolo.models.efficientnetv2.model.LibreEfficientNetV2",
+        "LibreEfficientNetV2",
+        "classify",
+        (_task("classify", (("b0", 224), ("b1", 240), ("b2", 260), ("b3", 300))),),
+    ),
+    _family(
+        "eomt",
+        "libreyolo.models.eomt.model.LibreEoMT",
+        "LibreEoMT",
+        "semantic",
+        (
+            _task(
+                "semantic",
+                (("s", 512), ("b", 512), ("l", 512)),
+                overrides=(
+                    ("s", PublicationState.CONFIG_ONLY),
+                    ("b", PublicationState.CONFIG_ONLY),
+                ),
+            ),
+            _task(
+                "segment",
+                (("s", 640), ("b", 640), ("l", 640)),
+                overrides=(
+                    ("s", PublicationState.CONFIG_ONLY),
+                    ("b", PublicationState.CONFIG_ONLY),
+                ),
+            ),
+            _task("panoptic", (("s", 640), ("b", 640), ("l", 640))),
+        ),
+        optional_extra="eomt",
+        dependency="transformers",
+        export_override="custom",
+        variants=(
+            VariantSpec(
+                "1280", "segment", ("l",), PublicationState.PUBLISHED, native_imgsz=1280
+            ),
+        ),
+    ),
+    _family(
+        "florence2",
+        "libreyolo.models.vlm.florence2.LibreFlorence2",
+        "LibreFlorence2",
+        "detect",
+        (_task("detect", (("base", 768), ("large", 768))),),
+        factory=FactoryKind.VLM,
+        optional_extra="vlm",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "base",
+                "florence-2-base",
+                ("florence-2", "florence2", "florence-2-base"),
+                "florence-community/Florence-2-base",
+            ),
+            _factory_model(
+                "large",
+                "florence-2-large",
+                ("florence-2-large",),
+                "florence-community/Florence-2-large",
+            ),
+        ),
+    ),
+    _family(
+        "fomo",
+        "libreyolo.models.fomo.model.LibreFOMO",
+        "LibreFOMO",
+        "point",
+        (
+            _task(
+                "point",
+                (("s", 96), ("m", 192), ("l", 224)),
+                publication=PublicationState.UNKNOWN,
+            ),
+        ),
+    ),
+    _family(
+        "grounding_dino",
+        "libreyolo.models.openvocab.grounding_dino.LibreGroundingDINO",
+        "LibreGroundingDINO",
+        "detect",
+        (_task("detect", (("t", 800), ("b", 800))),),
+        factory=FactoryKind.OPENVOCAB,
+        optional_extra="openvocab",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "t",
+                "grounding-dino-tiny",
+                (
+                    "grounding-dino",
+                    "groundingdino",
+                    "grounding-dino-tiny",
+                    "groundingdino-tiny",
+                    "grounding-dino-t",
+                    "groundingdino-t",
+                ),
+                "LibreYOLO/LibreGroundingDINOt",
+            ),
+            _factory_model(
+                "b",
+                "grounding-dino-base",
+                (
+                    "grounding-dino-base",
+                    "groundingdino-base",
+                    "grounding-dino-b",
+                    "groundingdino-b",
+                ),
+                "LibreYOLO/LibreGroundingDINOb",
+            ),
+        ),
+    ),
+    _family(
+        "internvl3",
+        "libreyolo.models.vlm.internvl3.LibreInternVL3",
+        "LibreInternVL3",
+        "detect",
+        (
+            _task(
+                "detect",
+                (("1b", 448), ("2b", 448), ("8b", 448)),
+                publication=PublicationState.GATED,
+            ),
+        ),
+        factory=FactoryKind.VLM,
+        optional_extra="vlm",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "1b",
+                "internvl3-1b",
+                ("internvl3-1b",),
+                "OpenGVLab/InternVL3-1B-hf",
+            ),
+            _factory_model(
+                "2b",
+                "internvl3-2b",
+                ("internvl3", "internvl3-2b"),
+                "OpenGVLab/InternVL3-2B-hf",
+            ),
+            _factory_model(
+                "8b",
+                "internvl3-8b",
+                ("internvl3-8b",),
+                "OpenGVLab/InternVL3-8B-hf",
+            ),
+        ),
+    ),
+    _family(
+        "kosmos2",
+        "libreyolo.models.vlm.kosmos2.LibreKosmos2",
+        "LibreKosmos2",
+        "detect",
+        (_task("detect", (("224", 224),)),),
+        factory=FactoryKind.VLM,
+        optional_extra="vlm",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "224",
+                "kosmos-2",
+                ("kosmos-2", "kosmos2"),
+                "microsoft/kosmos-2-patch14-224",
+            ),
+        ),
+    ),
+    _family(
+        "l2cs",
+        "libreyolo.models.l2cs.model.LibreL2CS",
+        "LibreL2CS",
+        "gaze",
+        (
+            _task(
+                "gaze",
+                (
+                    ("r18", 448),
+                    ("r34", 448),
+                    ("r50", 448),
+                    ("r101", 448),
+                    ("r152", 448),
+                ),
+                publication=PublicationState.CONFIG_ONLY,
+                overrides=(("r50", PublicationState.DIRECT),),
+            ),
+        ),
+        optional_extra="gaze",
+        export_override="custom",
+        suffixless_tasks=("gaze",),
+        download_kind="none",
+    ),
+    _family(
+        "lfm2vl",
+        "libreyolo.models.vlm.lfm2.LibreLFM2VL",
+        "LibreLFM2VL",
+        "detect",
+        (
+            _task(
+                "detect",
+                (("450m", 512), ("1.6b", 512)),
+                publication=PublicationState.GATED,
+            ),
+        ),
+        factory=FactoryKind.VLM,
+        optional_extra="vlm",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "450m",
+                "lfm2-vl-450m",
+                ("lfm2-vl", "lfm2-vl-450m"),
+                "LiquidAI/LFM2.5-VL-450M",
+            ),
+            _factory_model(
+                "1.6b",
+                "lfm2-vl-1.6b",
+                ("lfm2-vl-1.6b",),
+                "LiquidAI/LFM2.5-VL-1.6B",
+            ),
+        ),
+    ),
+    _family(
+        "locateanything",
+        "libreyolo.models.vlm.locateanything.LibreLocateAnything",
+        "LocateAnything",
+        "detect",
+        (
+            _task(
+                "detect",
+                (("3b", 2500),),
+                publication=PublicationState.GATED,
+            ),
+            _task(
+                "point",
+                (("3b", 2500),),
+                publication=PublicationState.GATED,
+            ),
+        ),
+        factory=FactoryKind.VLM,
+        optional_extra="vlm",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        dependencies=("decord", "lmdb", "peft"),
+        factory_models=(
+            _factory_model(
+                "3b",
+                "locate-anything-3b",
+                (
+                    "locate-anything",
+                    "locateanything",
+                    "locate-anything-3b",
+                    "locateanything-3b",
+                ),
+                "nvidia/LocateAnything-3B",
+                revision="c32291ca5e996f5a7a485845b4f57a233936bba0",
+            ),
+        ),
+    ),
+    _family(
+        "mobilenetv4",
+        "libreyolo.models.mobilenetv4.model.LibreMobileNetV4",
+        "LibreMobileNetV4",
+        "classify",
+        (_task("classify", (("s", 224), ("m", 224), ("l", 256))),),
+    ),
+    _family(
+        "mobilesam",
+        "libreyolo.models.mobilesam.model.LibreMobileSAM",
+        "LibreMobileSAM",
+        "segment",
+        (_task("segment", (("tiny", 1024),)),),
+        factory=FactoryKind.SAM,
+        optional_extra="sam",
+        dependencies=("transformers", "huggingface_hub"),
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "tiny",
+                "mobilesam",
+                (
+                    "mobilesam",
+                    "mobilesam-tiny",
+                    "mobilesam_t",
+                    "mobile-sam",
+                    "mobile-sam-tiny",
+                ),
+                "LibreYOLO/LibreMobileSAM",
+            ),
+        ),
+    ),
+    _family(
+        "nafnet",
+        "libreyolo.models.nafnet.model.LibreNAFNet",
+        "LibreNAFNet",
+        "restore",
+        (
+            _task(
+                "restore",
+                (("s", 256), ("l", 256)),
+                publication=PublicationState.UNKNOWN,
+            ),
+        ),
+        variants=(VariantSpec("sidd", "restore", ("l",), PublicationState.PUBLISHED),),
+    ),
+    _family(
+        "owlv2",
+        "libreyolo.models.openvocab.owlv2.LibreOWLv2",
+        "LibreOWLv2",
+        "detect",
+        (_task("detect", (("b16", 960), ("l14", 1008))),),
+        factory=FactoryKind.OPENVOCAB,
+        optional_extra="openvocab",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "b16",
+                "owlv2-b16",
+                (
+                    "owlv2",
+                    "owl-v2",
+                    "owlv2-base",
+                    "owl-v2-base",
+                    "owlv2-b16",
+                    "owl-v2-b16",
+                ),
+                "LibreYOLO/LibreOWLv2b16",
+            ),
+            _factory_model(
+                "l14",
+                "owlv2-l14",
+                (
+                    "owlv2-large",
+                    "owl-v2-large",
+                    "owlv2-l14",
+                    "owl-v2-l14",
+                ),
+                "LibreYOLO/LibreOWLv2l14",
+            ),
+        ),
+    ),
+    _family(
+        "picodet",
+        "libreyolo.models.picodet.model.LibrePICODET",
+        "LibrePICODET",
+        "detect",
+        (_task("detect", (("s", 320), ("m", 416), ("l", 640))),),
+    ),
+    _family(
+        "picosam3",
+        "libreyolo.models.picosam3.model.LibrePicoSAM3",
+        "LibrePicoSAM3",
+        "segment",
+        (_task("segment", (("pico", 96),)),),
+        factory=FactoryKind.SAM,
+        optional_extra="sam",
+        dependencies=("huggingface_hub",),
+        export_override="custom",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "pico",
+                "picosam3",
+                ("picosam3", "picosam3-pico", "picosam3_pico", "pico-sam3"),
+                "LibreYOLO/LibrePicoSAM3",
+            ),
+        ),
+    ),
+    _family(
+        "pidnet",
+        "libreyolo.models.pidnet.model.LibrePIDNet",
+        "LibrePIDNet",
+        "semantic",
+        (_task("semantic", (("s", 1024), ("m", 1024), ("l", 1024))),),
+        export_override="custom",
+    ),
+    _family(
+        "ppocr",
+        "libreyolo.models.ppocr.model.LibrePPOCR",
+        "LibrePPOCR",
+        "ocr",
+        (_task("ocr", (("t", 960), ("l", 960))),),
+    ),
+    _family(
+        "qwen3vl",
+        "libreyolo.models.vlm.qwen3vl.LibreQwen3VL",
+        "LibreQwen3VL",
+        "detect",
+        (_task("detect", (("2b", 1024), ("4b", 1024), ("8b", 1024))),),
+        factory=FactoryKind.VLM,
+        optional_extra="vlm",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "2b",
+                "qwen3-vl-2b",
+                ("qwen3-vl-2b",),
+                "Qwen/Qwen3-VL-2B-Instruct",
+            ),
+            _factory_model(
+                "4b",
+                "qwen3-vl-4b",
+                ("qwen3-vl", "qwen3-vl-4b"),
+                "Qwen/Qwen3-VL-4B-Instruct",
+            ),
+            _factory_model(
+                "8b",
+                "qwen3-vl-8b",
+                ("qwen3-vl-8b",),
+                "Qwen/Qwen3-VL-8B-Instruct",
+            ),
+        ),
+    ),
+    _family(
+        "realesrgan",
+        "libreyolo.models.realesrgan.model.LibreRealESRGAN",
+        "LibreRealESRGAN",
+        "restore",
+        (_task("restore", (("x4", 64), ("x2", 64), ("x4t", 64))),),
+    ),
+    _family(
+        "resnet",
+        "libreyolo.models.resnet.model.LibreResNet",
+        "LibreResNet",
+        "classify",
+        (_task("classify", (("18", 224), ("34", 224), ("50", 224), ("101", 224))),),
+    ),
+    _family(
+        "rfdetr",
+        "libreyolo.models.rfdetr.model.LibreRFDETR",
+        "LibreRFDETR",
+        "detect",
+        (
+            _task("detect", (("n", 384), ("s", 512), ("m", 576), ("l", 704))),
+            _task(
+                "segment",
+                (
+                    ("n", 312),
+                    ("s", 384),
+                    ("m", 432),
+                    ("l", 504),
+                    ("x", 624),
+                    ("xx", 768),
+                ),
+            ),
+            _task("pose", (("x", 576),)),
+            _task("obb", (("n", 384), ("s", 512), ("m", 576), ("l", 704))),
+        ),
+        optional_extra="rfdetr",
+        dependency="transformers",
+        export_override="custom",
+    ),
+    _family(
+        "rtdetr",
+        "libreyolo.models.rtdetr.model.LibreRTDETR",
+        "LibreRTDETR",
+        "detect",
+        (
+            _task(
+                "detect",
+                (
+                    ("r18", 640),
+                    ("r34", 640),
+                    ("r50", 640),
+                    ("r50m", 640),
+                    ("r101", 640),
+                    ("l", 640),
+                    ("x", 640),
+                ),
+            ),
+        ),
+        export_override="custom",
+    ),
+    _family(
+        "rtdetrv2",
+        "libreyolo.models.rtdetrv2.model.LibreRTDETRv2",
+        "LibreRTDETRv2",
+        "detect",
+        (
+            _task(
+                "detect",
+                (
+                    ("r18", 640),
+                    ("r34", 640),
+                    ("r50", 640),
+                    ("r50m", 640),
+                    ("r101", 640),
+                ),
+            ),
+        ),
+        export_override="custom",
+    ),
+    _family(
+        "rtdetrv4",
+        "libreyolo.models.rtdetrv4.model.LibreRTDETRv4",
+        "LibreRTDETRv4",
+        "detect",
+        (_task("detect", (("s", 640), ("m", 640), ("l", 640), ("x", 640))),),
+    ),
+    _family(
+        "rtmdet",
+        "libreyolo.models.rtmdet.model.LibreRTMDet",
+        "LibreRTMDet",
+        "detect",
+        (
+            _task(
+                "detect", (("t", 640), ("s", 640), ("m", 640), ("l", 640), ("x", 640))
+            ),
+            _task(
+                "segment", (("t", 640), ("s", 640), ("m", 640), ("l", 640), ("x", 640))
+            ),
+        ),
+    ),
+    _family(
+        "sam",
+        "libreyolo.models.sam.model.LibreSAM1",
+        "LibreSAM",
+        "segment",
+        (_task("segment", (("base", 1024), ("large", 1024), ("huge", 1024))),),
+        factory=FactoryKind.SAM,
+        optional_extra="sam",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "base",
+                "base",
+                ("base", "b", "sam-base", "sam_b"),
+                "facebook/sam-vit-base",
+            ),
+            _factory_model(
+                "large",
+                "large",
+                ("large", "l", "sam-large", "sam_l"),
+                "facebook/sam-vit-large",
+            ),
+            _factory_model(
+                "huge",
+                "huge",
+                ("huge", "h", "sam-huge", "sam_h"),
+                "facebook/sam-vit-huge",
+            ),
+        ),
+    ),
+    _family(
+        "sam2",
+        "libreyolo.models.sam.sam2.LibreSAM2",
+        "LibreSAM2",
+        "segment",
+        (
+            _task(
+                "segment",
+                (("tiny", 1024), ("small", 1024), ("base-plus", 1024), ("large", 1024)),
+            ),
+        ),
+        factory=FactoryKind.SAM,
+        optional_extra="sam",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "tiny",
+                "sam2-tiny",
+                ("sam2-tiny", "sam2-t", "sam2_t"),
+                "LibreYOLO/LibreSAM2tiny",
+            ),
+            _factory_model(
+                "small",
+                "sam2-small",
+                ("sam2-small", "sam2-s", "sam2_s"),
+                "LibreYOLO/LibreSAM2small",
+            ),
+            _factory_model(
+                "base-plus",
+                "sam2-base-plus",
+                ("sam2-base-plus", "sam2-baseplus", "sam2-bp", "sam2_bp"),
+                "LibreYOLO/LibreSAM2base-plus",
+            ),
+            _factory_model(
+                "large",
+                "sam2-large",
+                ("sam2-large", "sam2-l", "sam2_l"),
+                "LibreYOLO/LibreSAM2large",
+            ),
+        ),
+    ),
+    _family(
+        "sam3",
+        "libreyolo.models.sam.sam3.LibreSAM3",
+        "LibreSAM3",
+        "segment",
+        (_task("segment", (("large", 1008),), publication=PublicationState.GATED),),
+        factory=FactoryKind.SAM,
+        optional_extra="sam",
+        dependency="transformers",
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "large",
+                "sam3",
+                ("sam3", "sam-3", "sam3-large"),
+                "facebook/sam3",
+            ),
+        ),
+    ),
+    _family(
+        "segformer",
+        "libreyolo.models.segformer.model.LibreSegformer",
+        "LibreSegformer",
+        "semantic",
+        (
+            _task(
+                "semantic",
+                (
+                    ("b0", 512),
+                    ("b1", 512),
+                    ("b2", 512),
+                    ("b3", 512),
+                    ("b4", 512),
+                    ("b5", 640),
+                ),
+            ),
+        ),
+        export_override="blocked",
+    ),
+    _family(
+        "siglip2",
+        "libreyolo.models.siglip2.model.LibreSigLIP2",
+        "LibreSigLIP2",
+        "classify",
+        (_task("classify", (("b16", 256), ("so400m", 384))),),
+        optional_extra="siglip2",
+        dependency="sentencepiece",
+        export_override="custom",
+    ),
+    _family(
+        "smolvlm2",
+        "libreyolo.models.vlm.smolvlm.LibreSmolVLM2",
+        "LibreSmolVLM2",
+        "detect",
+        (_task("detect", (("2.2b", 512), ("500m", 512))),),
+        factory=FactoryKind.VLM,
+        optional_extra="vlm",
+        dependency="transformers",
+        dependencies=("num2words",),
+        export_override="blocked",
+        download_kind="snapshot",
+        factory_models=(
+            _factory_model(
+                "2.2b",
+                "smolvlm2-2.2b",
+                ("smolvlm2", "smolvlm2-2.2b"),
+                "HuggingFaceTB/SmolVLM2-2.2B-Instruct",
+            ),
+            _factory_model(
+                "500m",
+                "smolvlm2-500m",
+                ("smolvlm2-500m",),
+                "HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+            ),
+        ),
+    ),
+    _family(
+        "swinir",
+        "libreyolo.models.swinir.model.LibreSwinIR",
+        "LibreSwinIR",
+        "restore",
+        (_task("restore", (("s", 64), ("m", 64), ("l", 64))),),
+    ),
+    _family(
+        "yolo1",
+        "libreyolo.models.yolo1.model.LibreYOLO1",
+        "LibreYOLO1",
+        "detect",
+        (
+            _task(
+                "detect", (("t", 448), ("b", 448)), publication=PublicationState.UNKNOWN
+            ),
+        ),
+    ),
+    _family(
+        "yolo2",
+        "libreyolo.models.yolo2.model.LibreYOLO2",
+        "LibreYOLO2",
+        "detect",
+        (_task("detect", (("t", 416), ("b", 608))),),
+    ),
+    _family(
+        "yolo3",
+        "libreyolo.models.yolo3.model.LibreYOLO3",
+        "LibreYOLO3",
+        "detect",
+        (_task("detect", (("t", 416), ("b", 416), ("spp", 608))),),
+    ),
+    _family(
+        "yolo4",
+        "libreyolo.models.yolo4.model.LibreYOLO4",
+        "LibreYOLO4",
+        "detect",
+        (_task("detect", (("t", 416), ("b", 608))),),
+    ),
+    _family(
+        "yolo7",
+        "libreyolo.models.yolo7.model.LibreYOLO7",
+        "LibreYOLO7",
+        "detect",
+        (_task("detect", (("b", 640),)),),
+    ),
+    _family(
+        "yolo9",
+        "libreyolo.models.yolo9.model.LibreYOLO9",
+        "LibreYOLO9",
+        "detect",
+        (_task("detect", (("t", 640), ("s", 640), ("m", 640), ("c", 640))),),
+    ),
+    _family(
+        "yolo9_e2e",
+        "libreyolo.models.yolo9_e2e.model.LibreYOLO9E2E",
+        "LibreYOLO9E2E",
+        "detect",
+        (_task("detect", (("t", 640), ("s", 640), ("m", 640), ("c", 640))),),
+    ),
+    _family(
+        "yolo9_p2",
+        "libreyolo.models.yolo9_p2.model.LibreYOLO9P2",
+        "LibreYOLO9P2",
+        "detect",
+        (
+            _task(
+                "detect",
+                (("t", 640), ("s", 640)),
+                publication=PublicationState.CONFIG_ONLY,
+            ),
+        ),
+        variants=(
+            VariantSpec(
+                "visdrone",
+                "detect",
+                ("t", "s"),
+                PublicationState.GATED,
+                download_kind="none",
+            ),
+        ),
+    ),
+    _family(
+        "yolonas",
+        "libreyolo.models.yolonas.model.LibreYOLONAS",
+        "LibreYOLONAS",
+        "detect",
+        (
+            _task(
+                "detect",
+                (("s", 640), ("m", 640), ("l", 640)),
+                publication=PublicationState.DIRECT,
+            ),
+            _task(
+                "pose",
+                (("n", 640), ("s", 640), ("m", 640), ("l", 640)),
+                publication=PublicationState.DIRECT,
+            ),
+        ),
+        download_kind="family",
+    ),
+    _family(
+        "yolox",
+        "libreyolo.models.yolox.model.LibreYOLOX",
+        "LibreYOLOX",
+        "detect",
+        (
+            _task(
+                "detect",
+                (
+                    ("n", 416),
+                    ("t", 416),
+                    ("s", 640),
+                    ("m", 640),
+                    ("l", 640),
+                    ("x", 640),
+                ),
+            ),
+        ),
+    ),
+    _family(
+        "zipdepth",
+        "libreyolo.models.zipdepth.model.LibreZipDepth",
+        "LibreZipDepth",
+        "depth",
+        (_task("depth", (("b", 384), ("bnpu", 384))),),
+    ),
+)
+
+
+def _canonical_filename(
+    family: FamilySpec, task: str, size: str, variant: str | None = None
+) -> str | None:
+    if family.factory is not FactoryKind.CHECKPOINT:
+        return None
+    suffix = None if task in family.suffixless_tasks else task_to_suffix(task)
+    task_part = f"-{suffix}" if suffix else ""
+    variant_part = f"-{variant}" if variant else ""
+    return f"{family.filename_prefix}{size}{task_part}{variant_part}{family.weight_ext}"
+
+
+def _download_details(
+    family: FamilySpec,
+    filename: str | None,
+    publication: PublicationState,
+    *,
+    override_kind: str | None = None,
+    repository: str | None = None,
+) -> tuple[str, str | None]:
+    if publication in {PublicationState.CONFIG_ONLY, PublicationState.UNKNOWN}:
+        return "none", None
+    if family.factory is not FactoryKind.CHECKPOINT:
+        if repository is None:
+            return "none", None
+        return "snapshot", f"https://huggingface.co/{repository}"
+    kind = override_kind or family.download_kind
+    if kind == "none":
+        return "none", None
+    if kind == "family":
+        return "family", None
+    if kind == "hf" and filename is not None:
+        stem = filename[: -len(family.weight_ext)]
+        return (
+            "hf",
+            f"https://huggingface.co/LibreYOLO/{stem}/resolve/main/{filename}",
+        )
+    return "none", None
+
+
+def _build_indices():
+    families: dict[str, FamilySpec] = {}
+    artifacts: dict[tuple[str, str, str, str | None], ArtifactSpec] = {}
+    filenames: dict[str, ArtifactSpec] = {}
+    aliases: dict[str, ArtifactSpec] = {}
+    factory_aliases: dict[
+        tuple[FactoryKind, str], tuple[FamilySpec, FactoryModelSpec]
+    ] = {}
+
+    for family in MODEL_FAMILIES:
+        if family.family in families:
+            raise RuntimeError(f"Duplicate model family in manifest: {family.family!r}")
+        families[family.family] = family
+        factory_models = {item.size: item for item in family.factory_models}
+        if len(factory_models) != len(family.factory_models):
+            raise RuntimeError(f"Duplicate sibling-factory size for {family.family!r}")
+        if family.factory is FactoryKind.CHECKPOINT and factory_models:
+            raise RuntimeError(
+                f"Checkpoint family {family.family!r} declares factory models"
+            )
+        declared_sizes = {size.code for task in family.tasks for size in task.sizes}
+        if family.factory is not FactoryKind.CHECKPOINT:
+            if set(factory_models) != declared_sizes:
+                raise RuntimeError(
+                    f"{family.family!r} sibling-factory sizes do not match its "
+                    "task size declarations"
+                )
+            for factory_model in factory_models.values():
+                if (
+                    factory_model.model not in factory_model.aliases
+                    or not factory_model.repository
+                ):
+                    raise RuntimeError(
+                        f"Invalid sibling-factory model for {family.family!r}/"
+                        f"{factory_model.size!r}"
+                    )
+        task_names = {task.task for task in family.tasks}
+        if family.default_task not in task_names:
+            raise RuntimeError(
+                f"{family.family!r} default task {family.default_task!r} is not declared"
+            )
+        for task in family.tasks:
+            normalized_task = normalize_task(task.task)
+            if normalized_task != task.task:
+                raise RuntimeError(
+                    f"{family.family!r} uses noncanonical task {task.task!r}"
+                )
+            for size in task.sizes:
+                if not size.code or size.native_imgsz <= 0:
+                    raise RuntimeError(
+                        f"Invalid size declaration for {family.family}/{task.task}: {size!r}"
+                    )
+                factory_model = factory_models.get(size.code)
+                if (
+                    family.factory is not FactoryKind.CHECKPOINT
+                    and factory_model is None
+                ):
+                    raise RuntimeError(
+                        f"{family.family!r} size {size.code!r} has no public "
+                        "factory model declaration"
+                    )
+                filename = _canonical_filename(family, task.task, size.code)
+                artifact_aliases: list[str] = []
+                if family.factory is FactoryKind.CHECKPOINT:
+                    suffix = task_to_suffix(task.task)
+                    if task.task == family.default_task:
+                        artifact_aliases.append(f"{family.family}-{size.code}")
+                    if suffix:
+                        artifact_aliases.append(f"{family.family}-{size.code}-{suffix}")
+                elif factory_model is not None:
+                    artifact_aliases.extend(factory_model.aliases)
+                download_kind, download_url = _download_details(
+                    family,
+                    filename,
+                    size.publication,
+                    repository=(
+                        factory_model.repository if factory_model is not None else None
+                    ),
+                )
+                artifact = ArtifactSpec(
+                    family=family.family,
+                    size=size.code,
+                    task=task.task,
+                    native_imgsz=size.native_imgsz,
+                    factory=family.factory,
+                    canonical_filename=filename,
+                    publication=size.publication,
+                    download_kind=download_kind,
+                    download_url=download_url,
+                    aliases=tuple(artifact_aliases),
+                    factory_model=(
+                        factory_model.model if factory_model is not None else None
+                    ),
+                    repository=(
+                        factory_model.repository if factory_model is not None else None
+                    ),
+                    revision=(
+                        factory_model.revision if factory_model is not None else None
+                    ),
+                )
+                key = (family.family, size.code, task.task, None)
+                if key in artifacts:
+                    raise RuntimeError(f"Duplicate model artifact in manifest: {key!r}")
+                artifacts[key] = artifact
+                if filename is not None:
+                    filename_key = filename.casefold()
+                    if filename_key in filenames:
+                        raise RuntimeError(
+                            f"Duplicate canonical model filename: {filename!r}"
+                        )
+                    filenames[filename_key] = artifact
+                if family.factory is FactoryKind.CHECKPOINT:
+                    for name in artifact_aliases:
+                        alias_key = name.casefold()
+                        previous = aliases.get(alias_key)
+                        if previous is not None and previous != artifact:
+                            raise RuntimeError(f"Duplicate CLI model alias: {name!r}")
+                        aliases[alias_key] = artifact
+                elif factory_model is not None:
+                    for name in factory_model.aliases:
+                        alias_key = (family.factory, name.casefold())
+                        previous = factory_aliases.get(alias_key)
+                        selection = (family, factory_model)
+                        if previous is not None and previous != selection:
+                            raise RuntimeError(
+                                f"Duplicate {family.factory.value} model alias: "
+                                f"{name!r}"
+                            )
+                        factory_aliases[alias_key] = selection
+
+        for variant in family.variants:
+            for size_code in variant.sizes:
+                base = artifacts.get((family.family, size_code, variant.task, None))
+                if base is None:
+                    raise RuntimeError(
+                        f"Variant {family.family}/{variant.name} targets unknown "
+                        f"{variant.task}/{size_code} artifact"
+                    )
+                filename = _canonical_filename(
+                    family, variant.task, size_code, variant.name
+                )
+                download_kind, download_url = _download_details(
+                    family,
+                    filename,
+                    variant.publication,
+                    override_kind=variant.download_kind,
+                )
+                artifact = ArtifactSpec(
+                    family=family.family,
+                    size=size_code,
+                    task=variant.task,
+                    native_imgsz=variant.native_imgsz or base.native_imgsz,
+                    factory=family.factory,
+                    canonical_filename=filename,
+                    publication=variant.publication,
+                    download_kind=download_kind,
+                    download_url=download_url,
+                    variant=variant.name,
+                )
+                key = (family.family, size_code, variant.task, variant.name)
+                artifacts[key] = artifact
+                if filename is not None:
+                    filename_key = filename.casefold()
+                    if filename_key in filenames:
+                        raise RuntimeError(
+                            f"Duplicate canonical model filename: {filename!r}"
+                        )
+                    filenames[filename_key] = artifact
+
+    return (
+        MappingProxyType(families),
+        MappingProxyType(artifacts),
+        MappingProxyType(filenames),
+        MappingProxyType(aliases),
+        MappingProxyType(factory_aliases),
+    )
+
+
+(
+    FAMILY_BY_ID,
+    ARTIFACT_BY_KEY,
+    ARTIFACT_BY_FILENAME,
+    CLI_MODEL_ALIASES,
+    FACTORY_MODEL_ALIASES,
+) = _build_indices()
+
+FACTORY_DEFAULT_MODELS = MappingProxyType(
+    {
+        FactoryKind.SAM: "base",
+        FactoryKind.VLM: "qwen3-vl-4b",
+        FactoryKind.OPENVOCAB: "grounding-dino-tiny",
+    }
+)
+for _factory, _model in FACTORY_DEFAULT_MODELS.items():
+    if (_factory, _model.casefold()) not in FACTORY_MODEL_ALIASES:
+        raise RuntimeError(f"Default {_factory.value} model {_model!r} is not declared")
+
+
+def iter_family_specs(
+    factory: FactoryKind | None = None,
+) -> Iterator[FamilySpec]:
+    """Iterate families in stable manifest order."""
+    for family in MODEL_FAMILIES:
+        if factory is None or family.factory is factory:
+            yield family
+
+
+def get_family_spec(family: str) -> FamilySpec | None:
+    """Return a family declaration without importing its implementation."""
+    return FAMILY_BY_ID.get(str(family).strip().lower())
+
+
+def get_artifact_spec(
+    family: str,
+    size: str,
+    task: str,
+    *,
+    variant: str | None = None,
+) -> ArtifactSpec | None:
+    """Return an exact family/task/size artifact declaration."""
+    try:
+        canonical_task = normalize_task(task)
+    except ValueError:
+        return None
+    if canonical_task is None:
+        return None
+    normalized_variant = str(variant).lower() if variant is not None else None
+    return ARTIFACT_BY_KEY.get(
+        (str(family).lower(), str(size).lower(), canonical_task, normalized_variant)
+    )
+
+
+def match_weight_filename(model: str | os.PathLike[str]) -> ArtifactSpec | None:
+    """Match a complete canonical filename, case-insensitively."""
+    filename = Path(os.fspath(model)).name.casefold()
+    return ARTIFACT_BY_FILENAME.get(filename)
+
+
+def resolve_cli_model(name: str) -> ArtifactSpec | None:
+    """Resolve one generic CLI alias without importing model modules."""
+    return CLI_MODEL_ALIASES.get(str(name).casefold())
+
+
+def resolve_factory_model(
+    factory: FactoryKind | str,
+    model: str | None = None,
+) -> tuple[FamilySpec, FactoryModelSpec] | None:
+    """Resolve a sibling-factory model identifier without importing it."""
+    try:
+        factory_kind = FactoryKind(factory)
+    except ValueError:
+        return None
+    if factory_kind is FactoryKind.CHECKPOINT:
+        return None
+    if model is None:
+        model = FACTORY_DEFAULT_MODELS.get(factory_kind)
+    if model is None:
+        return None
+    return FACTORY_MODEL_ALIASES.get((factory_kind, str(model).strip().casefold()))
+
+
+def load_family_class(spec: FamilySpec | str):
+    """Import exactly the implementation class named by a manifest entry."""
+    if isinstance(spec, str):
+        resolved = get_family_spec(spec)
+        if resolved is None:
+            raise KeyError(f"Unknown model family: {spec!r}")
+        spec = resolved
+    module_name, class_name = spec.class_path.rsplit(".", 1)
+    return getattr(importlib.import_module(module_name), class_name)
+
+
+__all__ = [
+    "ARTIFACT_BY_FILENAME",
+    "ARTIFACT_BY_KEY",
+    "CLI_MODEL_ALIASES",
+    "FACTORY_DEFAULT_MODELS",
+    "FACTORY_MODEL_ALIASES",
+    "FAMILY_BY_ID",
+    "MODEL_FAMILIES",
+    "ArtifactSpec",
+    "FactoryKind",
+    "FactoryModelSpec",
+    "FamilySpec",
+    "PublicationState",
+    "SizeSpec",
+    "TaskSpec",
+    "VariantSpec",
+    "get_artifact_spec",
+    "get_family_spec",
+    "iter_family_specs",
+    "load_family_class",
+    "match_weight_filename",
+    "resolve_cli_model",
+    "resolve_factory_model",
+]

--- a/libreyolo/models/openvocab/__init__.py
+++ b/libreyolo/models/openvocab/__init__.py
@@ -7,51 +7,42 @@ and returns standard detection ``Results``.
 
 from __future__ import annotations
 
-from typing import Dict, Tuple, Type
-
 from .base import LibreOpenVocabDetector
 from .grounding_dino import LibreGroundingDINO
 from .owlv2 import LibreOWLv2
+from ..manifest import (
+    FACTORY_DEFAULT_MODELS,
+    FACTORY_MODEL_ALIASES,
+    FactoryKind,
+    load_family_class,
+    resolve_factory_model,
+)
 
-_ALIASES: Dict[str, Tuple[Type[LibreOpenVocabDetector], str]] = {
-    "grounding-dino": (LibreGroundingDINO, "t"),
-    "groundingdino": (LibreGroundingDINO, "t"),
-    "grounding-dino-tiny": (LibreGroundingDINO, "t"),
-    "groundingdino-tiny": (LibreGroundingDINO, "t"),
-    "grounding-dino-t": (LibreGroundingDINO, "t"),
-    "groundingdino-t": (LibreGroundingDINO, "t"),
-    "grounding-dino-base": (LibreGroundingDINO, "b"),
-    "groundingdino-base": (LibreGroundingDINO, "b"),
-    "grounding-dino-b": (LibreGroundingDINO, "b"),
-    "groundingdino-b": (LibreGroundingDINO, "b"),
-    "owlv2": (LibreOWLv2, "b16"),
-    "owl-v2": (LibreOWLv2, "b16"),
-    "owlv2-base": (LibreOWLv2, "b16"),
-    "owl-v2-base": (LibreOWLv2, "b16"),
-    "owlv2-b16": (LibreOWLv2, "b16"),
-    "owl-v2-b16": (LibreOWLv2, "b16"),
-    "owlv2-large": (LibreOWLv2, "l14"),
-    "owl-v2-large": (LibreOWLv2, "l14"),
-    "owlv2-l14": (LibreOWLv2, "l14"),
-    "owl-v2-l14": (LibreOWLv2, "l14"),
+_ALIASES = {
+    alias: (load_family_class(family), selection.size)
+    for (factory, alias), (family, selection) in FACTORY_MODEL_ALIASES.items()
+    if factory is FactoryKind.OPENVOCAB
 }
 
-_DEFAULT_MODEL = "grounding-dino-tiny"
+_DEFAULT_MODEL = FACTORY_DEFAULT_MODELS[FactoryKind.OPENVOCAB]
 
 
-def LibreOpenVocab(
-    model: str = _DEFAULT_MODEL, **kwargs
-) -> LibreOpenVocabDetector:
+def LibreOpenVocab(model: str = _DEFAULT_MODEL, **kwargs) -> LibreOpenVocabDetector:
     """Load an open-vocabulary detector by alias."""
-    key = str(model).strip().lower()
-    match = _ALIASES.get(key)
+    match = resolve_factory_model(FactoryKind.OPENVOCAB, model)
     if match is None:
+        aliases = sorted(
+            alias
+            for (factory, alias) in FACTORY_MODEL_ALIASES
+            if factory is FactoryKind.OPENVOCAB
+        )
         raise ValueError(
             f"Unknown open-vocabulary detector {model!r}. Known aliases: "
-            f"{', '.join(sorted(_ALIASES))}."
+            f"{', '.join(aliases)}."
         )
-    family_cls, size = match
-    return family_cls(size=size, **kwargs)
+    family, selection = match
+    family_cls = load_family_class(family)
+    return family_cls(size=selection.size, **kwargs)
 
 
 __all__ = [

--- a/libreyolo/models/picosam3/model.py
+++ b/libreyolo/models/picosam3/model.py
@@ -10,11 +10,13 @@ from typing import ClassVar, Dict, Optional
 import torch
 import torch.nn as nn
 
+from ...utils.download import WeightPublicationError
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.serialization import (
     load_untrusted_torch_file,
     unwrap_libreyolo_checkpoint,
 )
+from ..manifest import get_artifact_spec
 from ..sam.base import _INSTALL_HINT, _SNAPSHOT_COMPLETE_MARKER, LibreSAMModel
 from ..sam.prompts import normalize_boxes
 from .nn import PicoSAM3Network
@@ -54,10 +56,34 @@ class LibrePicoSAM3(LibreSAMModel):
         ).exists()
 
     def _ensure_weights(self) -> str:
-        repo = self.HF_REPOS[self.size]
         local_dir = Path("weights") / f"{self.FILENAME_PREFIX}{self.size}"
         if self._snapshot_complete(local_dir):
             return str(local_dir)
+
+        artifact = get_artifact_spec(self.FAMILY, self.size, self.DEFAULT_TASK)
+        if (
+            artifact is None
+            or not artifact.downloadable
+            or artifact.download_kind != "snapshot"
+            or not artifact.repository
+        ):
+            publication = (
+                artifact.publication.value if artifact is not None else "undeclared"
+            )
+            raise WeightPublicationError(
+                f"{self.FAMILY!r} size {self.size!r} is a valid architecture "
+                f"artifact, but its publication state is {publication!r} and "
+                "LibreYOLO does not declare a public snapshot route. Provide "
+                "a complete local snapshot."
+            )
+
+        repo = artifact.repository
+        class_repo = self.HF_REPOS.get(self.size)
+        if class_repo != repo:
+            raise RuntimeError(
+                f"PicoSAM3 repository metadata drift: class declares "
+                f"{class_repo!r}, manifest declares {repo!r}."
+            )
         try:
             from huggingface_hub import hf_hub_download
         except ImportError as exc:

--- a/libreyolo/models/pidnet/model.py
+++ b/libreyolo/models/pidnet/model.py
@@ -112,7 +112,7 @@ class LibrePIDNet(BaseModel):
     REQUIRE_TASK_SUFFIX: ClassVar[bool] = True
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"s": 1024, "m": 1024, "l": 1024}
 
-    semantic_resize_mode: ClassVar[str] = "letterbox"
+    semantic_resize_mode: ClassVar[str] = "native"
     semantic_imgsz_divisor: ClassVar[int] = 8
 
     _SIZE_CONFIGS: ClassVar[dict] = SIZE_CONFIGS
@@ -352,6 +352,11 @@ class LibrePIDNet(BaseModel):
                 f"Checkpoint was trained for task={normalize_task(ckpt_task)!r}, "
                 "but LibrePIDNet is semantic-only."
             )
+
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
 
         if isinstance(loaded.get("model"), dict):
             raw_state = loaded["model"]

--- a/libreyolo/models/ppocr/inference.py
+++ b/libreyolo/models/ppocr/inference.py
@@ -67,9 +67,13 @@ class OCRInferenceRunner:
         Args:
             source: Image path/PIL/array, list of those, directory, or video.
             conf: Minimum recognition confidence for a kept region.
-            imgsz: Detection long-side limit override (default 960).
+            imgsz: Detection long-side limit override (default: checkpoint/native).
             rec_batch: Recognition crops per forward pass.
         """
+        effective_imgsz = (
+            self.model._get_input_size() if imgsz is None else imgsz
+        )
+        imgsz = self.model._validate_predict_input_size(effective_imgsz)
         if augment:
             raise ValueError(
                 "TTA (augment=True) is not supported for OCR models. "
@@ -239,7 +243,7 @@ class OCRInferenceRunner:
         orig_shape = (src_h, src_w)
 
         pipeline = model.pipeline_config
-        limit = int(imgsz) if imgsz else int(pipeline.get("det_limit_side_len", 960))
+        limit = imgsz if imgsz is not None else model._get_input_size()
 
         # Stage 1: detection.
         resized, _, _ = det_resize(img_bgr, limit_side_len=limit)

--- a/libreyolo/models/ppocr/model.py
+++ b/libreyolo/models/ppocr/model.py
@@ -68,6 +68,7 @@ class LibrePPOCR(BaseModel):
     WEIGHT_EXT = ".pt"
     # The size value is the detection long-side limit (DetResizeForTest).
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"t": 960, "l": 960}
+    INPUT_SIZE_MIN = 32
     SUPPORTED_TASKS = ("ocr",)
     DEFAULT_TASK = "ocr"
     REQUIRE_TASK_SUFFIX = True

--- a/libreyolo/models/realesrgan/model.py
+++ b/libreyolo/models/realesrgan/model.py
@@ -24,7 +24,12 @@ from ...postprocess.realesrgan import postprocess as _realesrgan_postprocess
 from ...utils.image_loader import ImageInput
 from ..base import BaseModel
 from .nn import RRDBNet, SRVGGNetCompact
-from .utils import forward_with_optional_tiling, preprocess_image, preprocess_numpy
+from .utils import (
+    _reflect_pad_to_multiple,
+    forward_with_optional_tiling,
+    preprocess_image,
+    preprocess_numpy,
+)
 
 
 # Per-size architecture. ``pad_multiple`` is the input divisibility required by
@@ -243,6 +248,10 @@ class LibreRealESRGAN(BaseModel):
             tile_size=self._tile,
             tile_pad=self._tile_pad,
         )
+
+    def _preprocess_validation_batch(self, images: torch.Tensor) -> torch.Tensor:
+        """Apply the same divisibility padding used by native prediction."""
+        return _reflect_pad_to_multiple(images, self._pad_multiple)
 
     def _postprocess(
         self,

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -670,6 +670,23 @@ class LibreRFDETR(BaseModel):
             name=name,
         )
 
+    def _validate_input_size(
+        self,
+        imgsz,
+        *,
+        context: str,
+        allow_fixed_override: bool = False,
+    ):
+        imgsz = super()._validate_input_size(
+            imgsz,
+            context=context,
+            allow_fixed_override=allow_fixed_override,
+        )
+        return self._validate_imgsz(
+            imgsz,
+            name=f"RF-DETR {context} imgsz",
+        )
+
     def _get_val_preprocessor(self, img_size: int | None = None):
         if img_size is not None:
             img_size = self._validate_imgsz(
@@ -914,6 +931,11 @@ class LibreRFDETR(BaseModel):
                         "Pass the matching task or use explicit training transfer."
                     )
 
+            self._apply_checkpoint_input_size(
+                loaded,
+                is_native_v1=is_native_v1,
+            )
+
             # Replay LoRA injection for adapter checkpoints. A model trained with
             # lora=True saves its DINOv2 encoder under PeftModel keys; rebuild the
             # same wrapped graph here (the recipe is fixed, so re-running the
@@ -1111,11 +1133,9 @@ class LibreRFDETR(BaseModel):
 
     def export(self, format: str = "onnx", *, opset: int = 17, **kwargs) -> str:
         """Export model. RF-DETR requires opset >= 17 for LayerNormalization."""
-        if kwargs.get("imgsz") is not None:
-            kwargs["imgsz"] = self._validate_imgsz(
-                kwargs["imgsz"],
-                name="RF-DETR export imgsz",
-            )
+        requested_imgsz = kwargs.get("imgsz")
+        if requested_imgsz is not None:
+            kwargs["imgsz"] = self._validate_export_input_size(requested_imgsz)
         return super().export(format, opset=opset, **kwargs)
 
     def val(self, *args, workers: int = 0, **kwargs) -> Dict:

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -145,6 +145,8 @@ class LibreRTDETR(BaseModel):
         "l": 640,
         "x": 640,
     }
+    INPUT_SIZE_DIVISOR = 32
+    INPUT_SIZE_MIN = 128
     TRAIN_CONFIG = RTDETRConfig
     val_preprocessor_class = RTDETRValPreprocessor
 

--- a/libreyolo/models/rtdetrv2/model.py
+++ b/libreyolo/models/rtdetrv2/model.py
@@ -17,6 +17,7 @@ class LibreRTDETRv2(LibreRTDETR):
     FAMILY = "rtdetrv2"
     FILENAME_PREFIX = "LibreRTDETRv2"
     INPUT_SIZES = {"r18": 640, "r34": 640, "r50": 640, "r50m": 640, "r101": 640}
+    INPUT_SIZE_FIXED = True
     val_preprocessor_class = RTDETRv2ValPreprocessor
 
     @classmethod

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -51,6 +51,7 @@ class LibreRTMDet(BaseModel):
     FAMILY = "rtmdet"
     FILENAME_PREFIX = "LibreRTMDet"
     INPUT_SIZES = {"t": 640, "s": 640, "m": 640, "l": 640, "x": 640}
+    INPUT_SIZE_DIVISOR = 32
     SUPPORTED_TASKS = ("detect", "segment")
     DEFAULT_TASK = "detect"
     TASK_INPUT_SIZES = {

--- a/libreyolo/models/sam/model.py
+++ b/libreyolo/models/sam/model.py
@@ -25,11 +25,16 @@ through the permissive ``transformers`` model API. See
 
 from __future__ import annotations
 
-from typing import Dict, Tuple, Type
-
 from .base import LibreSAMModel
 from .sam2 import LibreSAM2
 from .sam3 import LibreSAM3
+from ..manifest import (
+    FACTORY_DEFAULT_MODELS,
+    FACTORY_MODEL_ALIASES,
+    FactoryKind,
+    load_family_class,
+    resolve_factory_model,
+)
 
 
 class LibreSAM1(LibreSAMModel):
@@ -45,51 +50,26 @@ class LibreSAM1(LibreSAMModel):
     INPUT_SIZES = {"base": 1024, "large": 1024, "huge": 1024}
 
 
-# alias -> (family class, size)
 _MOBILE_SAM = "mobilesam"
 _PICO_SAM3 = "picosam3"
 
-_ALIASES: Dict[str, Tuple[Type[LibreSAMModel] | str, str]] = {
-    "base": (LibreSAM1, "base"),
-    "large": (LibreSAM1, "large"),
-    "huge": (LibreSAM1, "huge"),
-    "b": (LibreSAM1, "base"),
-    "l": (LibreSAM1, "large"),
-    "h": (LibreSAM1, "huge"),
-    "sam-base": (LibreSAM1, "base"),
-    "sam-large": (LibreSAM1, "large"),
-    "sam-huge": (LibreSAM1, "huge"),
-    "sam_b": (LibreSAM1, "base"),
-    "sam_l": (LibreSAM1, "large"),
-    "sam_h": (LibreSAM1, "huge"),
-    "sam2-tiny": (LibreSAM2, "tiny"),
-    "sam2-small": (LibreSAM2, "small"),
-    "sam2-base-plus": (LibreSAM2, "base-plus"),
-    "sam2-baseplus": (LibreSAM2, "base-plus"),
-    "sam2-large": (LibreSAM2, "large"),
-    "sam2-t": (LibreSAM2, "tiny"),
-    "sam2-s": (LibreSAM2, "small"),
-    "sam2-bp": (LibreSAM2, "base-plus"),
-    "sam2-l": (LibreSAM2, "large"),
-    "sam2_t": (LibreSAM2, "tiny"),
-    "sam2_s": (LibreSAM2, "small"),
-    "sam2_bp": (LibreSAM2, "base-plus"),
-    "sam2_l": (LibreSAM2, "large"),
-    "sam3": (LibreSAM3, "large"),
-    "sam-3": (LibreSAM3, "large"),
-    "sam3-large": (LibreSAM3, "large"),
-    "mobilesam": (_MOBILE_SAM, "tiny"),
-    "mobilesam-tiny": (_MOBILE_SAM, "tiny"),
-    "mobilesam_t": (_MOBILE_SAM, "tiny"),
-    "mobile-sam": (_MOBILE_SAM, "tiny"),
-    "mobile-sam-tiny": (_MOBILE_SAM, "tiny"),
-    "picosam3": (_PICO_SAM3, "pico"),
-    "picosam3-pico": (_PICO_SAM3, "pico"),
-    "picosam3_pico": (_PICO_SAM3, "pico"),
-    "pico-sam3": (_PICO_SAM3, "pico"),
+
+def _compat_alias_target(family, selection):
+    if family.family == "mobilesam":
+        return _MOBILE_SAM, selection.size
+    if family.family == "picosam3":
+        return _PICO_SAM3, selection.size
+    return load_family_class(family), selection.size
+
+
+# Backward-compatible private view, generated from the public manifest.
+_ALIASES = {
+    alias: _compat_alias_target(family, selection)
+    for (factory, alias), (family, selection) in FACTORY_MODEL_ALIASES.items()
+    if factory is FactoryKind.SAM
 }
 
-_DEFAULT_MODEL = "base"
+_DEFAULT_MODEL = FACTORY_DEFAULT_MODELS[FactoryKind.SAM]
 
 
 def LibreSAM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreSAMModel:
@@ -110,23 +90,19 @@ def LibreSAM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreSAMModel:
     Returns:
         A ``LibreSAMModel`` with the interactive ``set_image``/``predict`` surface.
     """
-    key = str(model).strip().lower()
-    match = _ALIASES.get(key)
+    match = resolve_factory_model(FactoryKind.SAM, model)
     if match is None:
-        raise ValueError(
-            f"Unknown SAM model {model!r}. Known aliases: "
-            f"{', '.join(sorted(_ALIASES))}."
+        aliases = sorted(
+            alias
+            for (factory, alias) in FACTORY_MODEL_ALIASES
+            if factory is FactoryKind.SAM
         )
-    family_cls, size = match
-    if family_cls == _MOBILE_SAM:
-        from ..mobilesam import LibreMobileSAM
-
-        family_cls = LibreMobileSAM
-    elif family_cls == _PICO_SAM3:
-        from ..picosam3 import LibrePicoSAM3
-
-        family_cls = LibrePicoSAM3
-    return family_cls(size=size, **kwargs)
+        raise ValueError(
+            f"Unknown SAM model {model!r}. Known aliases: {', '.join(aliases)}."
+        )
+    family, selection = match
+    family_cls = load_family_class(family)
+    return family_cls(size=selection.size, **kwargs)
 
 
 __all__ = ["LibreSAM", "LibreSAM1", "LibreSAM2", "LibreSAM3"]

--- a/libreyolo/models/segformer/model.py
+++ b/libreyolo/models/segformer/model.py
@@ -101,6 +101,7 @@ class LibreSegformer(BaseModel):
     # Read by SegformerTrainer._setup_semantic_data and SemanticValidator.
     semantic_resize_mode: ClassVar[str] = "resize_crop"
     semantic_imgsz_divisor: ClassVar[int] = 32
+    SUPPORTS_RECTANGULAR_INPUT: ClassVar[bool] = True
     semantic_scale_jitter: ClassVar[Tuple[float, float]] = (0.5, 2.0)
     # The reference ADE20K recipe uses no photometric jitter. SemanticDataset
     # defaults to 0.5, so this has to be declared explicitly or training quietly
@@ -334,7 +335,7 @@ class LibreSegformer(BaseModel):
 
         if not isinstance(loaded, dict):
             raise TypeError("LibreSegformer checkpoints must be dictionaries")
-        loaded, _is_native_v1 = self._parse_checkpoint_metadata(
+        loaded, is_native_v1 = self._parse_checkpoint_metadata(
             loaded,
             context="SegFormer semantic checkpoint",
         )
@@ -365,6 +366,11 @@ class LibreSegformer(BaseModel):
         ckpt_size = self.detect_size(state) or loaded.get("size")
         if ckpt_size is not None and ckpt_size != self.size:
             self._rebuild_for_new_size(str(ckpt_size))
+
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
 
         ckpt_nc = loaded.get("nc") or self.detect_nb_classes(state)
         if ckpt_nc is not None and int(ckpt_nc) != self.nb_classes:

--- a/libreyolo/models/siglip2/model.py
+++ b/libreyolo/models/siglip2/model.py
@@ -102,6 +102,7 @@ class LibreSigLIP2(BaseModel):
     INPUT_SIZES: ClassVar[Dict[str, int]] = {
         size: cfg.image_size for size, cfg in SIGLIP2_CONFIGS.items()
     }
+    INPUT_SIZE_FIXED: ClassVar[bool] = True
     SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("classify",)
     DEFAULT_TASK: ClassVar[str] = "classify"
     TRAIN_CONFIG = None
@@ -383,7 +384,7 @@ class LibreSigLIP2(BaseModel):
 
         if not isinstance(loaded, dict):
             raise TypeError("LibreSigLIP2 checkpoints must be dictionaries.")
-        loaded, _is_native_v1 = self._parse_checkpoint_metadata(
+        loaded, is_native_v1 = self._parse_checkpoint_metadata(
             loaded,
             context="LibreSigLIP2 checkpoint",
         )
@@ -399,6 +400,11 @@ class LibreSigLIP2(BaseModel):
             raise RuntimeError(
                 f"Checkpoint task={normalize_task(ckpt_task)!r} is not 'classify'."
             )
+
+        self._apply_checkpoint_input_size(
+            loaded,
+            is_native_v1=is_native_v1,
+        )
 
         state = self._extract_state(loaded)
         if "logit_bias" not in state or "vision_model.embeddings.patch_embedding.weight" not in state:
@@ -432,6 +438,11 @@ class LibreSigLIP2(BaseModel):
         """
         from ...data.classify_dataset import get_class_names, resolve_classify_data
 
+        requested_imgsz = kwargs.get("imgsz")
+        kwargs["imgsz"] = self._validate_input_size(
+            self._get_input_size() if requested_imgsz is None else requested_imgsz,
+            context="validation",
+        )
         if data is None:
             raise ValueError("LibreSigLIP2.val() requires data= (an ImageFolder root).")
         root = resolve_classify_data(data)
@@ -472,6 +483,11 @@ class LibreSigLIP2(BaseModel):
                 "(frozen-class) is supported. Open-vocabulary export (two towers "
                 "+ tokenizer) is out of scope for v1."
             )
+        requested_imgsz = kwargs.get("imgsz")
+        kwargs["imgsz"] = self._validate_input_size(
+            self._get_input_size() if requested_imgsz is None else requested_imgsz,
+            context="export",
+        )
         if self._text_embeds is None:
             raise RuntimeError("No classes set; call set_classes() before export().")
 

--- a/libreyolo/models/vlm/__init__.py
+++ b/libreyolo/models/vlm/__init__.py
@@ -17,8 +17,6 @@ See ``docs/librevlm_design.md`` and ``docs/adr/0002-librevlm-contract.md``.
 
 from __future__ import annotations
 
-from typing import Dict, Tuple, Type
-
 from .base import LibreVLMModel
 from .florence2 import LibreFlorence2
 from .internvl3 import LibreInternVL3
@@ -27,36 +25,21 @@ from .lfm2 import LibreLFM2VL
 from .locateanything import LibreLocateAnything
 from .qwen3vl import LibreQwen3VL
 from .smolvlm import LibreSmolVLM2
+from ..manifest import (
+    FACTORY_DEFAULT_MODELS,
+    FACTORY_MODEL_ALIASES,
+    FactoryKind,
+    load_family_class,
+    resolve_factory_model,
+)
 
-# alias -> (family class, size)
-_ALIASES: Dict[str, Tuple[Type[LibreVLMModel], str]] = {
-    "qwen3-vl": (LibreQwen3VL, "4b"),
-    "qwen3-vl-2b": (LibreQwen3VL, "2b"),
-    "qwen3-vl-4b": (LibreQwen3VL, "4b"),
-    "qwen3-vl-8b": (LibreQwen3VL, "8b"),
-    "lfm2-vl": (LibreLFM2VL, "450m"),
-    "lfm2-vl-450m": (LibreLFM2VL, "450m"),
-    "lfm2-vl-1.6b": (LibreLFM2VL, "1.6b"),
-    "internvl3": (LibreInternVL3, "2b"),
-    "internvl3-1b": (LibreInternVL3, "1b"),
-    "internvl3-2b": (LibreInternVL3, "2b"),
-    "internvl3-8b": (LibreInternVL3, "8b"),
-    "smolvlm2": (LibreSmolVLM2, "2.2b"),
-    "smolvlm2-2.2b": (LibreSmolVLM2, "2.2b"),
-    "smolvlm2-500m": (LibreSmolVLM2, "500m"),
-    "florence-2": (LibreFlorence2, "base"),
-    "florence2": (LibreFlorence2, "base"),
-    "florence-2-base": (LibreFlorence2, "base"),
-    "florence-2-large": (LibreFlorence2, "large"),
-    "kosmos-2": (LibreKosmos2, "224"),
-    "kosmos2": (LibreKosmos2, "224"),
-    "locate-anything": (LibreLocateAnything, "3b"),
-    "locateanything": (LibreLocateAnything, "3b"),
-    "locate-anything-3b": (LibreLocateAnything, "3b"),
-    "locateanything-3b": (LibreLocateAnything, "3b"),
+_ALIASES = {
+    alias: (load_family_class(family), selection.size)
+    for (factory, alias), (family, selection) in FACTORY_MODEL_ALIASES.items()
+    if factory is FactoryKind.VLM
 }
 
-_DEFAULT_MODEL = "qwen3-vl-4b"
+_DEFAULT_MODEL = FACTORY_DEFAULT_MODELS[FactoryKind.VLM]
 
 
 def LibreVLM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreVLMModel:
@@ -72,15 +55,19 @@ def LibreVLM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreVLMModel:
     Returns:
         A ``LibreVLMModel`` instance with the standard predict/track surface.
     """
-    key = str(model).strip().lower()
-    match = _ALIASES.get(key)
+    match = resolve_factory_model(FactoryKind.VLM, model)
     if match is None:
-        raise ValueError(
-            f"Unknown VLM model {model!r}. Known aliases: "
-            f"{', '.join(sorted(_ALIASES))}."
+        aliases = sorted(
+            alias
+            for (factory, alias) in FACTORY_MODEL_ALIASES
+            if factory is FactoryKind.VLM
         )
-    family_cls, size = match
-    return family_cls(size=size, **kwargs)
+        raise ValueError(
+            f"Unknown VLM model {model!r}. Known aliases: {', '.join(aliases)}."
+        )
+    family, selection = match
+    family_cls = load_family_class(family)
+    return family_cls(size=selection.size, **kwargs)
 
 
 __all__ = [

--- a/libreyolo/models/vlm/base.py
+++ b/libreyolo/models/vlm/base.py
@@ -153,24 +153,50 @@ class LibreVLMModel(BaseModel):
     # Open-vocabulary API
     # =========================================================================
 
-    def __call__(self, source=None, **kwargs):
-        """Reject image-geometry modes owned by the VLM processor."""
-        if kwargs.get("imgsz") is not None:
+    def _validate_geometry_options(
+        self,
+        *,
+        imgsz=None,
+        augment: bool = False,
+        tiling: bool = False,
+    ) -> None:
+        """Reject geometry modes that the VLM processor cannot honor."""
+        if imgsz is not None:
             raise ValueError(
                 f"{type(self).__name__} does not support imgsz=: the model "
                 "processor owns image resizing for this VLM tier."
             )
-        if kwargs.get("augment", False):
+        if augment:
             raise ValueError(
                 f"{type(self).__name__} does not support augment=True; "
                 "test-time augmentation is out of scope for this VLM tier."
             )
-        if kwargs.get("tiling", False):
+        if tiling:
             raise ValueError(
                 f"{type(self).__name__} does not support tiling=True; "
                 "tile-level autoregressive generation has no defined merge contract."
             )
+
+    def __call__(self, source=None, **kwargs):
+        """Reject image-geometry modes owned by the VLM processor."""
+        self._validate_geometry_options(
+            imgsz=kwargs.get("imgsz"),
+            augment=kwargs.get("augment", False),
+            tiling=kwargs.get("tiling", False),
+        )
         return super().__call__(source, **kwargs)
+
+    def track(self, *args, **kwargs):
+        """Apply the same VLM geometry contract to per-frame tracking."""
+        self._validate_geometry_options(
+            imgsz=kwargs.get("imgsz"),
+            augment=kwargs.get("augment", False),
+            tiling=kwargs.get("tiling", False),
+        )
+        # BaseModel.track has no tiling path. A false compatibility value is a
+        # no-op and must not leak into tracker configuration.
+        kwargs.pop("tiling", None)
+        return super().track(*args, **kwargs)
 
     def set_classes(self, classes: list) -> "LibreVLMModel":
         """Set the open-vocabulary class list to detect.

--- a/libreyolo/models/vlm/base.py
+++ b/libreyolo/models/vlm/base.py
@@ -153,6 +153,25 @@ class LibreVLMModel(BaseModel):
     # Open-vocabulary API
     # =========================================================================
 
+    def __call__(self, source=None, **kwargs):
+        """Reject image-geometry modes owned by the VLM processor."""
+        if kwargs.get("imgsz") is not None:
+            raise ValueError(
+                f"{type(self).__name__} does not support imgsz=: the model "
+                "processor owns image resizing for this VLM tier."
+            )
+        if kwargs.get("augment", False):
+            raise ValueError(
+                f"{type(self).__name__} does not support augment=True; "
+                "test-time augmentation is out of scope for this VLM tier."
+            )
+        if kwargs.get("tiling", False):
+            raise ValueError(
+                f"{type(self).__name__} does not support tiling=True; "
+                "tile-level autoregressive generation has no defined merge contract."
+            )
+        return super().__call__(source, **kwargs)
+
     def set_classes(self, classes: list) -> "LibreVLMModel":
         """Set the open-vocabulary class list to detect.
 

--- a/libreyolo/models/yolo1/model.py
+++ b/libreyolo/models/yolo1/model.py
@@ -26,6 +26,7 @@ import torch
 from PIL import Image
 
 from ...utils.image_loader import ImageInput
+from ...validation.preprocessors import YOLO1ValPreprocessor
 from ..darknet.family import DarknetFamily
 from ..darknet.preprocess import preprocess_image_stretch as _v1_preprocess_image
 from ..darknet.preprocess import preprocess_numpy_stretch as _v1_preprocess_numpy
@@ -63,6 +64,7 @@ class LibreYOLO1(DarknetFamily):
     # decoder rejects batch > 1. Force the inference runner to loop per image
     # for list inputs instead of attempting a real batch.
     SUPPORTS_BATCHED_PREDICT = False
+    INPUT_SIZE_FIXED = True
     FILENAME_PREFIX = "LibreYOLO1"
     INPUT_SIZES = {"t": 448, "b": 448}
 
@@ -77,6 +79,29 @@ class LibreYOLO1(DarknetFamily):
     SIDE = 7            # S: the S x S grid
     BOXES_PER_CELL = 2  # B: predicted boxes per cell
     COORDS = 4          # box coordinates per box
+
+    def __init__(
+        self,
+        model_path=None,
+        size: str | None = None,
+        nb_classes: int | None = None,
+        device: str = "auto",
+        **kwargs,
+    ) -> None:
+        if nb_classes is not None and nb_classes != self.DEFAULT_NB_CLASSES:
+            raise ValueError(
+                "LibreYOLO1 has a fixed Pascal VOC 20-class fully-connected "
+                f"head; nb_classes must be 20, got {nb_classes}."
+            )
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=self.DEFAULT_NB_CLASSES,
+            device=device,
+            **kwargs,
+        )
+
+    val_preprocessor_class = YOLO1ValPreprocessor
 
     @classmethod
     def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
@@ -95,6 +120,19 @@ class LibreYOLO1(DarknetFamily):
                 nc = out // (cls.SIDE * cls.SIDE) - cls.BOXES_PER_CELL * (cls.COORDS + 1)
                 return nc if nc > 0 else None
         return None
+
+    def _adapt_checkpoint_num_classes(
+        self,
+        ckpt_nc: int | None,
+        checkpoint_task: str | None = None,
+    ) -> int | None:
+        del checkpoint_task
+        if ckpt_nc is not None and ckpt_nc != self.DEFAULT_NB_CLASSES:
+            raise RuntimeError(
+                "LibreYOLO1 checkpoints must use the fixed Pascal VOC "
+                f"20-class head; checkpoint declares nc={ckpt_nc}."
+            )
+        return ckpt_nc
 
     # --- YOLOv1-specific preprocessing ------------------------------------
     # The FC head needs a plain square stretch, not the letterbox the shared

--- a/libreyolo/models/yolo2/model.py
+++ b/libreyolo/models/yolo2/model.py
@@ -24,6 +24,7 @@ class LibreYOLO2(DarknetFamily):
     FAMILY = "yolo2"
     FILENAME_PREFIX = "LibreYOLO2"
     INPUT_SIZES = {"t": 416, "b": 608}
+    INPUT_SIZE_DIVISOR = 32
 
     CFG_BY_SIZE = {"t": "yolov2-tiny", "b": "yolov2"}
     CONV_COUNT_TO_SIZE = {9: "t", 23: "b"}

--- a/libreyolo/models/yolo3/model.py
+++ b/libreyolo/models/yolo3/model.py
@@ -20,6 +20,7 @@ class LibreYOLO3(DarknetFamily):
     FAMILY = "yolo3"
     FILENAME_PREFIX = "LibreYOLO3"
     INPUT_SIZES = {"t": 416, "b": 416, "spp": 608}
+    INPUT_SIZE_DIVISOR = 32
 
     CFG_BY_SIZE = {"t": "yolov3-tiny", "b": "yolov3", "spp": "yolov3-spp"}
     CONV_COUNT_TO_SIZE = {13: "t", 75: "b", 76: "spp"}

--- a/libreyolo/models/yolo4/model.py
+++ b/libreyolo/models/yolo4/model.py
@@ -22,6 +22,7 @@ class LibreYOLO4(DarknetFamily):
     FAMILY = "yolo4"
     FILENAME_PREFIX = "LibreYOLO4"
     INPUT_SIZES = {"t": 416, "b": 608}
+    INPUT_SIZE_DIVISOR = 32
 
     CFG_BY_SIZE = {"t": "yolov4-tiny", "b": "yolov4"}
     CONV_COUNT_TO_SIZE = {21: "t", 110: "b"}

--- a/libreyolo/models/yolo7/model.py
+++ b/libreyolo/models/yolo7/model.py
@@ -34,6 +34,7 @@ class LibreYOLO7(BaseModel):
     FAMILY = "yolo7"
     FILENAME_PREFIX = "LibreYOLO7"
     INPUT_SIZES = {"b": 640}
+    INPUT_SIZE_DIVISOR = 32
     SUPPORTED_TASKS = ("detect",)
     DEFAULT_TASK = "detect"
     # Letterbox + RGB + /255 + gray(114) pad — same contract as YOLO9.

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -54,6 +54,8 @@ class LibreYOLO9(BaseModel):
     FAMILY = "yolo9"
     FILENAME_PREFIX = "LibreYOLO9"
     INPUT_SIZES = {"t": 640, "s": 640, "m": 640, "c": 640}
+    INPUT_SIZE_DIVISOR = 32
+    SUPPORTS_RECTANGULAR_INPUT = True
     SUPPORTED_TASKS = ("detect",)
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,

--- a/libreyolo/models/yolo9/nn.py
+++ b/libreyolo/models/yolo9/nn.py
@@ -546,8 +546,8 @@ class DDetect(nn.Module):
         self.dynamic = False
         self.export = False
         self.shape = None
-        self.anchors = torch.empty(0)
-        self.strides = torch.empty(0)
+        self.register_buffer("anchors", torch.empty(0), persistent=False)
+        self.register_buffer("strides", torch.empty(0), persistent=False)
         # Register stride as a buffer so .to(device) moves it. Plain
         # attribute assignment leaves it on CPU even after model.to("cuda")
         # which silently breaks device-mismatch checks under DDP. dtype
@@ -642,19 +642,7 @@ class DDetect(nn.Module):
         # In export mode, always regenerate anchors to ensure trace
         # consistency (JIT trace runs the model twice and checks outputs).
         shape = preds[0].shape  # BCHW
-        if self.export:
-            anchors, strides = (
-                generated.transpose(0, 1)
-                for generated in self._make_anchors(preds, self.stride, 0.5)
-            )
-        else:
-            if self.dynamic or self.shape != shape:
-                self.anchors, self.strides = (
-                    generated.transpose(0, 1)
-                    for generated in self._make_anchors(preds, self.stride, 0.5)
-                )
-                self.shape = shape
-            anchors, strides = self.anchors, self.strides
+        anchors, strides = self._inference_anchors(preds)
 
         # Flatten every scale to (B, no, HW) and concatenate the scales, then
         # split the channel dim into the 4*reg_max distance distributions and
@@ -670,6 +658,30 @@ class DDetect(nn.Module):
         y = torch.cat((boxes, class_logits.sigmoid()), 1)
 
         return y, preds
+
+    @staticmethod
+    def _anchor_cache_signature(feats):
+        """Describe every feature map property that determines a safe cache."""
+        return tuple(
+            (tuple(feature.shape), feature.dtype, feature.device) for feature in feats
+        )
+
+    def _inference_anchors(self, feats):
+        """Return anchor tensors, rebuilding the inference cache when needed."""
+        if self.export:
+            return tuple(
+                generated.transpose(0, 1)
+                for generated in self._make_anchors(feats, self.stride, 0.5)
+            )
+
+        signature = self._anchor_cache_signature(feats)
+        if self.dynamic or self.shape != signature:
+            self.anchors, self.strides = (
+                generated.transpose(0, 1)
+                for generated in self._make_anchors(feats, self.stride, 0.5)
+            )
+            self.shape = signature
+        return self.anchors, self.strides
 
     def _make_anchors(self, feats, strides, grid_cell_offset=0.5):
         """Anchor centers plus per-anchor stride, one row per feature cell.

--- a/libreyolo/models/yolo9_e2e/nn.py
+++ b/libreyolo/models/yolo9_e2e/nn.py
@@ -76,18 +76,12 @@ class YOLO9E2EDetect(DDetect):
 
     def _inference(self, x):
         shape = x[0].shape
-
-        if self.export or self.dynamic or self.shape != shape:
-            self.anchors, self.strides = (
-                xi.transpose(0, 1) for xi in self._make_anchors(x, self.stride, 0.5)
-            )
-            if not self.export:
-                self.shape = shape
+        anchors, strides = self._inference_anchors(x)
 
         x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
         box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
         dbox = (
-            self._decode_bboxes(self.dfl(box), self.anchors.unsqueeze(0)) * self.strides
+            self._decode_bboxes(self.dfl(box), anchors.unsqueeze(0)) * strides
         )
         y = torch.cat((dbox, cls.sigmoid()), 1)
         return y, x

--- a/libreyolo/models/yolo9_p2/model.py
+++ b/libreyolo/models/yolo9_p2/model.py
@@ -51,7 +51,8 @@ class LibreYOLO9P2(LibreYOLO9):
     # Base yolo9 detect checkpoints are valid transfer sources (their tensors
     # are remapped by _prepare_state_dict).
     TRANSFER_COMPATIBLE_FAMILIES = ("yolo9",)
-    # Published VisDrone research-preview checkpoint (10 aerial classes).
+    # Recognized local VisDrone research-checkpoint variant (10 aerial classes).
+    # LibreYOLO does not publish or auto-download these restricted weights.
     WEIGHT_VARIANTS = ("visdrone",)
 
     # =====================================================================
@@ -79,6 +80,12 @@ class LibreYOLO9P2(LibreYOLO9):
         claim upstream YOLOv9 checkpoints for this family (it is registered
         first) and misattribute them to yolo9_p2.
         """
+        return None
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> None:
+        """P2 architectures are available, but no public weights are hosted."""
+        del filename
         return None
 
     @classmethod

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -34,6 +34,8 @@ class LibreYOLONAS(BaseModel):
     FAMILY = "yolonas"
     FILENAME_PREFIX = "LibreYOLONAS"
     INPUT_SIZES = {"s": 640, "m": 640, "l": 640}
+    INPUT_SIZE_DIVISOR = 32
+    INPUT_SIZE_MIN = 640
     POSE_INPUT_SIZES = {"n": 640, "s": 640, "m": 640, "l": 640}
     SUPPORTED_TASKS = ("detect", "pose")
     DEFAULT_TASK = "detect"
@@ -479,6 +481,11 @@ class LibreYOLONAS(BaseModel):
                         f"but is being loaded into '{own_family}'. "
                         f"Use the correct model class for this checkpoint."
                     )
+
+                self._apply_checkpoint_input_size(
+                    loaded,
+                    is_native_v1=is_native_v1,
+                )
 
                 ckpt_names = loaded.get("names")
                 ckpt_nc = self._normalize_checkpoint_nc(loaded.get("nc"))

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -42,6 +42,7 @@ class LibreYOLOX(BaseModel):
     FAMILY = "yolox"
     FILENAME_PREFIX = "LibreYOLOX"
     INPUT_SIZES = {"n": 416, "t": 416, "s": 640, "m": 640, "l": 640, "x": 640}
+    INPUT_SIZE_DIVISOR = 32
     TRAIN_CONFIG = YOLOXConfig
     val_preprocessor_class = YOLOXValPreprocessor
 

--- a/libreyolo/models/yolox/nn.py
+++ b/libreyolo/models/yolox/nn.py
@@ -600,7 +600,11 @@ class YOLOXHead(nn.Module):
         batch_size = output.shape[0]
         n_ch = 5 + self.num_classes
         hsize, wsize = output.shape[-2:]
-        if grid.shape[2:4] != output.shape[2:4]:
+        if (
+            grid.shape[2:4] != output.shape[2:4]
+            or grid.dtype != output.dtype
+            or grid.device != device
+        ):
             yv, xv = meshgrid([torch.arange(hsize), torch.arange(wsize)])
             grid = (
                 torch.stack((xv, yv), 2)

--- a/libreyolo/models/zipdepth/model.py
+++ b/libreyolo/models/zipdepth/model.py
@@ -62,10 +62,9 @@ class LibreZipDepth(BaseModel):
 
     # Encoder stride; the depth dataset and validator enforce divisibility.
     depth_imgsz_divisor = IMGSZ_DIVISOR
-    # Validation letterboxes to a fixed square (padded pixels are invalid depth,
-    # excluded from metrics); predict uses the native keep-aspect resize, so val
-    # metrics on non-square images are a documented approximation of predict.
-    depth_resize_mode = "letterbox"
+    # Validation delegates to the same keep-aspect preprocessing and
+    # original-canvas postprocessing used by predict.
+    depth_resize_mode = "native"
 
     # Keep-aspect preprocessing yields per-image variable sizes, so the stacked
     # single-forward batched-predict path does not apply.

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import re
 import time
 import uuid
 from contextlib import contextmanager
@@ -34,6 +33,10 @@ class WeightDownloadLockTimeout(WeightDownloadError, TimeoutError):
     """Raised when another process holds a target download lock too long."""
 
 
+class WeightPublicationError(WeightDownloadError):
+    """Raised when architecture support exists but no public download is declared."""
+
+
 def _get_hf_token() -> Optional[str]:
     """Get HuggingFace token from env var or cached login."""
     token = os.environ.get("HF_TOKEN")
@@ -61,18 +64,6 @@ def _notify_yolonas_license_once() -> None:
         "  https://github.com/Deci-AI/super-gradients/blob/master/LICENSE.YOLONAS.md\n"
         "─────────────────────────────────────────────────────────────────────\n"
     )
-
-
-def _detect_family_from_filename(filename: str) -> Optional[str]:
-    """Return model family hint from filename (for download routing only)."""
-    fl = filename.lower()
-    if re.search(r"librerfdetr", fl):
-        return "rfdetr"
-    if re.search(r"libreyolox", fl):
-        return "yolox"
-    if re.search(r"libreyolo9", fl):
-        return "yolo9"
-    return None
 
 
 @contextmanager
@@ -195,7 +186,7 @@ def _publish_verified_temp(partial: Path, destination: Path) -> bool:
 
 
 def download_weights(model_path: str, size: str):
-    """Download weights from Hugging Face if not found locally."""
+    """Download a declared public artifact, with a legacy registry fallback."""
     path = Path(model_path)
 
     # An existing path is user-owned input, not a cache entry managed by this
@@ -205,25 +196,61 @@ def download_weights(model_path: str, size: str):
         return
 
     from libreyolo.models.base.model import BaseModel
+    from libreyolo.models.manifest import (
+        get_family_spec,
+        load_family_class,
+        match_weight_filename,
+    )
 
+    artifact = match_weight_filename(path)
+    cls = None
     url = None
-    for cls in BaseModel._registry:
-        url = cls.get_download_url(path.name)
-        if url:
-            break
+    if artifact is not None:
+        if str(size).casefold() != artifact.size:
+            raise ValueError(
+                f"Size {size!r} conflicts with canonical filename "
+                f"size {artifact.size!r}."
+            )
+        if not artifact.downloadable:
+            if path.exists():
+                return
+            raise WeightPublicationError(
+                f"{path.name!r} is a valid {artifact.family} architecture "
+                f"artifact, but its publication state is "
+                f"{artifact.publication.value!r} and LibreYOLO does not declare "
+                "a public auto-download route. Provide a local checkpoint."
+            )
 
-    # RF-DETR is lazily registered — try loading it if no match yet
-    if url is None:
-        try:
-            from libreyolo.models import _ensure_rfdetr
+        family = get_family_spec(artifact.family)
+        if family is None:  # pragma: no cover - guarded by manifest invariants
+            raise RuntimeError(f"Manifest family {artifact.family!r} is missing.")
+        cls = load_family_class(family)
+        if artifact.download_kind == "hf":
+            url = artifact.download_url
+        elif artifact.download_kind == "family":
+            url = cls.get_download_url(path.name)
+    else:
+        # Compatibility path for noncanonical, family-specific references and
+        # third-party callers that install a temporary BaseModel registry.
+        for candidate in BaseModel._registry:
+            url = candidate.get_download_url(path.name)
+            if url:
+                cls = candidate
+                break
 
-            _ensure_rfdetr()
-            for cls in BaseModel._registry:
-                url = cls.get_download_url(path.name)
-                if url:
-                    break
-        except (ModuleNotFoundError, ImportError):
-            pass
+        # Legacy RF-DETR references may require its optional lazy registration.
+        if url is None:
+            try:
+                from libreyolo.models import _ensure_rfdetr
+
+                _ensure_rfdetr()
+                for candidate in BaseModel._registry:
+                    url = candidate.get_download_url(path.name)
+                    if url:
+                        cls = candidate
+                        break
+            except (ModuleNotFoundError, ImportError):
+                pass
 
     if url is None:
         raise ValueError(f"Could not determine download URL for '{path.name}'.")

--- a/libreyolo/utils/serialization.py
+++ b/libreyolo/utils/serialization.py
@@ -7,6 +7,7 @@ import warnings
 from dataclasses import dataclass, replace
 from fnmatch import fnmatchcase
 from importlib.metadata import PackageNotFoundError, version
+from numbers import Integral
 from pathlib import Path
 from typing import Any
 
@@ -207,15 +208,15 @@ def inspect_state_dict_load(
         loaded_keys=tuple(sorted(loaded)),
         missing_keys=tuple(sorted(set(missing) - set(allowed_missing))),
         unexpected_keys=tuple(sorted(set(unexpected) - set(allowed_unexpected))),
-        shape_mismatches=tuple(
-            sorted(set(shape_mismatches) - set(allowed_mismatches))
-        ),
+        shape_mismatches=tuple(sorted(set(shape_mismatches) - set(allowed_mismatches))),
         allowed_missing_keys=tuple(allowed_missing),
         allowed_unexpected_keys=tuple(allowed_unexpected),
         allowed_shape_mismatches=tuple(allowed_mismatches),
         total_target_tensors=len(target),
         loaded_elements=sum(_state_value_elements(target[key]) for key in loaded),
-        total_target_elements=sum(_state_value_elements(value) for value in target.values()),
+        total_target_elements=sum(
+            _state_value_elements(value) for value in target.values()
+        ),
         allowed_unloaded_elements=sum(
             _state_value_elements(target[key])
             for key in (*allowed_missing, *allowed_mismatches)
@@ -340,9 +341,7 @@ def load_state_dict_checked(
     report = inspect_state_dict_load(module, state_dict, policy=policy)
     enforce_checkpoint_load_report(report, policy=policy, context=context)
 
-    ignored = set(report.allowed_unexpected_keys) | set(
-        report.allowed_shape_mismatches
-    )
+    ignored = set(report.allowed_unexpected_keys) | set(report.allowed_shape_mismatches)
     filtered = {key: value for key, value in state_dict.items() if key not in ignored}
     module.load_state_dict(filtered, strict=False)
     return report
@@ -514,22 +513,69 @@ def _infer_checkpoint_imgsz(
     size: str,
     task: str,
 ) -> int | None:
-    """Infer square input size from registered family metadata when possible."""
+    """Infer square input size from the immutable public model manifest."""
+    from ..models.manifest import get_artifact_spec
+
+    artifact = get_artifact_spec(model_family, size, task)
+    return artifact.native_imgsz if artifact is not None else None
+
+
+def _checkpoint_imgsz_contract_error(
+    *,
+    model_family: str,
+    size: str,
+    task: str,
+    imgsz: int,
+) -> str | None:
+    """Return a public family input-contract error without building a model."""
+    from ..models.manifest import get_artifact_spec, load_family_class
+
+    artifact = get_artifact_spec(model_family, size, task)
+    if artifact is None:
+        return None
     try:
-        from ..models.base import BaseModel
-    except Exception:
+        model_class = load_family_class(model_family)
+    except (ImportError, ModuleNotFoundError):
+        # Metadata inspection must remain available without optional model
+        # extras. The installed reader performs its family-specific validation.
         return None
 
-    for cls in BaseModel._registry:
-        if cls.FAMILY != model_family:
-            continue
-        task_sizes = getattr(cls, "TASK_INPUT_SIZES", {}) or {}
-        input_sizes = (
-            task_sizes[task] if task in task_sizes else getattr(cls, "INPUT_SIZES", {})
+    model = object.__new__(model_class)
+    model.input_size = artifact.native_imgsz
+    model.size = artifact.size
+    model.task = artifact.task
+    if artifact.family == "rfdetr":
+        from types import SimpleNamespace
+
+        from ..models.rfdetr.nn import (
+            RFDETR_CONFIGS,
+            RFDETR_POSE_CONFIGS,
+            RFDETR_SEG_CONFIGS,
         )
-        value = input_sizes.get(size)
-        if value is not None:
-            return int(value)
+
+        configs = (
+            RFDETR_SEG_CONFIGS
+            if artifact.task == "segment"
+            else RFDETR_POSE_CONFIGS
+            if artifact.task == "pose"
+            else RFDETR_CONFIGS
+        )
+        config = configs[artifact.size]
+        model.model = SimpleNamespace(
+            patch_size=config.patch_size,
+            num_windows=config.num_windows,
+        )
+    try:
+        model_class._validate_input_size(
+            model,
+            imgsz,
+            context="checkpoint",
+            allow_fixed_override=bool(
+                getattr(model_class, "CHECKPOINT_INPUT_SIZE_OVERRIDE", False)
+            ),
+        )
+    except (RuntimeError, ValueError) as exc:
+        return str(exc)
     return None
 
 
@@ -557,6 +603,10 @@ def wrap_libreyolo_checkpoint(
     normalized_task = normalize_task(task)
     if normalized_task is None:
         raise CheckpointMetadataError("task is required.")
+    if isinstance(model_family, str):
+        model_family = model_family.strip().casefold()
+    if isinstance(size, str):
+        size = size.strip().casefold()
 
     if names is None:
         names = build_class_names(nc)
@@ -572,6 +622,19 @@ def wrap_libreyolo_checkpoint(
         raise CheckpointMetadataError(
             "imgsz is required and could not be inferred from model_family/size/task."
         )
+    if isinstance(imgsz, bool) or not isinstance(imgsz, Integral) or imgsz <= 0:
+        raise CheckpointMetadataError(
+            f"imgsz must be a positive int, got {imgsz!r}."
+        )
+    imgsz = int(imgsz)
+    imgsz_error = _checkpoint_imgsz_contract_error(
+        model_family=model_family,
+        size=size,
+        task=normalized_task,
+        imgsz=imgsz,
+    )
+    if imgsz_error is not None:
+        raise CheckpointMetadataError(imgsz_error)
 
     checkpoint: dict[str, Any] = {
         "model": state_dict,
@@ -582,7 +645,7 @@ def wrap_libreyolo_checkpoint(
         "task": normalized_task,
         "nc": nc,
         "names": normalized_names,
-        "imgsz": int(imgsz),
+        "imgsz": imgsz,
     }
     # Optional fields with None are intentionally omitted from checkpoint files.
     checkpoint.update({k: v for k, v in extra_metadata.items() if v is not None})
@@ -634,12 +697,53 @@ def validate_checkpoint_metadata(
         if "size" in checkpoint and not (isinstance(size, str) and size):
             errors.append("size must be a non-empty string.")
 
+        raw_task = checkpoint.get("task")
         try:
-            task = normalize_task(checkpoint.get("task"))
+            task = normalize_task(raw_task)
             if task is None:
                 errors.append("task is required.")
+            elif raw_task != task:
+                errors.append(
+                    f"task must use canonical identifier {task!r}, got "
+                    f"{raw_task!r}."
+                )
         except ValueError as exc:
+            task = None
             errors.append(str(exc))
+
+        artifact = None
+        if (
+            isinstance(model_family, str)
+            and model_family
+            and isinstance(size, str)
+            and size
+            and task is not None
+        ):
+            from ..models.manifest import get_artifact_spec, get_family_spec
+
+            family_spec = get_family_spec(model_family)
+            if family_spec is None:
+                errors.append(
+                    f"model_family {model_family!r} is not declared in the "
+                    "public model manifest."
+                )
+            else:
+                if model_family != family_spec.family:
+                    errors.append(
+                        "model_family must use canonical identifier "
+                        f"{family_spec.family!r}, got {model_family!r}."
+                    )
+                artifact = get_artifact_spec(model_family, size, task)
+                if artifact is not None and size != artifact.size:
+                    errors.append(
+                        f"size must use canonical identifier {artifact.size!r}, "
+                        f"got {size!r}."
+                    )
+            if family_spec is not None and artifact is None:
+                errors.append(
+                    "model_family/size/task must identify a declared model "
+                    f"artifact, got {model_family!r}/{size!r}/{task!r}."
+                )
 
         nc = checkpoint.get("nc")
         if not isinstance(nc, int) or isinstance(nc, bool) or nc <= 0:
@@ -661,6 +765,15 @@ def validate_checkpoint_metadata(
         imgsz = checkpoint.get("imgsz")
         if not isinstance(imgsz, int) or isinstance(imgsz, bool) or imgsz <= 0:
             errors.append("imgsz must be a positive int.")
+        elif artifact is not None:
+            imgsz_error = _checkpoint_imgsz_contract_error(
+                model_family=model_family,
+                size=size,
+                task=task,
+                imgsz=imgsz,
+            )
+            if imgsz_error is not None:
+                errors.append(imgsz_error)
 
     if strict and errors:
         raise CheckpointMetadataError("; ".join(errors))

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import time
 from abc import ABC, abstractmethod
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional, TYPE_CHECKING
@@ -20,6 +20,47 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from libreyolo.models.base import BaseModel
+
+
+def _module_device(module: torch.nn.Module, fallback: Any) -> torch.device:
+    """Return a module's actual device, including parameterless modules."""
+    for tensor in module.parameters():
+        return tensor.device
+    for tensor in module.buffers():
+        return tensor.device
+    return torch.device(fallback)
+
+
+@contextmanager
+def validation_model_state(model: Any, device: Any):
+    """Temporarily move a native model to ``device`` and exact eval state."""
+    module = model.model
+    # Exported-runtime backends expose a lightweight ``.model.eval()``
+    # compatibility proxy rather than a movable ``torch.nn.Module``. Their
+    # runtime provider owns placement, so preserve the existing backend path.
+    if not isinstance(module, torch.nn.Module):
+        yield
+        return
+
+    had_wrapper_device = hasattr(model, "device")
+    wrapper_device = getattr(model, "device", device)
+    original_device = _module_device(module, wrapper_device)
+    training_states = [
+        (submodule, bool(submodule.training)) for submodule in module.modules()
+    ]
+
+    try:
+        module.to(device)
+        module.eval()
+        if had_wrapper_device:
+            model.device = torch.device(device)
+        yield
+    finally:
+        module.to(original_device)
+        if had_wrapper_device:
+            model.device = wrapper_device
+        for submodule, was_training in training_states:
+            submodule.training = was_training
 
 
 class BaseValidator(ABC):
@@ -59,9 +100,28 @@ class BaseValidator(ABC):
 
     def run(self, **kwargs) -> Dict[str, float]:
         """Main validation entry point (template method)."""
-        self._setup(**kwargs)
-        self._run_validation()
-        return self._finalize()
+        with self._validation_model_state():
+            self._setup(**kwargs)
+            self._run_validation()
+            return self._finalize()
+
+    @contextmanager
+    def _validation_model_state(self):
+        """Temporarily move the model to the validation device and eval mode.
+
+        ``val(device=...)`` is a per-call override.  It must not permanently
+        migrate the live wrapper or leave a training model in eval mode, even
+        when dataset setup, inference, metric computation, or finalization
+        raises.
+        """
+        if not hasattr(self, "model"):
+            # Some metric-only validator uses construct a bare instance and
+            # replace the execution hooks. There is no live model state to
+            # transact in that case.
+            yield
+            return
+        with validation_model_state(self.model, self.device):
+            yield
 
     def _setup_device(self) -> torch.device:
         if self.config.device == "auto":
@@ -200,7 +260,13 @@ class BaseValidator(ABC):
             logger.info("Warming up model (%d iterations)...", n_warmup)
 
         imgsz = self.config.imgsz
-        batch_size = min(self.config.batch_size, 4)
+        loader_batch_size = getattr(self.dataloader, "batch_size", None)
+        effective_batch_size = (
+            loader_batch_size
+            if isinstance(loader_batch_size, int) and loader_batch_size > 0
+            else self.config.batch_size
+        )
+        batch_size = min(effective_batch_size, 4)
 
         dummy_input = torch.zeros(
             (batch_size, 3, imgsz, imgsz),

--- a/libreyolo/validation/depth_validator.py
+++ b/libreyolo/validation/depth_validator.py
@@ -91,6 +91,7 @@ class DepthValidator(BaseValidator):
                 f"divisible by {int(divisor)} for this model family."
             )
         resize_mode = getattr(self.model, "depth_resize_mode", "letterbox")
+        self._native_preprocess = resize_mode == "native"
         dataset = DepthDataset(
             data_config,
             split=split,
@@ -98,9 +99,18 @@ class DepthValidator(BaseValidator):
             augment=False,
             resize_mode=resize_mode,
         )
+        batch_size = self.config.batch_size
+        if self._native_preprocess:
+            if batch_size != 1:
+                logger.info(
+                    "Native-aspect depth validation runs one image at a time "
+                    "(batch_size=%d ignored).",
+                    batch_size,
+                )
+            batch_size = 1
         return DataLoader(
             dataset,
-            batch_size=self.config.batch_size,
+            batch_size=batch_size,
             shuffle=False,
             num_workers=self.config.num_workers,
             pin_memory=self.device.type == "cuda",
@@ -122,10 +132,58 @@ class DepthValidator(BaseValidator):
 
     def _preprocess_batch(self, batch: Any) -> tuple:
         images, targets, img_info, img_ids = batch
+        if getattr(self, "_native_preprocess", False):
+            if len(img_info) != 1:
+                raise ValueError(
+                    "Native-aspect depth validation requires exactly one image "
+                    "per batch."
+                )
+            info = img_info[0]
+            tensor, _, original_size, _ = self.model._preprocess(
+                info["img_path"],
+                color_format="rgb",
+                input_size=self.config.imgsz,
+            )
+            expected_size = (int(info["orig_shape"][1]), int(info["orig_shape"][0]))
+            if tuple(original_size) != expected_size:
+                raise ValueError(
+                    "Depth native preprocessing changed the source canvas: "
+                    f"reported {tuple(original_size)}, expected {expected_size}."
+                )
+            self._native_original_size = tuple(original_size)
+            images = tensor
         return images, targets, img_info, img_ids
 
     def _postprocess_predictions(self, preds: Any, batch: Any) -> Any:
         """Decode raw model output into ``[B, H, W]`` inverse-depth maps."""
+        if getattr(self, "_native_preprocess", False):
+            decoded = self.model._postprocess(
+                preds,
+                conf_thres=self.config.conf_thres,
+                iou_thres=self.config.iou_thres,
+                original_size=self._native_original_size,
+                input_size=self.config.imgsz,
+            )
+            output = decoded.get("depth") if isinstance(decoded, dict) else decoded
+            output = torch.as_tensor(output)
+            if output.ndim == 2:
+                output = output.unsqueeze(0)
+            targets = torch.as_tensor(batch[1])
+            if output.ndim != 3:
+                raise ValueError(
+                    "Native depth postprocessing must return [H, W] or "
+                    f"[B, H, W], got {tuple(output.shape)}."
+                )
+            require_matching_batch_sizes(
+                "Depth validation", predictions=output, targets=targets
+            )
+            if output.shape != targets.shape:
+                raise ValueError(
+                    "Native depth prediction and target canvases must match, got "
+                    f"{tuple(output.shape)} and {tuple(targets.shape)}."
+                )
+            return output
+
         output = preds
         if isinstance(output, dict):
             output = output.get("depth", output.get("predictions"))

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -120,7 +120,14 @@ class DetectionValidator(BaseValidator):
                 allow_scripts=self.config.allow_download_scripts,
             )
             data_dir = data_cfg["root"]
-            self.nc = int(data_cfg.get("nc", self.nc))
+            dataset_nc = int(data_cfg.get("nc", self.nc))
+            if dataset_nc != int(self.nc):
+                raise ValueError(
+                    f"Detection dataset has {dataset_nc} classes but "
+                    f"{type(self.model).__name__} predicts {self.nc}. Load a "
+                    "checkpoint with the matching class head before validation."
+                )
+            self.nc = dataset_nc
 
             names = data_cfg.get("names", None)
             if isinstance(names, dict):

--- a/libreyolo/validation/pose_validator.py
+++ b/libreyolo/validation/pose_validator.py
@@ -100,6 +100,10 @@ class PoseValidator(BaseValidator):
     # =========================================================================
 
     def run(self, **_kwargs) -> Dict[str, float]:
+        with self._validation_model_state():
+            return self._run_pose(**_kwargs)
+
+    def _run_pose(self, **_kwargs) -> Dict[str, float]:
         try:
             from pycocotools.coco import COCO  # noqa: F401
             from pycocotools.cocoeval import COCOeval  # noqa: F401

--- a/libreyolo/validation/preprocessors.py
+++ b/libreyolo/validation/preprocessors.py
@@ -298,6 +298,45 @@ class DarknetValPreprocessor(YOLO9ValPreprocessor):
         super().__init__(img_size, max_labels, pad_value=pad_value)
 
 
+class YOLO1ValPreprocessor(BaseValPreprocessor):
+    """YOLOv1 square-stretch preprocessing used by native prediction."""
+
+    @property
+    def normalize(self) -> bool:
+        return True
+
+    @property
+    def wants_unresized_image(self) -> bool:
+        return True
+
+    def __call__(
+        self, img: np.ndarray, targets: np.ndarray, input_size: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        from ..models.darknet.preprocess import preprocess_numpy_stretch
+
+        orig_h, orig_w = img.shape[:2]
+        target_h, target_w = input_size
+        if target_h != target_w:
+            raise ValueError(
+                "YOLOv1 validation requires a square input canvas, got "
+                f"{input_size}."
+            )
+
+        # Validation datasets decode with OpenCV (BGR); native prediction loads
+        # RGB before calling the same family helper.
+        rgb = np.ascontiguousarray(img[:, :, ::-1])
+        resized, _ = preprocess_numpy_stretch(rgb, input_size=target_h)
+
+        padded_targets = np.zeros((self.max_labels, 5), dtype=np.float32)
+        if len(targets) > 0:
+            targets = np.asarray(targets, dtype=np.float32).copy()
+            n = min(len(targets), self.max_labels)
+            targets[:n, [0, 2]] *= target_w / orig_w
+            targets[:n, [1, 3]] *= target_h / orig_h
+            padded_targets[:n] = targets[:n]
+        return resized, padded_targets
+
+
 class YOLONASValPreprocessor(YOLO9ValPreprocessor):
     """YOLO-NAS preprocessor: resize to 636 (longest side), center-pad to 640, RGB, 0-1.
 

--- a/libreyolo/validation/restore_validator.py
+++ b/libreyolo/validation/restore_validator.py
@@ -126,9 +126,18 @@ class RestoreValidator(BaseValidator):
             augment=False,
             scale=scale,
         )
+        batch_size = self.config.batch_size
+        if callable(getattr(self.model, "_preprocess_validation_batch", None)):
+            if batch_size != 1:
+                logger.info(
+                    "Native-geometry restore validation runs one image at a "
+                    "time (batch_size=%d ignored).",
+                    batch_size,
+                )
+            batch_size = 1
         return DataLoader(
             dataset,
-            batch_size=self.config.batch_size,
+            batch_size=batch_size,
             shuffle=False,
             num_workers=self.config.num_workers,
             pin_memory=self.device.type == "cuda",
@@ -141,6 +150,9 @@ class RestoreValidator(BaseValidator):
 
     def _preprocess_batch(self, batch: Any) -> tuple:
         images, targets, img_info, img_ids = batch
+        preprocess = getattr(self.model, "_preprocess_validation_batch", None)
+        if callable(preprocess):
+            images = preprocess(images)
         return images, targets, img_info, img_ids
 
     def _postprocess_predictions(self, preds: Any, batch: Any) -> torch.Tensor:

--- a/libreyolo/validation/semantic_validator.py
+++ b/libreyolo/validation/semantic_validator.py
@@ -52,6 +52,7 @@ class SemanticValidator(BaseValidator):
                 f"divisible by {int(divisor)} for this model family."
             )
         resize_mode = getattr(self.model, "semantic_resize_mode", "letterbox")
+        self._native_preprocess = resize_mode == "native"
         dataset = SemanticDataset(
             data_config,
             split=split,
@@ -70,9 +71,18 @@ class SemanticValidator(BaseValidator):
         self._num_classes = dataset.nc
         self._class_names = dict(dataset.names)
         self._ignore_index = dataset.ignore_index
+        batch_size = self.config.batch_size
+        if self._native_preprocess:
+            if batch_size != 1:
+                logger.info(
+                    "Native-geometry semantic validation runs one image at a "
+                    "time (batch_size=%d ignored).",
+                    batch_size,
+                )
+            batch_size = 1
         return DataLoader(
             dataset,
-            batch_size=self.config.batch_size,
+            batch_size=batch_size,
             shuffle=False,
             num_workers=self.config.num_workers,
             pin_memory=self.device.type == "cuda",
@@ -85,10 +95,65 @@ class SemanticValidator(BaseValidator):
 
     def _preprocess_batch(self, batch: Any) -> tuple:
         images, targets, img_info, img_ids = batch
+        if getattr(self, "_native_preprocess", False):
+            if len(img_info) != 1:
+                raise ValueError(
+                    "Native-geometry semantic validation requires exactly one "
+                    "image per batch."
+                )
+            info = img_info[0]
+            tensor, _, original_size, ratio = self.model._preprocess(
+                info["img_path"],
+                color_format="rgb",
+                input_size=self.config.imgsz,
+            )
+            expected_size = (int(info["orig_shape"][1]), int(info["orig_shape"][0]))
+            if tuple(original_size) != expected_size:
+                raise ValueError(
+                    "Semantic native preprocessing changed the source canvas: "
+                    f"reported {tuple(original_size)}, expected {expected_size}."
+                )
+            self._native_original_size = tuple(original_size)
+            self._native_ratio = float(ratio)
+            images = tensor
         return images, targets, img_info, img_ids
 
     def _postprocess_predictions(self, preds: Any, batch: Any) -> Any:
         """Decode raw model output into ``[B, H, W]`` class maps."""
+        if getattr(self, "_native_preprocess", False):
+            decoded = self.model._postprocess(
+                preds,
+                conf_thres=self.config.conf_thres,
+                iou_thres=self.config.iou_thres,
+                original_size=self._native_original_size,
+                ratio=self._native_ratio,
+                input_size=self.config.imgsz,
+            )
+            predictions = (
+                decoded.get("semantic") if isinstance(decoded, dict) else decoded
+            )
+            predictions = torch.as_tensor(predictions)
+            if predictions.ndim == 2:
+                predictions = predictions.unsqueeze(0)
+            targets = torch.as_tensor(batch[1])
+            if predictions.ndim != 3:
+                raise ValueError(
+                    "Native semantic postprocessing must return [H, W] or "
+                    f"[B, H, W], got {tuple(predictions.shape)}."
+                )
+            require_matching_batch_sizes(
+                "Semantic validation", predictions=predictions, targets=targets
+            )
+            if predictions.shape != targets.shape:
+                raise ValueError(
+                    "Native semantic prediction and target canvases must match, "
+                    f"got {tuple(predictions.shape)} and {tuple(targets.shape)}."
+                )
+            require_class_ids(
+                predictions, self._num_classes, "Semantic validation predictions"
+            )
+            return predictions
+
         logits = preds
         if isinstance(logits, dict):
             logits = logits.get("semantic_logits", logits.get("logits"))

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -13,10 +13,74 @@
       "t": 1024,
       "l": 1024
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "matte": {
+        "t": 1024,
+        "l": 1024
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "birefnet-l",
+      "birefnet-l-matte",
+      "birefnet-t",
+      "birefnet-t-matte"
+    ],
+    "downloadable_cli_names": [
+      "birefnet-l",
+      "birefnet-l-matte"
+    ],
+    "local_only_cli_names": [
+      "birefnet-t",
+      "birefnet-t-matte"
+    ],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "matte",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": "LibreBiRefNett-matte.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "birefnet-t",
+          "birefnet-t-matte"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreBiRefNett-matte.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "matte",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": "LibreBiRefNetl-matte.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreBiRefNetl-matte/resolve/main/LibreBiRefNetl-matte.pt",
+        "aliases": [
+          "birefnet-l",
+          "birefnet-l-matte"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreBiRefNetl-matte.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "clip": {
     "class": "libreyolo.models.clip.model.LibreCLIP",
@@ -34,10 +98,101 @@
       "b16": 224,
       "l14": 224
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "classify": {
+        "b32": 224,
+        "b16": 224,
+        "l14": 224
+      }
+    },
     "export_override": "custom",
-    "optional_extra": null,
-    "available": true
+    "optional_extra": "clip",
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "clip-b16",
+      "clip-b16-cls",
+      "clip-b32",
+      "clip-b32-cls",
+      "clip-l14",
+      "clip-l14-cls"
+    ],
+    "downloadable_cli_names": [
+      "clip-b16",
+      "clip-b16-cls",
+      "clip-b32",
+      "clip-b32-cls"
+    ],
+    "local_only_cli_names": [
+      "clip-l14",
+      "clip-l14-cls"
+    ],
+    "artifacts": [
+      {
+        "size": "b32",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreCLIPb32-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreCLIPb32-cls/resolve/main/LibreCLIPb32-cls.pt",
+        "aliases": [
+          "clip-b32",
+          "clip-b32-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreCLIPb32-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b16",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreCLIPb16-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreCLIPb16-cls/resolve/main/LibreCLIPb16-cls.pt",
+        "aliases": [
+          "clip-b16",
+          "clip-b16-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreCLIPb16-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l14",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreCLIPl14-cls.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "clip-l14",
+          "clip-l14-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreCLIPl14-cls.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "regex",
+      "ftfy"
+    ]
   },
   "convnext": {
     "class": "libreyolo.models.convnext.model.LibreConvNeXt",
@@ -55,10 +210,97 @@
       "s": 224,
       "b": 224
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "classify": {
+        "t": 224,
+        "s": 224,
+        "b": 224
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "convnext-b",
+      "convnext-b-cls",
+      "convnext-s",
+      "convnext-s-cls",
+      "convnext-t",
+      "convnext-t-cls"
+    ],
+    "downloadable_cli_names": [
+      "convnext-b",
+      "convnext-b-cls",
+      "convnext-s",
+      "convnext-s-cls",
+      "convnext-t",
+      "convnext-t-cls"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreConvNeXtt-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreConvNeXtt-cls/resolve/main/LibreConvNeXtt-cls.pt",
+        "aliases": [
+          "convnext-t",
+          "convnext-t-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreConvNeXtt-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreConvNeXts-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreConvNeXts-cls/resolve/main/LibreConvNeXts-cls.pt",
+        "aliases": [
+          "convnext-s",
+          "convnext-s-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreConvNeXts-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreConvNeXtb-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreConvNeXtb-cls/resolve/main/LibreConvNeXtb-cls.pt",
+        "aliases": [
+          "convnext-b",
+          "convnext-b-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreConvNeXtb-cls.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "deim": {
     "class": "libreyolo.models.deim.model.LibreDEIM",
@@ -80,10 +322,130 @@
       "l": 640,
       "x": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "n": 640,
+        "s": 640,
+        "m": 640,
+        "l": 640,
+        "x": 640
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "deim-l",
+      "deim-m",
+      "deim-n",
+      "deim-s",
+      "deim-x"
+    ],
+    "downloadable_cli_names": [
+      "deim-l",
+      "deim-m",
+      "deim-n",
+      "deim-s",
+      "deim-x"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "n",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMn.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMn/resolve/main/LibreDEIMn.pt",
+        "aliases": [
+          "deim-n"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMn.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMs.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMs/resolve/main/LibreDEIMs.pt",
+        "aliases": [
+          "deim-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMs.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMm.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMm/resolve/main/LibreDEIMm.pt",
+        "aliases": [
+          "deim-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMl/resolve/main/LibreDEIMl.pt",
+        "aliases": [
+          "deim-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMx.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMx/resolve/main/LibreDEIMx.pt",
+        "aliases": [
+          "deim-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMx.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "deimv2": {
     "class": "libreyolo.models.deimv2.model.LibreDEIMv2",
@@ -111,10 +473,193 @@
       "l": 640,
       "x": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "atto": 320,
+        "femto": 416,
+        "pico": 640,
+        "n": 640,
+        "s": 640,
+        "m": 640,
+        "l": 640,
+        "x": 640
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "deimv2-atto",
+      "deimv2-femto",
+      "deimv2-l",
+      "deimv2-m",
+      "deimv2-n",
+      "deimv2-pico",
+      "deimv2-s",
+      "deimv2-x"
+    ],
+    "downloadable_cli_names": [
+      "deimv2-atto",
+      "deimv2-femto",
+      "deimv2-l",
+      "deimv2-m",
+      "deimv2-n",
+      "deimv2-pico",
+      "deimv2-s",
+      "deimv2-x"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "atto",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 320,
+        "filename": "LibreDEIMv2atto.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2atto/resolve/main/LibreDEIMv2atto.pt",
+        "aliases": [
+          "deimv2-atto"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2atto.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "femto",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibreDEIMv2femto.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2femto/resolve/main/LibreDEIMv2femto.pt",
+        "aliases": [
+          "deimv2-femto"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2femto.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "pico",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMv2pico.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2pico/resolve/main/LibreDEIMv2pico.pt",
+        "aliases": [
+          "deimv2-pico"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2pico.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "n",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMv2n.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2n/resolve/main/LibreDEIMv2n.pt",
+        "aliases": [
+          "deimv2-n"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2n.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMv2s.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2s/resolve/main/LibreDEIMv2s.pt",
+        "aliases": [
+          "deimv2-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2s.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMv2m.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2m/resolve/main/LibreDEIMv2m.pt",
+        "aliases": [
+          "deimv2-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2m.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMv2l.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2l/resolve/main/LibreDEIMv2l.pt",
+        "aliases": [
+          "deimv2-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2l.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDEIMv2x.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDEIMv2x/resolve/main/LibreDEIMv2x.pt",
+        "aliases": [
+          "deimv2-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDEIMv2x.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "depth_anything": {
     "class": "libreyolo.models.depth_anything.model.LibreDepthAnythingV2",
@@ -134,10 +679,122 @@
       "l": 518,
       "g": 518
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "depth": {
+        "s": 518,
+        "b": 518,
+        "l": 518,
+        "g": 518
+      }
+    },
     "export_override": "custom",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "depth_anything-b",
+      "depth_anything-b-depth",
+      "depth_anything-g",
+      "depth_anything-g-depth",
+      "depth_anything-l",
+      "depth_anything-l-depth",
+      "depth_anything-s",
+      "depth_anything-s-depth"
+    ],
+    "downloadable_cli_names": [
+      "depth_anything-s",
+      "depth_anything-s-depth"
+    ],
+    "local_only_cli_names": [
+      "depth_anything-b",
+      "depth_anything-b-depth",
+      "depth_anything-g",
+      "depth_anything-g-depth",
+      "depth_anything-l",
+      "depth_anything-l-depth"
+    ],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "depth",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDepthAnythingV2s-depth.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDepthAnythingV2s-depth/resolve/main/LibreDepthAnythingV2s-depth.pt",
+        "aliases": [
+          "depth_anything-s",
+          "depth_anything-s-depth"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDepthAnythingV2s-depth.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "depth",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDepthAnythingV2b-depth.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "depth_anything-b",
+          "depth_anything-b-depth"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDepthAnythingV2b-depth.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "depth",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDepthAnythingV2l-depth.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "depth_anything-l",
+          "depth_anything-l-depth"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDepthAnythingV2l-depth.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "g",
+        "task": "depth",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDepthAnythingV2g-depth.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "depth_anything-g",
+          "depth_anything-g-depth"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDepthAnythingV2g-depth.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "depth_anything3": {
     "class": "libreyolo.models.depth_anything3.model.LibreDepthAnything3",
@@ -151,10 +808,49 @@
     "default_imgsz": {
       "l": 504
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "depth": {
+        "l": 504
+      }
+    },
     "export_override": "blocked",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "depth_anything3-l",
+      "depth_anything3-l-depth"
+    ],
+    "downloadable_cli_names": [
+      "depth_anything3-l",
+      "depth_anything3-l-depth"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "l",
+        "task": "depth",
+        "variant": null,
+        "imgsz": 504,
+        "filename": "LibreDepthAnything3l-depth.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDepthAnything3l-depth/resolve/main/LibreDepthAnything3l-depth.pt",
+        "aliases": [
+          "depth_anything3-l",
+          "depth_anything3-l-depth"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDepthAnything3l-depth.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "dfine": {
     "class": "libreyolo.models.dfine.model.LibreDFINE",
@@ -195,7 +891,219 @@
     },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "dfine-l",
+      "dfine-l-seg",
+      "dfine-m",
+      "dfine-m-seg",
+      "dfine-n",
+      "dfine-n-seg",
+      "dfine-s",
+      "dfine-s-seg",
+      "dfine-x",
+      "dfine-x-seg"
+    ],
+    "downloadable_cli_names": [
+      "dfine-l",
+      "dfine-l-seg",
+      "dfine-m",
+      "dfine-m-seg",
+      "dfine-n",
+      "dfine-n-seg",
+      "dfine-s",
+      "dfine-s-seg",
+      "dfine-x",
+      "dfine-x-seg"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "n",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEn.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEn/resolve/main/LibreDFINEn.pt",
+        "aliases": [
+          "dfine-n"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEn.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEs.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEs/resolve/main/LibreDFINEs.pt",
+        "aliases": [
+          "dfine-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEs.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEm.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEm/resolve/main/LibreDFINEm.pt",
+        "aliases": [
+          "dfine-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEl/resolve/main/LibreDFINEl.pt",
+        "aliases": [
+          "dfine-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEx.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEx/resolve/main/LibreDFINEx.pt",
+        "aliases": [
+          "dfine-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEx.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "n",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEn-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEn-seg/resolve/main/LibreDFINEn-seg.pt",
+        "aliases": [
+          "dfine-n-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEn-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEs-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEs-seg/resolve/main/LibreDFINEs-seg.pt",
+        "aliases": [
+          "dfine-s-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEs-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEm-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEm-seg/resolve/main/LibreDFINEm-seg.pt",
+        "aliases": [
+          "dfine-m-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEm-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEl-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEl-seg/resolve/main/LibreDFINEl-seg.pt",
+        "aliases": [
+          "dfine-l-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEl-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreDFINEx-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreDFINEx-seg/resolve/main/LibreDFINEx-seg.pt",
+        "aliases": [
+          "dfine-x-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDFINEx-seg.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "dinov2": {
     "class": "libreyolo.models.dinov2.model.LibreDINOv2",
@@ -217,6 +1125,12 @@
       "l": 518
     },
     "task_sizes": {
+      "semantic": {
+        "n": 518,
+        "s": 518,
+        "m": 518,
+        "l": 518
+      },
       "classify": {
         "n": 224,
         "s": 224,
@@ -226,7 +1140,193 @@
     },
     "export_override": "custom",
     "optional_extra": "rfdetr",
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "dinov2-l",
+      "dinov2-l-cls",
+      "dinov2-l-sem",
+      "dinov2-m",
+      "dinov2-m-cls",
+      "dinov2-m-sem",
+      "dinov2-n",
+      "dinov2-n-cls",
+      "dinov2-n-sem",
+      "dinov2-s",
+      "dinov2-s-cls",
+      "dinov2-s-sem"
+    ],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [
+      "dinov2-l",
+      "dinov2-l-cls",
+      "dinov2-l-sem",
+      "dinov2-m",
+      "dinov2-m-cls",
+      "dinov2-m-sem",
+      "dinov2-n",
+      "dinov2-n-cls",
+      "dinov2-n-sem",
+      "dinov2-s",
+      "dinov2-s-cls",
+      "dinov2-s-sem"
+    ],
+    "artifacts": [
+      {
+        "size": "n",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDINOv2n.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-n",
+          "dinov2-n-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2n.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDINOv2s.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-s",
+          "dinov2-s-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2s.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDINOv2m.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-m",
+          "dinov2-m-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2m.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 518,
+        "filename": "LibreDINOv2l.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-l",
+          "dinov2-l-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2l.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "n",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreDINOv2n-cls.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-n-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2n-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreDINOv2s-cls.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-s-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2s-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreDINOv2m-cls.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-m-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2m-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreDINOv2l-cls.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "dinov2-l-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreDINOv2l-cls.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "ec": {
     "class": "libreyolo.models.ec.model.LibreEC",
@@ -270,7 +1370,259 @@
     },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "ec-l",
+      "ec-l-pose",
+      "ec-l-seg",
+      "ec-m",
+      "ec-m-pose",
+      "ec-m-seg",
+      "ec-s",
+      "ec-s-pose",
+      "ec-s-seg",
+      "ec-x",
+      "ec-x-pose",
+      "ec-x-seg"
+    ],
+    "downloadable_cli_names": [
+      "ec-l",
+      "ec-l-pose",
+      "ec-l-seg",
+      "ec-m",
+      "ec-m-pose",
+      "ec-m-seg",
+      "ec-s",
+      "ec-s-pose",
+      "ec-s-seg",
+      "ec-x",
+      "ec-x-pose",
+      "ec-x-seg"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECs.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECs/resolve/main/LibreECs.pt",
+        "aliases": [
+          "ec-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECs.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECm.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECm/resolve/main/LibreECm.pt",
+        "aliases": [
+          "ec-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECl/resolve/main/LibreECl.pt",
+        "aliases": [
+          "ec-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECx.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECx/resolve/main/LibreECx.pt",
+        "aliases": [
+          "ec-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECx.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECs-pose.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECs-pose/resolve/main/LibreECs-pose.pt",
+        "aliases": [
+          "ec-s-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECs-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECm-pose.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECm-pose/resolve/main/LibreECm-pose.pt",
+        "aliases": [
+          "ec-m-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECm-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECl-pose.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECl-pose/resolve/main/LibreECl-pose.pt",
+        "aliases": [
+          "ec-l-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECl-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECx-pose.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECx-pose/resolve/main/LibreECx-pose.pt",
+        "aliases": [
+          "ec-x-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECx-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECs-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECs-seg/resolve/main/LibreECs-seg.pt",
+        "aliases": [
+          "ec-s-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECs-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECm-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECm-seg/resolve/main/LibreECm-seg.pt",
+        "aliases": [
+          "ec-m-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECm-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECl-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECl-seg/resolve/main/LibreECl-seg.pt",
+        "aliases": [
+          "ec-l-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECl-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreECx-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreECx-seg/resolve/main/LibreECx-seg.pt",
+        "aliases": [
+          "ec-x-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreECx-seg.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "efficientnetv2": {
     "class": "libreyolo.models.efficientnetv2.model.LibreEfficientNetV2",
@@ -290,10 +1642,121 @@
       "b2": 260,
       "b3": 300
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "classify": {
+        "b0": 224,
+        "b1": 240,
+        "b2": 260,
+        "b3": 300
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "efficientnetv2-b0",
+      "efficientnetv2-b0-cls",
+      "efficientnetv2-b1",
+      "efficientnetv2-b1-cls",
+      "efficientnetv2-b2",
+      "efficientnetv2-b2-cls",
+      "efficientnetv2-b3",
+      "efficientnetv2-b3-cls"
+    ],
+    "downloadable_cli_names": [
+      "efficientnetv2-b0",
+      "efficientnetv2-b0-cls",
+      "efficientnetv2-b1",
+      "efficientnetv2-b1-cls",
+      "efficientnetv2-b2",
+      "efficientnetv2-b2-cls",
+      "efficientnetv2-b3",
+      "efficientnetv2-b3-cls"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "b0",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreEfficientNetV2b0-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEfficientNetV2b0-cls/resolve/main/LibreEfficientNetV2b0-cls.pt",
+        "aliases": [
+          "efficientnetv2-b0",
+          "efficientnetv2-b0-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEfficientNetV2b0-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b1",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 240,
+        "filename": "LibreEfficientNetV2b1-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEfficientNetV2b1-cls/resolve/main/LibreEfficientNetV2b1-cls.pt",
+        "aliases": [
+          "efficientnetv2-b1",
+          "efficientnetv2-b1-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEfficientNetV2b1-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b2",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 260,
+        "filename": "LibreEfficientNetV2b2-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEfficientNetV2b2-cls/resolve/main/LibreEfficientNetV2b2-cls.pt",
+        "aliases": [
+          "efficientnetv2-b2",
+          "efficientnetv2-b2-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEfficientNetV2b2-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b3",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 300,
+        "filename": "LibreEfficientNetV2b3-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEfficientNetV2b3-cls/resolve/main/LibreEfficientNetV2b3-cls.pt",
+        "aliases": [
+          "efficientnetv2-b3",
+          "efficientnetv2-b3-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEfficientNetV2b3-cls.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "eomt": {
     "class": "libreyolo.models.eomt.model.LibreEoMT",
@@ -331,8 +1794,228 @@
       }
     },
     "export_override": "custom",
-    "optional_extra": null,
-    "available": true
+    "optional_extra": "eomt",
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "eomt-b",
+      "eomt-b-panoptic",
+      "eomt-b-seg",
+      "eomt-b-sem",
+      "eomt-l",
+      "eomt-l-panoptic",
+      "eomt-l-seg",
+      "eomt-l-sem",
+      "eomt-s",
+      "eomt-s-panoptic",
+      "eomt-s-seg",
+      "eomt-s-sem"
+    ],
+    "downloadable_cli_names": [
+      "eomt-b-panoptic",
+      "eomt-l",
+      "eomt-l-panoptic",
+      "eomt-l-seg",
+      "eomt-l-sem",
+      "eomt-s-panoptic"
+    ],
+    "local_only_cli_names": [
+      "eomt-b",
+      "eomt-b-seg",
+      "eomt-b-sem",
+      "eomt-s",
+      "eomt-s-seg",
+      "eomt-s-sem"
+    ],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreEoMTs-sem.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "eomt-s",
+          "eomt-s-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTs-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreEoMTb-sem.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "eomt-b",
+          "eomt-b-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTb-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreEoMTl-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEoMTl-sem/resolve/main/LibreEoMTl-sem.pt",
+        "aliases": [
+          "eomt-l",
+          "eomt-l-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTl-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreEoMTs-seg.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "eomt-s-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTs-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreEoMTb-seg.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "eomt-b-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTb-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreEoMTl-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEoMTl-seg/resolve/main/LibreEoMTl-seg.pt",
+        "aliases": [
+          "eomt-l-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTl-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "panoptic",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreEoMTs-panoptic.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEoMTs-panoptic/resolve/main/LibreEoMTs-panoptic.pt",
+        "aliases": [
+          "eomt-s-panoptic"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTs-panoptic.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "panoptic",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreEoMTb-panoptic.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEoMTb-panoptic/resolve/main/LibreEoMTb-panoptic.pt",
+        "aliases": [
+          "eomt-b-panoptic"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTb-panoptic.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "panoptic",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreEoMTl-panoptic.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEoMTl-panoptic/resolve/main/LibreEoMTl-panoptic.pt",
+        "aliases": [
+          "eomt-l-panoptic"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTl-panoptic.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "segment",
+        "variant": "1280",
+        "imgsz": 1280,
+        "filename": "LibreEoMTl-seg-1280.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreEoMTl-seg-1280/resolve/main/LibreEoMTl-seg-1280.pt",
+        "aliases": [],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreEoMTl-seg-1280.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "florence2": {
     "class": "libreyolo.models.vlm.florence2.LibreFlorence2",
@@ -348,10 +2031,65 @@
       "base": 768,
       "large": 768
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "base": 768,
+        "large": 768
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "vlm",
-    "available": true
+    "available": true,
+    "factory": "vlm",
+    "public_entrypoint": "LibreVLM",
+    "factory_default_model": "qwen3-vl-4b",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "base",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 768,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/florence-community/Florence-2-base",
+        "aliases": [
+          "florence-2",
+          "florence2",
+          "florence-2-base"
+        ],
+        "factory_model": "florence-2-base",
+        "invocation": "LibreVLM('florence-2-base')",
+        "repository": "florence-community/Florence-2-base",
+        "revision": null
+      },
+      {
+        "size": "large",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 768,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/florence-community/Florence-2-large",
+        "aliases": [
+          "florence-2-large"
+        ],
+        "factory_model": "florence-2-large",
+        "invocation": "LibreVLM('florence-2-large')",
+        "repository": "florence-community/Florence-2-large",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "fomo": {
     "class": "libreyolo.models.fomo.model.LibreFOMO",
@@ -369,10 +2107,97 @@
       "m": 192,
       "l": 224
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "point": {
+        "s": 96,
+        "m": 192,
+        "l": 224
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "fomo-l",
+      "fomo-l-point",
+      "fomo-m",
+      "fomo-m-point",
+      "fomo-s",
+      "fomo-s-point"
+    ],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [
+      "fomo-l",
+      "fomo-l-point",
+      "fomo-m",
+      "fomo-m-point",
+      "fomo-s",
+      "fomo-s-point"
+    ],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "point",
+        "variant": null,
+        "imgsz": 96,
+        "filename": "LibreFOMOs-point.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "fomo-s",
+          "fomo-s-point"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreFOMOs-point.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "point",
+        "variant": null,
+        "imgsz": 192,
+        "filename": "LibreFOMOm-point.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "fomo-m",
+          "fomo-m-point"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreFOMOm-point.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "point",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreFOMOl-point.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "fomo-l",
+          "fomo-l-point"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreFOMOl-point.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "grounding_dino": {
     "class": "libreyolo.models.openvocab.grounding_dino.LibreGroundingDINO",
@@ -388,10 +2213,71 @@
       "t": 800,
       "b": 800
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "t": 800,
+        "b": 800
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "openvocab",
-    "available": true
+    "available": true,
+    "factory": "openvocab",
+    "public_entrypoint": "LibreOpenVocab",
+    "factory_default_model": "grounding-dino-tiny",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 800,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreGroundingDINOt",
+        "aliases": [
+          "grounding-dino",
+          "groundingdino",
+          "grounding-dino-tiny",
+          "groundingdino-tiny",
+          "grounding-dino-t",
+          "groundingdino-t"
+        ],
+        "factory_model": "grounding-dino-tiny",
+        "invocation": "LibreOpenVocab('grounding-dino-tiny')",
+        "repository": "LibreYOLO/LibreGroundingDINOt",
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 800,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreGroundingDINOb",
+        "aliases": [
+          "grounding-dino-base",
+          "groundingdino-base",
+          "grounding-dino-b",
+          "groundingdino-b"
+        ],
+        "factory_model": "grounding-dino-base",
+        "invocation": "LibreOpenVocab('grounding-dino-base')",
+        "repository": "LibreYOLO/LibreGroundingDINOb",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "internvl3": {
     "class": "libreyolo.models.vlm.internvl3.LibreInternVL3",
@@ -409,10 +2295,83 @@
       "2b": 448,
       "8b": 448
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "1b": 448,
+        "2b": 448,
+        "8b": 448
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "vlm",
-    "available": true
+    "available": true,
+    "factory": "vlm",
+    "public_entrypoint": "LibreVLM",
+    "factory_default_model": "qwen3-vl-4b",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "1b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 448,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/OpenGVLab/InternVL3-1B-hf",
+        "aliases": [
+          "internvl3-1b"
+        ],
+        "factory_model": "internvl3-1b",
+        "invocation": "LibreVLM('internvl3-1b')",
+        "repository": "OpenGVLab/InternVL3-1B-hf",
+        "revision": null
+      },
+      {
+        "size": "2b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 448,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/OpenGVLab/InternVL3-2B-hf",
+        "aliases": [
+          "internvl3",
+          "internvl3-2b"
+        ],
+        "factory_model": "internvl3-2b",
+        "invocation": "LibreVLM('internvl3-2b')",
+        "repository": "OpenGVLab/InternVL3-2B-hf",
+        "revision": null
+      },
+      {
+        "size": "8b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 448,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/OpenGVLab/InternVL3-8B-hf",
+        "aliases": [
+          "internvl3-8b"
+        ],
+        "factory_model": "internvl3-8b",
+        "invocation": "LibreVLM('internvl3-8b')",
+        "repository": "OpenGVLab/InternVL3-8B-hf",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "kosmos2": {
     "class": "libreyolo.models.vlm.kosmos2.LibreKosmos2",
@@ -426,10 +2385,45 @@
     "default_imgsz": {
       "224": 224
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "224": 224
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "vlm",
-    "available": true
+    "available": true,
+    "factory": "vlm",
+    "public_entrypoint": "LibreVLM",
+    "factory_default_model": "qwen3-vl-4b",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "224",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 224,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/microsoft/kosmos-2-patch14-224",
+        "aliases": [
+          "kosmos-2",
+          "kosmos2"
+        ],
+        "factory_model": "kosmos-2",
+        "invocation": "LibreVLM('kosmos-2')",
+        "repository": "microsoft/kosmos-2-patch14-224",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "l2cs": {
     "class": "libreyolo.models.l2cs.model.LibreL2CS",
@@ -451,10 +2445,145 @@
       "r101": 448,
       "r152": 448
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "gaze": {
+        "r18": 448,
+        "r34": 448,
+        "r50": 448,
+        "r101": 448,
+        "r152": 448
+      }
+    },
     "export_override": "custom",
-    "optional_extra": null,
-    "available": true
+    "optional_extra": "gaze",
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "l2cs-r101",
+      "l2cs-r101-gaze",
+      "l2cs-r152",
+      "l2cs-r152-gaze",
+      "l2cs-r18",
+      "l2cs-r18-gaze",
+      "l2cs-r34",
+      "l2cs-r34-gaze",
+      "l2cs-r50",
+      "l2cs-r50-gaze"
+    ],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [
+      "l2cs-r101",
+      "l2cs-r101-gaze",
+      "l2cs-r152",
+      "l2cs-r152-gaze",
+      "l2cs-r18",
+      "l2cs-r18-gaze",
+      "l2cs-r34",
+      "l2cs-r34-gaze",
+      "l2cs-r50",
+      "l2cs-r50-gaze"
+    ],
+    "artifacts": [
+      {
+        "size": "r18",
+        "task": "gaze",
+        "variant": null,
+        "imgsz": 448,
+        "filename": "LibreL2CSr18.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "l2cs-r18",
+          "l2cs-r18-gaze"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreL2CSr18.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r34",
+        "task": "gaze",
+        "variant": null,
+        "imgsz": 448,
+        "filename": "LibreL2CSr34.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "l2cs-r34",
+          "l2cs-r34-gaze"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreL2CSr34.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r50",
+        "task": "gaze",
+        "variant": null,
+        "imgsz": 448,
+        "filename": "LibreL2CSr50.pt",
+        "publication": "direct",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "l2cs-r50",
+          "l2cs-r50-gaze"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreL2CSr50.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r101",
+        "task": "gaze",
+        "variant": null,
+        "imgsz": 448,
+        "filename": "LibreL2CSr101.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "l2cs-r101",
+          "l2cs-r101-gaze"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreL2CSr101.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r152",
+        "task": "gaze",
+        "variant": null,
+        "imgsz": 448,
+        "filename": "LibreL2CSr152.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "l2cs-r152",
+          "l2cs-r152-gaze"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreL2CSr152.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "lfm2vl": {
     "class": "libreyolo.models.vlm.lfm2.LibreLFM2VL",
@@ -470,10 +2599,64 @@
       "450m": 512,
       "1.6b": 512
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "450m": 512,
+        "1.6b": 512
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "vlm",
-    "available": true
+    "available": true,
+    "factory": "vlm",
+    "public_entrypoint": "LibreVLM",
+    "factory_default_model": "qwen3-vl-4b",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "450m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 512,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
+        "aliases": [
+          "lfm2-vl",
+          "lfm2-vl-450m"
+        ],
+        "factory_model": "lfm2-vl-450m",
+        "invocation": "LibreVLM('lfm2-vl-450m')",
+        "repository": "LiquidAI/LFM2.5-VL-450M",
+        "revision": null
+      },
+      {
+        "size": "1.6b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 512,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B",
+        "aliases": [
+          "lfm2-vl-1.6b"
+        ],
+        "factory_model": "lfm2-vl-1.6b",
+        "invocation": "LibreVLM('lfm2-vl-1.6b')",
+        "repository": "LiquidAI/LFM2.5-VL-1.6B",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "locateanything": {
     "class": "libreyolo.models.vlm.locateanything.LibreLocateAnything",
@@ -488,10 +2671,74 @@
     "default_imgsz": {
       "3b": 2500
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "3b": 2500
+      },
+      "point": {
+        "3b": 2500
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "vlm",
-    "available": true
+    "available": false,
+    "factory": "vlm",
+    "public_entrypoint": "LibreVLM",
+    "factory_default_model": "qwen3-vl-4b",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "3b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 2500,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/nvidia/LocateAnything-3B",
+        "aliases": [
+          "locate-anything",
+          "locateanything",
+          "locate-anything-3b",
+          "locateanything-3b"
+        ],
+        "factory_model": "locate-anything-3b",
+        "invocation": "LibreVLM('locate-anything-3b')",
+        "repository": "nvidia/LocateAnything-3B",
+        "revision": "c32291ca5e996f5a7a485845b4f57a233936bba0"
+      },
+      {
+        "size": "3b",
+        "task": "point",
+        "variant": null,
+        "imgsz": 2500,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/nvidia/LocateAnything-3B",
+        "aliases": [
+          "locate-anything",
+          "locateanything",
+          "locate-anything-3b",
+          "locateanything-3b"
+        ],
+        "factory_model": "locate-anything-3b",
+        "invocation": "LibreVLM('locate-anything-3b')",
+        "repository": "nvidia/LocateAnything-3B",
+        "revision": "c32291ca5e996f5a7a485845b4f57a233936bba0"
+      }
+    ],
+    "dependencies": [
+      "transformers",
+      "decord",
+      "lmdb",
+      "peft"
+    ]
   },
   "mobilenetv4": {
     "class": "libreyolo.models.mobilenetv4.model.LibreMobileNetV4",
@@ -509,10 +2756,97 @@
       "m": 224,
       "l": 256
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "classify": {
+        "s": 224,
+        "m": 224,
+        "l": 256
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "mobilenetv4-l",
+      "mobilenetv4-l-cls",
+      "mobilenetv4-m",
+      "mobilenetv4-m-cls",
+      "mobilenetv4-s",
+      "mobilenetv4-s-cls"
+    ],
+    "downloadable_cli_names": [
+      "mobilenetv4-l",
+      "mobilenetv4-l-cls",
+      "mobilenetv4-m",
+      "mobilenetv4-m-cls",
+      "mobilenetv4-s",
+      "mobilenetv4-s-cls"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreMobileNetV4s-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreMobileNetV4s-cls/resolve/main/LibreMobileNetV4s-cls.pt",
+        "aliases": [
+          "mobilenetv4-s",
+          "mobilenetv4-s-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreMobileNetV4s-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreMobileNetV4m-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreMobileNetV4m-cls/resolve/main/LibreMobileNetV4m-cls.pt",
+        "aliases": [
+          "mobilenetv4-m",
+          "mobilenetv4-m-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreMobileNetV4m-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 256,
+        "filename": "LibreMobileNetV4l-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreMobileNetV4l-cls/resolve/main/LibreMobileNetV4l-cls.pt",
+        "aliases": [
+          "mobilenetv4-l",
+          "mobilenetv4-l-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreMobileNetV4l-cls.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "mobilesam": {
     "class": "libreyolo.models.mobilesam.model.LibreMobileSAM",
@@ -526,10 +2860,49 @@
     "default_imgsz": {
       "tiny": 1024
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "segment": {
+        "tiny": 1024
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "sam",
-    "available": true
+    "available": true,
+    "factory": "sam",
+    "public_entrypoint": "LibreSAM",
+    "factory_default_model": "base",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "tiny",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreMobileSAM",
+        "aliases": [
+          "mobilesam",
+          "mobilesam-tiny",
+          "mobilesam_t",
+          "mobile-sam",
+          "mobile-sam-tiny"
+        ],
+        "factory_model": "mobilesam",
+        "invocation": "LibreSAM('mobilesam')",
+        "repository": "LibreYOLO/LibreMobileSAM",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers",
+      "huggingface_hub"
+    ]
   },
   "nafnet": {
     "class": "libreyolo.models.nafnet.model.LibreNAFNet",
@@ -545,10 +2918,89 @@
       "s": 256,
       "l": 256
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "restore": {
+        "s": 256,
+        "l": 256
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "nafnet-l",
+      "nafnet-l-restore",
+      "nafnet-s",
+      "nafnet-s-restore"
+    ],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [
+      "nafnet-l",
+      "nafnet-l-restore",
+      "nafnet-s",
+      "nafnet-s-restore"
+    ],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 256,
+        "filename": "LibreNAFNets-restore.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "nafnet-s",
+          "nafnet-s-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreNAFNets-restore.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 256,
+        "filename": "LibreNAFNetl-restore.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "nafnet-l",
+          "nafnet-l-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreNAFNetl-restore.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "restore",
+        "variant": "sidd",
+        "imgsz": 256,
+        "filename": "LibreNAFNetl-restore-sidd.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreNAFNetl-restore-sidd/resolve/main/LibreNAFNetl-restore-sidd.pt",
+        "aliases": [],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreNAFNetl-restore-sidd.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "owlv2": {
     "class": "libreyolo.models.openvocab.owlv2.LibreOWLv2",
@@ -564,10 +3016,71 @@
       "b16": 960,
       "l14": 1008
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "b16": 960,
+        "l14": 1008
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "openvocab",
-    "available": true
+    "available": true,
+    "factory": "openvocab",
+    "public_entrypoint": "LibreOpenVocab",
+    "factory_default_model": "grounding-dino-tiny",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "b16",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 960,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreOWLv2b16",
+        "aliases": [
+          "owlv2",
+          "owl-v2",
+          "owlv2-base",
+          "owl-v2-base",
+          "owlv2-b16",
+          "owl-v2-b16"
+        ],
+        "factory_model": "owlv2-b16",
+        "invocation": "LibreOpenVocab('owlv2-b16')",
+        "repository": "LibreYOLO/LibreOWLv2b16",
+        "revision": null
+      },
+      {
+        "size": "l14",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 1008,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreOWLv2l14",
+        "aliases": [
+          "owlv2-large",
+          "owl-v2-large",
+          "owlv2-l14",
+          "owl-v2-l14"
+        ],
+        "factory_model": "owlv2-l14",
+        "invocation": "LibreOpenVocab('owlv2-l14')",
+        "repository": "LibreYOLO/LibreOWLv2l14",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "picodet": {
     "class": "libreyolo.models.picodet.model.LibrePICODET",
@@ -585,10 +3098,88 @@
       "m": 416,
       "l": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "s": 320,
+        "m": 416,
+        "l": 640
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "picodet-l",
+      "picodet-m",
+      "picodet-s"
+    ],
+    "downloadable_cli_names": [
+      "picodet-l",
+      "picodet-m",
+      "picodet-s"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 320,
+        "filename": "LibrePICODETs.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePICODETs/resolve/main/LibrePICODETs.pt",
+        "aliases": [
+          "picodet-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePICODETs.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibrePICODETm.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePICODETm/resolve/main/LibrePICODETm.pt",
+        "aliases": [
+          "picodet-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePICODETm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibrePICODETl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePICODETl/resolve/main/LibrePICODETl.pt",
+        "aliases": [
+          "picodet-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePICODETl.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "picosam3": {
     "class": "libreyolo.models.picosam3.model.LibrePicoSAM3",
@@ -602,10 +3193,47 @@
     "default_imgsz": {
       "pico": 96
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "segment": {
+        "pico": 96
+      }
+    },
     "export_override": "custom",
     "optional_extra": "sam",
-    "available": true
+    "available": true,
+    "factory": "sam",
+    "public_entrypoint": "LibreSAM",
+    "factory_default_model": "base",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "pico",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 96,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePicoSAM3",
+        "aliases": [
+          "picosam3",
+          "picosam3-pico",
+          "picosam3_pico",
+          "pico-sam3"
+        ],
+        "factory_model": "picosam3",
+        "invocation": "LibreSAM('picosam3')",
+        "repository": "LibreYOLO/LibrePicoSAM3",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "huggingface_hub"
+    ]
   },
   "pidnet": {
     "class": "libreyolo.models.pidnet.model.LibrePIDNet",
@@ -623,10 +3251,97 @@
       "m": 1024,
       "l": 1024
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "semantic": {
+        "s": 1024,
+        "m": 1024,
+        "l": 1024
+      }
+    },
     "export_override": "custom",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "pidnet-l",
+      "pidnet-l-sem",
+      "pidnet-m",
+      "pidnet-m-sem",
+      "pidnet-s",
+      "pidnet-s-sem"
+    ],
+    "downloadable_cli_names": [
+      "pidnet-l",
+      "pidnet-l-sem",
+      "pidnet-m",
+      "pidnet-m-sem",
+      "pidnet-s",
+      "pidnet-s-sem"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": "LibrePIDNets-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePIDNets-sem/resolve/main/LibrePIDNets-sem.pt",
+        "aliases": [
+          "pidnet-s",
+          "pidnet-s-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePIDNets-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": "LibrePIDNetm-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePIDNetm-sem/resolve/main/LibrePIDNetm-sem.pt",
+        "aliases": [
+          "pidnet-m",
+          "pidnet-m-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePIDNetm-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": "LibrePIDNetl-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePIDNetl-sem/resolve/main/LibrePIDNetl-sem.pt",
+        "aliases": [
+          "pidnet-l",
+          "pidnet-l-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePIDNetl-sem.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "ppocr": {
     "class": "libreyolo.models.ppocr.model.LibrePPOCR",
@@ -642,10 +3357,73 @@
       "t": 960,
       "l": 960
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "ocr": {
+        "t": 960,
+        "l": 960
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "ppocr-l",
+      "ppocr-l-ocr",
+      "ppocr-t",
+      "ppocr-t-ocr"
+    ],
+    "downloadable_cli_names": [
+      "ppocr-l",
+      "ppocr-l-ocr",
+      "ppocr-t",
+      "ppocr-t-ocr"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "ocr",
+        "variant": null,
+        "imgsz": 960,
+        "filename": "LibrePPOCRt-ocr.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePPOCRt-ocr/resolve/main/LibrePPOCRt-ocr.pt",
+        "aliases": [
+          "ppocr-t",
+          "ppocr-t-ocr"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePPOCRt-ocr.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "ocr",
+        "variant": null,
+        "imgsz": 960,
+        "filename": "LibrePPOCRl-ocr.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibrePPOCRl-ocr/resolve/main/LibrePPOCRl-ocr.pt",
+        "aliases": [
+          "ppocr-l",
+          "ppocr-l-ocr"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibrePPOCRl-ocr.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "qwen3vl": {
     "class": "libreyolo.models.vlm.qwen3vl.LibreQwen3VL",
@@ -663,10 +3441,83 @@
       "4b": 1024,
       "8b": 1024
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "2b": 1024,
+        "4b": 1024,
+        "8b": 1024
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "vlm",
-    "available": true
+    "available": true,
+    "factory": "vlm",
+    "public_entrypoint": "LibreVLM",
+    "factory_default_model": "qwen3-vl-4b",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "2b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
+        "aliases": [
+          "qwen3-vl-2b"
+        ],
+        "factory_model": "qwen3-vl-2b",
+        "invocation": "LibreVLM('qwen3-vl-2b')",
+        "repository": "Qwen/Qwen3-VL-2B-Instruct",
+        "revision": null
+      },
+      {
+        "size": "4b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct",
+        "aliases": [
+          "qwen3-vl",
+          "qwen3-vl-4b"
+        ],
+        "factory_model": "qwen3-vl-4b",
+        "invocation": "LibreVLM('qwen3-vl-4b')",
+        "repository": "Qwen/Qwen3-VL-4B-Instruct",
+        "revision": null
+      },
+      {
+        "size": "8b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
+        "aliases": [
+          "qwen3-vl-8b"
+        ],
+        "factory_model": "qwen3-vl-8b",
+        "invocation": "LibreVLM('qwen3-vl-8b')",
+        "repository": "Qwen/Qwen3-VL-8B-Instruct",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "realesrgan": {
     "class": "libreyolo.models.realesrgan.model.LibreRealESRGAN",
@@ -684,10 +3535,97 @@
       "x2": 64,
       "x4t": 64
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "restore": {
+        "x4": 64,
+        "x2": 64,
+        "x4t": 64
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "realesrgan-x2",
+      "realesrgan-x2-restore",
+      "realesrgan-x4",
+      "realesrgan-x4-restore",
+      "realesrgan-x4t",
+      "realesrgan-x4t-restore"
+    ],
+    "downloadable_cli_names": [
+      "realesrgan-x2",
+      "realesrgan-x2-restore",
+      "realesrgan-x4",
+      "realesrgan-x4-restore",
+      "realesrgan-x4t",
+      "realesrgan-x4t-restore"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "x4",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 64,
+        "filename": "LibreRealESRGANx4-restore.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRealESRGANx4-restore/resolve/main/LibreRealESRGANx4-restore.pt",
+        "aliases": [
+          "realesrgan-x4",
+          "realesrgan-x4-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRealESRGANx4-restore.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x2",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 64,
+        "filename": "LibreRealESRGANx2-restore.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRealESRGANx2-restore/resolve/main/LibreRealESRGANx2-restore.pt",
+        "aliases": [
+          "realesrgan-x2",
+          "realesrgan-x2-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRealESRGANx2-restore.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x4t",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 64,
+        "filename": "LibreRealESRGANx4t-restore.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRealESRGANx4t-restore/resolve/main/LibreRealESRGANx4t-restore.pt",
+        "aliases": [
+          "realesrgan-x4t",
+          "realesrgan-x4t-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRealESRGANx4t-restore.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "resnet": {
     "class": "libreyolo.models.resnet.model.LibreResNet",
@@ -707,10 +3645,121 @@
       "50": 224,
       "101": 224
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "classify": {
+        "18": 224,
+        "34": 224,
+        "50": 224,
+        "101": 224
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "resnet-101",
+      "resnet-101-cls",
+      "resnet-18",
+      "resnet-18-cls",
+      "resnet-34",
+      "resnet-34-cls",
+      "resnet-50",
+      "resnet-50-cls"
+    ],
+    "downloadable_cli_names": [
+      "resnet-101",
+      "resnet-101-cls",
+      "resnet-18",
+      "resnet-18-cls",
+      "resnet-34",
+      "resnet-34-cls",
+      "resnet-50",
+      "resnet-50-cls"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "18",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreResNet18-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreResNet18-cls/resolve/main/LibreResNet18-cls.pt",
+        "aliases": [
+          "resnet-18",
+          "resnet-18-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreResNet18-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "34",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreResNet34-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreResNet34-cls/resolve/main/LibreResNet34-cls.pt",
+        "aliases": [
+          "resnet-34",
+          "resnet-34-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreResNet34-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "50",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreResNet50-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreResNet50-cls/resolve/main/LibreResNet50-cls.pt",
+        "aliases": [
+          "resnet-50",
+          "resnet-50-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreResNet50-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "101",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 224,
+        "filename": "LibreResNet101-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreResNet101-cls/resolve/main/LibreResNet101-cls.pt",
+        "aliases": [
+          "resnet-101",
+          "resnet-101-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreResNet101-cls.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "rfdetr": {
     "class": "libreyolo.models.rfdetr.model.LibreRFDETR",
@@ -762,7 +3811,321 @@
     },
     "export_override": "custom",
     "optional_extra": "rfdetr",
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "rfdetr-l",
+      "rfdetr-l-obb",
+      "rfdetr-l-seg",
+      "rfdetr-m",
+      "rfdetr-m-obb",
+      "rfdetr-m-seg",
+      "rfdetr-n",
+      "rfdetr-n-obb",
+      "rfdetr-n-seg",
+      "rfdetr-s",
+      "rfdetr-s-obb",
+      "rfdetr-s-seg",
+      "rfdetr-x-pose",
+      "rfdetr-x-seg",
+      "rfdetr-xx-seg"
+    ],
+    "downloadable_cli_names": [
+      "rfdetr-l",
+      "rfdetr-l-obb",
+      "rfdetr-l-seg",
+      "rfdetr-m",
+      "rfdetr-m-obb",
+      "rfdetr-m-seg",
+      "rfdetr-n",
+      "rfdetr-n-obb",
+      "rfdetr-n-seg",
+      "rfdetr-s",
+      "rfdetr-s-obb",
+      "rfdetr-s-seg",
+      "rfdetr-x-pose",
+      "rfdetr-x-seg",
+      "rfdetr-xx-seg"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "n",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 384,
+        "filename": "LibreRFDETRn.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRn/resolve/main/LibreRFDETRn.pt",
+        "aliases": [
+          "rfdetr-n"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRn.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreRFDETRs.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRs/resolve/main/LibreRFDETRs.pt",
+        "aliases": [
+          "rfdetr-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRs.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 576,
+        "filename": "LibreRFDETRm.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRm/resolve/main/LibreRFDETRm.pt",
+        "aliases": [
+          "rfdetr-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 704,
+        "filename": "LibreRFDETRl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRl/resolve/main/LibreRFDETRl.pt",
+        "aliases": [
+          "rfdetr-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "n",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 312,
+        "filename": "LibreRFDETRn-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRn-seg/resolve/main/LibreRFDETRn-seg.pt",
+        "aliases": [
+          "rfdetr-n-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRn-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 384,
+        "filename": "LibreRFDETRs-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRs-seg/resolve/main/LibreRFDETRs-seg.pt",
+        "aliases": [
+          "rfdetr-s-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRs-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 432,
+        "filename": "LibreRFDETRm-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRm-seg/resolve/main/LibreRFDETRm-seg.pt",
+        "aliases": [
+          "rfdetr-m-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRm-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 504,
+        "filename": "LibreRFDETRl-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRl-seg/resolve/main/LibreRFDETRl-seg.pt",
+        "aliases": [
+          "rfdetr-l-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRl-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 624,
+        "filename": "LibreRFDETRx-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRx-seg/resolve/main/LibreRFDETRx-seg.pt",
+        "aliases": [
+          "rfdetr-x-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRx-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "xx",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 768,
+        "filename": "LibreRFDETRxx-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRxx-seg/resolve/main/LibreRFDETRxx-seg.pt",
+        "aliases": [
+          "rfdetr-xx-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRxx-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 576,
+        "filename": "LibreRFDETRx-pose.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRx-pose/resolve/main/LibreRFDETRx-pose.pt",
+        "aliases": [
+          "rfdetr-x-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRx-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "n",
+        "task": "obb",
+        "variant": null,
+        "imgsz": 384,
+        "filename": "LibreRFDETRn-obb.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRn-obb/resolve/main/LibreRFDETRn-obb.pt",
+        "aliases": [
+          "rfdetr-n-obb"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRn-obb.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "obb",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreRFDETRs-obb.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRs-obb/resolve/main/LibreRFDETRs-obb.pt",
+        "aliases": [
+          "rfdetr-s-obb"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRs-obb.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "obb",
+        "variant": null,
+        "imgsz": 576,
+        "filename": "LibreRFDETRm-obb.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRm-obb/resolve/main/LibreRFDETRm-obb.pt",
+        "aliases": [
+          "rfdetr-m-obb"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRm-obb.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "obb",
+        "variant": null,
+        "imgsz": 704,
+        "filename": "LibreRFDETRl-obb.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRFDETRl-obb/resolve/main/LibreRFDETRl-obb.pt",
+        "aliases": [
+          "rfdetr-l-obb"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRFDETRl-obb.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "rtdetr": {
     "class": "libreyolo.models.rtdetr.model.LibreRTDETR",
@@ -788,10 +4151,172 @@
       "l": 640,
       "x": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "r18": 640,
+        "r34": 640,
+        "r50": 640,
+        "r50m": 640,
+        "r101": 640,
+        "l": 640,
+        "x": 640
+      }
+    },
     "export_override": "custom",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "rtdetr-l",
+      "rtdetr-r101",
+      "rtdetr-r18",
+      "rtdetr-r34",
+      "rtdetr-r50",
+      "rtdetr-r50m",
+      "rtdetr-x"
+    ],
+    "downloadable_cli_names": [
+      "rtdetr-l",
+      "rtdetr-r101",
+      "rtdetr-r18",
+      "rtdetr-r34",
+      "rtdetr-r50",
+      "rtdetr-r50m",
+      "rtdetr-x"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "r18",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRr18.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRr18/resolve/main/LibreRTDETRr18.pt",
+        "aliases": [
+          "rtdetr-r18"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRr18.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r34",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRr34.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRr34/resolve/main/LibreRTDETRr34.pt",
+        "aliases": [
+          "rtdetr-r34"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRr34.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r50",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRr50.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRr50/resolve/main/LibreRTDETRr50.pt",
+        "aliases": [
+          "rtdetr-r50"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRr50.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r50m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRr50m.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRr50m/resolve/main/LibreRTDETRr50m.pt",
+        "aliases": [
+          "rtdetr-r50m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRr50m.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r101",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRr101.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRr101/resolve/main/LibreRTDETRr101.pt",
+        "aliases": [
+          "rtdetr-r101"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRr101.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRl/resolve/main/LibreRTDETRl.pt",
+        "aliases": [
+          "rtdetr-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRx.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRx/resolve/main/LibreRTDETRx.pt",
+        "aliases": [
+          "rtdetr-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRx.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "rtdetrv2": {
     "class": "libreyolo.models.rtdetrv2.model.LibreRTDETRv2",
@@ -813,10 +4338,130 @@
       "r50m": 640,
       "r101": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "r18": 640,
+        "r34": 640,
+        "r50": 640,
+        "r50m": 640,
+        "r101": 640
+      }
+    },
     "export_override": "custom",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "rtdetrv2-r101",
+      "rtdetrv2-r18",
+      "rtdetrv2-r34",
+      "rtdetrv2-r50",
+      "rtdetrv2-r50m"
+    ],
+    "downloadable_cli_names": [
+      "rtdetrv2-r101",
+      "rtdetrv2-r18",
+      "rtdetrv2-r34",
+      "rtdetrv2-r50",
+      "rtdetrv2-r50m"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "r18",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv2r18.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv2r18/resolve/main/LibreRTDETRv2r18.pt",
+        "aliases": [
+          "rtdetrv2-r18"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv2r18.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r34",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv2r34.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv2r34/resolve/main/LibreRTDETRv2r34.pt",
+        "aliases": [
+          "rtdetrv2-r34"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv2r34.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r50",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv2r50.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv2r50/resolve/main/LibreRTDETRv2r50.pt",
+        "aliases": [
+          "rtdetrv2-r50"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv2r50.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r50m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv2r50m.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv2r50m/resolve/main/LibreRTDETRv2r50m.pt",
+        "aliases": [
+          "rtdetrv2-r50m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv2r50m.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "r101",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv2r101.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv2r101/resolve/main/LibreRTDETRv2r101.pt",
+        "aliases": [
+          "rtdetrv2-r101"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv2r101.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "rtdetrv4": {
     "class": "libreyolo.models.rtdetrv4.model.LibreRTDETRv4",
@@ -836,10 +4481,109 @@
       "l": 640,
       "x": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "s": 640,
+        "m": 640,
+        "l": 640,
+        "x": 640
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "rtdetrv4-l",
+      "rtdetrv4-m",
+      "rtdetrv4-s",
+      "rtdetrv4-x"
+    ],
+    "downloadable_cli_names": [
+      "rtdetrv4-l",
+      "rtdetrv4-m",
+      "rtdetrv4-s",
+      "rtdetrv4-x"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv4s.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv4s/resolve/main/LibreRTDETRv4s.pt",
+        "aliases": [
+          "rtdetrv4-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv4s.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv4m.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv4m/resolve/main/LibreRTDETRv4m.pt",
+        "aliases": [
+          "rtdetrv4-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv4m.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv4l.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv4l/resolve/main/LibreRTDETRv4l.pt",
+        "aliases": [
+          "rtdetrv4-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv4l.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTDETRv4x.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTDETRv4x/resolve/main/LibreRTDETRv4x.pt",
+        "aliases": [
+          "rtdetrv4-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTDETRv4x.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "rtmdet": {
     "class": "libreyolo.models.rtmdet.model.LibreRTMDet",
@@ -880,7 +4624,219 @@
     },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "rtmdet-l",
+      "rtmdet-l-seg",
+      "rtmdet-m",
+      "rtmdet-m-seg",
+      "rtmdet-s",
+      "rtmdet-s-seg",
+      "rtmdet-t",
+      "rtmdet-t-seg",
+      "rtmdet-x",
+      "rtmdet-x-seg"
+    ],
+    "downloadable_cli_names": [
+      "rtmdet-l",
+      "rtmdet-l-seg",
+      "rtmdet-m",
+      "rtmdet-m-seg",
+      "rtmdet-s",
+      "rtmdet-s-seg",
+      "rtmdet-t",
+      "rtmdet-t-seg",
+      "rtmdet-x",
+      "rtmdet-x-seg"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDett.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDett/resolve/main/LibreRTMDett.pt",
+        "aliases": [
+          "rtmdet-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDett.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDets.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDets/resolve/main/LibreRTMDets.pt",
+        "aliases": [
+          "rtmdet-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDets.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDetm.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDetm/resolve/main/LibreRTMDetm.pt",
+        "aliases": [
+          "rtmdet-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDetm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDetl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDetl/resolve/main/LibreRTMDetl.pt",
+        "aliases": [
+          "rtmdet-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDetl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDetx.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDetx/resolve/main/LibreRTMDetx.pt",
+        "aliases": [
+          "rtmdet-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDetx.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "t",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDett-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDett-seg/resolve/main/LibreRTMDett-seg.pt",
+        "aliases": [
+          "rtmdet-t-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDett-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDets-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDets-seg/resolve/main/LibreRTMDets-seg.pt",
+        "aliases": [
+          "rtmdet-s-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDets-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDetm-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDetm-seg/resolve/main/LibreRTMDetm-seg.pt",
+        "aliases": [
+          "rtmdet-m-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDetm-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDetl-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDetl-seg/resolve/main/LibreRTMDetl-seg.pt",
+        "aliases": [
+          "rtmdet-l-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDetl-seg.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreRTMDetx-seg.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreRTMDetx-seg/resolve/main/LibreRTMDetx-seg.pt",
+        "aliases": [
+          "rtmdet-x-seg"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreRTMDetx-seg.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "sam": {
     "class": "libreyolo.models.sam.model.LibreSAM1",
@@ -898,10 +4854,91 @@
       "large": 1024,
       "huge": 1024
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "segment": {
+        "base": 1024,
+        "large": 1024,
+        "huge": 1024
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "sam",
-    "available": true
+    "available": true,
+    "factory": "sam",
+    "public_entrypoint": "LibreSAM",
+    "factory_default_model": "base",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "base",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/facebook/sam-vit-base",
+        "aliases": [
+          "base",
+          "b",
+          "sam-base",
+          "sam_b"
+        ],
+        "factory_model": "base",
+        "invocation": "LibreSAM('base')",
+        "repository": "facebook/sam-vit-base",
+        "revision": null
+      },
+      {
+        "size": "large",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/facebook/sam-vit-large",
+        "aliases": [
+          "large",
+          "l",
+          "sam-large",
+          "sam_l"
+        ],
+        "factory_model": "large",
+        "invocation": "LibreSAM('large')",
+        "repository": "facebook/sam-vit-large",
+        "revision": null
+      },
+      {
+        "size": "huge",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/facebook/sam-vit-huge",
+        "aliases": [
+          "huge",
+          "h",
+          "sam-huge",
+          "sam_h"
+        ],
+        "factory_model": "huge",
+        "invocation": "LibreSAM('huge')",
+        "repository": "facebook/sam-vit-huge",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "sam2": {
     "class": "libreyolo.models.sam.sam2.LibreSAM2",
@@ -921,10 +4958,110 @@
       "base-plus": 1024,
       "large": 1024
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "segment": {
+        "tiny": 1024,
+        "small": 1024,
+        "base-plus": 1024,
+        "large": 1024
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "sam",
-    "available": true
+    "available": true,
+    "factory": "sam",
+    "public_entrypoint": "LibreSAM",
+    "factory_default_model": "base",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "tiny",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSAM2tiny",
+        "aliases": [
+          "sam2-tiny",
+          "sam2-t",
+          "sam2_t"
+        ],
+        "factory_model": "sam2-tiny",
+        "invocation": "LibreSAM('sam2-tiny')",
+        "repository": "LibreYOLO/LibreSAM2tiny",
+        "revision": null
+      },
+      {
+        "size": "small",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSAM2small",
+        "aliases": [
+          "sam2-small",
+          "sam2-s",
+          "sam2_s"
+        ],
+        "factory_model": "sam2-small",
+        "invocation": "LibreSAM('sam2-small')",
+        "repository": "LibreYOLO/LibreSAM2small",
+        "revision": null
+      },
+      {
+        "size": "base-plus",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSAM2base-plus",
+        "aliases": [
+          "sam2-base-plus",
+          "sam2-baseplus",
+          "sam2-bp",
+          "sam2_bp"
+        ],
+        "factory_model": "sam2-base-plus",
+        "invocation": "LibreSAM('sam2-base-plus')",
+        "repository": "LibreYOLO/LibreSAM2base-plus",
+        "revision": null
+      },
+      {
+        "size": "large",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1024,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSAM2large",
+        "aliases": [
+          "sam2-large",
+          "sam2-l",
+          "sam2_l"
+        ],
+        "factory_model": "sam2-large",
+        "invocation": "LibreSAM('sam2-large')",
+        "repository": "LibreYOLO/LibreSAM2large",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "sam3": {
     "class": "libreyolo.models.sam.sam3.LibreSAM3",
@@ -938,10 +5075,46 @@
     "default_imgsz": {
       "large": 1008
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "segment": {
+        "large": 1008
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "sam",
-    "available": true
+    "available": true,
+    "factory": "sam",
+    "public_entrypoint": "LibreSAM",
+    "factory_default_model": "base",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "large",
+        "task": "segment",
+        "variant": null,
+        "imgsz": 1008,
+        "filename": null,
+        "publication": "gated",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/facebook/sam3",
+        "aliases": [
+          "sam3",
+          "sam-3",
+          "sam3-large"
+        ],
+        "factory_model": "sam3",
+        "invocation": "LibreSAM('sam3')",
+        "repository": "facebook/sam3",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers"
+    ]
   },
   "segformer": {
     "class": "libreyolo.models.segformer.model.LibreSegformer",
@@ -965,10 +5138,169 @@
       "b4": 512,
       "b5": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "semantic": {
+        "b0": 512,
+        "b1": 512,
+        "b2": 512,
+        "b3": 512,
+        "b4": 512,
+        "b5": 640
+      }
+    },
     "export_override": "blocked",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "segformer-b0",
+      "segformer-b0-sem",
+      "segformer-b1",
+      "segformer-b1-sem",
+      "segformer-b2",
+      "segformer-b2-sem",
+      "segformer-b3",
+      "segformer-b3-sem",
+      "segformer-b4",
+      "segformer-b4-sem",
+      "segformer-b5",
+      "segformer-b5-sem"
+    ],
+    "downloadable_cli_names": [
+      "segformer-b0",
+      "segformer-b0-sem",
+      "segformer-b1",
+      "segformer-b1-sem",
+      "segformer-b2",
+      "segformer-b2-sem",
+      "segformer-b3",
+      "segformer-b3-sem",
+      "segformer-b4",
+      "segformer-b4-sem",
+      "segformer-b5",
+      "segformer-b5-sem"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "b0",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreSegformerb0-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSegformerb0-sem/resolve/main/LibreSegformerb0-sem.pt",
+        "aliases": [
+          "segformer-b0",
+          "segformer-b0-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSegformerb0-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b1",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreSegformerb1-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSegformerb1-sem/resolve/main/LibreSegformerb1-sem.pt",
+        "aliases": [
+          "segformer-b1",
+          "segformer-b1-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSegformerb1-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b2",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreSegformerb2-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSegformerb2-sem/resolve/main/LibreSegformerb2-sem.pt",
+        "aliases": [
+          "segformer-b2",
+          "segformer-b2-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSegformerb2-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b3",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreSegformerb3-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSegformerb3-sem/resolve/main/LibreSegformerb3-sem.pt",
+        "aliases": [
+          "segformer-b3",
+          "segformer-b3-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSegformerb3-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b4",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 512,
+        "filename": "LibreSegformerb4-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSegformerb4-sem/resolve/main/LibreSegformerb4-sem.pt",
+        "aliases": [
+          "segformer-b4",
+          "segformer-b4-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSegformerb4-sem.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b5",
+        "task": "semantic",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreSegformerb5-sem.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSegformerb5-sem/resolve/main/LibreSegformerb5-sem.pt",
+        "aliases": [
+          "segformer-b5",
+          "segformer-b5-sem"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSegformerb5-sem.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "siglip2": {
     "class": "libreyolo.models.siglip2.model.LibreSigLIP2",
@@ -984,10 +5316,75 @@
       "b16": 256,
       "so400m": 384
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "classify": {
+        "b16": 256,
+        "so400m": 384
+      }
+    },
     "export_override": "custom",
-    "optional_extra": null,
-    "available": true
+    "optional_extra": "siglip2",
+    "available": false,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "siglip2-b16",
+      "siglip2-b16-cls",
+      "siglip2-so400m",
+      "siglip2-so400m-cls"
+    ],
+    "downloadable_cli_names": [
+      "siglip2-b16",
+      "siglip2-b16-cls",
+      "siglip2-so400m",
+      "siglip2-so400m-cls"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "b16",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 256,
+        "filename": "LibreSigLIP2b16-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSigLIP2b16-cls/resolve/main/LibreSigLIP2b16-cls.pt",
+        "aliases": [
+          "siglip2-b16",
+          "siglip2-b16-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSigLIP2b16-cls.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "so400m",
+        "task": "classify",
+        "variant": null,
+        "imgsz": 384,
+        "filename": "LibreSigLIP2so400m-cls.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSigLIP2so400m-cls/resolve/main/LibreSigLIP2so400m-cls.pt",
+        "aliases": [
+          "siglip2-so400m",
+          "siglip2-so400m-cls"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSigLIP2so400m-cls.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "sentencepiece"
+    ]
   },
   "smolvlm2": {
     "class": "libreyolo.models.vlm.smolvlm.LibreSmolVLM2",
@@ -1003,10 +5400,65 @@
       "2.2b": 512,
       "500m": 512
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "2.2b": 512,
+        "500m": 512
+      }
+    },
     "export_override": "blocked",
     "optional_extra": "vlm",
-    "available": true
+    "available": false,
+    "factory": "vlm",
+    "public_entrypoint": "LibreVLM",
+    "factory_default_model": "qwen3-vl-4b",
+    "generic_cli": false,
+    "cli_names": [],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "2.2b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 512,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/HuggingFaceTB/SmolVLM2-2.2B-Instruct",
+        "aliases": [
+          "smolvlm2",
+          "smolvlm2-2.2b"
+        ],
+        "factory_model": "smolvlm2-2.2b",
+        "invocation": "LibreVLM('smolvlm2-2.2b')",
+        "repository": "HuggingFaceTB/SmolVLM2-2.2B-Instruct",
+        "revision": null
+      },
+      {
+        "size": "500m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 512,
+        "filename": null,
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "snapshot",
+        "download_url": "https://huggingface.co/HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+        "aliases": [
+          "smolvlm2-500m"
+        ],
+        "factory_model": "smolvlm2-500m",
+        "invocation": "LibreVLM('smolvlm2-500m')",
+        "repository": "HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+        "revision": null
+      }
+    ],
+    "dependencies": [
+      "transformers",
+      "num2words"
+    ]
   },
   "swinir": {
     "class": "libreyolo.models.swinir.model.LibreSwinIR",
@@ -1024,10 +5476,97 @@
       "m": 64,
       "l": 64
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "restore": {
+        "s": 64,
+        "m": 64,
+        "l": 64
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "swinir-l",
+      "swinir-l-restore",
+      "swinir-m",
+      "swinir-m-restore",
+      "swinir-s",
+      "swinir-s-restore"
+    ],
+    "downloadable_cli_names": [
+      "swinir-l",
+      "swinir-l-restore",
+      "swinir-m",
+      "swinir-m-restore",
+      "swinir-s",
+      "swinir-s-restore"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 64,
+        "filename": "LibreSwinIRs-restore.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSwinIRs-restore/resolve/main/LibreSwinIRs-restore.pt",
+        "aliases": [
+          "swinir-s",
+          "swinir-s-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSwinIRs-restore.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 64,
+        "filename": "LibreSwinIRm-restore.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSwinIRm-restore/resolve/main/LibreSwinIRm-restore.pt",
+        "aliases": [
+          "swinir-m",
+          "swinir-m-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSwinIRm-restore.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "restore",
+        "variant": null,
+        "imgsz": 64,
+        "filename": "LibreSwinIRl-restore.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreSwinIRl-restore/resolve/main/LibreSwinIRl-restore.pt",
+        "aliases": [
+          "swinir-l",
+          "swinir-l-restore"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreSwinIRl-restore.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo1": {
     "class": "libreyolo.models.yolo1.model.LibreYOLO1",
@@ -1043,10 +5582,67 @@
       "t": 448,
       "b": 448
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "t": 448,
+        "b": 448
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo1-b",
+      "yolo1-t"
+    ],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [
+      "yolo1-b",
+      "yolo1-t"
+    ],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 448,
+        "filename": "LibreYOLO1t.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "yolo1-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO1t.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 448,
+        "filename": "LibreYOLO1b.pt",
+        "publication": "unknown",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "yolo1-b"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO1b.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo2": {
     "class": "libreyolo.models.yolo2.model.LibreYOLO2",
@@ -1062,10 +5658,67 @@
       "t": 416,
       "b": 608
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "t": 416,
+        "b": 608
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo2-b",
+      "yolo2-t"
+    ],
+    "downloadable_cli_names": [
+      "yolo2-b",
+      "yolo2-t"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibreYOLO2t.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO2t/resolve/main/LibreYOLO2t.pt",
+        "aliases": [
+          "yolo2-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO2t.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 608,
+        "filename": "LibreYOLO2b.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO2b/resolve/main/LibreYOLO2b.pt",
+        "aliases": [
+          "yolo2-b"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO2b.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo3": {
     "class": "libreyolo.models.yolo3.model.LibreYOLO3",
@@ -1083,10 +5736,88 @@
       "b": 416,
       "spp": 608
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "t": 416,
+        "b": 416,
+        "spp": 608
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo3-b",
+      "yolo3-spp",
+      "yolo3-t"
+    ],
+    "downloadable_cli_names": [
+      "yolo3-b",
+      "yolo3-spp",
+      "yolo3-t"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibreYOLO3t.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO3t/resolve/main/LibreYOLO3t.pt",
+        "aliases": [
+          "yolo3-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO3t.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibreYOLO3b.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO3b/resolve/main/LibreYOLO3b.pt",
+        "aliases": [
+          "yolo3-b"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO3b.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "spp",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 608,
+        "filename": "LibreYOLO3spp.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO3spp/resolve/main/LibreYOLO3spp.pt",
+        "aliases": [
+          "yolo3-spp"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO3spp.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo4": {
     "class": "libreyolo.models.yolo4.model.LibreYOLO4",
@@ -1102,10 +5833,67 @@
       "t": 416,
       "b": 608
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "t": 416,
+        "b": 608
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo4-b",
+      "yolo4-t"
+    ],
+    "downloadable_cli_names": [
+      "yolo4-b",
+      "yolo4-t"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibreYOLO4t.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO4t/resolve/main/LibreYOLO4t.pt",
+        "aliases": [
+          "yolo4-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO4t.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 608,
+        "filename": "LibreYOLO4b.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO4b/resolve/main/LibreYOLO4b.pt",
+        "aliases": [
+          "yolo4-b"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO4b.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo7": {
     "class": "libreyolo.models.yolo7.model.LibreYOLO7",
@@ -1119,10 +5907,46 @@
     "default_imgsz": {
       "b": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "b": 640
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo7-b"
+    ],
+    "downloadable_cli_names": [
+      "yolo7-b"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "b",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO7b.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO7b/resolve/main/LibreYOLO7b.pt",
+        "aliases": [
+          "yolo7-b"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO7b.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo9": {
     "class": "libreyolo.models.yolo9.model.LibreYOLO9",
@@ -1152,7 +5976,99 @@
     },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo9-c",
+      "yolo9-m",
+      "yolo9-s",
+      "yolo9-t"
+    ],
+    "downloadable_cli_names": [
+      "yolo9-c",
+      "yolo9-m",
+      "yolo9-s",
+      "yolo9-t"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9t.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9t/resolve/main/LibreYOLO9t.pt",
+        "aliases": [
+          "yolo9-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9t.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9s.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9s/resolve/main/LibreYOLO9s.pt",
+        "aliases": [
+          "yolo9-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9s.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9m.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9m/resolve/main/LibreYOLO9m.pt",
+        "aliases": [
+          "yolo9-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9m.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "c",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9c.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9c/resolve/main/LibreYOLO9c.pt",
+        "aliases": [
+          "yolo9-c"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9c.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo9_e2e": {
     "class": "libreyolo.models.yolo9_e2e.model.LibreYOLO9E2E",
@@ -1182,7 +6098,99 @@
     },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo9_e2e-c",
+      "yolo9_e2e-m",
+      "yolo9_e2e-s",
+      "yolo9_e2e-t"
+    ],
+    "downloadable_cli_names": [
+      "yolo9_e2e-c",
+      "yolo9_e2e-m",
+      "yolo9_e2e-s",
+      "yolo9_e2e-t"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9E2Et.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9E2Et/resolve/main/LibreYOLO9E2Et.pt",
+        "aliases": [
+          "yolo9_e2e-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9E2Et.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9E2Es.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9E2Es/resolve/main/LibreYOLO9E2Es.pt",
+        "aliases": [
+          "yolo9_e2e-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9E2Es.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9E2Em.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9E2Em/resolve/main/LibreYOLO9E2Em.pt",
+        "aliases": [
+          "yolo9_e2e-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9E2Em.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "c",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9E2Ec.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLO9E2Ec/resolve/main/LibreYOLO9E2Ec.pt",
+        "aliases": [
+          "yolo9_e2e-c"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9E2Ec.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolo9_p2": {
     "class": "libreyolo.models.yolo9_p2.model.LibreYOLO9P2",
@@ -1206,7 +6214,91 @@
     },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolo9_p2-s",
+      "yolo9_p2-t"
+    ],
+    "downloadable_cli_names": [],
+    "local_only_cli_names": [
+      "yolo9_p2-s",
+      "yolo9_p2-t"
+    ],
+    "artifacts": [
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9P2t.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "yolo9_p2-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9P2t.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLO9P2s.pt",
+        "publication": "config_only",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [
+          "yolo9_p2-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9P2s.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": "visdrone",
+        "imgsz": 640,
+        "filename": "LibreYOLO9P2t-visdrone.pt",
+        "publication": "gated",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9P2t-visdrone.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": "visdrone",
+        "imgsz": 640,
+        "filename": "LibreYOLO9P2s-visdrone.pt",
+        "publication": "gated",
+        "downloadable": false,
+        "download_kind": "none",
+        "download_url": null,
+        "aliases": [],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLO9P2s-visdrone.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolonas": {
     "class": "libreyolo.models.yolonas.model.LibreYOLONAS",
@@ -1241,7 +6333,159 @@
     },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolonas-l",
+      "yolonas-l-pose",
+      "yolonas-m",
+      "yolonas-m-pose",
+      "yolonas-n-pose",
+      "yolonas-s",
+      "yolonas-s-pose"
+    ],
+    "downloadable_cli_names": [
+      "yolonas-l",
+      "yolonas-l-pose",
+      "yolonas-m",
+      "yolonas-m-pose",
+      "yolonas-n-pose",
+      "yolonas-s",
+      "yolonas-s-pose"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLONASs.pt",
+        "publication": "direct",
+        "downloadable": true,
+        "download_kind": "family",
+        "download_url": null,
+        "aliases": [
+          "yolonas-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLONASs.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLONASm.pt",
+        "publication": "direct",
+        "downloadable": true,
+        "download_kind": "family",
+        "download_url": null,
+        "aliases": [
+          "yolonas-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLONASm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLONASl.pt",
+        "publication": "direct",
+        "downloadable": true,
+        "download_kind": "family",
+        "download_url": null,
+        "aliases": [
+          "yolonas-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLONASl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "n",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLONASn-pose.pt",
+        "publication": "direct",
+        "downloadable": true,
+        "download_kind": "family",
+        "download_url": null,
+        "aliases": [
+          "yolonas-n-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLONASn-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLONASs-pose.pt",
+        "publication": "direct",
+        "downloadable": true,
+        "download_kind": "family",
+        "download_url": null,
+        "aliases": [
+          "yolonas-s-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLONASs-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLONASm-pose.pt",
+        "publication": "direct",
+        "downloadable": true,
+        "download_kind": "family",
+        "download_url": null,
+        "aliases": [
+          "yolonas-m-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLONASm-pose.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "pose",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLONASl-pose.pt",
+        "publication": "direct",
+        "downloadable": true,
+        "download_kind": "family",
+        "download_url": null,
+        "aliases": [
+          "yolonas-l-pose"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLONASl-pose.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "yolox": {
     "class": "libreyolo.models.yolox.model.LibreYOLOX",
@@ -1265,10 +6509,151 @@
       "l": 640,
       "x": 640
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "detect": {
+        "n": 416,
+        "t": 416,
+        "s": 640,
+        "m": 640,
+        "l": 640,
+        "x": 640
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "yolox-l",
+      "yolox-m",
+      "yolox-n",
+      "yolox-s",
+      "yolox-t",
+      "yolox-x"
+    ],
+    "downloadable_cli_names": [
+      "yolox-l",
+      "yolox-m",
+      "yolox-n",
+      "yolox-s",
+      "yolox-t",
+      "yolox-x"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "n",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibreYOLOXn.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLOXn/resolve/main/LibreYOLOXn.pt",
+        "aliases": [
+          "yolox-n"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLOXn.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "t",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 416,
+        "filename": "LibreYOLOXt.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLOXt/resolve/main/LibreYOLOXt.pt",
+        "aliases": [
+          "yolox-t"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLOXt.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "s",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLOXs.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLOXs/resolve/main/LibreYOLOXs.pt",
+        "aliases": [
+          "yolox-s"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLOXs.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "m",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLOXm.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLOXm/resolve/main/LibreYOLOXm.pt",
+        "aliases": [
+          "yolox-m"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLOXm.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "l",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLOXl.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLOXl/resolve/main/LibreYOLOXl.pt",
+        "aliases": [
+          "yolox-l"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLOXl.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "x",
+        "task": "detect",
+        "variant": null,
+        "imgsz": 640,
+        "filename": "LibreYOLOXx.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreYOLOXx/resolve/main/LibreYOLOXx.pt",
+        "aliases": [
+          "yolox-x"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreYOLOXx.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   },
   "zipdepth": {
     "class": "libreyolo.models.zipdepth.model.LibreZipDepth",
@@ -1284,9 +6669,72 @@
       "b": 384,
       "bnpu": 384
     },
-    "task_sizes": {},
+    "task_sizes": {
+      "depth": {
+        "b": 384,
+        "bnpu": 384
+      }
+    },
     "export_override": "none",
     "optional_extra": null,
-    "available": true
+    "available": true,
+    "factory": "libreyolo",
+    "public_entrypoint": "LibreYOLO",
+    "factory_default_model": null,
+    "generic_cli": true,
+    "cli_names": [
+      "zipdepth-b",
+      "zipdepth-b-depth",
+      "zipdepth-bnpu",
+      "zipdepth-bnpu-depth"
+    ],
+    "downloadable_cli_names": [
+      "zipdepth-b",
+      "zipdepth-b-depth",
+      "zipdepth-bnpu",
+      "zipdepth-bnpu-depth"
+    ],
+    "local_only_cli_names": [],
+    "artifacts": [
+      {
+        "size": "b",
+        "task": "depth",
+        "variant": null,
+        "imgsz": 384,
+        "filename": "LibreZipDepthb-depth.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreZipDepthb-depth/resolve/main/LibreZipDepthb-depth.pt",
+        "aliases": [
+          "zipdepth-b",
+          "zipdepth-b-depth"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreZipDepthb-depth.pt')",
+        "repository": null,
+        "revision": null
+      },
+      {
+        "size": "bnpu",
+        "task": "depth",
+        "variant": null,
+        "imgsz": 384,
+        "filename": "LibreZipDepthbnpu-depth.pt",
+        "publication": "published",
+        "downloadable": true,
+        "download_kind": "hf",
+        "download_url": "https://huggingface.co/LibreYOLO/LibreZipDepthbnpu-depth/resolve/main/LibreZipDepthbnpu-depth.pt",
+        "aliases": [
+          "zipdepth-bnpu",
+          "zipdepth-bnpu-depth"
+        ],
+        "factory_model": null,
+        "invocation": "LibreYOLO('LibreZipDepthbnpu-depth.pt')",
+        "repository": null,
+        "revision": null
+      }
+    ],
+    "dependencies": []
   }
 }

--- a/tests/unit/test_deimv2_export.py
+++ b/tests/unit/test_deimv2_export.py
@@ -185,7 +185,7 @@ def test_deimv2_export_rejects_non_native_imgsz(tmp_path):
     from libreyolo import LibreDEIMv2
 
     model = LibreDEIMv2(None, size="atto", device="cpu")
-    with pytest.raises(ValueError, match="fixed decoder anchors"):
+    with pytest.raises(ValueError, match="requires imgsz=320"):
         model.export(
             "onnx",
             output_path=str(tmp_path / "bad.onnx"),

--- a/tests/unit/test_depth_validator.py
+++ b/tests/unit/test_depth_validator.py
@@ -240,3 +240,58 @@ def test_imgsz_divisor_mismatch_raises(tmp_path):
 
     with pytest.raises(ValueError, match="divisible by 14"):
         DepthValidator(model, config).run()
+
+
+def test_native_depth_validation_uses_family_geometry_and_postprocess(tmp_path):
+    width, height = 20, 10
+    _write_image(tmp_path / "images" / "val" / "a.jpg", width, height)
+    depth = np.full((height, width), FAR_DEPTH, dtype=np.float64)
+    _write_depth(tmp_path / "depths" / "val" / "a.png", depth)
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        f"path: {tmp_path.as_posix()}\nval: images/val\nnames: [depth]\n"
+    )
+
+    class _NativeModel(_StubDepthModel):
+        depth_resize_mode = "native"
+
+        def _preprocess(self, image, color_format, input_size):
+            del image, color_format, input_size
+            return torch.zeros(1, 3, 16, 32), None, (width, height), 1.0
+
+        def _postprocess(self, output, **kwargs):
+            assert kwargs["original_size"] == (width, height)
+            resized = torch.nn.functional.interpolate(
+                output,
+                size=(height, width),
+                mode="bilinear",
+                align_corners=True,
+            )
+            return {"depth": resized[0, 0]}
+
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=32,
+        batch_size=4,
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+    )
+    validator = DepthValidator(_NativeModel(), config)
+    validator.dataloader = validator._setup_dataloader()
+    batch = next(iter(validator.dataloader))
+
+    images, targets, infos, ids = validator._preprocess_batch(batch)
+    raw = torch.tensor([[[[0.0, 1.0], [2.0, 4.0]]]])
+    decoded = validator._postprocess_predictions(raw, batch)
+    align_false = torch.nn.functional.interpolate(
+        raw, size=(height, width), mode="bilinear", align_corners=False
+    )[:, 0]
+
+    assert images.shape == (1, 3, 16, 32)
+    assert targets.shape == (1, height, width)
+    assert infos[0]["orig_shape"] == (height, width)
+    assert ids == [0]
+    assert decoded.shape == (1, height, width)
+    assert not torch.allclose(decoded, align_false)

--- a/tests/unit/test_detection_grid_caches.py
+++ b/tests/unit/test_detection_grid_caches.py
@@ -1,0 +1,104 @@
+"""Regression tests for detection-head geometry caches."""
+
+import pytest
+import torch
+
+from libreyolo.models.yolo9.nn import DDetect
+from libreyolo.models.yolo9_e2e.nn import YOLO9E2EDetect
+from libreyolo.models.yolo9_p2.nn import LibreYOLO9P2Model
+from libreyolo.models.yolox.nn import YOLOXHead
+
+pytestmark = pytest.mark.unit
+
+
+def _raw_predictions(head, shapes, *, dtype=torch.float32, device="cpu"):
+    return [
+        torch.zeros((1, head.no, height, width), dtype=dtype, device=device)
+        for height, width in shapes
+    ]
+
+
+def test_yolo9_anchor_cache_tracks_every_feature_shape():
+    head = DDetect(nc=2, ch=(4, 8, 16), reg_max=4, stride=(8, 16, 32)).eval()
+
+    first = [
+        torch.zeros(1, 4, 8, 8),
+        torch.zeros(1, 8, 4, 4),
+        torch.zeros(1, 16, 2, 2),
+    ]
+    second = [first[0], torch.zeros(1, 8, 5, 4), first[2]]
+
+    first_decoded, _ = head(first)
+    second_decoded, _ = head(second)
+
+    assert first_decoded.shape[-1] == 84
+    assert second_decoded.shape[-1] == 88
+    assert head.anchors.shape[-1] == 88
+
+
+def test_yolo9_e2e_anchor_cache_tracks_every_feature_shape():
+    head = YOLO9E2EDetect(
+        nc=2, ch=(4, 8, 16), reg_max=4, stride=(8, 16, 32)
+    ).eval()
+    first = _raw_predictions(head, [(8, 8), (4, 4), (2, 2)])
+    second = _raw_predictions(head, [(8, 8), (4, 4), (3, 2)])
+
+    first_decoded, _ = head._inference(first)
+    second_decoded, _ = head._inference(second)
+
+    assert first_decoded.shape[-1] == 84
+    assert second_decoded.shape[-1] == 86
+    assert head.anchors.shape[-1] == 86
+
+
+def test_yolo9_p2_anchor_cache_tracks_fourth_feature_shape():
+    head = LibreYOLO9P2Model(config="t", nb_classes=2).head.eval()
+    first = _raw_predictions(head, [(8, 8), (4, 4), (2, 2), (1, 1)])
+    second = _raw_predictions(head, [(8, 8), (4, 4), (2, 2), (1, 2)])
+
+    head._inference_anchors(first)
+    anchors, _ = head._inference_anchors(second)
+
+    assert anchors.shape[-1] == 86
+
+
+def test_yolo9_anchor_cache_tracks_dtype_and_device_and_is_nonpersistent():
+    head = DDetect(nc=2, ch=(4,), reg_max=4, stride=(8,)).eval()
+
+    float_anchors, _ = head._inference_anchors(
+        _raw_predictions(head, [(2, 3)], dtype=torch.float32)
+    )
+    double_anchors, _ = head._inference_anchors(
+        _raw_predictions(head, [(2, 3)], dtype=torch.float64)
+    )
+    meta_anchors, _ = head._inference_anchors(
+        _raw_predictions(head, [(2, 3)], dtype=torch.float64, device="meta")
+    )
+
+    assert float_anchors.dtype == torch.float32
+    assert double_anchors.dtype == torch.float64
+    assert meta_anchors.device.type == "meta"
+    assert {"anchors", "strides"} <= dict(head.named_buffers()).keys()
+    assert "anchors" not in head.state_dict()
+    assert "strides" not in head.state_dict()
+
+
+def test_yolox_training_grid_cache_tracks_shape_dtype_and_device():
+    head = YOLOXHead(
+        num_classes=2, width=0.25, strides=[8], in_channels=[64]
+    )
+
+    output = torch.zeros(1, 7, 2, 3, dtype=torch.float64)
+    _, grid = head.get_output_and_grid(output, 0, 8, output.type())
+    assert grid.shape == (1, 6, 2)
+    assert grid.dtype == torch.float64
+    assert grid.device.type == "cpu"
+
+    output = torch.zeros(1, 7, 2, 4, dtype=torch.float32)
+    _, grid = head.get_output_and_grid(output, 0, 8, output.type())
+    assert grid.shape == (1, 8, 2)
+    assert grid.dtype == torch.float32
+
+    meta_output = torch.empty(1, 7, 2, 4, device="meta")
+    _, grid = head.get_output_and_grid(meta_output, 0, 8, meta_output.type())
+    assert grid.device.type == "meta"

--- a/tests/unit/test_dinov2_semantic.py
+++ b/tests/unit/test_dinov2_semantic.py
@@ -320,6 +320,46 @@ def test_dinov2_semantic_rejects_head_only_native_checkpoint(fake_backbone):
         )
 
 
+@pytest.mark.parametrize(
+    ("task", "checkpoint_imgsz"),
+    [("semantic", 532), ("classify", 238)],
+)
+def test_dinov2_custom_loader_adopts_native_checkpoint_imgsz(
+    fake_backbone,
+    task,
+    checkpoint_imgsz,
+):
+    from libreyolo.models.dinov2.model import LibreDINOv2
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    source = LibreDINOv2(
+        model_path=None,
+        size="n",
+        task=task,
+        nb_classes=3,
+        device="cpu",
+    )
+    checkpoint = wrap_libreyolo_checkpoint(
+        source.model.state_dict(),
+        model_family="dinov2",
+        size="n",
+        task=task,
+        nc=3,
+        names=["a", "b", "c"],
+        imgsz=checkpoint_imgsz,
+    )
+
+    loaded = LibreDINOv2(
+        model_path=checkpoint,
+        size="n",
+        task=task,
+        nb_classes=3,
+        device="cpu",
+    )
+
+    assert loaded.input_size == checkpoint_imgsz
+
+
 @pytest.mark.external_data
 @pytest.mark.network
 @pytest.mark.slow

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -317,3 +317,77 @@ def test_download_lock_timeout_is_typed(tmp_path, monkeypatch):
     with pytest.raises(download.WeightDownloadLockTimeout):
         with download._download_lock(destination):
             pytest.fail("lock unexpectedly acquired")
+
+
+@pytest.mark.parametrize(
+    ("filename", "size", "status"),
+    [
+        ("LibreYOLO1t.pt", "t", "unknown"),
+        ("LibreDepthAnythingV2b-depth.pt", "b", "config_only"),
+        ("LibreL2CSr50.pt", "r50", "direct"),
+        ("LibreYOLO9P2s-visdrone.pt", "s", "gated"),
+    ],
+)
+def test_known_unpublished_artifact_fails_before_network(
+    tmp_path, monkeypatch, filename, size, status
+):
+    def unexpected_request(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("unpublished artifact must fail before a network request")
+
+    monkeypatch.setattr(download.requests, "get", unexpected_request)
+
+    with pytest.raises(download.WeightPublicationError, match=status):
+        download.download_weights(str(tmp_path / filename), size)
+
+
+@pytest.mark.parametrize(
+    ("filename", "size"),
+    [
+        ("LibreYOLOXs.pt", "s"),
+        ("LibreRFDETRn.pt", "n"),
+    ],
+)
+def test_canonical_download_uses_manifest_route_not_registry(
+    tmp_path, monkeypatch, filename, size
+):
+    from libreyolo.models import manifest
+
+    destination = tmp_path / filename
+    seen = {}
+
+    class ManifestFamily:
+        @classmethod
+        def get_download_notice(cls, filename, url):
+            del cls, filename, url
+            return None
+
+        @classmethod
+        def verify_downloaded_file(cls, local_path, source_url):
+            del cls
+            seen["verified"] = (Path(local_path), source_url)
+
+    class RegistryTrap:
+        @classmethod
+        def get_download_url(cls, filename):
+            del cls, filename
+            pytest.fail("canonical routing must not inspect the mutable registry")
+
+    monkeypatch.setattr(BaseModel, "_registry", [RegistryTrap])
+    monkeypatch.setattr(manifest, "load_family_class", lambda family: ManifestFamily)
+
+    def fake_get(url, **kwargs):
+        seen["url"] = url
+        seen["kwargs"] = kwargs
+        return _Response(b"weights")
+
+    monkeypatch.setattr(download.requests, "get", fake_get)
+
+    download.download_weights(str(destination), size)
+
+    expected = (
+        f"https://huggingface.co/LibreYOLO/{destination.stem}/resolve/main/{filename}"
+    )
+    assert seen["url"] == expected
+    assert seen["verified"][1] == expected
+    assert destination.read_bytes() == b"weights"

--- a/tests/unit/test_eomt.py
+++ b/tests/unit/test_eomt.py
@@ -277,7 +277,9 @@ class TestEoMTPredict:
         assert tuple(result.semantic_mask.data.shape) == (45, 90)
         assert set(torch.unique(result.semantic_mask.data).tolist()) <= {0, 1, 2}
 
-    def test_predict_rejects_non_patch_imgsz(self, fake_eomt_net, tmp_path):
+    def test_predict_rejects_non_native_imgsz_before_preprocessing(
+        self, fake_eomt_net, tmp_path
+    ):
         from libreyolo.models.eomt.model import LibreEoMT
 
         img_path = tmp_path / "img.jpg"
@@ -286,7 +288,7 @@ class TestEoMTPredict:
             model_path=None, size="l", task="semantic", nb_classes=2, device="cpu"
         )
 
-        with pytest.raises(ValueError, match="divisible by 16"):
+        with pytest.raises(ValueError, match="requires imgsz=512"):
             model.predict(str(img_path), imgsz=66)
 
     def test_predict_rejects_non_native_imgsz(self, fake_eomt_net, tmp_path):
@@ -436,6 +438,29 @@ class _FakeEoMTNetSeg(nn.Module):
         from torch.nn.modules.module import _IncompatibleKeys
 
         return _IncompatibleKeys([], [])
+
+
+class _PositionAwareEoMTNet(_FakeEoMTNetSeg):
+    """Fake whose graph carries the resolution-dependent position table."""
+
+    def __init__(
+        self,
+        config: str = "l",
+        nb_classes: int = 80,
+        image_size: int = 640,
+        num_queries: int = 100,
+    ):
+        super().__init__(
+            config=config,
+            nb_classes=nb_classes,
+            image_size=image_size,
+            num_queries=num_queries,
+        )
+        self.embeddings.position_embeddings = nn.Embedding(
+            (self.image_size // 16) ** 2,
+            self.hidden_size,
+        )
+
 
 @pytest.fixture
 def fake_eomt_seg_net(monkeypatch):
@@ -623,6 +648,76 @@ class TestEoMTSizes:
         assert loaded.task == "segment"
         assert loaded.input_size == 640
 
+    def test_checkpoint_load_rebuilds_the_real_1280_graph(self, monkeypatch):
+        import libreyolo.models.eomt.model as eomt_model
+        from libreyolo.models.eomt.model import LibreEoMT
+        from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+        monkeypatch.setattr(eomt_model, "LibreEoMTNet", _PositionAwareEoMTNet)
+        source = _PositionAwareEoMTNet(
+            config="l",
+            nb_classes=80,
+            image_size=1280,
+            num_queries=100,
+        )
+        checkpoint = wrap_libreyolo_checkpoint(
+            source.state_dict(),
+            model_family="eomt",
+            size="l",
+            task="segment",
+            nc=80,
+            names={i: f"coco_{i}" for i in range(80)},
+            imgsz=1280,
+        )
+
+        loaded = LibreEoMT(
+            model_path=checkpoint,
+            size="l",
+            task="segment",
+            nb_classes=80,
+            device="cpu",
+        )
+
+        assert loaded.input_size == 1280
+        assert loaded.model.image_size == 1280
+        assert loaded.model.embeddings.position_embeddings.num_embeddings == 6400
+
+    def test_checkpoint_rejects_metadata_and_position_grid_disagreement(
+        self, monkeypatch
+    ):
+        import libreyolo.models.eomt.model as eomt_model
+        from libreyolo.models.eomt.model import LibreEoMT
+        from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+        monkeypatch.setattr(eomt_model, "LibreEoMTNet", _PositionAwareEoMTNet)
+        source = _PositionAwareEoMTNet(
+            config="l",
+            nb_classes=80,
+            image_size=1280,
+            num_queries=100,
+        )
+        checkpoint = wrap_libreyolo_checkpoint(
+            source.state_dict(),
+            model_family="eomt",
+            size="l",
+            task="segment",
+            nc=80,
+            names={i: f"coco_{i}" for i in range(80)},
+            imgsz=640,
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"metadata imgsz=640 conflicts with state-derived imgsz=1280",
+        ):
+            LibreEoMT(
+                model_path=checkpoint,
+                size="l",
+                task="segment",
+                nb_classes=80,
+                device="cpu",
+            )
+
     def test_auto_task_and_size_from_filename(self, fake_eomt_seg_net, tmp_path):
         """LibreEoMT(path) infers task and size from the checkpoint without task= kwarg."""
         from libreyolo.models.eomt.model import LibreEoMT
@@ -808,6 +903,10 @@ def test_val_smoke_uses_split_inference_path(fake_eomt_net, tmp_path):
     model = LibreEoMT(
         model_path=None, size="l", task="semantic", nb_classes=2, device="cpu"
     )
+    model.model.train()
+    mixed_child = next(module for module in model.model.modules() if module is not model.model)
+    mixed_child.eval()
+    original_modes = [module.training for module in model.model.modules()]
 
     metrics = model.val(
         data=str(yaml_path),
@@ -826,6 +925,36 @@ def test_val_smoke_uses_split_inference_path(fake_eomt_net, tmp_path):
     assert 0.0 <= metrics["metrics/mIoU"] <= 1.0
     assert "speed/preprocess_ms" in metrics
     assert (tmp_path / "val_out" / "config.yaml").exists()
+    assert [module.training for module in model.model.modules()] == original_modes
+
+
+def test_custom_semantic_val_restores_mode_after_exception(fake_eomt_net):
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    model = LibreEoMT(
+        model_path=None, size="l", task="semantic", nb_classes=2, device="cpu"
+    )
+    model.model.train()
+    mixed_child = next(module for module in model.model.modules() if module is not model.model)
+    mixed_child.eval()
+    original_modes = [module.training for module in model.model.modules()]
+
+    with pytest.raises(ValueError, match="requires data"):
+        model.val(data=None, imgsz=512, verbose=False)
+
+    assert model.device == torch.device("cpu")
+    assert [module.training for module in model.model.modules()] == original_modes
+
+
+def test_custom_semantic_val_rejects_non_integer_imgsz_before_data(fake_eomt_net):
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    model = LibreEoMT(
+        model_path=None, size="l", task="semantic", nb_classes=2, device="cpu"
+    )
+
+    with pytest.raises(ValueError, match="positive integer"):
+        model.val(data="missing.yaml", imgsz=512.0, verbose=False)
 
 
 def test_val_segment_routes_to_base_val(fake_eomt_seg_net, monkeypatch):
@@ -1135,8 +1264,8 @@ def _panoptic_stub(nc: int, thing_class_ids):
         thing_class_ids=thing_class_ids,
         _last_eomt_patch_offsets=None,
         _last_eomt_resized_shape=None,
-        _last_eomt_content_size=None,  # unpadded already
     )
+    stub._coco_content_size = LibreEoMT._coco_content_size
     stub._stuff_class_ids = lambda: LibreEoMT._stuff_class_ids(stub)
     stub._unpad_and_resize_mask_logits = lambda ml, osz: (
         LibreEoMT._unpad_and_resize_mask_logits(stub, ml, osz)
@@ -1281,8 +1410,56 @@ def test_preprocess_pads_for_coco_tasks_and_splits_for_semantic(fake_eomt_seg_ne
     tensor, _, orig_size, _ = seg._preprocess(img, "rgb")
     assert tuple(tensor.shape) == (1, 3, 640, 640)  # single padded image
     assert seg._last_eomt_patch_offsets is None
-    assert seg._last_eomt_content_size == (480, 640)
+    assert not hasattr(seg, "_last_eomt_content_size")
     assert orig_size == (768, 576)
     # Padding is zeros in [0, 1] space (the net normalizes afterwards).
     assert float(tensor[0, :, 500:, :].abs().max()) == 0.0
     assert float(tensor[0, :, :480, :640].abs().max()) > 0.0
+
+
+def test_segment_validation_preprocessor_matches_native_coco_geometry(
+    fake_eomt_seg_net,
+):
+    import numpy as np
+
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    model = LibreEoMT(
+        model_path=None, size="l", task="segment", nb_classes=80, device="cpu"
+    )
+    rgb = np.zeros((1194, 1536, 3), dtype=np.uint8)
+    rgb[..., 0] = 25
+    rgb[..., 1] = 100
+    rgb[..., 2] = 220
+    bgr = np.ascontiguousarray(rgb[..., ::-1])
+
+    expected, content_size = model._preprocess_pil_pad(Image.fromarray(rgb), 640)
+    preprocessor = model._get_val_preprocessor(img_size=640)
+    actual, _ = preprocessor(
+        bgr, np.zeros((0, 5), dtype=np.float32), (640, 640)
+    )
+
+    assert content_size == (498, 640)
+    assert torch.equal(torch.from_numpy(actual), expected[0])
+
+
+def test_eomt_unpadding_is_derived_from_current_image_not_stale_state(
+    fake_eomt_seg_net,
+):
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    model = LibreEoMT(
+        model_path=None, size="l", task="segment", nb_classes=80, device="cpu"
+    )
+    model._last_eomt_content_size = (1, 1)  # legacy stale state must be ignored
+    logits = torch.arange(160 * 160, dtype=torch.float32).reshape(1, 160, 160)
+
+    actual = model._unpad_and_resize_mask_logits(logits, (768, 576))
+    expected = torch.nn.functional.interpolate(
+        logits[:, :120, :160].unsqueeze(0),
+        size=(576, 768),
+        mode="bilinear",
+        align_corners=False,
+    )[0]
+
+    assert torch.equal(actual, expected)

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -16,7 +16,6 @@ from libreyolo.export.exporter import NcnnExporter, OnnxExporter
 from libreyolo.export.support import EXPORT_FORMATS, SUPPORT, get_support
 from libreyolo.models.inventory import collect_model_inventory
 from libreyolo.tasks import TASKS
-from libreyolo.tasks import task_to_suffix
 
 
 pytestmark = pytest.mark.unit
@@ -168,7 +167,13 @@ def test_dump_inventory_refuses_partial_overwrite(tmp_path):
 )
 def test_committed_inventory_matches_runtime_inventory():
     committed = json.loads(INVENTORY_SNAPSHOT.read_text(encoding="utf-8"))
-    assert committed == collect_model_inventory()
+    runtime = collect_model_inventory()
+    # Dependency availability is intentionally local-environment state; every
+    # declarative capability/publication field must still match the snapshot.
+    for inventory in (committed, runtime):
+        for metadata in inventory.values():
+            metadata.pop("available", None)
+    assert committed == runtime
 
 
 def test_partial_exporters_are_custom_not_blocked():
@@ -195,28 +200,25 @@ def test_partial_exporters_are_custom_not_blocked():
 
 def test_default_download_urls_keep_task_repo_suffixes():
     from libreyolo.models.base.model import BaseModel
+    from libreyolo.models.manifest import ARTIFACT_BY_FILENAME
 
     for metadata in collect_model_inventory().values():
+        if not metadata["generic_cli"] or not metadata["available"]:
+            continue
         module_name, class_name = metadata["class"].rsplit(".", 1)
         cls = getattr(importlib.import_module(module_name), class_name)
         if "get_download_url" in cls.__dict__:
             continue
-        for task in metadata["tasks"]:
-            sizes = metadata["task_sizes"].get(task) or metadata["default_imgsz"]
-            if not sizes or not cls.FILENAME_PREFIX:
-                continue
-            size = next(iter(sizes))
-            suffix = task_to_suffix(task)
-            filename = f"{cls.FILENAME_PREFIX}{size}"
-            if suffix:
-                filename += f"-{suffix}"
-            filename += cls.WEIGHT_EXT
+        artifacts = [
+            artifact
+            for artifact in ARTIFACT_BY_FILENAME.values()
+            if artifact.family == cls.FAMILY and artifact.download_kind == "hf"
+        ]
+        for artifact in artifacts:
+            filename = artifact.canonical_filename
             url = BaseModel.get_download_url.__func__(cls, filename)
-            assert url is not None
-            expected_repo = f"/{cls.FILENAME_PREFIX}{size}"
-            if suffix:
-                expected_repo += f"-{suffix}"
-            assert expected_repo + "/resolve/main/" in url
+            assert url == artifact.download_url
+            assert f"/{filename.removesuffix(cls.WEIGHT_EXT)}/resolve/main/" in url
 
 
 def test_generated_export_docs_are_current():

--- a/tests/unit/test_grad_accum.py
+++ b/tests/unit/test_grad_accum.py
@@ -107,7 +107,7 @@ def _fake_image_loader(
 def _make_trainer(model: nn.Module, accum: int = 1, num_batches: int = 4):
     """Build a minimal concrete BaseTrainer with fake loader already wired in."""
     class _MinimalTrainer(_BaseTrainer):
-        def get_model_family(self): return "test"
+        def get_model_family(self): return "yolo9"
         def get_model_tag(self): return "test"
         def create_transforms(self): return None, None
         def create_scheduler(self, iters_per_epoch): return _ConstScheduler()

--- a/tests/unit/test_input_size_contracts.py
+++ b/tests/unit/test_input_size_contracts.py
@@ -1,0 +1,524 @@
+"""Shared prediction, validation, and checkpoint input-size contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo.models.base.inference import InferenceRunner
+from libreyolo.models.base.model import BaseModel
+
+pytestmark = pytest.mark.unit
+
+
+class _ContractModel(BaseModel):
+    FAMILY = "contract"
+    FILENAME_PREFIX = "LibreContract"
+    INPUT_SIZES = {"s": 640}
+
+    def _init_model(self):
+        return torch.nn.Identity()
+
+    def _get_available_layers(self):
+        return {}
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        return None
+
+    def _preprocess(self, image, color_format="auto", input_size=None):
+        raise AssertionError("preprocessing must not run in contract tests")
+
+    def _forward(self, input_tensor):
+        raise AssertionError("forward must not run in contract tests")
+
+    def _postprocess(
+        self,
+        output,
+        conf_thres,
+        iou_thres,
+        original_size,
+        max_det=300,
+        ratio=1.0,
+        **kwargs,
+    ):
+        raise AssertionError("postprocessing must not run in contract tests")
+
+
+class _DivisibleContractModel(_ContractModel):
+    INPUT_SIZE_DIVISOR = 32
+    INPUT_SIZE_MIN = 128
+
+
+class _RectangularContractModel(_DivisibleContractModel):
+    SUPPORTS_RECTANGULAR_INPUT = True
+
+
+class _FixedContractModel(_ContractModel):
+    INPUT_SIZE_FIXED = True
+
+
+class _CheckpointFixedContractModel(_FixedContractModel):
+    CHECKPOINT_INPUT_SIZE_OVERRIDE = True
+
+
+class _FixedTrainContractModel(_FixedContractModel):
+    def train(self, data, *, imgsz=640):
+        del data, imgsz
+        raise AssertionError("training body must not run after invalid preflight")
+
+
+class _KwargTrainContractModel(_FixedContractModel):
+    def train(self, data, **kwargs):
+        del data, kwargs
+        raise AssertionError("training body must not run after invalid preflight")
+
+
+def _stub(model_class=_ContractModel, *, input_size=640):
+    model = object.__new__(model_class)
+    model.input_size = input_size
+    model.task = "detect"
+    model.size = "s"
+    model.device = torch.device("cpu")
+    model.model = torch.nn.Identity()
+    return model
+
+
+def _family_stub(model_class, *, size, task="detect"):
+    model = object.__new__(model_class)
+    model.size = size
+    model.task = task
+    task_sizes = getattr(model_class, "TASK_INPUT_SIZES", {})
+    sizes = task_sizes.get(task, model_class.INPUT_SIZES)
+    model.input_size = sizes[size]
+    return model
+
+
+@pytest.mark.parametrize("value", [True, False, 640.0, "640", 0, -32])
+def test_input_size_rejects_non_integer_or_nonpositive_values(value):
+    model = _stub()
+
+    with pytest.raises(ValueError, match="imgsz"):
+        model._validate_input_size(value, context="inference")
+
+
+def test_input_size_enforces_minimum_and_divisor():
+    model = _stub(_DivisibleContractModel)
+
+    with pytest.raises(ValueError, match="at least 128"):
+        model._validate_input_size(96, context="inference")
+    with pytest.raises(ValueError, match="divisible by 32"):
+        model._validate_input_size(130, context="inference")
+    assert model._validate_input_size(160, context="inference") == 160
+
+
+def test_prediction_input_size_preserves_valid_rectangular_canvas():
+    model = _stub(_RectangularContractModel)
+
+    assert model._validate_predict_input_size((640, 672)) == (640, 672)
+    assert model._validate_predict_input_size([640, 672]) == (640, 672)
+    with pytest.raises(ValueError, match="divisible by 32"):
+        model._validate_predict_input_size((640, 650))
+    with pytest.raises(ValueError, match="height, width"):
+        model._validate_predict_input_size((640,))
+
+
+def test_scalar_only_prediction_normalizes_square_pair_and_rejects_rectangle():
+    model = _stub(_DivisibleContractModel)
+
+    assert model._validate_predict_input_size((640, 640)) == 640
+    with pytest.raises(ValueError, match="does not support rectangular"):
+        model._validate_predict_input_size((640, 672))
+
+
+def test_scalar_only_rectangular_rejection_precedes_source_and_device_work():
+    model = _stub(_DivisibleContractModel)
+    runner = InferenceRunner(model)
+
+    with pytest.raises(ValueError, match="does not support rectangular"):
+        runner(
+            Path("definitely-missing.jpg"),
+            imgsz=(640, 672),
+            device="cuda:0",
+        )
+    assert model.device == torch.device("cpu")
+
+
+def test_rectangular_tiling_rejection_precedes_source_and_device_work():
+    model = _stub(_RectangularContractModel)
+    runner = InferenceRunner(model)
+
+    with pytest.raises(ValueError, match="Tiled inference requires a square imgsz"):
+        runner(
+            Path("definitely-missing.jpg"),
+            imgsz=(640, 672),
+            tiling=True,
+            device="cuda:0",
+        )
+    assert model.device == torch.device("cpu")
+
+
+def test_yolo9_declares_verified_rectangular_prediction_contract():
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = _family_stub(LibreYOLO9, size="s")
+    assert model._validate_predict_input_size((640, 672)) == (640, 672)
+
+
+def test_fixed_input_size_rejects_override():
+    model = _stub(_FixedContractModel)
+
+    with pytest.raises(ValueError, match="requires imgsz=640"):
+        model._validate_input_size(608, context="validation")
+    assert model._validate_input_size(640, context="validation") == 640
+
+
+def test_prediction_preflight_runs_before_device_or_source_work():
+    model = _stub(_FixedContractModel)
+    runner = InferenceRunner(model)
+
+    with pytest.raises(ValueError, match="requires imgsz=640"):
+        runner(
+            Path("definitely-missing.jpg"),
+            imgsz=608,
+            device="cuda:0",
+        )
+    assert model.device == torch.device("cpu")
+
+
+def test_validation_preflight_runs_before_dataset_setup():
+    model = _stub(_FixedContractModel)
+
+    with pytest.raises(ValueError, match="requires imgsz=640"):
+        model.val(data="definitely-missing.yaml", imgsz=608)
+
+
+def test_export_preflight_runs_before_exporter_creation(monkeypatch):
+    from libreyolo.export import BaseExporter
+
+    model = _stub(_FixedContractModel)
+
+    def _unexpected_create(*args, **kwargs):
+        raise AssertionError("exporter creation must not run")
+
+    monkeypatch.setattr(BaseExporter, "create", _unexpected_create)
+    with pytest.raises(ValueError, match="requires imgsz=640"):
+        model.export(imgsz=608)
+
+
+def test_explicit_none_export_imgsz_keeps_native_default_semantics(monkeypatch):
+    from libreyolo.export import BaseExporter
+
+    model = _stub(_FixedContractModel)
+    captured = {}
+
+    def _create(*args, **kwargs):
+        del args, kwargs
+
+        def _export(**export_kwargs):
+            captured.update(export_kwargs)
+            return "model.onnx"
+
+        return _export
+
+    monkeypatch.setattr(BaseExporter, "create", _create)
+
+    assert model.export(imgsz=None) == "model.onnx"
+    assert captured == {"imgsz": None}
+
+
+def test_rectangular_export_validates_each_dimension():
+    from libreyolo.export.exporter import OnnxExporter
+
+    model = _stub(_FixedContractModel)
+    exporter = OnnxExporter(model)
+
+    with pytest.raises(ValueError, match="requires imgsz=640"):
+        exporter._resolve_params(
+            output_path="model.onnx",
+            imgsz=(640, 608),
+            device="cpu",
+            half=False,
+            int8=False,
+        )
+
+
+def test_rectangular_export_preflight_runs_before_exporter_creation(monkeypatch):
+    from libreyolo.export import BaseExporter
+
+    model = _stub(_FixedContractModel)
+
+    def _unexpected_create(*args, **kwargs):
+        raise AssertionError("exporter creation must not run")
+
+    monkeypatch.setattr(BaseExporter, "create", _unexpected_create)
+    with pytest.raises(ValueError, match="requires imgsz=640"):
+        model.export(imgsz=(640, 608))
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [_FixedTrainContractModel, _KwargTrainContractModel],
+)
+def test_training_preflight_runs_before_family_body(model_class):
+    model = _stub(model_class)
+
+    with pytest.raises(ValueError, match="requires imgsz=640"):
+        model.train("data.yaml", imgsz=608)
+
+
+def test_checkpoint_imgsz_updates_dynamic_runtime_default():
+    model = _stub(_DivisibleContractModel)
+
+    model._apply_checkpoint_input_size({"imgsz": 768}, is_native_v1=True)
+
+    assert model.input_size == 768
+
+
+def test_fixed_checkpoint_imgsz_requires_explicit_family_opt_in():
+    model = _stub(_FixedContractModel)
+    with pytest.raises(RuntimeError, match="checkpoint imgsz=768"):
+        model._apply_checkpoint_input_size({"imgsz": 768}, is_native_v1=True)
+
+    opted_in = _stub(_CheckpointFixedContractModel)
+    opted_in._apply_checkpoint_input_size({"imgsz": 768}, is_native_v1=True)
+    assert opted_in.input_size == 768
+
+
+def _deim_loader_stub():
+    from libreyolo.models.deim.model import LibreDEIM
+
+    model = object.__new__(LibreDEIM)
+    model.task = "detect"
+    model.size = "n"
+    model.input_size = 640
+    model.nb_classes = 2
+    model.names = {0: "left", 1: "right"}
+    model.device = torch.device("cpu")
+    model.model = torch.nn.Identity()
+    return model
+
+
+def test_fixed_custom_loader_rejects_native_checkpoint_imgsz_mismatch(
+    monkeypatch,
+    tmp_path,
+):
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    checkpoint = wrap_libreyolo_checkpoint(
+        {},
+        model_family="deim",
+        size="n",
+        task="detect",
+        nc=2,
+        names={0: "left", 1: "right"},
+        imgsz=640,
+    )
+    checkpoint["imgsz"] = 672
+    checkpoint_path = tmp_path / "LibreDEIMn.pt"
+    checkpoint_path.write_bytes(b"checkpoint fixture")
+    monkeypatch.setattr(
+        "libreyolo.models.deim.model.torch.load",
+        lambda *args, **kwargs: checkpoint,
+    )
+
+    with pytest.raises(RuntimeError, match=r"checkpoint requires imgsz=640, got 672"):
+        _deim_loader_stub()._load_weights(str(checkpoint_path))
+
+
+def test_custom_loader_rejects_malformed_native_checkpoint_imgsz(
+    monkeypatch,
+    tmp_path,
+):
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    checkpoint = wrap_libreyolo_checkpoint(
+        {},
+        model_family="deim",
+        size="n",
+        task="detect",
+        nc=2,
+        names={0: "left", 1: "right"},
+        imgsz=640,
+    )
+    checkpoint["imgsz"] = "640"
+    checkpoint_path = tmp_path / "LibreDEIMn.pt"
+    checkpoint_path.write_bytes(b"checkpoint fixture")
+    monkeypatch.setattr(
+        "libreyolo.models.deim.model.torch.load",
+        lambda *args, **kwargs: checkpoint,
+    )
+
+    with pytest.raises(RuntimeError, match="imgsz must be a positive int"):
+        _deim_loader_stub()._load_weights(str(checkpoint_path))
+
+
+def test_legacy_raw_checkpoint_does_not_change_runtime_default():
+    model = _stub(_DivisibleContractModel)
+
+    model._apply_checkpoint_input_size({"imgsz": 768}, is_native_v1=False)
+
+    assert model.input_size == 640
+
+
+def test_yolo9_p2_accepts_valid_checkpoint_imgsz_metadata():
+    from libreyolo.models.yolo9_p2.model import LibreYOLO9P2
+
+    model = object.__new__(LibreYOLO9P2)
+    model.input_size = 640
+    model.task = "detect"
+    model.size = "s"
+
+    model._apply_checkpoint_input_size({"imgsz": 768}, is_native_v1=True)
+
+    assert model.input_size == 768
+
+
+def test_yolo9_accepts_only_stride_compatible_overrides():
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = _family_stub(LibreYOLO9, size="s")
+    assert model._validate_input_size(672, context="inference") == 672
+    with pytest.raises(ValueError, match="divisible by 32"):
+        model._validate_input_size(650, context="inference")
+
+
+def test_dfine_rejects_tiny_or_odd_decoder_canvases():
+    from libreyolo.models.dfine.model import LibreDFINE
+
+    model = _family_stub(LibreDFINE, size="n")
+    with pytest.raises(ValueError, match="at least 128"):
+        model._validate_input_size(96, context="inference")
+    with pytest.raises(ValueError, match="divisible by 32"):
+        model._validate_input_size(130, context="inference")
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "size"),
+    [
+        ("libreyolo.models.birefnet.model", "LibreBiRefNet", "t"),
+        ("libreyolo.models.deim.model", "LibreDEIM", "n"),
+        ("libreyolo.models.rtdetrv2.model", "LibreRTDETRv2", "r18"),
+        ("libreyolo.models.ec.model", "LibreEC", "s"),
+        ("libreyolo.models.fomo.model", "LibreFOMO", "s"),
+        ("libreyolo.models.l2cs.model", "LibreL2CS", "r18"),
+        ("libreyolo.models.clip.model", "LibreCLIP", "b32"),
+        ("libreyolo.models.siglip2.model", "LibreSigLIP2", "b16"),
+    ],
+)
+def test_fixed_families_reject_non_native_override(
+    module_name,
+    class_name,
+    size,
+):
+    module = __import__(module_name, fromlist=[class_name])
+    model_class = getattr(module, class_name)
+    model = _family_stub(model_class, size=size, task=model_class.DEFAULT_TASK)
+
+    with pytest.raises(ValueError, match="requires imgsz"):
+        model._validate_input_size(model.input_size + 32, context="inference")
+
+
+def test_dinov2_requires_patch_grid_compatible_size_for_every_task():
+    from libreyolo.models.dinov2.model import LibreDINOv2
+
+    classify = _family_stub(LibreDINOv2, size="s", task="classify")
+    semantic = _family_stub(LibreDINOv2, size="s", task="semantic")
+    assert classify._validate_input_size(224, context="inference") == 224
+    assert semantic._validate_input_size(518, context="validation") == 518
+    with pytest.raises(ValueError, match="divisible by 14"):
+        classify._validate_input_size(225, context="inference")
+
+
+def test_yolonas_accepts_larger_stride_compatible_public_canvas():
+    from libreyolo.models.yolonas.model import LibreYOLONAS
+
+    model = _family_stub(LibreYOLONAS, size="s")
+    assert model._validate_input_size(672, context="inference") == 672
+    with pytest.raises(ValueError, match="at least 640"):
+        model._validate_input_size(608, context="inference")
+    with pytest.raises(ValueError, match="divisible by 32"):
+        model._validate_input_size(650, context="inference")
+
+
+def test_yolonas_672_preprocess_and_inverse_geometry_for_detect_and_pose():
+    import numpy as np
+
+    from libreyolo.models.yolonas.utils import preprocess_numpy
+    from libreyolo.postprocess.yolonas import postprocess, postprocess_pose
+
+    original_size = (800, 600)
+    image = np.zeros((600, 800, 3), dtype=np.uint8)
+
+    detect_chw, detect_ratio = preprocess_numpy(image, input_size=672)
+    detect_box = torch.tensor([[[97.5, 136.75, 336.0, 335.5]]])
+    detect = postprocess(
+        (detect_box, torch.tensor([[[0.9]]])),
+        conf_thres=0.1,
+        input_size=672,
+        original_size=original_size,
+    )
+    assert detect_chw.shape == (3, 672, 672)
+    assert detect_ratio == pytest.approx(636 / 800)
+    assert torch.allclose(
+        detect["boxes"],
+        torch.tensor([[100.0, 50.0, 400.0, 300.0]]),
+    )
+
+    pose_chw, pose_ratio = preprocess_numpy(
+        image,
+        input_size=672,
+        resize_size=640,
+        padding_mode="bottom_right",
+        pad_value=127,
+    )
+    pose = postprocess_pose(
+        (
+            torch.tensor([[[80.0, 40.0, 320.0, 240.0]]]),
+            torch.tensor([[[0.9]]]),
+            torch.tensor([[[[160.0, 80.0], [400.0, 320.0]]]]),
+            torch.tensor([[[0.8, 0.7]]]),
+        ),
+        conf_thres=0.1,
+        input_size=672,
+        original_size=original_size,
+    )
+    assert pose_chw.shape == (3, 672, 672)
+    assert pose_ratio == pytest.approx(640 / 800)
+    assert torch.allclose(
+        pose["boxes"],
+        torch.tensor([[100.0, 50.0, 400.0, 300.0]]),
+    )
+    assert torch.allclose(
+        pose["keypoints"][..., :2],
+        torch.tensor([[[200.0, 100.0], [500.0, 400.0]]]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "size"),
+    [
+        ("libreyolo.models.clip.model", "LibreCLIP", "b32"),
+        ("libreyolo.models.siglip2.model", "LibreSigLIP2", "b16"),
+    ],
+)
+def test_custom_classifier_exports_enforce_fixed_canvas_before_export_work(
+    module_name,
+    class_name,
+    size,
+):
+    module = __import__(module_name, fromlist=[class_name])
+    model_class = getattr(module, class_name)
+    model = _family_stub(model_class, size=size, task="classify")
+    model._text_embeds = None
+
+    with pytest.raises(ValueError, match="requires imgsz"):
+        model.export(imgsz=model.input_size + 32)
+
+    with pytest.raises(ValueError, match="requires imgsz"):
+        model.val(data="missing-image-folder", imgsz=model.input_size + 32)
+
+    with pytest.raises(RuntimeError, match="No classes set"):
+        model.export(imgsz=None)

--- a/tests/unit/test_l2cs.py
+++ b/tests/unit/test_l2cs.py
@@ -210,6 +210,21 @@ def test_libre_l2cs_callable_face_detector(tmp_path):
     assert isinstance(model.face_detector, type(None))  # not cached on instance
 
 
+@pytest.mark.parametrize("imgsz", [True, 448.0, "448", 640])
+def test_gaze_runner_rejects_invalid_or_non_native_imgsz_before_source(imgsz):
+    from libreyolo.models.l2cs.inference import GazeInferenceRunner
+
+    model = object.__new__(LibreL2CS)
+    model.input_size = 448
+    model.task = "gaze"
+    model.device = torch.device("cpu")
+    runner = GazeInferenceRunner(model)
+
+    with pytest.raises(ValueError, match="imgsz"):
+        runner(Path("definitely-missing.jpg"), imgsz=imgsz, device="cuda:0")
+    assert model.device == torch.device("cpu")
+
+
 def test_libre_l2cs_bare_predict_uses_default_detector(tmp_path, monkeypatch):
     """No face_boxes and no face_detector → default_face_detector() fallback,
     cached on the model. Stubbed so the test is offline and works on any

--- a/tests/unit/test_merge_tta.py
+++ b/tests/unit/test_merge_tta.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import torch
+from PIL import Image
 
 from libreyolo.models.base.model import BaseModel
 
@@ -33,6 +35,45 @@ def test_pose_rejects_tta_before_keypoint_merge():
 
     with pytest.raises(ValueError, match="pose keypoints"):
         BaseModel._predict_augment(model, image=None)
+
+
+def test_tta_threads_rectangular_input_size_into_postprocessing():
+    seen = []
+
+    def preprocess(image, color_format, input_size):
+        del image, color_format
+        seen.append(("preprocess", input_size))
+        return torch.zeros(1, 3, *input_size), None, (80, 40), 1.0
+
+    def postprocess(*args, **kwargs):
+        del args
+        seen.append(("postprocess", kwargs["input_size"]))
+        return _det([], [], [])
+
+    model = SimpleNamespace(
+        task="detect",
+        TTA_FIXED_SIZE=True,
+        device=torch.device("cpu"),
+        _get_input_size=lambda: 640,
+        _preprocess=preprocess,
+        _forward=lambda tensor: tensor,
+        _postprocess=postprocess,
+        _merge_tta=lambda *args, **kwargs: "merged",
+    )
+
+    result = BaseModel._predict_augment(
+        model,
+        Image.new("RGB", (80, 40)),
+        imgsz=(640, 672),
+    )
+
+    assert result == "merged"
+    assert seen == [
+        ("preprocess", (640, 672)),
+        ("postprocess", (640, 672)),
+        ("preprocess", (640, 672)),
+        ("postprocess", (640, 672)),
+    ]
 
 
 def _det(boxes, scores, classes):

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -160,9 +160,7 @@ def test_factory_warns_for_legacy_libreyolo_metadata_checkpoint(tmp_path, caplog
     assert "legacy compatibility path" in caplog.text
 
 
-def test_factory_autoconverts_partial_metadata_upstream_yolo9(
-    tmp_path, monkeypatch
-):
+def test_factory_autoconverts_partial_metadata_upstream_yolo9(tmp_path, monkeypatch):
     upstream_path = tmp_path / "v9-t-custom.pt"
     converted_path = tmp_path / "LibreYOLO9t.pt"
     torch.save(
@@ -316,3 +314,74 @@ def test_factory_routes_onnx_before_native_task_validation(monkeypatch, tmp_path
         "device": "cpu",
         "task": "segment",
     }
+
+
+def test_factory_accepts_pathlike_and_casefolds_backend_suffix(monkeypatch, tmp_path):
+    import libreyolo.backends.onnx as onnx_backend
+
+    captured = {}
+
+    class _FakeOnnxBackend:
+        def __init__(self, onnx_path, nb_classes=80, device="auto", task=None):
+            captured.update(
+                path=onnx_path,
+                nb_classes=nb_classes,
+                device=device,
+                task=task,
+            )
+
+    monkeypatch.setattr(onnx_backend, "OnnxBackend", _FakeOnnxBackend)
+    path = tmp_path / "MODEL.ONNX"
+    path.write_bytes(b"not a real onnx model")
+
+    loaded = LibreYOLO(path, device="cpu")
+
+    assert isinstance(loaded, _FakeOnnxBackend)
+    assert captured == {
+        "path": str(path),
+        "nb_classes": 80,
+        "device": "cpu",
+        "task": None,
+    }
+
+
+def test_factory_rejects_sibling_factory_checkpoint_metadata(tmp_path):
+    path = tmp_path / "vlm-wrapper.pt"
+    torch.save(
+        wrap_libreyolo_checkpoint(
+            {"layer.weight": torch.zeros(1)},
+            model_family="qwen3vl",
+            size="4b",
+            task="detect",
+            nc=1,
+            names={0: "object"},
+            imgsz=1024,
+        ),
+        path,
+    )
+
+    with pytest.raises(ValueError, match="separate LibreVLM model tier"):
+        LibreYOLO(path, device="cpu")
+
+
+def test_native_metadata_size_wins_over_existing_filename_hint(tmp_path):
+    model = LibreYOLO9Model(config="t", nb_classes=80)
+    misleading_path = tmp_path / "LibreYOLO9s.pt"
+    torch.save(
+        wrap_libreyolo_checkpoint(
+            model.state_dict(),
+            model_family="yolo9",
+            size="t",
+            task="detect",
+            nc=80,
+            names={index: f"class_{index}" for index in range(80)},
+            imgsz=640,
+        ),
+        misleading_path,
+    )
+
+    loaded = LibreYOLO(misleading_path, device="cpu")
+
+    assert loaded.size == "t"
+    with pytest.raises(ValueError, match="checkpoint metadata size 't'"):
+        LibreYOLO(misleading_path, size="s", device="cpu")

--- a/tests/unit/test_model_manifest.py
+++ b/tests/unit/test_model_manifest.py
@@ -141,6 +141,29 @@ def test_unpublished_or_restricted_checkpoints_have_no_shared_download_route():
         )
 
 
+def test_legacy_filename_fallback_cannot_bypass_config_only_publication():
+    from libreyolo.models.base.model import BaseModel
+    from libreyolo.models.depth_anything.model import LibreDepthAnythingV2
+
+    # The legacy parser intentionally uses regex search for foreign filenames.
+    # Neither an embedded canonical name nor a suffixless historical spelling
+    # may turn a manifest-local-only size back into an auto-download.
+    assert (
+        BaseModel.get_download_url.__func__(
+            LibreDepthAnythingV2,
+            "foreign-LibreDepthAnythingV2b-depth.pt",
+        )
+        is None
+    )
+    assert (
+        BaseModel.get_download_url.__func__(
+            LibreDepthAnythingV2,
+            "LibreDepthAnythingV2b.pt",
+        )
+        is None
+    )
+
+
 def test_public_inventory_does_not_change_with_runtime_registry(monkeypatch):
     from libreyolo.models.base.model import BaseModel
     from libreyolo.models.inventory import collect_model_inventory

--- a/tests/unit/test_model_manifest.py
+++ b/tests/unit/test_model_manifest.py
@@ -1,0 +1,152 @@
+"""Regression tests for deterministic public model discovery."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from libreyolo.cli.config import (
+    detect_family_from_weight_filename,
+    resolve_model_name,
+)
+from libreyolo.models.manifest import (
+    ARTIFACT_BY_FILENAME,
+    CLI_MODEL_ALIASES,
+    FACTORY_DEFAULT_MODELS,
+    FACTORY_MODEL_ALIASES,
+    FAMILY_BY_ID,
+    FactoryKind,
+    PublicationState,
+    get_artifact_spec,
+    match_weight_filename,
+    resolve_factory_model,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_manifest_indices_and_records_are_immutable():
+    with pytest.raises(TypeError):
+        FAMILY_BY_ID["new-family"] = object()
+    with pytest.raises(TypeError):
+        ARTIFACT_BY_FILENAME["new.pt"] = object()
+    with pytest.raises(FrozenInstanceError):
+        FAMILY_BY_ID["yolox"].family = "changed"
+
+
+def test_every_generic_alias_round_trips_to_an_exact_canonical_filename():
+    for alias, artifact in CLI_MODEL_ALIASES.items():
+        assert resolve_model_name(alias) == artifact.canonical_filename
+        assert match_weight_filename(artifact.canonical_filename) == artifact
+        assert detect_family_from_weight_filename(artifact.canonical_filename) == (
+            artifact.family
+        )
+
+
+@pytest.mark.parametrize(
+    ("alias", "filename"),
+    [
+        ("mobilenetv4-s", "LibreMobileNetV4s-cls.pt"),
+        ("convnext-t", "LibreConvNeXtt-cls.pt"),
+        ("fomo-s", "LibreFOMOs-point.pt"),
+        ("nafnet-l", "LibreNAFNetl-restore.pt"),
+        ("ppocr-t", "LibrePPOCRt-ocr.pt"),
+        ("l2cs-r50", "LibreL2CSr50.pt"),
+        ("dinov2-n", "LibreDINOv2n.pt"),
+        ("dinov2-n-sem", "LibreDINOv2n.pt"),
+        ("dinov2-n-cls", "LibreDINOv2n-cls.pt"),
+    ],
+)
+def test_task_aware_aliases_use_canonical_filenames(alias, filename):
+    assert resolve_model_name(alias) == filename
+
+
+def test_dinov2_inventory_contains_both_task_specific_size_maps():
+    semantic = get_artifact_spec("dinov2", "n", "semantic")
+    classify = get_artifact_spec("dinov2", "n", "classify")
+
+    assert semantic is not None and semantic.native_imgsz == 518
+    assert classify is not None and classify.native_imgsz == 224
+    assert semantic.canonical_filename == "LibreDINOv2n.pt"
+    assert classify.canonical_filename == "LibreDINOv2n-cls.pt"
+
+
+def test_canonical_filename_match_is_complete_and_case_insensitive():
+    artifact = match_weight_filename("weights/LIBREMOBILENETV4S-CLS.PT")
+
+    assert artifact is not None and artifact.family == "mobilenetv4"
+    assert match_weight_filename("LibreMobileNetV4s-cls.pt.bak") is None
+    assert match_weight_filename("LibreDINOv2n-seg.pt") is None
+
+
+def test_separate_factory_aliases_and_defaults_resolve_without_generic_cli():
+    expected = {
+        FactoryKind.SAM: ("base", "sam", "base"),
+        FactoryKind.VLM: ("qwen3-vl-4b", "qwen3vl", "4b"),
+        FactoryKind.OPENVOCAB: (
+            "grounding-dino-tiny",
+            "grounding_dino",
+            "t",
+        ),
+    }
+    for factory, (default, family, size) in expected.items():
+        assert FACTORY_DEFAULT_MODELS[factory] == default
+        selection = resolve_factory_model(factory)
+        assert selection is not None
+        family_spec, factory_model = selection
+        assert family_spec.family == family
+        assert factory_model.size == size
+
+    assert resolve_factory_model("vlm", "locateanything-3b")[1].revision == (
+        "c32291ca5e996f5a7a485845b4f57a233936bba0"
+    )
+    assert not any(
+        artifact.factory is not FactoryKind.CHECKPOINT
+        for artifact in CLI_MODEL_ALIASES.values()
+    )
+
+
+def test_sibling_factory_aliases_have_snapshot_identity():
+    for (_factory, _alias), (family, selection) in FACTORY_MODEL_ALIASES.items():
+        assert selection.repository
+        artifact = get_artifact_spec(
+            family.family,
+            selection.size,
+            family.default_task,
+        )
+        assert artifact is not None
+        assert artifact.factory_model == selection.model
+        assert artifact.repository == selection.repository
+        assert artifact.invocation.startswith(family.public_entrypoint + "(")
+
+
+def test_unpublished_or_restricted_checkpoints_have_no_shared_download_route():
+    from libreyolo.models.base.model import BaseModel
+    from libreyolo.models.manifest import load_family_class
+
+    cases = [
+        ("depth_anything", "b", "depth", PublicationState.CONFIG_ONLY),
+        ("l2cs", "r50", "gaze", PublicationState.DIRECT),
+        ("yolo1", "t", "detect", PublicationState.UNKNOWN),
+        ("yolo9_p2", "s", "detect", PublicationState.CONFIG_ONLY),
+    ]
+    for family, size, task, publication in cases:
+        artifact = get_artifact_spec(family, size, task)
+        assert artifact is not None
+        assert artifact.publication is publication
+        assert artifact.downloadable is False
+        assert artifact.download_url is None
+        cls = load_family_class(family)
+        assert (
+            BaseModel.get_download_url.__func__(cls, artifact.canonical_filename) is None
+        )
+
+
+def test_public_inventory_does_not_change_with_runtime_registry(monkeypatch):
+    from libreyolo.models.base.model import BaseModel
+    from libreyolo.models.inventory import collect_model_inventory
+
+    before = collect_model_inventory()
+    monkeypatch.setattr(BaseModel, "_registry", [])
+
+    assert collect_model_inventory() == before
+    assert resolve_model_name("dinov2-n") == "LibreDINOv2n.pt"

--- a/tests/unit/test_picosam3_logic.py
+++ b/tests/unit/test_picosam3_logic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 import torch
 from PIL import Image
@@ -107,6 +109,30 @@ def test_epoch1_picosam2_checkpoint_is_rejected(tmp_path):
 
     with pytest.raises(ValueError, match="older PicoSAM2 architecture"):
         model._init_model()
+
+
+def test_missing_snapshot_honors_manifest_publication(monkeypatch, tmp_path):
+    from libreyolo.models.manifest import PublicationState, get_artifact_spec
+    from libreyolo.utils.download import WeightPublicationError
+
+    artifact = get_artifact_spec("picosam3", "pico", "segment")
+    assert artifact is not None
+    local_only = replace(
+        artifact,
+        publication=PublicationState.CONFIG_ONLY,
+        download_kind="none",
+        download_url=None,
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "libreyolo.models.picosam3.model.get_artifact_spec",
+        lambda *args, **kwargs: local_only,
+    )
+    model = object.__new__(LibrePicoSAM3)
+    model.size = "pico"
+
+    with pytest.raises(WeightPublicationError, match="public snapshot route"):
+        model._ensure_weights()
 
 
 def test_conversion_round_trip_writes_provenance_metadata(tmp_path):

--- a/tests/unit/test_pidnet.py
+++ b/tests/unit/test_pidnet.py
@@ -41,7 +41,7 @@ class TestPIDNetMetadata:
         assert LibrePIDNet.SUPPORTED_TASKS == ("semantic",)
         assert LibrePIDNet.DEFAULT_TASK == "semantic"
         assert LibrePIDNet.REQUIRE_TASK_SUFFIX
-        assert LibrePIDNet.semantic_resize_mode == "letterbox"
+        assert LibrePIDNet.semantic_resize_mode == "native"
         assert LibrePIDNet.semantic_imgsz_divisor == 8
         assert set(LibrePIDNet.INPUT_SIZES) == {"s", "m", "l"}
 
@@ -150,6 +150,72 @@ class TestPIDNetForwardAndPredict:
 
         assert result["semantic"].shape == (40, 80)
         assert torch.equal(result["semantic"].unique(), torch.tensor([1]))
+
+    def test_validation_uses_native_floor_geometry_and_postprocess(
+        self, tmp_path
+    ):
+        import yaml
+
+        from libreyolo.models.pidnet.model import LibrePIDNet
+        from libreyolo.validation import SemanticValidator, ValidationConfig
+
+        image_path = tmp_path / "images" / "val" / "a.png"
+        mask_path = tmp_path / "masks" / "val" / "a.png"
+        image_path.parent.mkdir(parents=True)
+        mask_path.parent.mkdir(parents=True)
+        Image.fromarray(
+            np.full((37, 100, 3), (20, 90, 180), dtype=np.uint8), mode="RGB"
+        ).save(image_path)
+        Image.fromarray(np.zeros((37, 100), dtype=np.uint8), mode="L").save(mask_path)
+        data = {
+            "path": str(tmp_path),
+            "val": "images/val",
+            "masks_dir": "masks",
+            "nc": 2,
+            "names": {0: "zero", 1: "one"},
+        }
+        data_path = tmp_path / "data.yaml"
+        data_path.write_text(yaml.safe_dump(data))
+
+        model = LibrePIDNet(
+            model_path=None, size="s", task="semantic", nb_classes=2, device="cpu"
+        )
+        config = ValidationConfig(
+            data=str(data_path),
+            imgsz=64,
+            batch_size=4,
+            device="cpu",
+            num_workers=0,
+            verbose=False,
+            save_dir=str(tmp_path / "runs"),
+        )
+        validator = SemanticValidator(model, config)
+        validator.dataloader = validator._setup_dataloader()
+        batch = next(iter(validator.dataloader))
+        images, targets, _, _ = validator._preprocess_batch(batch)
+        native, _, original_size, ratio = model._preprocess(
+            image_path, color_format="rgb", input_size=64
+        )
+
+        logits = torch.zeros(1, 2, 8, 8)
+        logits[:, 0] = 1.0
+        logits[:, 1, :3] = 2.0
+        actual = validator._postprocess_predictions(logits, batch)
+        expected = model._postprocess(
+            logits,
+            conf_thres=0.0,
+            iou_thres=0.6,
+            original_size=original_size,
+            ratio=ratio,
+            input_size=64,
+        )["semantic"].unsqueeze(0)
+
+        # 37 * (64 / 100) floors to 23 content rows in the native helper.
+        content_rows = (images[0] - 114.0 / 255.0).abs().amax(dim=(0, 2)) > 0
+        assert int(content_rows.sum()) == 23
+        assert torch.equal(images, native)
+        assert targets.shape == (1, 37, 100)
+        assert torch.equal(actual, expected)
 
     def test_predict_rejects_non_stride_imgsz(self, tmp_path):
         from libreyolo.models.pidnet.model import LibrePIDNet

--- a/tests/unit/test_ppocr.py
+++ b/tests/unit/test_ppocr.py
@@ -306,6 +306,45 @@ def test_predict_without_charset_raises():
         model.predict(img)
 
 
+@pytest.mark.parametrize("imgsz", [True, 960.0, "960", 0, -32, 16])
+def test_ocr_runner_rejects_invalid_imgsz_before_source_or_device(imgsz):
+    from libreyolo.models.ppocr.inference import OCRInferenceRunner
+    from libreyolo.models.ppocr.model import LibrePPOCR
+
+    model = object.__new__(LibrePPOCR)
+    model.input_size = 736
+    model.task = "ocr"
+    model.device = torch.device("cpu")
+    runner = OCRInferenceRunner(model)
+
+    with pytest.raises(ValueError, match="imgsz"):
+        runner(Path("definitely-missing.jpg"), imgsz=imgsz, device="cuda:0")
+    assert model.device == torch.device("cpu")
+
+
+def test_ocr_runner_uses_checkpoint_runtime_imgsz_by_default(monkeypatch):
+    from libreyolo.models.ppocr.inference import OCRInferenceRunner
+    from libreyolo.models.ppocr.model import LibrePPOCR
+
+    model = object.__new__(LibrePPOCR)
+    model.input_size = 736
+    model.task = "ocr"
+    model.device = torch.device("cpu")
+    runner = OCRInferenceRunner(model)
+    captured = {}
+
+    def fake_predict_single(image, **kwargs):
+        captured["image"] = image
+        captured.update(kwargs)
+        return "result"
+
+    monkeypatch.setattr(runner, "_predict_single", fake_predict_single)
+    image = np.zeros((32, 64, 3), dtype=np.uint8)
+
+    assert runner(image) == "result"
+    assert captured["imgsz"] == 736
+
+
 # --------------------------------------------------------------------------
 # Dataset resolver on the committed fixture
 # --------------------------------------------------------------------------

--- a/tests/unit/test_realesrgan.py
+++ b/tests/unit/test_realesrgan.py
@@ -231,6 +231,31 @@ def test_restore_collate_pads_inputs_and_targets_separately():
     assert targets.shape[-2:] == (32, 48)  # target max (independent)
 
 
+def test_x2_validation_pads_odd_input_and_crops_to_target_canvas():
+    from libreyolo.validation.restore_validator import RestoreValidator
+
+    model = LibreRealESRGAN(size="x2", device="cpu")
+    validator = object.__new__(RestoreValidator)
+    validator.model = model
+    images = torch.rand(1, 3, 3, 5)
+    targets = torch.rand(1, 3, 6, 10)
+    batch = (
+        images,
+        targets,
+        [{"orig_shape": (3, 5), "target_shape": (6, 10)}],
+        [0],
+    )
+
+    padded, _, _, _ = validator._preprocess_batch(batch)
+    with torch.no_grad():
+        output = model._forward(padded)
+    restored = validator._postprocess_predictions(output, batch)
+
+    assert padded.shape[-2:] == (4, 6)
+    assert output.shape[-2:] == (8, 12)
+    assert restored.shape[-2:] == (6, 10)
+
+
 def test_val_runs_on_correct_hr_pairs(tmp_path):
     root = tmp_path / "srval"
     yaml_path = _write_pairs(root, "val", (8, 8), (32, 32))

--- a/tests/unit/test_rfdetr_obb.py
+++ b/tests/unit/test_rfdetr_obb.py
@@ -234,6 +234,8 @@ def test_rfdetr_top_level_names_override_nested_args_metadata():
 
     class DummyRFDETR(torch.nn.Module):
         nb_classes = 2
+        patch_size = 16
+        num_windows = 2
 
         def load_state_dict(self, state_dict, strict=False, canonical_v1=False):
             from torch.nn.modules.module import _IncompatibleKeys
@@ -247,6 +249,8 @@ def test_rfdetr_top_level_names_override_nested_args_metadata():
     wrapper._model_num_classes = 2
     wrapper._allow_detect_to_obb_transfer = False
     wrapper._allow_detect_to_pose_transfer = False
+    wrapper.size = "n"
+    wrapper.input_size = 384
     checkpoint = wrap_libreyolo_checkpoint(
         {},
         model_family="rfdetr",
@@ -261,6 +265,46 @@ def test_rfdetr_top_level_names_override_nested_args_metadata():
     wrapper._load_weights(checkpoint)
 
     assert wrapper.names == {0: "top-left", 1: "top-right"}
+    assert wrapper.input_size == 384
+    assert wrapper.model.training is False
+
+
+def test_rfdetr_custom_loader_adopts_native_checkpoint_imgsz():
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    class DummyRFDETR(torch.nn.Module):
+        nb_classes = 2
+        patch_size = 16
+        num_windows = 2
+
+        def load_state_dict(self, state_dict, strict=False, canonical_v1=False):
+            from torch.nn.modules.module import _IncompatibleKeys
+
+            return _IncompatibleKeys([], [])
+
+    wrapper = object.__new__(LibreRFDETR)
+    wrapper.task = "detect"
+    wrapper.model = DummyRFDETR()
+    wrapper.nb_classes = 2
+    wrapper._model_num_classes = 2
+    wrapper._allow_detect_to_obb_transfer = False
+    wrapper._allow_detect_to_pose_transfer = False
+    wrapper.size = "n"
+    wrapper.input_size = 384
+    checkpoint = wrap_libreyolo_checkpoint(
+        {},
+        model_family="rfdetr",
+        size="n",
+        task="detect",
+        nc=2,
+        names={0: "left", 1: "right"},
+        imgsz=416,
+    )
+
+    wrapper._load_weights(checkpoint)
+
+    assert wrapper.input_size == 416
     assert wrapper.model.training is False
 
 

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -21,6 +21,8 @@ GroupPose module:
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 import torch
 
@@ -268,10 +270,37 @@ def test_detection_model_has_no_keypoint_modules():
 
 @pytest.mark.parametrize("task", ["detect", "segment", "obb"])
 def test_release_checkpoint_without_empty_kp_active_mask_loads(monkeypatch, task):
+    import libreyolo.models.manifest as model_manifest
     import libreyolo.models.rfdetr.model as rfdetr_model
     from libreyolo.models.rfdetr.model import LibreRFDETR
 
     cfg = _small_pose_config()
+    canonical_artifact = model_manifest.get_artifact_spec("rfdetr", "n", task)
+    assert canonical_artifact is not None
+    synthetic_artifact = replace(
+        canonical_artifact,
+        size="tiny",
+        native_imgsz=cfg.resolution,
+        canonical_filename=None,
+    )
+    original_get_artifact_spec = model_manifest.get_artifact_spec
+
+    def get_artifact_spec(family, size, artifact_task, *, variant=None):
+        if (family, size, artifact_task, variant) == (
+            "rfdetr",
+            "tiny",
+            task,
+            None,
+        ):
+            return synthetic_artifact
+        return original_get_artifact_spec(
+            family,
+            size,
+            artifact_task,
+            variant=variant,
+        )
+
+    monkeypatch.setattr(model_manifest, "get_artifact_spec", get_artifact_spec)
     config_table = (
         rfdetr_model.RFDETR_SEG_CONFIGS
         if task == "segment"

--- a/tests/unit/test_segformer.py
+++ b/tests/unit/test_segformer.py
@@ -462,6 +462,34 @@ class TestSegformerReferenceFidelity:
         assert loaded.size == size
         assert loaded.input_size == LibreSegformer.INPUT_SIZES[size]
 
+    def test_native_checkpoint_applies_imgsz_after_size_rebuild(self, tmp_path):
+        from libreyolo.models.segformer.model import LibreSegformer
+        from libreyolo.models.segformer.nn import LibreSegformerNet
+        from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+        net = LibreSegformerNet(size="b1", num_classes=3)
+        checkpoint = wrap_libreyolo_checkpoint(
+            net.state_dict(),
+            model_family="segformer",
+            size="b1",
+            task="semantic",
+            nc=3,
+            names=["road", "sky", "tree"],
+            imgsz=640,
+        )
+        checkpoint_path = tmp_path / "LibreSegformerb1-sem.pt"
+        torch.save(checkpoint, checkpoint_path)
+
+        loaded = LibreSegformer(
+            model_path=str(checkpoint_path),
+            size="b0",
+            nb_classes=3,
+            device="cpu",
+        )
+
+        assert loaded.size == "b1"
+        assert loaded.input_size == 640
+
     def test_class_rebuild_keeps_the_reference_init(self):
         """Re-heading for a new dataset is THE fine-tuning path. A fresh nn.Conv2d
         carries torch's default init, so the new classifier must be re-initialized

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -379,3 +379,147 @@ def test_wrap_checkpoint_does_not_fall_back_to_default_size_for_empty_task_map(
             nc=1,
             names={0: "person"},
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("model_family", "not-a-family", "public model manifest"),
+        ("size", "not-a-size", "declared model artifact"),
+        ("task", "semantic", "declared model artifact"),
+    ],
+)
+def test_native_metadata_requires_declared_family_size_task_identity(
+    field, value, message
+):
+    checkpoint = serialization.wrap_libreyolo_checkpoint(
+        {"layer.weight": object()},
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=1,
+        names={0: "object"},
+        imgsz=640,
+    )
+    checkpoint[field] = value
+
+    with pytest.raises(serialization.CheckpointMetadataError, match=message):
+        serialization.validate_checkpoint_metadata(checkpoint, strict=True)
+
+
+def test_checkpoint_wrapper_writes_canonical_identity_values():
+    checkpoint = serialization.wrap_libreyolo_checkpoint(
+        {"layer.weight": object()},
+        model_family=" YOLO9 ",
+        size="T",
+        task="DETECTION",
+        nc=1,
+        names={0: "object"},
+        imgsz=640,
+    )
+
+    assert checkpoint["model_family"] == "yolo9"
+    assert checkpoint["size"] == "t"
+    assert checkpoint["task"] == "detect"
+
+
+@pytest.mark.parametrize("imgsz", [True, 640.5, "640", 0, -1])
+def test_checkpoint_wrapper_rejects_lossy_or_invalid_imgsz(imgsz):
+    with pytest.raises(serialization.CheckpointMetadataError, match="positive int"):
+        serialization.wrap_libreyolo_checkpoint(
+            {"layer.weight": object()},
+            model_family="yolo9",
+            size="t",
+            task="detect",
+            nc=1,
+            names={0: "object"},
+            imgsz=imgsz,
+        )
+
+
+def test_checkpoint_writer_and_validator_enforce_family_imgsz_contract():
+    kwargs = {
+        "model_family": "yolo9",
+        "size": "t",
+        "task": "detect",
+        "nc": 1,
+        "names": {0: "object"},
+        "imgsz": 641,
+    }
+    with pytest.raises(serialization.CheckpointMetadataError, match="divisible by 32"):
+        serialization.wrap_libreyolo_checkpoint(
+            {"layer.weight": object()},
+            **kwargs,
+        )
+
+    checkpoint = serialization.wrap_libreyolo_checkpoint(
+        {"layer.weight": object()},
+        **{**kwargs, "imgsz": 640},
+    )
+    checkpoint["imgsz"] = 641
+    with pytest.raises(serialization.CheckpointMetadataError, match="divisible by 32"):
+        serialization.validate_checkpoint_metadata(checkpoint, strict=True)
+
+
+def test_checkpoint_writer_uses_rfdetr_patch_window_contract():
+    common = {
+        "model_family": "rfdetr",
+        "size": "n",
+        "task": "detect",
+        "nc": 1,
+        "names": {0: "object"},
+    }
+    valid = serialization.wrap_libreyolo_checkpoint(
+        {"layer.weight": object()},
+        imgsz=384,
+        **common,
+    )
+    assert valid["imgsz"] == 384
+
+    with pytest.raises(serialization.CheckpointMetadataError, match="divisible by 32"):
+        serialization.wrap_libreyolo_checkpoint(
+            {"layer.weight": object()},
+            imgsz=641,
+            **common,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("model_family", "YOLO9"),
+        ("size", "T"),
+        ("task", "DETECTION"),
+    ],
+)
+def test_native_metadata_rejects_noncanonical_identity_values(field, value):
+    checkpoint = serialization.wrap_libreyolo_checkpoint(
+        {"layer.weight": object()},
+        model_family="yolo9",
+        size="t",
+        task="detect",
+        nc=1,
+        names={0: "object"},
+        imgsz=640,
+    )
+    checkpoint[field] = value
+
+    with pytest.raises(serialization.CheckpointMetadataError, match="canonical"):
+        serialization.validate_checkpoint_metadata(checkpoint, strict=True)
+
+
+def test_checkpoint_imgsz_inference_is_independent_of_runtime_registry(monkeypatch):
+    from libreyolo.models.base import BaseModel
+
+    monkeypatch.setattr(BaseModel, "_registry", [])
+
+    checkpoint = serialization.wrap_libreyolo_checkpoint(
+        {"layer.weight": object()},
+        model_family="dinov2",
+        size="n",
+        task="semantic",
+        nc=1,
+        names={0: "foreground"},
+    )
+
+    assert checkpoint["imgsz"] == 518

--- a/tests/unit/test_validator_device.py
+++ b/tests/unit/test_validator_device.py
@@ -23,6 +23,33 @@ class _StubValidator(BaseValidator):
     def _compute_metrics(self): return {}
 
 
+class _TransactionalValidator(_StubValidator):
+    def _setup(self, **kwargs):
+        del kwargs
+
+    def _run_validation(self):
+        assert self.model.device == self.device
+        expected = getattr(self, "expected_actual_device", self.device)
+        assert next(self.model.model.parameters()).device == expected
+        assert not self.model.model.training
+        if self.raise_during_validation:
+            raise RuntimeError("validation failed")
+
+    def _finalize(self):
+        return {"ok": 1.0}
+
+
+class _TrackingLinear(torch.nn.Linear):
+    def __init__(self):
+        super().__init__(1, 1)
+        self.to_calls = []
+
+    def to(self, device, *args, **kwargs):
+        del args, kwargs
+        self.to_calls.append(torch.device(device))
+        return self
+
+
 def _setup_device(device: str) -> "torch.device":
     config = ValidationConfig(data="x.yaml", device=device)
     v = object.__new__(_StubValidator)
@@ -34,6 +61,17 @@ def _stub_validator(*, half: bool, device: str):
     validator = object.__new__(_StubValidator)
     validator.config = ValidationConfig(data="x.yaml", device=device, half=half)
     validator.device = torch.device(device)
+    return validator
+
+
+def _transactional_validator(*, raise_during_validation: bool):
+    validator = object.__new__(_TransactionalValidator)
+    validator.model = type("Wrapper", (), {})()
+    validator.model.model = torch.nn.Linear(1, 1).train()
+    validator.model.model.add_module("dropout", torch.nn.Dropout().eval())
+    validator.model.device = torch.device("cpu")
+    validator.device = torch.device("cpu")
+    validator.raise_during_validation = raise_during_validation
     return validator
 
 
@@ -76,3 +114,107 @@ def test_half_validation_uses_cuda_autocast_only(monkeypatch, device, expected_c
         pass
 
     assert calls == expected_calls
+
+
+def test_validation_restores_model_device_and_mode_after_success():
+    validator = _transactional_validator(raise_during_validation=False)
+
+    assert validator.run() == {"ok": 1.0}
+    assert validator.model.device == torch.device("cpu")
+    assert next(validator.model.model.parameters()).device.type == "cpu"
+    assert validator.model.model.training
+    assert not validator.model.model.dropout.training
+
+
+def test_validation_restores_model_device_and_mode_after_exception():
+    validator = _transactional_validator(raise_during_validation=True)
+
+    with pytest.raises(RuntimeError, match="validation failed"):
+        validator.run()
+
+    assert validator.model.device == torch.device("cpu")
+    assert next(validator.model.model.parameters()).device.type == "cpu"
+    assert validator.model.model.training
+    assert not validator.model.model.dropout.training
+
+
+def test_validation_device_override_is_temporary():
+    validator = _transactional_validator(raise_during_validation=False)
+    module = _TrackingLinear().train()
+    validator.model.model = module
+    validator.device = torch.device("cuda:7")
+    validator.expected_actual_device = torch.device("cpu")
+
+    validator.run()
+
+    assert module.to_calls == [torch.device("cuda:7"), torch.device("cpu")]
+    assert validator.model.device == torch.device("cpu")
+
+
+def test_exported_backend_eval_proxy_skips_native_module_migration():
+    class _EvalProxy:
+        def eval(self):
+            return self
+
+    validator = object.__new__(_StubValidator)
+    validator.model = type("Backend", (), {"model": _EvalProxy()})()
+    validator.device = torch.device("cpu")
+
+    with validator._validation_model_state():
+        pass
+
+
+def test_warmup_uses_effective_dataloader_batch_size():
+    seen_shapes = []
+
+    class _Wrapper:
+        model = torch.nn.Identity()
+
+        def _forward(self, tensor):
+            seen_shapes.append(tuple(tensor.shape))
+            return tensor
+
+    validator = object.__new__(_StubValidator)
+    validator.model = _Wrapper()
+    validator.device = torch.device("cpu")
+    validator.config = ValidationConfig(
+        data="x.yaml",
+        imgsz=32,
+        batch_size=8,
+        device="cpu",
+        verbose=False,
+    )
+    validator.dataloader = type("Loader", (), {"batch_size": 1})()
+
+    validator._warmup_model(n_warmup=1)
+
+    assert seen_shapes == [(1, 3, 32, 32)]
+
+
+def test_pose_validator_override_uses_transactional_model_state():
+    from libreyolo.validation.pose_validator import PoseValidator
+
+    validator = object.__new__(PoseValidator)
+    validator.model = type("Wrapper", (), {})()
+    validator.model.model = torch.nn.Sequential(
+        torch.nn.Linear(1, 1),
+        torch.nn.Dropout(),
+    ).train()
+    validator.model.model[1].eval()
+    validator.model.device = torch.device("cpu")
+    validator.device = torch.device("cpu")
+    original_modes = [module.training for module in validator.model.model.modules()]
+
+    def fail_inside_pose(**kwargs):
+        assert kwargs == {"sentinel": True}
+        assert not validator.model.model.training
+        assert not validator.model.model[1].training
+        raise RuntimeError("pose validation failed")
+
+    validator._run_pose = fail_inside_pose
+
+    with pytest.raises(RuntimeError, match="pose validation failed"):
+        validator.run(sentinel=True)
+
+    assert [module.training for module in validator.model.model.modules()] == original_modes
+    assert validator.model.device == torch.device("cpu")

--- a/tests/unit/test_vlm_api.py
+++ b/tests/unit/test_vlm_api.py
@@ -63,6 +63,21 @@ class TestSetClasses:
             m.set_classes(["Boat", "boat"])
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"imgsz": 640}, "does not support imgsz"),
+        ({"augment": True}, "augment=True"),
+        ({"tiling": True}, "tiling=True"),
+    ],
+)
+def test_vlm_rejects_processor_owned_or_undefined_geometry_modes(kwargs, message):
+    model = _bare_model()
+
+    with pytest.raises(ValueError, match=message):
+        model("definitely-missing.jpg", **kwargs)
+
+
 class TestFactoryResolution:
     """The LibreVLM(...) name resolution (offline; no model is loaded)."""
 

--- a/tests/unit/test_vlm_api.py
+++ b/tests/unit/test_vlm_api.py
@@ -78,6 +78,21 @@ def test_vlm_rejects_processor_owned_or_undefined_geometry_modes(kwargs, message
         model("definitely-missing.jpg", **kwargs)
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"imgsz": 640}, "does not support imgsz"),
+        ({"augment": True}, "augment=True"),
+        ({"tiling": True}, "tiling=True"),
+    ],
+)
+def test_vlm_track_rejects_ignored_geometry_modes_before_video_io(kwargs, message):
+    model = _bare_model()
+
+    with pytest.raises(ValueError, match=message):
+        model.track("definitely-missing.mp4", **kwargs)
+
+
 class TestFactoryResolution:
     """The LibreVLM(...) name resolution (offline; no model is loaded)."""
 

--- a/tests/unit/test_yolo1.py
+++ b/tests/unit/test_yolo1.py
@@ -296,6 +296,87 @@ def test_stretch_preprocess_fills_square_canvas():
     assert 0.0 <= float(chw.min()) and float(chw.max()) <= 1.0
 
 
+def test_validation_preprocessor_matches_native_stretch_on_nonsquare_image():
+    import numpy as np
+
+    from libreyolo.models.yolo1.model import LibreYOLO1
+
+    rgb = np.zeros((37, 101, 3), dtype=np.uint8)
+    rgb[..., 0] = np.arange(101, dtype=np.uint8)
+    rgb[..., 1] = 60
+    bgr = np.ascontiguousarray(rgb[..., ::-1])
+    expected, _ = preprocess_numpy_stretch(rgb, input_size=448)
+
+    preprocessor = LibreYOLO1.val_preprocessor_class((448, 448))
+    actual, _ = preprocessor(bgr, np.zeros((0, 5), dtype=np.float32), (448, 448))
+
+    assert np.array_equal(actual, expected)
+
+
+def test_yolo1_rejects_non_voc_class_count_before_model_construction(monkeypatch):
+    from libreyolo.models.yolo1.model import LibreYOLO1
+
+    constructed = False
+
+    def fail_if_constructed(self):
+        nonlocal constructed
+        constructed = True
+        raise AssertionError("model construction must not run")
+
+    monkeypatch.setattr(LibreYOLO1, "_init_model", fail_if_constructed)
+    with pytest.raises(ValueError, match="fixed Pascal VOC 20-class"):
+        LibreYOLO1(model_path=None, size="t", nb_classes=3, device="cpu")
+    assert not constructed
+
+
+def test_yolo1_rejects_non_voc_checkpoint_before_class_rebuild():
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    model = LibreYOLO1(model_path=None, size="t", device="cpu")
+    checkpoint = wrap_libreyolo_checkpoint(
+        _prefixed_state_dict("yolov1-tiny", "yolo1", nc=3),
+        model_family="yolo1",
+        size="t",
+        task="detect",
+        nc=3,
+        names={0: "a", 1: "b", 2: "c"},
+        imgsz=448,
+    )
+
+    with pytest.raises(RuntimeError, match="fixed Pascal VOC 20-class head"):
+        model._apply_loaded_checkpoint(checkpoint, context="YOLO1 test checkpoint")
+
+    assert model.nb_classes == 20
+
+
+def test_yolo1_validation_rejects_non_voc_dataset_class_space(tmp_path):
+    from libreyolo.validation import DetectionValidator, ValidationConfig
+
+    (tmp_path / "images" / "val").mkdir(parents=True)
+    data_path = tmp_path / "data.yaml"
+    data_path.write_text(
+        f"path: {tmp_path.as_posix()}\n"
+        "val: images/val\n"
+        "nc: 3\n"
+        "names: [a, b, c]\n",
+        encoding="utf-8",
+    )
+    model = LibreYOLO1(model_path=None, size="t", device="cpu")
+    validator = DetectionValidator(
+        model,
+        ValidationConfig(
+            data=str(data_path),
+            imgsz=448,
+            batch_size=1,
+            device="cpu",
+            verbose=False,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="dataset has 3 classes"):
+        validator._setup_dataloader()
+
+
 # ---------------------------------------------------------------------------
 # end-to-end: convert -> factory load -> predict (synthetic weights)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_yolo9_layers.py
+++ b/tests/unit/test_yolo9_layers.py
@@ -737,6 +737,10 @@ def test_yolo9_trainer_checkpoint_uses_resolved_data_classes_for_obb(tmp_path):
     trainer.save_dir = tmp_path / "run"
     trainer.save_dir.mkdir()
     trainer.optimizer = torch.optim.SGD(trainer.model.parameters(), lr=0.01)
+    # This isolated trainer fixture exercises OBB dataset/class resolution with
+    # a synthetic Conv2d rather than a public YOLO9 architecture. Use the
+    # manifest-declared OBB family when serializing its metadata.
+    trainer.get_model_family = lambda: "rfdetr"
     trainer._save_checkpoint(epoch=0, loss=1.0, is_best=True)
 
     checkpoint = load_trusted_torch_file(

--- a/tests/unit/test_yolo9_p2.py
+++ b/tests/unit/test_yolo9_p2.py
@@ -211,9 +211,7 @@ def test_yolo9_p2_prepare_state_dict_passes_p2_checkpoints_through():
 
 
 def test_yolo9_p2_visdrone_variant_filename_routing():
-    """The published VisDrone research-preview weight must route like any
-    other weight file: size detected, base family not claiming it, and the
-    download URL pointing at the variant's own HF repo."""
+    """The local VisDrone variant is recognized but never auto-downloaded."""
     from libreyolo import LibreYOLO9, LibreYOLO9P2
 
     name = "LibreYOLO9P2s-visdrone.pt"
@@ -222,12 +220,9 @@ def test_yolo9_p2_visdrone_variant_filename_routing():
     assert LibreYOLO9.detect_size_from_filename(name) is None
 
     url = LibreYOLO9P2.get_download_url(name)
-    assert url == (
-        "https://huggingface.co/LibreYOLO/LibreYOLO9P2s-visdrone/"
-        "resolve/main/LibreYOLO9P2s-visdrone.pt"
-    )
+    assert url is None
 
-    notice = LibreYOLO9P2.get_download_notice(name, url)
+    notice = LibreYOLO9P2.get_download_notice(name, "local-only")
     assert notice is not None
     assert "NON-COMMERCIAL" in notice
     assert "CC BY-NC-SA" in notice
@@ -240,11 +235,8 @@ def test_yolo9_p2_plain_filenames_have_no_variant_or_notice():
     assert LibreYOLO9P2.detect_size_from_filename(name) == "t"
     assert LibreYOLO9P2.detect_variant_from_filename(name) is None
     url = LibreYOLO9P2.get_download_url(name)
-    assert url == (
-        "https://huggingface.co/LibreYOLO/LibreYOLO9P2t/"
-        "resolve/main/LibreYOLO9P2t.pt"
-    )
-    assert LibreYOLO9P2.get_download_notice(name, url) is None
+    assert url is None
+    assert LibreYOLO9P2.get_download_notice(name, "local-only") is None
 
 
 def test_yolo9_p2_loads_transfer_trained_checkpoint(tmp_path):

--- a/tests/unit/test_yolonas_edge_export.py
+++ b/tests/unit/test_yolonas_edge_export.py
@@ -33,6 +33,9 @@ def test_yolonas_raw_parity(tmp_path, task, size, format):
         task=task,
         device="cpu",
     )
+    # This test isolates raw graph/backend parity on a tiny synthetic tensor.
+    # Production YOLO-NAS export keeps the public >=640 preprocessing contract.
+    model.INPUT_SIZE_MIN = 32
     model.model.eval()
     tensor = torch.rand(1, 3, 96, 96)
     traced = torch.jit.trace(model.model, tensor)

--- a/tools/dump_model_inventory.py
+++ b/tools/dump_model_inventory.py
@@ -14,12 +14,10 @@ DEFAULT_OUTPUT = REPO_ROOT / "reports" / "export_inventory.json"
 def write_inventory(output: Path, *, allow_family_removal: bool = False) -> dict:
     """Collect the runtime inventory and write it to ``output``.
 
-    The committed snapshot is canonical: it is collected in a fully
-    provisioned environment where every optional tier imports. When optional
-    dependencies are missing, ``collect_model_inventory()`` silently returns a
-    subset, and writing that subset would drop families from the generated
-    compatibility tables. Refuse to shrink the family set unless the caller
-    explicitly allows it (for intentional family removals).
+    The committed snapshot is canonical. Model-family membership comes from
+    the static manifest and is complete even when optional dependencies are
+    absent. Refuse to shrink the family set unless the caller explicitly
+    allows it for an intentional family removal.
     """
     from libreyolo.models.inventory import collect_model_inventory
 
@@ -31,10 +29,8 @@ def write_inventory(output: Path, *, allow_family_removal: bool = False) -> dict
             raise SystemExit(
                 f"Refusing to overwrite {output}: the fresh inventory is "
                 f"missing families present in the committed snapshot: "
-                f"{', '.join(missing)}. This usually means optional "
-                "dependencies (for example libreyolo[rfdetr]) are not "
-                "installed in this environment. Install them and rerun, or "
-                "pass --allow-family-removal for an intentional removal."
+                f"{', '.join(missing)}. Update the static manifest, then pass "
+                "--allow-family-removal only for an intentional removal."
             )
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(inventory, indent=2) + "\n", encoding="utf-8")


### PR DESCRIPTION
# What does this PR do?

Fixes model-discovery, input-geometry, and preprocessing findings tracked in #591.

- Adds an immutable public model manifest for family aliases, canonical filenames, tasks, sizes, native canvases, publication state, and download routes.
- Aligns factory, CLI, inventory, and export discovery with the manifest and prevents synthesized routes for unpublished or restricted artifacts.
- Centralizes fixed, dynamic, patch-grid, and rectangular input-size contracts and validates them before loading, training, validation, or export.
- Corrects family-specific preprocessing and inverse geometry for depth, EoMT, RF-DETR OBB, and YOLOv1 paths.
- Makes validator device/mode changes transactional and prevents stale detector-grid caches.
- Adds manifest-aware RF-DETR release-checkpoint regression coverage.
- Rejects unsupported VLM tracking geometry/options instead of silently accepting them.

# Provenance declaration (required)

## Code provenance

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

# How was this tested?

- Focused capability/input/VLM regressions: 37 passed.
- Changed-area regression selection: 697 passed, 18 skipped.
- Exact hermetic combined-stack PR gate at the reviewed final stack: 4,585 passed, 36 skipped, 60 deselected, 4 expected failures.
- Published YOLO9 and RF-DETR checkpoint regressions: 4 passed.
- Ruff and `git diff --check`: clean.
- GitHub unit and install-smoke workflows are dispatched again for this exact rewritten head before merge.
