### PR TITLE
Fix export and backend runtime contracts

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -164,15 +164,28 @@ Pose runtime exports may also write these flat metadata keys:
   counts for GroupPose-style heads. Readers must preserve zero-keypoint class
   slots because they define the class-to-keypoint schema.
 
-Classification runtime exports (MobileNetV4 / ConvNeXt / EfficientNetV2 /
-ResNet) may also write these flat metadata keys so that exported-backend
-preprocessing reproduces the native model's resize/crop and the logits stay
-bit-identical:
+Classification runtime exports, including frozen-class CLIP and SigLIP2 ONNX
+artifacts, write these flat metadata keys so backend preprocessing and
+probability semantics reproduce native inference:
 
-- `crop_pct`: float center-crop ratio. The pre-crop resize target is
-  `round(imgsz / crop_pct)`. Readers default to `0.875` when the key is absent.
-- `interpolation`: resize filter, `"bilinear"` or `"bicubic"`. Readers default
-  to `"bilinear"` when the key is absent.
+- `classification_mean` / `classification_std`: three RGB normalization
+  values. ONNX stores them as JSON lists; native sidecars store ordinary
+  sequences. Legacy artifacts without them use ImageNet defaults.
+- `classification_crop_pct`: center-crop ratio in `(0, 1]`. The aspect-preserving
+  pre-crop resize target is `floor(imgsz / classification_crop_pct)`. Readers
+  also accept legacy `crop_pct`; the default is `0.875`.
+- `classification_interpolation`: `"nearest"`, `"bilinear"`, or `"bicubic"`.
+  Readers also accept legacy `interpolation`; the default is `"bilinear"`.
+- `classification_square_resize`: boolean. `true` stretches directly to the
+  square model canvas instead of aspect-preserving resize plus center crop.
+  Missing means `false`.
+- `classification_activation`: `"softmax"` for mutually exclusive classes or
+  `"sigmoid"` for independent multi-label probabilities. Missing means
+  `"softmax"`.
+
+Writers temporarily retain `crop_pct` and `interpolation` aliases for older
+backend readers. New readers prefer the `classification_*` keys and reject
+malformed values instead of silently changing the inference contract.
 
 For ONNX YOLO9 detection exports with `nms=true`, output `0` / `output` is the
 standalone post-NMS tensor using the export-time `nms_conf`, `nms_iou`, and

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -181,6 +181,92 @@ def _read_pose_metadata(meta: dict) -> dict[str, Any]:
     return pose_meta
 
 
+def _read_classification_metadata(meta: dict) -> dict[str, Any]:
+    """Parse the portable classifier preprocessing/postprocessing contract.
+
+    Missing fields preserve the legacy ImageNet/softmax behavior. Present but
+    malformed fields are rejected so an artifact cannot silently run with a
+    different normalization or probability interpretation.
+    """
+
+    def _triplet(key: str, default: tuple[float, float, float]):
+        raw = meta.get(key)
+        if raw is None:
+            return default
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid {key} metadata: expected three numbers."
+                ) from exc
+        if not isinstance(raw, (list, tuple)) or len(raw) != 3:
+            raise ValueError(f"Invalid {key} metadata: expected three numbers.")
+        try:
+            values = tuple(float(item) for item in raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid {key} metadata: expected three numbers."
+            ) from exc
+        if not all(np.isfinite(item) for item in values):
+            raise ValueError(f"Invalid {key} metadata: values must be finite.")
+        return values
+
+    mean = _triplet("classification_mean", (0.485, 0.456, 0.406))
+    std = _triplet("classification_std", (0.229, 0.224, 0.225))
+    if any(item <= 0 for item in std):
+        raise ValueError(
+            "Invalid classification_std metadata: values must be positive."
+        )
+
+    raw_crop = meta.get("classification_crop_pct", meta.get("crop_pct", 0.875))
+    try:
+        crop_pct = float(raw_crop)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid classification_crop_pct metadata.") from exc
+    if not 0 < crop_pct <= 1:
+        raise ValueError("classification_crop_pct metadata must be in (0, 1].")
+
+    interpolation = str(
+        meta.get(
+            "classification_interpolation",
+            meta.get("interpolation", "bilinear"),
+        )
+    ).lower()
+    if interpolation not in {"bilinear", "bicubic", "nearest"}:
+        raise ValueError(
+            "classification_interpolation metadata must be bilinear, bicubic, or nearest."
+        )
+
+    raw_square = meta.get("classification_square_resize", False)
+    if isinstance(raw_square, str):
+        normalized_square = raw_square.strip().lower()
+        if normalized_square not in {"true", "false"}:
+            raise ValueError(
+                "classification_square_resize metadata must be true or false."
+            )
+        square_resize = normalized_square == "true"
+    elif isinstance(raw_square, bool):
+        square_resize = raw_square
+    else:
+        raise ValueError("classification_square_resize metadata must be a boolean.")
+
+    activation = str(meta.get("classification_activation", "softmax")).lower()
+    if activation not in {"softmax", "sigmoid"}:
+        raise ValueError(
+            "classification_activation metadata must be softmax or sigmoid."
+        )
+
+    return {
+        "crop_pct": crop_pct,
+        "interpolation": interpolation,
+        "classification_mean": mean,
+        "classification_std": std,
+        "classification_square_resize": square_resize,
+        "classification_activation": activation,
+    }
+
+
 def _nms_numpy(
     boxes: np.ndarray, scores: np.ndarray, iou_threshold: float = 0.45
 ) -> list:
@@ -322,6 +408,11 @@ class BaseBackend(ABC):
         default_task: str | None = None,
         crop_pct: float | None = None,
         interpolation: str | None = None,
+        classification_mean: tuple[float, float, float] | None = None,
+        classification_std: tuple[float, float, float] | None = None,
+        classification_square_resize: bool = False,
+        classification_activation: str = "softmax",
+        dynamic_spatial: bool = False,
         num_keypoints: int | None = None,
         keypoint_dim: int | None = None,
         num_keypoints_per_class: list[int] | None = None,
@@ -371,6 +462,15 @@ class BaseBackend(ABC):
         # legacy behavior. Lets exported-backend classify inference match native.
         self.crop_pct = crop_pct if crop_pct is not None else 0.875
         self.interpolation = interpolation or "bilinear"
+        self.classification_mean = classification_mean or (0.485, 0.456, 0.406)
+        self.classification_std = classification_std or (0.229, 0.224, 0.225)
+        self.classification_square_resize = bool(classification_square_resize)
+        self._dynamic_spatial = bool(dynamic_spatial)
+        if classification_activation not in {"softmax", "sigmoid"}:
+            raise ValueError(
+                "classification_activation must be 'softmax' or 'sigmoid'."
+            )
+        self.classification_activation = classification_activation
         # Set by backends that load a model with NMS baked into the graph; such
         # models emit final (1, max_det, 6) detections instead of raw tensors.
         if not hasattr(self, "embedded_nms"):
@@ -417,7 +517,7 @@ class BaseBackend(ABC):
             Tuple of (input_tensor, original_img, original_size, ratio).
         """
         if self.task == "restore" or self.model_family == "nafnet":
-            if self.model_family == "realesrgan":
+            if self.model_family == "realesrgan" and self._dynamic_spatial:
                 return self._preprocess_restore_native(image, color_format)
             return self._preprocess_restore(image, effective_imgsz, color_format)
         if self.task == "depth":
@@ -537,8 +637,11 @@ class BaseBackend(ABC):
         transform = build_classify_transforms(
             h,
             augment=False,
+            mean=self.classification_mean,
+            std=self.classification_std,
             crop_pct=getattr(self, "crop_pct", 0.875),
             interpolation=getattr(self, "interpolation", "bilinear"),
+            square_resize=self.classification_square_resize,
         )
         img_tensor = transform(img).unsqueeze(0)
         return img_tensor, img, original_size, 1.0
@@ -2046,8 +2149,7 @@ class BaseBackend(ABC):
     # Result building
     # =========================================================================
 
-    @staticmethod
-    def _parse_classify_probs(all_outputs) -> torch.Tensor:
+    def _parse_classify_probs(self, all_outputs) -> torch.Tensor:
         logits = np.asarray(all_outputs[0])
         if logits.ndim == 1:
             logits = logits[None, :]
@@ -2057,6 +2159,8 @@ class BaseBackend(ABC):
                 f"got {tuple(logits.shape)}."
             )
         logits_t = torch.from_numpy(logits).float()
+        if self.classification_activation == "sigmoid":
+            return torch.sigmoid(logits_t)[0]
         return torch.softmax(logits_t, dim=1)[0]
 
     @staticmethod

--- a/libreyolo/backends/coreml.py
+++ b/libreyolo/backends/coreml.py
@@ -26,6 +26,7 @@ from .base import (
     BaseBackend,
     ImageSize,
     _imgsz_hw,
+    _read_classification_metadata,
     _read_metadata_imgsz,
     _read_pose_metadata,
 )
@@ -85,8 +86,7 @@ class CoreMLBackend(BaseBackend):
     ):
         if sys.platform != "darwin":
             raise RuntimeError(
-                "CoreML inference requires macOS. "
-                f"Current platform: {sys.platform}."
+                f"CoreML inference requires macOS. Current platform: {sys.platform}."
             )
         try:
             import coremltools as ct
@@ -137,6 +137,9 @@ class CoreMLBackend(BaseBackend):
             default_task=default_task,
             supported_tasks=supported_tasks,
         )
+        classification_metadata = (
+            _read_classification_metadata(meta) if resolved_task == "classify" else {}
+        )
 
         self._has_embedded_nms = has_embedded_nms
 
@@ -151,6 +154,7 @@ class CoreMLBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **classification_metadata,
             **pose_metadata,
         )
 
@@ -353,6 +357,65 @@ class CoreMLBackend(BaseBackend):
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
         return boxes, max_scores, class_ids, None
+
+    def _forward(self, input_tensor: torch.Tensor):
+        """Adapt validator-native tensors to the package's canonical RGB input."""
+        canonical = self._validation_tensor_to_canonical_rgb(input_tensor)
+        if self._has_embedded_nms:
+            # CoreML's NMS adapter intentionally removes the graph batch axis,
+            # so concatenate would mix detections from different images. Run
+            # the batch-1 package per image and restore an explicit leading
+            # batch dimension for validator slicing.
+            per_image = [
+                self._run_inference(
+                    canonical[index : index + 1].detach().cpu().numpy()
+                )
+                for index in range(canonical.shape[0])
+            ]
+            outputs = [
+                np.stack(
+                    [np.asarray(item[output_index]) for item in per_image],
+                    axis=0,
+                )
+                for output_index in range(len(per_image[0]))
+            ]
+            return [torch.from_numpy(output) for output in outputs]
+        return super()._forward(canonical)
+
+    def _validation_tensor_to_canonical_rgb(
+        self, input_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """Invert first-party validation normalization for CoreML ImageType.
+
+        Normal prediction already supplies canonical RGB pixels through
+        :meth:`_preprocess`. Validators instead hand back the native family
+        tensor, so convert only this internal ``_forward`` path.
+        """
+        if input_tensor.ndim != 4 or input_tensor.shape[1] != 3:
+            raise ValueError(
+                "CoreML validation expects an NCHW three-channel tensor, got "
+                f"{tuple(input_tensor.shape)}."
+            )
+        family = (self.model_family or "").lower()
+        if family == "yolox":
+            # Validator uses BGR [0,255]; the package ImageType accepts RGB.
+            canonical = input_tensor[:, [2, 1, 0], :, :]
+        elif family == "rfdetr":
+            mean = input_tensor.new_tensor((0.485, 0.456, 0.406)).view(1, 3, 1, 1)
+            std = input_tensor.new_tensor((0.229, 0.224, 0.225)).view(1, 3, 1, 1)
+            canonical = (input_tensor * std + mean) * 255.0
+        elif family in {"yolo9", "rtdetr"}:
+            # Validator already uses canonical RGB, normalized to [0,1].
+            canonical = input_tensor * 255.0
+        else:
+            raise NotImplementedError(
+                "CoreML validation preprocessing is not defined for model family "
+                f"{self.model_family!r}."
+            )
+        # Validation originates from uint8 images; rounding recovers the exact
+        # pixel after normalization/de-normalization instead of truncating an
+        # expression such as 127.999 to 127 at the ImageType boundary.
+        return canonical.round().clamp_(0, 255)
 
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run CoreML inference on a (1, 3, H, W) canonical RGB uint8 blob.

--- a/libreyolo/backends/ncnn.py
+++ b/libreyolo/backends/ncnn.py
@@ -8,7 +8,12 @@ import numpy as np
 
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, _read_metadata_imgsz, _read_pose_metadata
+from .base import (
+    BaseBackend,
+    _read_classification_metadata,
+    _read_metadata_imgsz,
+    _read_pose_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +70,7 @@ class NcnnBackend(BaseBackend):
         resolved_nb_classes = nb_classes if nb_classes is not None else 80
         names = self.build_names(resolved_nb_classes)
         pose_metadata = {}
+        classification_metadata = {}
 
         metadata_path = model_dir / "metadata.yaml"
         if metadata_path.exists():
@@ -78,6 +84,7 @@ class NcnnBackend(BaseBackend):
                 resolved_nb_classes,
                 names,
                 pose_metadata,
+                classification_metadata,
             ) = self._read_metadata(metadata_path, nb_classes)
             task = resolve_task(
                 explicit_task=explicit_task,
@@ -113,12 +120,15 @@ class NcnnBackend(BaseBackend):
         input_names_fn = getattr(self.net, "input_names", None)
         output_names_fn = getattr(self.net, "output_names", None)
         if callable(input_names_fn) and callable(output_names_fn):
-            self._input_names = list(input_names_fn())
-            self._output_names = list(output_names_fn())
+            runtime_inputs = list(input_names_fn())
+            runtime_outputs = list(output_names_fn())
         else:
-            self._input_names, self._output_names = self._discover_blob_names(
-                param_path
-            )
+            runtime_inputs = []
+            runtime_outputs = []
+        parsed_inputs, parsed_outputs = self._parse_blob_names(param_path)
+        self._input_names = runtime_inputs or parsed_inputs or ["in0"]
+        self._output_names = runtime_outputs or parsed_outputs or ["out0"]
+        self._output_names_are_fallback = not runtime_outputs and not parsed_outputs
 
         super().__init__(
             model_path=str(model_dir),
@@ -131,29 +141,55 @@ class NcnnBackend(BaseBackend):
             task=task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **classification_metadata,
             **pose_metadata,
         )
 
     @staticmethod
-    def _discover_blob_names(param_path: Path):
-        """Read the .param file to discover input and output blob names.
-
-        Falls back to 'in0'/'out0' convention if parsing fails.
-        """
-        input_names = []
-        output_names = []
+    def _parse_blob_names(param_path: Path) -> tuple[list[str], list[str]]:
+        """Parse graph inputs and terminal output blobs from an ncnn param file."""
+        input_names: list[str] = []
+        produced_names: list[str] = []
+        consumed_names: set[str] = set()
         try:
             with open(param_path) as f:
                 lines = f.readlines()
+            # A layer row is: type, name, bottom_count, top_count, then the
+            # declared bottom/top blob names followed by numeric parameters.
             for line in lines:
                 parts = line.strip().split()
-                if not parts:
+                if len(parts) < 4:
                     continue
                 layer_type = parts[0]
-                if layer_type == "Input" and len(parts) >= 4:
-                    input_names.append(parts[-1])
-        except Exception:
-            pass
+                try:
+                    bottom_count = int(parts[2])
+                    top_count = int(parts[3])
+                except ValueError:
+                    continue
+                names_end = 4 + bottom_count + top_count
+                if bottom_count < 0 or top_count < 0 or len(parts) < names_end:
+                    continue
+
+                bottoms = parts[4 : 4 + bottom_count]
+                tops = parts[4 + bottom_count : names_end]
+                consumed_names.update(bottoms)
+                for name in tops:
+                    if name not in produced_names:
+                        produced_names.append(name)
+                if layer_type == "Input":
+                    for name in tops:
+                        if name not in input_names:
+                            input_names.append(name)
+        except (OSError, UnicodeError):
+            return [], []
+
+        output_names = [name for name in produced_names if name not in consumed_names]
+        return input_names, output_names
+
+    @staticmethod
+    def _discover_blob_names(param_path: Path):
+        """Discover names, falling back only when graph metadata is unavailable."""
+        input_names, output_names = NcnnBackend._parse_blob_names(param_path)
 
         if not input_names:
             input_names = ["in0"]
@@ -166,7 +202,9 @@ class NcnnBackend(BaseBackend):
         """Read metadata from metadata.yaml file.
 
         Returns:
-            Tuple of (model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names, pose_metadata).
+            Tuple of (model_family, model_size, task, supported_tasks,
+            default_task, imgsz, nb_classes, names, pose metadata,
+            classification metadata).
         """
         import yaml
 
@@ -216,6 +254,7 @@ class NcnnBackend(BaseBackend):
             nb_classes,
             names,
             _read_pose_metadata(meta),
+            _read_classification_metadata(meta) if task == "classify" else {},
         )
 
     def _run_inference(self, blob: np.ndarray) -> list:
@@ -246,15 +285,17 @@ class NcnnBackend(BaseBackend):
         all_outputs = []
         for out_name in self._output_names:
             ret, mat_out = ex.extract(out_name)
-            if ret != 0:
+            if ret != 0 and self._output_names_are_fallback:
                 for fallback in ("out0", "output", "output0"):
+                    if fallback == out_name:
+                        continue
                     ret, mat_out = ex.extract(fallback)
                     if ret == 0:
                         break
-                if ret != 0:
-                    raise RuntimeError(
-                        f"Failed to extract output '{out_name}' from ncnn model"
-                    )
+            if ret != 0:
+                raise RuntimeError(
+                    f"Failed to extract output '{out_name}' from ncnn model"
+                )
             all_outputs.append(np.array(mat_out).reshape(1, *np.array(mat_out).shape))
 
         # YOLO-NAS exports two outputs (scores, boxes) from pnnx as out1/out0.

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -12,11 +12,67 @@ from .base import (
     BaseBackend,
     ImageSize,
     MetadataImageSizeError,
+    _read_classification_metadata,
     _read_metadata_imgsz,
     _read_pose_metadata,
 )
 
 logger = logging.getLogger(__name__)
+
+
+_ONNX_TENSOR_DTYPES = {
+    "tensor(bool)": np.bool_,
+    "tensor(double)": np.float64,
+    "tensor(float)": np.float32,
+    "tensor(float16)": np.float16,
+    "tensor(int8)": np.int8,
+    "tensor(int16)": np.int16,
+    "tensor(int32)": np.int32,
+    "tensor(int64)": np.int64,
+    "tensor(uint8)": np.uint8,
+    "tensor(uint16)": np.uint16,
+    "tensor(uint32)": np.uint32,
+    "tensor(uint64)": np.uint64,
+}
+
+
+def _resolve_onnx_providers(device, available_providers) -> tuple[list, str]:
+    """Resolve ONNX Runtime providers without warning for an explicit CPU."""
+    key = str(device).lower()
+    if key == "auto":
+        if "CUDAExecutionProvider" in available_providers:
+            return ["CUDAExecutionProvider", "CPUExecutionProvider"], "cuda"
+        return ["CPUExecutionProvider"], "cpu"
+    if key == "cpu":
+        return ["CPUExecutionProvider"], "cpu"
+    if key in {"cuda", "gpu"} or key.startswith("cuda:"):
+        indexed_device = None
+        if key.startswith("cuda:"):
+            try:
+                indexed_device = int(key.split(":", 1)[1])
+            except ValueError as exc:
+                raise ValueError(f"Invalid ONNX CUDA device {device!r}.") from exc
+            if indexed_device < 0:
+                raise ValueError(f"Invalid ONNX CUDA device {device!r}.")
+        if "CUDAExecutionProvider" in available_providers:
+            cuda_provider = (
+                "CUDAExecutionProvider"
+                if indexed_device is None
+                else ("CUDAExecutionProvider", {"device_id": indexed_device})
+            )
+            resolved = "cuda" if indexed_device is None else f"cuda:{indexed_device}"
+            return [cuda_provider, "CPUExecutionProvider"], resolved
+        logger.warning(
+            "Requested device %r but CUDAExecutionProvider is not available; "
+            "falling back to CPU.",
+            device,
+        )
+        return ["CPUExecutionProvider"], "cpu"
+    logger.warning(
+        "Requested device %r is not supported by the ONNX backend; falling back to CPU.",
+        device,
+    )
+    return ["CPUExecutionProvider"], "cpu"
 
 
 class OnnxBackend(BaseBackend):
@@ -51,37 +107,15 @@ class OnnxBackend(BaseBackend):
         if not Path(onnx_path).exists():
             raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
 
-        available_providers = ort.get_available_providers()
-        if device == "auto":
-            if "CUDAExecutionProvider" in available_providers:
-                providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-                resolved_device = "cuda"
-            else:
-                providers = ["CPUExecutionProvider"]
-                resolved_device = "cpu"
-        elif device in ("cuda", "gpu") or device.startswith("cuda:"):
-            if "CUDAExecutionProvider" in available_providers:
-                providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-                resolved_device = "cuda"
-            else:
-                providers = ["CPUExecutionProvider"]
-                resolved_device = "cpu"
-                logger.warning(
-                    "Requested device %r but CUDAExecutionProvider is not "
-                    "available; falling back to CPU.",
-                    device,
-                )
-        else:
-            providers = ["CPUExecutionProvider"]
-            resolved_device = "cpu"
-            logger.warning(
-                "Requested device %r is not supported by the ONNX backend; "
-                "falling back to CPU.",
-                device,
-            )
+        providers, resolved_device = _resolve_onnx_providers(
+            device,
+            ort.get_available_providers(),
+        )
 
         self.session = ort.InferenceSession(onnx_path, providers=providers)
-        self.input_name = self.session.get_inputs()[0].name
+        input_info = self.session.get_inputs()[0]
+        self.input_name = input_info.name
+        self.input_dtype = self._numpy_dtype_for_onnx_type(input_info.type)
         self.output_names = [output.name for output in self.session.get_outputs()]
         try:
             runtime_metadata = dict(
@@ -89,6 +123,7 @@ class OnnxBackend(BaseBackend):
             )
         except Exception:
             runtime_metadata = {}
+        metadata = runtime_metadata or self._load_embedded_metadata(onnx_path)
 
         (
             model_family,
@@ -100,10 +135,10 @@ class OnnxBackend(BaseBackend):
             embedded_nms,
             metadata_imgsz,
         ) = self._read_onnx_metadata(
-            onnx_path, nb_classes, runtime_metadata=runtime_metadata
+            onnx_path, nb_classes, runtime_metadata=metadata
         )
         pose_metadata = self._read_onnx_pose_metadata(
-            onnx_path, runtime_metadata=runtime_metadata
+            onnx_path, runtime_metadata=metadata
         )
         # Models exported with nms=True emit final (1, max_det, 6) detections.
         # Newer YOLO9 ONNX exports also include a raw auxiliary output so the
@@ -114,11 +149,14 @@ class OnnxBackend(BaseBackend):
             if embedded_nms and "raw" in self.output_names
             else None
         )
-        input_shape = self.session.get_inputs()[0].shape
+        input_shape = input_info.shape
         # Dynamic-batch exports carry a symbolic dim ("batch") or None at
         # axis 0; static exports carry an int.
         self._dynamic_batch_axis = bool(input_shape) and not isinstance(
             input_shape[0], int
+        )
+        dynamic_spatial = len(input_shape) == 4 and any(
+            not isinstance(dim, int) for dim in input_shape[2:4]
         )
         static_imgsz = self._read_static_input_imgsz(input_shape)
         if static_imgsz is not None:
@@ -133,6 +171,11 @@ class OnnxBackend(BaseBackend):
             default_task=default_task,
             supported_tasks=supported_tasks,
         )
+        classification_metadata = (
+            _read_classification_metadata(metadata)
+            if resolved_task == "classify"
+            else {}
+        )
 
         super().__init__(
             model_path=onnx_path,
@@ -145,27 +188,23 @@ class OnnxBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
-            crop_pct=(
-                float(runtime_metadata["crop_pct"])
-                if runtime_metadata.get("crop_pct")
-                else None
-            ),
-            interpolation=runtime_metadata.get("interpolation"),
+            dynamic_spatial=dynamic_spatial,
             num_bins=(
-                int(runtime_metadata["num_bins"])
-                if runtime_metadata.get("num_bins")
+                int(metadata["num_bins"])
+                if metadata.get("num_bins")
                 else None
             ),
             bin_width_deg=(
-                float(runtime_metadata["bin_width_deg"])
-                if runtime_metadata.get("bin_width_deg")
+                float(metadata["bin_width_deg"])
+                if metadata.get("bin_width_deg")
                 else None
             ),
             offset_deg=(
-                float(runtime_metadata["offset_deg"])
-                if runtime_metadata.get("offset_deg")
+                float(metadata["offset_deg"])
+                if metadata.get("offset_deg")
                 else None
             ),
+            **classification_metadata,
             **pose_metadata,
         )
 
@@ -177,6 +216,18 @@ class OnnxBackend(BaseBackend):
         if not isinstance(h, int) or not isinstance(w, int) or h <= 0 or w <= 0:
             return None
         return h if h == w else (h, w)
+
+    @staticmethod
+    def _load_embedded_metadata(onnx_path: str) -> dict:
+        """Load the complete metadata map directly from an ONNX artifact."""
+        try:
+            import onnx
+
+            model_proto = onnx.load(onnx_path)
+            return {entry.key: entry.value for entry in model_proto.metadata_props}
+        except Exception as exc:
+            logger.warning("Failed to load ONNX metadata from %s: %s", onnx_path, exc)
+            return {}
 
     @staticmethod
     def _read_onnx_metadata(
@@ -199,12 +250,11 @@ class OnnxBackend(BaseBackend):
         imgsz = None
         embedded_nms = False
         try:
-            meta = dict(runtime_metadata or {})
-            if not meta:
-                import onnx
-
-                model_proto = onnx.load(onnx_path)
-                meta = {p.key: p.value for p in model_proto.metadata_props}
+            meta = (
+                dict(runtime_metadata)
+                if runtime_metadata is not None
+                else OnnxBackend._load_embedded_metadata(onnx_path)
+            )
             warn_on_metadata_schema_version(
                 meta,
                 artifact=f"ONNX metadata for {onnx_path}",
@@ -267,12 +317,11 @@ class OnnxBackend(BaseBackend):
         runtime_metadata: dict | None = None,
     ) -> dict:
         try:
-            meta = dict(runtime_metadata or {})
-            if not meta:
-                import onnx
-
-                model_proto = onnx.load(onnx_path)
-                meta = {p.key: p.value for p in model_proto.metadata_props}
+            meta = (
+                dict(runtime_metadata)
+                if runtime_metadata is not None
+                else OnnxBackend._load_embedded_metadata(onnx_path)
+            )
         except Exception as e:
             logger.warning(
                 "Failed to read ONNX pose metadata from %s: %s", onnx_path, e
@@ -286,6 +335,18 @@ class OnnxBackend(BaseBackend):
         # dynamic batch axis accepts stacked blobs directly.
         return self._dynamic_batch_axis and not self.embedded_nms
 
+    @staticmethod
+    def _numpy_dtype_for_onnx_type(type_name: str) -> np.dtype:
+        """Translate an ONNX Runtime tensor type into its NumPy dtype."""
+        try:
+            return np.dtype(_ONNX_TENSOR_DTYPES[type_name])
+        except KeyError as exc:
+            raise TypeError(
+                "Unsupported ONNX Runtime input type "
+                f"{type_name!r}; this backend cannot construct a matching NumPy input."
+            ) from exc
+
     def _run_inference(self, blob: np.ndarray) -> list:
         """Run ONNX Runtime inference."""
-        return self.session.run(None, {self.input_name: blob})
+        runtime_blob = np.ascontiguousarray(blob, dtype=self.input_dtype)
+        return self.session.run(None, {self.input_name: runtime_blob})

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -1,7 +1,12 @@
 """ONNX runtime inference backend for LibreYOLO."""
 
+import os
+import shutil
+import stat
 import logging
+from contextlib import contextmanager
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from tempfile import TemporaryDirectory
 
 import numpy as np
 
@@ -82,8 +87,28 @@ def _parse_external_data_integer(
     return parsed
 
 
-def _load_validated_onnx_metadata(onnx_path: str) -> dict:
-    """Parse metadata and confine every external tensor to the model directory."""
+def _validate_external_data_bounds(
+    *,
+    tensor_name: str,
+    source_name: str,
+    file_size: int,
+    offset: int,
+    length: int,
+) -> None:
+    """Reject external tensor slices that exceed their captured source."""
+    if offset > file_size or (length and length > file_size - offset):
+        raise ValueError(
+            f"ONNX external tensor {tensor_name!r} references bytes outside "
+            f"{source_name!r} (offset={offset}, length={length}, size={file_size})."
+        )
+
+
+def _load_validated_onnx_artifact(
+    onnx_path: str,
+    *,
+    stage_dir: Path | None = None,
+) -> tuple[Path | None, dict]:
+    """Validate one ONNX snapshot and optionally stage it for atomic loading."""
     try:
         import onnx
     except ImportError as exc:
@@ -92,15 +117,44 @@ def _load_validated_onnx_metadata(onnx_path: str) -> dict:
             "onnxruntime. Install with: pip install 'libreyolo[onnx]'"
         ) from exc
 
-    artifact = Path(onnx_path)
-    if not artifact.is_file():
-        raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
+    artifact_path = Path(os.path.abspath(onnx_path))
+    open_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NONBLOCK", 0)
     try:
-        model_proto = onnx.load(str(artifact), load_external_data=False)
+        model_fd = os.open(artifact_path, open_flags)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"ONNX model not found: {onnx_path}") from exc
+    except OSError as exc:
+        raise OSError(f"Failed to open ONNX model {onnx_path}: {exc}") from exc
+
+    try:
+        with os.fdopen(model_fd, "rb") as model_file:
+            opened_model_stat = os.fstat(model_file.fileno())
+            if not stat.S_ISREG(opened_model_stat.st_mode):
+                raise ValueError(f"ONNX model is not a regular file: {onnx_path}")
+            try:
+                artifact = artifact_path.resolve(strict=True)
+                resolved_model_stat = artifact.stat()
+            except FileNotFoundError as exc:
+                raise RuntimeError(
+                    f"ONNX model {onnx_path} changed while it was being validated."
+                ) from exc
+            if not os.path.samestat(opened_model_stat, resolved_model_stat):
+                raise RuntimeError(
+                    f"ONNX model {onnx_path} changed while it was being validated."
+                )
+            model_bytes = model_file.read()
+    except (RuntimeError, ValueError):
+        raise
+    except Exception as exc:
+        raise ValueError(f"Failed to read ONNX model {onnx_path}: {exc}") from exc
+
+    try:
+        model_proto = onnx.load_model_from_string(model_bytes)
     except Exception as exc:
         raise ValueError(f"Failed to parse ONNX model {onnx_path}: {exc}") from exc
 
     base_dir = artifact.parent.resolve()
+    source_snapshots: dict[Path, tuple[PurePosixPath | None, int, str]] = {}
     for tensor in _iter_onnx_tensors(model_proto):
         if not tensor.HasField("data_location") or (
             tensor.data_location != onnx.TensorProto.EXTERNAL
@@ -109,6 +163,7 @@ def _load_validated_onnx_metadata(onnx_path: str) -> dict:
 
         tensor_name = tensor.name or "<unnamed>"
         entries = {}
+        entry_messages = {}
         for entry in tensor.external_data:
             if entry.key in entries:
                 raise ValueError(
@@ -116,6 +171,7 @@ def _load_validated_onnx_metadata(onnx_path: str) -> dict:
                     f"external_data key {entry.key!r}."
                 )
             entries[entry.key] = entry.value
+            entry_messages[entry.key] = entry
 
         location = entries.get("location")
         if not location or "\x00" in location:
@@ -130,32 +186,132 @@ def _load_validated_onnx_metadata(onnx_path: str) -> dict:
                 f"{location!r}."
             )
 
-        candidate = (base_dir / Path(*normalized_path.parts)).resolve()
+        candidate = Path(os.path.abspath(base_dir / Path(*normalized_path.parts)))
         if not candidate.is_relative_to(base_dir):
             raise ValueError(
                 f"ONNX external tensor {tensor_name!r} escapes the model directory: "
                 f"{location!r}."
             )
-        if not candidate.is_file():
-            raise FileNotFoundError(
-                f"ONNX external tensor data not found for {tensor_name!r}: {candidate}"
-            )
-
         offset = _parse_external_data_integer(
             entries.get("offset"), key="offset", tensor_name=tensor_name
         )
         length = _parse_external_data_integer(
             entries.get("length"), key="length", tensor_name=tensor_name
         )
-        file_size = candidate.stat().st_size
-        if offset > file_size or (length and length > file_size - offset):
-            raise ValueError(
-                f"ONNX external tensor {tensor_name!r} references bytes outside "
-                f"{candidate.name!r} (offset={offset}, length={length}, "
-                f"size={file_size})."
+        captured = source_snapshots.get(candidate)
+        if captured is not None:
+            staged_relative, file_size, source_name = captured
+            _validate_external_data_bounds(
+                tensor_name=tensor_name,
+                source_name=source_name,
+                file_size=file_size,
+                offset=offset,
+                length=length,
+            )
+            if stage_dir is not None:
+                assert staged_relative is not None
+                entry_messages["location"].value = staged_relative.as_posix()
+            continue
+
+        try:
+            source_fd = os.open(candidate, open_flags)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"ONNX external tensor data not found for {tensor_name!r}: {candidate}"
+            ) from exc
+        except OSError as exc:
+            raise OSError(
+                f"Failed to open ONNX external tensor data for {tensor_name!r}: "
+                f"{candidate}: {exc}"
+            ) from exc
+
+        with os.fdopen(source_fd, "rb") as source:
+            opened_stat = os.fstat(source.fileno())
+            if not stat.S_ISREG(opened_stat.st_mode):
+                raise ValueError(
+                    f"ONNX external tensor data for {tensor_name!r} is not a "
+                    f"regular file: {candidate}."
+                )
+            try:
+                resolved_candidate = candidate.resolve(strict=True)
+                resolved_stat = resolved_candidate.stat()
+            except FileNotFoundError as exc:
+                raise RuntimeError(
+                    f"ONNX external tensor {tensor_name!r} changed while it was "
+                    "being validated."
+                ) from exc
+            if not resolved_candidate.is_relative_to(base_dir):
+                raise ValueError(
+                    f"ONNX external tensor {tensor_name!r} escapes the model "
+                    f"directory: {location!r}."
+                )
+            if not os.path.samestat(opened_stat, resolved_stat):
+                raise RuntimeError(
+                    f"ONNX external tensor {tensor_name!r} changed while it was "
+                    "being validated."
+                )
+
+            file_size = opened_stat.st_size
+            _validate_external_data_bounds(
+                tensor_name=tensor_name,
+                source_name=resolved_candidate.name,
+                file_size=file_size,
+                offset=offset,
+                length=length,
             )
 
-    return {entry.key: entry.value for entry in model_proto.metadata_props}
+            staged_relative = None
+            if stage_dir is not None:
+                staged_relative = PurePosixPath(
+                    "_libreyolo_external",
+                    f"tensor-data-{len(source_snapshots)}.bin",
+                )
+                staged_path = stage_dir / Path(*staged_relative.parts)
+                staged_path.parent.mkdir(parents=True, exist_ok=True)
+                source.seek(0)
+                with staged_path.open("xb") as staged_file:
+                    shutil.copyfileobj(source, staged_file)
+                if staged_path.stat().st_size != file_size:
+                    raise RuntimeError(
+                        f"ONNX external tensor {tensor_name!r} changed while its "
+                        "validated snapshot was being copied."
+                    )
+                entry_messages["location"].value = staged_relative.as_posix()
+            source_snapshots[candidate] = (
+                staged_relative,
+                file_size,
+                resolved_candidate.name,
+            )
+
+    metadata = {entry.key: entry.value for entry in model_proto.metadata_props}
+    if stage_dir is None:
+        return None, metadata
+
+    staged_model = stage_dir / artifact.name
+    try:
+        with staged_model.open("xb") as staged_file:
+            staged_file.write(model_proto.SerializeToString())
+    except Exception as exc:
+        raise ValueError(f"Failed to stage ONNX model {onnx_path}: {exc}") from exc
+    return staged_model, metadata
+
+
+def _load_validated_onnx_metadata(onnx_path: str) -> dict:
+    """Parse metadata and confine every external tensor to the model directory."""
+    _, metadata = _load_validated_onnx_artifact(onnx_path)
+    return metadata
+
+
+@contextmanager
+def _stage_validated_onnx_artifact(onnx_path: str):
+    """Yield an immutable private ONNX snapshot for runtime session creation."""
+    with TemporaryDirectory(prefix="libreyolo-onnx-runtime-") as workspace_name:
+        staged_path, metadata = _load_validated_onnx_artifact(
+            onnx_path,
+            stage_dir=Path(workspace_name),
+        )
+        assert staged_path is not None
+        yield staged_path, metadata
 
 
 def _resolve_onnx_providers(device, available_providers) -> tuple[list, str]:
@@ -233,14 +389,18 @@ class OnnxBackend(BaseBackend):
                 "Install with: pip install onnxruntime"
             ) from e
 
-        validated_metadata = _load_validated_onnx_metadata(onnx_path)
-
         providers, resolved_device = _resolve_onnx_providers(
             device,
             ort.get_available_providers(),
         )
 
-        self.session = ort.InferenceSession(onnx_path, providers=providers)
+        with _stage_validated_onnx_artifact(onnx_path) as (
+            staged_onnx_path,
+            validated_metadata,
+        ):
+            self.session = ort.InferenceSession(
+                str(staged_onnx_path), providers=providers
+            )
         input_info = self.session.get_inputs()[0]
         self.input_name = input_info.name
         self.input_dtype = self._numpy_dtype_for_onnx_type(input_info.type)

--- a/libreyolo/backends/onnx.py
+++ b/libreyolo/backends/onnx.py
@@ -1,7 +1,7 @@
 """ONNX runtime inference backend for LibreYOLO."""
 
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import numpy as np
 
@@ -36,9 +36,138 @@ _ONNX_TENSOR_DTYPES = {
 }
 
 
+def _iter_onnx_tensors(message):
+    """Yield every TensorProto nested in an ONNX protobuf message."""
+    for field, value in message.ListFields():
+        if field.message_type is None:
+            continue
+        is_repeated = getattr(field, "is_repeated", None)
+        if is_repeated is None:
+            is_repeated = field.label == field.LABEL_REPEATED
+        if is_repeated:
+            children = (
+                value.values() if field.message_type.GetOptions().map_entry else value
+            )
+        else:
+            children = (value,)
+        for child in children:
+            descriptor = getattr(child, "DESCRIPTOR", None)
+            if descriptor is None:
+                continue
+            if descriptor.full_name == "onnx.TensorProto":
+                yield child
+            else:
+                yield from _iter_onnx_tensors(child)
+
+
+def _parse_external_data_integer(
+    value: str | None,
+    *,
+    key: str,
+    tensor_name: str,
+) -> int:
+    """Parse a non-negative ONNX external-data offset or length."""
+    if value in {None, ""}:
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"ONNX external tensor {tensor_name!r} has invalid {key}={value!r}."
+        ) from exc
+    if parsed < 0:
+        raise ValueError(
+            f"ONNX external tensor {tensor_name!r} has negative {key}={parsed}."
+        )
+    return parsed
+
+
+def _load_validated_onnx_metadata(onnx_path: str) -> dict:
+    """Parse metadata and confine every external tensor to the model directory."""
+    try:
+        import onnx
+    except ImportError as exc:
+        raise ImportError(
+            "Safe ONNX inference requires the 'onnx' package in addition to "
+            "onnxruntime. Install with: pip install 'libreyolo[onnx]'"
+        ) from exc
+
+    artifact = Path(onnx_path)
+    if not artifact.is_file():
+        raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
+    try:
+        model_proto = onnx.load(str(artifact), load_external_data=False)
+    except Exception as exc:
+        raise ValueError(f"Failed to parse ONNX model {onnx_path}: {exc}") from exc
+
+    base_dir = artifact.parent.resolve()
+    for tensor in _iter_onnx_tensors(model_proto):
+        if not tensor.HasField("data_location") or (
+            tensor.data_location != onnx.TensorProto.EXTERNAL
+        ):
+            continue
+
+        tensor_name = tensor.name or "<unnamed>"
+        entries = {}
+        for entry in tensor.external_data:
+            if entry.key in entries:
+                raise ValueError(
+                    f"ONNX external tensor {tensor_name!r} repeats "
+                    f"external_data key {entry.key!r}."
+                )
+            entries[entry.key] = entry.value
+
+        location = entries.get("location")
+        if not location or "\x00" in location:
+            raise ValueError(
+                f"ONNX external tensor {tensor_name!r} has no valid location."
+            )
+        windows_path = PureWindowsPath(location)
+        normalized_path = PurePosixPath(location.replace("\\", "/"))
+        if windows_path.drive or normalized_path.is_absolute():
+            raise ValueError(
+                f"ONNX external tensor {tensor_name!r} uses an absolute location: "
+                f"{location!r}."
+            )
+
+        candidate = (base_dir / Path(*normalized_path.parts)).resolve()
+        if not candidate.is_relative_to(base_dir):
+            raise ValueError(
+                f"ONNX external tensor {tensor_name!r} escapes the model directory: "
+                f"{location!r}."
+            )
+        if not candidate.is_file():
+            raise FileNotFoundError(
+                f"ONNX external tensor data not found for {tensor_name!r}: {candidate}"
+            )
+
+        offset = _parse_external_data_integer(
+            entries.get("offset"), key="offset", tensor_name=tensor_name
+        )
+        length = _parse_external_data_integer(
+            entries.get("length"), key="length", tensor_name=tensor_name
+        )
+        file_size = candidate.stat().st_size
+        if offset > file_size or (length and length > file_size - offset):
+            raise ValueError(
+                f"ONNX external tensor {tensor_name!r} references bytes outside "
+                f"{candidate.name!r} (offset={offset}, length={length}, "
+                f"size={file_size})."
+            )
+
+    return {entry.key: entry.value for entry in model_proto.metadata_props}
+
+
 def _resolve_onnx_providers(device, available_providers) -> tuple[list, str]:
     """Resolve ONNX Runtime providers without warning for an explicit CPU."""
-    key = str(device).lower()
+    if isinstance(device, bool):
+        raise ValueError(f"Invalid ONNX device {device!r}.")
+    if isinstance(device, int):
+        key = f"cuda:{device}"
+    else:
+        key = "auto" if device is None else str(device).strip().lower()
+        if key.isdigit():
+            key = f"cuda:{key}"
     if key == "auto":
         if "CUDAExecutionProvider" in available_providers:
             return ["CUDAExecutionProvider", "CPUExecutionProvider"], "cuda"
@@ -104,8 +233,7 @@ class OnnxBackend(BaseBackend):
                 "Install with: pip install onnxruntime"
             ) from e
 
-        if not Path(onnx_path).exists():
-            raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
+        validated_metadata = _load_validated_onnx_metadata(onnx_path)
 
         providers, resolved_device = _resolve_onnx_providers(
             device,
@@ -123,7 +251,7 @@ class OnnxBackend(BaseBackend):
             )
         except Exception:
             runtime_metadata = {}
-        metadata = runtime_metadata or self._load_embedded_metadata(onnx_path)
+        metadata = runtime_metadata or validated_metadata
 
         (
             model_family,
@@ -134,9 +262,7 @@ class OnnxBackend(BaseBackend):
             names,
             embedded_nms,
             metadata_imgsz,
-        ) = self._read_onnx_metadata(
-            onnx_path, nb_classes, runtime_metadata=metadata
-        )
+        ) = self._read_onnx_metadata(onnx_path, nb_classes, runtime_metadata=metadata)
         pose_metadata = self._read_onnx_pose_metadata(
             onnx_path, runtime_metadata=metadata
         )
@@ -189,20 +315,14 @@ class OnnxBackend(BaseBackend):
             supported_tasks=supported_tasks,
             default_task=default_task,
             dynamic_spatial=dynamic_spatial,
-            num_bins=(
-                int(metadata["num_bins"])
-                if metadata.get("num_bins")
-                else None
-            ),
+            num_bins=(int(metadata["num_bins"]) if metadata.get("num_bins") else None),
             bin_width_deg=(
                 float(metadata["bin_width_deg"])
                 if metadata.get("bin_width_deg")
                 else None
             ),
             offset_deg=(
-                float(metadata["offset_deg"])
-                if metadata.get("offset_deg")
-                else None
+                float(metadata["offset_deg"]) if metadata.get("offset_deg") else None
             ),
             **classification_metadata,
             **pose_metadata,
@@ -223,7 +343,7 @@ class OnnxBackend(BaseBackend):
         try:
             import onnx
 
-            model_proto = onnx.load(onnx_path)
+            model_proto = onnx.load(onnx_path, load_external_data=False)
             return {entry.key: entry.value for entry in model_proto.metadata_props}
         except Exception as exc:
             logger.warning("Failed to load ONNX metadata from %s: %s", onnx_path, exc)

--- a/libreyolo/backends/openvino.py
+++ b/libreyolo/backends/openvino.py
@@ -8,7 +8,13 @@ import numpy as np
 
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, ImageSize, _read_metadata_imgsz, _read_pose_metadata
+from .base import (
+    BaseBackend,
+    ImageSize,
+    _read_classification_metadata,
+    _read_metadata_imgsz,
+    _read_pose_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +67,7 @@ class OpenVINOBackend(BaseBackend):
         resolved_nb_classes = nb_classes if nb_classes is not None else 80
         names = self.build_names(resolved_nb_classes)
         pose_metadata = {}
+        classification_metadata = {}
 
         metadata_path = model_dir / "metadata.yaml"
         if metadata_path.exists():
@@ -74,6 +81,7 @@ class OpenVINOBackend(BaseBackend):
                 resolved_nb_classes,
                 names,
                 pose_metadata,
+                classification_metadata,
             ) = self._read_metadata(metadata_path, nb_classes)
             task = resolve_task(
                 explicit_task=explicit_task,
@@ -103,6 +111,7 @@ class OpenVINOBackend(BaseBackend):
         core = ov.Core()
         ov_model = core.read_model(str(xml_path))
         self._dynamic_batch_axis = self._detect_dynamic_batch_axis(ov_model)
+        dynamic_spatial = self._detect_dynamic_spatial_axes(ov_model)
         self.compiled_model = core.compile_model(ov_model, ov_device)
 
         static_imgsz = self._read_static_input_imgsz(ov_model)
@@ -120,6 +129,8 @@ class OpenVINOBackend(BaseBackend):
             task=task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            dynamic_spatial=dynamic_spatial,
+            **classification_metadata,
             **pose_metadata,
         )
 
@@ -132,6 +143,15 @@ class OpenVINOBackend(BaseBackend):
         """
         try:
             return bool(ov_model.inputs[0].get_partial_shape()[0].is_dynamic)
+        except Exception:
+            return False
+
+    @staticmethod
+    def _detect_dynamic_spatial_axes(ov_model) -> bool:
+        """True when either input height or width is dynamic."""
+        try:
+            shape = ov_model.inputs[0].get_partial_shape()
+            return len(shape) == 4 and any(shape[index].is_dynamic for index in (2, 3))
         except Exception:
             return False
 
@@ -159,7 +179,9 @@ class OpenVINOBackend(BaseBackend):
         """Read metadata from metadata.yaml file.
 
         Returns:
-            Tuple of (model_family, model_size, task, supported_tasks, default_task, imgsz, nb_classes, names, pose_metadata).
+            Tuple of (model_family, model_size, task, supported_tasks,
+            default_task, imgsz, nb_classes, names, pose metadata,
+            classification metadata).
         """
         import yaml
 
@@ -175,7 +197,9 @@ class OpenVINOBackend(BaseBackend):
         model_size = meta.get("model_size") or meta.get("size")
         default_task = normalize_task(meta.get("default_task"), default="detect")
         task = normalize_task(meta.get("task"), default=default_task)
-        supported_tasks = normalize_supported_tasks(meta.get("supported_tasks", (task,)))
+        supported_tasks = normalize_supported_tasks(
+            meta.get("supported_tasks", (task,))
+        )
         imgsz = (
             _read_metadata_imgsz(
                 meta,
@@ -207,6 +231,7 @@ class OpenVINOBackend(BaseBackend):
             nb_classes,
             names,
             _read_pose_metadata(meta),
+            _read_classification_metadata(meta) if task == "classify" else {},
         )
 
     def _run_inference(self, blob: np.ndarray) -> list:

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -24,19 +24,25 @@ logger = logging.getLogger(__name__)
 
 def _resolve_tensorrt_device(device) -> torch.device:
     """Resolve and validate the CUDA device used by a TensorRT runtime."""
-    key = str(device or "auto").lower()
-    if key in {"auto", "cuda", "gpu"}:
-        index = int(torch.cuda.current_device())
-    elif key.startswith("cuda:"):
-        try:
-            index = int(key.split(":", 1)[1])
-        except ValueError as exc:
-            raise ValueError(f"Invalid TensorRT CUDA device {device!r}.") from exc
+    if isinstance(device, int):
+        index = device
     else:
-        raise ValueError(
-            "TensorRT inference requires device='cuda', 'cuda:N', 'gpu', or 'auto'; "
-            f"got {device!r}."
-        )
+        key = "auto" if device is None else str(device).strip().lower()
+        if key in {"auto", "cuda", "gpu"}:
+            index = int(torch.cuda.current_device())
+        elif key.isdigit():
+            index = int(key)
+        elif key.startswith("cuda:"):
+            try:
+                index = int(key.split(":", 1)[1])
+            except ValueError as exc:
+                raise ValueError(f"Invalid TensorRT CUDA device {device!r}.") from exc
+        else:
+            raise ValueError(
+                "TensorRT inference requires device=0, device='0', 'cuda', "
+                "'cuda:N', 'gpu', or 'auto'; "
+                f"got {device!r}."
+            )
     if index < 0 or index >= torch.cuda.device_count():
         raise ValueError(
             f"TensorRT CUDA device index {index} is unavailable; "
@@ -55,7 +61,9 @@ class TensorRTBackend(BaseBackend):
             from it automatically.
         nb_classes: Number of classes. When ``None`` (default), uses the value
             from the sidecar file if available, otherwise defaults to 80.
-        device: Device for inference. Must be "cuda" or "auto" (TensorRT requires GPU).
+        device: CUDA device for inference. Accepts an integer index, numeric
+            string, ``"cuda"``, ``"cuda:N"``, ``"gpu"``, ``"auto"``, or a
+            CUDA ``torch.device``.
 
     Example:
         >>> model = TensorRTBackend("model.engine")
@@ -67,7 +75,7 @@ class TensorRTBackend(BaseBackend):
         self,
         engine_path: str,
         nb_classes: int | None = None,
-        device: str = "auto",
+        device: str | int | torch.device = "auto",
         task: str | None = None,
     ):
         try:

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 def _resolve_tensorrt_device(device) -> torch.device:
     """Resolve and validate the CUDA device used by a TensorRT runtime."""
+    if isinstance(device, bool):
+        raise ValueError(f"Invalid TensorRT CUDA device {device!r}.")
     if isinstance(device, int):
         index = device
     else:
@@ -346,6 +348,14 @@ class TensorRTBackend(BaseBackend):
                 "TensorRT execute_async_v3 returned False; inference was not executed."
             )
 
+    def _set_tensor_address(self, name: str, tensor: torch.Tensor) -> None:
+        """Bind one I/O tensor and fail if TensorRT rejects its device pointer."""
+        accepted = self.context.set_tensor_address(name, tensor.data_ptr())
+        if accepted is False:
+            raise RuntimeError(
+                f"TensorRT rejected the device address for tensor {name!r}."
+            )
+
     def _wait_for_input_copy(self) -> None:
         """Order TensorRT's stream after the PyTorch stream that filled input."""
         self.stream.wait_stream(torch.cuda.current_stream(self.device))
@@ -508,11 +518,9 @@ class TensorRTBackend(BaseBackend):
         self.inputs[self.input_name].copy_(input_tensor)
         self._wait_for_input_copy()
 
-        self.context.set_tensor_address(
-            self.input_name, self.inputs[self.input_name].data_ptr()
-        )
+        self._set_tensor_address(self.input_name, self.inputs[self.input_name])
         for name in self.output_names:
-            self.context.set_tensor_address(name, self.outputs[name].data_ptr())
+            self._set_tensor_address(name, self.outputs[name])
 
         self._execute()
         self.stream.synchronize()

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -11,9 +11,38 @@ import torch
 
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, ImageSize, _read_metadata_imgsz, _read_pose_metadata
+from .base import (
+    BaseBackend,
+    ImageSize,
+    _read_classification_metadata,
+    _read_metadata_imgsz,
+    _read_pose_metadata,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_tensorrt_device(device) -> torch.device:
+    """Resolve and validate the CUDA device used by a TensorRT runtime."""
+    key = str(device or "auto").lower()
+    if key in {"auto", "cuda", "gpu"}:
+        index = int(torch.cuda.current_device())
+    elif key.startswith("cuda:"):
+        try:
+            index = int(key.split(":", 1)[1])
+        except ValueError as exc:
+            raise ValueError(f"Invalid TensorRT CUDA device {device!r}.") from exc
+    else:
+        raise ValueError(
+            "TensorRT inference requires device='cuda', 'cuda:N', 'gpu', or 'auto'; "
+            f"got {device!r}."
+        )
+    if index < 0 or index >= torch.cuda.device_count():
+        raise ValueError(
+            f"TensorRT CUDA device index {index} is unavailable; "
+            f"detected {torch.cuda.device_count()} CUDA device(s)."
+        )
+    return torch.device("cuda", index)
 
 
 class TensorRTBackend(BaseBackend):
@@ -51,6 +80,9 @@ class TensorRTBackend(BaseBackend):
 
         if not torch.cuda.is_available():
             raise RuntimeError("TensorRT requires CUDA. No CUDA-capable GPU detected.")
+        resolved_device = _resolve_tensorrt_device(device)
+        torch.cuda.set_device(resolved_device)
+        self.device = resolved_device
 
         if not Path(engine_path).exists():
             raise FileNotFoundError(f"TensorRT engine not found: {engine_path}")
@@ -74,13 +106,17 @@ class TensorRTBackend(BaseBackend):
             else self._metadata.get("nb_classes", self._metadata.get("nc", 80))
         )
         model_family = self._metadata.get("model_family")
-        default_task = normalize_task(self._metadata.get("default_task"), default="detect")
+        default_task = normalize_task(
+            self._metadata.get("default_task"), default="detect"
+        )
         metadata_task = normalize_task(self._metadata.get("task"), default=default_task)
         supported_tasks = normalize_supported_tasks(
             self._metadata.get("supported_tasks", (metadata_task,))
         )
         pose_metadata = _read_pose_metadata(self._metadata)
-        self._sidecar_size = self._metadata.get("model_size") or self._metadata.get("size")
+        self._sidecar_size = self._metadata.get("model_size") or self._metadata.get(
+            "size"
+        )
 
         sidecar_names = self._metadata.get("names")
         if sidecar_names is not None and nb_classes is None:
@@ -104,26 +140,39 @@ class TensorRTBackend(BaseBackend):
         self.output_names: List[str] = []
         self.input_shape = None
         self.output_shapes: Dict[str, Tuple] = {}
+        self.input_numpy_dtype = None
+        self.input_torch_dtype = None
+        self.output_numpy_dtypes: Dict[str, np.dtype] = {}
+        self.output_torch_dtypes: Dict[str, torch.dtype] = {}
 
         for i in range(self.engine.num_io_tensors):
             name = self.engine.get_tensor_name(i)
             shape = self.engine.get_tensor_shape(name)
             mode = self.engine.get_tensor_mode(name)
+            numpy_dtype, torch_dtype = self._binding_dtypes(
+                trt,
+                self.engine.get_tensor_dtype(name),
+                tensor_name=name,
+            )
 
             if mode == trt.TensorIOMode.INPUT:
                 self.input_name = name
                 self.input_shape = tuple(shape)
+                self.input_numpy_dtype = numpy_dtype
+                self.input_torch_dtype = torch_dtype
             else:
                 self.output_names.append(name)
                 self.output_shapes[name] = tuple(shape)
+                self.output_numpy_dtypes[name] = numpy_dtype
+                self.output_torch_dtypes[name] = torch_dtype
 
         if self.input_name is None:
             raise RuntimeError("No input tensor found in TensorRT engine")
 
+        self._dynamic_input = any(dim == -1 for dim in self.input_shape)
         self._dynamic_batch = self.input_shape[0] == -1  # -1 = dynamic batch
-        self._max_batch = self._detect_max_batch()
-
-        self._allocate_buffers()
+        self._min_batch, self._max_batch = self._detect_batch_limits()
+        dynamic_spatial = self._detect_dynamic_spatial_profile()
 
         if model_family is None:
             model_family = self._detect_model_family()
@@ -133,6 +182,7 @@ class TensorRTBackend(BaseBackend):
             artifact=f"TensorRT metadata sidecar {sidecar_path}",
         )
         imgsz = self._read_static_input_imgsz(self.input_shape) or metadata_imgsz or 640
+        self._allocate_buffers(self._initial_input_shape(imgsz))
         if not self._metadata:
             inferred_task = self._detect_task_from_filename()
             if inferred_task is not None:
@@ -146,11 +196,16 @@ class TensorRTBackend(BaseBackend):
             default_task=default_task,
             supported_tasks=supported_tasks,
         )
+        classification_metadata = (
+            _read_classification_metadata(self._metadata)
+            if resolved_task == "classify"
+            else {}
+        )
 
         super().__init__(
             model_path=engine_path,
             nb_classes=resolved_nb_classes,
-            device="cuda",
+            device=str(resolved_device),
             imgsz=imgsz,
             model_family=model_family,
             names=names,
@@ -158,6 +213,8 @@ class TensorRTBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            dynamic_spatial=dynamic_spatial,
+            **classification_metadata,
             **pose_metadata,
         )
 
@@ -174,47 +231,168 @@ class TensorRTBackend(BaseBackend):
             return h if h == w else (h, w)
         return None
 
-    def _allocate_buffers(self, batch_size: int = 1):
-        """Allocate CUDA memory for input and output tensors."""
-        self.inputs = {}
-        self.outputs = {}
-        self.bindings = []
-        self.stream = torch.cuda.Stream()
-        self._current_batch = batch_size
+    def _detect_dynamic_spatial_profile(self) -> bool:
+        """Return whether the active TensorRT profile varies height or width."""
+        if len(self.input_shape) != 4 or not any(
+            dim == -1 for dim in self.input_shape[2:4]
+        ):
+            return False
+        try:
+            min_shape, _, max_shape = self.engine.get_tensor_profile_shape(
+                self.input_name, 0
+            )
+            return any(
+                int(min_shape[index]) != int(max_shape[index]) for index in (2, 3)
+            )
+        except (AttributeError, IndexError, TypeError, ValueError):
+            return False
 
-        def _resolve_shape(shape):
-            return tuple(batch_size if d == -1 else d for d in shape)
+    @staticmethod
+    def _binding_dtypes(trt, trt_dtype, *, tensor_name: str):
+        """Return NumPy and torch dtypes for a TensorRT I/O tensor."""
+        try:
+            numpy_dtype = np.dtype(trt.nptype(trt_dtype))
+            torch_dtype = torch.from_numpy(np.empty((0,), dtype=numpy_dtype)).dtype
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise TypeError(
+                f"TensorRT tensor {tensor_name!r} uses unsupported dtype {trt_dtype!r}."
+            ) from exc
+        return numpy_dtype, torch_dtype
 
-        resolved_input = _resolve_shape(self.input_shape)
-        input_size = int(np.prod(resolved_input))
-        self.inputs[self.input_name] = torch.zeros(
-            input_size, dtype=torch.float32, device="cuda"
-        )
-
-        for name in self.output_names:
-            shape = _resolve_shape(self.output_shapes[name])
-            size = int(np.prod(shape))
-            self.outputs[name] = torch.zeros(size, dtype=torch.float32, device="cuda")
-
-    def _detect_max_batch(self) -> int:
-        """Return the largest batch size this engine can execute."""
-        if not self._dynamic_batch:
-            return int(self.input_shape[0])
+    def _initial_input_shape(self, imgsz: ImageSize) -> tuple[int, ...]:
+        """Resolve a concrete startup shape, preferring profile-opt dimensions."""
+        if not self._dynamic_input:
+            return tuple(int(dim) for dim in self.input_shape)
 
         try:
             profile_shapes = self.engine.get_tensor_profile_shape(self.input_name, 0)
-            return int(profile_shapes[2][0])
+            opt_shape = tuple(int(dim) for dim in profile_shapes[1])
+            if len(opt_shape) == len(self.input_shape) and all(
+                dim > 0 for dim in opt_shape
+            ):
+                return opt_shape
         except (AttributeError, IndexError, TypeError, ValueError):
             pass
 
+        if len(self.input_shape) != 4:
+            raise RuntimeError(
+                "TensorRT dynamic input has no usable optimization-profile shape: "
+                f"{self.input_shape}."
+            )
+        if isinstance(imgsz, tuple):
+            input_h, input_w = (int(imgsz[0]), int(imgsz[1]))
+        else:
+            input_h = input_w = int(imgsz)
+        fallback = (1, 3, input_h, input_w)
+        return tuple(
+            int(engine_dim) if engine_dim > 0 else fallback[index]
+            for index, engine_dim in enumerate(self.input_shape)
+        )
+
+    def _validate_input_shape(self, shape: tuple[int, ...]) -> None:
+        """Validate a concrete runtime shape against the engine declaration."""
+        if len(shape) != len(self.input_shape):
+            raise ValueError(
+                f"TensorRT input {self.input_name!r} expects {len(self.input_shape)} "
+                f"dimensions, got shape {shape}."
+            )
+        for axis, (actual, declared) in enumerate(zip(shape, self.input_shape)):
+            if actual <= 0:
+                raise ValueError(f"TensorRT input shape must be positive, got {shape}.")
+            if declared > 0 and actual != declared:
+                raise ValueError(
+                    f"TensorRT input {self.input_name!r} axis {axis} is fixed at "
+                    f"{declared}, got {actual} (shape {shape})."
+                )
+
+    def _set_runtime_input_shape(self, shape: tuple[int, ...]) -> None:
+        """Set a dynamic input shape and reject profiles that do not accept it."""
+        self._validate_input_shape(shape)
+        if not self._dynamic_input:
+            return
+        accepted = self.context.set_input_shape(self.input_name, shape)
+        if accepted is False:
+            raise ValueError(
+                f"TensorRT optimization profile rejected input shape {shape} "
+                f"for tensor {self.input_name!r}."
+            )
+
+    def _runtime_output_shape(self, name: str) -> tuple[int, ...]:
+        """Read a fully resolved output shape after the input shape is set."""
+        try:
+            shape = tuple(int(dim) for dim in self.context.get_tensor_shape(name))
+        except AttributeError:
+            shape = tuple(int(dim) for dim in self.output_shapes[name])
+        if not shape or any(dim <= 0 for dim in shape):
+            raise RuntimeError(
+                f"TensorRT output {name!r} has unresolved runtime shape {shape}; "
+                "ensure the optimization profile covers the input shape."
+            )
+        return shape
+
+    def _execute(self) -> None:
+        """Execute the current bindings and fail if TensorRT rejects the launch."""
+        executed = self.context.execute_async_v3(self.stream.cuda_stream)
+        if not executed:
+            raise RuntimeError(
+                "TensorRT execute_async_v3 returned False; inference was not executed."
+            )
+
+    def _wait_for_input_copy(self) -> None:
+        """Order TensorRT's stream after the PyTorch stream that filled input."""
+        self.stream.wait_stream(torch.cuda.current_stream(self.device))
+
+    def _allocate_buffers(self, input_shape: tuple[int, ...]):
+        """Set the input shape, then allocate dtype-correct CUDA I/O buffers."""
+        concrete_shape = tuple(int(dim) for dim in input_shape)
+        self._set_runtime_input_shape(concrete_shape)
+
+        self.inputs = {}
+        self.outputs = {}
+        if not hasattr(self, "stream"):
+            self.stream = torch.cuda.Stream(device=self.device)
+        self._current_input_shape = concrete_shape
+        self._current_batch = concrete_shape[0]
+
+        input_size = int(np.prod(concrete_shape))
+        self.inputs[self.input_name] = torch.empty(
+            input_size, dtype=self.input_torch_dtype, device=self.device
+        )
+
+        self._runtime_output_shapes: Dict[str, tuple[int, ...]] = {}
+        for name in self.output_names:
+            shape = self._runtime_output_shape(name)
+            self._runtime_output_shapes[name] = shape
+            size = int(np.prod(shape))
+            self.outputs[name] = torch.empty(
+                size,
+                dtype=self.output_torch_dtypes[name],
+                device=self.device,
+            )
+
+    def _detect_batch_limits(self) -> tuple[int, int]:
+        """Return the smallest and largest batch sizes the engine can execute."""
+        if not self._dynamic_batch:
+            batch = int(self.input_shape[0])
+            return batch, batch
+
+        try:
+            profile_shapes = self.engine.get_tensor_profile_shape(self.input_name, 0)
+            return int(profile_shapes[0][0]), int(profile_shapes[2][0])
+        except (AttributeError, IndexError, TypeError, ValueError):
+            pass
+
+        metadata_min = self._metadata.get("trt_min_batch")
         metadata_max = self._metadata.get("trt_max_batch")
-        if metadata_max is not None:
+        if metadata_min is not None or metadata_max is not None:
             try:
-                return max(1, int(metadata_max))
+                minimum = max(1, int(metadata_min or 1))
+                maximum = max(minimum, int(metadata_max or minimum))
+                return minimum, maximum
             except (TypeError, ValueError):
                 pass
 
-        return 1
+        return 1, 1
 
     def _detect_model_family(self) -> Optional[str]:
         """Detect model family from output shapes when sidecar metadata is absent."""
@@ -286,21 +464,41 @@ class TensorRTBackend(BaseBackend):
         Returns:
             Dict mapping output tensor names to numpy arrays.
         """
-        input_array = np.ascontiguousarray(input_array, dtype=np.float32)
+        with torch.cuda.device(self.device):
+            return self._infer_current_device(input_array)
 
+    def _infer_current_device(self, input_array: np.ndarray) -> Dict[str, np.ndarray]:
+        """Run inference while the engine's CUDA device is current."""
+        input_array = np.asarray(input_array)
         if input_array.ndim == 3:
             input_array = input_array[np.newaxis]
-        actual_batch = input_array.shape[0]
+        requested_batch = int(input_array.shape[0])
+        if requested_batch < 1:
+            raise ValueError("TensorRT inference requires at least one input image.")
+        if requested_batch < self._min_batch:
+            padding = np.repeat(
+                input_array[-1:], self._min_batch - requested_batch, axis=0
+            )
+            input_array = np.concatenate((input_array, padding), axis=0)
+        actual_shape = tuple(int(dim) for dim in input_array.shape)
+        self._validate_input_shape(actual_shape)
+        if actual_shape[0] > self._max_batch:
+            raise ValueError(
+                f"TensorRT engine supports at most batch {self._max_batch}, "
+                f"got batch {actual_shape[0]}."
+            )
+        if actual_shape != self._current_input_shape:
+            # Dynamic output dimensions are resolved only after the actual
+            # input shape is applied, so shape changes must precede allocation.
+            self._allocate_buffers(actual_shape)
 
-        if actual_batch != self._current_batch:
-            self._allocate_buffers(actual_batch)
-
-        if self._dynamic_batch:
-            _, c, h, w = self.input_shape
-            self.context.set_input_shape(self.input_name, (actual_batch, c, h, w))
-
-        input_tensor = torch.from_numpy(input_array).cuda().flatten()
+        runtime_input = np.ascontiguousarray(
+            input_array,
+            dtype=self.input_numpy_dtype,
+        )
+        input_tensor = torch.from_numpy(runtime_input).to(self.device).flatten()
         self.inputs[self.input_name].copy_(input_tensor)
+        self._wait_for_input_copy()
 
         self.context.set_tensor_address(
             self.input_name, self.inputs[self.input_name].data_ptr()
@@ -308,15 +506,15 @@ class TensorRTBackend(BaseBackend):
         for name in self.output_names:
             self.context.set_tensor_address(name, self.outputs[name].data_ptr())
 
-        self.context.execute_async_v3(self.stream.cuda_stream)
+        self._execute()
         self.stream.synchronize()
 
         results = {}
         for name in self.output_names:
-            shape = tuple(
-                actual_batch if d == -1 else d for d in self.output_shapes[name]
-            )
+            shape = self._runtime_output_shapes[name]
             output = self.outputs[name].cpu().numpy().reshape(shape)
+            if output.ndim > 0 and output.shape[0] == actual_shape[0]:
+                output = output[:requested_batch]
             results[name] = output
 
         return results
@@ -329,6 +527,10 @@ class TensorRTBackend(BaseBackend):
         """Run TensorRT inference and return outputs as a list."""
         outputs_dict = self._infer(blob)
         return [outputs_dict[name] for name in self.output_names]
+
+    def _supports_batched_inference(self) -> bool:
+        """Use the shared task-complete batch path for dynamic-batch engines."""
+        return self._max_batch > 1
 
     def _process_in_batches(
         self,
@@ -343,127 +545,23 @@ class TensorRTBackend(BaseBackend):
         max_det: int = 300,
         color_format: str = "auto",
     ) -> list:
-        """Process multiple images with GPU batching when possible.
-
-        When batch > 1 and the engine supports it (dynamic batch or static
-        batch >= requested), images are preprocessed, stacked, and inferred
-        together in a single forward pass. Otherwise falls back to sequential
-        processing.
-        """
-        effective_batch = batch
+        """Clamp chunks to the engine profile, then use shared task dispatch."""
         if self._dynamic_batch:
             effective_batch = min(batch, self._max_batch)
-
-        can_batch = batch > 1 and (
-            (self._dynamic_batch and effective_batch > 1)
-            or (not self._dynamic_batch and self._max_batch >= batch)
+        else:
+            effective_batch = self._max_batch
+        return super()._process_in_batches(
+            images,
+            batch=effective_batch,
+            save=save,
+            output_path=output_path,
+            conf=conf,
+            iou=iou,
+            imgsz=imgsz,
+            classes=classes,
+            max_det=max_det,
+            color_format=color_format,
         )
-        if not can_batch:
-            return super()._process_in_batches(
-                images,
-                batch=batch,
-                save=save,
-                output_path=output_path,
-                conf=conf,
-                iou=iou,
-                imgsz=imgsz,
-                classes=classes,
-                max_det=max_det,
-                color_format=color_format,
-            )
-
-        effective_imgsz = self._resolve_predict_imgsz(imgsz)
-        results = []
-
-        for i in range(0, len(images), effective_batch):
-            chunk = images[i : i + effective_batch]
-
-            tensors = []
-            preprocess_info = []
-            for offset, image in enumerate(chunk):
-                preprocess_out = self._preprocess(image, effective_imgsz, color_format)
-                if len(preprocess_out) == 4:
-                    tensor, orig_img, orig_size, ratio = preprocess_out
-                else:
-                    tensor, orig_img, orig_size = preprocess_out
-                    ratio = None
-                tensors.append(tensor)
-                # In-memory images have no path: keep Results.path None and
-                # use an indexed stem so save=True does not overwrite files.
-                image_path = image if isinstance(image, (str, Path)) else None
-                save_name = (
-                    image_path if image_path is not None else f"image{i + offset}"
-                )
-                preprocess_info.append(
-                    (orig_img, orig_size, ratio, image_path, save_name)
-                )
-
-            batched_input = np.concatenate(
-                [t.numpy() for t in tensors], axis=0
-            )  # (B, C, H, W)
-            batch_outputs = self._infer(batched_input)
-
-            for idx, (
-                orig_img,
-                orig_size,
-                ratio,
-                image_path,
-                save_name,
-            ) in enumerate(preprocess_info):
-                per_image = [
-                    batch_outputs[name][idx : idx + 1] for name in self.output_names
-                ]
-
-                orig_w, orig_h = orig_size
-                orig_shape = (orig_h, orig_w)
-                # Mirror _predict_single: classify exports skip the detection
-                # parser, and iou/max_det reach parsers that apply NMS.
-                if self.task == "classify":
-                    result = self._build_classify_result(
-                        per_image,
-                        orig_shape=orig_shape,
-                        image_path=image_path,
-                    )
-                elif self.task == "depth":
-                    result = self._build_depth_result(
-                        per_image,
-                        orig_shape=orig_shape,
-                        original_size=orig_size,
-                        image_path=image_path,
-                    )
-                else:
-                    parsed = self._parse_outputs(
-                        per_image,
-                        effective_imgsz,
-                        orig_size,
-                        conf,
-                        ratio=ratio if ratio is not None else 1.0,
-                        iou=iou,
-                        max_det=max_det,
-                    )
-                    boxes, max_scores, class_ids, masks, obb, keypoints = (
-                        self._unpack_parsed_outputs(parsed)
-                    )
-                    result = self._build_result(
-                        boxes,
-                        max_scores,
-                        class_ids,
-                        masks=masks,
-                        obb=obb,
-                        keypoints=keypoints,
-                        orig_shape=orig_shape,
-                        image_path=image_path,
-                        iou=iou,
-                        classes=classes,
-                        max_det=max_det,
-                    )
-
-                if save:
-                    self._save_annotated(result, orig_img, save_name, output_path)
-
-                results.append(result)
-
-        return results
 
     # =========================================================================
     # Metadata helpers

--- a/libreyolo/backends/tflite.py
+++ b/libreyolo/backends/tflite.py
@@ -11,7 +11,12 @@ import numpy as np
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.general import COCO_CLASSES
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, _read_metadata_imgsz, _read_pose_metadata
+from .base import (
+    BaseBackend,
+    _read_classification_metadata,
+    _read_metadata_imgsz,
+    _read_pose_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +66,11 @@ class TFLiteBackend(BaseBackend):
             default_task=default_task,
             supported_tasks=supported_tasks,
         )
+        classification_metadata = (
+            _read_classification_metadata(metadata)
+            if resolved_task == "classify"
+            else {}
+        )
         resolved_nc = int(
             nb_classes
             if nb_classes is not None
@@ -101,10 +111,7 @@ class TFLiteBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
-            crop_pct=(
-                float(metadata["crop_pct"]) if metadata.get("crop_pct") else None
-            ),
-            interpolation=metadata.get("interpolation"),
+            **classification_metadata,
             **_read_pose_metadata(metadata),
         )
 

--- a/libreyolo/backends/torchscript.py
+++ b/libreyolo/backends/torchscript.py
@@ -12,7 +12,12 @@ import torch
 from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
 from ..utils.general import COCO_CLASSES
 from ..utils.serialization import warn_on_metadata_schema_version
-from .base import BaseBackend, _read_metadata_imgsz, _read_pose_metadata
+from .base import (
+    BaseBackend,
+    _read_classification_metadata,
+    _read_metadata_imgsz,
+    _read_pose_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +51,7 @@ class TorchScriptBackend(BaseBackend):
             model_path, map_location=map_location, _extra_files=extra_files
         )
         self.model.eval()
+        self.input_dtype = self._floating_model_dtype(self.model)
 
         metadata = {}
         raw_meta = extra_files.get("libreyolo_metadata.json", "")
@@ -79,6 +85,11 @@ class TorchScriptBackend(BaseBackend):
         if metadata_imgsz is not None:
             input_size = metadata_imgsz
         pose_metadata = _read_pose_metadata(metadata)
+        classification_metadata = (
+            _read_classification_metadata(metadata)
+            if resolved_task == "classify"
+            else {}
+        )
 
         if nb_classes is not None:
             resolved_nb_classes = nb_classes
@@ -108,11 +119,31 @@ class TorchScriptBackend(BaseBackend):
             task=resolved_task,
             supported_tasks=supported_tasks,
             default_task=default_task,
+            **classification_metadata,
             **pose_metadata,
         )
 
+    @staticmethod
+    def _floating_model_dtype(model) -> torch.dtype:
+        """Return the first floating parameter/buffer dtype used by a module."""
+        for attribute in ("parameters", "buffers"):
+            tensor_iter = getattr(model, attribute, None)
+            if not callable(tensor_iter):
+                continue
+            try:
+                tensors = tensor_iter()
+            except (AttributeError, RuntimeError, TypeError):
+                continue
+            for tensor in tensors:
+                if isinstance(tensor, torch.Tensor) and tensor.is_floating_point():
+                    return tensor.dtype
+        return torch.float32
+
     def _run_inference(self, blob: np.ndarray) -> list:
-        tensor = torch.from_numpy(blob).to(self.device)
+        tensor = torch.from_numpy(blob).to(
+            device=self.device,
+            dtype=self.input_dtype,
+        )
         with torch.no_grad():
             outputs = self.model(tensor)
 

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -21,7 +21,9 @@ def export_cmd(
         "onnx",
         help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite (alias: litert), coreml",
     ),
-    imgsz: Optional[str] = typer.Option(None, help="Input image size (e.g. 640 or 640,480)"),
+    imgsz: Optional[str] = typer.Option(
+        None, help="Input image size (e.g. 640 or 640,480)"
+    ),
     batch: int = typer.Option(1, help="Export batch size"),
     half: bool = typer.Option(False, help="FP16 precision"),
     int8: bool = typer.Option(False, help="INT8 quantization"),
@@ -75,11 +77,12 @@ def export_cmd(
         exit_with_error(
             out,
             "nms_unsupported_format",
-            "Embedded NMS (--nms) is only supported for ONNX and CoreML, "
-            f"not {fmt!r}.",
+            f"Embedded NMS (--nms) is only supported for ONNX and CoreML, not {fmt!r}.",
         )
     if nms and fmt == "onnx" and dynamic:
-        out.warning("Embedded ONNX NMS uses a fixed batch-1 graph. Using dynamic=False.")
+        out.warning(
+            "Embedded ONNX NMS uses a fixed batch-1 graph. Using dynamic=False."
+        )
         dynamic = False
     if nms and fmt == "coreml" and max_det != 300:
         exit_with_error(
@@ -100,6 +103,26 @@ def export_cmd(
     loaded_model = load_model_or_exit(
         out, model=model, model_path=model_path, device=device
     )
+
+    from libreyolo.export.support import get_export_capabilities
+
+    model_family = getattr(loaded_model, "FAMILY", "")
+    if not model_family and hasattr(loaded_model, "_get_model_name"):
+        model_family = loaded_model._get_model_name()
+    model_task = getattr(loaded_model, "task", "detect")
+    if not isinstance(model_task, str):
+        model_task = "detect"
+    capabilities = get_export_capabilities(model_family, model_task, fmt)
+    if (
+        dynamic
+        and fmt != "tflite"
+        and capabilities.support.tier != "blocked"
+        and not capabilities.supports_dynamic
+    ):
+        out.warning(
+            f"{fmt.upper()} export uses a fixed input graph. Using dynamic=False."
+        )
+        dynamic = False
 
     # Build export kwargs
     export_kwargs: dict = {
@@ -122,16 +145,28 @@ def export_cmd(
         if "," in imgsz:
             parts = imgsz.split(",")
             if len(parts) != 2:
-                exit_with_error(out, "invalid_imgsz", f"Invalid imgsz format: {imgsz}. Use e.g. 640 or 640,480.")
+                exit_with_error(
+                    out,
+                    "invalid_imgsz",
+                    f"Invalid imgsz format: {imgsz}. Use e.g. 640 or 640,480.",
+                )
             try:
                 export_kwargs["imgsz"] = (int(parts[0]), int(parts[1]))
             except ValueError:
-                exit_with_error(out, "invalid_imgsz", f"Invalid imgsz values: {imgsz}. Use integer dimensions.")
+                exit_with_error(
+                    out,
+                    "invalid_imgsz",
+                    f"Invalid imgsz values: {imgsz}. Use integer dimensions.",
+                )
         else:
             try:
                 export_kwargs["imgsz"] = int(imgsz)
             except ValueError:
-                exit_with_error(out, "invalid_imgsz", f"Invalid imgsz: {imgsz}. Use e.g. 640 or 640,480.")
+                exit_with_error(
+                    out,
+                    "invalid_imgsz",
+                    f"Invalid imgsz: {imgsz}. Use e.g. 640 or 640,480.",
+                )
     if data is not None:
         export_kwargs["data"] = data
     if data is not None or int8:
@@ -185,7 +220,7 @@ def export_cmd(
 
     data_out = {
         "source_model": model,
-        "model_family": loaded_model.FAMILY,
+        "model_family": model_family,
         "format": fmt,
         "output_path": str(output_path),
         "file_size_mb": round(size_mb, 1),
@@ -197,7 +232,7 @@ def export_cmd(
 
     if not json_output:
         data_out["_human_text"] = (
-            f"Exported {loaded_model.FAMILY}-{loaded_model.size} to {fmt.upper()}: "
+            f"Exported {model_family}-{loaded_model.size} to {fmt.upper()}: "
             f"{output_path} ({size_mb:.1f} MB)\n"
             f"  Input: [{batch}, 3, {input_h}, {input_w}], "
             f"dynamic={dynamic}, half={half}, int8={int8}"

--- a/libreyolo/cli/commands/special.py
+++ b/libreyolo/cli/commands/special.py
@@ -256,7 +256,7 @@ def formats_cmd(
 ) -> None:
     """List supported export formats."""
     from libreyolo.export.exporter import BaseExporter
-    from libreyolo.export.support import get_support
+    from libreyolo.export.support import get_export_capabilities
     from libreyolo.models.inventory import collect_model_inventory
     from libreyolo.tasks import normalize_task
 
@@ -293,6 +293,7 @@ def formats_cmd(
             "extension": cls.suffix,
             "int8": cls.supports_int8,
             "fp16": cls.supports_fp16,
+            "dynamic": name in {"onnx", "tensorrt", "openvino"},
             "requires_onnx": cls.requires_onnx,
         }
         aliases = sorted(
@@ -301,10 +302,18 @@ def formats_cmd(
         if aliases:
             info["aliases"] = aliases
         if family is not None and selected_task is not None:
-            support = get_support(family, selected_task, name)
-            info["tier"] = support.tier
-            info["reason"] = support.reason
-            info["constraint"] = support.constraint
+            capabilities = get_export_capabilities(family, selected_task, name)
+            support = capabilities.support
+            info.update(
+                {
+                    "dynamic": capabilities.supports_dynamic,
+                    "fp16": capabilities.supports_fp16,
+                    "int8": capabilities.supports_int8,
+                    "tier": support.tier,
+                    "reason": support.reason,
+                    "constraint": support.constraint,
+                }
+            )
         formats.append(info)
 
     out = _get_output(json_output, quiet)
@@ -316,7 +325,8 @@ def formats_cmd(
             alias = f" (alias: {', '.join(f['aliases'])})" if f.get("aliases") else ""
             lines.append(f"  {f['name']}{alias}")
             lines.append(
-                f"    Extension: {f['extension']}, FP16: {f['fp16']}, INT8: {f['int8']}"
+                f"    Extension: {f['extension']}, Dynamic: {f['dynamic']}, "
+                f"FP16: {f['fp16']}, INT8: {f['int8']}"
             )
             if "tier" in f:
                 lines.append(f"    Tier: {f['tier']} ({f['reason']})")

--- a/libreyolo/export/__init__.py
+++ b/libreyolo/export/__init__.py
@@ -18,7 +18,34 @@ Example::
     model.export(format="tensorrt", half=True)
 """
 
-from .exporter import BaseExporter
-from .support import SupportEntry, get_support
+from .exporter import (
+    BaseExporter,
+    CoreMLExporter,
+    NcnnExporter,
+    OnnxExporter,
+    OpenVINOExporter,
+    TensorRTExporter,
+    TFLiteExporter,
+    TorchScriptExporter,
+)
+from .support import (
+    ExportCapabilities,
+    SupportEntry,
+    get_export_capabilities,
+    get_support,
+)
 
-__all__ = ["BaseExporter", "SupportEntry", "get_support"]
+__all__ = [
+    "BaseExporter",
+    "CoreMLExporter",
+    "ExportCapabilities",
+    "NcnnExporter",
+    "OnnxExporter",
+    "OpenVINOExporter",
+    "SupportEntry",
+    "TFLiteExporter",
+    "TensorRTExporter",
+    "TorchScriptExporter",
+    "get_export_capabilities",
+    "get_support",
+]

--- a/libreyolo/export/calibration.py
+++ b/libreyolo/export/calibration.py
@@ -245,12 +245,15 @@ class CalibrationDataLoader:
     def __iter__(self) -> Iterator[np.ndarray]:
         """Yield batches of calibration data as numpy arrays."""
         batch_data = []
+        padding_pool = []
         valid_samples = 0
 
         for img_path in self.img_files:
             try:
                 img = self._preprocess(img_path)
                 batch_data.append(img)
+                if len(padding_pool) < self.batch - 1:
+                    padding_pool.append(img)
                 valid_samples += 1
             except Exception as e:
                 logger.warning("Skipping %s: %s", img_path, e)
@@ -260,10 +263,15 @@ class CalibrationDataLoader:
                 yield np.stack(batch_data, axis=0)
                 batch_data = []
 
-        # Pad last batch to full size (required by TensorRT)
+        # Static calibration graphs require a full final batch. Cycle over a
+        # bounded pool of valid samples instead of repeating the tail image,
+        # which would give one sample disproportionate calibration weight.
         if batch_data:
-            while len(batch_data) < self.batch:
-                batch_data.append(batch_data[-1].copy())
+            missing = self.batch - len(batch_data)
+            batch_data.extend(
+                padding_pool[index % len(padding_pool)].copy()
+                for index in range(missing)
+            )
             yield np.stack(batch_data, axis=0)
         elif valid_samples == 0:
             raise RuntimeError(

--- a/libreyolo/export/calibration.py
+++ b/libreyolo/export/calibration.py
@@ -54,6 +54,10 @@ class CalibrationDataLoader:
         fraction: float = 1.0,
         preprocess_fn=None,
         allow_download_scripts: bool = False,
+        model_family: str | None = None,
+        task: str | None = None,
+        model_size: str | None = None,
+        input_shape: tuple[int, int, int, int] | None = None,
     ):
         """
         Initialize calibration data loader.
@@ -67,11 +71,45 @@ class CalibrationDataLoader:
             preprocess_fn: Callable ``(img_rgb_hwc, input_size) -> (chw_float32, ratio)``.
                 Obtained from ``model._get_preprocess_numpy()``.
             allow_download_scripts: Allow embedded Python in dataset YAML downloads.
+            model_family: Canonical family used to select task-specific runtime
+                preprocessing where the generic model callback is insufficient.
+            task: Export task used to select dense/pose runtime preprocessing.
+            model_size: Canonical model size (reserved for family runtime contracts).
+            input_shape: Concrete NCHW trace shape. Calibration samples are
+                validated against its CHW portion before batching.
         """
+        if int(batch) < 1:
+            raise ValueError(f"Calibration batch must be positive, got {batch}.")
         self.imgsz = imgsz
-        self.batch = batch
+        self.batch = int(batch)
         self.fraction = max(0.0, min(1.0, fraction))
         self._preprocess_fn = preprocess_fn
+        self.model_family = str(model_family or "").lower() or None
+        self.task = str(task or "").lower() or None
+        self.model_size = model_size
+
+        if input_shape is None:
+            input_h, input_w = _imgsz_hw(imgsz)
+            self.input_shape = (self.batch, 3, input_h, input_w)
+        else:
+            self.input_shape = tuple(int(dim) for dim in input_shape)
+            if len(self.input_shape) != 4 or any(dim <= 0 for dim in self.input_shape):
+                raise ValueError(
+                    "Calibration input_shape must be a positive NCHW tuple, got "
+                    f"{self.input_shape}."
+                )
+            if self.input_shape[0] != self.batch or self.input_shape[1] != 3:
+                raise ValueError(
+                    "Calibration input_shape must match batch and contain three "
+                    f"image channels, got batch={self.batch}, shape={self.input_shape}."
+                )
+        self._sample_shape = self.input_shape[1:]
+
+        if self._preprocess_fn is None and not self._uses_runtime_preprocessor:
+            raise ValueError(
+                "Calibration requires preprocess_fn for this model family/task so "
+                "samples match exported-runtime preprocessing."
+            )
 
         # Load dataset config (handles resolve, download, path resolution)
         data_config = load_data_config(
@@ -104,24 +142,116 @@ class CalibrationDataLoader:
         self.img_files = self.img_files[: self.num_samples]
         self._num_batches = (self.num_samples + self.batch - 1) // self.batch
 
+    @property
+    def _uses_runtime_preprocessor(self) -> bool:
+        return (
+            self.task == "depth"
+            or self.task == "restore"
+            or self.model_family in {"nafnet", "realesrgan", "swinir"}
+            or (self.model_family == "yolonas" and self.task == "pose")
+        )
+
+    def _coerce_sample(self, sample) -> np.ndarray:
+        """Convert a preprocessor result to one contiguous CHW float32 sample."""
+        if hasattr(sample, "detach"):
+            sample = sample.detach().cpu().numpy()
+        array = np.asarray(sample)
+        if array.ndim == 4 and array.shape[0] == 1:
+            array = array[0]
+        if array.ndim != 3:
+            raise ValueError(
+                "Calibration preprocessing must return CHW or 1xCHW data, got "
+                f"shape {array.shape}."
+            )
+        if tuple(array.shape) != tuple(self._sample_shape):
+            raise ValueError(
+                "Calibration preprocessing must match the exported runtime input "
+                f"shape {self._sample_shape}, got {tuple(array.shape)}."
+            )
+        return np.ascontiguousarray(array, dtype=np.float32)
+
+    def _preprocess_runtime(self, img_rgb: np.ndarray):
+        """Apply task-specific preprocessing used by exported backends."""
+        _, target_h, target_w = self._sample_shape
+        if self.task == "depth":
+            from libreyolo.backends.base import BaseBackend
+
+            tensor, *_ = BaseBackend._preprocess_depth(
+                img_rgb,
+                (target_h, target_w),
+                "rgb",
+            )
+            return tensor
+
+        if self.task == "restore" or self.model_family in {
+            "nafnet",
+            "realesrgan",
+            "swinir",
+        }:
+            from libreyolo.backends.base import BaseBackend
+
+            source_h, source_w = img_rgb.shape[:2]
+            if source_h > target_h or source_w > target_w:
+                scale = min(target_h / source_h, target_w / source_w)
+                resized_h = max(1, min(target_h, int(round(source_h * scale))))
+                resized_w = max(1, min(target_w, int(round(source_w * scale))))
+                img_rgb = cv2.resize(
+                    img_rgb,
+                    (resized_w, resized_h),
+                    interpolation=cv2.INTER_AREA,
+                )
+            tensor, *_ = BaseBackend._preprocess_restore(
+                img_rgb,
+                (target_h, target_w),
+                "rgb",
+            )
+            return tensor
+
+        if self.model_family == "yolonas" and self.task == "pose":
+            if target_h != target_w:
+                raise ValueError(
+                    "YOLO-NAS pose calibration requires a square runtime input, "
+                    f"got {(target_h, target_w)}."
+                )
+            from libreyolo.models.yolonas.utils import preprocess_pose_image
+
+            tensor, *_ = preprocess_pose_image(
+                img_rgb,
+                input_size=target_h,
+                color_format="rgb",
+            )
+            return tensor
+
+        raise RuntimeError("No built-in calibration runtime preprocessor selected.")
+
+    def _preprocess_array(self, img_rgb: np.ndarray) -> np.ndarray:
+        """Preprocess one RGB image and enforce the trace-time CHW contract."""
+        if self._uses_runtime_preprocessor:
+            result = self._preprocess_runtime(img_rgb)
+        else:
+            result = self._preprocess_fn(img_rgb, self.imgsz)
+            if isinstance(result, tuple):
+                result = result[0]
+        return self._coerce_sample(result)
+
     def _preprocess(self, img_path: Path) -> np.ndarray:
-        """Preprocess a single image using the model's ``preprocess_fn``."""
+        """Read and preprocess one calibration image."""
         img = cv2.imread(str(img_path))
         if img is None:
             raise FileNotFoundError(f"Cannot read image: {img_path}")
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-
-        result, _ = self._preprocess_fn(img_rgb, self.imgsz)
-        return result
+        return self._preprocess_array(img_rgb)
 
     def __iter__(self) -> Iterator[np.ndarray]:
         """Yield batches of calibration data as numpy arrays."""
         batch_data = []
+        valid_samples = 0
 
         for img_path in self.img_files:
             try:
                 img = self._preprocess(img_path)
                 batch_data.append(img)
+                valid_samples += 1
             except Exception as e:
                 logger.warning("Skipping %s: %s", img_path, e)
                 continue
@@ -135,6 +265,10 @@ class CalibrationDataLoader:
             while len(batch_data) < self.batch:
                 batch_data.append(batch_data[-1].copy())
             yield np.stack(batch_data, axis=0)
+        elif valid_samples == 0:
+            raise RuntimeError(
+                "No calibration images matched the exported runtime input contract."
+            )
 
     def __len__(self) -> int:
         """Return number of calibration batches."""
@@ -143,8 +277,11 @@ class CalibrationDataLoader:
     @property
     def shape(self) -> tuple:
         """Return shape of a single batch: (batch, channels, height, width)."""
-        h, w = _imgsz_hw(self.imgsz)
-        return (self.batch, 3, h, w)
+        sample_shape = getattr(self, "_sample_shape", None)
+        if sample_shape is None:
+            h, w = _imgsz_hw(self.imgsz)
+            sample_shape = (3, h, w)
+        return (self.batch, *sample_shape)
 
     @property
     def dtype(self) -> np.dtype:
@@ -159,6 +296,10 @@ def get_calibration_dataloader(
     fraction: float = 1.0,
     preprocess_fn=None,
     allow_download_scripts: bool = False,
+    model_family: str | None = None,
+    task: str | None = None,
+    model_size: str | None = None,
+    input_shape: tuple[int, int, int, int] | None = None,
 ) -> CalibrationDataLoader:
     """
     Factory function for calibration data loader.
@@ -169,15 +310,23 @@ def get_calibration_dataloader(
         batch: Batch size for calibration.
         fraction: Fraction of dataset to use.
         preprocess_fn: Callable ``(img_rgb_hwc, input_size) -> (chw_float32, ratio)``.
+        model_family: Canonical family for runtime preprocessing selection.
+        task: Export task for runtime preprocessing selection.
+        model_size: Canonical model size.
+        input_shape: Concrete NCHW trace shape used for per-sample validation.
 
     Returns:
         CalibrationDataLoader instance.
     """
     return CalibrationDataLoader(
-        data,
-        imgsz,
-        batch,
-        fraction,
-        preprocess_fn,
-        allow_download_scripts,
+        data=data,
+        imgsz=imgsz,
+        batch=batch,
+        fraction=fraction,
+        preprocess_fn=preprocess_fn,
+        allow_download_scripts=allow_download_scripts,
+        model_family=model_family,
+        task=task,
+        model_size=model_size,
+        input_shape=input_shape,
     )

--- a/libreyolo/export/coreml.py
+++ b/libreyolo/export/coreml.py
@@ -13,6 +13,7 @@ Family conventions, mapped by the wrapper:
 
 from __future__ import annotations
 
+import copy
 import json
 from typing import Any
 
@@ -299,6 +300,13 @@ def export_coreml(
             "(DETR set-prediction). Export with nms=False and run NMS in your "
             "application."
         )
+
+    # RT-DETR's fixed-shape preparation replaces registered anchor tensors and
+    # creates resolution-specific encoder attributes.  Prepare an isolated
+    # copy so a successful export -- or an exception partway through setup --
+    # cannot mutate the caller's live module tree.
+    if family == "rtdetr":
+        nn_model = copy.deepcopy(nn_model)
 
     yolo9_restore = None
     if family == "rtdetr":

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -513,7 +513,12 @@ class BaseExporter(ABC):
             raise NotImplementedError(
                 f"{self.format_name.upper()} INT8 export is not supported."
             )
-        if int8 and data is None and not self.default_int8_calibration_data:
+        if (
+            available
+            and int8
+            and data is None
+            and not self.default_int8_calibration_data
+        ):
             raise ValueError("INT8 export requires calibration data. Pass data=...")
         return half, int8
 

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -25,7 +25,7 @@ from .onnx import (
     quantize_onnx_int8,
 )
 from .torchscript import export_torchscript
-from .support import get_support, validated_alternatives
+from .support import get_export_capabilities, validated_alternatives
 from ..tasks import task_to_suffix
 from ..utils.serialization import SCHEMA_VERSION
 
@@ -307,6 +307,8 @@ class BaseExporter(ABC):
             Path to the exported model file.
         """
         task = getattr(self.model, "task", "detect")
+        if not isinstance(task, str):
+            task = "detect"
         if task == "depth":
             # Depth export uses the fixed-resolution dense contract: backends
             # stretch-resize to the exported canvas and resize the depth map
@@ -348,6 +350,20 @@ class BaseExporter(ABC):
             warnings.warn(
                 "Matte export uses a fixed-resolution runtime contract "
                 "(native 1024); forcing dynamic=False.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            dynamic = False
+        family = self.model._get_model_name()
+        capabilities = get_export_capabilities(family, task, self.format_name)
+        if (
+            dynamic
+            and capabilities.support.tier != "blocked"
+            and not capabilities.supports_dynamic
+        ):
+            warnings.warn(
+                f"{self.format_name.upper()} export uses a static input graph; "
+                "forcing dynamic=False.",
                 RuntimeWarning,
                 stacklevel=2,
             )
@@ -400,6 +416,7 @@ class BaseExporter(ABC):
                         batch,
                         fraction,
                         allow_download_scripts,
+                        input_shape=tuple(int(dim) for dim in dummy.shape),
                     )
                     if int8 and data is not None
                     else None
@@ -481,13 +498,76 @@ class BaseExporter(ABC):
                 stacklevel=2,
             )
             half = False
-        if int8 and not self.supports_int8:
+        task = getattr(self.model, "task", "detect")
+        if not isinstance(task, str):
+            task = "detect"
+        capabilities = get_export_capabilities(
+            self.model._get_model_name(),
+            task,
+            self.format_name,
+        )
+        available = capabilities.support.tier != "blocked"
+        if half and available and not capabilities.supports_fp16:
+            raise NotImplementedError(
+                f"{self.format_name.upper()} FP16 export is not supported."
+            )
+        if int8 and available and not capabilities.supports_int8:
             raise NotImplementedError(
                 f"{self.format_name.upper()} INT8 export is not supported."
             )
         if int8 and data is None and not self.default_int8_calibration_data:
             raise ValueError("INT8 export requires calibration data. Pass data=...")
         return half, int8
+
+    def _classification_runtime_metadata(self) -> dict:
+        """Return the complete exported-classifier preprocessing contract."""
+        task = getattr(self.model, "task", "detect")
+        if task != "classify":
+            return {}
+
+        from ..data.classify_dataset import IMAGENET_MEAN, IMAGENET_STD
+
+        def _triplet(value, default):
+            if not isinstance(value, (list, tuple)) or len(value) != 3:
+                return tuple(float(item) for item in default)
+            try:
+                return tuple(float(item) for item in value)
+            except (TypeError, ValueError):
+                return tuple(float(item) for item in default)
+
+        mean = _triplet(
+            getattr(self.model, "classification_mean", None),
+            IMAGENET_MEAN,
+        )
+        std = _triplet(
+            getattr(self.model, "classification_std", None),
+            IMAGENET_STD,
+        )
+        crop_pct = getattr(self.model, "crop_pct", 0.875)
+        if not isinstance(crop_pct, (int, float)):
+            crop_pct = 0.875
+        interpolation = getattr(self.model, "interpolation", "bilinear")
+        if not isinstance(interpolation, str):
+            interpolation = getattr(interpolation, "value", "bilinear")
+        interpolation = str(interpolation).lower()
+        square_resize = getattr(self.model, "classification_square_resize", False)
+        if not isinstance(square_resize, bool):
+            square_resize = False
+        activation = getattr(self.model, "classification_activation", "softmax")
+        if not isinstance(activation, str) or activation.lower() not in {
+            "softmax",
+            "sigmoid",
+        }:
+            activation = "softmax"
+
+        return {
+            "classification_mean": list(mean),
+            "classification_std": list(std),
+            "classification_crop_pct": float(crop_pct),
+            "classification_interpolation": interpolation,
+            "classification_square_resize": square_resize,
+            "classification_activation": activation.lower(),
+        }
 
     def _resolve_calibration_data(
         self, int8: bool, data: Optional[str]
@@ -509,7 +589,11 @@ class BaseExporter(ABC):
         task = getattr(self.model, "task", "detect")
         if not isinstance(task, str):
             task = "detect"
-        support = get_support(family, task, self.format_name)
+        support = get_export_capabilities(
+            family,
+            task,
+            self.format_name,
+        ).support
         if support.tier == "blocked":
             alternatives = validated_alternatives(family, task)
             alternatives_text = (
@@ -674,8 +758,134 @@ class BaseExporter(ABC):
         return f"-{suffix}" if suffix else ""
 
     @contextmanager
+    def _preserve_live_model_state(self, *, restore_values: bool):
+        """Restore the user's live module exactly after an export attempt.
+
+        Export setup temporarily changes device, precision, and evaluation
+        modes.  Module-level ``train()`` restoration is insufficient for a
+        mixed train/eval tree, and casting a mixed-precision model back with
+        ``float()`` loses both dtypes and values.  Snapshot the owning slots so
+        replaced buffers/parameters and existing gradients are restored too.
+        Tensor values only need cloning when an FP16 trace can round them.
+        """
+        root_model = self.model.model
+        module_modes = [
+            (module, bool(module.training)) for module in root_model.modules()
+        ]
+        attribute_states = []
+        for module in root_model.modules():
+            for name in (
+                "export",
+                "_export",
+                "_forward_origin",
+                "shape",
+                "forward",
+                "interpolate_pos_encoding",
+            ):
+                had_own_value = name in module.__dict__
+                attribute_states.append(
+                    (
+                        module,
+                        name,
+                        had_own_value,
+                        module.__dict__.get(name),
+                    )
+                )
+        tensor_states = []
+        for module in root_model.modules():
+            for kind, slots in (
+                ("parameter", module._parameters),
+                ("buffer", module._buffers),
+            ):
+                for name, tensor in slots.items():
+                    if tensor is None:
+                        continue
+                    value = tensor.detach().clone() if restore_values else None
+                    grad = tensor.grad if kind == "parameter" else None
+                    grad_value = (
+                        grad.detach().clone()
+                        if restore_values and grad is not None
+                        else None
+                    )
+                    tensor_states.append(
+                        (
+                            module,
+                            kind,
+                            name,
+                            tensor,
+                            tensor.device,
+                            tensor.dtype,
+                            value,
+                            grad,
+                            grad.device if grad is not None else None,
+                            grad.dtype if grad is not None else None,
+                            grad_value,
+                        )
+                    )
+        try:
+            yield
+        finally:
+            with torch.no_grad():
+                for (
+                    module,
+                    kind,
+                    name,
+                    original,
+                    device,
+                    dtype,
+                    value,
+                    original_grad,
+                    grad_device,
+                    grad_dtype,
+                    grad_value,
+                ) in tensor_states:
+                    slots = (
+                        module._parameters if kind == "parameter" else module._buffers
+                    )
+                    slots[name] = original
+                    restored = value if value is not None else original.detach()
+                    original.data = restored.to(device=device, dtype=dtype)
+                    if kind == "parameter":
+                        if original_grad is None:
+                            original.grad = None
+                        else:
+                            restored_grad = (
+                                grad_value
+                                if grad_value is not None
+                                else original_grad.detach()
+                            )
+                            original_grad.data = restored_grad.to(
+                                device=grad_device,
+                                dtype=grad_dtype,
+                            )
+                            original.grad = original_grad
+            for module, name, had_own_value, value in attribute_states:
+                if had_own_value:
+                    setattr(module, name, value)
+                else:
+                    module.__dict__.pop(name, None)
+            # Assign the flag directly: Module.train() recursively overwrites
+            # child modes and cannot reproduce a deliberately mixed-mode tree.
+            for module, training in module_modes:
+                module.training = training
+
+    @contextmanager
     def _model_context(self, device, half, int8, batch, imgsz):
-        """Setup model for export and restore state afterwards."""
+        """Setup model for export while preserving the live model exactly."""
+        restore_values = bool(half and not int8 and self.apply_model_half)
+        with self._preserve_live_model_state(restore_values=restore_values):
+            with self._model_context_impl(
+                device,
+                half,
+                int8,
+                batch,
+                imgsz,
+            ) as prepared:
+                yield prepared
+
+    @contextmanager
+    def _model_context_impl(self, device, half, int8, batch, imgsz):
+        """Prepare the trace module; the outer context restores live state."""
         nn_model = self.model.model
         root_model = nn_model
         original_training = root_model.training
@@ -869,6 +1079,8 @@ class BaseExporter(ABC):
         batch,
         fraction,
         allow_download_scripts=False,
+        *,
+        input_shape=None,
     ):
         from .calibration import get_calibration_dataloader
 
@@ -880,6 +1092,10 @@ class BaseExporter(ABC):
             fraction=fraction,
             preprocess_fn=preprocess_fn,
             allow_download_scripts=allow_download_scripts,
+            model_family=self.model._get_model_name(),
+            task=getattr(self.model, "task", "detect"),
+            model_size=getattr(self.model, "size", None),
+            input_shape=input_shape,
         )
         logger.info(
             "Calibration dataset: %d batches, %d images",
@@ -956,6 +1172,13 @@ class BaseExporter(ABC):
         }
         if onnx_path is not None:
             meta["exported_from"] = str(Path(onnx_path).name)
+        classification_meta = self._classification_runtime_metadata()
+        if classification_meta:
+            meta.update(classification_meta)
+            # Transitional aliases read by artifacts from the earlier, partial
+            # classifier metadata contract.
+            meta["crop_pct"] = classification_meta["classification_crop_pct"]
+            meta["interpolation"] = classification_meta["classification_interpolation"]
         if task == "pose":
             meta.update(_pose_keypoint_shape_metadata(self.model))
         if task == "gaze":
@@ -1016,14 +1239,35 @@ class BaseExporter(ABC):
             ).lower(),
             "obb": str(task == "obb").lower(),
         }
-        # Classification eval preprocessing — lets exported-backend inference
-        # match native predict()/val() (per-family crop_pct + interpolation).
-        _crop_pct = getattr(self.model, "crop_pct", None)
-        _interp = getattr(self.model, "interpolation", None)
-        if _crop_pct is not None:
-            meta["crop_pct"] = str(_crop_pct)
-        if _interp is not None:
-            meta["interpolation"] = str(_interp)
+        classification_meta = self._classification_runtime_metadata()
+        if classification_meta:
+            meta.update(
+                {
+                    "classification_mean": json.dumps(
+                        classification_meta["classification_mean"]
+                    ),
+                    "classification_std": json.dumps(
+                        classification_meta["classification_std"]
+                    ),
+                    "classification_crop_pct": str(
+                        classification_meta["classification_crop_pct"]
+                    ),
+                    "classification_interpolation": classification_meta[
+                        "classification_interpolation"
+                    ],
+                    "classification_square_resize": str(
+                        classification_meta["classification_square_resize"]
+                    ).lower(),
+                    "classification_activation": classification_meta[
+                        "classification_activation"
+                    ],
+                    # Legacy aliases retained for older backend readers.
+                    "crop_pct": str(classification_meta["classification_crop_pct"]),
+                    "interpolation": classification_meta[
+                        "classification_interpolation"
+                    ],
+                }
+            )
         if task == "pose":
             pose_meta = _pose_keypoint_shape_metadata(self.model)
             meta.update(
@@ -1100,6 +1344,7 @@ class OnnxExporter(BaseExporter):
     default_int8_calibration_data = True
 
     def _preflight(self, *, half: bool, int8: bool, data: Optional[str], **kwargs):
+        super()._preflight(half=half, int8=int8, data=data, **kwargs)
         if int8:
             task = getattr(self.model, "task", "detect")
             if not isinstance(task, str):
@@ -1118,7 +1363,6 @@ class OnnxExporter(BaseExporter):
                     "Embedded NMS ONNX export currently supports YOLO9 "
                     "detection models only."
                 )
-        super()._preflight(half=half, int8=int8, data=data, **kwargs)
 
     def _export(
         self,
@@ -1256,6 +1500,24 @@ class TensorRTExporter(BaseExporter):
     supports_fp16 = True
     apply_model_half = False
 
+    def __call__(self, *args, trt_config=None, **kwargs):
+        # Resolve graph-affecting config before the intermediate ONNX is traced.
+        # The low-level TensorRT builder loads the same config for workspace,
+        # profile bounds, device, and hardware compatibility.
+        if trt_config is not None:
+            from .config import load_export_config
+
+            config = load_export_config(trt_config)
+            kwargs.update(
+                {
+                    "dynamic": bool(config.dynamic.enabled),
+                    "half": bool(config.half),
+                    "int8": bool(config.int8),
+                    "verbose": bool(config.verbose),
+                }
+            )
+        return super().__call__(*args, trt_config=trt_config, **kwargs)
+
     def _preflight(self, **kwargs):
         super()._preflight(**kwargs)
         from .tensorrt import check_tensorrt_available
@@ -1314,6 +1576,7 @@ class TensorRTExporter(BaseExporter):
             device=gpu_device,
             config=trt_config,
             metadata=trt_metadata,
+            input_shape=tuple(int(dim) for dim in dummy.shape),
         )
 
 
@@ -1468,6 +1731,7 @@ class CoreMLExporter(BaseExporter):
     supports_embedded_nms = True
 
     def _preflight(self, *, half: bool, int8: bool, data: Optional[str], **kwargs):
+        super()._preflight(half=half, int8=int8, data=data, **kwargs)
         if kwargs.get("nms"):
             family = self.model._get_model_name()
             task = getattr(self.model, "task", "detect")
@@ -1488,7 +1752,6 @@ class CoreMLExporter(BaseExporter):
                     "CoreML embedded NMS does not support max_det. "
                     "Use ONNX embedded NMS when max_det control is required."
                 )
-        super()._preflight(half=half, int8=int8, data=data, **kwargs)
 
     def _build_metadata(self, precision, dynamic, onnx_path, imgsz=None):
         # CoreML uses a hard-fixed ct.ImageType(shape=...); the exported graph

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -13,6 +13,7 @@ import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Optional, Tuple, Union
 
 import torch
@@ -404,7 +405,7 @@ class BaseExporter(ABC):
         precision = _resolve_precision(half, int8)
         onnx_path = None
 
-        try:
+        with self._intermediate_onnx_workspace(output_path) as intermediate_output:
             with self._model_context(device, half, int8, batch, imgsz) as (
                 nn_model,
                 dummy,
@@ -426,7 +427,7 @@ class BaseExporter(ABC):
                     self._export_intermediate_onnx(
                         nn_model,
                         dummy,
-                        output_path,
+                        intermediate_output,
                         opset,
                         simplify,
                         dynamic,
@@ -458,9 +459,6 @@ class BaseExporter(ABC):
                     verbose=verbose,
                     **kwargs,
                 )
-        finally:
-            if onnx_path and Path(onnx_path).exists():
-                Path(onnx_path).unlink()
 
         self._print_summary(result, precision, imgsz)
         return result
@@ -1107,9 +1105,8 @@ class BaseExporter(ABC):
     def _export_intermediate_onnx(
         self, nn_model, dummy, output_path, opset, simplify, dynamic
     ):
-        # Use a distinct intermediate name so it never collides with (and the
-        # finally-block cleanup never deletes) a real ONNX export the user may
-        # have written to the default ``<stem>.onnx`` path.
+        # Keep a recognizable name inside the invocation-owned workspace.
+        # Workspace isolation prevents collisions with user-owned ONNX files.
         out = Path(output_path)
         onnx_output = str(out.with_name(f"{out.stem}.export_intermediate.onnx"))
         logger.info("Step 1/2: Exporting to ONNX (%s)", onnx_output)
@@ -1127,6 +1124,19 @@ class BaseExporter(ABC):
                 imgsz=(dummy.shape[-2], dummy.shape[-1]),
             ),
         )
+
+    @contextmanager
+    def _intermediate_onnx_workspace(self, output_path):
+        """Yield an invocation-owned output path for intermediate ONNX files."""
+        if not self.requires_onnx:
+            yield output_path
+            return
+
+        output = Path(output_path)
+        with TemporaryDirectory(
+            prefix="libreyolo-export-", dir=output.parent
+        ) as workspace:
+            yield str(Path(workspace) / output.name)
 
     def _build_metadata(
         self,

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -1531,6 +1531,12 @@ class TensorRTExporter(BaseExporter):
                     "verbose": bool(config.verbose),
                 }
             )
+            trace_device = kwargs.get("device")
+            if trace_device is None or str(trace_device).lower() == "auto":
+                # One TensorRT config device governs both ONNX tracing and the
+                # engine build; otherwise a GPU-1 graph could silently be built
+                # under GPU 0's CUDA context.
+                kwargs["device"] = int(config.device)
         return super().__call__(*args, trt_config=trt_config, **kwargs)
 
     def _preflight(self, **kwargs):
@@ -1558,11 +1564,63 @@ class TensorRTExporter(BaseExporter):
         opt_batch=1,
         max_batch=8,
         hardware_compatibility="none",
-        gpu_device=0,
+        gpu_device=None,
         trt_config=None,
         **kwargs,
     ):
         from .tensorrt import export_tensorrt
+
+        dummy_device = torch.device(dummy.device)
+        traced_gpu = None
+        if dummy_device.type == "cuda":
+            traced_gpu = dummy_device.index
+            if traced_gpu is None:
+                traced_gpu = torch.cuda.current_device()
+
+        def normalize_gpu(value):
+            if isinstance(value, bool):
+                raise ValueError(
+                    "TensorRT gpu_device must be a non-negative integer, got "
+                    f"{value!r}."
+                )
+            try:
+                if isinstance(value, str):
+                    if not value.strip().isdigit():
+                        raise ValueError
+                    index = int(value.strip())
+                else:
+                    index = value.__index__()
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    "TensorRT gpu_device must be a non-negative integer, got "
+                    f"{value!r}."
+                ) from exc
+            if index < 0:
+                raise ValueError(
+                    f"TensorRT gpu_device must be non-negative, got {index}."
+                )
+            return index
+
+        configured_gpu = None
+        if trt_config is not None:
+            from .config import load_export_config
+
+            configured_gpu = int(load_export_config(trt_config).device)
+            if gpu_device is not None and normalize_gpu(gpu_device) != configured_gpu:
+                raise ValueError(
+                    "TensorRT config and gpu_device must select the same build "
+                    f"device, got cuda:{configured_gpu} and cuda:{gpu_device}."
+                )
+        requested_gpu = configured_gpu if configured_gpu is not None else gpu_device
+        if requested_gpu is None:
+            requested_gpu = traced_gpu if traced_gpu is not None else 0
+        requested_gpu = normalize_gpu(requested_gpu)
+        if traced_gpu is not None and requested_gpu != traced_gpu:
+            raise ValueError(
+                "TensorRT trace and build devices must match: the ONNX graph was "
+                f"traced on cuda:{traced_gpu}, but the engine requested "
+                f"cuda:{requested_gpu}."
+            )
 
         trt_metadata = dict(metadata or {})
         if dynamic:
@@ -1588,7 +1646,7 @@ class TensorRTExporter(BaseExporter):
             opt_batch=opt_batch,
             max_batch=max_batch,
             hardware_compatibility=hardware_compatibility,
-            device=gpu_device,
+            device=requested_gpu,
             config=trt_config,
             metadata=trt_metadata,
             input_shape=tuple(int(dim) for dim in dummy.shape),

--- a/libreyolo/export/ncnn.py
+++ b/libreyolo/export/ncnn.py
@@ -1,6 +1,7 @@
 """ncnn export implementation via PNNX."""
 
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
@@ -10,6 +11,20 @@ from typing import Optional
 import yaml
 
 logger = logging.getLogger(__name__)
+
+
+def _is_missing_optional_pnnx_loader(exc: FileNotFoundError, traced_path: Path) -> bool:
+    """Return whether PNNX failed to load its optional generated Python helper."""
+    loader_name = f"{traced_path.stem}_pnnx.py"
+    filenames = [
+        value
+        for value in (getattr(exc, "filename", None), getattr(exc, "filename2", None))
+        if value is not None
+    ]
+    if filenames:
+        return any(Path(str(value)).name == loader_name for value in filenames)
+    pattern = rf"(?<![A-Za-z0-9_.-]){re.escape(loader_name)}(?![A-Za-z0-9_.-])"
+    return re.search(pattern, str(exc)) is not None
 
 
 def check_ncnn_export_available() -> None:
@@ -125,6 +140,22 @@ def _export_pnnx_direct(nn_model, dummy, output_dir: Path, half: bool):
                 "were written; using the completed artifacts: %s",
                 exc,
             )
+        except FileNotFoundError as exc:
+            # Some PNNX wheels remove or fail to import their generated
+            # ``<trace>_pnnx.py`` inspection helper after conversion. This is
+            # safe to ignore only for that exact helper and only when the
+            # matching deployable artifact pair is already present.
+            if (
+                not _is_missing_optional_pnnx_loader(exc, temp_pt)
+                or not src_param.is_file()
+                or not src_bin.is_file()
+            ):
+                raise
+            logger.warning(
+                "PNNX optional loader was unavailable after NCNN artifacts "
+                "were written; using the completed artifacts: %s",
+                exc,
+            )
 
         if not src_param.exists() or not src_bin.exists():
             # PNNX may use different naming; search for .ncnn.param/.ncnn.bin
@@ -216,7 +247,7 @@ def _save_metadata(output_dir: Path, metadata: dict) -> None:
     """Save metadata.yaml for ncnn model."""
     metadata_path = output_dir / "metadata.yaml"
     with open(metadata_path, "w") as f:
-        yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
+        yaml.safe_dump(metadata, f, default_flow_style=False, sort_keys=False)
     logger.info("Saved metadata: %s", metadata_path)
 
 
@@ -242,7 +273,8 @@ def export_ncnn(
         nn_model: PyTorch model (nn.Module) in eval mode.
         dummy: Dummy input tensor for tracing.
         output_path: Output directory for ncnn model files.
-        half: Export in FP16 precision (default: False).
+        half: Reserved compatibility flag. ``True`` is rejected because the
+            current PNNX path does not produce a distinct FP16 artifact.
         opset: ONNX opset version for fallback path (default: 13).
         simplify: Simplify ONNX graph in fallback path (default: True).
         metadata: Optional dict of model metadata to save as metadata.yaml.
@@ -251,9 +283,14 @@ def export_ncnn(
         Path to exported ncnn model directory.
 
     Raises:
+        NotImplementedError: If ``half=True`` is requested.
         ImportError: If pnnx is not installed.
         RuntimeError: If both direct and fallback export paths fail.
     """
+    if half:
+        raise NotImplementedError(
+            "NCNN FP16 export is not supported; omit half=True for FP32."
+        )
     check_ncnn_export_available()
 
     output_dir = Path(output_path)

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -80,7 +80,7 @@ def _should_skip_onnx_simplify() -> bool:
     )
 
 
-def _postprocess_onnx(
+def finalize_onnx_artifact(
     path: str,
     *,
     simplify: bool,
@@ -88,7 +88,12 @@ def _postprocess_onnx(
     half: bool,
     metadata: dict,
 ) -> None:
-    """Load the ONNX file, optionally simplify, embed metadata, and save."""
+    """Validate and finalize an ONNX artifact with shared LibreYOLO metadata.
+
+    Custom-family exporters use this after tracing so simplification, metadata
+    replacement, checker validation, and the macOS-arm safety guard stay
+    identical to the unified exporter path.
+    """
     try:
         import onnx
     except ImportError:
@@ -128,6 +133,11 @@ def _postprocess_onnx(
 
     onnx.checker.check_model(model_proto)
     onnx.save(model_proto, path)
+
+
+# Backward-compatible private alias for callers inside this module. New custom
+# exporters should use the public helper above.
+_postprocess_onnx = finalize_onnx_artifact
 
 
 def _detect_num_outputs(nn_model, dummy):

--- a/libreyolo/export/openvino.py
+++ b/libreyolo/export/openvino.py
@@ -63,7 +63,7 @@ def _save_metadata(output_dir: Path, metadata: dict) -> None:
     """Save metadata.yaml for OpenVINO model."""
     metadata_path = output_dir / "metadata.yaml"
     with open(metadata_path, "w") as f:
-        yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
+        yaml.safe_dump(metadata, f, default_flow_style=False, sort_keys=False)
     logger.info("Saved metadata: %s", metadata_path)
 
 

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterator, Literal
 
+from ..models.manifest import get_family_spec
 from ..tasks import TASKS
 
 
@@ -28,6 +29,28 @@ class SupportEntry:
     reason: str = ""
     since: str | None = None
     constraint: str | None = None
+
+
+@dataclass(frozen=True)
+class ExportCapabilities:
+    """Effective option support for one family, task, and export format."""
+
+    support: SupportEntry
+    supports_dynamic: bool
+    supports_fp16: bool
+    supports_int8: bool
+
+
+_FORMAT_CAPABILITIES: dict[str, tuple[bool, bool, bool]] = {
+    # format: (dynamic input, FP16, INT8)
+    "onnx": (True, True, True),
+    "torchscript": (False, True, False),
+    "tensorrt": (True, True, True),
+    "openvino": (True, True, True),
+    "ncnn": (False, False, False),
+    "tflite": (False, False, False),
+    "coreml": (False, True, False),
+}
 
 
 SUPPORT: dict[tuple[str, str, str], SupportEntry] = {}
@@ -709,6 +732,13 @@ def get_support(family: str, task: str, fmt: str) -> SupportEntry:
     exact = SUPPORT.get((family, task, fmt))
     if exact is not None:
         return exact
+    family_spec = get_family_spec(family)
+    if family_spec is not None:
+        declared_tasks = {item.task for item in family_spec.tasks}
+        if task not in declared_tasks:
+            return SupportEntry(
+                "blocked", f"{family!r} does not declare the canonical task {task!r}."
+            )
     if family in _FAMILY_BLOCKS:
         return SupportEntry("blocked", _FAMILY_BLOCKS[family])
     if task in _TASK_BLOCKS:
@@ -720,6 +750,11 @@ def get_support(family: str, task: str, fmt: str) -> SupportEntry:
             f"NCNN export is not supported for {label}: the model requires decoder "
             "or sampling operations unavailable in NCNN. "
             "Use ONNX, OpenVINO, TorchScript, or TensorRT instead.",
+        )
+    if family_spec is not None and family_spec.export_override == "blocked":
+        return SupportEntry(
+            "blocked",
+            f"{family!r} declares export as blocked in the public model manifest.",
         )
     if fmt in {"tensorrt", "openvino"}:
         runtime = "TensorRT" if fmt == "tensorrt" else "OpenVINO"
@@ -741,6 +776,42 @@ def get_support(family: str, task: str, fmt: str) -> SupportEntry:
     return SupportEntry(
         "experimental",
         "This combination exports without a numeric parity guarantee.",
+    )
+
+
+def get_export_capabilities(family: str, task: str, fmt: str) -> ExportCapabilities:
+    """Return family-aware option support for an export combination.
+
+    Format-level capability flags are narrowed by the canonical support matrix.
+    ONNX INT8 is currently implemented only for YOLO9 detection, even though the
+    ONNX exporter also supports FP16 and dynamic shapes for other families.
+    """
+    normalized_family = str(family or "").lower()
+    normalized_task = str(task or "detect").lower()
+    normalized_format = str(fmt or "").lower()
+    support = get_support(normalized_family, normalized_task, normalized_format)
+    format_capabilities = _FORMAT_CAPABILITIES.get(
+        normalized_format, (False, False, False)
+    )
+    available = support.tier != "blocked"
+    supports_dynamic, supports_fp16, supports_int8 = format_capabilities
+    if normalized_task in {"depth", "matte"} or (
+        normalized_task == "restore" and normalized_family != "realesrgan"
+    ):
+        supports_dynamic = False
+    if (normalized_family, normalized_task) in {
+        ("clip", "classify"),
+        ("siglip2", "classify"),
+        ("picosam3", "segment"),
+    }:
+        supports_fp16 = False
+    if normalized_format == "onnx":
+        supports_int8 = normalized_family == "yolo9" and normalized_task == "detect"
+    return ExportCapabilities(
+        support=support,
+        supports_dynamic=available and supports_dynamic,
+        supports_fp16=available and supports_fp16,
+        supports_int8=available and supports_int8,
     )
 
 
@@ -774,10 +845,12 @@ def validated_alternatives(family: str, task: str) -> tuple[str, ...]:
 
 __all__ = [
     "EXPORT_FORMATS",
+    "ExportCapabilities",
     "SUPPORT",
     "SupportEntry",
     "Tier",
     "get_support",
+    "get_export_capabilities",
     "iter_blocked",
     "iter_entries",
     "iter_validated",

--- a/libreyolo/export/tensorrt.py
+++ b/libreyolo/export/tensorrt.py
@@ -51,7 +51,7 @@ def _create_calibrator_class():
             def __init__(self, data_loader, cache_file="calibration.cache"):
                 super().__init__()
                 self.data_loader = data_loader
-                self.cache_file = Path(cache_file)
+                self.cache_file = Path(cache_file) if cache_file else None
                 self.batch_iter = None
                 self._device_input = None
                 self._batch_size = data_loader.batch
@@ -124,14 +124,17 @@ def _create_calibrator_class():
                         pass  # pycuda frees via its own DeviceAllocation.__del__
 
             def read_calibration_cache(self):
-                if self.cache_file.exists():
+                if self.cache_file is not None and self.cache_file.exists():
                     logger.info("Loading calibration cache: %s", self.cache_file)
                     with open(self.cache_file, "rb") as f:
                         return f.read()
                 return None
 
             def write_calibration_cache(self, cache):
+                if self.cache_file is None:
+                    return
                 logger.info("Saving calibration cache: %s", self.cache_file)
+                self.cache_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(self.cache_file, "wb") as f:
                     f.write(cache)
 
@@ -146,6 +149,168 @@ def _create_calibrator_class():
 def get_calibrator_class():
     """Get the appropriate calibrator class based on TensorRT availability."""
     return _create_calibrator_class()
+
+
+def _validate_batch_profile(min_batch: int, opt_batch: int, max_batch: int) -> None:
+    """Validate TensorRT's ordered, positive dynamic-batch profile bounds."""
+    if not (1 <= min_batch <= opt_batch <= max_batch):
+        raise ValueError(
+            "TensorRT dynamic batch bounds must satisfy "
+            "1 <= min_batch <= opt_batch <= max_batch, got "
+            f"{min_batch}, {opt_batch}, {max_batch}."
+        )
+
+
+def _resolve_hardware_compatibility_level(trt, requested: str):
+    """Resolve a TensorRT compatibility enum without assuming API availability."""
+    levels = getattr(trt, "HardwareCompatibilityLevel", None)
+    if levels is None:
+        return None
+    attribute = {
+        "ampere_plus": "AMPERE_PLUS",
+        "same_compute_capability": "SAME_COMPUTE_CAPABILITY",
+    }.get(requested)
+    return getattr(levels, attribute, None) if attribute is not None else None
+
+
+def _select_tensorrt_device(device: int) -> int:
+    """Select the requested CUDA device before creating TensorRT objects."""
+    try:
+        index = int(device)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"TensorRT device must be a non-negative integer, got {device!r}.") from exc
+    if index < 0:
+        raise ValueError(f"TensorRT device must be non-negative, got {index}.")
+    if not torch.cuda.is_available():
+        raise RuntimeError("TensorRT export requires a CUDA-capable GPU.")
+    if index >= torch.cuda.device_count():
+        raise ValueError(
+            f"TensorRT CUDA device index {index} is unavailable; "
+            f"detected {torch.cuda.device_count()} CUDA device(s)."
+        )
+    torch.cuda.set_device(index)
+    logger.info("Using GPU device: %d (%s)", index, torch.cuda.get_device_name(index))
+    return index
+
+
+def _calibration_cache_fingerprint(calibration_data) -> str | None:
+    """Hash exact preprocessed batches, disabling reuse if they are not stable."""
+    try:
+        if iter(calibration_data) is calibration_data:
+            return None
+    except TypeError:
+        return None
+
+    def hash_pass() -> str | None:
+        digest = hashlib.sha256()
+        count = 0
+        try:
+            for batch in calibration_data:
+                array = np.ascontiguousarray(np.asarray(batch))
+                if array.size == 0 or array.dtype.hasobject:
+                    return None
+                digest.update(array.dtype.str.encode("ascii"))
+                digest.update(json.dumps(array.shape).encode("ascii"))
+                digest.update(array.tobytes())
+                count += 1
+        except Exception:
+            return None
+        return digest.hexdigest() if count else None
+
+    first = hash_pass()
+    second = hash_pass()
+    return first if first is not None and first == second else None
+
+
+def _calibration_cache_path(
+    output_path: str | Path,
+    onnx_data: bytes,
+    calibration_data,
+    *,
+    enabled: bool,
+) -> Path | None:
+    """Return a cache path keyed by both graph and calibration identity."""
+    if not enabled:
+        return None
+    calibration_hash = _calibration_cache_fingerprint(calibration_data)
+    if calibration_hash is None:
+        return None
+    digest = hashlib.sha256(onnx_data)
+    digest.update(calibration_hash.encode("ascii"))
+    cache_out = Path(output_path)
+    return cache_out.with_name(f"{cache_out.stem}.{digest.hexdigest()[:16]}.cache")
+
+
+def _validate_dynamic_calibration_contract(
+    calibration_data,
+    *,
+    int8: bool,
+    dynamic: bool,
+    opt_batch: int,
+    traced_shape: tuple[int, ...] | None,
+) -> None:
+    """Require TensorRT dynamic INT8 calibration to use the OPT batch-1 shape."""
+    if not int8 or not dynamic:
+        return
+    if calibration_data is None:
+        raise ValueError("INT8 quantization requires calibration data.")
+    try:
+        calibration_shape = tuple(int(dim) for dim in calibration_data.shape)
+        calibration_batch = int(calibration_data.batch)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "Dynamic TensorRT INT8 calibration requires a loader with batch and "
+            "NCHW shape metadata."
+        ) from exc
+    if opt_batch != 1 or calibration_batch != 1 or calibration_shape[0] != 1:
+        raise ValueError(
+            "Dynamic TensorRT INT8 calibration requires opt_batch=1 and a "
+            f"batch-1 calibration loader, got opt_batch={opt_batch}, "
+            f"loader batch={calibration_batch}, shape={calibration_shape}."
+        )
+    if traced_shape is not None and calibration_shape[1:] != traced_shape[1:]:
+        raise ValueError(
+            "Dynamic TensorRT INT8 calibration shape must match the traced input "
+            f"CHW dimensions, got {calibration_shape} versus {traced_shape}."
+        )
+
+
+def _profile_shape(
+    declared_shape,
+    traced_shape: tuple[int, ...] | None,
+    *,
+    batch: int,
+) -> tuple[int, ...]:
+    """Resolve one profile shape without replacing non-batch axes by batch."""
+    declared = tuple(int(dim) for dim in declared_shape)
+    traced = None if traced_shape is None else tuple(int(dim) for dim in traced_shape)
+    if traced is not None:
+        if len(traced) != len(declared) or any(dim <= 0 for dim in traced):
+            raise ValueError(
+                "TensorRT traced input_shape must contain one positive value per "
+                f"network axis, got {traced} for declared shape {declared}."
+            )
+        for axis, (actual, fixed) in enumerate(zip(traced, declared)):
+            if fixed > 0 and actual != fixed:
+                raise ValueError(
+                    f"TensorRT traced input_shape axis {axis} is {actual}, but the "
+                    f"ONNX input fixes it at {fixed}."
+                )
+
+    resolved = []
+    for axis, dim in enumerate(declared):
+        if dim > 0:
+            resolved.append(dim)
+        elif axis == 0:
+            resolved.append(batch)
+        elif traced is not None:
+            resolved.append(traced[axis])
+        else:
+            raise ValueError(
+                "TensorRT cannot derive a dynamic non-batch profile axis without "
+                f"the traced input_shape; ONNX input shape is {declared}."
+            )
+    return tuple(resolved)
 
 
 def export_tensorrt(
@@ -165,6 +330,7 @@ def export_tensorrt(
     device: int = 0,
     config: Optional[Union[str, Path, dict, TensorRTExportConfig]] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    input_shape: tuple[int, int, int, int] | None = None,
 ) -> str:
     """Export ONNX model to TensorRT engine.
 
@@ -201,6 +367,8 @@ def export_tensorrt(
                If provided, overrides individual parameters.
         metadata: Optional dict of model metadata to write as a JSON sidecar
                  file alongside the engine (e.g. model_family, nb_classes, names).
+        input_shape: Concrete NCHW shape of the tensor used to trace the ONNX
+                     graph. Required when a non-batch input axis is dynamic.
 
     Returns:
         Path to exported .engine file.
@@ -225,6 +393,7 @@ def export_tensorrt(
         export_tensorrt("model.onnx", "model.engine",
                        config="tensorrt_default.yaml")
     """
+    use_calibration_cache = True
     if config is not None:
         from .config import load_export_config
 
@@ -235,23 +404,53 @@ def export_tensorrt(
         verbose = cfg.verbose
         hardware_compatibility = cfg.hardware_compatibility
         device = cfg.device
-        if cfg.dynamic.enabled:
-            dynamic = True
+        use_calibration_cache = bool(cfg.int8_calibration.cache)
+        dynamic = bool(cfg.dynamic.enabled)
+        if dynamic:
             min_batch = cfg.dynamic.min_batch
             opt_batch = cfg.dynamic.opt_batch
             max_batch = cfg.dynamic.max_batch
         if cfg.int8:
-            # int8_calibration (dataset/fraction/cache) is parsed and validated
-            # by TensorRTExportConfig but not consumed here: calibration comes
+            # int8_calibration dataset/fraction are parsed and validated by
+            # TensorRTExportConfig but not consumed here: calibration comes
             # from the pre-built ``calibration_data`` loader (the export()
             # data=/fraction= arguments). Warn rather than silently drop it.
             warnings.warn(
-                "TensorRTExportConfig.int8_calibration "
-                "(dataset/fraction/cache) is currently ignored: INT8 "
+                "TensorRTExportConfig.int8_calibration dataset/fraction are "
+                "currently ignored: INT8 "
                 "calibration is driven by the export() data=/fraction= "
                 "arguments (passed here as calibration_data). Set those to "
                 "control INT8 calibration."
             )
+
+    min_batch = int(min_batch)
+    opt_batch = int(opt_batch)
+    max_batch = int(max_batch)
+    _validate_batch_profile(min_batch, opt_batch, max_batch)
+    traced_input_shape = (
+        None if input_shape is None else tuple(int(dim) for dim in input_shape)
+    )
+    if traced_input_shape is not None and (
+        len(traced_input_shape) != 4 or any(dim <= 0 for dim in traced_input_shape)
+    ):
+        raise ValueError(
+            "TensorRT input_shape must be a positive NCHW tuple, got "
+            f"{traced_input_shape}."
+        )
+
+    if int8 and calibration_data is None:
+        raise ValueError(
+            "INT8 quantization requires calibration data.\n"
+            "Provide calibration_data parameter or use data='coco8.yaml' "
+            "in the export() call."
+        )
+    _validate_dynamic_calibration_contract(
+        calibration_data,
+        int8=int8,
+        dynamic=dynamic,
+        opt_batch=opt_batch,
+        traced_shape=traced_input_shape,
+    )
 
     if metadata is not None:
         metadata = dict(metadata)
@@ -267,19 +466,7 @@ def export_tensorrt(
     check_tensorrt_available()
     import tensorrt as trt
 
-    if device != 0:
-        if torch.cuda.is_available():
-            torch.cuda.set_device(device)
-            logger.info(
-                "Using GPU device: %d (%s)", device, torch.cuda.get_device_name(device)
-            )
-
-    if int8 and calibration_data is None:
-        raise ValueError(
-            "INT8 quantization requires calibration data.\n"
-            "Provide calibration_data parameter or use data='coco8.yaml' "
-            "in the export() call."
-        )
+    device = _select_tensorrt_device(device)
 
     if half and int8:
         warnings.warn(
@@ -325,30 +512,22 @@ def export_tensorrt(
 
     if hardware_compatibility != "none":
         try:
-            compat_level = {
-                "ampere_plus": trt.HardwareCompatibilityLevel.AMPERE_PLUS,
-                "same_compute_capability": trt.HardwareCompatibilityLevel.NONE,  # TRT 8.x fallback
-            }.get(hardware_compatibility)
+            compat_level = _resolve_hardware_compatibility_level(
+                trt, hardware_compatibility
+            )
 
             if compat_level is not None:
                 builder_config.hardware_compatibility_level = compat_level
-                if (
-                    hardware_compatibility == "same_compute_capability"
-                    and compat_level == trt.HardwareCompatibilityLevel.NONE
-                ):
-                    # This TRT build has no real "same compute capability" level;
-                    # it falls back to NONE, which yields a current-GPU-only
-                    # engine. Do not claim portability was applied.
-                    warnings.warn(
-                        "hardware_compatibility='same_compute_capability' is not "
-                        "supported on this TensorRT build and maps to NONE: the "
-                        "engine is optimized for the current GPU only and is not "
-                        "portable to other GPUs of the same compute capability."
-                    )
-                else:
-                    logger.info(
-                        "Hardware compatibility: %s", hardware_compatibility
-                    )
+                logger.info("Hardware compatibility: %s", hardware_compatibility)
+            elif hardware_compatibility in {
+                "ampere_plus",
+                "same_compute_capability",
+            }:
+                warnings.warn(
+                    f"hardware_compatibility={hardware_compatibility!r} is not "
+                    "supported by this TensorRT API. The engine will use the "
+                    "default current-GPU compatibility."
+                )
             else:
                 warnings.warn(
                     f"Unknown hardware_compatibility '{hardware_compatibility}'. "
@@ -379,6 +558,7 @@ def export_tensorrt(
             # FP32 (mixed precision); no-op for CNN backbones.
             try:
                 import onnx as _onnx
+
                 _vit = any(
                     n.op_type in ("LayerNormalization", "Erf")
                     and "backbone" in (n.name or "")
@@ -391,11 +571,17 @@ def export_tensorrt(
                 _npin = 0
                 for _i in range(network.num_layers):
                     _lyr = network.get_layer(_i)
-                    if "backbone" not in (_lyr.name or "") or _lyr.type == trt.LayerType.SHAPE:
+                    if (
+                        "backbone" not in (_lyr.name or "")
+                        or _lyr.type == trt.LayerType.SHAPE
+                    ):
                         continue
                     try:
                         _outs = [_lyr.get_output(_j) for _j in range(_lyr.num_outputs)]
-                        if any(o is None or o.dtype not in (trt.float32, trt.float16) for o in _outs):
+                        if any(
+                            o is None or o.dtype not in (trt.float32, trt.float16)
+                            for o in _outs
+                        ):
                             continue
                         _lyr.precision = trt.float32
                         for _j in range(_lyr.num_outputs):
@@ -424,12 +610,21 @@ def export_tensorrt(
             # Key the calibration cache on model identity (ONNX content hash) so
             # calibration scales for one model are never reused for another that
             # happens to export to the same output path.
-            model_hash = hashlib.sha1(onnx_data).hexdigest()[:12]
-            cache_out = Path(output_path)
-            cache_file = cache_out.with_name(f"{cache_out.stem}.{model_hash}.cache")
+            cache_file = _calibration_cache_path(
+                output_path,
+                onnx_data,
+                calibration_data,
+                enabled=use_calibration_cache,
+            )
+            if use_calibration_cache and cache_file is None:
+                warnings.warn(
+                    "TensorRT calibration cache reuse is disabled because a "
+                    "complete calibration dataset/preprocessor identity could not "
+                    "be established."
+                )
             calibrator = CalibratorClass(
                 calibration_data,
-                cache_file=str(cache_file),
+                cache_file=str(cache_file) if cache_file is not None else None,
             )
             builder_config.int8_calibrator = calibrator
             logger.info(
@@ -442,26 +637,54 @@ def export_tensorrt(
 
     logger.info("Precision: %s", precision_str)
 
-    # Dynamic shapes (only if ONNX has dynamic batch dimension)
-    input_tensor = network.get_input(0)
-    input_shape = input_tensor.shape
-    has_dynamic_batch = input_shape[0] == -1  # -1 means dynamic in ONNX/TRT
+    # Dynamic profiles. Non-batch dynamic axes are fixed to the concrete shape
+    # used for tracing; they must never be substituted with a batch value.
+    network_input_shapes = [
+        tuple(int(dim) for dim in network.get_input(i).shape)
+        for i in range(network.num_inputs)
+    ]
+    has_dynamic_axes = any(dim == -1 for shape in network_input_shapes for dim in shape)
 
-    if dynamic and has_dynamic_batch:
+    if has_dynamic_axes:
         profile = builder.create_optimization_profile()
+        if dynamic:
+            profile_batches = (min_batch, opt_batch, max_batch)
+        else:
+            fixed_batch = traced_input_shape[0] if traced_input_shape else 1
+            profile_batches = (fixed_batch, fixed_batch, fixed_batch)
 
         for i in range(network.num_inputs):
             input_tensor = network.get_input(i)
             input_name = input_tensor.name
-            input_shape = input_tensor.shape
+            declared_shape = network_input_shapes[i]
+            concrete_shape = traced_input_shape if i == 0 else None
+            min_shape = _profile_shape(
+                declared_shape,
+                concrete_shape,
+                batch=profile_batches[0],
+            )
+            opt_shape = _profile_shape(
+                declared_shape,
+                concrete_shape,
+                batch=profile_batches[1],
+            )
+            max_shape = _profile_shape(
+                declared_shape,
+                concrete_shape,
+                batch=profile_batches[2],
+            )
 
-            _, c, h, w = input_shape  # (batch, channels, height, width)
-
-            min_shape = (min_batch, c, h, w)
-            opt_shape = (opt_batch, c, h, w)
-            max_shape = (max_batch, c, h, w)
-
-            profile.set_shape(input_name, min_shape, opt_shape, max_shape)
+            accepted = profile.set_shape(
+                input_name,
+                min_shape,
+                opt_shape,
+                max_shape,
+            )
+            if accepted is False:
+                raise ValueError(
+                    f"TensorRT rejected optimization profile for {input_name!r}: "
+                    f"min={min_shape}, opt={opt_shape}, max={max_shape}."
+                )
             logger.info(
                 "Dynamic input '%s': min=%s, opt=%s, max=%s",
                 input_name,
@@ -471,10 +694,10 @@ def export_tensorrt(
             )
 
         builder_config.add_optimization_profile(profile)
-    elif dynamic and not has_dynamic_batch:
+    elif dynamic:
         logger.info(
-            "Note: ONNX has static batch size (%s), using static optimization",
-            input_shape[0],
+            "Note: ONNX inputs are static, using static optimization (%s)",
+            network_input_shapes,
         )
 
     logger.info("Building TensorRT engine... (this may take several minutes)")

--- a/libreyolo/export/tensorrt.py
+++ b/libreyolo/export/tensorrt.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import uuid
 import warnings
 from pathlib import Path
@@ -52,12 +53,21 @@ def _create_calibrator_class():
         class _TensorRTCalibratorImpl(trt.IInt8EntropyCalibrator2):
             """INT8 entropy calibrator for TensorRT engine builds."""
 
-            def __init__(self, data_loader, cache_file="calibration.cache"):
+            def __init__(
+                self,
+                data_loader,
+                cache_file="calibration.cache",
+                *,
+                device_index=0,
+            ):
                 super().__init__()
                 self.data_loader = data_loader
                 self.cache_file = Path(cache_file) if cache_file else None
                 self.batch_iter = None
                 self._device_input = None
+                self._allocation_backend = None
+                self._pycuda_context = None
+                self._device_index = int(device_index)
                 self._batch_size = data_loader.batch
                 self._batch_idx = 0
 
@@ -85,10 +95,14 @@ def _create_calibrator_class():
                 try:
                     from cuda.bindings import runtime as cudart
 
+                    (err,) = cudart.cudaSetDevice(self._device_index)
+                    if err != cudart.cudaError_t.cudaSuccess:
+                        raise RuntimeError(f"cudaSetDevice failed: {err}")
                     if self._device_input is None:
                         err, self._device_input = cudart.cudaMalloc(batch.nbytes)
                         if err != cudart.cudaError_t.cudaSuccess:
                             raise RuntimeError(f"cudaMalloc failed: {err}")
+                        self._allocation_backend = "cuda-bindings"
                     (err,) = cudart.cudaMemcpy(
                         self._device_input,
                         batch.ctypes.data,
@@ -104,13 +118,22 @@ def _create_calibrator_class():
                 # Fall back to pycuda
                 try:
                     import pycuda.driver as cuda
-                    import pycuda.autoinit  # noqa: F401
 
-                    if self._device_input is None:
-                        self._device_input = cuda.mem_alloc(batch.nbytes)
+                    if self._pycuda_context is None:
+                        cuda.init()
+                        self._pycuda_context = cuda.Device(
+                            self._device_index
+                        ).retain_primary_context()
+                    self._pycuda_context.push()
+                    try:
+                        if self._device_input is None:
+                            self._device_input = cuda.mem_alloc(batch.nbytes)
+                            self._allocation_backend = "pycuda"
 
-                    cuda.memcpy_htod(self._device_input, batch)
-                    return int(self._device_input)
+                        cuda.memcpy_htod(self._device_input, batch)
+                        return int(self._device_input)
+                    finally:
+                        self._pycuda_context.pop()
                 except ImportError:
                     raise ImportError(
                         "INT8 calibration requires cuda-python or pycuda.\n"
@@ -118,14 +141,41 @@ def _create_calibrator_class():
                         "Or: pip install pycuda (requires python3-dev)"
                     )
 
-            def __del__(self):
-                if self._device_input is not None:
-                    try:
+            def _release_cuda_memory(self):
+                try:
+                    if (
+                        self._device_input is not None
+                        and self._allocation_backend == "cuda-bindings"
+                    ):
                         from cuda.bindings import runtime as cudart
 
-                        cudart.cudaFree(self._device_input)
-                    except (ImportError, Exception):
-                        pass  # pycuda frees via its own DeviceAllocation.__del__
+                        (err,) = cudart.cudaSetDevice(self._device_index)
+                        if err == cudart.cudaError_t.cudaSuccess:
+                            cudart.cudaFree(self._device_input)
+                    elif (
+                        self._device_input is not None
+                        and self._allocation_backend == "pycuda"
+                        and self._pycuda_context is not None
+                    ):
+                        self._pycuda_context.push()
+                        try:
+                            self._device_input.free()
+                        finally:
+                            self._pycuda_context.pop()
+                except Exception:
+                    pass
+                finally:
+                    self._device_input = None
+                    self._allocation_backend = None
+                    if self._pycuda_context is not None:
+                        try:
+                            self._pycuda_context.detach()
+                        except Exception:
+                            pass
+                        self._pycuda_context = None
+
+            def __del__(self):
+                self._release_cuda_memory()
 
             def read_calibration_cache(self):
                 if self.cache_file is not None and self.cache_file.exists():
@@ -222,7 +272,7 @@ def _publish_tensorrt_artifacts(
         prefix="libreyolo-tensorrt-publish-", dir=output.parent
     ) as workspace_name:
         workspace = Path(workspace_name)
-        staged = {output: workspace / output.name}
+        staged: dict[Path, Path | None] = {output: workspace / output.name}
         with open(staged[output], "xb") as file:
             file.write(serialized_engine)
             file.flush()
@@ -235,26 +285,51 @@ def _publish_tensorrt_artifacts(
                 file.write("\n")
                 file.flush()
                 os.fsync(file.fileno())
+        else:
+            # A metadata-free rebuild must not leave metadata from an older
+            # engine describing the newly-published artifact.
+            staged[sidecar] = None
 
         backups: dict[Path, Path | None] = {}
-        for target in staged:
-            if not target.exists():
-                backups[target] = None
-                continue
-            backup = output.parent / (
-                f".{target.name}.{os.getpid()}.{uuid.uuid4().hex}.bak"
-            )
-            try:
-                os.link(target, backup)
-            except OSError:
-                shutil.copyfile(target, backup)
-            backups[target] = backup
+        target_modes: dict[Path, int] = {}
+        pending_backup: Path | None = None
+        try:
+            for target in staged:
+                if not target.exists():
+                    backups[target] = None
+                    continue
+                target_modes[target] = stat.S_IMODE(target.stat().st_mode)
+                pending_backup = output.parent / (
+                    f".{target.name}.{os.getpid()}.{uuid.uuid4().hex}.bak"
+                )
+                try:
+                    os.link(target, pending_backup)
+                except OSError:
+                    # Keep restrictive source modes on a backup that may need
+                    # to survive an incomplete rollback.
+                    shutil.copy2(target, pending_backup)
+                backups[target] = pending_backup
+                pending_backup = None
+        except BaseException:
+            if pending_backup is not None:
+                pending_backup.unlink(missing_ok=True)
+            for backup in backups.values():
+                if backup is not None:
+                    backup.unlink(missing_ok=True)
+            raise
 
         promoted = []
         retained_backups = set()
         try:
             for target, temporary in staged.items():
-                os.replace(temporary, target)
+                if temporary is None:
+                    if not target.exists():
+                        continue
+                    target.unlink()
+                else:
+                    if target in target_modes:
+                        temporary.chmod(target_modes[target])
+                    os.replace(temporary, target)
                 promoted.append(target)
         except BaseException as promotion_error:
             rollback_errors = []
@@ -368,6 +443,62 @@ def _validate_dynamic_calibration_contract(
             "Dynamic TensorRT INT8 calibration shape must match the traced input "
             f"CHW dimensions, got {calibration_shape} versus {traced_shape}."
         )
+
+
+def _validate_static_calibration_contract(
+    calibration_data,
+    *,
+    int8: bool,
+    dynamic: bool,
+    traced_shape: tuple[int, ...] | None,
+    network_shape: tuple[int, ...] | None = None,
+) -> None:
+    """Require a static INT8 loader to match its traced and parsed NCHW input."""
+    if not int8 or dynamic:
+        return
+    if calibration_data is None:
+        raise ValueError("INT8 quantization requires calibration data.")
+    try:
+        calibration_shape = tuple(int(dim) for dim in calibration_data.shape)
+        calibration_batch = int(calibration_data.batch)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "Static TensorRT INT8 calibration requires a loader with batch and "
+            "NCHW shape metadata."
+        ) from exc
+    if (
+        len(calibration_shape) != 4
+        or any(dim <= 0 for dim in calibration_shape)
+        or calibration_batch <= 0
+        or calibration_shape[0] != calibration_batch
+    ):
+        raise ValueError(
+            "Static TensorRT INT8 calibration requires positive NCHW shape "
+            "metadata whose first axis equals loader.batch, got "
+            f"batch={calibration_batch}, shape={calibration_shape}."
+        )
+
+    if traced_shape is not None and calibration_shape != traced_shape:
+        raise ValueError(
+            "Static TensorRT INT8 calibration shape must match the traced input "
+            f"NCHW shape, got {calibration_shape} versus {traced_shape}."
+        )
+
+    if network_shape is None:
+        return
+    declared = tuple(int(dim) for dim in network_shape)
+    if len(declared) != 4:
+        raise ValueError(
+            "Static TensorRT INT8 calibration requires a rank-4 network input, "
+            f"got shape {declared}."
+        )
+    for axis, (actual, fixed) in enumerate(zip(calibration_shape, declared)):
+        if fixed > 0 and actual != fixed:
+            raise ValueError(
+                "Static TensorRT INT8 calibration shape does not match the parsed "
+                f"network input at axis {axis}: got {calibration_shape}, network "
+                f"declares {declared}."
+            )
 
 
 def _profile_shape(
@@ -546,6 +677,12 @@ def export_tensorrt(
         opt_batch=opt_batch,
         traced_shape=traced_input_shape,
     )
+    _validate_static_calibration_contract(
+        calibration_data,
+        int8=int8,
+        dynamic=dynamic,
+        traced_shape=traced_input_shape,
+    )
 
     if metadata is not None:
         metadata = dict(metadata)
@@ -598,6 +735,19 @@ def export_tensorrt(
         network.num_outputs,
         network.num_layers,
     )
+    if int8:
+        if network.num_inputs != 1:
+            raise ValueError(
+                "TensorRT INT8 calibration currently supports exactly one network "
+                f"input, but the parsed ONNX graph has {network.num_inputs}."
+            )
+        _validate_static_calibration_contract(
+            calibration_data,
+            int8=int8,
+            dynamic=dynamic,
+            traced_shape=traced_input_shape,
+            network_shape=tuple(int(dim) for dim in network.get_input(0).shape),
+        )
 
     builder_config = builder.create_builder_config()
 
@@ -720,6 +870,7 @@ def export_tensorrt(
             calibrator = CalibratorClass(
                 calibration_data,
                 cache_file=str(cache_file) if cache_file is not None else None,
+                device_index=device,
             )
             builder_config.int8_calibrator = calibrator
             logger.info(

--- a/libreyolo/export/tensorrt.py
+++ b/libreyolo/export/tensorrt.py
@@ -3,8 +3,12 @@
 import hashlib
 import json
 import logging
+import os
+import shutil
+import uuid
 import warnings
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Dict, Optional, Union
 
 import numpy as np
@@ -175,10 +179,21 @@ def _resolve_hardware_compatibility_level(trt, requested: str):
 
 def _select_tensorrt_device(device: int) -> int:
     """Select the requested CUDA device before creating TensorRT objects."""
+    if isinstance(device, bool):
+        raise ValueError(
+            f"TensorRT device must be a non-negative integer, got {device!r}."
+        )
     try:
-        index = int(device)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"TensorRT device must be a non-negative integer, got {device!r}.") from exc
+        if isinstance(device, str):
+            if not device.strip().isdigit():
+                raise ValueError
+            index = int(device.strip())
+        else:
+            index = device.__index__()
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"TensorRT device must be a non-negative integer, got {device!r}."
+        ) from exc
     if index < 0:
         raise ValueError(f"TensorRT device must be non-negative, got {index}.")
     if not torch.cuda.is_available():
@@ -191,6 +206,86 @@ def _select_tensorrt_device(device: int) -> int:
     torch.cuda.set_device(index)
     logger.info("Using GPU device: %d (%s)", index, torch.cuda.get_device_name(index))
     return index
+
+
+def _publish_tensorrt_artifacts(
+    serialized_engine,
+    output_path: str | Path,
+    metadata: dict | None,
+) -> str:
+    """Stage and transactionally publish an engine and optional sidecar."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    sidecar = Path(str(output) + ".json")
+
+    with TemporaryDirectory(
+        prefix="libreyolo-tensorrt-publish-", dir=output.parent
+    ) as workspace_name:
+        workspace = Path(workspace_name)
+        staged = {output: workspace / output.name}
+        with open(staged[output], "xb") as file:
+            file.write(serialized_engine)
+            file.flush()
+            os.fsync(file.fileno())
+
+        if metadata is not None:
+            staged[sidecar] = workspace / sidecar.name
+            with open(staged[sidecar], "x", encoding="utf-8") as file:
+                json.dump(metadata, file, allow_nan=False, indent=2)
+                file.write("\n")
+                file.flush()
+                os.fsync(file.fileno())
+
+        backups: dict[Path, Path | None] = {}
+        for target in staged:
+            if not target.exists():
+                backups[target] = None
+                continue
+            backup = output.parent / (
+                f".{target.name}.{os.getpid()}.{uuid.uuid4().hex}.bak"
+            )
+            try:
+                os.link(target, backup)
+            except OSError:
+                shutil.copyfile(target, backup)
+            backups[target] = backup
+
+        promoted = []
+        retained_backups = set()
+        try:
+            for target, temporary in staged.items():
+                os.replace(temporary, target)
+                promoted.append(target)
+        except BaseException as promotion_error:
+            rollback_errors = []
+            for target in reversed(promoted):
+                backup = backups[target]
+                try:
+                    if backup is None:
+                        target.unlink(missing_ok=True)
+                    else:
+                        os.replace(backup, target)
+                        backups[target] = None
+                except OSError as rollback_error:
+                    if backup is not None:
+                        retained_backups.add(backup)
+                    rollback_errors.append(
+                        f"{target}: {rollback_error}; previous artifact retained "
+                        f"at {backup}"
+                    )
+            if rollback_errors:
+                raise RuntimeError(
+                    "TensorRT artifact publication failed and rollback was "
+                    "incomplete: " + "; ".join(rollback_errors)
+                ) from promotion_error
+            raise
+        finally:
+            for backup in backups.values():
+                if backup is None or backup in retained_backups:
+                    continue
+                backup.unlink(missing_ok=True)
+
+    return str(output)
 
 
 def _calibration_cache_fingerprint(calibration_data) -> str | None:
@@ -713,22 +808,15 @@ def export_tensorrt(
             "Try running with verbose=True for detailed error messages."
         )
 
-    output_path = Path(output_path)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    with open(output_path, "wb") as f:
-        f.write(serialized_engine)
-
     if metadata is not None:
         # Reflect the precision actually realized by the build (e.g. fp16 after
         # an INT8→FP16 fallback) instead of the pre-build request.
         metadata["precision"] = actual_precision
-        sidecar_path = Path(str(output_path) + ".json")
-        with open(sidecar_path, "w") as f:
-            json.dump(metadata, f, indent=2)
-        logger.info("Metadata sidecar: %s", sidecar_path)
+    result = _publish_tensorrt_artifacts(serialized_engine, output_path, metadata)
+    if metadata is not None:
+        logger.info("Metadata sidecar: %s.json", output_path)
 
-    engine_size_mb = output_path.stat().st_size / (1024 * 1024)
-    logger.info("Engine saved: %s (%.1f MB)", output_path, engine_size_mb)
+    engine_size_mb = Path(result).stat().st_size / (1024 * 1024)
+    logger.info("Engine saved: %s (%.1f MB)", result, engine_size_mb)
 
-    return str(output_path)
+    return result

--- a/libreyolo/models/clip/export.py
+++ b/libreyolo/models/clip/export.py
@@ -11,12 +11,15 @@ The exported model is fixed to the labels and input resolution at export time.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Optional
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from ...utils.serialization import SCHEMA_VERSION
 
 
 class _FrozenCLIPClassifier(nn.Module):
@@ -37,33 +40,57 @@ class _FrozenCLIPClassifier(nn.Module):
 def export_frozen_onnx(
     model,
     imgsz: Optional[int] = None,
-    opset: int = 14,
+    opset: Optional[int] = None,
     output: Optional[str] = None,
-    dynamic_batch: bool = True,
+    *,
+    batch: int = 1,
+    dynamic: bool = True,
+    device: str | torch.device | int | None = None,
+    simplify: bool = True,
+    verbose: bool = False,
 ) -> str:
     """Export ``model`` (with its current classes) to a frozen-class ONNX file."""
+    from ...export.onnx import _get_version, finalize_onnx_artifact
+    from .model import CLIP_MEAN, CLIP_STD
+
     res = int(imgsz or model.input_size)
+    opset = 14 if opset is None else int(opset)
     if opset < 14:
         raise ValueError("LibreCLIP ONNX export needs opset >= 14 (ViT attention).")
+    if isinstance(batch, bool) or not isinstance(batch, int) or batch < 1:
+        raise ValueError(
+            f"LibreCLIP export batch must be a positive integer, got {batch!r}."
+        )
 
-    text_embeds = model._text_embeds.detach().to("cpu", torch.float32)
+    visual = model.model.visual
+    first_parameter = next(visual.parameters())
+    original_device = first_parameter.device
+    trace_device = _resolve_export_device(device, original_device)
+    trace_dtype = first_parameter.dtype
+
+    text_embeds = model._text_embeds.detach().to(trace_device, trace_dtype)
     scale = float(model.model.logit_scale.exp().detach().cpu())
     weight = scale * text_embeds  # [K, D]
 
-    original_device = next(model.model.visual.parameters()).device
-    visual = model.model.visual.to("cpu").eval()
-    frozen = _FrozenCLIPClassifier(visual, weight).eval()
+    training_states = {module: module.training for module in visual.modules()}
 
     if output is None:
         output = f"{model.FILENAME_PREFIX}{model.size}-cls.onnx"
     output = str(output)
     Path(output).parent.mkdir(parents=True, exist_ok=True)
 
-    dummy = torch.zeros(1, 3, res, res, dtype=torch.float32)
-    dynamic_axes = (
-        {"images": {0: "batch"}, "logits": {0: "batch"}} if dynamic_batch else None
+    dummy = torch.zeros(
+        batch,
+        3,
+        res,
+        res,
+        dtype=trace_dtype,
+        device=trace_device,
     )
+    dynamic_axes = {"images": {0: "batch"}, "logits": {0: "batch"}} if dynamic else None
     try:
+        visual = visual.to(trace_device).eval()
+        frozen = _FrozenCLIPClassifier(visual, weight).eval()
         with torch.no_grad():
             torch.onnx.export(
                 frozen,
@@ -73,12 +100,65 @@ def export_frozen_onnx(
                 output_names=["logits"],
                 opset_version=opset,
                 dynamic_axes=dynamic_axes,
+                verbose=bool(verbose),
                 # Stable TorchScript exporter (no onnxscript dependency); the
                 # frozen graph is a plain ViT + matmul that exports cleanly.
                 dynamo=False,
             )
+        metadata = {
+            "schema_version": SCHEMA_VERSION,
+            "libreyolo_version": _get_version(),
+            "model_family": model.FAMILY,
+            "size": model.size,
+            "model_size": model.size,
+            "task": "classify",
+            "supported_tasks": json.dumps(["classify"]),
+            "default_task": "classify",
+            "nc": str(model.nb_classes),
+            "nb_classes": str(model.nb_classes),
+            "names": json.dumps(
+                {str(key): value for key, value in model.names.items()}
+            ),
+            "imgsz": str(res),
+            "imgsz_h": str(res),
+            "imgsz_w": str(res),
+            "precision": "fp16" if trace_dtype == torch.float16 else "fp32",
+            "dynamic": str(bool(dynamic)),
+            "half": str(trace_dtype == torch.float16),
+            "classification_mean": json.dumps(list(CLIP_MEAN)),
+            "classification_std": json.dumps(list(CLIP_STD)),
+            "classification_crop_pct": "1.0",
+            "classification_interpolation": "bicubic",
+            "classification_square_resize": "false",
+            "classification_activation": "softmax",
+            "crop_pct": "1.0",
+            "interpolation": "bicubic",
+        }
+        finalize_onnx_artifact(
+            output,
+            simplify=bool(simplify),
+            dynamic=bool(dynamic),
+            half=trace_dtype == torch.float16,
+            metadata=metadata,
+        )
     finally:
         # Restore the tower to its original device even if export raised, so the
         # model instance stays usable for further predict()/_forward() calls.
-        model.model.visual.to(original_device)
+        visual.to(original_device)
+        for module, training in training_states.items():
+            module.training = training
     return output
+
+
+def _resolve_export_device(
+    requested: str | torch.device | int | None,
+    current: torch.device,
+) -> torch.device:
+    """Resolve the tracing device without changing the owning model's device."""
+    if requested is None or str(requested).lower() == "auto":
+        return current
+    if isinstance(requested, int) or (
+        isinstance(requested, str) and requested.isdigit()
+    ):
+        requested = f"cuda:{requested}"
+    return torch.device(requested)

--- a/libreyolo/models/clip/model.py
+++ b/libreyolo/models/clip/model.py
@@ -71,7 +71,9 @@ class LibreCLIP(BaseModel):
     # the model resizes to a fixed square; keep predict to a single forward.
     TTA_ENABLED: ClassVar[bool] = False
 
-    validator_class: ClassVar[Optional[type]] = None  # set lazily (see _resolve_validator)
+    validator_class: ClassVar[Optional[type]] = (
+        None  # set lazily (see _resolve_validator)
+    )
 
     # =========================================================================
     # Registry classmethods
@@ -141,10 +143,14 @@ class LibreCLIP(BaseModel):
         else:
             # Zero-config: pick a default size and autodownload its checkpoint.
             size = size or "b32"
-            weight_source = self._resolve_weights_path(f"{self.FILENAME_PREFIX}{size}-cls.pt")
+            weight_source = self._resolve_weights_path(
+                f"{self.FILENAME_PREFIX}{size}-cls.pt"
+            )
         size = size or "b32"
 
-        self._default_templates = list(templates) if templates else list(DEFAULT_TEMPLATES)
+        self._default_templates = (
+            list(templates) if templates else list(DEFAULT_TEMPLATES)
+        )
         self._text_embeds: Optional[torch.Tensor] = None
         self.tokenizer = None  # built after super().__init__
 
@@ -269,8 +275,12 @@ class LibreCLIP(BaseModel):
         def _preprocess_numpy(img_rgb_hwc, input_size=224):
             res = input_size if isinstance(input_size, int) else input_size[0]
             transform = build_classify_transforms(
-                res, augment=False, mean=CLIP_MEAN, std=CLIP_STD,
-                interpolation=InterpolationMode.BICUBIC, crop_pct=1.0,
+                res,
+                augment=False,
+                mean=CLIP_MEAN,
+                std=CLIP_STD,
+                interpolation=InterpolationMode.BICUBIC,
+                crop_pct=1.0,
             )
             pil = Image.fromarray(_np.asarray(img_rgb_hwc).astype("uint8"))
             return transform(pil).numpy(), 1.0
@@ -419,7 +429,23 @@ class LibreCLIP(BaseModel):
     # Export — frozen-class ONNX
     # =========================================================================
 
-    def export(self, format: str = "onnx", **kwargs) -> str:
+    def export(
+        self,
+        format: str = "onnx",
+        *,
+        output: str | Path | None = None,
+        output_path: str | Path | None = None,
+        imgsz: int | tuple[int, int] | list[int] | None = None,
+        opset: int | None = None,
+        simplify: bool = True,
+        dynamic: bool = True,
+        half: bool = False,
+        int8: bool = False,
+        batch: int = 1,
+        device: str | torch.device | int | None = None,
+        verbose: bool = False,
+        **kwargs,
+    ) -> str:
         """Export a **frozen-class** ONNX classifier for the current labels.
 
         The current ``set_classes`` text embeddings are baked into a final
@@ -428,20 +454,51 @@ class LibreCLIP(BaseModel):
         inference). The ONNX is fixed to the labels set at export time and to a
         fixed input resolution; re-export to change either.
         """
-        if format.lower() != "onnx":
+        if str(format).lower() != "onnx":
             raise NotImplementedError(
                 f"LibreCLIP export to {format!r} is not implemented; only 'onnx' "
                 "(frozen-class) is supported. Open-vocabulary export (two towers "
                 "+ tokenizer) is out of scope for v1."
             )
-        requested_imgsz = kwargs.get("imgsz")
-        kwargs["imgsz"] = self._validate_input_size(
-            self._get_input_size() if requested_imgsz is None else requested_imgsz,
-            context="export",
+        if half:
+            raise NotImplementedError(
+                "LibreCLIP frozen-class ONNX export does not support half=True."
+            )
+        if int8:
+            raise NotImplementedError(
+                "LibreCLIP frozen-class ONNX export does not support int8=True."
+            )
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unsupported LibreCLIP export arguments: {unknown}")
+        if output is not None and output_path is not None:
+            raise ValueError("Pass only one of output= or output_path=.")
+        if isinstance(batch, bool) or not isinstance(batch, int) or batch < 1:
+            raise ValueError(
+                f"LibreCLIP export batch must be a positive integer, got {batch!r}."
+            )
+        validated_imgsz = self._validate_export_input_size(
+            self._get_input_size() if imgsz is None else imgsz,
+        )
+        export_imgsz = (
+            int(validated_imgsz[0])
+            if isinstance(validated_imgsz, tuple)
+            else int(validated_imgsz)
         )
         if self._text_embeds is None:
             raise RuntimeError("No classes set; call set_classes() before export().")
 
         from .export import export_frozen_onnx
 
-        return export_frozen_onnx(self, **kwargs)
+        destination = output_path if output_path is not None else output
+        return export_frozen_onnx(
+            self,
+            imgsz=export_imgsz,
+            opset=opset,
+            output=None if destination is None else str(destination),
+            batch=batch,
+            dynamic=dynamic,
+            device=device,
+            simplify=simplify,
+            verbose=verbose,
+        )

--- a/libreyolo/models/picosam3/model.py
+++ b/libreyolo/models/picosam3/model.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from ...utils.download import WeightPublicationError
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.serialization import (
+    SCHEMA_VERSION,
     load_untrusted_torch_file,
     unwrap_libreyolo_checkpoint,
 )
@@ -44,6 +45,7 @@ class LibrePicoSAM3(LibreSAMModel):
     FILENAME_PREFIX = "LibrePicoSAM3"
     HF_REPOS: ClassVar[Dict[str, str]] = {"pico": "LibreYOLO/LibrePicoSAM3"}
     INPUT_SIZES: ClassVar[Dict[str, int]] = {"pico": 96}
+    INPUT_SIZE_FIXED: ClassVar[bool] = True
     WEIGHT_FILE: ClassVar[str] = "LibrePicoSAM3pico.pt"
 
     def __init__(self, size: str = "pico", **kwargs) -> None:
@@ -243,39 +245,141 @@ class LibrePicoSAM3(LibreSAMModel):
         *,
         output: str | Path | None = None,
         output_path: str | Path | None = None,
-        opset: int = 13,
+        imgsz: int | tuple[int, int] | list[int] | None = None,
+        opset: int | None = None,
+        simplify: bool = True,
         dynamic: bool = True,
+        half: bool = False,
+        int8: bool = False,
+        batch: int = 1,
+        device: str | torch.device | int | None = None,
+        verbose: bool = False,
         **kwargs,
     ) -> str:
         """Export the raw 96x96 ROI CNN as ``roi_image -> mask_logits``."""
 
-        if kwargs:
-            unknown = ", ".join(sorted(kwargs))
-            raise TypeError(f"Unsupported PicoSAM3 export arguments: {unknown}")
         if str(format).lower() != "onnx":
             raise NotImplementedError(
                 "LibrePicoSAM3 export currently supports ONNX only."
             )
+        if half:
+            raise NotImplementedError(
+                "LibrePicoSAM3 ONNX export does not support half=True."
+            )
+        if int8:
+            raise NotImplementedError(
+                "LibrePicoSAM3 ONNX export does not support int8=True."
+            )
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unsupported PicoSAM3 export arguments: {unknown}")
         if output is not None and output_path is not None:
             raise ValueError("Pass only one of output= or output_path=.")
-        destination = Path(output_path or output or "LibrePicoSAM3pico.onnx")
+        if isinstance(batch, bool) or not isinstance(batch, int) or batch < 1:
+            raise ValueError(
+                f"LibrePicoSAM3 export batch must be a positive integer, got {batch!r}."
+            )
+        native_imgsz = self.INPUT_SIZES[self.size]
+        export_imgsz = native_imgsz if imgsz is None else imgsz
+        if isinstance(export_imgsz, (list, tuple)):
+            if len(export_imgsz) == 2 and all(
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and value == native_imgsz
+                for value in export_imgsz
+            ):
+                export_imgsz = native_imgsz
+        if (
+            isinstance(export_imgsz, bool)
+            or not isinstance(export_imgsz, int)
+            or export_imgsz != native_imgsz
+        ):
+            raise ValueError(
+                f"LibrePicoSAM3 export requires imgsz={native_imgsz}, "
+                f"got {export_imgsz!r}."
+            )
+        opset = 13 if opset is None else int(opset)
+
+        destination_value = output_path if output_path is not None else output
+        destination = Path(destination_value or "LibrePicoSAM3pico.onnx")
         destination.parent.mkdir(parents=True, exist_ok=True)
         axes = None
         if dynamic:
             axes = {"roi_image": {0: "batch"}, "mask_logits": {0: "batch"}}
-        imgsz = self.INPUT_SIZES[self.size]
-        self.model.eval()
-        torch.onnx.export(
-            self.model,
-            torch.zeros((1, 3, imgsz, imgsz), device=self.device),
-            str(destination),
-            input_names=["roi_image"],
-            output_names=["mask_logits"],
-            dynamic_axes=axes,
-            opset_version=int(opset),
-            dynamo=False,
-        )
+
+        first_parameter = next(self.model.parameters())
+        original_device = first_parameter.device
+        trace_device = _resolve_export_device(device, original_device)
+        trace_dtype = first_parameter.dtype
+        training_states = {module: module.training for module in self.model.modules()}
+
+        try:
+            self.model.to(trace_device).eval()
+            torch.onnx.export(
+                self.model,
+                torch.zeros(
+                    (batch, 3, export_imgsz, export_imgsz),
+                    device=trace_device,
+                    dtype=trace_dtype,
+                ),
+                str(destination),
+                input_names=["roi_image"],
+                output_names=["mask_logits"],
+                dynamic_axes=axes,
+                opset_version=opset,
+                verbose=bool(verbose),
+                dynamo=False,
+            )
+
+            from ...export.onnx import _get_version, finalize_onnx_artifact
+
+            nb_classes = int(getattr(self, "nb_classes", 1))
+            names = getattr(self, "names", {0: "object"})
+            metadata = {
+                "schema_version": SCHEMA_VERSION,
+                "libreyolo_version": _get_version(),
+                "model_family": self.FAMILY,
+                "size": self.size,
+                "model_size": self.size,
+                "task": "segment",
+                "supported_tasks": json.dumps(["segment"]),
+                "default_task": "segment",
+                "nc": str(nb_classes),
+                "nb_classes": str(nb_classes),
+                "names": json.dumps({str(key): value for key, value in names.items()}),
+                "imgsz": str(export_imgsz),
+                "imgsz_h": str(export_imgsz),
+                "imgsz_w": str(export_imgsz),
+                "precision": "fp16" if trace_dtype == torch.float16 else "fp32",
+                "dynamic": str(bool(dynamic)),
+                "half": str(trace_dtype == torch.float16),
+            }
+            finalize_onnx_artifact(
+                str(destination),
+                simplify=bool(simplify),
+                dynamic=bool(dynamic),
+                half=trace_dtype == torch.float16,
+                metadata=metadata,
+            )
+        finally:
+            self.model.to(original_device)
+            for module, training in training_states.items():
+                module.training = training
         return str(destination)
+
+
+def _resolve_export_device(
+    requested: str | torch.device | int | None,
+    current: torch.device,
+) -> torch.device:
+    """Resolve the tracing device without changing the owning model's device."""
+    if requested is None or str(requested).lower() == "auto":
+        return current
+    if isinstance(requested, int) or (
+        isinstance(requested, str) and requested.isdigit()
+    ):
+        requested = f"cuda:{requested}"
+    return torch.device(requested)
 
 
 __all__ = ["LibrePicoSAM3", "PicoSAM3Network"]

--- a/libreyolo/models/siglip2/export.py
+++ b/libreyolo/models/siglip2/export.py
@@ -13,6 +13,7 @@ model is fixed to the labels and input resolution at export time.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Optional
 
@@ -20,11 +21,15 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...utils.serialization import SCHEMA_VERSION
+
 
 class _FrozenSigLIP2Classifier(nn.Module):
     """Image tower + baked text-embedding linear head -> ``[B, K]`` logits."""
 
-    def __init__(self, vision_model: nn.Module, weight: torch.Tensor, bias: torch.Tensor):
+    def __init__(
+        self, vision_model: nn.Module, weight: torch.Tensor, bias: torch.Tensor
+    ):
         super().__init__()
         self.vision_model = vision_model
         # weight = logit_scale.exp() * text_embeds, shape [K, D]; bias = logit_bias.
@@ -40,34 +45,58 @@ class _FrozenSigLIP2Classifier(nn.Module):
 def export_frozen_onnx(
     model,
     imgsz: Optional[int] = None,
-    opset: int = 14,
+    opset: Optional[int] = None,
     output: Optional[str] = None,
-    dynamic_batch: bool = True,
+    *,
+    batch: int = 1,
+    dynamic: bool = True,
+    device: str | torch.device | int | None = None,
+    simplify: bool = True,
+    verbose: bool = False,
 ) -> str:
     """Export ``model`` (with its current classes) to a frozen-class ONNX file."""
+    from ...export.onnx import _get_version, finalize_onnx_artifact
+    from .model import SIGLIP_MEAN, SIGLIP_STD
+
     res = int(imgsz or model.input_size)
+    opset = 14 if opset is None else int(opset)
     if opset < 14:
         raise ValueError("LibreSigLIP2 ONNX export needs opset >= 14 (ViT attention).")
+    if isinstance(batch, bool) or not isinstance(batch, int) or batch < 1:
+        raise ValueError(
+            f"LibreSigLIP2 export batch must be a positive integer, got {batch!r}."
+        )
 
-    text_embeds = model._text_embeds.detach().to("cpu", torch.float32)
+    vision = model.model.vision_model
+    first_parameter = next(vision.parameters())
+    original_device = first_parameter.device
+    trace_device = _resolve_export_device(device, original_device)
+    trace_dtype = first_parameter.dtype
+
+    text_embeds = model._text_embeds.detach().to(trace_device, trace_dtype)
     scale = float(model.model.logit_scale.exp().detach().cpu())
     weight = scale * text_embeds  # [K, D]
-    bias = model.model.logit_bias.detach().to("cpu", torch.float32).reshape(())
+    bias = model.model.logit_bias.detach().to(trace_device, trace_dtype).reshape(())
 
-    original_device = next(model.model.vision_model.parameters()).device
-    vision = model.model.vision_model.to("cpu").eval()
-    frozen = _FrozenSigLIP2Classifier(vision, weight, bias).eval()
+    training_states = {module: module.training for module in vision.modules()}
 
     if output is None:
         output = f"{model.FILENAME_PREFIX}{model.size}-cls.onnx"
     output = str(output)
     Path(output).parent.mkdir(parents=True, exist_ok=True)
 
-    dummy = torch.zeros(1, 3, res, res, dtype=torch.float32)
-    dynamic_axes = (
-        {"images": {0: "batch"}, "logits": {0: "batch"}} if dynamic_batch else None
+    dummy = torch.zeros(
+        batch,
+        3,
+        res,
+        res,
+        dtype=trace_dtype,
+        device=trace_device,
     )
+    dynamic_axes = {"images": {0: "batch"}, "logits": {0: "batch"}} if dynamic else None
     try:
+        vision = vision.to(trace_device).eval()
+        frozen = _FrozenSigLIP2Classifier(vision, weight, bias).eval()
         with torch.no_grad():
             torch.onnx.export(
                 frozen,
@@ -77,8 +106,63 @@ def export_frozen_onnx(
                 output_names=["logits"],
                 opset_version=opset,
                 dynamic_axes=dynamic_axes,
+                verbose=bool(verbose),
                 dynamo=False,
             )
+        metadata = {
+            "schema_version": SCHEMA_VERSION,
+            "libreyolo_version": _get_version(),
+            "model_family": model.FAMILY,
+            "size": model.size,
+            "model_size": model.size,
+            "task": "classify",
+            "supported_tasks": json.dumps(["classify"]),
+            "default_task": "classify",
+            "nc": str(model.nb_classes),
+            "nb_classes": str(model.nb_classes),
+            "names": json.dumps(
+                {str(key): value for key, value in model.names.items()}
+            ),
+            "imgsz": str(res),
+            "imgsz_h": str(res),
+            "imgsz_w": str(res),
+            "precision": "fp16" if trace_dtype == torch.float16 else "fp32",
+            "dynamic": str(bool(dynamic)),
+            "half": str(trace_dtype == torch.float16),
+            "classification_mean": json.dumps(list(SIGLIP_MEAN)),
+            "classification_std": json.dumps(list(SIGLIP_STD)),
+            "classification_crop_pct": "1.0",
+            "classification_interpolation": "bilinear",
+            "classification_square_resize": "true",
+            "classification_activation": (
+                "sigmoid" if model._multi_label else "softmax"
+            ),
+            "crop_pct": "1.0",
+            "interpolation": "bilinear",
+        }
+        finalize_onnx_artifact(
+            output,
+            simplify=bool(simplify),
+            dynamic=bool(dynamic),
+            half=trace_dtype == torch.float16,
+            metadata=metadata,
+        )
     finally:
-        model.model.vision_model.to(original_device)
+        vision.to(original_device)
+        for module, training in training_states.items():
+            module.training = training
     return output
+
+
+def _resolve_export_device(
+    requested: str | torch.device | int | None,
+    current: torch.device,
+) -> torch.device:
+    """Resolve the tracing device without changing the owning model's device."""
+    if requested is None or str(requested).lower() == "auto":
+        return current
+    if isinstance(requested, int) or (
+        isinstance(requested, str) and requested.isdigit()
+    ):
+        requested = f"cuda:{requested}"
+    return torch.device(requested)

--- a/libreyolo/models/siglip2/model.py
+++ b/libreyolo/models/siglip2/model.py
@@ -46,7 +46,12 @@ from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.serialization import load_trusted_torch_file
 from ..base.model import BaseModel
-from .labels import DEFAULT_TEMPLATES, humanize_labels, imagenet1k_classnames, openai_imagenet_templates
+from .labels import (
+    DEFAULT_TEMPLATES,
+    humanize_labels,
+    imagenet1k_classnames,
+    openai_imagenet_templates,
+)
 from .nn import SIGLIP2_CONFIGS, build_siglip2_model
 
 logger = logging.getLogger(__name__)
@@ -69,9 +74,13 @@ def siglip2_logits(
     L2-normalized class matrix ``[K, D]``. Returns ``[B, K]`` logits.
     """
     image_features = F.normalize(image_features, dim=-1)
-    scale = logit_scale.exp().to(device=image_features.device, dtype=image_features.dtype)
+    scale = logit_scale.exp().to(
+        device=image_features.device, dtype=image_features.dtype
+    )
     bias = logit_bias.to(device=image_features.device, dtype=image_features.dtype)
-    text_embeds = text_embeds.to(device=image_features.device, dtype=image_features.dtype)
+    text_embeds = text_embeds.to(
+        device=image_features.device, dtype=image_features.dtype
+    )
     return scale * (image_features @ text_embeds.t()) + bias
 
 
@@ -110,7 +119,9 @@ class LibreSigLIP2(BaseModel):
     # Attention pooling + fixed square resize make multi-scale TTA meaningless.
     TTA_ENABLED: ClassVar[bool] = False
 
-    validator_class: ClassVar[Optional[type]] = None  # set lazily (see _resolve_validator)
+    validator_class: ClassVar[Optional[type]] = (
+        None  # set lazily (see _resolve_validator)
+    )
 
     # =========================================================================
     # Registry classmethods
@@ -165,7 +176,9 @@ class LibreSigLIP2(BaseModel):
     ) -> None:
         resolved_task = normalize_task(task) if task is not None else "classify"
         if resolved_task != "classify":
-            raise ValueError(f"LibreSigLIP2 only supports task='classify'; got {task!r}.")
+            raise ValueError(
+                f"LibreSigLIP2 only supports task='classify'; got {task!r}."
+            )
 
         if isinstance(model_path, dict):
             weight_source: str | dict = model_path
@@ -177,10 +190,14 @@ class LibreSigLIP2(BaseModel):
                 size = self.detect_size_from_filename(model_path)
         else:
             size = size or "b16"
-            weight_source = self._resolve_weights_path(f"{self.FILENAME_PREFIX}{size}-cls.pt")
+            weight_source = self._resolve_weights_path(
+                f"{self.FILENAME_PREFIX}{size}-cls.pt"
+            )
         size = size or "b16"
 
-        self._default_templates = list(templates) if templates else list(DEFAULT_TEMPLATES)
+        self._default_templates = (
+            list(templates) if templates else list(DEFAULT_TEMPLATES)
+        )
         self._multi_label = bool(multi_label)
         self._text_embeds: Optional[torch.Tensor] = None
         self.tokenizer = None  # built after super().__init__
@@ -318,8 +335,13 @@ class LibreSigLIP2(BaseModel):
         def _preprocess_numpy(img_rgb_hwc, input_size=224):
             res = input_size if isinstance(input_size, int) else input_size[0]
             transform = build_classify_transforms(
-                res, augment=False, mean=SIGLIP_MEAN, std=SIGLIP_STD,
-                interpolation=InterpolationMode.BILINEAR, crop_pct=1.0, square_resize=True,
+                res,
+                augment=False,
+                mean=SIGLIP_MEAN,
+                std=SIGLIP_STD,
+                interpolation=InterpolationMode.BILINEAR,
+                crop_pct=1.0,
+                square_resize=True,
             )
             pil = Image.fromarray(_np.asarray(img_rgb_hwc).astype("uint8"))
             return transform(pil).numpy(), 1.0
@@ -407,7 +429,10 @@ class LibreSigLIP2(BaseModel):
         )
 
         state = self._extract_state(loaded)
-        if "logit_bias" not in state or "vision_model.embeddings.patch_embedding.weight" not in state:
+        if (
+            "logit_bias" not in state
+            or "vision_model.embeddings.patch_embedding.weight" not in state
+        ):
             raise RuntimeError(
                 "Checkpoint does not look like a LibreSigLIP2 model (missing "
                 "'logit_bias'/'vision_model.embeddings.patch_embedding.weight')."
@@ -466,7 +491,23 @@ class LibreSigLIP2(BaseModel):
     # Export - frozen-class ONNX
     # =========================================================================
 
-    def export(self, format: str = "onnx", **kwargs) -> str:
+    def export(
+        self,
+        format: str = "onnx",
+        *,
+        output: str | Path | None = None,
+        output_path: str | Path | None = None,
+        imgsz: int | tuple[int, int] | list[int] | None = None,
+        opset: int | None = None,
+        simplify: bool = True,
+        dynamic: bool = True,
+        half: bool = False,
+        int8: bool = False,
+        batch: int = 1,
+        device: str | torch.device | int | None = None,
+        verbose: bool = False,
+        **kwargs,
+    ) -> str:
         """Export a **frozen-class** ONNX classifier for the current labels.
 
         The current ``set_classes`` text embeddings are baked into a final linear
@@ -477,20 +518,51 @@ class LibreSigLIP2(BaseModel):
         the labels and input resolution set at export time; re-export to change
         either.
         """
-        if format.lower() != "onnx":
+        if str(format).lower() != "onnx":
             raise NotImplementedError(
                 f"LibreSigLIP2 export to {format!r} is not implemented; only 'onnx' "
                 "(frozen-class) is supported. Open-vocabulary export (two towers "
                 "+ tokenizer) is out of scope for v1."
             )
-        requested_imgsz = kwargs.get("imgsz")
-        kwargs["imgsz"] = self._validate_input_size(
-            self._get_input_size() if requested_imgsz is None else requested_imgsz,
-            context="export",
+        if half:
+            raise NotImplementedError(
+                "LibreSigLIP2 frozen-class ONNX export does not support half=True."
+            )
+        if int8:
+            raise NotImplementedError(
+                "LibreSigLIP2 frozen-class ONNX export does not support int8=True."
+            )
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unsupported LibreSigLIP2 export arguments: {unknown}")
+        if output is not None and output_path is not None:
+            raise ValueError("Pass only one of output= or output_path=.")
+        if isinstance(batch, bool) or not isinstance(batch, int) or batch < 1:
+            raise ValueError(
+                f"LibreSigLIP2 export batch must be a positive integer, got {batch!r}."
+            )
+        validated_imgsz = self._validate_export_input_size(
+            self._get_input_size() if imgsz is None else imgsz,
+        )
+        export_imgsz = (
+            int(validated_imgsz[0])
+            if isinstance(validated_imgsz, tuple)
+            else int(validated_imgsz)
         )
         if self._text_embeds is None:
             raise RuntimeError("No classes set; call set_classes() before export().")
 
         from .export import export_frozen_onnx
 
-        return export_frozen_onnx(self, **kwargs)
+        destination = output_path if output_path is not None else output
+        return export_frozen_onnx(
+            self,
+            imgsz=export_imgsz,
+            opset=opset,
+            output=None if destination is None else str(destination),
+            batch=batch,
+            dynamic=dynamic,
+            device=device,
+            simplify=simplify,
+            verbose=verbose,
+        )

--- a/libreyolo/postprocess/picodet.py
+++ b/libreyolo/postprocess/picodet.py
@@ -150,8 +150,12 @@ def postprocess(
     # ``conf_thres``. Multi-label per anchor (vs argmax) so anchors with two
     # strong classes emit both candidates.
     valid_scores, class_ids, valid_boxes = _per_level_filter_topk(
-        cls_scores, bbox_preds, strides=strides, reg_max=reg_max,
-        score_thr=conf_thres, nms_pre=1000,
+        cls_scores,
+        bbox_preds,
+        strides=strides,
+        reg_max=reg_max,
+        score_thr=conf_thres,
+        nms_pre=1000,
         canvas_size=(input_size, input_size),
     )
     if valid_scores.numel() == 0:
@@ -178,6 +182,13 @@ def postprocess(
 
     if valid_scores.numel() == 0:
         return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
+
+    # torchvision's CPU NMS kernels require fp32/fp64. Exported FP16 runtime
+    # outputs are valid inputs to postprocess, so promote before suppression.
+    if valid_boxes.dtype in {torch.float16, torch.bfloat16}:
+        valid_boxes = valid_boxes.float()
+    if valid_scores.dtype in {torch.float16, torch.bfloat16}:
+        valid_scores = valid_scores.float()
 
     # Single batched NMS across all classes (one C++ call).
     keep = tvo.batched_nms(valid_boxes, valid_scores, class_ids, iou_thres)

--- a/libreyolo/postprocess/yolo9.py
+++ b/libreyolo/postprocess/yolo9.py
@@ -22,7 +22,9 @@ ImageSize = Union[int, Tuple[int, int]]
 def _input_size_hw(input_size: ImageSize) -> Tuple[int, int]:
     if isinstance(input_size, tuple):
         if len(input_size) != 2:
-            raise ValueError(f"input_size must be int or (height, width), got {input_size}")
+            raise ValueError(
+                f"input_size must be int or (height, width), got {input_size}"
+            )
         h, w = int(input_size[0]), int(input_size[1])
     else:
         h = w = int(input_size)
@@ -57,6 +59,12 @@ def _nms_keep_indices(
     # (boxes.max() + 1) and only separates classes when all coords are
     # non-negative. Translation-invariant for IoU.
     nms_boxes = boxes - boxes.min().clamp(max=0)
+    # torchvision's CPU NMS kernels do not accept fp16/bfloat16. Exported
+    # FP16 runtimes can return either, so run only suppression in fp32.
+    if nms_boxes.dtype in {torch.float16, torch.bfloat16}:
+        nms_boxes = nms_boxes.float()
+    if scores.dtype in {torch.float16, torch.bfloat16}:
+        scores = scores.float()
     keep = batched_nms(nms_boxes, scores, class_ids, iou_thres)
     if len(keep) == 0:
         return torch.zeros(0, dtype=torch.long, device=boxes.device)
@@ -104,7 +112,12 @@ def _xywhr_to_xyxy(xywhr: torch.Tensor) -> torch.Tensor:
     x = corners[..., 0]
     y = corners[..., 1]
     return torch.stack(
-        [x.min(dim=1).values, y.min(dim=1).values, x.max(dim=1).values, y.max(dim=1).values],
+        [
+            x.min(dim=1).values,
+            y.min(dim=1).values,
+            x.max(dim=1).values,
+            y.max(dim=1).values,
+        ],
         dim=1,
     )
 
@@ -296,7 +309,9 @@ def postprocess(
             max_scores = max_scores[pre_keep]
             class_ids = class_ids[pre_keep]
 
-        keep = _rotated_nms_keep_indices(xywhr, max_scores, class_ids, iou_thres, max_det)
+        keep = _rotated_nms_keep_indices(
+            xywhr, max_scores, class_ids, iou_thres, max_det
+        )
         if len(keep) == 0:
             return {
                 "boxes": [],

--- a/libreyolo/postprocess/yolonas.py
+++ b/libreyolo/postprocess/yolonas.py
@@ -104,6 +104,10 @@ def postprocess(
     if boxes.numel() == 0:
         return {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
 
+    if boxes.dtype in {torch.float16, torch.bfloat16}:
+        boxes = boxes.float()
+    if scores.dtype in {torch.float16, torch.bfloat16}:
+        scores = scores.float()
     keep = torchvision.ops.batched_nms(boxes, scores, class_ids, iou_thres)
     if keep.numel() > max_det:
         keep = keep[:max_det]
@@ -194,7 +198,9 @@ def postprocess_pose(
         scores = output["scores"]
         pose_xy = output["keypoints_xy"]
         pose_conf = output["keypoints_conf"]
-    elif isinstance(output, tuple) and len(output) == 2 and isinstance(output[0], tuple):
+    elif (
+        isinstance(output, tuple) and len(output) == 2 and isinstance(output[0], tuple)
+    ):
         bboxes, scores, pose_xy, pose_conf = output[0]
     else:
         bboxes, scores, pose_xy, pose_conf = output
@@ -229,6 +235,7 @@ def postprocess_pose(
     scores = scores[mask].float()
     pose_xy = pose_xy[mask].float()
     pose_conf = pose_conf[mask].float()
+
     if class_ids is not None:
         class_ids = class_ids[mask]
 

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -34,10 +34,10 @@ def _module_device(module: torch.nn.Module, fallback: Any) -> torch.device:
 @contextmanager
 def validation_model_state(model: Any, device: Any):
     """Temporarily move a native model to ``device`` and exact eval state."""
-    module = model.model
-    # Exported-runtime backends expose a lightweight ``.model.eval()``
-    # compatibility proxy rather than a movable ``torch.nn.Module``. Their
-    # runtime provider owns placement, so preserve the existing backend path.
+    module = getattr(model, "model", None)
+    # Exported runtimes need not expose an inner torch module. Their runtime
+    # provider owns placement and evaluation semantics, so there is no native
+    # state to transact in that case.
     if not isinstance(module, torch.nn.Module):
         yield
         return
@@ -167,7 +167,7 @@ class BaseValidator(ABC):
             logger.info("Batch size: %d", self.config.batch_size)
 
     def _run_validation(self) -> None:
-        self.model.model.eval()
+        self._set_model_eval()
 
         if self.config.augment:
             self._run_validation_augmented()
@@ -205,6 +205,17 @@ class BaseValidator(ABC):
     def _run_validation_augmented(self) -> None:
         """TTA validation — subclasses override to call model._predict_augment per image."""
         raise NotImplementedError
+
+    def _set_model_eval(self) -> None:
+        """Enter eval mode when the wrapped runtime exposes that operation."""
+        module = getattr(self.model, "model", None)
+        eval_fn = getattr(module, "eval", None)
+        if callable(eval_fn):
+            eval_fn()
+            return
+        eval_fn = getattr(self.model, "eval", None)
+        if callable(eval_fn):
+            eval_fn()
 
     def _finalize(self) -> Dict[str, float]:
         metrics = self._compute_metrics()
@@ -278,7 +289,7 @@ class BaseValidator(ABC):
         if hasattr(self.model, "_original_size"):
             self.model._original_size = (imgsz, imgsz)
 
-        self.model.model.eval()
+        self._set_model_eval()
         with torch.no_grad():
             for _ in range(n_warmup):
                 try:

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -500,7 +500,7 @@ class DetectionValidator(BaseValidator):
         import time
         from tqdm import tqdm
 
-        self.model.model.eval()
+        self._set_model_eval()
         dataset = self.dataloader.dataset
         n_images = len(dataset)
         n_passes = 2  # original + hflip

--- a/tests/unit/cli/commands/test_export.py
+++ b/tests/unit/cli/commands/test_export.py
@@ -103,3 +103,91 @@ def test_export_cli_rejects_coreml_max_det(monkeypatch):
     data = _parse_json_output(result.output)
     assert data["error"] == "config_unsupported"
     assert "max_det is only supported for ONNX" in data["message"]
+
+
+@pytest.mark.parametrize("format_name", ["torchscript", "ncnn", "coreml"])
+def test_export_cli_reports_effective_static_dynamic(
+    monkeypatch, tmp_path, format_name
+):
+    from libreyolo.cli.commands import export
+
+    captured = {}
+    monkeypatch.setattr(export, "resolve_model_or_exit", lambda out, model: model)
+    monkeypatch.setattr(
+        export,
+        "load_model_or_exit",
+        lambda out, model, model_path, device: _LoadedModel(
+            tmp_path / f"model_{format_name}", captured
+        ),
+    )
+
+    result = runner.invoke(
+        _build_app(),
+        [
+            "model=dummy.pt",
+            f"format={format_name}",
+            "dynamic=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = _parse_json_output(result.output)
+    assert captured["kwargs"]["dynamic"] is False
+    assert data["dynamic"] is False
+
+
+def test_export_cli_keeps_tflite_dynamic_for_explicit_rejection(monkeypatch, tmp_path):
+    from libreyolo.cli.commands import export
+
+    captured = {}
+    monkeypatch.setattr(export, "resolve_model_or_exit", lambda out, model: model)
+    monkeypatch.setattr(
+        export,
+        "load_model_or_exit",
+        lambda out, model, model_path, device: _LoadedModel(
+            tmp_path / "model.tflite", captured
+        ),
+    )
+
+    result = runner.invoke(
+        _build_app(),
+        ["model=dummy.pt", "format=tflite", "dynamic=true", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["dynamic"] is True
+    assert _parse_json_output(result.output)["dynamic"] is True
+
+
+def test_export_cli_custom_classifier_reports_int8_before_cli_only_kwargs(monkeypatch):
+    from libreyolo.cli.commands import export
+    from libreyolo.models.clip.model import LibreCLIP
+
+    model = object.__new__(LibreCLIP)
+    model.size = "b32"
+    model.task = "classify"
+    monkeypatch.setattr(export, "resolve_model_or_exit", lambda out, model: model)
+    monkeypatch.setattr(
+        export,
+        "load_model_or_exit",
+        lambda out, model, model_path, device: model_instance,
+    )
+    model_instance = model
+
+    result = runner.invoke(
+        _build_app(),
+        [
+            "model=dummy.pt",
+            "format=onnx",
+            "int8=true",
+            "fraction=0.5",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 5
+    data = _parse_json_output(result.output)
+    assert data["error"] == "format_precision_unsupported"
+    assert "int8=True" in data["message"]
+    assert "Unsupported LibreCLIP export arguments" not in data["message"]

--- a/tests/unit/cli/commands/test_formats.py
+++ b/tests/unit/cli/commands/test_formats.py
@@ -1,0 +1,49 @@
+"""Tests for family-aware export format reporting."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from libreyolo.cli.commands import special
+from libreyolo.cli.parsing import KeyValueCommand
+
+
+pytestmark = pytest.mark.unit
+runner = CliRunner()
+
+
+def _build_app() -> typer.Typer:
+    app = typer.Typer(add_completion=False)
+    app.command("formats", cls=KeyValueCommand)(special.formats_cmd)
+    return app
+
+
+def _format(output: dict, name: str) -> dict:
+    return next(item for item in output["formats"] if item["name"] == name)
+
+
+def test_formats_reports_family_specific_capabilities():
+    result = runner.invoke(
+        _build_app(), ["family=yolox", "task=detect", "--json", "--quiet"]
+    )
+
+    assert result.exit_code == 0, result.output
+    output = json.loads(result.stdout)
+    assert _format(output, "onnx")["int8"] is False
+    assert _format(output, "onnx")["dynamic"] is True
+    assert _format(output, "torchscript")["dynamic"] is False
+    assert _format(output, "ncnn")["fp16"] is False
+
+
+def test_formats_reports_yolo9_onnx_int8_support():
+    result = runner.invoke(
+        _build_app(), ["family=yolo9", "task=detect", "--json", "--quiet"]
+    )
+
+    assert result.exit_code == 0, result.output
+    output = json.loads(result.stdout)
+    assert _format(output, "onnx")["int8"] is True

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -1463,6 +1463,57 @@ def test_classify_backend_postprocess_returns_probs():
     assert det["probs"].argmax().item() == 1
 
 
+def test_classify_backend_uses_metadata_declared_sigmoid_activation():
+    backend = _DummyBackend(
+        "siglip2",
+        task="classify",
+        supported_tasks=("classify",),
+        imgsz=8,
+        classification_activation="sigmoid",
+    )
+    probs = backend._parse_classify_probs([np.array([[0.0, 2.0]], dtype=np.float32)])
+
+    torch.testing.assert_close(probs, torch.tensor([0.5, 0.8807971]))
+
+
+def test_classification_metadata_parser_preserves_complete_contract():
+    parsed = backend_base._read_classification_metadata(
+        {
+            "classification_mean": "[0.1, 0.2, 0.3]",
+            "classification_std": [0.4, 0.5, 0.6],
+            "classification_crop_pct": "1.0",
+            "classification_interpolation": "bicubic",
+            "classification_square_resize": "true",
+            "classification_activation": "sigmoid",
+        }
+    )
+
+    assert parsed == {
+        "crop_pct": 1.0,
+        "interpolation": "bicubic",
+        "classification_mean": (0.1, 0.2, 0.3),
+        "classification_std": (0.4, 0.5, 0.6),
+        "classification_square_resize": True,
+        "classification_activation": "sigmoid",
+    }
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "match"),
+    [
+        ("classification_mean", "bad", "classification_mean"),
+        ("classification_std", [1, 0, 1], "classification_std"),
+        ("classification_crop_pct", 0, "classification_crop_pct"),
+        ("classification_interpolation", "area", "classification_interpolation"),
+        ("classification_square_resize", "yes", "classification_square_resize"),
+        ("classification_activation", "none", "classification_activation"),
+    ],
+)
+def test_classification_metadata_parser_rejects_malformed_contract(key, value, match):
+    with pytest.raises(ValueError, match=match):
+        backend_base._read_classification_metadata({key: value})
+
+
 def test_classify_backend_predict_returns_probs_and_saves_original(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/test_backend_runtime_contracts.py
+++ b/tests/unit/test_backend_runtime_contracts.py
@@ -7,8 +7,12 @@ import numpy as np
 import pytest
 import torch
 
-from libreyolo.backends.onnx import OnnxBackend, _resolve_onnx_providers
 from libreyolo.backends.coreml import CoreMLBackend
+from libreyolo.backends.onnx import (
+    OnnxBackend,
+    _load_validated_onnx_metadata,
+    _resolve_onnx_providers,
+)
 from libreyolo.backends.torchscript import TorchScriptBackend
 from libreyolo.validation.base import BaseValidator, validation_model_state
 from libreyolo.validation.detection_validator import DetectionValidator
@@ -64,9 +68,106 @@ def test_onnx_indexed_cuda_passes_device_id_to_execution_provider():
     assert resolved == "cuda:2"
 
 
+@pytest.mark.parametrize("device", [0, "0", torch.device("cuda:0")])
+def test_onnx_numeric_cuda_device_zero_selects_cuda_provider(device):
+    providers, resolved = _resolve_onnx_providers(
+        device,
+        ["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert providers == [
+        ("CUDAExecutionProvider", {"device_id": 0}),
+        "CPUExecutionProvider",
+    ]
+    assert resolved == "cuda:0"
+
+
 def test_onnx_runtime_rejects_unrepresentable_input_type():
     with pytest.raises(TypeError, match=r"tensor\(bfloat16\)"):
         OnnxBackend._numpy_dtype_for_onnx_type("tensor(bfloat16)")
+
+
+def _write_external_onnx(path, location, *, offset=None, length=None):
+    onnx = pytest.importorskip("onnx")
+    tensor = onnx.TensorProto()
+    tensor.name = "weight"
+    tensor.data_type = onnx.TensorProto.FLOAT
+    tensor.dims.append(1)
+    tensor.data_location = onnx.TensorProto.EXTERNAL
+    for key, value in (
+        ("location", location),
+        ("offset", offset),
+        ("length", length),
+    ):
+        if value is None:
+            continue
+        entry = tensor.external_data.add()
+        entry.key = key
+        entry.value = str(value)
+    graph = onnx.helper.make_graph([], "external", [], [], initializer=[tensor])
+    onnx.save_model(onnx.helper.make_model(graph), path)
+
+
+def test_onnx_external_data_is_confined_and_bounds_checked(tmp_path):
+    model_path = tmp_path / "model.onnx"
+    external_path = tmp_path / "weights.bin"
+    external_path.write_bytes(b"01234567")
+    _write_external_onnx(model_path, "weights.bin", offset=2, length=4)
+
+    assert _load_validated_onnx_metadata(str(model_path)) == {}
+
+
+@pytest.mark.parametrize("location", ["../outside.bin", "..\\outside.bin"])
+def test_onnx_external_data_rejects_parent_escape(tmp_path, location):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (tmp_path / "outside.bin").write_bytes(b"outside")
+    model_path = model_dir / "model.onnx"
+    _write_external_onnx(model_path, location)
+
+    with pytest.raises(ValueError, match="escapes the model directory"):
+        _load_validated_onnx_metadata(str(model_path))
+
+
+def test_onnx_external_data_rejects_absolute_path(tmp_path):
+    external_path = tmp_path / "outside.bin"
+    external_path.write_bytes(b"outside")
+    model_path = tmp_path / "model.onnx"
+    _write_external_onnx(model_path, str(external_path.resolve()))
+
+    with pytest.raises(ValueError, match="absolute location"):
+        _load_validated_onnx_metadata(str(model_path))
+
+
+def test_onnx_external_data_rejects_symlink_escape(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"outside")
+    link = model_dir / "linked.bin"
+    try:
+        link.symlink_to(outside)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    model_path = model_dir / "model.onnx"
+    _write_external_onnx(model_path, "linked.bin")
+
+    with pytest.raises(ValueError, match="escapes the model directory"):
+        _load_validated_onnx_metadata(str(model_path))
+
+
+def test_onnx_external_data_rejects_missing_or_out_of_bounds_file(tmp_path):
+    missing_model = tmp_path / "missing.onnx"
+    _write_external_onnx(missing_model, "missing.bin")
+    with pytest.raises(FileNotFoundError, match="external tensor data not found"):
+        _load_validated_onnx_metadata(str(missing_model))
+
+    external_path = tmp_path / "short.bin"
+    external_path.write_bytes(b"1234")
+    bounds_model = tmp_path / "bounds.onnx"
+    _write_external_onnx(bounds_model, "short.bin", offset=3, length=2)
+    with pytest.raises(ValueError, match="references bytes outside"):
+        _load_validated_onnx_metadata(str(bounds_model))
 
 
 def test_onnx_embedded_metadata_fallback_is_used_for_all_runtime_contracts(
@@ -94,9 +195,7 @@ def test_onnx_embedded_metadata_fallback_is_used_for_all_runtime_contracts(
     class _Session:
         def get_inputs(self):
             return [
-                SimpleNamespace(
-                    name="images", type="tensor(float)", shape=[1, 3, 8, 8]
-                )
+                SimpleNamespace(name="images", type="tensor(float)", shape=[1, 3, 8, 8])
             ]
 
         def get_outputs(self):
@@ -110,12 +209,13 @@ def test_onnx_embedded_metadata_fallback_is_used_for_all_runtime_contracts(
         InferenceSession=lambda path, providers: _Session(),
     )
     fake_onnx = SimpleNamespace(
-        load=lambda path: SimpleNamespace(
+        TensorProto=SimpleNamespace(EXTERNAL=1),
+        load=lambda path, load_external_data=False: SimpleNamespace(
+            ListFields=lambda: [],
             metadata_props=[
-                SimpleNamespace(key=key, value=value)
-                for key, value in metadata.items()
-            ]
-        )
+                SimpleNamespace(key=key, value=value) for key, value in metadata.items()
+            ],
+        ),
     )
     monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
     monkeypatch.setitem(sys.modules, "onnx", fake_onnx)
@@ -231,9 +331,7 @@ def test_coreml_validation_inverts_rfdetr_imagenet_normalization():
     mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1)
     std = torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1)
 
-    restored = backend._validation_tensor_to_canonical_rgb(
-        (canonical - mean) / std
-    )
+    restored = backend._validation_tensor_to_canonical_rgb((canonical - mean) / std)
 
     torch.testing.assert_close(restored, canonical * 255.0)
 

--- a/tests/unit/test_backend_runtime_contracts.py
+++ b/tests/unit/test_backend_runtime_contracts.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.backends.onnx import OnnxBackend, _resolve_onnx_providers
+from libreyolo.backends.coreml import CoreMLBackend
+from libreyolo.backends.torchscript import TorchScriptBackend
+from libreyolo.validation.base import BaseValidator, validation_model_state
+from libreyolo.validation.detection_validator import DetectionValidator
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_onnx_runtime_input_is_cast_to_declared_dtype():
+    captured = {}
+
+    class _Session:
+        def run(self, output_names, feed):
+            captured["output_names"] = output_names
+            captured["blob"] = feed["images"]
+            return [np.zeros((1,), dtype=np.float16)]
+
+    backend = OnnxBackend.__new__(OnnxBackend)
+    backend.session = _Session()
+    backend.input_name = "images"
+    backend.input_dtype = np.dtype(np.float16)
+
+    outputs = backend._run_inference(np.ones((1, 3, 4, 4), dtype=np.float32))
+
+    assert outputs[0].dtype == np.float16
+    assert captured["output_names"] is None
+    assert captured["blob"].dtype == np.float16
+    assert captured["blob"].flags.c_contiguous
+
+
+@pytest.mark.parametrize("device", ["cpu", "CPU", torch.device("cpu")])
+def test_onnx_explicit_cpu_uses_cpu_provider_without_warning(device, caplog):
+    providers, resolved = _resolve_onnx_providers(
+        device,
+        ["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert providers == ["CPUExecutionProvider"]
+    assert resolved == "cpu"
+    assert not caplog.records
+
+
+def test_onnx_indexed_cuda_passes_device_id_to_execution_provider():
+    providers, resolved = _resolve_onnx_providers(
+        "cuda:2",
+        ["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert providers == [
+        ("CUDAExecutionProvider", {"device_id": 2}),
+        "CPUExecutionProvider",
+    ]
+    assert resolved == "cuda:2"
+
+
+def test_onnx_runtime_rejects_unrepresentable_input_type():
+    with pytest.raises(TypeError, match=r"tensor\(bfloat16\)"):
+        OnnxBackend._numpy_dtype_for_onnx_type("tensor(bfloat16)")
+
+
+def test_onnx_embedded_metadata_fallback_is_used_for_all_runtime_contracts(
+    monkeypatch, tmp_path
+):
+    metadata = {
+        "model_family": "clip",
+        "model_size": "tiny",
+        "task": "classify",
+        "supported_tasks": '["classify"]',
+        "default_task": "classify",
+        "names": '{"0": "cat", "1": "dog"}',
+        "imgsz": "8",
+        "classification_mean": "[0.1, 0.2, 0.3]",
+        "classification_std": "[0.4, 0.5, 0.6]",
+        "classification_crop_pct": "1.0",
+        "classification_interpolation": "bicubic",
+        "classification_square_resize": "true",
+        "classification_activation": "sigmoid",
+        "num_bins": "12",
+        "bin_width_deg": "5.0",
+        "offset_deg": "-30.0",
+    }
+
+    class _Session:
+        def get_inputs(self):
+            return [
+                SimpleNamespace(
+                    name="images", type="tensor(float)", shape=[1, 3, 8, 8]
+                )
+            ]
+
+        def get_outputs(self):
+            return [SimpleNamespace(name="scores")]
+
+        def get_modelmeta(self):
+            raise RuntimeError("runtime metadata unavailable")
+
+    fake_ort = SimpleNamespace(
+        get_available_providers=lambda: ["CPUExecutionProvider"],
+        InferenceSession=lambda path, providers: _Session(),
+    )
+    fake_onnx = SimpleNamespace(
+        load=lambda path: SimpleNamespace(
+            metadata_props=[
+                SimpleNamespace(key=key, value=value)
+                for key, value in metadata.items()
+            ]
+        )
+    )
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+    monkeypatch.setitem(sys.modules, "onnx", fake_onnx)
+    model_path = tmp_path / "classifier.onnx"
+    model_path.write_bytes(b"placeholder")
+
+    backend = OnnxBackend(str(model_path), device="cpu")
+
+    assert backend.task == "classify"
+    assert backend.classification_mean == (0.1, 0.2, 0.3)
+    assert backend.classification_std == (0.4, 0.5, 0.6)
+    assert backend.crop_pct == 1.0
+    assert backend.interpolation == "bicubic"
+    assert backend.classification_square_resize is True
+    assert backend.classification_activation == "sigmoid"
+    assert backend.num_bins == 12
+    assert backend.bin_width_deg == 5.0
+    assert backend.offset_deg == -30.0
+
+
+def test_torchscript_uses_first_floating_parameter_dtype():
+    model = torch.nn.Conv2d(3, 2, 1).half()
+
+    assert TorchScriptBackend._floating_model_dtype(model) == torch.float16
+
+
+def test_torchscript_uses_floating_buffer_for_parameterless_module():
+    class _Buffered(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("scale", torch.ones(1, dtype=torch.float64))
+
+    assert TorchScriptBackend._floating_model_dtype(_Buffered()) == torch.float64
+
+
+def test_torchscript_runtime_casts_input_to_loaded_model_dtype():
+    class _Capture(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.seen_dtype = None
+
+        def forward(self, tensor):
+            self.seen_dtype = tensor.dtype
+            return tensor
+
+    backend = TorchScriptBackend.__new__(TorchScriptBackend)
+    backend.model = _Capture()
+    backend.device = torch.device("cpu")
+    backend.input_dtype = torch.float16
+
+    outputs = backend._run_inference(np.ones((1, 3, 2, 2), dtype=np.float32))
+
+    assert backend.model.seen_dtype == torch.float16
+    assert outputs[0].dtype == np.float16
+
+
+def test_validation_state_allows_runtime_without_inner_torch_model():
+    runtime = SimpleNamespace(device="cpu")
+
+    with validation_model_state(runtime, torch.device("cpu")):
+        pass
+
+
+def test_validator_eval_hook_is_noop_for_non_pytorch_runtime():
+    validator = SimpleNamespace(model=SimpleNamespace(model=SimpleNamespace()))
+
+    BaseValidator._set_model_eval(validator)
+
+
+def test_coreml_validation_forward_restores_canonical_rgb_pixels():
+    backend = CoreMLBackend.__new__(CoreMLBackend)
+    backend.model_family = "yolo9"
+    backend._has_embedded_nms = False
+    captured = {}
+
+    def run(blob):
+        captured["blob"] = blob.copy()
+        return [np.zeros((1, 1), dtype=np.float32)]
+
+    backend._run_inference = run
+    backend._forward(torch.full((1, 3, 2, 2), 0.5))
+
+    np.testing.assert_allclose(captured["blob"], 128.0)
+
+
+def test_coreml_embedded_nms_forward_restores_batch_axis():
+    backend = CoreMLBackend.__new__(CoreMLBackend)
+    backend.model_family = "yolo9"
+    backend._has_embedded_nms = True
+
+    def run(blob):
+        marker = float(blob[0, 0, 0, 0])
+        return [
+            np.full((3, 2), marker, dtype=np.float32),
+            np.full((3, 4), marker, dtype=np.float32),
+        ]
+
+    backend._run_inference = run
+    confidence, coordinates = backend._forward(
+        torch.tensor([0.25, 0.75]).view(2, 1, 1, 1).expand(2, 3, 1, 1)
+    )
+
+    assert confidence.shape == (2, 3, 2)
+    assert coordinates.shape == (2, 3, 4)
+    assert confidence[0, 0, 0].item() == 64.0
+    assert confidence[1, 0, 0].item() == 191.0
+
+
+def test_coreml_validation_inverts_rfdetr_imagenet_normalization():
+    backend = CoreMLBackend.__new__(CoreMLBackend)
+    backend.model_family = "rfdetr"
+    canonical = torch.tensor([0.2, 0.4, 0.6]).view(1, 3, 1, 1)
+    mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1)
+    std = torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1)
+
+    restored = backend._validation_tensor_to_canonical_rgb(
+        (canonical - mean) / std
+    )
+
+    torch.testing.assert_close(restored, canonical * 255.0)
+
+
+def test_coreml_validation_converts_yolox_bgr_to_rgb():
+    backend = CoreMLBackend.__new__(CoreMLBackend)
+    backend.model_family = "yolox"
+    bgr = torch.tensor([10.0, 20.0, 30.0]).view(1, 3, 1, 1)
+
+    restored = backend._validation_tensor_to_canonical_rgb(bgr)
+
+    torch.testing.assert_close(
+        restored,
+        torch.tensor([30.0, 20.0, 10.0]).view(1, 3, 1, 1),
+    )
+
+
+class _RuntimeValidator(BaseValidator):
+    def _setup_dataloader(self):
+        return []
+
+    def _init_metrics(self):
+        pass
+
+    def _preprocess_batch(self, batch):
+        return batch, None, None, None
+
+    def _postprocess_predictions(self, preds, batch):
+        return preds
+
+    def _update_metrics(self, detections, targets, img_info, img_ids):
+        pass
+
+    def _compute_metrics(self):
+        return {}
+
+
+class _Runtime:
+    def __init__(self):
+        self.forward_calls = 0
+
+    def _forward(self, images):
+        self.forward_calls += 1
+        return []
+
+
+def test_validator_normal_loop_allows_runtime_without_model_eval():
+    validator = object.__new__(_RuntimeValidator)
+    validator.model = _Runtime()
+    validator.config = SimpleNamespace(augment=False, verbose=False, half=False)
+    validator.device = torch.device("cpu")
+    validator.dataloader = [torch.zeros(1, 3, 2, 2)]
+    validator.speed = {
+        "preprocess": 0.0,
+        "inference": 0.0,
+        "postprocess": 0.0,
+        "total": 0.0,
+    }
+    validator.seen = 0
+
+    validator._run_validation()
+
+    assert validator.model.forward_calls == 1
+
+
+def test_validator_warmup_allows_runtime_without_model_eval():
+    validator = object.__new__(_RuntimeValidator)
+    validator.model = _Runtime()
+    validator.config = SimpleNamespace(
+        verbose=False,
+        imgsz=4,
+        batch_size=1,
+        half=False,
+    )
+    validator.device = torch.device("cpu")
+    validator.dataloader = SimpleNamespace(batch_size=1)
+
+    validator._warmup_model(n_warmup=1)
+
+    assert validator.model.forward_calls == 1
+
+
+def test_augmented_loop_allows_runtime_without_model_eval():
+    class _EmptyLoader(list):
+        dataset = []
+
+    validator = object.__new__(DetectionValidator)
+    validator.model = SimpleNamespace(model=SimpleNamespace(), model_family="coreml")
+    validator.config = SimpleNamespace(verbose=False, conf_thres=0.25)
+    validator.device = torch.device("cpu")
+    validator.dataloader = _EmptyLoader()
+    validator.speed = {"inference": 0.0, "total": 0.0}
+    validator.seen = 0
+
+    validator._run_validation_augmented()
+
+    assert validator.seen == 0

--- a/tests/unit/test_backend_runtime_contracts.py
+++ b/tests/unit/test_backend_runtime_contracts.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import sys
+import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -12,6 +14,7 @@ from libreyolo.backends.onnx import (
     OnnxBackend,
     _load_validated_onnx_metadata,
     _resolve_onnx_providers,
+    _stage_validated_onnx_artifact,
 )
 from libreyolo.backends.torchscript import TorchScriptBackend
 from libreyolo.validation.base import BaseValidator, validation_model_state
@@ -108,6 +111,28 @@ def _write_external_onnx(path, location, *, offset=None, length=None):
     onnx.save_model(onnx.helper.make_model(graph), path)
 
 
+def _write_shared_external_onnx(path, location, slices):
+    onnx = pytest.importorskip("onnx")
+    tensors = []
+    for index, (offset, length) in enumerate(slices):
+        tensor = onnx.TensorProto()
+        tensor.name = f"weight-{index}"
+        tensor.data_type = onnx.TensorProto.FLOAT
+        tensor.dims.append(1)
+        tensor.data_location = onnx.TensorProto.EXTERNAL
+        for key, value in (
+            ("location", location),
+            ("offset", offset),
+            ("length", length),
+        ):
+            entry = tensor.external_data.add()
+            entry.key = key
+            entry.value = str(value)
+        tensors.append(tensor)
+    graph = onnx.helper.make_graph([], "shared-external", [], [], initializer=tensors)
+    onnx.save_model(onnx.helper.make_model(graph), path)
+
+
 def test_onnx_external_data_is_confined_and_bounds_checked(tmp_path):
     model_path = tmp_path / "model.onnx"
     external_path = tmp_path / "weights.bin"
@@ -124,6 +149,16 @@ def test_onnx_external_data_rejects_parent_escape(tmp_path, location):
     (tmp_path / "outside.bin").write_bytes(b"outside")
     model_path = model_dir / "model.onnx"
     _write_external_onnx(model_path, location)
+
+    with pytest.raises(ValueError, match="escapes the model directory"):
+        _load_validated_onnx_metadata(str(model_path))
+
+
+def test_onnx_external_data_rejects_missing_parent_escape_before_open(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    model_path = model_dir / "model.onnx"
+    _write_external_onnx(model_path, "../missing-outside.bin")
 
     with pytest.raises(ValueError, match="escapes the model directory"):
         _load_validated_onnx_metadata(str(model_path))
@@ -170,6 +205,115 @@ def test_onnx_external_data_rejects_missing_or_out_of_bounds_file(tmp_path):
         _load_validated_onnx_metadata(str(bounds_model))
 
 
+def test_onnx_external_data_rejects_open_path_identity_race(tmp_path, monkeypatch):
+    model_path = tmp_path / "model.onnx"
+    expected = tmp_path / "weights.bin"
+    outside = tmp_path / "outside.bin"
+    expected.write_bytes(b"safe")
+    outside.write_bytes(b"outside")
+    _write_external_onnx(model_path, "weights.bin", length=4)
+
+    original_open = os.open
+
+    def raced_open(path, *args, **kwargs):
+        if Path(path) == expected:
+            return original_open(outside, *args, **kwargs)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("libreyolo.backends.onnx.os.open", raced_open)
+    with pytest.raises(RuntimeError, match="changed while it was being validated"):
+        _load_validated_onnx_metadata(str(model_path))
+
+
+def test_onnx_runtime_uses_private_validated_snapshot(tmp_path):
+    onnx = pytest.importorskip("onnx")
+    model_path = tmp_path / "model.onnx"
+    external_path = tmp_path / "weights.bin"
+    external_path.write_bytes(b"01234567")
+    _write_external_onnx(model_path, "weights.bin", offset=2, length=4)
+
+    with _stage_validated_onnx_artifact(str(model_path)) as (staged, metadata):
+        assert staged != model_path
+        assert staged.is_file()
+        assert metadata == {}
+        loaded = onnx.load(str(staged), load_external_data=True)
+        assert loaded.graph.initializer[0].raw_data == b"2345"
+
+
+def test_onnx_shared_external_data_uses_one_captured_snapshot(tmp_path, monkeypatch):
+    model_path = tmp_path / "model.onnx"
+    external_path = tmp_path / "weights.bin"
+    external_path.write_bytes(b"AAAA")
+    _write_shared_external_onnx(
+        model_path,
+        "weights.bin",
+        [(0, 4), (4, 4)],
+    )
+    real_open = os.open
+    external_opens = 0
+
+    def counted_open(path, *args, **kwargs):
+        nonlocal external_opens
+        if Path(path) == external_path:
+            external_opens += 1
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("libreyolo.backends.onnx.os.open", counted_open)
+    with pytest.raises(ValueError, match="references bytes outside"):
+        with _stage_validated_onnx_artifact(str(model_path)):
+            pass
+
+    assert external_opens == 1
+
+
+def test_onnx_backend_opens_runtime_session_from_private_snapshot(
+    tmp_path, monkeypatch
+):
+    onnx = pytest.importorskip("onnx")
+    model_path = tmp_path / "model.onnx"
+    (tmp_path / "weights.bin").write_bytes(b"01234567")
+    _write_external_onnx(model_path, "weights.bin", offset=2, length=4)
+    captured = {}
+
+    class _Session:
+        def __init__(self, path, providers):
+            staged = Path(path)
+            captured["path"] = staged
+            captured["providers"] = providers
+            captured["raw_data"] = (
+                onnx.load(str(staged), load_external_data=True)
+                .graph.initializer[0]
+                .raw_data
+            )
+
+        def get_inputs(self):
+            return [
+                SimpleNamespace(name="images", type="tensor(float)", shape=[1, 3, 8, 8])
+            ]
+
+        def get_outputs(self):
+            return [SimpleNamespace(name="scores")]
+
+        def get_modelmeta(self):
+            return SimpleNamespace(custom_metadata_map={})
+
+    monkeypatch.setitem(
+        sys.modules,
+        "onnxruntime",
+        SimpleNamespace(
+            get_available_providers=lambda: ["CPUExecutionProvider"],
+            InferenceSession=_Session,
+        ),
+    )
+
+    OnnxBackend(str(model_path), device="cpu")
+
+    assert captured["path"] != model_path
+    assert captured["path"].parent.name.startswith("libreyolo-onnx-runtime-")
+    assert captured["providers"] == ["CPUExecutionProvider"]
+    assert captured["raw_data"] == b"2345"
+
+
 def test_onnx_embedded_metadata_fallback_is_used_for_all_runtime_contracts(
     monkeypatch, tmp_path
 ):
@@ -208,14 +352,16 @@ def test_onnx_embedded_metadata_fallback_is_used_for_all_runtime_contracts(
         get_available_providers=lambda: ["CPUExecutionProvider"],
         InferenceSession=lambda path, providers: _Session(),
     )
+    fake_model = SimpleNamespace(
+        ListFields=lambda: [],
+        metadata_props=[
+            SimpleNamespace(key=key, value=value) for key, value in metadata.items()
+        ],
+        SerializeToString=lambda: b"staged-placeholder",
+    )
     fake_onnx = SimpleNamespace(
         TensorProto=SimpleNamespace(EXTERNAL=1),
-        load=lambda path, load_external_data=False: SimpleNamespace(
-            ListFields=lambda: [],
-            metadata_props=[
-                SimpleNamespace(key=key, value=value) for key, value in metadata.items()
-            ],
-        ),
+        load_model_from_string=lambda payload: fake_model,
     )
     monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
     monkeypatch.setitem(sys.modules, "onnx", fake_onnx)

--- a/tests/unit/test_calibration_runtime_contracts.py
+++ b/tests/unit/test_calibration_runtime_contracts.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from libreyolo.export.calibration import CalibrationDataLoader
+
+
+pytestmark = pytest.mark.unit
+
+
+def _loader(*, family: str | None, task: str | None, shape=(1, 3, 8, 12)):
+    loader = CalibrationDataLoader.__new__(CalibrationDataLoader)
+    loader.imgsz = (shape[2], shape[3])
+    loader.batch = shape[0]
+    loader.input_shape = shape
+    loader._sample_shape = shape[1:]
+    loader.model_family = family
+    loader.task = task
+    loader.model_size = None
+    loader._preprocess_fn = None
+    return loader
+
+
+def test_depth_calibration_uses_fixed_runtime_stretch():
+    loader = _loader(family="depth_anything", task="depth")
+    image = np.zeros((3, 5, 3), dtype=np.uint8)
+    image[..., 0] = 255
+
+    sample = loader._preprocess_array(image)
+
+    assert sample.shape == (3, 8, 12)
+    assert sample.dtype == np.float32
+    assert np.all(sample[0] == 1.0)
+    assert np.all(sample[1:] == 0.0)
+
+
+@pytest.mark.parametrize("source_shape", [(3, 5), (24, 30)])
+def test_restoration_calibration_is_fixed_to_profile_shape(source_shape):
+    loader = _loader(family="nafnet", task="restore")
+    image = np.full((*source_shape, 3), 127, dtype=np.uint8)
+
+    sample = loader._preprocess_array(image)
+
+    assert sample.shape == (3, 8, 12)
+    assert sample.dtype == np.float32
+
+
+def test_yolonas_pose_calibration_matches_runtime_pose_preprocessor():
+    from libreyolo.models.yolonas.utils import preprocess_pose_image
+
+    loader = _loader(family="yolonas", task="pose", shape=(1, 3, 640, 640))
+    image = np.zeros((9, 5, 3), dtype=np.uint8)
+    image[..., 0] = 255
+
+    actual = loader._preprocess_array(image)
+    expected, *_ = preprocess_pose_image(
+        image,
+        input_size=640,
+        color_format="rgb",
+    )
+
+    np.testing.assert_allclose(actual, expected.squeeze(0).numpy())
+
+
+def test_generic_calibration_rejects_variable_preprocess_shape():
+    loader = _loader(family="yolo9", task="detect")
+    loader._preprocess_fn = lambda image, imgsz: (
+        np.zeros((3, 4, 4), dtype=np.float32),
+        1.0,
+    )
+
+    with pytest.raises(ValueError, match="must match the exported runtime"):
+        loader._preprocess_array(np.zeros((4, 4, 3), dtype=np.uint8))

--- a/tests/unit/test_calibration_runtime_contracts.py
+++ b/tests/unit/test_calibration_runtime_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -20,6 +22,27 @@ def _loader(*, family: str | None, task: str | None, shape=(1, 3, 8, 12)):
     loader.model_size = None
     loader._preprocess_fn = None
     return loader
+
+
+def _iter_loader(sample_ids, *, batch: int, failing_ids=()):
+    loader = CalibrationDataLoader.__new__(CalibrationDataLoader)
+    loader.batch = batch
+    loader.img_files = [Path(str(sample_id)) for sample_id in sample_ids]
+    loader._num_batches = (len(loader.img_files) + batch - 1) // batch
+    failing_ids = set(failing_ids)
+
+    def preprocess(path):
+        sample_id = int(path.name)
+        if sample_id in failing_ids:
+            raise ValueError("invalid calibration sample")
+        return np.full((1, 1, 1), sample_id, dtype=np.float32)
+
+    loader._preprocess = preprocess
+    return loader
+
+
+def _batch_ids(batch):
+    return batch[:, 0, 0, 0].astype(int).tolist()
 
 
 def test_depth_calibration_uses_fixed_runtime_stretch():
@@ -72,3 +95,42 @@ def test_generic_calibration_rejects_variable_preprocess_shape():
 
     with pytest.raises(ValueError, match="must match the exported runtime"):
         loader._preprocess_array(np.zeros((4, 4, 3), dtype=np.uint8))
+
+
+@pytest.mark.parametrize(
+    ("sample_ids", "batch_size", "expected_counts"),
+    [
+        (range(8), 16, [2] * 8),
+        (range(18), 16, [2] * 14 + [1] * 4),
+    ],
+)
+def test_calibration_tail_padding_balances_valid_samples(
+    sample_ids, batch_size, expected_counts
+):
+    batches = list(_iter_loader(sample_ids, batch=batch_size))
+    observed = np.bincount(
+        [sample_id for batch in batches for sample_id in _batch_ids(batch)],
+        minlength=len(expected_counts),
+    )
+
+    assert all(batch.shape == (batch_size, 1, 1, 1) for batch in batches)
+    assert observed.tolist() == expected_counts
+
+
+def test_calibration_tail_padding_excludes_invalid_samples():
+    batches = list(_iter_loader(range(4), batch=4, failing_ids={1}))
+
+    assert _batch_ids(batches[0]) == [0, 2, 3, 0]
+
+
+def test_calibration_loader_rejects_all_invalid_samples():
+    loader = _iter_loader(range(2), batch=4, failing_ids={0, 1})
+
+    with pytest.raises(RuntimeError, match="No calibration images matched"):
+        list(loader)
+
+
+def test_calibration_exact_batches_are_not_padded():
+    batches = list(_iter_loader(range(4), batch=2))
+
+    assert [_batch_ids(batch) for batch in batches] == [[0, 1], [2, 3]]

--- a/tests/unit/test_clip.py
+++ b/tests/unit/test_clip.py
@@ -7,6 +7,8 @@ against open_clip and accuracy live in ``test_clip_parity.py`` (external_data).
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 import torch
@@ -71,7 +73,9 @@ class TestRegistry:
         }
         assert LibreCLIP.can_load(good)
         # Missing any one signature key -> not a CLIP checkpoint.
-        assert not LibreCLIP.can_load({k: v for k, v in good.items() if k != "logit_scale"})
+        assert not LibreCLIP.can_load(
+            {k: v for k, v in good.items() if k != "logit_scale"}
+        )
         assert not LibreCLIP.can_load({"backbone.0.weight": torch.zeros(1)})
 
     @pytest.mark.parametrize(
@@ -223,15 +227,109 @@ class TestScope:
         with pytest.raises(NotImplementedError):
             tiny_clip.export(format="torchscript")
 
+    def test_export_accepts_standard_cli_arguments(
+        self, tiny_clip, monkeypatch, tmp_path
+    ):
+        captured = {}
+
+        def fake_export(model, **kwargs):
+            captured["model"] = model
+            captured.update(kwargs)
+            return kwargs["output"]
+
+        monkeypatch.setattr(
+            "libreyolo.models.clip.export.export_frozen_onnx", fake_export
+        )
+        output = tmp_path / "clip.onnx"
+
+        result = tiny_clip.export(
+            format="onnx",
+            output_path=output,
+            opset=None,
+            simplify=False,
+            dynamic=False,
+            half=False,
+            int8=False,
+            imgsz=(32, 32),
+            batch=2,
+            device="cpu",
+            verbose=True,
+        )
+
+        assert result == str(output)
+        assert captured == {
+            "model": tiny_clip,
+            "imgsz": 32,
+            "opset": None,
+            "output": str(output),
+            "batch": 2,
+            "dynamic": False,
+            "device": "cpu",
+            "simplify": False,
+            "verbose": True,
+        }
+
+    @pytest.mark.parametrize(
+        "kwargs,error,match",
+        [
+            ({"half": True}, NotImplementedError, "half=True"),
+            ({"int8": True}, NotImplementedError, "int8=True"),
+            (
+                {"int8": True, "fraction": 0.5, "allow_download_scripts": False},
+                NotImplementedError,
+                "int8=True",
+            ),
+            ({"batch": 0}, ValueError, "positive integer"),
+            ({"batch": True}, ValueError, "positive integer"),
+            ({"imgsz": 64}, ValueError, "only supports imgsz=32"),
+            ({"imgsz": (32, 31)}, ValueError, "only supports imgsz=32"),
+        ],
+    )
+    def test_export_rejects_unsupported_requests(
+        self, tiny_clip, tmp_path, kwargs, error, match
+    ):
+        output = tmp_path / "should-not-exist.onnx"
+        with pytest.raises(error, match=match):
+            tiny_clip.export(output_path=output, **kwargs)
+        assert not output.exists()
+
     def test_frozen_onnx_roundtrip(self, tiny_clip, tmp_path):
-        pytest.importorskip("onnx")
+        onnx = pytest.importorskip("onnx")
         ort = pytest.importorskip("onnxruntime")
         tiny_clip.set_classes(["a cat", "a dog", "a truck"])
-        out = tiny_clip.export(format="onnx", output=str(tmp_path / "clip.onnx"))
+        out = tiny_clip.export(
+            format="onnx",
+            output_path=tmp_path / "clip.onnx",
+            opset=None,
+            batch=2,
+            dynamic=False,
+            device="cpu",
+            simplify=False,
+            verbose=False,
+        )
+        proto = onnx.load(out)
+        metadata = {entry.key: entry.value for entry in proto.metadata_props}
+        assert proto.graph.input[0].type.tensor_type.shape.dim[0].dim_value == 2
+        assert metadata["model_family"] == "clip"
+        assert metadata["task"] == "classify"
+        assert json.loads(metadata["names"]) == {
+            "0": "a cat",
+            "1": "a dog",
+            "2": "a truck",
+        }
+        assert json.loads(metadata["classification_mean"]) == pytest.approx(
+            [0.48145466, 0.4578275, 0.40821073]
+        )
+        assert metadata["classification_crop_pct"] == "1.0"
+        assert metadata["classification_interpolation"] == "bicubic"
+        assert metadata["classification_square_resize"] == "false"
+        assert metadata["classification_activation"] == "softmax"
         sess = ort.InferenceSession(out, providers=["CPUExecutionProvider"])
-        x = np.zeros((1, 3, tiny_clip.input_size, tiny_clip.input_size), dtype=np.float32)
+        x = np.zeros(
+            (2, 3, tiny_clip.input_size, tiny_clip.input_size), dtype=np.float32
+        )
         (logits,) = sess.run(None, {"images": x})
-        assert logits.shape == (1, 3)
+        assert logits.shape == (2, 3)
         # ONNX frozen head must match the eager zero-shot logits.
         with torch.no_grad():
             eager = tiny_clip._forward(torch.from_numpy(x)).cpu().numpy()

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -158,6 +158,16 @@ class TestExporterFormats:
 
         assert not output.exists()
 
+    def test_blocked_int8_export_reports_support_before_calibration(self, tmp_path):
+        wrapper = _make_wrapper(model_name="rfdetr")
+        wrapper.task = "detect"
+        output = tmp_path / "model_ncnn"
+
+        with pytest.raises(NotImplementedError, match="NCNN export is not supported"):
+            NcnnExporter(wrapper)(output_path=str(output), int8=True)
+
+        assert not output.exists()
+
     def test_unsupported_exporter_rejects_embedded_nms(self):
         exporter = TorchScriptExporter(_make_wrapper())
 
@@ -427,9 +437,7 @@ class TestExporterFormats:
 
         monkeypatch.setattr(exporter, "_preflight", lambda **kwargs: None)
 
-        def fake_intermediate(
-            nn_model, dummy, output_path, opset, simplify, dynamic
-        ):
+        def fake_intermediate(nn_model, dummy, output_path, opset, simplify, dynamic):
             captured["intermediate_dynamic"] = dynamic
             return str(tmp_path / "intermediate.onnx")
 
@@ -466,9 +474,7 @@ class TestExporterFormats:
 
         monkeypatch.setattr(exporter, "_preflight", lambda **kwargs: None)
 
-        def fake_intermediate(
-            nn_model, dummy, output_path, opset, simplify, dynamic
-        ):
+        def fake_intermediate(nn_model, dummy, output_path, opset, simplify, dynamic):
             out = Path(output_path)
             generated = out.with_name(f"{out.stem}.export_intermediate.onnx")
             generated.write_bytes(b"generated")
@@ -506,9 +512,7 @@ class TestExporterFormats:
 
         monkeypatch.setattr(exporter, "_preflight", lambda **kwargs: None)
 
-        def fake_intermediate(
-            nn_model, dummy, output_path, opset, simplify, dynamic
-        ):
+        def fake_intermediate(nn_model, dummy, output_path, opset, simplify, dynamic):
             out = Path(output_path)
             generated = out.with_name(f"{out.stem}.export_intermediate.onnx")
             generated.write_bytes(b"generated")
@@ -532,6 +536,51 @@ class TestExporterFormats:
         generated = captured["generated"]
         assert not generated.exists()
         assert not generated.parent.exists()
+
+    @pytest.mark.parametrize(
+        ("exporter_cls", "suffix"),
+        [
+            (TensorRTExporter, ".engine"),
+            (OpenVINOExporter, "_openvino"),
+            (TFLiteExporter, ".tflite"),
+        ],
+    )
+    def test_intermediate_workspace_returns_requested_final_path(
+        self, monkeypatch, tmp_path, exporter_cls, suffix
+    ):
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "detect"
+        exporter = exporter_cls(wrapper)
+        output_path = tmp_path / f"model{suffix}"
+        captured = {}
+
+        monkeypatch.setattr(exporter, "_preflight", lambda **kwargs: None)
+
+        def fake_intermediate(nn_model, dummy, workspace_output, *args):
+            generated = Path(workspace_output).with_suffix(".onnx")
+            generated.write_bytes(b"generated")
+            captured["generated"] = generated
+            return str(generated)
+
+        def fake_export(nn_model, dummy, *, output_path, onnx_path, **kwargs):
+            assert Path(onnx_path).read_bytes() == b"generated"
+            assert output_path == str(output_path_expected)
+            return output_path
+
+        output_path_expected = output_path
+        monkeypatch.setattr(exporter, "_export_intermediate_onnx", fake_intermediate)
+        monkeypatch.setattr(exporter, "_export", fake_export)
+
+        result = exporter(
+            output_path=str(output_path),
+            device="cpu",
+            simplify=False,
+            dynamic=False,
+        )
+
+        assert result == str(output_path)
+        assert not captured["generated"].exists()
+        assert not captured["generated"].parent.exists()
 
     def test_rfdetr_export_defaults_to_cpu(self):
         wrapper = _make_wrapper(model_name="rfdetr")

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -148,6 +148,16 @@ class TestExporterFormats:
         assert TFLiteExporter.requires_onnx is True
         assert TFLiteExporter.supports_fp16 is False
 
+    def test_ncnn_rejects_requested_fp16_before_artifact_creation(self, tmp_path):
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "detect"
+        output = tmp_path / "model_ncnn"
+
+        with pytest.raises(NotImplementedError, match="NCNN FP16"):
+            NcnnExporter(wrapper)(output_path=str(output), half=True)
+
+        assert not output.exists()
+
     def test_unsupported_exporter_rejects_embedded_nms(self):
         exporter = TorchScriptExporter(_make_wrapper())
 
@@ -174,7 +184,7 @@ class TestExporterFormats:
         wrapper.task = "segment"
         exporter = CoreMLExporter(wrapper)
 
-        with pytest.raises(NotImplementedError, match="YOLO9 detection"):
+        with pytest.raises(NotImplementedError, match="segmentation export"):
             exporter._preflight(half=False, int8=False, data=None, nms=True)
 
     def test_export_rejects_yolo9_segment(self):
@@ -274,6 +284,39 @@ class TestExporterFormats:
         assert onnx_metadata["task"] == "obb"
         assert onnx_metadata["obb"] == "true"
 
+    def test_classifier_metadata_is_complete_for_all_artifact_kinds(self):
+        wrapper = _make_wrapper(model_name="convnext")
+        wrapper.task = "classify"
+        wrapper.SUPPORTED_TASKS = ("classify",)
+        wrapper.DEFAULT_TASK = "classify"
+        wrapper.crop_pct = 0.95
+        wrapper.interpolation = "bicubic"
+        wrapper.classification_mean = (0.1, 0.2, 0.3)
+        wrapper.classification_std = (0.4, 0.5, 0.6)
+        wrapper.classification_square_resize = True
+        wrapper.classification_activation = "sigmoid"
+
+        native = TorchScriptExporter(wrapper)._build_metadata(
+            precision="fp32", dynamic=False, onnx_path=None
+        )
+        onnx = OnnxExporter(wrapper)._build_onnx_metadata(
+            dynamic=False,
+            half=False,
+        )
+
+        assert native["classification_mean"] == [0.1, 0.2, 0.3]
+        assert native["classification_std"] == [0.4, 0.5, 0.6]
+        assert native["classification_crop_pct"] == 0.95
+        assert native["classification_interpolation"] == "bicubic"
+        assert native["classification_square_resize"] is True
+        assert native["classification_activation"] == "sigmoid"
+        assert json.loads(onnx["classification_mean"]) == [0.1, 0.2, 0.3]
+        assert json.loads(onnx["classification_std"]) == [0.4, 0.5, 0.6]
+        assert onnx["classification_crop_pct"] == "0.95"
+        assert onnx["classification_interpolation"] == "bicubic"
+        assert onnx["classification_square_resize"] == "true"
+        assert onnx["classification_activation"] == "sigmoid"
+
     def test_rfdetr_export_metadata_is_single_task(self):
         wrapper = _make_wrapper(model_name="rfdetr")
         wrapper.task = "segment"
@@ -365,7 +408,50 @@ class TestExporterFormats:
         assert captured["metadata"]["trt_min_batch"] == 2
         assert captured["metadata"]["trt_opt_batch"] == 4
         assert captured["metadata"]["trt_max_batch"] == 16
+        assert captured["input_shape"] == (1, 3, 32, 32)
         assert "trt_max_batch" not in metadata
+
+    def test_tensorrt_config_disables_dynamic_before_intermediate_onnx(
+        self, monkeypatch, tmp_path
+    ):
+        from libreyolo.export.config import DynamicBatchConfig, TensorRTExportConfig
+
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "detect"
+        exporter = TensorRTExporter(wrapper)
+        captured = {}
+        config = TensorRTExportConfig(
+            precision="fp32",
+            dynamic=DynamicBatchConfig(enabled=False),
+        )
+
+        monkeypatch.setattr(exporter, "_preflight", lambda **kwargs: None)
+
+        def fake_intermediate(
+            nn_model, dummy, output_path, opset, simplify, dynamic
+        ):
+            captured["intermediate_dynamic"] = dynamic
+            return str(tmp_path / "intermediate.onnx")
+
+        def fake_export(nn_model, dummy, *, output_path, dynamic, **kwargs):
+            captured["export_dynamic"] = dynamic
+            return output_path
+
+        monkeypatch.setattr(exporter, "_export_intermediate_onnx", fake_intermediate)
+        monkeypatch.setattr(exporter, "_export", fake_export)
+
+        result = exporter(
+            output_path=str(tmp_path / "model.engine"),
+            dynamic=True,
+            trt_config=config,
+            device="cpu",
+        )
+
+        assert result == str(tmp_path / "model.engine")
+        assert captured == {
+            "intermediate_dynamic": False,
+            "export_dynamic": False,
+        }
 
     def test_rfdetr_export_defaults_to_cpu(self):
         wrapper = _make_wrapper(model_name="rfdetr")
@@ -667,10 +753,13 @@ class TestExporterFormats:
             batch,
             fraction,
             allow_download_scripts=False,
+            *,
+            input_shape=None,
         ):
             captured["data"] = data
             captured["imgsz"] = imgsz
             captured["batch"] = batch
+            captured["input_shape"] = input_shape
             return object()
 
         def fake_export(nn_model, dummy, *, output_path, calibration_data, **kwargs):
@@ -699,6 +788,7 @@ class TestExporterFormats:
         assert captured["data"] == "coco8.yaml"
         assert captured["imgsz"] == (32, 32)
         assert captured["batch"] == 2
+        assert captured["input_shape"] == (2, 3, 32, 32)
         assert captured["dummy_dtype"] == torch.float32
         assert captured["param_dtype"] == torch.float32
         assert captured["half"] is False
@@ -707,14 +797,18 @@ class TestExporterFormats:
         assert "8-image fallback is not representative" in caplog.text
 
     @pytest.mark.parametrize(
-        ("family", "task"),
-        [("rfdetr", "detect"), ("yolo9", "segment"), ("yolo9_e2e", "detect")],
+        ("family", "task", "error"),
+        [
+            ("rfdetr", "detect", "YOLO9 detection"),
+            ("yolo9", "segment", "segmentation export"),
+            ("yolo9_e2e", "detect", "YOLO9 detection"),
+        ],
     )
-    def test_onnx_int8_scope_is_yolo9_detect_only(self, family, task):
+    def test_onnx_int8_scope_is_yolo9_detect_only(self, family, task, error):
         wrapper = _make_wrapper(model_name=family, input_size=32)
         wrapper.task = task
 
-        with pytest.raises(NotImplementedError, match="YOLO9 detection"):
+        with pytest.raises(NotImplementedError, match=error):
             OnnxExporter(wrapper)._preflight(
                 half=False,
                 int8=True,
@@ -889,9 +983,12 @@ class TestExporterFormats:
             batch,
             fraction,
             allow_download_scripts=False,
+            *,
+            input_shape=None,
         ):
             captured["imgsz"] = imgsz
             captured["batch"] = batch
+            captured["input_shape"] = input_shape
             return object()
 
         def fake_export(nn_model, dummy, *, output_path, calibration_data, **kwargs):
@@ -917,6 +1014,7 @@ class TestExporterFormats:
         assert captured["imgsz"] == (16, 32)
         assert captured["batch"] == 2
         assert captured["dummy_shape"] == (2, 3, 16, 32)
+        assert captured["input_shape"] == (2, 3, 16, 32)
         assert captured["calibration_data"] is not None
 
 
@@ -1149,6 +1247,87 @@ class TestModelStateRestored:
 
         param = next(wrapper.model.parameters())
         assert param.dtype == torch.float32
+
+    def test_mixed_modes_dtypes_values_and_gradients_restore_after_failure(
+        self, monkeypatch, tmp_path
+    ):
+        wrapper = _make_wrapper()
+        wrapper.model.train()
+        wrapper.model.conv.eval()
+        wrapper.model.fc.train()
+        wrapper.model.fc.double()
+        wrapper.model.register_buffer(
+            "mixed_precision_buffer",
+            torch.tensor([1.123456789], dtype=torch.float64),
+        )
+        wrapper.model.conv.weight.grad = torch.randn_like(wrapper.model.conv.weight)
+
+        modes = {
+            name: module.training for name, module in wrapper.model.named_modules()
+        }
+        tensors = {
+            name: value.detach().clone()
+            for name, value in (
+                *wrapper.model.named_parameters(),
+                *wrapper.model.named_buffers(),
+            )
+        }
+        dtypes = {name: value.dtype for name, value in tensors.items()}
+        grad = wrapper.model.conv.weight.grad.detach().clone()
+
+        exporter = TorchScriptExporter(wrapper)
+
+        def fail_export(nn_model, dummy, **kwargs):
+            assert dummy.dtype == torch.float16
+            assert all(
+                value.dtype == torch.float16
+                for value in (*nn_model.parameters(), *nn_model.buffers())
+                if value.is_floating_point()
+            )
+            raise RuntimeError("synthetic export failure")
+
+        monkeypatch.setattr(exporter, "_export", fail_export)
+        with pytest.raises(RuntimeError, match="synthetic export failure"):
+            exporter(
+                output_path=str(tmp_path / "failed.torchscript"),
+                half=True,
+                dynamic=False,
+            )
+
+        assert {
+            name: module.training for name, module in wrapper.model.named_modules()
+        } == modes
+        for name, value in (
+            *wrapper.model.named_parameters(),
+            *wrapper.model.named_buffers(),
+        ):
+            assert value.dtype == dtypes[name]
+            assert torch.equal(value, tensors[name])
+        assert torch.equal(wrapper.model.conv.weight.grad, grad)
+
+    def test_setup_failure_restores_export_flags_before_yield(self, monkeypatch):
+        wrapper = _make_wrapper()
+        wrapper.model.head = nn.Module()
+        wrapper.model.head.export = False
+        exporter = TorchScriptExporter(wrapper)
+
+        def fail_dummy(*args, **kwargs):
+            assert wrapper.model.head.export is True
+            raise RuntimeError("synthetic dummy allocation failure")
+
+        monkeypatch.setattr(exporter_module.torch, "randn", fail_dummy)
+
+        with pytest.raises(RuntimeError, match="dummy allocation failure"):
+            with exporter._model_context(
+                torch.device("cpu"),
+                False,
+                False,
+                1,
+                (32, 32),
+            ):
+                pass
+
+        assert wrapper.model.head.export is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -453,6 +453,86 @@ class TestExporterFormats:
             "export_dynamic": False,
         }
 
+    def test_intermediate_onnx_does_not_replace_preexisting_user_file(
+        self, monkeypatch, tmp_path
+    ):
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "detect"
+        exporter = TensorRTExporter(wrapper)
+        output_path = tmp_path / "model.engine"
+        victim = tmp_path / "model.export_intermediate.onnx"
+        victim.write_bytes(b"user-owned")
+        captured = {}
+
+        monkeypatch.setattr(exporter, "_preflight", lambda **kwargs: None)
+
+        def fake_intermediate(
+            nn_model, dummy, output_path, opset, simplify, dynamic
+        ):
+            out = Path(output_path)
+            generated = out.with_name(f"{out.stem}.export_intermediate.onnx")
+            generated.write_bytes(b"generated")
+            captured["generated"] = generated
+            return str(generated)
+
+        def fake_export(nn_model, dummy, *, output_path, onnx_path, **kwargs):
+            assert Path(onnx_path).read_bytes() == b"generated"
+            return output_path
+
+        monkeypatch.setattr(exporter, "_export_intermediate_onnx", fake_intermediate)
+        monkeypatch.setattr(exporter, "_export", fake_export)
+
+        result = exporter(
+            output_path=str(output_path),
+            device="cpu",
+            simplify=False,
+            dynamic=False,
+        )
+
+        generated = captured["generated"]
+        assert result == str(output_path)
+        assert victim.read_bytes() == b"user-owned"
+        assert generated != victim
+        assert not generated.exists()
+        assert not generated.parent.exists()
+
+    def test_intermediate_onnx_workspace_is_removed_after_export_failure(
+        self, monkeypatch, tmp_path
+    ):
+        wrapper = _make_wrapper(model_name="yolo9")
+        wrapper.task = "detect"
+        exporter = TensorRTExporter(wrapper)
+        captured = {}
+
+        monkeypatch.setattr(exporter, "_preflight", lambda **kwargs: None)
+
+        def fake_intermediate(
+            nn_model, dummy, output_path, opset, simplify, dynamic
+        ):
+            out = Path(output_path)
+            generated = out.with_name(f"{out.stem}.export_intermediate.onnx")
+            generated.write_bytes(b"generated")
+            captured["generated"] = generated
+            return str(generated)
+
+        def fail_export(*args, **kwargs):
+            raise RuntimeError("engine build failed")
+
+        monkeypatch.setattr(exporter, "_export_intermediate_onnx", fake_intermediate)
+        monkeypatch.setattr(exporter, "_export", fail_export)
+
+        with pytest.raises(RuntimeError, match="engine build failed"):
+            exporter(
+                output_path=str(tmp_path / "model.engine"),
+                device="cpu",
+                simplify=False,
+                dynamic=False,
+            )
+
+        generated = captured["generated"]
+        assert not generated.exists()
+        assert not generated.parent.exists()
+
     def test_rfdetr_export_defaults_to_cpu(self):
         wrapper = _make_wrapper(model_name="rfdetr")
         wrapper.device = torch.device("cuda")

--- a/tests/unit/test_export_coreml.py
+++ b/tests/unit/test_export_coreml.py
@@ -78,6 +78,94 @@ class _DummyRtdetrExportModel(torch.nn.Module):
         }
 
 
+class _DummyRtdetrStaticEncoder(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.eval_spatial_size = [96, 80]
+        self.use_encoder_idx = [0, 1]
+        self.feat_strides = [8, 16]
+        self.hidden_dim = 4
+        self.pe_temperature = 10_000
+        self.register_buffer(
+            "pos_embed0",
+            torch.full((1, 1, self.hidden_dim), -1.0),
+            persistent=False,
+        )
+
+    @staticmethod
+    def build_2d_sincos_position_embedding(width, height, hidden_dim, temperature):
+        del temperature
+        return torch.full((1, width * height, hidden_dim), 7.0)
+
+
+class _DummyRtdetrStaticDecoder(torch.nn.Module):
+    def __init__(self, *, fail_preparation=False):
+        super().__init__()
+        self.eval_spatial_size = [96, 80]
+        self.fail_preparation = fail_preparation
+        self.register_buffer("anchors", torch.full((1, 4), -2.0), persistent=False)
+
+    def _generate_anchors(self, *, device):
+        if self.fail_preparation:
+            raise RuntimeError("anchor preparation failed")
+        return torch.full((1, 4), 3.0, device=device), torch.ones(
+            (1, 1), dtype=torch.bool, device=device
+        )
+
+
+class _DummyRtdetrStaticModel(torch.nn.Module):
+    def __init__(self, *, fail_preparation=False):
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.tensor(2.0))
+        self.encoder = _DummyRtdetrStaticEncoder()
+        self.decoder = _DummyRtdetrStaticDecoder(fail_preparation=fail_preparation)
+
+    def forward(self, x):
+        batch = x.shape[0]
+        return {
+            "pred_logits": self.scale
+            * torch.ones(batch, 2, 3, dtype=x.dtype, device=x.device),
+            "pred_boxes": self.scale
+            * torch.ones(batch, 2, 4, dtype=x.dtype, device=x.device),
+        }
+
+
+def _snapshot_module_tensors(model):
+    return {
+        "parameters": {
+            name: (tensor, tensor.detach().clone(), tensor.device, tensor.dtype)
+            for name, tensor in model.named_parameters()
+        },
+        "buffers": {
+            name: (tensor, tensor.detach().clone(), tensor.device, tensor.dtype)
+            for name, tensor in model.named_buffers()
+        },
+        "modes": [(module, module.training) for module in model.modules()],
+        "attribute_keys": [
+            (module, frozenset(module.__dict__)) for module in model.modules()
+        ],
+    }
+
+
+def _assert_module_tensors_unchanged(model, snapshot):
+    for kind in ("parameters", "buffers"):
+        current = dict(
+            model.named_parameters() if kind == "parameters" else model.named_buffers()
+        )
+        assert current.keys() == snapshot[kind].keys()
+        for name, (original, value, device, dtype) in snapshot[kind].items():
+            assert current[name] is original
+            assert current[name].device == device
+            assert current[name].dtype == dtype
+            assert torch.equal(current[name], value)
+    assert [(module, module.training) for module in model.modules()] == snapshot[
+        "modes"
+    ]
+    assert [
+        (module, frozenset(module.__dict__)) for module in model.modules()
+    ] == snapshot["attribute_keys"]
+
+
 def _patch_ct(monkeypatch):
     """Reset the fake coremltools module and return the mock for assertions."""
     # Create the main coremltools mock
@@ -208,6 +296,57 @@ class TestExportCoreML:
 
         assert logits.shape == (1, 300, 80)
         assert boxes.shape == (1, 300, 4)
+
+    @pytest.mark.parametrize("failure_stage", [None, "trace", "preparation"])
+    def test_rtdetr_static_preparation_does_not_mutate_live_model(
+        self, tmp_path, monkeypatch, failure_stage
+    ):
+        fake, _ = _patch_ct(monkeypatch)
+        from libreyolo.export.coreml import export_coreml
+
+        model = _DummyRtdetrStaticModel(fail_preparation=failure_stage == "preparation")
+        model.train()
+        model.encoder.eval()  # Exercise restoration of a mixed-mode module tree.
+        encoder_size = model.encoder.eval_spatial_size
+        decoder_size = model.decoder.eval_spatial_size
+        snapshot = _snapshot_module_tensors(model)
+
+        def trace(prepared, dummy):
+            inner = prepared.model
+            assert inner is not model
+            assert inner.encoder.eval_spatial_size == (32, 48)
+            assert inner.decoder.eval_spatial_size == (32, 48)
+            assert torch.all(inner.encoder.pos_embed0 == 7)
+            assert hasattr(inner.encoder, "pos_embed1")
+            assert torch.all(inner.decoder.anchors == 3)
+            assert torch.all(inner.decoder.valid_mask)
+            if failure_stage == "trace":
+                raise RuntimeError("trace failed")
+            return MagicMock(name="traced")
+
+        monkeypatch.setattr(torch.jit, "trace", trace)
+
+        def call():
+            return export_coreml(
+                model,
+                torch.randn(1, 3, 32, 48),
+                output_path=str(tmp_path / "rtdetr.mlpackage"),
+                metadata={"model_family": "rtdetr"},
+                model_family="rtdetr",
+            )
+
+        if failure_stage is None:
+            call()
+            fake.convert.assert_called_once()
+        else:
+            with pytest.raises(RuntimeError):
+                call()
+
+        _assert_module_tensors_unchanged(model, snapshot)
+        assert model.encoder.eval_spatial_size is encoder_size
+        assert model.decoder.eval_spatial_size is decoder_size
+        assert not hasattr(model.encoder, "pos_embed1")
+        assert "valid_mask" not in model.decoder._buffers
 
 
 class TestUnsupportedFamily:

--- a/tests/unit/test_export_ncnn.py
+++ b/tests/unit/test_export_ncnn.py
@@ -1,7 +1,9 @@
 """Unit tests for the ncnn export module."""
 
 import tempfile
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -165,6 +167,30 @@ class TestNCNNMetadataYAML:
         assert parsed[5] == (320, 640)
 
 
+class TestNCNNBlobDiscovery:
+    def test_param_parser_preserves_all_terminal_output_names(self, tmp_path):
+        from libreyolo.backends.ncnn import NcnnBackend
+
+        param_path = tmp_path / "model.ncnn.param"
+        param_path.write_text(
+            "\n".join(
+                [
+                    "7767517",
+                    "4 5",
+                    "Input input 0 1 images",
+                    "Split split 1 2 images left right",
+                    "Convolution scores_head 1 1 left scores 0=4",
+                    "Convolution boxes_head 1 1 right boxes 0=4",
+                ]
+            )
+        )
+
+        inputs, outputs = NcnnBackend._discover_blob_names(param_path)
+
+        assert inputs == ["images"]
+        assert outputs == ["scores", "boxes"]
+
+
 class TestNCNNExportValidation:
     """Test ncnn export validation in exporter."""
 
@@ -183,3 +209,87 @@ class TestNCNNExportValidation:
         with tempfile.TemporaryDirectory() as tmpdir:
             with pytest.raises(ImportError, match="pnnx"):
                 exporter(output_path=str(Path(tmpdir) / "model_ncnn"))
+
+    def test_low_level_ncnn_rejects_half_before_dependency_check(self, tmp_path):
+        from libreyolo.export.ncnn import export_ncnn
+
+        output = tmp_path / "model_ncnn"
+        with pytest.raises(NotImplementedError, match="NCNN FP16"):
+            export_ncnn(
+                _TinyModel().eval(),
+                torch.zeros(1, 3, 8, 8),
+                output_path=str(output),
+                half=True,
+            )
+        assert not output.exists()
+
+
+class TestPNNXOptionalLoaderFailure:
+    """Only a completed conversion may tolerate a missing PNNX helper."""
+
+    @staticmethod
+    def _run_direct_export(monkeypatch, tmp_path, export):
+        from libreyolo.export.ncnn import _export_pnnx_direct
+
+        monkeypatch.setitem(sys.modules, "pnnx", SimpleNamespace(export=export))
+        model = _TinyModel().eval()
+        dummy = torch.zeros(1, 3, 8, 8)
+        return _export_pnnx_direct(model, dummy, tmp_path, half=False)
+
+    def test_accepts_missing_matching_optional_loader_after_artifacts(
+        self, monkeypatch, tmp_path
+    ):
+        def fake_export(model, traced_path, dummy, fp16):
+            trace_dir = Path(traced_path).parent
+            (trace_dir / "model.ncnn.param").write_text("param", encoding="utf-8")
+            (trace_dir / "model.ncnn.bin").write_bytes(b"bin")
+            raise FileNotFoundError("model_pnnx.py")
+
+        param_path, bin_path = self._run_direct_export(
+            monkeypatch, tmp_path, fake_export
+        )
+
+        assert param_path.read_text(encoding="utf-8") == "param"
+        assert bin_path.read_bytes() == b"bin"
+
+    def test_reraises_unrelated_missing_file_even_after_artifacts(
+        self, monkeypatch, tmp_path
+    ):
+        def fake_export(model, traced_path, dummy, fp16):
+            trace_dir = Path(traced_path).parent
+            (trace_dir / "model.ncnn.param").write_text("param", encoding="utf-8")
+            (trace_dir / "model.ncnn.bin").write_bytes(b"bin")
+            raise FileNotFoundError("labels.txt")
+
+        with pytest.raises(FileNotFoundError, match="labels.txt"):
+            self._run_direct_export(monkeypatch, tmp_path, fake_export)
+
+    def test_reraises_missing_loader_when_artifacts_are_incomplete(
+        self, monkeypatch, tmp_path
+    ):
+        def fake_export(model, traced_path, dummy, fp16):
+            trace_dir = Path(traced_path).parent
+            (trace_dir / "model.ncnn.param").write_text("param", encoding="utf-8")
+            raise FileNotFoundError("model_pnnx.py")
+
+        with pytest.raises(FileNotFoundError, match="model_pnnx.py"):
+            self._run_direct_export(monkeypatch, tmp_path, fake_export)
+
+
+def test_ncnn_metadata_is_safe_loadable_with_classifier_sequences(tmp_path):
+    import yaml
+
+    from libreyolo.export.ncnn import _save_metadata
+
+    _save_metadata(
+        tmp_path,
+        {
+            "task": "classify",
+            "classification_mean": (0.485, 0.456, 0.406),
+            "classification_std": [0.229, 0.224, 0.225],
+        },
+    )
+
+    loaded = yaml.safe_load((tmp_path / "metadata.yaml").read_text(encoding="utf-8"))
+    assert loaded["classification_mean"] == [0.485, 0.456, 0.406]
+    assert loaded["classification_std"] == [0.229, 0.224, 0.225]

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -13,7 +13,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from libreyolo.export.exporter import NcnnExporter, OnnxExporter
-from libreyolo.export.support import EXPORT_FORMATS, SUPPORT, get_support
+from libreyolo.export.support import (
+    EXPORT_FORMATS,
+    SUPPORT,
+    get_export_capabilities,
+    get_support,
+)
 from libreyolo.models.inventory import collect_model_inventory
 from libreyolo.tasks import TASKS
 
@@ -196,6 +201,98 @@ def test_partial_exporters_are_custom_not_blocked():
                     f"{family}/{task}/{format} is validated in the support "
                     "matrix but the inventory reports export as blocked"
                 )
+
+
+def test_export_capabilities_are_family_and_task_aware():
+    yolo9_onnx = get_export_capabilities("yolo9", "detect", "onnx")
+    yolox_onnx = get_export_capabilities("yolox", "detect", "onnx")
+    yolo9_torchscript = get_export_capabilities("yolo9", "detect", "torchscript")
+    yolo9_ncnn = get_export_capabilities("yolo9", "detect", "ncnn")
+
+    assert yolo9_onnx.supports_int8 is True
+    assert yolox_onnx.supports_int8 is False
+    assert yolo9_torchscript.supports_dynamic is False
+    assert yolo9_ncnn.supports_dynamic is False
+    assert yolo9_ncnn.supports_fp16 is False
+
+
+@pytest.mark.parametrize(
+    ("family", "task"),
+    [
+        ("depth_anything", "depth"),
+        ("birefnet", "matte"),
+        ("nafnet", "restore"),
+        ("swinir", "restore"),
+    ],
+)
+def test_fixed_runtime_contracts_do_not_advertise_dynamic_onnx(family, task):
+    assert get_export_capabilities(family, task, "onnx").supports_dynamic is False
+
+
+def test_realesrgan_keeps_dynamic_onnx_capability():
+    assert get_export_capabilities("realesrgan", "restore", "onnx").supports_dynamic
+
+
+@pytest.mark.parametrize(
+    ("family", "task"),
+    [
+        ("clip", "classify"),
+        ("siglip2", "classify"),
+        ("picosam3", "segment"),
+    ],
+)
+def test_custom_onnx_exporters_do_not_advertise_unsupported_fp16(family, task):
+    assert get_export_capabilities(family, task, "onnx").supports_fp16 is False
+
+
+def test_blocked_export_has_no_effective_option_capabilities():
+    capabilities = get_export_capabilities("rfdetr", "detect", "ncnn")
+
+    assert capabilities.support.tier == "blocked"
+    assert capabilities.supports_dynamic is False
+    assert capabilities.supports_fp16 is False
+    assert capabilities.supports_int8 is False
+
+
+def test_manifest_blocked_override_prevents_generic_fallback(monkeypatch):
+    from types import SimpleNamespace
+
+    from libreyolo.export import support
+
+    manifest_entry = SimpleNamespace(
+        tasks=(SimpleNamespace(task="detect"),), export_override="blocked"
+    )
+    monkeypatch.setattr(support, "get_family_spec", lambda family: manifest_entry)
+
+    entry = support.get_support("future_family", "detect", "onnx")
+
+    assert entry.tier == "blocked"
+    assert "public model manifest" in entry.reason
+
+
+def test_concrete_exporters_are_publicly_importable():
+    from libreyolo.export import (
+        CoreMLExporter,
+        NcnnExporter,
+        OnnxExporter,
+        OpenVINOExporter,
+        TensorRTExporter,
+        TFLiteExporter,
+        TorchScriptExporter,
+    )
+
+    assert {
+        exporter.format_name
+        for exporter in (
+            CoreMLExporter,
+            NcnnExporter,
+            OnnxExporter,
+            OpenVINOExporter,
+            TensorRTExporter,
+            TFLiteExporter,
+            TorchScriptExporter,
+        )
+    } == set(EXPORT_FORMATS)
 
 
 def test_default_download_urls_keep_task_repo_suffixes():

--- a/tests/unit/test_fp16_nms.py
+++ b/tests/unit/test_fp16_nms.py
@@ -1,0 +1,80 @@
+"""FP16 exported-runtime outputs must be safe on CPU NMS kernels."""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+
+def test_yolo9_nms_promotes_fp16_inputs(monkeypatch):
+    from libreyolo.postprocess import yolo9
+
+    seen = {}
+
+    def fake_batched_nms(boxes, scores, class_ids, _iou):
+        seen["boxes"] = boxes.dtype
+        seen["scores"] = scores.dtype
+        return torch.tensor([0], dtype=torch.long)
+
+    monkeypatch.setattr(yolo9, "batched_nms", fake_batched_nms)
+    keep = yolo9._nms_keep_indices(
+        torch.tensor([[0, 0, 4, 4]], dtype=torch.float16),
+        torch.tensor([0.9], dtype=torch.float16),
+        torch.tensor([0]),
+        0.5,
+        10,
+    )
+
+    assert keep.tolist() == [0]
+    assert seen == {"boxes": torch.float32, "scores": torch.float32}
+
+
+def test_yolonas_nms_promotes_fp16_inputs(monkeypatch):
+    from libreyolo.postprocess import yolonas
+
+    seen = {}
+
+    def fake_batched_nms(boxes, scores, class_ids, _iou):
+        seen["boxes"] = boxes.dtype
+        seen["scores"] = scores.dtype
+        return torch.tensor([0], dtype=torch.long)
+
+    monkeypatch.setattr(yolonas.torchvision.ops, "batched_nms", fake_batched_nms)
+    result = yolonas.postprocess(
+        (
+            torch.tensor([[[0, 0, 4, 4]]], dtype=torch.float16),
+            torch.tensor([[[0.9, 0.1]]], dtype=torch.float16),
+        ),
+        conf_thres=0.2,
+        original_size=None,
+    )
+
+    assert result["num_detections"] == 1
+    assert seen == {"boxes": torch.float32, "scores": torch.float32}
+
+
+def test_picodet_nms_promotes_fp16_inputs(monkeypatch):
+    from libreyolo.postprocess import picodet
+    import torchvision.ops
+
+    monkeypatch.setattr(
+        picodet,
+        "_per_level_filter_topk",
+        lambda *args, **kwargs: (
+            torch.tensor([0.9], dtype=torch.float16),
+            torch.tensor([0]),
+            torch.tensor([[0, 0, 4, 4]], dtype=torch.float16),
+        ),
+    )
+    seen = {}
+
+    def fake_batched_nms(boxes, scores, class_ids, _iou):
+        seen["boxes"] = boxes.dtype
+        seen["scores"] = scores.dtype
+        return torch.tensor([0], dtype=torch.long)
+
+    monkeypatch.setattr(torchvision.ops, "batched_nms", fake_batched_nms)
+    result = picodet.postprocess(([], []), original_size=None)
+
+    assert result["num_detections"] == 1
+    assert seen == {"boxes": torch.float32, "scores": torch.float32}

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -331,6 +331,7 @@ def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
             torch.zeros(1, 3, imgsz, imgsz),
             np.zeros((imgsz, imgsz, 3), dtype=np.uint8),
             (imgsz, imgsz),
+            1.0,
         )
 
     def infer(batched_input):
@@ -868,6 +869,7 @@ def test_backend_without_batch_support_stays_sequential():
     backend._run_inference = run_inference
     backend._parse_outputs = _marker_parse_outputs
     backend._build_result = _marker_build_result
+    backend._supports_batched_inference = lambda: False
 
     images = [np.full((8, 8, 3), v, dtype=np.uint8) for v in (10, 60)]
     results = BaseBackend._process_in_batches(backend, images, batch=2)

--- a/tests/unit/test_picosam3_logic.py
+++ b/tests/unit/test_picosam3_logic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import json
 
 import pytest
 import torch
@@ -152,13 +153,58 @@ def test_conversion_round_trip_writes_provenance_metadata(tmp_path):
     PicoSAM3Network().load_state_dict(checkpoint["model"], strict=True)
 
 
+@pytest.mark.parametrize(
+    "kwargs,error,match",
+    [
+        ({"half": True}, NotImplementedError, "half=True"),
+        ({"int8": True}, NotImplementedError, "int8=True"),
+        (
+            {"int8": True, "fraction": 0.5, "allow_download_scripts": False},
+            NotImplementedError,
+            "int8=True",
+        ),
+        ({"batch": 0}, ValueError, "positive integer"),
+        ({"batch": True}, ValueError, "positive integer"),
+        ({"imgsz": 128}, ValueError, "requires imgsz=96"),
+        ({"imgsz": (96, 95)}, ValueError, "requires imgsz=96"),
+    ],
+)
+def test_export_rejects_unsupported_requests(tmp_path, kwargs, error, match):
+    output = tmp_path / "should-not-exist.onnx"
+    with pytest.raises(error, match=match):
+        _bare_picosam3().export(output_path=output, **kwargs)
+    assert not output.exists()
+
+
 def test_raw_onnx_export_matches_pytorch(tmp_path):
+    onnx = pytest.importorskip("onnx")
     ort = pytest.importorskip("onnxruntime")
     model = _bare_picosam3()
     output = tmp_path / "picosam3.onnx"
-    model.export(output=output)
+    result = model.export(
+        output_path=output,
+        opset=None,
+        simplify=False,
+        dynamic=False,
+        half=False,
+        int8=False,
+        imgsz=(96, 96),
+        batch=2,
+        device="cpu",
+        verbose=False,
+    )
 
-    inputs = torch.randn((3, 3, 96, 96))
+    assert result == str(output)
+    proto = onnx.load(output)
+    metadata = {entry.key: entry.value for entry in proto.metadata_props}
+    assert proto.graph.input[0].type.tensor_type.shape.dim[0].dim_value == 2
+    assert metadata["model_family"] == "picosam3"
+    assert metadata["task"] == "segment"
+    assert json.loads(metadata["supported_tasks"]) == ["segment"]
+    assert metadata["imgsz"] == "96"
+    assert metadata["dynamic"] == "False"
+
+    inputs = torch.randn((2, 3, 96, 96))
     with torch.no_grad():
         expected = model.model(inputs).numpy()
     session = ort.InferenceSession(str(output), providers=["CPUExecutionProvider"])

--- a/tests/unit/test_siglip2_export_contract.py
+++ b/tests/unit/test_siglip2_export_contract.py
@@ -1,0 +1,229 @@
+"""Offline export-contract tests for LibreSigLIP2."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from libreyolo.models.siglip2.model import LibreSigLIP2, siglip2_logits
+
+pytestmark = [pytest.mark.unit, pytest.mark.siglip2]
+
+
+class _TinyVision(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.projection = nn.Conv2d(3, 4, kernel_size=1)
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return self.projection(images).mean(dim=(2, 3))
+
+
+class _TinySigLIP2Core(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.vision_model = _TinyVision()
+        self.logit_scale = nn.Parameter(torch.tensor(0.25))
+        self.logit_bias = nn.Parameter(torch.tensor(-0.1))
+
+    def encode_image(self, images: torch.Tensor) -> torch.Tensor:
+        return self.vision_model(images)
+
+
+@pytest.fixture
+def tiny_siglip2_export_model() -> LibreSigLIP2:
+    torch.manual_seed(7)
+    model = object.__new__(LibreSigLIP2)
+    model.model = _TinySigLIP2Core().eval()
+    model.device = torch.device("cpu")
+    model.size = "tiny"
+    model.input_size = 8
+    model.nb_classes = 2
+    model.names = {0: "cat", 1: "dog"}
+    model.task = "classify"
+    model._text_embeds = F.normalize(torch.randn(2, 4), dim=-1)
+    model._multi_label = False
+    return model
+
+
+def test_export_accepts_standard_cli_arguments(
+    tiny_siglip2_export_model, monkeypatch, tmp_path
+):
+    captured = {}
+
+    def fake_export(model, **kwargs):
+        captured["model"] = model
+        captured.update(kwargs)
+        return kwargs["output"]
+
+    monkeypatch.setattr(
+        "libreyolo.models.siglip2.export.export_frozen_onnx", fake_export
+    )
+    output = tmp_path / "siglip2.onnx"
+
+    result = tiny_siglip2_export_model.export(
+        output_path=output,
+        opset=None,
+        simplify=False,
+        dynamic=False,
+        half=False,
+        int8=False,
+        imgsz=(8, 8),
+        batch=2,
+        device="cpu",
+        verbose=True,
+    )
+
+    assert result == str(output)
+    assert captured == {
+        "model": tiny_siglip2_export_model,
+        "imgsz": 8,
+        "opset": None,
+        "output": str(output),
+        "batch": 2,
+        "dynamic": False,
+        "device": "cpu",
+        "simplify": False,
+        "verbose": True,
+    }
+
+
+def test_export_helper_honors_graph_and_finalization_options(
+    tiny_siglip2_export_model, monkeypatch, tmp_path
+):
+    captured = {}
+
+    def fake_torch_export(module, dummy, output, **kwargs):
+        captured["dummy_shape"] = tuple(dummy.shape)
+        captured["torch_output"] = output
+        captured["torch_kwargs"] = kwargs
+
+    def fake_finalize(path, **kwargs):
+        captured["finalize_path"] = path
+        captured["finalize_kwargs"] = kwargs
+
+    monkeypatch.setattr(torch.onnx, "export", fake_torch_export)
+    monkeypatch.setattr("libreyolo.export.onnx.finalize_onnx_artifact", fake_finalize)
+    output = tmp_path / "options.onnx"
+
+    tiny_siglip2_export_model.export(
+        output_path=output,
+        opset=None,
+        batch=3,
+        dynamic=True,
+        device="auto",
+        simplify=True,
+        verbose=True,
+    )
+
+    assert captured["dummy_shape"] == (3, 3, 8, 8)
+    assert captured["torch_output"] == str(output)
+    assert captured["torch_kwargs"]["opset_version"] == 14
+    assert captured["torch_kwargs"]["dynamic_axes"] == {
+        "images": {0: "batch"},
+        "logits": {0: "batch"},
+    }
+    assert captured["torch_kwargs"]["verbose"] is True
+    assert captured["finalize_path"] == str(output)
+    assert captured["finalize_kwargs"]["simplify"] is True
+    assert captured["finalize_kwargs"]["dynamic"] is True
+
+
+def test_export_restores_mixed_module_modes_after_trace_failure(
+    tiny_siglip2_export_model, monkeypatch, tmp_path
+):
+    vision = tiny_siglip2_export_model.model.vision_model
+    vision.train()
+    vision.projection.eval()
+    original_modes = [module.training for module in vision.modules()]
+
+    def fail_export(*args, **kwargs):
+        raise RuntimeError("synthetic trace failure")
+
+    monkeypatch.setattr(torch.onnx, "export", fail_export)
+
+    with pytest.raises(RuntimeError, match="synthetic trace failure"):
+        tiny_siglip2_export_model.export(
+            output_path=tmp_path / "failed.onnx",
+            simplify=False,
+        )
+
+    assert [module.training for module in vision.modules()] == original_modes
+
+
+@pytest.mark.parametrize(
+    "kwargs,error,match",
+    [
+        ({"half": True}, NotImplementedError, "half=True"),
+        ({"int8": True}, NotImplementedError, "int8=True"),
+        (
+            {"int8": True, "fraction": 0.5, "allow_download_scripts": False},
+            NotImplementedError,
+            "int8=True",
+        ),
+        ({"batch": 0}, ValueError, "positive integer"),
+        ({"batch": True}, ValueError, "positive integer"),
+        ({"imgsz": 16}, ValueError, "only supports imgsz=8"),
+        ({"imgsz": (8, 7)}, ValueError, "only supports imgsz=8"),
+    ],
+)
+def test_export_rejects_unsupported_requests(
+    tiny_siglip2_export_model, tmp_path, kwargs, error, match
+):
+    output = tmp_path / "should-not-exist.onnx"
+    with pytest.raises(error, match=match):
+        tiny_siglip2_export_model.export(output_path=output, **kwargs)
+    assert not output.exists()
+
+
+def test_frozen_onnx_roundtrip_records_multilabel_contract(
+    tiny_siglip2_export_model, tmp_path
+):
+    onnx = pytest.importorskip("onnx")
+    ort = pytest.importorskip("onnxruntime")
+    tiny_siglip2_export_model._multi_label = True
+    output = tmp_path / "siglip2.onnx"
+
+    exported = tiny_siglip2_export_model.export(
+        output_path=output,
+        opset=None,
+        batch=2,
+        dynamic=False,
+        device="cpu",
+        simplify=False,
+    )
+
+    proto = onnx.load(exported)
+    metadata = {entry.key: entry.value for entry in proto.metadata_props}
+    assert proto.graph.input[0].type.tensor_type.shape.dim[0].dim_value == 2
+    assert metadata["model_family"] == "siglip2"
+    assert metadata["task"] == "classify"
+    assert json.loads(metadata["names"]) == {"0": "cat", "1": "dog"}
+    assert json.loads(metadata["classification_mean"]) == [0.5, 0.5, 0.5]
+    assert json.loads(metadata["classification_std"]) == [0.5, 0.5, 0.5]
+    assert metadata["classification_crop_pct"] == "1.0"
+    assert metadata["classification_interpolation"] == "bilinear"
+    assert metadata["classification_square_resize"] == "true"
+    assert metadata["classification_activation"] == "sigmoid"
+    assert metadata["crop_pct"] == "1.0"
+    assert metadata["interpolation"] == "bilinear"
+
+    inputs = np.random.default_rng(3).normal(size=(2, 3, 8, 8)).astype(np.float32)
+    session = ort.InferenceSession(exported, providers=["CPUExecutionProvider"])
+    (actual,) = session.run(None, {"images": inputs})
+    with torch.no_grad():
+        image_features = tiny_siglip2_export_model.model.encode_image(
+            torch.from_numpy(inputs)
+        )
+        expected = siglip2_logits(
+            image_features,
+            tiny_siglip2_export_model._text_embeds,
+            tiny_siglip2_export_model.model.logit_scale,
+            tiny_siglip2_export_model.model.logit_bias,
+        ).numpy()
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)

--- a/tests/unit/test_tensorrt_backend.py
+++ b/tests/unit/test_tensorrt_backend.py
@@ -101,7 +101,7 @@ def test_tensorrt_dynamic_max_batch_uses_engine_profile():
     backend.input_name = "input"
     backend._metadata = {}
 
-    assert backend._detect_max_batch() == 16
+    assert backend._detect_batch_limits() == (1, 16)
 
 
 def test_tensorrt_dynamic_max_batch_falls_back_to_metadata():
@@ -112,9 +112,9 @@ def test_tensorrt_dynamic_max_batch_falls_back_to_metadata():
     backend._dynamic_batch = True
     backend.engine = _Engine()
     backend.input_name = "input"
-    backend._metadata = {"trt_max_batch": "12"}
+    backend._metadata = {"trt_min_batch": "2", "trt_max_batch": "12"}
 
-    assert backend._detect_max_batch() == 12
+    assert backend._detect_batch_limits() == (2, 12)
 
 
 def test_tensorrt_backend_reads_static_input_imgsz():
@@ -136,6 +136,7 @@ def test_tensorrt_dynamic_batching_caps_requested_batch_to_profile():
             torch.zeros(1, 3, imgsz, imgsz),
             np.zeros((imgsz, imgsz, 3), dtype=np.uint8),
             (imgsz, imgsz),
+            1.0,
         )
 
     def infer(batched_input):
@@ -198,6 +199,7 @@ def test_tensorrt_dynamic_batching_preserves_pose_keypoints():
             torch.zeros(1, 3, imgsz, imgsz),
             np.zeros((imgsz, imgsz, 3), dtype=np.uint8),
             (imgsz, imgsz),
+            1.0,
         )
 
     def infer(batched_input):

--- a/tests/unit/test_tensorrt_runtime_contracts.py
+++ b/tests/unit/test_tensorrt_runtime_contracts.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import stat
 import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 import pytest
@@ -12,6 +14,8 @@ import torch
 
 from libreyolo.backends.base import BaseBackend
 from libreyolo.backends.tensorrt import TensorRTBackend, _resolve_tensorrt_device
+from libreyolo.export.config import TensorRTExportConfig
+from libreyolo.export.exporter import BaseExporter, TensorRTExporter
 from libreyolo.export.tensorrt import (
     _calibration_cache_path,
     _create_calibrator_class,
@@ -21,6 +25,7 @@ from libreyolo.export.tensorrt import (
     _select_tensorrt_device,
     _validate_batch_profile,
     _validate_dynamic_calibration_contract,
+    _validate_static_calibration_contract,
     export_tensorrt,
 )
 
@@ -88,6 +93,74 @@ def test_tensorrt_export_rejects_non_integer_devices(device):
         _select_tensorrt_device(device)
 
 
+def test_tensorrt_unified_export_builds_on_traced_cuda_device(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_export_tensorrt(**kwargs):
+        captured.update(kwargs)
+        return kwargs["output_path"]
+
+    monkeypatch.setattr(
+        "libreyolo.export.tensorrt.export_tensorrt", fake_export_tensorrt
+    )
+    dummy = SimpleNamespace(device=torch.device("cuda:1"), shape=(1, 3, 32, 32))
+    exporter = TensorRTExporter(SimpleNamespace())
+
+    exporter._export(
+        None,
+        dummy,
+        output_path=str(tmp_path / "model.engine"),
+        precision="fp16",
+        metadata={},
+        calibration_data=None,
+        onnx_path=str(tmp_path / "model.onnx"),
+        half=True,
+        int8=False,
+        dynamic=False,
+        verbose=False,
+    )
+
+    assert captured["device"] == 1
+
+
+def test_tensorrt_unified_export_rejects_trace_build_device_mismatch(tmp_path):
+    dummy = SimpleNamespace(device=torch.device("cuda:1"), shape=(1, 3, 32, 32))
+    exporter = TensorRTExporter(SimpleNamespace())
+
+    with pytest.raises(ValueError, match="trace and build devices must match"):
+        exporter._export(
+            None,
+            dummy,
+            output_path=str(tmp_path / "model.engine"),
+            precision="fp16",
+            metadata={},
+            calibration_data=None,
+            onnx_path=str(tmp_path / "model.onnx"),
+            half=True,
+            int8=False,
+            dynamic=False,
+            verbose=False,
+            gpu_device=0,
+        )
+
+
+def test_tensorrt_config_device_is_used_for_auto_trace(monkeypatch):
+    captured = {}
+
+    def fake_base_call(self, *args, **kwargs):
+        captured.update(kwargs)
+        return "model.engine"
+
+    monkeypatch.setattr(BaseExporter, "__call__", fake_base_call)
+    exporter = TensorRTExporter(SimpleNamespace())
+
+    assert (
+        exporter(trt_config=TensorRTExportConfig(device=2), device="auto")
+        == "model.engine"
+    )
+    assert captured["device"] == 2
+
+
 def test_tensorrt_artifact_publication_is_atomic_and_returns_requested_path(tmp_path):
     output = tmp_path / "model.engine"
 
@@ -115,6 +188,107 @@ def test_tensorrt_artifact_staging_failure_preserves_existing_files(tmp_path):
     assert output.read_bytes() == b"old-engine"
     assert sidecar.read_text() == '{"old": true}'
     assert not list(tmp_path.glob("libreyolo-tensorrt-publish-*"))
+
+
+def test_tensorrt_metadata_free_publication_removes_stale_sidecar(tmp_path):
+    output = tmp_path / "model.engine"
+    sidecar = Path(f"{output}.json")
+    output.write_bytes(b"old-engine")
+    sidecar.write_text('{"stale": true}')
+
+    _publish_tensorrt_artifacts(b"new-engine", output, None)
+
+    assert output.read_bytes() == b"new-engine"
+    assert not sidecar.exists()
+    assert not list(tmp_path.glob(".*.bak"))
+
+
+def test_tensorrt_stale_sidecar_removal_failure_rolls_back_engine(
+    monkeypatch, tmp_path
+):
+    output = tmp_path / "model.engine"
+    sidecar = Path(f"{output}.json")
+    output.write_bytes(b"old-engine")
+    sidecar.write_text('{"old": true}')
+    real_unlink = Path.unlink
+    failed = False
+
+    def fail_sidecar_once(path, *args, **kwargs):
+        nonlocal failed
+        if path == sidecar and not failed:
+            failed = True
+            raise OSError("synthetic sidecar removal failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_sidecar_once)
+
+    with pytest.raises(OSError, match="synthetic sidecar removal failure"):
+        _publish_tensorrt_artifacts(b"new-engine", output, None)
+
+    assert output.read_bytes() == b"old-engine"
+    assert sidecar.read_text() == '{"old": true}'
+    assert not list(tmp_path.glob(".*.bak"))
+
+
+def test_tensorrt_backup_failure_cleans_prior_and_partial_backups(
+    monkeypatch, tmp_path
+):
+    output = tmp_path / "model.engine"
+    sidecar = Path(f"{output}.json")
+    output.write_bytes(b"old-engine")
+    sidecar.write_text('{"old": true}')
+    real_link = os.link
+
+    def fail_sidecar_link(source, destination):
+        if Path(source) == sidecar:
+            raise OSError("links unavailable")
+        return real_link(source, destination)
+
+    def fail_sidecar_copy(source, destination):
+        Path(destination).write_bytes(b"partial-backup")
+        raise PermissionError("backup denied")
+
+    monkeypatch.setattr(os, "link", fail_sidecar_link)
+    monkeypatch.setattr("libreyolo.export.tensorrt.shutil.copy2", fail_sidecar_copy)
+
+    with pytest.raises(PermissionError, match="backup denied"):
+        _publish_tensorrt_artifacts(b"new-engine", output, {"new": True})
+
+    assert output.read_bytes() == b"old-engine"
+    assert sidecar.read_text() == '{"old": true}'
+    assert not list(tmp_path.glob(".*.bak"))
+    assert not list(tmp_path.glob("libreyolo-tensorrt-publish-*"))
+
+
+def test_tensorrt_backup_copy_preserves_restrictive_source_mode(monkeypatch, tmp_path):
+    output = tmp_path / "model.engine"
+    output.write_bytes(b"old-engine")
+    output.chmod(0o600)
+    original_mode = stat.S_IMODE(output.stat().st_mode)
+    real_copy2 = shutil.copy2
+    copied_modes = []
+
+    def no_hardlinks(source, destination):
+        raise OSError("hardlinks unavailable")
+
+    def checked_copy2(source, destination):
+        result = real_copy2(source, destination)
+        copied_modes.append(
+            (
+                stat.S_IMODE(Path(source).stat().st_mode),
+                stat.S_IMODE(Path(destination).stat().st_mode),
+            )
+        )
+        return result
+
+    monkeypatch.setattr(os, "link", no_hardlinks)
+    monkeypatch.setattr("libreyolo.export.tensorrt.shutil.copy2", checked_copy2)
+
+    _publish_tensorrt_artifacts(b"new-engine", output, None)
+
+    assert copied_modes
+    assert all(source_mode == backup_mode for source_mode, backup_mode in copied_modes)
+    assert stat.S_IMODE(output.stat().st_mode) == original_mode
 
 
 def test_tensorrt_artifact_promotion_failure_rolls_back(monkeypatch, tmp_path):
@@ -207,6 +381,95 @@ def test_tensorrt_calibrator_creates_nested_cache_parent(monkeypatch, tmp_path):
     assert cache_path.read_bytes() == b"cache"
 
 
+def test_tensorrt_calibrator_cuda_bindings_reselects_requested_device(monkeypatch):
+    fake_trt = SimpleNamespace(IInt8EntropyCalibrator2=object)
+    events = []
+    success = 0
+    cudart = SimpleNamespace(
+        cudaError_t=SimpleNamespace(cudaSuccess=success),
+        cudaMemcpyKind=SimpleNamespace(cudaMemcpyHostToDevice=1),
+        cudaSetDevice=lambda index: events.append(("device", index)) or (success,),
+        cudaMalloc=lambda size: events.append(("malloc", size)) or (success, 123),
+        cudaMemcpy=lambda pointer, source, size, kind: (
+            events.append(("copy", pointer, size, kind)) or (success,)
+        ),
+        cudaFree=lambda pointer: events.append(("free", pointer)) or (success,),
+    )
+    cuda_package = ModuleType("cuda")
+    cuda_package.__path__ = []
+    bindings_package = ModuleType("cuda.bindings")
+    bindings_package.__path__ = []
+    bindings_package.runtime = cudart
+    monkeypatch.setitem(sys.modules, "tensorrt", fake_trt)
+    monkeypatch.setitem(sys.modules, "cuda", cuda_package)
+    monkeypatch.setitem(sys.modules, "cuda.bindings", bindings_package)
+    monkeypatch.setitem(sys.modules, "cuda.bindings.runtime", cudart)
+    loader = SimpleNamespace(batch=1)
+    calibrator = _create_calibrator_class()(loader, device_index=2)
+
+    assert calibrator._ensure_cuda_memory(np.zeros((1, 3, 2, 2))) == 123
+    calibrator._release_cuda_memory()
+
+    assert events[0] == ("device", 2)
+    assert events[1][0] == "malloc"
+    assert events[2][0] == "copy"
+    assert events[-2:] == [("device", 2), ("free", 123)]
+
+
+def test_tensorrt_calibrator_pycuda_uses_requested_primary_context(monkeypatch):
+    fake_trt = SimpleNamespace(IInt8EntropyCalibrator2=object)
+    events = []
+
+    class _Allocation:
+        def __int__(self):
+            return 456
+
+        def free(self):
+            events.append("free")
+
+    class _Context:
+        def push(self):
+            events.append("push")
+
+        def pop(self):
+            events.append("pop")
+
+    context = _Context()
+
+    class _Device:
+        def __init__(self, index):
+            events.append(("device", index))
+
+        def retain_primary_context(self):
+            events.append("retain")
+            return context
+
+    driver = ModuleType("pycuda.driver")
+    driver.init = lambda: events.append("init")
+    driver.Device = _Device
+    driver.mem_alloc = lambda size: events.append(("alloc", size)) or _Allocation()
+    driver.memcpy_htod = lambda allocation, batch: events.append(("copy", batch.nbytes))
+    cuda_package = ModuleType("cuda")
+    cuda_package.__path__ = []
+    pycuda_package = ModuleType("pycuda")
+    pycuda_package.__path__ = []
+    pycuda_package.driver = driver
+    monkeypatch.setitem(sys.modules, "tensorrt", fake_trt)
+    monkeypatch.setitem(sys.modules, "cuda", cuda_package)
+    monkeypatch.setitem(sys.modules, "pycuda", pycuda_package)
+    monkeypatch.setitem(sys.modules, "pycuda.driver", driver)
+    monkeypatch.delitem(sys.modules, "pycuda.autoinit", raising=False)
+    loader = SimpleNamespace(batch=1)
+    calibrator = _create_calibrator_class()(loader, device_index=3)
+
+    assert calibrator._ensure_cuda_memory(np.zeros((1, 3, 2, 2))) == 456
+    calibrator._release_cuda_memory()
+
+    assert events[:4] == ["init", ("device", 3), "retain", "push"]
+    assert events[-3:] == ["push", "free", "pop"]
+    assert "pycuda.autoinit" not in sys.modules
+
+
 @pytest.mark.parametrize(
     "bounds",
     [
@@ -277,6 +540,54 @@ def test_dynamic_int8_calibration_rejects_profile_mismatch(loader, opt_batch, ma
             dynamic=True,
             opt_batch=opt_batch,
             traced_shape=(1, 3, 320, 640),
+        )
+
+
+def test_static_int8_calibration_accepts_matching_trace_and_network_shape():
+    loader = SimpleNamespace(batch=4, shape=(4, 3, 320, 640))
+
+    _validate_static_calibration_contract(
+        loader,
+        int8=True,
+        dynamic=False,
+        traced_shape=(4, 3, 320, 640),
+        network_shape=(-1, 3, 320, 640),
+    )
+
+
+@pytest.mark.parametrize(
+    ("loader", "traced_shape", "network_shape", "match"),
+    [
+        (
+            SimpleNamespace(batch=2, shape=(1, 3, 320, 640)),
+            None,
+            (1, 3, 320, 640),
+            "first axis equals",
+        ),
+        (
+            SimpleNamespace(batch=1, shape=(1, 3, 224, 224)),
+            (1, 3, 320, 640),
+            None,
+            "match the traced",
+        ),
+        (
+            SimpleNamespace(batch=1, shape=(1, 3, 320, 640)),
+            None,
+            (1, 3, 640, 640),
+            "parsed network input",
+        ),
+    ],
+)
+def test_static_int8_calibration_rejects_loader_contract_mismatch(
+    loader, traced_shape, network_shape, match
+):
+    with pytest.raises(ValueError, match=match):
+        _validate_static_calibration_contract(
+            loader,
+            int8=True,
+            dynamic=False,
+            traced_shape=traced_shape,
+            network_shape=network_shape,
         )
 
 

--- a/tests/unit/test_tensorrt_runtime_contracts.py
+++ b/tests/unit/test_tensorrt_runtime_contracts.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.backends.base import BaseBackend
+from libreyolo.backends.tensorrt import TensorRTBackend, _resolve_tensorrt_device
+from libreyolo.export.tensorrt import (
+    _calibration_cache_path,
+    _create_calibrator_class,
+    _profile_shape,
+    _resolve_hardware_compatibility_level,
+    _select_tensorrt_device,
+    _validate_batch_profile,
+    _validate_dynamic_calibration_contract,
+    export_tensorrt,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _bare_backend() -> TensorRTBackend:
+    backend = TensorRTBackend.__new__(TensorRTBackend)
+    backend.input_name = "images"
+    backend.input_shape = (-1, 3, -1, -1)
+    backend._dynamic_input = True
+    backend.device = torch.device("cuda")
+    return backend
+
+
+def test_profile_shape_preserves_dynamic_spatial_dimensions():
+    traced = (1, 3, 320, 640)
+
+    assert _profile_shape((-1, 3, -1, -1), traced, batch=8) == (
+        8,
+        3,
+        320,
+        640,
+    )
+
+
+def test_same_compute_capability_uses_available_tensorrt_enum():
+    expected = object()
+    fake_trt = SimpleNamespace(
+        HardwareCompatibilityLevel=SimpleNamespace(
+            SAME_COMPUTE_CAPABILITY=expected
+        )
+    )
+
+    assert (
+        _resolve_hardware_compatibility_level(
+            fake_trt, "same_compute_capability"
+        )
+        is expected
+    )
+
+
+def test_same_compute_capability_is_unavailable_on_older_tensorrt_api():
+    fake_trt = SimpleNamespace(
+        HardwareCompatibilityLevel=SimpleNamespace(NONE=object())
+    )
+
+    assert (
+        _resolve_hardware_compatibility_level(
+            fake_trt, "same_compute_capability"
+        )
+        is None
+    )
+
+
+def test_tensorrt_export_selects_device_zero_explicitly(monkeypatch):
+    selected = []
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(torch.cuda, "set_device", selected.append)
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda index: f"gpu-{index}")
+
+    assert _select_tensorrt_device(0) == 0
+    assert selected == [0]
+
+
+def test_tensorrt_calibration_cache_tracks_exact_preprocessed_batches(tmp_path):
+    image = tmp_path / "sample.bin"
+    image.write_bytes(b"first")
+
+    class _Loader:
+        def __iter__(self):
+            values = np.frombuffer(image.read_bytes(), dtype=np.uint8)
+            yield values.reshape(1, 1, 1, -1)
+
+    loader = _Loader()
+
+    first = _calibration_cache_path(
+        tmp_path / "model.engine", b"onnx", loader, enabled=True
+    )
+    image.write_bytes(b"second")
+    second = _calibration_cache_path(
+        tmp_path / "model.engine", b"onnx", loader, enabled=True
+    )
+    image.write_bytes(b"third-value")
+    third = _calibration_cache_path(
+        tmp_path / "model.engine", b"onnx", loader, enabled=True
+    )
+
+    assert first is not None
+    assert len({first, second, third}) == 3
+    assert _calibration_cache_path(
+        tmp_path / "model.engine", b"onnx", loader, enabled=False
+    ) is None
+
+
+def test_tensorrt_calibration_cache_disables_unstable_preprocessing(tmp_path):
+    class _UnstableLoader:
+        def __init__(self):
+            self.value = 0
+
+        def __iter__(self):
+            self.value += 1
+            yield np.array([self.value], dtype=np.float32)
+
+    assert _calibration_cache_path(
+        tmp_path / "model.engine",
+        b"onnx",
+        _UnstableLoader(),
+        enabled=True,
+    ) is None
+
+
+def test_tensorrt_calibrator_creates_nested_cache_parent(monkeypatch, tmp_path):
+    fake_trt = SimpleNamespace(IInt8EntropyCalibrator2=object)
+    monkeypatch.setitem(sys.modules, "tensorrt", fake_trt)
+    loader = SimpleNamespace(batch=1)
+    cache_path = tmp_path / "new" / "nested" / "model.cache"
+
+    calibrator = _create_calibrator_class()(loader, cache_file=cache_path)
+    calibrator.write_calibration_cache(b"cache")
+
+    assert cache_path.read_bytes() == b"cache"
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        (0, 1, 1),
+        (2, 1, 4),
+        (1, 5, 4),
+    ],
+)
+def test_dynamic_batch_profile_bounds_are_ordered_and_positive(bounds):
+    with pytest.raises(ValueError, match="1 <= min_batch"):
+        _validate_batch_profile(*bounds)
+
+
+def test_invalid_batch_profile_fails_before_dependency_check(monkeypatch, tmp_path):
+    dependency_checked = False
+
+    def check_dependency():
+        nonlocal dependency_checked
+        dependency_checked = True
+
+    monkeypatch.setattr(
+        "libreyolo.export.tensorrt.check_tensorrt_available",
+        check_dependency,
+    )
+
+    with pytest.raises(ValueError, match="1 <= min_batch"):
+        export_tensorrt(
+            str(tmp_path / "missing.onnx"),
+            str(tmp_path / "model.engine"),
+            min_batch=2,
+            opt_batch=1,
+            max_batch=4,
+        )
+
+    assert dependency_checked is False
+
+
+def test_profile_shape_requires_trace_shape_for_dynamic_non_batch_axis():
+    with pytest.raises(ValueError, match="traced input_shape"):
+        _profile_shape((-1, 3, -1, -1), None, batch=1)
+
+
+def test_dynamic_int8_calibration_accepts_batch_one_opt_shape():
+    loader = SimpleNamespace(batch=1, shape=(1, 3, 320, 640))
+
+    _validate_dynamic_calibration_contract(
+        loader,
+        int8=True,
+        dynamic=True,
+        opt_batch=1,
+        traced_shape=(4, 3, 320, 640),
+    )
+
+
+@pytest.mark.parametrize(
+    ("loader", "opt_batch", "match"),
+    [
+        (SimpleNamespace(batch=2, shape=(2, 3, 320, 640)), 1, "batch-1"),
+        (SimpleNamespace(batch=1, shape=(1, 3, 320, 640)), 2, "opt_batch=1"),
+        (SimpleNamespace(batch=1, shape=(1, 3, 224, 224)), 1, "match the traced"),
+    ],
+)
+def test_dynamic_int8_calibration_rejects_profile_mismatch(loader, opt_batch, match):
+    with pytest.raises(ValueError, match=match):
+        _validate_dynamic_calibration_contract(
+            loader,
+            int8=True,
+            dynamic=True,
+            opt_batch=opt_batch,
+            traced_shape=(1, 3, 320, 640),
+        )
+
+
+def test_binding_dtype_uses_tensorrt_declared_numpy_type():
+    fake_trt = SimpleNamespace(nptype=lambda dtype: np.float16)
+
+    numpy_dtype, torch_dtype = TensorRTBackend._binding_dtypes(
+        fake_trt,
+        "HALF",
+        tensor_name="images",
+    )
+
+    assert numpy_dtype == np.dtype(np.float16)
+    assert torch_dtype == torch.float16
+
+
+def test_tensorrt_runtime_resolves_indexed_cuda_device(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 3)
+
+    assert _resolve_tensorrt_device("cuda:2") == torch.device("cuda:2")
+
+
+def test_tensorrt_runtime_rejects_cpu_device(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+    with pytest.raises(ValueError, match="requires device"):
+        _resolve_tensorrt_device("cpu")
+
+
+def test_tensorrt_inference_reenters_engine_cuda_device(monkeypatch):
+    backend = _bare_backend()
+    backend.device = torch.device("cuda:2")
+    events = []
+
+    class _DeviceContext:
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, exc_type, exc, traceback):
+            events.append("exit")
+
+    monkeypatch.setattr(
+        torch.cuda,
+        "device",
+        lambda device: events.append(device) or _DeviceContext(),
+    )
+    backend._infer_current_device = lambda array: "result"
+
+    assert backend._infer(np.zeros((1, 3, 1, 1), dtype=np.float32)) == "result"
+    assert events == [torch.device("cuda:2"), "enter", "exit"]
+
+
+def test_dynamic_shape_rejection_is_not_ignored():
+    backend = _bare_backend()
+    backend.context = SimpleNamespace(set_input_shape=lambda name, shape: False)
+
+    with pytest.raises(ValueError, match="rejected input shape"):
+        backend._set_runtime_input_shape((1, 3, 320, 640))
+
+
+def test_output_shape_is_read_from_context_after_input_resolution():
+    backend = _bare_backend()
+    backend.output_shapes = {"scores": (-1, 100, 80)}
+    backend.context = SimpleNamespace(
+        get_tensor_shape=lambda name: (4, 100, 80),
+    )
+
+    assert backend._runtime_output_shape("scores") == (4, 100, 80)
+
+
+def test_tensorrt_fixed_spatial_profile_uses_export_canvas_for_realesrgan():
+    backend = _bare_backend()
+    backend.engine = SimpleNamespace(
+        get_tensor_profile_shape=lambda name, profile: (
+            (1, 3, 8, 8),
+            (1, 3, 8, 8),
+            (4, 3, 8, 8),
+        )
+    )
+    backend.model_family = "realesrgan"
+    backend.task = "restore"
+    backend.imgsz = 8
+    backend._dynamic_spatial = backend._detect_dynamic_spatial_profile()
+
+    blob, _, original_size, _ = backend._preprocess(
+        np.zeros((5, 7, 3), dtype=np.uint8), 8, "rgb"
+    )
+
+    assert backend._dynamic_spatial is False
+    assert original_size == (7, 5)
+    assert blob.shape == (1, 3, 8, 8)
+
+
+def test_buffer_allocation_sets_input_shape_before_reading_outputs(monkeypatch):
+    backend = _bare_backend()
+    backend.input_torch_dtype = torch.float16
+    backend.output_names = ["scores"]
+    backend.output_torch_dtypes = {"scores": torch.int32}
+    events = []
+
+    backend._set_runtime_input_shape = lambda shape: events.append(("input", shape))
+
+    def output_shape(name):
+        events.append(("output", name))
+        return (2, 10)
+
+    backend._runtime_output_shape = output_shape
+    monkeypatch.setattr(
+        torch.cuda, "Stream", lambda device=None: SimpleNamespace()
+    )
+
+    allocations = []
+
+    def fake_empty(size, *, dtype, device):
+        allocations.append((size, dtype, device))
+        return SimpleNamespace()
+
+    monkeypatch.setattr(torch, "empty", fake_empty)
+
+    backend._allocate_buffers((2, 3, 32, 64))
+
+    assert events == [("input", (2, 3, 32, 64)), ("output", "scores")]
+    assert allocations == [
+        (2 * 3 * 32 * 64, torch.float16, torch.device("cuda")),
+        (20, torch.int32, torch.device("cuda")),
+    ]
+
+
+def test_execute_async_false_is_a_hard_failure():
+    backend = _bare_backend()
+    backend.context = SimpleNamespace(execute_async_v3=lambda stream: False)
+    backend.stream = SimpleNamespace(cuda_stream=123)
+
+    with pytest.raises(RuntimeError, match="execute_async_v3 returned False"):
+        backend._execute()
+
+
+def test_tensorrt_stream_waits_for_pytorch_input_copy(monkeypatch):
+    backend = _bare_backend()
+    producer = object()
+    seen = []
+    backend.stream = SimpleNamespace(wait_stream=lambda stream: seen.append(stream))
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda device=None: producer)
+
+    backend._wait_for_input_copy()
+
+    assert seen == [producer]
+
+
+def test_tensorrt_restore_batch_uses_shared_task_dispatch(monkeypatch):
+    backend = _bare_backend()
+    backend._dynamic_batch = True
+    backend._max_batch = 2
+    backend.task = "restore"
+    captured = {}
+
+    def shared(self, images, **kwargs):
+        captured["task"] = self.task
+        captured["batch"] = kwargs["batch"]
+        return ["shared"]
+
+    monkeypatch.setattr(BaseBackend, "_process_in_batches", shared)
+
+    result = backend._process_in_batches([object()] * 3, batch=8)
+
+    assert result == ["shared"]
+    assert captured == {"task": "restore", "batch": 2}
+
+
+def test_tensorrt_static_batch_uses_engine_batch_and_allows_a_short_tail(monkeypatch):
+    backend = _bare_backend()
+    backend._dynamic_batch = False
+    backend._max_batch = 4
+    backend.task = "restore"
+    captured = {}
+
+    def shared(self, images, **kwargs):
+        captured["count"] = len(images)
+        captured["batch"] = kwargs["batch"]
+        return ["shared"]
+
+    monkeypatch.setattr(BaseBackend, "_process_in_batches", shared)
+
+    result = backend._process_in_batches([object()] * 5, batch=1)
+
+    assert result == ["shared"]
+    assert captured == {"count": 5, "batch": 4}
+
+
+def test_tensorrt_inference_pads_below_profile_minimum_and_slices_outputs():
+    backend = _bare_backend()
+    backend.input_shape = (-1, 1, 1, 1)
+    backend._min_batch = 2
+    backend._max_batch = 4
+    backend.input_numpy_dtype = np.dtype(np.float32)
+    backend.input_torch_dtype = torch.float32
+    backend.device = torch.device("cpu")
+    backend._current_input_shape = (2, 1, 1, 1)
+    backend.inputs = {"images": torch.empty(2)}
+    backend.output_names = ["scores"]
+    backend.outputs = {"scores": torch.tensor([[10.0], [20.0]])}
+    backend._runtime_output_shapes = {"scores": (2, 1)}
+    backend.context = SimpleNamespace(set_tensor_address=lambda name, address: None)
+    backend.stream = SimpleNamespace(synchronize=lambda: None)
+    backend._wait_for_input_copy = lambda: None
+    backend._execute = lambda: None
+
+    outputs = backend._infer_current_device(
+        np.ones((1, 1, 1, 1), dtype=np.float32)
+    )
+
+    assert backend.inputs["images"].tolist() == [1.0, 1.0]
+    assert outputs["scores"].shape == (1, 1)
+    assert outputs["scores"].tolist() == [[10.0]]

--- a/tests/unit/test_tensorrt_runtime_contracts.py
+++ b/tests/unit/test_tensorrt_runtime_contracts.py
@@ -229,6 +229,17 @@ def test_binding_dtype_uses_tensorrt_declared_numpy_type():
     assert torch_dtype == torch.float16
 
 
+@pytest.mark.parametrize(
+    "device",
+    [0, "0", "cuda:0", torch.device("cuda:0")],
+)
+def test_tensorrt_runtime_resolves_explicit_device_zero(monkeypatch, device):
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 3)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 2)
+
+    assert _resolve_tensorrt_device(device) == torch.device("cuda:0")
+
+
 def test_tensorrt_runtime_resolves_indexed_cuda_device(monkeypatch):
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 3)
 

--- a/tests/unit/test_tensorrt_runtime_contracts.py
+++ b/tests/unit/test_tensorrt_runtime_contracts.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -13,6 +16,7 @@ from libreyolo.export.tensorrt import (
     _calibration_cache_path,
     _create_calibrator_class,
     _profile_shape,
+    _publish_tensorrt_artifacts,
     _resolve_hardware_compatibility_level,
     _select_tensorrt_device,
     _validate_batch_profile,
@@ -47,15 +51,11 @@ def test_profile_shape_preserves_dynamic_spatial_dimensions():
 def test_same_compute_capability_uses_available_tensorrt_enum():
     expected = object()
     fake_trt = SimpleNamespace(
-        HardwareCompatibilityLevel=SimpleNamespace(
-            SAME_COMPUTE_CAPABILITY=expected
-        )
+        HardwareCompatibilityLevel=SimpleNamespace(SAME_COMPUTE_CAPABILITY=expected)
     )
 
     assert (
-        _resolve_hardware_compatibility_level(
-            fake_trt, "same_compute_capability"
-        )
+        _resolve_hardware_compatibility_level(fake_trt, "same_compute_capability")
         is expected
     )
 
@@ -66,9 +66,7 @@ def test_same_compute_capability_is_unavailable_on_older_tensorrt_api():
     )
 
     assert (
-        _resolve_hardware_compatibility_level(
-            fake_trt, "same_compute_capability"
-        )
+        _resolve_hardware_compatibility_level(fake_trt, "same_compute_capability")
         is None
     )
 
@@ -82,6 +80,66 @@ def test_tensorrt_export_selects_device_zero_explicitly(monkeypatch):
 
     assert _select_tensorrt_device(0) == 0
     assert selected == [0]
+
+
+@pytest.mark.parametrize("device", [True, False, 0.5, "0.5"])
+def test_tensorrt_export_rejects_non_integer_devices(device):
+    with pytest.raises(ValueError, match="non-negative integer"):
+        _select_tensorrt_device(device)
+
+
+def test_tensorrt_artifact_publication_is_atomic_and_returns_requested_path(tmp_path):
+    output = tmp_path / "model.engine"
+
+    result = _publish_tensorrt_artifacts(
+        b"new-engine",
+        output,
+        {"precision": "fp16"},
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == b"new-engine"
+    assert json.loads(Path(f"{output}.json").read_text()) == {"precision": "fp16"}
+    assert not list(tmp_path.glob("libreyolo-tensorrt-publish-*"))
+
+
+def test_tensorrt_artifact_staging_failure_preserves_existing_files(tmp_path):
+    output = tmp_path / "model.engine"
+    sidecar = Path(f"{output}.json")
+    output.write_bytes(b"old-engine")
+    sidecar.write_text('{"old": true}')
+
+    with pytest.raises(TypeError):
+        _publish_tensorrt_artifacts(b"new-engine", output, {"bad": {object()}})
+
+    assert output.read_bytes() == b"old-engine"
+    assert sidecar.read_text() == '{"old": true}'
+    assert not list(tmp_path.glob("libreyolo-tensorrt-publish-*"))
+
+
+def test_tensorrt_artifact_promotion_failure_rolls_back(monkeypatch, tmp_path):
+    output = tmp_path / "model.engine"
+    sidecar = Path(f"{output}.json")
+    output.write_bytes(b"old-engine")
+    sidecar.write_text('{"old": true}')
+    real_replace = os.replace
+    failed = False
+
+    def fail_sidecar_once(source, destination):
+        nonlocal failed
+        if Path(destination) == sidecar and not failed:
+            failed = True
+            raise OSError("synthetic sidecar promotion failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", fail_sidecar_once)
+
+    with pytest.raises(OSError, match="synthetic sidecar promotion failure"):
+        _publish_tensorrt_artifacts(b"new-engine", output, {"new": True})
+
+    assert output.read_bytes() == b"old-engine"
+    assert sidecar.read_text() == '{"old": true}'
+    assert not list(tmp_path.glob("libreyolo-tensorrt-publish-*"))
 
 
 def test_tensorrt_calibration_cache_tracks_exact_preprocessed_batches(tmp_path):
@@ -109,9 +167,12 @@ def test_tensorrt_calibration_cache_tracks_exact_preprocessed_batches(tmp_path):
 
     assert first is not None
     assert len({first, second, third}) == 3
-    assert _calibration_cache_path(
-        tmp_path / "model.engine", b"onnx", loader, enabled=False
-    ) is None
+    assert (
+        _calibration_cache_path(
+            tmp_path / "model.engine", b"onnx", loader, enabled=False
+        )
+        is None
+    )
 
 
 def test_tensorrt_calibration_cache_disables_unstable_preprocessing(tmp_path):
@@ -123,12 +184,15 @@ def test_tensorrt_calibration_cache_disables_unstable_preprocessing(tmp_path):
             self.value += 1
             yield np.array([self.value], dtype=np.float32)
 
-    assert _calibration_cache_path(
-        tmp_path / "model.engine",
-        b"onnx",
-        _UnstableLoader(),
-        enabled=True,
-    ) is None
+    assert (
+        _calibration_cache_path(
+            tmp_path / "model.engine",
+            b"onnx",
+            _UnstableLoader(),
+            enabled=True,
+        )
+        is None
+    )
 
 
 def test_tensorrt_calibrator_creates_nested_cache_parent(monkeypatch, tmp_path):
@@ -240,6 +304,14 @@ def test_tensorrt_runtime_resolves_explicit_device_zero(monkeypatch, device):
     assert _resolve_tensorrt_device(device) == torch.device("cuda:0")
 
 
+@pytest.mark.parametrize("device", [True, False])
+def test_tensorrt_runtime_rejects_boolean_device(monkeypatch, device):
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+
+    with pytest.raises(ValueError, match="Invalid TensorRT CUDA device"):
+        _resolve_tensorrt_device(device)
+
+
 def test_tensorrt_runtime_resolves_indexed_cuda_device(monkeypatch):
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 3)
 
@@ -331,9 +403,7 @@ def test_buffer_allocation_sets_input_shape_before_reading_outputs(monkeypatch):
         return (2, 10)
 
     backend._runtime_output_shape = output_shape
-    monkeypatch.setattr(
-        torch.cuda, "Stream", lambda device=None: SimpleNamespace()
-    )
+    monkeypatch.setattr(torch.cuda, "Stream", lambda device=None: SimpleNamespace())
 
     allocations = []
 
@@ -359,6 +429,16 @@ def test_execute_async_false_is_a_hard_failure():
 
     with pytest.raises(RuntimeError, match="execute_async_v3 returned False"):
         backend._execute()
+
+
+def test_rejected_tensor_address_is_a_hard_failure():
+    backend = _bare_backend()
+    backend.context = SimpleNamespace(
+        set_tensor_address=lambda name, address: name != "scores"
+    )
+
+    with pytest.raises(RuntimeError, match="tensor 'scores'"):
+        backend._set_tensor_address("scores", torch.empty(1))
 
 
 def test_tensorrt_stream_waits_for_pytorch_input_copy(monkeypatch):
@@ -431,9 +511,7 @@ def test_tensorrt_inference_pads_below_profile_minimum_and_slices_outputs():
     backend._wait_for_input_copy = lambda: None
     backend._execute = lambda: None
 
-    outputs = backend._infer_current_device(
-        np.ones((1, 1, 1, 1), dtype=np.float32)
-    )
+    outputs = backend._infer_current_device(np.ones((1, 1, 1, 1), dtype=np.float32))
 
     assert backend.inputs["images"].tolist() == [1.0, 1.0]
     assert outputs["scores"].shape == (1, 1)


### PR DESCRIPTION
# What does this PR do?

Fixes export and backend runtime-contract findings tracked in #591.

- Defines family/task/format-aware export capabilities and enforces effective dynamic-shape, FP16, and INT8 support.
- Adds classification runtime metadata for normalization, crop geometry, interpolation, resize, and output activation.
- Makes runtime backends honor declared input dtypes, devices, metadata, dynamic shapes, and non-PyTorch validation behavior.
- Corrects TensorRT binding dtypes, profiles, device selection, allocation, synchronization, calibration caching, and short-tail batches.
- Aligns calibration preprocessing with runtime preprocessing and rejects incompatible variable-shape batches.
- Hardens NCNN discovery and FP16 rejection, preserves model state after failed exports, and promotes FP16 inputs before NMS.
- Prevents ONNX time-of-check/time-of-use replacement, stale sidecar reuse, and destructive artifact replacement; preserves backups and file modes.

# Provenance declaration (required)

## Code provenance

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

# How was this tested?

- Combined changed-area regression selection: 519 passed, 3 skipped.
- Focused export/backend security and runtime selection: 236 passed, 1 skipped.
- Independent re-review selection: 88 passed, 1 skipped.
- Real ONNX Runtime and RT-DETR smoke checks passed.
- Exact hermetic combined-stack PR gate: 4,585 passed, 36 skipped, 60 deselected, 4 expected failures.
- Greptile calibration-tail finding fixed; focused export/calibration regression selection: 188 passed.
- Independent tail-padding review: 10 passed, with exhaustive batch/skip simulation confirming balanced, deterministic full batches.
- Ruff and `git diff --check`: clean.
- TensorRT and CoreML hardware execution was not available locally; their contracts are covered by unit regressions and must remain part of platform-specific release validation.
- GitHub unit and install-smoke workflows will be dispatched for the exact rewritten head before merge.
