### PR TITLE
add tta for semantic segmentation

### DIFF
--- a/libreyolo/data/__init__.py
+++ b/libreyolo/data/__init__.py
@@ -48,6 +48,7 @@ from .semantic_dataset import (
     img2mask_paths,
     resolve_semantic_data,
     semantic_collate_fn,
+    valid_content_hw,
 )
 from .utils import (
     DATASETS_DIR,
@@ -105,4 +106,5 @@ __all__ = [
     "img2mask_paths",
     "resolve_semantic_data",
     "semantic_collate_fn",
+    "valid_content_hw",
 ]

--- a/libreyolo/data/semantic_dataset.py
+++ b/libreyolo/data/semantic_dataset.py
@@ -150,6 +150,24 @@ def _rasterize_polygon_labels(
     return np.asarray(canvas).astype(np.int64)
 
 
+def valid_content_hw(
+    orig_shape: Tuple[int, int], ratio: float, canvas_hw: Tuple[int, int]
+) -> Tuple[int, int]:
+    """Size of the real (unpadded) content region inside a letterboxed canvas.
+
+    Matches :meth:`SemanticDataset._resize`'s own ``new_h``/``new_w``
+    computation exactly, so callers (e.g. flip-TTA validation, which must
+    flip only the real content and leave letterbox padding in place) can
+    locate the top-left-anchored valid region without re-deriving this math
+    and risking it drifting out of sync with the dataset's actual resize.
+    """
+    orig_h, orig_w = orig_shape
+    canvas_h, canvas_w = canvas_hw
+    new_h = min(canvas_h, max(1, int(round(orig_h * ratio))))
+    new_w = min(canvas_w, max(1, int(round(orig_w * ratio))))
+    return new_h, new_w
+
+
 def resolve_semantic_data(data: str | Path, allow_scripts: bool = False) -> Dict:
     """Load and sanity-check a semantic dataset YAML config.
 
@@ -299,8 +317,9 @@ class SemanticDataset(Dataset):
             ratio = 1.0
         else:
             ratio = min(self.imgsz / h0, self.imgsz / w0) * scale
-            new_w = max(1, int(round(w0 * ratio)))
-            new_h = max(1, int(round(h0 * ratio)))
+            new_h, new_w = valid_content_hw(
+                (h0, w0), ratio, (self.imgsz, self.imgsz)
+            )
 
         img_pil = Image.fromarray(img).resize((new_w, new_h), Image.BILINEAR)
         mask_pil = Image.fromarray(mask.astype(np.int32), mode="I").resize(

--- a/libreyolo/data/semantic_dataset.py
+++ b/libreyolo/data/semantic_dataset.py
@@ -155,11 +155,17 @@ def valid_content_hw(
 ) -> Tuple[int, int]:
     """Size of the real (unpadded) content region inside a letterboxed canvas.
 
-    Matches :meth:`SemanticDataset._resize`'s own ``new_h``/``new_w``
-    computation exactly, so callers (e.g. flip-TTA validation, which must
-    flip only the real content and leave letterbox padding in place) can
-    locate the top-left-anchored valid region without re-deriving this math
-    and risking it drifting out of sync with the dataset's actual resize.
+    This is the content size *after* :meth:`SemanticDataset._resize` finishes,
+    so callers (e.g. flip-TTA validation, which must flip only the real content
+    and leave letterbox padding in place) can locate the top-left-anchored valid
+    region without re-deriving the math.
+
+    The clamp to the canvas is what makes it the *final* content size rather
+    than the intermediate resize size: ``_resize`` may scale past ``imgsz`` when
+    ``scale > 1`` (training jitter) and then random-crop the overflow back down,
+    so the stored content is capped at the canvas either way. Do not use this to
+    compute ``_resize``'s resize step itself — clamping there would squash the
+    aspect ratio and skip the crop.
     """
     orig_h, orig_w = orig_shape
     canvas_h, canvas_w = canvas_hw
@@ -317,9 +323,14 @@ class SemanticDataset(Dataset):
             ratio = 1.0
         else:
             ratio = min(self.imgsz / h0, self.imgsz / w0) * scale
-            new_h, new_w = valid_content_hw(
-                (h0, w0), ratio, (self.imgsz, self.imgsz)
-            )
+            # Deliberately NOT clamped to imgsz: with scale > 1 (training
+            # jitter) this overshoots the canvas on purpose, and the random-crop
+            # below takes the overflow back out. Clamping here instead would
+            # squash the aspect ratio and make that crop dead code, turning
+            # zoom-in jitter into a plain resize. valid_content_hw() reports the
+            # post-crop size and is the right thing for readers of the canvas.
+            new_w = max(1, int(round(w0 * ratio)))
+            new_h = max(1, int(round(h0 * ratio)))
 
         img_pil = Image.fromarray(img).resize((new_w, new_h), Image.BILINEAR)
         mask_pil = Image.fromarray(mask.astype(np.int32), mode="I").resize(

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -828,6 +828,24 @@ class BaseModel(ABC):
 
         return self._merge_tta(aug_dets, iou, image_path, (orig_w, orig_h), classes)
 
+    def _postprocess_semantic_logits(
+        self,
+        output: Any,
+        original_size: Tuple[int, int],
+        **kwargs,
+    ) -> torch.Tensor:
+        """Return raw ``[1, C, H, W]`` semantic logits at ``original_size``.
+
+        Semantic families must implement this: flip TTA merges views before
+        the argmax, so it needs the pre-argmax logits that ``_postprocess``
+        throws away.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement _postprocess_semantic_logits(), "
+            "which the semantic task requires (it backs both _postprocess and "
+            "flip TTA)."
+        )
+
     def _predict_augment_semantic(
         self,
         img_pil,

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -757,11 +757,6 @@ class BaseModel(ABC):
                 "Test-time augmentation does not support point-task models yet. "
                 "Use augment=False for point models."
             )
-        if getattr(self, "task", "detect") == "semantic":
-            raise ValueError(
-                "Test-time augmentation does not support semantic segmentation yet. "
-                "Use augment=False for semantic models."
-            )
         if getattr(self, "task", "detect") == "panoptic":
             raise ValueError(
                 "Test-time augmentation does not support panoptic segmentation yet. "
@@ -790,6 +785,16 @@ class BaseModel(ABC):
         img_pil = ImageLoader.load(image, color_format=color_format)
         image_path = image if isinstance(image, (str, Path)) else None
         orig_w, orig_h = img_pil.size
+
+        if getattr(self, "task", "detect") == "semantic":
+            return self._predict_augment_semantic(
+                img_pil,
+                image_path,
+                (orig_w, orig_h),
+                effective_imgsz,
+                color_format,
+                **kwargs,
+            )
 
         scales = (1.0,) if self.TTA_FIXED_SIZE else self.TTA_SCALES
 
@@ -822,6 +827,59 @@ class BaseModel(ABC):
             return self._merge_classify_tta(aug_dets, image_path, (orig_w, orig_h))
 
         return self._merge_tta(aug_dets, iou, image_path, (orig_w, orig_h), classes)
+
+    def _predict_augment_semantic(
+        self,
+        img_pil,
+        image_path,
+        original_size: Tuple[int, int],
+        effective_imgsz,
+        color_format: str,
+        **kwargs,
+    ) -> Results:
+        """Flip-only TTA for semantic segmentation.
+
+        Runs the image and its horizontal flip, flips the flipped view's
+        logits back into alignment, averages softmax probabilities across
+        the two views (not raw logits — see ``_postprocess_semantic_logits``
+        callers), then argmaxes once. Scale variation (``TTA_SCALES``) does
+        not apply to dense per-pixel prediction, so this always runs exactly
+        two forward passes regardless of the family's TTA policy flags.
+        """
+        from PIL import Image as PILImage
+
+        from ...utils.results import Results, SemanticMask
+        from ...utils.tta import average_flip_softmax
+
+        orig_w, orig_h = original_size
+        logits_views = []
+        for is_flipped in (False, True):
+            src = (
+                img_pil.transpose(PILImage.Transpose.FLIP_LEFT_RIGHT)
+                if is_flipped
+                else img_pil
+            )
+            tensor, _, orig_size, ratio = self._preprocess(
+                src, color_format, input_size=effective_imgsz
+            )
+            with torch.no_grad():
+                raw = self._forward(tensor.to(self.device))
+            logits = self._postprocess_semantic_logits(
+                raw, orig_size, ratio=ratio, input_size=effective_imgsz, **kwargs
+            )
+            if is_flipped:
+                logits = logits.flip(-1)
+            logits_views.append(logits)
+
+        avg_probs = average_flip_softmax(logits_views[0], logits_views[1])
+        mask = avg_probs.argmax(dim=1)[0].cpu()
+        return Results(
+            boxes=None,
+            orig_shape=(orig_h, orig_w),
+            path=str(image_path) if image_path else None,
+            names=self.names,
+            semantic_mask=SemanticMask(mask.long(), (orig_h, orig_w)),
+        )
 
     def _merge_classify_tta(
         self,
@@ -1280,11 +1338,6 @@ class BaseModel(ABC):
             raise ValueError(
                 "Augmented validation does not support point-task models yet. "
                 "Use augment=False for point models."
-            )
-        if augment and self.task == "semantic":
-            raise ValueError(
-                "Augmented validation does not support semantic segmentation "
-                "yet. Use augment=False for semantic models."
             )
         if augment and self.task == "panoptic":
             raise ValueError(

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -444,17 +444,31 @@ class LibreDINOv2(BaseModel):
                 logits = logits.get("logits", logits.get("predictions"))
             probs = torch.softmax(logits.float(), dim=1)[0]
             return {"probs": probs.cpu()}
+        logits = self._postprocess_semantic_logits(output, original_size, **kwargs)
+        return {"semantic": logits.argmax(dim=1)[0].cpu()}
+
+    def _postprocess_semantic_logits(
+        self,
+        output: Any,
+        original_size: Tuple[int, int],
+        **kwargs,
+    ) -> torch.Tensor:
+        """Interpolate raw semantic logits to ``original_size``, pre-argmax.
+
+        Shared by ``_postprocess`` (single-view predict/val) and
+        ``BaseModel._predict_augment_semantic`` (flip TTA), which needs the
+        pre-argmax logits to average across augmented views.
+        """
         logits = output
         if isinstance(logits, dict):
             logits = logits.get("semantic_logits", logits.get("predictions"))
         orig_w, orig_h = original_size
-        logits = torch.nn.functional.interpolate(
+        return torch.nn.functional.interpolate(
             logits.float(),
             size=(orig_h, orig_w),
             mode="bilinear",
             align_corners=False,
         )
-        return {"semantic": logits.argmax(dim=1)[0].cpu()}
 
     # =========================================================================
     # Weights I/O

--- a/libreyolo/models/eomt/model.py
+++ b/libreyolo/models/eomt/model.py
@@ -626,9 +626,20 @@ class LibreEoMT(BaseModel):
             return empty
         return {"panoptic": segmentation.cpu(), "segments_info": segments_info}
 
-    def _postprocess_semantic(
-        self, output: Any, original_size: Tuple[int, int]
-    ) -> Dict:
+    def _postprocess_semantic_logits(
+        self, output: Any, original_size: Tuple[int, int], **kwargs
+    ) -> torch.Tensor:
+        """Interpolate/stitch raw semantic logits to ``original_size``, pre-argmax.
+
+        Shared by ``_postprocess_semantic`` (single-view predict/val),
+        ``LibreEoMT.val()``'s own per-image augment branch, and
+        ``BaseModel._predict_augment_semantic`` (flip TTA), which needs the
+        pre-argmax logits to average across augmented views. Always returns
+        a ``[1, C, H, W]`` tensor, whether or not the patch-stitch branch
+        (only taken when ``_preprocess`` split the image into sliding-window
+        patches, i.e. per-image predict — never during batched validation)
+        fires.
+        """
         logits = output
         if isinstance(logits, dict):
             logits = logits.get("semantic_logits", logits.get("logits"))
@@ -650,14 +661,19 @@ class LibreEoMT(BaseModel):
                 resized_shape=resized_shape,
                 original_shape=(orig_h, orig_w),
             )
-            return {"semantic": logits_hw.argmax(dim=0).cpu()}
+            return logits_hw.unsqueeze(0)
 
-        logits = F.interpolate(
+        return F.interpolate(
             logits.float(),
             size=(orig_h, orig_w),
             mode="bilinear",
             align_corners=False,
         )
+
+    def _postprocess_semantic(
+        self, output: Any, original_size: Tuple[int, int]
+    ) -> Dict:
+        logits = self._postprocess_semantic_logits(output, original_size)
         return {"semantic": logits.argmax(dim=1)[0].cpu()}
 
     def _postprocess_segment(
@@ -1006,11 +1022,6 @@ class LibreEoMT(BaseModel):
             logger.warning("LibreEoMT validation does not generate plots yet.")
         if data is None:
             raise ValueError("LibreEoMT validation requires data= (a dataset YAML).")
-        if augment:
-            raise ValueError(
-                "Augmented validation does not support semantic segmentation yet. "
-                "Use augment=False for semantic models."
-            )
         effective_imgsz = self.input_size if imgsz is None else int(imgsz)
         if effective_imgsz != self.input_size:
             raise ValueError(
@@ -1026,6 +1037,7 @@ class LibreEoMT(BaseModel):
             resolve_semantic_data,
         )
         from ...data.utils import get_img_files
+        from ...utils.tta import average_flip_softmax
 
         if device is not None and str(device).lower() != "auto":
             device_str = f"cuda:{device}" if str(device).isdigit() else str(device)
@@ -1114,8 +1126,15 @@ class LibreEoMT(BaseModel):
                         "Use label_mapping to remap source IDs."
                     )
 
+                # Original and (if augment) flipped views each run their own
+                # preprocess -> forward -> postprocess in sequence, not
+                # interleaved: _preprocess stashes per-call instance state
+                # (self._last_eomt_patch_offsets / _resized_shape) that
+                # _postprocess_semantic_logits reads back, so a later
+                # _preprocess call must not run before the earlier view's
+                # postprocess has consumed its own state.
                 t1 = time.time()
-                tensor, _, original_size, _ = self._preprocess(
+                tensor, loaded_img, original_size, _ = self._preprocess(
                     img_path,
                     color_format="rgb",
                     input_size=effective_imgsz,
@@ -1131,17 +1150,38 @@ class LibreEoMT(BaseModel):
                 inference_time += time.time() - t2
 
                 t3 = time.time()
-                pred = (
-                    self._postprocess(
-                        output,
-                        conf_thres=0.0,
-                        iou_thres=0.0,
-                        original_size=original_size,
-                    )["semantic"]
-                    .long()
-                    .view(-1)
-                )
+                logits = self._postprocess_semantic_logits(output, original_size)
+                if not augment:
+                    pred = logits.argmax(dim=1)[0].cpu().long().view(-1)
                 postprocess_time += time.time() - t3
+
+                if augment:
+                    # Reuse the image _preprocess already loaded from disk
+                    # instead of reading img_path a second time.
+                    t1f = time.time()
+                    flipped = loaded_img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+                    flip_tensor, _, flip_original_size, _ = self._preprocess(
+                        flipped,
+                        color_format="rgb",
+                        input_size=effective_imgsz,
+                    )
+                    preprocess_time += time.time() - t1f
+
+                    t2f = time.time()
+                    if half and self.device.type == "cuda":
+                        with torch.amp.autocast("cuda"):
+                            flip_output = self._forward(flip_tensor.to(self.device))
+                    else:
+                        flip_output = self._forward(flip_tensor.to(self.device))
+                    inference_time += time.time() - t2f
+
+                    t3f = time.time()
+                    flip_logits = self._postprocess_semantic_logits(
+                        flip_output, flip_original_size
+                    ).flip(-1)
+                    avg_probs = average_flip_softmax(logits, flip_logits)
+                    pred = avg_probs.argmax(dim=1)[0].cpu().long().view(-1)
+                    postprocess_time += time.time() - t3f
 
                 target = (
                     torch.from_numpy(np.ascontiguousarray(target_np)).long().view(-1)

--- a/libreyolo/models/pidnet/model.py
+++ b/libreyolo/models/pidnet/model.py
@@ -254,16 +254,19 @@ class LibrePIDNet(BaseModel):
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         return self.model(input_tensor)
 
-    def _postprocess(
+    def _postprocess_semantic_logits(
         self,
         output: Any,
-        conf_thres: float,
-        iou_thres: float,
         original_size: Tuple[int, int],
-        max_det: int = 300,
         ratio: float = 1.0,
         **kwargs,
-    ) -> Dict:
+    ) -> torch.Tensor:
+        """Interpolate raw semantic logits to ``original_size``, pre-argmax.
+
+        Shared by ``_postprocess`` (single-view predict/val) and
+        ``BaseModel._predict_augment_semantic`` (flip TTA), which needs the
+        pre-argmax logits to average across augmented views.
+        """
         logits = output
         if isinstance(logits, dict):
             logits = logits.get("semantic_logits", logits.get("predictions"))
@@ -277,12 +280,24 @@ class LibrePIDNet(BaseModel):
         valid_h = min(logits.shape[-2], max(int(round(orig_h * ratio * scale_y)), 1))
         valid_w = min(logits.shape[-1], max(int(round(orig_w * ratio * scale_x)), 1))
         logits = logits[..., :valid_h, :valid_w]
-        logits = F.interpolate(
+        return F.interpolate(
             logits.float(),
             size=(orig_h, orig_w),
             mode="bilinear",
             align_corners=True,
         )
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        logits = self._postprocess_semantic_logits(output, original_size, ratio=ratio, **kwargs)
         return {"semantic": logits.argmax(dim=1)[0].cpu()}
 
     def _strict_loading(self) -> bool:

--- a/libreyolo/models/segformer/model.py
+++ b/libreyolo/models/segformer/model.py
@@ -279,16 +279,19 @@ class LibreSegformer(BaseModel):
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         return self.model(input_tensor)
 
-    def _postprocess(
+    def _postprocess_semantic_logits(
         self,
         output: Any,
-        conf_thres: float,
-        iou_thres: float,
         original_size: Tuple[int, int],
-        max_det: int = 300,
         ratio: float = 1.0,
         **kwargs,
-    ) -> Dict:
+    ) -> torch.Tensor:
+        """Interpolate raw semantic logits to ``original_size``, pre-argmax.
+
+        Shared by ``_postprocess`` (single-view predict/val) and
+        ``BaseModel._predict_augment_semantic`` (flip TTA), which needs the
+        pre-argmax logits to average across augmented views.
+        """
         logits = output
         if isinstance(logits, dict):
             logits = logits.get("semantic_logits", logits.get("predictions"))
@@ -300,7 +303,19 @@ class LibreSegformer(BaseModel):
         valid_h = min(logits.shape[-2], max(int(round(orig_h * ratio * scale_y)), 1))
         valid_w = min(logits.shape[-1], max(int(round(orig_w * ratio * scale_x)), 1))
         logits = logits[..., :valid_h, :valid_w]
-        logits = F.interpolate(logits.float(), size=(orig_h, orig_w), mode="bilinear", align_corners=False)
+        return F.interpolate(logits.float(), size=(orig_h, orig_w), mode="bilinear", align_corners=False)
+
+    def _postprocess(
+        self,
+        output: Any,
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        logits = self._postprocess_semantic_logits(output, original_size, ratio=ratio, **kwargs)
         return {"semantic": logits.argmax(dim=1)[0].cpu()}
 
     def _strict_loading(self) -> bool:

--- a/libreyolo/utils/tta.py
+++ b/libreyolo/utils/tta.py
@@ -22,5 +22,14 @@ def average_flip_softmax(logits_a: torch.Tensor, logits_b: torch.Tensor) -> torc
     a proper simplex before combining, so a logit-scale mismatch between the
     two views (e.g. near letterbox-padding borders) can't disproportionately
     dominate the merge.
+
+    The accumulate/divide runs in place on this function's own freshly
+    allocated softmax buffer (never on a caller's tensor) so that a dense
+    semantic merge holds two full ``[B, C, H, W]`` float tensors rather than
+    four: at ADE20K scale (150 classes, 512x512, batch 8) each one is 1.2 GB,
+    so the naive ``(a.softmax() + b.softmax()) / 2`` spends several GB on
+    temporaries that exist only to be discarded.
     """
-    return (logits_a.softmax(dim=1) + logits_b.softmax(dim=1)) / 2
+    probs = logits_a.softmax(dim=1)
+    probs.add_(logits_b.softmax(dim=1)).div_(2)
+    return probs

--- a/libreyolo/utils/tta.py
+++ b/libreyolo/utils/tta.py
@@ -1,0 +1,26 @@
+"""Shared merge math for flip test-time-augmentation.
+
+Used by the three independent flip-TTA call sites for semantic segmentation
+(``BaseModel._predict_augment_semantic``, ``SemanticValidator``'s batched
+validation, and ``LibreEoMT.val()``'s bespoke per-image loop) so the merge
+policy lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def average_flip_softmax(logits_a: torch.Tensor, logits_b: torch.Tensor) -> torch.Tensor:
+    """Average softmax probabilities of two spatially-aligned logit views.
+
+    Both tensors must already be in the same spatial orientation (the
+    flipped view's logits flipped back before calling this) and share
+    ``[..., C, ...]`` shape with softmax taken over ``dim=1``. Averaging
+    probabilities rather than raw logits is the standard flip-TTA
+    convention (e.g. mmsegmentation): it bounds each view's contribution to
+    a proper simplex before combining, so a logit-scale mismatch between the
+    two views (e.g. near letterbox-padding borders) can't disproportionately
+    dominate the merge.
+    """
+    return (logits_a.softmax(dim=1) + logits_b.softmax(dim=1)) / 2

--- a/libreyolo/validation/semantic_validator.py
+++ b/libreyolo/validation/semantic_validator.py
@@ -98,9 +98,14 @@ class SemanticValidator(BaseValidator):
                 f"Semantic validation expects [B, C, H, W] logits, got shape "
                 f"{tuple(logits.shape)}."
             )
+        # Upcast before, not inside, the interpolate branch: under half=True a
+        # model whose logits already sit at target_hw would otherwise stay fp16
+        # all the way into the softmax merge. (.float() on an fp32 tensor is a
+        # no-op that returns self, so the common path allocates nothing.)
+        logits = logits.float()
         if tuple(logits.shape[-2:]) != target_hw:
             logits = F.interpolate(
-                logits.float(), size=target_hw, mode="bilinear", align_corners=False
+                logits, size=target_hw, mode="bilinear", align_corners=False
             )
         return logits
 
@@ -111,8 +116,10 @@ class SemanticValidator(BaseValidator):
         logits = self._extract_logits(preds, target_hw)
         return logits.argmax(dim=1)
 
-    def _flip_content(self, tensor: torch.Tensor, img_info: Any) -> torch.Tensor:
-        """Flip each item's real (unpadded) content along width, in place.
+    def _flip_content(
+        self, tensor: torch.Tensor, img_info: Any, inplace: bool = False
+    ) -> torch.Tensor:
+        """Flip each item's real (unpadded) content along width.
 
         ``SemanticDataset`` anchors real content at the top-left origin and
         pads only the bottom/right (see ``valid_content_hw``). A naive
@@ -127,15 +134,31 @@ class SemanticValidator(BaseValidator):
 
         ``stretch`` resize mode has no padding (the whole canvas is
         content), so a plain full-width flip is exact there.
+
+        ``inplace`` mutates ``tensor`` and is for the flip-back of a logits
+        tensor the caller solely owns — at ADE20K scale the defensive copy is
+        1.2 GB. Never pass it for the dataloader's image batch.
         """
         if self._resize_mode == "stretch":
             return tensor.flip(-1)
+        if self._resize_mode not in ("letterbox", "resize_crop"):
+            # Anything else pads somewhere this window math does not model
+            # (EoMT's "split", say). Unreachable today only because
+            # SemanticDataset rejects such modes outright; fail loudly rather
+            # than silently mirroring the wrong region if that ever changes.
+            raise ValueError(
+                f"Flip TTA does not know how to place letterbox padding for "
+                f"semantic_resize_mode={self._resize_mode!r}."
+            )
 
         canvas_hw = tuple(tensor.shape[-2:])
-        flipped = tensor.clone()
+        flipped = tensor if inplace else tensor.clone()
         for i, info in enumerate(img_info):
             new_h, new_w = valid_content_hw(info["orig_shape"], info["ratio"], canvas_hw)
-            flipped[i, ..., :new_h, :new_w] = tensor[i, ..., :new_h, :new_w].flip(-1)
+            window = tensor[i, ..., :new_h, :new_w]
+            # .flip() already materializes a copy, so this stays correct even
+            # when source and destination are the same storage.
+            flipped[i, ..., :new_h, :new_w] = window.flip(-1)
         return flipped
 
     def _run_validation_augmented(self) -> None:
@@ -183,11 +206,16 @@ class SemanticValidator(BaseValidator):
                 t3 = time.time()
                 target_hw = tuple(targets.shape[-2:])
                 logits_orig = self._extract_logits(preds_orig, target_hw)
+                # inplace: the extracted flipped logits are a private buffer
+                # here (nothing else reads preds_flip afterwards), and at
+                # ADE20K scale each [B, C, H, W] float copy is ~1.2 GB.
                 logits_flip = self._flip_content(
-                    self._extract_logits(preds_flip, target_hw), img_info
+                    self._extract_logits(preds_flip, target_hw), img_info, inplace=True
                 )
                 avg_probs = average_flip_softmax(logits_orig, logits_flip)
+                del logits_orig, logits_flip, preds_orig, preds_flip
                 detections = avg_probs.argmax(dim=1)
+                del avg_probs
                 self.speed["postprocess"] += time.time() - t3
 
                 self._update_metrics(detections, targets, img_info, img_ids)

--- a/libreyolo/validation/semantic_validator.py
+++ b/libreyolo/validation/semantic_validator.py
@@ -181,7 +181,8 @@ class SemanticValidator(BaseValidator):
 
         from ..utils.tta import average_flip_softmax
 
-        self.model.model.eval()
+        # BaseValidator._run_validation already put the model in eval() before
+        # dispatching here.
         pbar = tqdm(
             self.dataloader,
             desc="Validating (TTA x2)",

--- a/libreyolo/validation/semantic_validator.py
+++ b/libreyolo/validation/semantic_validator.py
@@ -20,6 +20,7 @@ from ..data.semantic_dataset import (
     SemanticDataset,
     resolve_semantic_data,
     semantic_collate_fn,
+    valid_content_hw,
 )
 from .base import BaseValidator
 
@@ -47,6 +48,7 @@ class SemanticValidator(BaseValidator):
                 f"divisible by {int(divisor)} for this model family."
             )
         resize_mode = getattr(self.model, "semantic_resize_mode", "letterbox")
+        self._resize_mode = resize_mode
         dataset = SemanticDataset(
             data_config,
             split=split,
@@ -82,8 +84,8 @@ class SemanticValidator(BaseValidator):
         images, targets, img_info, img_ids = batch
         return images, targets, img_info, img_ids
 
-    def _postprocess_predictions(self, preds: Any, batch: Any) -> Any:
-        """Decode raw model output into ``[B, H, W]`` class maps."""
+    def _extract_logits(self, preds: Any, target_hw: tuple) -> torch.Tensor:
+        """Unwrap raw model output into ``[B, C, H, W]`` logits at ``target_hw``."""
         logits = preds
         if isinstance(logits, dict):
             logits = logits.get("semantic_logits", logits.get("logits"))
@@ -91,8 +93,6 @@ class SemanticValidator(BaseValidator):
             logits = logits[0]
         logits = torch.as_tensor(logits)
 
-        targets = batch[1]
-        target_hw = tuple(targets.shape[-2:])
         if logits.ndim != 4:
             raise ValueError(
                 f"Semantic validation expects [B, C, H, W] logits, got shape "
@@ -102,7 +102,98 @@ class SemanticValidator(BaseValidator):
             logits = F.interpolate(
                 logits.float(), size=target_hw, mode="bilinear", align_corners=False
             )
+        return logits
+
+    def _postprocess_predictions(self, preds: Any, batch: Any) -> Any:
+        """Decode raw model output into ``[B, H, W]`` class maps."""
+        targets = batch[1]
+        target_hw = tuple(targets.shape[-2:])
+        logits = self._extract_logits(preds, target_hw)
         return logits.argmax(dim=1)
+
+    def _flip_content(self, tensor: torch.Tensor, img_info: Any) -> torch.Tensor:
+        """Flip each item's real (unpadded) content along width, in place.
+
+        ``SemanticDataset`` anchors real content at the top-left origin and
+        pads only the bottom/right (see ``valid_content_hw``). A naive
+        ``torch.flip`` on the whole padded canvas would relocate that
+        padding to the top-left for the flipped view — an input layout the
+        model never saw in training or non-augmented validation. Flipping
+        only the valid content window, in its original position, keeps the
+        padding exactly where the model expects it in both views. Applying
+        this same operation to a logits tensor undoes the mirroring
+        (flip-back), since flipping a fixed window twice restores its
+        original order.
+
+        ``stretch`` resize mode has no padding (the whole canvas is
+        content), so a plain full-width flip is exact there.
+        """
+        if self._resize_mode == "stretch":
+            return tensor.flip(-1)
+
+        canvas_hw = tuple(tensor.shape[-2:])
+        flipped = tensor.clone()
+        for i, info in enumerate(img_info):
+            new_h, new_w = valid_content_hw(info["orig_shape"], info["ratio"], canvas_hw)
+            flipped[i, ..., :new_h, :new_w] = tensor[i, ..., :new_h, :new_w].flip(-1)
+        return flipped
+
+    def _run_validation_augmented(self) -> None:
+        """Flip TTA: average softmax(original) and softmax(h-flip), then argmax.
+
+        Runs directly on the dataloader's already-letterboxed batch tensors
+        (unlike DetectionValidator, which reloads each image from disk to
+        recover true-original-resolution boxes). Semantic targets are dense
+        per-pixel masks already aligned 1:1 with the input tensor, so
+        flipping the batch tensor and merging in that same space is both
+        correct and far cheaper than re-deriving full-resolution masks per
+        image and resizing them back down — as long as the flip only
+        mirrors the real content and leaves letterbox padding in place
+        (see ``_flip_content``).
+        """
+        import sys
+        import time
+
+        from tqdm import tqdm
+
+        from ..utils.tta import average_flip_softmax
+
+        self.model.model.eval()
+        pbar = tqdm(
+            self.dataloader,
+            desc="Validating (TTA x2)",
+            total=len(self.dataloader),
+            disable=not self.config.verbose or not sys.stderr.isatty(),
+            file=sys.stderr,
+        )
+
+        total_start = time.time()
+
+        with torch.no_grad():
+            for batch in pbar:
+                t1 = time.time()
+                images, targets, img_info, img_ids = self._preprocess_batch(batch)
+                self.speed["preprocess"] += time.time() - t1
+
+                t2 = time.time()
+                preds_orig = self._inference(images)
+                preds_flip = self._inference(self._flip_content(images, img_info))
+                self.speed["inference"] += time.time() - t2
+
+                t3 = time.time()
+                target_hw = tuple(targets.shape[-2:])
+                logits_orig = self._extract_logits(preds_orig, target_hw)
+                logits_flip = self._flip_content(
+                    self._extract_logits(preds_flip, target_hw), img_info
+                )
+                avg_probs = average_flip_softmax(logits_orig, logits_flip)
+                detections = avg_probs.argmax(dim=1)
+                self.speed["postprocess"] += time.time() - t3
+
+                self._update_metrics(detections, targets, img_info, img_ids)
+                self.seen += len(images)
+
+        self.speed["total"] = time.time() - total_start
 
     def _update_metrics(
         self, preds: Any, targets: Any, img_info: Any, img_ids: Any = None

--- a/tests/unit/test_dinov2_semantic.py
+++ b/tests/unit/test_dinov2_semantic.py
@@ -140,6 +140,21 @@ class TestDINOv2SemanticSegmenter:
         assert result.semantic_mask is not None
         assert tuple(result.semantic_mask.data.shape) == (45, 90)
 
+    def test_wrapper_predict_augment_returns_semantic_mask(self, fake_backbone, tmp_path):
+        from libreyolo.models.dinov2.model import LibreDINOv2
+
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (90, 45), color=(50, 90, 130)).save(img_path)
+
+        m = LibreDINOv2(
+            model_path=None, size="n", task="semantic", nb_classes=3, device="cpu"
+        )
+        result = m.predict(str(img_path), imgsz=70, augment=True)
+
+        assert result.boxes is None
+        assert result.semantic_mask is not None
+        assert tuple(result.semantic_mask.data.shape) == (45, 90)
+
     def test_wrapper_class_rebuild(self, fake_backbone):
         from libreyolo.models.dinov2.model import LibreDINOv2
 

--- a/tests/unit/test_eomt.py
+++ b/tests/unit/test_eomt.py
@@ -252,6 +252,22 @@ class TestEoMTPredict:
         assert tuple(result.semantic_mask.data.shape) == (45, 90)
         assert set(torch.unique(result.semantic_mask.data).tolist()) <= {0, 1, 2}
 
+    def test_predict_augment_returns_semantic_mask(self, fake_eomt_net, tmp_path):
+        from libreyolo.models.eomt.model import LibreEoMT
+
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (90, 45), color=(50, 90, 130)).save(img_path)
+
+        model = LibreEoMT(
+            model_path=None, size="l", task="semantic", nb_classes=3, device="cpu"
+        )
+        result = model.predict(str(img_path), imgsz=512, augment=True)
+
+        assert result.boxes is None
+        assert result.semantic_mask is not None
+        assert tuple(result.semantic_mask.data.shape) == (45, 90)
+        assert set(torch.unique(result.semantic_mask.data).tolist()) <= {0, 1, 2}
+
     def test_predict_rejects_non_patch_imgsz(self, fake_eomt_net, tmp_path):
         from libreyolo.models.eomt.model import LibreEoMT
 
@@ -795,6 +811,46 @@ def test_val_smoke_uses_split_inference_path(fake_eomt_net, tmp_path):
     assert 0.0 <= metrics["metrics/mIoU"] <= 1.0
     assert "speed/preprocess_ms" in metrics
     assert (tmp_path / "val_out" / "config.yaml").exists()
+
+
+def test_val_augment_smoke(fake_eomt_net, tmp_path):
+    """augment=True must run LibreEoMT's own flip-TTA branch, not raise."""
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    for i in range(2):
+        img_dir = tmp_path / "images" / "val"
+        mask_dir = tmp_path / "masks" / "val"
+        img_dir.mkdir(parents=True, exist_ok=True)
+        mask_dir.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", (64, 64), color=(20 + i, 30, 40)).save(img_dir / f"img{i}.jpg")
+        Image.new("L", (64, 64), color=i % 2).save(mask_dir / f"img{i}.png")
+
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "val": "images/val",
+                "masks_dir": "masks",
+                "nc": 2,
+                "names": {0: "left", 1: "right"},
+            }
+        )
+    )
+    model = LibreEoMT(
+        model_path=None, size="l", task="semantic", nb_classes=2, device="cpu"
+    )
+
+    metrics = model.val(
+        data=str(yaml_path),
+        imgsz=512,
+        augment=True,
+        save_dir=str(tmp_path / "val_out"),
+        verbose=False,
+    )
+
+    assert "metrics/mIoU" in metrics
+    assert 0.0 <= metrics["metrics/mIoU"] <= 1.0
 
 
 def test_val_segment_routes_to_base_val(fake_eomt_seg_net, monkeypatch):

--- a/tests/unit/test_pidnet.py
+++ b/tests/unit/test_pidnet.py
@@ -129,6 +129,21 @@ class TestPIDNetForwardAndPredict:
         assert result.semantic_mask is not None
         assert tuple(result.semantic_mask.data.shape) == (45, 90)
 
+    def test_predict_augment_returns_semantic_mask(self, tmp_path):
+        from libreyolo.models.pidnet.model import LibrePIDNet
+
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (90, 45), color=(50, 90, 130)).save(img_path)
+
+        model = LibrePIDNet(
+            model_path=None, size="s", task="semantic", nb_classes=3, device="cpu"
+        )
+        result = model.predict(str(img_path), imgsz=64, augment=True)
+
+        assert result.boxes is None
+        assert result.semantic_mask is not None
+        assert tuple(result.semantic_mask.data.shape) == (45, 90)
+
     def test_postprocess_crops_letterbox_padding(self):
         from libreyolo.models.pidnet.model import LibrePIDNet
 

--- a/tests/unit/test_segformer.py
+++ b/tests/unit/test_segformer.py
@@ -225,6 +225,40 @@ class TestSegformerWrapper:
         assert result.semantic_mask is not None
         assert tuple(result.semantic_mask.data.shape) == (45, 90)
 
+    def test_wrapper_predict_augment_returns_semantic_mask(self, tmp_path):
+        from libreyolo.models.segformer.model import LibreSegformer
+
+        img_path = tmp_path / "img.jpg"
+        Image.new("RGB", (90, 45), color=(50, 90, 130)).save(img_path)
+
+        m = LibreSegformer(model_path=None, size="b0", task="semantic", nb_classes=3, device="cpu")
+        result = m.predict(str(img_path), imgsz=64, augment=True)
+
+        assert result.boxes is None
+        assert result.semantic_mask is not None
+        assert tuple(result.semantic_mask.data.shape) == (45, 90)
+
+    def test_val_augment_smoke(self, tmp_path):
+        """augment=True must run the shared BaseModel/SemanticValidator flip
+        TTA path, not raise the old 'does not support semantic segmentation'
+        error."""
+        from libreyolo.models.segformer.model import LibreSegformer
+
+        yaml_path = _make_semantic_yaml(tmp_path)
+        m = LibreSegformer(model_path=None, size="b0", task="semantic", nb_classes=2, device="cpu")
+
+        metrics = m.val(
+            data=str(yaml_path),
+            imgsz=64,
+            batch=2,
+            workers=0,
+            augment=True,
+            verbose=False,
+        )
+
+        assert "metrics/mIoU" in metrics
+        assert 0.0 <= metrics["metrics/mIoU"] <= 1.0
+
     def test_wrapper_class_rebuild_only_touches_classifier(self):
         from libreyolo.models.segformer.model import LibreSegformer
 

--- a/tests/unit/test_semantic_dataset.py
+++ b/tests/unit/test_semantic_dataset.py
@@ -325,3 +325,51 @@ def test_polygon_out_of_range_class_raises(tmp_path):
 
     with pytest.raises(ValueError, match="outside 0..0"):
         dataset[0]
+
+
+def test_resize_zoom_in_jitter_crops_overflow_instead_of_squashing(tmp_path, monkeypatch):
+    """Training scale jitter > 1 must resize PAST the canvas (keeping aspect) and
+    let the random crop take the overflow out — not clamp the resize to imgsz.
+
+    Both behaviours yield the same 64x64 padded canvas, so this asserts on
+    CONTENT: a marker band living only in the bottom rows of the source must be
+    cropped AWAY when we force the crop to the top of an oversized resize. If
+    the resize were clamped to imgsz instead, the whole image (band included)
+    would be squashed into the canvas and the band would survive.
+    """
+    from libreyolo.data import semantic_dataset as sd
+
+    imgsz = 64
+    orig_h, orig_w = 100, 50  # portrait, aspect 2.0
+    _write_image(tmp_path / "images" / "train" / "a.jpg", orig_w, orig_h)
+    _write_mask(tmp_path / "masks" / "train" / "a.png", np.zeros((orig_h, orig_w), np.uint8))
+    config = {
+        "path": str(tmp_path),
+        "train": str(tmp_path / "images" / "train"),
+        "masks_dir": "masks",
+        "names": {0: "bg"},
+        "nc": 1,
+    }
+    dataset = SemanticDataset(config, split="train", imgsz=imgsz, resize_mode="letterbox")
+
+    # Marker band in the bottom 10 source rows only.
+    img = np.zeros((orig_h, orig_w, 3), dtype=np.uint8)
+    img[-10:, :, :] = 255
+    mask = np.zeros((orig_h, orig_w), dtype=np.uint8)
+
+    monkeypatch.setattr(sd.random, "randint", lambda a, b: 0)  # crop from the top
+    scale = 1.5
+    img_out, _, ratio, _ = dataset._resize(img, mask, scale)
+
+    assert ratio == pytest.approx(min(imgsz / orig_h, imgsz / orig_w) * scale)
+    assert round(orig_h * ratio) > imgsz  # there IS overflow, so a crop must happen
+    assert img_out.shape[:2] == (imgsz, imgsz)
+
+    # Content is the aspect-preserving width, padded on the right.
+    content_w = round(orig_w * ratio)
+    assert content_w < imgsz
+
+    # The band lived in the bottom of the source; cropping from the top must
+    # have discarded it. A clamped (squashing) resize would keep it.
+    content = img_out[:, :content_w, :]
+    assert content.max() == 0, "bottom marker band survived: resize squashed instead of cropping"

--- a/tests/unit/test_semantic_tta.py
+++ b/tests/unit/test_semantic_tta.py
@@ -1,0 +1,119 @@
+"""Unit tests for BaseModel._predict_augment_semantic (flip TTA).
+
+Locks two behaviors: (1) the flipped view's logits are correctly flipped back
+into spatial alignment with the original view before merging, and (2) views
+are merged by averaging *softmax probabilities*, not raw logits — the two
+differ whenever per-view logit magnitudes diverge (see
+``test_merge_averages_softmax_not_raw_logits``), and softmax-then-average is
+the standard flip-TTA convention (e.g. mmsegmentation), so this is the
+contract worth pinning.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.base.model import BaseModel
+
+pytestmark = pytest.mark.unit
+
+
+def test_predict_augment_semantic_flips_logits_back_into_alignment():
+    """A content-aware stub: flipping the image must flip its raw
+    prediction, and _predict_augment_semantic must flip it back before
+    merging — otherwise the two views disagree and the merge degrades to
+    a near-uniform, ambiguous distribution instead of a confident one.
+    """
+
+    class _ContentAwareModel:
+        task = "semantic"
+        names = {0: "dark", 1: "light"}
+        device = torch.device("cpu")
+
+        def _preprocess(self, image, color_format="auto", input_size=None):
+            arr = torch.from_numpy(
+                np.asarray(image.convert("L"), dtype=np.float32).copy()
+            ).view(1, 1, image.height, image.width)
+            return arr, image, image.size, 1.0
+
+        def _forward(self, tensor):
+            return tensor
+
+        def _postprocess_semantic_logits(self, output, original_size, **kwargs):
+            dark = output < 128
+            logits = torch.zeros(1, 2, output.shape[-2], output.shape[-1])
+            logits[:, 0:1][dark] = 10.0
+            logits[:, 1:2][~dark] = 10.0
+            return logits
+
+    # Left half dark (class 0), right half light (class 1).
+    img = Image.new("L", (4, 1))
+    img.putdata([0, 0, 255, 255])
+    img = img.convert("RGB")
+
+    model = _ContentAwareModel()
+    result = BaseModel._predict_augment_semantic(
+        model,
+        img,
+        image_path=None,
+        original_size=(4, 1),
+        effective_imgsz=4,
+        color_format="auto",
+    )
+
+    assert result.semantic_mask.data.tolist() == [[0, 0, 1, 1]]
+
+
+def test_merge_averages_softmax_not_raw_logits():
+    """Constructed so raw-logit averaging and softmax averaging disagree.
+
+    view_a = [-11.48, -1.42, 9.97] -> raw argmax with view_b averages to
+    class 1, but softmax(view_a) + softmax(view_b) averages to class 2.
+    A regression to "average logits, then argmax" would silently flip this
+    test's expected class.
+    """
+
+    class _SequencedLogitsModel:
+        task = "semantic"
+        names = {0: "a", 1: "b", 2: "c"}
+        device = torch.device("cpu")
+
+        def __init__(self, views):
+            self._views = views
+            self._call = 0
+
+        def _preprocess(self, image, color_format="auto", input_size=None):
+            return torch.zeros(1, 1, 1, 1), image, image.size, 1.0
+
+        def _forward(self, tensor):
+            return tensor
+
+        def _postprocess_semantic_logits(self, output, original_size, **kwargs):
+            logits = self._views[self._call].view(1, -1, 1, 1)
+            self._call += 1
+            return logits
+
+    view_a = torch.tensor([-11.48, -1.42, 9.97])
+    view_b = torch.tensor([7.32, 7.32, -10.03])
+    raw_avg = (view_a + view_b) / 2
+    softmax_avg = (torch.softmax(view_a, dim=0) + torch.softmax(view_b, dim=0)) / 2
+    assert raw_avg.argmax().item() != softmax_avg.argmax().item()
+
+    # 1x1 image: flip(-1) on the flipped view's logits is a spatial no-op,
+    # so the call order alone controls which view is which.
+    img = Image.new("RGB", (1, 1))
+    model = _SequencedLogitsModel([view_a, view_b])
+
+    result = BaseModel._predict_augment_semantic(
+        model,
+        img,
+        image_path=None,
+        original_size=(1, 1),
+        effective_imgsz=1,
+        color_format="auto",
+    )
+
+    assert result.semantic_mask.data.item() == softmax_avg.argmax().item()

--- a/tests/unit/test_semantic_validator.py
+++ b/tests/unit/test_semantic_validator.py
@@ -76,6 +76,151 @@ class _StubSemanticModel:
         return logits
 
 
+class _ContentAwareSemanticModel(_StubSemanticModel):
+    """Predicts per-pixel class from image intensity, not tensor shape.
+
+    ``_StubSemanticModel._forward`` reads off tensor shape alone, so it
+    can't tell a flipped batch from an unflipped one — flip-TTA would be a
+    no-op either way. This stub actually looks at pixel intensity so
+    flipping the input tensor flips the raw prediction too, letting the
+    flip-back-and-average round trip in ``_run_validation_augmented`` mean
+    something.
+    """
+
+    def _forward(self, images: torch.Tensor) -> torch.Tensor:
+        intensity = images.mean(dim=1, keepdim=True)
+        dark = intensity < 0.5
+        logits = torch.zeros((images.shape[0], self.nb_classes, images.shape[2], images.shape[3]))
+        logits[:, 0:1][dark] = 10.0
+        logits[:, 1:2][~dark] = 10.0
+        return logits
+
+
+def _write_two_tone_image(path: Path, width: int, height: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img = Image.new("RGB", (width, height), color=(0, 0, 0))
+    pixels = img.load()
+    for y in range(height):
+        for x in range(width // 2, width):
+            pixels[x, y] = (255, 255, 255)
+    img.save(path)
+
+
+def test_flip_content_leaves_padding_in_place_and_mirrors_content_only():
+    """torch.flip on the whole padded canvas would move letterbox padding to
+    the wrong side for the flipped view; _flip_content must mirror only the
+    real (unpadded) content and leave padding exactly where SemanticDataset
+    put it (bottom/right — see valid_content_hw)."""
+    from types import SimpleNamespace
+
+    # Content occupies columns [0:2]; columns [2:4] are letterbox padding
+    # (marker value 99, distinct from any real content value used here).
+    tensor = torch.tensor([[[[1.0, 2.0, 99.0, 99.0]]]])
+    img_info = [{"orig_shape": (1, 2), "ratio": 1.0}]
+    fake_self = SimpleNamespace(_resize_mode="letterbox")
+
+    flipped = SemanticValidator._flip_content(fake_self, tensor, img_info)
+
+    assert flipped.tolist() == [[[[2.0, 1.0, 99.0, 99.0]]]]
+
+
+def test_flip_content_stretch_mode_flips_whole_canvas():
+    """stretch resize mode has no padding, so the whole canvas is content."""
+    from types import SimpleNamespace
+
+    tensor = torch.tensor([[[[1.0, 2.0, 3.0, 4.0]]]])
+    fake_self = SimpleNamespace(_resize_mode="stretch")
+
+    flipped = SemanticValidator._flip_content(fake_self, tensor, img_info=[{}])
+
+    assert flipped.tolist() == [[[[4.0, 3.0, 2.0, 1.0]]]]
+
+
+def test_valid_content_hw_matches_real_dataset_letterbox_boundary(tmp_path):
+    """valid_content_hw must locate exactly the boundary SemanticDataset
+    itself pads at, on a real non-square image — the historical bug only
+    manifests when padding is asymmetric (a non-square source image), since
+    a square imgsz x imgsz image has no padding to misplace."""
+    from libreyolo.data.semantic_dataset import (
+        _PAD_COLOR,
+        SemanticDataset,
+        resolve_semantic_data,
+        valid_content_hw,
+    )
+
+    orig_w, orig_h = 16, IMGSZ  # portrait: letterboxes into IMGSZ x IMGSZ
+    # with padding on the width axis only (the axis flip-TTA operates on).
+    _write_image(tmp_path / "images" / "val" / "img0.jpg", orig_w, orig_h)
+    mask = np.zeros((orig_h, orig_w), dtype=np.uint8)
+    _write_mask(tmp_path / "masks" / "val" / "img0.png", mask)
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        "\n".join(
+            [
+                f"path: {tmp_path.as_posix()}",
+                "val: images/val",
+                "masks_dir: masks",
+                "nc: 1",
+                "names:",
+                "  0: bg",
+                "",
+            ]
+        )
+    )
+    data_config = resolve_semantic_data(str(yaml_path))
+    dataset = SemanticDataset(data_config, split="val", imgsz=IMGSZ, augment=False)
+    img_tensor, _, img_info, _ = dataset[0]
+
+    new_h, new_w = valid_content_hw(
+        img_info["orig_shape"], img_info["ratio"], (IMGSZ, IMGSZ)
+    )
+
+    assert new_h == IMGSZ
+    assert new_w == orig_w
+    img_uint8 = (img_tensor * 255.0).round()
+    # Last real-content column must not be the pad color; first padding
+    # column must be exactly the pad color.
+    assert not torch.allclose(img_uint8[:, 0, new_w - 1], torch.full((3,), float(_PAD_COLOR)))
+    assert torch.allclose(img_uint8[:, 0, new_w], torch.full((3,), float(_PAD_COLOR)))
+
+
+def test_augmented_validation_matches_non_augmented_on_content_aware_model(tmp_path):
+    for i in range(2):
+        _write_two_tone_image(tmp_path / "images" / "val" / f"img{i}.jpg", IMGSZ, IMGSZ)
+        mask = np.zeros((IMGSZ, IMGSZ), dtype=np.uint8)
+        mask[:, IMGSZ // 2 :] = 1
+        _write_mask(tmp_path / "masks" / "val" / f"img{i}.png", mask)
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        "\n".join(
+            [
+                f"path: {tmp_path.as_posix()}",
+                "val: images/val",
+                "masks_dir: masks",
+                "nc: 2",
+                "names:",
+                "  0: left",
+                "  1: right",
+                "",
+            ]
+        )
+    )
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=IMGSZ,
+        batch_size=2,
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+        augment=True,
+    )
+    metrics = SemanticValidator(_ContentAwareSemanticModel(), config).run()
+
+    assert metrics["metrics/mIoU"] == pytest.approx(1.0)
+    assert metrics["metrics/pixel_accuracy"] == pytest.approx(1.0)
+
+
 def _run_validator(tmp_path, prediction: str, **overrides):
     yaml_path = _make_dataset_yaml(tmp_path)
     config = ValidationConfig(

--- a/tests/unit/test_semantic_validator.py
+++ b/tests/unit/test_semantic_validator.py
@@ -221,6 +221,119 @@ def test_augmented_validation_matches_non_augmented_on_content_aware_model(tmp_p
     assert metrics["metrics/pixel_accuracy"] == pytest.approx(1.0)
 
 
+def test_augmented_validation_keeps_padding_on_the_right_for_nonsquare_input(tmp_path):
+    """End-to-end guard for the letterbox-padding bug on a NON-SQUARE image.
+
+    A pixelwise stub cannot catch a naive whole-canvas flip end-to-end (flip
+    then flip-back cancels for any permutation-equivariant model), and a square
+    image has no padding to misplace — so neither existing test would notice if
+    ``_flip_content`` regressed to ``tensor.flip(-1)``. Instead, capture the
+    tensors the model is actually fed and assert the flipped view still has its
+    letterbox padding on the RIGHT, where every non-TTA code path puts it. A
+    whole-canvas flip would relocate it to the left and fail here.
+    """
+    from libreyolo.data.semantic_dataset import _PAD_COLOR
+
+    content_w = IMGSZ // 2  # portrait -> pads on the width axis, which flip touches
+
+    class _RecordingModel(_ContentAwareSemanticModel):
+        def __init__(self):
+            super().__init__()
+            self.seen_inputs = []
+
+        def _forward(self, images: torch.Tensor) -> torch.Tensor:
+            self.seen_inputs.append(images.clone())
+            return super()._forward(images)
+
+    for i in range(2):
+        img = Image.new("RGB", (content_w, IMGSZ), color=(30, 60, 90))  # dark -> class 0
+        pixels = img.load()
+        for y in range(IMGSZ):
+            for x in range(content_w // 2, content_w):
+                pixels[x, y] = (255, 255, 255)  # light -> class 1
+        path = tmp_path / "images" / "val" / f"img{i}.jpg"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        img.save(path)
+
+        mask = np.zeros((IMGSZ, content_w), dtype=np.uint8)
+        mask[:, content_w // 2 :] = 1
+        _write_mask(tmp_path / "masks" / "val" / f"img{i}.png", mask)
+
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        "\n".join(
+            [
+                f"path: {tmp_path.as_posix()}",
+                "val: images/val",
+                "masks_dir: masks",
+                "nc: 2",
+                "names:",
+                "  0: left",
+                "  1: right",
+                "",
+            ]
+        )
+    )
+    config = ValidationConfig(
+        data=str(yaml_path),
+        imgsz=IMGSZ,
+        batch_size=2,
+        device="cpu",
+        num_workers=0,
+        verbose=False,
+        save_dir=str(tmp_path / "runs"),
+        augment=True,
+    )
+    model = _RecordingModel()
+    metrics = SemanticValidator(model, config).run()
+
+    # BaseValidator._warmup_model fires dummy forwards first; the real batch is
+    # the last two calls (one original view + one flipped view).
+    assert len(model.seen_inputs) >= 2
+    original, flipped = model.seen_inputs[-2:]
+    pad_value = _PAD_COLOR / 255.0
+
+    # Sanity: the un-augmented view is letterboxed with padding on the right.
+    assert torch.allclose(
+        original[:, :, :, content_w:], torch.full_like(original[:, :, :, content_w:], pad_value), atol=1e-2
+    )
+
+    # The contract: the flipped view's padding is STILL on the right. A naive
+    # tensor.flip(-1) would put pad_value in columns [0:content_w) instead.
+    assert torch.allclose(
+        flipped[:, :, :, content_w:], torch.full_like(flipped[:, :, :, content_w:], pad_value), atol=1e-2
+    )
+    # ...and its real content is the mirror of the original's real content.
+    assert torch.allclose(
+        flipped[:, :, :, :content_w], original[:, :, :, :content_w].flip(-1)
+    )
+
+    assert metrics["metrics/mIoU"] == pytest.approx(1.0)
+
+
+def test_flip_content_rejects_unknown_resize_mode():
+    """Modes whose padding this window math does not model must fail loudly
+    (EoMT's "split", say) rather than silently mirror the wrong region."""
+    from types import SimpleNamespace
+
+    fake_self = SimpleNamespace(_resize_mode="split")
+    with pytest.raises(ValueError, match="split"):
+        SemanticValidator._flip_content(
+            fake_self, torch.zeros(1, 1, 1, 4), [{"orig_shape": (1, 2), "ratio": 1.0}]
+        )
+
+
+def test_extract_logits_upcasts_half_precision_at_target_resolution():
+    """Under half=True a model whose logits already sit at target_hw must not
+    carry fp16 into the softmax merge."""
+    from types import SimpleNamespace
+
+    half_logits = torch.zeros(1, 2, 4, 4, dtype=torch.float16)
+    out = SemanticValidator._extract_logits(SimpleNamespace(), half_logits, (4, 4))
+
+    assert out.dtype == torch.float32
+
+
 def _run_validator(tmp_path, prediction: str, **overrides):
     yaml_path = _make_dataset_yaml(tmp_path)
     config = ValidationConfig(


### PR DESCRIPTION
# Add horizontal-flip TTA for semantic segmentation

## Code provenance

Original code written for this PR. The flip-TTA merge policy (average
softmax probabilities of the original and horizontally-flipped views, not
raw logits) follows the standard convention used by e.g. mmsegmentation's
flip-test augmentation — no code was copied from it.

## Summary

`augment=True` (flip test-time augmentation) previously raised
"... does not support semantic segmentation yet" for every semantic model.
This adds real flip-TTA support across all four semantic families:

- **`BaseModel._predict_augment_semantic`**: new flip-only TTA path for
  single-image `predict(..., augment=True)`.
- **`SemanticValidator._run_validation_augmented`**: batched flip-TTA for
  `val(..., augment=True)` on SegFormer / PIDNet / DINOv2. Flips only the
  real (unpadded) content of each letterboxed image and leaves padding in
  place — a naive whole-tensor flip would relocate letterbox padding to the
  wrong side for non-square inputs, feeding the model a layout it never saw
  in training. New `valid_content_hw()` helper in `semantic_dataset.py` is
  shared with `SemanticDataset._resize` so the two can't drift apart.
- **`LibreEoMT.val()`**: its own bespoke per-image validation loop got a
  matching `augment=True` branch (it doesn't use `SemanticValidator`).
- Each family's `_postprocess` was refactored to expose a
  `_postprocess_semantic_logits()` hook (pre-argmax logits) — a pure
  extraction, no behavior change for the non-TTA path.
- The softmax-average-merge math lives in one place now:
  `libreyolo/utils/tta.py::average_flip_softmax`, used by all three call
  sites above.

## Results

Full ADE20K val split, RTX 3090, `scripts/val_semantic_augment_compare.py`:

| model | augment | mIoU | pixel acc. | time |
|---|---|---|---|---|
| SegFormer-b0 | off | 0.3653 | 0.7700 | 20.9s |
| SegFormer-b0 | **on** | **0.3683** (+0.0029) | **0.7722** (+0.0022) | 46.7s |
| EoMT-L | off | 0.5838 | 0.8668 | 228.4s |
| EoMT-L | **on** | **0.5893** (+0.0055) | **0.8684** (+0.0016) | 449.4s |

Small, consistent mIoU gains from flip TTA on both families, at ~2x
inference cost (expected — two forward passes per image). PIDNet has no
shipped semantic weights yet and DINOv2 has no published HF repo, so
neither could be validated end-to-end; both are wired into the same code
paths and covered by unit tests.

## Test plan

- [x] `pytest tests/unit -m unit` — 3240 passed, 0 failures
- [x] New tests: `test_semantic_tta.py` (flip-alignment + softmax-vs-raw-logit
      merge contract), `SemanticValidator` TTA + letterbox-boundary tests,
      one `augment=True` smoke test per family in each of
      `test_{segformer,eomt,pidnet,dinov2_semantic}.py`
- [x] Real end-to-end validation on ADE20K for SegFormer-b0 and EoMT-L (see
      Results above)
