### PR TITLE
Shard DDP batches in trainers that own their data pipeline (#484)

### DIFF
--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -422,14 +422,37 @@ class DEIMTrainer(BaseTrainer):
 
             collate_fn = yolox_collate_fn
 
+        # ``batch`` is the global batch under DDP. Each rank's loader is built
+        # with ``batch // world_size`` over a DistributedSampler shard.
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        train_sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            train_sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_dataset) >= self.world_size,
+            )
+
+        # Under DDP each rank only sees ``len(sampler)`` samples, so base the
+        # drop_last decision on the per-rank visible count. Otherwise a small
+        # dataset split across ranks could drop every rank's only partial
+        # batch and leave zero iterations.
+        visible_samples = (
+            len(train_sampler) if train_sampler is not None else len(train_dataset)
+        )
         self.train_loader = DataLoader(
             train_dataset,
-            batch_size=self.config.batch,
+            batch_size=per_rank_batch,
             num_workers=self.config.workers,
-            shuffle=True,
+            shuffle=train_sampler is None,
+            sampler=train_sampler,
             pin_memory=True,
             collate_fn=collate_fn,
-            drop_last=True,
+            drop_last=visible_samples >= per_rank_batch,
         )
 
         return train_dataset
@@ -455,6 +478,11 @@ class DEIMTrainer(BaseTrainer):
             return self._train_epoch_accum(epoch)
 
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
@@ -557,6 +585,11 @@ class DEIMTrainer(BaseTrainer):
         the optimizer step, clipping, EMA and LR update fire once per window.
         """
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -471,14 +471,37 @@ class DFINETrainer(BaseTrainer):
                 )
             collate_fn = yolox_collate_fn
 
+        # ``batch`` is the global batch under DDP. Each rank's loader is built
+        # with ``batch // world_size`` over a DistributedSampler shard.
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        train_sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            train_sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_dataset) >= self.world_size,
+            )
+
+        # Under DDP each rank only sees ``len(sampler)`` samples, so base the
+        # drop_last decision on the per-rank visible count. Otherwise a small
+        # dataset split across ranks could drop every rank's only partial
+        # batch and leave zero iterations.
+        visible_samples = (
+            len(train_sampler) if train_sampler is not None else len(train_dataset)
+        )
         self.train_loader = DataLoader(
             train_dataset,
-            batch_size=self.config.batch,
+            batch_size=per_rank_batch,
             num_workers=self.config.workers,
-            shuffle=True,
+            shuffle=train_sampler is None,
+            sampler=train_sampler,
             pin_memory=True,
             collate_fn=collate_fn,
-            drop_last=True,
+            drop_last=visible_samples >= per_rank_batch,
         )
 
         return train_dataset
@@ -504,6 +527,11 @@ class DFINETrainer(BaseTrainer):
             return self._train_epoch_accum(epoch)
 
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
@@ -606,6 +634,11 @@ class DFINETrainer(BaseTrainer):
         the optimizer step, clipping, EMA and LR update fire once per window.
         """
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -164,7 +164,23 @@ class YOLONASPoseTrainer(BaseTrainer):
             affine_interpolation=self.config.affine_interpolation,
         )
         train_ds = self._build_dataset(train_imgs, train_lbls, train_tf)
-        drop_last = len(train_ds) >= self.config.batch
+        # ``batch`` is the global batch under DDP. Each rank's loader is built
+        # with ``batch // world_size`` over a DistributedSampler shard.
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        train_sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            train_sampler = DistributedSampler(
+                train_ds,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_ds) >= self.world_size,
+            )
+
+        visible_samples = len(train_sampler) if train_sampler is not None else len(train_ds)
+        drop_last = visible_samples >= per_rank_batch
         loader_kwargs = {}
         if self.config.workers > 0:
             loader_kwargs.update(
@@ -174,8 +190,9 @@ class YOLONASPoseTrainer(BaseTrainer):
             )
         self.train_loader = DataLoader(
             train_ds,
-            batch_size=self.config.batch,
-            shuffle=True,
+            batch_size=per_rank_batch,
+            shuffle=train_sampler is None,
+            sampler=train_sampler,
             num_workers=self.config.workers,
             pin_memory=self.config.pin_memory,
             drop_last=drop_last,
@@ -197,7 +214,7 @@ class YOLONASPoseTrainer(BaseTrainer):
             )
             self.val_loader = DataLoader(
                 val_ds,
-                batch_size=self.config.batch,
+                batch_size=per_rank_batch,
                 shuffle=False,
                 num_workers=self.config.workers,
                 pin_memory=self.config.pin_memory,
@@ -214,7 +231,12 @@ class YOLONASPoseTrainer(BaseTrainer):
             )
 
         logger.info("Training dataset: %d images", len(train_ds))
-        logger.info("Iterations per epoch: %d", len(self.train_loader))
+        logger.info(
+            "Iterations per epoch: %d (batch_per_rank=%d, world_size=%d)",
+            len(self.train_loader),
+            per_rank_batch,
+            self.world_size,
+        )
         return train_ds
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -263,11 +263,23 @@ class YOLONASPoseTrainer(BaseTrainer):
             "pose_reg": log_losses[4],
         }
 
-    def _validate_epoch(self, epoch: int):
-        if getattr(self, "val_loader", None) is None:
+    def _validate_epoch(self, epoch: int, *, save_plots: bool | None = None):
+        from ...training.distributed import barrier, is_main_process, unwrap_model
+
+        # Validation runs on rank 0 only, mirroring BaseTrainer._validate_epoch:
+        # concurrent ranks write predictions.json into the shared save_dir and
+        # corrupt the JSON another rank is reading (issue #484). Non-zero ranks
+        # barrier-wait so the next epoch's set_epoch fires in lockstep.
+        if self.is_distributed and not is_main_process():
+            barrier()
             return None
 
-        model = self.ema_model.ema if self.ema_model else self.model
+        if getattr(self, "val_loader", None) is None:
+            if self.is_distributed:
+                barrier()
+            return None
+
+        model = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
         was_training = model.training
         model.eval()
 
@@ -286,6 +298,8 @@ class YOLONASPoseTrainer(BaseTrainer):
         finally:
             if was_training:
                 model.train()
+            if self.is_distributed:
+                barrier()
 
         avg_loss = total_loss / max(num_batches, 1)
         metrics = {"loss/val": avg_loss}

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -1,0 +1,225 @@
+"""DDP loader sharding for trainers that own their data pipeline.
+
+``batch`` is the global batch under DDP: each rank's loader must be built
+with ``batch // world_size`` over a DistributedSampler shard. Regression
+coverage for issue #484 where multi-GPU YOLO-NAS-Pose (and the DEIM/D-FINE
+trainers, inherited by DEIMv2/RT-DETRv4/EC) put the full global batch and
+the full dataset on every rank.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data.distributed import DistributedSampler
+
+cv2 = pytest.importorskip("cv2")
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Dataset fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_pose_dataset(tmp_path, num_keypoints=4, num_samples=4):
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    for i in range(num_samples):
+        cv2.imwrite(
+            str(img_dir / f"sample{i}.jpg"),
+            np.full((480, 640, 3), 127, dtype=np.uint8),
+        )
+        row = ["0", "0.5", "0.5", "0.3", "0.4"]
+        for k in range(num_keypoints):
+            row += [f"{0.4 + 0.02 * k:.3f}", f"{0.45 + 0.02 * k:.3f}", "2"]
+        (lbl_dir / f"sample{i}.txt").write_text(" ".join(row) + "\n")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "train": "images/train",
+                "names": ["object"],
+                "kpt_shape": [num_keypoints, 3],
+            }
+        )
+    )
+    return data_yaml
+
+
+def _write_detect_dataset(tmp_path, num_samples=4):
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    for i in range(num_samples):
+        cv2.imwrite(
+            str(img_dir / f"sample{i}.jpg"),
+            np.full((480, 640, 3), 127, dtype=np.uint8),
+        )
+        (lbl_dir / f"sample{i}.txt").write_text("0 0.5 0.5 0.3 0.4\n")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "train": "images/train",
+                "nc": 1,
+                "names": ["object"],
+            }
+        )
+    )
+    return data_yaml
+
+
+def _fake_two_rank_ddp(trainer, rank=0):
+    """Make the trainer believe it is rank ``rank`` of a 2-rank run.
+
+    ``DistributedSampler`` takes explicit ``num_replicas``/``rank`` so no
+    process group is required for loader wiring.
+    """
+    trainer.is_distributed = True
+    trainer.world_size = 2
+    trainer.rank = rank
+    trainer.local_rank = rank
+
+
+# ---------------------------------------------------------------------------
+# YOLO-NAS-Pose
+# ---------------------------------------------------------------------------
+
+
+def _build_pose_trainer(data_yaml, **overrides):
+    from libreyolo.models.yolonas.pose_trainer import YOLONASPoseTrainer
+
+    kwargs = dict(
+        model=torch.nn.Identity(),
+        size="s",
+        num_keypoints=4,
+        data=str(data_yaml),
+        batch=4,
+        workers=0,
+        device="cpu",
+    )
+    kwargs.update(overrides)
+    return YOLONASPoseTrainer(**kwargs)
+
+
+def test_yolonas_pose_loader_shards_batch_across_ranks(tmp_path):
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer)
+
+    trainer._setup_data()
+
+    assert isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 2
+    # 4 samples / 2 ranks / per-rank batch 2 = 1 iteration per rank.
+    assert len(trainer.train_loader) == 1
+
+
+def test_yolonas_pose_single_process_loader_unchanged(tmp_path):
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+
+    trainer._setup_data()
+
+    assert not isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 4
+
+
+# ---------------------------------------------------------------------------
+# DEIM / D-FINE (inherited by DEIMv2, RT-DETRv4, EC-detect)
+# ---------------------------------------------------------------------------
+
+
+def _build_detr_trainer(trainer_cls, data_yaml, **overrides):
+    kwargs = dict(
+        model=torch.nn.Identity(),
+        size="n",
+        num_classes=1,
+        data=str(data_yaml),
+        epochs=1,
+        batch=4,
+        imgsz=640,
+        device="cpu",
+        amp=False,
+        ema=False,
+        workers=0,
+        eval_interval=-1,
+    )
+    kwargs.update(overrides)
+    return trainer_cls(**kwargs)
+
+
+def _detr_trainer_classes():
+    from libreyolo.models.deim.trainer import DEIMTrainer
+    from libreyolo.models.dfine.trainer import DFINETrainer
+
+    return {"deim": DEIMTrainer, "dfine": DFINETrainer}
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_loader_shards_batch_across_ranks(tmp_path, family):
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml)
+    _fake_two_rank_ddp(trainer)
+
+    trainer._setup_data()
+
+    assert isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 2
+    assert len(trainer.train_loader) == 1
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_single_process_loader_unchanged(tmp_path, family):
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml)
+
+    trainer._setup_data()
+
+    assert not isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 4
+
+
+class _SpySampler(DistributedSampler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.epochs = []
+
+    def set_epoch(self, epoch):
+        self.epochs.append(epoch)
+        super().set_epoch(epoch)
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_train_epoch_sets_sampler_epoch(tmp_path, family):
+    """The DEIM/D-FINE ``_train_epoch`` overrides must set the sampler epoch
+    like ``BaseTrainer._train_epoch`` does, or every DDP epoch reuses the
+    same shuffle order.
+    """
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path)
+    model = torch.nn.Linear(2, 2)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml, model=model)
+
+    empty_ds = TensorDataset(torch.empty(0, 2))
+    sampler = _SpySampler(empty_ds, num_replicas=2, rank=0, shuffle=True)
+    trainer.train_loader = DataLoader(empty_ds, batch_size=1, sampler=sampler)
+    trainer.optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    trainer._train_epoch(epoch=3)
+
+    assert sampler.epochs == [3]

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -194,6 +194,69 @@ def test_detr_single_process_loader_unchanged(tmp_path, family):
     assert trainer.train_loader.batch_size == 4
 
 
+# ---------------------------------------------------------------------------
+# YOLO-NAS-Pose validation gating
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingLoader:
+    """Iterating this loader means the rank ran validation when it must not."""
+
+    def __iter__(self):
+        raise AssertionError("validation ran on a non-main rank")
+
+
+def test_yolonas_pose_validation_skipped_on_non_main_rank(tmp_path, monkeypatch):
+    """Every rank used to run pose mAP validation, racing on the shared
+    save_dir's predictions.json (issue #484 screenshots). Non-zero ranks must
+    barrier and return without validating.
+    """
+    import libreyolo.training.distributed as dist_mod
+
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer, rank=1)
+    trainer.val_loader = _ExplodingLoader()
+
+    barrier_calls = []
+    monkeypatch.setattr(dist_mod, "barrier", lambda: barrier_calls.append(1))
+    monkeypatch.setattr(dist_mod, "is_main_process", lambda: False)
+
+    result = trainer._validate_epoch(0)
+
+    assert result is None
+    assert barrier_calls == [1]
+
+
+def test_yolonas_pose_main_rank_barriers_after_validation(tmp_path, monkeypatch):
+    import libreyolo.training.distributed as dist_mod
+
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer, rank=0)
+    trainer.val_loader = None
+
+    barrier_calls = []
+    monkeypatch.setattr(dist_mod, "barrier", lambda: barrier_calls.append(1))
+    monkeypatch.setattr(dist_mod, "is_main_process", lambda: True)
+
+    result = trainer._validate_epoch(0)
+
+    assert result is None
+    assert barrier_calls == [1]
+
+
+def test_yolonas_pose_validate_epoch_accepts_save_plots(tmp_path):
+    """BaseTrainer calls ``_validate_epoch(epoch, save_plots=True)`` on the
+    final epoch when save_plots is set; the override must accept the kwarg.
+    """
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    trainer.val_loader = None
+
+    assert trainer._validate_epoch(0, save_plots=True) is None
+
+
 class _SpySampler(DistributedSampler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -183,7 +183,7 @@ def test_detr_loader_shards_batch_across_ranks(tmp_path, family):
 
 
 @pytest.mark.parametrize("family", ["deim", "dfine"])
-def test_detr_single_process_loader_unchanged(tmp_path, family):
+def test_detr_single_process_batch_and_sampler_unchanged(tmp_path, family):
     trainer_cls = _detr_trainer_classes()[family]
     data_yaml = _write_detect_dataset(tmp_path)
     trainer = _build_detr_trainer(trainer_cls, data_yaml)
@@ -192,6 +192,25 @@ def test_detr_single_process_loader_unchanged(tmp_path, family):
 
     assert not isinstance(trainer.train_loader.sampler, DistributedSampler)
     assert trainer.train_loader.batch_size == 4
+    # 4 samples at batch 4: exactly one full batch survives drop_last.
+    assert len(trainer.train_loader) == 1
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_dataset_smaller_than_batch_keeps_partial_batch(tmp_path, family):
+    """Deliberate behavior change from unconditional ``drop_last=True``: a
+    dataset smaller than ``batch`` used to yield ZERO training iterations
+    silently. It now keeps the partial batch, matching BaseTrainer's
+    visible-count drop_last policy.
+    """
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path, num_samples=2)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml)
+
+    trainer._setup_data()
+
+    assert trainer.train_loader.drop_last is False
+    assert len(trainer.train_loader) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #484: kaiwen0901 reported (comment updated with screenshots) two multi-GPU YOLONAS-Pose problems:

1. With the same `batch`, per-GPU memory in multi-GPU training matches single-GPU training: the batch is not split across ranks.
2. Occasional `Pose mAP validation failed at epoch N: Expecting ',' delimiter: line 1 column 47009224` errors during training.

### Bug 1: DDP batch not sharded

Three trainers override `_setup_data` with their own `DataLoader` construction and skipped the DDP sharding that `BaseTrainer._setup_data` does:

- `libreyolo/models/yolonas/pose_trainer.py` (the reported case)
- `libreyolo/models/deim/trainer.py` (inherited by DEIMv2 and RT-DETRv4)
- `libreyolo/models/dfine/trainer.py` (inherited by EC detect)

Under DDP each rank built its loader with the full global `batch` and no `DistributedSampler`, so every rank loaded the entire dataset with the entire batch: N times the intended effective batch, N times the intended epoch length, and per-GPU memory identical to single-GPU, exactly as reported.

### Bug 2: validation raced across ranks

`YOLONASPoseTrainer._validate_epoch` was missing the rank-0 gate + barriers that `BaseTrainer._validate_epoch` and the EC pose trainer have. Every rank ran pose mAP validation concurrently, all writing `predictions.json` / `ground_truth_yolo_pose.json` into the same broadcast `save_dir`; pycocotools then read half-written JSON, producing the reported errors. Not harmless: whenever rank 0 lost the race, that epoch's keypoint mAP was dropped and best.pt selection silently fell back to val loss, plus N-fold redundant validation work per eval epoch. The override also didn't accept the `save_plots` kwarg that BaseTrainer passes on the final epoch when `save_plots` is set (TypeError).

## Changes

- Each rank's train loader is now built with `batch // world_size` over a `DistributedSampler` shard, mirroring `BaseTrainer._setup_data` and `ec/pose_trainer.py` (including the per-rank-visible-count `drop_last` guard so tiny datasets keep at least one iteration).
- The DEIM/D-FINE `_train_epoch` / `_train_epoch_accum` overrides now call `sampler.set_epoch(epoch)` like the base loop, so DDP shuffling differs per epoch. The guard duck-types on the sampler so single-process runs are unaffected. (YOLONAS-Pose uses the base epoch loop, which already handles it.)
- `YOLONASPoseTrainer._validate_epoch` now gates to rank 0 with the same barrier lockstep as the EC pose trainer, accepts `save_plots`, and unwraps the DDP-wrapped model.
- New wiring tests in `tests/unit/test_ddp_loader_sharding.py`: per-rank batch and sampler type for all three trainers under a faked 2-rank setup, single-process behavior unchanged, `set_epoch` propagation in the DEIM/D-FINE epoch overrides, and validation rank-gating (non-main rank barriers and returns without validating; `save_plots` accepted).

## Behavior note

Anyone who tuned multi-GPU runs around the old (broken) semantics effectively trained with `batch * num_gpus`; after this fix they should raise `batch` accordingly to reproduce those runs.

## Testing

- `tests/unit/test_ddp_loader_sharding.py` (11 new tests) pass.
- `test_yolonas_pose_training.py`, `test_yolonas_multiclass_pose.py`, `test_yolonas_pose.py`, `test_deim_trainer_smoke.py`, `test_dfine_trainer_smoke.py`, `test_deimv2_trainer.py`, `test_ec_pose.py`, `test_deim.py`, `test_dfine_seg.py`, `test_dfine_validation.py`, `test_ddp_distributed.py`, `test_ddp_syncbn.py` all pass locally.

## Code provenance

All changes written from scratch for this PR, mirroring existing LibreYOLO patterns (`BaseTrainer._setup_data`, `BaseTrainer._validate_epoch`, and `libreyolo/models/ec/pose_trainer.py`). No external code consulted or copied.