### PR TITLE
Shard DDP batches and make pose validation DDP-safe (#484)

### DIFF
--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -422,14 +422,37 @@ class DEIMTrainer(BaseTrainer):
 
             collate_fn = yolox_collate_fn
 
+        # ``batch`` is the global batch under DDP. Each rank's loader is built
+        # with ``batch // world_size`` over a DistributedSampler shard.
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        train_sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            train_sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_dataset) >= self.world_size,
+            )
+
+        # Under DDP each rank only sees ``len(sampler)`` samples, so base the
+        # drop_last decision on the per-rank visible count. Otherwise a small
+        # dataset split across ranks could drop every rank's only partial
+        # batch and leave zero iterations.
+        visible_samples = (
+            len(train_sampler) if train_sampler is not None else len(train_dataset)
+        )
         self.train_loader = DataLoader(
             train_dataset,
-            batch_size=self.config.batch,
+            batch_size=per_rank_batch,
             num_workers=self.config.workers,
-            shuffle=True,
+            shuffle=train_sampler is None,
+            sampler=train_sampler,
             pin_memory=True,
             collate_fn=collate_fn,
-            drop_last=True,
+            drop_last=visible_samples >= per_rank_batch,
         )
 
         return train_dataset
@@ -455,6 +478,11 @@ class DEIMTrainer(BaseTrainer):
             return self._train_epoch_accum(epoch)
 
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
@@ -557,6 +585,11 @@ class DEIMTrainer(BaseTrainer):
         the optimizer step, clipping, EMA and LR update fire once per window.
         """
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -471,14 +471,37 @@ class DFINETrainer(BaseTrainer):
                 )
             collate_fn = yolox_collate_fn
 
+        # ``batch`` is the global batch under DDP. Each rank's loader is built
+        # with ``batch // world_size`` over a DistributedSampler shard.
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        train_sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            train_sampler = DistributedSampler(
+                train_dataset,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_dataset) >= self.world_size,
+            )
+
+        # Under DDP each rank only sees ``len(sampler)`` samples, so base the
+        # drop_last decision on the per-rank visible count. Otherwise a small
+        # dataset split across ranks could drop every rank's only partial
+        # batch and leave zero iterations.
+        visible_samples = (
+            len(train_sampler) if train_sampler is not None else len(train_dataset)
+        )
         self.train_loader = DataLoader(
             train_dataset,
-            batch_size=self.config.batch,
+            batch_size=per_rank_batch,
             num_workers=self.config.workers,
-            shuffle=True,
+            shuffle=train_sampler is None,
+            sampler=train_sampler,
             pin_memory=True,
             collate_fn=collate_fn,
-            drop_last=True,
+            drop_last=visible_samples >= per_rank_batch,
         )
 
         return train_dataset
@@ -504,6 +527,11 @@ class DFINETrainer(BaseTrainer):
             return self._train_epoch_accum(epoch)
 
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)
@@ -606,6 +634,11 @@ class DFINETrainer(BaseTrainer):
         the optimizer step, clipping, EMA and LR update fire once per window.
         """
         # 1. Epoch propagation.
+        # DistributedSampler needs its epoch set so shuffling differs per
+        # epoch while staying deterministic for resume.
+        sampler = getattr(self.train_loader, "sampler", None)
+        if hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(epoch)
         ds = self.train_loader.dataset
         if hasattr(ds, "set_epoch"):
             ds.set_epoch(epoch)

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -398,10 +398,6 @@ class ECPoseTrainer(BaseTrainer):
     def _validate_epoch(self, epoch: int, *, save_plots: bool | None = None):
         from ...training.distributed import barrier, is_main_process, unwrap_model
 
-        if self.is_distributed and not is_main_process():
-            barrier()
-            return None
-
         if getattr(self, "val_loader", None) is None:
             if self.is_distributed:
                 barrier()
@@ -414,6 +410,11 @@ class ECPoseTrainer(BaseTrainer):
         total_loss, num_batches = 0.0, 0
         pose_metrics = None
         try:
+            # The val-loss pass runs on EVERY rank: the criterion all-reduces
+            # its box normalizer (a collective), so a rank-0-only pass would
+            # pair rank 0's all_reduce with the other ranks' barrier and
+            # deadlock. The val loader is identical on all ranks, so
+            # collectives align.
             with torch.no_grad():
                 for batch in self.val_loader:
                     imgs = batch[0].to(self.device, non_blocking=True)
@@ -431,12 +432,17 @@ class ECPoseTrainer(BaseTrainer):
                     model.eval()
                     total_loss += float(sum(losses.values()).item())
                     num_batches += 1
-            pose_metrics = self._run_pose_metric_validation(model, epoch)
+            # Only rank 0 runs the file-writing pose mAP validator.
+            if not self.is_distributed or is_main_process():
+                pose_metrics = self._run_pose_metric_validation(model, epoch)
         finally:
             if was_training:
                 model.train()
             if self.is_distributed:
                 barrier()
+
+        if self.is_distributed and not is_main_process():
+            return None
 
         avg_loss = total_loss / max(num_batches, 1)
         metrics = {"loss/val": avg_loss}

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -494,7 +494,11 @@ class ECPoseTrainer(BaseTrainer):
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
-                batch_size=self.config.batch,
+                # Global batch / world_size, like BaseTrainer._run_validation:
+                # this runs on rank 0 alone, and the global batch is sized for
+                # world_size GPUs. An OOM here is swallowed by the except
+                # below, silently dropping the epoch's keypoint mAP.
+                batch_size=max(1, self.config.batch // max(self.world_size, 1)),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,
                 iou_thres=0.65,

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -494,10 +494,11 @@ class ECPoseTrainer(BaseTrainer):
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
-                # Global batch / world_size, like BaseTrainer._run_validation:
-                # this runs on rank 0 alone, and the global batch is sized for
-                # world_size GPUs. An OOM here is swallowed by the except
-                # below, silently dropping the epoch's keypoint mAP.
+                # Rank-local capacity, matching BaseTrainer._run_validation.
+                # No runtime effect today: PoseValidator runs per-image
+                # inference and ignores batch_size. Kept consistent so a
+                # future batched PoseValidator doesn't inherit the global
+                # batch on the single rank that runs it.
                 batch_size=max(1, self.config.batch // max(self.world_size, 1)),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -434,7 +434,9 @@ class ECPoseTrainer(BaseTrainer):
                     num_batches += 1
             # Only rank 0 runs the file-writing pose mAP validator.
             if not self.is_distributed or is_main_process():
-                pose_metrics = self._run_pose_metric_validation(model, epoch)
+                pose_metrics = self._run_pose_metric_validation(
+                    model, epoch, save_plots=save_plots
+                )
         finally:
             if was_training:
                 model.train()
@@ -474,13 +476,21 @@ class ECPoseTrainer(BaseTrainer):
             "metrics": metrics,
         }
 
-    def _run_pose_metric_validation(self, eval_model, epoch: int):
+    def _run_pose_metric_validation(
+        self, eval_model, epoch: int, *, save_plots: bool | None = None
+    ):
         if self.wrapper_model is None:
             logger.warning("Skipping pose mAP validation: wrapper_model is missing")
             return None
         try:
             from libreyolo.validation import PoseValidator, ValidationConfig
 
+            val_save_plots = (
+                bool(save_plots)
+                if save_plots is not None
+                else bool(getattr(self.config, "save_plots", False))
+                and self._is_final_epoch(epoch)
+            )
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
@@ -494,6 +504,7 @@ class ECPoseTrainer(BaseTrainer):
                 num_workers=self.config.workers,
                 allow_download_scripts=self.config.allow_download_scripts,
                 oks_sigmas=self._resolve_oks_sigmas(),
+                save_plots=val_save_plots,
                 save_dir=str(self.save_dir / "val"),
             )
             original_model = self.wrapper_model.model

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -266,14 +266,6 @@ class YOLONASPoseTrainer(BaseTrainer):
     def _validate_epoch(self, epoch: int, *, save_plots: bool | None = None):
         from ...training.distributed import barrier, is_main_process, unwrap_model
 
-        # Validation runs on rank 0 only, mirroring BaseTrainer._validate_epoch:
-        # concurrent ranks write predictions.json into the shared save_dir and
-        # corrupt the JSON another rank is reading (issue #484). Non-zero ranks
-        # barrier-wait so the next epoch's set_epoch fires in lockstep.
-        if self.is_distributed and not is_main_process():
-            barrier()
-            return None
-
         if getattr(self, "val_loader", None) is None:
             if self.is_distributed:
                 barrier()
@@ -286,6 +278,10 @@ class YOLONASPoseTrainer(BaseTrainer):
         total_loss, num_batches = 0.0, 0
         pose_metrics = None
         try:
+            # The val-loss pass runs on EVERY rank: YoloNASPoseLoss all-reduces
+            # its normalizer (a collective), so a rank-0-only pass would pair
+            # rank 0's all_reduce with the other ranks' barrier and deadlock.
+            # The val loader is identical on all ranks, so collectives align.
             with torch.no_grad():
                 for batch in self.val_loader:
                     imgs = batch[0].to(self.device, non_blocking=True)
@@ -294,14 +290,21 @@ class YOLONASPoseTrainer(BaseTrainer):
                     total_loss += float(loss.item())
                     num_batches += 1
 
-            pose_metrics = self._run_pose_metric_validation(
-                model, epoch, save_plots=save_plots
-            )
+            # Only rank 0 runs the file-writing pose mAP validator: concurrent
+            # ranks writing predictions.json into the shared save_dir corrupt
+            # the JSON another rank is reading (issue #484).
+            if not self.is_distributed or is_main_process():
+                pose_metrics = self._run_pose_metric_validation(
+                    model, epoch, save_plots=save_plots
+                )
         finally:
             if was_training:
                 model.train()
             if self.is_distributed:
                 barrier()
+
+        if self.is_distributed and not is_main_process():
+            return None
 
         avg_loss = total_loss / max(num_batches, 1)
         metrics = {"loss/val": avg_loss}

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -359,7 +359,11 @@ class YOLONASPoseTrainer(BaseTrainer):
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
-                batch_size=self.config.batch,
+                # Global batch / world_size, like BaseTrainer._run_validation:
+                # this runs on rank 0 alone, and the global batch is sized for
+                # world_size GPUs. An OOM here is swallowed by the except
+                # below, silently dropping the epoch's keypoint mAP.
+                batch_size=max(1, self.config.batch // max(self.world_size, 1)),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,
                 iou_thres=0.65,

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -164,7 +164,23 @@ class YOLONASPoseTrainer(BaseTrainer):
             affine_interpolation=self.config.affine_interpolation,
         )
         train_ds = self._build_dataset(train_imgs, train_lbls, train_tf)
-        drop_last = len(train_ds) >= self.config.batch
+        # ``batch`` is the global batch under DDP. Each rank's loader is built
+        # with ``batch // world_size`` over a DistributedSampler shard.
+        per_rank_batch = max(1, self.config.batch // max(self.world_size, 1))
+        train_sampler = None
+        if self.is_distributed:
+            from torch.utils.data.distributed import DistributedSampler
+
+            train_sampler = DistributedSampler(
+                train_ds,
+                num_replicas=self.world_size,
+                rank=self.rank,
+                shuffle=True,
+                drop_last=len(train_ds) >= self.world_size,
+            )
+
+        visible_samples = len(train_sampler) if train_sampler is not None else len(train_ds)
+        drop_last = visible_samples >= per_rank_batch
         loader_kwargs = {}
         if self.config.workers > 0:
             loader_kwargs.update(
@@ -174,8 +190,9 @@ class YOLONASPoseTrainer(BaseTrainer):
             )
         self.train_loader = DataLoader(
             train_ds,
-            batch_size=self.config.batch,
-            shuffle=True,
+            batch_size=per_rank_batch,
+            shuffle=train_sampler is None,
+            sampler=train_sampler,
             num_workers=self.config.workers,
             pin_memory=self.config.pin_memory,
             drop_last=drop_last,
@@ -197,7 +214,7 @@ class YOLONASPoseTrainer(BaseTrainer):
             )
             self.val_loader = DataLoader(
                 val_ds,
-                batch_size=self.config.batch,
+                batch_size=per_rank_batch,
                 shuffle=False,
                 num_workers=self.config.workers,
                 pin_memory=self.config.pin_memory,
@@ -214,7 +231,12 @@ class YOLONASPoseTrainer(BaseTrainer):
             )
 
         logger.info("Training dataset: %d images", len(train_ds))
-        logger.info("Iterations per epoch: %d", len(self.train_loader))
+        logger.info(
+            "Iterations per epoch: %d (batch_per_rank=%d, world_size=%d)",
+            len(self.train_loader),
+            per_rank_batch,
+            self.world_size,
+        )
         return train_ds
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -294,7 +294,9 @@ class YOLONASPoseTrainer(BaseTrainer):
                     total_loss += float(loss.item())
                     num_batches += 1
 
-            pose_metrics = self._run_pose_metric_validation(model, epoch)
+            pose_metrics = self._run_pose_metric_validation(
+                model, epoch, save_plots=save_plots
+            )
         finally:
             if was_training:
                 model.train()
@@ -332,7 +334,11 @@ class YOLONASPoseTrainer(BaseTrainer):
         }
 
     def _run_pose_metric_validation(
-        self, eval_model: torch.nn.Module, epoch: int
+        self,
+        eval_model: torch.nn.Module,
+        epoch: int,
+        *,
+        save_plots: bool | None = None,
     ) -> Dict[str, float] | None:
         if self.wrapper_model is None:
             logger.warning("Skipping pose mAP validation: wrapper_model is missing")
@@ -341,6 +347,12 @@ class YOLONASPoseTrainer(BaseTrainer):
         try:
             from libreyolo.validation import PoseValidator, ValidationConfig
 
+            val_save_plots = (
+                bool(save_plots)
+                if save_plots is not None
+                else bool(getattr(self.config, "save_plots", False))
+                and self._is_final_epoch(epoch)
+            )
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
@@ -354,6 +366,7 @@ class YOLONASPoseTrainer(BaseTrainer):
                 num_workers=self.config.workers,
                 allow_download_scripts=self.config.allow_download_scripts,
                 oks_sigmas=self._resolve_oks_sigmas(),
+                save_plots=val_save_plots,
                 save_dir=str(self.save_dir / "val"),
             )
 

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -263,11 +263,23 @@ class YOLONASPoseTrainer(BaseTrainer):
             "pose_reg": log_losses[4],
         }
 
-    def _validate_epoch(self, epoch: int):
-        if getattr(self, "val_loader", None) is None:
+    def _validate_epoch(self, epoch: int, *, save_plots: bool | None = None):
+        from ...training.distributed import barrier, is_main_process, unwrap_model
+
+        # Validation runs on rank 0 only, mirroring BaseTrainer._validate_epoch:
+        # concurrent ranks write predictions.json into the shared save_dir and
+        # corrupt the JSON another rank is reading (issue #484). Non-zero ranks
+        # barrier-wait so the next epoch's set_epoch fires in lockstep.
+        if self.is_distributed and not is_main_process():
+            barrier()
             return None
 
-        model = self.ema_model.ema if self.ema_model else self.model
+        if getattr(self, "val_loader", None) is None:
+            if self.is_distributed:
+                barrier()
+            return None
+
+        model = self.ema_model.ema if self.ema_model else unwrap_model(self.model)
         was_training = model.training
         model.eval()
 
@@ -286,6 +298,8 @@ class YOLONASPoseTrainer(BaseTrainer):
         finally:
             if was_training:
                 model.train()
+            if self.is_distributed:
+                barrier()
 
         avg_loss = total_loss / max(num_batches, 1)
         metrics = {"loss/val": avg_loss}

--- a/libreyolo/models/yolonas/pose_trainer.py
+++ b/libreyolo/models/yolonas/pose_trainer.py
@@ -359,10 +359,11 @@ class YOLONASPoseTrainer(BaseTrainer):
             val_config = ValidationConfig(
                 data=self.config.data,
                 split="val",
-                # Global batch / world_size, like BaseTrainer._run_validation:
-                # this runs on rank 0 alone, and the global batch is sized for
-                # world_size GPUs. An OOM here is swallowed by the except
-                # below, silently dropping the epoch's keypoint mAP.
+                # Rank-local capacity, matching BaseTrainer._run_validation.
+                # No runtime effect today: PoseValidator runs per-image
+                # inference and ignores batch_size. Kept consistent so a
+                # future batched PoseValidator doesn't inherit the global
+                # batch on the single rank that runs it.
                 batch_size=max(1, self.config.batch // max(self.world_size, 1)),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1252,6 +1252,24 @@ class BaseTrainer(ABC):
             if is_main_process():
                 logger.info("AutoBatch: resolved global batch size = %d", self.config.batch)
 
+        # ``batch`` is the global batch under DDP: every rank trains at
+        # batch // world_size, so a non-divisible value would silently train
+        # at a different global batch than requested (e.g. batch=6 on 4 GPUs
+        # trains at 4). Fail fast instead of silently changing the batch.
+        # AutoBatch above already returns world_size-divisible values.
+        if self.is_distributed and self.config.batch % self.world_size != 0:
+            lower = (self.config.batch // self.world_size) * self.world_size
+            higher = lower + self.world_size
+            options = (
+                f"batch={higher}" if lower == 0 else f"batch={lower} or batch={higher}"
+            )
+            raise ValueError(
+                f"batch={self.config.batch} is the global batch and must be "
+                f"divisible by world_size={self.world_size}: each rank trains at "
+                f"batch // world_size, so this value would silently train at a "
+                f"different global batch than requested. Use {options}."
+            )
+
         # BN statistics quality under DDP: with SyncBatchNorm off, each rank's
         # BatchNorm tracks only its own per-rank shard (batch // world_size).
         # A small per-rank batch produces noisy running stats and degrades the

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1210,6 +1210,37 @@ class BaseTrainer(ABC):
     # Setup / train / epoch
     # =========================================================================
 
+    def _check_ddp_train_loader(self) -> None:
+        """Verify the train loader actually shards across DDP ranks.
+
+        Duck-types on ``num_replicas``/``rank`` rather than requiring
+        ``DistributedSampler`` so distributed-aware custom samplers pass.
+        """
+        loader = getattr(self, "train_loader", None)
+        if loader is None:
+            return
+        sampler = getattr(loader, "sampler", None)
+        if (
+            getattr(sampler, "num_replicas", None) != self.world_size
+            or getattr(sampler, "rank", None) != self.rank
+        ):
+            raise ValueError(
+                f"{type(self).__name__} built a train loader that does not "
+                f"shard across DDP ranks (sampler={type(sampler).__name__}): "
+                "every rank would train on the full dataset. Build the loader "
+                "with a DistributedSampler and batch // world_size per rank, "
+                "like BaseTrainer._setup_data."
+            )
+        per_rank_batch = max(1, self.config.batch // self.world_size)
+        loader_batch = getattr(loader, "batch_size", None)
+        if loader_batch is not None and loader_batch != per_rank_batch:
+            raise ValueError(
+                f"{type(self).__name__} built a train loader with "
+                f"batch_size={loader_batch}, but batch={self.config.batch} is "
+                f"the global batch: world_size={self.world_size} requires "
+                f"{per_rank_batch} per rank."
+            )
+
     def setup(self):
         if self._is_setup:
             return
@@ -1252,6 +1283,12 @@ class BaseTrainer(ABC):
             if is_main_process():
                 logger.info("AutoBatch: resolved global batch size = %d", self.config.batch)
 
+        if int(getattr(self.config, "batch", 16)) < 1:
+            raise ValueError(
+                f"batch={self.config.batch} is invalid: use a positive global "
+                "batch size, or -1 for AutoBatch."
+            )
+
         # ``batch`` is the global batch under DDP: every rank trains at
         # batch // world_size, so a non-divisible value would silently train
         # at a different global batch than requested (e.g. batch=6 on 4 GPUs
@@ -1293,6 +1330,15 @@ class BaseTrainer(ABC):
                 )
 
         self._setup_data()
+
+        # DDP loader invariant: trainers that own their data pipeline must
+        # shard like BaseTrainer._setup_data does (issue #484: three trainers
+        # built plain DataLoaders and every rank trained the full dataset at
+        # the full global batch). Catch that bug class at startup for every
+        # current and future family.
+        if self.is_distributed:
+            self._check_ddp_train_loader()
+
         self._apply_freeze_config()
         self.optimizer = self._setup_optimizer()
         self._setup_distillation()

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -1,0 +1,225 @@
+"""DDP loader sharding for trainers that own their data pipeline.
+
+``batch`` is the global batch under DDP: each rank's loader must be built
+with ``batch // world_size`` over a DistributedSampler shard. Regression
+coverage for issue #484 where multi-GPU YOLO-NAS-Pose (and the DEIM/D-FINE
+trainers, inherited by DEIMv2/RT-DETRv4/EC) put the full global batch and
+the full dataset on every rank.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data.distributed import DistributedSampler
+
+cv2 = pytest.importorskip("cv2")
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Dataset fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_pose_dataset(tmp_path, num_keypoints=4, num_samples=4):
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    for i in range(num_samples):
+        cv2.imwrite(
+            str(img_dir / f"sample{i}.jpg"),
+            np.full((480, 640, 3), 127, dtype=np.uint8),
+        )
+        row = ["0", "0.5", "0.5", "0.3", "0.4"]
+        for k in range(num_keypoints):
+            row += [f"{0.4 + 0.02 * k:.3f}", f"{0.45 + 0.02 * k:.3f}", "2"]
+        (lbl_dir / f"sample{i}.txt").write_text(" ".join(row) + "\n")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "train": "images/train",
+                "names": ["object"],
+                "kpt_shape": [num_keypoints, 3],
+            }
+        )
+    )
+    return data_yaml
+
+
+def _write_detect_dataset(tmp_path, num_samples=4):
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    for i in range(num_samples):
+        cv2.imwrite(
+            str(img_dir / f"sample{i}.jpg"),
+            np.full((480, 640, 3), 127, dtype=np.uint8),
+        )
+        (lbl_dir / f"sample{i}.txt").write_text("0 0.5 0.5 0.3 0.4\n")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "train": "images/train",
+                "nc": 1,
+                "names": ["object"],
+            }
+        )
+    )
+    return data_yaml
+
+
+def _fake_two_rank_ddp(trainer, rank=0):
+    """Make the trainer believe it is rank ``rank`` of a 2-rank run.
+
+    ``DistributedSampler`` takes explicit ``num_replicas``/``rank`` so no
+    process group is required for loader wiring.
+    """
+    trainer.is_distributed = True
+    trainer.world_size = 2
+    trainer.rank = rank
+    trainer.local_rank = rank
+
+
+# ---------------------------------------------------------------------------
+# YOLO-NAS-Pose
+# ---------------------------------------------------------------------------
+
+
+def _build_pose_trainer(data_yaml, **overrides):
+    from libreyolo.models.yolonas.pose_trainer import YOLONASPoseTrainer
+
+    kwargs = dict(
+        model=torch.nn.Identity(),
+        size="s",
+        num_keypoints=4,
+        data=str(data_yaml),
+        batch=4,
+        workers=0,
+        device="cpu",
+    )
+    kwargs.update(overrides)
+    return YOLONASPoseTrainer(**kwargs)
+
+
+def test_yolonas_pose_loader_shards_batch_across_ranks(tmp_path):
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer)
+
+    trainer._setup_data()
+
+    assert isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 2
+    # 4 samples / 2 ranks / per-rank batch 2 = 1 iteration per rank.
+    assert len(trainer.train_loader) == 1
+
+
+def test_yolonas_pose_single_process_loader_unchanged(tmp_path):
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+
+    trainer._setup_data()
+
+    assert not isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 4
+
+
+# ---------------------------------------------------------------------------
+# DEIM / D-FINE (inherited by DEIMv2, RT-DETRv4, EC-detect)
+# ---------------------------------------------------------------------------
+
+
+def _build_detr_trainer(trainer_cls, data_yaml, **overrides):
+    kwargs = dict(
+        model=torch.nn.Identity(),
+        size="n",
+        num_classes=1,
+        data=str(data_yaml),
+        epochs=1,
+        batch=4,
+        imgsz=640,
+        device="cpu",
+        amp=False,
+        ema=False,
+        workers=0,
+        eval_interval=-1,
+    )
+    kwargs.update(overrides)
+    return trainer_cls(**kwargs)
+
+
+def _detr_trainer_classes():
+    from libreyolo.models.deim.trainer import DEIMTrainer
+    from libreyolo.models.dfine.trainer import DFINETrainer
+
+    return {"deim": DEIMTrainer, "dfine": DFINETrainer}
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_loader_shards_batch_across_ranks(tmp_path, family):
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml)
+    _fake_two_rank_ddp(trainer)
+
+    trainer._setup_data()
+
+    assert isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 2
+    assert len(trainer.train_loader) == 1
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_single_process_loader_unchanged(tmp_path, family):
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml)
+
+    trainer._setup_data()
+
+    assert not isinstance(trainer.train_loader.sampler, DistributedSampler)
+    assert trainer.train_loader.batch_size == 4
+
+
+class _SpySampler(DistributedSampler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.epochs = []
+
+    def set_epoch(self, epoch):
+        self.epochs.append(epoch)
+        super().set_epoch(epoch)
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_train_epoch_sets_sampler_epoch(tmp_path, family):
+    """The DEIM/D-FINE ``_train_epoch`` overrides must set the sampler epoch
+    like ``BaseTrainer._train_epoch`` does, or every DDP epoch reuses the
+    same shuffle order.
+    """
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path)
+    model = torch.nn.Linear(2, 2)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml, model=model)
+
+    empty_ds = TensorDataset(torch.empty(0, 2))
+    sampler = _SpySampler(empty_ds, num_replicas=2, rank=0, shuffle=True)
+    trainer.train_loader = DataLoader(empty_ds, batch_size=1, sampler=sampler)
+    trainer.optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    trainer._train_epoch(epoch=3)
+
+    assert sampler.epochs == [3]

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -9,6 +9,9 @@ the full dataset on every rank.
 
 from __future__ import annotations
 
+import contextlib
+import socket
+import sys
 from types import SimpleNamespace
 
 import numpy as np
@@ -220,24 +223,33 @@ def test_detr_dataset_smaller_than_batch_keeps_partial_batch(tmp_path, family):
 # ---------------------------------------------------------------------------
 
 
-class _ExplodingLoader:
-    """Iterating this loader means the rank ran validation when it must not."""
-
-    def __iter__(self):
-        raise AssertionError("validation ran on a non-main rank")
-
-
-def test_yolonas_pose_validation_skipped_on_non_main_rank(tmp_path, monkeypatch):
-    """Every rank used to run pose mAP validation, racing on the shared
-    save_dir's predictions.json (issue #484 screenshots). Non-zero ranks must
-    barrier and return without validating.
+def test_yolonas_pose_non_main_rank_runs_loss_but_not_metric_phase(
+    tmp_path, monkeypatch
+):
+    """Non-zero ranks must run the val-loss pass (YoloNASPoseLoss all-reduces
+    its normalizer, a collective, so skipping the pass on some ranks pairs
+    rank 0's all_reduce with the others' barrier and deadlocks) but must NOT
+    run the pose mAP validator, which races on the shared save_dir's
+    predictions.json (issue #484 screenshots).
     """
     import libreyolo.training.distributed as dist_mod
 
     data_yaml = _write_pose_dataset(tmp_path)
     trainer = _build_pose_trainer(data_yaml)
     _fake_two_rank_ddp(trainer, rank=1)
-    trainer.val_loader = _ExplodingLoader()
+    trainer.ema_model = None
+    trainer.val_loader = [(torch.zeros(1, 3, 64, 64), torch.zeros(1, 2, 17))]
+
+    loss_calls = []
+
+    def _stub_loss(outputs, targets):
+        loss_calls.append(1)
+        return torch.tensor(0.5), None
+
+    trainer.loss_fn = _stub_loss
+    trainer._run_pose_metric_validation = lambda *a, **k: pytest.fail(
+        "pose mAP validation ran on a non-main rank"
+    )
 
     barrier_calls = []
     monkeypatch.setattr(dist_mod, "barrier", lambda: barrier_calls.append(1))
@@ -246,6 +258,7 @@ def test_yolonas_pose_validation_skipped_on_non_main_rank(tmp_path, monkeypatch)
     result = trainer._validate_epoch(0)
 
     assert result is None
+    assert loss_calls == [1]
     assert barrier_calls == [1]
 
 
@@ -355,3 +368,90 @@ def test_detr_train_epoch_sets_sampler_epoch(tmp_path, family, accum):
     trainer._train_epoch(epoch=3)
 
     assert sampler.epochs == [3]
+
+
+# ---------------------------------------------------------------------------
+# Real 2-rank gloo regression: validation collectives must stay aligned
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _pose_val_gate_worker(rank, world_size, port, out_dir):
+    import os
+    from pathlib import Path
+
+    import torch
+    import torch.distributed as dist
+
+    out_path = Path(out_dir) / f"rank_{rank}.txt"
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
+        dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+        from libreyolo.data import default_oks_sigmas
+        from libreyolo.models.yolonas.loss import YoloNASPoseLoss
+        from libreyolo.models.yolonas.nn import LibreYOLONASPoseModel
+        from libreyolo.models.yolonas.pose_trainer import YOLONASPoseTrainer
+
+        K = 4
+        torch.manual_seed(0)
+        model = LibreYOLONASPoseModel(config="s", num_keypoints=K).eval()
+
+        targets = torch.zeros(1, 4, 5 + 3 * K)
+        targets[0, 0, 1:5] = torch.tensor([320.0, 300.0, 120.0, 200.0])
+        for k in range(K):
+            targets[0, 0, 5 + 3 * k] = 320.0 + k * 5.0
+            targets[0, 0, 5 + 3 * k + 1] = 300.0 + k * 5.0
+            targets[0, 0, 5 + 3 * k + 2] = 2.0
+
+        trainer = YOLONASPoseTrainer.__new__(YOLONASPoseTrainer)
+        trainer.is_distributed = True
+        trainer.rank = rank
+        trainer.world_size = world_size
+        trainer.device = torch.device("cpu")
+        trainer.model = model
+        trainer.ema_model = None
+        trainer.loss_fn = YoloNASPoseLoss(oks_sigmas=default_oks_sigmas(K))
+        trainer.val_loader = [(torch.zeros(1, 3, 640, 640), targets)]
+        trainer._run_pose_metric_validation = lambda *a, **k: None
+
+        result = trainer._validate_epoch(0)
+
+        if rank == 0:
+            assert result is not None and "loss/val" in result["metrics"]
+        else:
+            assert result is None
+        out_path.write_text("ok\n")
+    except Exception as exc:
+        out_path.write_text(f"error: {type(exc).__name__}: {exc}\n")
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" and sys.version_info < (3, 8),
+    reason="mp.spawn on Windows needs Python 3.8+",
+)
+def test_yolonas_pose_validation_collectives_align_2_ranks_gloo(tmp_path):
+    """Regression for the collective mismatch: YoloNASPoseLoss calls
+    all_reduce_avg_scalar, so the val-loss pass must run on every rank. With
+    a rank-0-only gate around the whole body, gloo pairs rank 0's all_reduce
+    with rank 1's barrier and the run errors or hangs.
+    """
+    import torch.multiprocessing as mp
+
+    port = _free_port()
+    mp.spawn(
+        _pose_val_gate_worker, args=(2, port, str(tmp_path)), nprocs=2, join=True
+    )
+    for rank in range(2):
+        text = (tmp_path / f"rank_{rank}.txt").read_text()
+        assert text == "ok\n", f"rank {rank}: {text!r}"

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -194,6 +194,69 @@ def test_detr_single_process_loader_unchanged(tmp_path, family):
     assert trainer.train_loader.batch_size == 4
 
 
+# ---------------------------------------------------------------------------
+# YOLO-NAS-Pose validation gating
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingLoader:
+    """Iterating this loader means the rank ran validation when it must not."""
+
+    def __iter__(self):
+        raise AssertionError("validation ran on a non-main rank")
+
+
+def test_yolonas_pose_validation_skipped_on_non_main_rank(tmp_path, monkeypatch):
+    """Every rank used to run pose mAP validation, racing on the shared
+    save_dir's predictions.json (issue #484 screenshots). Non-zero ranks must
+    barrier and return without validating.
+    """
+    import libreyolo.training.distributed as dist_mod
+
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer, rank=1)
+    trainer.val_loader = _ExplodingLoader()
+
+    barrier_calls = []
+    monkeypatch.setattr(dist_mod, "barrier", lambda: barrier_calls.append(1))
+    monkeypatch.setattr(dist_mod, "is_main_process", lambda: False)
+
+    result = trainer._validate_epoch(0)
+
+    assert result is None
+    assert barrier_calls == [1]
+
+
+def test_yolonas_pose_main_rank_barriers_after_validation(tmp_path, monkeypatch):
+    import libreyolo.training.distributed as dist_mod
+
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer, rank=0)
+    trainer.val_loader = None
+
+    barrier_calls = []
+    monkeypatch.setattr(dist_mod, "barrier", lambda: barrier_calls.append(1))
+    monkeypatch.setattr(dist_mod, "is_main_process", lambda: True)
+
+    result = trainer._validate_epoch(0)
+
+    assert result is None
+    assert barrier_calls == [1]
+
+
+def test_yolonas_pose_validate_epoch_accepts_save_plots(tmp_path):
+    """BaseTrainer calls ``_validate_epoch(epoch, save_plots=True)`` on the
+    final epoch when save_plots is set; the override must accept the kwarg.
+    """
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    trainer.val_loader = None
+
+    assert trainer._validate_epoch(0, save_plots=True) is None
+
+
 class _SpySampler(DistributedSampler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -183,7 +183,7 @@ def test_detr_loader_shards_batch_across_ranks(tmp_path, family):
 
 
 @pytest.mark.parametrize("family", ["deim", "dfine"])
-def test_detr_single_process_loader_unchanged(tmp_path, family):
+def test_detr_single_process_batch_and_sampler_unchanged(tmp_path, family):
     trainer_cls = _detr_trainer_classes()[family]
     data_yaml = _write_detect_dataset(tmp_path)
     trainer = _build_detr_trainer(trainer_cls, data_yaml)
@@ -192,6 +192,25 @@ def test_detr_single_process_loader_unchanged(tmp_path, family):
 
     assert not isinstance(trainer.train_loader.sampler, DistributedSampler)
     assert trainer.train_loader.batch_size == 4
+    # 4 samples at batch 4: exactly one full batch survives drop_last.
+    assert len(trainer.train_loader) == 1
+
+
+@pytest.mark.parametrize("family", ["deim", "dfine"])
+def test_detr_dataset_smaller_than_batch_keeps_partial_batch(tmp_path, family):
+    """Deliberate behavior change from unconditional ``drop_last=True``: a
+    dataset smaller than ``batch`` used to yield ZERO training iterations
+    silently. It now keeps the partial batch, matching BaseTrainer's
+    visible-count drop_last policy.
+    """
+    trainer_cls = _detr_trainer_classes()[family]
+    data_yaml = _write_detect_dataset(tmp_path, num_samples=2)
+    trainer = _build_detr_trainer(trainer_cls, data_yaml)
+
+    trainer._setup_data()
+
+    assert trainer.train_loader.drop_last is False
+    assert len(trainer.train_loader) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -297,20 +297,38 @@ def test_yolonas_pose_validate_epoch_accepts_save_plots(tmp_path):
     assert trainer._validate_epoch(0, save_plots=True) is None
 
 
+def _build_ec_pose_trainer(data_yaml, **overrides):
+    from libreyolo.models.ec.pose_trainer import ECPoseTrainer
+
+    kwargs = dict(
+        model=torch.nn.Identity(),
+        num_keypoints=4,
+        data=str(data_yaml),
+        batch=4,
+        workers=0,
+        device="cpu",
+    )
+    kwargs.update(overrides)
+    return ECPoseTrainer(**kwargs)
+
+
+@pytest.mark.parametrize("family", ["yolonas", "ec"])
 @pytest.mark.parametrize(
     "save_plots,expected",
     [(True, True), (False, False), (None, False)],
 )
-def test_yolonas_pose_save_plots_reaches_validation_config(
-    tmp_path, monkeypatch, save_plots, expected
+def test_pose_save_plots_reaches_validation_config(
+    tmp_path, monkeypatch, family, save_plots, expected
 ):
     """``save_plots`` must flow into ``ValidationConfig`` (None resolves to the
-    config default, final-epoch only), not be accepted and dropped.
+    config default, final-epoch only), not be accepted and dropped. Covers
+    both pose trainers that gate the metric phase to rank 0.
     """
     import libreyolo.validation as validation_mod
 
     data_yaml = _write_pose_dataset(tmp_path)
-    trainer = _build_pose_trainer(data_yaml, epochs=10)
+    builder = {"yolonas": _build_pose_trainer, "ec": _build_ec_pose_trainer}[family]
+    trainer = builder(data_yaml, epochs=10)
     trainer.save_dir = tmp_path
     trainer.wrapper_model = SimpleNamespace(model=None)
 
@@ -409,6 +427,50 @@ def test_setup_accepts_divisible_or_single_process_batch(
     monkeypatch.setattr(trainer, "_setup_data", _sentinel)
     with pytest.raises(_GuardPassed):
         trainer.setup()
+
+
+def test_setup_rejects_zero_batch(tmp_path):
+    """batch=0 is divisible by every world_size; the positive-batch check
+    must catch it before max(1, ...) silently turns it into 1 per rank.
+    """
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml, batch=0)
+
+    with pytest.raises(ValueError, match="positive global"):
+        trainer.setup()
+
+
+def test_setup_rejects_unsharded_train_loader(tmp_path, monkeypatch):
+    """The post-_setup_data invariant: a future trainer that builds a plain
+    DataLoader (the original #484 bug) must fail at startup, not train every
+    rank on the full dataset.
+    """
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer)
+
+    def _plain_loader():
+        ds = TensorDataset(torch.zeros(4, 1))
+        trainer.train_loader = DataLoader(ds, batch_size=4, shuffle=True)
+
+    monkeypatch.setattr(trainer, "_setup_data", _plain_loader)
+    with pytest.raises(ValueError, match="does not shard"):
+        trainer.setup()
+
+
+def test_setup_accepts_sharded_train_loader(tmp_path, monkeypatch):
+    """A correctly sharded loader (the real _setup_data) passes the invariant."""
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml)
+    _fake_two_rank_ddp(trainer)
+
+    def _sentinel():
+        raise _GuardPassed
+
+    monkeypatch.setattr(trainer, "_apply_freeze_config", _sentinel)
+    with pytest.raises(_GuardPassed):
+        trainer.setup()
+    assert isinstance(trainer.train_loader.sampler, DistributedSampler)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -371,6 +371,47 @@ def test_detr_train_epoch_sets_sampler_epoch(tmp_path, family, accum):
 
 
 # ---------------------------------------------------------------------------
+# Global-batch divisibility guard (BaseTrainer.setup, covers every family)
+# ---------------------------------------------------------------------------
+
+
+class _GuardPassed(Exception):
+    """Sentinel proving setup() got past the divisibility guard."""
+
+
+@pytest.mark.parametrize("batch", [6, 2])
+def test_setup_rejects_non_divisible_global_batch(tmp_path, monkeypatch, batch):
+    """batch is the global batch; batch=6 or 2 on 4 ranks would silently
+    train at 4. setup() must fail fast instead.
+    """
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml, batch=batch)
+    _fake_two_rank_ddp(trainer)
+    trainer.world_size = 4
+
+    with pytest.raises(ValueError, match="divisible by world_size"):
+        trainer.setup()
+
+
+@pytest.mark.parametrize("distributed,batch", [(True, 8), (False, 7)])
+def test_setup_accepts_divisible_or_single_process_batch(
+    tmp_path, monkeypatch, distributed, batch
+):
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml, batch=batch)
+    if distributed:
+        _fake_two_rank_ddp(trainer)
+        trainer.world_size = 4
+
+    def _sentinel():
+        raise _GuardPassed
+
+    monkeypatch.setattr(trainer, "_setup_data", _sentinel)
+    with pytest.raises(_GuardPassed):
+        trainer.setup()
+
+
+# ---------------------------------------------------------------------------
 # Real 2-rank gloo regression: validation collectives must stay aligned
 # ---------------------------------------------------------------------------
 
@@ -392,7 +433,17 @@ def _pose_val_gate_worker(rank, world_size, port, out_dir):
     try:
         os.environ["MASTER_ADDR"] = "127.0.0.1"
         os.environ["MASTER_PORT"] = str(port)
-        dist.init_process_group("gloo", rank=rank, world_size=world_size)
+        # Short op timeout: if the collective mismatch this test guards
+        # against ever returns, fail within a minute instead of hanging the
+        # unit job on PyTorch's long default.
+        from datetime import timedelta
+
+        dist.init_process_group(
+            "gloo",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=60),
+        )
 
         from libreyolo.data import default_oks_sigmas
         from libreyolo.models.yolonas.loss import YoloNASPoseLoss

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -9,6 +9,8 @@ the full dataset on every rank.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
@@ -248,12 +250,17 @@ def test_yolonas_pose_validation_skipped_on_non_main_rank(tmp_path, monkeypatch)
 
 
 def test_yolonas_pose_main_rank_barriers_after_validation(tmp_path, monkeypatch):
+    """Rank 0 must hit the finally-barrier after running the validation body
+    (empty val loader drives the full body without needing a real model).
+    """
     import libreyolo.training.distributed as dist_mod
 
     data_yaml = _write_pose_dataset(tmp_path)
     trainer = _build_pose_trainer(data_yaml)
     _fake_two_rank_ddp(trainer, rank=0)
-    trainer.val_loader = None
+    trainer.val_loader = []
+    trainer.ema_model = None
+    trainer.wrapper_model = None
 
     barrier_calls = []
     monkeypatch.setattr(dist_mod, "barrier", lambda: barrier_calls.append(1))
@@ -261,7 +268,8 @@ def test_yolonas_pose_main_rank_barriers_after_validation(tmp_path, monkeypatch)
 
     result = trainer._validate_epoch(0)
 
-    assert result is None
+    assert result is not None
+    assert result["best_metric_key"] == "loss/val"
     assert barrier_calls == [1]
 
 
@@ -276,6 +284,41 @@ def test_yolonas_pose_validate_epoch_accepts_save_plots(tmp_path):
     assert trainer._validate_epoch(0, save_plots=True) is None
 
 
+@pytest.mark.parametrize(
+    "save_plots,expected",
+    [(True, True), (False, False), (None, False)],
+)
+def test_yolonas_pose_save_plots_reaches_validation_config(
+    tmp_path, monkeypatch, save_plots, expected
+):
+    """``save_plots`` must flow into ``ValidationConfig`` (None resolves to the
+    config default, final-epoch only), not be accepted and dropped.
+    """
+    import libreyolo.validation as validation_mod
+
+    data_yaml = _write_pose_dataset(tmp_path)
+    trainer = _build_pose_trainer(data_yaml, epochs=10)
+    trainer.save_dir = tmp_path
+    trainer.wrapper_model = SimpleNamespace(model=None)
+
+    captured = {}
+
+    class _FakeValidator:
+        def __init__(self, model, config):
+            captured["config"] = config
+
+        def run(self):
+            return {}
+
+    monkeypatch.setattr(validation_mod, "PoseValidator", _FakeValidator)
+
+    trainer._run_pose_metric_validation(
+        torch.nn.Identity(), epoch=0, save_plots=save_plots
+    )
+
+    assert captured["config"].save_plots is expected
+
+
 class _SpySampler(DistributedSampler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -287,15 +330,22 @@ class _SpySampler(DistributedSampler):
 
 
 @pytest.mark.parametrize("family", ["deim", "dfine"])
-def test_detr_train_epoch_sets_sampler_epoch(tmp_path, family):
-    """The DEIM/D-FINE ``_train_epoch`` overrides must set the sampler epoch
-    like ``BaseTrainer._train_epoch`` does, or every DDP epoch reuses the
-    same shuffle order.
+@pytest.mark.parametrize("accum", [False, True])
+def test_detr_train_epoch_sets_sampler_epoch(tmp_path, family, accum):
+    """The DEIM/D-FINE ``_train_epoch`` AND ``_train_epoch_accum`` overrides
+    must set the sampler epoch like ``BaseTrainer._train_epoch`` does, or
+    every DDP epoch reuses the same shuffle order.
     """
     trainer_cls = _detr_trainer_classes()[family]
     data_yaml = _write_detect_dataset(tmp_path)
     model = torch.nn.Linear(2, 2)
-    trainer = _build_detr_trainer(trainer_cls, data_yaml, model=model)
+    # nbs=8 with batch=4 makes _accum_steps=2, so _train_epoch delegates to
+    # _train_epoch_accum.
+    overrides = {"model": model}
+    if accum:
+        overrides["nbs"] = 8
+    trainer = _build_detr_trainer(trainer_cls, data_yaml, **overrides)
+    assert (trainer._accum_steps > 1) is accum
 
     empty_ds = TensorDataset(torch.empty(0, 2))
     sampler = _SpySampler(empty_ds, num_replicas=2, rank=0, shuffle=True)


### PR DESCRIPTION
## Summary

Follow-up to #484: kaiwen0901 reported two multi-GPU YOLONAS-Pose problems (comment updated with screenshots):

1. With the same `batch`, per-GPU memory in multi-GPU training matches single-GPU training: the batch is not split across ranks.
2. Occasional `Pose mAP validation failed at epoch N: Expecting ',' delimiter: line 1 column 47009224` errors during training.

### Bug 1: DDP batch not sharded

Three trainers override `_setup_data` with their own `DataLoader` construction and skipped the DDP sharding that `BaseTrainer._setup_data` does:

- `libreyolo/models/yolonas/pose_trainer.py` (the reported case)
- `libreyolo/models/deim/trainer.py` (inherited by DEIMv2 and RT-DETRv4)
- `libreyolo/models/dfine/trainer.py` (inherited by EC detect)

Under DDP each rank built its loader with the full global `batch` and no `DistributedSampler`, so every rank iterated the entire dataset with the entire batch. Iterations per epoch were unchanged (dataset and batch were both N times too large per rank), but each epoch consumed N times the intended samples at N times the intended effective batch, with no multi-GPU speedup, and per-GPU activation memory matched single-GPU training, exactly as reported.

### Bug 2: pose validation was not DDP-safe

Two layered problems, one per pose trainer generation:

- `YOLONASPoseTrainer._validate_epoch` had no rank gating at all: every rank ran pose mAP validation concurrently, all writing `predictions.json` / `ground_truth_yolo_pose.json` into the same broadcast `save_dir`; pycocotools read half-written JSON, producing the reported errors, and best.pt selection silently fell back to val loss whenever rank 0 lost the race.
- A rank-0-only gate around the whole method (the EC pose trainer's shipped pattern) is itself a DDP bug: the pose losses all-reduce their normalizers inside `forward` (collectives), so rank 0 running the val-loss loop while other ranks sit in `barrier()` mismatches collectives and deadlocks. Verified empirically: a real 2-rank gloo run hangs with that gate.

Final design, applied to both YOLONAS-Pose and EC-Pose: the val-loss pass runs on every rank (the val loader is identical everywhere, so collectives align) and only the file-writing pose mAP validator is rank-0 gated.

## Changes

- Each rank's train loader is built with `batch // world_size` over a `DistributedSampler` shard, mirroring `BaseTrainer._setup_data` (including the per-rank-visible-count `drop_last` guard).
- The DEIM/D-FINE `_train_epoch` / `_train_epoch_accum` overrides call `sampler.set_epoch(epoch)` like the base loop. (YOLONAS-Pose uses the base epoch loop, which already handles it.)
- YOLONAS-Pose and EC-Pose validation: symmetric val-loss pass, rank-0-only mAP phase, DDP model unwrap, and the rank-0 validator's `ValidationConfig.batch_size` divided by world_size for consistency with `BaseTrainer._run_validation` (no runtime effect today: `PoseValidator` runs per-image inference and ignores `batch_size`).
- `save_plots` now flows into `ValidationConfig` in both pose trainers (explicit value wins, otherwise `config.save_plots` on the final epoch), resolving a TypeError (YOLONAS accepted no such kwarg) and a silent ignore (EC accepted and dropped it).
- New centralized guards in `BaseTrainer.setup()`, covering every family including future ones:
  - `batch` must be >= 1 after AutoBatch resolution (`batch=0` was divisible by everything and silently clamped to 1 per rank).
  - Under DDP, a global `batch` not divisible by `world_size` raises immediately (each rank trains at `batch // world_size`, so `batch=6` on 4 GPUs would silently train at 4). AutoBatch already returns divisible values.
  - After `_setup_data()` under DDP, the train loader must actually shard: its sampler needs matching `num_replicas`/`rank` (duck-typed, so distributed-aware custom samplers pass) and its batch must equal `batch // world_size`. A future trainer that overrides `_setup_data` with a plain `DataLoader` (the original bug here) now fails at startup instead of training every rank on the full dataset.
- 29 tests in `tests/unit/test_ddp_loader_sharding.py`: loader sharding for all three trainers under a faked 2-rank setup, single-process behavior, the partial-batch change pinned explicitly, `set_epoch` through both epoch loops, validation rank-gating, `save_plots` propagation for both pose trainers, the three setup guards (reject and accept paths), and a real 2-rank gloo regression that drives `_validate_epoch` with the real collective-bearing loss (hangs against the broken gate; 60s op timeout so a regression fails rather than stalls CI).

## Behavior notes

- Runs tuned under the broken semantics effectively trained with `batch * num_gpus` per optimizer step and consumed N dataset-equivalents per epoch. Raising `batch` to the old effective value restores the per-step global batch, but each epoch then takes N times fewer steps and sees the dataset once; approximating the old trajectory also requires roughly N times the epochs with scheduler/warmup adjusted. Exact reproduction is not possible either way, since sampling order changes.
- DEIM/D-FINE single-process `drop_last` moves from unconditional `True` to the visible-count policy: a dataset smaller than `batch` used to yield zero training iterations silently; it now keeps the partial batch.
- Non-divisible `batch`/`world_size` combinations (and `batch < 1`) now error at setup for every family; previously they silently rounded down (or clamped up).

## Testing

- `tests/unit/test_ddp_loader_sharding.py` (29 new tests) pass, including the 2-rank gloo regression.
- `test_yolonas_pose_training.py`, `test_yolonas_multiclass_pose.py`, `test_yolonas_pose.py`, `test_ec_pose.py`, `test_deim_trainer_smoke.py`, `test_dfine_trainer_smoke.py`, `test_deimv2_trainer.py`, `test_deim.py`, `test_dfine_seg.py`, `test_dfine_validation.py`, `test_ddp_distributed.py`, `test_ddp_syncbn.py`, `test_autobatch.py`, `test_trainer_validation_plots.py` all pass locally.

## Code provenance

All changes written from scratch for this PR, mirroring existing LibreYOLO patterns (`BaseTrainer._setup_data`, `BaseTrainer._validate_epoch`, and the RF-DETR pose trainer's `save_plots` resolution). No external code consulted or copied.
