### PR TITLE
Fix task-specific model and validation contracts

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -203,6 +203,19 @@ D-FINE-seg (Apache License 2.0)
     D-FINE-seg repository is Apache-2.0; its maintainer approved reuse
     with attribution in ArgoHA/D-FINE-seg#70.
 
+RF-DETR / Roboflow (Apache License 2.0)
+    Path:    libreyolo/models/rfdetr/, libreyolo/postprocess/rfdetr.py,
+             libreyolo/training/lora.py, libreyolo/data/yolo_coco_api.py
+    License: libreyolo/models/rfdetr/NOTICE  (Apache-2.0)
+    Source:  https://github.com/roboflow/rf-detr
+    Commit:  779e55254ccfbffc8cc23b7ecee29a4201489e13 (tag 1.8.0)
+
+    LibreYOLO's RF-DETR family and GroupPose-style keypoint support are
+    derived from Roboflow's RF-DETR implementation (Copyright 2025 Roboflow,
+    Inc.). The port includes the keypoint token stream, matcher and losses,
+    task-aware postprocessing, LoRA recipe helpers, and COCO evaluation glue.
+    The Apache-2.0 license text is available at licenses/Apache-2.0.txt.
+
 ------------------------------------------------------------------------
 Pretrained model weights
 ------------------------------------------------------------------------

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -230,6 +230,7 @@ Used for: RT-DETR model family (libreyolo/models/rtdetr/) including
 RF-DETR (Roboflow)
 --------------------------------------------------------------------
 Source: https://github.com/roboflow/rf-detr
+Commit: 779e55254ccfbffc8cc23b7ecee29a4201489e13 (tag 1.8.0)
 License: Apache License 2.0
 Copyright (c) 2024-2025 Roboflow, Inc.
 Used for: RF-DETR model family (libreyolo/models/rfdetr/), LoRA

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -232,7 +232,7 @@ RF-DETR (Roboflow)
 Source: https://github.com/roboflow/rf-detr
 Commit: 779e55254ccfbffc8cc23b7ecee29a4201489e13 (tag 1.8.0)
 License: Apache License 2.0
-Copyright (c) 2024-2025 Roboflow, Inc.
+Copyright (c) 2025 Roboflow, Inc.
 Used for: RF-DETR model family (libreyolo/models/rfdetr/), LoRA
           adapter recipe helpers (libreyolo/training/lora.py), and
           COCO evaluation glue (libreyolo/data/yolo_coco_api.py).

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -243,6 +243,14 @@ Used for: RF-DETR model family (libreyolo/models/rfdetr/), LoRA
           RF-DETR keypoint preview weights (Apache-2.0, COCO person
           pretrained) are redistributed with attribution.
 
+The separately hosted LibreRFDETR{n,s,m,l}-obb checkpoints are LibreYOLO
+fine-tunes on the Roboflow Universe dataset "My First Project - v8" supplied
+by user bobo:
+https://universe.roboflow.com/bobo-48pem/my-first-project-ewwrm
+The dataset and resulting fine-tuned weights are published under Creative
+Commons Attribution 4.0 International (CC BY 4.0), not Apache-2.0. The base
+RF-DETR code and initialization weights remain Apache-2.0.
+
 --------------------------------------------------------------------
 DINOv2 (Meta AI / facebookresearch)
 --------------------------------------------------------------------

--- a/docs/adr/0007-libresam-contract.md
+++ b/docs/adr/0007-libresam-contract.md
@@ -94,7 +94,11 @@ r.boxes.xyxy      # tight boxes derived from masks
 - `conf` filters by predicted mask-IoU (mask quality, **not** a detection
   confidence). `None` keeps all in the prompted path and applies the family grid
   threshold in "segment everything"; `0.0` disables filtering in either mode.
-- `device=` on `predict` moves the model and invalidates the cached embedding.
+- `device=` on `predict` moves the model and any cached embeddings together.
+- Interactive session operations on one model instance are serialized. A
+  `set_image()`/`reset_image()`/device move cannot interleave with `predict()`
+  and pair prompts with a different image's embeddings; use separate model
+  instances when concurrent inference is required.
 - SAM 3 visual prompts follow the same contract through `Sam3TrackerModel`.
   Its `text=` extension instead performs Promptable Concept Segmentation through
   a lazily loaded `Sam3Model`; text is mutually exclusive with points and boxes.
@@ -111,9 +115,10 @@ r.boxes.xyxy      # tight boxes derived from masks
 `LibreSAMModel` satisfies `BaseModel`'s abstract hooks but overrides `predict()`
 / `__call__` directly rather than driving `InferenceRunner` — the promptless
 preprocess/forward/postprocess hooks have no meaning here and raise. The
-encode-once lifecycle lives in `set_image()` (caches image embeddings) and is
-reused by every later `predict()` until `reset_image()`. A `device=` switch moves
-cached embeddings when possible so interactive sessions survive device changes.
+encode-once lifecycle lives in `set_image()` and commits the image, path, and
+embeddings as one instance-locked session. The same lock serializes later
+`predict()`, `reset_image()`, and device moves. A `device=` switch moves cached
+embeddings when possible so interactive sessions survive device changes.
 
 | Field             | Meaning                                              |
 |-------------------|------------------------------------------------------|

--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -274,8 +274,9 @@ Two layouts are accepted:
 Matte rules:
 
 - the matte is grayscale; values are read as alpha in `[0, 1]` (`/255`);
-- a matte is resized to the prediction canvas with bilinear interpolation when
-  the shapes differ;
+- a prediction is resized to the matte's native canvas with bilinear
+  interpolation when the shapes differ; the ground-truth matte is never
+  resampled for metric computation;
 - metrics are MAE and S-measure (Fan et al., ICCV 2017), computed on the
   original image canvas; best-checkpoint fitness is S-measure.
 

--- a/docs/rfdetr_keypoints_port.md
+++ b/docs/rfdetr_keypoints_port.md
@@ -15,6 +15,9 @@ which their benchmark reports as ahead of the leading AGPL-3.0 pose models at co
 A permissively licensed, strong, AGPL-free pose model is exactly the "match then leapfrog, permissive
 license is the wedge" play, so LibreYOLO adopts it.
 
+The port is pinned to upstream commit
+`779e55254ccfbffc8cc23b7ecee29a4201489e13` (tag `1.8.0`).
+
 The official model is a **GroupPose-style** architecture (not a simple per-query MLP), so its weights
 cannot load into the old clean-room head. Adopting the weights therefore means porting the official
 keypoint architecture and **removing the old clean-room RF-DETR pose head**.

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -377,7 +377,7 @@ def _logsumexp_np(values: np.ndarray, axis: int) -> np.ndarray:
 
 
 def _rfdetr_keypoint_log_mean_trace_np(active_keypoints: np.ndarray) -> np.ndarray:
-    finite = np.isfinite(active_keypoints[..., [2, 4, 5, 6]]).all(axis=-1)
+    finite = np.isfinite(active_keypoints[..., [0, 1, 2, 4, 5, 6]]).all(axis=-1)
     safe_keypoints = np.where(finite[..., None], active_keypoints, 0.0)
     log_l11 = safe_keypoints[..., 4]
     l21 = safe_keypoints[..., 5]
@@ -1328,7 +1328,8 @@ class BaseBackend(ABC):
             keypoints_all = np.asarray(all_outputs[1][0], dtype=np.float32)
 
         if self.model_family == "yolo9_e2e" and self.task == "detect":
-            scores = np.where(np.isfinite(scores), scores, -np.inf)
+            valid_geometry = np.isfinite(boxes_input_all).all(axis=1, keepdims=True)
+            scores = np.where(np.isfinite(scores) & valid_geometry, scores, -np.inf)
             topk_anchors = min(max_det, scores.shape[0])
             if topk_anchors == 0 or scores.shape[-1] == 0:
                 return (
@@ -1849,7 +1850,18 @@ class BaseBackend(ABC):
             else:
                 raw_masks = all_outputs[2][0]
 
+        finite_logits = np.isfinite(logits)
         scores = 1.0 / (1.0 + np.exp(-logits.astype(np.float64))).astype(np.float32)
+        finite_geometry = np.isfinite(boxes_all).all(axis=-1)
+        if raw_angles is not None:
+            finite_geometry &= np.isfinite(raw_angles).reshape(len(boxes_all), -1).all(
+                axis=1
+            )
+        scores = np.where(
+            finite_logits & finite_geometry[:, None],
+            scores,
+            -np.inf,
+        )
         num_queries, num_classes = scores.shape
         if raw_keypoint_output is not None:
             raw_keypoints = self._normalize_rfdetr_keypoint_output(
@@ -2091,13 +2103,27 @@ class BaseBackend(ABC):
         keypoints_out = None
         if keypoints_raw is not None:
             keypoints_out = np.asarray(keypoints_raw, dtype=np.float32).copy()
+            public_width = min(keypoints_out.shape[-1], 3)
+            finite_keypoints = np.isfinite(
+                keypoints_out[..., :public_width]
+            ).all(axis=-1)
+            keypoints_out = np.where(
+                finite_keypoints[..., None],
+                keypoints_out,
+                np.zeros_like(keypoints_out),
+            )
             keypoints_out[..., 0] *= float(orig_w)
             keypoints_out[..., 1] *= float(orig_h)
             if keypoints_out.shape[-1] == 2:
-                visibility = np.ones((*keypoints_out.shape[:-1], 1), dtype=np.float32)
+                visibility = finite_keypoints[..., None].astype(np.float32)
                 keypoints_out = np.concatenate([keypoints_out, visibility], axis=-1)
             else:
                 keypoints_out[..., 2] = 1.0 / (1.0 + np.exp(-keypoints_out[..., 2]))
+                keypoints_out[..., 2] = np.where(
+                    finite_keypoints,
+                    keypoints_out[..., 2],
+                    0.0,
+                )
                 keypoints_out = keypoints_out[..., :3]
             if grouppose_active_keypoints is not None:
                 keypoints_out[~grouppose_active_keypoints] = 0.0

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -400,7 +400,9 @@ def _rfdetr_keypoint_log_mean_trace_np(active_keypoints: np.ndarray) -> np.ndarr
     result = np.zeros_like(log_numerator)
     np.subtract(log_numerator, log_denominator, out=result, where=has_finite)
     return np.where(
-        has_finite & np.isfinite(result), result, np.zeros_like(result)
+        has_finite & np.isfinite(result),
+        result,
+        np.full_like(result, np.inf),
     )
 
 
@@ -1980,6 +1982,7 @@ class BaseBackend(ABC):
                     keypoint_counts[0] = 0
             active_counts = keypoint_counts[internal_class_ids]
             valid_pose_class = active_counts > 0
+            usable_pose = np.zeros(len(selected), dtype=bool)
 
             if np.any(valid_pose_class):
                 trace_alpha = 0.2
@@ -2011,12 +2014,20 @@ class BaseBackend(ABC):
             for row_idx, active_count in enumerate(active_counts):
                 if active_count <= 0:
                     continue
+                usable_pose[row_idx] = np.isfinite(
+                    selected[row_idx, :active_count, :3]
+                ).all(axis=-1).any()
                 keypoints_selected[row_idx, :active_count, :3] = selected[
                     row_idx,
                     :active_count,
                     :3,
                 ]
                 active_keypoint_mask[row_idx, :active_count] = True
+
+            # Keep exported runtime behavior aligned with native GroupPose:
+            # poses with no usable public keypoint must fail the standard
+            # ``score > conf`` filter instead of exposing a confident zero pose.
+            max_scores[~usable_pose] = 0.0
 
             boxes_raw = boxes_raw[valid_pose_class]
             max_scores = max_scores[valid_pose_class]

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -13,6 +13,7 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 
+from ..data.obb import scale_xywhr
 from ..models.yolo9.utils import (
     _YOLO9_MAX_NMS_CANDIDATES,
     postprocess as yolo9_postprocess,
@@ -360,16 +361,28 @@ def _rfdetr_num_select(task: str, model_size: Optional[str]) -> int:
 
 def _logsumexp_np(values: np.ndarray, axis: int) -> np.ndarray:
     max_values = np.max(values, axis=axis, keepdims=True)
-    return np.squeeze(max_values, axis=axis) + np.log(
-        np.sum(np.exp(values - max_values), axis=axis)
+    finite_max = np.isfinite(max_values)
+    shifted = np.full_like(values, -np.inf)
+    np.subtract(
+        values,
+        max_values,
+        out=shifted,
+        where=np.broadcast_to(finite_max, values.shape),
     )
+    exp_sum = np.sum(np.exp(shifted), axis=axis)
+    log_sum = np.zeros_like(exp_sum)
+    np.log(exp_sum, out=log_sum, where=exp_sum > 0)
+    result = np.squeeze(max_values, axis=axis) + log_sum
+    return np.where(np.squeeze(finite_max, axis=axis), result, -np.inf)
 
 
 def _rfdetr_keypoint_log_mean_trace_np(active_keypoints: np.ndarray) -> np.ndarray:
-    log_l11 = active_keypoints[..., 4]
-    l21 = active_keypoints[..., 5]
-    log_l22 = active_keypoints[..., 6]
-    w_find = 1.0 / (1.0 + np.exp(-active_keypoints[..., 2]))
+    finite = np.isfinite(active_keypoints[..., [2, 4, 5, 6]]).all(axis=-1)
+    safe_keypoints = np.where(finite[..., None], active_keypoints, 0.0)
+    log_l11 = safe_keypoints[..., 4]
+    l21 = safe_keypoints[..., 5]
+    log_l22 = safe_keypoints[..., 6]
+    w_find = 1.0 / (1.0 + np.exp(-safe_keypoints[..., 2]))
     log_t1 = -2.0 * log_l11
     log_t2 = -2.0 * log_l22
     log_t3 = 2.0 * np.log(np.clip(np.abs(l21), 1e-12, None)) + log_t1 + log_t2
@@ -378,9 +391,16 @@ def _rfdetr_keypoint_log_mean_trace_np(active_keypoints: np.ndarray) -> np.ndarr
         axis=-1,
     )
     log_w_find = np.log(np.clip(w_find, 1e-12, None))
-    return _logsumexp_np(log_trace_sigma + log_w_find, axis=-1) - _logsumexp_np(
-        log_w_find,
-        axis=-1,
+    masked_log_w_find = np.where(finite, log_w_find, -np.inf)
+    log_numerator = _logsumexp_np(
+        np.where(finite, log_trace_sigma + log_w_find, -np.inf), axis=-1
+    )
+    log_denominator = _logsumexp_np(masked_log_w_find, axis=-1)
+    has_finite = finite.any(axis=-1)
+    result = np.zeros_like(log_numerator)
+    np.subtract(log_numerator, log_denominator, out=result, where=has_finite)
+    return np.where(
+        has_finite & np.isfinite(result), result, np.zeros_like(result)
     )
 
 
@@ -1308,6 +1328,7 @@ class BaseBackend(ABC):
             keypoints_all = np.asarray(all_outputs[1][0], dtype=np.float32)
 
         if self.model_family == "yolo9_e2e" and self.task == "detect":
+            scores = np.where(np.isfinite(scores), scores, -np.inf)
             topk_anchors = min(max_det, scores.shape[0])
             if topk_anchors == 0 or scores.shape[-1] == 0:
                 return (
@@ -1828,12 +1849,6 @@ class BaseBackend(ABC):
             else:
                 raw_masks = all_outputs[2][0]
 
-        if raw_keypoint_output is not None and not getattr(
-            self, "num_keypoints_per_class", None
-        ):
-            public_classes = int(self.nb_classes)
-            if 0 < public_classes < logits.shape[-1]:
-                logits = logits[:, :public_classes]
         scores = 1.0 / (1.0 + np.exp(-logits.astype(np.float64))).astype(np.float32)
         num_queries, num_classes = scores.shape
         if raw_keypoint_output is not None:
@@ -1842,21 +1857,68 @@ class BaseBackend(ABC):
                 query_count=num_queries,
                 num_classes=num_classes,
             )
+
+        class_id_map = np.arange(num_classes, dtype=np.int64)
+        schema = getattr(self, "num_keypoints_per_class", None)
+        has_grouppose_layout = (
+            self.task == "pose"
+            and raw_keypoints is not None
+            and raw_keypoints.ndim == 3
+            and raw_keypoints.shape[-1] >= 7
+            and num_classes > 1
+            and raw_keypoints.shape[1] % num_classes == 0
+        )
+        if self.task == "pose" and schema:
+            schema_counts = np.asarray([int(count) for count in schema], dtype=np.int64)
+            if schema_counts.size != num_classes:
+                raise ValueError(
+                    "Invalid RF-DETR GroupPose num_keypoints_per_class metadata "
+                    f"for {num_classes} classes: {list(schema_counts)}"
+                )
+            class_id_map.fill(-1)
+            keypoint_classes = np.flatnonzero(schema_counts > 0)
+            class_id_map[keypoint_classes] = np.arange(len(keypoint_classes), dtype=np.int64)
+        elif has_grouppose_layout and self.nb_classes == num_classes - 1:
+            class_id_map.fill(-1)
+            class_id_map[1:] = np.arange(num_classes - 1, dtype=np.int64)
+        elif num_classes == 91 and self.nb_classes == 80:
+            from ..models.rfdetr.model import _COCO91_TO_COCO80
+
+            class_id_map = np.asarray(
+                [_COCO91_TO_COCO80.get(class_id, -1) for class_id in range(num_classes)],
+                dtype=np.int64,
+            )
+        elif 0 < int(self.nb_classes) < num_classes:
+            class_id_map[int(self.nb_classes) :] = -1
+
+        valid_internal_classes = np.flatnonzero(class_id_map >= 0)
+        candidate_scores = scores[:, valid_internal_classes]
         model_size = self.model_size or getattr(self, "size", None)
         num_select = (
             _rfdetr_num_select(self.task, model_size)
             if int(max_det) == 300
             else int(max_det)
         )
-        k = min(
-            num_select,
-            num_queries * num_classes,
+        k = max(
+            0,
+            min(
+                num_select,
+                num_queries * len(valid_internal_classes),
+            ),
         )
-        flat_indexes = np.argpartition(scores.reshape(-1), -k)[-k:]
-        flat_indexes = flat_indexes[np.argsort(scores.reshape(-1)[flat_indexes])[::-1]]
-        max_scores = scores.reshape(-1)[flat_indexes]
-        query_idx = flat_indexes // num_classes
-        class_ids = flat_indexes % num_classes
+        flat_scores = candidate_scores.reshape(-1)
+        if k > 0:
+            flat_indexes = np.argpartition(-flat_scores, k - 1)[:k]
+            flat_indexes = flat_indexes[np.argsort(flat_scores[flat_indexes])[::-1]]
+        else:
+            flat_indexes = np.empty(0, dtype=np.int64)
+        max_scores = flat_scores[flat_indexes]
+        candidate_class_count = len(valid_internal_classes)
+        query_idx = flat_indexes // max(candidate_class_count, 1)
+        internal_class_ids = valid_internal_classes[
+            flat_indexes % max(candidate_class_count, 1)
+        ]
+        class_ids = class_id_map[internal_class_ids]
         boxes_raw = boxes_all[query_idx]
         angles_raw = raw_angles[query_idx] if raw_angles is not None else None
         keypoints_raw = (
@@ -1865,14 +1927,7 @@ class BaseBackend(ABC):
         if raw_masks is not None:
             raw_masks = raw_masks[query_idx]
 
-        if (
-            self.task == "pose"
-            and keypoints_raw is not None
-            and keypoints_raw.ndim == 3
-            and keypoints_raw.shape[-1] >= 7
-            and num_classes > 1
-            and keypoints_raw.shape[1] % num_classes == 0
-        ):
+        if has_grouppose_layout and keypoints_raw is not None:
             schema = getattr(self, "num_keypoints_per_class", None)
             keypoint_counts = None
             if schema:
@@ -1900,7 +1955,7 @@ class BaseBackend(ABC):
                 max_num_keypoints,
                 keypoints_raw.shape[-1],
             )
-            selected = grouped[np.arange(len(class_ids)), class_ids]
+            selected = grouped[np.arange(len(internal_class_ids)), internal_class_ids]
 
             # GroupPose exports use internal class 0 for no-keypoint detections
             # and keypoint-bearing classes after it. Public pose labels are
@@ -1911,7 +1966,7 @@ class BaseBackend(ABC):
                 )
                 if self.nb_classes == num_classes - 1:
                     keypoint_counts[0] = 0
-            active_counts = keypoint_counts[class_ids]
+            active_counts = keypoint_counts[internal_class_ids]
             valid_pose_class = active_counts > 0
 
             if np.any(valid_pose_class):
@@ -1920,13 +1975,18 @@ class BaseBackend(ABC):
                 for class_idx, active_count in enumerate(keypoint_counts):
                     if active_count <= 0:
                         continue
-                    class_mask = class_ids == class_idx
+                    class_mask = internal_class_ids == class_idx
                     if not np.any(class_mask):
                         continue
                     log_mean_traces[class_mask] = _rfdetr_keypoint_log_mean_trace_np(
                         selected[class_mask, :active_count]
                     )
-                max_scores = max_scores * np.exp(-trace_alpha * log_mean_traces)
+                max_scores = np.nan_to_num(
+                    max_scores * np.exp(-trace_alpha * log_mean_traces),
+                    nan=0.0,
+                    posinf=1.0,
+                    neginf=0.0,
+                ).clip(0.0, 1.0)
 
             keypoints_selected = np.zeros(
                 (len(selected), max_num_keypoints, 3),
@@ -1946,13 +2006,10 @@ class BaseBackend(ABC):
                 ]
                 active_keypoint_mask[row_idx, :active_count] = True
 
-            kp_classes = np.flatnonzero(keypoint_counts > 0)
-            remap = np.full(num_classes, -1, dtype=class_ids.dtype)
-            remap[kp_classes] = np.arange(len(kp_classes), dtype=class_ids.dtype)
-
             boxes_raw = boxes_raw[valid_pose_class]
             max_scores = max_scores[valid_pose_class]
-            class_ids = remap[class_ids[valid_pose_class]]
+            class_ids = class_ids[valid_pose_class]
+            internal_class_ids = internal_class_ids[valid_pose_class]
             if angles_raw is not None:
                 angles_raw = angles_raw[valid_pose_class]
             if keypoints_raw is not None:
@@ -1986,44 +2043,6 @@ class BaseBackend(ABC):
                 return boxes_raw, max_scores, class_ids, None, None, keypoints_raw
             return boxes_raw, max_scores, class_ids, None
 
-        # COCO 91→80 class mapping
-        if num_classes == 91 and self.nb_classes == 80:
-            from ..models.rfdetr.model import _COCO91_TO_COCO80
-
-            mapped = np.array([_COCO91_TO_COCO80.get(int(c), -1) for c in class_ids])
-            valid = mapped >= 0
-            boxes_raw = boxes_raw[valid]
-            max_scores = max_scores[valid]
-            class_ids = mapped[valid]
-            if angles_raw is not None:
-                angles_raw = angles_raw[valid]
-            if keypoints_raw is not None:
-                keypoints_raw = keypoints_raw[valid]
-                if grouppose_active_keypoints is not None:
-                    grouppose_active_keypoints = grouppose_active_keypoints[valid]
-            if raw_masks is not None:
-                raw_masks = raw_masks[valid]
-
-        if len(boxes_raw) == 0:
-            if self.task == "obb":
-                return (
-                    boxes_raw,
-                    max_scores,
-                    class_ids,
-                    None,
-                    np.zeros((0, 7), dtype=np.float32),
-                )
-            if self.task == "pose" and keypoints_raw is not None:
-                return (
-                    boxes_raw,
-                    max_scores,
-                    class_ids,
-                    None,
-                    None,
-                    keypoints_raw,
-                )
-            return boxes_raw, max_scores, class_ids, None
-
         cx, cy, w, h = (
             boxes_raw[:, 0],
             boxes_raw[:, 1],
@@ -2042,15 +2061,17 @@ class BaseBackend(ABC):
         obb_out = None
         if angles_raw is not None:
             angles = np.asarray(angles_raw, dtype=np.float32).reshape(-1)
-            obb_out = np.stack(
+            obb_xywhr = scale_xywhr(
+                np.stack([cx, cy, w, h, angles], axis=1),
+                float(orig_w),
+                float(orig_h),
+                min_size=1e-4,
+            )
+            obb_out = np.concatenate(
                 [
-                    cx * orig_w,
-                    cy * orig_h,
-                    w * orig_w,
-                    h * orig_h,
-                    angles,
-                    max_scores,
-                    class_ids.astype(np.float32),
+                    obb_xywhr,
+                    max_scores[:, None],
+                    class_ids.astype(np.float32)[:, None],
                 ],
                 axis=1,
             ).astype(np.float32, copy=False)

--- a/libreyolo/ensemble/model.py
+++ b/libreyolo/ensemble/model.py
@@ -359,8 +359,12 @@ class LibreEnsemble:
         normalize_predict_kwargs(kwargs)
         del batch
         if isinstance(max_det, bool) or not isinstance(max_det, Integral):
-            raise ValueError(f"max_det must be an integer, got {max_det!r}")
+            raise TypeError(
+                f"max_det must be an integer, got {type(max_det).__name__}."
+            )
         max_det = int(max_det)
+        if max_det < 0:
+            raise ValueError(f"max_det must be non-negative, got {max_det!r}.")
         if stream or is_video_file(source):
             raise NotImplementedError(
                 "video and stream ensembling are not available yet; run the "
@@ -469,8 +473,7 @@ class LibreEnsemble:
             )
             f_boxes, f_scores, f_labels = f_boxes[keep], f_scores[keep], f_labels[keep]
         order = torch.argsort(f_scores, descending=True)
-        if max_det >= 0:
-            order = order[:max_det]
+        order = order[:max_det]
         f_boxes, f_scores, f_labels = f_boxes[order], f_scores[order], f_labels[order]
 
         result = Results(

--- a/libreyolo/ensemble/model.py
+++ b/libreyolo/ensemble/model.py
@@ -21,7 +21,9 @@ automatically capped per class by how many members know that class.
 from __future__ import annotations
 
 import logging
+import math
 import time
+from numbers import Integral
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -48,7 +50,44 @@ Detections = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 def _sanitize_names(names) -> Dict[int, str]:
     if not isinstance(names, dict) or not names:
         raise TypeError("names must be a non-empty dict mapping class id to name")
-    return {int(k): str(v) for k, v in names.items()}
+    clean: Dict[int, str] = {}
+    seen_names = set()
+    for raw_id, raw_name in names.items():
+        if isinstance(raw_id, bool) or not isinstance(raw_id, Integral):
+            raise TypeError(
+                "names keys must be non-negative integers; implicit casting can "
+                f"merge distinct keys, got {raw_id!r}"
+            )
+        class_id = int(raw_id)
+        if class_id < 0:
+            raise ValueError(f"names keys must be non-negative, got {class_id}")
+        if not isinstance(raw_name, str):
+            raise TypeError(
+                "class names must be strings; implicit casting can merge distinct "
+                f"values, got {raw_name!r}"
+            )
+        if raw_name in seen_names:
+            raise ValueError(
+                f"class names must be unique within a member, duplicate {raw_name!r}"
+            )
+        clean[class_id] = raw_name
+        seen_names.add(raw_name)
+    return clean
+
+
+def _labels_as_int(labels, *, context: str) -> torch.Tensor:
+    """Validate label ids before converting them to integer indices."""
+    labels = torch.as_tensor(labels).reshape(-1)
+    if labels.dtype == torch.bool or labels.is_complex():
+        raise ValueError(f"{context} labels must be integer-valued class ids")
+    if labels.dtype.is_floating_point:
+        if not bool(torch.isfinite(labels).all()):
+            raise ValueError(f"{context} labels must contain only finite values")
+        if not bool((labels == labels.round()).all()):
+            raise ValueError(
+                f"{context} labels must be integer-valued; fractional ids are invalid"
+            )
+    return labels.to(dtype=torch.long)
 
 
 class ExternalDetector:
@@ -84,7 +123,7 @@ class ExternalDetector:
             )
         boxes = torch.as_tensor(out[0], dtype=torch.float32)
         scores = torch.as_tensor(out[1], dtype=torch.float32).reshape(-1)
-        labels = torch.as_tensor(out[2]).reshape(-1)
+        labels = _labels_as_int(out[2], context="ExternalDetector")
         if boxes.numel() == 0:
             boxes = boxes.reshape(0, 4)
         if boxes.ndim != 2 or boxes.shape[1] != 4:
@@ -172,10 +211,13 @@ class LibreEnsemble:
                 raise ValueError(
                     f"weights has {len(weights)} entries for {n} members"
                 )
-            # Positivity (not non-negativity) so NaN weights also fail loudly.
-            if not all(w > 0 for w in weights):
-                raise ValueError("weights must all be positive")
-            self.weights = [float(w) for w in weights]
+            try:
+                parsed_weights = [float(w) for w in weights]
+            except (TypeError, ValueError) as exc:
+                raise ValueError("weights must all be finite positive numbers") from exc
+            if not all(math.isfinite(w) and w > 0 for w in parsed_weights):
+                raise ValueError("weights must all be finite and positive")
+            self.weights = parsed_weights
         else:
             self.weights = [1.0] * n
 
@@ -204,6 +246,10 @@ class LibreEnsemble:
             )
         self.min_votes = min_votes
         self.fusion_iou = float(fusion_iou)
+        if not math.isfinite(self.fusion_iou) or not 0 <= self.fusion_iou <= 1:
+            raise ValueError(
+                f"fusion_iou must be a finite value in [0, 1], got {fusion_iou!r}"
+            )
 
         (
             self.names,
@@ -312,6 +358,9 @@ class LibreEnsemble:
         """
         normalize_predict_kwargs(kwargs)
         del batch
+        if isinstance(max_det, bool) or not isinstance(max_det, Integral):
+            raise ValueError(f"max_det must be an integer, got {max_det!r}")
+        max_det = int(max_det)
         if stream or is_video_file(source):
             raise NotImplementedError(
                 "video and stream ensembling are not available yet; run the "
@@ -410,14 +459,18 @@ class LibreEnsemble:
             label_weights=self._label_weights.to(boxes.device),
         )
         speed["fusion"] = (time.perf_counter() - start) * 1000.0
-        f_boxes, f_scores, f_labels = self._validate_fused(fused)
+        f_boxes, f_scores, f_labels = self._validate_fused(
+            fused, num_classes=len(self.names)
+        )
 
         if classes is not None and f_labels.numel() > 0:
             keep = torch.isin(
                 f_labels, torch.as_tensor(list(classes), device=f_labels.device)
             )
             f_boxes, f_scores, f_labels = f_boxes[keep], f_scores[keep], f_labels[keep]
-        order = torch.argsort(f_scores, descending=True)[:max_det]
+        order = torch.argsort(f_scores, descending=True)
+        if max_det >= 0:
+            order = order[:max_det]
         f_boxes, f_scores, f_labels = f_boxes[order], f_scores[order], f_labels[order]
 
         result = Results(
@@ -447,7 +500,7 @@ class LibreEnsemble:
                 continue
             b = torch.as_tensor(bx.xyxy, dtype=torch.float32)
             s = torch.as_tensor(bx.conf, dtype=torch.float32).reshape(-1)
-            c = torch.as_tensor(bx.cls).reshape(-1).long()
+            c = _labels_as_int(bx.cls, context=f"ensemble member {i}")
             if device is None:
                 device = b.device
             b, s, c = b.to(device), s.to(device), c.to(device)
@@ -485,7 +538,7 @@ class LibreEnsemble:
         )
 
     @staticmethod
-    def _validate_fused(fused) -> Detections:
+    def _validate_fused(fused, *, num_classes: int) -> Detections:
         if not isinstance(fused, (tuple, list)) or len(fused) != 3:
             raise TypeError(
                 "fusion must return (boxes, scores, labels), got "
@@ -493,7 +546,7 @@ class LibreEnsemble:
             )
         boxes = torch.as_tensor(fused[0], dtype=torch.float32)
         scores = torch.as_tensor(fused[1], dtype=torch.float32).reshape(-1)
-        labels = torch.as_tensor(fused[2]).reshape(-1).long()
+        labels = _labels_as_int(fused[2], context="fusion output")
         if boxes.numel() == 0:
             boxes = boxes.reshape(0, 4)
         if (
@@ -506,6 +559,20 @@ class LibreEnsemble:
                 "fusion returned inconsistent shapes: "
                 f"boxes {tuple(boxes.shape)}, scores {tuple(scores.shape)}, "
                 f"labels {tuple(labels.shape)}"
+            )
+        if not bool(torch.isfinite(boxes).all()) or not bool(
+            torch.isfinite(scores).all()
+        ):
+            raise ValueError("fusion output boxes and scores must be finite")
+        if bool(((scores < 0) | (scores > 1)).any()):
+            raise ValueError("fusion output scores must be in [0, 1]")
+        if boxes.numel() and bool((boxes[:, 2:] < boxes[:, :2]).any()):
+            raise ValueError("fusion output boxes must satisfy x2 >= x1 and y2 >= y1")
+        if labels.numel() and (
+            int(labels.min()) < 0 or int(labels.max()) >= num_classes
+        ):
+            raise ValueError(
+                f"fusion output labels must be in [0, {num_classes - 1}]"
             )
         return boxes, scores, labels
 

--- a/libreyolo/models/efficientnetv2/model.py
+++ b/libreyolo/models/efficientnetv2/model.py
@@ -42,6 +42,9 @@ class LibreEfficientNetV2(BaseModel):
     DEFAULT_TASK = "classify"
     REQUIRE_TASK_SUFFIX = True  # canonical weights are LibreEfficientNetV2<size>-cls.pt
     TRAIN_CONFIG = EfficientNetV2Config
+    # At small accepted resolutions the final BatchNorm input can be 1x1, so
+    # every training batch must contain at least two samples.
+    MIN_TRAIN_BATCH_SIZE = 2
 
     # timm eval crop_pct per checkpoint — matches the upstream benchmark preprocessing.
     CROP_PCT = {"b0": 0.875, "b1": 0.882, "b2": 0.890, "b3": 0.904}

--- a/libreyolo/models/eomt/model.py
+++ b/libreyolo/models/eomt/model.py
@@ -60,30 +60,14 @@ def _eomt_keys(weights_dict: dict[str, Any]) -> set[str]:
 
 def _eomt_coco_content_size(orig_h: int, orig_w: int, size: int) -> Tuple[int, int]:
     """Return EoMT's aspect-preserving COCO content size."""
-    min_o, max_o = float(min(orig_h, orig_w)), float(max(orig_h, orig_w))
-    target = size
-    raw: Optional[float] = None
-    if max_o / min_o * size > size:
-        raw = size * min_o / max_o
-        target = int(round(raw))
-    if (orig_h <= orig_w and orig_h == target) or (
-        orig_w <= orig_h and orig_w == target
-    ):
+    if max(orig_h, orig_w) == size:
         return orig_h, orig_w
     if orig_w < orig_h:
-        out_w = target
-        out_h = (
-            int(raw * orig_h / orig_w)
-            if raw is not None
-            else int(size * orig_h / orig_w)
-        )
+        out_h = size
+        out_w = max(1, int(round(size * orig_w / orig_h)))
     else:
-        out_h = target
-        out_w = (
-            int(raw * orig_w / orig_h)
-            if raw is not None
-            else int(size * orig_w / orig_h)
-        )
+        out_w = size
+        out_h = max(1, int(round(size * orig_h / orig_w)))
     return out_h, out_w
 
 
@@ -596,7 +580,7 @@ class LibreEoMT(BaseModel):
         than silently mislabeled.
         """
         thing_ids = getattr(self, "thing_class_ids", None)
-        if not thing_ids:
+        if thing_ids is None:
             logger.warning(
                 "LibreEoMT panoptic checkpoint has no 'thing_class_ids' metadata; "
                 "treating every category as a thing. Stuff regions will not be "
@@ -678,12 +662,12 @@ class LibreEoMT(BaseModel):
             won = winner == k
             own_mask = mask_probs[k] >= self.PANOPTIC_MASK_THRESHOLD
             final_mask = won & own_mask
-            won_area = int(won.sum())
+            final_area = int(final_mask.sum())
             own_area = int(own_mask.sum())
-            if won_area == 0 or own_area == 0 or int(final_mask.sum()) == 0:
+            if own_area == 0 or final_area == 0:
                 continue
             # Mostly-occluded queries are dropped rather than left as slivers.
-            if won_area / own_area <= self.PANOPTIC_OVERLAP_THRESHOLD:
+            if final_area / own_area <= self.PANOPTIC_OVERLAP_THRESHOLD:
                 continue
 
             if is_stuff and label in stuff_memory:

--- a/libreyolo/models/fomo/utils.py
+++ b/libreyolo/models/fomo/utils.py
@@ -56,20 +56,26 @@ def decode_points_from_logits(
             continue
 
         scores = prob[ys, xs]
-        order = torch.argsort(scores, descending=True)
-        suppressed = torch.zeros((h, w), dtype=torch.bool, device=prob.device)
+        order = torch.argsort(scores, descending=True, stable=True)
+        suppressed = torch.zeros(
+            (probs.shape[1] - class_offset, h, w),
+            dtype=torch.bool,
+            device=prob.device,
+        )
         kept = []
         for idx in order:
             y = int(ys[idx])
             x = int(xs[idx])
-            if suppressed[y, x]:
+            class_channel = int(cls_idx[b, y, x])
+            class_index = class_channel - class_offset
+            if suppressed[class_index, y, x]:
                 continue
             kept.append(torch.stack((xs[idx].float(), ys[idx].float(), cls_idx[b, y, x].float(), scores[idx].float())))
             y0 = max(0, y - nms_radius)
             y1 = min(h, y + nms_radius + 1)
             x0 = max(0, x - nms_radius)
             x1 = min(w, x + nms_radius + 1)
-            suppressed[y0:y1, x0:x1] = True
+            suppressed[class_index, y0:y1, x0:x1] = True
             if max_points is not None and len(kept) >= max_points:
                 break
         batch_points.append(torch.stack(kept) if kept else torch.zeros((0, 4), dtype=pred_logits.dtype, device=pred_logits.device))

--- a/libreyolo/models/mobilenetv4/model.py
+++ b/libreyolo/models/mobilenetv4/model.py
@@ -40,6 +40,9 @@ class LibreMobileNetV4(BaseModel):
     DEFAULT_TASK = "classify"
     REQUIRE_TASK_SUFFIX = True  # canonical weights are LibreMobileNetV4<size>-cls.pt
     TRAIN_CONFIG = MobileNetV4Config
+    # ``norm_head`` runs after global pooling, where a singleton batch leaves
+    # BatchNorm2d with only one value per channel during training.
+    MIN_TRAIN_BATCH_SIZE = 2
 
     # timm eval crop_pct per checkpoint — matches the upstream benchmark preprocessing.
     CROP_PCT = {"s": 0.875, "m": 0.95, "l": 0.95}

--- a/libreyolo/models/nafnet/model.py
+++ b/libreyolo/models/nafnet/model.py
@@ -239,6 +239,11 @@ class LibreNAFNet(BaseModel):
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         return self.model(input_tensor)
 
+    @staticmethod
+    def _preprocess_validation_batch(images: torch.Tensor) -> torch.Tensor:
+        """Keep native geometry and opt into per-sample restore validation."""
+        return images
+
     def _postprocess(
         self,
         output: Any,

--- a/libreyolo/models/nafnet/trainer.py
+++ b/libreyolo/models/nafnet/trainer.py
@@ -47,20 +47,56 @@ class NAFNetTrainer(BaseTrainer):
         # time, so forwarding training through the fixed-window local pool is a
         # train/inference mismatch. Switch the model to global pooling for
         # training (weight-preserving — pooling ops carry no parameters) and
-        # remember the removed TLC modules so inference-time local pooling is
-        # restored in :meth:`train`. The optimizer/EMA are built after this hook,
-        # so they operate on the plain-pooling model.
+        # remember that inference-time local pooling must be rebuilt in
+        # :meth:`train`. The optimizer/EMA are built after this hook, so they
+        # operate on the plain-pooling model.
         from .nn import use_global_pooling
 
-        self._tlc_restore = use_global_pooling(self.model)
+        use_global_pooling(self.model)
+        self._pooling_prepared = True
+
+    def _inference_pooling_geometry(self) -> tuple[int, int]:
+        """Return the training-crop geometry that defines TLC windows."""
+        imgsz = self.config.imgsz
+        if isinstance(imgsz, (tuple, list)):
+            return int(imgsz[0]), int(imgsz[1])
+        side = int(imgsz)
+        return side, side
+
+    def _enable_inference_pooling(self, model: torch.nn.Module) -> None:
+        """Rebuild and materialize TLC pooling for the configured crop size."""
+        from .nn import replace_adaptive_avg_pool2d, use_global_pooling
+
+        # Always start from the plain graph. This also makes repeated
+        # validation calls safe after a partially completed conversion.
+        use_global_pooling(model)
+        train_h, train_w = self._inference_pooling_geometry()
+        replace_adaptive_avg_pool2d(
+            model,
+            base_size=(int(train_h * 1.5), int(train_w * 1.5)),
+            train_size=(1, 3, train_h, train_w),
+        )
+        was_training = model.training
+        try:
+            model.eval()
+            parameter = next(model.parameters())
+            with torch.no_grad():
+                model(
+                    torch.zeros(
+                        (1, 3, train_h, train_w),
+                        device=parameter.device,
+                        dtype=parameter.dtype,
+                    )
+                )
+        finally:
+            model.train(was_training)
 
     def _restore_inference_pooling(self) -> None:
-        from .nn import restore_local_pooling
+        from ...training.distributed import unwrap_model
 
-        restore = getattr(self, "_tlc_restore", None)
-        if restore:
-            restore_local_pooling(restore)
-        self._tlc_restore = None
+        if getattr(self, "_pooling_prepared", False):
+            self._enable_inference_pooling(unwrap_model(self.model))
+        self._pooling_prepared = False
 
     def train(self) -> Dict[str, Any]:
         # Train through the plain global-pool model, then re-attach the TLC
@@ -69,6 +105,20 @@ class NAFNetTrainer(BaseTrainer):
             return super().train()
         finally:
             self._restore_inference_pooling()
+
+    def _run_restore_validation(self, epoch: int):
+        """Evaluate checkpoints with the TLC graph used by public inference."""
+        from ...training.distributed import unwrap_model
+        from .nn import use_global_pooling
+
+        eval_model = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
+        was_training = eval_model.training
+        try:
+            self._enable_inference_pooling(eval_model)
+            return super()._run_restore_validation(epoch)
+        finally:
+            use_global_pooling(eval_model)
+            eval_model.train(was_training)
 
     def create_scheduler(self, iters_per_epoch: int):
         require_training_choice(

--- a/libreyolo/models/openvocab/base.py
+++ b/libreyolo/models/openvocab/base.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import logging
 import re
-import warnings
 from collections.abc import MutableMapping
 from pathlib import Path
 from types import GeneratorType
@@ -23,6 +22,7 @@ import torch.nn as nn
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.results import Results
 from ..base.model import BaseModel
+from ..vlm.parsing import finalize_detection_dict
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +34,7 @@ _SNAPSHOT_COMPLETE_MARKER = ".libreyolo_snapshot_complete"
 _SPACE_RE = re.compile(r"\s+")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _ARTICLES = {"a", "an", "the"}
+_LEADING_ARTICLE_RE = re.compile(r"^(?:a|an|the)(?:\s+|$)", re.IGNORECASE)
 
 
 def _normalize_label(text: str) -> str:
@@ -54,6 +55,15 @@ def _contains_subsequence(haystack: list[str], needle: list[str]) -> bool:
         return False
     n = len(needle)
     return any(haystack[i : i + n] == needle for i in range(len(haystack) - n + 1))
+
+
+def _prompt_label(text: str) -> str:
+    """Preserve label punctuation while normalizing prompt whitespace/case."""
+    return _SPACE_RE.sub(" ", str(text).strip()).lower()
+
+
+def _has_leading_article(text: str) -> bool:
+    return _LEADING_ARTICLE_RE.match(text) is not None
 
 
 class LibreOpenVocabDetector(BaseModel):
@@ -146,12 +156,6 @@ class LibreOpenVocabDetector(BaseModel):
             raise ValueError(
                 f"{type(self).__name__} does not support augment=True; "
                 "test-time augmentation is out of scope for this tier."
-            )
-        if "iou" in kwargs:
-            warnings.warn(
-                f"{type(self).__name__} does not run LibreYOLO NMS; iou= is "
-                "accepted for API compatibility but ignored.",
-                stacklevel=2,
             )
         if text_threshold is None:
             return super().__call__(source, conf=conf, **kwargs)
@@ -364,46 +368,34 @@ class LibreOpenVocabDetector(BaseModel):
         original_size: Tuple[int, int],
         max_det: int,
         classes: Optional[List[int]] = None,
+        iou_thres: float | None = 0.45,
     ) -> Dict:
-        boxes_t = self._as_cpu_tensor(boxes, torch.float32).reshape(-1, 4)
-        scores_t = self._as_cpu_tensor(scores, torch.float32).reshape(-1)
-        class_t = self._as_cpu_tensor(class_ids, torch.int64).reshape(-1)
-        n = min(boxes_t.shape[0], scores_t.shape[0], class_t.shape[0])
-        boxes_t, scores_t, class_t = boxes_t[:n], scores_t[:n], class_t[:n]
-        if n == 0:
-            return self._empty_detections()
-
-        width, height = original_size
-        finite = torch.isfinite(boxes_t).all(dim=1) & torch.isfinite(scores_t)
-        keep = finite & (scores_t >= float(conf_thres))
-        if classes is not None:
-            allowed = torch.as_tensor(classes, dtype=torch.int64)
-            keep &= (class_t[:, None] == allowed[None, :]).any(dim=1)
-        boxes_t, scores_t, class_t = boxes_t[keep], scores_t[keep], class_t[keep]
-        if boxes_t.numel() == 0:
-            return self._empty_detections()
-
-        boxes_t[:, 0::2] = boxes_t[:, 0::2].clamp(0, float(width))
-        boxes_t[:, 1::2] = boxes_t[:, 1::2].clamp(0, float(height))
-        valid = (boxes_t[:, 2] > boxes_t[:, 0]) & (boxes_t[:, 3] > boxes_t[:, 1])
-        boxes_t, scores_t, class_t = boxes_t[valid], scores_t[valid], class_t[valid]
-        if boxes_t.numel() == 0:
-            return self._empty_detections()
-
-        order = scores_t.argsort(descending=True)[:max_det]
-        boxes_t, scores_t, class_t = boxes_t[order], scores_t[order], class_t[order]
+        boxes_value = boxes.detach().cpu() if isinstance(boxes, torch.Tensor) else boxes
+        scores_value = (
+            scores.detach().cpu() if isinstance(scores, torch.Tensor) else scores
+        )
+        class_value = (
+            class_ids.detach().cpu()
+            if isinstance(class_ids, torch.Tensor)
+            else class_ids
+        )
+        finalized = finalize_detection_dict(
+            boxes_value,
+            scores_value,
+            class_value,
+            original_size,
+            conf_thres=conf_thres,
+            iou_thres=iou_thres,
+            max_det=max_det,
+            classes=classes,
+            num_classes=len(self.names),
+        )
         return {
-            "boxes": boxes_t,
-            "scores": scores_t,
-            "classes": class_t,
-            "num_detections": int(boxes_t.shape[0]),
+            "boxes": torch.tensor(finalized["boxes"], dtype=torch.float32).reshape(-1, 4),
+            "scores": torch.tensor(finalized["scores"], dtype=torch.float32),
+            "classes": torch.tensor(finalized["classes"], dtype=torch.int64),
+            "num_detections": finalized["num_detections"],
         }
-
-    @staticmethod
-    def _as_cpu_tensor(value: Any, dtype: torch.dtype) -> torch.Tensor:
-        if isinstance(value, torch.Tensor):
-            return value.detach().to(device="cpu", dtype=dtype)
-        return torch.as_tensor(value, dtype=dtype)
 
     @staticmethod
     def _empty_detections() -> Dict:
@@ -451,4 +443,6 @@ __all__ = [
     "_label_tokens",
     "_normalize_label",
     "_contains_subsequence",
+    "_prompt_label",
+    "_has_leading_article",
 ]

--- a/libreyolo/models/openvocab/grounding_dino.py
+++ b/libreyolo/models/openvocab/grounding_dino.py
@@ -9,8 +9,10 @@ import torch
 from .base import (
     _INSTALL_HINT,
     _contains_subsequence,
+    _has_leading_article,
     _label_tokens,
     _normalize_label,
+    _prompt_label,
     LibreOpenVocabDetector,
 )
 
@@ -51,8 +53,8 @@ class LibreGroundingDINO(LibreOpenVocabDetector):
         return model, processor
 
     def _class_phrase(self, class_id: int) -> str:
-        name = str(self.names[class_id]).strip().lower()
-        return f"a {name}"
+        name = _prompt_label(self.names[class_id])
+        return name if _has_leading_article(name) else f"a {name}"
 
     def _prompt(self, class_ids: list[int] | None = None) -> str:
         class_ids = list(range(len(self.names))) if class_ids is None else class_ids
@@ -133,30 +135,39 @@ class LibreGroundingDINO(LibreOpenVocabDetector):
             target_sizes=[(height, width)],
         )
         result = results[0]
-        boxes = torch.as_tensor(result.get("boxes", []), dtype=torch.float32).reshape(
-            -1, 4
-        )
-        scores = torch.as_tensor(result.get("scores", []), dtype=torch.float32).reshape(
-            -1
-        )
+        try:
+            raw_boxes = list(result.get("boxes", []))
+            raw_scores = list(result.get("scores", []))
+        except (TypeError, ValueError):
+            raw_boxes, raw_scores = [], []
         phrases = self._read_text_labels(result)
+        boxes = []
+        scores = []
         class_ids = []
-        keep_indices = []
-        for index, phrase in enumerate(phrases[: min(len(phrases), boxes.shape[0])]):
+        count = min(len(phrases), len(raw_boxes), len(raw_scores))
+        for index, phrase in enumerate(phrases[:count]):
             class_id = self._phrase_to_class_id(phrase)
-            if class_id is not None:
-                keep_indices.append(index)
-                class_ids.append(class_id)
-        if not keep_indices:
+            if class_id is None:
+                continue
+            try:
+                box = torch.as_tensor(raw_boxes[index], dtype=torch.float32)
+                score = float(raw_scores[index])
+            except (TypeError, ValueError, RuntimeError):
+                continue
+            if box.ndim != 1 or box.numel() != 4:
+                continue
+            boxes.append(box)
+            scores.append(score)
+            class_ids.append(class_id)
+        if not boxes:
             return (
                 torch.zeros((0, 4), dtype=torch.float32),
                 torch.zeros((0,), dtype=torch.float32),
                 torch.zeros((0,), dtype=torch.int64),
             )
-        keep = torch.as_tensor(keep_indices, dtype=torch.long)
         return (
-            boxes[keep],
-            scores[keep],
+            torch.stack(boxes),
+            torch.as_tensor(scores, dtype=torch.float32),
             torch.as_tensor(class_ids, dtype=torch.int64),
         )
 
@@ -188,6 +199,7 @@ class LibreGroundingDINO(LibreOpenVocabDetector):
             original_size=original_size,
             max_det=max_det,
             classes=kwargs.get("classes"),
+            iou_thres=iou_thres,
         )
 
     @staticmethod
@@ -197,7 +209,12 @@ class LibreGroundingDINO(LibreOpenVocabDetector):
             labels = result.get("labels", [])
         if isinstance(labels, torch.Tensor):
             return []
-        return [str(label) for label in labels]
+        if isinstance(labels, (str, bytes)):
+            return [str(labels)]
+        try:
+            return [str(label) for label in labels]
+        except TypeError:
+            return [str(labels)]
 
     def _phrase_to_class_id(self, phrase: str) -> Optional[int]:
         norm = _normalize_label(phrase)

--- a/libreyolo/models/openvocab/owlv2.py
+++ b/libreyolo/models/openvocab/owlv2.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from numbers import Real
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
 import torch
 
-from .base import _INSTALL_HINT, _contains_subsequence, _label_tokens
+from .base import (
+    _INSTALL_HINT,
+    _contains_subsequence,
+    _has_leading_article,
+    _label_tokens,
+    _prompt_label,
+)
 from .base import LibreOpenVocabDetector
 
 
@@ -39,8 +46,11 @@ class LibreOWLv2(LibreOpenVocabDetector):
     def _text_labels(self) -> list[list[str]]:
         labels = []
         for class_id in range(len(self.names)):
-            name = str(self.names[class_id]).strip().lower()
-            labels.append(self.PROMPT_TEMPLATE.format(name))
+            name = _prompt_label(self.names[class_id])
+            if _has_leading_article(name):
+                labels.append(f"a photo of {name}")
+            else:
+                labels.append(self.PROMPT_TEMPLATE.format(name))
         return [labels]
 
     def _build_inputs(self, img: Any) -> Any:
@@ -75,43 +85,50 @@ class LibreOWLv2(LibreOpenVocabDetector):
             raw_labels = result.get("text_labels", [])
 
         class_ids = self._labels_to_class_ids(raw_labels)
-        boxes_t = torch.as_tensor(boxes, dtype=torch.float32).reshape(-1, 4)
-        scores_t = torch.as_tensor(scores, dtype=torch.float32).reshape(-1)
-        keep = class_ids >= 0
-        n = min(boxes_t.shape[0], scores_t.shape[0], class_ids.shape[0])
-        boxes_t, scores_t, class_ids, keep = (
-            boxes_t[:n],
-            scores_t[:n],
-            class_ids[:n],
-            keep[:n],
-        )
         return self._detections_to_dict(
-            boxes_t[keep],
-            scores_t[keep],
-            class_ids[keep],
+            boxes,
+            scores,
+            class_ids,
             conf_thres=conf_thres,
             original_size=original_size,
             max_det=max_det,
             classes=kwargs.get("classes"),
+            iou_thres=iou_thres,
         )
 
     def _labels_to_class_ids(self, labels: Any) -> torch.Tensor:
         if isinstance(labels, torch.Tensor):
-            class_ids = labels.detach().cpu().long().reshape(-1)
+            raw = labels.detach().cpu().reshape(-1)
+            if raw.dtype == torch.bool:
+                return torch.full((raw.numel(),), -1, dtype=torch.int64)
+            try:
+                numeric = raw.to(torch.float64)
+            except (TypeError, RuntimeError):
+                return torch.full((raw.numel(),), -1, dtype=torch.int64)
         else:
-            values = list(labels)
+            if isinstance(labels, (str, bytes)):
+                values = [labels]
+            else:
+                try:
+                    values = list(labels)
+                except TypeError:
+                    values = [labels]
             if not values:
                 return torch.zeros((0,), dtype=torch.int64)
-            if all(isinstance(value, (int, float)) for value in values):
-                class_ids = torch.as_tensor(values, dtype=torch.int64).reshape(-1)
+            if all(isinstance(value, Real) and not isinstance(value, bool) for value in values):
+                numeric = torch.as_tensor(values, dtype=torch.float64).reshape(-1)
             else:
                 mapped = [self._text_label_to_class_id(str(value)) for value in values]
                 return torch.as_tensor(
                     [-1 if class_id is None else class_id for class_id in mapped],
                     dtype=torch.int64,
                 )
-        valid = (class_ids >= 0) & (class_ids < len(self.names))
-        return torch.where(valid, class_ids, torch.full_like(class_ids, -1))
+        integral = torch.isfinite(numeric) & (numeric == numeric.round())
+        in_range = (numeric >= 0) & (numeric < len(self.names))
+        valid = integral & in_range
+        class_ids = torch.full(numeric.shape, -1, dtype=torch.int64)
+        class_ids[valid] = numeric[valid].to(torch.int64)
+        return class_ids
 
     def _text_label_to_class_id(self, text: str) -> Optional[int]:
         phrase = _label_tokens(text)

--- a/libreyolo/models/picodet/model.py
+++ b/libreyolo/models/picodet/model.py
@@ -120,6 +120,38 @@ class LibrePICODET(BaseModel):
         # or auxiliary keys we drop. Strict loading would refuse them.
         return False
 
+    def _rebuild_for_new_classes(self, new_nb_classes: int):
+        """Rebuild class channels while preserving the shared DFL predictor."""
+        old_head = self.model.head
+        old_num_classes = int(old_head.num_classes)
+        old_predictors = list(old_head.gfl_cls)
+
+        super()._rebuild_for_new_classes(int(new_nb_classes))
+
+        new_head = self.model.head
+        shared_classes = min(old_num_classes, int(new_head.num_classes))
+        with torch.no_grad():
+            for old_predictor, new_predictor in zip(
+                old_predictors, new_head.gfl_cls
+            ):
+                old_regression = old_predictor.weight[old_num_classes:]
+                new_regression = new_predictor.weight[new_head.num_classes:]
+                if old_regression.shape != new_regression.shape:
+                    raise RuntimeError(
+                        "PicoDet class rebuild changed the shared DFL predictor shape."
+                    )
+                new_predictor.weight[:shared_classes].copy_(
+                    old_predictor.weight[:shared_classes]
+                )
+                new_regression.copy_(old_regression)
+                if old_predictor.bias is not None and new_predictor.bias is not None:
+                    new_predictor.bias[:shared_classes].copy_(
+                        old_predictor.bias[:shared_classes]
+                    )
+                    new_predictor.bias[new_head.num_classes:].copy_(
+                        old_predictor.bias[old_num_classes:]
+                    )
+
     # ---- inference -------------------------------------------------------
 
     @staticmethod

--- a/libreyolo/models/picosam3/model.py
+++ b/libreyolo/models/picosam3/model.py
@@ -18,8 +18,13 @@ from ...utils.serialization import (
     unwrap_libreyolo_checkpoint,
 )
 from ..manifest import get_artifact_spec
-from ..sam.base import _INSTALL_HINT, _SNAPSHOT_COMPLETE_MARKER, LibreSAMModel
-from ..sam.prompts import normalize_boxes
+from ..sam.base import (
+    _INSTALL_HINT,
+    _SNAPSHOT_COMPLETE_MARKER,
+    LibreSAMModel,
+    _synchronized_image_state,
+)
+from ..sam.prompts import normalize_boxes, validate_max_det
 from .nn import PicoSAM3Network
 from .preprocess import padded_square_roi, place_roi_logits, preprocess_roi
 
@@ -157,6 +162,7 @@ class LibrePicoSAM3(LibreSAMModel):
         self._model_dtype = next(model.parameters()).dtype
         return model
 
+    @_synchronized_image_state
     def set_image(
         self, source: ImageInput, color_format: str = "auto"
     ) -> "LibrePicoSAM3":
@@ -167,6 +173,7 @@ class LibrePicoSAM3(LibreSAMModel):
         self._image_embeddings = None
         return self
 
+    @_synchronized_image_state
     def predict(
         self,
         source: Optional[ImageInput] = None,
@@ -185,6 +192,7 @@ class LibrePicoSAM3(LibreSAMModel):
     ):
         """Segment the ROI inside each xyxy box prompt."""
 
+        max_det = validate_max_det(max_det)
         unsupported = []
         if points is not None:
             unsupported.append("points")
@@ -212,8 +220,6 @@ class LibrePicoSAM3(LibreSAMModel):
                 "PicoSAM3 requires bboxes=; segment-everything mode is not "
                 "supported. Use LibreSAM2 or LibreSAM3 for that mode."
             )
-        if max_det < 1:
-            raise ValueError("max_det must be >= 1.")
         conf_thres = 0.0 if conf is None else float(conf)
         if not 0.0 <= conf_thres <= 1.0:
             raise ValueError("conf must be between 0.0 and 1.0.")

--- a/libreyolo/models/ppocr/inference.py
+++ b/libreyolo/models/ppocr/inference.py
@@ -10,6 +10,7 @@ runner property.
 from __future__ import annotations
 
 import logging
+from numbers import Integral
 from pathlib import Path
 from typing import TYPE_CHECKING, Generator, List, Optional, Union
 
@@ -26,12 +27,54 @@ from ...utils.general import (
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.results import OCRRegions, Results
 from ...utils.video import collect_video_results, is_video_file, run_video_inference
-from .preprocess import det_normalize, det_resize, get_rotate_crop_image, rec_batches
+from .preprocess import (
+    det_normalize,
+    det_resize,
+    get_rotate_crop_image,
+    normalize_rec_image_shape,
+    rec_batches,
+)
 
 if TYPE_CHECKING:
     from .model import LibrePPOCR
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_detector_limit(
+    imgsz: Optional[int], pipeline: dict, default: int
+) -> int:
+    """Resolve explicit runtime size over the checkpoint detector pipeline size."""
+    value = (
+        imgsz
+        if imgsz is not None
+        else pipeline.get("det_limit_side_len", default)
+    )
+    if isinstance(value, bool) or not isinstance(value, Integral) or value <= 0:
+        raise ValueError(
+            "PPOCR det_limit_side_len/imgsz must be a positive integer, "
+            f"got {value!r}."
+        )
+    return int(value)
+
+
+def _crop_probability_to_source_extent(
+    prob_map: np.ndarray,
+    *,
+    resized_shape: tuple[int, int],
+    source_shape: tuple[int, int],
+    ratio_h: float,
+    ratio_w: float,
+) -> np.ndarray:
+    """Remove the padded part of a detector map before source scaling."""
+    resized_h, resized_w = resized_shape
+    source_h, source_w = source_shape
+    map_h, map_w = prob_map.shape[:2]
+    valid_h = int(np.ceil(source_h * ratio_h * map_h / resized_h))
+    valid_w = int(np.ceil(source_w * ratio_w * map_w / resized_w))
+    valid_h = min(map_h, max(1, valid_h))
+    valid_w = min(map_w, max(1, valid_w))
+    return prob_map[:valid_h, :valid_w]
 
 
 class OCRInferenceRunner:
@@ -243,14 +286,23 @@ class OCRInferenceRunner:
         orig_shape = (src_h, src_w)
 
         pipeline = model.pipeline_config
-        limit = imgsz if imgsz is not None else model._get_input_size()
+        limit = _resolve_detector_limit(
+            imgsz, pipeline, int(model._get_input_size())
+        )
 
         # Stage 1: detection.
-        resized, _, _ = det_resize(img_bgr, limit_side_len=limit)
+        resized, ratio_h, ratio_w = det_resize(img_bgr, limit_side_len=limit)
         det_input = det_normalize(resized).to(model.device)
         with torch.no_grad():
             prob = model.model.det(det_input)
         prob_map = prob[0, 0].detach().float().cpu().numpy()
+        prob_map = _crop_probability_to_source_extent(
+            prob_map,
+            resized_shape=resized.shape[:2],
+            source_shape=(src_h, src_w),
+            ratio_h=ratio_h,
+            ratio_w=ratio_w,
+        )
         quads, det_scores = db_postprocess(
             prob_map,
             src_w,
@@ -294,7 +346,14 @@ class OCRInferenceRunner:
 
         texts: List[str] = [""] * len(crops)
         rec_scores = np.zeros(len(crops), dtype=np.float32)
-        for chunk_indices, batch in rec_batches(crops, batch_size=max(1, int(rec_batch))):
+        rec_image_shape = normalize_rec_image_shape(
+            pipeline.get("rec_image_shape", (3, 48, 320))
+        )
+        for chunk_indices, batch in rec_batches(
+            crops,
+            batch_size=max(1, int(rec_batch)),
+            rec_image_shape=rec_image_shape,
+        ):
             batch_t = torch.from_numpy(batch).to(model.device)
             with torch.no_grad():
                 # fp32 by default: CTC confidences are sensitive to reduced

--- a/libreyolo/models/ppocr/model.py
+++ b/libreyolo/models/ppocr/model.py
@@ -42,6 +42,7 @@ _DEFAULT_PIPELINE: Dict[str, Any] = {
     "det_db_thresh": 0.3,
     "det_db_box_thresh": 0.6,
     "det_db_unclip_ratio": 1.5,
+    "rec_image_shape": [3, 48, 320],
 }
 
 
@@ -164,15 +165,42 @@ class LibrePPOCR(BaseModel):
             pipeline = checkpoint.get("pipeline")
             if isinstance(pipeline, dict):
                 self.pipeline_config = {**_DEFAULT_PIPELINE, **pipeline}
+        from .preprocess import normalize_rec_image_shape
+
+        self.pipeline_config["rec_image_shape"] = list(
+            normalize_rec_image_shape(
+                self.pipeline_config.get("rec_image_shape", [3, 48, 320])
+            )
+        )
         fc = state_dict.get("rec.head.ctc_head.fc.weight")
-        if fc is not None and self.charset is not None:
-            expected = len(self.charset)
-            if int(fc.shape[0]) != expected:
+        if fc is not None:
+            if not isinstance(fc, torch.Tensor) or fc.ndim != 2 or fc.shape[0] <= 0:
                 raise RuntimeError(
-                    f"Checkpoint CTC head emits {int(fc.shape[0])} classes but its "
-                    f"charset metadata lists {expected} entries; the checkpoint "
+                    "Checkpoint rec.head.ctc_head.fc.weight must be a non-empty "
+                    "2D tensor."
+                )
+            output_width = int(fc.shape[0])
+            if self.charset is not None and output_width != len(self.charset):
+                raise RuntimeError(
+                    f"Checkpoint CTC head emits {output_width} classes but its "
+                    f"charset metadata lists {len(self.charset)} entries; the checkpoint "
                     "is inconsistent."
                 )
+            bias = state_dict.get("rec.head.ctc_head.fc.bias")
+            if bias is not None and (
+                not isinstance(bias, torch.Tensor)
+                or bias.ndim != 1
+                or int(bias.shape[0]) != output_width
+            ):
+                raise RuntimeError(
+                    "Checkpoint CTC head weight and bias output widths do not match."
+                )
+
+            current_width = self.model.rec.head.ctc_head.fc.out_features
+            if current_width != output_width:
+                rec_training = self.model.rec.training
+                self.model.rec = PPOCRRecModel(self.size, output_width).to(self.device)
+                self.model.rec.train(rec_training)
         return None
 
     def _rebuild_for_checkpoint_classes(self, new_nb_classes: int, state_dict: dict):

--- a/libreyolo/models/ppocr/preprocess.py
+++ b/libreyolo/models/ppocr/preprocess.py
@@ -17,6 +17,7 @@ before normalization. Keep that in mind before "fixing" the channel order.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from typing import List, Tuple
 
 import cv2
@@ -30,6 +31,35 @@ _DET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
 REC_IMAGE_SHAPE = (3, 48, 320)  # C, H, W
 
 
+def normalize_rec_image_shape(value: object) -> Tuple[int, int, int]:
+    """Validate a checkpoint ``pipeline.rec_image_shape`` value."""
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(
+            "PPOCR pipeline.rec_image_shape must be a three-item sequence "
+            f"[channels, height, width], got {value!r}."
+        )
+    if len(value) != 3:
+        raise ValueError(
+            "PPOCR pipeline.rec_image_shape must contain exactly three values "
+            f"[channels, height, width], got {value!r}."
+        )
+    shape = []
+    for item in value:
+        if isinstance(item, bool) or not isinstance(item, (int, np.integer)):
+            raise ValueError(
+                "PPOCR pipeline.rec_image_shape values must be positive integers, "
+                f"got {value!r}."
+            )
+        shape.append(int(item))
+    channels, height, width = shape
+    if channels != 3 or height != REC_IMAGE_SHAPE[1] or width <= 0:
+        raise ValueError(
+            "PPOCR pipeline.rec_image_shape must be [3, 48, positive width] "
+            f"for the height-1 CTC encoder, got {value!r}."
+        )
+    return channels, height, width
+
+
 def det_resize(
     img: np.ndarray,
     limit_side_len: int = 960,
@@ -39,7 +69,8 @@ def det_resize(
 
     Returns the resized image and ``(ratio_h, ratio_w)``.
     """
-    h, w = img.shape[:2]
+    source_h, source_w = img.shape[:2]
+    h, w = source_h, source_w
     if h + w < 64:
         pad = np.zeros((max(32, h), max(32, w), img.shape[2]), dtype=np.uint8)
         pad[:h, :w] = img
@@ -59,6 +90,10 @@ def det_resize(
     resize_h = max(int(round(resize_h / 32) * 32), 32)
     resize_w = max(int(round(resize_w / 32) * 32), 32)
     resized = cv2.resize(img, (resize_w, resize_h))
+    # These ratios describe the source pixels' transform into the resized
+    # tensor.  For tiny inputs the source occupies only the top-left of the
+    # padded canvas, so callers must retain the ratios and crop the detector's
+    # probability map back to that valid extent before mapping boxes.
     return resized, resize_h / h, resize_w / w
 
 
@@ -98,12 +133,16 @@ def get_rotate_crop_image(img: np.ndarray, points: np.ndarray) -> np.ndarray:
     return dst
 
 
-def rec_resize_norm(img_bgr: np.ndarray, max_wh_ratio: float) -> np.ndarray:
-    """Resize a BGR crop to height 48 preserving aspect, pad to the bucket width.
+def rec_resize_norm(
+    img_bgr: np.ndarray,
+    max_wh_ratio: float,
+    rec_image_shape: Sequence[int] = REC_IMAGE_SHAPE,
+) -> np.ndarray:
+    """Resize to the configured recognition height and pad to the bucket width.
 
-    Returns a ``(3, 48, W)`` float32 array normalized to ``[-1, 1]``.
+    Returns a ``(C, H, W)`` float32 array normalized to ``[-1, 1]``.
     """
-    img_c, img_h, _ = REC_IMAGE_SHAPE
+    img_c, img_h, _ = normalize_rec_image_shape(rec_image_shape)
     img_w = int(img_h * max_wh_ratio)
     h, w = img_bgr.shape[:2]
     ratio = w / float(h)
@@ -120,14 +159,15 @@ def rec_resize_norm(img_bgr: np.ndarray, max_wh_ratio: float) -> np.ndarray:
 def rec_batches(
     crops: List[np.ndarray],
     batch_size: int = 6,
+    rec_image_shape: Sequence[int] = REC_IMAGE_SHAPE,
 ) -> List[Tuple[List[int], np.ndarray]]:
     """Bucket crops by aspect ratio into padded batches, upstream-style.
 
     Crops are sorted by width/height ratio; each chunk shares one padded
-    width driven by the widest member (never narrower than 320/48). Returns
-    ``(original_indices, batch_tensor)`` pairs.
+    width driven by the widest member (never narrower than the configured
+    width/height ratio). Returns ``(original_indices, batch_tensor)`` pairs.
     """
-    img_c, img_h, img_w = REC_IMAGE_SHAPE
+    _img_c, img_h, img_w = normalize_rec_image_shape(rec_image_shape)
     ratios = [c.shape[1] / float(c.shape[0]) for c in crops]
     indices = np.argsort(np.array(ratios))
 
@@ -137,7 +177,10 @@ def rec_batches(
         max_wh_ratio = img_w / img_h
         for i in chunk:
             max_wh_ratio = max(max_wh_ratio, ratios[i])
-        norm = [rec_resize_norm(crops[i], max_wh_ratio) for i in chunk]
+        norm = [
+            rec_resize_norm(crops[i], max_wh_ratio, rec_image_shape)
+            for i in chunk
+        ]
         batches.append((chunk, np.stack(norm)))
     return batches
 
@@ -149,4 +192,5 @@ __all__ = [
     "rec_resize_norm",
     "rec_batches",
     "REC_IMAGE_SHAPE",
+    "normalize_rec_image_shape",
 ]

--- a/libreyolo/models/resnet/model.py
+++ b/libreyolo/models/resnet/model.py
@@ -41,6 +41,9 @@ class LibreResNet(BaseModel):
     DEFAULT_TASK = "classify"
     REQUIRE_TASK_SUFFIX = True  # canonical weights are LibreResNet<size>-cls.pt
     TRAIN_CONFIG = ResNetConfig
+    # Small accepted training resolutions can reduce the last feature map to
+    # 1x1, where a singleton batch is invalid for the backbone BatchNorm layers.
+    MIN_TRAIN_BATCH_SIZE = 2
 
     # timm a1 eval crop_pct (matches the upstream benchmark preprocessing).
     CROP_PCT = {"18": 0.95, "34": 0.95, "50": 0.95, "101": 0.95}

--- a/libreyolo/models/rfdetr/NOTICE
+++ b/libreyolo/models/rfdetr/NOTICE
@@ -1,0 +1,16 @@
+RF-DETR third-party notice
+==========================
+
+LibreYOLO's RF-DETR family and its GroupPose-style keypoint support are
+derived from Roboflow's RF-DETR project.
+
+Source: https://github.com/roboflow/rf-detr
+Commit: 779e55254ccfbffc8cc23b7ecee29a4201489e13 (tag 1.8.0)
+License: Apache License 2.0
+Copyright: 2024-2025 Roboflow, Inc.
+
+The derived implementation is under ``libreyolo/models/rfdetr/`` and
+``libreyolo/postprocess/rfdetr.py``. The same upstream revision supplies the
+GroupPose-style keypoint architecture used by the published RF-DETR keypoint
+preview checkpoint. The Apache-2.0 license text is available at
+``licenses/Apache-2.0.txt`` and in the pinned upstream repository.

--- a/libreyolo/models/rfdetr/NOTICE
+++ b/libreyolo/models/rfdetr/NOTICE
@@ -7,10 +7,12 @@ derived from Roboflow's RF-DETR project.
 Source: https://github.com/roboflow/rf-detr
 Commit: 779e55254ccfbffc8cc23b7ecee29a4201489e13 (tag 1.8.0)
 License: Apache License 2.0
-Copyright: 2024-2025 Roboflow, Inc.
+Copyright: 2025 Roboflow, Inc.
 
 The derived implementation is under ``libreyolo/models/rfdetr/`` and
-``libreyolo/postprocess/rfdetr.py``. The same upstream revision supplies the
+``libreyolo/postprocess/rfdetr.py``. RF-DETR-derived LoRA recipe helpers and
+COCO evaluation glue are under ``libreyolo/training/lora.py`` and
+``libreyolo/data/yolo_coco_api.py``. The same upstream revision supplies the
 GroupPose-style keypoint architecture used by the published RF-DETR keypoint
 preview checkpoint. The Apache-2.0 license text is available at
 ``licenses/Apache-2.0.txt`` and in the pinned upstream repository.

--- a/libreyolo/models/rfdetr/keypoints.py
+++ b/libreyolo/models/rfdetr/keypoints.py
@@ -175,65 +175,63 @@ def compute_l1_keypoint_loss(
     valid_area = torch.isfinite(area) & (area > area_eps)
     pred_xy = selected_pred_keypoints[:, :, :2]
     target_xy = target_keypoints[:, :, :2]
-    finite_pred_xy = torch.isfinite(pred_xy).all(dim=-1)
     finite_target_xy = torch.isfinite(target_xy).all(dim=-1)
-    valid_xy = finite_pred_xy & finite_target_xy
     finite_visibility = torch.isfinite(target_keypoints[:, :, 2])
     safe_visibility = torch.where(
         finite_visibility, target_keypoints[:, :, 2], torch.zeros_like(target_keypoints[:, :, 2])
     )
     valid_visibility = finite_visibility & (safe_visibility > 0)
-    location_loss_mask = keypoints_loss_mask & valid_visibility & valid_xy & valid_area.unsqueeze(1)
+    location_loss_mask = (
+        keypoints_loss_mask
+        & valid_visibility
+        & finite_target_xy
+        & valid_area.unsqueeze(1)
+    )
     location_count = location_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     valid_count = location_count.clamp(min=1)
     visibility_loss_mask = keypoints_loss_mask & finite_visibility
     visibility_count = visibility_loss_mask.sum(-1).clamp(min=1).to(selected_pred_keypoints.dtype)
     safe_area = torch.where(valid_area, area, torch.ones_like(area))
     safe_area_sqrt = safe_area.sqrt()
-    safe_pred_xy = torch.where(finite_pred_xy.unsqueeze(-1), pred_xy, torch.zeros_like(pred_xy))
     safe_target_xy = torch.where(
         finite_target_xy.unsqueeze(-1), target_xy, torch.zeros_like(target_xy)
     )
 
+    per_keypoint_l1 = F.l1_loss(
+        pred_xy, safe_target_xy, reduction="none"
+    ).sum(-1)
     scaled_masked_l1 = (
-        F.l1_loss(safe_pred_xy, safe_target_xy, reduction="none").sum(-1)
-        * location_loss_mask.to(selected_pred_keypoints.dtype)
+        per_keypoint_l1.masked_fill(~location_loss_mask, 0.0)
         / safe_area_sqrt.unsqueeze(1)
     )
     location_loss = scaled_masked_l1.sum(-1) / valid_count
 
-    findable_loss = (
-        F.binary_cross_entropy_with_logits(
-            selected_pred_keypoints[:, :, 2],
-            (safe_visibility > 0).to(selected_pred_keypoints.dtype),
-            reduction="none",
-        )
-        * visibility_loss_mask.to(selected_pred_keypoints.dtype)
-    ).sum(-1) / visibility_count
+    findable_raw = F.binary_cross_entropy_with_logits(
+        selected_pred_keypoints[:, :, 2],
+        (safe_visibility > 0).to(selected_pred_keypoints.dtype),
+        reduction="none",
+    )
+    findable_loss = findable_raw.masked_fill(~visibility_loss_mask, 0.0).sum(
+        -1
+    ) / visibility_count
 
-    visible_loss = (
-        F.binary_cross_entropy_with_logits(
-            selected_pred_keypoints[:, :, 3],
-            (safe_visibility > 1).to(selected_pred_keypoints.dtype),
-            reduction="none",
-        )
-        * visibility_loss_mask.to(selected_pred_keypoints.dtype)
-    ).sum(-1) / visibility_count
+    visible_raw = F.binary_cross_entropy_with_logits(
+        selected_pred_keypoints[:, :, 3],
+        (safe_visibility > 1).to(selected_pred_keypoints.dtype),
+        reduction="none",
+    )
+    visible_loss = visible_raw.masked_fill(~visibility_loss_mask, 0.0).sum(
+        -1
+    ) / visibility_count
 
-    dxdy = (safe_pred_xy - safe_target_xy).to(torch.float32)
+    dxdy = (pred_xy - safe_target_xy).to(torch.float32)
     dx = dxdy[:, :, 0]
     dy = dxdy[:, :, 1]
 
     raw_log_l11 = selected_pred_keypoints[:, :, 4].to(torch.float32)
     raw_l21 = selected_pred_keypoints[:, :, 5].to(torch.float32)
     raw_log_l22 = selected_pred_keypoints[:, :, 6].to(torch.float32)
-    finite_uncertainty = torch.isfinite(raw_log_l11) & torch.isfinite(raw_l21) & torch.isfinite(raw_log_l22)
-    if not finite_uncertainty.all():
-        logger.debug(
-            "NLL loss: %d keypoint(s) with non-finite uncertainty dropped from loss.",
-            (~finite_uncertainty).sum().item(),
-        )
-    gaussian_loss_mask = location_loss_mask & finite_uncertainty
+    gaussian_loss_mask = location_loss_mask
 
     # Intentionally unclamped: the model is expected to learn bounded log-scale values;
     # clamping would mask divergence instead of exposing it during development.
@@ -246,11 +244,9 @@ def compute_l1_keypoint_loss(
     u0 = l11 * dx + l21 * dy
     u1 = l22 * dy
     maha2 = u0 * u0 + u1 * u1
-    gaussian_loss_mask = gaussian_loss_mask & torch.isfinite(u0) & torch.isfinite(u1) & torch.isfinite(maha2)
     gaussian_count = gaussian_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     gaussian_valid_count = gaussian_count.clamp(min=1)
     nll_raw = 0.5 * (maha2 / safe_area.unsqueeze(1)) - (log_l11 + log_l22)
-    nll_raw = torch.nan_to_num(nll_raw, nan=0.0, posinf=0.0, neginf=torch.finfo(nll_raw.dtype).min)
     nll_keypoints = nll_raw.masked_fill(~gaussian_loss_mask, 0.0)
     nll_loss = nll_keypoints.sum(-1) / gaussian_valid_count
     no_valid = gaussian_count <= 0
@@ -269,7 +265,7 @@ def _cdist_bce_with_logits(
         dot = torch.matmul(x, y_float.t())
         return softplus - dot
     elementwise = F.softplus(x).unsqueeze(1) - x.unsqueeze(1) * y_float.unsqueeze(0)
-    return (elementwise * valid.to(dtype=x.dtype).unsqueeze(0)).sum(dim=-1)
+    return elementwise.masked_fill(~valid.unsqueeze(0), 0.0).sum(dim=-1)
 
 
 def compute_keypoint_matching_cost(
@@ -367,7 +363,6 @@ def compute_keypoint_matching_cost(
         scaled_loc = per_kpt_l1.sum(-1)  # (flat_bq, n_targets)
 
         loc_cost = (scaled_loc / nll_denom.unsqueeze(0)).div(area_sqrt.unsqueeze(0))
-        loc_cost = torch.nan_to_num(loc_cost, nan=0.0, posinf=0.0, neginf=0.0)
         cost_l1[:, :, target_indices] = loc_cost.reshape(b, num_queries, n_targets_by_class).to(
             all_pred_keypoints.dtype
         )
@@ -381,22 +376,16 @@ def compute_keypoint_matching_cost(
         l11 = log_l11.exp()  # (flat_bq, num_kpts)
         l22 = log_l22.exp()
 
-        finite_xy = torch.isfinite(pred_xy_flat).all(dim=-1)  # (flat_bq, num_kpts)
-        finite_pred = finite_xy & torch.isfinite(raw_log_l11) & torch.isfinite(raw_l21) & torch.isfinite(raw_log_l22)
-
         dx = diff[..., 0]  # (flat_bq, n_targets, num_kpts)
         dy = diff[..., 1]
         u0 = l11.unsqueeze(1) * dx + l21.unsqueeze(1) * dy
         u1 = l22.unsqueeze(1) * dy
         maha2 = u0 * u0 + u1 * u1
 
-        keypoint_mask = (
-            visible_btk & finite_pred.unsqueeze(1) & torch.isfinite(u0) & torch.isfinite(u1) & torch.isfinite(maha2)
-        )
+        keypoint_mask = visible_btk
         nll_k = 0.5 * (maha2 / safe_areas.view(1, n_targets_by_class, 1)) - (
             log_l11 + log_l22
         ).unsqueeze(1)
-        nll_k = torch.nan_to_num(nll_k, nan=0.0, posinf=0.0, neginf=torch.finfo(nll_k.dtype).min)
         nll_k = nll_k.masked_fill(~keypoint_mask, 0.0)
         nll_sum = nll_k.sum(-1)  # (flat_bq, n_targets)
 

--- a/libreyolo/models/rfdetr/keypoints.py
+++ b/libreyolo/models/rfdetr/keypoints.py
@@ -170,22 +170,33 @@ def compute_l1_keypoint_loss(
         active_keypoints_mask[class_idx, :num_keypoints] = True
 
     keypoints_loss_mask = active_keypoints_mask[target_classes]
-    keypoints_per_target = keypoints_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     area = target_areas.to(torch.float32)
     area_eps = torch.finfo(area.dtype).eps
     valid_area = torch.isfinite(area) & (area > area_eps)
-    valid_xy = torch.isfinite(selected_pred_keypoints[:, :, :2]).all(dim=-1) & torch.isfinite(
-        target_keypoints[:, :, :2]
-    ).all(dim=-1)
-    valid_visibility = torch.isfinite(target_keypoints[:, :, 2]) & (target_keypoints[:, :, 2] > 0)
+    pred_xy = selected_pred_keypoints[:, :, :2]
+    target_xy = target_keypoints[:, :, :2]
+    finite_pred_xy = torch.isfinite(pred_xy).all(dim=-1)
+    finite_target_xy = torch.isfinite(target_xy).all(dim=-1)
+    valid_xy = finite_pred_xy & finite_target_xy
+    finite_visibility = torch.isfinite(target_keypoints[:, :, 2])
+    safe_visibility = torch.where(
+        finite_visibility, target_keypoints[:, :, 2], torch.zeros_like(target_keypoints[:, :, 2])
+    )
+    valid_visibility = finite_visibility & (safe_visibility > 0)
     location_loss_mask = keypoints_loss_mask & valid_visibility & valid_xy & valid_area.unsqueeze(1)
     location_count = location_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     valid_count = location_count.clamp(min=1)
-    denom_keypoints = keypoints_per_target.clamp(min=1).to(dtype=selected_pred_keypoints.dtype)
-    safe_area_sqrt = area.clamp_min(area_eps).sqrt()
+    visibility_loss_mask = keypoints_loss_mask & finite_visibility
+    visibility_count = visibility_loss_mask.sum(-1).clamp(min=1).to(selected_pred_keypoints.dtype)
+    safe_area = torch.where(valid_area, area, torch.ones_like(area))
+    safe_area_sqrt = safe_area.sqrt()
+    safe_pred_xy = torch.where(finite_pred_xy.unsqueeze(-1), pred_xy, torch.zeros_like(pred_xy))
+    safe_target_xy = torch.where(
+        finite_target_xy.unsqueeze(-1), target_xy, torch.zeros_like(target_xy)
+    )
 
     scaled_masked_l1 = (
-        F.l1_loss(selected_pred_keypoints[:, :, :2], target_keypoints[:, :, :2], reduction="none").sum(-1)
+        F.l1_loss(safe_pred_xy, safe_target_xy, reduction="none").sum(-1)
         * location_loss_mask.to(selected_pred_keypoints.dtype)
         / safe_area_sqrt.unsqueeze(1)
     )
@@ -194,22 +205,22 @@ def compute_l1_keypoint_loss(
     findable_loss = (
         F.binary_cross_entropy_with_logits(
             selected_pred_keypoints[:, :, 2],
-            (target_keypoints[:, :, 2] > 0).to(selected_pred_keypoints.dtype),
+            (safe_visibility > 0).to(selected_pred_keypoints.dtype),
             reduction="none",
         )
-        * keypoints_loss_mask.to(selected_pred_keypoints.dtype)
-    ).sum(-1) / denom_keypoints
+        * visibility_loss_mask.to(selected_pred_keypoints.dtype)
+    ).sum(-1) / visibility_count
 
     visible_loss = (
         F.binary_cross_entropy_with_logits(
             selected_pred_keypoints[:, :, 3],
-            (target_keypoints[:, :, 2] > 1).to(selected_pred_keypoints.dtype),
+            (safe_visibility > 1).to(selected_pred_keypoints.dtype),
             reduction="none",
         )
-        * keypoints_loss_mask.to(selected_pred_keypoints.dtype)
-    ).sum(-1) / denom_keypoints
+        * visibility_loss_mask.to(selected_pred_keypoints.dtype)
+    ).sum(-1) / visibility_count
 
-    dxdy = (selected_pred_keypoints[:, :, :2] - target_keypoints[:, :, :2]).to(torch.float32)
+    dxdy = (safe_pred_xy - safe_target_xy).to(torch.float32)
     dx = dxdy[:, :, 0]
     dy = dxdy[:, :, 1]
 
@@ -238,7 +249,7 @@ def compute_l1_keypoint_loss(
     gaussian_loss_mask = gaussian_loss_mask & torch.isfinite(u0) & torch.isfinite(u1) & torch.isfinite(maha2)
     gaussian_count = gaussian_loss_mask.sum(-1).to(dtype=selected_pred_keypoints.dtype)
     gaussian_valid_count = gaussian_count.clamp(min=1)
-    nll_raw = 0.5 * (maha2 / area.clamp_min(area_eps).unsqueeze(1)) - (log_l11 + log_l22)
+    nll_raw = 0.5 * (maha2 / safe_area.unsqueeze(1)) - (log_l11 + log_l22)
     nll_raw = torch.nan_to_num(nll_raw, nan=0.0, posinf=0.0, neginf=torch.finfo(nll_raw.dtype).min)
     nll_keypoints = nll_raw.masked_fill(~gaussian_loss_mask, 0.0)
     nll_loss = nll_keypoints.sum(-1) / gaussian_valid_count
@@ -248,12 +259,17 @@ def compute_l1_keypoint_loss(
     return location_loss, findable_loss, visible_loss, nll_loss
 
 
-def _cdist_bce_with_logits(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+def _cdist_bce_with_logits(
+    x: torch.Tensor, y: torch.Tensor, valid: torch.Tensor | None = None
+) -> torch.Tensor:
     """Compute pairwise BCE-with-logits summed along the last dim."""
     y_float = y.to(dtype=x.dtype)
-    softplus = F.softplus(x).sum(dim=1, keepdim=True)
-    dot = torch.matmul(x, y_float.t())
-    return softplus - dot
+    if valid is None:
+        softplus = F.softplus(x).sum(dim=1, keepdim=True)
+        dot = torch.matmul(x, y_float.t())
+        return softplus - dot
+    elementwise = F.softplus(x).unsqueeze(1) - x.unsqueeze(1) * y_float.unsqueeze(0)
+    return (elementwise * valid.to(dtype=x.dtype).unsqueeze(0)).sum(dim=-1)
 
 
 def compute_keypoint_matching_cost(
@@ -334,11 +350,15 @@ def compute_keypoint_matching_cost(
         nll_denom = valid_per_target.clamp(min=1)
         has_visible = valid_per_target > 0
 
-        area_sqrt = areas.clamp_min(area_eps).sqrt()
+        safe_areas = torch.where(valid_area, areas, torch.ones_like(areas))
+        area_sqrt = safe_areas.sqrt()
 
         # Vectorize over `num_kpts` to avoid one CUDA kernel launch per keypoint.
         pred_xy_flat = pred_by_class[:, :, :, :2].reshape(flat_bq, num_kpts, 2).to(torch.float32)
-        target_xy_f32 = target_xy.to(torch.float32)
+        finite_target_xy = torch.isfinite(target_xy).all(dim=-1)
+        target_xy_f32 = torch.where(
+            finite_target_xy.unsqueeze(-1), target_xy, torch.zeros_like(target_xy)
+        ).to(torch.float32)
 
         diff = pred_xy_flat.unsqueeze(1) - target_xy_f32.unsqueeze(0)
         per_kpt_l1 = diff.abs().sum(-1)  # (flat_bq, n_targets, num_kpts)
@@ -373,7 +393,7 @@ def compute_keypoint_matching_cost(
         keypoint_mask = (
             visible_btk & finite_pred.unsqueeze(1) & torch.isfinite(u0) & torch.isfinite(u1) & torch.isfinite(maha2)
         )
-        nll_k = 0.5 * (maha2 / areas.clamp_min(area_eps).view(1, n_targets_by_class, 1)) - (
+        nll_k = 0.5 * (maha2 / safe_areas.view(1, n_targets_by_class, 1)) - (
             log_l11 + log_l22
         ).unsqueeze(1)
         nll_k = torch.nan_to_num(nll_k, nan=0.0, posinf=0.0, neginf=torch.finfo(nll_k.dtype).min)
@@ -385,19 +405,25 @@ def compute_keypoint_matching_cost(
         cost_nll[:, :, target_indices] = mean_nll.to(all_pred_keypoints.dtype)
 
         pred_findable = pred_by_class[:, :, :, 2].reshape(flat_bq, num_kpts)
-        target_findable = (target_by_class[:, :, 2] > 0).to(all_pred_keypoints.dtype).reshape(
+        target_visibility = target_by_class[:, :, 2]
+        finite_target_visibility = torch.isfinite(target_visibility)
+        safe_target_visibility = torch.where(
+            finite_target_visibility, target_visibility, torch.zeros_like(target_visibility)
+        )
+        target_findable = (safe_target_visibility > 0).to(all_pred_keypoints.dtype).reshape(
             n_targets_by_class, num_kpts
         )
         pred_visible = pred_by_class[:, :, :, 3].reshape(flat_bq, num_kpts)
-        target_visible = (target_by_class[:, :, 2] > 1).to(all_pred_keypoints.dtype).reshape(
+        target_visible = (safe_target_visibility > 1).to(all_pred_keypoints.dtype).reshape(
             n_targets_by_class, num_kpts
         )
-        cost_findable[:, :, target_indices] = _cdist_bce_with_logits(pred_findable, target_findable).reshape(
-            b, num_queries, n_targets_by_class
-        ) / float(num_kpts)
-        cost_visible[:, :, target_indices] = _cdist_bce_with_logits(pred_visible, target_visible).reshape(
-            b, num_queries, n_targets_by_class
-        ) / float(num_kpts)
+        valid_visibility_count = finite_target_visibility.sum(-1).clamp(min=1).to(torch.float32)
+        cost_findable[:, :, target_indices] = _cdist_bce_with_logits(
+            pred_findable, target_findable, finite_target_visibility
+        ).reshape(b, num_queries, n_targets_by_class) / valid_visibility_count
+        cost_visible[:, :, target_indices] = _cdist_bce_with_logits(
+            pred_visible, target_visible, finite_target_visibility
+        ).reshape(b, num_queries, n_targets_by_class) / valid_visibility_count
 
     return cost_l1, cost_findable, cost_visible, cost_nll
 

--- a/libreyolo/models/rfdetr/loss.py
+++ b/libreyolo/models/rfdetr/loss.py
@@ -52,15 +52,19 @@ def _classic_keypoint_losses(
     visible = finite_xy & finite_vis & (target_vis > 0)
     visible_f = visible.to(src_keypoints.dtype)
     visible_count = visible_f.sum(dim=-1).clamp(min=1.0)
+    safe_target_xy = torch.where(
+        finite_xy.unsqueeze(-1), target_xy, torch.zeros_like(target_xy)
+    )
     loss_l1 = (
-        F.l1_loss(src_keypoints[..., :2], target_xy, reduction="none").sum(dim=-1)
+        F.l1_loss(src_keypoints[..., :2], safe_target_xy, reduction="none").sum(dim=-1)
         * visible_f
     ).sum(dim=-1) / visible_count
 
     valid_vis_f = finite_vis.to(src_keypoints.dtype)
     vis_count = valid_vis_f.sum(dim=-1).clamp(min=1.0)
     pred_vis_logits = src_keypoints[..., 2]
-    target_findable = (target_vis > 0).to(src_keypoints.dtype)
+    safe_target_vis = torch.where(finite_vis, target_vis, torch.zeros_like(target_vis))
+    target_findable = (safe_target_vis > 0).to(src_keypoints.dtype)
     loss_findable = (
         F.binary_cross_entropy_with_logits(
             pred_vis_logits,
@@ -72,6 +76,30 @@ def _classic_keypoint_losses(
     loss_visible = torch.zeros_like(loss_findable)
     loss_nll = torch.zeros_like(loss_l1)
     return loss_l1, loss_findable, loss_visible, loss_nll
+
+
+def _align_equivalent_obb_targets(
+    src_boxes: torch.Tensor,
+    target_boxes: torch.Tensor,
+    src_angles: torch.Tensor,
+    target_angles: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Choose the closest equivalent ``(w, h, angle)`` target encoding."""
+    if src_boxes.numel() == 0:
+        return target_boxes, target_angles
+
+    swapped_boxes = target_boxes[..., [0, 1, 3, 2]]
+    swapped_angles = target_angles + torch.pi / 2
+    direct_cost = (src_boxes - target_boxes).abs().sum(dim=-1) + 1.0 - torch.cos(
+        2.0 * (src_angles - target_angles)
+    )
+    swapped_cost = (src_boxes - swapped_boxes).abs().sum(dim=-1) + 1.0 - torch.cos(
+        2.0 * (src_angles - swapped_angles)
+    )
+    use_swapped = (swapped_cost < direct_cost).detach()
+    aligned_boxes = torch.where(use_swapped.unsqueeze(-1), swapped_boxes, target_boxes)
+    aligned_angles = torch.where(use_swapped, swapped_angles, target_angles)
+    return aligned_boxes, aligned_angles
 
 
 @torch.no_grad()
@@ -434,6 +462,14 @@ class SetCriterion(nn.Module):
         idx = self._get_src_permutation_idx(indices)
         src_boxes = outputs["pred_boxes"][idx]
         target_boxes = torch.cat([t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0)
+        if "pred_angles" in outputs and all("angles" in target for target in targets):
+            src_angles = outputs["pred_angles"][idx].squeeze(-1)
+            target_angles = torch.cat(
+                [t["angles"][i] for t, (_, i) in zip(targets, indices)], dim=0
+            )
+            target_boxes, _ = _align_equivalent_obb_targets(
+                src_boxes, target_boxes, src_angles, target_angles
+            )
 
         loss_bbox = F.l1_loss(src_boxes, target_boxes, reduction="none")
 
@@ -463,6 +499,14 @@ class SetCriterion(nn.Module):
 
         src_angles = src_angles_all[idx].squeeze(-1)
         target_angles = torch.cat([t["angles"][i] for t, (_, i) in zip(targets, indices)], dim=0)
+        if "pred_boxes" in outputs and all("boxes" in target for target in targets):
+            src_boxes = outputs["pred_boxes"][idx]
+            target_boxes = torch.cat(
+                [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+            )
+            _, target_angles = _align_equivalent_obb_targets(
+                src_boxes, target_boxes, src_angles, target_angles
+            )
         loss_angle = 1.0 - torch.cos(2.0 * (src_angles - target_angles))
         return {"loss_angle": loss_angle.sum() / num_boxes}
 

--- a/libreyolo/models/rfdetr/matcher.py
+++ b/libreyolo/models/rfdetr/matcher.py
@@ -50,8 +50,13 @@ def _classic_keypoint_matching_cost(
     visible = finite_xy & finite_vis & (target_vis > 0)
     visible_f = visible.to(pred.dtype)
     visible_count = visible_f.sum(dim=-1).clamp(min=1.0)
+    safe_target_xy = torch.where(
+        finite_xy.unsqueeze(-1), target_xy, torch.zeros_like(target_xy)
+    )
 
-    l1 = (pred[:, :, None, :, :2] - target_xy[None, None, :, :, :]).abs().sum(dim=-1)
+    l1 = (
+        pred[:, :, None, :, :2] - safe_target_xy[None, None, :, :, :]
+    ).abs().sum(dim=-1)
     cost_l1 = (l1 * visible_f[None, None]).sum(dim=-1) / visible_count[None, None]
 
     pred_vis_logits = pred[..., 2][:, :, None, :].expand(
@@ -215,9 +220,44 @@ class HungarianMatcher(nn.Module):
         if keypoints_present:
             tgt_keypoints = torch.cat([v["keypoints"] for v in targets], dim=0)
 
-        # Compute the giou cost between boxes
-        giou = generalized_box_iou(box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox))
-        cost_giou = -giou
+        # Compute the geometry cost. An OBB has two equivalent parameterizations:
+        # (w, h, angle) and (h, w, angle + pi/2). Compare each prediction with
+        # both complete target encodings and keep the cheaper combined geometry
+        # cost; minimizing each term independently could mix representations.
+        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+        cost_giou = -generalized_box_iou(
+            box_cxcywh_to_xyxy(out_bbox), box_cxcywh_to_xyxy(tgt_bbox)
+        )
+        cost_angle = 0
+        if out_angles is not None and tgt_angles is not None:
+            cost_angle = 1.0 - torch.cos(
+                2.0 * (out_angles[:, None] - tgt_angles[None, :])
+            )
+            swapped_tgt_bbox = tgt_bbox[:, [0, 1, 3, 2]]
+            swapped_tgt_angles = tgt_angles + torch.pi / 2
+            swapped_cost_bbox = torch.cdist(out_bbox, swapped_tgt_bbox, p=1)
+            swapped_cost_giou = -generalized_box_iou(
+                box_cxcywh_to_xyxy(out_bbox),
+                box_cxcywh_to_xyxy(swapped_tgt_bbox),
+            )
+            swapped_cost_angle = 1.0 - torch.cos(
+                2.0 * (out_angles[:, None] - swapped_tgt_angles[None, :])
+            )
+            direct_geometry_cost = (
+                self.cost_bbox * cost_bbox
+                + self.cost_giou * cost_giou
+                + self.cost_angle * cost_angle
+            )
+            swapped_geometry_cost = (
+                self.cost_bbox * swapped_cost_bbox
+                + self.cost_giou * swapped_cost_giou
+                + self.cost_angle * swapped_cost_angle
+            )
+            geometry_cost = torch.minimum(
+                direct_geometry_cost, swapped_geometry_cost
+            )
+        else:
+            geometry_cost = self.cost_bbox * cost_bbox + self.cost_giou * cost_giou
 
         # Compute the classification cost.
         alpha = 0.25
@@ -242,12 +282,6 @@ class HungarianMatcher(nn.Module):
         if self.num_keypoints_per_class:
             cls_tgt_ids = map_labels_to_keypoint_schema(tgt_ids, self.num_keypoints_per_class)
         cost_class = pos_cost_class[:, cls_tgt_ids] - neg_cost_class[:, cls_tgt_ids]
-
-        # Compute the L1 cost between boxes
-        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
-        cost_angle = 0
-        if out_angles is not None and tgt_angles is not None and self.cost_angle:
-            cost_angle = 1.0 - torch.cos(2.0 * (out_angles[:, None] - tgt_angles[None, :]))
 
         if masks_present:
             tgt_masks = torch.cat([v["masks"] for v in targets])
@@ -324,10 +358,8 @@ class HungarianMatcher(nn.Module):
 
         # Final cost matrix
         cost_matrix = (
-            self.cost_bbox * cost_bbox
+            geometry_cost
             + self.cost_class * cost_class
-            + self.cost_giou * cost_giou
-            + self.cost_angle * cost_angle
         )
         if masks_present:
             cost_matrix = cost_matrix + self.cost_mask_ce * cost_mask_ce + self.cost_mask_dice * cost_mask_dice

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -792,10 +792,18 @@ class LibreRFDETR(BaseModel):
         is_grouppose = self._is_pose and len(num_keypoints_per_class) > 0
 
         logits = output["pred_logits"]
-        if self._is_pose and not is_grouppose and logits.shape[-1] > self.nb_classes:
-            output = dict(output)
-            output["pred_logits"] = logits[..., : self.nb_classes]
-            logits = output["pred_logits"]
+        raw_num_classes = logits.shape[-1]
+        class_id_map = None
+        if not is_grouppose and raw_num_classes == 91 and self.nb_classes == 80:
+            class_id_map = [
+                _COCO91_TO_COCO80.get(internal_id, -1)
+                for internal_id in range(raw_num_classes)
+            ]
+        elif not is_grouppose and raw_num_classes > self.nb_classes:
+            class_id_map = [
+                internal_id if internal_id < self.nb_classes else -1
+                for internal_id in range(raw_num_classes)
+            ]
         default_num_select = getattr(self.model, "num_select", max_det)
         requested_num_select = kwargs.get(
             "num_select",
@@ -815,6 +823,7 @@ class LibreRFDETR(BaseModel):
             num_select=num_select,
             num_keypoints_per_class=num_keypoints_per_class if is_grouppose else None,
             trace_alpha=trace_alpha,
+            class_id_map=class_id_map,
         )
 
         result = results[0]
@@ -838,29 +847,6 @@ class LibreRFDETR(BaseModel):
             keypoint_precision = keypoint_precision[keep]
         if obb is not None:
             obb = obb[keep]
-
-        # Map COCO 91-class IDs to YOLO 80-class indices if needed
-        num_output_classes = output["pred_logits"].shape[-1]
-        if num_output_classes == 91 and self.nb_classes == 80:
-            mapped = torch.tensor(
-                [_COCO91_TO_COCO80.get(int(c), -1) for c in labels.cpu()],
-                dtype=labels.dtype,
-                device=labels.device,
-            )
-            valid = mapped >= 0
-            boxes = boxes[valid]
-            scores = scores[valid]
-            labels = mapped[valid]
-            if masks is not None:
-                masks = masks[valid]
-            if keypoints is not None:
-                keypoints = keypoints[valid]
-            if keypoint_precision is not None:
-                keypoint_precision = keypoint_precision[valid]
-            if obb is not None:
-                obb = obb[valid]
-                obb[:, 5] = scores
-                obb[:, 6] = labels.float()
 
         det = {
             "boxes": boxes.cpu().tolist(),

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -972,7 +972,9 @@ class RFDETRTrainer(BaseTrainer):
 
         model = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
         was_training = model.training
+        criterion_was_training = self.criterion.training
         model.eval()
+        self.criterion.eval()
 
         total_loss = 0.0
         num_batches = 0
@@ -999,8 +1001,8 @@ class RFDETRTrainer(BaseTrainer):
                         num_batches += 1
             pose_metrics = self._run_pose_metric_validation(model, epoch, save_plots=save_plots)
         finally:
-            if was_training:
-                model.train()
+            model.train(was_training)
+            self.criterion.train(criterion_was_training)
 
         avg_loss = total_loss / max(num_batches, 1)
         metrics = {"loss/val": avg_loss}

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -755,11 +755,20 @@ class TransformerDecoder(nn.Module):
 
         Ported from RF-DETR v1.8.0 (GroupPose keypoint additions).
         """
+        existing_mask = self._buffers.get("keypoint_class_mask")
+        if existing_mask is not None:
+            device = existing_mask.device
+        elif self.keypoint_pos_embed is not None:
+            device = self.keypoint_pos_embed.device
+        else:
+            device = self.ref_point_head.layers[0].weight.device
         if not self.num_keypoints_per_class:
-            mask = torch.zeros(1, 1, dtype=torch.bool)
+            mask = torch.zeros(1, 1, dtype=torch.bool, device=device)
         else:
             total_kp = sum(self.num_keypoints_per_class)
-            mask = torch.zeros(1 + total_kp, 1 + total_kp, dtype=torch.bool)
+            mask = torch.zeros(
+                1 + total_kp, 1 + total_kp, dtype=torch.bool, device=device
+            )
             offset = 1
             for class_idx_i, num_kp_i in enumerate(self.num_keypoints_per_class):
                 if num_kp_i == 0:

--- a/libreyolo/models/sam/base.py
+++ b/libreyolo/models/sam/base.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
+from functools import wraps
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional
 
@@ -35,6 +37,7 @@ from .prompts import (
     normalize_boxes,
     normalize_labels,
     normalize_points,
+    validate_max_det,
 )
 
 logger = logging.getLogger(__name__)
@@ -59,6 +62,17 @@ def _is_empty_prompt(prompt) -> bool:
         return len(prompt) == 0
     except TypeError:
         return False
+
+
+def _synchronized_image_state(method):
+    """Serialize operations that read or mutate an interactive image session."""
+
+    @wraps(method)
+    def synchronized(self, *args, **kwargs):
+        with self._get_image_state_lock():
+            return method(self, *args, **kwargs)
+
+    return synchronized
 
 
 class LibreSAMModel(BaseModel):
@@ -114,6 +128,7 @@ class LibreSAMModel(BaseModel):
                 f"Invalid size {size!r} for {type(self).__name__}. "
                 f"Must be one of: {', '.join(self.HF_REPOS)}"
             )
+        self._image_state_lock = threading.RLock()
         self._default_multimask = multimask
         # Single foreground class; promptable masks are class-agnostic "object".
         super().__init__(
@@ -242,11 +257,20 @@ class LibreSAMModel(BaseModel):
     # Interactive image session (encode once, prompt many)
     # =========================================================================
 
+    def _get_image_state_lock(self) -> threading.RLock:
+        lock = getattr(self, "_image_state_lock", None)
+        if lock is None:
+            lock = threading.RLock()
+            self._image_state_lock = lock
+        return lock
+
+    @_synchronized_image_state
     def _clear_image_state(self) -> None:
         self._image = None
         self._image_path = None
         self._image_embeddings = None
 
+    @_synchronized_image_state
     def set_image(
         self, source: ImageInput, color_format: str = "auto"
     ) -> "LibreSAMModel":
@@ -264,6 +288,7 @@ class LibreSAMModel(BaseModel):
         self._image_path = source if isinstance(source, (str, Path)) else None
         return self
 
+    @_synchronized_image_state
     def reset_image(self) -> "LibreSAMModel":
         """Drop the cached image and embeddings from ``set_image()``."""
         self._clear_image_state()
@@ -273,6 +298,7 @@ class LibreSAMModel(BaseModel):
     # Prediction
     # =========================================================================
 
+    @_synchronized_image_state
     def predict(
         self,
         source: Optional[ImageInput] = None,
@@ -320,6 +346,7 @@ class LibreSAMModel(BaseModel):
                 ``DEFAULT_POINTS_PER_SIDE``; on CPU the default of 32 runs
                 ~1024 decoder passes and is slow — lower it for interactivity).
         """
+        max_det = validate_max_det(max_det)
         if text is not None:
             raise NotImplementedError(
                 "Text prompts require SAM 3; load LibreSAM('sam3')."
@@ -365,9 +392,9 @@ class LibreSAMModel(BaseModel):
                 cached_emb=cached_emb,
             )
 
-        npoints = normalize_points(points)
+        npoints = normalize_points(points, image_size=img.size)
         nlabels = normalize_labels(labels, npoints)
-        nboxes = normalize_boxes(bboxes)
+        nboxes = normalize_boxes(bboxes, image_size=img.size)
         if npoints is not None and nboxes is not None and len(npoints) != len(nboxes):
             raise ValueError(
                 f"points has {len(npoints)} objects but bboxes has "
@@ -392,6 +419,7 @@ class LibreSAMModel(BaseModel):
         """Move cached image embeddings to ``device``."""
         return embeddings.to(device)
 
+    @_synchronized_image_state
     def _set_device(self, device: str) -> "LibreSAMModel":
         """Move the model to ``device``, keeping any ``set_image()`` session.
 
@@ -415,6 +443,7 @@ class LibreSAMModel(BaseModel):
 
     # ---- prediction internals ------------------------------------------------
 
+    @_synchronized_image_state
     def _resolve_image(self, source, color_format):
         """Return ``(pil_image, path, cached_embeddings_or_None)``."""
         if source is not None:

--- a/libreyolo/models/sam/prompts.py
+++ b/libreyolo/models/sam/prompts.py
@@ -21,6 +21,8 @@ offline without torch, transformers, or model weights.
 
 from __future__ import annotations
 
+import math
+from numbers import Integral
 from typing import List, Optional, Sequence
 
 
@@ -47,7 +49,40 @@ def _depth(x) -> int:
     return d
 
 
-def normalize_points(points) -> Optional[List[List[List[float]]]]:
+def _image_bounds(image_size) -> tuple[float, float] | None:
+    if image_size is None:
+        return None
+    try:
+        width, height = (float(value) for value in image_size)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("image_size must be a finite positive (width, height) pair.") from exc
+    if not all(math.isfinite(value) and value > 0 for value in (width, height)):
+        raise ValueError("image_size must be a finite positive (width, height) pair.")
+    return width, height
+
+
+def _finite_coordinate(value, *, kind: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{kind} coordinates must be finite numbers; got {value!r}.")
+    try:
+        coordinate = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{kind} coordinates must be finite numbers; got {value!r}."
+        ) from exc
+    if not math.isfinite(coordinate):
+        raise ValueError(f"{kind} coordinates must be finite numbers; got {value!r}.")
+    return coordinate
+
+
+def validate_max_det(max_det) -> int:
+    """Return a valid positive integer mask cap or raise before inference."""
+    if isinstance(max_det, bool) or not isinstance(max_det, Integral) or max_det < 1:
+        raise ValueError("max_det must be an integer >= 1.")
+    return int(max_det)
+
+
+def normalize_points(points, image_size=None) -> Optional[List[List[List[float]]]]:
     """Coerce user points into ``[point_batch, num_points, 2]``.
 
     Returns ``None`` when ``points`` is ``None`` so callers can omit the key.
@@ -80,6 +115,19 @@ def normalize_points(points) -> Optional[List[List[List[float]]]]:
             f"counts {[len(obj) for obj in canonical]}. Pad them to equal length "
             "or prompt the objects in separate predict() calls."
         )
+    bounds = _image_bounds(image_size)
+    for obj in canonical:
+        for point in obj:
+            x = _finite_coordinate(point[0], kind="point")
+            y = _finite_coordinate(point[1], kind="point")
+            if bounds is not None:
+                width, height = bounds
+                if not (0.0 <= x < width and 0.0 <= y < height):
+                    raise ValueError(
+                        f"point {[x, y]!r} is outside image bounds "
+                        f"[0, {width}) x [0, {height})."
+                    )
+            point[:] = [x, y]
     return canonical
 
 
@@ -145,7 +193,7 @@ def normalize_labels(
     return out
 
 
-def normalize_boxes(boxes) -> Optional[List[List[float]]]:
+def normalize_boxes(boxes, image_size=None) -> Optional[List[List[float]]]:
     """Coerce user boxes into ``[num_boxes, 4]`` xyxy. ``None`` passes through."""
     if boxes is None:
         return None
@@ -160,9 +208,25 @@ def normalize_boxes(boxes) -> Optional[List[List[float]]]:
             "boxes must be [x1, y1, x2, y2] or [[x1, y1, x2, y2], ...]; "
             f"got nesting depth {d}."
         )
+    bounds = _image_bounds(image_size)
     for b in out:
         if len(b) != 4:
             raise ValueError(f"each box must be [x1, y1, x2, y2]; got {b!r}.")
+        x1, y1, x2, y2 = (
+            _finite_coordinate(value, kind="box") for value in b
+        )
+        if x2 <= x1 or y2 <= y1:
+            raise ValueError(
+                f"each box must satisfy x2 > x1 and y2 > y1; got {b!r}."
+            )
+        if bounds is not None:
+            width, height = bounds
+            if not (0.0 <= x1 < x2 <= width and 0.0 <= y1 < y2 <= height):
+                raise ValueError(
+                    f"box {[x1, y1, x2, y2]!r} is outside image bounds "
+                    f"[0, {width}] x [0, {height}]."
+                )
+        b[:] = [x1, y1, x2, y2]
     return out
 
 

--- a/libreyolo/models/sam/sam3.py
+++ b/libreyolo/models/sam/sam3.py
@@ -12,7 +12,13 @@ from typing import Any, ClassVar, Dict
 
 import torch
 
-from .base import _INSTALL_HINT, _is_empty_prompt, LibreSAMModel
+from .base import (
+    _INSTALL_HINT,
+    _is_empty_prompt,
+    _synchronized_image_state,
+    LibreSAMModel,
+)
+from .prompts import validate_max_det
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +105,7 @@ class LibreSAM3(LibreSAMModel):
         self._pcs_processor = Sam3Processor.from_pretrained(self._snapshot_dir)
         return self._pcs_model, self._pcs_processor
 
+    @_synchronized_image_state
     def _set_device(self, device: str) -> "LibreSAM3":
         super()._set_device(device)
         pcs_model = getattr(self, "_pcs_model", None)
@@ -130,6 +137,7 @@ class LibreSAM3(LibreSAMModel):
             }
         return inputs
 
+    @_synchronized_image_state
     def predict(
         self,
         source=None,
@@ -154,6 +162,7 @@ class LibreSAM3(LibreSAMModel):
         Text is mutually exclusive with points, boxes, labels, masks, and
         segment-everything controls.
         """
+        max_det = validate_max_det(max_det)
         if text is None:
             return super().predict(
                 source,

--- a/libreyolo/models/vlm/base.py
+++ b/libreyolo/models/vlm/base.py
@@ -218,6 +218,8 @@ class LibreVLMModel(BaseModel):
             raise ValueError("set_classes() requires a non-empty list of labels.")
         names = [str(c) for c in classes]
         keys = [name.strip().lower() for name in names]
+        if any(not key for key in keys):
+            raise ValueError("set_classes() labels must not be blank.")
         if len(keys) != len(set(keys)):
             raise ValueError("set_classes() labels must be unique case-insensitively.")
         self.names = {i: name for i, name in enumerate(names)}

--- a/libreyolo/models/vlm/florence2.py
+++ b/libreyolo/models/vlm/florence2.py
@@ -19,6 +19,7 @@ from typing import Any, ClassVar, Dict, Tuple
 
 from ...utils.image_loader import ImageInput, ImageLoader
 from .base import LibreVLMModel
+from .parsing import finalize_detection_dict
 
 
 class LibreFlorence2(LibreVLMModel):
@@ -79,46 +80,32 @@ class LibreFlorence2(LibreVLMModel):
             text, task=self.TASK, image_size=original_size
         )
         od = parsed.get(self.TASK, {})
-        labels = od.get("bboxes_labels", od.get("labels", []))
+        raw_boxes = od.get("bboxes", [])
+        raw_labels = od.get("bboxes_labels", od.get("labels", []))
+        try:
+            detections = zip(list(raw_boxes), list(raw_labels))
+        except (TypeError, ValueError):
+            detections = []
         boxes, scores, classes = [], [], []
-        allowed_classes = (
-            set(kwargs["classes"]) if kwargs.get("classes") is not None else None
-        )
-        if max_det <= 0:
-            return {
-                "boxes": boxes,
-                "scores": scores,
-                "classes": classes,
-                "num_detections": 0,
-            }
-        # Every box carries the placeholder score, so conf filtering is all-or-nothing.
-        detections = zip(od.get("bboxes", []), labels) if self.DEFAULT_SCORE >= conf_thres else []
-        # Florence returns pixel xyxy already, so no normalize/scale step.
         for box, label in detections:
             class_id = self._name_to_id.get(str(label).strip().lower())
             if class_id is None:
                 continue
-            if allowed_classes is not None and class_id not in allowed_classes:
-                continue
-            if not isinstance(box, (list, tuple)) or len(box) != 4:
-                continue
-            try:
-                x1, y1, x2, y2 = (float(v) for v in box)
-            except (TypeError, ValueError):
-                continue
-            if x2 <= x1 or y2 <= y1:
-                continue
-            boxes.append([x1, y1, x2, y2])
+            boxes.append(box)
             scores.append(self.DEFAULT_SCORE)
             classes.append(class_id)
-            if len(boxes) >= max_det:
-                break
-        return {
-            "boxes": boxes,
-            "scores": scores,
-            "classes": classes,
-            "num_detections": len(boxes),
-        }
+        # Florence returns pixel xyxy already, so the shared finalizer only
+        # validates/clips/filter/NMSes; it does not rescale geometry.
+        return finalize_detection_dict(
+            boxes,
+            scores,
+            classes,
+            original_size,
+            conf_thres=conf_thres,
+            iou_thres=iou_thres,
+            max_det=max_det,
+            classes=kwargs.get("classes"),
+        )
 
     def chat(self, *args, **kwargs):
         raise NotImplementedError(

--- a/libreyolo/models/vlm/kosmos2.py
+++ b/libreyolo/models/vlm/kosmos2.py
@@ -17,6 +17,7 @@ from typing import Any, ClassVar, Dict, Optional, Tuple
 
 from ...utils.image_loader import ImageInput, ImageLoader
 from .base import LibreVLMModel
+from .parsing import finalize_detection_dict
 
 
 class LibreKosmos2(LibreVLMModel):
@@ -37,14 +38,21 @@ class LibreKosmos2(LibreVLMModel):
 
     def _match_label(self, name: str) -> Optional[int]:
         # Kosmos grounds noun phrases ("the boats"), so match leniently against
-        # the vocabulary in addition to exact lookup.
+        # the vocabulary in addition to exact lookup. Prefer the longest unique
+        # match so overlapping labels never depend on vocabulary insertion order.
         key = str(name).strip().lower()
         if key in self._name_to_id:
             return self._name_to_id[key]
+        matches = []
         for cname, cid in self._name_to_id.items():
             if cname in key or key in cname:
-                return cid
-        return None
+                matches.append((len(cname.split()), len(cname), cname, cid))
+        if not matches:
+            return None
+        matches.sort(reverse=True)
+        best_specificity = matches[0][:2]
+        best = [match for match in matches if match[:2] == best_specificity]
+        return best[0][3] if len(best) == 1 else None
 
     def _preprocess(
         self,
@@ -78,41 +86,49 @@ class LibreKosmos2(LibreVLMModel):
         _caption, entities = self.processor.post_process_generation(text)
         width, height = original_size
         boxes, scores, classes = [], [], []
-        allowed_classes = (
-            set(kwargs["classes"]) if kwargs.get("classes") is not None else None
-        )
-        if max_det <= 0:
-            return {
-                "boxes": boxes,
-                "scores": scores,
-                "classes": classes,
-                "num_detections": 0,
-            }
-        # Every box carries the placeholder score, so conf filtering is all-or-nothing.
-        scored = entities if self.DEFAULT_SCORE >= conf_thres else []
-        for name, _span, entity_boxes in scored:
-            if len(boxes) >= max_det:
-                break
+        try:
+            entity_rows = list(entities)
+        except (TypeError, ValueError):
+            entity_rows = []
+        for entity in entity_rows:
+            try:
+                name, _span, entity_boxes = entity
+                entity_boxes = list(entity_boxes)
+            except (TypeError, ValueError):
+                continue
             class_id = self._match_label(name)
             if class_id is None:
                 continue
-            if allowed_classes is not None and class_id not in allowed_classes:
-                continue
             for box in entity_boxes:  # normalized [0,1] xyxy
-                x1, y1, x2, y2 = box
-                if x2 <= x1 or y2 <= y1:
+                try:
+                    values = list(box)
+                except (TypeError, ValueError):
                     continue
-                boxes.append([x1 * width, y1 * height, x2 * width, y2 * height])
+                if len(values) != 4:
+                    continue
+                try:
+                    boxes.append(
+                        [
+                            float(values[0]) * width,
+                            float(values[1]) * height,
+                            float(values[2]) * width,
+                            float(values[3]) * height,
+                        ]
+                    )
+                except (TypeError, ValueError):
+                    continue
                 scores.append(self.DEFAULT_SCORE)
                 classes.append(class_id)
-                if len(boxes) >= max_det:
-                    break
-        return {
-            "boxes": boxes,
-            "scores": scores,
-            "classes": classes,
-            "num_detections": len(boxes),
-        }
+        return finalize_detection_dict(
+            boxes,
+            scores,
+            classes,
+            original_size,
+            conf_thres=conf_thres,
+            iou_thres=iou_thres,
+            max_det=max_det,
+            classes=kwargs.get("classes"),
+        )
 
     def chat(self, *args, **kwargs):
         raise NotImplementedError(

--- a/libreyolo/models/vlm/kosmos2.py
+++ b/libreyolo/models/vlm/kosmos2.py
@@ -13,11 +13,54 @@ mechanism, but its boxes are coarse compared with newer grounders.
 
 from __future__ import annotations
 
+import re
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
 from ...utils.image_loader import ImageInput, ImageLoader
 from .base import LibreVLMModel
 from .parsing import finalize_detection_dict
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_LEADING_ARTICLES = {"a", "an", "the"}
+
+
+def _phrase_tokens(value: str) -> list[str]:
+    tokens = _TOKEN_RE.findall(str(value).lower())
+    while tokens and tokens[0] in _LEADING_ARTICLES:
+        tokens.pop(0)
+    return tokens
+
+
+def _plural_forms(token: str) -> set[str]:
+    """Return conservative English plural forms for one label token."""
+    forms = {token, f"{token}s"}
+    if token.endswith(("s", "x", "z", "ch", "sh")):
+        forms.add(f"{token}es")
+    if (
+        len(token) > 1
+        and token.endswith("y")
+        and token[-2] not in "aeiou"
+    ):
+        forms.add(f"{token[:-1]}ies")
+    return forms
+
+
+def _same_label_token(left: str, right: str) -> bool:
+    return right in _plural_forms(left) or left in _plural_forms(right)
+
+
+def _contains_label_phrase(haystack: list[str], needle: list[str]) -> bool:
+    if not needle or len(needle) > len(haystack):
+        return False
+    width = len(needle)
+    return any(
+        all(
+            _same_label_token(haystack[start + offset], needle[offset])
+            for offset in range(width)
+        )
+        for start in range(len(haystack) - width + 1)
+    )
 
 
 class LibreKosmos2(LibreVLMModel):
@@ -43,10 +86,14 @@ class LibreKosmos2(LibreVLMModel):
         key = str(name).strip().lower()
         if key in self._name_to_id:
             return self._name_to_id[key]
+        phrase_tokens = _phrase_tokens(key)
         matches = []
         for cname, cid in self._name_to_id.items():
-            if cname in key or key in cname:
-                matches.append((len(cname.split()), len(cname), cname, cid))
+            class_tokens = _phrase_tokens(cname)
+            if _contains_label_phrase(
+                phrase_tokens, class_tokens
+            ) or _contains_label_phrase(class_tokens, phrase_tokens):
+                matches.append((len(class_tokens), len(cname), cname, cid))
         if not matches:
             return None
         matches.sort(reverse=True)

--- a/libreyolo/models/vlm/locateanything.py
+++ b/libreyolo/models/vlm/locateanything.py
@@ -279,6 +279,12 @@ class LibreLocateAnything(LibreVLMModel):
 
     def _generate(self, inputs: Any, max_new_tokens: Optional[int] = None):
         inputs = self._prepare_generation_inputs(inputs)
+        input_ids = inputs.get("input_ids") if isinstance(inputs, MutableMapping) else None
+        prompt_length = (
+            int(input_ids.shape[1])
+            if isinstance(input_ids, torch.Tensor) and input_ids.ndim == 2
+            else None
+        )
         generation_kwargs = dict(inputs)
         generation_kwargs.update(
             {
@@ -294,7 +300,27 @@ class LibreLocateAnything(LibreVLMModel):
         if self.do_sample:
             generation_kwargs["temperature"] = self.temperature
             generation_kwargs["top_p"] = self.top_p
-        return self.model.generate(**generation_kwargs)
+        output = self.model.generate(**generation_kwargs)
+        return self._strip_prompt_tokens(output, prompt_length)
+
+    @staticmethod
+    def _strip_prompt_tokens(output: Any, prompt_length: int | None) -> Any:
+        """Remove the input prefix from standard autoregressive token output."""
+        if prompt_length is None:
+            return output
+
+        def strip(tokens):
+            if (
+                isinstance(tokens, torch.Tensor)
+                and tokens.ndim == 2
+                and tokens.shape[1] >= prompt_length
+            ):
+                return tokens[:, prompt_length:]
+            return tokens
+
+        if isinstance(output, tuple) and output:
+            return (strip(output[0]), *output[1:])
+        return strip(output)
 
     def _decode_output(self, output: Any, inputs: Any | None = None) -> str:
         if isinstance(output, tuple):
@@ -332,7 +358,7 @@ class LibreLocateAnything(LibreVLMModel):
         inputs = self._processor_inputs(img, prompt).to(self.device)
         with torch.no_grad():
             output = self._generate(inputs, max_new_tokens=max_new_tokens)
-        return self._decode_output(output, inputs)
+        return self._decode_output(output)
 
     def _preprocess(
         self,

--- a/libreyolo/models/vlm/parsing.py
+++ b/libreyolo/models/vlm/parsing.py
@@ -15,7 +15,10 @@ The coordinate contract follows the documented LFM2-VL schema: ``bbox`` is
 from __future__ import annotations
 
 import json
+import math
 import re
+from collections.abc import Iterable
+from numbers import Integral
 from typing import Dict, List, Optional, Tuple
 
 __all__ = [
@@ -23,6 +26,7 @@ __all__ = [
     "normalize_bbox",
     "to_xyxy",
     "resolve_label",
+    "finalize_detection_dict",
     "build_detection_dict",
 ]
 
@@ -211,6 +215,148 @@ def _iou_xyxy(a, b) -> float:
     return inter / union if union > 0 else 0.0
 
 
+def _empty_detection_dict() -> dict:
+    return {
+        "boxes": [],
+        "scores": [],
+        "classes": [],
+        "num_detections": 0,
+    }
+
+
+def _as_rows(value) -> list:
+    """Return a concrete sequence for list/array/tensor-like output."""
+    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
+        return []
+    try:
+        return list(value)
+    except (TypeError, ValueError):
+        return []
+
+
+def finalize_detection_dict(
+    boxes,
+    scores,
+    class_ids,
+    original_size: Tuple[int, int],
+    *,
+    conf_thres: float = 0.0,
+    iou_thres: Optional[float] = None,
+    max_det: int = 300,
+    classes: Optional[List[int]] = None,
+    num_classes: Optional[int] = None,
+) -> dict:
+    """Validate pixel-space detections and apply class-aware NMS.
+
+    This is the common finalization contract for generative VLM adapters and
+    discriminative open-vocabulary adapters. Malformed, non-finite, fractional-
+    class, and zero-area rows are dropped; boxes are clipped to the image;
+    output is stably score-sorted and capped only after class-aware NMS.
+    """
+    if isinstance(max_det, bool) or not isinstance(max_det, Integral):
+        raise ValueError("max_det must be an integer.")
+    if max_det <= 0:
+        return _empty_detection_dict()
+    try:
+        width, height = (float(v) for v in original_size)
+        conf_value = float(conf_thres)
+    except (TypeError, ValueError):
+        return _empty_detection_dict()
+    if not all(math.isfinite(v) and v > 0 for v in (width, height)):
+        return _empty_detection_dict()
+    if not math.isfinite(conf_value):
+        raise ValueError("conf_thres must be finite.")
+
+    if iou_thres is not None:
+        try:
+            iou_value = float(iou_thres)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("iou_thres must be a finite number between 0 and 1.") from exc
+        if not math.isfinite(iou_value) or not 0.0 <= iou_value <= 1.0:
+            raise ValueError("iou_thres must be a finite number between 0 and 1.")
+    else:
+        iou_value = None
+
+    allowed_classes = None
+    if classes is not None:
+        try:
+            allowed_values = [float(value) for value in classes]
+        except (TypeError, ValueError) as exc:
+            raise ValueError("classes must contain integer class ids.") from exc
+        if any(not math.isfinite(value) or not value.is_integer() for value in allowed_values):
+            raise ValueError("classes must contain integer class ids.")
+        allowed_classes = {int(value) for value in allowed_values}
+
+    candidates = []
+    for index, (box, score, class_id) in enumerate(
+        zip(_as_rows(boxes), _as_rows(scores), _as_rows(class_ids))
+    ):
+        if isinstance(box, (str, bytes)):
+            continue
+        try:
+            box_values = list(box)
+        except (TypeError, ValueError):
+            continue
+        if len(box_values) != 4:
+            continue
+        try:
+            x1, y1, x2, y2 = (float(value) for value in box_values)
+            score_value = float(score)
+            class_value = float(class_id)
+        except (TypeError, ValueError):
+            continue
+        if not all(
+            math.isfinite(value)
+            for value in (x1, y1, x2, y2, score_value, class_value)
+        ):
+            continue
+        if not class_value.is_integer():
+            continue
+        class_int = int(class_value)
+        if num_classes is not None and not 0 <= class_int < num_classes:
+            continue
+        if allowed_classes is not None and class_int not in allowed_classes:
+            continue
+        if score_value < conf_value:
+            continue
+
+        x1, x2 = min(width, max(0.0, x1)), min(width, max(0.0, x2))
+        y1, y2 = min(height, max(0.0, y1)), min(height, max(0.0, y2))
+        if x2 <= x1 or y2 <= y1:
+            continue
+        normalized = (x1, y1, x2, y2)
+        candidates.append((index, normalized, score_value, class_int))
+
+    if not candidates:
+        return _empty_detection_dict()
+
+    # Stable ordering makes equal synthetic VLM scores deterministic.
+    candidates.sort(key=lambda row: (-row[2], row[0]))
+    kept = []
+    seen = set()
+    for candidate in candidates:
+        _, box, _, class_id = candidate
+        exact_key = (class_id, *box)
+        if exact_key in seen:
+            continue
+        if iou_value is not None and any(
+            class_id == kept_row[3] and _iou_xyxy(box, kept_row[1]) > iou_value
+            for kept_row in kept
+        ):
+            continue
+        seen.add(exact_key)
+        kept.append(candidate)
+        if len(kept) >= max_det:
+            break
+
+    return {
+        "boxes": [list(row[1]) for row in kept],
+        "scores": [row[2] for row in kept],
+        "classes": [row[3] for row in kept],
+        "num_detections": len(kept),
+    }
+
+
 def build_detection_dict(
     items: List[dict],
     name_to_id: Dict[str, int],
@@ -237,30 +383,14 @@ def build_detection_dict(
     confidence (the VLM emits none); rows below ``conf_thres`` are dropped so
     ``conf=`` still filters.
     """
-    if max_det <= 0:
-        return {
-            "boxes": [],
-            "scores": [],
-            "classes": [],
-            "num_detections": 0,
-        }
-
     width, height = original_size
     boxes: List[List[float]] = []
-    norm_boxes: List[Tuple[float, float, float, float]] = []
     scores: List[float] = []
     class_ids: List[int] = []
-    allowed_classes = set(classes) if classes is not None else None
-    # Generative decoding can loop and emit the same object many times. A real
-    # detector never reports an identical box twice, so drop duplicates (same
-    # class + box rounded to ~0.1% of the image).
-    seen = set()
 
     for item in items:
         class_id = resolve_label(item.get("label"), name_to_id)
         if class_id is None:
-            continue
-        if allowed_classes is not None and class_id not in allowed_classes:
             continue
         raw = item.get(bbox_key)
         box = None
@@ -272,28 +402,18 @@ def build_detection_dict(
             box = normalize_bbox(to_xyxy(scaled, box_format)) if scaled else None
         if box is None:
             continue
-        if default_score < conf_thres:
-            continue
-        key = (class_id, *(round(v, 3) for v in box))
-        if key in seen:
-            continue
-        if iou_thres is not None and any(
-            class_id == kept_class and _iou_xyxy(box, kept_box) > iou_thres
-            for kept_box, kept_class in zip(norm_boxes, class_ids)
-        ):
-            continue
-        seen.add(key)
         x1, y1, x2, y2 = box
-        norm_boxes.append(box)
         boxes.append([x1 * width, y1 * height, x2 * width, y2 * height])
         scores.append(default_score)
         class_ids.append(class_id)
-        if len(boxes) >= max_det:
-            break
 
-    return {
-        "boxes": boxes,
-        "scores": scores,
-        "classes": class_ids,
-        "num_detections": len(boxes),
-    }
+    return finalize_detection_dict(
+        boxes,
+        scores,
+        class_ids,
+        original_size,
+        conf_thres=conf_thres,
+        iou_thres=iou_thres,
+        max_det=max_det,
+        classes=classes,
+    )

--- a/libreyolo/ops/fusion.py
+++ b/libreyolo/ops/fusion.py
@@ -57,12 +57,25 @@ WeightsLike = Union[torch.Tensor, Sequence[float], None]
 _EPS = 1e-12
 
 
+def _as_integral_ids(values, *, name: str, device: torch.device) -> torch.Tensor:
+    """Validate public integer-id tensors before converting their dtype."""
+    values = torch.as_tensor(values, device=device).reshape(-1)
+    if values.dtype == torch.bool or values.is_complex():
+        raise ValueError(f"{name} must contain integer-valued ids")
+    if values.dtype.is_floating_point:
+        if not bool(torch.isfinite(values).all()):
+            raise ValueError(f"{name} must contain only finite ids")
+        if not bool((values == values.round()).all()):
+            raise ValueError(f"{name} must contain integer-valued ids")
+    return values.to(dtype=torch.long)
+
+
 def _validate_stacked(boxes, scores, labels, model_ids):
     """Convert inputs to canonical tensors and check shapes line up."""
     boxes = torch.as_tensor(boxes, dtype=torch.float32)
     scores = torch.as_tensor(scores, dtype=torch.float32, device=boxes.device)
-    labels = torch.as_tensor(labels, device=boxes.device).long()
-    model_ids = torch.as_tensor(model_ids, device=boxes.device).long()
+    labels = _as_integral_ids(labels, name="labels", device=boxes.device)
+    model_ids = _as_integral_ids(model_ids, name="model_ids", device=boxes.device)
 
     if boxes.numel() == 0:
         boxes = boxes.reshape(0, 4)
@@ -76,6 +89,10 @@ def _validate_stacked(boxes, scores, labels, model_ids):
                 f"got {t.reshape(-1).shape[0]}"
             )
     labels = labels.reshape(-1)
+    if not bool(torch.isfinite(boxes).all()) or not bool(
+        torch.isfinite(scores).all()
+    ):
+        raise ValueError("boxes and scores must contain only finite values")
     # Negative ids would index per-class metadata (models_per_label,
     # label_weights) from the wrong end instead of failing fast.
     if labels.numel() > 0 and int(labels.min()) < 0:
@@ -113,9 +130,8 @@ def _resolve_weights(
             f"got {w.reshape(-1).shape[0]}"
         )
     w = w.reshape(-1)
-    # Positivity (not non-negativity) so NaN weights also fail loudly.
-    if not bool((w > 0).all()):
-        raise ValueError("weights must all be positive")
+    if not bool(torch.isfinite(w).all()) or not bool((w > 0).all()):
+        raise ValueError("weights must all be finite and positive")
     return w
 
 

--- a/libreyolo/postprocess/rfdetr.py
+++ b/libreyolo/postprocess/rfdetr.py
@@ -32,16 +32,33 @@ def _keypoint_log_mean_trace(active_keypoints: torch.Tensor) -> torch.Tensor:
     log space for numerical stability. Supports a leading batch dimension so it
     can be called once per keypoint class group.
     """
-    log_l11 = active_keypoints[..., 4]
-    l21 = active_keypoints[..., 5]
-    log_l22 = active_keypoints[..., 6]
-    w_find = active_keypoints[..., 2].sigmoid()
+    finite = torch.isfinite(active_keypoints[..., [2, 4, 5, 6]]).all(dim=-1)
+    safe_keypoints = torch.where(
+        finite.unsqueeze(-1), active_keypoints, torch.zeros_like(active_keypoints)
+    )
+    log_l11 = safe_keypoints[..., 4]
+    l21 = safe_keypoints[..., 5]
+    log_l22 = safe_keypoints[..., 6]
+    w_find = safe_keypoints[..., 2].sigmoid()
     log_t1 = -2.0 * log_l11
     log_t2 = -2.0 * log_l22
     log_t3 = 2.0 * torch.log(l21.abs().clamp(min=1e-12)) + log_t1 + log_t2
     log_trace_sigma = torch.logsumexp(torch.stack([log_t1, log_t2, log_t3], dim=-1), dim=-1)
     log_w_find = torch.log(w_find.clamp(min=1e-12))
-    return torch.logsumexp(log_trace_sigma + log_w_find, dim=-1) - torch.logsumexp(log_w_find, dim=-1)
+    has_finite = finite.any(dim=-1)
+    reduction_mask = finite.clone()
+    reduction_mask[..., 0] |= ~has_finite
+    neg_inf = torch.full_like(log_w_find, float("-inf"))
+    log_numerator = torch.logsumexp(
+        torch.where(reduction_mask, log_trace_sigma + log_w_find, neg_inf), dim=-1
+    )
+    log_denominator = torch.logsumexp(
+        torch.where(reduction_mask, log_w_find, neg_inf), dim=-1
+    )
+    result = log_numerator - log_denominator
+    return torch.where(
+        has_finite & torch.isfinite(result), result, torch.zeros_like(result)
+    )
 
 
 def _postprocess_grouppose_keypoints(
@@ -123,7 +140,10 @@ def _postprocess_grouppose_keypoints(
                 selected_keypoints[class_mask, :num_active]
             )
         scores_i = scores_i.clone()
-        scores_i[valid_indices] = scores_i[valid_indices] * torch.exp(-trace_alpha * log_mean_traces)
+        fused_scores = scores_i[valid_indices] * torch.exp(-trace_alpha * log_mean_traces)
+        scores_i[valid_indices] = torch.nan_to_num(
+            fused_scores, nan=0.0, posinf=1.0, neginf=0.0
+        ).clamp_(0.0, 1.0)
 
     img_h, img_w = target_size
     for class_idx in range(num_keypoint_classes):
@@ -170,6 +190,7 @@ def postprocess(
     num_select: int = 300,
     num_keypoints_per_class: Optional[Sequence[int]] = None,
     trace_alpha: float = 0.2,
+    class_id_map: Optional[Sequence[int]] = None,
 ) -> list[dict[str, torch.Tensor]]:
     """
     Postprocess RF-DETR outputs to get final detections.
@@ -192,6 +213,10 @@ def postprocess(
             confidence + trace-fusion scoring). Ignored for non-keypoint outputs.
         trace_alpha: Keypoint uncertainty fusion weight (default 0.2, matching
             RF-DETR). ``0`` disables fusion. Only used for GroupPose keypoints.
+        class_id_map: Optional internal-to-public class mapping. Entries set to
+            ``-1`` are excluded before top-K selection so non-public/background
+            logits cannot consume detection slots. When omitted for GroupPose,
+            the mapping is derived from the keypoint-bearing classes.
 
     Returns:
         List of dictionaries, one per image, each containing:
@@ -210,16 +235,58 @@ def postprocess(
 
     prob = out_logits.sigmoid()
 
-    # Top-K across all (queries × classes)
+    # Restrict top-K candidates to public classes. RF-DETR checkpoints may
+    # expose an N+1/background column (or COCO's sparse 91-column layout); those
+    # internal logits must not consume a public detection slot.
     batch_size = out_logits.shape[0]
     num_classes = out_logits.shape[2]
+    if class_id_map is None and num_keypoints_per_class is not None:
+        if len(num_keypoints_per_class) != num_classes:
+            raise ValueError(
+                "GroupPose keypoint schema length must match the RF-DETR logit width: "
+                f"{len(num_keypoints_per_class)} vs {num_classes}."
+            )
+        public_idx = 0
+        derived_map = []
+        for count in num_keypoints_per_class:
+            if int(count) > 0:
+                derived_map.append(public_idx)
+                public_idx += 1
+            else:
+                derived_map.append(-1)
+        class_id_map = derived_map
+    if class_id_map is None:
+        class_id_map = list(range(num_classes))
+    if len(class_id_map) != num_classes:
+        raise ValueError(
+            "RF-DETR class_id_map length must match the logit width: "
+            f"{len(class_id_map)} vs {num_classes}."
+        )
 
-    topk_values, topk_indexes = torch.topk(prob.view(batch_size, -1), num_select, dim=1)
+    class_map = torch.as_tensor(class_id_map, dtype=torch.long, device=out_logits.device)
+    if (class_map < -1).any():
+        raise ValueError("RF-DETR class_id_map entries must be public IDs or -1.")
+    valid_internal_classes = (class_map >= 0).nonzero(as_tuple=True)[0]
+    num_selectable_classes = int(valid_internal_classes.numel())
+    candidate_prob = prob.index_select(2, valid_internal_classes)
+
+    k = min(max(int(num_select), 0), out_logits.shape[1] * num_selectable_classes)
+    flat_candidate_prob = candidate_prob.reshape(
+        batch_size, out_logits.shape[1] * num_selectable_classes
+    )
+    topk_values, topk_indexes = torch.topk(flat_candidate_prob, k, dim=1)
 
     scores = topk_values
 
-    topk_boxes = topk_indexes // num_classes  # Which query
-    labels = topk_indexes % num_classes  # Which class
+    if num_selectable_classes:
+        topk_boxes = topk_indexes // num_selectable_classes  # Which query
+        candidate_labels = topk_indexes % num_selectable_classes
+        internal_labels = valid_internal_classes[candidate_labels]
+        labels = class_map[internal_labels]
+    else:
+        topk_boxes = topk_indexes
+        internal_labels = topk_indexes
+        labels = topk_indexes
 
     boxes = cxcywh_to_xyxy(out_bbox)
 
@@ -296,62 +363,24 @@ def postprocess(
             # keypoints are (Q, num_classes * max_K, D); the predicted-class slot
             # is gathered per query, xy scaled to original pixels, confidence =
             # findable.sigmoid(), and trace fusion adjusts the object scores.
-            # NOTE: the slot select uses ``labels[i]`` (the model's INTERNAL
-            # GroupPose class index) so keypoint xy/conf stay byte-identical to
-            # upstream; the emitted detection label is remapped below.
+            # NOTE: the slot select uses ``internal_labels[i]`` (the model's INTERNAL
+            # GroupPose class index) so keypoint xy/conf stay aligned with the
+            # selected public detection class.
             scores_i, keypoints_i, precision_i = _postprocess_grouppose_keypoints(
                 out_keypoints[i],
                 topk_boxes[i],
-                labels[i],
+                internal_labels[i],
                 scores[i],
                 target_sizes[i],
                 num_keypoints_per_class or [],
                 trace_alpha,
             )
 
-            # Class-index remap (LibreYOLO contiguous pose convention).
-            #
-            # The GroupPose schema ``num_keypoints_per_class`` (e.g. ``[0, 17]``)
-            # makes the keypoint-bearing "person" class the INTERNAL index 1, so
-            # the model emits detection label 1. LibreYOLO's person-only pose
-            # convention is contiguous index 0 (nc=1, names={0: "person"}). Map
-            # the internal predicted class to its position among the
-            # keypoint-bearing classes (``kp_classes.index(internal)``), so
-            # person -> 0. Detections whose predicted class is NOT a
-            # keypoint-bearing class (e.g. internal class 0, the empty slot) are
-            # not valid pose detections and are dropped -- upstream returns only
-            # the person class. Keypoints/scores/boxes for the kept detections are
-            # left byte-identical (they are only re-indexed, not recomputed).
-            kp_classes = [
-                cls_idx
-                for cls_idx, count in enumerate(num_keypoints_per_class or [])
-                if count > 0
-            ]
-            labels_i = labels[i]
-            if kp_classes:
-                kp_class_tensor = torch.as_tensor(
-                    kp_classes, dtype=labels_i.dtype, device=labels_i.device
-                )
-                # remap[internal] = contiguous index, or -1 when not keypoint-bearing.
-                remap = labels_i.new_full((num_classes,), -1)
-                remap[kp_class_tensor] = torch.arange(
-                    len(kp_classes), dtype=labels_i.dtype, device=labels_i.device
-                )
-                contiguous_labels = remap[labels_i]
-                keep_kp = contiguous_labels >= 0
-            else:
-                # No keypoint-bearing class in the schema: nothing is a valid
-                # pose detection. Keep the (empty-mask) filter consistent.
-                contiguous_labels = labels_i
-                keep_kp = labels_i.new_zeros(labels_i.shape, dtype=torch.bool)
-
-            res_i["labels"] = contiguous_labels[keep_kp]
-            res_i["boxes"] = boxes[i][keep_kp]
-            # Trace fusion may rescale scores; keep boxes/scores/keypoints in
-            # lockstep so the downstream confidence threshold filters all heads.
-            res_i["scores"] = scores_i[keep_kp]
-            res_i["keypoints"] = keypoints_i[keep_kp]
-            res_i["keypoint_precision_cholesky"] = precision_i[keep_kp]
+            # Invalid/non-keypoint classes were removed before top-K. Keep all
+            # selected heads in lockstep and emit the already-public labels.
+            res_i["scores"] = scores_i
+            res_i["keypoints"] = keypoints_i
+            res_i["keypoint_precision_cholesky"] = precision_i
         elif out_keypoints is not None:
             res_i["keypoints"] = _postprocess_classic_keypoints(
                 out_keypoints[i],

--- a/libreyolo/postprocess/rfdetr.py
+++ b/libreyolo/postprocess/rfdetr.py
@@ -32,7 +32,7 @@ def _keypoint_log_mean_trace(active_keypoints: torch.Tensor) -> torch.Tensor:
     log space for numerical stability. Supports a leading batch dimension so it
     can be called once per keypoint class group.
     """
-    finite = torch.isfinite(active_keypoints[..., [2, 4, 5, 6]]).all(dim=-1)
+    finite = torch.isfinite(active_keypoints[..., [0, 1, 2, 4, 5, 6]]).all(dim=-1)
     safe_keypoints = torch.where(
         finite.unsqueeze(-1), active_keypoints, torch.zeros_like(active_keypoints)
     )
@@ -101,8 +101,8 @@ def _postprocess_grouppose_keypoints(
     )
 
     output_keypoints = keypoints_i.new_zeros((keypoints_i.shape[0], max_num_keypoints, 3))
-    output_keypoint_precision = keypoints_i.new_full(
-        (keypoints_i.shape[0], max_num_keypoints, 3), float("nan")
+    output_keypoint_precision = keypoints_i.new_zeros(
+        (keypoints_i.shape[0], max_num_keypoints, 3)
     )
 
     if num_keypoint_classes == 0 or max_num_keypoints == 0:
@@ -155,11 +155,30 @@ def _postprocess_grouppose_keypoints(
             continue
         out_idx = valid_indices[class_mask]
         active_keypoints = selected_keypoints[class_mask, :num_active]
-        output_keypoints[out_idx, :num_active, 0] = active_keypoints[..., 0] * img_w
-        output_keypoints[out_idx, :num_active, 1] = active_keypoints[..., 1] * img_h
-        output_keypoints[out_idx, :num_active, 2] = active_keypoints[..., 2].sigmoid()
+        valid_public = torch.isfinite(active_keypoints[..., :3]).all(dim=-1)
+        output_keypoints[out_idx, :num_active, 0] = torch.where(
+            valid_public,
+            active_keypoints[..., 0] * img_w,
+            torch.zeros_like(active_keypoints[..., 0]),
+        )
+        output_keypoints[out_idx, :num_active, 1] = torch.where(
+            valid_public,
+            active_keypoints[..., 1] * img_h,
+            torch.zeros_like(active_keypoints[..., 1]),
+        )
+        output_keypoints[out_idx, :num_active, 2] = torch.where(
+            valid_public,
+            active_keypoints[..., 2].sigmoid(),
+            torch.zeros_like(active_keypoints[..., 2]),
+        )
         if has_precision:
-            output_keypoint_precision[out_idx, :num_active] = active_keypoints[..., 4:7]
+            precision = active_keypoints[..., 4:7]
+            valid_precision = valid_public & torch.isfinite(precision).all(dim=-1)
+            output_keypoint_precision[out_idx, :num_active] = torch.where(
+                valid_precision.unsqueeze(-1),
+                precision,
+                torch.zeros_like(precision),
+            )
 
     return scores_i, output_keypoints, output_keypoint_precision
 
@@ -178,9 +197,22 @@ def _postprocess_classic_keypoints(
         ),
     ).clone()
     img_h, img_w = target_size
-    keypoints_i[..., 0] = keypoints_i[..., 0] * img_w
-    keypoints_i[..., 1] = keypoints_i[..., 1] * img_h
-    keypoints_i[..., 2] = keypoints_i[..., 2].sigmoid()
+    valid_public = torch.isfinite(keypoints_i[..., :3]).all(dim=-1)
+    keypoints_i[..., 0] = torch.where(
+        valid_public,
+        keypoints_i[..., 0] * img_w,
+        torch.zeros_like(keypoints_i[..., 0]),
+    )
+    keypoints_i[..., 1] = torch.where(
+        valid_public,
+        keypoints_i[..., 1] * img_h,
+        torch.zeros_like(keypoints_i[..., 1]),
+    )
+    keypoints_i[..., 2] = torch.where(
+        valid_public,
+        keypoints_i[..., 2].sigmoid(),
+        torch.zeros_like(keypoints_i[..., 2]),
+    )
     return keypoints_i
 
 
@@ -268,7 +300,17 @@ def postprocess(
         raise ValueError("RF-DETR class_id_map entries must be public IDs or -1.")
     valid_internal_classes = (class_map >= 0).nonzero(as_tuple=True)[0]
     num_selectable_classes = int(valid_internal_classes.numel())
+    candidate_logits = out_logits.index_select(2, valid_internal_classes)
     candidate_prob = prob.index_select(2, valid_internal_classes)
+    valid_query_geometry = torch.isfinite(out_bbox).all(dim=-1)
+    if out_angles is not None:
+        valid_query_geometry &= torch.isfinite(out_angles).flatten(2).all(dim=-1)
+    valid_candidates = torch.isfinite(candidate_logits) & valid_query_geometry.unsqueeze(-1)
+    candidate_prob = torch.where(
+        valid_candidates,
+        candidate_prob,
+        torch.full_like(candidate_prob, -torch.inf),
+    )
 
     k = min(max(int(num_select), 0), out_logits.shape[1] * num_selectable_classes)
     flat_candidate_prob = candidate_prob.reshape(

--- a/libreyolo/postprocess/rfdetr.py
+++ b/libreyolo/postprocess/rfdetr.py
@@ -57,7 +57,9 @@ def _keypoint_log_mean_trace(active_keypoints: torch.Tensor) -> torch.Tensor:
     )
     result = log_numerator - log_denominator
     return torch.where(
-        has_finite & torch.isfinite(result), result, torch.zeros_like(result)
+        has_finite & torch.isfinite(result),
+        result,
+        torch.full_like(result, float("inf")),
     )
 
 
@@ -126,6 +128,8 @@ def _postprocess_grouppose_keypoints(
     selected_labels = labels_i[valid_indices]
     selected_keypoints = reshaped[valid_indices, selected_labels]
     has_precision = selected_keypoints.shape[-1] >= 7
+    usable_pose = torch.zeros_like(selected_labels, dtype=torch.bool)
+    scores_i = scores_i.clone()
 
     if trace_alpha > 0 and has_precision:
         log_mean_traces = selected_keypoints.new_zeros(selected_labels.shape[0])
@@ -139,7 +143,6 @@ def _postprocess_grouppose_keypoints(
             log_mean_traces[class_mask] = _keypoint_log_mean_trace(
                 selected_keypoints[class_mask, :num_active]
             )
-        scores_i = scores_i.clone()
         fused_scores = scores_i[valid_indices] * torch.exp(-trace_alpha * log_mean_traces)
         scores_i[valid_indices] = torch.nan_to_num(
             fused_scores, nan=0.0, posinf=1.0, neginf=0.0
@@ -156,6 +159,7 @@ def _postprocess_grouppose_keypoints(
         out_idx = valid_indices[class_mask]
         active_keypoints = selected_keypoints[class_mask, :num_active]
         valid_public = torch.isfinite(active_keypoints[..., :3]).all(dim=-1)
+        usable_pose[class_mask] = valid_public.any(dim=-1)
         output_keypoints[out_idx, :num_active, 0] = torch.where(
             valid_public,
             active_keypoints[..., 0] * img_w,
@@ -179,6 +183,11 @@ def _postprocess_grouppose_keypoints(
                 precision,
                 torch.zeros_like(precision),
             )
+
+    # A detection with no usable public keypoint is not a usable pose. Give it
+    # zero confidence even when uncertainty fusion is explicitly disabled so
+    # the caller's standard ``scores > conf`` filter removes it.
+    scores_i[valid_indices[~usable_pose]] = 0.0
 
     return scores_i, output_keypoints, output_keypoint_precision
 

--- a/libreyolo/postprocess/yolo9_e2e.py
+++ b/libreyolo/postprocess/yolo9_e2e.py
@@ -59,6 +59,14 @@ def postprocess(
     preds = predictions.transpose(1, 2)  # (B, N, 4+nc)
     boxes = preds[..., :4]
     scores = preds[..., 4:]
+    # ``topk`` ranks NaNs ahead of finite values on supported Torch backends.
+    # Mask them before the first anchor reduction so one invalid score cannot
+    # consume a small max_det budget and hide a valid detection.
+    scores = torch.where(
+        torch.isfinite(scores),
+        scores,
+        torch.full_like(scores, -torch.inf),
+    )
 
     batch_size, num_anchors, num_classes = scores.shape
     topk_anchors = min(max_det, num_anchors)

--- a/libreyolo/postprocess/yolo9_e2e.py
+++ b/libreyolo/postprocess/yolo9_e2e.py
@@ -62,8 +62,9 @@ def postprocess(
     # ``topk`` ranks NaNs ahead of finite values on supported Torch backends.
     # Mask them before the first anchor reduction so one invalid score cannot
     # consume a small max_det budget and hide a valid detection.
+    valid_geometry = torch.isfinite(boxes).all(dim=-1, keepdim=True)
     scores = torch.where(
-        torch.isfinite(scores),
+        torch.isfinite(scores) & valid_geometry,
         scores,
         torch.full_like(scores, -torch.inf),
     )

--- a/libreyolo/tracking/config.py
+++ b/libreyolo/tracking/config.py
@@ -3,14 +3,27 @@
 import math
 import warnings
 from dataclasses import dataclass, fields
+from numbers import Integral
 
 
 def _require_finite(config, *names: str) -> None:
     """Reject NaN/Inf before one-sided range checks can accidentally accept them."""
     for name in names:
         value = getattr(config, name)
-        if not math.isfinite(value):
+        try:
+            finite = math.isfinite(value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be a finite number, got {value!r}") from exc
+        if not finite:
             raise ValueError(f"{name} must be finite, got {value}")
+
+
+def _require_integral(config, *names: str) -> None:
+    """Validate frame/count fields before they reach ``range`` or counters."""
+    for name in names:
+        value = getattr(config, name)
+        if isinstance(value, bool) or not isinstance(value, Integral):
+            raise ValueError(f"{name} must be an integer, got {value!r}")
 
 
 @dataclass(kw_only=True)
@@ -52,6 +65,12 @@ class TrackConfig:
             "match_thresh",
             "match_thresh_low",
             "match_thresh_unconfirmed",
+            "track_buffer",
+            "frame_rate",
+            "minimum_consecutive_frames",
+        )
+        _require_integral(
+            self,
             "track_buffer",
             "frame_rate",
             "minimum_consecutive_frames",
@@ -162,6 +181,7 @@ class DeepOCSortConfig:
             "alpha_fixed_emb",
             "aw_param",
         )
+        _require_integral(self, "max_age", "min_hits", "delta_t")
         if not (0 <= self.det_thresh < 1):
             # < 1 because the appearance EMA trust term divides by
             # (1 - det_thresh).
@@ -246,6 +266,7 @@ class OCSortConfig:
             "delta_t",
             "inertia",
         )
+        _require_integral(self, "max_age", "min_hits", "delta_t")
         if not (0 <= self.det_thresh <= 1):
             raise ValueError(f"det_thresh must be in [0, 1], got {self.det_thresh}")
         if not (0 <= self.iou_threshold <= 1):

--- a/libreyolo/tracking/config.py
+++ b/libreyolo/tracking/config.py
@@ -1,7 +1,16 @@
 """Tracking configuration for ByteTrack."""
 
+import math
 import warnings
 from dataclasses import dataclass, fields
+
+
+def _require_finite(config, *names: str) -> None:
+    """Reject NaN/Inf before one-sided range checks can accidentally accept them."""
+    for name in names:
+        value = getattr(config, name)
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite, got {value}")
 
 
 @dataclass(kw_only=True)
@@ -35,6 +44,18 @@ class TrackConfig:
     minimum_consecutive_frames: int = 1
 
     def __post_init__(self):
+        _require_finite(
+            self,
+            "track_high_thresh",
+            "track_low_thresh",
+            "new_track_thresh",
+            "match_thresh",
+            "match_thresh_low",
+            "match_thresh_unconfirmed",
+            "track_buffer",
+            "frame_rate",
+            "minimum_consecutive_frames",
+        )
         if self.frame_rate <= 0:
             raise ValueError(f"frame_rate must be > 0, got {self.frame_rate}")
         if not (0 <= self.track_high_thresh <= 1):
@@ -129,6 +150,18 @@ class DeepOCSortConfig:
     embedder: str = "osnet_ain_x0_25"
 
     def __post_init__(self):
+        _require_finite(
+            self,
+            "det_thresh",
+            "max_age",
+            "min_hits",
+            "iou_threshold",
+            "delta_t",
+            "inertia",
+            "w_association_emb",
+            "alpha_fixed_emb",
+            "aw_param",
+        )
         if not (0 <= self.det_thresh < 1):
             # < 1 because the appearance EMA trust term divides by
             # (1 - det_thresh).
@@ -204,6 +237,15 @@ class OCSortConfig:
     use_byte: bool = False
 
     def __post_init__(self):
+        _require_finite(
+            self,
+            "det_thresh",
+            "max_age",
+            "min_hits",
+            "iou_threshold",
+            "delta_t",
+            "inertia",
+        )
         if not (0 <= self.det_thresh <= 1):
             raise ValueError(f"det_thresh must be in [0, 1], got {self.det_thresh}")
         if not (0 <= self.iou_threshold <= 1):

--- a/libreyolo/tracking/deepocsort.py
+++ b/libreyolo/tracking/deepocsort.py
@@ -156,8 +156,38 @@ class _EmbTrack(_Track):
 
     def update_emb(self, emb: np.ndarray, alpha: float):
         """Blend a new detection embedding into the track EMA."""
-        self.emb = alpha * self.emb + (1 - alpha) * emb
-        self.emb /= np.linalg.norm(self.emb)
+        blended = alpha * self.emb + (1 - alpha) * emb
+        norm = np.linalg.norm(blended)
+        if not np.isfinite(norm) or norm <= np.finfo(blended.dtype).eps:
+            # Exact cancellation can occur for opposite unit vectors at
+            # alpha=0.5. Keeping the last valid appearance is safer than
+            # injecting NaN into every later association matrix.
+            return
+        self.emb = blended / norm
+
+
+def _validated_embeddings(embs: np.ndarray, count: int) -> np.ndarray:
+    """Return finite, non-zero, row-normalized embeddings for ``count`` boxes."""
+    embs = np.asarray(embs, dtype=np.float64)
+    if count == 0:
+        if embs.size == 0:
+            return np.empty((0, 1), dtype=np.float64)
+        if embs.ndim != 2 or embs.shape[0] != 0:
+            raise ValueError(
+                "appearance embeddings must have shape (N, D) aligned with detections"
+            )
+        return embs
+    if embs.ndim != 2 or embs.shape[0] != count or embs.shape[1] == 0:
+        raise ValueError(
+            "appearance embeddings must have shape (N, D) aligned with detections; "
+            f"got {embs.shape} for {count} detections"
+        )
+    if not np.all(np.isfinite(embs)):
+        raise ValueError("appearance embeddings must contain only finite values")
+    norms = np.linalg.norm(embs, axis=1)
+    if not np.all(np.isfinite(norms)) or np.any(norms <= 0):
+        raise ValueError("appearance embeddings must have non-zero finite norms")
+    return embs / norms[:, np.newaxis]
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +273,7 @@ class DeepOCSortTracker:
                 with ``dets``.
             orig: ``(N,)`` original detection indices for Results slicing.
         """
+        embs = _validated_embeddings(embs, len(dets))
         cfg = self.config
         self.frame_count += 1
 

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -99,6 +99,32 @@ _TRAINING_CHECKPOINT_CORE_KEYS = set(REQUIRED_CHECKPOINT_METADATA_KEYS) | {
 }
 
 
+def _classification_drop_last(
+    visible_samples: int,
+    batch_size: int,
+    minimum_batch_size: int,
+    *,
+    family: str,
+) -> bool:
+    """Drop only a partial batch that violates a classifier's batch contract."""
+    if minimum_batch_size < 1:
+        raise ValueError(
+            f"{family} declares invalid MIN_TRAIN_BATCH_SIZE={minimum_batch_size}"
+        )
+    if batch_size < minimum_batch_size:
+        raise ValueError(
+            f"{family} training needs an effective per-rank batch size >= "
+            f"{minimum_batch_size}, got {batch_size}"
+        )
+    if visible_samples < minimum_batch_size:
+        raise ValueError(
+            f"{family} training needs at least {minimum_batch_size} samples per rank, "
+            f"got {visible_samples}"
+        )
+    remainder = visible_samples % batch_size
+    return 0 < remainder < minimum_batch_size
+
+
 def _atomic_save_checkpoint(checkpoint: Dict[str, Any], targets: List[Path]) -> None:
     """Validate once and atomically replace each target with error rollback.
 
@@ -1057,24 +1083,27 @@ class BaseTrainer(ABC):
         )
 
         per_rank_batch = self._per_rank_batch_size()
-        if per_rank_batch < 2:
-            raise ValueError(
-                "Classification training needs an effective per-rank batch size >= 2 "
-                f"(got {per_rank_batch} from batch={self.config.batch}, "
-                f"world_size={self.world_size}). A batch of 1 breaks the BatchNorm in "
-                "the pooled classifier head (e.g. MobileNetV4/EfficientNetV2 norm_head). "
-                "Increase batch (or reduce world_size)."
-            )
+        family = str(getattr(wrapper, "family", "classification"))
+        minimum_batch_size = int(
+            getattr(wrapper, "MIN_TRAIN_BATCH_SIZE", 1)
+        )
         sampler = None
         if self.is_distributed:
             from torch.utils.data.distributed import DistributedSampler
 
+            # Prefer truncation when every rank still receives a valid batch.
+            # Otherwise let DistributedSampler pad evenly; this can turn a
+            # one-sample shard into a valid two-sample MobileNetV4 shard.
+            sampler_drop_last = len(train_dataset) >= self.world_size and (
+                minimum_batch_size == 1
+                or len(train_dataset) // self.world_size >= minimum_batch_size
+            )
             sampler = DistributedSampler(
                 train_dataset,
                 num_replicas=self.world_size,
                 rank=self.rank,
                 shuffle=True,
-                drop_last=len(train_dataset) >= self.world_size,
+                drop_last=sampler_drop_last,
                 seed=distributed_sampler_seed(self.config.seed),
             )
 
@@ -1086,6 +1115,12 @@ class BaseTrainer(ABC):
             visible_samples = len(sampler) if sampler is not None else len(train_dataset)
         except TypeError:
             visible_samples = len(train_dataset)
+        drop_last = _classification_drop_last(
+            visible_samples,
+            per_rank_batch,
+            minimum_batch_size,
+            family=family,
+        )
         self.train_loader = DataLoader(
             train_dataset,
             batch_size=per_rank_batch,
@@ -1094,7 +1129,7 @@ class BaseTrainer(ABC):
             num_workers=self.config.workers,
             pin_memory=self.device.type == "cuda",
             collate_fn=collate_fn,
-            drop_last=visible_samples >= per_rank_batch,
+            drop_last=drop_last,
             **dataloader_seed_kwargs(
                 self.config.seed,
                 rank=self.rank,

--- a/libreyolo/validation/fomo_validator.py
+++ b/libreyolo/validation/fomo_validator.py
@@ -6,11 +6,10 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import torch
-from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 
 from .contracts import require_finite, require_matching_batch_sizes
-from .point_validator import PointValidator
+from .point_validator import PointValidator, _hungarian_match
 
 __all__ = ["FOMOValidator"]
 
@@ -101,9 +100,11 @@ class FOMOValidator(PointValidator):
             if len(rows) > 0:
                 preds_xy = rows[:, :2].numpy()
                 preds_cls = (rows[:, 2].long() - 1).numpy()
+                pred_scores = rows[:, 3].numpy()
             else:
                 preds_xy = np.zeros((0, 2))
                 preds_cls = np.zeros(0, dtype=np.int64)
+                pred_scores = np.zeros(0, dtype=np.float64)
 
             if len(preds_xy) == 0 and len(trues_xy) == 0:
                 continue
@@ -115,25 +116,19 @@ class FOMOValidator(PointValidator):
                 continue
 
             dist_mat = cdist(preds_xy, trues_xy)
-            for pi in range(len(preds_cls)):
-                for ti in range(len(true_cls_np)):
-                    if preds_cls[pi] != true_cls_np[ti]:
-                        dist_mat[pi, ti] = np.inf
-
-            row_ind, col_ind = linear_sum_assignment(
-                np.where(np.isfinite(dist_mat), dist_mat, 1e9)
+            dist_mat[preds_cls[:, None] != true_cls_np[None, :]] = np.inf
+            tp_pairs, fp_idx, fn_idx = _hungarian_match(
+                dist_mat,
+                self.distance_tolerance,
+                pred_scores,
             )
-            matched_preds = set()
-            matched_trues = set()
-            for r, c in zip(row_ind, col_ind):
-                d = dist_mat[r, c]
-                if np.isfinite(d) and d <= self.distance_tolerance:
-                    stats["tp"] += 1
-                    stats["total_dist"] += d
-                    matched_preds.add(r)
-                    matched_trues.add(c)
-            stats["fp"] += len(preds_xy) - len(matched_preds)
-            stats["fn"] += len(trues_xy) - len(matched_trues)
+            stats["tp"] += len(tp_pairs)
+            if len(tp_pairs):
+                stats["total_dist"] += float(
+                    dist_mat[tp_pairs[:, 0], tp_pairs[:, 1]].sum()
+                )
+            stats["fp"] += len(fp_idx)
+            stats["fn"] += len(fn_idx)
 
     def _update_metrics(self, preds: Any, targets: Any, img_info: Any, img_ids: Any = None) -> None:
         logits = getattr(self, "last_logits", None)

--- a/libreyolo/validation/matte_validator.py
+++ b/libreyolo/validation/matte_validator.py
@@ -111,7 +111,7 @@ def _s_region(pred: np.ndarray, gt: np.ndarray) -> float:
         cx = min(max(cx, 0), w - 1)
         cy = min(max(cy, 0), h - 1)
 
-    # Four quadrants around the GT centroid, weighted by GT area fraction.
+    # Four quadrants around the GT centroid, weighted by spatial area.
     quads = [
         (gt[: cy + 1, : cx + 1], pred[: cy + 1, : cx + 1]),
         (gt[: cy + 1, cx + 1:], pred[: cy + 1, cx + 1:]),
@@ -123,7 +123,7 @@ def _s_region(pred: np.ndarray, gt: np.ndarray) -> float:
     for g_q, p_q in quads:
         if g_q.size == 0:
             continue
-        w_q = float(g_q.sum() / (total + _EPS)) if total > 0 else g_q.size / area
+        w_q = g_q.size / area
         score += w_q * _ssim(p_q, g_q)
     return score
 
@@ -172,11 +172,11 @@ class MatteValidator:
             if gt.shape != pred.shape:
                 from PIL import Image
 
-                # Resize in float32 ("F" mode) so the soft alpha values are not
-                # quantized to 8 bits before the metric is computed.
-                gt = np.asarray(
-                    Image.fromarray(gt, mode="F").resize(
-                        (pred.shape[1], pred.shape[0]), Image.BILINEAR
+                # Metrics are defined on the native ground-truth canvas. Resize
+                # the prediction up/down to that canvas; never alter the target.
+                pred = np.asarray(
+                    Image.fromarray(pred, mode="F").resize(
+                        (gt.shape[1], gt.shape[0]), Image.BILINEAR
                     ),
                     dtype=np.float32,
                 )

--- a/libreyolo/validation/obb_validator.py
+++ b/libreyolo/validation/obb_validator.py
@@ -481,11 +481,11 @@ class OBBValidator(BaseValidator):
                 [xywhr_iou(pred["xywhr"], gt) for gt in gt_rows],
                 dtype=np.float32,
             )
+            ious[matched[image_id]] = -1.0
             best_idx = int(ious.argmax()) if ious.size else -1
             if (
                 best_idx >= 0
                 and float(ious[best_idx]) >= iou_threshold
-                and not matched[image_id][best_idx]
             ):
                 tp[pred_idx] = 1.0
                 matched[image_id][best_idx] = True

--- a/libreyolo/validation/ocr_validator.py
+++ b/libreyolo/validation/ocr_validator.py
@@ -4,8 +4,8 @@ Metrics on the OCR dataset schema (``docs/dataset_schema.md``):
 
 - **Detection hmean**: ICDAR-style precision/recall/F1 with one-to-one
   polygon matching at IoU > 0.5. Ground-truth regions marked ``"###"``
-  (unreadable) are don't-care: they are not counted as targets and any
-  prediction overlapping one is dropped from the precision denominator.
+  (unreadable) are don't-care: they are not counted as targets and predictions
+  whose area is mostly covered by one are dropped from the precision denominator.
 - **End-to-end F1** (headline): a match additionally requires the exact
   transcript after normalization. Normalization is Unicode NFKC plus removal
   of all whitespace; matching stays case-sensitive (case is part of what an
@@ -106,6 +106,45 @@ def polygon_iou(a: np.ndarray, b: np.ndarray) -> float:
     return float(inter / union) if union > 0 else 0.0
 
 
+def _prediction_area_coverage(prediction: np.ndarray, region: np.ndarray) -> float:
+    """Return the fraction of a prediction covered by an ignore region."""
+    prediction = np.asarray(prediction, dtype=np.float64)
+    region = np.asarray(region, dtype=np.float64)
+    pred_area = _polygon_area(prediction)
+    if pred_area <= 0:
+        return 0.0
+    intersection = _clip_polygon(prediction, region)
+    if len(intersection) < 3:
+        return 0.0
+    return min(1.0, _polygon_area(intersection) / pred_area)
+
+
+def _maximum_cardinality_assignment(
+    eligible: np.ndarray,
+    tie_break: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Match the most eligible pairs, using a bounded tie-break second."""
+    eligible = np.asarray(eligible, dtype=bool)
+    tie_break = np.asarray(tie_break, dtype=np.float64)
+    if eligible.shape != tie_break.shape or eligible.ndim != 2:
+        raise ValueError("OCR assignment matrices must be matching 2D arrays.")
+    if eligible.size == 0 or not eligible.any():
+        return np.zeros(0, dtype=np.int64), np.zeros(0, dtype=np.int64)
+
+    # The total tie-break contribution is strictly below one, so gaining one
+    # eligible edge always beats any aggregate IoU improvement.  This is the
+    # cardinality guarantee that a plain ``1 + IoU`` reward does not provide.
+    max_pairs = min(eligible.shape)
+    bounded_tie = np.clip(tie_break, 0.0, 1.0) / (max_pairs + 1.0)
+    reward = np.where(eligible, 1.0 + bounded_tie, 0.0)
+
+    from scipy.optimize import linear_sum_assignment
+
+    rows, cols = linear_sum_assignment(reward, maximize=True)
+    valid = eligible[rows, cols]
+    return rows[valid].astype(np.int64), cols[valid].astype(np.int64)
+
+
 # =============================================================================
 # Text metrics
 # =============================================================================
@@ -157,10 +196,9 @@ def match_image(
 ) -> Dict[str, float]:
     """Optimal one-to-one IoU matching for one image.
 
-    Uses a linear-sum assignment over the IoU > 0.5 candidate pairs so the
-    maximum number of valid pairs is matched (a greedy best-IoU-first pass
-    can strand a prediction in crowded layouts when its only ground truth
-    was taken by a prediction that had another option).
+    Detection and transcript-aware end-to-end counts use separate linear-sum
+    assignments over their IoU > 0.5 candidate pairs.  Each maximizes the
+    number of valid pairs before using IoU as a tie-break.
 
     Returns the raw counts the corpus metrics aggregate over.
     """
@@ -205,49 +243,53 @@ def match_image(
     care_gt = [g for g in gt_regions if g["text"] != DONT_CARE]
     dont_care_gt = [g for g in gt_regions if g["text"] == DONT_CARE]
 
-    # Drop predictions that sit on don't-care regions (not penalized).
+    # Drop predictions whose own area is mostly covered by a don't-care
+    # region.  IoU is unsuitable here: a small prediction fully contained in
+    # a large ignore polygon has low IoU but must not count as a false positive.
     kept_idx: List[int] = []
     for i, poly in enumerate(pred_polys):
         ignored = any(
-            polygon_iou(poly, g["polygon"]) > _IOU_THRESHOLD for g in dont_care_gt
+            _prediction_area_coverage(poly, g["polygon"]) > _IOU_THRESHOLD
+            for g in dont_care_gt
         )
         if not ignored:
             kept_idx.append(i)
 
-    # Reward matrix over valid pairs: 1 per matchable pair (cardinality
-    # dominates) plus the IoU as a tie-break so equal-cardinality solutions
-    # prefer better-aligned pairs.
-    reward = np.zeros((len(kept_idx), len(care_gt)), dtype=np.float64)
+    ious = np.zeros((len(kept_idx), len(care_gt)), dtype=np.float64)
+    eligible = np.zeros_like(ious, dtype=bool)
     for pi_pos, pi in enumerate(kept_idx):
         for gi, gt in enumerate(care_gt):
             iou = polygon_iou(pred_polys[pi], gt["polygon"])
             if iou > _IOU_THRESHOLD:
-                reward[pi_pos, gi] = 1.0 + iou
+                eligible[pi_pos, gi] = True
+                ious[pi_pos, gi] = iou
 
-    det_matches = 0
-    e2e_matches = 0
     ned_scores: List[float] = []
-    if reward.size and reward.any():
-        from scipy.optimize import linear_sum_assignment
+    det_rows, det_cols = _maximum_cardinality_assignment(eligible, ious)
+    normalized_preds = [normalize_text(pred_texts[i]) for i in kept_idx]
+    normalized_gt = [normalize_text(gt["text"]) for gt in care_gt]
+    for pi_pos, gi in zip(det_rows, det_cols):
+        ned_scores.append(
+            one_minus_ned(normalized_preds[pi_pos], normalized_gt[gi])
+        )
 
-        rows, cols = linear_sum_assignment(reward, maximize=True)
-        for pi_pos, gi in zip(rows, cols):
-            if reward[pi_pos, gi] <= 0:
-                continue  # assignment filler below the IoU threshold
-            det_matches += 1
-            pred_text = pred_texts[kept_idx[pi_pos]]
-            gt_text = care_gt[gi]["text"]
-            ned_scores.append(
-                one_minus_ned(normalize_text(pred_text), normalize_text(gt_text))
-            )
-            if normalize_text(pred_text) == normalize_text(gt_text):
-                e2e_matches += 1
+    # End-to-end matching is a separate transcript-aware assignment.  Reusing
+    # the detection-optimal pairs can report zero text matches even when a
+    # different geometrically valid one-to-one assignment reads every region.
+    transcript_equal = np.zeros_like(eligible)
+    for pi_pos, pred_text in enumerate(normalized_preds):
+        for gi, gt_text in enumerate(normalized_gt):
+            transcript_equal[pi_pos, gi] = pred_text == gt_text
+    e2e_rows, _ = _maximum_cardinality_assignment(
+        eligible & transcript_equal,
+        ious,
+    )
 
     return {
         "num_pred": len(kept_idx),
         "num_gt": len(care_gt),
-        "det_matches": det_matches,
-        "e2e_matches": e2e_matches,
+        "det_matches": len(det_rows),
+        "e2e_matches": len(e2e_rows),
         "ned_scores": ned_scores,
     }
 

--- a/libreyolo/validation/point_validator.py
+++ b/libreyolo/validation/point_validator.py
@@ -42,8 +42,21 @@ def _euclidean_distance_matrix(
 def _hungarian_match(
     dist_matrix: np.ndarray, threshold: float, pred_scores: np.ndarray
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Apply the Hungarian algorithm and split matches by distance threshold."""
+    """Match cardinality first, then confidence order, then distance."""
+    dist_matrix = np.asarray(dist_matrix, dtype=np.float64)
+    pred_scores = np.asarray(pred_scores, dtype=np.float64)
+    if dist_matrix.ndim != 2:
+        raise ValueError("Point matching distances must be a 2D matrix.")
     n_pred, n_gt = dist_matrix.shape
+    if pred_scores.shape != (n_pred,):
+        raise ValueError(
+            "Point matching scores must have shape [N_pred], got "
+            f"{pred_scores.shape}."
+        )
+    if not np.isfinite(pred_scores).all():
+        raise ValueError("Point matching scores must be finite.")
+    if not np.isfinite(threshold) or threshold < 0:
+        raise ValueError("Point matching threshold must be finite and non-negative.")
 
     if n_pred == 0 or n_gt == 0:
         return (
@@ -52,14 +65,40 @@ def _hungarian_match(
             np.arange(n_gt, dtype=np.int64),
         )
 
-    cost_matrix = dist_matrix.copy()
-    cost_matrix[cost_matrix > threshold] = 1e6
-    cost_matrix = cost_matrix - pred_scores[:, np.newaxis] * 10.0
+    eligible = np.isfinite(dist_matrix) & (dist_matrix <= threshold)
+    if not eligible.any():
+        return (
+            np.empty((0, 2), dtype=np.int64),
+            np.arange(n_pred, dtype=np.int64),
+            np.arange(n_gt, dtype=np.int64),
+        )
 
-    row_ind, col_ind = linear_sum_assignment(cost_matrix)
+    # Distinct confidence ranks come before distance; equal-score candidates
+    # fall through to the distance tie-break.  All secondary rewards are
+    # bounded below one in aggregate, so one additional eligible pair always
+    # wins.  Confidence-rank differences in turn dominate aggregate distance
+    # differences.
+    unique_scores = np.unique(pred_scores)
+    confidence_rank = np.searchsorted(unique_scores, pred_scores) + 1.0
+    max_pairs = min(n_pred, n_gt)
+    confidence_unit = 0.5 / (
+        (max_pairs + 1.0) * (len(unique_scores) + 1.0)
+    )
+    distance_unit = confidence_unit / (2.0 * (max_pairs + 1.0))
+    if threshold > 0:
+        proximity = np.clip(1.0 - dist_matrix / threshold, 0.0, 1.0)
+    else:
+        proximity = (dist_matrix == 0).astype(np.float64)
+    reward = np.where(
+        eligible,
+        1.0
+        + confidence_rank[:, np.newaxis] * confidence_unit
+        + proximity * distance_unit,
+        0.0,
+    )
 
-    dists = dist_matrix[row_ind, col_ind]
-    valid = dists <= threshold
+    row_ind, col_ind = linear_sum_assignment(reward, maximize=True)
+    valid = eligible[row_ind, col_ind]
     tp_pairs = np.stack([row_ind[valid], col_ind[valid]], axis=1).astype(np.int64)
 
     matched_pred = set(row_ind[valid].tolist())
@@ -482,46 +521,34 @@ class PointValidator(BaseValidator):
             return np.zeros((0, 2), np.float64), np.zeros(0, np.int64)
         require_finite(arr, "Point validation targets")
 
-        is_pixel_scaled = len(arr) > 0 and float(np.abs(arr[:, 1:5]).max()) > 1.5
+        # Validation preprocessors have one explicit target contract:
+        # ``[x1, y1, x2, y2, class]`` in the validation canvas.  Guessing a
+        # normalized YOLO row from its numeric range accidentally treated the
+        # class column as geometry and dropped valid one-pixel class-zero boxes.
+        valid = (arr[:, 2] > arr[:, 0]) & (arr[:, 3] > arr[:, 1])
+        vgt = arr[valid]
+        if len(vgt) == 0:
+            return np.zeros((0, 2), np.float64), np.zeros(0, np.int64)
 
-        if is_pixel_scaled:
-            valid = (arr[:, 2] > arr[:, 0]) & (arr[:, 3] > arr[:, 1])
-            vgt = arr[valid]
-            if len(vgt) == 0:
-                return np.zeros((0, 2), np.float64), np.zeros(0, np.int64)
-
-            uses_lb = getattr(self.val_preproc, "uses_letterbox", False)
-            if uses_lb:
-                r, off_x, off_y = self.val_preproc.letterbox_scale(
-                    orig_h, orig_w, self._actual_imgsz
-                )
-                x_orig_px = ((vgt[:, 0] + vgt[:, 2]) / 2.0 - off_x) / r
-                y_orig_px = ((vgt[:, 1] + vgt[:, 3]) / 2.0 - off_y) / r
-            else:
-                sx = self._actual_imgsz / float(orig_w)
-                sy = self._actual_imgsz / float(orig_h)
-                x_orig_px = (vgt[:, 0] + vgt[:, 2]) / 2.0 / sx
-                y_orig_px = (vgt[:, 1] + vgt[:, 3]) / 2.0 / sy
-
-            x_norm = np.clip(x_orig_px / float(orig_w), 0.0, 1.0)
-            y_norm = np.clip(y_orig_px / float(orig_h), 0.0, 1.0)
-            xy_norm = np.stack([x_norm, y_norm], axis=1).astype(np.float64)
-            classes = require_class_ids(
-                vgt[:, 4], self.nc, "Point validation targets"
-            ).cpu().numpy()
+        uses_lb = getattr(self.val_preproc, "uses_letterbox", False)
+        if uses_lb:
+            r, off_x, off_y = self.val_preproc.letterbox_scale(
+                orig_h, orig_w, self._actual_imgsz
+            )
+            x_orig_px = ((vgt[:, 0] + vgt[:, 2]) / 2.0 - off_x) / r
+            y_orig_px = ((vgt[:, 1] + vgt[:, 3]) / 2.0 - off_y) / r
         else:
-            valid = (arr[:, 3] > 0) & (arr[:, 4] > 0)
-            vgt = arr[valid]
-            if len(vgt) == 0:
-                return np.zeros((0, 2), np.float64), np.zeros(0, np.int64)
-            xy_norm = np.stack(
-                [np.clip(vgt[:, 1], 0.0, 1.0),
-                 np.clip(vgt[:, 2], 0.0, 1.0)],
-                axis=1,
-            ).astype(np.float64)
-            classes = require_class_ids(
-                vgt[:, 0], self.nc, "Point validation targets"
-            ).cpu().numpy()
+            sx = self._actual_imgsz / float(orig_w)
+            sy = self._actual_imgsz / float(orig_h)
+            x_orig_px = (vgt[:, 0] + vgt[:, 2]) / 2.0 / sx
+            y_orig_px = (vgt[:, 1] + vgt[:, 3]) / 2.0 / sy
+
+        x_norm = np.clip(x_orig_px / float(orig_w), 0.0, 1.0)
+        y_norm = np.clip(y_orig_px / float(orig_h), 0.0, 1.0)
+        xy_norm = np.stack([x_norm, y_norm], axis=1).astype(np.float64)
+        classes = require_class_ids(
+            vgt[:, 4], self.nc, "Point validation targets"
+        ).cpu().numpy()
 
         return xy_norm, classes.astype(np.int64)
 

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -534,14 +534,15 @@ def test_rfdetr_pose_backend_sanitizes_nonfinite_grouppose_keypoints(
         "rfdetr",
         task="pose",
         supported_tasks=("detect", "pose"),
-        num_keypoints_per_class=[0, 1],
+        num_keypoints_per_class=[0, 2],
     )
     backend.nb_classes = 1
     boxes = np.array([[[0.5, 0.5, 0.2, 0.4]]], dtype=np.float32)
     logits = np.array([[[-10.0, 4.0]]], dtype=np.float32)
-    keypoints = np.zeros((1, 1, 2, 8), dtype=np.float32)
-    keypoints[0, 0, 1, :3] = [0.25, 0.5, 4.0]
-    keypoints[0, 0, 1, invalid_channel] = np.nan
+    keypoints = np.zeros((1, 1, 4, 8), dtype=np.float32)
+    keypoints[0, 0, 2, :3] = [0.25, 0.5, 4.0]
+    keypoints[0, 0, 3, :3] = [0.75, 0.25, 2.0]
+    keypoints[0, 0, 2, invalid_channel] = np.nan
 
     parsed = backend._parse_rfdetr(
         [boxes, logits, keypoints],
@@ -552,9 +553,37 @@ def test_rfdetr_pose_backend_sanitizes_nonfinite_grouppose_keypoints(
     )
     parsed_keypoints = parsed[5]
 
+    assert parsed[0].shape == (1, 4)
     assert np.isfinite(parsed_keypoints).all()
     if invalid_channel in {0, 2}:
         np.testing.assert_array_equal(parsed_keypoints[0, 0], np.zeros(3))
+
+
+def test_rfdetr_pose_backend_filters_all_unusable_grouppose_keypoints():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+        num_keypoints_per_class=[0, 2],
+    )
+    backend.nb_classes = 1
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.4]]], dtype=np.float32)
+    logits = np.array([[[-10.0, 4.0]]], dtype=np.float32)
+    keypoints = np.zeros((1, 1, 4, 8), dtype=np.float32)
+    keypoints[0, 0, 2:, :7] = np.nan
+
+    parsed = backend._parse_rfdetr(
+        [boxes, logits, keypoints],
+        orig_w=200,
+        orig_h=100,
+        conf=0.0,
+        max_det=1,
+    )
+
+    assert parsed[0].shape == (0, 4)
+    assert parsed[1].shape == (0,)
+    assert parsed[2].shape == (0,)
+    assert parsed[5].shape == (0, 2, 3)
 
 
 def test_rfdetr_classic_pose_backend_sanitizes_nonfinite_keypoints():

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -220,6 +220,29 @@ def test_yolo9_e2e_backend_uses_native_topk_anchor_ranking():
     np.testing.assert_allclose(boxes[0], [20, 20, 25, 25])
 
 
+def test_yolo9_e2e_backend_masks_nan_before_anchor_topk():
+    backend = _DummyBackend("yolo9_e2e")
+    output = np.zeros((1, 5, 2), dtype=np.float32)
+    output[0, :4, :] = np.array(
+        [[10, 30], [10, 30], [20, 40], [20, 40]],
+        dtype=np.float32,
+    )
+    output[0, 4, :] = np.array([np.nan, 0.9], dtype=np.float32)
+
+    boxes, scores, classes = backend._parse_yolo9(
+        [output],
+        effective_imgsz=100,
+        orig_w=100,
+        orig_h=100,
+        conf=0.25,
+        max_det=1,
+    )
+
+    np.testing.assert_allclose(boxes, [[30, 30, 40, 40]])
+    np.testing.assert_allclose(scores, [0.9])
+    np.testing.assert_array_equal(classes, [0])
+
+
 def test_yolox_backend_recomputes_validation_letterbox_ratio():
     backend = _DummyBackend("yolox")
     # Canvas-space xywh for an original 200x100 image letterboxed to 100x100.
@@ -312,6 +335,8 @@ def test_rfdetr_backend_uses_topk_over_queries_and_classes():
 
 
 def test_rfdetr_obb_backend_parses_angle_output():
+    from libreyolo.postprocess.rfdetr import postprocess
+
     backend = _DummyBackend(
         "rfdetr",
         task="obb",
@@ -331,11 +356,20 @@ def test_rfdetr_obb_backend_parses_angle_output():
     assert masks is None
     assert classes.tolist() == [1]
     np.testing.assert_allclose(parsed_boxes[0], [80.0, 20.0, 120.0, 30.0])
+    native_obb = postprocess(
+        {
+            "pred_boxes": torch.from_numpy(boxes),
+            "pred_logits": torch.from_numpy(logits),
+            "pred_angles": torch.from_numpy(angles),
+        },
+        torch.tensor([[100, 200]]),
+        num_select=1,
+    )[0]["obb"]
     np.testing.assert_allclose(
-        obb[0],
-        [100.0, 25.0, 40.0, 10.0, 0.3, scores[0], 1.0],
-        rtol=1e-6,
-        atol=1e-6,
+        obb,
+        native_obb.numpy(),
+        rtol=1e-5,
+        atol=1e-5,
     )
 
 
@@ -414,7 +448,7 @@ def test_rfdetr_pose_backend_decodes_grouppose_keypoint_slots():
     assert 0.7 < scores[0] < 1.0
 
 
-def test_rfdetr_grouppose_backend_honors_requested_max_det():
+def test_rfdetr_grouppose_backend_filters_internal_classes_before_max_det():
     backend = _DummyBackend(
         "rfdetr",
         task="pose",
@@ -441,10 +475,10 @@ def test_rfdetr_grouppose_backend_honors_requested_max_det():
 
     assert masks is None
     assert obb is None
-    assert parsed_boxes.shape == (0, 4)
-    assert scores.shape == (0,)
-    assert classes.shape == (0,)
-    assert parsed_keypoints.shape == (0, 17, 3)
+    assert parsed_boxes.shape == (1, 4)
+    assert scores.shape == (1,)
+    assert classes.tolist() == [0]
+    assert parsed_keypoints.shape == (1, 17, 3)
 
 
 def test_rfdetr_pose_backend_uses_exported_grouppose_schema():
@@ -1252,7 +1286,7 @@ def test_backend_sets_pose_metadata_attributes():
     assert backend.num_keypoints_per_class == [0, 17, 4]
 
 
-def test_rfdetr_classic_pose_slices_background_logits_before_topk():
+def test_rfdetr_classic_pose_filters_background_logits_before_topk():
     backend = _DummyBackend(
         "rfdetr",
         task="pose",

--- a/tests/unit/test_backend_postprocess.py
+++ b/tests/unit/test_backend_postprocess.py
@@ -243,6 +243,29 @@ def test_yolo9_e2e_backend_masks_nan_before_anchor_topk():
     np.testing.assert_array_equal(classes, [0])
 
 
+def test_yolo9_e2e_backend_masks_nonfinite_boxes_before_anchor_topk():
+    backend = _DummyBackend("yolo9_e2e")
+    output = np.zeros((1, 5, 2), dtype=np.float32)
+    output[0, :4, :] = np.array(
+        [[np.nan, 30], [10, 30], [20, 40], [20, 40]],
+        dtype=np.float32,
+    )
+    output[0, 4, :] = np.array([0.99, 0.9], dtype=np.float32)
+
+    boxes, scores, classes = backend._parse_yolo9(
+        [output],
+        effective_imgsz=100,
+        orig_w=100,
+        orig_h=100,
+        conf=0.25,
+        max_det=1,
+    )
+
+    np.testing.assert_allclose(boxes, [[30, 30, 40, 40]])
+    np.testing.assert_allclose(scores, [0.9])
+    np.testing.assert_array_equal(classes, [0])
+
+
 def test_yolox_backend_recomputes_validation_letterbox_ratio():
     backend = _DummyBackend("yolox")
     # Canvas-space xywh for an original 200x100 image letterboxed to 100x100.
@@ -334,6 +357,33 @@ def test_rfdetr_backend_uses_topk_over_queries_and_classes():
     np.testing.assert_allclose(parsed_boxes[1], [37.5, 37.5, 62.5, 62.5])
 
 
+@pytest.mark.parametrize("invalid_field", ["logit", "box"])
+def test_rfdetr_backend_filters_nonfinite_candidates_before_topk(invalid_field):
+    backend = _DummyBackend("rfdetr")
+    boxes = np.array(
+        [[[0.2, 0.2, 0.1, 0.1], [0.7, 0.7, 0.1, 0.1]]],
+        dtype=np.float32,
+    )
+    logits = np.array([[[8.0], [4.0]]], dtype=np.float32)
+    if invalid_field == "logit":
+        logits[0, 0, 0] = np.nan
+    else:
+        boxes[0, 0, 0] = np.nan
+
+    parsed_boxes, scores, classes, masks = backend._parse_rfdetr(
+        [boxes, logits],
+        orig_w=100,
+        orig_h=100,
+        conf=0.0,
+        max_det=1,
+    )
+
+    assert masks is None
+    np.testing.assert_allclose(scores, [1.0 / (1.0 + np.exp(-4.0))])
+    np.testing.assert_allclose(parsed_boxes, [[65.0, 65.0, 75.0, 75.0]])
+    np.testing.assert_array_equal(classes, [0])
+
+
 def test_rfdetr_obb_backend_parses_angle_output():
     from libreyolo.postprocess.rfdetr import postprocess
 
@@ -371,6 +421,34 @@ def test_rfdetr_obb_backend_parses_angle_output():
         rtol=1e-5,
         atol=1e-5,
     )
+
+
+def test_rfdetr_obb_backend_filters_nonfinite_angles_before_topk():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="obb",
+        supported_tasks=("detect", "segment", "obb"),
+    )
+    boxes = np.array(
+        [[[0.2, 0.2, 0.1, 0.1], [0.7, 0.7, 0.1, 0.1]]],
+        dtype=np.float32,
+    )
+    logits = np.array([[[8.0], [4.0]]], dtype=np.float32)
+    angles = np.array([[[np.nan], [0.2]]], dtype=np.float32)
+
+    parsed_boxes, scores, classes, masks, obb = backend._parse_rfdetr(
+        [boxes, logits, angles],
+        orig_w=100,
+        orig_h=100,
+        conf=0.0,
+        max_det=1,
+    )
+
+    assert masks is None
+    assert np.isfinite(obb).all()
+    np.testing.assert_allclose(scores, [1.0 / (1.0 + np.exp(-4.0))])
+    np.testing.assert_allclose(parsed_boxes, [[65.0, 65.0, 75.0, 75.0]])
+    np.testing.assert_array_equal(classes, [0])
 
 
 def test_rfdetr_pose_backend_parses_keypoints_not_masks():
@@ -446,6 +524,60 @@ def test_rfdetr_pose_backend_decodes_grouppose_keypoint_slots():
         rtol=1e-5,
     )
     assert 0.7 < scores[0] < 1.0
+
+
+@pytest.mark.parametrize("invalid_channel", [0, 2, 4])
+def test_rfdetr_pose_backend_sanitizes_nonfinite_grouppose_keypoints(
+    invalid_channel,
+):
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("detect", "pose"),
+        num_keypoints_per_class=[0, 1],
+    )
+    backend.nb_classes = 1
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.4]]], dtype=np.float32)
+    logits = np.array([[[-10.0, 4.0]]], dtype=np.float32)
+    keypoints = np.zeros((1, 1, 2, 8), dtype=np.float32)
+    keypoints[0, 0, 1, :3] = [0.25, 0.5, 4.0]
+    keypoints[0, 0, 1, invalid_channel] = np.nan
+
+    parsed = backend._parse_rfdetr(
+        [boxes, logits, keypoints],
+        orig_w=200,
+        orig_h=100,
+        conf=0.0,
+        max_det=1,
+    )
+    parsed_keypoints = parsed[5]
+
+    assert np.isfinite(parsed_keypoints).all()
+    if invalid_channel in {0, 2}:
+        np.testing.assert_array_equal(parsed_keypoints[0, 0], np.zeros(3))
+
+
+def test_rfdetr_classic_pose_backend_sanitizes_nonfinite_keypoints():
+    backend = _DummyBackend(
+        "rfdetr",
+        task="pose",
+        supported_tasks=("pose",),
+    )
+    backend.nb_classes = 1
+    boxes = np.array([[[0.5, 0.5, 0.2, 0.4]]], dtype=np.float32)
+    logits = np.array([[[4.0]]], dtype=np.float32)
+    keypoints = np.array([[[[np.nan, 0.5, 4.0]]]], dtype=np.float32)
+
+    parsed = backend._parse_rfdetr(
+        [boxes, logits, keypoints],
+        orig_w=200,
+        orig_h=100,
+        conf=0.0,
+        max_det=1,
+    )
+
+    assert np.isfinite(parsed[5]).all()
+    np.testing.assert_array_equal(parsed[5][0, 0], np.zeros(3))
 
 
 def test_rfdetr_grouppose_backend_filters_internal_classes_before_max_det():

--- a/tests/unit/test_classification.py
+++ b/tests/unit/test_classification.py
@@ -328,6 +328,97 @@ def test_dinov2_classify_rejects_metadata_head_class_mismatch(monkeypatch):
         )
 
 
+@pytest.mark.parametrize(
+    ("visible_samples", "batch_size", "minimum_batch_size", "expected"),
+    [
+        (5, 4, 2, True),
+        (6, 4, 2, False),
+        (5, 4, 1, False),
+        (1, 1, 1, False),
+    ],
+)
+def test_classification_loader_drops_only_invalid_partial_batches(
+    visible_samples, batch_size, minimum_batch_size, expected
+):
+    from libreyolo.training.trainer import _classification_drop_last
+
+    assert (
+        _classification_drop_last(
+            visible_samples,
+            batch_size,
+            minimum_batch_size,
+            family="test",
+        )
+        is expected
+    )
+
+
+def test_classification_loader_rejects_unavoidable_singleton_for_mobilenet():
+    from libreyolo.training.trainer import _classification_drop_last
+
+    with pytest.raises(ValueError, match="at least 2 samples per rank"):
+        _classification_drop_last(1, 4, 2, family="mobilenetv4")
+    with pytest.raises(ValueError, match="per-rank batch size >= 2"):
+        _classification_drop_last(4, 1, 2, family="mobilenetv4")
+
+
+def test_batchnorm_classifiers_declare_a_two_sample_training_minimum():
+    from libreyolo.models.convnext.model import LibreConvNeXt
+    from libreyolo.models.dinov2.model import LibreDINOv2
+    from libreyolo.models.efficientnetv2.model import LibreEfficientNetV2
+    from libreyolo.models.mobilenetv4.model import LibreMobileNetV4
+    from libreyolo.models.resnet.model import LibreResNet
+
+    for classifier in (LibreMobileNetV4, LibreResNet, LibreEfficientNetV2):
+        assert classifier.MIN_TRAIN_BATCH_SIZE == 2
+    for classifier in (LibreConvNeXt, LibreDINOv2):
+        assert getattr(classifier, "MIN_TRAIN_BATCH_SIZE", 1) == 1
+
+
+@pytest.mark.parametrize("family", ["resnet", "efficientnetv2"])
+def test_batchnorm_classifier_loader_drops_a_singleton_partial_batch(
+    tmp_path, family
+):
+    if family == "resnet":
+        from libreyolo.models.resnet.model import LibreResNet as Model
+        from libreyolo.models.resnet.trainer import ResNetTrainer as Trainer
+
+        size = "18"
+    else:
+        from libreyolo.models.efficientnetv2.model import LibreEfficientNetV2 as Model
+        from libreyolo.models.efficientnetv2.trainer import (
+            EfficientNetV2Trainer as Trainer,
+        )
+
+        size = "b0"
+
+    data_root = tmp_path / family
+    _make_imagefolder(data_root, n_classes=1, n_per=5, size=32)
+    wrapper = Model(size=size, device="cpu")
+    trainer = Trainer(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size=size,
+        num_classes=wrapper.nb_classes,
+        data=str(data_root),
+        imgsz=32,
+        batch=4,
+        workers=0,
+        device="cpu",
+        project=str(tmp_path / "runs"),
+        name=family,
+        exist_ok=True,
+    )
+
+    trainer._setup_classify_data()
+    images, targets, *_ = next(iter(trainer.train_loader))
+    output = trainer.on_forward(images, targets)
+
+    assert trainer.train_loader.drop_last is True
+    assert images.shape[0] == 4
+    assert torch.isfinite(output["total_loss"])
+
+
 def test_classify_family_train_end_to_end(tmp_path):
     """A classify family must actually fine-tune through the shared trainer.
 

--- a/tests/unit/test_deepocsort.py
+++ b/tests/unit/test_deepocsort.py
@@ -92,6 +92,8 @@ def test_config_defaults():
         {"max_age": -1},
         {"min_hits": -1},
         {"delta_t": 0},
+        {"delta_t": 1.5},
+        {"delta_t": True},
         {"inertia": -0.5},
         {"w_association_emb": -0.1},
         {"alpha_fixed_emb": 1.5},

--- a/tests/unit/test_deepocsort.py
+++ b/tests/unit/test_deepocsort.py
@@ -96,6 +96,10 @@ def test_config_defaults():
         {"w_association_emb": -0.1},
         {"alpha_fixed_emb": 1.5},
         {"aw_param": -1.0},
+        {"max_age": float("nan")},
+        {"inertia": float("nan")},
+        {"w_association_emb": float("inf")},
+        {"aw_param": float("nan")},
     ],
 )
 def test_config_validation_rejects_bad_values(kwargs):
@@ -239,6 +243,32 @@ def test_custom_embedder_skips_osnet_construction():
     tracker.update(_make_results([_box(100, 200)], [0.9], [0]), IMAGE)
     assert fake.calls == 1
     assert tracker._embedder is fake
+
+
+def test_zero_norm_embedder_output_is_rejected_before_association():
+    class ZeroEmbedder:
+        def __call__(self, image, boxes):
+            return np.zeros((len(boxes), 8), dtype=np.float32)
+
+    tracker = DeepOCSortTracker(
+        config=DeepOCSortConfig(min_hits=1), embedder=ZeroEmbedder()
+    )
+    result = _make_results([_box(100, 200)], [0.9], [0])
+
+    with pytest.raises(ValueError, match="non-zero finite norms"):
+        tracker.update(result, IMAGE)
+
+    assert tracker.trackers == []
+    assert tracker.frame_count == 0
+
+
+def test_embedding_ema_exact_cancellation_keeps_last_valid_vector():
+    emb = np.array([1.0, 0.0])
+    trk = _EmbTrack(np.array(_box(100, 100) + [0.9]), 0, 0, 3, emb.copy())
+
+    trk.update_emb(-emb, alpha=0.5)
+
+    np.testing.assert_array_equal(trk.emb, emb)
 
 
 def test_update_tracks_numeric_entry():

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -91,6 +91,13 @@ class TestConstruction:
             LibreEnsemble(members, weights=[1.0, 0.0])
         with pytest.raises(ValueError, match="positive"):
             LibreEnsemble(members, weights=[float("nan"), 1.0])
+        with pytest.raises(ValueError, match="finite"):
+            LibreEnsemble(members, weights=[float("inf"), 1.0])
+
+    @pytest.mark.parametrize("fusion_iou", [float("nan"), float("inf"), -0.1, 1.1])
+    def test_rejects_invalid_fusion_iou(self, fusion_iou):
+        with pytest.raises(ValueError, match="fusion_iou must be a finite value"):
+            LibreEnsemble(list(_pair_members()), fusion_iou=fusion_iou)
 
     def test_rejects_bool_min_votes(self):
         with pytest.raises(ValueError, match="positive int"):
@@ -102,6 +109,16 @@ class TestConstruction:
 
 
 class TestNamesUnion:
+    def test_rejects_class_id_casting_and_duplicate_names(self):
+        with pytest.raises(TypeError, match="keys must be non-negative integers"):
+            LibreEnsemble(
+                [StubMember({0: "cat", "0": "dog"}), StubMember({0: "cat"})]
+            )
+        with pytest.raises(ValueError, match="class names must be unique"):
+            LibreEnsemble(
+                [StubMember({0: "cat", 1: "cat"}), StubMember({0: "cat"})]
+            )
+
     def test_identical_names_pass_through(self):
         ens = LibreEnsemble(list(_pair_members()))
         assert ens.names == COCOISH
@@ -212,6 +229,16 @@ class TestPredict:
         assert len(result) == 3
         assert torch.all(result.boxes.conf[:-1] >= result.boxes.conf[1:])
 
+    def test_negative_one_max_det_keeps_every_fused_detection(self, image):
+        a = StubMember(
+            COCOISH,
+            boxes=[[0, 0, 10, 10], [50, 50, 60, 60]],
+            scores=[0.9, 0.8],
+            cls=[0, 1],
+        )
+        result = LibreEnsemble([a, StubMember(COCOISH)])(image, max_det=-1)
+        assert len(result) == 2
+
     def test_classes_filter_uses_union_ids(self, image):
         a = StubMember(
             COCOISH, boxes=[[0, 0, 10, 10], [50, 50, 60, 60]],
@@ -269,6 +296,11 @@ class TestPredict:
         with pytest.raises(RuntimeError, match="outside its names"):
             LibreEnsemble([a, StubMember(COCOISH)])(image)
 
+    def test_fractional_member_class_id_raises(self, image):
+        a = StubMember(COCOISH, boxes=[[0, 0, 10, 10]], scores=[0.9], cls=[0.5])
+        with pytest.raises(ValueError, match="fractional ids"):
+            LibreEnsemble([a, StubMember(COCOISH)])(image)
+
     def test_custom_fusion_callable(self, image):
         seen = {}
 
@@ -298,6 +330,21 @@ class TestPredict:
 
         ens = LibreEnsemble(list(_pair_members()), fusion=bad_labels)
         with pytest.raises(ValueError, match="inconsistent shapes"):
+            ens(image)
+
+    @pytest.mark.parametrize(
+        ("output", "message"),
+        [
+            (([[0, 0, float("nan"), 10]], [0.9], [0]), "must be finite"),
+            (([[0, 0, 10, 10]], [1.1], [0]), "scores must be in"),
+            (([[10, 0, 0, 10]], [0.9], [0]), "x2 >= x1"),
+            (([[0, 0, 10, 10]], [0.9], [0.5]), "fractional ids"),
+            (([[0, 0, 10, 10]], [0.9], [7]), "labels must be in"),
+        ],
+    )
+    def test_custom_fusion_numeric_contract_is_validated(self, image, output, message):
+        ens = LibreEnsemble(list(_pair_members()), fusion=lambda *args, **kwargs: output)
+        with pytest.raises(ValueError, match=message):
             ens(image)
 
     def test_video_raises(self):
@@ -391,6 +438,13 @@ class TestExternalDetector:
             lambda img: ([[0, 0, 10, 10]], [0.9], [4]), names={0: "person"}
         )
         with pytest.raises(ValueError, match="class ids"):
+            det(image)
+
+    def test_rejects_fractional_class_id(self, image):
+        det = ExternalDetector(
+            lambda img: ([[0, 0, 10, 10]], [0.9], [0.5]), names={0: "person"}
+        )
+        with pytest.raises(ValueError, match="fractional ids"):
             det(image)
 
     def test_as_ensemble_member(self, image):

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -229,15 +229,24 @@ class TestPredict:
         assert len(result) == 3
         assert torch.all(result.boxes.conf[:-1] >= result.boxes.conf[1:])
 
-    def test_negative_one_max_det_keeps_every_fused_detection(self, image):
+    def test_negative_max_det_is_rejected(self, image):
         a = StubMember(
             COCOISH,
             boxes=[[0, 0, 10, 10], [50, 50, 60, 60]],
             scores=[0.9, 0.8],
             cls=[0, 1],
         )
-        result = LibreEnsemble([a, StubMember(COCOISH)])(image, max_det=-1)
-        assert len(result) == 2
+        with pytest.raises(ValueError, match="max_det must be non-negative"):
+            LibreEnsemble([a, StubMember(COCOISH)])(image, max_det=-1)
+
+    @pytest.mark.parametrize("max_det", [True, 1.5, "3"])
+    def test_non_integer_max_det_is_rejected(self, image, max_det):
+        with pytest.raises(TypeError, match="max_det must be an integer"):
+            LibreEnsemble(list(_pair_members()))(image, max_det=max_det)
+
+    def test_zero_max_det_returns_empty_result(self, image):
+        result = LibreEnsemble(list(_pair_members()))(image, max_det=0)
+        assert len(result) == 0
 
     def test_classes_filter_uses_union_ids(self, image):
         a = StubMember(

--- a/tests/unit/test_eomt.py
+++ b/tests/unit/test_eomt.py
@@ -1361,6 +1361,47 @@ def test_panoptic_merge_without_thing_class_ids_fuses_nothing():
     assert all(e["isthing"] for e in out["segments_info"])
 
 
+def test_panoptic_merge_empty_thing_ids_treats_every_category_as_stuff():
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=4, thing_class_ids=[])
+    out = LibreEoMT._postprocess_panoptic(
+        stub, _quadrant_panoptic_output(nc=4), 0.5, (4, 4)
+    )
+
+    assert len(out["segments_info"]) == 2
+    assert all(not entry["isthing"] for entry in out["segments_info"])
+
+
+def test_panoptic_overlap_uses_actual_surviving_mask_area():
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=2, thing_class_ids=[0, 1])
+    class_logits = torch.full((1, 2, 3), -10.0)
+    class_logits[0, 0, 0] = 5.0
+    class_logits[0, 1, 1] = 5.0
+    mask_logits = torch.full((1, 2, 4, 4), -2.1972246)
+    mask_logits[0, 0] = -0.0400053  # p=0.49: wins outside but is not its mask
+    mask_logits[0, 0, :2, :2] = 0.4054651  # p=0.60: four-pixel own mask
+    mask_logits[0, 1, 0, 0] = -2.1972246
+    mask_logits[0, 1, 0, 1] = 2.1972246
+    mask_logits[0, 1, 1, 0] = 2.1972246
+    mask_logits[0, 1, 1, 1] = 2.1972246
+
+    out = LibreEoMT._postprocess_panoptic(
+        stub,
+        {
+            "class_queries_logits": class_logits,
+            "masks_queries_logits": mask_logits,
+        },
+        0.5,
+        (4, 4),
+    )
+
+    assert all(entry["category_id"] != 0 for entry in out["segments_info"])
+    assert int((out["panoptic"] > 0).sum()) == 3
+
+
 def test_panoptic_merge_empty_when_all_queries_are_null():
     from libreyolo.models.eomt.model import LibreEoMT
 
@@ -1388,10 +1429,18 @@ def test_coco_content_size_matches_upstream_aspect_ratio_rule():
         (576, 768): (480, 640),  # landscape
         (1194, 1536): (498, 640),  # landscape, rounds to 498
         (852, 1280): (426, 640),  # landscape
+        (12, 13): (591, 640),  # longest edge remains exact after rounding
         (640, 640): (640, 640),  # already square
     }
     for (oh, ow), expected in cases.items():
         assert LibreEoMT._coco_content_size(oh, ow, 640) == expected
+
+
+def test_coco_content_size_never_rounds_a_valid_side_to_zero():
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    assert LibreEoMT._coco_content_size(1, 10000, 640) == (1, 640)
+    assert LibreEoMT._coco_content_size(10000, 1, 640) == (640, 1)
 
 
 def test_preprocess_pads_for_coco_tasks_and_splits_for_semantic(fake_eomt_seg_net):

--- a/tests/unit/test_fomo_validation.py
+++ b/tests/unit/test_fomo_validation.py
@@ -233,6 +233,24 @@ class TestLibreFOMOParseGtPoints:
         np.testing.assert_allclose(xy[0], [0.5, 0.5], atol=1e-5)
         assert cls[0] == 0
 
+    def test_one_pixel_class_zero_box_is_not_misread_as_normalized(self) -> None:
+        from libreyolo.validation.point_validator import PointValidator
+
+        validator = object.__new__(PointValidator)
+        validator.nc = 1
+        validator._actual_imgsz = 100
+        validator.val_preproc = type("_Preproc", (), {"uses_letterbox": False})()
+        row = np.array([[0.0, 0.0, 1.0, 1.0, 0.0]], dtype=np.float32)
+
+        xy, classes = validator.parse_gt_points_from_boxes(
+            row,
+            orig_h=100,
+            orig_w=100,
+        )
+
+        np.testing.assert_allclose(xy, [[0.005, 0.005]])
+        assert classes.tolist() == [0]
+
 
 class TestLibreFOMOValidator:
     """FOMOValidator grid-specific metric handling."""
@@ -261,6 +279,8 @@ class TestLibreFOMOValidator:
             conf_thresholds=(0.9,),
             nms_radii=(1,),
         )
+        validator._actual_imgsz = 96
+        validator.val_preproc = type("_Preproc", (), {"uses_letterbox": False})()
         validator._init_metrics()
         assert validator.last_logits is None
         assert not hasattr(validator, "grid_cached")
@@ -275,7 +295,10 @@ class TestLibreFOMOValidator:
                 "classes": np.array([0], dtype=np.int64),
             }
         ]
-        targets = torch.tensor([[[0.0, 0.5, 0.5, 0.05, 0.05]]], dtype=torch.float32)
+        targets = torch.tensor(
+            [[[43.2, 43.2, 52.8, 52.8, 0.0]]],
+            dtype=torch.float32,
+        )
 
         validator._update_metrics(preds, targets, [(96, 96)])
 
@@ -284,6 +307,28 @@ class TestLibreFOMOValidator:
         assert stats["fp"] == 0.0
         assert stats["fn"] == 0.0
         assert not hasattr(validator, "grid_cached")
+
+    def test_grid_matching_maximizes_pairs_before_distance(self) -> None:
+        from libreyolo.validation.fomo_validator import FOMOValidator
+
+        validator = object.__new__(FOMOValidator)
+        validator.distance_tolerance = 4.0
+        decoded = [
+            torch.tensor(
+                [[8.0, 6.0, 1.0, 0.9], [7.0, 5.0, 1.0, 0.8]],
+                dtype=torch.float32,
+            )
+        ]
+        targets = torch.zeros((1, 10, 10), dtype=torch.long)
+        targets[0, 2, 9] = 1
+        targets[0, 4, 8] = 1
+        stats = {"tp": 0.0, "fp": 0.0, "fn": 0.0, "total_dist": 0.0}
+
+        validator._update_grid_stats(decoded, targets, stats)
+
+        assert stats["tp"] == 2.0
+        assert stats["fp"] == 0.0
+        assert stats["fn"] == 0.0
 
 
 class TestDecodePoints:
@@ -319,6 +364,22 @@ class TestDecodePoints:
         results_r2 = _decode_points(logits, conf_threshold=0.01, nms_radius=2)
         results_r0 = _decode_points(logits, conf_threshold=0.01, nms_radius=0)
         assert len(results_r2[0]) < len(results_r0[0])
+
+    def test_nms_does_not_suppress_adjacent_different_classes(self) -> None:
+        from libreyolo.models.fomo.utils import decode_points_from_logits as _decode_points
+
+        logits = torch.zeros(1, 3, 6, 6)
+        logits[0, 1, 3, 3] = 20.0
+        logits[0, 2, 3, 4] = 19.0
+
+        [points] = _decode_points(
+            logits,
+            conf_threshold=0.6,
+            nms_radius=1,
+        )
+
+        assert len(points) == 2
+        assert set(points[:, 2].long().tolist()) == {1, 2}
 
     def test_class_index_correct(self) -> None:
         """Returned class channel index must equal the argmax foreground channel."""

--- a/tests/unit/test_matte.py
+++ b/tests/unit/test_matte.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -254,6 +255,43 @@ def test_smeasure_all_background_and_all_foreground():
     assert s_measure(np.zeros_like(gt0), gt0) == pytest.approx(1.0)
     gt1 = np.ones((16, 16), np.float32)
     assert s_measure(np.ones_like(gt1), gt1) == pytest.approx(1.0)
+
+
+def test_smeasure_region_quadrants_are_weighted_by_spatial_area(monkeypatch):
+    import libreyolo.validation.matte_validator as matte_validator
+
+    gt = np.zeros((4, 4), dtype=np.float32)
+    gt[0, 0] = 1.0
+    pred = np.zeros_like(gt)
+    monkeypatch.setattr(
+        matte_validator,
+        "_ssim",
+        lambda pred_region, gt_region: float(gt_region.sum() == 0),
+    )
+
+    assert matte_validator._s_region(pred, gt) == pytest.approx(15 / 16)
+
+
+def test_matte_validator_keeps_ground_truth_native_canvas(monkeypatch):
+    import libreyolo.validation.matte_validator as matte_validator
+
+    gt = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+    model = SimpleNamespace(
+        predict=lambda *args, **kwargs: [
+            SimpleNamespace(matte=SimpleNamespace(array=np.array([[0.5]], np.float32)))
+        ]
+    )
+    config = SimpleNamespace(data="data", split="val", verbose=False)
+    monkeypatch.setattr(
+        matte_validator,
+        "resolve_matte_pairs",
+        lambda data, split: [(Path("image.png"), Path("matte.png"))],
+    )
+    monkeypatch.setattr(matte_validator, "_load_matte_gt", lambda path: gt.copy())
+
+    metrics = matte_validator.MatteValidator(model, config)()
+
+    assert metrics["metrics/MAE"] == pytest.approx(0.5)
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_nafnet_restore.py
+++ b/tests/unit/test_nafnet_restore.py
@@ -68,6 +68,12 @@ def test_nafnet_preprocess_keeps_native_resolution_and_pads_to_stride():
     assert tuple(tensor.shape) == (1, 3, 32, 32)
 
 
+def test_nafnet_validation_batch_hook_preserves_native_tensor_identity():
+    images = torch.rand(1, 3, 37, 53)
+
+    assert LibreNAFNet._preprocess_validation_batch(images) is images
+
+
 def test_librenafnet_predict_returns_restored_original_shape():
     model = LibreNAFNet(model_path=None, size="s", device="cpu")
     model.model.eval()

--- a/tests/unit/test_nafnet_train_uses_global_pool.py
+++ b/tests/unit/test_nafnet_train_uses_global_pool.py
@@ -16,6 +16,9 @@ These tests prove:
 
 from __future__ import annotations
 
+import copy
+from types import SimpleNamespace
+
 import torch
 import torch.nn as nn
 import pytest
@@ -28,6 +31,7 @@ from libreyolo.models.nafnet.nn import (
     use_global_pooling,
 )
 from libreyolo.models.nafnet.trainer import NAFNetTrainer
+from libreyolo.training.trainer import BaseTrainer
 
 pytestmark = pytest.mark.unit
 
@@ -73,7 +77,7 @@ def test_trainer_forwards_through_global_pooling():
     assert all(p.output_size == 1 for p in pools)
     # on_setup mutates the shared model in place (so optimizer/EMA see it).
     assert trainer.model is local
-    assert len(trainer._tlc_restore) == _NUM_SCA
+    assert trainer._pooling_prepared is True
 
 
 def test_trainer_restores_tlc_pooling_for_inference():
@@ -86,10 +90,10 @@ def test_trainer_restores_tlc_pooling_for_inference():
 
     trainer._restore_inference_pooling()
 
-    # TLC local pooling is back for inference; the exact original modules return.
+    # TLC local pooling is back for inference using the configured crop geometry.
     assert _count(local, AvgPool2d) == _NUM_SCA
     assert _count(local, nn.AdaptiveAvgPool2d) == 0
-    assert trainer._tlc_restore is None
+    assert trainer._pooling_prepared is False
 
 
 def test_use_global_pooling_is_reversible_and_weight_preserving():
@@ -155,3 +159,58 @@ def test_tlc_equals_global_at_train_size_but_can_diverge_larger():
     x_big = torch.rand(1, 3, 192, 192)  # > base_size (1.5 * 64 = 96)
     with torch.no_grad():
         assert not torch.allclose(plain(x_big), local(x_big), atol=1e-4)
+
+
+@pytest.mark.parametrize("use_ema", [False, True])
+def test_training_validation_temporarily_uses_configured_tlc_pooling(
+    monkeypatch, use_ema
+):
+    local = _make_local()
+    trainer = NAFNetTrainer(
+        model=local, size="s", device="cpu", imgsz=32, epochs=1
+    )
+    trainer.on_setup()
+    if use_ema:
+        trainer.ema_model = SimpleNamespace(ema=copy.deepcopy(trainer.model))
+    observed = {}
+
+    def fake_validation(self, epoch):
+        eval_model = self.ema_model.ema if self.ema_model else self.model
+        pools = [m for m in eval_model.modules() if isinstance(m, AvgPool2d)]
+        observed["epoch"] = epoch
+        observed["local"] = len(pools)
+        observed["global"] = _count(eval_model, nn.AdaptiveAvgPool2d)
+        observed["train_sizes"] = {tuple(pool.train_size) for pool in pools}
+        return {"metrics/PSNR": 1.0}
+
+    monkeypatch.setattr(BaseTrainer, "_run_restore_validation", fake_validation)
+
+    result = trainer._run_restore_validation(3)
+
+    assert result == {"metrics/PSNR": 1.0}
+    assert observed == {
+        "epoch": 3,
+        "local": _NUM_SCA,
+        "global": 0,
+        "train_sizes": {(1, 3, 32, 32)},
+    }
+    assert _count(trainer.model, AvgPool2d) == 0
+    assert _count(trainer.model, nn.AdaptiveAvgPool2d) == _NUM_SCA
+    if use_ema:
+        assert _count(trainer.ema_model.ema, AvgPool2d) == 0
+        assert _count(trainer.ema_model.ema, nn.AdaptiveAvgPool2d) == _NUM_SCA
+
+
+def test_post_training_pooling_uses_configured_crop_not_constructor_size():
+    local = _make_local()  # Constructed for 64x64 inference.
+    trainer = NAFNetTrainer(
+        model=local, size="s", device="cpu", imgsz=32, epochs=1
+    )
+    trainer.on_setup()
+
+    trainer._restore_inference_pooling()
+
+    pools = [m for m in local.modules() if isinstance(m, AvgPool2d)]
+    assert len(pools) == _NUM_SCA
+    assert {tuple(pool.train_size) for pool in pools} == {(1, 3, 32, 32)}
+    assert {tuple(pool.base_size) for pool in pools} == {(48, 48)}

--- a/tests/unit/test_obb_validation.py
+++ b/tests/unit/test_obb_validation.py
@@ -138,6 +138,34 @@ def test_obb_validator_metrics_are_perfect_for_exact_prediction():
     assert metrics["metrics/mAP50-95"] == pytest.approx(1.0)
 
 
+def test_obb_validator_matches_best_remaining_ground_truth(monkeypatch):
+    import libreyolo.validation.obb_validator as obb_validator_module
+
+    ious = np.array([[0.9, 0.1], [0.8, 0.7]], dtype=np.float32)
+    monkeypatch.setattr(
+        obb_validator_module,
+        "xywhr_iou",
+        lambda prediction, target: float(ious[int(prediction[0]), int(target[0])]),
+    )
+    validator = OBBValidator.__new__(OBBValidator)
+    validator._num_gt_by_class = {0: 2}
+    validator._gt_by_class = {
+        0: {0: [np.array([0.0]), np.array([1.0])]}
+    }
+    validator._predictions_by_class = {
+        0: [
+            {"image_id": 0, "score": 0.9, "xywhr": np.array([0.0])},
+            {"image_id": 0, "score": 0.8, "xywhr": np.array([1.0])},
+        ]
+    }
+
+    precision, recall, average_precision = validator._evaluate_class(0, 0.5)
+
+    assert precision == pytest.approx(1.0)
+    assert recall == pytest.approx(1.0)
+    assert average_precision == pytest.approx(1.0)
+
+
 def test_obb_validation_rejects_augmented_validation_before_base_tta():
     with pytest.raises(ValueError, match="oriented boxes"):
         BaseModel.val(_DummyOBBModel(), data="unused.yaml", imgsz=64, augment=True)

--- a/tests/unit/test_ocsort.py
+++ b/tests/unit/test_ocsort.py
@@ -55,6 +55,8 @@ def test_config_defaults():
         {"min_hits": -1},
         {"delta_t": 0},
         {"inertia": -0.5},
+        {"max_age": float("nan")},
+        {"inertia": float("nan")},
     ],
 )
 def test_config_validation_rejects_bad_values(kwargs):

--- a/tests/unit/test_ocsort.py
+++ b/tests/unit/test_ocsort.py
@@ -54,6 +54,8 @@ def test_config_defaults():
         {"max_age": -1},
         {"min_hits": -1},
         {"delta_t": 0},
+        {"delta_t": 1.5},
+        {"delta_t": True},
         {"inertia": -0.5},
         {"max_age": float("nan")},
         {"inertia": float("nan")},

--- a/tests/unit/test_openvocab.py
+++ b/tests/unit/test_openvocab.py
@@ -168,14 +168,17 @@ class TestCallDefaults:
         with pytest.raises(ValueError, match="augment=True"):
             m("image.jpg", augment=True)
 
-    def test_iou_warns_because_hf_postprocess_has_no_nms(self, monkeypatch):
+    def test_iou_is_forwarded_for_shared_nms(self, monkeypatch):
+        captured = {}
+
         def fake_call(self, source=None, **kwargs):
+            captured.update(kwargs)
             return "ok"
 
         monkeypatch.setattr(BaseModel, "__call__", fake_call)
         m = _bare(LibreOWLv2)
-        with pytest.warns(UserWarning, match="iou=.+ignored"):
-            assert m("image.jpg", iou=0.7) == "ok"
+        assert m("image.jpg", iou=0.7) == "ok"
+        assert captured["iou"] == pytest.approx(0.7)
 
     def test_track_raises_in_v1(self):
         m = _bare(LibreOWLv2)
@@ -184,6 +187,11 @@ class TestCallDefaults:
 
 
 class TestGroundingDinoPhraseMapping:
+    def test_prompt_does_not_double_leading_article(self):
+        m = _bare(LibreGroundingDINO)
+        m.set_classes(["a red car", "an apple"])
+        assert m._prompt() == "a red car. an apple."
+
     def test_exact_match(self):
         m = _bare(LibreGroundingDINO)
         m.set_classes(["remote control", "cat"])
@@ -329,6 +337,26 @@ class TestOWLv2Mapping:
         m.set_classes(["Remote Control", "Cat"])
         assert m._text_labels() == [["a photo of a remote control", "a photo of a cat"]]
 
+    def test_prompt_template_does_not_double_leading_articles(self):
+        m = _bare(LibreOWLv2)
+        m.set_classes(["a Red Car", "an Apple", "the Cat"])
+        assert m._text_labels() == [
+            ["a photo of a red car", "a photo of an apple", "a photo of the cat"]
+        ]
+
+    @pytest.mark.parametrize(
+        "labels",
+        [
+            torch.tensor([1.9, float("nan"), float("inf"), 1.0]),
+            [1.9, float("nan"), float("inf"), 1.0],
+        ],
+    )
+    def test_fractional_and_nonfinite_query_ids_are_rejected(self, labels):
+        m = _bare(LibreOWLv2)
+        m.set_classes(["cat", "dog"])
+
+        assert m._labels_to_class_ids(labels).tolist() == [-1, -1, -1, 1]
+
     def test_postprocess_filters_invalid_query_ids(self):
         m = _bare(LibreOWLv2)
         m.set_classes(["cat", "dog"])
@@ -365,3 +393,43 @@ class TestDetectionDict:
         assert det["boxes"].device.type == "cpu"
         assert det["scores"].device.type == "cpu"
         assert det["classes"].device.type == "cpu"
+
+    def test_shared_finalizer_validates_bounds_shape_and_runs_class_aware_nms(self):
+        m = _bare(LibreOWLv2)
+        det = m._detections_to_dict(
+            [
+                [-3.0, -2.0, 12.0, 12.0],
+                [0.0, 0.0, 11.0, 11.0],
+                [0.0, 0.0, 11.0, 11.0],
+                [float("nan"), 0.0, 5.0, 5.0],
+                [18.0, 18.0, 30.0, 30.0],
+                [3.0, 2.0, 1.0, 8.0],
+            ],
+            [0.9, 0.8, 0.7, 1.0, 0.6, 0.5],
+            [0, 0, 1, 0, 1, 0],
+            conf_thres=0.1,
+            original_size=(20, 20),
+            max_det=10,
+            iou_thres=0.5,
+        )
+
+        assert det["boxes"].tolist() == [
+            [0.0, 0.0, 12.0, 12.0],
+            [0.0, 0.0, 11.0, 11.0],
+            [18.0, 18.0, 20.0, 20.0],
+        ]
+        assert det["classes"].tolist() == [0, 1, 1]
+
+    def test_malformed_box_shape_returns_empty_contract(self):
+        m = _bare(LibreOWLv2)
+        det = m._detections_to_dict(
+            [1.0, 2.0, 3.0],
+            [0.9],
+            [0],
+            conf_thres=0.1,
+            original_size=(20, 20),
+            max_det=10,
+        )
+
+        assert det["num_detections"] == 0
+        assert det["boxes"].shape == (0, 4)

--- a/tests/unit/test_ops_fusion.py
+++ b/tests/unit/test_ops_fusion.py
@@ -89,6 +89,8 @@ class TestSharedBehavior:
             op(boxes, scores, labels, model_ids, weights=[1.0, -1.0])
         with pytest.raises(ValueError, match="positive"):
             op(boxes, scores, labels, model_ids, weights=[float("nan"), 1.0])
+        with pytest.raises(ValueError, match="finite"):
+            op(boxes, scores, labels, model_ids, weights=[float("inf"), 1.0])
         with pytest.raises(ValueError, match="model_ids contains index"):
             op(boxes, scores, labels, model_ids, num_models=1)
 
@@ -106,6 +108,30 @@ class TestSharedBehavior:
         boxes, scores, _, model_ids = _pair()
         with pytest.raises(ValueError, match="non-negative"):
             op(boxes, scores, torch.tensor([0, -1]), model_ids, num_models=2)
+
+    @pytest.mark.parametrize("op", ALL_OPS)
+    @pytest.mark.parametrize("field", ["labels", "model_ids"])
+    def test_fractional_ids_rejected_before_integer_conversion(self, op, field):
+        boxes, scores, labels, model_ids = _pair()
+        values = torch.tensor([0.0, 0.5])
+        if field == "labels":
+            labels = values
+        else:
+            model_ids = values
+        with pytest.raises(ValueError, match=rf"{field} must contain integer-valued"):
+            op(boxes, scores, labels, model_ids, num_models=2)
+
+    @pytest.mark.parametrize("op", ALL_OPS)
+    def test_nonfinite_boxes_and_scores_rejected(self, op):
+        boxes, scores, labels, model_ids = _pair()
+        bad_boxes = boxes.clone()
+        bad_boxes[0, 0] = float("nan")
+        with pytest.raises(ValueError, match="only finite values"):
+            op(bad_boxes, scores, labels, model_ids, num_models=2)
+        bad_scores = scores.clone()
+        bad_scores[0] = float("inf")
+        with pytest.raises(ValueError, match="only finite values"):
+            op(boxes, bad_scores, labels, model_ids, num_models=2)
 
 
 class TestWeightedBoxesFusion:

--- a/tests/unit/test_picodet_train_smoke.py
+++ b/tests/unit/test_picodet_train_smoke.py
@@ -133,3 +133,35 @@ def test_picodet_config_finetune_lr():
     cfg = PICODETConfig()
     assert cfg.lr0 == 0.01
     assert cfg.warmup_lr_start <= cfg.lr0 * 0.2
+
+
+def test_picodet_class_rebuild_preserves_shared_dfl_predictor():
+    from libreyolo.models.picodet.model import LibrePICODET
+
+    model = LibrePICODET(model_path=None, size="s", nb_classes=3, device="cpu")
+    old_predictors = []
+    with torch.no_grad():
+        for index, predictor in enumerate(model.model.head.gfl_cls):
+            predictor.weight.copy_(
+                torch.arange(predictor.weight.numel()).reshape_as(predictor.weight)
+                + index * predictor.weight.numel()
+            )
+            predictor.bias.copy_(
+                torch.arange(predictor.bias.numel(), dtype=predictor.bias.dtype)
+                + index * predictor.bias.numel()
+            )
+            old_predictors.append(
+                (predictor.weight.clone(), predictor.bias.clone())
+            )
+
+    model._rebuild_for_new_classes(2)
+
+    assert model.nb_classes == 2
+    assert model.model.head.num_classes == 2
+    for (old_weight, old_bias), predictor in zip(
+        old_predictors, model.model.head.gfl_cls
+    ):
+        torch.testing.assert_close(predictor.weight[:2], old_weight[:2])
+        torch.testing.assert_close(predictor.bias[:2], old_bias[:2])
+        torch.testing.assert_close(predictor.weight[2:], old_weight[3:])
+        torch.testing.assert_close(predictor.bias[2:], old_bias[3:])

--- a/tests/unit/test_picosam3_logic.py
+++ b/tests/unit/test_picosam3_logic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 import json
+import threading
 
 import pytest
 import torch
@@ -84,6 +85,74 @@ def test_multiple_boxes_are_batched_and_set_image_is_reused():
         assert len(result.masks) == 2
     finally:
         model.reset_image()
+
+
+@pytest.mark.parametrize("max_det", [-1, 0, 1.5, True])
+def test_predict_rejects_invalid_max_det_before_inference(max_det):
+    with pytest.raises(ValueError, match="integer >= 1"):
+        _bare_picosam3().predict(
+            Image.new("RGB", (16, 16)),
+            bboxes=[1, 1, 8, 8],
+            max_det=max_det,
+        )
+
+
+def test_predict_serializes_forward_with_device_changes():
+    model = _bare_picosam3()
+    forward_started = threading.Event()
+    allow_forward = threading.Event()
+    device_call_started = threading.Event()
+    device_call_done = threading.Event()
+    errors = []
+
+    class BlockingModel(torch.nn.Module):
+        def forward(self, batch):
+            forward_started.set()
+            if not allow_forward.wait(timeout=2):
+                raise TimeoutError("test did not release PicoSAM3 forward")
+            return torch.ones(
+                (batch.shape[0], 1, 96, 96),
+                device=batch.device,
+                dtype=batch.dtype,
+            )
+
+    model.model = BlockingModel().eval()
+
+    def run_predict():
+        try:
+            model.predict(
+                Image.new("RGB", (16, 16)),
+                bboxes=[1, 1, 8, 8],
+            )
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def set_device():
+        device_call_started.set()
+        try:
+            model._set_device("cpu")
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+        finally:
+            device_call_done.set()
+
+    prediction = threading.Thread(target=run_predict)
+    prediction.start()
+    assert forward_started.wait(timeout=2)
+
+    device_change = threading.Thread(target=set_device)
+    device_change.start()
+    assert device_call_started.wait(timeout=2)
+    assert not device_call_done.wait(timeout=0.05), (
+        "device mutation escaped while PicoSAM3 prediction held the session lock"
+    )
+
+    allow_forward.set()
+    prediction.join(timeout=2)
+    device_change.join(timeout=2)
+    assert not prediction.is_alive()
+    assert not device_change.is_alive()
+    assert not errors
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_point_validator.py
+++ b/tests/unit/test_point_validator.py
@@ -414,11 +414,11 @@ def test_point_validator_edge_custom_threshold_changes_values():
 # Coordinate Normalization & Target Parsing
 # ===========================================================================
 
-def test_point_validator_parse_gt_yolo_normalised():
+def test_point_validator_parse_gt_pixel_boxes():
     row = np.array(
         [
-            [0.0, 0.25, 0.75, 0.10, 0.10],
-            [1.0, 0.80, 0.20, 0.05, 0.05],
+            [20.0, 70.0, 30.0, 80.0, 0.0],
+            [75.0, 15.0, 85.0, 25.0, 1.0],
             [0.0, 0.00, 0.00, 0.00, 0.00],
         ],
         dtype=np.float32,
@@ -433,7 +433,7 @@ def test_point_validator_parse_gt_yolo_normalised():
 
 
 def test_point_validator_parse_gt_clipped_coords():
-    row = np.array([[0.0, 1.2, -0.1, 0.1, 0.1]], dtype=np.float32)
+    row = np.array([[-20.0, -10.0, 260.0, 120.0, 0.0]], dtype=np.float32)
     v = _make_validator_for_parsing()
     xy, cls = v._parse_gt_points(row, orig_h=640, orig_w=640)
     assert xy.shape == (1, 2)
@@ -464,7 +464,7 @@ def test_point_validator_parse_gt_empty_padded_yolo_row():
 def test_point_validator_parse_gt_single_valid_with_padding():
     row = np.array(
         [
-            [0.0, 0.5, 0.5, 0.1, 0.1],
+            [45.0, 45.0, 55.0, 55.0, 0.0],
             [0.0, 0.0, 0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0, 0.0, 0.0],
         ],
@@ -477,7 +477,7 @@ def test_point_validator_parse_gt_single_valid_with_padding():
 
 
 def test_point_validator_parse_gt_1d_row():
-    row = np.array([0.0, 0.3, 0.7, 0.1, 0.1], dtype=np.float32)
+    row = np.array([25.0, 65.0, 35.0, 75.0, 0.0], dtype=np.float32)
     v = _make_validator_for_parsing()
     xy, cls = v._parse_gt_points(row, orig_h=640, orig_w=640)
     assert xy.shape == (1, 2)
@@ -655,7 +655,7 @@ def test_point_validator_update_metrics_numpy():
             "classes": np.array([0], np.int64),
         }
     ]
-    targets = np.array([[[0.0, 0.5, 0.5, 0.1, 0.1]]], np.float32)
+    targets = np.array([[[288.0, 288.0, 352.0, 352.0, 0.0]]], np.float32)
     img_info = [(640, 640)]
 
     v._update_metrics(preds, targets, img_info)
@@ -686,7 +686,10 @@ def test_point_validator_update_metrics_torch_tensor():
             "classes": np.array([1], np.int64),
         }
     ]
-    targets = torch.tensor([[[1.0, 0.2, 0.8, 0.1, 0.1]]], dtype=torch.float32)
+    targets = torch.tensor(
+        [[[96.0, 480.0, 160.0, 544.0, 1.0]]],
+        dtype=torch.float32,
+    )
     img_info = [(640, 640)]
 
     v._update_metrics(preds, targets, img_info)
@@ -845,3 +848,17 @@ def test_point_validator_hungarian_match_confidence_priority():
     tp_with_score, _, _ = _hungarian_match(dist_mat, threshold=0.05, pred_scores=pred_scores)
     assert len(tp_with_score) == 1
     assert tp_with_score[0, 0] == 0
+
+
+def test_point_match_confidence_priority_survives_invalid_assignment_fillers():
+    from libreyolo.validation.point_validator import _hungarian_match
+
+    # Both predictions can match GT 0; GT 1 is outside tolerance for both.
+    # Penalizing invalid edges and subtracting score from every row makes the
+    # score terms cancel in a square assignment and incorrectly picks row 1.
+    distances = np.array([[0.04, 0.051], [0.01, 0.052]], dtype=np.float64)
+    scores = np.array([0.9, 0.3], dtype=np.float64)
+
+    pairs, _, _ = _hungarian_match(distances, threshold=0.05, pred_scores=scores)
+
+    assert pairs.tolist() == [[0, 0]]

--- a/tests/unit/test_ppocr.py
+++ b/tests/unit/test_ppocr.py
@@ -240,6 +240,77 @@ def test_rec_batches_bucket_by_aspect():
     assert batches[1][1].shape[3] == int(48 * (800 / 48))
 
 
+def test_rec_batches_honor_checkpoint_image_shape():
+    from libreyolo.models.ppocr.preprocess import rec_batches
+
+    crops = [np.zeros((16, 32, 3), dtype=np.uint8)]
+    [(indices, batch)] = rec_batches(
+        crops,
+        batch_size=1,
+        rec_image_shape=[3, 48, 128],
+    )
+    assert indices == [0]
+    assert batch.shape == (1, 3, 48, 128)
+
+
+def test_rec_image_shape_rejects_height_incompatible_with_ctc_encoder():
+    from libreyolo.models.ppocr.preprocess import normalize_rec_image_shape
+
+    with pytest.raises(ValueError, match="height-1 CTC encoder"):
+        normalize_rec_image_shape([3, 32, 128])
+
+
+def test_detector_limit_uses_checkpoint_pipeline_unless_imgsz_overrides():
+    from libreyolo.models.ppocr.inference import _resolve_detector_limit
+
+    pipeline = {"det_limit_side_len": 768}
+    assert _resolve_detector_limit(None, pipeline, 960) == 768
+    assert _resolve_detector_limit(640, pipeline, 960) == 640
+    with pytest.raises(ValueError, match="positive integer"):
+        _resolve_detector_limit(None, {"det_limit_side_len": float("nan")}, 960)
+
+
+def test_tiny_detector_map_is_cropped_to_unpadded_source_extent():
+    from libreyolo.models.ppocr.inference import _crop_probability_to_source_extent
+    from libreyolo.models.ppocr.preprocess import det_resize
+    from libreyolo.postprocess.ppocr import db_postprocess
+
+    image = np.zeros((10, 20, 3), dtype=np.uint8)
+    resized, ratio_h, ratio_w = det_resize(image)
+    assert resized.shape[:2] == (32, 32)
+
+    probability = np.ones(resized.shape[:2], dtype=np.float32)
+    cropped = _crop_probability_to_source_extent(
+        probability,
+        resized_shape=resized.shape[:2],
+        source_shape=image.shape[:2],
+        ratio_h=ratio_h,
+        ratio_w=ratio_w,
+    )
+    assert cropped.shape == image.shape[:2]
+
+    probability.fill(0.0)
+    probability[1:9, 1:19] = 1.0
+    cropped = _crop_probability_to_source_extent(
+        probability,
+        resized_shape=resized.shape[:2],
+        source_shape=image.shape[:2],
+        ratio_h=ratio_h,
+        ratio_w=ratio_w,
+    )
+    quads, _ = db_postprocess(
+        cropped,
+        dest_width=20,
+        dest_height=10,
+        box_thresh=0.5,
+        unclip_ratio=0.0,
+        min_size=1,
+    )
+    assert quads.shape == (1, 4, 2)
+    assert quads[0, :, 0].max() >= 18
+    assert quads[0, :, 1].max() >= 8
+
+
 # --------------------------------------------------------------------------
 # Checkpoint discrimination
 # --------------------------------------------------------------------------
@@ -265,6 +336,36 @@ def test_can_load_and_size_detection():
     assert LibrePPOCR.detect_size(_composite_keys("l")) == "l"
     assert LibrePPOCR.detect_checkpoint_task(_composite_keys("l")) == "ocr"
     assert LibrePPOCR.detect_nb_classes(_composite_keys("t")) == 1
+
+
+def test_checkpoint_charset_rebuilds_ctc_head_before_strict_load():
+    from libreyolo.models.ppocr.model import LibrePPOCR, LibrePPOCRModel
+    from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+    charset = ["blank", "a", "b", " "]
+    source = LibrePPOCRModel("t", num_classes=len(charset))
+    checkpoint = wrap_libreyolo_checkpoint(
+        source.state_dict(),
+        model_family="ppocr",
+        size="t",
+        task="ocr",
+        nc=1,
+        names={0: "text"},
+        imgsz=960,
+        charset=charset,
+        pipeline={"rec_image_shape": [3, 48, 128]},
+        components={},
+    )
+
+    loaded = LibrePPOCR(
+        model_path=checkpoint,
+        size="t",
+        device="cpu",
+    )
+
+    assert loaded.model.rec.head.ctc_head.fc.out_features == len(charset)
+    assert loaded.charset == charset
+    assert loaded.pipeline_config["rec_image_shape"] == [3, 48, 128]
 
 
 def test_can_load_rejects_foreign_checkpoints():
@@ -436,6 +537,49 @@ def test_match_image_one_to_one():
     counts = match_image(preds, ["x", "x"], gt)
     assert counts["det_matches"] == 1
     assert counts["num_pred"] == 2  # the second stays a false positive
+
+
+def test_match_image_ignores_prediction_contained_by_dont_care_region():
+    from libreyolo.validation.ocr_validator import match_image
+
+    gt = [{"polygon": _square(0, 0, 100), "text": "###"}]
+    counts = match_image([_square(20, 20, 10)], ["ignored"], gt)
+    assert counts["num_pred"] == 0
+
+
+def test_match_image_uses_separate_transcript_aware_assignment():
+    from libreyolo.validation.ocr_validator import match_image
+
+    def box(x1, x2):
+        return np.array([[x1, 0], [x2, 0], [x2, 10], [x1, 10]], dtype=np.float64)
+
+    gt = [
+        {"polygon": box(0, 20), "text": "one"},
+        {"polygon": box(4, 24), "text": "two"},
+    ]
+    # IoU-optimal detection pairs are the identical boxes, but the crossed
+    # pairs both remain above threshold and are the transcript-correct choice.
+    counts = match_image(
+        [box(0, 20), box(4, 24)],
+        ["two", "one"],
+        gt,
+    )
+    assert counts["det_matches"] == 2
+    assert counts["e2e_matches"] == 2
+
+
+def test_ocr_assignment_prioritizes_cardinality_over_total_iou():
+    from libreyolo.validation.ocr_validator import _maximum_cardinality_assignment
+
+    ious = np.zeros((5, 5), dtype=np.float64)
+    for index in range(4):
+        ious[index, index] = 1.0
+    for index in range(5):
+        ious[index, (index + 1) % 5] = 0.51
+    eligible = ious > 0.5
+
+    rows, _ = _maximum_cardinality_assignment(eligible, ious)
+    assert len(rows) == 5
 
 
 def test_match_image_optimal_assignment_in_crowded_layouts():

--- a/tests/unit/test_rfdetr_obb.py
+++ b/tests/unit/test_rfdetr_obb.py
@@ -327,6 +327,69 @@ def test_rfdetr_angle_loss_is_pi_periodic():
     torch.testing.assert_close(losses["loss_angle"], torch.tensor(0.0), atol=1e-6, rtol=0.0)
 
 
+def test_rfdetr_obb_losses_accept_width_height_swap_with_quarter_turn():
+    from libreyolo.models.rfdetr.loss import SetCriterion
+
+    criterion = SetCriterion(
+        num_classes=1,
+        matcher=None,
+        weight_dict={"loss_bbox": 1.0, "loss_giou": 1.0, "loss_angle": 1.0},
+        focal_alpha=0.25,
+        losses=["boxes", "angles"],
+    )
+    outputs = {
+        "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+        "pred_angles": torch.tensor([[[0.25]]]),
+    }
+    targets = [
+        {
+            "boxes": torch.tensor([[0.5, 0.5, 0.4, 0.2]]),
+            "angles": torch.tensor([0.25 + torch.pi / 2]),
+        }
+    ]
+    indices = [(torch.tensor([0]), torch.tensor([0]))]
+
+    losses = {
+        **criterion.loss_boxes(outputs, targets, indices, num_boxes=1.0),
+        **criterion.loss_angles(outputs, targets, indices, num_boxes=1.0),
+    }
+
+    for loss in losses.values():
+        torch.testing.assert_close(loss, torch.tensor(0.0), atol=1e-6, rtol=0.0)
+
+
+def test_rfdetr_obb_matcher_accepts_equivalent_target_encodings():
+    from libreyolo.models.rfdetr.matcher import HungarianMatcher
+
+    matcher = HungarianMatcher(
+        cost_class=0.0,
+        cost_bbox=5.0,
+        cost_giou=2.0,
+        cost_angle=1.0,
+    )
+    outputs = {
+        "pred_logits": torch.zeros(1, 2, 1),
+        "pred_boxes": torch.tensor(
+            [[[0.5, 0.5, 0.4, 0.2], [0.5, 0.5, 0.2, 0.4]]]
+        ),
+        "pred_angles": torch.full((1, 2, 1), torch.pi / 2),
+    }
+    targets = [
+        {
+            "labels": torch.tensor([0, 0]),
+            "boxes": torch.tensor(
+                [[0.5, 0.5, 0.2, 0.4], [0.5, 0.5, 0.4, 0.2]]
+            ),
+            "angles": torch.zeros(2),
+        }
+    ]
+
+    indices = matcher(outputs, targets)
+
+    assert indices[0][0].tolist() == [0, 1]
+    assert indices[0][1].tolist() == [0, 1]
+
+
 def test_rfdetr_trainer_forward_passes_obb_angles_to_criterion():
     from libreyolo.models.rfdetr.trainer import RFDETRTrainer
 

--- a/tests/unit/test_rfdetr_obb.py
+++ b/tests/unit/test_rfdetr_obb.py
@@ -153,6 +153,28 @@ def test_rfdetr_postprocess_tolerates_degenerate_obb_prediction():
     assert results[0]["obb"][0, 3] > 0.0
 
 
+def test_rfdetr_postprocess_filters_nonfinite_angles_before_topk():
+    from libreyolo.models.rfdetr.utils import postprocess
+
+    outputs = {
+        "pred_logits": torch.tensor([[[8.0], [4.0]]]),
+        "pred_boxes": torch.tensor(
+            [[[0.2, 0.2, 0.1, 0.1], [0.7, 0.7, 0.1, 0.1]]]
+        ),
+        "pred_angles": torch.tensor([[[float("nan")], [0.2]]]),
+    }
+
+    result = postprocess(
+        outputs,
+        torch.tensor([[100.0, 100.0]]),
+        num_select=1,
+    )[0]
+
+    assert torch.isfinite(result["obb"]).all()
+    torch.testing.assert_close(result["scores"], torch.tensor([4.0]).sigmoid())
+    torch.testing.assert_close(result["boxes"][0, :2], torch.tensor([65.0, 65.0]))
+
+
 def test_rfdetr_obb_load_rejects_detect_checkpoint_without_transfer_flag():
     from libreyolo.models.rfdetr.model import LibreRFDETR
 

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -193,6 +193,18 @@ def test_grouppose_reinitialize_keypoint_head_updates_schema():
     assert model.get_num_keypoints_per_class_from_checkpoint(state_dict) == [0, 15]
 
 
+def test_grouppose_reinitialize_keeps_decoder_mask_on_current_device():
+    model = _build_pose_model(num_keypoints_per_class=(0, 17), nb_classes=2)
+    decoder = model.transformer.decoder
+    decoder.keypoint_pos_embed = torch.nn.Parameter(decoder.keypoint_pos_embed.to("meta"))
+    decoder._buffers["keypoint_class_mask"] = decoder.keypoint_class_mask.to("meta")
+
+    model.reinitialize_keypoint_head([0, 15])
+
+    assert decoder.keypoint_class_mask.device.type == "meta"
+    assert tuple(decoder.keypoint_class_mask.shape) == (16, 16)
+
+
 # ---------------------------------------------------------------------------
 # 5. Checkpoint round-trip (strict)
 # ---------------------------------------------------------------------------
@@ -385,6 +397,67 @@ def test_grouppose_postprocess_remaps_keypoint_class_to_contiguous_zero():
     # Keypoint xy still scale to (x*width, y*height) = (30, 60); the remap only
     # touches the integer label, not the decoded keypoints.
     assert result["keypoints"][0, 0, :2].tolist() == pytest.approx([30.0, 60.0])
+
+
+def test_grouppose_filters_empty_internal_class_before_topk():
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    logits = torch.tensor([[[10.0, 9.0]]])
+    boxes = torch.tensor([[[0.5, 0.5, 0.2, 0.4]]])
+    keypoints = torch.zeros(1, 1, 34, 8)
+
+    result = postprocess(
+        {"pred_logits": logits, "pred_boxes": boxes, "pred_keypoints": keypoints},
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+        num_keypoints_per_class=[0, 17],
+        trace_alpha=0.0,
+    )[0]
+
+    assert result["labels"].tolist() == [0]
+    assert result["boxes"].shape == (1, 4)
+    assert result["keypoints"].shape == (1, 17, 3)
+
+
+def test_rfdetr_postprocess_filters_mapped_background_before_topk():
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    result = postprocess(
+        {
+            "pred_logits": torch.tensor([[[9.0, 10.0]]]),
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+        },
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+        class_id_map=[0, -1],
+    )[0]
+
+    assert result["labels"].tolist() == [0]
+    assert result["scores"].shape == (1,)
+
+
+def test_grouppose_trace_fusion_scores_are_finite_probabilities():
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    keypoints = torch.zeros(1, 1, 34, 8)
+    active = keypoints[0, 0, 17:]
+    active[:, 2] = 10.0
+    active[:, 4] = 10.0
+    active[:, 6] = 10.0
+    active[0, 4] = float("nan")
+    result = postprocess(
+        {
+            "pred_logits": torch.tensor([[[-10.0, 2.0]]]),
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+            "pred_keypoints": keypoints,
+        },
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+        num_keypoints_per_class=[0, 17],
+    )[0]
+
+    assert torch.isfinite(result["scores"]).all()
+    assert ((result["scores"] >= 0.0) & (result["scores"] <= 1.0)).all()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -266,6 +266,34 @@ def test_grouppose_postprocess_emits_keypoints_with_normalized_visibility():
     assert person_xy.tolist() == pytest.approx([100.0, 50.0])
 
 
+def test_grouppose_postprocess_zero_fills_inactive_precision_slots():
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    keypoints = torch.zeros(1, 1, 3 * 17, 8)
+    keypoints[..., 0] = 0.5
+    keypoints[..., 1] = 0.5
+    keypoints[..., 2] = 4.0
+    keypoints[..., 4:7] = 0.25
+
+    result = postprocess(
+        {
+            "pred_logits": torch.tensor([[[-10.0, -10.0, 4.0]]]),
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+            "pred_keypoints": keypoints,
+        },
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+        num_keypoints_per_class=[0, 17, 4],
+        trace_alpha=0.0,
+    )[0]
+
+    precision = result["keypoint_precision_cholesky"]
+    assert precision.shape == (1, 17, 3)
+    assert torch.isfinite(precision).all()
+    torch.testing.assert_close(precision[0, :4], torch.full((4, 3), 0.25))
+    torch.testing.assert_close(precision[0, 4:], torch.zeros(13, 3))
+
+
 # ---------------------------------------------------------------------------
 # 7. Detection path unaffected
 # ---------------------------------------------------------------------------
@@ -436,6 +464,32 @@ def test_rfdetr_postprocess_filters_mapped_background_before_topk():
     assert result["scores"].shape == (1,)
 
 
+@pytest.mark.parametrize("invalid_field", ["logit", "box"])
+def test_rfdetr_postprocess_filters_nonfinite_candidates_before_topk(invalid_field):
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    logits = torch.tensor([[[8.0], [4.0]]])
+    boxes = torch.tensor(
+        [[[0.2, 0.2, 0.1, 0.1], [0.7, 0.7, 0.1, 0.1]]]
+    )
+    if invalid_field == "logit":
+        logits[0, 0, 0] = float("nan")
+    else:
+        boxes[0, 0, 0] = float("nan")
+
+    result = postprocess(
+        {"pred_logits": logits, "pred_boxes": boxes},
+        torch.tensor([[100.0, 100.0]]),
+        num_select=1,
+    )[0]
+
+    torch.testing.assert_close(result["scores"], torch.tensor([4.0]).sigmoid())
+    torch.testing.assert_close(
+        result["boxes"],
+        torch.tensor([[65.0, 65.0, 75.0, 75.0]]),
+    )
+
+
 def test_grouppose_trace_fusion_scores_are_finite_probabilities():
     from libreyolo.postprocess.rfdetr import postprocess
 
@@ -458,6 +512,56 @@ def test_grouppose_trace_fusion_scores_are_finite_probabilities():
 
     assert torch.isfinite(result["scores"]).all()
     assert ((result["scores"] >= 0.0) & (result["scores"] <= 1.0)).all()
+
+
+@pytest.mark.parametrize("invalid_channel", [0, 2, 4])
+def test_grouppose_sanitizes_nonfinite_active_keypoint_outputs(invalid_channel):
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    keypoints = torch.zeros(1, 1, 34, 8)
+    active = keypoints[0, 0, 17:]
+    active[:, 0] = 0.25
+    active[:, 1] = 0.5
+    active[:, 2] = 4.0
+    active[0, invalid_channel] = float("nan")
+
+    result = postprocess(
+        {
+            "pred_logits": torch.tensor([[[-10.0, 4.0]]]),
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+            "pred_keypoints": keypoints,
+        },
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+        num_keypoints_per_class=[0, 17],
+    )[0]
+
+    assert torch.isfinite(result["scores"]).all()
+    assert torch.isfinite(result["keypoints"]).all()
+    assert torch.isfinite(result["keypoint_precision_cholesky"]).all()
+    if invalid_channel in {0, 2}:
+        torch.testing.assert_close(result["keypoints"][0, 0], torch.zeros(3))
+    else:
+        torch.testing.assert_close(
+            result["keypoint_precision_cholesky"][0, 0], torch.zeros(3)
+        )
+
+
+def test_classic_pose_sanitizes_nonfinite_keypoint_outputs():
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    result = postprocess(
+        {
+            "pred_logits": torch.tensor([[[4.0]]]),
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+            "pred_keypoints": torch.tensor([[[[float("nan"), 0.5, 4.0]]]]),
+        },
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+    )[0]
+
+    assert torch.isfinite(result["keypoints"]).all()
+    torch.testing.assert_close(result["keypoints"][0, 0], torch.zeros(3))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rfdetr_pose.py
+++ b/tests/unit/test_rfdetr_pose.py
@@ -22,6 +22,7 @@ GroupPose module:
 from __future__ import annotations
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -545,6 +546,71 @@ def test_grouppose_sanitizes_nonfinite_active_keypoint_outputs(invalid_channel):
         torch.testing.assert_close(
             result["keypoint_precision_cholesky"][0, 0], torch.zeros(3)
         )
+
+
+@pytest.mark.parametrize("trace_alpha", [0.0, 0.2])
+def test_grouppose_zeroes_score_when_all_active_keypoints_are_unusable(
+    trace_alpha,
+):
+    from libreyolo.postprocess.rfdetr import postprocess
+
+    keypoints = torch.zeros(1, 1, 34, 8)
+    active = keypoints[0, 0, 17:]
+    active[:, :7] = float("nan")
+
+    result = postprocess(
+        {
+            "pred_logits": torch.tensor([[[-10.0, 4.0]]]),
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+            "pred_keypoints": keypoints,
+        },
+        torch.tensor([[100.0, 200.0]]),
+        num_select=1,
+        num_keypoints_per_class=[0, 17],
+        trace_alpha=trace_alpha,
+    )[0]
+
+    torch.testing.assert_close(result["scores"], torch.zeros(1))
+    torch.testing.assert_close(result["keypoints"], torch.zeros(1, 17, 3))
+    torch.testing.assert_close(
+        result["keypoint_precision_cholesky"], torch.zeros(1, 17, 3)
+    )
+
+
+def test_rfdetr_model_filters_unusable_grouppose_detection_at_zero_conf():
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    inner = SimpleNamespace(
+        use_grouppose_keypoints=True,
+        get_num_keypoints_per_class=lambda: [0, 17],
+    )
+    model = LibreRFDETR.__new__(LibreRFDETR)
+    model.task = "pose"
+    model.nb_classes = 1
+    model.device = torch.device("cpu")
+    model.model = SimpleNamespace(
+        model=inner,
+        num_select=1,
+        postprocess_trace_alpha=0.2,
+    )
+
+    keypoints = torch.zeros(1, 1, 34, 8)
+    keypoints[0, 0, 17:, :7] = float("nan")
+    result = model._postprocess(
+        {
+            "pred_logits": torch.tensor([[[-10.0, 4.0]]]),
+            "pred_boxes": torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
+            "pred_keypoints": keypoints,
+        },
+        conf_thres=0.0,
+        iou_thres=0.45,
+        original_size=(200, 100),
+        max_det=1,
+    )
+
+    assert result["num_detections"] == 0
+    assert result["scores"] == []
+    assert result["keypoints"].shape == (0, 17, 3)
 
 
 def test_classic_pose_sanitizes_nonfinite_keypoint_outputs():

--- a/tests/unit/test_rfdetr_pose_training.py
+++ b/tests/unit/test_rfdetr_pose_training.py
@@ -24,10 +24,17 @@ from __future__ import annotations
 import pytest
 import torch
 
-from libreyolo.models.rfdetr.keypoints import map_labels_to_keypoint_schema
-from libreyolo.models.rfdetr.loss import SetCriterion
+from libreyolo.models.rfdetr.keypoints import (
+    compute_keypoint_matching_cost,
+    compute_l1_keypoint_loss,
+    map_labels_to_keypoint_schema,
+)
+from libreyolo.models.rfdetr.loss import SetCriterion, _classic_keypoint_losses
 from libreyolo.models.rfdetr.lwdetr import build_criterion_and_postprocessors, build_model
-from libreyolo.models.rfdetr.matcher import HungarianMatcher
+from libreyolo.models.rfdetr.matcher import (
+    HungarianMatcher,
+    _classic_keypoint_matching_cost,
+)
 from libreyolo.models.rfdetr.nn import RFDETRSizeConfig, _make_args
 from libreyolo.models.rfdetr.tensors import NestedTensor
 
@@ -210,3 +217,110 @@ def test_grouppose_criterion_keeps_two_logit_head():
     assert criterion.num_classes == 2
     assert "loss_keypoints_l1" in criterion.weight_dict
     assert "keypoints" in criterion.losses
+
+
+def test_grouppose_nonfinite_invisible_targets_keep_losses_and_costs_finite():
+    pred = torch.zeros(1, _K_TOTAL, 8, requires_grad=True)
+    target = torch.zeros(1, max(_SCHEMA), 3)
+    target[..., :2] = 0.5
+    target[..., 2] = 2.0
+    target[0, 0] = torch.tensor([float("nan"), float("nan"), 0.0])
+    target[0, 1] = torch.tensor([float("nan"), float("nan"), float("nan")])
+    target_classes = torch.tensor([1])
+    target_areas = torch.tensor([0.25])
+
+    losses = compute_l1_keypoint_loss(
+        pred, target, target_classes, target_areas, _SCHEMA
+    )
+    assert all(torch.isfinite(loss).all() for loss in losses)
+    sum(loss.sum() for loss in losses).backward()
+    assert pred.grad is not None
+    assert torch.isfinite(pred.grad).all()
+
+    costs = compute_keypoint_matching_cost(
+        pred.detach().unsqueeze(0),
+        target,
+        target_classes,
+        target_areas,
+        _SCHEMA,
+    )
+    assert all(torch.isfinite(cost).all() for cost in costs)
+
+
+def test_classic_pose_nonfinite_invisible_targets_keep_loss_and_grad_finite():
+    pred = torch.zeros(1, 3, 3, requires_grad=True)
+    target = torch.tensor(
+        [[[float("nan"), float("nan"), 0.0], [0.5, 0.5, 2.0], [0.0, 0.0, float("nan")]]]
+    )
+
+    losses = _classic_keypoint_losses(pred, target)
+    assert all(torch.isfinite(loss).all() for loss in losses)
+    sum(loss.sum() for loss in losses).backward()
+    assert pred.grad is not None
+    assert torch.isfinite(pred.grad).all()
+
+    costs = _classic_keypoint_matching_cost(pred.detach().unsqueeze(0), target)
+    assert all(torch.isfinite(cost).all() for cost in costs)
+
+
+def test_pose_validation_evaluates_and_restores_criterion_mode():
+    from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+    class DummyModel(torch.nn.Module):
+        def forward(self, imgs, targets=None):
+            return {"loss": imgs.sum() * 0.0}
+
+    class RecordingCriterion(torch.nn.Module):
+        weight_dict = {"loss": 1.0}
+
+        def __init__(self):
+            super().__init__()
+            self.seen_modes = []
+
+        def forward(self, outputs, targets):
+            self.seen_modes.append(self.training)
+            return {"loss": outputs["loss"]}
+
+    trainer = object.__new__(RFDETRTrainer)
+    trainer.wrapper_model = type("Wrapper", (), {"task": "pose"})()
+    trainer.model = DummyModel().train()
+    trainer.criterion = RecordingCriterion().train()
+    trainer.ema_model = None
+    trainer.val_loader = [(torch.zeros(1, 3, 8, 8), torch.zeros(1, 1, 1))]
+    trainer.device = torch.device("cpu")
+    trainer.is_distributed = False
+    trainer._targets_to_rfdetr_list = lambda targets, height, width: []
+    trainer._run_pose_metric_validation = (
+        lambda model, epoch, save_plots=None: None
+    )
+
+    trainer._run_validation(0)
+
+    assert trainer.criterion.seen_modes == [False]
+    assert trainer.model.training is True
+    assert trainer.criterion.training is True
+
+
+def test_pose_validation_restores_modes_after_metric_failure():
+    from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+    trainer = object.__new__(RFDETRTrainer)
+    trainer.wrapper_model = type("Wrapper", (), {"task": "pose"})()
+    trainer.model = torch.nn.Linear(1, 1).eval()
+    trainer.criterion = torch.nn.Linear(1, 1).train()
+    trainer.criterion.weight_dict = {}
+    trainer.ema_model = None
+    trainer.val_loader = []
+    trainer.device = torch.device("cpu")
+    trainer.is_distributed = False
+
+    def fail_validation(model, epoch, save_plots=None):
+        raise RuntimeError("metric failure")
+
+    trainer._run_pose_metric_validation = fail_validation
+
+    with pytest.raises(RuntimeError, match="metric failure"):
+        trainer._run_validation(0)
+
+    assert trainer.model.training is False
+    assert trainer.criterion.training is True

--- a/tests/unit/test_rfdetr_pose_training.py
+++ b/tests/unit/test_rfdetr_pose_training.py
@@ -247,6 +247,58 @@ def test_grouppose_nonfinite_invisible_targets_keep_losses_and_costs_finite():
     assert all(torch.isfinite(cost).all() for cost in costs)
 
 
+def test_grouppose_nonfinite_prediction_is_quarantined_from_matching():
+    from libreyolo.models.rfdetr.matcher import HungarianMatcher
+
+    schema = [0, 1]
+    pred_keypoints = torch.zeros(1, 2, 2, 8)
+    pred_keypoints[0, 0, 1, :2] = float("nan")
+    pred_keypoints[0, 1, 1, :2] = 0.6
+    outputs = {
+        "pred_logits": torch.zeros(1, 2, 2),
+        "pred_boxes": torch.tensor(
+            [[[0.5, 0.5, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5]]]
+        ),
+        "pred_keypoints": pred_keypoints,
+    }
+    targets = [
+        {
+            "labels": torch.tensor([0]),
+            "boxes": torch.tensor([[0.5, 0.5, 0.5, 0.5]]),
+            "keypoints": torch.tensor([[[0.5, 0.5, 2.0]]]),
+        }
+    ]
+    matcher = HungarianMatcher(
+        num_keypoints_per_class=schema,
+        keypoint_l1_loss_coef=1.0,
+        keypoint_nll_loss_coef=1.0,
+    )
+
+    [(pred_indices, target_indices)] = matcher(outputs, targets)
+
+    assert pred_indices.tolist() == [1]
+    assert target_indices.tolist() == [0]
+
+
+def test_grouppose_matched_nonfinite_prediction_reaches_finite_loss_guard():
+    schema = [0, 1]
+    pred = torch.zeros(1, 2, 8, requires_grad=True)
+    with torch.no_grad():
+        pred[0, 1, :2] = float("nan")
+    target = torch.tensor([[[0.5, 0.5, 2.0]]])
+
+    losses = compute_l1_keypoint_loss(
+        pred,
+        target,
+        torch.tensor([1]),
+        torch.tensor([0.25]),
+        schema,
+    )
+
+    assert not torch.isfinite(losses[0]).all()
+    assert not torch.isfinite(losses[3]).all()
+
+
 def test_classic_pose_nonfinite_invisible_targets_keep_loss_and_grad_finite():
     pred = torch.zeros(1, 3, 3, requires_grad=True)
     target = torch.tensor(

--- a/tests/unit/test_sam3_logic.py
+++ b/tests/unit/test_sam3_logic.py
@@ -132,6 +132,13 @@ def test_text_path_default_score_threshold_and_explicit_keep_all():
     )
 
 
+def test_text_path_rejects_nonpositive_max_det_before_inference():
+    with pytest.raises(ValueError, match="integer >= 1"):
+        _bare_sam3().predict(
+            Image.new("RGB", (10, 8)), text="person", max_det=0
+        )
+
+
 def test_lazy_loader_instantiates_pcs_once(monkeypatch):
     model = _bare_sam3()
     model._pcs_model = None

--- a/tests/unit/test_sam_logic.py
+++ b/tests/unit/test_sam_logic.py
@@ -5,6 +5,8 @@ alias errors — paths that were bug-prone in review but are reachable without
 downloading a checkpoint.
 """
 
+import threading
+
 import pytest
 import torch
 from PIL import Image
@@ -142,6 +144,60 @@ class TestEmptyPromptDispatch:
         import numpy as np
 
         assert _is_empty_prompt(np.array([900, 370])) is False
+
+
+@pytest.mark.parametrize("max_det", [-1, 0, 1.5, True])
+def test_predict_rejects_invalid_max_det_before_inference(max_det):
+    model = _bare_model()
+
+    with pytest.raises(ValueError, match="integer >= 1"):
+        model.predict(Image.new("RGB", (8, 8)), points=[1, 1], max_det=max_det)
+
+
+def test_set_image_and_cache_read_are_one_locked_transaction():
+    model = _bare_model()
+    model._clear_image_state()
+    model._image = Image.new("RGB", (4, 4), color="red")
+    model._image_embeddings = "red-embedding"
+
+    encode_started = threading.Event()
+    allow_encode = threading.Event()
+    read_started = threading.Event()
+    observed = {}
+
+    def encode(image, **kwargs):
+        encode_started.set()
+        assert allow_encode.wait(timeout=2)
+        return {"embedding": f"{image.getpixel((0, 0))}-embedding"}
+
+    model._encode = encode
+    model._image_embeddings_from_encoding = lambda enc: enc["embedding"]
+    new_image = Image.new("RGB", (4, 4), color="blue")
+
+    setter = threading.Thread(target=model.set_image, args=(new_image,))
+    setter.start()
+    assert encode_started.wait(timeout=2)
+
+    def read_cache():
+        read_started.set()
+        observed["state"] = model._resolve_image(None, "auto")
+
+    reader = threading.Thread(target=read_cache)
+    reader.start()
+    assert read_started.wait(timeout=2)
+    reader.join(timeout=0.05)
+    assert reader.is_alive(), "cache read escaped while set_image held the session lock"
+
+    allow_encode.set()
+    setter.join(timeout=2)
+    reader.join(timeout=2)
+    assert not setter.is_alive()
+    assert not reader.is_alive()
+
+    image, path, embedding = observed["state"]
+    assert image.getpixel((0, 0)) == (0, 0, 255)
+    assert path is None
+    assert embedding == "(0, 0, 255)-embedding"
 
 
 class TestFactoryAliases:

--- a/tests/unit/test_sam_prompts.py
+++ b/tests/unit/test_sam_prompts.py
@@ -8,6 +8,7 @@ from libreyolo.models.sam.prompts import (
     normalize_boxes,
     normalize_labels,
     normalize_points,
+    validate_max_det,
 )
 
 pytestmark = pytest.mark.unit
@@ -56,6 +57,19 @@ class TestNormalizePoints:
         # processor with an opaque numpy error; reject it up front.
         with pytest.raises(ValueError, match="same number of points"):
             normalize_points([[[400, 370]], [[500, 370], [600, 370]]])
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), "x", True])
+    def test_nonfinite_or_nonnumeric_coordinates_raise(self, value):
+        with pytest.raises(ValueError, match="finite numbers"):
+            normalize_points([value, 1])
+
+    @pytest.mark.parametrize("point", [[-1, 2], [10, 2], [2, -1], [2, 8]])
+    def test_out_of_image_points_raise(self, point):
+        with pytest.raises(ValueError, match="outside image bounds"):
+            normalize_points(point, image_size=(10, 8))
+
+    def test_points_on_last_pixel_are_valid(self):
+        assert normalize_points([9, 7], image_size=(10, 8)) == [[[9.0, 7.0]]]
 
 
 class TestNormalizeLabels:
@@ -135,6 +149,31 @@ class TestNormalizeBoxes:
             [100, 100, 200, 200]
         ]
 
+    @pytest.mark.parametrize(
+        "box",
+        [
+            [4, 1, 2, 5],
+            [1, 4, 5, 2],
+            [1, 1, float("nan"), 5],
+            [1, 1, float("inf"), 5],
+        ],
+    )
+    def test_reversed_or_nonfinite_boxes_raise(self, box):
+        with pytest.raises(ValueError):
+            normalize_boxes(box)
+
+    @pytest.mark.parametrize(
+        "box", [[-1, 0, 5, 5], [0, -1, 5, 5], [0, 0, 11, 5], [0, 0, 5, 9]]
+    )
+    def test_out_of_image_boxes_raise(self, box):
+        with pytest.raises(ValueError, match="outside image bounds"):
+            normalize_boxes(box, image_size=(10, 8))
+
+    def test_full_image_box_is_valid(self):
+        assert normalize_boxes([0, 0, 10, 8], image_size=(10, 8)) == [
+            [0.0, 0.0, 10.0, 8.0]
+        ]
+
 
 class TestBuildPointGrid:
     def test_count(self):
@@ -153,3 +192,13 @@ class TestBuildPointGrid:
     def test_invalid_raises(self):
         with pytest.raises(ValueError):
             build_point_grid(0)
+
+
+@pytest.mark.parametrize("value", [-1, 0, 1.5, True, "3"])
+def test_validate_max_det_rejects_nonpositive_or_noninteger_values(value):
+    with pytest.raises(ValueError, match="integer >= 1"):
+        validate_max_det(value)
+
+
+def test_validate_max_det_accepts_positive_integer():
+    assert validate_max_det(np.int64(3)) == 3

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -100,6 +100,11 @@ class TestTrackConfig:
         with pytest.raises(ValueError, match="minimum_consecutive_frames must be >= 1"):
             TrackConfig(minimum_consecutive_frames=0)
 
+    @pytest.mark.parametrize("field", ["frame_rate", "track_buffer"])
+    def test_rejects_nan_for_one_sided_numeric_fields(self, field):
+        with pytest.raises(ValueError, match=rf"{field} must be finite"):
+            TrackConfig(**{field: float("nan")})
+
 
 # --------------------------------------------------------------------------
 # KalmanFilter

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -105,6 +105,14 @@ class TestTrackConfig:
         with pytest.raises(ValueError, match=rf"{field} must be finite"):
             TrackConfig(**{field: float("nan")})
 
+    @pytest.mark.parametrize(
+        "field", ["frame_rate", "track_buffer", "minimum_consecutive_frames"]
+    )
+    @pytest.mark.parametrize("value", [1.5, True])
+    def test_rejects_noninteger_frame_and_count_fields(self, field, value):
+        with pytest.raises(ValueError, match=rf"{field} must be an integer"):
+            TrackConfig(**{field: value})
+
 
 # --------------------------------------------------------------------------
 # KalmanFilter

--- a/tests/unit/test_vlm_api.py
+++ b/tests/unit/test_vlm_api.py
@@ -43,6 +43,11 @@ class TestSetClasses:
         with pytest.raises(ValueError):
             m.set_classes([])
 
+    def test_blank_label_raises(self):
+        m = _bare_model()
+        with pytest.raises(ValueError, match="must not be blank"):
+            m.set_classes(["person", "   "])
+
     def test_string_or_scalar_raises(self):
         # A bare string would enumerate into one-character classes; reject it.
         m = _bare_model()
@@ -377,6 +382,66 @@ class TestOverrideConfThreshold:
         det = self._kosmos()._postprocess(None, 1.5, 0.5, (100, 100))
         assert det["num_detections"] == 0
 
+    def test_florence_validates_clips_and_suppresses_boxes(self):
+        from libreyolo.models.vlm.florence2 import LibreFlorence2
+
+        m = object.__new__(LibreFlorence2)
+        m._name_to_id = {"boat": 0}
+        m.processor = _StubProc(
+            {
+                LibreFlorence2.TASK: {
+                    "bboxes": [
+                        [float("nan"), 0, 5, 5],
+                        [float("inf"), 0, 5, 5],
+                        [-4, -3, 12, 12],
+                        [0, 0, 11, 11],
+                        [15, 15, 30, 30],
+                        [9, 9, 2, 2],
+                        [1, 2, 3],
+                    ],
+                    "bboxes_labels": ["boat"] * 7,
+                }
+            }
+        )
+
+        det = m._postprocess(None, 0.0, 0.5, (20, 20))
+
+        assert det == {
+            "boxes": [[0.0, 0.0, 12.0, 12.0], [15.0, 15.0, 20.0, 20.0]],
+            "scores": [1.0, 1.0],
+            "classes": [0, 0],
+            "num_detections": 2,
+        }
+
+    def test_kosmos_validates_shape_and_applies_nms(self):
+        m = self._kosmos()
+        m.processor = _StubProc(
+            (
+                "boats",
+                [
+                    (
+                        "boat",
+                        (0, 5),
+                        [
+                            [0.1, 0.1, 0.5, 0.5],
+                            [0.11, 0.11, 0.51, 0.51],
+                            [float("nan"), 0.0, 1.0, 1.0],
+                            [0.8, 0.8, 1.2, 1.2],
+                            [0.1, 0.2, 0.3],
+                        ],
+                    )
+                ],
+            )
+        )
+
+        det = m._postprocess(None, 0.0, 0.5, (100, 80))
+
+        assert det["boxes"] == [
+            [10.0, 8.0, 50.0, 40.0],
+            [80.0, 64.0, 100.0, 80.0],
+        ]
+        assert det["num_detections"] == 2
+
 
 class TestKosmosMatchLabel:
     """Kosmos-2's lenient noun-phrase to vocabulary matching (pure, offline)."""
@@ -394,6 +459,10 @@ class TestKosmosMatchLabel:
     def test_lenient_plural_phrase(self):
         # Kosmos grounds noun phrases ("the boats"); lenient substring still maps.
         assert self._kosmos(["boat"])._match_label("the boats") == 0
+
+    def test_longest_match_wins_independently_of_vocabulary_order(self):
+        assert self._kosmos(["car", "red car"])._match_label("the red car") == 1
+        assert self._kosmos(["red car", "car"])._match_label("the red car") == 0
 
     def test_out_of_vocab_returns_none(self):
         assert self._kosmos(["boat"])._match_label("airplane") is None

--- a/tests/unit/test_vlm_api.py
+++ b/tests/unit/test_vlm_api.py
@@ -460,6 +460,9 @@ class TestKosmosMatchLabel:
         # Kosmos grounds noun phrases ("the boats"); lenient substring still maps.
         assert self._kosmos(["boat"])._match_label("the boats") == 0
 
+    def test_partial_word_does_not_map_to_shorter_class(self):
+        assert self._kosmos(["car"])._match_label("carpet") is None
+
     def test_longest_match_wins_independently_of_vocabulary_order(self):
         assert self._kosmos(["car", "red car"])._match_label("the red car") == 1
         assert self._kosmos(["red car", "car"])._match_label("the red car") == 0

--- a/tests/unit/test_vlm_locateanything.py
+++ b/tests/unit/test_vlm_locateanything.py
@@ -1,6 +1,7 @@
 """Offline tests for the LocateAnything VLM adapter."""
 
 import pytest
+import torch
 from inspect import signature
 
 from libreyolo.models.vlm.locateanything import (
@@ -181,6 +182,24 @@ class TestLocateAnythingPrompt:
         m._custom_prompt = "custom"
 
         assert m._detection_prompt() == "custom"
+
+    def test_prediction_forward_strips_prompt_tokens(self):
+        m = _bare()
+        m._model_dtype = None
+        m.tokenizer = object()
+        m.generation_mode = "hybrid"
+        m.do_sample = False
+        m.verbose = False
+
+        class Model:
+            def generate(self, **kwargs):
+                assert kwargs["input_ids"].tolist() == [[10, 11]]
+                return torch.tensor([[10, 11, 90, 91]])
+
+        m.model = Model()
+        output = m._forward({"input_ids": torch.tensor([[10, 11]])})
+
+        assert output.tolist() == [[90, 91]]
 
 
 class TestLocateAnythingLicenseNotice:

--- a/tests/unit/test_vlm_parsing.py
+++ b/tests/unit/test_vlm_parsing.py
@@ -5,6 +5,7 @@ import pytest
 from libreyolo.models.vlm.parsing import (
     build_detection_dict,
     extract_detections,
+    finalize_detection_dict,
     normalize_bbox,
     resolve_label,
 )
@@ -228,6 +229,16 @@ class TestBuildDetectionDict:
             "classes": [],
             "num_detections": 0,
         }
+
+    def test_exact_duplicate_keeps_highest_score_before_deduplication(self):
+        det = finalize_detection_dict(
+            [[1, 1, 5, 5], [1, 1, 5, 5]],
+            [0.2, 0.9],
+            [0, 0],
+            (10, 10),
+        )
+
+        assert det["scores"] == [0.9]
 
     def test_box_format_xywh(self):
         # x,y,w,h: [0.25,0.25,0.25,0.5] -> xyxy [0.25,0.25,0.5,0.75] -> px

--- a/tests/unit/test_yolo9_e2e.py
+++ b/tests/unit/test_yolo9_e2e.py
@@ -152,6 +152,29 @@ def test_yolo9_e2e_postprocess_topk_no_nms_caps_at_max_det():
     assert (diffs <= 1e-6).all()
 
 
+def test_yolo9_e2e_masks_nan_scores_before_first_topk():
+    from libreyolo.models.yolo9_e2e.utils import postprocess
+
+    predictions = torch.zeros(1, 5, 2)
+    predictions[0, :4, 0] = torch.tensor([10.0, 10.0, 20.0, 20.0])
+    predictions[0, :4, 1] = torch.tensor([30.0, 30.0, 40.0, 40.0])
+    predictions[0, 4, 0] = float("nan")
+    predictions[0, 4, 1] = 0.9
+
+    out = postprocess(
+        {"predictions": predictions},
+        conf_thres=0.25,
+        max_det=1,
+    )
+
+    assert out["num_detections"] == 1
+    torch.testing.assert_close(out["scores"], torch.tensor([0.9]))
+    torch.testing.assert_close(
+        out["boxes"],
+        torch.tensor([[30.0, 30.0, 40.0, 40.0]]),
+    )
+
+
 def test_yolo9_e2e_postprocess_defaults_to_letterbox_inverse():
     """E2E predict geometry matches YOLO9 letterboxed inputs."""
     from libreyolo.models.yolo9_e2e.utils import postprocess

--- a/tests/unit/test_yolo9_e2e.py
+++ b/tests/unit/test_yolo9_e2e.py
@@ -175,6 +175,31 @@ def test_yolo9_e2e_masks_nan_scores_before_first_topk():
     )
 
 
+def test_yolo9_e2e_masks_nonfinite_boxes_before_first_topk():
+    from libreyolo.models.yolo9_e2e.utils import postprocess
+
+    predictions = torch.zeros(1, 5, 2)
+    predictions[0, :4, 0] = torch.tensor(
+        [float("nan"), 10.0, 20.0, 20.0]
+    )
+    predictions[0, :4, 1] = torch.tensor([30.0, 30.0, 40.0, 40.0])
+    predictions[0, 4, 0] = 0.99
+    predictions[0, 4, 1] = 0.9
+
+    out = postprocess(
+        {"predictions": predictions},
+        conf_thres=0.25,
+        max_det=1,
+    )
+
+    assert out["num_detections"] == 1
+    torch.testing.assert_close(out["scores"], torch.tensor([0.9]))
+    torch.testing.assert_close(
+        out["boxes"],
+        torch.tensor([[30.0, 30.0, 40.0, 40.0]]),
+    )
+
+
 def test_yolo9_e2e_postprocess_defaults_to_letterbox_inverse():
     """E2E predict geometry matches YOLO9 letterboxed inputs."""
     from libreyolo.models.yolo9_e2e.utils import postprocess

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -40,11 +40,20 @@ project the weights were derived from. Per-family summary:
              The authors' MIT re-release, not WongKinYiu/yolov7 (GPL-3.0).
              Convert v7.pt with weights/convert_yolo7_weights.py.
 
-    RF-DETR  (LibreRFDETR{n,s,m,l}, LibreRFDETRx-pose) Apache-2.0
+    RF-DETR  (LibreRFDETR{n,s,m,l},                    Apache-2.0
+              LibreRFDETR{n,s,m,l,x,xx}-seg,
+              LibreRFDETRx-pose)
              upstream: roboflow/rf-detr
              code/pose revision: 779e55254ccfbffc8cc23b7ecee29a4201489e13
              (tag 1.8.0)
              (backbone: facebookresearch/dinov2, Apache-2.0)
+
+    RF-DETR OBB (LibreRFDETR{n,s,m,l}-obb)              CC-BY-4.0
+             initialized from the Apache-2.0 RF-DETR detection weights;
+             fine-tuned by LibreYOLO on Roboflow Universe dataset
+             bobo-48pem/my-first-project-ewwrm ("My First Project - v8"),
+             whose published license is CC BY 4.0. The hosted fine-tuned
+             weights preserve that attribution requirement.
 
     RT-DETR  (LibreRTDETR{r18,r34,r50,r50m,r101})      Apache-2.0
              upstream: lyuwenyu/RT-DETR

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -40,8 +40,10 @@ project the weights were derived from. Per-family summary:
              The authors' MIT re-release, not WongKinYiu/yolov7 (GPL-3.0).
              Convert v7.pt with weights/convert_yolo7_weights.py.
 
-    RF-DETR  (LibreRFDETR{n,s,m,l})                    Apache-2.0
+    RF-DETR  (LibreRFDETR{n,s,m,l}, LibreRFDETRx-pose) Apache-2.0
              upstream: roboflow/rf-detr
+             code/pose revision: 779e55254ccfbffc8cc23b7ecee29a4201489e13
+             (tag 1.8.0)
              (backbone: facebookresearch/dinov2, Apache-2.0)
 
     RT-DETR  (LibreRTDETR{r18,r34,r50,r50m,r101})      Apache-2.0


### PR DESCRIPTION
# What does this PR do?

Fixes task-specific model and validation-contract findings tracked in #591.

- Corrects RF-DETR pose/GroupPose filtering, confidence, invisible-keypoint losses, mode restoration, device-safe state, and OBB matching.
- Applies consistent bounds, NMS, prompt, query, and max-detection contracts across ensembles, open-vocabulary models, VLMs, SAM, and tracking.
- Serializes SAM image-cache operations so prompts cannot use embeddings from another concurrent image.
- Restores PPOCR checkpoint, charset, crop, ignore-region, transcript matching, and assignment contracts.
- Corrects EoMT panoptic geometry, FOMO/point/OBB matching, matte metrics, and NAFNet validation/pooling behavior.
- Validates tracking configuration and masks invalid YOLO9-E2E scores before ranking.

# Provenance declaration (required)

## Code provenance

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
| `libreyolo/models/rfdetr/keypoints.py`, `transformer.py`, `model.py`, `trainer.py` | https://github.com/roboflow/rf-detr | `779e55254ccfbffc8cc23b7ecee29a4201489e13` (tag `1.8.0`) | Apache-2.0 |
| `libreyolo/models/rfdetr/loss.py`, `matcher.py` | https://github.com/roboflow/rf-detr | `779e55254ccfbffc8cc23b7ecee29a4201489e13` (tag `1.8.0`) | Apache-2.0 |
| `libreyolo/postprocess/rfdetr.py` | https://github.com/roboflow/rf-detr | `779e55254ccfbffc8cc23b7ecee29a4201489e13` (tag `1.8.0`) | Apache-2.0 |
| `libreyolo/training/lora.py` | https://github.com/roboflow/rf-detr | `779e55254ccfbffc8cc23b7ecee29a4201489e13` (tag `1.8.0`) | Apache-2.0 |
| `libreyolo/data/yolo_coco_api.py` | https://github.com/roboflow/rf-detr | `779e55254ccfbffc8cc23b7ecee29a4201489e13` (tag `1.8.0`) | Apache-2.0 |

All remaining changes are original bug fixes to existing LibreYOLO integrations; no third-party code was copied or adapted for those changes.

# How was this tested?

- Task-specific regression suite: 960 passed, 4 skipped.
- Export/backend predecessor regression suite: 533 passed, 3 skipped.
- YOLO9 and RF-DETR flagship anchors: 171 passed.
- Exact hermetic combined-stack PR gate: 4,585 passed, 36 skipped, 60 deselected, 4 expected failures.
- Rebased combined-tree changed-area selection after review fixes: 977 passed, 4 skipped, 1 deselected.
- Ensemble/shared predict-contract regression selection: 117 passed.
- Greptile GroupPose non-finite-keypoint finding fixed for native and exported runtimes; RF-DETR pose/backend regression selection: 136 passed.
- Ruff and `git diff --check`: clean.
- GitHub unit and install-smoke workflows will be dispatched for the exact rewritten head before merge.
