### PR TITLE
Harden LibreLabel and training UI integrity

### DIFF
--- a/docs/training_loggers.md
+++ b/docs/training_loggers.md
@@ -123,6 +123,13 @@ alongside the family artifact writer. `status.json` is the cheap read for a
 polling agent (a few tokens vs. re-parsing a log); the atomic write means a
 reader never observes a half-written file.
 
+`status.json` schema version 2 uses zero-based `current_epoch` and `best_epoch`
+indices, while `completed_epochs` is the absolute number of completed epochs
+and `progress` is bounded to `[0, 1]`. Public callback events and the `epoch`
+column in `metrics.jsonl`/`results.csv` remain one-based. Monitor clients should
+prefer `completed_epochs` for progress and use `schema_version` when reading
+older status files.
+
 ### Live web dashboard
 
 ```bash

--- a/libreyolo/cli/commands/label.py
+++ b/libreyolo/cli/commands/label.py
@@ -39,17 +39,18 @@ def label_cmd(
     """
     out = OutputHandler(json_mode=json_output, quiet=quiet)
 
-    from libreyolo.label.server import _lan_ip, serve
+    from libreyolo.label.server import _lan_ip, _lan_url_host, serve
 
     bind_host = "0.0.0.0" if share else host
     if not share and bind_host not in ("127.0.0.1", "::1", "localhost", "0.0.0.0", "::", ""):
-        # A concrete NIC bind makes the host itself indistinguishable from a LAN
-        # client, so EVERY client gets admin (switch/delete projects, run compute).
-        # --share (wildcard bind) is the safe way to let teammates join.
+        # A concrete interface exposes the current project like --share, but it is
+        # an advanced path and may not offer a separate loopback URL. Host-admin
+        # actions remain restricted by the accepted socket's peer address.
         out.progress(
-            "WARNING: binding to a specific interface (host=%s) gives every LAN "
-            "client full admin over projects and files. Prefer --share, which "
-            "keeps admin on this machine." % bind_host
+            "WARNING: binding to a specific interface (host=%s) exposes the open "
+            "project to clients on that interface. Prefer --share for the supported "
+            "LAN workflow; host-admin actions remain limited to this machine."
+            % bind_host
         )
     httpd = None
     url = ""
@@ -84,7 +85,8 @@ def label_cmd(
     # requested `candidate`, so the printed/JSON URLs are reachable.
     bound = httpd.server_address[1]
     shown_url = "http://127.0.0.1:%d" % bound if share else url
-    lan_url = "http://%s:%d" % (_lan_ip(), bound) if share else None
+    lan_host = _lan_url_host(bind_host, _lan_ip()) if share else None
+    lan_url = "http://%s:%d" % (lan_host, bound) if lan_host else None
     share_line = (
         "\n  Teammates on your network: %s" % lan_url if lan_url else ""
     )

--- a/libreyolo/label/boost.py
+++ b/libreyolo/label/boost.py
@@ -40,27 +40,33 @@ class BoostEngine:
         self.engine = engine          # AssistEngine: where the boosted model is registered
         self.boosted_model = None     # in-memory boosted model (usable after a run)
         self._lock = threading.Lock()
+        self._state_lock = threading.Lock()
         self._thread = None
+        self._generation = 0
         self.state: dict = {"state": "idle"}
 
     # -- public surface ----------------------------------------------------
     def status(self) -> dict:
-        return dict(self.state)
+        with self._state_lock:
+            return dict(self.state)
 
     def _running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
-    def _set(self, **kw) -> None:
-        # Atomic reference swap (not in-place mutation) so a concurrent status()
-        # read never sees a half-updated dict.
-        self.state = {**self.state, **kw}
+    def _set_for_run(self, session, generation: int, **kw) -> bool:
+        """Publish worker status only while its project generation is current."""
+        with self._state_lock:
+            if self.session is not session or self._generation != generation:
+                return False
+            self.state = {**self.state, **kw}
+            return True
 
     def on_project_switch(self, session) -> None:
-        """Rebind to a new project. A still-running boost keeps its state and its
-        own (thread-local) temp dir -- we never stomp a live worker to 'idle'."""
-        self.session = session
-        self.boosted_model = None
-        if not self._running():
+        """Rebind to a new project and invalidate every old worker publication."""
+        with self._state_lock:
+            self.session = session
+            self._generation += 1
+            self.boosted_model = None
             self.state = {"state": "idle"}
 
     def start(self, *, epochs: int = 2, imgsz: int = 512, batch: int = 4) -> dict:
@@ -83,10 +89,13 @@ class BoostEngine:
                 return {"started": False, "reason": msg}
             names = list(session.names)   # frozen now: a mid-boost switch can't skew it
             started_session = session     # only publish the result if still on this project
-            self.state = {"state": "running", "phase": "starting", "n": len(images)}
+            with self._state_lock:
+                generation = self._generation
+                self.state = {"state": "running", "phase": "starting", "n": len(images)}
             self._thread = threading.Thread(
                 target=self._run, name="librelabel-boost", daemon=True,
-                args=(images, labels, accepted_cls, names, started_session, epochs, imgsz, batch))
+                args=(images, labels, accepted_cls, names, started_session,
+                      generation, epochs, imgsz, batch))
             self._thread.start()
             return {"started": True, "n": len(images)}
 
@@ -196,7 +205,8 @@ class BoostEngine:
         return hits / total if total else 0.0
 
     # -- background worker -------------------------------------------------
-    def _run(self, images, labels, accepted_cls, names, started_session, epochs, imgsz, batch):
+    def _run(self, images, labels, accepted_cls, names, started_session,
+             generation, epochs, imgsz, batch):
         import shutil
         import tempfile
 
@@ -226,16 +236,27 @@ class BoostEngine:
                     f"download weights automatically -- fetch it once (e.g. "
                     f"`libreyolo predict model={self.model_name} source=...`), then try Boost again.")
 
-            self._set(phase="measuring your model's current agreement")
+            self._set_for_run(
+                started_session, generation,
+                phase="measuring your model's current agreement",
+            )
             base = LibreYOLO(weight, device="cpu")
             base_agree = self._agreement(base, images, accepted_cls, names)
-            self._set(base_agreement=round(base_agree, 3))
+            self._set_for_run(
+                started_session, generation, base_agreement=round(base_agree, 3)
+            )
 
-            self._set(phase="snapshotting your accepted labels")
+            self._set_for_run(
+                started_session, generation,
+                phase="snapshotting your accepted labels",
+            )
             tmp = tempfile.mkdtemp(prefix="librelabel_boost_")
             data_yaml = self._snapshot(tmp, images, labels, names)
 
-            self._set(phase="training the head on your labels (a few minutes)")
+            self._set_for_run(
+                started_session, generation,
+                phase="training the head on your labels (a few minutes)",
+            )
             model = LibreYOLO(weight, device="cpu")
             results = model.train(
                 data=data_yaml, epochs=epochs, batch=batch, imgsz=imgsz,
@@ -246,7 +267,9 @@ class BoostEngine:
             if not ckpt:
                 raise RuntimeError("training produced no checkpoint")
 
-            self._set(phase="measuring the boosted model")
+            self._set_for_run(
+                started_session, generation, phase="measuring the boosted model"
+            )
             boosted = LibreYOLO(ckpt, device="cpu")
             boost_agree = self._agreement(boosted, images, accepted_cls, names)
 
@@ -255,24 +278,33 @@ class BoostEngine:
             # under "boosted" so prelabel/auto-label/Radar can use it (the flywheel
             # actually turning -- not just a number).
             usable = False
-            if self.engine is not None:
-                try:
-                    with self.engine._lock:
-                        if self.session is started_session:   # discard if switched away mid-train
-                            self.engine._models["boosted"] = boosted
-                            self.boosted_model = boosted
-                            usable = True
-                except Exception:  # noqa: BLE001
-                    logger.exception("could not register the boosted model")
-
-            self.state = {"state": "done", "n": len(images),
+            done_state = {"state": "done", "n": len(images),
                           "base_agreement": round(base_agree, 3),
                           "boosted_agreement": round(boost_agree, 3),
                           "delta": round(boost_agree - base_agree, 3),
-                          "epochs": epochs, "usable": usable}
+                          "epochs": epochs, "usable": False}
+            if self.engine is not None:
+                try:
+                    with self.engine._lock:
+                        with self._state_lock:
+                            if (self.session is started_session
+                                    and self._generation == generation):
+                                self.engine._models["boosted"] = boosted
+                                self.boosted_model = boosted
+                                usable = True
+                                self.state = {**done_state, "usable": True}
+                except Exception:  # noqa: BLE001
+                    logger.exception("could not register the boosted model")
+                if not usable:
+                    self._set_for_run(started_session, generation, **done_state)
+            else:
+                self._set_for_run(started_session, generation, **done_state)
         except Exception as exc:  # noqa: BLE001 - surface as a chip, never crash the server
             logger.exception("boost failed")
-            self.state = {"state": "error", "error": str(exc)}
+            with self._state_lock:
+                if (self.session is started_session
+                        and self._generation == generation):
+                    self.state = {"state": "error", "error": str(exc)}
         finally:
             # Restore the process-wide thread count: set_num_threads() is global,
             # so without this each boost run permanently shrinks the pool for later

--- a/libreyolo/label/dataset.py
+++ b/libreyolo/label/dataset.py
@@ -9,12 +9,12 @@ them. No database; the filesystem dataset is the store.
 from __future__ import annotations
 
 import hashlib
+import errno
 import json
 import math
 import os
 import random
 import re
-import shutil
 import stat
 import tempfile
 import threading
@@ -47,13 +47,34 @@ _SIDECAR_LOCK = threading.RLock()
 
 
 def _path_identity(path) -> str:
-    """Canonical, case-folded identity for cross-platform dataset paths."""
+    """Canonical identity using the current platform's path case semantics."""
     value = Path(path).expanduser()
     try:
         value = value.resolve(strict=False)
     except (OSError, RuntimeError):
         value = Path(os.path.abspath(os.path.normpath(str(value))))
-    return os.path.normcase(str(value)).casefold()
+    return os.path.normcase(str(value))
+
+
+def _portable_path_identity(path) -> str:
+    """Case-folded identity for locks and portable collision detection."""
+    return _path_identity(path).casefold()
+
+
+def _windows_handle_identity_matches(
+    expected: Tuple[int, int], observed: Tuple[int, int]
+) -> bool:
+    """Compare CPython stat identity with the full Windows handle identity."""
+    expected_volume, expected_file = expected
+    observed_volume, observed_file = observed
+    if expected_file != observed_file:
+        return False
+    # CPython 3.10 exposes the legacy 32-bit Windows volume serial in st_dev;
+    # newer CPython exposes the 64-bit FileIdInfo value used by the handle API.
+    return expected_volume == observed_volume or (
+        0 <= expected_volume <= 0xFFFFFFFF
+        and expected_volume == observed_volume & 0xFFFFFFFF
+    )
 
 
 @contextmanager
@@ -61,7 +82,9 @@ def _interprocess_path_lock(path: Path, *, namespace: str = "librelabel-locks"):
     """Serialize one canonical filesystem target across LibreLabel processes."""
     lock_root = Path(tempfile.gettempdir()) / namespace
     lock_root.mkdir(parents=True, exist_ok=True)
-    identity = _path_identity(path).encode("utf-8")
+    # Preserve the historical case-folded namespace so older LibreLabel
+    # processes and case-insensitive filesystems lock the same target.
+    identity = _portable_path_identity(path).encode("utf-8")
     lock_path = lock_root / (hashlib.sha256(identity).hexdigest() + ".lock")
     with open(lock_path, "a+b") as handle:
         if os.name == "nt":
@@ -342,6 +365,319 @@ def _is_link_or_reparse_point(path: Path) -> bool:
     )
 
 
+def _validated_project_root(
+    lexical_root: Path,
+    *,
+    expected: Optional[Tuple[str, Tuple[int, int]]] = None,
+) -> Tuple[Path, Tuple[str, Tuple[int, int]]]:
+    """Resolve a non-linked project root and capture its filesystem identity."""
+    if any(
+        _is_link_or_reparse_point(path)
+        for path in reversed([lexical_root, *lexical_root.parents])
+    ):
+        raise ValueError(
+            "Refusing to trash a project opened through a directory link; "
+            "reopen its real path first."
+        )
+    try:
+        canonical = lexical_root.resolve(strict=True)
+        info = canonical.stat()
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("The project path changed during trash validation.") from exc
+    if not stat.S_ISDIR(info.st_mode) or _is_link_or_reparse_point(canonical):
+        raise ValueError("The project path changed during trash validation.")
+    snapshot = (
+        os.path.normcase(str(canonical)),
+        (int(info.st_dev), int(info.st_ino)),
+    )
+    if expected is not None and snapshot != expected:
+        raise ValueError("The project path changed during trash validation.")
+    return canonical, snapshot
+
+
+def _move_validated_project_root(
+    source: Path,
+    dest: Path,
+    expected: Tuple[str, Tuple[int, int]],
+    expected_trash_identity: Tuple[int, int],
+) -> None:
+    """Move the validated directory without resolving its source path again."""
+    if os.name == "nt":
+        _move_validated_project_root_windows(
+            source, dest, expected[1], expected_trash_identity
+        )
+    else:
+        _move_validated_project_root_posix(
+            source, dest, expected[1], expected_trash_identity
+        )
+
+
+def _move_validated_project_root_posix(
+    source: Path,
+    dest: Path,
+    expected_identity: Tuple[int, int],
+    expected_trash_identity: Tuple[int, int],
+) -> None:
+    """Rename through held directory descriptors so ancestor swaps cannot redirect it."""
+    if os.rename not in os.supports_dir_fd:
+        raise OSError("Safe directory-relative rename is unavailable on this platform.")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+
+    def open_directory_strict(path: Path) -> int:
+        absolute = Path(os.path.abspath(os.fspath(path)))
+        descriptor = os.open(absolute.anchor or os.sep, flags | nofollow)
+        try:
+            for component in absolute.parts[1:]:
+                child = os.open(component, flags | nofollow, dir_fd=descriptor)
+                os.close(descriptor)
+                descriptor = child
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    descriptors = []
+    try:
+        parent_fd = open_directory_strict(source.parent)
+        descriptors.append(parent_fd)
+        root_fd = os.open(source.name, flags | nofollow, dir_fd=parent_fd)
+        descriptors.append(root_fd)
+        trash_fd = open_directory_strict(dest.parent)
+        descriptors.append(trash_fd)
+        root_info = os.fstat(root_fd)
+        entry_info = os.stat(source.name, dir_fd=parent_fd, follow_symlinks=False)
+        trash_info = os.fstat(trash_fd)
+        root_identity = (int(root_info.st_dev), int(root_info.st_ino))
+        entry_identity = (int(entry_info.st_dev), int(entry_info.st_ino))
+        if (
+            root_identity != expected_identity
+            or entry_identity != expected_identity
+            or not stat.S_ISDIR(root_info.st_mode)
+            or not stat.S_ISDIR(entry_info.st_mode)
+        ):
+            raise ValueError("The project path changed before it could be trashed.")
+        trash_identity = (int(trash_info.st_dev), int(trash_info.st_ino))
+        if trash_identity != expected_trash_identity:
+            raise ValueError("The trash directory changed before the project could be moved.")
+        if trash_identity[0] != expected_identity[0]:
+            raise ValueError(
+                "Cannot safely trash a project across filesystem boundaries; "
+                "move it manually instead."
+            )
+        try:
+            os.stat(dest.name, dir_fd=trash_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(f"Trash destination already exists: {dest}")
+        try:
+            os.rename(
+                source.name,
+                dest.name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=trash_fd,
+            )
+        except OSError as exc:
+            if exc.errno == errno.EXDEV:
+                raise ValueError(
+                    "Cannot safely trash a project across filesystem boundaries; "
+                    "move it manually instead."
+                ) from exc
+            raise
+        moved_fd = os.open(dest.name, flags | nofollow, dir_fd=trash_fd)
+        descriptors.append(moved_fd)
+        moved_info = os.fstat(moved_fd)
+        moved_identity = (int(moved_info.st_dev), int(moved_info.st_ino))
+        if moved_identity != expected_identity:
+            raise RuntimeError(
+                "The project changed during trash; an unexpected directory was "
+                f"quarantined at {dest}."
+            )
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _move_validated_project_root_windows(
+    source: Path,
+    dest: Path,
+    expected_identity: Tuple[int, int],
+    expected_trash_identity: Tuple[int, int],
+) -> None:
+    """Rename the exact validated Windows directory through its open handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    class _FileId128(ctypes.Structure):
+        _fields_ = [("identifier", ctypes.c_ubyte * 16)]
+
+    class _FileIdInfo(ctypes.Structure):
+        _fields_ = [
+            ("volume_serial_number", ctypes.c_ulonglong),
+            ("file_id", _FileId128),
+        ]
+
+    class _FileAttributeTagInfo(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("reparse_tag", wintypes.DWORD),
+        ]
+
+    class _FileRenameHeader(ctypes.Structure):
+        _fields_ = [
+            ("replace_if_exists", wintypes.DWORD),
+            ("root_directory", wintypes.HANDLE),
+            ("file_name_length", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    get_info = kernel32.GetFileInformationByHandleEx
+    get_info.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    get_info.restype = wintypes.BOOL
+    set_info = kernel32.SetFileInformationByHandle
+    set_info.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    set_info.restype = wintypes.BOOL
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    delete_access = 0x00010000
+    read_attributes = 0x00000080
+    share_read = 0x00000001
+    share_write = 0x00000002
+    open_existing = 3
+    backup_semantics = 0x02000000
+    open_reparse_point = 0x00200000
+    file_attribute_directory = 0x00000010
+    file_attribute_reparse_point = 0x00000400
+    file_attribute_tag_info = 9
+    file_rename_info = 3
+    file_id_info = 18
+    invalid_handle = ctypes.c_void_p(-1).value
+
+    def extended_path(path: Path) -> str:
+        value = os.path.abspath(os.fspath(path))
+        if value.startswith("\\\\?\\"):
+            return value
+        if value.startswith("\\\\"):
+            return "\\\\?\\UNC\\" + value[2:]
+        return "\\\\?\\" + value
+
+    def open_directory(path: Path, access: int):
+        opened = create_file(
+            extended_path(path),
+            access,
+            share_read | share_write,
+            None,
+            open_existing,
+            backup_semantics | open_reparse_point,
+            None,
+        )
+        if opened == invalid_handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        return opened
+
+    def directory_identity(opened, *, message: str) -> Tuple[int, int]:
+        identity = _FileIdInfo()
+        if not get_info(
+            opened,
+            file_id_info,
+            ctypes.byref(identity),
+            ctypes.sizeof(identity),
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        attributes = _FileAttributeTagInfo()
+        if not get_info(
+            opened,
+            file_attribute_tag_info,
+            ctypes.byref(attributes),
+            ctypes.sizeof(attributes),
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        if (
+            not attributes.file_attributes & file_attribute_directory
+            or attributes.file_attributes & file_attribute_reparse_point
+        ):
+            raise ValueError(message)
+        return (
+            int(identity.volume_serial_number),
+            int.from_bytes(bytes(identity.file_id.identifier), "little"),
+        )
+
+    source_handle = open_directory(source, delete_access | read_attributes)
+    trash_handle = None
+    try:
+        handle_identity = directory_identity(
+            source_handle,
+            message="The project path changed before it could be trashed.",
+        )
+        if not _windows_handle_identity_matches(expected_identity, handle_identity):
+            raise ValueError("The project path changed before it could be trashed.")
+        trash_handle = open_directory(dest.parent, read_attributes)
+        trash_identity = directory_identity(
+            trash_handle,
+            message="The trash directory changed before the project could be moved.",
+        )
+        if not _windows_handle_identity_matches(
+            expected_trash_identity, trash_identity
+        ):
+            raise ValueError("The trash directory changed before the project could be moved.")
+        if trash_identity[0] != handle_identity[0]:
+            raise ValueError(
+                "Cannot safely trash a project across filesystem boundaries; "
+                "move it manually instead."
+            )
+
+        encoded_dest = extended_path(dest).encode("utf-16-le")
+        name_offset = (
+            _FileRenameHeader.file_name_length.offset + ctypes.sizeof(wintypes.DWORD)
+        )
+        buffer = ctypes.create_string_buffer(name_offset + len(encoded_dest) + 2)
+        header = _FileRenameHeader.from_buffer(buffer)
+        header.replace_if_exists = 0
+        header.root_directory = None
+        header.file_name_length = len(encoded_dest)
+        ctypes.memmove(
+            ctypes.addressof(buffer) + name_offset,
+            encoded_dest,
+            len(encoded_dest),
+        )
+        if not set_info(source_handle, file_rename_info, buffer, len(buffer)):
+            error = ctypes.get_last_error()
+            if error == 17:
+                raise ValueError(
+                    "Cannot safely trash a project across filesystem boundaries; "
+                    "move it manually instead."
+                )
+            raise ctypes.WinError(error)
+    finally:
+        if trash_handle is not None:
+            close_handle(trash_handle)
+        close_handle(source_handle)
+
+
 def set_sidecar_name(data: str, name: str) -> str:
     """Update (or create) the project display name in the ``librelabel.json``
     sidecar next to ``data.yaml``. Returns the project root path."""
@@ -366,18 +702,19 @@ def update_sidecar(data: str, **fields) -> str:
 def trash_project(data: str) -> str:
     """Soft-delete a project: move its whole folder to ``~/.librelabel/trash/``
     (recoverable) rather than erasing anything. Returns the trash path."""
+    requested = Path(data).expanduser()
+    if requested.suffix.lower() in (".yaml", ".yml") and _is_link_or_reparse_point(
+        requested
+    ):
+        raise ValueError(
+            "Refusing to trash a project opened through a filesystem link; "
+            "reopen its real path first."
+        )
     root = _project_root(data)
     if not root.is_dir():
         raise FileNotFoundError(f"Not a folder: {root}")
-    if _is_link_or_reparse_point(root):
-        raise ValueError(
-            "Refusing to trash a project opened through a directory link; "
-            "reopen its real path first."
-        )
-    try:
-        canonical = root.resolve(strict=True)
-    except (OSError, RuntimeError):
-        canonical = Path(os.path.abspath(str(root)))
+    lexical_root = Path(os.path.abspath(str(root.expanduser())))
+    canonical, snapshot = _validated_project_root(lexical_root)
     anchor = Path(canonical.anchor)
     home = Path.home().resolve(strict=False)
     registry = (home / ".librelabel").resolve(strict=False)
@@ -389,15 +726,17 @@ def trash_project(data: str) -> str:
         or registry.is_relative_to(canonical)
     ):
         raise ValueError("Refusing to trash a filesystem, home, or LibreLabel root.")
-    trash = Path.home() / ".librelabel" / "trash"
-    trash.mkdir(parents=True, exist_ok=True)
-    trash = trash.resolve(strict=True)
+    trash_root = Path.home() / ".librelabel" / "trash"
+    trash_root.mkdir(parents=True, exist_ok=True)
+    trash_lexical = Path(os.path.abspath(str(trash_root.expanduser())))
+    trash, trash_snapshot = _validated_project_root(trash_lexical)
     if canonical == trash or canonical.is_relative_to(trash):
         raise ValueError("This project is already inside LibreLabel's trash.")
     dest = trash / (
-        f"{time.time_ns()}-{uuid.uuid4().hex[:12]}-{root.name or 'dataset'}"
+        f"{time.time_ns()}-{uuid.uuid4().hex}-{root.name or 'dataset'}"
     )
-    shutil.move(str(root), str(dest))
+    canonical, _ = _validated_project_root(lexical_root, expected=snapshot)
+    _move_validated_project_root(canonical, dest, snapshot, trash_snapshot[1])
     return str(dest)
 
 
@@ -640,7 +979,8 @@ class DatasetSession:
         _linked_lab = Path(self.yaml_file).parent / "labels"
 
         self._items: List[Tuple[Path, Path, str]] = []
-        seen: dict = {}                # normalized label path -> normalized image path
+        seen: dict = {}                # native label path -> native image path
+        portable_seen: dict = {}       # portable label path -> native image path
         self._path_splits: dict = {}   # normalized label path -> {splits it appears in}
         label_clash: Optional[Tuple[str, str]] = None   # two DIFFERENT images, one label file
         for split in ("train", "val", "test"):
@@ -651,7 +991,7 @@ class DatasetSession:
             for ip, lp in zip(imgs, labels, strict=True):
                 if self.linked:
                     h = hashlib.sha1(
-                        _path_identity(ip).encode("utf-8")
+                        _portable_path_identity(ip).encode("utf-8")
                     ).hexdigest()[:8]
                     lp = _linked_lab / split / f"{Path(ip).stem}-{h}.txt"
                 # A yaml may reuse a folder across splits; expose each label file
@@ -659,6 +999,7 @@ class DatasetSession:
                 # remember every split it was in, for exact-overlap leakage detection.
                 key = _path_identity(lp)
                 ikey = _path_identity(ip)
+                portable_key = _portable_path_identity(lp)
                 self._path_splits.setdefault(key, set()).add(split)
                 if key in seen:
                     # Same label file again. Same image -> split overlap (leakage,
@@ -668,7 +1009,15 @@ class DatasetSession:
                     if label_clash is None and seen[key] != ikey:
                         label_clash = (Path(seen[key]).name, Path(ip).name)
                     continue
+                portable_image = portable_seen.get(portable_key)
+                if (
+                    label_clash is None
+                    and portable_image is not None
+                    and portable_image != ikey
+                ):
+                    label_clash = (Path(portable_image).name, Path(ip).name)
                 seen[key] = ikey
+                portable_seen.setdefault(portable_key, ikey)
                 self._items.append((Path(ip), Path(lp), split))
 
         # Raw split sources (resolved paths/lists) so the duplicate fixer can

--- a/libreyolo/label/dataset.py
+++ b/libreyolo/label/dataset.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import random
 import re
 import shutil
+import tempfile
+import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -33,6 +37,66 @@ from .labelio import (
     parse_annotations,
     sanitize_annotations,
 )
+
+
+_UPLOAD_LOCK = threading.RLock()
+
+
+def _path_identity(path) -> str:
+    """Canonical, case-folded identity for cross-platform dataset paths."""
+    value = Path(path).expanduser()
+    try:
+        value = value.resolve(strict=False)
+    except (OSError, RuntimeError):
+        value = Path(os.path.abspath(os.path.normpath(str(value))))
+    return os.path.normcase(str(value)).casefold()
+
+
+@contextmanager
+def _interprocess_upload_lock(dst: Path):
+    """Serialize upload/finalize operations for one destination across processes."""
+    lock_root = Path(tempfile.gettempdir()) / "librelabel-upload-locks"
+    lock_root.mkdir(parents=True, exist_ok=True)
+    identity = _path_identity(dst).encode("utf-8")
+    lock_path = lock_root / (hashlib.sha256(identity).hexdigest() + ".lock")
+    with open(lock_path, "a+b") as handle:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _publish_no_clobber(temp_path: Path, target: Path) -> None:
+    """Atomically replace an exclusively-created placeholder with a staged file."""
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    fd = os.open(target, flags, 0o644)
+    os.close(fd)
+    try:
+        os.replace(temp_path, target)
+    except BaseException:
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def _names_to_list(names) -> List[str]:
@@ -60,9 +124,24 @@ def _resolve_data_arg(data: str) -> str:
 
 def _atomic_write_text(path: Path, text: str) -> None:
     """Write via a temp file + ``os.replace`` so a label is never half-written."""
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(text, encoding="utf-8")
-    os.replace(tmp, path)
+    try:
+        mode = path.stat().st_mode & 0o777
+    except FileNotFoundError:
+        mode = 0o644
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def folder_yaml(folder: str) -> Optional[str]:
@@ -119,9 +198,9 @@ def scaffold_data_yaml(folder: str, names: Optional[List[str]] = None,
         "names": classes,
         "nc": len(classes),
     }
-    t = str(task or "").strip().lower()
-    if t and t != "detect":               # detect is the default; only stamp non-default tasks
-        cfg["task"] = t
+    # LibreLabel knows the user's selected authoring task; stamp even detection so
+    # later transforming exports never have to guess an optional schema intent.
+    cfg["task"] = str(task or "detect").strip().lower()
     text = (
         "# LibreLabel project -- created from a folder of images.\n"
         "# Labels are written next to the images, where `libreyolo train` reads them.\n"
@@ -143,7 +222,9 @@ def update_class_names(yaml_file: str, names: List[str]) -> None:
     cfg["names"] = list(names)
     cfg["nc"] = len(names)
     # Keep the leading comment block (LibreLabel project hints) that safe_dump drops.
-    comment = "\n".join(l for l in original.splitlines() if l.lstrip().startswith("#"))
+    comment = "\n".join(
+        line for line in original.splitlines() if line.lstrip().startswith("#")
+    )
     body = yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True)
     _atomic_write_text(p, (comment + "\n\n" + body) if comment else body)
 
@@ -153,9 +234,61 @@ IMG_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".webp", ".tif", ".tiff"}
 
 
 def _write_json_atomic(path: Path, obj) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
-    os.replace(tmp, path)
+    _atomic_write_text(path, json.dumps(obj, indent=2, ensure_ascii=False))
+
+
+def _assert_unique_image_stems(paths, context: str) -> None:
+    """Reject image sets whose derived ``<stem>.txt`` label names collide."""
+    seen = {}
+    for value in paths:
+        path = Path(value)
+        key = path.stem.casefold()
+        if key in seen:
+            raise ValueError(
+                f"{context}: {seen[key].name} and {path.name} share the label basename "
+                f"{path.stem!r}; rename one image before continuing."
+            )
+        seen[key] = path
+
+
+def _move_validation_images(
+    paths: List[Path], val_dir: Path
+) -> Tuple[List[Tuple[Path, Path]], bool]:
+    """Move a planned validation subset, rolling back the whole subset on error."""
+    moved: List[Tuple[Path, Path]] = []
+    created_val_dir = not val_dir.exists()
+    try:
+        val_dir.mkdir(parents=True, exist_ok=True)
+        for src in paths:
+            dest = val_dir / src.name
+            if dest.exists():
+                raise FileExistsError(f"Validation destination already exists: {dest}")
+            os.replace(src, dest)
+            moved.append((src, dest))
+    except BaseException:
+        for src, dest in reversed(moved):
+            if dest.exists() and not src.exists():
+                os.replace(dest, src)
+        if created_val_dir:
+            try:
+                val_dir.rmdir()
+            except OSError:
+                pass
+        raise
+    return moved, created_val_dir
+
+
+def _rollback_validation_images(
+    moved: List[Tuple[Path, Path]], val_dir: Path, *, remove_val_dir: bool
+) -> None:
+    for src, dest in reversed(moved):
+        if dest.exists() and not src.exists():
+            os.replace(dest, src)
+    if remove_val_dir:
+        try:
+            val_dir.rmdir()
+        except OSError:
+            pass
 
 
 def load_sidecar(base: str) -> dict:
@@ -228,19 +361,51 @@ def save_uploaded_image(dst: str, name: str, data: bytes) -> str:
         raise ValueError(f"unsupported file type: {safe}")
     if not data:
         raise ValueError("empty file")
-    if folder_yaml(dst):
-        raise FileExistsError(
-            "That folder is already a dataset (it has a data.yaml) - open it instead, "
-            "or pick an empty folder for the new project.")
-    out_dir = Path(dst) / "images" / "train"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out = out_dir / safe
-    if out.exists():
-        raise FileExistsError(f"{safe} already exists in that folder - not overwriting it.")
-    tmp = out.with_suffix(out.suffix + ".uptmp")
-    tmp.write_bytes(data)
-    os.replace(tmp, out)
-    return str(out)
+    with _UPLOAD_LOCK, _interprocess_upload_lock(Path(dst)):
+        if folder_yaml(dst):
+            raise FileExistsError(
+                "That folder is already a dataset (it has a data.yaml) - open it instead, "
+                "or pick an empty folder for the new project.")
+        out_dir = Path(dst) / "images" / "train"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / safe
+        # Image suffixes disappear when the trainer derives ``<stem>.txt``. Treat
+        # foo.jpg + foo.png as the same occupied label slot, including on
+        # case-sensitive filesystems where the eventual training/export target may
+        # still be case-insensitive.
+        stem_key = out.stem.casefold()
+        if any(
+            p.is_file() and p.suffix.lower() in IMG_EXTS and p.stem.casefold() == stem_key
+            for p in out_dir.iterdir()
+        ):
+            raise FileExistsError(
+                f"An image with label basename {out.stem!r} already exists in that folder - "
+                "not overwriting or sharing its label file."
+            )
+
+        # Publish a fully-written unique temp through an exclusive placeholder and
+        # atomic replacement. This preserves no-clobber semantics on filesystems
+        # that do not support hard links (removable/network/cloud-backed storage).
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".librelabel-upload-", suffix=".tmp", dir=str(out_dir)
+        )
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+            os.chmod(tmp, 0o644)
+            try:
+                _publish_no_clobber(tmp, out)
+            except FileExistsError as exc:
+                raise FileExistsError(
+                    f"{safe} already exists in that folder - not overwriting it."
+                ) from exc
+        finally:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        return str(out)
 
 
 def create_uploaded_project(dst: str, *, name: Optional[str] = None,
@@ -249,6 +414,27 @@ def create_uploaded_project(dst: str, *, name: Optional[str] = None,
                             colors: Optional[List[str]] = None,
                             task: Optional[str] = None,
                             make_val: bool = False, val_frac: float = 0.2) -> str:
+    """Create an uploaded project while excluding concurrent upload requests."""
+    with _UPLOAD_LOCK, _interprocess_upload_lock(Path(dst)):
+        return _create_uploaded_project_locked(
+            dst,
+            name=name,
+            description=description,
+            color=color,
+            classes=classes,
+            colors=colors,
+            task=task,
+            make_val=make_val,
+            val_frac=val_frac,
+        )
+
+
+def _create_uploaded_project_locked(dst: str, *, name: Optional[str] = None,
+                                    description: str = "", color: str = "",
+                                    classes: Optional[List[str]] = None,
+                                    colors: Optional[List[str]] = None,
+                                    task: Optional[str] = None,
+                                    make_val: bool = False, val_frac: float = 0.2) -> str:
     """Turn just-uploaded images (``<dst>/images/train``) into a real LibreYOLO
     dataset: an optional held-out ``val`` split, a ``data.yaml`` the trainer reads
     directly, and a ``librelabel.json`` sidecar (name + per-class colors).
@@ -264,33 +450,49 @@ def create_uploaded_project(dst: str, *, name: Optional[str] = None,
         imgs = []
     if not imgs:
         raise FileNotFoundError("No uploaded images found - add some images first.")
+    _assert_unique_image_stems(imgs, "Uploaded project")
     cls = [str(c).strip() for c in (classes or []) if str(c).strip()]
     cols = list(colors or [])
 
     has_val = False
+    moved: List[Tuple[Path, Path]] = []
+    remove_val_dir = False
+    val_dir = base / "images" / "val"
     if make_val and len(imgs) >= 4:
-        k = max(1, min(len(imgs) - 1, int(round(len(imgs) * float(val_frac)))))
-        val_dir = base / "images" / "val"
-        val_dir.mkdir(parents=True, exist_ok=True)
-        for i in random.Random(1234).sample(range(len(imgs)), k):
-            src = Path(imgs[i])
-            os.replace(src, val_dir / src.name)
+        if val_dir.is_dir() and any(val_dir.iterdir()):
+            raise ValueError(
+                "Validation directory is not empty; use an empty upload folder so "
+                "the wizard cannot merge unrelated images or label stems."
+            )
+        try:
+            fraction = float(val_frac)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("Validation fraction must be a finite number in [0, 1].") from exc
+        if not 0.0 <= fraction <= 1.0 or not math.isfinite(fraction):
+            raise ValueError("Validation fraction must be a finite number in [0, 1].")
+        k = max(1, min(len(imgs) - 1, int(round(len(imgs) * fraction))))
+        selected = [Path(imgs[i]) for i in random.Random(1234).sample(range(len(imgs)), k)]
+        moved, remove_val_dir = _move_validation_images(selected, val_dir)
         has_val = True
 
-    cfg = {"path": base.resolve().as_posix(), "train": "images/train"}
-    if has_val:
-        cfg["val"] = "images/val"
-    cfg["names"] = cls
-    cfg["nc"] = len(cls)
-    t = str(task or "").strip().lower()
-    if t and t != "detect":
-        cfg["task"] = t
-    text = (
-        "# LibreLabel project -- created with the New Project wizard.\n"
-        "# Labels are written next to the images, where `libreyolo train` reads them.\n\n"
-        + yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True)
-    )
-    _atomic_write_text(base / "data.yaml", text)
+    try:
+        cfg = {"path": base.resolve().as_posix(), "train": "images/train"}
+        if has_val:
+            cfg["val"] = "images/val"
+        cfg["names"] = cls
+        cfg["nc"] = len(cls)
+        cfg["task"] = str(task or "detect").strip().lower()
+        text = (
+            "# LibreLabel project -- created with the New Project wizard.\n"
+            "# Labels are written next to the images, where `libreyolo train` reads them.\n\n"
+            + yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True)
+        )
+        _atomic_write_text(base / "data.yaml", text)
+    except BaseException:
+        _rollback_validation_images(
+            moved, val_dir, remove_val_dir=remove_val_dir
+        )
+        raise
 
     sidecar = {
         "name": name or base.name,
@@ -340,9 +542,7 @@ def create_linked_project(src: str, *, name: Optional[str] = None,
     cls = [str(c).strip() for c in (classes or []) if str(c).strip()]
     cfg = {"path": proj.resolve().as_posix(), "train": "images.txt",
            "names": cls, "nc": len(cls)}
-    t = str(task or "").strip().lower()
-    if t and t != "detect":
-        cfg["task"] = t
+    cfg["task"] = str(task or "detect").strip().lower()
     text = (
         "# LibreLabel LINKED project -- the images stay in place, untouched:\n"
         f"#   {srcp.resolve().as_posix()}\n"
@@ -396,14 +596,14 @@ class DatasetSession:
             for ip, lp in zip(imgs, labels, strict=True):
                 if self.linked:
                     h = hashlib.sha1(
-                        os.path.normcase(os.path.normpath(str(ip))).encode("utf-8")
+                        _path_identity(ip).encode("utf-8")
                     ).hexdigest()[:8]
                     lp = _linked_lab / split / f"{Path(ip).stem}-{h}.txt"
                 # A yaml may reuse a folder across splits; expose each label file
                 # once so a single image can't be saved twice under two ids -- but
                 # remember every split it was in, for exact-overlap leakage detection.
-                key = os.path.normcase(os.path.normpath(str(lp)))
-                ikey = os.path.normcase(os.path.normpath(str(ip)))
+                key = _path_identity(lp)
+                ikey = _path_identity(ip)
                 self._path_splits.setdefault(key, set()).add(split)
                 if key in seen:
                     # Same label file again. Same image -> split overlap (leakage,
@@ -422,6 +622,7 @@ class DatasetSession:
             s: cfg.get(s) for s in ("train", "val", "test") if cfg.get(s)
         }
         self.writable, self.reason = self._check_writable()
+        self._label_clash = label_clash is not None
         if self.writable and label_clash:
             self.writable = False
             self.reason = (
@@ -429,25 +630,115 @@ class DatasetSession:
                 f"({label_clash[0]} and {label_clash[1]} share a name): saving one "
                 "would overwrite the other's labels. Rename one and reopen."
             )
+        # Resolve an omitted task only when on-disk geometry makes it unambiguous.
+        # The common schema does not require ``task``; non-quad polygons can only be
+        # segmentation, while a four-corner row remains segment-vs-OBB ambiguous.
+        declared_task = str(cfg.get("task") or "").strip().lower()
+        has_polygon = False
+        has_nonquad_polygon = False
+        for _ip, label_path, _split in self._items:
+            try:
+                annotations = parse_annotations(label_path.read_text(encoding="utf-8"))
+            except (FileNotFoundError, OSError, UnicodeError):
+                continue
+            for annotation in annotations:
+                if annotation.get("type") != "poly":
+                    continue
+                has_polygon = True
+                if len(annotation.get("points") or []) != 8:
+                    has_nonquad_polygon = True
+        inferred_task = "segment" if not declared_task and has_nonquad_polygon else ""
+        task = declared_task or inferred_task
+        self._task_declared_or_inferred = bool(task)
+        self._task_ambiguous = bool(not task and has_polygon)
+        if self.writable and self._task_ambiguous:
+            self.writable = False
+            self.reason = (
+                "Four-corner labels are ambiguous without task: segment or task: "
+                "obb. Declare the task before editing so box and OBB geometry cannot "
+                "be mixed in one dataset."
+            )
+
         # Pose (kpt_shape), semantic-seg (masks_dir) and depth datasets store dense
         # labels LibreLabel can't edit; writing YOLO boxes would pollute them. The
         # `task:` key alone is enough to know -- a depth yaml may omit depths_dir
         # (the loader defaults it), a classify yaml uses no .txt labels at all, and
         # an OBB yaml's 9-field rows are oriented rectangles we'd corrupt if saved as
         # arbitrary polygons -- so treat those tasks as view-only on the task key too.
-        task = str(cfg.get("task") or "").strip().lower()
         self._task = task   # used to disambiguate 4-point (OBB-vs-polygon) rows on read/write
         # obb is editable: its 9-field rows are 4-corner quads that round-trip
         # byte-identically as 4-vertex polygons (see labelio), so LibreLabel can
         # author oriented boxes without corrupting them.
+        native_annotations = any(
+            cfg.get(f"{split}_annotation_file") for split in ("train", "val", "test")
+        )
+        self._native_annotations = bool(native_annotations)
+        unsupported_task = bool(task and task not in ("detect", "segment", "obb"))
+        task_specific_markers = any(
+            key in cfg
+            for key in (
+                "panoptic_dir",
+                "label_mapping",
+                "depth_scale",
+                "depth_mask_suffix",
+                "depth_stem_suffix",
+                "input_dir",
+                "target_dir",
+                "target_stem_suffix",
+                "target_stem_suffixes",
+                "val_mattes",
+                "train_mattes",
+                "mattes_dir",
+                "flip_idx",
+            )
+        ) or ("images" in cfg and "labels" in cfg)
+        root_path = Path(self.root) if self.root else Path(self.yaml_file).parent
+        obvious_paired_layout = (
+            ((root_path / "inputs").is_dir() and (root_path / "targets").is_dir())
+            or (
+                (root_path / "images").is_dir()
+                and any(
+                    (root_path / directory).is_dir()
+                    for directory in (
+                        "depths",
+                        "mattes",
+                        "matte",
+                        "gt",
+                        "masks",
+                        "mask",
+                        "alpha",
+                    )
+                )
+            )
+            or (
+                (root_path / "labels").is_dir()
+                and any((root_path / "labels").glob("*.jsonl"))
+            )
+        )
         dense = (cfg.get("kpt_shape") or cfg.get("masks_dir")
                  or cfg.get("depths_dir") or cfg.get("depth")
-                 or task in ("depth", "classify", "pose"))
-        if self.writable and dense:
+                 or unsupported_task or task_specific_markers
+                 or obvious_paired_layout)
+        # The generic exporter only knows image + YOLO box/polygon pairs. Keep a
+        # separate flag from ``writable``: an ambiguous but ordinary detection
+        # layout can still be copied safely, while dense/task-specific datasets
+        # must never be exported with their masks/keypoints/targets omitted.
+        self._lossy_export = bool(dense or native_annotations)
+        if self.writable and native_annotations:
             self.writable = False
-            self.reason = ("Keypoint / mask / depth / classify dataset: view-only in "
-                           "LibreLabel - it edits boxes and polygons, and saving would drop "
-                           "or corrupt the dense / task-specific labels.")
+            self.reason = (
+                "Native COCO-JSON annotations are view-only in LibreLabel; this "
+                "session does not load or rewrite the JSON and must not create "
+                "parallel empty YOLO labels."
+            )
+        elif self.writable and dense:
+            self.writable = False
+            self.reason = (
+                "Keypoint / mask / depth / restore / task-specific dataset: "
+                "view-only in LibreLabel - it edits detection boxes, segmentation "
+                "polygons, and OBB corners only; saving would create parallel or "
+                "incomplete labels."
+            )
         self._deleted: set = set()  # ids of duplicates removed this session (tombstones)
 
     # -- safety ------------------------------------------------------------
@@ -646,7 +937,7 @@ class DatasetSession:
         dup_groups.sort(key=lambda g: -len(g["ids"]))
         # Exact same label-path listed in >1 split (deduped out of _items, so the
         # dHash pass above can't see it) -- still real train/val leakage.
-        kidx = {os.path.normcase(os.path.normpath(str(self._items[i][1]))): i
+        kidx = {_path_identity(self._items[i][1]): i
                 for i in range(len(self._items)) if i not in self._deleted}
         for key, splits in self._path_splits.items():
             if len(splits) > 1 and key in kidx:
@@ -843,30 +1134,41 @@ class DatasetSession:
         if not lp.exists():
             return [], self.writable   # a read-only session stays inert even for unlabeled images
         text = lp.read_text(encoding="utf-8")
+        annotations = parse_annotations(text)
+        has_boxes = any(a.get("type") == "box" for a in annotations)
+        has_polygons = any(a.get("type") == "poly" for a in annotations)
         # A file is editable only if the whole dataset is writable (a dense/pose/OBB
         # dataset's box-shaped rows are a partial view we must never round-trip) AND
         # the file has no rows a save would silently alter: keypoint/malformed rows,
-        # an out-of-[0,nc) class, or out-of-[0,1] coordinates the sanitizers clamp.
+        # an out-of-[0,nc) class, or out-of-[0,1] coordinates the writer rejects.
         editable = self.writable and not (
             has_unsupported_rows(text)
             or has_out_of_range_rows(text, self.nc)
             or has_out_of_bounds_coords(text)
             or has_degenerate_polygon(text)
             or has_zero_area_box(text)
+            or (self._task == "detect" and has_polygons)
+            or (self._task == "obb" and has_boxes)
             # 4-point rows are OBB-or-polygon-ambiguous only when the dataset declares
             # no task; segment (free polygons) and obb (oriented boxes) both edit them
             or (self._task not in ("segment", "obb") and has_obb_shaped_rows(text)))
-        return parse_annotations(text), editable
+        return annotations, editable
 
     def label_rev(self, idx: int) -> int:
-        """A monotonic revision token for the label file (its mtime in ns, 0 if
-        absent), so a save can detect that another teammate rewrote it meanwhile."""
+        """A content revision token for optimistic label-write concurrency.
+
+        Filesystem timestamps are too coarse on some removable/network filesystems
+        for a compare-and-swap contract.  A fixed digest changes whenever the label
+        bytes change; zero remains the sentinel for an absent file.
+        """
         self._check_index(idx)
         lp = self._items[idx][1]
         try:
-            return lp.stat().st_mtime_ns if lp.exists() else 0
-        except OSError:
+            data = lp.read_bytes()
+        except FileNotFoundError:
             return 0
+        digest = hashlib.blake2b(data, digest_size=8, person=b"LibreLbl").digest()
+        return int.from_bytes(digest, "big") + 1
 
     # -- mutation ----------------------------------------------------------
     def write_label(self, idx: int, annotations: List[dict], expected_rev: Optional[int] = None) -> int:
@@ -899,10 +1201,27 @@ class DatasetSession:
                 raise RuntimeError("This label file has a zero-area (collinear/collapsed) polygon; it is read-only.")
             if has_zero_area_box(existing):
                 raise RuntimeError("This label file has a zero-width/height box; it is read-only.")
+            parsed_existing = parse_annotations(existing)
+            if self._task == "detect" and any(
+                annotation.get("type") == "poly"
+                for annotation in parsed_existing
+            ):
+                raise RuntimeError(
+                    "This detection label file contains polygon rows; it is read-only."
+                )
+            if self._task == "obb" and any(
+                annotation.get("type") == "box"
+                for annotation in parsed_existing
+            ):
+                raise RuntimeError(
+                    "This OBB label file contains axis-aligned box rows; it is read-only."
+                )
             if self._task not in ("segment", "obb") and has_obb_shaped_rows(existing):
                 raise RuntimeError("This label file has 4-point (OBB/quad) rows; without task: segment "
                                    "or task: obb they're ambiguous and kept read-only.")
-        clean = sanitize_annotations(annotations, self.nc)
+        clean = sanitize_annotations(
+            annotations, self.nc, task=self._task or "detect"
+        )
         lp.parent.mkdir(parents=True, exist_ok=True)
         _atomic_write_text(lp, format_annotations(clean))
         return len(clean)

--- a/libreyolo/label/dataset.py
+++ b/libreyolo/label/dataset.py
@@ -40,6 +40,7 @@ from .labelio import (
 
 
 _UPLOAD_LOCK = threading.RLock()
+_LABEL_LOCK = threading.RLock()
 
 
 def _path_identity(path) -> str:
@@ -53,11 +54,11 @@ def _path_identity(path) -> str:
 
 
 @contextmanager
-def _interprocess_upload_lock(dst: Path):
-    """Serialize upload/finalize operations for one destination across processes."""
-    lock_root = Path(tempfile.gettempdir()) / "librelabel-upload-locks"
+def _interprocess_path_lock(path: Path, *, namespace: str = "librelabel-locks"):
+    """Serialize one canonical filesystem target across LibreLabel processes."""
+    lock_root = Path(tempfile.gettempdir()) / namespace
     lock_root.mkdir(parents=True, exist_ok=True)
-    identity = _path_identity(dst).encode("utf-8")
+    identity = _path_identity(path).encode("utf-8")
     lock_path = lock_root / (hashlib.sha256(identity).hexdigest() + ".lock")
     with open(lock_path, "a+b") as handle:
         if os.name == "nt":
@@ -82,6 +83,15 @@ def _interprocess_upload_lock(dst: Path):
                 yield
             finally:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _interprocess_upload_lock(dst: Path):
+    """Serialize upload/finalize operations for one destination across processes."""
+    # Keep the historical namespace so concurrently running older LibreLabel
+    # processes still participate in the same upload/finalization lock.
+    with _interprocess_path_lock(dst, namespace="librelabel-upload-locks"):
+        yield
 
 
 def _publish_no_clobber(temp_path: Path, target: Path) -> None:
@@ -326,10 +336,7 @@ def update_sidecar(data: str, **fields) -> str:
     for k, v in fields.items():
         if v is not None:
             sc[k] = v
-    try:
-        _write_json_atomic(root / "librelabel.json", sc)
-    except OSError:
-        pass
+    _write_json_atomic(root / "librelabel.json", sc)
     return str(root)
 
 
@@ -1131,6 +1138,12 @@ class DatasetSession:
         """
         self._check_index(idx)
         lp = self._items[idx][1]
+        with _LABEL_LOCK, _interprocess_path_lock(lp):
+            return self._read_label_unlocked(idx)
+
+    def _read_label_unlocked(self, idx: int) -> Tuple[List[dict], bool]:
+        """Read one label while the caller owns its canonical filesystem lock."""
+        lp = self._items[idx][1]
         if not lp.exists():
             return [], self.writable   # a read-only session stays inert even for unlabeled images
         text = lp.read_text(encoding="utf-8")
@@ -1154,6 +1167,14 @@ class DatasetSession:
             or (self._task not in ("segment", "obb") and has_obb_shaped_rows(text)))
         return annotations, editable
 
+    def read_label_with_rev(self, idx: int) -> tuple[List[dict], bool, int]:
+        """Return annotations, editability, and one matching content revision."""
+        self._check_index(idx)
+        lp = self._items[idx][1]
+        with _LABEL_LOCK, _interprocess_path_lock(lp):
+            annotations, editable = self._read_label_unlocked(idx)
+            return annotations, editable, self._label_rev_unlocked(idx)
+
     def label_rev(self, idx: int) -> int:
         """A content revision token for optimistic label-write concurrency.
 
@@ -1162,6 +1183,12 @@ class DatasetSession:
         bytes change; zero remains the sentinel for an absent file.
         """
         self._check_index(idx)
+        lp = self._items[idx][1]
+        with _LABEL_LOCK, _interprocess_path_lock(lp):
+            return self._label_rev_unlocked(idx)
+
+    def _label_rev_unlocked(self, idx: int) -> int:
+        """Return a content revision while the caller owns the label lock."""
         lp = self._items[idx][1]
         try:
             data = lp.read_bytes()
@@ -1179,6 +1206,30 @@ class DatasetSession:
         the write is refused so collaborative edits don't clobber each other.
         """
         self._check_index(idx)
+        lp = self._items[idx][1]
+        with _LABEL_LOCK, _interprocess_path_lock(lp):
+            return self._write_label_unlocked(idx, annotations, expected_rev)
+
+    def write_label_with_rev(
+        self,
+        idx: int,
+        annotations: List[dict],
+        expected_rev: Optional[int] = None,
+    ) -> tuple[int, int]:
+        """Atomically compare, write, and return the resulting content revision."""
+        self._check_index(idx)
+        lp = self._items[idx][1]
+        with _LABEL_LOCK, _interprocess_path_lock(lp):
+            count = self._write_label_unlocked(idx, annotations, expected_rev)
+            return count, self._label_rev_unlocked(idx)
+
+    def _write_label_unlocked(
+        self,
+        idx: int,
+        annotations: List[dict],
+        expected_rev: Optional[int],
+    ) -> int:
+        """Validate and write while the caller owns the canonical label lock."""
         if idx in self._deleted:
             # Tombstoned by duplicate/leakage cleanup: a stale client must not be
             # able to recreate a label file for a removed image.
@@ -1186,7 +1237,7 @@ class DatasetSession:
         if not self.writable:
             raise RuntimeError(self.reason)
         lp = self._items[idx][1]
-        if expected_rev is not None and self.label_rev(idx) != expected_rev:
+        if expected_rev is not None and self._label_rev_unlocked(idx) != expected_rev:
             raise RuntimeError("This image was changed by someone else since you opened it; "
                                "reload it before saving so their labels aren't overwritten.")
         if lp.exists():

--- a/libreyolo/label/dataset.py
+++ b/libreyolo/label/dataset.py
@@ -15,9 +15,11 @@ import os
 import random
 import re
 import shutil
+import stat
 import tempfile
 import threading
 import time
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -41,6 +43,7 @@ from .labelio import (
 
 _UPLOAD_LOCK = threading.RLock()
 _LABEL_LOCK = threading.RLock()
+_SIDECAR_LOCK = threading.RLock()
 
 
 def _path_identity(path) -> str:
@@ -317,8 +320,26 @@ def load_sidecar(base: str) -> dict:
 
 def _project_root(data: str) -> Path:
     """The folder LibreLabel treats as a project: the dir holding ``data.yaml``."""
-    p = Path(data)
-    return p.parent if p.is_file() else p
+    p = Path(data).expanduser()
+    if p.is_dir():
+        return p
+    if p.suffix.lower() in (".yaml", ".yml"):
+        if not p.is_file():
+            raise FileNotFoundError(f"Not a dataset YAML: {p}")
+        return p.parent
+    return p
+
+
+def _is_link_or_reparse_point(path: Path) -> bool:
+    """Return whether moving ``path`` would follow an alias to another tree."""
+    try:
+        info = path.lstat()
+    except OSError:
+        return False
+    return path.is_symlink() or bool(
+        getattr(info, "st_file_attributes", 0)
+        & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    )
 
 
 def set_sidecar_name(data: str, name: str) -> str:
@@ -332,11 +353,13 @@ def update_sidecar(data: str, **fields) -> str:
     ``librelabel.json`` sidecar next to ``data.yaml``; ``None`` values are
     ignored. Returns the project root path."""
     root = _project_root(data)
-    sc = load_sidecar(str(root)) or {}
-    for k, v in fields.items():
-        if v is not None:
-            sc[k] = v
-    _write_json_atomic(root / "librelabel.json", sc)
+    sidecar = root / "librelabel.json"
+    with _SIDECAR_LOCK, _interprocess_path_lock(sidecar):
+        sc = load_sidecar(str(root)) or {}
+        for k, v in fields.items():
+            if v is not None:
+                sc[k] = v
+        _write_json_atomic(sidecar, sc)
     return str(root)
 
 
@@ -346,9 +369,34 @@ def trash_project(data: str) -> str:
     root = _project_root(data)
     if not root.is_dir():
         raise FileNotFoundError(f"Not a folder: {root}")
+    if _is_link_or_reparse_point(root):
+        raise ValueError(
+            "Refusing to trash a project opened through a directory link; "
+            "reopen its real path first."
+        )
+    try:
+        canonical = root.resolve(strict=True)
+    except (OSError, RuntimeError):
+        canonical = Path(os.path.abspath(str(root)))
+    anchor = Path(canonical.anchor)
+    home = Path.home().resolve(strict=False)
+    registry = (home / ".librelabel").resolve(strict=False)
+    if (
+        canonical == anchor
+        or canonical == home
+        or home.is_relative_to(canonical)
+        or registry == canonical
+        or registry.is_relative_to(canonical)
+    ):
+        raise ValueError("Refusing to trash a filesystem, home, or LibreLabel root.")
     trash = Path.home() / ".librelabel" / "trash"
     trash.mkdir(parents=True, exist_ok=True)
-    dest = trash / f"{int(time.time())}-{root.name or 'dataset'}"
+    trash = trash.resolve(strict=True)
+    if canonical == trash or canonical.is_relative_to(trash):
+        raise ValueError("This project is already inside LibreLabel's trash.")
+    dest = trash / (
+        f"{time.time_ns()}-{uuid.uuid4().hex[:12]}-{root.name or 'dataset'}"
+    )
     shutil.move(str(root), str(dest))
     return str(dest)
 

--- a/libreyolo/label/export.py
+++ b/libreyolo/label/export.py
@@ -19,6 +19,7 @@ import json
 import math
 import os
 import shutil
+import stat
 import tempfile
 import xml.sax.saxutils as _sx
 import zipfile
@@ -286,6 +287,35 @@ def _normpath(path: Path) -> str:
     return _path_identity(path)
 
 
+def _is_link_or_reparse(path: Path) -> bool:
+    """Whether moving ``path`` could relocate link semantics instead of bytes."""
+    if path.is_symlink():
+        return True
+    try:
+        attributes = getattr(os.lstat(path), "st_file_attributes", 0)
+    except OSError:
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def _link_or_reparse_component(path: Path) -> Path | None:
+    """Return the first lexical path component that redirects filesystem access."""
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    for component in reversed((absolute, *absolute.parents)):
+        if _is_link_or_reparse(component):
+            return component
+    return None
+
+
+def _reject_link_or_reparse_components(path: Path, role: str) -> None:
+    component = _link_or_reparse_component(path)
+    if component is not None:
+        raise ValueError(
+            f"In-place export cannot safely use {role} through symbolic-link or "
+            f"reparse-point component {component}; use a copy export instead."
+        )
+
+
 def _flatten_split_sources(value):
     if isinstance(value, (list, tuple)):
         for item in value:
@@ -328,18 +358,133 @@ def _reject_destination_inside_source(session, destination: Path) -> None:
         )
 
 
+def _infer_move_location(move: dict) -> str:
+    """Resolve an interruptible move from its phase and filesystem state."""
+    state = move["location"]
+    candidates = {
+        "orig": ("orig",),
+        "moving_to_stage": ("orig", "stage"),
+        "stage": ("stage",),
+        "moving_to_dest": ("stage", "dest"),
+        "dest": ("dest",),
+        "rolling_dest_to_stage": ("dest", "stage"),
+        "rolling_stage_to_orig": ("stage", "orig"),
+    }.get(state)
+    if candidates is None:
+        raise RuntimeError(f"unknown in-place move phase: {state}")
+
+    existing = []
+    seen = set()
+    for location in candidates:
+        path = move[location]
+        identity = _normpath(path)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if os.path.lexists(path):
+            existing.append(location)
+    if len(existing) != 1:
+        raise RuntimeError(
+            f"cannot determine in-place move location during phase {state}"
+        )
+    location = existing[0]
+    if location == "dest" and _normpath(move["orig"]) == _normpath(move["dest"]):
+        return "orig"
+    return location
+
+
 def _rollback_moves(moves: List[dict]) -> None:
     """Return every staged/finalized move to its original path in two phases."""
+    errors: List[BaseException] = []
+
+    # First vacate every final destination.  This preserves permutation-style
+    # reorganizations where one file's destination is another file's origin.
     for move in moves:
-        if move["location"] == "dest" and move["dest"].exists():
+        try:
+            location = _infer_move_location(move)
+        except BaseException as exc:
+            errors.append(exc)
+            continue
+        move["location"] = location
+        if location != "dest":
+            continue
+        try:
             move["stage"].parent.mkdir(parents=True, exist_ok=True)
+            _reject_link_or_reparse_components(
+                move["dest"].parent, "a rollback source parent"
+            )
+            _reject_link_or_reparse_components(
+                move["stage"].parent, "a rollback staging parent"
+            )
+        except BaseException as exc:
+            errors.append(exc)
+            continue
+        move["location"] = "rolling_dest_to_stage"
+        try:
             shutil.move(str(move["dest"]), str(move["stage"]))
-            move["location"] = "stage"
+        except BaseException as exc:
+            try:
+                location = _infer_move_location(move)
+            except BaseException as state_exc:
+                errors.extend((exc, state_exc))
+                continue
+            if location != "stage":
+                errors.append(exc)
+                move["location"] = location
+                continue
+        move["location"] = "stage"
+
+    # Then restore every staged source.  If a move completed before an async
+    # exception was delivered, filesystem inference recognizes that completion.
     for move in moves:
-        if move["location"] == "stage" and move["stage"].exists():
+        try:
+            location = _infer_move_location(move)
+        except BaseException as exc:
+            errors.append(exc)
+            continue
+        move["location"] = location
+        if location == "orig":
+            continue
+        if location != "stage":
+            errors.append(RuntimeError("in-place source remains at its destination"))
+            continue
+        try:
             move["orig"].parent.mkdir(parents=True, exist_ok=True)
+            _reject_link_or_reparse_components(
+                move["stage"].parent, "a rollback staging parent"
+            )
+            _reject_link_or_reparse_components(
+                move["orig"].parent, "a rollback destination parent"
+            )
+        except BaseException as exc:
+            errors.append(exc)
+            continue
+        move["location"] = "rolling_stage_to_orig"
+        try:
             shutil.move(str(move["stage"]), str(move["orig"]))
-            move["location"] = "orig"
+        except BaseException as exc:
+            try:
+                location = _infer_move_location(move)
+            except BaseException as state_exc:
+                errors.extend((exc, state_exc))
+                continue
+            if location != "orig":
+                errors.append(exc)
+                move["location"] = location
+                continue
+        move["location"] = "orig"
+
+    for move in moves:
+        try:
+            location = _infer_move_location(move)
+        except BaseException as exc:
+            errors.append(exc)
+        else:
+            move["location"] = location
+            if location != "orig":
+                errors.append(RuntimeError("in-place source was not restored"))
+    if errors:
+        raise RuntimeError("one or more in-place moves could not be restored") from errors[0]
 
 
 def _mkdir_parents_recorded(path: Path, created: List[Path]) -> None:
@@ -372,13 +517,23 @@ def _in_place_export(
         ip, lp = Path(ip), Path(lp)
         if not ip.is_file():
             raise FileNotFoundError(f"Image disappeared before export: {ip}")
+        _reject_link_or_reparse_components(ip, "an image source")
+        label_exists = os.path.lexists(lp)
+        if label_exists:
+            _reject_link_or_reparse_components(lp, "a label source")
+        if label_exists and not lp.is_file():
+            raise ValueError(f"In-place export label source is not a file: {lp}")
         dest_name = unique(split_name, ip.name)
+        dest_img = base / "images" / split_name / dest_name
+        dest_lbl = base / "labels" / split_name / f"{Path(dest_name).stem}.txt"
+        _reject_link_or_reparse_components(dest_img, "an image destination")
+        _reject_link_or_reparse_components(dest_lbl, "a label destination")
         plans.append(
             (
                 ip,
-                base / "images" / split_name / dest_name,
-                lp if lp.exists() else None,
-                base / "labels" / split_name / f"{Path(dest_name).stem}.txt",
+                dest_img,
+                lp if label_exists else None,
+                dest_lbl,
             )
         )
 
@@ -441,12 +596,13 @@ def _in_place_export(
                         f"{existing}"
                     )
 
-    stage = Path(tempfile.mkdtemp(prefix=f".{base.name}-librelabel-export-", dir=str(base.parent)))
     yaml_path = Path(yaml_path).resolve()
     original_yaml = yaml_path.read_bytes() if yaml_path.exists() else None
+    stage = Path(tempfile.mkdtemp(prefix=f".{base.name}-librelabel-export-", dir=str(base.parent)))
     moves: List[dict] = []
     created_dirs: List[Path] = []
     committed = False
+    preserve_stage = False
     try:
         for index, (ip, dest_img, lp, dest_lbl) in enumerate(plans):
             pairs = [(ip, dest_img)]
@@ -454,14 +610,30 @@ def _in_place_export(
                 pairs.append((lp, dest_lbl))
             for subindex, (orig, dest) in enumerate(pairs):
                 staged = stage / f"{index}-{subindex}{orig.suffix}"
-                shutil.move(str(orig), str(staged))
                 moves.append(
-                    {"orig": orig, "stage": staged, "dest": dest, "location": "stage"}
+                    {"orig": orig, "stage": staged, "dest": dest, "location": "orig"}
                 )
         for move in moves:
+            _reject_link_or_reparse_components(move["orig"], "a source")
+            move["location"] = "moving_to_stage"
+            shutil.move(str(move["orig"]), str(move["stage"]))
+            move["location"] = "stage"
+            _reject_link_or_reparse_components(move["stage"], "a staged source")
+            _reject_link_or_reparse_components(
+                move["orig"].parent, "a source parent"
+            )
+        for move in moves:
+            _reject_link_or_reparse_components(move["dest"], "a destination")
             _mkdir_parents_recorded(move["dest"].parent, created_dirs)
+            _reject_link_or_reparse_components(move["dest"], "a destination")
+            if os.path.lexists(move["dest"]):
+                raise FileExistsError(
+                    f"In-place export destination appeared during export: {move['dest']}"
+                )
+            move["location"] = "moving_to_dest"
             shutil.move(str(move["stage"]), str(move["dest"]))
             move["location"] = "dest"
+            _reject_link_or_reparse_components(move["dest"], "a destination")
         written_yaml = _write_yaml(
             base, splits, names, nc, task, output_path=yaml_path
         )
@@ -469,15 +641,38 @@ def _in_place_export(
         committed = True
         return written_yaml, reopened
     except BaseException:
-        if any(move["location"] != "orig" for move in moves):
+        committed = False
+        recovery_errors: List[BaseException] = []
+        try:
             _rollback_moves(moves)
-        if original_yaml is None:
+        except BaseException as exc:
+            recovery_errors.append(exc)
+        try:
+            if original_yaml is None:
+                try:
+                    yaml_path.unlink()
+                except FileNotFoundError:
+                    pass
+            else:
+                _atomic_write_bytes(yaml_path, original_yaml)
+        except BaseException as exc:
             try:
-                yaml_path.unlink()
-            except FileNotFoundError:
-                pass
-        else:
-            _atomic_write_bytes(yaml_path, original_yaml)
+                restored = (
+                    not yaml_path.exists()
+                    if original_yaml is None
+                    else yaml_path.read_bytes() == original_yaml
+                )
+            except OSError:
+                restored = False
+            if not restored:
+                recovery_errors.append(exc)
+        if recovery_errors:
+            preserve_stage = True
+            raise RuntimeError(
+                "In-place export failed and rollback was incomplete; "
+                f"the staging directory was preserved at {stage}. Files may "
+                "remain at their original, staging, or destination paths."
+            ) from recovery_errors[0]
         raise
     finally:
         if not committed:
@@ -486,7 +681,14 @@ def _in_place_export(
                     directory.rmdir()
                 except OSError:
                     pass
-        shutil.rmtree(stage, ignore_errors=True)
+        try:
+            stage_holds_files = any(
+                path.is_file() or path.is_symlink() for path in stage.rglob("*")
+            )
+        except OSError:
+            stage_holds_files = True
+        if not preserve_stage and not stage_holds_files:
+            shutil.rmtree(stage, ignore_errors=True)
 
 
 def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),

--- a/libreyolo/label/export.py
+++ b/libreyolo/label/export.py
@@ -6,7 +6,7 @@ Two modes:
   and shared across every requested format, so exporting to all three formats
   does not triplicate the image bytes.
 - in place: re-organise the working folder into train/val(/test) subdirs and
-  rewrite ``data.yaml`` (YOLO only; it is the live dataset).
+  rewrite the opened dataset YAML (YOLO only; it is the live dataset).
 
 An optional seeded train/val/test split is applied either way. Labels read from
 the YOLO ``.txt`` files the rest of LibreLabel already wrote; nothing here parses
@@ -16,7 +16,10 @@ pixels except to read image dimensions for COCO/VOC.
 from __future__ import annotations
 
 import json
+import math
+import os
 import shutil
+import tempfile
 import xml.sax.saxutils as _sx
 import zipfile
 from pathlib import Path
@@ -24,20 +27,44 @@ from typing import List, Optional
 
 import yaml
 
-from .dataset import _atomic_write_text
-from .labelio import parse_annotations
+from .dataset import IMG_EXTS, _atomic_write_text, _path_identity, _publish_no_clobber
+from .labelio import (
+    has_degenerate_polygon,
+    has_out_of_bounds_coords,
+    has_out_of_range_rows,
+    has_unsupported_rows,
+    has_zero_area_box,
+    parse_annotations,
+    sanitize_annotations,
+)
+
+
+_FORMATS = {"yolo", "coco", "voc"}
+_TASK_FORMATS = {
+    "detect": _FORMATS,
+    "segment": {"yolo", "coco"},
+    "obb": {"yolo"},
+}
 
 
 def _assign_splits(n: int, mode: str, val_frac: float, test_frac: float, seed: int) -> List[str]:
     """A per-item split label list ('train'/'val'/'test'), seeded and reproducible."""
+    if mode not in {"none", "trainval", "trainvaltest"}:
+        raise ValueError("split must be 'none', 'trainval', or 'trainvaltest'")
+    try:
+        vf = float(val_frac)
+        tf = float(test_frac)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("split fractions must be finite numbers in [0, 1]") from exc
+    if not all(math.isfinite(v) and 0.0 <= v <= 1.0 for v in (vf, tf)):
+        raise ValueError("split fractions must be finite numbers in [0, 1]")
     if mode == "none" or n <= 1:
         return ["train"] * n
     import random
     idx = list(range(n))
     random.Random(seed).shuffle(idx)
-    vf = max(0.0, float(val_frac))
-    tf = max(0.0, float(test_frac)) if mode == "trainvaltest" else 0.0
-    n_test = int(round(n * tf)) if tf else 0
+    tf = tf if mode == "trainvaltest" else 0.0
+    n_test = min(int(round(n * tf)), n - 1) if tf else 0
     n_val = int(round(n * vf)) if vf else 0
     n_val = min(n_val, max(0, n - 1 - n_test))   # always keep >= 1 train image
     out = ["train"] * n
@@ -62,8 +89,17 @@ def _img_size(p: Path):
         return (0, 0)
 
 
-def _write_yaml(base: Path, splits, names, nc, task) -> str:
-    cfg = {"path": base.resolve().as_posix(), "train": "images/train"}
+def _write_yaml(
+    base: Path,
+    splits,
+    names,
+    nc,
+    task,
+    *,
+    dataset_root: Optional[Path] = None,
+    output_path: Optional[Path] = None,
+) -> str:
+    cfg = {"path": (dataset_root or base).resolve().as_posix(), "train": "images/train"}
     if any(s == "val" for s in splits):
         cfg["val"] = "images/val"
     if any(s == "test" for s in splits):
@@ -71,14 +107,36 @@ def _write_yaml(base: Path, splits, names, nc, task) -> str:
     cfg["names"] = list(names)
     cfg["nc"] = int(nc)
     t = str(task or "").strip().lower()
-    if t and t != "detect":
+    if t:
         cfg["task"] = t
+    out = Path(output_path) if output_path is not None else base / "data.yaml"
     text = ("# LibreLabel export -- YOLO dataset.\n"
-            "# Train with: libreyolo train data=data.yaml\n\n"
+            f"# Train with: libreyolo train data={out.name}\n\n"
             + yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True))
-    out = base / "data.yaml"
     _atomic_write_text(out, text)
     return str(out)
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Restore an exact byte snapshot without platform newline translation."""
+    try:
+        mode = path.stat().st_mode & 0o777
+    except FileNotFoundError:
+        mode = 0o644
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def _coco_init(names):
@@ -86,7 +144,7 @@ def _coco_init(names):
             "categories": [{"id": i, "name": n} for i, n in enumerate(names)]}
 
 
-def _coco_add(c, state, fname, W, H, anns):
+def _coco_add(c, state, fname, W, H, anns, task="detect"):
     state["img"] += 1
     img_id = state["img"]
     c["images"].append({"id": img_id, "file_name": fname, "width": W, "height": H})
@@ -94,7 +152,10 @@ def _coco_add(c, state, fname, W, H, anns):
         state["ann"] += 1
         if a["type"] == "box":
             x1, y1, x2, y2 = _xyxy_px(a["cx"], a["cy"], a["w"], a["h"], W, H)
-            seg = []
+            # A five-field row in a segment dataset means a rectangular mask, not
+            # merely a detection box. Preserve that mask in COCO instead of emitting
+            # an empty segmentation payload.
+            seg = [[x1, y1, x2, y1, x2, y2, x1, y2]] if task == "segment" else []
         else:
             pts = a.get("points") or []
             xs = [pts[i] * W for i in range(0, len(pts) - 1, 2)]
@@ -104,10 +165,21 @@ def _coco_add(c, state, fname, W, H, anns):
             x1, y1, x2, y2 = min(xs), min(ys), max(xs), max(ys)
             seg = [[v for xy in zip(xs, ys) for v in xy]]
         bw, bh = x2 - x1, y2 - y1
+        if seg:
+            ring = seg[0]
+            area = abs(
+                sum(
+                    ring[i] * ring[(i + 3) % len(ring)]
+                    - ring[(i + 2) % len(ring)] * ring[(i + 1) % len(ring)]
+                    for i in range(0, len(ring), 2)
+                )
+            ) / 2.0
+        else:
+            area = bw * bh
         c["annotations"].append({
             "id": state["ann"], "image_id": img_id, "category_id": int(a["cls"]),
             "bbox": [round(x1, 2), round(y1, 2), round(bw, 2), round(bh, 2)],
-            "area": round(bw * bh, 2), "iscrowd": 0, "segmentation": seg})
+            "area": round(area, 2), "iscrowd": 0, "segmentation": seg})
 
 
 def _voc_write(out_dir: Path, fname, W, H, anns, names):
@@ -136,36 +208,297 @@ def _voc_write(out_dir: Path, fname, W, H, anns, names):
     (out_dir / (Path(fname).stem + ".xml")).write_text(xml, encoding="utf-8")
 
 
-def _zip_dir(src: Path, zip_path: str):
+def _zip_dir(src: Path, zip_path: str, *, archive_root: Optional[str] = None):
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
         for p in src.rglob("*"):
             if p.is_file():
-                z.write(p, p.relative_to(src.parent))
+                root = Path(archive_root or src.name)
+                z.write(p, root / p.relative_to(src))
 
 
 def _uniquifier():
-    """Per-split unique basenames: nested source dirs can hold same-named images
-    (``a/0001.jpg`` + ``b/0001.jpg``), and flattening into ``images/<split>/``
-    would otherwise silently overwrite one with the other."""
+    """Per-split unique *stems*, including collisions across image suffixes.
+
+    ``a/foo.jpg`` and ``b/foo.png`` are distinct image filenames but both derive
+    ``foo.txt`` (and ``foo.xml``), so reserving full names is insufficient.
+    """
     used = {sp: set() for sp in ("train", "val", "test")}
 
     def unique(sp: str, name: str) -> str:
         stem, ext = Path(name).stem, Path(name).suffix
         cand, n = name, 1
-        while cand.lower() in used[sp]:
+        while Path(cand).stem.casefold() in used[sp]:
             n += 1
             cand = f"{stem}_{n}{ext}"
-        used[sp].add(cand.lower())
+        used[sp].add(Path(cand).stem.casefold())
         return cand
 
     return unique
 
 
+def _validate_request(task: str, formats, in_place: bool) -> set[str]:
+    if isinstance(formats, (str, bytes)):
+        formats = (formats,)
+    fmts = {str(value).strip().lower() for value in formats if str(value).strip()} or {"yolo"}
+    unknown = fmts - _FORMATS
+    if unknown:
+        raise ValueError(f"Unsupported export format(s): {', '.join(sorted(unknown))}")
+    if in_place and fmts != {"yolo"}:
+        raise ValueError("In-place export supports YOLO only; COCO/VOC require a copy export.")
+    allowed = _TASK_FORMATS.get(task)
+    if allowed is None:
+        raise ValueError(
+            f"LibreLabel cannot safely export task {task!r}: this exporter only preserves "
+            "detection boxes, segmentation polygons, and OBB corners."
+        )
+    lossy = fmts - allowed
+    if lossy:
+        raise ValueError(
+            f"Exporting task {task!r} as {', '.join(sorted(lossy))} would discard "
+            "task-specific geometry; choose a lossless format."
+        )
+    return fmts
+
+
+def _validated_label_text(path: Path, nc: int, task: str) -> tuple[str, List[dict]]:
+    if not path.exists():
+        return "", []
+    text = path.read_text(encoding="utf-8")
+    invalid = (
+        has_unsupported_rows(text)
+        or has_out_of_range_rows(text, nc)
+        or has_out_of_bounds_coords(text)
+        or has_degenerate_polygon(text)
+        or has_zero_area_box(text)
+    )
+    if invalid:
+        raise ValueError(f"Cannot export invalid label file without data loss: {path}")
+    annotations = parse_annotations(text)
+    try:
+        sanitize_annotations(annotations, nc, task=task)
+    except ValueError as exc:
+        raise ValueError(f"Cannot export invalid label file {path}: {exc}") from exc
+    return text, annotations
+
+
+def _normpath(path: Path) -> str:
+    return _path_identity(path)
+
+
+def _flatten_split_sources(value):
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _flatten_split_sources(item)
+    elif value is not None:
+        yield value
+
+
+def _recursive_split_directories(session) -> List[Path]:
+    """Return configured directory splits that recursively discover images."""
+    base = Path(session.root or Path(session.yaml_file).parent)
+    directories = []
+    for value in getattr(session, "_split_sources", {}).values():
+        for source in _flatten_split_sources(value):
+            path = Path(str(source)).expanduser()
+            if not path.is_absolute():
+                path = base / path
+            try:
+                resolved = path.resolve(strict=False)
+            except (OSError, RuntimeError):
+                resolved = Path(os.path.abspath(str(path)))
+            if resolved.is_dir():
+                directories.append(resolved)
+    return directories
+
+
+def _reject_destination_inside_source(session, destination: Path) -> None:
+    try:
+        resolved = destination.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        resolved = Path(os.path.abspath(str(destination)))
+    for source_dir in _recursive_split_directories(session):
+        try:
+            resolved.relative_to(source_dir)
+        except ValueError:
+            continue
+        raise ValueError(
+            f"Export destination {resolved} is inside recursive source split "
+            f"{source_dir}; choose a folder outside the source dataset."
+        )
+
+
+def _rollback_moves(moves: List[dict]) -> None:
+    """Return every staged/finalized move to its original path in two phases."""
+    for move in moves:
+        if move["location"] == "dest" and move["dest"].exists():
+            move["stage"].parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(move["dest"]), str(move["stage"]))
+            move["location"] = "stage"
+    for move in moves:
+        if move["location"] == "stage" and move["stage"].exists():
+            move["orig"].parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(move["stage"]), str(move["orig"]))
+            move["location"] = "orig"
+
+
+def _mkdir_parents_recorded(path: Path, created: List[Path]) -> None:
+    """Create missing parents and record only directories made by this call."""
+    missing = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    for directory in reversed(missing):
+        try:
+            directory.mkdir()
+        except FileExistsError:
+            if not directory.is_dir():
+                raise
+        else:
+            created.append(directory)
+
+
+def _in_place_export(
+    base: Path, items, splits, names, nc, task, *, yaml_path: Path, validator=None
+) -> tuple[str, object | None]:
+    """Reorganize through an external staging dir and roll back on any failure."""
+    unique = _uniquifier()
+    plans = []
+    for (ip, lp), split_name in zip(items, splits, strict=True):
+        ip, lp = Path(ip), Path(lp)
+        if not ip.is_file():
+            raise FileNotFoundError(f"Image disappeared before export: {ip}")
+        dest_name = unique(split_name, ip.name)
+        plans.append(
+            (
+                ip,
+                base / "images" / split_name / dest_name,
+                lp if lp.exists() else None,
+                base / "labels" / split_name / f"{Path(dest_name).stem}.txt",
+            )
+        )
+
+    source_paths = {
+        _normpath(path)
+        for ip, _di, lp, _dl in plans
+        for path in (ip, lp)
+        if path is not None
+    }
+    # The regenerated YAML recursively scans these canonical split directories.
+    # Any supported image or label not owned by this transaction would silently
+    # join the exported dataset, even when it does not collide with a planned name.
+    for split_name in ("train", "val", "test"):
+        image_dir = base / "images" / split_name
+        if image_dir.is_dir():
+            for existing in image_dir.rglob("*"):
+                if (
+                    existing.is_file()
+                    and existing.suffix.lower() in IMG_EXTS
+                    and _normpath(existing) not in source_paths
+                ):
+                    raise FileExistsError(
+                        "In-place export target contains an unrelated image: "
+                        f"{existing}"
+                    )
+        label_dir = base / "labels" / split_name
+        if label_dir.is_dir():
+            for existing in label_dir.rglob("*.txt"):
+                if existing.is_file() and _normpath(existing) not in source_paths:
+                    raise FileExistsError(
+                        "In-place export target contains an unrelated label: "
+                        f"{existing}"
+                    )
+    for _ip, dest_img, lp, dest_lbl in plans:
+        for dest in (dest_img, dest_lbl if lp is not None else None):
+            if dest is not None and dest.exists() and _normpath(dest) not in source_paths:
+                raise FileExistsError(f"In-place export destination already exists: {dest}")
+        if dest_img.parent.is_dir():
+            for existing in dest_img.parent.iterdir():
+                if (
+                    existing.is_file()
+                    and existing.suffix.lower() in IMG_EXTS
+                    and existing.stem.casefold() == dest_img.stem.casefold()
+                    and _normpath(existing) not in source_paths
+                ):
+                    raise FileExistsError(
+                        "In-place export image stem collides with an existing file: "
+                        f"{existing}"
+                    )
+        if lp is not None and dest_lbl.parent.is_dir():
+            for existing in dest_lbl.parent.iterdir():
+                if (
+                    existing.is_file()
+                    and existing.suffix.lower() == ".txt"
+                    and existing.stem.casefold() == dest_lbl.stem.casefold()
+                    and _normpath(existing) not in source_paths
+                ):
+                    raise FileExistsError(
+                        "In-place export label stem collides with an existing file: "
+                        f"{existing}"
+                    )
+
+    stage = Path(tempfile.mkdtemp(prefix=f".{base.name}-librelabel-export-", dir=str(base.parent)))
+    yaml_path = Path(yaml_path).resolve()
+    original_yaml = yaml_path.read_bytes() if yaml_path.exists() else None
+    moves: List[dict] = []
+    created_dirs: List[Path] = []
+    committed = False
+    try:
+        for index, (ip, dest_img, lp, dest_lbl) in enumerate(plans):
+            pairs = [(ip, dest_img)]
+            if lp is not None:
+                pairs.append((lp, dest_lbl))
+            for subindex, (orig, dest) in enumerate(pairs):
+                staged = stage / f"{index}-{subindex}{orig.suffix}"
+                shutil.move(str(orig), str(staged))
+                moves.append(
+                    {"orig": orig, "stage": staged, "dest": dest, "location": "stage"}
+                )
+        for move in moves:
+            _mkdir_parents_recorded(move["dest"].parent, created_dirs)
+            shutil.move(str(move["stage"]), str(move["dest"]))
+            move["location"] = "dest"
+        written_yaml = _write_yaml(
+            base, splits, names, nc, task, output_path=yaml_path
+        )
+        reopened = validator(written_yaml) if validator is not None else None
+        committed = True
+        return written_yaml, reopened
+    except BaseException:
+        if any(move["location"] != "orig" for move in moves):
+            _rollback_moves(moves)
+        if original_yaml is None:
+            try:
+                yaml_path.unlink()
+            except FileNotFoundError:
+                pass
+        else:
+            _atomic_write_bytes(yaml_path, original_yaml)
+        raise
+    finally:
+        if not committed:
+            for directory in reversed(created_dirs):
+                try:
+                    directory.rmdir()
+                except OSError:
+                    pass
+        shutil.rmtree(stage, ignore_errors=True)
+
+
 def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
                    split: str = "trainval", val_frac: float = 0.2,
                    test_frac: float = 0.0, seed: int = 1234,
-                   in_place: bool = False, make_zip: bool = False) -> dict:
+                   in_place: bool = False, make_zip: bool = False,
+                   _in_place_validator=None) -> dict:
     """Export the open ``session``. Returns a dict describing what was written."""
+    if getattr(session, "_label_clash", False):
+        raise ValueError(
+            "Two source images share one derived label file (for example foo.jpg and "
+            "foo.png). Rename one image before exporting so neither image or label is lost."
+        )
     items = [(ip, lp) for i, (ip, lp, _s) in enumerate(session._items)
              if i not in getattr(session, "_deleted", set())]
     if not items:
@@ -173,86 +506,144 @@ def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
     names = list(session.names or [])
     nc = int(session.nc or len(names))
     task = getattr(session, "_task", None) or "detect"
+    if getattr(session, "_lossy_export", False):
+        raise ValueError(
+            "This project uses pose, mask, depth, classification, or other task-specific "
+            "labels that LibreLabel's box/polygon exporter cannot preserve."
+        )
+    fmts = _validate_request(task, formats, in_place)
+    if not getattr(session, "_task_declared_or_inferred", bool(getattr(session, "_task", None))):
+        raise ValueError(
+            "This dataset does not declare a task and its labels do not resolve "
+            "one unambiguously. Declare task: detect, segment, or obb before "
+            "copying, converting, or reorganizing it; a generic export could omit "
+            "default task-specific targets."
+        )
+    if in_place and make_zip:
+        raise ValueError("Create a copy export before making a zip; in-place export cannot be zipped safely.")
     splits = _assign_splits(len(items), split, val_frac, test_frac, seed)
+    payloads = []
+    for ip, lp in items:
+        if not Path(ip).is_file():
+            raise FileNotFoundError(f"Image disappeared before export: {ip}")
+        validation_task = (
+            task
+            if getattr(session, "_task_declared_or_inferred", False)
+            else ""
+        )
+        payloads.append(_validated_label_text(Path(lp), nc, validation_task))
 
     if in_place and getattr(session, "linked", False):
         raise ValueError("Linked projects never modify the source folder - "
                          "use a copy export instead of re-splitting in place.")
     if in_place:
         base = Path(session.root or Path(session.yaml_file).parent).resolve()
-        unique = _uniquifier()
-        for (ip, lp), sp in zip(items, splits):
-            ip = Path(ip)
-            if not ip.exists():
-                continue
-            dest_img = base / "images" / sp / ip.name
-            if ip.resolve() == dest_img.resolve():
-                unique(sp, ip.name)          # already in place: just reserve its name
-                dest_name = ip.name
-            else:
-                dest_name = unique(sp, ip.name)
-                dest_img = base / "images" / sp / dest_name
-                dest_img.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(ip), str(dest_img))
-            lp = Path(lp)
-            if lp.exists():
-                dest_lbl = base / "labels" / sp / (Path(dest_name).stem + ".txt")
-                dest_lbl.parent.mkdir(parents=True, exist_ok=True)
-                if lp.resolve() != dest_lbl.resolve():
-                    shutil.move(str(lp), str(dest_lbl))
-        yaml_path = _write_yaml(base, splits, names, nc, task)
-        return {"in_place": True, "out": str(base), "yaml": yaml_path,
-                "counts": {s: splits.count(s) for s in ("train", "val", "test")}}
+        yaml_path, reopened = _in_place_export(
+            base,
+            items,
+            splits,
+            names,
+            nc,
+            task,
+            yaml_path=Path(session.yaml_file),
+            validator=_in_place_validator,
+        )
+        result = {"in_place": True, "out": str(base), "yaml": yaml_path,
+                  "counts": {s: splits.count(s) for s in ("train", "val", "test")}}
+        if reopened is not None:
+            result["_reopened_session"] = reopened
+        return result
 
     if not dst:
         raise ValueError("A destination folder is required for a copy export.")
     dstp = Path(dst)
+    _reject_destination_inside_source(session, dstp)
+    if dstp.exists() and not dstp.is_dir():
+        raise ValueError("The export destination exists and is not a folder.")
     if dstp.is_dir() and any(dstp.iterdir()):
         # A previous export's leftovers would be rescanned by the generated
         # data.yaml (stale images/labels silently joining the new dataset).
         raise ValueError("The destination folder is not empty - pick a new or empty "
                          "folder so stale files can't mix into the export.")
-    dstp.mkdir(parents=True, exist_ok=True)
-    fmts = {f.lower() for f in formats} or {"yolo"}
+    dstp.parent.mkdir(parents=True, exist_ok=True)
+    had_empty_destination = dstp.is_dir()
+    zip_target = Path(str(dstp.absolute()) + ".zip") if make_zip else None
+    if zip_target is not None and zip_target.exists():
+        raise ValueError(f"The export zip already exists: {zip_target}")
+    stage = Path(
+        tempfile.mkdtemp(prefix=f".{dstp.name or 'export'}-librelabel-", dir=str(dstp.parent))
+    )
+    zip_stage: Optional[Path] = None
     need_dims = bool(fmts & {"coco", "voc"})
     coco = {sp: _coco_init(names) for sp in ("train", "val", "test")}
     cstate = {sp: {"img": 0, "ann": 0} for sp in ("train", "val", "test")}
 
-    unique = _uniquifier()
-    for (ip, lp), sp in zip(items, splits):
-        ip = Path(ip)
-        if not ip.exists():
-            continue
-        img_out = dstp / "images" / sp / unique(sp, ip.name)
-        img_out.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(str(ip), str(img_out))
-        txt = Path(lp).read_text(encoding="utf-8") if Path(lp).exists() else ""
-        anns = parse_annotations(txt)
-        if "yolo" in fmts:
-            lo = dstp / "labels" / sp / (img_out.stem + ".txt")
-            lo.parent.mkdir(parents=True, exist_ok=True)
-            lo.write_text(txt, encoding="utf-8")
-        if need_dims:
-            W, H = _img_size(ip)
-            if "coco" in fmts:
-                _coco_add(coco[sp], cstate[sp], img_out.name, W, H, anns)
-            if "voc" in fmts:
-                _voc_write(dstp / "voc" / sp / "Annotations", img_out.name, W, H, anns, names)
+    committed = False
+    try:
+        unique = _uniquifier()
+        for ((ip, _lp), sp, (txt, anns)) in zip(items, splits, payloads, strict=True):
+            ip = Path(ip)
+            img_out = stage / "images" / sp / unique(sp, ip.name)
+            img_out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(ip), str(img_out))
+            if "yolo" in fmts:
+                lo = stage / "labels" / sp / (img_out.stem + ".txt")
+                lo.parent.mkdir(parents=True, exist_ok=True)
+                _atomic_write_text(lo, txt)
+            if need_dims:
+                W, H = _img_size(ip)
+                if W <= 0 or H <= 0:
+                    raise ValueError(f"Cannot read image dimensions for export: {ip}")
+                if "coco" in fmts:
+                    _coco_add(coco[sp], cstate[sp], img_out.name, W, H, anns, task)
+                if "voc" in fmts:
+                    _voc_write(stage / "voc" / sp / "Annotations", img_out.name, W, H, anns, names)
 
-    if "yolo" in fmts:
-        _write_yaml(dstp, splits, names, nc, task)
-    if "coco" in fmts:
-        ann_dir = dstp / "annotations"
-        ann_dir.mkdir(exist_ok=True)
-        for sp, c in coco.items():
-            if c["images"]:
-                _atomic_write_text(ann_dir / f"instances_{sp}.json", json.dumps(c))
+        if "yolo" in fmts:
+            _write_yaml(stage, splits, names, nc, task, dataset_root=dstp.absolute())
+        if "coco" in fmts:
+            ann_dir = stage / "annotations"
+            ann_dir.mkdir(exist_ok=True)
+            for sp, c in coco.items():
+                if c["images"]:
+                    _atomic_write_text(ann_dir / f"instances_{sp}.json", json.dumps(c))
+        if make_zip:
+            fd, zip_name = tempfile.mkstemp(
+                prefix=f".{dstp.name or 'export'}-", suffix=".zip.tmp", dir=str(dstp.parent)
+            )
+            os.close(fd)
+            zip_stage = Path(zip_name)
+            _zip_dir(stage, str(zip_stage), archive_root=dstp.name)
+            os.chmod(zip_stage, 0o644)
+
+        if had_empty_destination:
+            dstp.rmdir()
+        os.replace(stage, dstp)
+        committed = True
+        if zip_stage is not None and zip_target is not None:
+            # Publish without replacing a zip another exporter created after the
+            # preflight check, without requiring hard-link filesystem support.
+            _publish_no_clobber(zip_stage, zip_target)
+            zip_stage = None
+    except BaseException:
+        if committed and dstp.exists():
+            os.replace(dstp, stage)
+            committed = False
+        if had_empty_destination and not dstp.exists():
+            dstp.mkdir(parents=True, exist_ok=True)
+        raise
+    finally:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        if zip_stage is not None:
+            try:
+                zip_stage.unlink()
+            except OSError:
+                pass
 
     res = {"in_place": False, "out": str(dstp),
            "counts": {s: splits.count(s) for s in ("train", "val", "test")},
            "formats": sorted(fmts)}
-    if make_zip:
-        zp = str(dstp.resolve()) + ".zip"
-        _zip_dir(dstp, zp)
-        res["zip"] = zp
+    if zip_target is not None:
+        res["zip"] = str(zip_target)
     return res

--- a/libreyolo/label/export.py
+++ b/libreyolo/label/export.py
@@ -260,10 +260,11 @@ def _validate_request(task: str, formats, in_place: bool) -> set[str]:
     return fmts
 
 
-def _validated_label_text(path: Path, nc: int, task: str) -> tuple[str, List[dict]]:
+def _validated_label_text(path: Path, nc: int, task: str) -> tuple[bytes, List[dict]]:
     if not path.exists():
-        return "", []
-    text = path.read_text(encoding="utf-8")
+        return b"", []
+    raw = path.read_bytes()
+    text = raw.decode("utf-8")
     invalid = (
         has_unsupported_rows(text)
         or has_out_of_range_rows(text, nc)
@@ -278,7 +279,7 @@ def _validated_label_text(path: Path, nc: int, task: str) -> tuple[str, List[dic
         sanitize_annotations(annotations, nc, task=task)
     except ValueError as exc:
         raise ValueError(f"Cannot export invalid label file {path}: {exc}") from exc
-    return text, annotations
+    return raw, annotations
 
 
 def _normpath(path: Path) -> str:
@@ -506,19 +507,27 @@ def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
     names = list(session.names or [])
     nc = int(session.nc or len(names))
     task = getattr(session, "_task", None) or "detect"
+    task_resolved = bool(
+        getattr(
+            session,
+            "_task_declared_or_inferred",
+            bool(getattr(session, "_task", None)),
+        )
+    )
     if getattr(session, "_lossy_export", False):
         raise ValueError(
             "This project uses pose, mask, depth, classification, or other task-specific "
             "labels that LibreLabel's box/polygon exporter cannot preserve."
         )
     fmts = _validate_request(task, formats, in_place)
-    if not getattr(session, "_task_declared_or_inferred", bool(getattr(session, "_task", None))):
+    if not task_resolved and fmts != {"yolo"}:
         raise ValueError(
             "This dataset does not declare a task and its labels do not resolve "
-            "one unambiguously. Declare task: detect, segment, or obb before "
-            "copying, converting, or reorganizing it; a generic export could omit "
-            "default task-specific targets."
+            "one unambiguously. Only a lossless YOLO copy or in-place reorganization "
+            "is safe until task: detect, segment, or obb is declared; converting it "
+            "could omit default task-specific targets."
         )
+    yaml_task = task if task_resolved else ""
     if in_place and make_zip:
         raise ValueError("Create a copy export before making a zip; in-place export cannot be zipped safely.")
     splits = _assign_splits(len(items), split, val_frac, test_frac, seed)
@@ -526,11 +535,7 @@ def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
     for ip, lp in items:
         if not Path(ip).is_file():
             raise FileNotFoundError(f"Image disappeared before export: {ip}")
-        validation_task = (
-            task
-            if getattr(session, "_task_declared_or_inferred", False)
-            else ""
-        )
+        validation_task = task if task_resolved else ""
         payloads.append(_validated_label_text(Path(lp), nc, validation_task))
 
     if in_place and getattr(session, "linked", False):
@@ -544,7 +549,7 @@ def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
             splits,
             names,
             nc,
-            task,
+            yaml_task,
             yaml_path=Path(session.yaml_file),
             validator=_in_place_validator,
         )
@@ -581,7 +586,7 @@ def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
     committed = False
     try:
         unique = _uniquifier()
-        for ((ip, _lp), sp, (txt, anns)) in zip(items, splits, payloads, strict=True):
+        for (ip, _lp), sp, (raw, anns) in zip(items, splits, payloads, strict=True):
             ip = Path(ip)
             img_out = stage / "images" / sp / unique(sp, ip.name)
             img_out.parent.mkdir(parents=True, exist_ok=True)
@@ -589,7 +594,7 @@ def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
             if "yolo" in fmts:
                 lo = stage / "labels" / sp / (img_out.stem + ".txt")
                 lo.parent.mkdir(parents=True, exist_ok=True)
-                _atomic_write_text(lo, txt)
+                _atomic_write_bytes(lo, raw)
             if need_dims:
                 W, H = _img_size(ip)
                 if W <= 0 or H <= 0:
@@ -600,7 +605,9 @@ def export_dataset(session, *, dst: Optional[str] = None, formats=("yolo",),
                     _voc_write(stage / "voc" / sp / "Annotations", img_out.name, W, H, anns, names)
 
         if "yolo" in fmts:
-            _write_yaml(stage, splits, names, nc, task, dataset_root=dstp.absolute())
+            _write_yaml(
+                stage, splits, names, nc, yaml_task, dataset_root=dstp.absolute()
+            )
         if "coco" in fmts:
             ann_dir = stage / "annotations"
             ann_dir.mkdir(exist_ok=True)

--- a/libreyolo/label/labelio.py
+++ b/libreyolo/label/labelio.py
@@ -18,6 +18,7 @@ can refuse to overwrite them in box-only mode rather than silently destroy them.
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping, Sequence
 from typing import List, Optional, Tuple, TypedDict
 
 
@@ -72,9 +73,10 @@ def format_label_text(boxes: List[Box]) -> str:
     abort the whole image's label load. Coordinates use ``%.6f``. An empty list
     serialises to ``""`` (an empty ``.txt`` == a valid background image).
     """
+    clean = sanitize_boxes(boxes)
     lines = [
-        f"{int(b['cls'])} {b['cx']:.6f} {b['cy']:.6f} {b['w']:.6f} {b['h']:.6f}"
-        for b in boxes
+        f"{b['cls']} {b['cx']:.6f} {b['cy']:.6f} {b['w']:.6f} {b['h']:.6f}"
+        for b in clean
     ]
     return ("\n".join(lines) + "\n") if lines else ""
 
@@ -83,27 +85,212 @@ def _clamp01(v: float) -> float:
     return 0.0 if v < 0.0 else 1.0 if v > 1.0 else v
 
 
-def sanitize_boxes(boxes: List[Box], nc: Optional[int] = None) -> List[Box]:
-    """Validate/clamp boxes before writing.
+def _class_id(value, nc: Optional[int], where: str) -> int:
+    """Return an exact integer class id, never a truncation of a float."""
+    if isinstance(value, bool):
+        raise ValueError(f"{where}: class id must be an integer")
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{where}: class id must be an integer") from exc
+    if not math.isfinite(numeric) or not numeric.is_integer():
+        raise ValueError(f"{where}: class id must be a finite integer")
+    cls = int(numeric)
+    if cls < 0 or (nc is not None and cls >= nc):
+        limit = f"0..{nc - 1}" if nc is not None else "zero or greater"
+        raise ValueError(f"{where}: class id {cls} is outside {limit}")
+    return cls
 
-    Drops boxes with a negative class, a class ``>= nc`` (when ``nc`` is known),
-    or zero/negative area; clamps every coordinate into ``[0, 1]``.
-    """
+
+def _finite_float(value, field: str, where: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{where}: {field} must be a finite number")
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{where}: {field} must be a finite number") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"{where}: {field} must be finite")
+    return result
+
+
+def _disk_float(value: float) -> float:
+    """Canonical value represented by the six-decimal on-disk format."""
+    return float(f"{value:.6f}")
+
+
+def _polygon_area2(points: Sequence[float]) -> float:
+    xs, ys = points[0::2], points[1::2]
+    n = len(xs)
+    return abs(
+        sum(
+            xs[i] * ys[(i + 1) % n] - xs[(i + 1) % n] * ys[i]
+            for i in range(n)
+        )
+    )
+
+
+def _clip_obb(points: List[float], where: str) -> List[float]:
+    """Translate an out-of-canvas OBB into bounds without shearing it."""
+    xs, ys = points[0::2], points[1::2]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys), max(ys)
+    if not _obb_overlaps_unit_square(points):
+        raise ValueError(f"{where}: oriented box does not overlap the image canvas")
+    if max_x - min_x > 1.0 + 1e-9 or max_y - min_y > 1.0 + 1e-9:
+        raise ValueError(f"{where}: oriented box is larger than the image canvas")
+    dx = max(0.0, -min_x) - max(0.0, max_x - 1.0)
+    dy = max(0.0, -min_y) - max(0.0, max_y - 1.0)
+    shifted = [
+        _clamp01(value + (dx if i % 2 == 0 else dy))
+        for i, value in enumerate(points)
+    ]
+    return shifted
+
+
+def _obb_overlaps_unit_square(points: Sequence[float]) -> bool:
+    """Strict positive-area intersection using the separating-axis theorem."""
+    polygon = [(points[index], points[index + 1]) for index in range(0, 8, 2)]
+    square = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+    axes = [(1.0, 0.0), (0.0, 1.0)]
+    for index in range(4):
+        x1, y1 = polygon[index]
+        x2, y2 = polygon[(index + 1) % 4]
+        axes.append((-(y2 - y1), x2 - x1))
+    for axis_x, axis_y in axes:
+        norm = math.hypot(axis_x, axis_y)
+        if norm <= 1e-12:
+            continue
+        obb_projection = [x * axis_x + y * axis_y for x, y in polygon]
+        square_projection = [x * axis_x + y * axis_y for x, y in square]
+        overlap = min(max(obb_projection), max(square_projection)) - max(
+            min(obb_projection), min(square_projection)
+        )
+        if overlap <= 1e-12 * norm:
+            return False
+    return True
+
+
+def _clip_polygon_to_unit_square(points: Sequence[float]) -> List[float]:
+    """Clip a polygon to ``[0, 1]²`` with Sutherland-Hodgman clipping."""
+    vertices = [
+        (float(points[index]), float(points[index + 1]))
+        for index in range(0, len(points), 2)
+    ]
+
+    def clip(vertices, inside, intersection):
+        if not vertices:
+            return []
+        output = []
+        start = vertices[-1]
+        start_inside = inside(start)
+        for end in vertices:
+            end_inside = inside(end)
+            if end_inside:
+                if not start_inside:
+                    output.append(intersection(start, end))
+                output.append(end)
+            elif start_inside:
+                output.append(intersection(start, end))
+            start, start_inside = end, end_inside
+        return output
+
+    def at_x(start, end, boundary):
+        ratio = (boundary - start[0]) / (end[0] - start[0])
+        return boundary, start[1] + ratio * (end[1] - start[1])
+
+    def at_y(start, end, boundary):
+        ratio = (boundary - start[1]) / (end[1] - start[1])
+        return start[0] + ratio * (end[0] - start[0]), boundary
+
+    vertices = clip(vertices, lambda point: point[0] >= 0.0,
+                    lambda start, end: at_x(start, end, 0.0))
+    vertices = clip(vertices, lambda point: point[0] <= 1.0,
+                    lambda start, end: at_x(start, end, 1.0))
+    vertices = clip(vertices, lambda point: point[1] >= 0.0,
+                    lambda start, end: at_y(start, end, 0.0))
+    vertices = clip(vertices, lambda point: point[1] <= 1.0,
+                    lambda start, end: at_y(start, end, 1.0))
+
+    deduplicated = []
+    for vertex in vertices:
+        if not deduplicated or any(
+            abs(vertex[axis] - deduplicated[-1][axis]) > 1e-12
+            for axis in (0, 1)
+        ):
+            deduplicated.append(vertex)
+    if len(deduplicated) > 1 and all(
+        abs(deduplicated[0][axis] - deduplicated[-1][axis]) <= 1e-12
+        for axis in (0, 1)
+    ):
+        deduplicated.pop()
+    return [coordinate for vertex in deduplicated for coordinate in vertex]
+
+
+def _validate_obb_rectangle(points: Sequence[float], where: str) -> None:
+    """Require four cyclic corners of a rectangle, within text-rounding tolerance."""
+    vertices = [
+        (points[index], points[index + 1]) for index in range(0, 8, 2)
+    ]
+    edges = [
+        (
+            vertices[(index + 1) % 4][0] - vertices[index][0],
+            vertices[(index + 1) % 4][1] - vertices[index][1],
+        )
+        for index in range(4)
+    ]
+    lengths = [math.hypot(x, y) for x, y in edges]
+    if min(lengths) <= 1e-8:
+        raise ValueError(f"{where}: oriented box corners must be distinct")
+    span = max(
+        max(points[0::2]) - min(points[0::2]),
+        max(points[1::2]) - min(points[1::2]),
+        1e-4,
+    )
+    coordinate_tolerance = 2e-5 * span + 2e-6
+    # Diagonals of a parallelogram bisect each other. Combined with one right
+    # angle this is exactly a rectangle and rejects trapezoids/bow-ties.
+    midpoint_error = max(
+        abs(vertices[0][axis] + vertices[2][axis] - vertices[1][axis] - vertices[3][axis])
+        for axis in (0, 1)
+    )
+    right_angle_error = abs(edges[0][0] * edges[1][0] + edges[0][1] * edges[1][1])
+    # Each serialized coordinate is rounded to six decimals, so an edge component
+    # can accumulate ~1e-6 error at both ends. Include that absolute dot-product
+    # error as well as the scale-relative angular tolerance; otherwise legitimate
+    # thin rotated rectangles are rejected merely because their short edge is tiny.
+    quantization_tolerance = 2e-6 * (lengths[0] + lengths[1]) + 4e-12
+    angular_tolerance = max(
+        2e-5 * lengths[0] * lengths[1] + 2e-10,
+        quantization_tolerance,
+    )
+    if midpoint_error > coordinate_tolerance or right_angle_error > angular_tolerance:
+        raise ValueError(
+            f"{where}: four OBB corners must form an oriented rectangle in cyclic order"
+        )
+
+
+def sanitize_boxes(boxes: List[Box], nc: Optional[int] = None) -> List[Box]:
+    """Validate boxes before writing, raising instead of silently changing them."""
+    if not isinstance(boxes, (list, tuple)):
+        raise ValueError("boxes must be a list")
     out: List[Box] = []
-    for b in boxes:
-        try:
-            cls = int(b["cls"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        if cls < 0 or (nc is not None and cls >= nc):
-            continue
-        raw = (float(b["cx"]), float(b["cy"]), float(b["w"]), float(b["h"]))
-        if not all(math.isfinite(v) for v in raw):
-            continue   # reject nan/inf BEFORE clamp turns inf into an edge value
-        cx, cy = _clamp01(raw[0]), _clamp01(raw[1])
-        w, h = _clamp01(raw[2]), _clamp01(raw[3])
+    for i, b in enumerate(boxes):
+        where = f"box {i}"
+        if not isinstance(b, Mapping):
+            raise ValueError(f"{where}: expected an object")
+        cls = _class_id(b.get("cls"), nc, where)
+        cx = _finite_float(b.get("cx"), "cx", where)
+        cy = _finite_float(b.get("cy"), "cy", where)
+        w = _finite_float(b.get("w"), "w", where)
+        h = _finite_float(b.get("h"), "h", where)
+        if any(v < 0.0 or v > 1.0 for v in (cx, cy, w, h)):
+            raise ValueError(f"{where}: coordinates must be normalized to [0, 1]")
+        cx, cy, w, h = (_disk_float(value) for value in (cx, cy, w, h))
         if w <= 0.0 or h <= 0.0:
-            continue
+            raise ValueError(
+                f"{where}: width and height must remain positive at six-decimal precision"
+            )
         out.append(Box(cls=cls, cx=cx, cy=cy, w=w, h=h))
     return out
 
@@ -180,8 +367,8 @@ def has_out_of_bounds_coords(text: str) -> bool:
     """True if any normalized coordinate is outside ``[0, 1]`` (beyond float-format
     tolerance) or non-finite.
 
-    Such rows would be silently clamped into range and rewritten by the sanitizers
-    on any unrelated save, so the file must stay read-only to preserve them verbatim.
+    Such rows violate the normalized file contract. Keep the file read-only so an
+    unrelated save cannot rewrite geometry the user has not explicitly repaired.
     """
     tol = 1e-6
     for raw in text.splitlines():
@@ -227,8 +414,8 @@ def has_obb_shaped_rows(text: str) -> bool:
 def has_zero_area_box(text: str) -> bool:
     """True if any box row (``cls cx cy w h``) has ``w <= 0`` or ``h <= 0``.
 
-    ``sanitize_boxes``/``sanitize_annotations`` drop such zero-area boxes, so a file
-    containing one would lose that row on any save -- keep it read-only instead.
+    The strict write validator rejects such boxes. Keep an existing malformed file
+    read-only so an unrelated edit cannot implicitly repair or delete the row.
     """
     for raw in text.splitlines():
         line = raw.strip()
@@ -248,10 +435,9 @@ def has_zero_area_box(text: str) -> bool:
 def has_degenerate_polygon(text: str) -> bool:
     """True if any polygon row has ~zero clamped shoelace area (``area2 <= 1e-8``).
 
-    ``sanitize_annotations`` silently *drops* such collinear/collapsed polygons, so a
-    file containing one must stay read-only -- otherwise an unrelated edit/save would
-    delete that row before the user could recover its vertices. Mirrors the
-    sanitizer's clamp-then-area sequence exactly so read/write stay in lockstep.
+    A file containing one stays read-only so an unrelated edit/save cannot rewrite the
+    malformed row before the user repairs it. Mirrors the sanitizer's
+    clamp-then-area sequence exactly so read/write stay in lockstep.
     """
     for raw in text.splitlines():
         line = raw.strip()
@@ -279,10 +465,9 @@ def has_degenerate_polygon(text: str) -> bool:
 def has_out_of_range_rows(text: str, nc: Optional[int]) -> bool:
     """True if any row's integer class is outside ``[0, nc)``.
 
-    Such a file must stay read-only: ``sanitize_annotations`` drops out-of-range
-    rows, so an unrelated edit/save would silently delete that annotation before
-    the user could recover it. (Malformed/non-integer rows are handled by
-    :func:`has_unsupported_rows`.)
+    Such a file must stay read-only so an unrelated edit/save cannot rewrite the
+    invalid annotation before the user repairs it. (Malformed/non-integer rows are
+    handled by :func:`has_unsupported_rows`.)
     """
     if not nc or nc <= 0:
         return False
@@ -304,7 +489,7 @@ def format_annotations(anns: List[dict]) -> str:
     """Serialize mixed box/polygon annotations to YOLO label text."""
     lines: List[str] = []
     for a in anns:
-        cls = int(a["cls"])
+        cls = _class_id(a.get("cls"), None, "annotation")
         if a.get("type") == "poly":
             pts = a.get("points") or []
             if len(pts) >= 6:
@@ -316,41 +501,78 @@ def format_annotations(anns: List[dict]) -> str:
     return ("\n".join(lines) + "\n") if lines else ""
 
 
-def sanitize_annotations(anns: List[dict], nc: Optional[int] = None) -> List[dict]:
-    """Validate/clamp mixed annotations before writing."""
+def sanitize_annotations(
+    anns: List[dict], nc: Optional[int] = None, task: Optional[str] = None
+) -> List[dict]:
+    """Validate mixed annotations and return their canonical persisted geometry.
+
+    Boxes must already satisfy the normalized on-disk contract. Polygon vertices
+    are clipped to the image canvas because interactive vertex moves may cross an
+    edge. OBB quads are translated as a whole when possible so clipping does not
+    shear a rectangle. Invalid input raises ``ValueError``; a successful save never
+    reports fewer annotations than the caller supplied.
+    """
+    if not isinstance(anns, (list, tuple)):
+        raise ValueError("annotations must be a list")
+    normalized_task = str(task or "").strip().lower()
     out: List[dict] = []
-    for a in anns:
-        try:
-            cls = int(a["cls"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        if cls < 0 or (nc is not None and cls >= nc):
-            continue
-        if a.get("type") == "poly":
-            raw_pts = [float(v) for v in (a.get("points") or [])]
+    for i, a in enumerate(anns):
+        where = f"annotation {i}"
+        if not isinstance(a, Mapping):
+            raise ValueError(f"{where}: expected an object")
+        cls = _class_id(a.get("cls"), nc, where)
+        kind = a.get("type") or "box"
+        if kind not in ("box", "poly"):
+            raise ValueError(f"{where}: type must be 'box' or 'poly'")
+        if normalized_task == "detect" and kind != "box":
+            raise ValueError(f"{where}: detection annotations require boxes")
+        if normalized_task == "obb" and kind != "poly":
+            raise ValueError(f"{where}: OBB annotations require exactly 4 corners")
+        if kind == "poly":
+            values = a.get("points")
+            if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+                raise ValueError(f"{where}: polygon points must be a list")
+            raw_pts = [
+                _finite_float(value, f"point {j}", where)
+                for j, value in enumerate(values)
+            ]
             if len(raw_pts) < 6 or len(raw_pts) % 2 != 0:
-                continue
-            if not all(math.isfinite(v) for v in raw_pts):
-                continue   # nan/inf vertex -> drop BEFORE clamp (inf would clamp to a finite edge)
-            pts = [_clamp01(v) for v in raw_pts]
-            xs, ys = pts[0::2], pts[1::2]
-            # Shoelace area: a width/height (bbox) check misses *diagonal* collinear
-            # polygons -- e.g. (0,0),(0.5,0.5),(1,1) has positive bbox extents but
-            # zero area. Drop any polygon whose actual area is ~0 so we never write a
-            # degenerate segment that breaks training after vertex edits.
-            n = len(xs)
-            area2 = abs(sum(xs[i] * ys[(i + 1) % n] - xs[(i + 1) % n] * ys[i]
-                            for i in range(n)))
-            if area2 <= 1e-8:   # 2*area in normalised coords; ~0 -> collinear/collapsed
-                continue
+                raise ValueError(f"{where}: polygon needs at least 3 coordinate pairs")
+            if normalized_task == "obb":
+                if len(raw_pts) != 8:
+                    raise ValueError(f"{where}: OBB annotations require exactly 4 corners")
+                if _polygon_area2(raw_pts) <= 1e-8:
+                    raise ValueError(f"{where}: polygon must have non-zero area")
+                _validate_obb_rectangle(raw_pts, where)
+                pts = _clip_obb(raw_pts, where)
+            else:
+                pts = _clip_polygon_to_unit_square(raw_pts)
+                if len(pts) < 6:
+                    raise ValueError(
+                        f"{where}: polygon does not overlap the image canvas"
+                    )
+            pts = [_disk_float(value) for value in pts]
+            if len(set(zip(pts[0::2], pts[1::2], strict=True))) < 3:
+                raise ValueError(
+                    f"{where}: polygon needs 3 distinct points at six-decimal precision"
+                )
+            # Shoelace area catches collinear/collapsed polygons after clipping.
+            if _polygon_area2(pts) <= 1e-8:
+                raise ValueError(f"{where}: polygon must have non-zero area")
+            if normalized_task == "obb":
+                _validate_obb_rectangle(pts, where)
             out.append({"type": "poly", "cls": cls, "points": pts})
         else:
-            raw = (float(a["cx"]), float(a["cy"]), float(a["w"]), float(a["h"]))
-            if not all(math.isfinite(v) for v in raw):
-                continue   # reject nan/inf before clamp
-            cx, cy = _clamp01(raw[0]), _clamp01(raw[1])
-            w, h = _clamp01(raw[2]), _clamp01(raw[3])
+            cx = _finite_float(a.get("cx"), "cx", where)
+            cy = _finite_float(a.get("cy"), "cy", where)
+            w = _finite_float(a.get("w"), "w", where)
+            h = _finite_float(a.get("h"), "h", where)
+            if any(v < 0.0 or v > 1.0 for v in (cx, cy, w, h)):
+                raise ValueError(f"{where}: box coordinates must be normalized to [0, 1]")
+            cx, cy, w, h = (_disk_float(value) for value in (cx, cy, w, h))
             if w <= 0.0 or h <= 0.0:
-                continue
+                raise ValueError(
+                    f"{where}: box width and height must remain positive at six-decimal precision"
+                )
             out.append({"type": "box", "cls": cls, "cx": cx, "cy": cy, "w": w, "h": h})
     return out

--- a/libreyolo/label/labelio.py
+++ b/libreyolo/label/labelio.py
@@ -552,6 +552,13 @@ def sanitize_annotations(
                         f"{where}: polygon does not overlap the image canvas"
                     )
             pts = [_disk_float(value) for value in pts]
+            if any(
+                not math.isfinite(value) or value < 0.0 or value > 1.0
+                for value in pts
+            ):
+                raise ValueError(
+                    f"{where}: clipped polygon points must remain finite and normalized"
+                )
             if len(set(zip(pts[0::2], pts[1::2], strict=True))) < 3:
                 raise ValueError(
                     f"{where}: polygon needs 3 distinct points at six-decimal precision"

--- a/libreyolo/label/server.py
+++ b/libreyolo/label/server.py
@@ -29,6 +29,7 @@ import os
 import re
 import socket
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Optional
@@ -57,6 +58,15 @@ from .sam import SamEngine
 
 logger = logging.getLogger(__name__)
 
+# Request bodies are deliberately bounded. JSON endpoints never need image-sized
+# payloads, while the larger ceiling keeps the raw single-image upload useful.
+_MAX_JSON_BODY_BYTES = 8 * 1024 * 1024
+_MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
+_BODY_READ_CHUNK_BYTES = 64 * 1024
+_BODY_READ_TIMEOUT_SECONDS = 10.0
+_BODY_DISCARD_TIMEOUT_SECONDS = 1.0
+_MAX_CONTENT_LENGTH_DIGITS = 20
+
 # Absolute filesystem paths (Windows ``C:\...`` or POSIX ``/...``) we must not leak
 # to LAN clients in error strings on a shared server.
 _ABS_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)[^\s\"']+")
@@ -64,6 +74,14 @@ _ABS_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)[^\s\"']+")
 
 class _ProjectConflict(RuntimeError):
     """A request was bound to a project generation that is no longer current."""
+
+
+class _RequestBodyError(ValueError):
+    """The POST body framing is invalid or the declared body is incomplete."""
+
+
+class _RequestBodyTooLarge(_RequestBodyError):
+    """The declared POST body exceeds an endpoint's bounded body limit."""
 
 
 def _nonnegative_int(value, name: str) -> int:
@@ -731,6 +749,23 @@ class _Handler(BaseHTTPRequestHandler):
         except (BrokenPipeError, ConnectionResetError):
             pass
 
+    def _send_after_body_discard(
+        self, code: int, body, ctype: str = "application/json"
+    ) -> None:
+        """Finish an early POST response without closing on unread request bytes."""
+        try:
+            # Keep memory and wall time bounded, but consume every body that is
+            # valid under the server-wide framing contract.  A smaller size cap
+            # leaves otherwise-valid bytes unread and can make Windows reset the
+            # socket before the client receives this response.
+            self._discard_request_body()
+        except _RequestBodyTooLarge:
+            self._send(413, {"error": "request body too large"})
+        except _RequestBodyError:
+            self._send(400, {"error": "invalid or incomplete request body"})
+        else:
+            self._send(code, body, ctype)
+
     # -- GET ---------------------------------------------------------------
     def do_GET(self):  # noqa: N802
         parsed = urlparse(self.path)
@@ -888,14 +923,18 @@ class _Handler(BaseHTTPRequestHandler):
 
     # -- POST --------------------------------------------------------------
     def do_POST(self):  # noqa: N802
+        # A handler can process more than one HTTP/1.1 request, so body framing
+        # state belongs to one dispatch rather than the lifetime of the handler.
+        self._request_body_length = None
+        self._request_body_consumed = False
         parsed = urlparse(self.path)
         path = parsed.path
         try:
             if not self._host_allowed():
-                self._send(403, {"error": "host not allowed"})
+                self._send_after_body_discard(403, {"error": "host not allowed"})
                 return
             if not self._same_origin():
-                self._send(403, {"error": "cross-origin request blocked"})
+                self._send_after_body_discard(403, {"error": "cross-origin request blocked"})
                 return
             # Host-admin only: switching the project, pruning duplicates, and the
             # heavy full-dataset compute streams all rebind/clobber server-global
@@ -907,20 +946,25 @@ class _Handler(BaseHTTPRequestHandler):
                         "/api/projects/forget", "/api/pick-folder", "/api/classes", "/api/insights/fix",
                         "/api/boost", "/api/assist/autolabel", "/api/assist/radar",
                         "/api/embeddings") and not self._local_admin():
-                self._send(403, {"error": "This action (create / switch project, edit classes, "
-                                          "prune duplicates, full-dataset auto-label, Radar, "
-                                          "embeddings, Boost) is only allowed from the host "
-                                          "machine on a shared server."})
+                self._send_after_body_discard(
+                    403,
+                    {"error": "This action (create / switch project, edit classes, "
+                              "prune duplicates, full-dataset auto-label, Radar, "
+                              "embeddings, Boost) is only allowed from the host "
+                              "machine on a shared server."},
+                )
                 return
             if self.state.session is None and path not in (
                     "/api/projects/open", "/api/projects/create", "/api/projects/new", "/api/upload",
                     "/api/projects/inspect", "/api/projects/forget", "/api/projects/rename",
                     "/api/projects/delete", "/api/pick-folder"):
-                self._send(409, {"error": "no project open"})
+                self._send_after_body_discard(409, {"error": "no project open"})
                 return
             if (path.startswith("/api/assist/") or path in ("/api/embeddings", "/api/boost")) \
                     and not self.state.engine.enabled:
-                self._send(403, {"error": "AI assist is disabled (started with --no-assist)."})
+                self._send_after_body_discard(
+                    403, {"error": "AI assist is disabled (started with --no-assist)."}
+                )
                 return
             # Task-gate the assist stack. OBB: everything it emits (axis-aligned
             # boxes from prelabel/autolabel/Radar/Boost, free polygons from SAM)
@@ -932,14 +976,20 @@ class _Handler(BaseHTTPRequestHandler):
             if task == "obb" and (
                     path.startswith(("/api/assist/prelabel", "/api/assist/segment"))
                     or path in ("/api/assist/autolabel", "/api/assist/radar", "/api/boost")):
-                self._send(409, {"error": "AI assist works with boxes and masks, not oriented "
-                                          "boxes - it is disabled for OBB projects."})
+                self._send_after_body_discard(
+                    409,
+                    {"error": "AI assist works with boxes and masks, not oriented "
+                              "boxes - it is disabled for OBB projects."},
+                )
                 return
             if task == "segment" and (
                     path.startswith("/api/assist/prelabel")
                     or path in ("/api/assist/autolabel", "/api/boost")):
-                self._send(409, {"error": "Box auto-label is disabled for segmentation projects "
-                                          "- use SAM (S) or the polygon tool instead."})
+                self._send_after_body_discard(
+                    409,
+                    {"error": "Box auto-label is disabled for segmentation projects "
+                              "- use SAM (S) or the polygon tool instead."},
+                )
                 return
             if path == "/api/projects/open":
                 payload = self._read_json()
@@ -1216,29 +1266,129 @@ class _Handler(BaseHTTPRequestHandler):
                     epochs=int(kw.get("epochs", 2)), imgsz=int(kw.get("imgsz", 512)),
                     batch=int(kw.get("batch", 4))))
             else:
-                self._send(404, {"error": "not found"})
+                self._send_after_body_discard(404, {"error": "not found"})
+        except _RequestBodyTooLarge:
+            self._send(413, {"error": "request body too large"})
+        except _RequestBodyError:
+            self._send(400, {"error": "invalid or incomplete request body"})
         except (IndexError, ValueError) as exc:
-            self._send(400, {"error": str(exc)})
+            self._send_after_body_discard(400, {"error": str(exc)})
         except RuntimeError as exc:  # read-only / non-box file -> 409
             # 409 reasons are mostly path-free (read-only/conflict), but one can carry
             # an absolute path; scrub it for non-admin LAN clients.
             msg = str(exc) if self._local_admin() else _redact_paths(str(exc))
-            self._send(409, {"error": msg})
+            self._send_after_body_discard(409, {"error": msg})
         except Exception as exc:  # noqa: BLE001
             logger.exception("label POST failed: %s", path)
-            self._send(500, {"error": str(exc) if self._local_admin() else "internal error"})
+            self._send_after_body_discard(
+                500, {"error": str(exc) if self._local_admin() else "internal error"}
+            )
 
     def _read_json(self):
-        length = int(self.headers.get("Content-Length", 0) or 0)
-        data = self.rfile.read(length) if length else b""
+        data = self._read_body_bytes(limit=_MAX_JSON_BODY_BYTES)
         return (
             json.loads(data.decode("utf-8"), object_pairs_hook=_unique_json_object)
             if data else {}
         )
 
-    def _read_body_bytes(self) -> bytes:
-        length = int(self.headers.get("Content-Length", 0) or 0)
-        return self.rfile.read(length) if length else b""
+    def _declared_request_body_length(self) -> int:
+        cached = getattr(self, "_request_body_length", None)
+        if cached is not None:
+            return cached
+
+        transfer_encoding = self.headers.get_all("Transfer-Encoding", [])
+        content_lengths = self.headers.get_all("Content-Length", [])
+        if transfer_encoding:
+            self._request_body_consumed = True
+            self.close_connection = True
+            raise _RequestBodyError("Transfer-Encoding request bodies are unsupported")
+        if len(content_lengths) > 1:
+            self._request_body_consumed = True
+            self.close_connection = True
+            raise _RequestBodyError("exactly one Content-Length header is allowed")
+        if not content_lengths:
+            length = 0
+        else:
+            raw = content_lengths[0].strip()
+            if (
+                not raw
+                or len(raw) > _MAX_CONTENT_LENGTH_DIGITS
+                or re.fullmatch(r"[0-9]+", raw) is None
+            ):
+                self._request_body_consumed = True
+                self.close_connection = True
+                raise _RequestBodyError("invalid Content-Length header")
+            length = int(raw)
+        if length > _MAX_REQUEST_BODY_BYTES:
+            self._request_body_consumed = True
+            self.close_connection = True
+            raise _RequestBodyTooLarge("request body too large")
+        self._request_body_length = length
+        return length
+
+    def _consume_request_body(
+        self, *, collect: bool, limit: int, timeout: float
+    ) -> bytes:
+        if getattr(self, "_request_body_consumed", False):
+            if collect:
+                raise _RequestBodyError("request body was already consumed")
+            return b""
+
+        length = self._declared_request_body_length()
+        if length > limit:
+            self._request_body_consumed = True
+            self.close_connection = True
+            raise _RequestBodyTooLarge("request body too large")
+        self._request_body_consumed = True
+        if length == 0:
+            return b""
+
+        chunks = [] if collect else None
+        remaining = length
+        deadline = time.monotonic() + timeout
+        previous_timeout = self.connection.gettimeout()
+        read = getattr(self.rfile, "read1", self.rfile.read)
+        try:
+            while remaining:
+                time_left = deadline - time.monotonic()
+                if time_left <= 0:
+                    raise _RequestBodyError("incomplete request body")
+                try:
+                    self.connection.settimeout(time_left)
+                    chunk = read(min(remaining, _BODY_READ_CHUNK_BYTES))
+                except (OSError, ValueError) as exc:
+                    raise _RequestBodyError("incomplete request body") from exc
+                if not chunk:
+                    raise _RequestBodyError("incomplete request body")
+                remaining -= len(chunk)
+                if chunks is not None:
+                    chunks.append(chunk)
+        except _RequestBodyError:
+            self.close_connection = True
+            raise
+        finally:
+            try:
+                self.connection.settimeout(previous_timeout)
+            except OSError:
+                self.close_connection = True
+        return b"".join(chunks) if chunks is not None else b""
+
+    def _discard_request_body(self, *, limit: int = _MAX_REQUEST_BODY_BYTES) -> None:
+        self._consume_request_body(
+            collect=False,
+            limit=limit,
+            timeout=_BODY_DISCARD_TIMEOUT_SECONDS,
+        )
+
+    def _read_body_bytes(self, *, limit: int = _MAX_REQUEST_BODY_BYTES) -> bytes:
+        if self._declared_request_body_length() > limit:
+            # The endpoint limit prevents allocation; still drain bodies within the
+            # global framing ceiling so Windows clients reliably receive the 413.
+            self._discard_request_body(limit=_MAX_REQUEST_BODY_BYTES)
+            raise _RequestBodyTooLarge("request body too large")
+        return self._consume_request_body(
+            collect=True, limit=limit, timeout=_BODY_READ_TIMEOUT_SECONDS
+        )
 
     @staticmethod
     def _required_query_int(qs: dict, name: str) -> int:
@@ -1471,9 +1621,7 @@ class _Handler(BaseHTTPRequestHandler):
         """Stream NDJSON: one ``{"type":"progress"}`` per image, then a final
         ``{"type":"done"}`` (or ``{"type":"error"}``). No Content-Length so each
         flushed line reaches the browser's fetch stream immediately."""
-        length = int(self.headers.get("Content-Length", 0) or 0)
-        if length:
-            self.rfile.read(length)
+        self._discard_request_body()
         model, conf = self._model_conf(qs)
         engine = (qs.get("engine") or ["yolo"])[0]
         classes = [c for c in (qs.get("classes") or [""])[0].split(",") if c.strip()]
@@ -1540,9 +1688,7 @@ class _Handler(BaseHTTPRequestHandler):
         """Audit accepted labels with the model; stream per-image progress then a
         sorted ``deck`` of disagreements. Per-image findings are parked in state
         for the UI to overlay (``GET /api/assist/radar/<id>``)."""
-        length = int(self.headers.get("Content-Length", 0) or 0)
-        if length:
-            self.rfile.read(length)
+        self._discard_request_body()
         epoch = self._required_query_int(qs, "epoch")
         sess = self.state.capture_session(epoch, "running Radar")
         model, conf = self._model_conf(qs)
@@ -1564,9 +1710,7 @@ class _Handler(BaseHTTPRequestHandler):
 
     def _handle_embeddings_stream(self, qs: dict) -> None:
         """Embed every image and stream the 2-D PCA scatter (``{id,x,y}``)."""
-        length = int(self.headers.get("Content-Length", 0) or 0)
-        if length:
-            self.rfile.read(length)
+        self._discard_request_body()
         epoch = self._required_query_int(qs, "epoch")
         sess = self.state.capture_session(epoch, "mapping")
         if not self.state.embed.available():

--- a/libreyolo/label/server.py
+++ b/libreyolo/label/server.py
@@ -12,8 +12,8 @@ Endpoints
 ``GET  /api/dataset``          ``{root, names, nc, count, writable, reason}``
 ``GET  /api/images``           ``{images:[{id,name,split,status}]}`` (paged)
 ``GET  /api/image/<id>``       raw image bytes
-``GET  /api/label/<id>``       ``{boxes:[{cls,cx,cy,w,h}], editable}``
-``POST /api/label/<id>``       body ``{boxes:[...]}`` -> writes the ``.txt``
+``GET  /api/label/<id>``       ``{annotations:[...], editable, rev, epoch}``
+``POST /api/label/<id>``       query ``epoch``/``rev`` + body ``{annotations:[...]}``
 ``GET  /api/assist/status``    ``{available, models, default}``
 ``POST /api/assist/prelabel/<id>``  query ``model``/``conf`` -> ``{suggestions:[...]}``
 ``POST /api/assist/autolabel`` query ``model``/``conf`` -> NDJSON progress stream
@@ -60,6 +60,49 @@ logger = logging.getLogger(__name__)
 _ABS_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)[^\s\"']+")
 
 
+class _ProjectConflict(RuntimeError):
+    """A request was bound to a project generation that is no longer current."""
+
+
+def _nonnegative_int(value, name: str) -> int:
+    """Parse an explicit integer token without silently truncating floats/bools."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a non-negative integer")
+    if isinstance(value, int):
+        out = value
+    elif isinstance(value, str) and re.fullmatch(r"[0-9]+", value.strip()):
+        out = int(value.strip())
+    else:
+        raise ValueError(f"{name} must be a non-negative integer")
+    if out < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return out
+
+
+def _project_root_key(data) -> str:
+    """Canonical project-root identity for either a dataset dir or YAML path."""
+    p = Path(str(data)).expanduser()
+    # A directory may legitimately end in .yaml/.yml.  Only strip the filename
+    # suffix when the supplied path is not an existing directory.
+    if not p.is_dir() and p.suffix.lower() in (".yaml", ".yml"):
+        p = p.parent
+    try:
+        p = p.resolve(strict=False)
+    except (OSError, RuntimeError):
+        p = Path(os.path.abspath(str(p)))
+    return os.path.normcase(str(p)).casefold()
+
+
+def _unique_json_object(pairs):
+    """Reject duplicate JSON keys instead of silently keeping the last value."""
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise ValueError(f"duplicate JSON key: {key}")
+        out[key] = value
+    return out
+
+
 def _redact_paths(msg: str) -> str:
     return _ABS_PATH_RE.sub("<path>", str(msg))
 
@@ -90,7 +133,11 @@ class _LabelState:
         self.host = "127.0.0.1"               # bind address (for the teammate share URL)
         self.port = 0
         self.epoch = 0                        # bumps on every project switch (stale-save guard)
-        self._lock = threading.Lock()
+        # One project transaction lock covers session rebinding and every mutation
+        # whose target is derived from the live session.  It is re-entrant because an
+        # in-place export installs its freshly rebuilt DatasetSession before releasing
+        # the transaction.
+        self._lock = threading.RLock()
         self.engine = AssistEngine(device=device, enabled=assist)
         self.sam = SamEngine(enabled=assist, device=device)
         self.embed = EmbedEngine(device=device, enabled=assist)
@@ -102,20 +149,84 @@ class _LabelState:
         self._radar_lock = threading.Lock()
         self.embed_points = None              # cached 2-D embedding scatter
 
-    def register_current(self, data) -> None:
+    def _session_for_epoch_locked(self, expected_epoch, action: str):
+        if self.session is None:
+            raise RuntimeError("no project open")
+        if expected_epoch is not None and expected_epoch != self.epoch:
+            raise _ProjectConflict(f"project changed - reload before {action}")
+        return self.session
+
+    def capture_session(self, expected_epoch: int, action: str):
+        """Atomically bind a long-running request to its asserted project epoch."""
+        with self._lock:
+            return self._session_for_epoch_locked(expected_epoch, action)
+
+    def session_is_current(self, session) -> bool:
+        """Return whether ``session`` still owns the live project generation."""
+        with self._lock:
+            return self.session is session
+
+    def _clear_project_caches_locked(self, session) -> None:
+        self.engine.clear_pending()
+        with self._radar_lock:
+            self.radar_findings = {}
+        self.embed_points = None
+        self.embed._cache.clear()
+        self.sam._cur = None
+        with self.engine._lock:                       # mutually exclusive with boost publication
+            # Rebind before removing the model while still holding the publication
+            # lock.  A finishing worker must not observe its old session between
+            # these operations and republish that project's model after the switch.
+            self.boost.on_project_switch(session)
+            self.engine._models.pop("boosted", None)  # boosted model is per-project
+        with self._thumb_lock:
+            self._thumbs.clear()
+
+    def _install_session_locked(self, session, data) -> dict:
+        self.session = session
+        self._data = str(data)
+        self.epoch += 1
+        self._clear_project_caches_locked(session)
+        meta = session.meta()
+        meta["open"] = True
+        meta["epoch"] = self.epoch
+        return meta
+
+    def _drop_session_locked(self) -> None:
+        self.session = None
+        self._data = None
+        self.epoch += 1
+        self._clear_project_caches_locked(None)
+
+    def register_current(self, data, *, session=None, epoch=None) -> None:
         """Record the open dataset in the registry. The ``labeled`` count needs a
         full label scan, so it runs on a background thread -- never blocking the
         open/switch action (which would be seconds of dead UI on big datasets)."""
-        if self.session is None:
-            return
-        self._data = str(data)
-        session = self.session
+        with self._lock:
+            session = self.session if session is None else session
+            if session is None or self.session is not session:
+                return
+            epoch = self.epoch if epoch is None else epoch
+            if epoch != self.epoch:
+                return
+            self._data = str(data)
+        data = str(data)
 
         def _work():
             try:
-                projects.register(data, root=session.root or None,
-                                  count=session.meta().get("count"),
-                                  labeled=session.stats().get("labeled"))
+                count = session.meta().get("count")
+                labeled = session.stats().get("labeled")
+                # The scan above can be slow.  Re-check identity and register while
+                # holding the project lock so a later delete cannot forget the entry
+                # and then have this stale worker resurrect it.
+                with self._lock:
+                    if self.session is not session or self.epoch != epoch:
+                        return
+                    if self._data is None or _project_root_key(self._data) != _project_root_key(data):
+                        return
+                    name = session.meta().get("name") or None
+                    projects.register(data, name=name, root=session.root or None,
+                                      count=count, labeled=labeled)
             except Exception:  # noqa: BLE001 - registry is a convenience, never fatal
                 logger.exception("project registry update failed")
 
@@ -124,57 +235,127 @@ class _LabelState:
     def open_project(self, data) -> dict:
         """Switch the live session to ``data`` (a data.yaml/dir), resetting all
         per-project state the engines hold. Raises on a bad dataset path."""
-        session = DatasetSession(data)        # validate before mutating anything
         with self._lock:
-            self.session = session
-            self.epoch += 1                   # invalidate in-flight saves from the old project
-            self.engine.clear_pending()
-            self.radar_findings = {}
-            self.embed_points = None
-            self.embed._cache.clear()
-            self.sam._cur = None
-            with self.engine._lock:                     # mutually exclusive with the boost write
-                self.engine._models.pop("boosted", None)   # boosted model is per-project
-            self.boost.on_project_switch(session)       # keeps a running boost intact
-            with self._thumb_lock:
-                self._thumbs.clear()
-        self.register_current(data)
-        return session.meta()
+            # Construct under the same lock as export/delete.  Otherwise an open of
+            # the current path can validate a pre-export tree and install that stale
+            # view after an in-place export has reorganised it.
+            session = DatasetSession(data)
+            meta = self._install_session_locked(session, data)
+            epoch = self.epoch
+        self.register_current(data, session=session, epoch=epoch)
+        return meta
 
-    def set_class_names(self, names) -> dict:
+    def create_project(self, folder, *, classes, colors, task, link, name) -> dict:
+        """Create/open a folder project as one serialized project transaction."""
+        with self._lock:
+            existing = folder_yaml(str(folder))
+            if existing:
+                target = existing
+            elif link:
+                target = create_linked_project(
+                    str(folder), name=name or None, classes=classes or [],
+                    colors=colors or [], task=task)
+            else:
+                target = scaffold_data_yaml(str(folder), classes or [], task=task)
+            session = DatasetSession(target)
+            meta = self._install_session_locked(session, target)
+            meta["created"] = existing is None
+            epoch = self.epoch
+        self.register_current(target, session=session, epoch=epoch)
+        return meta
+
+    def save_upload(self, dst, name, data) -> str:
+        """Serialize upload reserve/write and New Project finalization."""
+        with self._lock:
+            return save_uploaded_image(str(dst), str(name), data)
+
+    def create_uploaded_project(self, dst, **kwargs) -> dict:
+        with self._lock:
+            target = create_uploaded_project(str(dst), **kwargs)
+            session = DatasetSession(target)
+            meta = self._install_session_locked(session, target)
+            meta["created"] = True
+            epoch = self.epoch
+        self.register_current(target, session=session, epoch=epoch)
+        return meta
+
+    def set_class_names(self, names, *, expected_epoch=None) -> dict:
         """Rename and/or append dataset classes -- never delete or reorder, so
         existing label class ids keep their meaning -- rewriting the YAML and
-        patching the live session in place. No epoch bump: ids are preserved, so
-        in-flight saves from this project stay valid."""
+        rebuilding the live session as a new project generation.  A rename changes
+        the semantic meaning of an id, so stale tabs and in-flight suggestions must
+        not remain writable merely because the integer positions are stable."""
+        reopened = None
+        data = None
+        epoch = None
         with self._lock:
-            if self.session is None:
-                raise RuntimeError("no project open")
+            session = self._session_for_epoch_locked(expected_epoch, "editing classes")
             cleaned = [str(n).strip() for n in names]
             if any(not n for n in cleaned):
                 raise ValueError("class names can't be empty")
             if len({n.lower() for n in cleaned}) != len(cleaned):
                 raise ValueError("class names must be unique")
-            if len(cleaned) < self.session.nc:
+            if len(cleaned) < session.nc:
                 raise ValueError("classes can be renamed or added here, not removed")
-            update_class_names(self.session.yaml_file, cleaned)
-            self.session.names = cleaned
-            self.session.nc = len(cleaned)
-            return self.session.meta()
+            if cleaned == list(session.names):
+                meta = session.meta()
+                meta["open"] = True
+                meta["epoch"] = self.epoch
+                return meta
+            # Validate/rebuild the session snapshot before touching the YAML. The
+            # class edit itself cannot then leave disk changed while state remains
+            # bound to an old generation if dataset reopening fails.
+            reopened = DatasetSession(session.yaml_file)
+            update_class_names(session.yaml_file, cleaned)
+            data = self._data or session.yaml_file
+            reopened.names = cleaned
+            reopened.nc = len(cleaned)
+            meta = self._install_session_locked(reopened, data)
+            epoch = self.epoch
+        self.register_current(data, session=reopened, epoch=epoch)
+        return meta
+
+    def _session_aliases_locked(self, session, submitted=None) -> set[str]:
+        values = {
+            str(value)
+            for value in (
+                submitted,
+                self._data,
+                session.yaml_file,
+                Path(session.yaml_file).parent,
+            )
+            if value
+        }
+        if session.root and _project_root_key(session.root) == _project_root_key(
+            session.yaml_file
+        ):
+            values.add(str(session.root))
+        return values
 
     def read_label_with_rev(self, idx: int) -> tuple:
         """Read annotations + revision under the save lock, so a save can't land
         between the two and hand a stale client old annotations with a NEW rev
         (which its next save would then use to pass the conflict check)."""
         with self._lock:
-            anns, editable = self.session.read_label(idx)
-            return anns, editable, self.session.label_rev(idx)
+            session = self._session_for_epoch_locked(None, "reading labels")
+            anns, editable = session.read_label(idx)
+            return anns, editable, session.label_rev(idx), self.epoch
+
+    def dataset_meta(self):
+        """Return metadata and its matching epoch from one session snapshot."""
+        with self._lock:
+            if self.session is None:
+                return None
+            meta = self.session.meta()
+            meta["open"] = True
+            meta["epoch"] = self.epoch
+            return meta
 
     def write_label(self, idx: int, boxes, epoch=None, expected_rev=None) -> tuple:
         with self._lock:  # serialize concurrent saves to the same tree (check+write atomic)
-            if epoch is not None and epoch != self.epoch:
-                raise RuntimeError("project changed; reload before saving")
-            count = self.session.write_label(idx, boxes, expected_rev=expected_rev)
-            return count, self.session.label_rev(idx)
+            session = self._session_for_epoch_locked(epoch, "saving")
+            count = session.write_label(idx, boxes, expected_rev=expected_rev)
+            return count, session.label_rev(idx)
 
     def store_pending(self, idx: int, sugg, sess) -> bool:
         """Store prelabel suggestions iff still on ``sess`` -- atomically with the
@@ -187,13 +368,128 @@ class _LabelState:
             self.engine.set_pending(idx, sugg)
             return True
 
+    def clear_pending(self, sess) -> bool:
+        """Clear suggestions only if the run still owns the live project."""
+        with self._lock:
+            if self.session is not sess:
+                return False
+            self.engine.clear_pending()
+            return True
+
+    def store_radar_findings(self, findings, sess) -> bool:
+        with self._lock:
+            if self.session is not sess:
+                return False
+            with self._radar_lock:
+                self.radar_findings = findings
+            return True
+
+    def store_embed_points(self, points, sess) -> bool:
+        with self._lock:
+            if self.session is not sess:
+                return False
+            self.embed_points = points
+            return True
+
     def resolve_duplicates(self, ids, purge: bool = False, epoch=None) -> dict:
         with self._lock:  # serialize against label writes on the same tree
             # Same stale-guard as write_label: a Fix request carrying a since-switched
             # project's epoch must not quarantine/purge same-id images in the new one.
-            if epoch is not None and epoch != self.epoch:
-                raise RuntimeError("project changed; reload before fixing duplicates")
-            return self.session.resolve_duplicates(ids, purge=purge)
+            session = self._session_for_epoch_locked(epoch, "fixing duplicates")
+            return session.resolve_duplicates(ids, purge=purge)
+
+    def update_project_meta(self, fields: dict, *, expected_epoch: int) -> dict:
+        """Update the open project's sidecar without a switch interleaving."""
+        with self._lock:
+            session = self._session_for_epoch_locked(expected_epoch, "editing settings")
+            target = self._data or session.yaml_file
+            update_sidecar(str(target), **fields)
+            if isinstance(session._sidecar, dict):
+                session._sidecar.update(fields)
+            else:
+                session._sidecar = dict(fields)
+            if "name" in fields:
+                for alias in self._session_aliases_locked(session, target):
+                    projects.rename(alias, fields["name"])
+            meta = session.meta()
+            meta["open"] = True
+            meta["epoch"] = self.epoch
+            return meta
+
+    def rename_project(self, data, name: str) -> None:
+        with self._lock:
+            set_sidecar_name(str(data), name)
+            aliases = {str(data)}
+            if self.session is not None and _project_root_key(data) == _project_root_key(self.session.yaml_file):
+                aliases.update(self._session_aliases_locked(self.session, data))
+                if not isinstance(self.session._sidecar, dict):
+                    self.session._sidecar = {}
+                self.session._sidecar["name"] = name
+            for alias in aliases:
+                projects.rename(alias, name)
+
+    def forget_project(self, data) -> None:
+        with self._lock:
+            projects.forget(str(data))
+
+    def delete_project(self, data, *, expected_epoch=None) -> dict:
+        """Trash a project and atomically detach it if it is the live session."""
+        with self._lock:
+            is_current = (
+                self.session is not None
+                and _project_root_key(data) == _project_root_key(self.session.yaml_file)
+            )
+            if is_current:
+                if expected_epoch is None:
+                    raise ValueError("epoch is required when deleting the open project")
+                if expected_epoch != self.epoch:
+                    raise _ProjectConflict("project changed - reload before deleting")
+            aliases = {str(data)}
+            if is_current:
+                aliases.update(self._session_aliases_locked(self.session, data))
+            trashed = trash_project(str(data))
+            for alias in aliases:
+                projects.forget(alias)
+            if is_current:
+                self._drop_session_locked()
+            return {"trash": trashed, "closed": is_current, "epoch": self.epoch}
+
+    def start_boost(self, *, expected_epoch: int, **kwargs) -> dict:
+        """Start Boost only for the project generation asserted by the client."""
+        with self._lock:
+            session = self._session_for_epoch_locked(expected_epoch, "starting Boost")
+            if self.boost.session is not session:
+                with self.engine._lock:
+                    self.boost.on_project_switch(session)
+            return self.boost.start(**kwargs)
+
+    def export_project(self, *, expected_epoch: int, **kwargs) -> dict:
+        """Export a stable session snapshot; rebind atomically after in-place work."""
+        from . import export as _export
+
+        reopened = None
+        reopen_data = None
+        reopen_epoch = None
+        with self._lock:
+            session = self._session_for_epoch_locked(expected_epoch, "exporting")
+            res = _export.export_dataset(
+                session, _in_place_validator=DatasetSession, **kwargs
+            )
+            if res.get("in_place"):
+                reopen_data = res.get("yaml") or self._data
+                if not reopen_data:
+                    raise RuntimeError("in-place export did not return a dataset path")
+                reopened = res.pop("_reopened_session", None)
+                if reopened is None:
+                    raise RuntimeError("in-place export did not validate its new session")
+                meta = self._install_session_locked(reopened, reopen_data)
+                reopen_epoch = self.epoch
+                res["epoch"] = reopen_epoch
+                res["reopened"] = True
+                res["dataset"] = meta
+        if reopened is not None:
+            self.register_current(reopen_data, session=reopened, epoch=reopen_epoch)
+        return res
 
     def thumb(self, idx: int, path: Path) -> bytes:
         # Key by the absolute image path, not the numeric id: after a project switch
@@ -271,12 +567,10 @@ class _Handler(BaseHTTPRequestHandler):
                     "shareable": shareable,
                 })
             elif path == "/api/dataset":
-                if self.state.session is None:
+                meta = self.state.dataset_meta()
+                if meta is None:
                     self._send(200, {"open": False})
                 else:
-                    meta = self.state.session.meta()
-                    meta["open"] = True
-                    meta["epoch"] = self.state.epoch
                     if not self._local_admin():
                         # root/yaml are host-local paths; `reason` can also embed an
                         # absolute path ("Could not derive a label path for <abs>").
@@ -304,10 +598,13 @@ class _Handler(BaseHTTPRequestHandler):
                 self._serve_thumb(int(path.rsplit("/", 1)[-1]))
             elif path.startswith("/api/label/"):
                 idx = int(path.rsplit("/", 1)[-1])
-                annotations, editable, rev = self.state.read_label_with_rev(idx)
+                annotations, editable, rev, epoch = self.state.read_label_with_rev(idx)
                 # rev as a STRING: nanosecond mtimes (~1e18) exceed JS Number.MAX_SAFE_INTEGER,
                 # so a numeric token would be rounded by the browser and every save would 409.
-                self._send(200, {"annotations": annotations, "editable": editable, "rev": str(rev)})
+                self._send(200, {
+                    "annotations": annotations, "editable": editable,
+                    "rev": str(rev), "epoch": epoch,
+                })
             elif path == "/api/assist/status":
                 st = self.state.engine.status()
                 st["sam"] = self.state.sam.available()
@@ -440,8 +737,6 @@ class _Handler(BaseHTTPRequestHandler):
                     return
                 try:
                     meta = self.state.open_project(str(data))
-                    meta["open"] = True
-                    meta["epoch"] = self.state.epoch
                     self._send(200, meta)
                 except Exception as exc:  # noqa: BLE001 - bad dataset path/config
                     logger.exception("open project failed")
@@ -482,20 +777,9 @@ class _Handler(BaseHTTPRequestHandler):
                     self._send(400, {"error": "folder path required"})
                     return
                 try:
-                    existing = folder_yaml(str(folder))   # don't clobber a real dataset
-                    if existing:
-                        target = existing
-                    elif link:
-                        target = create_linked_project(str(folder), name=name or None,
-                                                       classes=classes or [],
-                                                       colors=payload.get("colors") or [],
-                                                       task=task)
-                    else:
-                        target = scaffold_data_yaml(str(folder), classes or [], task=task)
-                    meta = self.state.open_project(target)
-                    meta["open"] = True
-                    meta["epoch"] = self.state.epoch
-                    meta["created"] = existing is None
+                    meta = self.state.create_project(
+                        str(folder), classes=classes or [], colors=payload.get("colors") or [],
+                        task=task, link=link, name=name)
                     self._send(200, meta)
                 except FileNotFoundError as exc:
                     self._send(400, {"error": str(exc).splitlines()[0][:140]
@@ -515,7 +799,7 @@ class _Handler(BaseHTTPRequestHandler):
                     self._send(400, {"error": "dst and name are required"})
                     return
                 try:
-                    saved = save_uploaded_image(str(dst), str(name), data)
+                    saved = self.state.save_upload(str(dst), str(name), data)
                     self._send(200, {"ok": True, "saved": Path(saved).name})
                 except Exception as exc:  # noqa: BLE001 - bad name / unwritable dst
                     self._send(400, {"error": str(exc).splitlines()[0][:140] or "upload failed"})
@@ -534,7 +818,7 @@ class _Handler(BaseHTTPRequestHandler):
                 if task not in ("detect", "segment", "obb", "classify"):
                     task = None
                 try:
-                    target = create_uploaded_project(
+                    meta = self.state.create_uploaded_project(
                         str(dst),
                         name=payload.get("name") or None,
                         description=payload.get("description") or "",
@@ -543,17 +827,12 @@ class _Handler(BaseHTTPRequestHandler):
                         colors=payload.get("colors") or [],
                         task=task,
                         make_val=bool(payload.get("make_val")),
-                        val_frac=float(payload.get("val_frac") or 0.2),
+                        val_frac=(
+                            0.2
+                            if payload.get("val_frac") in (None, "")
+                            else payload.get("val_frac")
+                        ),
                     )
-                    meta = self.state.open_project(target)
-                    meta["open"] = True
-                    meta["epoch"] = self.state.epoch
-                    meta["created"] = True
-                    try:
-                        projects.register(target, name=payload.get("name") or None,
-                                          root=meta.get("root"), count=meta.get("count"))
-                    except Exception:  # noqa: BLE001 - registry is convenience only
-                        pass
                     self._send(200, meta)
                 except FileNotFoundError as exc:
                     self._send(400, {"error": str(exc).splitlines()[0][:140] or "No images uploaded yet."})
@@ -568,12 +847,8 @@ class _Handler(BaseHTTPRequestHandler):
                 if not isinstance(names, list):
                     self._send(400, {"error": "names list required"})
                     return
-                if ep is not None and int(ep) != self.state.epoch:
-                    self._send(409, {"error": "project changed - reopen it before editing classes"})
-                    return
-                meta = self.state.set_class_names(names)
-                meta["open"] = True
-                meta["epoch"] = self.state.epoch
+                ep = _nonnegative_int(ep, "epoch")
+                meta = self.state.set_class_names(names, expected_epoch=ep)
                 self._send(200, meta)
             elif path == "/api/pick-folder":
                 # Pop a NATIVE OS "choose folder" dialog on the host and return the
@@ -592,7 +867,7 @@ class _Handler(BaseHTTPRequestHandler):
                 payload = self._read_json()
                 data = payload.get("data") if isinstance(payload, dict) else None
                 if data:
-                    projects.forget(str(data))
+                    self.state.forget_project(str(data))
                 self._send(200, {"ok": True})
             elif path == "/api/projects/meta":
                 # Project Settings for the OPEN project: display name, description,
@@ -601,34 +876,19 @@ class _Handler(BaseHTTPRequestHandler):
                 if not isinstance(payload, dict):
                     self._send(400, {"error": "bad payload"})
                     return
-                ep = payload.get("epoch")
-                if ep is not None and int(ep) != self.state.epoch:
-                    self._send(409, {"error": "project changed - reopen it before editing settings"})
-                    return
+                ep = _nonnegative_int(payload.get("epoch"), "epoch")
                 name = payload.get("name")
                 if name is not None and not str(name).strip():
                     self._send(400, {"error": "the project name can't be empty"})
                     return
                 try:
-                    sess = self.state.session
-                    target = self.state._data or sess.yaml_file
                     fields = {k: (str(payload[k]).strip() if k == "name" else str(payload[k]))
                               for k in ("name", "description", "instructions")
                               if payload.get(k) is not None}
-                    update_sidecar(str(target), **fields)
-                    if isinstance(sess._sidecar, dict):
-                        sess._sidecar.update(fields)
-                    else:
-                        sess._sidecar = dict(fields)
-                    if "name" in fields:
-                        try:
-                            projects.rename(str(target), fields["name"])
-                        except Exception:  # noqa: BLE001 - registry is convenience only
-                            pass
-                    meta = sess.meta()
-                    meta["open"] = True
-                    meta["epoch"] = self.state.epoch
+                    meta = self.state.update_project_meta(fields, expected_epoch=ep)
                     self._send(200, meta)
+                except _ProjectConflict:
+                    raise
                 except Exception as exc:  # noqa: BLE001 - unwritable sidecar
                     logger.exception("settings update failed")
                     self._send(400, {"error": str(exc).splitlines()[0][:140] or "could not save settings"})
@@ -640,8 +900,7 @@ class _Handler(BaseHTTPRequestHandler):
                     self._send(400, {"error": "data and name are required"})
                     return
                 try:
-                    set_sidecar_name(str(data), str(name).strip())
-                    projects.rename(str(data), str(name).strip())
+                    self.state.rename_project(str(data), str(name).strip())
                     self._send(200, {"ok": True})
                 except Exception as exc:  # noqa: BLE001 - bad path / unwritable
                     self._send(400, {"error": str(exc).splitlines()[0][:140] or "rename failed"})
@@ -654,17 +913,12 @@ class _Handler(BaseHTTPRequestHandler):
                     self._send(400, {"error": "data is required"})
                     return
                 try:
-                    cur = getattr(self.state, "_data", None)
-                    trashed = trash_project(str(data))
-                    projects.forget(str(data))
-                    # If we just deleted the live project, drop the session so the UI
-                    # stops reporting an open dataset whose files have moved.
-                    if cur and self.state.session is not None and \
-                            os.path.normcase(os.path.abspath(str(cur))) == os.path.normcase(os.path.abspath(str(data))):
-                        self.state.session = None
-                        self.state._data = None
-                        self.state.epoch += 1
-                    self._send(200, {"ok": True, "trash": trashed})
+                    raw_ep = payload.get("epoch") if isinstance(payload, dict) else None
+                    ep = _nonnegative_int(raw_ep, "epoch") if raw_ep is not None else None
+                    result = self.state.delete_project(str(data), expected_epoch=ep)
+                    self._send(200, {"ok": True, **result})
+                except _ProjectConflict:
+                    raise
                 except FileNotFoundError as exc:
                     self._send(400, {"error": str(exc).splitlines()[0][:140] or "project folder not found"})
                 except Exception as exc:  # noqa: BLE001 - move/permission failure
@@ -675,53 +929,57 @@ class _Handler(BaseHTTPRequestHandler):
                 if not isinstance(payload, dict):
                     self._send(400, {"error": "bad payload"})
                     return
-                ep = payload.get("epoch")
-                if ep is not None and int(ep) != self.state.epoch:
-                    # A stale tab must not copy or (worse) re-split in place a project
-                    # that was switched from another tab.
-                    self._send(409, {"error": "project changed - reload before exporting"})
-                    return
+                ep = _nonnegative_int(payload.get("epoch"), "epoch")
                 try:
-                    from . import export as _export
-                    res = _export.export_dataset(
-                        self.state.session,
+                    res = self.state.export_project(
+                        expected_epoch=ep,
                         dst=payload.get("dst") or None,
                         formats=tuple(payload.get("formats") or ["yolo"]),
                         split=payload.get("split") or "trainval",
-                        val_frac=float(payload.get("val_frac") or 0.2),
-                        test_frac=float(payload.get("test_frac") or 0.0),
-                        seed=int(payload.get("seed") or 1234),
+                        val_frac=(
+                            0.2
+                            if payload.get("val_frac") in (None, "")
+                            else payload.get("val_frac")
+                        ),
+                        test_frac=(
+                            0.0
+                            if payload.get("test_frac") in (None, "")
+                            else payload.get("test_frac")
+                        ),
+                        seed=(
+                            1234
+                            if payload.get("seed") in (None, "")
+                            else int(payload.get("seed"))
+                        ),
                         in_place=bool(payload.get("in_place")),
                         make_zip=bool(payload.get("make_zip")),
                     )
-                    if res.get("in_place"):
-                        # the working folder was reorganised; reopen so the live
-                        # session points at the new split layout.
-                        try:
-                            self.state.open_project(res.get("yaml") or self.state._data)
-                            res["epoch"] = self.state.epoch
-                            res["reopened"] = True
-                        except Exception:  # noqa: BLE001
-                            pass
                     self._send(200, {"ok": True, **res})
+                except _ProjectConflict:
+                    raise
                 except Exception as exc:  # noqa: BLE001 - bad dst / unreadable images
                     logger.exception("export failed")
                     self._send(400, {"error": str(exc).splitlines()[0][:160] or "export failed"})
             elif path.startswith("/api/label/"):
                 idx = int(path.rsplit("/", 1)[-1])
                 payload = self._read_json()
-                anns = payload.get("annotations", []) if isinstance(payload, dict) else []
+                if not isinstance(payload, dict) or "annotations" not in payload:
+                    raise ValueError("JSON object with an explicit annotations list required")
+                anns = payload["annotations"]
+                if not isinstance(anns, list):
+                    raise ValueError("annotations must be a list")
                 qs = parse_qs(parsed.query)
-                ep = (qs.get("epoch") or [None])[0]
-                rev = (qs.get("rev") or [None])[0]
+                ep = self._required_query_int(qs, "epoch")
+                rev = self._required_query_int(qs, "rev")
                 count, new_rev = self.state.write_label(
-                    idx, anns, epoch=int(ep) if ep is not None else None,
-                    expected_rev=int(rev) if rev is not None else None)
+                    idx, anns, epoch=ep, expected_rev=rev)
                 self._send(200, {"ok": True, "count": count, "rev": str(new_rev)})
             elif path.startswith("/api/assist/prelabel/"):
                 self._handle_prelabel(int(path.rsplit("/", 1)[-1]), parse_qs(parsed.query))
             elif path.startswith("/api/assist/segment/"):
-                self._handle_segment(int(path.rsplit("/", 1)[-1]))
+                self._handle_segment(
+                    int(path.rsplit("/", 1)[-1]), parse_qs(parsed.query)
+                )
             elif path == "/api/assist/autolabel":
                 self._handle_autolabel_stream(parse_qs(parsed.query))
             elif path == "/api/assist/radar":
@@ -735,12 +993,14 @@ class _Handler(BaseHTTPRequestHandler):
                 ep = payload.get("epoch") if isinstance(payload, dict) else None
                 res = self.state.resolve_duplicates(
                     [int(i) for i in ids], purge=purge,
-                    epoch=int(ep) if ep is not None else None)
+                    epoch=_nonnegative_int(ep, "epoch"))
                 self._send(200, res)
             elif path == "/api/boost":
                 payload = self._read_json()
                 kw = payload if isinstance(payload, dict) else {}
-                self._send(200, self.state.boost.start(
+                epoch = _nonnegative_int(kw.get("epoch"), "epoch")
+                self._send(200, self.state.start_boost(
+                    expected_epoch=epoch,
                     epochs=int(kw.get("epochs", 2)), imgsz=int(kw.get("imgsz", 512)),
                     batch=int(kw.get("batch", 4))))
             else:
@@ -759,11 +1019,21 @@ class _Handler(BaseHTTPRequestHandler):
     def _read_json(self):
         length = int(self.headers.get("Content-Length", 0) or 0)
         data = self.rfile.read(length) if length else b""
-        return json.loads(data.decode("utf-8")) if data else {}
+        return (
+            json.loads(data.decode("utf-8"), object_pairs_hook=_unique_json_object)
+            if data else {}
+        )
 
     def _read_body_bytes(self) -> bytes:
         length = int(self.headers.get("Content-Length", 0) or 0)
         return self.rfile.read(length) if length else b""
+
+    @staticmethod
+    def _required_query_int(qs: dict, name: str) -> int:
+        values = qs.get(name)
+        if not isinstance(values, list) or len(values) != 1:
+            raise ValueError(f"exactly one {name} query parameter is required")
+        return _nonnegative_int(values[0], name)
 
     @staticmethod
     def _is_loopback(addr: str) -> bool:
@@ -824,23 +1094,17 @@ class _Handler(BaseHTTPRequestHandler):
             conf = 0.25
         return model, conf
 
-    def _stale_epoch(self, qs: dict) -> bool:
-        """True when the client sent an ``epoch`` that no longer matches -- a stale
-        tab whose project was switched elsewhere must not run dataset-wide actions
-        (prelabel/radar/embeddings/export) against the newly current project."""
-        ep = (qs.get("epoch") or [None])[0]
-        return ep is not None and int(ep) != self.state.epoch
-
     def _handle_prelabel(self, idx: int, qs: dict) -> None:
         self._read_json()  # drain any body
-        if self._stale_epoch(qs):
-            self._send(409, {"error": "project changed - reload before auto-labeling"})
-            return
+        epoch = self._required_query_int(qs, "epoch")
+        # Epoch validation and session capture are one transaction.  A separate
+        # check followed by `self.state.session` can capture the *next* project if
+        # a switch lands between the two operations.
+        sess = self.state.capture_session(epoch, "auto-labeling")
         model, conf = self._model_conf(qs)
         # Snapshot the session up front: the predict below is slow, and if the user
         # switches projects mid-flight we must not store these suggestions into the
         # shared pending map (keyed by numeric id) for the now-current project.
-        sess = self.state.session
         # Don't suggest on polygon/OBB-locked images (box-only mode can't accept).
         _, editable = sess.read_label(idx)
         if not editable:
@@ -867,10 +1131,12 @@ class _Handler(BaseHTTPRequestHandler):
             return
         self._send(200, {"editable": True, "suggestions": sugg})
 
-    def _handle_segment(self, idx: int) -> None:
+    def _handle_segment(self, idx: int, qs: dict) -> None:
         payload = self._read_json() or {}
         if not isinstance(payload, dict):
             payload = {}
+        epoch = self._required_query_int(qs, "epoch")
+        sess = self.state.capture_session(epoch, "segmenting")
         box = payload.get("box")
         points = payload.get("points")
         try:
@@ -887,11 +1153,14 @@ class _Handler(BaseHTTPRequestHandler):
             self._send(400, {"error": "point {x,y}, points [[x,y],...], or box [x1,y1,x2,y2] required"})
             return
         try:
-            poly = self.state.sam.segment(self.state.session.image_path(idx), **kw)
+            poly = self.state.sam.segment(sess.image_path(idx), **kw)
         except Exception as exc:  # noqa: BLE001 - SAM load/inference problem
             logger.exception("segment failed")
             # PIL/torch errors embed absolute image paths; redact for LAN clients.
             self._send(503, {"error": str(exc) if self._local_admin() else _redact_paths(str(exc))})
+            return
+        if not self.state.session_is_current(sess):
+            self._send(409, {"error": "project changed; reopen and retry"})
             return
         self._send(200, {"polygon": poly})
 
@@ -905,12 +1174,8 @@ class _Handler(BaseHTTPRequestHandler):
         model, conf = self._model_conf(qs)
         engine = (qs.get("engine") or ["yolo"])[0]
         classes = [c for c in (qs.get("classes") or [""])[0].split(",") if c.strip()]
-        ep = (qs.get("epoch") or [None])[0]
-        if ep is not None and int(ep) != self.state.epoch:
-            # a stale tab (project switched in another tab) must not populate the
-            # current project's pending suggestions with the old dataset's run
-            self._send(409, {"error": "project changed - reload before auto-labeling"})
-            return
+        epoch = self._required_query_int(qs, "epoch")
+        sess = self.state.capture_session(epoch, "auto-labeling")
 
         self.send_response(200)
         self.send_header("Content-Type", "application/x-ndjson; charset=utf-8")
@@ -929,9 +1194,13 @@ class _Handler(BaseHTTPRequestHandler):
                 except (BrokenPipeError, ConnectionResetError, OSError):
                     pass
 
-        sess = self.state.session
         try:
-            self.state.engine.clear_pending()  # fresh run replaces stale suggestions
+            # Fresh run replaces old suggestions only while it still owns this
+            # project.  An old run resuming after a switch must not clear the new
+            # project's pending review deck.
+            if not self.state.clear_pending(sess):
+                emit({"type": "error", "error": "project changed; reopen and retry"})
+                return
             summary = self.state.engine.autolabel_dataset(
                 sess, model_name=model, conf=conf, progress=emit,
                 engine=engine, classes=classes,
@@ -971,22 +1240,20 @@ class _Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", 0) or 0)
         if length:
             self.rfile.read(length)
-        if self._stale_epoch(qs):
-            self._send(409, {"error": "project changed - reload before running Radar"})
-            return
+        epoch = self._required_query_int(qs, "epoch")
+        sess = self.state.capture_session(epoch, "running Radar")
         model, conf = self._model_conf(qs)
         if not self.state.engine.status().get("available"):
             self._send(503, {"error": "No model available for Radar "
                                       "(assist disabled or no weights)."})
             return
-        sess = self.state.session
         emit = self._ndjson_begin()
         try:
             result = scan_dataset(self.state.engine.predict_image, sess,
                                   model_name=model, conf=conf, progress=emit)
-            with self.state._radar_lock:
-                if self.state.session is sess:   # drop results if the project changed mid-scan
-                    self.state.radar_findings = result.pop("findings", {})
+            # Publish under the same project lock as open_project(), otherwise a
+            # switch can interleave after an identity check and receive stale ids.
+            self.state.store_radar_findings(result.pop("findings", {}), sess)
             emit(result)
         except Exception as exc:  # noqa: BLE001
             logger.exception("radar scan failed")
@@ -997,18 +1264,15 @@ class _Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", 0) or 0)
         if length:
             self.rfile.read(length)
-        if self._stale_epoch(qs):
-            self._send(409, {"error": "project changed - reload before mapping"})
-            return
+        epoch = self._required_query_int(qs, "epoch")
+        sess = self.state.capture_session(epoch, "mapping")
         if not self.state.embed.available():
             self._send(503, {"error": "Embeddings unavailable (assist disabled)."})
             return
-        sess = self.state.session
         emit = self._ndjson_begin()
         try:
             points = self.state.embed.scatter(sess, progress=emit)
-            if self.state.session is sess:       # drop if the project changed mid-embed
-                self.state.embed_points = points
+            self.state.store_embed_points(points, sess)
             emit({"type": "done", "points": points})
         except Exception as exc:  # noqa: BLE001
             logger.exception("embeddings failed")

--- a/libreyolo/label/server.py
+++ b/libreyolo/label/server.py
@@ -27,6 +27,7 @@ import logging
 import mimetypes
 import os
 import re
+import socket
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -80,13 +81,23 @@ def _nonnegative_int(value, name: str) -> int:
     return out
 
 
-def _project_root_path(data) -> Path:
-    """Return the canonical project root for either a dataset dir or YAML path."""
+def _project_root_entry_path(data, *, require_existing: bool = False) -> Path:
+    """Return an absolute project root without following its final directory link."""
     p = Path(str(data)).expanduser()
+    is_directory = p.is_dir()
+    is_yaml = p.is_file() and p.suffix.lower() in (".yaml", ".yml")
+    if require_existing and not (is_directory or is_yaml):
+        raise FileNotFoundError(f"Not an existing project root or dataset YAML: {p}")
     # A directory may legitimately end in .yaml/.yml.  Only strip the filename
     # suffix when the supplied path is not an existing directory.
-    if not p.is_dir() and p.suffix.lower() in (".yaml", ".yml"):
+    if not is_directory and p.suffix.lower() in (".yaml", ".yml"):
         p = p.parent
+    return Path(os.path.abspath(os.path.normpath(str(p))))
+
+
+def _project_root_path(data, *, require_existing: bool = False) -> Path:
+    """Return the canonical project root for either a dataset dir or YAML path."""
+    p = _project_root_entry_path(data, require_existing=require_existing)
     try:
         p = p.resolve(strict=False)
     except (OSError, RuntimeError):
@@ -94,9 +105,11 @@ def _project_root_path(data) -> Path:
     return p
 
 
-def _project_root_key(data) -> str:
+def _project_root_key(data, *, require_existing: bool = False) -> str:
     """Canonical project-root identity for either a dataset dir or YAML path."""
-    return os.path.normcase(str(_project_root_path(data))).casefold()
+    return os.path.normcase(
+        str(_project_root_path(data, require_existing=require_existing))
+    )
 
 
 def _unique_json_object(pairs):
@@ -165,19 +178,84 @@ def _ip_is_loopback(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> b
     return bool(mapped and mapped.is_loopback)
 
 
-def _lan_ip() -> str:
-    """Best-effort primary LAN IP (for the teammate share URL). Sends no packets."""
-    import socket
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+def _url_host(host: str) -> str:
+    """Render one host literal for an HTTP URL."""
+    value = str(host).strip().strip("[]")
     try:
-        s.connect(("8.8.8.8", 80))   # just selects the routable interface
+        return f"[{value}]" if ipaddress.ip_address(value).version == 6 else value
+    except ValueError:
+        return value
+
+
+def _local_access_host(bind_host: str) -> str:
+    """Return the address a browser on the server host can actually reach."""
+    host = str(bind_host).strip()
+    if host in ("", "0.0.0.0"):
+        return "127.0.0.1"
+    if host == "::":
+        return "::1"
+    return host
+
+
+def _lan_url_host(bind_host: str, candidate: str) -> Optional[str]:
+    """Return a usable teammate host, or ``None`` when only local access exists."""
+    raw_bind = str(bind_host).strip().strip("[]")
+    try:
+        bind_name = _normalize_host_name(raw_bind) if raw_bind else ""
+    except ValueError:
+        return None
+    try:
+        bind_address = ipaddress.ip_address(bind_name) if bind_name else None
+    except ValueError:
+        bind_address = None
+    wildcard = not bind_name or bool(bind_address and bind_address.is_unspecified)
+    if not wildcard:
+        if bind_name == "localhost" or bool(
+            bind_address and (_ip_is_loopback(bind_address) or bind_address.is_link_local)
+        ):
+            return None
+        return bind_name
+    try:
+        address = ipaddress.ip_address(str(candidate).strip().strip("[]"))
+    except ValueError:
+        return None
+    if (
+        _ip_is_loopback(address)
+        or address.is_unspecified
+        or address.is_multicast
+        or address.is_link_local
+    ):
+        return None
+    return address.compressed.lower()
+
+
+def _lan_ip(family: int = socket.AF_INET) -> str:
+    """Best-effort primary LAN IP (for the teammate share URL). Sends no packets."""
+    probe = (
+        ("2001:4860:4860::8888", 80, 0, 0)
+        if family == socket.AF_INET6
+        else ("8.8.8.8", 80)
+    )
+    s = socket.socket(family, socket.SOCK_DGRAM)
+    try:
+        s.connect(probe)   # just selects the routable interface
         return s.getsockname()[0]
     except OSError:
         try:
-            return socket.gethostbyname(socket.gethostname())
+            candidates = socket.getaddrinfo(
+                socket.gethostname(), None, family, socket.SOCK_DGRAM
+            )
+            for candidate in candidates:
+                address = candidate[4][0]
+                try:
+                    parsed = ipaddress.ip_address(address)
+                except ValueError:
+                    continue
+                if not parsed.is_unspecified:
+                    return address
         except OSError:
-            return "127.0.0.1"
+            pass
+        return "::1" if family == socket.AF_INET6 else "127.0.0.1"
     finally:
         s.close()
 
@@ -494,31 +572,59 @@ class _LabelState:
     def delete_project(self, data, *, expected_epoch=None) -> dict:
         """Trash a project and atomically detach it if it is the live session."""
         with self._lock:
-            submitted_key = _project_root_key(data)
-            current_root = (
-                _project_root_path(self.session.yaml_file)
+            try:
+                submitted_key = _project_root_key(data, require_existing=True)
+            except FileNotFoundError:
+                raise ValueError(
+                    "only an open project or an exact registered project root can be deleted"
+                ) from None
+            current_target = (
+                _project_root_entry_path(
+                    self.session.yaml_file, require_existing=True
+                )
                 if self.session is not None
                 else None
             )
             current_key = (
-                _project_root_key(current_root) if current_root is not None else None
+                _project_root_key(current_target)
+                if current_target is not None
+                else None
             )
-            registered_roots = {}
-            registered_aliases = {}
+            registered_target = None
+            registered_aliases = set()
             for entry in projects.list_projects():
                 registered_data = entry.get("data") if isinstance(entry, dict) else None
                 if not registered_data:
                     continue
-                root = _project_root_path(registered_data)
-                key = _project_root_key(root)
-                registered_roots[key] = root
-                registered_aliases.setdefault(key, set()).add(str(registered_data))
+                try:
+                    registered_key = _project_root_key(
+                        registered_data, require_existing=True
+                    )
+                except FileNotFoundError:
+                    continue
+                if registered_key != submitted_key:
+                    continue
+                registered_aliases.add(str(registered_data))
+                if registered_target is not None:
+                    continue
+                # The registry is convenience data, not filesystem authorization.
+                # A stale/malformed entry must not authorize moving its containing
+                # directory after the YAML disappeared.
+                try:
+                    registered_session = DatasetSession(str(registered_data))
+                except Exception:  # noqa: BLE001 - stale/corrupt registry entry
+                    continue
+                candidate = _project_root_entry_path(
+                    registered_session.yaml_file, require_existing=True
+                )
+                if _project_root_key(candidate) == submitted_key:
+                    registered_target = candidate
 
             is_current = current_key is not None and submitted_key == current_key
             if is_current:
-                target = current_root
+                target = current_target
             else:
-                target = registered_roots.get(submitted_key)
+                target = registered_target
             if target is None:
                 raise ValueError(
                     "only an open project or an exact registered project root can be deleted"
@@ -528,7 +634,7 @@ class _LabelState:
                     raise ValueError("epoch is required when deleting the open project")
                 if expected_epoch != self.epoch:
                     raise _ProjectConflict("project changed - reload before deleting")
-            aliases = {str(data), *registered_aliases.get(submitted_key, set())}
+            aliases = {str(data), *registered_aliases}
             if is_current:
                 aliases.update(self._session_aliases_locked(self.session, data))
             trashed = trash_project(str(target))
@@ -649,13 +755,27 @@ class _Handler(BaseHTTPRequestHandler):
                 else:
                     self._send(200, {"projects": [], "open": None})
             elif path == "/api/server":
-                ip = _lan_ip()
                 host = self.state.host
-                shareable = host in ("0.0.0.0", "::", "") or host == ip
+                try:
+                    family = (
+                        socket.AF_INET6
+                        if ipaddress.ip_address(host.strip("[]")).version == 6
+                        else socket.AF_INET
+                    )
+                except ValueError:
+                    family = socket.AF_INET
+                ip = _lan_ip(family)
+                lan_host = _lan_url_host(host, ip)
+                shareable = lan_host is not None
+                local_host = _local_access_host(host)
                 self._send(200, {
                     "host": host, "port": self.state.port,
-                    "local_url": "http://127.0.0.1:%d" % self.state.port,
-                    "lan_url": ("http://%s:%d" % (ip, self.state.port)) if shareable else None,
+                    "local_url": "http://%s:%d" % (_url_host(local_host), self.state.port),
+                    "lan_url": (
+                        "http://%s:%d" % (_url_host(lan_host), self.state.port)
+                        if lan_host is not None
+                        else None
+                    ),
                     "shareable": shareable,
                 })
             elif path == "/api/dataset":
@@ -1129,26 +1249,45 @@ class _Handler(BaseHTTPRequestHandler):
 
     @staticmethod
     def _is_loopback(addr: str) -> bool:
-        a = (addr or "").strip().lower()
-        return a in ("127.0.0.1", "::1", "localhost", "::ffff:127.0.0.1") or a.startswith("127.")
+        a = (addr or "").strip().lower().strip("[]")
+        if a.rstrip(".") == "localhost":
+            return True
+        try:
+            return _ip_is_loopback(ipaddress.ip_address(a))
+        except ValueError:
+            return False
 
     def _local_admin(self) -> bool:
         """Whether this client may perform host-level admin (switch project, prune
         duplicates, list the project registry) -- actions that rebind the global
         session, move/delete files, or expose host-local paths.
 
-        Only a *wildcard* bind (0.0.0.0/:: -- what ``--share`` uses) is both
-        LAN-reachable AND still serves loopback, so there the host connects via
-        127.0.0.1 while teammates use the LAN IP: require a loopback CLIENT to gate
-        teammates out. A loopback bind is local-only, and a concrete NIC bind
-        (``host=192.168.x.y``) forces the host itself to connect via that address --
-        indistinguishable from a teammate by IP -- so admin is allowed there (it's an
-        explicit, advanced exposure, not the default share path).
+        A wildcard bind (what ``--share`` uses) reserves admin for loopback peers.
+        On a concrete NIC bind, a host browser normally connects with the same
+        source address as the accepted socket's local endpoint; a LAN teammate has
+        a different peer address. This preserves local admin without granting every
+        client on that interface host filesystem authority.
         """
-        host = (self.state.host or "").strip().lower()
-        if host in ("0.0.0.0", "::", ""):
-            return self._is_loopback(self.client_address[0] if self.client_address else "")
-        return True
+        peer_text = self.client_address[0] if self.client_address else ""
+        if self._is_loopback(peer_text):
+            return True
+        host = (self.state.host or "").strip().lower().strip("[]")
+        try:
+            bind_address = ipaddress.ip_address(host)
+        except ValueError:
+            bind_address = None
+        if not host or bool(bind_address and bind_address.is_unspecified):
+            return False
+        try:
+            peer = ipaddress.ip_address(str(peer_text).strip().strip("[]"))
+            local = ipaddress.ip_address(
+                str(self.connection.getsockname()[0]).strip().strip("[]")
+            )
+        except (AttributeError, OSError, ValueError):
+            return False
+        peer_mapped = getattr(peer, "ipv4_mapped", None) or peer
+        local_mapped = getattr(local, "ipv4_mapped", None) or local
+        return peer_mapped == local_mapped
 
     def _same_origin(self) -> bool:
         """Compare a browser Origin to the normalized HTTP request authority."""
@@ -1187,7 +1326,21 @@ class _Handler(BaseHTTPRequestHandler):
             authority = _parse_authority(hosts[0], default_port=80)
         except (TypeError, ValueError):
             return None
-        return authority if authority[1] == self.state.port else None
+        if authority[1] != self.state.port:
+            return None
+        target = urlsplit(self.path)
+        if target.scheme or target.netloc:
+            if target.scheme.lower() != "http" or not target.netloc:
+                return None
+            try:
+                target_authority = _parse_authority(
+                    target.netloc, default_port=80
+                )
+            except (TypeError, ValueError):
+                return None
+            if target_authority != authority:
+                return None
+        return authority
 
     def _host_allowed(self) -> bool:
         """Allow only the configured host or explicit local numeric addresses."""
@@ -1465,21 +1618,40 @@ def serve(
     bound eagerly (an in-use port raises ``OSError`` to retry). Returns
     ``(httpd, url, session)`` (``session`` is ``None`` in home mode).
     """
+    bind_host = str(host).strip() or "0.0.0.0"
+    if bind_host.startswith("[") and bind_host.endswith("]"):
+        bind_host = bind_host[1:-1]
     session = DatasetSession(data) if data else None
     state = _LabelState(session, device=device, assist=assist)
-    state.host = host
+    state.host = bind_host
     handler = type("BoundLabelHandler", (_Handler,), {"state": state})
-    httpd = ThreadingHTTPServer((host, port), handler)
+    try:
+        ipv6_bind = ipaddress.ip_address(bind_host).version == 6
+    except ValueError:
+        ipv6_bind = False
+    server_type = ThreadingHTTPServer
+    if ipv6_bind:
+        server_type = type(
+            "IPv6ThreadingHTTPServer",
+            (ThreadingHTTPServer,),
+            {"address_family": socket.AF_INET6},
+        )
+    httpd = server_type((bind_host, port), handler)
     # Publish the *actual* bound port: with port=0 the OS assigns one, so the
     # requested value would yield unusable ":0" URLs and poison /api/server.
     bound_port = httpd.server_address[1]
     state.port = bound_port
     if session is not None:
         state.register_current(data)
-    url = "http://%s:%d" % (host, bound_port)
+    url = "http://%s:%d" % (_url_host(bind_host), bound_port)
     if open_browser:
         import webbrowser
 
-        browse = "http://127.0.0.1:%d" % bound_port if host in ("0.0.0.0", "::", "") else url
+        if bind_host in ("0.0.0.0", ""):
+            browse = "http://127.0.0.1:%d" % bound_port
+        elif bind_host == "::":
+            browse = "http://[::1]:%d" % bound_port
+        else:
+            browse = url
         threading.Timer(0.7, lambda: webbrowser.open(browse)).start()
     return httpd, url, session

--- a/libreyolo/label/server.py
+++ b/libreyolo/label/server.py
@@ -64,7 +64,7 @@ _MAX_JSON_BODY_BYTES = 8 * 1024 * 1024
 _MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
 _BODY_READ_CHUNK_BYTES = 64 * 1024
 _BODY_READ_TIMEOUT_SECONDS = 10.0
-_BODY_DISCARD_TIMEOUT_SECONDS = 1.0
+_BODY_DISCARD_TIMEOUT_SECONDS = 3.0
 _MAX_CONTENT_LENGTH_DIGITS = 20
 
 # Absolute filesystem paths (Windows ``C:\...`` or POSIX ``/...``) we must not leak
@@ -1319,15 +1319,11 @@ class _Handler(BaseHTTPRequestHandler):
                 self.close_connection = True
                 raise _RequestBodyError("invalid Content-Length header")
             length = int(raw)
-        if length > _MAX_REQUEST_BODY_BYTES:
-            self._request_body_consumed = True
-            self.close_connection = True
-            raise _RequestBodyTooLarge("request body too large")
         self._request_body_length = length
         return length
 
     def _consume_request_body(
-        self, *, collect: bool, limit: int, timeout: float
+        self, *, collect: bool, limit: Optional[int], timeout: float
     ) -> bytes:
         if getattr(self, "_request_body_consumed", False):
             if collect:
@@ -1335,7 +1331,7 @@ class _Handler(BaseHTTPRequestHandler):
             return b""
 
         length = self._declared_request_body_length()
-        if length > limit:
+        if limit is not None and length > limit:
             self._request_body_consumed = True
             self.close_connection = True
             raise _RequestBodyTooLarge("request body too large")
@@ -1373,19 +1369,37 @@ class _Handler(BaseHTTPRequestHandler):
                 self.close_connection = True
         return b"".join(chunks) if chunks is not None else b""
 
-    def _discard_request_body(self, *, limit: int = _MAX_REQUEST_BODY_BYTES) -> None:
-        self._consume_request_body(
-            collect=False,
-            limit=limit,
-            timeout=_BODY_DISCARD_TIMEOUT_SECONDS,
-        )
-
-    def _read_body_bytes(self, *, limit: int = _MAX_REQUEST_BODY_BYTES) -> bytes:
-        if self._declared_request_body_length() > limit:
-            # The endpoint limit prevents allocation; still drain bodies within the
-            # global framing ceiling so Windows clients reliably receive the 413.
-            self._discard_request_body(limit=_MAX_REQUEST_BODY_BYTES)
+    def _discard_request_body(self, *, limit: Optional[int] = None) -> None:
+        if limit is None:
+            limit = _MAX_REQUEST_BODY_BYTES
+        else:
+            limit = min(limit, _MAX_REQUEST_BODY_BYTES)
+        oversized = self._declared_request_body_length() > limit
+        try:
+            # Discarding is O(1) in memory and bounded by an absolute deadline.
+            # Do not reject from the declared length alone: closing with a queued
+            # body can make Windows discard the already-written HTTP response.
+            self._consume_request_body(
+                collect=False,
+                limit=None,
+                timeout=_BODY_DISCARD_TIMEOUT_SECONDS,
+            )
+        except _RequestBodyError as exc:
+            if oversized:
+                raise _RequestBodyTooLarge("request body too large") from exc
+            raise
+        if oversized:
             raise _RequestBodyTooLarge("request body too large")
+
+    def _read_body_bytes(self, *, limit: Optional[int] = None) -> bytes:
+        if limit is None:
+            limit = _MAX_REQUEST_BODY_BYTES
+        else:
+            limit = min(limit, _MAX_REQUEST_BODY_BYTES)
+        if self._declared_request_body_length() > limit:
+            # The endpoint limit prevents allocation.  Still drain under the
+            # absolute discard deadline so the client can receive the 413.
+            self._discard_request_body(limit=limit)
         return self._consume_request_body(
             collect=True, limit=limit, timeout=_BODY_READ_TIMEOUT_SECONDS
         )

--- a/libreyolo/label/server.py
+++ b/libreyolo/label/server.py
@@ -21,6 +21,7 @@ Endpoints
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import mimetypes
@@ -30,7 +31,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Optional
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse, urlsplit
 
 from . import projects
 from .assist import AssistEngine
@@ -79,8 +80,8 @@ def _nonnegative_int(value, name: str) -> int:
     return out
 
 
-def _project_root_key(data) -> str:
-    """Canonical project-root identity for either a dataset dir or YAML path."""
+def _project_root_path(data) -> Path:
+    """Return the canonical project root for either a dataset dir or YAML path."""
     p = Path(str(data)).expanduser()
     # A directory may legitimately end in .yaml/.yml.  Only strip the filename
     # suffix when the supplied path is not an existing directory.
@@ -90,7 +91,12 @@ def _project_root_key(data) -> str:
         p = p.resolve(strict=False)
     except (OSError, RuntimeError):
         p = Path(os.path.abspath(str(p)))
-    return os.path.normcase(str(p)).casefold()
+    return p
+
+
+def _project_root_key(data) -> str:
+    """Canonical project-root identity for either a dataset dir or YAML path."""
+    return os.path.normcase(str(_project_root_path(data))).casefold()
 
 
 def _unique_json_object(pairs):
@@ -105,6 +111,58 @@ def _unique_json_object(pairs):
 
 def _redact_paths(msg: str) -> str:
     return _ABS_PATH_RE.sub("<path>", str(msg))
+
+
+def _normalize_host_name(value: str) -> str:
+    """Normalize one DNS name or IP literal without resolving DNS."""
+    name = str(value).strip().lower()
+    if name.endswith("."):
+        name = name[:-1]
+    if not name or len(name) > 253 or "%" in name:
+        raise ValueError("invalid host")
+    try:
+        return ipaddress.ip_address(name).compressed.lower()
+    except ValueError:
+        labels = name.split(".")
+        if any(
+            not label
+            or len(label) > 63
+            or not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", label)
+            for label in labels
+        ):
+            raise ValueError("invalid host") from None
+        return name
+
+
+def _parse_authority(authority: str, *, default_port: int) -> tuple[str, int]:
+    """Parse and normalize an HTTP authority, rejecting ambiguous spellings."""
+    raw = str(authority)
+    if not raw or raw != raw.strip() or any(char.isspace() for char in raw):
+        raise ValueError("invalid authority")
+    if any(char in raw for char in "/?#@"):
+        raise ValueError("invalid authority")
+    try:
+        parsed = urlsplit("//" + raw)
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("invalid authority")
+        host = parsed.hostname
+        port = parsed.port
+    except (TypeError, ValueError):
+        raise ValueError("invalid authority") from None
+    if not host:
+        raise ValueError("invalid authority")
+    if ":" in host and not raw.startswith("["):
+        raise ValueError("IPv6 host literals must be bracketed")
+    if raw.endswith(":"):
+        raise ValueError("invalid authority")
+    return _normalize_host_name(host), default_port if port is None else port
+
+
+def _ip_is_loopback(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if address.is_loopback:
+        return True
+    mapped = getattr(address, "ipv4_mapped", None)
+    return bool(mapped and mapped.is_loopback)
 
 
 def _lan_ip() -> str:
@@ -338,8 +396,8 @@ class _LabelState:
         (which its next save would then use to pass the conflict check)."""
         with self._lock:
             session = self._session_for_epoch_locked(None, "reading labels")
-            anns, editable = session.read_label(idx)
-            return anns, editable, session.label_rev(idx), self.epoch
+            anns, editable, revision = session.read_label_with_rev(idx)
+            return anns, editable, revision, self.epoch
 
     def dataset_meta(self):
         """Return metadata and its matching epoch from one session snapshot."""
@@ -354,8 +412,9 @@ class _LabelState:
     def write_label(self, idx: int, boxes, epoch=None, expected_rev=None) -> tuple:
         with self._lock:  # serialize concurrent saves to the same tree (check+write atomic)
             session = self._session_for_epoch_locked(epoch, "saving")
-            count = session.write_label(idx, boxes, expected_rev=expected_rev)
-            return count, session.label_rev(idx)
+            return session.write_label_with_rev(
+                idx, boxes, expected_rev=expected_rev
+            )
 
     def store_pending(self, idx: int, sugg, sess) -> bool:
         """Store prelabel suggestions iff still on ``sess`` -- atomically with the
@@ -435,23 +494,53 @@ class _LabelState:
     def delete_project(self, data, *, expected_epoch=None) -> dict:
         """Trash a project and atomically detach it if it is the live session."""
         with self._lock:
-            is_current = (
-                self.session is not None
-                and _project_root_key(data) == _project_root_key(self.session.yaml_file)
+            submitted_key = _project_root_key(data)
+            current_root = (
+                _project_root_path(self.session.yaml_file)
+                if self.session is not None
+                else None
             )
+            current_key = (
+                _project_root_key(current_root) if current_root is not None else None
+            )
+            registered_roots = {}
+            registered_aliases = {}
+            for entry in projects.list_projects():
+                registered_data = entry.get("data") if isinstance(entry, dict) else None
+                if not registered_data:
+                    continue
+                root = _project_root_path(registered_data)
+                key = _project_root_key(root)
+                registered_roots[key] = root
+                registered_aliases.setdefault(key, set()).add(str(registered_data))
+
+            is_current = current_key is not None and submitted_key == current_key
+            if is_current:
+                target = current_root
+            else:
+                target = registered_roots.get(submitted_key)
+            if target is None:
+                raise ValueError(
+                    "only an open project or an exact registered project root can be deleted"
+                )
             if is_current:
                 if expected_epoch is None:
                     raise ValueError("epoch is required when deleting the open project")
                 if expected_epoch != self.epoch:
                     raise _ProjectConflict("project changed - reload before deleting")
-            aliases = {str(data)}
+            aliases = {str(data), *registered_aliases.get(submitted_key, set())}
             if is_current:
                 aliases.update(self._session_aliases_locked(self.session, data))
-            trashed = trash_project(str(data))
-            for alias in aliases:
-                projects.forget(alias)
+            trashed = trash_project(str(target))
             if is_current:
+                # The filesystem move succeeded, so the old path must stop being a
+                # live session before registry convenience cleanup can run.
                 self._drop_session_locked()
+            for alias in aliases:
+                try:
+                    projects.forget(alias)
+                except Exception:  # noqa: BLE001 - registry is convenience data
+                    logger.exception("project registry cleanup failed")
             return {"trash": trashed, "closed": is_current, "epoch": self.epoch}
 
     def start_boost(self, *, expected_epoch: int, **kwargs) -> dict:
@@ -541,6 +630,9 @@ class _Handler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
+            if not self._host_allowed():
+                self._send(403, {"error": "host not allowed"})
+                return
             sessionless = path in ("/", "/index.html", "/api/dataset", "/api/projects",
                                    "/api/server", "/api/assist/status", "/api/boost/status")
             if self.state.session is None and path.startswith("/api/") and not sessionless:
@@ -679,11 +771,11 @@ class _Handler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         try:
-            if not self._same_origin():
-                self._send(403, {"error": "cross-origin request blocked"})
-                return
             if not self._host_allowed():
                 self._send(403, {"error": "host not allowed"})
+                return
+            if not self._same_origin():
+                self._send(403, {"error": "cross-origin request blocked"})
                 return
             # Host-admin only: switching the project, pruning duplicates, and the
             # heavy full-dataset compute streams all rebind/clobber server-global
@@ -1059,31 +1151,89 @@ class _Handler(BaseHTTPRequestHandler):
         return True
 
     def _same_origin(self) -> bool:
-        """Block cross-origin state-changing requests (CSRF). A browser always sets
-        ``Origin`` on POST; a foreign site's Origin won't match our Host, so we
-        reject it before any write. Non-browser tools (no Origin) are allowed."""
-        origin = self.headers.get("Origin")
-        if not origin:
+        """Compare a browser Origin to the normalized HTTP request authority."""
+        origins = self.headers.get_all("Origin") or []
+        if not origins:
             return True
-        try:
-            return urlparse(origin).netloc == (self.headers.get("Host") or "")
-        except Exception:  # noqa: BLE001
+        if len(origins) != 1:
             return False
+        origin = origins[0]
+        if not origin or origin != origin.strip() or origin.lower() == "null":
+            return False
+        try:
+            parsed = urlsplit(origin)
+            if (
+                parsed.scheme.lower() != "http"
+                or not parsed.netloc
+                or parsed.path
+                or parsed.query
+                or parsed.fragment
+                or "?" in origin
+                or "#" in origin
+                or parsed.username is not None
+                or parsed.password is not None
+            ):
+                return False
+            origin_authority = _parse_authority(parsed.netloc, default_port=80)
+        except (TypeError, ValueError):
+            return False
+        return origin_authority == self._request_authority()
+
+    def _request_authority(self) -> Optional[tuple[str, int]]:
+        hosts = self.headers.get_all("Host") or []
+        if len(hosts) != 1:
+            return None
+        try:
+            authority = _parse_authority(hosts[0], default_port=80)
+        except (TypeError, ValueError):
+            return None
+        return authority if authority[1] == self.state.port else None
 
     def _host_allowed(self) -> bool:
-        """Defend against DNS rebinding: ``_same_origin`` passes when a malicious page
-        rebinds its own hostname to 127.0.0.1 (both Origin and Host read
-        ``attacker.example``). On a loopback bind the only legitimate Host is a
-        loopback name, so reject anything else. Wildcard / NIC binds are explicit
-        exposures and keep their LAN Host."""
-        bind = (self.state.host or "").strip().lower()
-        if bind not in ("127.0.0.1", "::1", "localhost", ""):
-            return True   # wildcard / concrete-NIC bind: a LAN Host is legitimate
-        host_hdr = (self.headers.get("Host") or "").strip().lower()
-        if not host_hdr:
-            return True   # non-browser client without a Host header
-        name = host_hdr.rsplit(":", 1)[0].strip("[]") if not host_hdr.endswith("]") else host_hdr.strip("[]")
-        return self._is_loopback(name)
+        """Allow only the configured host or explicit local numeric addresses."""
+        authority = self._request_authority()
+        if authority is None:
+            return False
+        name, _port = authority
+        try:
+            address = ipaddress.ip_address(name)
+        except ValueError:
+            address = None
+
+        bind_raw = (self.state.host or "").strip().lower().strip("[]")
+        try:
+            bind_name = _normalize_host_name(bind_raw) if bind_raw else ""
+        except ValueError:
+            return False
+        try:
+            bind_address = ipaddress.ip_address(bind_name) if bind_name else None
+        except ValueError:
+            bind_address = None
+
+        wildcard = not bind_name or bool(bind_address and bind_address.is_unspecified)
+        if name == "localhost":
+            return wildcard or bind_name == "localhost" or bool(
+                bind_address and _ip_is_loopback(bind_address)
+            )
+        if address is None:
+            # A deliberately configured DNS bind may use its exact name. Arbitrary
+            # DNS Host values are never accepted, including on --share.
+            return bool(bind_address is None and bind_name and name == bind_name)
+        if address.is_unspecified or address.is_multicast:
+            return False
+        if _ip_is_loopback(address):
+            return wildcard or bind_name == "localhost" or bool(
+                bind_address and _ip_is_loopback(bind_address)
+            )
+        if address.is_reserved:
+            return False
+        if wildcard:
+            return True
+        if bind_address is None:
+            return False
+        if _ip_is_loopback(bind_address):
+            return False
+        return address == bind_address
 
     @staticmethod
     def _model_conf(qs: dict) -> tuple:

--- a/libreyolo/label/web/js_app.py
+++ b/libreyolo/label/web/js_app.py
@@ -284,7 +284,16 @@ async function saveClassEdit(){
     const r=await fetch("/api/classes",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({names, epoch:(DS&&DS.epoch)||0})});
     const d=await r.json();
     if(!r.ok){ err.textContent=d.error||"Could not save classes."; return; }
-    DS.names=d.names; DS.nc=d.nc;
+    DS.names=d.names; DS.nc=d.nc; DS.epoch=d.epoch;
+    // A class rename changes the meaning of numeric ids. The server starts a new
+    // project generation and clears its AI caches; discard the matching browser
+    // state too so an old ghost/Boost result cannot be accepted under new names.
+    ghosts=[]; radarFindings=[]; radarDeck=[]; mapPoints=[]; mapFit=null;
+    suggestedIds=new Set();
+    const chip=$("#boostchip"); if(chip) chip.className="chip";
+    try{ IMAGES=(await jget("/api/images")).images; }catch(e){}
+    renderList(); updateProgress();
+    await initAssist();
     if(active>=DS.names.length) active=0;
     renderPalette();
     if(imgOk) draw();        // box labels may now read a renamed class

--- a/libreyolo/label/web/js_canvas.py
+++ b/libreyolo/label/web/js_canvas.py
@@ -338,8 +338,24 @@ cv.addEventListener("dblclick", e=>{
     if(d<bestD){ bestD=d; best=i; bx=px; by=py; } }
   if(best>=0 && Math.hypot(sx(bx)-mx, sy(by)-my)<14){ pushUndo(); p.pts.splice(2*(best+1),0, bx, by); markDirty(); draw(); }
 });
-function clipPoly(p){ if(!imgOk||!p) return; const iw=img.naturalWidth, ih=img.naturalHeight;
-  if(DS && DS.task==="obb" && p.pts.length===8){
+function clippedPolyPoints(raw, iw, ih){
+  let v=[]; for(let k=0;k<raw.length;k+=2) v.push([raw[k],raw[k+1]]);
+  const clip=(arr,inside,cross)=>{ if(!arr.length) return []; const out=[]; let s=arr[arr.length-1], sin=inside(s);
+    arr.forEach(e=>{ const ein=inside(e); if(ein){ if(!sin) out.push(cross(s,e)); out.push(e); }
+      else if(sin) out.push(cross(s,e)); s=e; sin=ein; }); return out; };
+  const atX=(a,b,x)=>{ const t=(x-a[0])/(b[0]-a[0]); return [x,a[1]+t*(b[1]-a[1])]; };
+  const atY=(a,b,y)=>{ const t=(y-a[1])/(b[1]-a[1]); return [a[0]+t*(b[0]-a[0]),y]; };
+  v=clip(v,q=>q[0]>=0,(a,b)=>atX(a,b,0)); v=clip(v,q=>q[0]<=iw,(a,b)=>atX(a,b,iw));
+  v=clip(v,q=>q[1]>=0,(a,b)=>atY(a,b,0)); v=clip(v,q=>q[1]<=ih,(a,b)=>atY(a,b,ih));
+  const clean=[]; v.forEach(q=>{ const z=clean[clean.length-1]; if(!z||Math.abs(q[0]-z[0])>1e-9||Math.abs(q[1]-z[1])>1e-9) clean.push(q); });
+  if(clean.length>1){ const a=clean[0],b=clean[clean.length-1]; if(Math.abs(a[0]-b[0])<=1e-9&&Math.abs(a[1]-b[1])<=1e-9) clean.pop(); }
+  return clean.flat();
+}
+function polyArea2Px(pts){ let a=0,n=pts.length/2; for(let i=0;i<n;i++){ const j=(i+1)%n; a+=pts[2*i]*pts[2*j+1]-pts[2*j]*pts[2*i+1]; } return Math.abs(a); }
+function clipPoly(p){ if(!imgOk||!p) return false; const iw=img.naturalWidth, ih=img.naturalHeight;
+  if(DS && DS.task==="obb"){
+    if(p.pts.length!==8) return false;
+    const overlap=clippedPolyPoints(p.pts,iw,ih); if(overlap.length<6||polyArea2Px(overlap)<=1e-8) return false;
     // Clamping corners individually would shear the rectangle; translate the whole
     // quad back inside instead (per-corner clamp only if it simply can't fit).
     let mnx=1e18,mxx=-1e18,mny=1e18,mxy=-1e18;
@@ -348,17 +364,22 @@ function clipPoly(p){ if(!imgOk||!p) return; const iw=img.naturalWidth, ih=img.n
     if(mxx-mnx<=iw && mxy-mny<=ih){
       const dx=Math.max(0,-mnx)-Math.max(0,mxx-iw), dy=Math.max(0,-mny)-Math.max(0,mxy-ih);
       if(dx||dy) for(let k=0;k<p.pts.length;k+=2){ p.pts[k]+=dx; p.pts[k+1]+=dy; }
-      return;
+      return true;
     }
+    return false;   // clipping an oversized OBB would destroy its rectangle contract
   }
-  for(let k=0;k<p.pts.length;k+=2){ p.pts[k]=Math.max(0,Math.min(p.pts[k],iw)); p.pts[k+1]=Math.max(0,Math.min(p.pts[k+1],ih)); } }
+  const clipped=clippedPolyPoints(p.pts,iw,ih);
+  if(clipped.length<6||polyArea2Px(clipped)<=1e-8) return false;
+  p.pts=clipped; return true; }
 function normalizeRect(b){ if(b.w<0){b.x+=b.w;b.w=-b.w;} if(b.h<0){b.y+=b.h;b.h=-b.h;} }
 function clipToImage(b){
-  if(!imgOk) return;
+  if(!imgOk||!b) return false;
   const iw=img.naturalWidth, ih=img.naturalHeight;
   const x1=Math.max(0,Math.min(b.x,iw)),     y1=Math.max(0,Math.min(b.y,ih));
   const x2=Math.max(0,Math.min(b.x+b.w,iw)), y2=Math.max(0,Math.min(b.y+b.h,ih));
+  if(![x1,y1,x2,y2].every(Number.isFinite)||x2<=x1||y2<=y1) return false;
   b.x=x1; b.y=y1; b.w=x2-x1; b.h=y2-y1;
+  return true;
 }
 function resizeBox(b, k, mx, my){
   if(k.includes("n")){ b.h += b.y-my; b.y=my; }

--- a/libreyolo/label/web/js_editor.py
+++ b/libreyolo/label/web/js_editor.py
@@ -40,6 +40,10 @@ async function load(i){
   try{ lab = await jget(`/api/label/${i}`); }
   catch(e){ if(myGen!==loadSeq) return; stageMsg = "Couldn't load this image's labels - pick another image."; draw(); return; }
   if(myGen !== loadSeq) return;
+  if(!DS || lab.epoch!==DS.epoch){
+    stageMsg = "Project changed in another tab - reopen it before labeling.";
+    banner(stageMsg); draw(); return;
+  }
   editable = lab.editable;
   curRev = (lab.rev!=null) ? lab.rev : null;
   stageMsg = "Loading…"; draw();
@@ -82,13 +86,30 @@ function polyToNorm(p){
 async function save(){
   clearTimeout(autosaveTimer); autosaveTimer = null;   // a real save supersedes any pending autosave
   if(!imgOk || !editable || (DS && !DS.writable)){ return true; }
+  if(!DS || curRev==null){
+    setSave("save failed"); banner("Labels were not loaded with a revision - reload this image before saving."); return false;
+  }
+  // Commit the same bounded geometry that the data layer persists.  Keeping the
+  // canvas in sync matters for polygons and oriented boxes: otherwise the save
+  // snapshot could describe out-of-image points while disk contains clipped or
+  // translated coordinates, and a later edit/navigation would look clean.
+  let invalidShapes = 0;
+  boxes.forEach(b=>{ normalizeRect(b); if(!clipToImage(b)) invalidShapes++; });
+  polys.forEach(p=>{ if(!clipPoly(p)) invalidShapes++; });
+  if(invalidShapes){
+    // Never send a partial annotation list: omitting one invalid canvas shape would
+    // make the server persist its deletion before this client could warn the user.
+    dirty = true; setSave("unsaved"); draw();
+    banner(`${invalidShapes} invalid shape${invalidShapes>1?"s":""} not saved - undo, fix, or delete before saving.`);
+    return false;
+  }
   const totalShapes = boxes.length + polys.length;   // everything on the canvas
-  const anns = boxes.map(pxToNorm).filter(b=>b.w>0&&b.h>0)
+  const anns = boxes.map(pxToNorm)
     .map(b=>({type:"box", cls:b.cls, cx:b.cx, cy:b.cy, w:b.w, h:b.h}));
-  polys.forEach(p=>{ const pts=polyToNorm(p); if(pts.length>=6) anns.push({type:"poly", cls:p.cls, points:pts}); });
+  polys.forEach(p=>{ anns.push({type:"poly", cls:p.cls, points:polyToNorm(p)}); });
   const cur = idx, sent = snap();   // snapshot of exactly what we're sending
   try{
-    const q = `epoch=${(DS&&DS.epoch)||0}` + (curRev!=null ? `&rev=${encodeURIComponent(curRev)}` : "");
+    const q = `epoch=${DS.epoch}&rev=${encodeURIComponent(curRev)}`;
     const r = await fetch(`/api/label/${cur}?${q}`,{method:"POST",
       headers:{"Content-Type":"application/json"}, body:JSON.stringify({annotations:anns})});
     if(!r.ok){ setSave("save failed"); banner((await r.json()).error||"save failed"); return false; }
@@ -172,6 +193,7 @@ async function carryForward(){
   const myGen = loadSeq, srcIdx = idx;
   let lab; try{ lab = await jget(`/api/label/${prevId}`); }catch(e){ banner("Couldn't read the previous image's labels."); return; }
   if(myGen!==loadSeq || idx!==srcIdx) return;   // navigated during the fetch -> don't paste onto the wrong image
+  if(!DS || lab.epoch!==DS.epoch){ banner("Project changed - reopen it before copying labels."); return; }
   if(boxes.length + polys.length > 0){ banner("This image already has labels - carry-forward only fills an empty image."); return; }   // drawn during the fetch -> don't merge stale labels
   if(lab.editable===false){ banner("The previous image's labels are read-only (keypoints/unsupported) - can't carry them forward."); return; }   // partial view: don't drop the unparsed rows
   const anns = lab.annotations||[];
@@ -181,7 +203,7 @@ async function carryForward(){
   anns.forEach(a=>{
     if(a.type==="box"){ const b={cls:a.cls, x:(a.cx-a.w/2)*iw, y:(a.cy-a.h/2)*ih, w:a.w*iw, h:a.h*ih};
       clipToImage(b); if(b.w>0 && b.h>0){ boxes.push(b); n++; } }
-    else if(a.type==="poly"){ const q={cls:a.cls, pts:a.points.map((v,k)=> k%2===0? v*iw : v*ih)}; clipPoly(q); polys.push(q); n++; }
+    else if(a.type==="poly"){ const q={cls:a.cls, pts:a.points.map((v,k)=> k%2===0? v*iw : v*ih)}; if(clipPoly(q)){ polys.push(q); n++; } }
   });
   if(!n){ undoStack.pop(); return; }
   markDirty(); draw();
@@ -311,7 +333,7 @@ async function segmentAt(mx,my){
   if(X<0||Y<0||X>iw||Y>ih) return;
   segBusy=true; const myGen=loadSeq; banner("Segmenting… (SAM, on your machine)"); cv.style.cursor="wait";
   try{
-    const r = await fetch(`/api/assist/segment/${idx}`, {method:"POST", headers:{"Content-Type":"application/json"},
+    const r = await fetch(`/api/assist/segment/${idx}?epoch=${DS.epoch}`, {method:"POST", headers:{"Content-Type":"application/json"},
       body:JSON.stringify({x:X/iw, y:Y/ih})});
     if(myGen!==loadSeq) return;
     if(!r.ok){ const e=await r.json().catch(()=>({})); banner("Segment failed: "+(e.error||r.status)); return; }
@@ -332,7 +354,7 @@ async function segmentBox(r){
   if(x2-x1<4 || y2-y1<4) return;
   segBusy=true; const myGen=loadSeq; banner("Segmenting… (SAM box prompt)"); cv.style.cursor="wait";
   try{
-    const rr = await fetch(`/api/assist/segment/${idx}`, {method:"POST", headers:{"Content-Type":"application/json"},
+    const rr = await fetch(`/api/assist/segment/${idx}?epoch=${DS.epoch}`, {method:"POST", headers:{"Content-Type":"application/json"},
       body:JSON.stringify({box:[x1/iw, y1/ih, x2/iw, y2/ih]})});
     if(myGen!==loadSeq) return;
     if(!rr.ok){ const e=await rr.json().catch(()=>({})); banner("Segment failed: "+(e.error||rr.status)); return; }

--- a/libreyolo/label/web/js_home.py
+++ b/libreyolo/label/web/js_home.py
@@ -253,11 +253,11 @@ async function doDelete(){
   if(!deleteTarget){ closeDelete(); return; }
   const btn=$("#delconfirm"), t=btn.textContent; btn.disabled=true; btn.textContent="Moving…";
   try{
-    const wasOpen = DS && (deleteTarget===DS.yaml || deleteTarget===DS.root);
-    const r=await fetch("/api/projects/delete",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({data:deleteTarget})});
+    const body={data:deleteTarget}; if(DS) body.epoch=DS.epoch;
+    const r=await fetch("/api/projects/delete",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
     const dd=await r.json().catch(()=>({})); if(!r.ok||!dd.ok){ $("#delerr").textContent=(dd&&dd.error)||"Delete failed."; return; }
     closeDelete();
-    if(wasOpen){   // deleted the live project (e.g. from Settings): the session is gone
+    if(dd.closed){   // deleted the live project (e.g. from Settings): the session is gone
       resetClientState(); DS=null;
       try{ sessionStorage.setItem("ll-home","1"); }catch(e){}
       showHome();
@@ -335,7 +335,11 @@ async function doExport(){
     const r=await fetch("/api/export",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
     const d=await r.json(); if(!r.ok||!d.ok){ $("#experr").textContent=(d&&d.error)||"Export failed."; return; }
     const c=d.counts||{}; const sp=`train ${c.train||0}, val ${c.val||0}${c.test?(", test "+c.test):""}`;
-    if(d.in_place){ banner("Re-split in place ("+sp+")."); closeExport(); const y=d.yaml||yamlp; if(y) openProject(y); }
+    if(d.in_place){
+      banner("Re-split in place ("+sp+")."); closeExport();
+      if(d.dataset){ resetClientState(); await enterLabeler(d.dataset); }
+      else { const y=d.yaml||yamlp; if(y) await openProject(y); }
+    }
     else { $("#expresult").innerHTML=`Exported (${sp}) to<br><b>${esc(d.out)}</b>`+(d.zip?`<br>zip: ${esc(d.zip)}`:""); }
   }catch(e){ $("#experr").textContent="Export failed."; }
   finally{ btn.disabled=false; btn.textContent=t; }

--- a/libreyolo/label/web/js_power.py
+++ b/libreyolo/label/web/js_power.py
@@ -161,7 +161,7 @@ async function runBoost(){
   if(dirty){ banner("You edited while saving - press → to save before boosting."); return; }   // in-flight edits: don't train on stale labels
   setBoostChip("run", "Boosting - warming up…");
   try{
-    const r=await fetch("/api/boost",{method:"POST",headers:{"Content-Type":"application/json"},body:"{}"});
+    const r=await fetch("/api/boost",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({epoch:DS.epoch})});
     const d=await r.json();
     if(!d.started){ setBoostChip("bad", d.reason||"Couldn't start Boost"); return; }
     pollBoost();

--- a/libreyolo/training/artifacts.py
+++ b/libreyolo/training/artifacts.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..utils.logging import LoggerLevelLease, ThreadLogFilter
 from .callbacks import (
     TrainEndEvent,
     TrainEpochEvent,
@@ -380,19 +381,26 @@ class TrainingStatusCallback:
         self._epoch_time_sum = 0.0
         self._epoch_time_count = 0
         self._base: dict[str, Any] = {}
+        self._status: dict[str, Any] = {}
+        self._start_completed_epochs = 0
+        self._completed_epochs = 0
         self._log_handler: logging.Handler | None = None
         self._log_path: Path | None = None
-        self._prev_log_level: int | None = None
+        self._log_level_lease: LoggerLevelLease | None = None
 
     # -- events ------------------------------------------------------------
 
     def on_train_start(self, event: TrainStartEvent) -> None:
+        self._close_log()
         save_dir = self._save_dir(event)
         self._start_time = time.time()
         self._epoch_time_sum = 0.0
         self._epoch_time_count = 0
+        self._status = {}
+        self._start_completed_epochs = max(int(event.start_epoch) - 1, 0)
+        self._completed_epochs = self._start_completed_epochs
         self._base = {
-            "schema_version": 1,
+            "schema_version": 2,
             "pid": os.getpid(),
             "model_family": event.model_family,
             "model_size": event.model_size,
@@ -410,11 +418,19 @@ class TrainingStatusCallback:
                     metrics_path.unlink()
                 except OSError:
                     logger.debug("Could not reset %s", self.metrics_name, exc_info=True)
+        else:
+            try:
+                self._trim_metrics_before_epoch(
+                    save_dir / self.metrics_name,
+                    start_epoch=event.start_epoch,
+                )
+            except OSError:
+                logger.debug("Could not trim %s", self.metrics_name, exc_info=True)
         self._open_log(save_dir, fresh=event.start_epoch <= 1)
         self._write(
             save_dir,
             state="running",
-            completed_epochs=max(event.start_epoch - 1, 0),
+            completed_epochs=self._completed_epochs,
             current_epoch=None,
         )
 
@@ -423,7 +439,11 @@ class TrainingStatusCallback:
         self._epoch_time_sum += event.epoch_seconds
         self._epoch_time_count += 1
         mean_epoch = self._epoch_time_sum / max(self._epoch_time_count, 1)
-        completed = event.epoch + 1
+        # Public callback events number completed epochs from 1. status.json
+        # keeps ``current_epoch`` zero-based for its UI/API consumers and stores
+        # an absolute completed count, including epochs from a resumed run.
+        completed = max(int(event.epoch), self._start_completed_epochs)
+        self._completed_epochs = max(self._completed_epochs, completed)
         remaining = max(event.total_epochs - completed, 0)
         metrics = {
             name.removeprefix("metrics/"): value
@@ -436,8 +456,8 @@ class TrainingStatusCallback:
         self._write(
             save_dir,
             state="running",
-            current_epoch=event.epoch,
-            completed_epochs=completed,
+            current_epoch=max(int(event.epoch) - 1, 0),
+            completed_epochs=self._completed_epochs,
             epoch_seconds=event.epoch_seconds,
             mean_epoch_seconds=mean_epoch,
             eta_seconds=mean_epoch * remaining,
@@ -448,19 +468,25 @@ class TrainingStatusCallback:
             current_metric_name=event.current_metric_name,
             best_metric=event.best_metric,
             best_metric_name=event.best_metric_name,
-            best_epoch=event.best_epoch,
+            best_epoch=(event.best_epoch - 1 if event.best_epoch is not None else None),
         )
 
     def on_train_end(self, event: TrainEndEvent) -> None:
         save_dir = self._save_dir(event)
+        absolute_completed = max(
+            self._completed_epochs,
+            self._start_completed_epochs + max(int(event.completed_epochs), 0),
+        )
+        absolute_completed = min(absolute_completed, max(int(event.total_epochs), 0))
+        self._completed_epochs = absolute_completed
         self._write(
             save_dir,
             state="completed",
-            completed_epochs=event.completed_epochs,
+            completed_epochs=absolute_completed,
             total_seconds=event.total_seconds,
             train_loss=event.final_loss,
             best_metric=event.best_metric,
-            best_epoch=event.best_epoch,
+            best_epoch=(event.best_epoch - 1 if event.best_epoch is not None else None),
             checkpoints={
                 "best": event.results.get("best_checkpoint"),
                 "last": event.results.get("last_checkpoint"),
@@ -473,7 +499,8 @@ class TrainingStatusCallback:
         self._write(
             save_dir,
             state="failed",
-            current_epoch=event.epoch,
+            current_epoch=(max(int(event.epoch) - 1, 0) if event.epoch is not None else None),
+            completed_epochs=self._completed_epochs,
             elapsed_seconds=event.elapsed_seconds,
             error={
                 "type": event.exception_type,
@@ -491,15 +518,16 @@ class TrainingStatusCallback:
         return save_dir
 
     def _write(self, save_dir: Path, **fields: Any) -> None:
+        self._status.update(fields)
         payload = dict(self._base)
-        payload.update(fields)
+        payload.update(self._status)
         if self._start_time is not None:
             payload.setdefault(
                 "elapsed_seconds", round(time.time() - self._start_time, 3)
             )
         total = payload.get("total_epochs") or 0
         completed = payload.get("completed_epochs") or 0
-        payload["progress"] = (completed / total) if total else 0.0
+        payload["progress"] = min(max(completed / total, 0.0), 1.0) if total else 0.0
         payload["updated_at"] = _utcnow_iso()
         try:
             _atomic_write_json(save_dir / self.status_name, payload)
@@ -514,6 +542,36 @@ class TrainingStatusCallback:
                 f.write(line + "\n")
         except Exception:
             logger.debug("Failed to append %s", self.metrics_name, exc_info=True)
+
+    @staticmethod
+    def _trim_metrics_before_epoch(path: Path, *, start_epoch: int) -> None:
+        """Atomically discard stale/duplicate JSONL rows at the resume boundary."""
+        if not path.exists() or path.stat().st_size == 0:
+            return
+        kept = []
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    row = json.loads(line)
+                    epoch = int(row.get("epoch")) if isinstance(row, Mapping) else None
+                except (TypeError, ValueError):
+                    continue
+                if epoch is not None and epoch < start_epoch:
+                    kept.append(json.dumps(_json_safe(row), allow_nan=False))
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent, text=True
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                if kept:
+                    handle.write("\n".join(kept) + "\n")
+            os.replace(tmp_name, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+            raise
 
     def _open_log(self, save_dir: Path, *, fresh: bool) -> None:
         if not self.write_log:
@@ -530,29 +588,35 @@ class TrainingStatusCallback:
                     datefmt="%Y-%m-%d %H:%M:%S",
                 )
             )
+            handler.addFilter(ThreadLogFilter())
             lib_logger = logging.getLogger("libreyolo")
-            # The handler only sees records the logger admits, so lift the
-            # logger to INFO if it is quieter (restored in _close_log).
-            if lib_logger.level == logging.NOTSET or lib_logger.level > logging.INFO:
-                self._prev_log_level = lib_logger.level
-                lib_logger.setLevel(logging.INFO)
+            self._log_level_lease = LoggerLevelLease(
+                lib_logger, logging.INFO
+            ).acquire()
             lib_logger.addHandler(handler)
             self._log_handler = handler
         except Exception:
+            if self._log_level_lease is not None:
+                self._log_level_lease.release()
+                self._log_level_lease = None
             logger.debug("Failed to open %s", self.log_name, exc_info=True)
             self._log_handler = None
 
     def _close_log(self) -> None:
         handler = self._log_handler
         if handler is None:
+            if self._log_level_lease is not None:
+                self._log_level_lease.release()
+                self._log_level_lease = None
             return
         self._log_handler = None
         try:
             lib_logger = logging.getLogger("libreyolo")
             lib_logger.removeHandler(handler)
             handler.close()
-            if self._prev_log_level is not None:
-                lib_logger.setLevel(self._prev_log_level)
-                self._prev_log_level = None
         except Exception:
             logger.debug("Failed to close %s", self.log_name, exc_info=True)
+        finally:
+            if self._log_level_lease is not None:
+                self._log_level_lease.release()
+                self._log_level_lease = None

--- a/libreyolo/training/artifacts.py
+++ b/libreyolo/training/artifacts.py
@@ -24,6 +24,33 @@ from .callbacks import (
 
 logger = logging.getLogger("libreyolo")
 
+_FILE_SHARING_RETRY_SECONDS = 1.0
+_FILE_SHARING_RETRY_INITIAL_SECONDS = 0.005
+_FILE_SHARING_RETRY_MAX_SECONDS = 0.05
+
+
+def _retry_transient_file_access(operation):
+    """Retry bounded Windows-style sharing violations from short-lived readers."""
+    deadline = time.monotonic() + _FILE_SHARING_RETRY_SECONDS
+    delay = _FILE_SHARING_RETRY_INITIAL_SECONDS
+    while True:
+        try:
+            return operation()
+        except PermissionError:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(delay, remaining))
+            delay = min(delay * 2.0, _FILE_SHARING_RETRY_MAX_SECONDS)
+
+
+def _replace_with_retry(source, destination) -> None:
+    _retry_transient_file_access(lambda: os.replace(source, destination))
+
+
+def _unlink_with_retry(path: Path) -> None:
+    _retry_transient_file_access(path.unlink)
+
 
 def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
     """Write ``value`` to ``path`` atomically (tmp file + ``os.replace``).
@@ -41,7 +68,7 @@ def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
                 _json_safe(value), f, allow_nan=False, indent=2, sort_keys=True
             )
             f.write("\n")
-        os.replace(tmp_name, path)
+        _replace_with_retry(tmp_name, path)
     except BaseException:
         try:
             os.unlink(tmp_name)
@@ -91,7 +118,7 @@ class TrainingArtifactsCallback:
             for filename in (self.results_name, self.summary_name):
                 path = save_dir / filename
                 if path.exists():
-                    path.unlink()
+                    _unlink_with_retry(path)
         else:
             self._trim_csv_before_epoch(
                 save_dir / self.results_name,
@@ -234,7 +261,7 @@ class TrainingArtifactsCallback:
                 writer = csv.DictWriter(f, fieldnames=fieldnames)
                 writer.writeheader()
                 writer.writerows(rows)
-            os.replace(tmp_name, path)
+            _replace_with_retry(tmp_name, path)
         except BaseException:
             try:
                 os.unlink(tmp_name)
@@ -271,7 +298,7 @@ class TrainingArtifactsCallback:
                     sort_keys=True,
                 )
                 f.write("\n")
-            os.replace(tmp_name, path)
+            _replace_with_retry(tmp_name, path)
         except BaseException:
             try:
                 os.unlink(tmp_name)
@@ -415,7 +442,7 @@ class TrainingStatusCallback:
             metrics_path = save_dir / self.metrics_name
             if metrics_path.exists():
                 try:
-                    metrics_path.unlink()
+                    _unlink_with_retry(metrics_path)
                 except OSError:
                     logger.debug("Could not reset %s", self.metrics_name, exc_info=True)
         else:
@@ -565,7 +592,7 @@ class TrainingStatusCallback:
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 if kept:
                     handle.write("\n".join(kept) + "\n")
-            os.replace(tmp_name, path)
+            _replace_with_retry(tmp_name, path)
         except BaseException:
             try:
                 os.unlink(tmp_name)
@@ -579,7 +606,7 @@ class TrainingStatusCallback:
         try:
             self._log_path = save_dir / self.log_name
             if fresh and self._log_path.exists():
-                self._log_path.unlink()
+                _unlink_with_retry(self._log_path)
             handler = logging.FileHandler(self._log_path, encoding="utf-8")
             handler.setLevel(logging.INFO)
             handler.setFormatter(

--- a/libreyolo/training/callbacks.py
+++ b/libreyolo/training/callbacks.py
@@ -30,6 +30,9 @@ class TrainStartEvent:
 class TrainEpochEvent:
     """Data emitted after a training epoch has completed.
 
+    ``epoch`` is the one-based number of the completed epoch. ``best_epoch``
+    uses the same convention.
+
     ``current_metric`` is the selected validation metric for this epoch.
     ``best_metric`` is the trainer's best-so-far value after this epoch updates
     best-state tracking.
@@ -86,7 +89,11 @@ class TrainEndEvent:
 
 @dataclass(frozen=True)
 class TrainExceptionEvent:
-    """Data emitted when training raises before returning results."""
+    """Data emitted when training raises before returning results.
+
+    ``epoch`` is the one-based epoch being attempted, or ``None`` when setup
+    failed before an epoch could start.
+    """
 
     epoch: int | None
     total_epochs: int

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -794,16 +794,26 @@ class BaseTrainer(ABC):
 
         project = Path(self.config.project)
         name = self.config.name
+        project.mkdir(parents=True, exist_ok=True)
+        base = project / name
+        # ``name`` may include a grouping path such as ``sweep/exp``. Preserve
+        # that long-standing layout while atomically reserving only the leaf.
+        base.parent.mkdir(parents=True, exist_ok=True)
+        if self.config.exist_ok:
+            save_dir = base
+            save_dir.mkdir(exist_ok=True)
+            return save_dir
 
-        save_dir = project / name
-        if not self.config.exist_ok and save_dir.exists():
-            i = 2
-            while (project / f"{name}{i}").exists():
-                i += 1
-            save_dir = project / f"{name}{i}"
-
-        save_dir.mkdir(parents=True, exist_ok=True)
-        return save_dir
+        # Directory creation, unlike exists-check-then-mkdir, is an atomic
+        # reservation across concurrent trainers in this process or another.
+        for index in range(1, 10_000):
+            candidate = base if index == 1 else base.with_name(f"{base.name}{index}")
+            try:
+                candidate.mkdir()
+            except FileExistsError:
+                continue
+            return candidate
+        raise FileExistsError(f"No free training run directory under {project}")
 
     def _setup_data(self):
         wrapper_task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
@@ -1786,6 +1796,10 @@ class BaseTrainer(ABC):
         # May be stale from a previous profile_then_stop run on this instance;
         # a leftover True would silently truncate this run's first epoch.
         self._stop_training = False
+        # Establish the first attempted epoch before setup/callback work. If a
+        # resumed setup fails after partially marking itself ready, exception
+        # telemetry still reports the correct absolute epoch.
+        self.current_epoch = self.start_epoch
         try:
             self.setup()
 

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -794,10 +794,11 @@ class BaseTrainer(ABC):
 
         project = Path(self.config.project)
         name = self.config.name
-        project.mkdir(parents=True, exist_ok=True)
         base = project / name
         # ``name`` may include a grouping path such as ``sweep/exp``. Preserve
         # that long-standing layout while atomically reserving only the leaf.
+        # Do not pre-create ``project`` itself: an empty public ``name`` makes
+        # that directory the leaf that must be reserved by the loop below.
         base.parent.mkdir(parents=True, exist_ok=True)
         if self.config.exist_ok:
             save_dir = base

--- a/libreyolo/ui/server.py
+++ b/libreyolo/ui/server.py
@@ -34,6 +34,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+from ..utils.logging import LoggerLevelLease, ThreadLogFilter
 from .page import INDEX_HTML
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,26 @@ def _sanitize_filename(name: str) -> str:
     if "." not in base:
         base += ".jpg"
     return base
+
+
+def _reserve_incremented_directory(path: str | Path) -> Path:
+    """Atomically reserve ``path`` or its next numbered sibling.
+
+    ``increment_path(..., mkdir=True)`` checks existence before creating the
+    directory, so two UI servers can both select the same name.  Directory
+    creation itself is atomic; retrying on ``FileExistsError`` keeps the
+    familiar ``predict``, ``predict2``, ... naming without that race.
+    """
+    base = Path(path)
+    base.parent.mkdir(parents=True, exist_ok=True)
+    for index in range(1, 10_000):
+        candidate = base if index == 1 else base.with_name(f"{base.name}{index}")
+        try:
+            candidate.mkdir()
+        except FileExistsError:
+            continue
+        return candidate
+    raise FileExistsError(f"No free run directory available for {base}")
 
 
 def _plural(n: int, singular: str, plural: str | None = None) -> str:
@@ -330,7 +351,10 @@ class _UIState:
     def __init__(self, device: str = "auto"):
         self.device = device
         self._models: dict[str, object] = {}
-        self._lock = threading.Lock()  # serialize inference (model not thread-safe)
+        # ``new_run`` shares this lock with inference so a request cannot move
+        # the active output directory halfway through another request.  It is
+        # re-entrant because inference lazily starts its first run.
+        self._lock = threading.RLock()
         self._upload_lock = threading.Lock()
         self._used_upload_names: set[str] = set()
         self.run_dir: Path | None = None
@@ -415,12 +439,13 @@ class _UIState:
         return model
 
     def new_run(self) -> Path:
-        from libreyolo.utils.general import increment_path
-
-        self.run_dir = increment_path(Path("runs/detect") / "predict", mkdir=True)
-        with self._upload_lock:
-            self._used_upload_names.clear()
-        return self.run_dir
+        with self._lock:
+            self.run_dir = _reserve_incremented_directory(
+                Path("runs/detect") / "predict"
+            )
+            with self._upload_lock:
+                self._used_upload_names.clear()
+            return self.run_dir
 
     def _write_upload(self, filename: str, data: bytes) -> tuple[Path, str]:
         safe = _sanitize_filename(filename)
@@ -472,14 +497,18 @@ class _UIState:
         with self._lock:
             if self.run_dir is None:
                 self.new_run()
+            # Keep the request bound to the directory selected under the lock;
+            # a later /api/run/new request must not rewrite its response.
+            run_dir = self.run_dir
+            assert run_dir is not None
             in_path, safe = self._write_upload(filename, data)
             lg = logging.getLogger("libreyolo")
             handler = _StreamLogHandler(emit) if emit is not None else None
-            prev_level = lg.level
+            level_lease = None
             if handler is not None:
                 handler.setLevel(logging.INFO)
-                if prev_level == logging.NOTSET or prev_level > logging.INFO:
-                    lg.setLevel(logging.INFO)
+                handler.addFilter(ThreadLogFilter())
+                level_lease = LoggerLevelLease(lg, logging.INFO).acquire()
                 lg.addHandler(handler)
             try:
                 # _get_model triggers weight download on first use; keep it
@@ -497,7 +526,7 @@ class _UIState:
                         original = uploaded.convert("RGB")
                     prompt_box = bbox or [0.0, 0.0, float(width), float(height)]
                     result = model(str(in_path), conf=conf, bboxes=prompt_box)
-                    save_path = resolve_save_path(self.run_dir, safe, ext="jpg")
+                    save_path = resolve_save_path(run_dir, safe, ext="jpg")
                     InferenceRunner(model)._save_annotated_image(
                         result, original, save_path
                     )
@@ -506,12 +535,14 @@ class _UIState:
                         str(in_path),
                         conf=conf,
                         save=True,
-                        output_path=str(self.run_dir),
+                        output_path=str(run_dir),
                     )
             finally:
                 if handler is not None:
                     lg.removeHandler(handler)
-                    lg.setLevel(prev_level)
+                    handler.close()
+                    if level_lease is not None:
+                        level_lease.release()
 
         if isinstance(result, list):
             result = result[0] if result else None
@@ -536,7 +567,7 @@ class _UIState:
             "task": task,
             "label": label,
             "rendered": "data:image/" + mime + ";base64," + encoded,
-            "dir": str(self.run_dir),
+            "dir": str(run_dir),
             "saved": str(saved),
         }
 

--- a/libreyolo/ui/server.py
+++ b/libreyolo/ui/server.py
@@ -572,10 +572,12 @@ class _UIState:
         }
 
     def open_folder(self) -> dict:
-        if self.run_dir is None or not Path(self.run_dir).exists():
-            return {"ok": False, "dir": str(self.run_dir) if self.run_dir else None}
-        ok = _open_in_file_manager(Path(self.run_dir))
-        return {"ok": ok, "dir": str(self.run_dir)}
+        with self._lock:
+            run_dir = self.run_dir
+            if run_dir is None or not run_dir.exists():
+                return {"ok": False, "dir": str(run_dir) if run_dir else None}
+            ok = _open_in_file_manager(run_dir)
+            return {"ok": ok, "dir": str(run_dir)}
 
 
 class _Handler(BaseHTTPRequestHandler):

--- a/libreyolo/ui/train_monitor.py
+++ b/libreyolo/ui/train_monitor.py
@@ -42,6 +42,70 @@ _RUN_MARKERS = ("status.json", "metrics.jsonl", "results.csv")
 _MAX_LOG_BYTES = 200_000
 
 
+def _finite_number(value) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return number
+
+
+def _normalize_status_view(status: dict) -> dict:
+    """Add tested display fields across status schema v1 and v2."""
+    view = dict(status)
+    schema = _finite_number(view.get("schema_version")) or 1
+    state = str(view.get("state") or "")
+    total = _finite_number(view.get("total_epochs"))
+    current = _finite_number(view.get("current_epoch"))
+    completed = _finite_number(view.get("completed_epochs"))
+    start = _finite_number(view.get("start_epoch")) or 1
+    raw_progress = _finite_number(view.get("progress"))
+
+    if schema >= 2:
+        display_epoch = current + 1 if state == "failed" and current is not None else completed
+        if display_epoch is None and current is not None:
+            display_epoch = current + 1
+        progress = raw_progress
+        if progress is None and completed is not None and total and total > 0:
+            progress = completed / total
+        best = _finite_number(view.get("best_epoch"))
+        display_best = best + 1 if best is not None else None
+    else:
+        if state == "completed" and completed is not None:
+            # Schema v1 TrainEndEvent stored invocation-local completion on resume.
+            display_epoch = max(start - 1, 0) + completed
+        elif current is not None:
+            # Schema v1 current_epoch came from an already one-based public event.
+            display_epoch = current
+        else:
+            display_epoch = completed
+        if total and total > 0:
+            if state == "completed" and completed is not None:
+                progress = (max(start - 1, 0) + completed) / total
+            elif state == "running" and current is not None:
+                progress = current / total
+            elif state == "failed" and current is not None:
+                progress = max(current - 1, start - 1, 0) / total
+            elif completed is not None:
+                progress = completed / total
+            else:
+                progress = raw_progress
+        else:
+            progress = raw_progress
+        display_best = _finite_number(view.get("best_epoch"))
+
+    if total is not None and display_epoch is not None:
+        display_epoch = min(display_epoch, max(total, 0))
+    view["display_epoch"] = max(0, int(display_epoch or 0))
+    view["display_progress"] = min(max(float(progress or 0.0), 0.0), 1.0)
+    view["display_best_epoch"] = (
+        max(0, int(display_best)) if display_best is not None else None
+    )
+    return view
+
+
 def is_run_dir(path: Path) -> bool:
     """True if ``path`` looks like a training run (carries a known marker)."""
     return path.is_dir() and any((path / m).exists() for m in _RUN_MARKERS)
@@ -115,7 +179,10 @@ def _read_status(run_dir: Path) -> dict:
     if not path.exists():
         return {"state": "missing", "save_dir": str(run_dir)}
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        status = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(status, dict):
+            raise ValueError("status must be an object")
+        return _normalize_status_view(status)
     except (OSError, ValueError):
         return {"state": "unreadable", "save_dir": str(run_dir)}
 
@@ -237,6 +304,7 @@ def _run_summary(root: Path, run_dir: Path) -> dict:
     """Compact per-run record for the index page."""
     status = _read_status(run_dir)
     return {
+        "schema_version": status.get("schema_version"),
         "id": run_id_for(root, run_dir),
         "name": run_id_for(root, run_dir),
         "state": status.get("state", "unknown"),
@@ -244,7 +312,10 @@ def _run_summary(root: Path, run_dir: Path) -> dict:
         + (status.get("model_size") or ""),
         "task": status.get("task"),
         "progress": status.get("progress", 0.0),
+        "display_progress": status.get("display_progress"),
         "current_epoch": status.get("current_epoch"),
+        "completed_epochs": status.get("completed_epochs"),
+        "display_epoch": status.get("display_epoch"),
         "total_epochs": status.get("total_epochs"),
         "best_metric": status.get("best_metric"),
         "best_metric_name": status.get("best_metric_name"),

--- a/libreyolo/ui/train_monitor_page.py
+++ b/libreyolo/ui/train_monitor_page.py
@@ -170,6 +170,44 @@ function fmtNum(v, d = 4) {
   if (v == null || v === "" || !isFinite(v)) return "-";
   return Number(v).toFixed(d).replace(/\.?0+$/, "");
 }
+function epochNumber(s) {
+  if (s.display_epoch != null && isFinite(Number(s.display_epoch))) {
+    return Math.max(0, Math.floor(Number(s.display_epoch)));
+  }
+  const modern = Number(s.schema_version) >= 2;
+  if (modern && s.completed_epochs != null && isFinite(Number(s.completed_epochs))) {
+    return Math.max(0, Math.floor(Number(s.completed_epochs)));
+  }
+  if (s.current_epoch != null && isFinite(Number(s.current_epoch))) {
+    // Schema v2 stores a zero-based index.  Older/missing schemas used a
+    // one-based value in real trainer events, so do not increment those.
+    const epoch = Math.floor(Number(s.current_epoch));
+    return Math.max(0, modern ? epoch + 1 : epoch);
+  }
+  if (s.completed_epochs != null && isFinite(Number(s.completed_epochs))) {
+    return Math.max(0, Math.floor(Number(s.completed_epochs)));
+  }
+  return 0;
+}
+function progressValue(s) {
+  if (s.display_progress != null && isFinite(Number(s.display_progress))) {
+    return Math.max(0, Math.min(1, Number(s.display_progress)));
+  }
+  let value = Number(s.progress);
+  if (s.progress == null || !isFinite(value)) {
+    const completed = Number(s.completed_epochs), total = Number(s.total_epochs);
+    value = isFinite(completed) && isFinite(total) && total > 0 ? completed / total : 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+function bestEpochNumber(s) {
+  if (s.display_best_epoch != null && isFinite(Number(s.display_best_epoch))) {
+    return Math.max(0, Math.floor(Number(s.display_best_epoch)));
+  }
+  if (s.best_epoch == null || !isFinite(Number(s.best_epoch))) return null;
+  const epoch = Math.floor(Number(s.best_epoch));
+  return Math.max(0, Number(s.schema_version) >= 2 ? epoch + 1 : epoch);
+}
 function card(label, value, sub) {
   return `<div class="card"><div class="label">${label}</div><div class="value">${value}</div>${sub ? `<div class="sub">${sub}</div>` : ""}</div>`;
 }
@@ -193,14 +231,15 @@ async function renderIndex() {
   $("runlist").innerHTML = runs.map(r => {
     const st = (r.state || "unknown").toLowerCase();
     const ep = r.total_epochs != null
-      ? `${r.current_epoch != null ? r.current_epoch + 1 : (r.state === 'completed' ? r.total_epochs : 0)}/${r.total_epochs}` : "-";
+      ? `${epochNumber(r)}/${r.total_epochs}` : "-";
+    const progress = progressValue(r);
     const best = r.best_metric != null ? `${r.best_metric_name || "best"} ${fmtNum(r.best_metric)}` : "";
     return `<a class="runcard" href="/?run=${encodeURIComponent(r.id)}">
       <div class="top"><span class="badge ${st}">${st}</span>
         ${st === "running" ? '<span class="dot live"></span>' : ""}</div>
       <div class="name">${r.name}</div>
       <div class="meta"><span>${r.model || ""} ${r.task || ""}</span><span>epoch ${ep}</span></div>
-      <div class="meta"><span>${best}</span><span>${((r.progress || 0) * 100).toFixed(0)}%</span></div>
+      <div class="meta"><span>${best}</span><span>${(progress * 100).toFixed(0)}%</span></div>
     </a>`;
   }).join("");
   setTimeout(renderIndex, 3000);
@@ -219,22 +258,24 @@ async function refreshStatus() {
   $("runpath").textContent = s.save_dir || RUN;
 
   const cards = [];
-  const cur = s.current_epoch != null ? s.current_epoch + 1 : (s.completed_epochs || 0);
+  const cur = epochNumber(s);
+  const progress = progressValue(s);
   cards.push(card("Epoch", `${cur} / ${s.total_epochs ?? "-"}`,
     s.mean_epoch_seconds ? `${fmtSecs(s.mean_epoch_seconds)}/epoch` : ""));
   cards.push(card("ETA", state === "running" ? fmtSecs(s.eta_seconds) : "-",
     `elapsed ${fmtSecs(s.elapsed_seconds)}`));
   const metricName = s.best_metric_name || s.current_metric_name || "metric";
+  const bestEpoch = bestEpochNumber(s);
   cards.push(card(`Best ${metricName}`, fmtNum(s.best_metric),
-    s.best_epoch != null ? `epoch ${s.best_epoch + 1}` : ""));
+    bestEpoch != null ? `epoch ${bestEpoch}` : ""));
   cards.push(card("Train loss", fmtNum(s.train_loss, 4),
     s.model_family ? `${s.model_family}${s.model_size || ""} ${s.task || ""}` : ""));
 
   let cardsHtml = cards.join("");
   cardsHtml += `<div class="card" style="grid-column:1/-1">
     <div class="label">Progress</div>
-    <div class="progress"><div style="width:${((s.progress || 0) * 100).toFixed(1)}%"></div></div>
-    <div class="sub">${((s.progress || 0) * 100).toFixed(1)}%</div></div>`;
+    <div class="progress"><div style="width:${(progress * 100).toFixed(1)}%"></div></div>
+    <div class="sub">${(progress * 100).toFixed(1)}%</div></div>`;
   $("cards").innerHTML = cardsHtml;
 
   if (state === "failed" && s.error) {
@@ -298,7 +339,8 @@ async function refreshMetrics() {
   const rows = m.rows || [];
   if (!rows.length) { $("metrics-empty").style.display = "block"; return; }
   $("metrics-empty").style.display = "none";
-  const xs = rows.map(r => r.epoch != null ? r.epoch + 1 : 0);
+  // Training artifact epochs are already 1-based.
+  const xs = rows.map(r => r.epoch != null ? r.epoch : 0);
   const lossCols = (m.columns || []).filter(c => c.startsWith("train/") && c.includes("loss"));
   const primaryLoss = lossCols.includes("train/loss") ? "train/loss" : lossCols[0];
   const lossSeries = primaryLoss ? [{ name: primaryLoss, data: rows.map(r => r[primaryLoss]) }] : [];

--- a/libreyolo/ui/train_monitor_page.py
+++ b/libreyolo/ui/train_monitor_page.py
@@ -278,10 +278,12 @@ async function refreshStatus() {
     <div class="sub">${(progress * 100).toFixed(1)}%</div></div>`;
   $("cards").innerHTML = cardsHtml;
 
+  let box = $("errbox");
   if (state === "failed" && s.error) {
-    let box = $("errbox");
     if (!box) { box = document.createElement("div"); box.id = "errbox"; box.className = "err-box"; $("cards").after(box); }
     box.textContent = `${s.error.type || "Error"}: ${s.error.message || ""}`;
+  } else if (box) {
+    box.remove();
   }
   return state;
 }

--- a/libreyolo/utils/logging.py
+++ b/libreyolo/utils/logging.py
@@ -12,11 +12,83 @@ handlers, formatting, and log level.
 
 import logging
 import sys
+import threading
+from collections import Counter
 from typing import ClassVar
 
 # Custom HEADER level — bold green banner for phase separators
 HEADER_LEVEL = 25
 logging.addLevelName(HEADER_LEVEL, "HEADER")
+
+_LEVEL_LEASE_LOCK = threading.Lock()
+_LEVEL_LEASES: dict[logging.Logger, dict] = {}
+
+
+class ThreadLogFilter(logging.Filter):
+    """Admit records emitted by one thread only."""
+
+    def __init__(self, thread_id: int | None = None):
+        super().__init__()
+        self.thread_id = threading.get_ident() if thread_id is None else thread_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.thread == self.thread_id
+
+
+class LoggerLevelLease:
+    """Temporarily admit a log level without racing other in-process users.
+
+    The shared ``libreyolo`` logger can be captured by overlapping training and
+    inference UI runs. Its original level is restored only after the final
+    lease closes.
+    """
+
+    def __init__(self, logger: logging.Logger, level: int = logging.INFO):
+        self.logger = logger
+        self.level = int(level)
+        self._acquired = False
+
+    def acquire(self) -> "LoggerLevelLease":
+        if self._acquired:
+            return self
+        with _LEVEL_LEASE_LOCK:
+            state = _LEVEL_LEASES.get(self.logger)
+            if state is None:
+                state = {"original": self.logger.level, "levels": Counter()}
+                _LEVEL_LEASES[self.logger] = state
+            state["levels"][self.level] += 1
+            self._apply_active_level(state)
+            self._acquired = True
+        return self
+
+    def release(self) -> None:
+        if not self._acquired:
+            return
+        with _LEVEL_LEASE_LOCK:
+            state = _LEVEL_LEASES.get(self.logger)
+            if state is not None:
+                levels: Counter = state["levels"]
+                levels[self.level] -= 1
+                if levels[self.level] <= 0:
+                    del levels[self.level]
+                if levels:
+                    self._apply_active_level(state)
+                else:
+                    self.logger.setLevel(int(state["original"]))
+                    del _LEVEL_LEASES[self.logger]
+            self._acquired = False
+
+    def _apply_active_level(self, state: dict) -> None:
+        requested = min(state["levels"])
+        original = int(state["original"])
+        target = requested if original == logging.NOTSET else min(original, requested)
+        self.logger.setLevel(target)
+
+    def __enter__(self) -> "LoggerLevelLease":
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.release()
 
 
 class ConsoleFormatter(logging.Formatter):

--- a/tests/unit/test_label_data_integrity.py
+++ b/tests/unit/test_label_data_integrity.py
@@ -1,0 +1,1002 @@
+"""LibreLabel data-layer integrity and rollback contracts."""
+
+from __future__ import annotations
+
+import math
+import json
+import multiprocessing
+import threading
+import zipfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from libreyolo.label.dataset import (
+    DatasetSession,
+    create_uploaded_project,
+    save_uploaded_image,
+)
+from libreyolo.label.export import _assign_splits, export_dataset
+from libreyolo.label.labelio import (
+    format_annotations,
+    parse_annotations,
+    sanitize_annotations,
+    sanitize_boxes,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _process_upload(root, name, payload, ready, start, outcomes):
+    """Spawn-safe worker for the cross-process stem reservation regression."""
+    ready.put(True)
+    start.wait(10)
+    try:
+        save_uploaded_image(root, name, payload)
+    except Exception as exc:  # noqa: BLE001 - serialized test outcome
+        outcomes.put(("error", type(exc).__name__))
+    else:
+        outcomes.put(("ok", name))
+
+
+def _dataset(root: Path, names=("cat", "dog"), task: str | None = "detect") -> DatasetSession:
+    for subdir, filename, color in (
+        ("a", "same.jpg", "red"),
+        ("b", "same.png", "blue"),
+    ):
+        image = root / "images" / "train" / subdir / filename
+        image.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", (24, 16), color).save(image)
+    lines = [
+        f"path: {root.as_posix()}",
+        "train: images/train",
+        f"nc: {len(names)}",
+        "names:",
+        *(f"  {i}: {name}" for i, name in enumerate(names)),
+    ]
+    if task:
+        lines.append(f"task: {task}")
+    (root / "data.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return DatasetSession(str(root / "data.yaml"))
+
+
+def _file_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _directory_snapshot(root: Path) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_dir()
+    }
+
+
+@pytest.mark.parametrize(
+    ("annotation", "message"),
+    [
+        ({"cls": 0.5, "cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2}, "integer"),
+        ({"cls": 2, "cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2}, "outside"),
+        ({"cls": 0, "cx": math.nan, "cy": 0.5, "w": 0.2, "h": 0.2}, "finite"),
+        ({"cls": 0, "cx": 1.1, "cy": 0.5, "w": 0.2, "h": 0.2}, "normalized"),
+        ({"cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.0, "h": 0.2}, "positive"),
+        ({"type": "poly", "cls": 0, "points": [0.1, 0.1, 0.2, 0.2]}, "3 coordinate"),
+        ({"type": "poly", "cls": 0, "points": [0.0, 0.0, 0.5, 0.5, 1.0, 1.0]}, "non-zero"),
+    ],
+)
+def test_annotation_ingress_rejects_instead_of_truncating_or_dropping(annotation, message):
+    with pytest.raises(ValueError, match=message):
+        sanitize_annotations([annotation], nc=2)
+
+
+def test_box_ingress_rejects_out_of_bounds_and_nonfinite():
+    with pytest.raises(ValueError, match="normalized"):
+        sanitize_boxes([{"cls": 0, "cx": -0.1, "cy": 0.5, "w": 0.2, "h": 0.2}], nc=1)
+    with pytest.raises(ValueError, match="finite"):
+        sanitize_boxes([{"cls": 0, "cx": 0.5, "cy": 0.5, "w": math.inf, "h": 0.2}], nc=1)
+    with pytest.raises(ValueError, match="six-decimal precision"):
+        sanitize_boxes([{"cls": 0, "cx": 0.5, "cy": 0.5, "w": 1e-7, "h": 0.2}], nc=1)
+
+
+def test_annotation_ingress_rejects_geometry_lost_by_disk_quantization():
+    with pytest.raises(ValueError, match="six-decimal precision"):
+        sanitize_annotations(
+            [{"type": "box", "cls": 0, "cx": 0.5, "cy": 0.5, "w": 1e-7, "h": 0.2}],
+            nc=1,
+            task="detect",
+        )
+    with pytest.raises(ValueError, match="non-zero area|distinct points"):
+        sanitize_annotations(
+            [{
+                "type": "poly",
+                "cls": 0,
+                "points": [0.1, 0.1, 0.9, 0.1, 0.9, 0.1000001, 0.1, 0.1000001],
+            }],
+            nc=1,
+            task="obb",
+        )
+
+
+def test_write_rejects_subprecision_geometry_without_publishing_label(tmp_path):
+    detect = _dataset(tmp_path / "detect", task="detect")
+    with pytest.raises(ValueError, match="six-decimal precision"):
+        detect.write_label(
+            0,
+            [{"type": "box", "cls": 0, "cx": 0.5, "cy": 0.5, "w": 1e-7, "h": 0.2}],
+        )
+    assert not detect.has_label_file(0)
+
+    obb = _dataset(tmp_path / "obb-subprecision", task="obb")
+    with pytest.raises(ValueError, match="non-zero area|distinct points"):
+        obb.write_label(
+            0,
+            [{
+                "type": "poly",
+                "cls": 0,
+                "points": [0.25, 0.5, 0.75, 0.5, 0.75, 0.5000001, 0.25, 0.5000001],
+            }],
+        )
+    assert not obb.has_label_file(0)
+
+
+def test_write_rejects_whole_payload_without_changing_existing_label(tmp_path):
+    session = _dataset(tmp_path / "ds")
+    good = {"cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2}
+    session.write_label(0, [good])
+    label = session._items[0][1]
+    before = label.read_bytes()
+
+    with pytest.raises(ValueError, match="class id"):
+        session.write_label(0, [good, {**good, "cls": 0.25}])
+
+    assert label.read_bytes() == before
+
+
+def test_segment_polygon_is_clipped_to_persisted_canvas(tmp_path):
+    session = _dataset(tmp_path / "seg", task="segment")
+    session.write_label(
+        0,
+        [{"type": "poly", "cls": 0, "points": [-0.2, 0.2, 0.4, 0.2, 0.4, 1.2]}],
+    )
+
+    annotations, editable = session.read_label(0)
+    assert editable
+    points = annotations[0]["points"]
+    assert len(points) >= 6
+    assert all(0.0 <= value <= 1.0 for value in points)
+
+
+def test_segment_rejects_diagonal_polygon_outside_canvas_corner(tmp_path):
+    session = _dataset(tmp_path / "segment", task="segment")
+    points = [-0.45, 0.35, 0.35, -0.45, 0.36, -0.44, -0.44, 0.36]
+
+    with pytest.raises(ValueError, match="does not overlap"):
+        session.write_label(
+            0, [{"type": "poly", "cls": 0, "points": points}]
+        )
+
+
+def test_obb_clipping_translates_rectangle_without_shearing(tmp_path):
+    session = _dataset(tmp_path / "obb", task="obb")
+    session.write_label(
+        0,
+        [{
+            "type": "poly",
+            "cls": 0,
+            "points": [-0.1, 0.2, 0.3, 0.2, 0.3, 0.6, -0.1, 0.6],
+        }],
+    )
+
+    annotations, editable = session.read_label(0)
+    assert editable
+    assert annotations[0]["points"] == pytest.approx([0.0, 0.2, 0.4, 0.2, 0.4, 0.6, 0.0, 0.6])
+
+
+def test_obb_rejects_degenerate_quad(tmp_path):
+    session = _dataset(tmp_path / "obb", task="obb")
+    with pytest.raises(ValueError, match="non-zero area"):
+        session.write_label(
+            0,
+            [{"type": "poly", "cls": 0, "points": [0.1, 0.1, 0.3, 0.3, 0.5, 0.5, 0.7, 0.7]}],
+        )
+    assert not session.has_label_file(0)
+
+
+def test_obb_rejects_axis_aligned_box_rows(tmp_path):
+    session = _dataset(tmp_path / "obb", task="obb")
+    with pytest.raises(ValueError, match="4 corners"):
+        session.write_label(
+            0,
+            [{"type": "box", "cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.3, "h": 0.2}],
+        )
+
+
+def test_obb_rejects_geometry_entirely_outside_canvas(tmp_path):
+    session = _dataset(tmp_path / "obb", task="obb")
+    with pytest.raises(ValueError, match="does not overlap"):
+        session.write_label(
+            0,
+            [{
+                "type": "poly",
+                "cls": 0,
+                "points": [-0.9, 0.2, -0.5, 0.2, -0.5, 0.6, -0.9, 0.6],
+            }],
+        )
+
+
+def test_obb_rejects_diagonal_geometry_outside_canvas_corner(tmp_path):
+    session = _dataset(tmp_path / "obb", task="obb")
+    cx = cy = -0.05
+    length, height = 0.8, 0.02
+    inv = math.sqrt(0.5)
+    ux, uy = inv * length / 2, -inv * length / 2
+    vx, vy = inv * height / 2, inv * height / 2
+    corners = [
+        cx - ux - vx, cy - uy - vy,
+        cx + ux - vx, cy + uy - vy,
+        cx + ux + vx, cy + uy + vy,
+        cx - ux + vx, cy - uy + vy,
+    ]
+
+    with pytest.raises(ValueError, match="does not overlap"):
+        session.write_label(
+            0, [{"type": "poly", "cls": 0, "points": corners}]
+        )
+
+
+def test_obb_rejects_non_rectangular_quad(tmp_path):
+    session = _dataset(tmp_path / "obb", task="obb")
+    with pytest.raises(ValueError, match="oriented rectangle"):
+        session.write_label(
+            0,
+            [{
+                "type": "poly",
+                "cls": 0,
+                "points": [0.1, 0.1, 0.8, 0.1, 0.7, 0.7, 0.2, 0.7],
+            }],
+        )
+
+
+def test_rotated_obb_survives_six_decimal_disk_quantization():
+    cx, cy, width, height, angle = 0.5, 0.5, 0.2, 0.08, 0.37
+    ux, uy = math.cos(angle) * width / 2, math.sin(angle) * width / 2
+    vx, vy = -math.sin(angle) * height / 2, math.cos(angle) * height / 2
+    corners = [
+        cx - ux - vx, cy - uy - vy,
+        cx + ux - vx, cy + uy - vy,
+        cx + ux + vx, cy + uy + vy,
+        cx - ux + vx, cy - uy + vy,
+    ]
+    text = format_annotations([{"type": "poly", "cls": 0, "points": corners}])
+
+    clean = sanitize_annotations(parse_annotations(text), nc=1, task="obb")
+
+    assert len(clean) == 1
+
+
+def test_thin_rotated_obb_survives_six_decimal_disk_quantization():
+    cx, cy, width, height, angle = 0.5, 0.5, 0.5, 0.001, 0.37
+    ux, uy = math.cos(angle) * width / 2, math.sin(angle) * width / 2
+    vx, vy = -math.sin(angle) * height / 2, math.cos(angle) * height / 2
+    corners = [
+        cx - ux - vx, cy - uy - vy,
+        cx + ux - vx, cy + uy - vy,
+        cx + ux + vx, cy + uy + vy,
+        cx - ux + vx, cy - uy + vy,
+    ]
+    text = format_annotations([{"type": "poly", "cls": 0, "points": corners}])
+
+    clean = sanitize_annotations(parse_annotations(text), nc=1, task="obb")
+
+    assert len(clean) == 1
+
+
+def test_export_uniquifies_stems_across_image_suffixes(tmp_path):
+    session = _dataset(tmp_path / "source", task="detect")
+    session.write_label(0, [{"cls": 0, "cx": 0.4, "cy": 0.4, "w": 0.2, "h": 0.2}])
+    session.write_label(1, [{"cls": 1, "cx": 0.6, "cy": 0.6, "w": 0.3, "h": 0.3}])
+
+    out = tmp_path / "out"
+    export_dataset(session, dst=str(out), formats=("yolo", "voc"), split="none")
+
+    images = sorted((out / "images" / "train").iterdir())
+    labels = sorted((out / "labels" / "train").iterdir())
+    xml = sorted((out / "voc" / "train" / "Annotations").iterdir())
+    assert [path.stem.casefold() for path in images] == ["same", "same_2"]
+    assert {path.stem.casefold() for path in labels} == {"same", "same_2"}
+    assert {path.stem.casefold() for path in xml} == {"same", "same_2"}
+    assert {path.read_text(encoding="utf-8").split()[0] for path in labels} == {"0", "1"}
+
+
+def test_export_rejects_source_images_that_already_share_one_label_path(tmp_path):
+    root = tmp_path / "source"
+    root.mkdir()
+    Image.new("RGB", (12, 8), "red").save(root / "same.jpg")
+    Image.new("RGB", (12, 8), "blue").save(root / "same.png")
+    (root / "data.yaml").write_text(
+        f"path: {root.as_posix()}\ntrain: .\nnc: 1\nnames:\n  0: thing\n",
+        encoding="utf-8",
+    )
+    session = DatasetSession(str(root / "data.yaml"))
+
+    with pytest.raises(ValueError, match="share one derived label"):
+        export_dataset(session, dst=str(tmp_path / "out"), formats=("yolo",), split="none")
+
+    assert not (tmp_path / "out").exists()
+
+
+def test_native_coco_project_is_view_only_and_cannot_export_empty_labels(tmp_path):
+    root = tmp_path / "native"
+    images = root / "images" / "train"
+    annotations = root / "annotations"
+    images.mkdir(parents=True)
+    annotations.mkdir()
+    Image.new("RGB", (12, 8), "red").save(images / "a.jpg")
+    (annotations / "train.json").write_text(
+        json.dumps(
+            {
+                "images": [{"id": 1, "file_name": "a.jpg", "width": 12, "height": 8}],
+                "annotations": [
+                    {"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 1, 4, 3]}
+                ],
+                "categories": [{"id": 1, "name": "thing"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "data.yaml").write_text(
+        f"path: {root.as_posix()}\ntrain: images/train\n"
+        "annotations:\n  train: annotations/train.json\n"
+        "names:\n  0: thing\nnc: 1\n",
+        encoding="utf-8",
+    )
+    session = DatasetSession(str(root / "data.yaml"))
+
+    assert session.writable is False
+    with pytest.raises(ValueError, match="cannot preserve"):
+        export_dataset(session, dst=str(tmp_path / "out"), formats=("yolo",))
+    assert not (tmp_path / "out").exists()
+
+
+def test_taskless_dataset_rejects_transforming_exports(tmp_path):
+    session = _dataset(tmp_path / "source", task=None)
+    with pytest.raises(ValueError, match="does not declare a task"):
+        export_dataset(session, dst=str(tmp_path / "coco"), formats=("coco",))
+    with pytest.raises(ValueError, match="detection annotations require boxes"):
+        session.write_label(
+            0,
+            [{
+                "type": "poly",
+                "cls": 0,
+                "points": [0.1, 0.1, 0.8, 0.1, 0.4, 0.7],
+            }],
+        )
+
+    with pytest.raises(ValueError, match="does not declare a task"):
+        export_dataset(
+            session, dst=str(tmp_path / "yolo"), formats=("yolo",), split="none"
+        )
+
+
+def test_taskless_nonquad_polygons_infer_segment_and_reject_voc(tmp_path):
+    root = tmp_path / "source"
+    initial = _dataset(root, task=None)
+    label = initial._items[0][1]
+    label.parent.mkdir(parents=True, exist_ok=True)
+    label.write_text("0 0.1 0.1 0.8 0.1 0.4 0.7\n", encoding="utf-8")
+    session = DatasetSession(str(root / "data.yaml"))
+
+    assert session.meta()["task"] == "segment"
+    with pytest.raises(ValueError, match="discard"):
+        export_dataset(session, dst=str(tmp_path / "voc"), formats=("voc",))
+
+
+def test_taskless_quad_dataset_is_globally_view_only(tmp_path):
+    root = tmp_path / "source"
+    initial = _dataset(root, task=None)
+    label = initial._items[0][1]
+    label.parent.mkdir(parents=True, exist_ok=True)
+    label.write_text(
+        "0 0.1 0.1 0.7 0.1 0.7 0.6 0.1 0.6\n", encoding="utf-8"
+    )
+    session = DatasetSession(str(root / "data.yaml"))
+
+    assert session._task_ambiguous is True
+    assert session.writable is False
+    assert session.read_label(1)[1] is False
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        session.write_label(
+            1,
+            [{"type": "box", "cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2}],
+        )
+
+
+@pytest.mark.parametrize(
+    ("task", "label_text"),
+    [
+        ("detect", "0 0.1 0.1 0.8 0.1 0.4 0.7\n"),
+        ("obb", "0 0.5 0.5 0.2 0.2\n"),
+    ],
+)
+def test_declared_task_mismatch_is_read_only(tmp_path, task, label_text):
+    root = tmp_path / task
+    initial = _dataset(root, task=task)
+    label = initial._items[0][1]
+    label.parent.mkdir(parents=True, exist_ok=True)
+    label.write_text(label_text, encoding="utf-8")
+    session = DatasetSession(str(root / "data.yaml"))
+
+    annotations, editable = session.read_label(0)
+    assert annotations
+    assert editable is False
+    with pytest.raises(RuntimeError, match="read-only"):
+        session.write_label(0, annotations)
+
+
+def test_segment_coco_export_preserves_rectangular_mask(tmp_path):
+    session = _dataset(tmp_path / "source", task="segment")
+    session.write_label(0, [{"type": "box", "cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.5, "h": 0.5}])
+
+    out = tmp_path / "out"
+    export_dataset(session, dst=str(out), formats=("coco",), split="none")
+    coco = json.loads((out / "annotations" / "instances_train.json").read_text(encoding="utf-8"))
+
+    assert len(coco["annotations"][0]["segmentation"][0]) == 8
+    assert coco["annotations"][0]["area"] > 0
+
+
+@pytest.mark.parametrize(
+    ("task", "formats", "message"),
+    [
+        ("segment", ("voc",), "discard"),
+        ("obb", ("coco",), "discard"),
+        ("pose", ("yolo",), "cannot preserve"),
+        ("semantic", ("yolo",), "cannot preserve"),
+    ],
+)
+def test_export_rejects_lossy_task_format_pairs(tmp_path, task, formats, message):
+    session = _dataset(tmp_path / task, task=task)
+    if task == "pose":
+        session._lossy_export = True
+    with pytest.raises(ValueError, match=message):
+        export_dataset(session, dst=str(tmp_path / "out"), formats=formats, split="none")
+    assert not (tmp_path / "out").exists()
+
+
+def test_export_rejects_unknown_format_and_inplace_ignored_options(tmp_path):
+    session = _dataset(tmp_path / "source")
+    with pytest.raises(ValueError, match="Unsupported"):
+        export_dataset(session, dst=str(tmp_path / "out"), formats=("bogus",), split="none")
+    with pytest.raises(ValueError, match="YOLO only"):
+        export_dataset(session, formats=("coco",), split="none", in_place=True)
+    with pytest.raises(ValueError, match="cannot be zipped"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True, make_zip=True)
+
+
+def test_copy_export_failure_leaves_new_destination_absent(tmp_path, monkeypatch):
+    from libreyolo.label import export as export_module
+
+    session = _dataset(tmp_path / "source")
+    real_copy = export_module.shutil.copy2
+    calls = 0
+
+    def fail_second_copy(src, dst, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected copy failure")
+        return real_copy(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(export_module.shutil, "copy2", fail_second_copy)
+    out = tmp_path / "out"
+    with pytest.raises(OSError, match="injected"):
+        export_dataset(session, dst=str(out), formats=("yolo",), split="none")
+
+    assert not out.exists()
+    assert not list(tmp_path.glob(".out-librelabel-*"))
+
+
+def test_copy_export_rejects_destination_inside_recursive_source(tmp_path):
+    root = tmp_path / "source"
+    session = _dataset(root, task="detect")
+    destination = root / "images" / "train" / "export"
+
+    with pytest.raises(ValueError, match="inside recursive source split"):
+        export_dataset(
+            session, dst=str(destination), formats=("yolo",), split="none"
+        )
+
+    assert not destination.exists()
+    assert len(DatasetSession(str(root / "data.yaml"))) == len(session)
+
+
+@pytest.mark.parametrize("stale_kind", ["image", "label"])
+def test_in_place_export_rejects_unrelated_target_content(tmp_path, stale_kind):
+    root = tmp_path / "source"
+    session = _dataset(root, task="detect")
+    if stale_kind == "image":
+        stale = root / "images" / "val" / "stale.jpg"
+        stale.parent.mkdir(parents=True)
+        Image.new("RGB", (12, 8), "black").save(stale)
+    else:
+        stale = root / "labels" / "val" / "stale.txt"
+        stale.parent.mkdir(parents=True)
+        stale.write_text("0 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="unrelated"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert stale.exists()
+
+
+def test_copy_export_failure_preserves_preexisting_empty_destination(tmp_path, monkeypatch):
+    from libreyolo.label import export as export_module
+
+    session = _dataset(tmp_path / "source")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    def fail_yaml(*args, **kwargs):
+        raise OSError("injected yaml failure")
+
+    monkeypatch.setattr(export_module, "_write_yaml", fail_yaml)
+    with pytest.raises(OSError, match="injected"):
+        export_dataset(session, dst=str(out), formats=("yolo",), split="none")
+
+    assert out.is_dir() and not any(out.iterdir())
+
+
+def test_copy_export_zip_uses_final_root_and_yaml_path(tmp_path):
+    import yaml
+
+    session = _dataset(tmp_path / "source")
+    out = tmp_path / "out"
+    result = export_dataset(
+        session, dst=str(out), formats=("yolo",), split="none", make_zip=True
+    )
+
+    config = yaml.safe_load((out / "data.yaml").read_text(encoding="utf-8"))
+    assert Path(config["path"]) == out.absolute()
+    with zipfile.ZipFile(result["zip"]) as archive:
+        assert archive.namelist()
+        assert all(name.startswith("out/") for name in archive.namelist())
+
+
+def test_explicit_detect_export_remains_reexportable(tmp_path):
+    source = _dataset(tmp_path / "source", task="detect")
+    first = tmp_path / "first"
+    export_dataset(source, dst=str(first), formats=("yolo",), split="none")
+
+    reopened = DatasetSession(str(first / "data.yaml"))
+    second = tmp_path / "second"
+    export_dataset(reopened, dst=str(second), formats=("yolo",), split="none")
+
+    assert reopened._task == "detect"
+    assert (second / "data.yaml").exists()
+
+
+def test_zip_publication_race_rolls_back_dataset_without_overwrite(tmp_path, monkeypatch):
+    from libreyolo.label import export as export_module
+
+    session = _dataset(tmp_path / "source")
+    out = tmp_path / "out"
+    zip_target = Path(str(out.absolute()) + ".zip")
+    real_zip = export_module._zip_dir
+
+    def race_zip(*args, **kwargs):
+        real_zip(*args, **kwargs)
+        zip_target.write_bytes(b"other exporter")
+
+    monkeypatch.setattr(export_module, "_zip_dir", race_zip)
+    with pytest.raises(FileExistsError):
+        export_dataset(
+            session, dst=str(out), formats=("yolo",), split="none", make_zip=True
+        )
+
+    assert not out.exists()
+    assert zip_target.read_bytes() == b"other exporter"
+
+
+def test_zip_cleanup_failure_does_not_report_failure_after_publication(
+    tmp_path, monkeypatch
+):
+    session = _dataset(tmp_path / "source")
+    out = tmp_path / "out"
+    real_unlink = Path.unlink
+
+    def fail_zip_temp_cleanup(path, *args, **kwargs):
+        if path.name.endswith(".zip.tmp"):
+            raise OSError("injected cleanup failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_zip_temp_cleanup)
+    result = export_dataset(
+        session, dst=str(out), formats=("yolo",), split="none", make_zip=True
+    )
+
+    assert out.is_dir()
+    assert Path(result["zip"]).is_file()
+
+
+def test_zip_publication_does_not_require_hard_links(tmp_path, monkeypatch):
+    from libreyolo.label import export as export_module
+
+    session = _dataset(tmp_path / "source")
+    monkeypatch.setattr(
+        export_module.os,
+        "link",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("unsupported")),
+    )
+
+    result = export_dataset(
+        session,
+        dst=str(tmp_path / "out"),
+        formats=("yolo",),
+        split="none",
+        make_zip=True,
+    )
+
+    assert Path(result["zip"]).is_file()
+
+
+def test_in_place_export_rolls_back_all_moves_on_mid_commit_failure(tmp_path, monkeypatch):
+    from libreyolo.label import export as export_module
+
+    root = tmp_path / "source"
+    session = _dataset(root)
+    session.write_label(0, [{"cls": 0, "cx": 0.4, "cy": 0.4, "w": 0.2, "h": 0.2}])
+    session.write_label(1, [{"cls": 1, "cx": 0.6, "cy": 0.6, "w": 0.3, "h": 0.3}])
+    before = _file_snapshot(root)
+    real_move = export_module.shutil.move
+    calls = 0
+
+    def fail_once(src, dst, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 6:
+            raise OSError("injected finalization failure")
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(export_module.shutil, "move", fail_once)
+    with pytest.raises(OSError, match="injected"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert _file_snapshot(root) == before
+    assert not list(tmp_path.glob(".source-libreyolo-export-*"))
+
+
+def test_in_place_export_rolls_back_when_yaml_commit_fails(tmp_path, monkeypatch):
+    from libreyolo.label import export as export_module
+
+    root = tmp_path / "source"
+    session = _dataset(root)
+    session.write_label(0, [{"cls": 0, "cx": 0.4, "cy": 0.4, "w": 0.2, "h": 0.2}])
+    before = _file_snapshot(root)
+
+    def fail_yaml(*args, **kwargs):
+        raise OSError("injected yaml failure")
+
+    monkeypatch.setattr(export_module, "_write_yaml", fail_yaml)
+    with pytest.raises(OSError, match="injected"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert _file_snapshot(root) == before
+
+
+def test_in_place_export_rolls_back_when_reopened_session_is_invalid(tmp_path):
+    root = tmp_path / "source"
+    session = _dataset(root, task="detect")
+    session.write_label(
+        0, [{"cls": 0, "cx": 0.4, "cy": 0.4, "w": 0.2, "h": 0.2}]
+    )
+    before = _file_snapshot(root)
+    before_dirs = _directory_snapshot(root)
+
+    def reject_reopen(_yaml_path):
+        raise RuntimeError("injected reopen failure")
+
+    with pytest.raises(RuntimeError, match="injected reopen"):
+        export_dataset(
+            session,
+            formats=("yolo",),
+            split="trainval",
+            val_frac=0.5,
+            in_place=True,
+            _in_place_validator=reject_reopen,
+        )
+
+    assert _file_snapshot(root) == before
+    assert _directory_snapshot(root) == before_dirs
+
+
+def test_in_place_export_rewrites_only_the_opened_custom_yaml(tmp_path):
+    root = tmp_path / "source"
+    original = _dataset(root, task="detect")
+    custom_yaml = root / "project.yml"
+    Path(original.yaml_file).replace(custom_yaml)
+    unrelated_yaml = root / "data.yaml"
+    unrelated = b"path: unrelated\r\ntrain: elsewhere\r\n"
+    unrelated_yaml.write_bytes(unrelated)
+    session = DatasetSession(str(custom_yaml))
+
+    result = export_dataset(
+        session, formats=("yolo",), split="none", in_place=True
+    )
+
+    assert Path(result["yaml"]).resolve() == custom_yaml.resolve()
+    assert unrelated_yaml.read_bytes() == unrelated
+    reopened = DatasetSession(str(custom_yaml))
+    assert len(reopened) == len(session)
+
+
+def test_uploaded_project_rolls_back_validation_moves_if_yaml_fails(tmp_path, monkeypatch):
+    from libreyolo.label import dataset as dataset_module
+
+    root = tmp_path / "uploads"
+    train = root / "images" / "train"
+    train.mkdir(parents=True)
+    for i in range(5):
+        Image.new("RGB", (12, 8), (i * 30, 0, 0)).save(train / f"image-{i}.jpg")
+    before = _file_snapshot(root)
+
+    def fail_write(*args, **kwargs):
+        raise OSError("injected yaml failure")
+
+    monkeypatch.setattr(dataset_module, "_atomic_write_text", fail_write)
+    with pytest.raises(OSError, match="injected"):
+        create_uploaded_project(str(root), classes=["thing"], make_val=True, val_frac=0.4)
+
+    assert _file_snapshot(root) == before
+    assert not (root / "data.yaml").exists()
+
+
+def test_uploaded_project_rollback_preserves_preexisting_empty_val_dir(
+    tmp_path, monkeypatch
+):
+    from libreyolo.label import dataset as dataset_module
+
+    root = tmp_path / "uploads"
+    train = root / "images" / "train"
+    val = root / "images" / "val"
+    train.mkdir(parents=True)
+    val.mkdir(parents=True)
+    for i in range(5):
+        Image.new("RGB", (12, 8), (i * 30, 0, 0)).save(train / f"image-{i}.jpg")
+
+    monkeypatch.setattr(
+        dataset_module,
+        "_atomic_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("injected")),
+    )
+    with pytest.raises(OSError, match="injected"):
+        create_uploaded_project(
+            str(root), classes=["thing"], make_val=True, val_frac=0.4
+        )
+
+    assert val.is_dir() and not any(val.iterdir())
+    assert len(list(train.glob("*.jpg"))) == 5
+
+
+def test_uploaded_project_rejects_preexisting_nonempty_val(tmp_path):
+    root = tmp_path / "uploads"
+    train = root / "images" / "train"
+    val = root / "images" / "val"
+    train.mkdir(parents=True)
+    val.mkdir(parents=True)
+    for i in range(5):
+        Image.new("RGB", (12, 8), "red").save(train / f"image-{i}.jpg")
+    Image.new("RGB", (12, 8), "blue").save(val / "unrelated.png")
+
+    with pytest.raises(ValueError, match="Validation directory is not empty"):
+        create_uploaded_project(
+            str(root), classes=["thing"], make_val=True, val_frac=0.4
+        )
+
+    assert not (root / "data.yaml").exists()
+
+
+def test_uploaded_project_rejects_cross_suffix_label_collision_before_split(tmp_path):
+    root = tmp_path / "uploads"
+    train = root / "images" / "train"
+    train.mkdir(parents=True)
+    Image.new("RGB", (12, 8), "red").save(train / "same.jpg")
+    Image.new("RGB", (12, 8), "blue").save(train / "same.png")
+
+    with pytest.raises(ValueError, match="share the label basename"):
+        create_uploaded_project(str(root), classes=["thing"], make_val=True)
+
+    assert not (root / "data.yaml").exists()
+    assert {path.name for path in train.iterdir()} == {"same.jpg", "same.png"}
+
+
+def test_concurrent_uploads_publish_exactly_one_complete_file(tmp_path):
+    root = tmp_path / "uploads"
+    barrier = threading.Barrier(2)
+    outcomes = []
+    payloads = [b"first-complete-payload", b"second-complete-payload"]
+
+    def upload(payload):
+        barrier.wait()
+        try:
+            outcomes.append(("ok", save_uploaded_image(str(root), "same.jpg", payload)))
+        except Exception as exc:  # noqa: BLE001 - record the racing result
+            outcomes.append(("error", exc))
+
+    threads = [threading.Thread(target=upload, args=(payload,)) for payload in payloads]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(kind for kind, _ in outcomes) == ["error", "ok"]
+    error = next(value for kind, value in outcomes if kind == "error")
+    assert isinstance(error, FileExistsError)
+    assert (root / "images" / "train" / "same.jpg").read_bytes() in payloads
+    assert not list((root / "images" / "train").glob(".librelabel-upload-*"))
+
+
+def test_cross_process_uploads_cannot_share_label_stem(tmp_path):
+    root = tmp_path / "uploads"
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    outcomes = context.Queue()
+    processes = [
+        context.Process(
+            target=_process_upload,
+            args=(str(root), name, payload, ready, start, outcomes),
+        )
+        for name, payload in (("same.jpg", b"jpg"), ("same.png", b"png"))
+    ]
+    for process in processes:
+        process.start()
+    assert ready.get(timeout=10) is True
+    assert ready.get(timeout=10) is True
+    start.set()
+    results = [outcomes.get(timeout=10), outcomes.get(timeout=10)]
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    assert sorted(kind for kind, _value in results) == ["error", "ok"]
+    files = list((root / "images" / "train").glob("same.*"))
+    assert len(files) == 1
+
+
+def test_cross_process_upload_lock_canonicalizes_directory_alias(tmp_path):
+    root = tmp_path / "uploads"
+    root.mkdir()
+    alias = tmp_path / "uploads-alias"
+    try:
+        alias.symlink_to(root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    outcomes = context.Queue()
+    processes = [
+        context.Process(
+            target=_process_upload,
+            args=(str(path), name, payload, ready, start, outcomes),
+        )
+        for path, name, payload in (
+            (root, "same.jpg", b"jpg"),
+            (alias, "same.png", b"png"),
+        )
+    ]
+    for process in processes:
+        process.start()
+    assert ready.get(timeout=10) is True
+    assert ready.get(timeout=10) is True
+    start.set()
+    results = [outcomes.get(timeout=10), outcomes.get(timeout=10)]
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    assert sorted(kind for kind, _value in results) == ["error", "ok"]
+    assert len(list((root / "images" / "train").glob("same.*"))) == 1
+
+
+def test_upload_temp_cleanup_failure_does_not_hide_success(tmp_path, monkeypatch):
+    root = tmp_path / "uploads"
+    real_unlink = Path.unlink
+
+    def fail_upload_temp_cleanup(path, *args, **kwargs):
+        if path.name.startswith(".librelabel-upload-"):
+            raise OSError("injected cleanup failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_upload_temp_cleanup)
+    saved = save_uploaded_image(str(root), "image.jpg", b"complete")
+
+    assert Path(saved).read_bytes() == b"complete"
+
+
+def test_upload_publication_does_not_require_hard_links(tmp_path, monkeypatch):
+    from libreyolo.label import dataset as dataset_module
+
+    monkeypatch.setattr(
+        dataset_module.os,
+        "link",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("unsupported")),
+    )
+
+    saved = save_uploaded_image(str(tmp_path / "uploads"), "image.jpg", b"complete")
+
+    assert Path(saved).read_bytes() == b"complete"
+
+
+@pytest.mark.parametrize("task", ["semantic", "restore", "matte", "ocr"])
+def test_non_annotation_tasks_are_view_only(tmp_path, task):
+    session = _dataset(tmp_path / task, task=task)
+
+    assert session.writable is False
+    with pytest.raises(RuntimeError, match="view-only"):
+        session.write_label(
+            0,
+            [{"type": "box", "cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2}],
+        )
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "target_dir: targets",
+        "panoptic_dir: annotations/panoptic",
+        "depth_scale: 256.0",
+        "val_mattes: mattes/val",
+        "images: images\nlabels: labels",
+    ],
+)
+def test_taskless_task_specific_markers_are_view_only(tmp_path, marker):
+    root = tmp_path / "marked"
+    _dataset(root, task=None)
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        yaml_path.read_text(encoding="utf-8") + marker + "\n",
+        encoding="utf-8",
+    )
+
+    session = DatasetSession(str(yaml_path))
+
+    assert session.writable is False
+    assert session._lossy_export is True
+
+
+def test_markerless_restore_layout_cannot_use_generic_export(tmp_path):
+    root = tmp_path / "restore"
+    inputs = root / "inputs" / "train"
+    targets = root / "targets" / "train"
+    inputs.mkdir(parents=True)
+    targets.mkdir(parents=True)
+    Image.new("RGB", (12, 8), "red").save(inputs / "a.jpg")
+    Image.new("RGB", (12, 8), "blue").save(targets / "a.jpg")
+    (root / "data.yaml").write_text(
+        f"path: {root.as_posix()}\ntrain: inputs/train\nnames: [image]\nnc: 1\n",
+        encoding="utf-8",
+    )
+    session = DatasetSession(str(root / "data.yaml"))
+
+    assert session.writable is False
+    with pytest.raises(ValueError, match="cannot preserve"):
+        export_dataset(
+            session, dst=str(tmp_path / "out"), formats=("yolo",), split="none"
+        )
+    assert (targets / "a.jpg").exists()
+
+
+def test_split_assignment_validates_fractions_and_keeps_train_image():
+    with pytest.raises(ValueError, match="finite"):
+        _assign_splits(5, "trainval", math.nan, 0.0, 1)
+    with pytest.raises(ValueError, match="split must"):
+        _assign_splits(5, "unexpected", 0.2, 0.0, 1)
+    assigned = _assign_splits(5, "trainvaltest", 1.0, 1.0, 1)
+    assert assigned.count("train") == 1

--- a/tests/unit/test_label_data_integrity.py
+++ b/tests/unit/test_label_data_integrity.py
@@ -240,6 +240,40 @@ def test_segment_polygon_is_clipped_to_persisted_canvas(tmp_path):
     assert all(0.0 <= value <= 1.0 for value in points)
 
 
+def test_segment_rejects_clipping_overflow_without_publishing_nan(tmp_path):
+    session = _dataset(tmp_path / "segment-overflow", task="segment")
+    good = {
+        "type": "poly",
+        "cls": 0,
+        "points": [0.1, 0.1, 0.8, 0.1, 0.4, 0.7],
+    }
+    session.write_label(0, [good])
+    label = session._items[0][1]
+    before = label.read_bytes()
+
+    with pytest.raises(ValueError, match="finite and normalized"):
+        session.write_label(
+            0,
+            [
+                {
+                    "type": "poly",
+                    "cls": 0,
+                    "points": [
+                        1e308,
+                        1e308,
+                        -1e308,
+                        -1e308,
+                        0.5,
+                        0.5,
+                    ],
+                }
+            ],
+        )
+
+    assert label.read_bytes() == before
+    assert b"nan" not in label.read_bytes().lower()
+
+
 def test_segment_rejects_diagonal_polygon_outside_canvas_corner(tmp_path):
     session = _dataset(tmp_path / "segment", task="segment")
     points = [-0.45, 0.35, 0.35, -0.45, 0.36, -0.44, -0.44, 0.36]
@@ -794,7 +828,257 @@ def test_in_place_export_rolls_back_all_moves_on_mid_commit_failure(tmp_path, mo
         export_dataset(session, formats=("yolo",), split="none", in_place=True)
 
     assert _file_snapshot(root) == before
-    assert not list(tmp_path.glob(".source-libreyolo-export-*"))
+    assert not list(tmp_path.glob(".source-librelabel-export-*"))
+
+
+@pytest.mark.parametrize("source_kind", ("image", "label"))
+def test_in_place_export_rejects_link_sources_but_copy_export_remains_safe(
+    tmp_path, source_kind
+):
+    root = tmp_path / "source"
+    session = _dataset(root)
+    if source_kind == "label":
+        session.write_label(
+            0, [{"cls": 0, "cx": 0.4, "cy": 0.4, "w": 0.2, "h": 0.2}]
+        )
+    source = session._items[0][0 if source_kind == "image" else 1]
+    target = source.with_name(f"linked-target{source.suffix}")
+    source.replace(target)
+    try:
+        source.symlink_to(target.name)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    expected = target.read_bytes()
+
+    with pytest.raises(ValueError, match="symbolic-link or reparse-point"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert source.is_symlink()
+    assert source.read_bytes() == expected
+    assert target.read_bytes() == expected
+
+    destination = tmp_path / "copy"
+    export_dataset(
+        session, dst=str(destination), formats=("yolo",), split="none"
+    )
+    assert destination.is_dir()
+
+
+def test_in_place_export_rejects_link_source_ancestor_but_copy_remains_safe(
+    tmp_path,
+):
+    root = tmp_path / "source"
+    external = tmp_path / "external"
+    external.mkdir()
+    image = external / "sample.jpg"
+    Image.new("RGB", (24, 16), "red").save(image)
+    (root / "images").mkdir(parents=True)
+    linked_split = root / "images" / "raw"
+    try:
+        linked_split.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink creation is unavailable: {exc}")
+    (root / "data.yaml").write_text(
+        "\n".join(
+            (
+                f"path: {root.as_posix()}",
+                "train: images/raw",
+                "nc: 1",
+                "names: [cat]",
+                "task: detect",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session = DatasetSession(str(root / "data.yaml"))
+    expected = image.read_bytes()
+
+    with pytest.raises(ValueError, match="symbolic-link or reparse-point"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert linked_split.is_symlink()
+    assert image.read_bytes() == expected
+    destination = tmp_path / "copy"
+    export_dataset(session, dst=str(destination), formats=("yolo",), split="none")
+    assert (destination / "images" / "train" / "sample.jpg").read_bytes() == expected
+
+
+def test_in_place_export_rejects_link_destination_ancestor(tmp_path):
+    root = tmp_path / "source"
+    source = root / "incoming" / "sample.jpg"
+    source.parent.mkdir(parents=True)
+    Image.new("RGB", (24, 16), "red").save(source)
+    external = tmp_path / "external"
+    external.mkdir()
+    (root / "images").mkdir()
+    linked_destination = root / "images" / "train"
+    try:
+        linked_destination.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink creation is unavailable: {exc}")
+    (root / "data.yaml").write_text(
+        "\n".join(
+            (
+                f"path: {root.as_posix()}",
+                "train: incoming",
+                "nc: 1",
+                "names: [cat]",
+                "task: detect",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session = DatasetSession(str(root / "data.yaml"))
+    expected = source.read_bytes()
+
+    with pytest.raises(ValueError, match="symbolic-link or reparse-point"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert source.read_bytes() == expected
+    assert linked_destination.is_symlink()
+    assert not list(external.iterdir())
+
+
+def test_in_place_export_rejects_future_label_destination_through_link(tmp_path):
+    root = tmp_path / "source"
+    source = root / "incoming" / "sample.jpg"
+    source.parent.mkdir(parents=True)
+    Image.new("RGB", (24, 16), "red").save(source)
+    external = tmp_path / "external-labels"
+    external.mkdir()
+    (root / "labels").mkdir()
+    linked_destination = root / "labels" / "train"
+    try:
+        linked_destination.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink creation is unavailable: {exc}")
+    (root / "data.yaml").write_text(
+        "\n".join(
+            (
+                f"path: {root.as_posix()}",
+                "train: incoming",
+                "nc: 1",
+                "names: [cat]",
+                "task: detect",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session = DatasetSession(str(root / "data.yaml"))
+    expected = source.read_bytes()
+
+    with pytest.raises(ValueError, match="symbolic-link or reparse-point"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert source.read_bytes() == expected
+    assert linked_destination.is_symlink()
+    assert not list(external.iterdir())
+
+
+def test_in_place_export_rejects_source_swapped_to_link_during_move(
+    tmp_path, monkeypatch
+):
+    from libreyolo.label import export as export_module
+
+    root = tmp_path / "source"
+    session = _dataset(root)
+    source = session._items[0][0]
+    original = source.read_bytes()
+    backup = source.with_name(f"{source.name}.original")
+    alternate = tmp_path / "alternate.jpg"
+    Image.new("RGB", (24, 16), "green").save(alternate)
+    probe = tmp_path / "symlink-probe"
+    try:
+        probe.symlink_to(alternate)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    probe.unlink()
+    real_move = export_module.shutil.move
+    swapped = False
+
+    def swap_source_then_move(src, dst, *args, **kwargs):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            source.replace(backup)
+            source.symlink_to(alternate)
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(export_module.shutil, "move", swap_source_then_move)
+    with pytest.raises(ValueError, match="symbolic-link or reparse-point"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert source.is_symlink()
+    assert source.read_bytes() == alternate.read_bytes()
+    assert backup.read_bytes() == original
+    assert not list(tmp_path.glob(".source-librelabel-export-*"))
+
+
+@pytest.mark.parametrize("interrupt_call", (1, 3))
+def test_in_place_export_recovers_move_that_completes_before_interrupt(
+    tmp_path, monkeypatch, interrupt_call
+):
+    from libreyolo.label import export as export_module
+
+    root = tmp_path / "source"
+    session = _dataset(root)
+    before = _file_snapshot(root)
+    real_move = export_module.shutil.move
+    calls = 0
+
+    def interrupt_after_move(src, dst, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        result = real_move(src, dst, *args, **kwargs)
+        if calls == interrupt_call:
+            raise KeyboardInterrupt("injected after completed move")
+        return result
+
+    monkeypatch.setattr(export_module.shutil, "move", interrupt_after_move)
+    with pytest.raises(KeyboardInterrupt, match="completed move"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    assert _file_snapshot(root) == before
+    assert not list(tmp_path.glob(".source-librelabel-export-*"))
+
+
+def test_in_place_export_preserves_stage_when_rollback_cannot_finish(
+    tmp_path, monkeypatch
+):
+    from libreyolo.label import export as export_module
+
+    root = tmp_path / "source"
+    session = _dataset(root)
+    before = _file_snapshot(root)
+    real_move = export_module.shutil.move
+    calls = 0
+
+    def fail_finalization_then_rollback(src, dst, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise OSError("injected finalization failure")
+        if calls == 4:
+            raise OSError("injected rollback failure")
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(
+        export_module.shutil, "move", fail_finalization_then_rollback
+    )
+    with pytest.raises(RuntimeError, match="staging directory was preserved"):
+        export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    recovery_dirs = list(tmp_path.glob(".source-librelabel-export-*"))
+    assert len(recovery_dirs) == 1
+    recovered_files = [
+        path.read_bytes() for path in recovery_dirs[0].rglob("*") if path.is_file()
+    ]
+    assert recovered_files
+    remaining = list(_file_snapshot(root).values()) + recovered_files
+    assert sorted(remaining) == sorted(before.values())
 
 
 def test_in_place_export_rolls_back_when_yaml_commit_fails(tmp_path, monkeypatch):

--- a/tests/unit/test_label_data_integrity.py
+++ b/tests/unit/test_label_data_integrity.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import math
 import multiprocessing
+import os
 import queue
+import subprocess
 import threading
 import zipfile
 from pathlib import Path
@@ -27,6 +29,26 @@ from libreyolo.label.labelio import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+def test_windows_handle_identity_accepts_python310_volume_serial_width():
+    from libreyolo.label.dataset import _windows_handle_identity_matches
+
+    full_volume = 0x746CA1C46CA1818A
+    file_id = 0x5000000243155
+
+    assert _windows_handle_identity_matches(
+        (full_volume & 0xFFFFFFFF, file_id), (full_volume, file_id)
+    )
+    assert _windows_handle_identity_matches(
+        (full_volume, file_id), (full_volume, file_id)
+    )
+    assert not _windows_handle_identity_matches(
+        (full_volume & 0xFFFFFFFF, file_id + 1), (full_volume, file_id)
+    )
+    assert not _windows_handle_identity_matches(
+        ((full_volume + 1) & 0xFFFFFFFF, file_id), (full_volume, file_id)
+    )
 
 
 def _process_upload(root, name, payload, ready, start, outcomes):
@@ -1070,6 +1092,191 @@ def test_trash_project_rejects_directory_links_without_moving_target(tmp_path):
 
     assert target.is_dir()
     assert (target / "data.yaml").is_file()
+
+
+def test_trash_project_rejects_directory_link_ancestor(tmp_path):
+    from libreyolo.label.dataset import trash_project
+
+    real_parent = tmp_path / "real-parent"
+    target = real_parent / "project"
+    target.mkdir(parents=True)
+    marker = target / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    alias = tmp_path / "parent-alias"
+    try:
+        alias.symlink_to(real_parent, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory links unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="directory link"):
+        trash_project(str(alias / "project"))
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_trash_project_rejects_ancestor_swap_during_validation(tmp_path, monkeypatch):
+    from libreyolo.label import dataset as dataset_module
+
+    alias_parent = tmp_path / "alias-parent"
+    safe_project = alias_parent / "project"
+    safe_project.mkdir(parents=True)
+    safe_marker = safe_project / "safe.txt"
+    safe_marker.write_text("safe", encoding="utf-8")
+    victim_parent = tmp_path / "victim-parent"
+    victim_project = victim_parent / "project"
+    victim_project.mkdir(parents=True)
+    victim_marker = victim_project / "victim.txt"
+    victim_marker.write_text("victim", encoding="utf-8")
+    saved_parent = tmp_path / "saved-parent"
+
+    def make_directory_link(alias, target):
+        if os.name == "nt":
+            result = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(alias), str(target)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode:
+                pytest.skip(f"directory junctions unavailable: {result.stderr}")
+        else:
+            alias.symlink_to(target, target_is_directory=True)
+
+    real_check = dataset_module._is_link_or_reparse_point
+    swapped = False
+
+    def swap_after_check(path):
+        nonlocal swapped
+        result = real_check(path)
+        if not swapped and Path(path) == safe_project:
+            os.replace(alias_parent, saved_parent)
+            make_directory_link(alias_parent, victim_parent)
+            swapped = True
+        return result
+
+    move_called = False
+
+    def reject_move(*args, **kwargs):
+        nonlocal move_called
+        move_called = True
+        raise AssertionError("unsafe move reached")
+
+    monkeypatch.setattr(dataset_module, "_is_link_or_reparse_point", swap_after_check)
+    monkeypatch.setattr(dataset_module, "_move_validated_project_root", reject_move)
+
+    with pytest.raises(ValueError, match="directory link|path changed"):
+        dataset_module.trash_project(str(safe_project))
+
+    assert move_called is False
+    assert (saved_parent / "project" / "safe.txt").read_text(encoding="utf-8") == "safe"
+    assert victim_marker.read_text(encoding="utf-8") == "victim"
+
+
+def test_trash_project_binds_move_after_final_validation(tmp_path, monkeypatch):
+    from libreyolo.label import dataset as dataset_module
+
+    alias_parent = tmp_path / "alias-parent"
+    safe_project = alias_parent / "project"
+    safe_project.mkdir(parents=True)
+    (safe_project / "safe.txt").write_text("safe", encoding="utf-8")
+    victim_parent = tmp_path / "victim-parent"
+    victim_project = victim_parent / "project"
+    victim_project.mkdir(parents=True)
+    victim_marker = victim_project / "victim.txt"
+    victim_marker.write_text("victim", encoding="utf-8")
+    saved_parent = tmp_path / "saved-parent"
+
+    def make_directory_link(alias, target):
+        if os.name == "nt":
+            result = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(alias), str(target)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode:
+                pytest.skip(f"directory junctions unavailable: {result.stderr}")
+        else:
+            alias.symlink_to(target, target_is_directory=True)
+
+    real_validate = dataset_module._validated_project_root
+    validations = 0
+
+    def swap_after_final_validation(*args, **kwargs):
+        nonlocal validations
+        result = real_validate(*args, **kwargs)
+        validations += 1
+        if validations == 2:
+            os.replace(alias_parent, saved_parent)
+            make_directory_link(alias_parent, victim_parent)
+        return result
+
+    monkeypatch.setattr(
+        dataset_module, "_validated_project_root", swap_after_final_validation
+    )
+
+    with pytest.raises((OSError, ValueError)):
+        dataset_module.trash_project(str(safe_project))
+
+    assert (saved_parent / "project" / "safe.txt").read_text(encoding="utf-8") == "safe"
+    assert victim_marker.read_text(encoding="utf-8") == "victim"
+
+
+def test_trash_project_binds_selected_trash_directory(tmp_path, monkeypatch):
+    from libreyolo.label import dataset as dataset_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    project_marker = project / "project.txt"
+    project_marker.write_text("project", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    real_move = dataset_module._move_validated_project_root
+    saved_trash = home / ".librelabel" / "saved-trash"
+
+    def swap_before_open(source, dest, expected, expected_trash_identity):
+        os.replace(dest.parent, saved_trash)
+        dest.parent.mkdir()
+        (dest.parent / "replacement.txt").write_text("replacement", encoding="utf-8")
+        return real_move(source, dest, expected, expected_trash_identity)
+
+    monkeypatch.setattr(
+        dataset_module, "_move_validated_project_root", swap_before_open
+    )
+
+    with pytest.raises(ValueError, match="trash directory changed"):
+        dataset_module.trash_project(str(project))
+
+    assert project_marker.read_text(encoding="utf-8") == "project"
+    assert (saved_trash).is_dir()
+    assert (home / ".librelabel" / "trash" / "replacement.txt").read_text(
+        encoding="utf-8"
+    ) == "replacement"
+
+
+def test_trash_project_rejects_linked_yaml_without_moving_alias_parent(tmp_path):
+    from libreyolo.label.dataset import trash_project
+
+    real_project = tmp_path / "real-project"
+    real_project.mkdir()
+    real_yaml = real_project / "data.yaml"
+    real_yaml.write_text("names: []\n", encoding="utf-8")
+    alias_parent = tmp_path / "unrelated"
+    alias_parent.mkdir()
+    marker = alias_parent / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    alias_yaml = alias_parent / "data.yaml"
+    try:
+        alias_yaml.symlink_to(real_yaml)
+    except OSError as exc:
+        pytest.skip(f"file links unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="filesystem link"):
+        trash_project(str(alias_yaml))
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert real_yaml.is_file()
 
 
 def test_trash_project_rejects_missing_yaml_without_moving_its_parent(tmp_path):

--- a/tests/unit/test_label_data_integrity.py
+++ b/tests/unit/test_label_data_integrity.py
@@ -64,6 +64,29 @@ def _process_label_write(yaml_path, cx, ready, start, attempting, outcomes):
         outcomes.put(("ok", cx, ""))
 
 
+def _process_sidecar_update(root, key, value, ready, start, loaded, release, outcomes):
+    """Force competing sidecar updates to overlap when no process lock exists."""
+    import libreyolo.label.dataset as dataset_module
+
+    original_load = dataset_module.load_sidecar
+
+    def synchronized_load(base):
+        result = original_load(base)
+        loaded.put(key)
+        release.wait(10)
+        return result
+
+    dataset_module.load_sidecar = synchronized_load
+    ready.put(True)
+    start.wait(10)
+    try:
+        dataset_module.update_sidecar(root, **{key: value})
+    except Exception as exc:  # noqa: BLE001 - serialized test outcome
+        outcomes.put(("error", key, type(exc).__name__, str(exc)))
+    else:
+        outcomes.put(("ok", key))
+
+
 def _dataset(root: Path, names=("cat", "dog"), task: str | None = "detect") -> DatasetSession:
     for subdir, filename, color in (
         ("a", "same.jpg", "red"),
@@ -980,6 +1003,127 @@ def test_cross_process_label_compare_and_swap_has_exactly_one_winner(tmp_path):
     assert "changed by someone else" in failure[2]
     saved = DatasetSession(str(yaml_path)).read_label(0)[0]
     assert saved[0]["cx"] in (0.25, 0.75)
+
+
+def test_cross_process_sidecar_updates_preserve_distinct_fields(tmp_path):
+    root = tmp_path / "dataset"
+    root.mkdir()
+    (root / "librelabel.json").write_text('{"base": true}', encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    loaded = context.Queue()
+    release = context.Event()
+    outcomes = context.Queue()
+    processes = [
+        context.Process(
+            target=_process_sidecar_update,
+            args=(str(root), key, value, ready, start, loaded, release, outcomes),
+        )
+        for key, value in (("name", "Project"), ("description", "Details"))
+    ]
+
+    try:
+        for process in processes:
+            process.start()
+        assert ready.get(timeout=10) is True
+        assert ready.get(timeout=10) is True
+        start.set()
+        loaded.get(timeout=10)
+        try:
+            loaded.get(timeout=0.5)
+        except queue.Empty:
+            pass
+        release.set()
+        results = [outcomes.get(timeout=10), outcomes.get(timeout=10)]
+    finally:
+        release.set()
+        for process in processes:
+            process.join(timeout=10)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+    assert all(process.exitcode == 0 for process in processes)
+    assert sorted(result[0] for result in results) == ["ok", "ok"]
+    assert json.loads((root / "librelabel.json").read_text(encoding="utf-8")) == {
+        "base": True,
+        "name": "Project",
+        "description": "Details",
+    }
+
+
+def test_trash_project_rejects_directory_links_without_moving_target(tmp_path):
+    from libreyolo.label.dataset import trash_project
+
+    target = tmp_path / "real-project"
+    target.mkdir()
+    (target / "data.yaml").write_text("names: []\n", encoding="utf-8")
+    alias = tmp_path / "project-alias"
+    try:
+        alias.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory links unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="directory link"):
+        trash_project(str(alias))
+
+    assert target.is_dir()
+    assert (target / "data.yaml").is_file()
+
+
+def test_trash_project_rejects_missing_yaml_without_moving_its_parent(tmp_path):
+    from libreyolo.label.dataset import trash_project
+
+    project = tmp_path / "project"
+    project.mkdir()
+    marker = project / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="dataset YAML"):
+        trash_project(str(project / "missing.yaml"))
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_trash_project_never_moves_the_user_home(tmp_path, monkeypatch):
+    from libreyolo.label import dataset as dataset_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    marker = home / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    with pytest.raises(ValueError, match="filesystem, home"):
+        dataset_module.trash_project(str(home))
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_trash_project_allocates_distinct_paths_in_the_same_tick(
+    tmp_path, monkeypatch
+):
+    from libreyolo.label import dataset as dataset_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(dataset_module.time, "time_ns", lambda: 123456789)
+    roots = []
+    for parent, value in (("first", "one"), ("second", "two")):
+        root = tmp_path / parent / "project"
+        root.mkdir(parents=True)
+        (root / "marker.txt").write_text(value, encoding="utf-8")
+        roots.append(root)
+
+    destinations = [Path(dataset_module.trash_project(str(root))) for root in roots]
+
+    assert destinations[0] != destinations[1]
+    assert [
+        (destination / "marker.txt").read_text(encoding="utf-8")
+        for destination in destinations
+    ] == ["one", "two"]
 
 
 def test_upload_temp_cleanup_failure_does_not_hide_success(tmp_path, monkeypatch):

--- a/tests/unit/test_label_data_integrity.py
+++ b/tests/unit/test_label_data_integrity.py
@@ -432,24 +432,72 @@ def test_native_coco_project_is_view_only_and_cannot_export_empty_labels(tmp_pat
     assert not (tmp_path / "out").exists()
 
 
-def test_taskless_dataset_rejects_transforming_exports(tmp_path):
+def test_taskless_dataset_allows_lossless_yolo_copy_only(tmp_path):
+    import yaml
+
     session = _dataset(tmp_path / "source", task=None)
-    with pytest.raises(ValueError, match="does not declare a task"):
-        export_dataset(session, dst=str(tmp_path / "coco"), formats=("coco",))
+    label = session._items[0][1]
+    label.parent.mkdir(parents=True, exist_ok=True)
+    original_label = b"0 0.500000 0.500000 0.250000 0.250000\r\n"
+    label.write_bytes(original_label)
+
+    assert session.writable is True
+    assert session.meta()["task"] == "detect"
+    assert session._task_declared_or_inferred is False
+
+    for index, formats in enumerate((("coco",), ("voc",), ("yolo", "coco"))):
+        destination = tmp_path / f"converted-{index}"
+        with pytest.raises(ValueError, match="does not declare a task"):
+            export_dataset(session, dst=str(destination), formats=formats)
+        assert not destination.exists()
+
     with pytest.raises(ValueError, match="detection annotations require boxes"):
         session.write_label(
             0,
-            [{
-                "type": "poly",
-                "cls": 0,
-                "points": [0.1, 0.1, 0.8, 0.1, 0.4, 0.7],
-            }],
+            [
+                {
+                    "type": "poly",
+                    "cls": 0,
+                    "points": [0.1, 0.1, 0.8, 0.1, 0.4, 0.7],
+                }
+            ],
         )
 
-    with pytest.raises(ValueError, match="does not declare a task"):
-        export_dataset(
-            session, dst=str(tmp_path / "yolo"), formats=("yolo",), split="none"
-        )
+    destination = tmp_path / "yolo"
+    export_dataset(session, dst=str(destination), formats=("yolo",), split="none")
+
+    exported_labels = [
+        path.read_bytes() for path in (destination / "labels" / "train").iterdir()
+    ]
+    assert original_label in exported_labels
+    config = yaml.safe_load((destination / "data.yaml").read_text(encoding="utf-8"))
+    assert "task" not in config
+    reopened = DatasetSession(str(destination / "data.yaml"))
+    assert reopened._task_declared_or_inferred is False
+    assert reopened.meta()["task"] == "detect"
+
+
+def test_taskless_dataset_allows_lossless_yolo_in_place(tmp_path):
+    import yaml
+
+    root = tmp_path / "source"
+    session = _dataset(root, task=None)
+    label = session._items[0][1]
+    label.parent.mkdir(parents=True, exist_ok=True)
+    original_label = b"0 0.400000 0.600000 0.200000 0.300000\r\n"
+    label.write_bytes(original_label)
+
+    result = export_dataset(session, formats=("yolo",), split="none", in_place=True)
+
+    exported_labels = [
+        path.read_bytes() for path in (root / "labels" / "train").rglob("*.txt")
+    ]
+    assert original_label in exported_labels
+    config = yaml.safe_load(Path(result["yaml"]).read_text(encoding="utf-8"))
+    assert "task" not in config
+    reopened = DatasetSession(result["yaml"])
+    assert reopened._task_declared_or_inferred is False
+    assert reopened.meta()["task"] == "detect"
 
 
 def test_taskless_nonquad_polygons_infer_segment_and_reject_voc(tmp_path):
@@ -466,13 +514,14 @@ def test_taskless_nonquad_polygons_infer_segment_and_reject_voc(tmp_path):
 
 
 def test_taskless_quad_dataset_is_globally_view_only(tmp_path):
+    import yaml
+
     root = tmp_path / "source"
     initial = _dataset(root, task=None)
     label = initial._items[0][1]
     label.parent.mkdir(parents=True, exist_ok=True)
-    label.write_text(
-        "0 0.1 0.1 0.7 0.1 0.7 0.6 0.1 0.6\n", encoding="utf-8"
-    )
+    original_label = b"0 0.1 0.1 0.7 0.1 0.7 0.6 0.1 0.6\r\n"
+    label.write_bytes(original_label)
     session = DatasetSession(str(root / "data.yaml"))
 
     assert session._task_ambiguous is True
@@ -483,6 +532,15 @@ def test_taskless_quad_dataset_is_globally_view_only(tmp_path):
             1,
             [{"type": "box", "cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2}],
         )
+
+    destination = tmp_path / "quad-yolo"
+    export_dataset(session, dst=str(destination), formats=("yolo",), split="none")
+    exported_labels = [
+        path.read_bytes() for path in (destination / "labels" / "train").iterdir()
+    ]
+    assert original_label in exported_labels
+    config = yaml.safe_load((destination / "data.yaml").read_text(encoding="utf-8"))
+    assert "task" not in config
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_label_data_integrity.py
+++ b/tests/unit/test_label_data_integrity.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import math
 import json
+import math
 import multiprocessing
+import queue
 import threading
 import zipfile
 from pathlib import Path
@@ -38,6 +39,29 @@ def _process_upload(root, name, payload, ready, start, outcomes):
         outcomes.put(("error", type(exc).__name__))
     else:
         outcomes.put(("ok", name))
+
+
+def _process_label_write(yaml_path, cx, ready, start, attempting, outcomes):
+    """Spawn-safe worker for the cross-process label CAS regression."""
+    session = DatasetSession(yaml_path)
+    revision = session.label_rev(0)
+    ready.put(revision)
+    start.wait(10)
+    attempting.put(True)
+    annotation = {
+        "type": "box",
+        "cls": 0,
+        "cx": cx,
+        "cy": 0.5,
+        "w": 0.2,
+        "h": 0.2,
+    }
+    try:
+        session.write_label(0, [annotation], expected_rev=revision)
+    except Exception as exc:  # noqa: BLE001 - serialized test outcome
+        outcomes.put(("error", type(exc).__name__, str(exc)))
+    else:
+        outcomes.put(("ok", cx, ""))
 
 
 def _dataset(root: Path, names=("cat", "dog"), task: str | None = "detect") -> DatasetSession:
@@ -903,6 +927,59 @@ def test_cross_process_upload_lock_canonicalizes_directory_alias(tmp_path):
 
     assert sorted(kind for kind, _value in results) == ["error", "ok"]
     assert len(list((root / "images" / "train").glob("same.*"))) == 1
+
+
+def test_cross_process_label_compare_and_swap_has_exactly_one_winner(tmp_path):
+    from libreyolo.label.dataset import _interprocess_path_lock
+
+    root = tmp_path / "dataset"
+    image_dir = root / "images" / "train"
+    image_dir.mkdir(parents=True)
+    Image.new("RGB", (20, 12), "red").save(image_dir / "a.jpg")
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        f"path: {root.as_posix()}\ntrain: images/train\nnc: 1\nnames: [thing]\n",
+        encoding="utf-8",
+    )
+    label_path = root / "labels" / "train" / "a.txt"
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    attempting = context.Queue()
+    outcomes = context.Queue()
+    processes = [
+        context.Process(
+            target=_process_label_write,
+            args=(str(yaml_path), cx, ready, start, attempting, outcomes),
+        )
+        for cx in (0.25, 0.75)
+    ]
+
+    try:
+        for process in processes:
+            process.start()
+        assert [ready.get(timeout=10), ready.get(timeout=10)] == [0, 0]
+        with _interprocess_path_lock(label_path):
+            start.set()
+            assert attempting.get(timeout=10) is True
+            assert attempting.get(timeout=10) is True
+            with pytest.raises(queue.Empty):
+                outcomes.get(timeout=0.25)
+        results = [outcomes.get(timeout=10), outcomes.get(timeout=10)]
+    finally:
+        for process in processes:
+            process.join(timeout=10)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+    assert all(process.exitcode == 0 for process in processes)
+    assert sorted(result[0] for result in results) == ["error", "ok"]
+    failure = next(result for result in results if result[0] == "error")
+    assert failure[1] == "RuntimeError"
+    assert "changed by someone else" in failure[2]
+    saved = DatasetSession(str(yaml_path)).read_label(0)[0]
+    assert saved[0]["cx"] in (0.25, 0.75)
 
 
 def test_upload_temp_cleanup_failure_does_not_hide_success(tmp_path, monkeypatch):

--- a/tests/unit/test_label_quality_radar.py
+++ b/tests/unit/test_label_quality_radar.py
@@ -573,9 +573,9 @@ def test_sanitize_rejects_non_finite_before_clamp():
 
 
 def test_local_admin_gating_by_bind_and_client():
-    # Codex round 8+9: gate host-admin on a *wildcard* (--share -> 0.0.0.0) bind by
-    # requiring a loopback client; a loopback bind or an explicit NIC bind allow it
-    # (the host has to reach an advertised NIC by its own address).
+    # Wildcard sharing reserves host-level administration for loopback clients.
+    # A concrete NIC bind additionally permits a client whose source address is
+    # the accepted socket's local address.
     from types import SimpleNamespace
 
     from libreyolo.label.server import _Handler
@@ -592,15 +592,19 @@ def test_local_admin_gating_by_bind_and_client():
     h.client_address = ("127.0.0.1", 5000)
     assert h._local_admin() is True
 
-    # loopback bind: only reachable locally -> always admin
+    # A synthetic non-loopback peer on a loopback bind is denied defensively.
     h.state = SimpleNamespace(host="127.0.0.1")
     h.client_address = ("192.168.1.50", 5000)
-    assert h._local_admin() is True
+    h.connection = SimpleNamespace(getsockname=lambda: ("127.0.0.1", 8000))
+    assert h._local_admin() is False
 
-    # explicit NIC bind: the host must connect via that address -> admin allowed
+    # On an explicit NIC bind, only a peer using the local endpoint is admin.
     h.state = SimpleNamespace(host="192.168.1.5")
     h.client_address = ("192.168.1.5", 5000)
+    h.connection = SimpleNamespace(getsockname=lambda: ("192.168.1.5", 8000))
     assert h._local_admin() is True
+    h.client_address = ("192.168.1.50", 5000)
+    assert h._local_admin() is False
 
 
 def test_out_of_range_class_is_read_only(tmp_path):

--- a/tests/unit/test_label_quality_radar.py
+++ b/tests/unit/test_label_quality_radar.py
@@ -335,12 +335,14 @@ def test_mask_dataset_is_view_only(tmp_path):
     assert ds.writable is False
 
 
-def test_degenerate_polygon_dropped():
-    # Codex P2: a collapsed (collinear) polygon would yield a zero-area box -> drop it.
+def test_degenerate_polygon_rejected():
+    # A collapsed polygon is rejected so the caller cannot mistake a dropped shape
+    # for a successful save.
     from libreyolo.label.labelio import sanitize_annotations
 
     flat = {"type": "poly", "cls": 0, "points": [0.1, 0.5, 0.5, 0.5, 0.9, 0.5, 0.5, 0.5]}
-    assert sanitize_annotations([flat], nc=2) == []
+    with pytest.raises(ValueError, match="non-zero area"):
+        sanitize_annotations([flat], nc=2)
     good = {"type": "poly", "cls": 0, "points": [0.1, 0.1, 0.4, 0.1, 0.4, 0.4, 0.1, 0.4]}
     assert len(sanitize_annotations([good], nc=2)) == 1
 
@@ -379,13 +381,14 @@ def test_my_images_ancestor_stays_writable(tmp_path):
     assert ds.writable is True
 
 
-def test_diagonal_collinear_polygon_dropped():
+def test_diagonal_collinear_polygon_rejected():
     # Codex round 3: a diagonal collinear polygon has positive bbox extents but
-    # zero area -- the area check must still drop it.
+    # zero area -- the area check must still reject it.
     from libreyolo.label.labelio import sanitize_annotations
 
     diag = {"type": "poly", "cls": 0, "points": [0.0, 0.0, 0.5, 0.5, 1.0, 1.0]}
-    assert sanitize_annotations([diag], nc=2) == []
+    with pytest.raises(ValueError, match="non-zero area"):
+        sanitize_annotations([diag], nc=2)
 
 
 def test_class_slip_requires_confidence():
@@ -557,11 +560,14 @@ def test_sanitize_rejects_non_finite_before_clamp():
 
     from libreyolo.label.labelio import sanitize_annotations, sanitize_boxes
 
-    assert sanitize_boxes([{"cls": 0, "cx": 0.5, "cy": 0.5, "w": math.inf, "h": 0.2}], nc=2) == []
-    assert sanitize_annotations(
-        [{"type": "box", "cls": 0, "cx": -math.inf, "cy": 0.5, "w": 0.2, "h": 0.2}], nc=2) == []
+    with pytest.raises(ValueError, match="finite"):
+        sanitize_boxes([{"cls": 0, "cx": 0.5, "cy": 0.5, "w": math.inf, "h": 0.2}], nc=2)
+    with pytest.raises(ValueError, match="finite"):
+        sanitize_annotations(
+            [{"type": "box", "cls": 0, "cx": -math.inf, "cy": 0.5, "w": 0.2, "h": 0.2}], nc=2)
     poly = {"type": "poly", "cls": 0, "points": [0.1, 0.1, 0.4, math.inf, 0.4, 0.4, 0.1, 0.4]}
-    assert sanitize_annotations([poly], nc=2) == []
+    with pytest.raises(ValueError, match="finite"):
+        sanitize_annotations([poly], nc=2)
     # a finite, valid box still round-trips
     assert len(sanitize_boxes([{"cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.3, "h": 0.3}], nc=2)) == 1
 
@@ -649,6 +655,26 @@ def test_write_label_revision_conflict(tmp_path):
     with pytest.raises(RuntimeError):
         ds.write_label(0, box, expected_rev=rev - 1)   # stale rev -> refused
     ds.write_label(0, box, expected_rev=rev)           # matching rev -> allowed
+
+
+def test_label_revision_depends_on_content_not_timestamp(tmp_path):
+    import os
+
+    from libreyolo.label.dataset import DatasetSession
+
+    ds = DatasetSession(str(_make_split_dataset(tmp_path)))
+    first = [{"type": "box", "cls": 0, "cx": 0.3, "cy": 0.5, "w": 0.2, "h": 0.2}]
+    second = [{"type": "box", "cls": 0, "cx": 0.7, "cy": 0.5, "w": 0.2, "h": 0.2}]
+    ds.write_label(0, first)
+    label_path = tmp_path / "labels" / "train" / "a.txt"
+    original_mtime = label_path.stat().st_mtime_ns
+    first_rev = ds.label_rev(0)
+
+    ds.write_label(0, second, expected_rev=first_rev)
+    os.utime(label_path, ns=(original_mtime, original_mtime))
+
+    assert label_path.stat().st_mtime_ns == original_mtime
+    assert ds.label_rev(0) != first_rev
 
 
 def test_degenerate_polygon_file_is_read_only(tmp_path):

--- a/tests/unit/test_label_roundtrip.py
+++ b/tests/unit/test_label_roundtrip.py
@@ -42,17 +42,22 @@ def test_empty_list_is_empty_file():
     assert format_label_text([]) == ""
 
 
-def test_sanitize_clamps_and_drops():
-    out = sanitize_boxes(
-        [
-            {"cls": 0, "cx": 1.4, "cy": -0.2, "w": 0.5, "h": 0.5},  # clamp
-            {"cls": 9, "cx": 0.5, "cy": 0.5, "w": 0.1, "h": 0.1},  # cls >= nc -> drop
-            {"cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.0, "h": 0.1},  # zero area -> drop
-        ],
-        nc=2,
-    )
-    assert len(out) == 1
-    assert out[0]["cx"] == 1.0 and out[0]["cy"] == 0.0
+def test_sanitize_rejects_invalid_box_instead_of_clamping_or_dropping():
+    with pytest.raises(ValueError, match="normalized"):
+        sanitize_boxes(
+            [{"cls": 0, "cx": 1.4, "cy": -0.2, "w": 0.5, "h": 0.5}],
+            nc=2,
+        )
+    with pytest.raises(ValueError, match="outside"):
+        sanitize_boxes(
+            [{"cls": 9, "cx": 0.5, "cy": 0.5, "w": 0.1, "h": 0.1}],
+            nc=2,
+        )
+    with pytest.raises(ValueError, match="positive"):
+        sanitize_boxes(
+            [{"cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.0, "h": 0.1}],
+            nc=2,
+        )
 
 
 def _make_dataset(root, with_images_in_root=False, task=None):
@@ -146,8 +151,12 @@ def test_annotation_parse_format_roundtrip():
     assert anns[0]["type"] == "box" and anns[0]["cls"] == 0
     assert anns[1]["type"] == "poly" and len(anns[1]["points"]) == 6
     assert format_annotations(anns).splitlines()[0].split()[0] == "0"  # integer cls
-    # a 2-vertex "polygon" (4 nums) is invalid and dropped
-    assert sanitize_annotations([{"type": "poly", "cls": 0, "points": [0.1, 0.1, 0.2, 0.2]}], nc=2) == []
+    # A 2-vertex "polygon" is rejected; a save never silently drops a shape.
+    with pytest.raises(ValueError, match="3 coordinate"):
+        sanitize_annotations(
+            [{"type": "poly", "cls": 0, "points": [0.1, 0.1, 0.2, 0.2]}],
+            nc=2,
+        )
 
 
 def test_polygon_roundtrip(tmp_path):
@@ -213,7 +222,7 @@ def _make_nested_dataset(tmp_path):
         (root / sub).mkdir(parents=True)
         Image.new("RGB", (16, 12), (60, 60, 60)).save(root / sub / "0001.jpg")
     (root / "data.yaml").write_text(
-        f"path: {root.as_posix()}\ntrain: .\nnc: 1\nnames:\n  0: thing\n",
+        f"path: {root.as_posix()}\ntrain: .\ntask: detect\nnc: 1\nnames:\n  0: thing\n",
         encoding="utf-8",
     )
     return root
@@ -280,6 +289,31 @@ def test_shared_label_file_makes_session_read_only(tmp_path):
     assert "same label file" in ds.reason
     with pytest.raises(RuntimeError):
         ds.write_label(0, [{"cls": 0, "cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2}])
+
+
+def test_shared_label_file_detection_is_casefolded(tmp_path):
+    from PIL import Image
+
+    from libreyolo.label.dataset import DatasetSession
+
+    root = tmp_path / "ds"
+    (root / "images" / "train").mkdir(parents=True)
+    Image.new("RGB", (16, 12), (10, 10, 10)).save(
+        root / "images" / "train" / "foo.jpg"
+    )
+    Image.new("RGB", (16, 12), (20, 20, 20)).save(
+        root / "images" / "train" / "FOO.png"
+    )
+    (root / "data.yaml").write_text(
+        f"path: {root.as_posix()}\ntrain: images/train\ntask: detect\n"
+        "nc: 1\nnames:\n  0: thing\n",
+        encoding="utf-8",
+    )
+
+    session = DatasetSession(str(root / "data.yaml"))
+
+    assert session.writable is False
+    assert "same label file" in session.reason
 
 
 def test_wizard_segment_project_polygon_roundtrip(tmp_path):

--- a/tests/unit/test_label_roundtrip.py
+++ b/tests/unit/test_label_roundtrip.py
@@ -1,5 +1,7 @@
 """Unit tests for LibreLabel v1 (boxes only): the format oracle + dataset R/W."""
 
+import os
+
 import pytest
 
 from pathlib import Path
@@ -314,6 +316,42 @@ def test_shared_label_file_detection_is_casefolded(tmp_path):
 
     assert session.writable is False
     assert "same label file" in session.reason
+
+
+def test_case_distinct_posix_items_are_rejected_instead_of_omitted(tmp_path):
+    from PIL import Image
+
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.export import export_dataset
+
+    if os.name == "nt":
+        pytest.skip("Windows paths are case-insensitive")
+    root = tmp_path / "ds"
+    images = root / "images" / "train"
+    labels = root / "labels" / "train"
+    images.mkdir(parents=True)
+    labels.mkdir(parents=True)
+    upper = images / "A.jpg"
+    lower = images / "a.jpg"
+    Image.new("RGB", (16, 12), (10, 10, 10)).save(upper)
+    Image.new("RGB", (16, 12), (20, 20, 20)).save(lower)
+    if upper.samefile(lower):
+        pytest.skip("the test filesystem is case-insensitive")
+    (labels / "A.txt").write_text("0 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+    (labels / "a.txt").write_text("0 0.4 0.4 0.2 0.2\n", encoding="utf-8")
+    (root / "data.yaml").write_text(
+        f"path: {root.as_posix()}\ntrain: images/train\ntask: detect\n"
+        "nc: 1\nnames:\n  0: thing\n",
+        encoding="utf-8",
+    )
+
+    session = DatasetSession(str(root / "data.yaml"))
+
+    assert len(session._items) == 2
+    assert session._label_clash is True
+    assert session.writable is False
+    with pytest.raises(ValueError, match="share one derived label file"):
+        export_dataset(session, dst=str(tmp_path / "export"))
 
 
 def test_wizard_segment_project_polygon_roundtrip(tmp_path):

--- a/tests/unit/test_label_server_integrity.py
+++ b/tests/unit/test_label_server_integrity.py
@@ -230,6 +230,27 @@ def test_json_body_limit_discards_oversize_payload_before_413(monkeypatch, tmp_p
 
 
 @pytest.mark.parametrize(
+    "path",
+    (
+        "/api/boost",
+        "/api/label/0?epoch=0&rev=0",
+    ),
+)
+def test_global_body_limit_discards_oversize_payload_before_413(
+    monkeypatch, tmp_path, path
+):
+    from libreyolo.label import server
+
+    monkeypatch.setattr(server, "_MAX_REQUEST_BODY_BYTES", 1024)
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path) as url:
+        for _ in range(8):
+            status, response = _post(url, path, _REJECTED_POST_BODY)
+            assert status == 413
+            assert response == {"error": "request body too large"}
+
+
+@pytest.mark.parametrize(
     ("framing", "expected"),
     (
         ("Content-Length: invalid\r\n", 400),

--- a/tests/unit/test_label_server_integrity.py
+++ b/tests/unit/test_label_server_integrity.py
@@ -1,0 +1,492 @@
+"""LibreLabel's project/session transaction and HTTP save contracts."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from PIL import Image
+
+pytestmark = pytest.mark.unit
+
+
+def test_label_client_rejects_partial_save_before_posting():
+    from libreyolo.label.page import INDEX_HTML
+
+    save_start = INDEX_HTML.index("async function save()")
+    preflight = INDEX_HTML.index("if(invalidShapes)", save_start)
+    post = INDEX_HTML.index("fetch(`/api/label/", save_start)
+
+    assert save_start < preflight < post
+    assert "if(!clipToImage(b)) invalidShapes++" in INDEX_HTML
+    assert "if(!clipPoly(p)) invalidShapes++" in INDEX_HTML
+    assert "boxes.map(pxToNorm).filter" not in INDEX_HTML
+
+
+def _make_dataset(root: Path, *, image_name: str = "a.jpg") -> Path:
+    image_dir = root / "images" / "train"
+    image_dir.mkdir(parents=True)
+    Image.new("RGB", (20, 12), color=(12, 34, 56)).save(image_dir / image_name)
+    yaml_path = root / "data.yaml"
+    yaml_path.write_text(
+        f"path: {root.as_posix()}\ntrain: images/train\nnc: 1\nnames:\n  0: thing\n",
+        encoding="utf-8",
+    )
+    return yaml_path
+
+
+@contextmanager
+def _label_server(yaml_path: Path):
+    from libreyolo.label import server
+
+    with mock.patch.object(server._LabelState, "register_current", lambda *a, **k: None):
+        httpd, url, _session = server.serve(
+            str(yaml_path), port=0, open_browser=False, assist=False
+        )
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield url
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            thread.join(timeout=5)
+
+
+def _get_json(url: str, path: str) -> tuple[int, dict]:
+    with urllib.request.urlopen(url + path, timeout=5) as response:
+        return response.status, json.load(response)
+
+
+def _post(url: str, path: str, body: bytes) -> tuple[int, dict]:
+    request = urllib.request.Request(
+        url + path,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.load(response)
+    except urllib.error.HTTPError as exc:
+        with exc:
+            return exc.code, json.load(exc)
+
+
+def _box(cx: float = 0.5) -> dict:
+    return {"type": "box", "cls": 0, "cx": cx, "cy": 0.5, "w": 0.2, "h": 0.2}
+
+
+def test_label_post_requires_explicit_payload_epoch_and_revision(tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+
+    yaml_path = _make_dataset(tmp_path)
+    session = DatasetSession(str(yaml_path))
+    session.write_label(0, [_box()])
+    label_path = tmp_path / "labels" / "train" / "a.txt"
+    original = label_path.read_bytes()
+
+    with _label_server(yaml_path) as url:
+        _, loaded = _get_json(url, "/api/label/0")
+        assert loaded["epoch"] == 0
+        rev = loaded["rev"]
+        malformed = [
+            (f"/api/label/0?epoch=0&rev={rev}", b""),
+            (f"/api/label/0?epoch=0&rev={rev}", b"{}"),
+            (f"/api/label/0?epoch=0&rev={rev}", b"[]"),
+            (f"/api/label/0?epoch=0&rev={rev}", b'{"annotations":null}'),
+            (
+                f"/api/label/0?epoch=0&rev={rev}",
+                b'{"annotations":[{"type":"box"}],"annotations":[]}',
+            ),
+            (f"/api/label/0?epoch=0&rev={rev}", b"{"),
+            ("/api/label/0?epoch=0", b'{"annotations":[]}'),
+            (f"/api/label/0?rev={rev}", b'{"annotations":[]}'),
+            (f"/api/label/0?epoch=0&rev={rev}&rev={rev}", b'{"annotations":[]}'),
+        ]
+        for path, body in malformed:
+            status, _response = _post(url, path, body)
+            assert status == 400
+            assert label_path.read_bytes() == original
+
+        # Empty annotations are still a valid, deliberate background-label save;
+        # they erase only when the payload, project epoch, and loaded revision are
+        # all supplied explicitly.
+        status, response = _post(
+            url,
+            f"/api/label/0?epoch=0&rev={rev}",
+            b'{"annotations":[]}',
+        )
+        assert status == 200 and response["count"] == 0
+        assert label_path.read_text(encoding="utf-8") == ""
+
+
+def test_label_post_rejects_stale_revision_without_clobbering(tmp_path):
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path) as url:
+        _, loaded = _get_json(url, "/api/label/0")
+        rev = loaded["rev"]
+        first = json.dumps({"annotations": [_box(0.3)]}).encode()
+        second = json.dumps({"annotations": [_box(0.7)]}).encode()
+        status, _ = _post(url, f"/api/label/0?epoch=0&rev={rev}", first)
+        assert status == 200
+        status, conflict = _post(url, f"/api/label/0?epoch=0&rev={rev}", second)
+        assert status == 409
+        assert "changed by someone else" in conflict["error"]
+        _, saved = _get_json(url, "/api/label/0")
+        assert saved["annotations"][0]["cx"] == pytest.approx(0.3)
+
+
+def test_server_upload_transaction_prevents_duplicate_temp_race(tmp_path):
+    from libreyolo.label.server import _LabelState
+
+    state = _LabelState(None, assist=False)
+    barrier = threading.Barrier(3)
+    successes = []
+    failures = []
+
+    def upload(data: bytes):
+        barrier.wait()
+        try:
+            state.save_upload(tmp_path, "same.jpg", data)
+            successes.append(data)
+        except Exception as exc:  # the losing duplicate must be a clean refusal
+            failures.append(exc)
+
+    threads = [
+        threading.Thread(target=upload, args=(b"first",)),
+        threading.Thread(target=upload, args=(b"second",)),
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(successes) == 1
+    assert len(failures) == 1 and isinstance(failures[0], FileExistsError)
+    assert (tmp_path / "images" / "train" / "same.jpg").read_bytes() == successes[0]
+
+
+def test_export_and_project_switch_share_one_transaction(monkeypatch, tmp_path):
+    from libreyolo.label import export
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    first = _make_dataset(tmp_path / "first")
+    second = _make_dataset(tmp_path / "second")
+    state = _LabelState(DatasetSession(str(first)), assist=False)
+    entered = threading.Event()
+    release = threading.Event()
+    switched = threading.Event()
+    monkeypatch.setattr(state, "register_current", lambda *a, **k: None)
+
+    def blocked_export(session, **kwargs):
+        assert session is state.session
+        entered.set()
+        assert release.wait(5)
+        return {"in_place": False, "out": "unused"}
+
+    monkeypatch.setattr(export, "export_dataset", blocked_export)
+    export_thread = threading.Thread(
+        target=lambda: state.export_project(expected_epoch=0, dst="unused")
+    )
+
+    def switch():
+        state.open_project(str(second))
+        switched.set()
+
+    export_thread.start()
+    assert entered.wait(5)
+    switch_thread = threading.Thread(target=switch)
+    switch_thread.start()
+    assert not switched.wait(0.15), "project switch interleaved with an active export"
+    release.set()
+    export_thread.join(timeout=5)
+    switch_thread.join(timeout=5)
+    assert switched.is_set()
+    assert Path(state.session.yaml_file) == second
+    assert state.epoch == 1
+
+
+def test_class_mutation_checks_epoch_inside_transaction(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState, _ProjectConflict
+
+    first = _make_dataset(tmp_path / "first")
+    second = _make_dataset(tmp_path / "second")
+    state = _LabelState(DatasetSession(str(first)), assist=False)
+    monkeypatch.setattr(state, "register_current", lambda *a, **k: None)
+    state.open_project(str(second))
+    with pytest.raises(_ProjectConflict):
+        state.set_class_names(["renamed"], expected_epoch=0)
+    assert state.session.names == ["thing"]
+
+
+def test_class_rename_creates_new_generation_and_invalidates_old_session(
+    monkeypatch, tmp_path
+):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState, _ProjectConflict
+
+    yaml_path = _make_dataset(tmp_path)
+    original = DatasetSession(str(yaml_path))
+    state = _LabelState(original, assist=False)
+    state._data = str(yaml_path)
+    monkeypatch.setattr(state, "register_current", lambda *a, **k: None)
+
+    meta = state.set_class_names(["renamed"], expected_epoch=0)
+
+    assert meta["epoch"] == 1
+    assert state.session is not original
+    assert state.session.names == ["renamed"]
+    assert state.store_pending(0, [_box()], original) is False
+    with pytest.raises(_ProjectConflict):
+        state.write_label(0, [_box()], epoch=0, expected_rev=0)
+
+
+def test_class_rename_schedules_registry_for_new_session(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    state = _LabelState(DatasetSession(str(yaml_path)), assist=False)
+    state._data = str(yaml_path)
+    calls = []
+    monkeypatch.setattr(
+        state,
+        "register_current",
+        lambda data, **kwargs: calls.append((data, kwargs)),
+    )
+
+    state.set_class_names(["renamed"], expected_epoch=0)
+
+    assert len(calls) == 1
+    assert calls[0][1]["session"] is state.session
+    assert calls[0][1]["epoch"] == state.epoch == 1
+
+
+def test_stale_background_publishers_cannot_mutate_new_project(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState, _ProjectConflict
+
+    first = DatasetSession(str(_make_dataset(tmp_path / "first")))
+    second_path = _make_dataset(tmp_path / "second")
+    state = _LabelState(first, assist=False)
+    monkeypatch.setattr(state, "register_current", lambda *a, **k: None)
+    state.open_project(str(second_path))
+    current_suggestion = [_box(0.4)]
+    state.engine.set_pending(0, current_suggestion)
+    state.radar_findings = {0: [{"type": "miss"}]}
+    state.embed_points = [{"id": 0, "x": 1.0, "y": 2.0}]
+
+    with pytest.raises(_ProjectConflict):
+        state.capture_session(0, "auto-labeling")
+    assert state.clear_pending(first) is False
+    assert state.store_radar_findings({9: []}, first) is False
+    assert state.store_embed_points([{"id": 9}], first) is False
+    assert state.engine.get_pending(0) == current_suggestion
+    assert state.radar_findings == {0: [{"type": "miss"}]}
+    assert state.embed_points == [{"id": 0, "x": 1.0, "y": 2.0}]
+
+
+def test_delete_matches_current_project_by_root_and_detaches(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    state = _LabelState(DatasetSession(str(yaml_path)), assist=False)
+    state._data = str(yaml_path)
+    monkeypatch.setattr("libreyolo.label.server.trash_project", lambda data: "trash/project")
+    forgotten = []
+    monkeypatch.setattr("libreyolo.label.server.projects.forget", forgotten.append)
+    result = state.delete_project(str(tmp_path), expected_epoch=0)
+    assert result == {"trash": "trash/project", "closed": True, "epoch": 1}
+    assert state.session is None and state._data is None
+    assert {Path(value) for value in forgotten} == {tmp_path, yaml_path}
+
+
+def test_boost_start_requires_current_epoch(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState, _ProjectConflict
+
+    first = _make_dataset(tmp_path / "first")
+    second = _make_dataset(tmp_path / "second")
+    state = _LabelState(DatasetSession(str(first)), assist=False)
+    monkeypatch.setattr(state, "register_current", lambda *a, **k: None)
+    state.open_project(str(second))
+    called = []
+    monkeypatch.setattr(state.boost, "start", lambda **kwargs: called.append(kwargs))
+
+    with pytest.raises(_ProjectConflict):
+        state.start_boost(expected_epoch=0)
+    assert called == []
+
+
+def test_project_switch_cannot_leave_old_boost_model_published(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    first = DatasetSession(str(_make_dataset(tmp_path / "first")))
+    second_path = _make_dataset(tmp_path / "second")
+    state = _LabelState(first, assist=False)
+    monkeypatch.setattr(state, "register_current", lambda *a, **k: None)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def publish_like_finishing_worker():
+        with state.engine._lock:
+            entered.set()
+            assert release.wait(5)
+            if state.boost.session is first:
+                state.engine._models["boosted"] = object()
+
+    worker = threading.Thread(target=publish_like_finishing_worker)
+    worker.start()
+    assert entered.wait(5)
+    switched = threading.Event()
+    switcher = threading.Thread(
+        target=lambda: (state.open_project(str(second_path)), switched.set())
+    )
+    switcher.start()
+    assert not switched.wait(0.1)
+    release.set()
+    worker.join(timeout=5)
+    switcher.join(timeout=5)
+
+    assert switched.is_set()
+    assert state.boost.session is state.session
+    assert "boosted" not in state.engine._models
+
+
+def test_old_boost_worker_cannot_publish_status_after_switch(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    first = DatasetSession(str(_make_dataset(tmp_path / "first")))
+    second_path = _make_dataset(tmp_path / "second")
+    state = _LabelState(first, assist=False)
+    monkeypatch.setattr(state, "register_current", lambda *a, **k: None)
+    generation = state.boost._generation
+
+    state.open_project(str(second_path))
+
+    assert state.boost._set_for_run(
+        first, generation, state="done", boosted_agreement=1.0
+    ) is False
+    assert state.boost.status() == {"state": "idle"}
+
+
+def test_project_root_key_preserves_yaml_suffixed_directory(tmp_path):
+    from libreyolo.label.server import _project_root_key
+
+    project = tmp_path / "project.yaml"
+    project.mkdir()
+    yaml_path = project / "data.yaml"
+    yaml_path.write_text("names: []\n")
+
+    assert _project_root_key(project) == _project_root_key(yaml_path)
+
+
+def test_stale_registry_worker_cannot_resurrect_deleted_project(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    session = DatasetSession(str(yaml_path))
+    state = _LabelState(session, assist=False)
+    entered = threading.Event()
+    release = threading.Event()
+    stats_done = threading.Event()
+    finished = threading.Event()
+    registered = []
+    real_stats = session.stats
+
+    def slow_stats():
+        entered.set()
+        assert release.wait(5)
+        result = real_stats()
+        stats_done.set()
+        return result
+
+    def register(*args, **kwargs):
+        registered.append((args, kwargs))
+        finished.set()
+
+    monkeypatch.setattr(session, "stats", slow_stats)
+    monkeypatch.setattr("libreyolo.label.server.projects.register", register)
+    monkeypatch.setattr("libreyolo.label.server.projects.forget", lambda data: None)
+    monkeypatch.setattr("libreyolo.label.server.trash_project", lambda data: "trash/project")
+    state.register_current(str(yaml_path))
+    assert entered.wait(5)
+    state.delete_project(str(tmp_path), expected_epoch=0)
+    release.set()
+    assert stats_done.wait(5)
+    assert not finished.wait(0.1)
+    assert registered == []
+
+
+def test_registry_worker_uses_latest_sidecar_name(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    session = DatasetSession(str(yaml_path))
+    state = _LabelState(session, assist=False)
+    entered = threading.Event()
+    release = threading.Event()
+    registered = threading.Event()
+    captured = []
+    real_stats = session.stats
+
+    def slow_stats():
+        entered.set()
+        assert release.wait(5)
+        return real_stats()
+
+    def register(*args, **kwargs):
+        captured.append((args, kwargs))
+        registered.set()
+
+    monkeypatch.setattr(session, "stats", slow_stats)
+    monkeypatch.setattr("libreyolo.label.server.projects.register", register)
+    monkeypatch.setattr("libreyolo.label.server.projects.rename", lambda *a: None)
+    state.register_current(str(yaml_path))
+    assert entered.wait(5)
+    state.update_project_meta({"name": "Latest name"}, expected_epoch=0)
+    release.set()
+    assert registered.wait(5)
+
+    assert captured[0][1]["name"] == "Latest name"
+
+
+def test_session_aliases_do_not_include_external_dataset_root(tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    external = tmp_path / "external"
+    image_dir = external / "images" / "train"
+    image_dir.mkdir(parents=True)
+    Image.new("RGB", (20, 12), color=(12, 34, 56)).save(image_dir / "a.jpg")
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    yaml_path = config_dir / "data.yaml"
+    yaml_path.write_text(
+        f"path: {external.as_posix()}\ntrain: images/train\nnames: [thing]\nnc: 1\n",
+        encoding="utf-8",
+    )
+    session = DatasetSession(str(yaml_path))
+    state = _LabelState(session, assist=False)
+    state._data = str(yaml_path)
+
+    with state._lock:
+        aliases = state._session_aliases_locked(session, yaml_path)
+
+    assert str(external) not in aliases
+    assert str(config_dir) in aliases

--- a/tests/unit/test_label_server_integrity.py
+++ b/tests/unit/test_label_server_integrity.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
+from urllib.parse import urlsplit
 from unittest import mock
 
 import pytest
@@ -42,16 +43,18 @@ def _make_dataset(root: Path, *, image_name: str = "a.jpg") -> Path:
 
 
 @contextmanager
-def _label_server(yaml_path: Path):
+def _label_server(yaml_path: Path, *, host: str = "127.0.0.1"):
     from libreyolo.label import server
 
     with mock.patch.object(server._LabelState, "register_current", lambda *a, **k: None):
         httpd, url, _session = server.serve(
-            str(yaml_path), port=0, open_browser=False, assist=False
+            str(yaml_path), host=host, port=0, open_browser=False, assist=False
         )
         thread = threading.Thread(target=httpd.serve_forever, daemon=True)
         thread.start()
         try:
+            if host in ("0.0.0.0", "::", ""):
+                url = f"http://127.0.0.1:{httpd.server_address[1]}"
             yield url
         finally:
             httpd.shutdown()
@@ -79,8 +82,106 @@ def _post(url: str, path: str, body: bytes) -> tuple[int, dict]:
             return exc.code, json.load(exc)
 
 
+def _request_json(
+    url: str,
+    path: str,
+    *,
+    method: str = "GET",
+    body: bytes | None = None,
+    headers: dict | None = None,
+) -> tuple[int, dict]:
+    request = urllib.request.Request(
+        url + path,
+        data=body,
+        headers=headers or {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.load(response)
+    except urllib.error.HTTPError as exc:
+        with exc:
+            return exc.code, json.load(exc)
+
+
 def _box(cx: float = 0.5) -> dict:
     return {"type": "box", "cls": 0, "cx": cx, "cy": 0.5, "w": 0.2, "h": 0.2}
+
+
+def test_loopback_host_header_matrix_blocks_dns_rebinding_on_get(tmp_path):
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path) as url:
+        port = urlsplit(url).port
+        cases = (
+            (f"127.0.0.1:{port}", 200),
+            (f"LOCALHOST:{port}", 200),
+            (f"127.0.0.42:{port}", 200),
+            (f"[::1]:{port}", 200),
+            (f"localhost.:{port}", 200),
+            (f"attacker.example:{port}", 403),
+            (f"192.168.1.20:{port}", 403),
+            ("127.0.0.1:80", 403),
+            (f"[::]:{port}", 403),
+        )
+        for host, expected in cases:
+            status, _response = _request_json(
+                url, "/api/dataset", headers={"Host": host}
+            )
+            assert status == expected, host
+
+
+def test_share_host_header_matrix_allows_numeric_lan_hosts_only(tmp_path):
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path, host="0.0.0.0") as url:
+        port = urlsplit(url).port
+        cases = (
+            (f"127.0.0.1:{port}", 200),
+            (f"localhost:{port}", 200),
+            (f"192.168.1.20:{port}", 200),
+            (f"10.12.0.8:{port}", 200),
+            (f"[fd00::1234]:{port}", 200),
+            (f"attacker.example:{port}", 403),
+            (f"0.0.0.0:{port}", 403),
+            (f"224.0.0.1:{port}", 403),
+            (f"[::]:{port}", 403),
+        )
+        for host, expected in cases:
+            status, _response = _request_json(
+                url, "/api/dataset", headers={"Host": host}
+            )
+            assert status == expected, host
+
+
+def test_post_origin_matrix_normalizes_authority_and_rejects_opaque_origins(tmp_path):
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path) as url:
+        port = urlsplit(url).port
+        cases = (
+            (f"LOCALHOST:{port}", None, 404),
+            (f"LOCALHOST:{port}", f"HTTP://localhost:{port}", 404),
+            (f"localhost.:{port}", f"http://LOCALHOST:{port}", 404),
+            (f"localhost:{port}", "null", 403),
+            (f"localhost:{port}", "file://localhost", 403),
+            (f"localhost:{port}", f"https://localhost:{port}", 403),
+            (f"localhost:{port}", "http://localhost", 403),
+            (f"localhost:{port}", f"http://localhost:{port}/path", 403),
+            (f"localhost:{port}", f"http://localhost:{port}?", 403),
+            (f"localhost:{port}", f"http://localhost:{port}#", 403),
+            (f"localhost:{port}", f"http://attacker.example:{port}", 403),
+            (f"attacker.example:{port}", f"http://attacker.example:{port}", 403),
+        )
+        for host, origin, expected in cases:
+            headers = {"Host": host, "Content-Type": "application/json"}
+            if origin is not None:
+                headers["Origin"] = origin
+            status, _response = _request_json(
+                url,
+                "/not-found",
+                method="POST",
+                body=b"{}",
+                headers=headers,
+            )
+            assert status == expected, (host, origin)
 
 
 def test_label_post_requires_explicit_payload_epoch_and_revision(tmp_path):
@@ -310,6 +411,107 @@ def test_delete_matches_current_project_by_root_and_detaches(monkeypatch, tmp_pa
     assert result == {"trash": "trash/project", "closed": True, "epoch": 1}
     assert state.session is None and state._data is None
     assert {Path(value) for value in forgotten} == {tmp_path, yaml_path}
+
+
+def test_delete_rejects_project_subtree_and_keeps_live_session(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    session = DatasetSession(str(yaml_path))
+    state = _LabelState(session, assist=False)
+    state._data = str(yaml_path)
+    trashed = []
+    monkeypatch.setattr(
+        "libreyolo.label.server.trash_project",
+        lambda data: trashed.append(data) or "trash/project",
+    )
+    monkeypatch.setattr("libreyolo.label.server.projects.list_projects", lambda: [])
+
+    with pytest.raises(ValueError, match="exact registered project root"):
+        state.delete_project(str(tmp_path / "images"), expected_epoch=0)
+
+    assert trashed == []
+    assert state.session is session
+    assert state._data == str(yaml_path)
+    assert state.epoch == 0
+
+
+def test_delete_allows_exact_registered_project_root(monkeypatch, tmp_path):
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    state = _LabelState(None, assist=False)
+    trashed = []
+    forgotten = []
+    monkeypatch.setattr(
+        "libreyolo.label.server.projects.list_projects",
+        lambda: [{"data": str(yaml_path)}],
+    )
+    monkeypatch.setattr(
+        "libreyolo.label.server.trash_project",
+        lambda data: trashed.append(data) or "trash/project",
+    )
+    monkeypatch.setattr("libreyolo.label.server.projects.forget", forgotten.append)
+
+    result = state.delete_project(str(tmp_path))
+
+    assert result == {"trash": "trash/project", "closed": False, "epoch": 0}
+    assert trashed == [str(tmp_path.resolve())]
+    assert {Path(value) for value in forgotten} == {tmp_path, yaml_path}
+
+
+def test_delete_detaches_live_session_even_if_registry_cleanup_fails(
+    monkeypatch, tmp_path
+):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    state = _LabelState(DatasetSession(str(yaml_path)), assist=False)
+    state._data = str(yaml_path)
+    monkeypatch.setattr(
+        "libreyolo.label.server.trash_project", lambda data: "trash/project"
+    )
+    monkeypatch.setattr(
+        "libreyolo.label.server.projects.forget",
+        lambda data: (_ for _ in ()).throw(OSError("registry unavailable")),
+    )
+
+    result = state.delete_project(str(tmp_path), expected_epoch=0)
+
+    assert result == {"trash": "trash/project", "closed": True, "epoch": 1}
+    assert state.session is None and state._data is None
+
+
+def test_project_meta_write_failure_rolls_back_memory_and_registry(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    sidecar = tmp_path / "librelabel.json"
+    sidecar.write_text('{"name": "Original"}', encoding="utf-8")
+    session = DatasetSession(str(yaml_path))
+    state = _LabelState(session, assist=False)
+    state._data = str(yaml_path)
+    before_memory = dict(session._sidecar)
+    before_disk = sidecar.read_bytes()
+    renamed = []
+    monkeypatch.setattr(
+        "libreyolo.label.dataset._write_json_atomic",
+        lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError("read only")),
+    )
+    monkeypatch.setattr(
+        "libreyolo.label.server.projects.rename",
+        lambda *args: renamed.append(args),
+    )
+
+    with pytest.raises(PermissionError, match="read only"):
+        state.update_project_meta({"name": "Changed"}, expected_epoch=0)
+
+    assert session._sidecar == before_memory
+    assert sidecar.read_bytes() == before_disk
+    assert renamed == []
 
 
 def test_boost_start_requires_current_epoch(monkeypatch, tmp_path):

--- a/tests/unit/test_label_server_integrity.py
+++ b/tests/unit/test_label_server_integrity.py
@@ -556,6 +556,31 @@ def test_delete_matches_current_project_by_root_and_detaches(monkeypatch, tmp_pa
     assert {Path(value) for value in forgotten} == {tmp_path, yaml_path}
 
 
+def test_delete_trash_failure_keeps_live_session_and_registry(monkeypatch, tmp_path):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    session = DatasetSession(str(yaml_path))
+    state = _LabelState(session, assist=False)
+    state._data = str(yaml_path)
+    forgotten = []
+
+    def fail_trash(data):
+        raise RuntimeError("unexpected directory quarantined")
+
+    monkeypatch.setattr("libreyolo.label.server.trash_project", fail_trash)
+    monkeypatch.setattr("libreyolo.label.server.projects.forget", forgotten.append)
+
+    with pytest.raises(RuntimeError, match="quarantined"):
+        state.delete_project(str(tmp_path), expected_epoch=0)
+
+    assert state.session is session
+    assert state._data == str(yaml_path)
+    assert state.epoch == 0
+    assert forgotten == []
+
+
 def test_delete_rejects_project_subtree_and_keeps_live_session(monkeypatch, tmp_path):
     from libreyolo.label.dataset import DatasetSession
     from libreyolo.label.server import _LabelState

--- a/tests/unit/test_label_server_integrity.py
+++ b/tests/unit/test_label_server_integrity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import socket
 import threading
 import urllib.error
 import urllib.request
@@ -104,6 +105,16 @@ def _request_json(
             return exc.code, json.load(exc)
 
 
+def _raw_status(url: str, request: str) -> int:
+    """Send an exact HTTP request so duplicate authority headers stay intact."""
+    target = urlsplit(url)
+    with socket.create_connection((target.hostname, target.port), timeout=5) as peer:
+        peer.sendall(request.encode("ascii"))
+        response = peer.makefile("rb")
+        status_line = response.readline().decode("ascii", errors="replace")
+    return int(status_line.split()[1])
+
+
 def _box(cx: float = 0.5) -> dict:
     return {"type": "box", "cls": 0, "cx": cx, "cy": 0.5, "w": 0.2, "h": 0.2}
 
@@ -182,6 +193,138 @@ def test_post_origin_matrix_normalizes_authority_and_rejects_opaque_origins(tmp_
                 headers=headers,
             )
             assert status == expected, (host, origin)
+
+
+def test_duplicate_authorities_and_absolute_targets_are_unambiguous(tmp_path):
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path) as url:
+        port = urlsplit(url).port
+        valid = f"localhost:{port}"
+        attacker = f"attacker.example:{port}"
+
+        assert _raw_status(
+            url,
+            "GET /api/dataset HTTP/1.1\r\n"
+            f"Host: {valid}\r\nHost: {valid}\r\nConnection: close\r\n\r\n",
+        ) == 403
+        assert _raw_status(
+            url,
+            "POST /not-found HTTP/1.1\r\n"
+            f"Host: {valid}\r\nOrigin: http://{valid}\r\n"
+            f"Origin: http://{valid}\r\nContent-Length: 0\r\n"
+            "Connection: close\r\n\r\n",
+        ) == 403
+        assert _raw_status(
+            url,
+            f"GET http://{attacker}/api/dataset HTTP/1.1\r\n"
+            f"Host: {valid}\r\nConnection: close\r\n\r\n",
+        ) == 403
+        assert _raw_status(
+            url,
+            f"GET http://{valid}/api/dataset HTTP/1.1\r\n"
+            f"Host: {valid}\r\nConnection: close\r\n\r\n",
+        ) == 200
+
+
+def test_authority_parser_applies_http_effective_ports_and_ipv6_rules():
+    from libreyolo.label.server import _parse_authority
+
+    assert _parse_authority("LOCALHOST.", default_port=80) == ("localhost", 80)
+    assert _parse_authority("[0:0::1]:8000", default_port=80) == ("::1", 8000)
+    for authority in (
+        "::1",
+        "localhost:",
+        "localhost:65536",
+        "localhost:80,attacker.example",
+        "user@localhost:80",
+        "[::1]:80:90",
+    ):
+        with pytest.raises(ValueError):
+            _parse_authority(authority, default_port=80)
+
+
+def test_serve_formats_ipv6_and_empty_wildcard_urls():
+    from libreyolo.label.server import _lan_url_host, _local_access_host, serve
+
+    assert _local_access_host("0.0.0.0") == "127.0.0.1"
+    assert _local_access_host("::") == "::1"
+    assert _local_access_host("fd00::1234") == "fd00::1234"
+    assert _lan_url_host("0.0.0.0", "192.168.1.5") == "192.168.1.5"
+    assert _lan_url_host("::", "fd00::1234") == "fd00::1234"
+    assert _lan_url_host("::", "fe80::1234") is None
+    assert _lan_url_host("0.0.0.0", "127.0.0.1") is None
+    assert _lan_url_host("192.168.1.5", "127.0.0.1") == "192.168.1.5"
+    assert _lan_url_host("label-host", "127.0.0.1") == "label-host"
+    assert _lan_url_host("localhost", "192.168.1.5") is None
+
+    httpd, url, _session = serve(
+        None, host="", port=0, open_browser=False, assist=False
+    )
+    try:
+        assert url == f"http://0.0.0.0:{httpd.server_address[1]}"
+    finally:
+        httpd.server_close()
+
+    try:
+        httpd, url, _session = serve(
+            None, host="::1", port=0, open_browser=False, assist=False
+        )
+    except OSError as exc:
+        pytest.skip(f"IPv6 loopback unavailable: {exc}")
+    try:
+        assert url == f"http://[::1]:{httpd.server_address[1]}"
+        assert httpd.address_family == socket.AF_INET6
+    finally:
+        httpd.server_close()
+
+
+def test_server_info_advertises_only_a_usable_lan_url(monkeypatch, tmp_path):
+    from libreyolo.label import server
+
+    yaml_path = _make_dataset(tmp_path)
+    monkeypatch.setattr(server, "_lan_ip", lambda family: "192.168.1.5")
+    with _label_server(yaml_path, host="0.0.0.0") as url:
+        status, info = _get_json(url, "/api/server")
+        port = urlsplit(url).port
+
+    assert status == 200
+    assert info == {
+        "host": "0.0.0.0",
+        "port": port,
+        "local_url": f"http://127.0.0.1:{port}",
+        "lan_url": f"http://192.168.1.5:{port}",
+        "shareable": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("bind_host", "peer", "local", "expected"),
+    (
+        ("0.0.0.0", "127.0.0.1", "127.0.0.1", True),
+        ("0.0.0.0", "192.168.1.5", "192.168.1.5", False),
+        ("::", "::ffff:127.0.0.1", "::1", True),
+        ("192.168.1.5", "192.168.1.5", "192.168.1.5", True),
+        ("192.168.1.5", "192.168.1.44", "192.168.1.5", False),
+        ("label-host", "192.168.1.5", "192.168.1.5", True),
+        ("label-host", "192.168.1.44", "192.168.1.5", False),
+        ("fd00::5", "fd00::5", "fd00::5", True),
+        ("fd00::5", "fd00::44", "fd00::5", False),
+    ),
+)
+def test_local_admin_uses_the_tcp_peer_boundary(bind_host, peer, local, expected):
+    from libreyolo.label.server import _Handler
+
+    class _Connection:
+        @staticmethod
+        def getsockname():
+            return (local, 8000)
+
+    handler = object.__new__(_Handler)
+    handler.state = mock.Mock(host=bind_host)
+    handler.client_address = (peer, 50000)
+    handler.connection = _Connection()
+
+    assert handler._local_admin() is expected
 
 
 def test_label_post_requires_explicit_payload_epoch_and_revision(tmp_path):
@@ -437,6 +580,30 @@ def test_delete_rejects_project_subtree_and_keeps_live_session(monkeypatch, tmp_
     assert state.epoch == 0
 
 
+def test_delete_rejects_missing_yaml_alias_inside_current_project(
+    monkeypatch, tmp_path
+):
+    from libreyolo.label.dataset import DatasetSession
+    from libreyolo.label.server import _LabelState
+
+    yaml_path = _make_dataset(tmp_path)
+    session = DatasetSession(str(yaml_path))
+    state = _LabelState(session, assist=False)
+    state._data = str(yaml_path)
+    trashed = []
+    monkeypatch.setattr(
+        "libreyolo.label.server.trash_project",
+        lambda data: trashed.append(data) or "trash/project",
+    )
+
+    with pytest.raises(ValueError, match="exact registered project root"):
+        state.delete_project(str(tmp_path / "missing.yaml"), expected_epoch=0)
+
+    assert trashed == []
+    assert state.session is session
+    assert state.epoch == 0
+
+
 def test_delete_allows_exact_registered_project_root(monkeypatch, tmp_path):
     from libreyolo.label.server import _LabelState
 
@@ -459,6 +626,32 @@ def test_delete_allows_exact_registered_project_root(monkeypatch, tmp_path):
     assert result == {"trash": "trash/project", "closed": False, "epoch": 0}
     assert trashed == [str(tmp_path.resolve())]
     assert {Path(value) for value in forgotten} == {tmp_path, yaml_path}
+
+
+def test_delete_rejects_stale_registry_directory_without_dataset(
+    monkeypatch, tmp_path
+):
+    from libreyolo.label.server import _LabelState
+
+    root = tmp_path / "stale-project"
+    root.mkdir()
+    (root / "unrelated.txt").write_text("keep", encoding="utf-8")
+    state = _LabelState(None, assist=False)
+    trashed = []
+    monkeypatch.setattr(
+        "libreyolo.label.server.projects.list_projects",
+        lambda: [{"data": str(root)}],
+    )
+    monkeypatch.setattr(
+        "libreyolo.label.server.trash_project",
+        lambda data: trashed.append(data) or "trash/project",
+    )
+
+    with pytest.raises(ValueError, match="exact registered project root"):
+        state.delete_project(str(root))
+
+    assert trashed == []
+    assert (root / "unrelated.txt").read_text(encoding="utf-8") == "keep"
 
 
 def test_delete_detaches_live_session_even_if_registry_cleanup_fails(

--- a/tests/unit/test_label_server_integrity.py
+++ b/tests/unit/test_label_server_integrity.py
@@ -17,6 +17,8 @@ from PIL import Image
 
 pytestmark = pytest.mark.unit
 
+_REJECTED_POST_BODY = b"x" * (128 * 1024)
+
 
 def test_label_client_rejects_partial_save_before_posting():
     from libreyolo.label.page import INDEX_HTML
@@ -189,10 +191,64 @@ def test_post_origin_matrix_normalizes_authority_and_rejects_opaque_origins(tmp_
                 url,
                 "/not-found",
                 method="POST",
-                body=b"{}",
+                body=_REJECTED_POST_BODY,
                 headers=headers,
             )
             assert status == expected, (host, origin)
+
+
+def test_assist_disabled_rejection_consumes_nonempty_post_body(tmp_path):
+    yaml_path = _make_dataset(tmp_path)
+    body = b'{"epoch":0,"padding":"' + _REJECTED_POST_BODY + b'"}'
+    with _label_server(yaml_path) as url:
+        for _ in range(8):
+            status, response = _post(url, "/api/boost", body)
+            assert status == 403
+            assert "AI assist is disabled" in response["error"]
+
+
+def test_assist_disabled_rejection_consumes_maximum_json_sized_body(tmp_path):
+    yaml_path = _make_dataset(tmp_path)
+    body = b"x" * (8 * 1024 * 1024)
+    with _label_server(yaml_path) as url:
+        for _ in range(3):
+            status, response = _post(url, "/api/boost", body)
+            assert status == 403
+            assert "AI assist is disabled" in response["error"]
+
+
+def test_json_body_limit_discards_oversize_payload_before_413(monkeypatch, tmp_path):
+    from libreyolo.label import server
+
+    monkeypatch.setattr(server, "_MAX_JSON_BODY_BYTES", 1024)
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path) as url:
+        for _ in range(8):
+            status, response = _post(url, "/api/label/0?epoch=0&rev=0", _REJECTED_POST_BODY)
+            assert status == 413
+            assert response == {"error": "request body too large"}
+
+
+@pytest.mark.parametrize(
+    ("framing", "expected"),
+    (
+        ("Content-Length: invalid\r\n", 400),
+        ("Content-Length: 0\r\nContent-Length: 0\r\n", 400),
+        ("Transfer-Encoding: chunked\r\n", 400),
+        (f"Content-Length: {64 * 1024 * 1024 + 1}\r\n", 413),
+        ("Content-Length: 1\r\n", 400),
+    ),
+)
+def test_rejected_post_body_framing_is_bounded(tmp_path, framing, expected):
+    yaml_path = _make_dataset(tmp_path)
+    with _label_server(yaml_path) as url:
+        port = urlsplit(url).port
+        assert _raw_status(
+            url,
+            "POST /not-found HTTP/1.1\r\n"
+            f"Host: localhost:{port}\r\nOrigin: http://localhost:{port}\r\n"
+            f"{framing}Connection: close\r\n\r\n",
+        ) == expected
 
 
 def test_duplicate_authorities_and_absolute_targets_are_unambiguous(tmp_path):

--- a/tests/unit/test_train_callbacks.py
+++ b/tests/unit/test_train_callbacks.py
@@ -451,6 +451,37 @@ def test_train_exception_callback_fires_and_original_error_reraises(tmp_path):
     assert isinstance(event.exception, RuntimeError)
 
 
+def test_resumed_preloop_exception_reports_first_attempted_epoch(tmp_path):
+    received = []
+
+    class FailingStartCallback:
+        def on_train_start(self, event):
+            raise RuntimeError("start callback failed")
+
+        def on_train_exception(self, event):
+            received.append(event)
+
+    trainer = CallbackTrainer(
+        model=nn.Linear(1, 1),
+        data=None,
+        device="cpu",
+        ema=False,
+        epochs=4,
+        callbacks=FailingStartCallback(),
+    )
+    trainer._test_save_dir = tmp_path
+    trainer.saved_checkpoints = []
+    # Zero-based resume state: epochs 1 and 2 are already complete, so epoch 3
+    # is the first epoch this invocation would attempt.
+    trainer.start_epoch = 2
+
+    with pytest.raises(RuntimeError, match="start callback failed"):
+        trainer.train()
+
+    assert len(received) == 1
+    assert received[0].epoch == 3
+
+
 def test_legacy_two_value_epoch_result_still_normalizes_lr():
     trainer = DummyTrainer(
         model=nn.Linear(1, 1),

--- a/tests/unit/test_training_status.py
+++ b/tests/unit/test_training_status.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,6 +18,7 @@ from libreyolo.training.callbacks import (
     TrainStartEvent,
 )
 from libreyolo.ui import train_monitor
+from libreyolo.training.trainer import BaseTrainer
 
 pytestmark = pytest.mark.unit
 
@@ -31,7 +35,7 @@ def _start(save_dir, *, start_epoch=1):
     )
 
 
-def _epoch(save_dir, *, epoch=0, metric=0.5, best_epoch=0):
+def _epoch(save_dir, *, epoch=1, metric=0.5, best_epoch=1):
     return TrainEpochEvent(
         epoch=epoch,
         total_epochs=4,
@@ -82,10 +86,11 @@ def test_status_running_then_completed(tmp_path):
     cb.on_train_start(_start(tmp_path))
     running = _load(tmp_path)
     assert running["state"] == "running"
+    assert running["schema_version"] == 2
     assert running["total_epochs"] == 4
     assert running["pid"] > 0
 
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0, metric=0.5))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1, metric=0.5))
     mid = _load(tmp_path)
     assert mid["state"] == "running"
     assert mid["current_epoch"] == 0
@@ -99,17 +104,18 @@ def test_status_running_then_completed(tmp_path):
     done = _load(tmp_path)
     assert done["state"] == "completed"
     assert done["best_metric"] == pytest.approx(0.62)
+    assert done["best_epoch"] == 2
     assert done["checkpoints"]["best"].endswith("best.pt")
 
 
 def test_status_failed_records_error(tmp_path):
     cb = TrainingStatusCallback()
     cb.on_train_start(_start(tmp_path))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1))
     exc = RuntimeError("CUDA out of memory")
     cb.on_train_exception(
         TrainExceptionEvent(
-            epoch=1,
+            epoch=2,
             total_epochs=4,
             model_family="yolo9",
             model_size="s",
@@ -123,6 +129,9 @@ def test_status_failed_records_error(tmp_path):
     )
     failed = _load(tmp_path)
     assert failed["state"] == "failed"
+    assert failed["current_epoch"] == 1
+    assert failed["completed_epochs"] == 1
+    assert failed["progress"] == pytest.approx(0.25)
     assert failed["error"]["type"] == "RuntimeError"
     assert "out of memory" in failed["error"]["message"]
 
@@ -131,7 +140,7 @@ def test_status_atomic_write_is_valid_json_every_time(tmp_path):
     """status.json must always parse; never a half-written file."""
     cb = TrainingStatusCallback(write_log=False)
     cb.on_train_start(_start(tmp_path))
-    for e in range(4):
+    for e in range(1, 5):
         cb.on_train_epoch_end(_epoch(tmp_path, epoch=e))
         json.loads((tmp_path / "status.json").read_text())  # raises if corrupt
 
@@ -154,7 +163,7 @@ def test_monitor_reads_status_and_results_csv_fallback(tmp_path):
 
     # results.csv is written by TrainingArtifactsCallback; emulate a couple rows.
     (tmp_path / "results.csv").write_text(
-        "epoch,train/loss,metrics/mAP50-95\n0,2.0,0.5\n1,1.9,0.55\n"
+        "epoch,train/loss,metrics/mAP50-95\n1,2.0,0.5\n2,1.9,0.55\n"
     )
     assert not (tmp_path / "metrics.jsonl").exists()
 
@@ -168,8 +177,8 @@ def test_metrics_jsonl_written_and_read(tmp_path):
     """Every family gets a universal, chart-ready metrics.jsonl history."""
     cb = TrainingStatusCallback(write_log=False)
     cb.on_train_start(_start(tmp_path))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0, metric=0.5))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1, metric=0.55))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1, metric=0.5))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=2, metric=0.55))
 
     lines = (tmp_path / "metrics.jsonl").read_text().strip().splitlines()
     assert len(lines) == 2
@@ -178,18 +187,171 @@ def test_metrics_jsonl_written_and_read(tmp_path):
     assert "epoch" in parsed["columns"]
     assert "train/loss" in parsed["columns"]
     assert "metrics/mAP50-95" in parsed["columns"]
+    assert [row["epoch"] for row in parsed["rows"]] == [1, 2]
     assert parsed["rows"][1]["metrics/mAP50-95"] == pytest.approx(0.55)
 
 
 def test_metrics_jsonl_reset_on_fresh_run(tmp_path):
     cb = TrainingStatusCallback(write_log=False)
     cb.on_train_start(_start(tmp_path))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1))
     # A new fresh run (start_epoch=1) must clear stale history.
     cb.on_train_start(_start(tmp_path, start_epoch=1))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1))
     lines = (tmp_path / "metrics.jsonl").read_text().strip().splitlines()
     assert len(lines) == 1
+
+
+def test_metrics_jsonl_trims_stale_resume_rows(tmp_path):
+    cb = TrainingStatusCallback(write_log=False)
+    cb.on_train_start(_start(tmp_path))
+    for epoch in range(1, 5):
+        cb.on_train_epoch_end(_epoch(tmp_path, epoch=epoch))
+
+    cb.on_train_start(_start(tmp_path, start_epoch=3))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=3))
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "metrics.jsonl").read_text().splitlines()
+    ]
+    assert [row["epoch"] for row in rows] == [1, 2, 3]
+
+
+def test_resume_status_keeps_absolute_progress_through_train_end(tmp_path):
+    cb = TrainingStatusCallback(write_log=False)
+    cb.on_train_start(_start(tmp_path, start_epoch=3))
+    started = _load(tmp_path)
+    assert started["completed_epochs"] == 2
+    assert started["progress"] == pytest.approx(0.5)
+
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=3, best_epoch=3))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=4, best_epoch=4))
+    end = _end(tmp_path)
+    end = TrainEndEvent(
+        total_epochs=end.total_epochs,
+        completed_epochs=2,  # current invocation only, as emitted by BaseTrainer
+        model_family=end.model_family,
+        model_size=end.model_size,
+        task=end.task,
+        save_dir=end.save_dir,
+        final_loss=end.final_loss,
+        best_metric=end.best_metric,
+        best_epoch=end.best_epoch,
+        total_seconds=end.total_seconds,
+        results=end.results,
+    )
+    cb.on_train_end(end)
+
+    done = _load(tmp_path)
+    assert done["completed_epochs"] == 4
+    assert done["current_epoch"] == 3
+    assert done["progress"] == pytest.approx(1.0)
+
+
+def test_concurrent_training_logs_are_isolated_and_level_restores(tmp_path):
+    lib_logger = logging.getLogger("libreyolo")
+    original_level = lib_logger.level
+    lib_logger.setLevel(logging.WARNING)
+    ready = threading.Barrier(3)
+    release_first = threading.Event()
+    first_closed = threading.Event()
+    errors = []
+
+    def run(name: str, wait_for_release: bool):
+        cb = TrainingStatusCallback()
+        run_dir = tmp_path / name
+        try:
+            cb.on_train_start(_start(run_dir))
+            lib_logger.info("message-%s", name)
+            ready.wait(timeout=2)
+            if wait_for_release:
+                assert release_first.wait(timeout=2)
+            cb.on_train_end(_end(run_dir))
+            if not wait_for_release:
+                first_closed.set()
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+            cb._close_log()
+
+    first = threading.Thread(target=run, args=("first", False))
+    second = threading.Thread(target=run, args=("second", True))
+    try:
+        first.start()
+        second.start()
+        ready.wait(timeout=2)
+        assert lib_logger.level == logging.INFO
+        assert first_closed.wait(timeout=2)
+        assert lib_logger.level == logging.INFO
+        release_first.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+        assert not first.is_alive() and not second.is_alive()
+        assert not errors
+        assert lib_logger.level == logging.WARNING
+        first_log = (tmp_path / "first" / "train.log").read_text()
+        second_log = (tmp_path / "second" / "train.log").read_text()
+        assert "message-first" in first_log and "message-second" not in first_log
+        assert "message-second" in second_log and "message-first" not in second_log
+    finally:
+        release_first.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+        lib_logger.setLevel(original_level)
+
+
+def test_training_run_directory_reservation_is_atomic(tmp_path):
+    trainers = [
+        SimpleNamespace(
+            config=SimpleNamespace(
+                project=str(tmp_path / "runs"), name="exp", exist_ok=False
+            )
+        )
+        for _ in range(12)
+    ]
+    barrier = threading.Barrier(len(trainers))
+
+    def reserve(trainer):
+        barrier.wait(timeout=5)
+        return BaseTrainer._get_save_dir(trainer)
+
+    with ThreadPoolExecutor(max_workers=len(trainers)) as pool:
+        paths = list(pool.map(reserve, trainers))
+
+    assert len(set(paths)) == len(trainers)
+    assert all(path.is_dir() for path in paths)
+    assert {path.name for path in paths} == {
+        "exp",
+        *(f"exp{index}" for index in range(2, len(trainers) + 1)),
+    }
+
+
+def test_training_run_directory_supports_nested_names(tmp_path):
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(
+            project=str(tmp_path / "runs"), name="sweep/exp", exist_ok=False
+        )
+    )
+
+    first = BaseTrainer._get_save_dir(trainer)
+    second = BaseTrainer._get_save_dir(trainer)
+
+    assert first == tmp_path / "runs" / "sweep" / "exp"
+    assert second == tmp_path / "runs" / "sweep" / "exp2"
+
+
+def test_training_run_directory_reuses_resume_target(tmp_path):
+    resume_dir = tmp_path / "original" / "exp"
+    trainer = SimpleNamespace(
+        _resume_save_dir=resume_dir,
+        config=SimpleNamespace(
+            project=str(tmp_path / "other"), name="new", exist_ok=False
+        ),
+    )
+
+    assert BaseTrainer._get_save_dir(trainer) == resume_dir
+    assert resume_dir.is_dir()
+    assert not (tmp_path / "other").exists()
 
 
 def test_metrics_jsonl_skips_torn_line(tmp_path):

--- a/tests/unit/test_training_status.py
+++ b/tests/unit/test_training_status.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
@@ -202,6 +204,97 @@ def test_metrics_jsonl_reset_on_fresh_run(tmp_path):
     assert len(lines) == 1
 
 
+def test_atomic_status_write_retries_transient_reader_sharing(monkeypatch, tmp_path):
+    from libreyolo.training import artifacts
+
+    real_replace = artifacts.os.replace
+    calls = 0
+
+    def transient_replace(source, destination):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise PermissionError("injected sharing violation")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(artifacts.os, "replace", transient_replace)
+    artifacts._atomic_write_json(tmp_path / "status.json", {"state": "running"})
+
+    assert calls == 3
+    assert json.loads((tmp_path / "status.json").read_text()) == {
+        "state": "running"
+    }
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows reader sharing semantics")
+def test_resume_waits_for_monitor_readers_before_rewriting_status_and_metrics(
+    tmp_path,
+):
+    cb = TrainingStatusCallback(write_log=False)
+    cb.on_train_start(_start(tmp_path))
+    for epoch in range(1, 5):
+        cb.on_train_epoch_end(_epoch(tmp_path, epoch=epoch))
+
+    readers = [
+        open(tmp_path / "status.json", encoding="utf-8"),
+        open(tmp_path / "metrics.jsonl", encoding="utf-8"),
+    ]
+
+    def release_readers():
+        time.sleep(0.05)
+        for reader in readers:
+            reader.close()
+
+    release = threading.Thread(target=release_readers)
+    release.start()
+    try:
+        cb.on_train_start(_start(tmp_path, start_epoch=3))
+    finally:
+        for reader in readers:
+            if not reader.closed:
+                reader.close()
+        release.join(timeout=2)
+
+    resumed = _load(tmp_path)
+    assert resumed["state"] == "running"
+    assert resumed["completed_epochs"] == 2
+    assert resumed["current_epoch"] is None
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=3))
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "metrics.jsonl").read_text().splitlines()
+    ]
+    assert [row["epoch"] for row in rows] == [1, 2, 3]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows reader sharing semantics")
+def test_fresh_status_start_waits_for_monitor_reader_before_resetting_log(tmp_path):
+    cb = TrainingStatusCallback()
+    cb.on_train_start(_start(tmp_path))
+    logging.getLogger("libreyolo").info("stale log line")
+    cb._close_log()
+    reader = open(tmp_path / "train.log", encoding="utf-8")
+
+    def release_reader():
+        time.sleep(0.05)
+        reader.close()
+
+    release = threading.Thread(target=release_reader)
+    release.start()
+    try:
+        cb.on_train_start(_start(tmp_path))
+    finally:
+        if not reader.closed:
+            reader.close()
+        release.join(timeout=2)
+    logging.getLogger("libreyolo").info("fresh log line")
+    cb._close_log()
+
+    log = (tmp_path / "train.log").read_text()
+    assert "fresh log line" in log
+    assert "stale log line" not in log
+
+
 def test_metrics_jsonl_trims_stale_resume_rows(tmp_path):
     cb = TrainingStatusCallback(write_log=False)
     cb.on_train_start(_start(tmp_path))
@@ -338,6 +431,21 @@ def test_training_run_directory_supports_nested_names(tmp_path):
 
     assert first == tmp_path / "runs" / "sweep" / "exp"
     assert second == tmp_path / "runs" / "sweep" / "exp2"
+
+
+def test_training_run_directory_preserves_empty_name(tmp_path):
+    trainer = SimpleNamespace(
+        config=SimpleNamespace(
+            project=str(tmp_path / "runs"), name="", exist_ok=False
+        )
+    )
+
+    first = BaseTrainer._get_save_dir(trainer)
+    second = BaseTrainer._get_save_dir(trainer)
+
+    assert first == tmp_path / "runs"
+    assert second == tmp_path / "runs2"
+    assert first.is_dir() and second.is_dir()
 
 
 def test_training_run_directory_reuses_resume_target(tmp_path):

--- a/tests/unit/ui/test_train_monitor_page.py
+++ b/tests/unit/ui/test_train_monitor_page.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from libreyolo.ui import train_monitor
+from libreyolo.ui.train_monitor_page import INDEX_HTML
+
+pytestmark = pytest.mark.unit
+
+
+def test_run_summary_exposes_absolute_completed_epoch_count(tmp_path):
+    root = tmp_path / "runs"
+    run = root / "train" / "exp"
+    run.mkdir(parents=True)
+    (run / "status.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "state": "running",
+                "current_epoch": 4,
+                "completed_epochs": 5,
+                "total_epochs": 10,
+                "progress": 0.5,
+            }
+        )
+    )
+
+    summary = train_monitor._run_summary(root, run)
+
+    assert summary["current_epoch"] == 4
+    assert summary["completed_epochs"] == 5
+    assert summary["progress"] == pytest.approx(0.5)
+    assert summary["schema_version"] == 2
+    assert summary["display_epoch"] == 5
+    assert summary["display_progress"] == pytest.approx(0.5)
+
+
+def test_status_view_repairs_legacy_running_off_by_one():
+    status = train_monitor._normalize_status_view(
+        {
+            "schema_version": 1,
+            "state": "running",
+            "start_epoch": 1,
+            "current_epoch": 1,
+            "completed_epochs": 2,
+            "total_epochs": 4,
+            "progress": 0.5,
+        }
+    )
+
+    assert status["display_epoch"] == 1
+    assert status["display_progress"] == pytest.approx(0.25)
+
+
+def test_status_view_repairs_legacy_resume_completion():
+    status = train_monitor._normalize_status_view(
+        {
+            "schema_version": 1,
+            "state": "completed",
+            "start_epoch": 3,
+            "completed_epochs": 2,
+            "total_epochs": 4,
+            "progress": 0.5,
+        }
+    )
+
+    assert status["display_epoch"] == 4
+    assert status["display_progress"] == pytest.approx(1.0)
+
+
+def test_status_view_shows_attempted_epoch_on_v2_failure():
+    status = train_monitor._normalize_status_view(
+        {
+            "schema_version": 2,
+            "state": "failed",
+            "current_epoch": 2,
+            "completed_epochs": 2,
+            "total_epochs": 4,
+            "progress": 0.5,
+        }
+    )
+
+    assert status["display_epoch"] == 3
+    assert status["display_progress"] == pytest.approx(0.5)
+
+
+def test_monitor_page_uses_zero_based_status_and_one_based_metric_contracts():
+    assert "s.display_epoch != null" in INDEX_HTML
+    assert "s.display_progress != null" in INDEX_HTML
+    assert "return Math.max(0, modern ? epoch + 1 : epoch);" in INDEX_HTML
+    assert "const bestEpoch = bestEpochNumber(s);" in INDEX_HTML
+    assert "const xs = rows.map(r => r.epoch != null ? r.epoch : 0);" in INDEX_HTML
+    assert "r.epoch != null ? r.epoch + 1 : 0" not in INDEX_HTML
+
+
+def test_monitor_page_bounds_progress_and_can_derive_it_from_completed_epochs():
+    assert "completed / total" in INDEX_HTML
+    assert "Math.max(0, Math.min(1, value))" in INDEX_HTML

--- a/tests/unit/ui/test_train_monitor_page.py
+++ b/tests/unit/ui/test_train_monitor_page.py
@@ -98,3 +98,12 @@ def test_monitor_page_uses_zero_based_status_and_one_based_metric_contracts():
 def test_monitor_page_bounds_progress_and_can_derive_it_from_completed_epochs():
     assert "completed / total" in INDEX_HTML
     assert "Math.max(0, Math.min(1, value))" in INDEX_HTML
+
+
+def test_monitor_page_clears_stale_failure_banner_after_resume():
+    refresh = INDEX_HTML[INDEX_HTML.index("async function refreshStatus()") :]
+    failed = refresh.index('if (state === "failed" && s.error)')
+    cleanup = refresh.index("box.remove();")
+    returned = refresh.index("return state;")
+
+    assert failed < cleanup < returned

--- a/tests/unit/ui/test_ui_concurrency.py
+++ b/tests/unit/ui/test_ui_concurrency.py
@@ -78,6 +78,47 @@ def test_new_run_waits_for_inference_and_does_not_rewrite_response_dir(
     assert state.run_dir == second_run
 
 
+def test_new_run_waits_for_open_folder_and_response_uses_opened_dir(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    state = _UIState(device="cpu")
+    first_run = state.new_run()
+    open_entered = threading.Event()
+    release_open = threading.Event()
+    new_run_started = threading.Event()
+    opened: list[Path] = []
+
+    def open_in_file_manager(path: Path) -> bool:
+        opened.append(path)
+        open_entered.set()
+        assert release_open.wait(timeout=5)
+        return True
+
+    monkeypatch.setattr(
+        "libreyolo.ui.server._open_in_file_manager", open_in_file_manager
+    )
+
+    def start_new_run():
+        new_run_started.set()
+        return state.new_run()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        opening = pool.submit(state.open_folder)
+        assert open_entered.wait(timeout=5)
+        next_run = pool.submit(start_new_run)
+        assert new_run_started.wait(timeout=5)
+        assert not next_run.done()
+        release_open.set()
+        response = opening.result(timeout=5)
+        second_run = next_run.result(timeout=5)
+
+    assert opened == [first_run]
+    assert response == {"ok": True, "dir": str(first_run)}
+    assert second_run != first_run
+    assert state.run_dir == second_run
+
+
 def test_ui_and_training_log_capture_are_isolated_when_interleaved(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/ui/test_ui_concurrency.py
+++ b/tests/unit/ui/test_ui_concurrency.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+
+import pytest
+
+from libreyolo.training.artifacts import TrainingStatusCallback
+from libreyolo.ui.server import _UIState
+
+pytestmark = pytest.mark.unit
+
+
+def test_new_run_reservation_is_atomic_across_server_states(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    states = [_UIState(device="cpu") for _ in range(12)]
+    barrier = threading.Barrier(len(states))
+
+    def reserve(state: _UIState) -> Path:
+        barrier.wait(timeout=5)
+        return state.new_run()
+
+    with ThreadPoolExecutor(max_workers=len(states)) as pool:
+        paths = list(pool.map(reserve, states))
+
+    assert len(set(paths)) == len(states)
+    assert all(path.is_dir() for path in paths)
+    assert {path.name for path in paths} == {
+        "predict",
+        *(f"predict{index}" for index in range(2, len(states) + 1)),
+    }
+
+
+def test_new_run_waits_for_inference_and_does_not_rewrite_response_dir(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    state = _UIState(device="cpu")
+    first_run = state.new_run()
+    inference_entered = threading.Event()
+    release_inference = threading.Event()
+    new_run_started = threading.Event()
+
+    class FakeModel:
+        def __call__(self, _source, *, conf, save, output_path):
+            assert conf == pytest.approx(0.25)
+            assert save is True
+            inference_entered.set()
+            assert release_inference.wait(timeout=5)
+            saved = Path(output_path) / "image.jpg"
+            saved.write_bytes(b"rendered")
+            return SimpleNamespace(saved_path=str(saved), boxes=[])
+
+    state._get_model = lambda _name: FakeModel()
+
+    def start_new_run():
+        new_run_started.set()
+        return state.new_run()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        inference = pool.submit(
+            state.infer, "fake", 0.25, "image.jpg", b"input"
+        )
+        assert inference_entered.wait(timeout=5)
+        next_run = pool.submit(start_new_run)
+        assert new_run_started.wait(timeout=5)
+        assert not next_run.done()
+        release_inference.set()
+        result = inference.result(timeout=5)
+        second_run = next_run.result(timeout=5)
+
+    assert result["dir"] == str(first_run)
+    assert result["saved"] == str(first_run / "image.jpg")
+    assert second_run != first_run
+    assert state.run_dir == second_run
+
+
+def test_ui_and_training_log_capture_are_isolated_when_interleaved(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    state = _UIState(device="cpu")
+    state.new_run()
+    ui_entered = threading.Event()
+    release_ui = threading.Event()
+    training_started = threading.Event()
+    release_training = threading.Event()
+    emitted: list[str] = []
+    run_dir = tmp_path / "train"
+
+    class FakeModel:
+        def __call__(self, _source, *, conf, save, output_path):
+            logging.getLogger("libreyolo").info("ui-only-message")
+            ui_entered.set()
+            assert release_ui.wait(timeout=5)
+            saved = Path(output_path) / "image.jpg"
+            saved.write_bytes(b"rendered")
+            return SimpleNamespace(saved_path=str(saved), boxes=[])
+
+    state._get_model = lambda _name: FakeModel()
+    start = SimpleNamespace(
+        start_epoch=1,
+        total_epochs=1,
+        model_family="yolo9",
+        model_size="t",
+        task="detect",
+        save_dir=str(run_dir),
+        config={},
+    )
+    end = SimpleNamespace(
+        total_epochs=1,
+        completed_epochs=1,
+        model_family="yolo9",
+        model_size="t",
+        task="detect",
+        save_dir=str(run_dir),
+        final_loss=0.0,
+        best_metric=None,
+        best_epoch=None,
+        total_seconds=0.1,
+        results={},
+    )
+    lib_logger = logging.getLogger("libreyolo")
+    original_level = lib_logger.level
+    lib_logger.setLevel(logging.WARNING)
+
+    def train():
+        callback = TrainingStatusCallback()
+        callback.on_train_start(start)
+        logging.getLogger("libreyolo").info("training-only-message")
+        training_started.set()
+        assert release_training.wait(timeout=5)
+        callback.on_train_end(end)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            inference = pool.submit(
+                state.infer,
+                "fake",
+                0.25,
+                "image.jpg",
+                b"input",
+                emitted.append,
+            )
+            assert ui_entered.wait(timeout=5)
+            training = pool.submit(train)
+            assert training_started.wait(timeout=5)
+            assert lib_logger.level == logging.INFO
+
+            release_ui.set()
+            inference.result(timeout=5)
+            # The training lease remains active after UI capture closes.
+            assert lib_logger.level == logging.INFO
+            release_training.set()
+            training.result(timeout=5)
+
+        assert lib_logger.level == logging.WARNING
+        ui_output = "\n".join(emitted)
+        training_output = (run_dir / "train.log").read_text()
+        assert "ui-only-message" in ui_output
+        assert "training-only-message" not in ui_output
+        assert "training-only-message" in training_output
+        assert "ui-only-message" not in training_output
+    finally:
+        release_ui.set()
+        release_training.set()
+        lib_logger.setLevel(original_level)


### PR DESCRIPTION
# What does this PR do?

Hardens LibreLabel, training-artifact, and UI integrity boundaries identified in #591.

- Rejects invalid, non-finite, out-of-range, degenerate, or disk-lossy annotations before publication.
- Makes uploads, splits, exports, ZIP publication, and in-place transformations transactional, collision-safe, task-aware, and rollback-capable.
- Marks destructive or lossy native-COCO, unsupported, ambiguous, and task-mismatched datasets read-only.
- Adds project epochs, content revisions, and synchronized transitions so stale workers or saves cannot mutate a newer session.
- Prevents concurrent upload clobbering and cross-suffix label collisions across processes and aliased paths.
- Makes run-directory reservation atomic, isolates concurrent logs, and corrects resume-aware epoch, metric, failure, and progress reporting.
- Uses fail-closed filesystem identity validation and pinned handles/descriptors for project trash moves, with no-clobber and recoverable race handling.
- Preserves taskless YOLO datasets byte-for-byte during copy or in-place reorganization without inventing task metadata, while continuing to reject lossy conversions.
- Validates and drains bounded POST bodies before early LibreLabel responses so Windows clients receive stable errors instead of connection resets, including globally oversized declarations.
- Rejects link/reparse path components and safely recovers interrupted in-place moves so source, destination, and future-label paths cannot escape the dataset boundary.
- Retries transient Windows artifact-sharing failures and keeps monitor folder, error-banner, and resumed-run state consistent under concurrency.

# Provenance declaration (required)

## Code provenance

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

# How was this tested?

- Final stacked changed-test selection: 411 passed, 11 skipped.
- Independent combined label review: 207 passed, 11 skipped, including POSIX/WSL source-ancestor, destination-ancestor, leaf-swap, and future-label redirection attacks.
- Independent training/UI review: 109 passed, including repeated Windows held-reader, run-reservation, and open-folder concurrency probes.
- Taskless-export regression selection: 78 passed, 4 skipped; focused edge cases: 7 passed.
- LibreLabel server-integrity selection: 50 passed.
- Windows transport stress passed 400 repeated 128 KiB early rejections, 20 repeated 8 MiB maximum-JSON early rejections, and 3 real 64 MiB+1 globally oversized requests without a reset; an independent review also passed 20 repeated 8 MiB unknown-route responses.
- In-place export interruption probes restored bytes exactly across staging, finalization, and rollback; incomplete recovery preserved the staging directory instead of deleting recoverable data.
- Python 3.10 normal and no-clobber filesystem probes passed.
- Python 3.12 normal, source-swap, trash-swap, no-clobber, and identity probes passed.
- Task-specific predecessor suite: 960 passed, 4 skipped.
- Export/backend predecessor suite: 533 passed, 3 skipped.
- YOLO9 and RF-DETR flagship anchors: 171 passed.
- Exact-head GitHub unit gate: Ubuntu 4,554 passed/108 skipped/57 deselected/4 expected failures; Windows 4,556/106/57/4; macOS 4,552/108/57/6 (run 29249480122).
- Exact-head install smoke: 8/8 jobs passed across PyPI, editable, sdist, and wheel paths on Ubuntu, macOS, and Windows (run 29249481657).
- Exact-head provenance passed, and Greptile scored the final 27-file diff 5/5 with no new findings.
- Predecessor exact hermetic local gate: 4,585 passed, 36 skipped, 60 deselected, 4 expected failures in 18m26s.
- Ruff and `git diff --check`: clean.
