### PR TITLE
Add OBB task to YOLO9

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Training capabilities are documented per family in
 | yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
+| yolo9 | obb | ✓ | ✓ | exp | exp | exp |  |  |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -70,6 +70,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
+| yolo9 | obb | ✓ | ✓ | exp | exp | exp |  |  |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
@@ -350,6 +351,8 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `yolo4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo7` / `detect` / `tflite`: The converted LiteRT graph changes decoded box coordinates beyond the detector parity tolerance.
 - `yolo7` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo9` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolo9` / `obb` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo9_e2e` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `yolo9_e2e` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo9_p2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -293,7 +293,7 @@ Detector-factory family support follows:
 | `yolo3`     | `("detect",)` (default)             | detect | YOLOv3 (Darknet, public domain); inference-only in LibreYOLO |
 | `yolo4`     | `("detect",)` (default)             | detect | YOLOv4 (Darknet, public domain); inference-only in LibreYOLO |
 | `yolo7`     | `("detect",)` (default)             | detect | YOLOv7 (MIT MultimediaTechLab/YOLO); trainable via SimOTA loss |
-| `yolo9`     | `("detect",)`                       | detect | detect-only (non-detect flagship variants removed in #436) |
+| `yolo9`     | `("detect", "obb")`                 | detect | OBB restored (#320); other non-detect variants removed in #436 |
 | `yolo9_e2e` | `("detect",)` (default)             | detect | detect-only |
 | `yolo9_p2`  | `("detect",)`                       | detect | detect-only |
 | `dfine`     | `("detect", "segment")`             | detect | segment uses the D-FINE-seg mask head; same sizes as detect; COCO `-seg` weights on HF (detect-to-segment fine-tune needs an explicit transfer flag) |
@@ -375,6 +375,10 @@ LibreRFDETRn.pt            # detect
 LibreRFDETRn-seg.pt        # segment
 LibreRFDETRx-pose.pt       # pose (preview; only size x ships)
 LibreRFDETRn-obb.pt        # obb
+
+# yolo9 - detect + obb
+LibreYOLO9t.pt             # detect (default)
+LibreYOLO9t-obb.pt         # obb
 
 # dinov2 — DINOv2 backbone + task head (NOT the RF-DETR detector)
 LibreDINOv2n.pt            # semantic (default task; dense head at 518)

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -86,6 +86,13 @@ _add(
     EXPORT_FORMATS,
     reason="YOLO9 segmentation export is not supported; YOLO9 is detection-only in LibreYOLO.",
 )
+_add(
+    "validated",
+    ("yolo9",),
+    ("obb",),
+    ("onnx", "torchscript"),
+    since="1.4",
+)
 _add("validated", ("yolo9_p2",), ("detect",), ("onnx",), since="1.3")
 _add(
     "validated",

--- a/libreyolo/models/yolo9/loss.py
+++ b/libreyolo/models/yolo9/loss.py
@@ -672,3 +672,141 @@ class YOLO9Loss:
 
         return loss_dict
 
+
+def _flatten_angle_predictions(angle_predictions: List[Tensor]) -> Tensor:
+    """Flatten per-level angle logits to ``(B, anchors, 1)``."""
+    flattened = []
+    for pred in angle_predictions:
+        bsz, channels, height, width = pred.shape
+        if channels != 1:
+            raise ValueError(
+                f"YOLO9 OBB angle branch must emit 1 channel, got {channels}"
+            )
+        flattened.append(pred.permute(0, 2, 3, 1).reshape(bsz, height * width, 1))
+    return torch.cat(flattened, dim=1)
+
+
+def _angle_logits_to_radians(angle_logits: Tensor) -> Tensor:
+    """Map angle logits to ``[-pi / 2, pi / 2)`` radians."""
+    return (angle_logits.sigmoid() - 0.5) * math.pi
+
+
+class YOLO9OBBLoss(YOLO9Loss):
+    """YOLO9 OBB loss using horizontal proxy boxes plus periodic angle loss."""
+
+    def __init__(
+        self,
+        *args,
+        angle_weight: float = 1.0,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.angle_weight = angle_weight
+
+    def __call__(
+        self,
+        predictions: List[Tensor],
+        targets: Tensor,
+        angle_predictions: List[Tensor],
+    ) -> Tuple[Tensor, Dict[str, float]]:
+        if targets.shape[-1] < 6:
+            raise ValueError(
+                "YOLO9 OBB training requires targets shaped "
+                "[B, max_targets, 6]: class, x1, y1, x2, y2, angle."
+            )
+        if self.vec2box is None:
+            raise RuntimeError("Vec2Box not initialized. Call update_anchors() first.")
+
+        preds_cls, preds_anc, preds_box = self.vec2box(predictions)
+        preds_angle = _angle_logits_to_radians(
+            _flatten_angle_predictions(angle_predictions)
+        )
+
+        bsz = targets.shape[0]
+        img_w, img_h = self.vec2box.image_size
+        scale = torch.tensor(
+            [1, img_w, img_h, img_w, img_h],
+            device=targets.device,
+            dtype=targets.dtype,
+        )
+        targets_box = targets[..., :5] * scale
+        targets_angle = targets[..., 5:6]
+
+        align_targets, valid_masks, matched_indices = self.matcher(
+            targets_box,
+            (preds_cls.detach(), preds_box.detach()),
+            return_indices=True,
+        )
+        targets_cls, targets_bbox = torch.split(
+            align_targets, (self.num_classes, 4), dim=-1
+        )
+
+        preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
+        targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
+
+        cls_norm = self._global_cls_norm(targets_cls)
+        box_norm = targets_cls.sum(-1)[valid_masks]
+
+        loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)
+        if valid_masks.any():
+            loss_box = self.box_loss(
+                preds_box_norm, targets_bbox_norm, valid_masks, box_norm, cls_norm
+            )
+            anchors_norm = (self.vec2box.anchor_grid / self.vec2box.scaler[:, None])[None]
+            loss_dfl = self.dfl_loss(
+                preds_anc,
+                targets_bbox_norm,
+                anchors_norm,
+                valid_masks,
+                box_norm,
+                cls_norm,
+            )
+
+            matched_angles = torch.gather(
+                targets_angle,
+                1,
+                matched_indices.unsqueeze(-1).clamp_min(0),
+            )
+            angle_delta = preds_angle[valid_masks] - matched_angles[valid_masks]
+            # Rectangles are pi-periodic, so use cos(2 * delta).
+            loss_angle = 0.5 * (1.0 - torch.cos(2.0 * angle_delta.squeeze(-1)))
+            loss_angle = (loss_angle * box_norm).sum() / cls_norm
+        else:
+            loss_box = preds_box_norm.sum() * 0.0
+            loss_dfl = preds_anc.sum() * 0.0
+            loss_angle = preds_angle.sum() * 0.0
+
+        loss_box_weighted = self.box_weight * loss_box
+        loss_dfl_weighted = self.dfl_weight * loss_dfl
+        loss_cls_weighted = self.cls_weight * loss_cls
+        loss_angle_weighted = self.angle_weight * loss_angle
+
+        total_loss = (
+            loss_box_weighted
+            + loss_dfl_weighted
+            + loss_cls_weighted
+            + loss_angle_weighted
+        )
+
+        loss_dict = {
+            "total_loss": total_loss,
+            "box_loss": loss_box_weighted,
+            "dfl_loss": loss_dfl_weighted,
+            "cls_loss": loss_cls_weighted,
+            "angle_loss": loss_angle_weighted,
+            "box": loss_box_weighted.item()
+            if isinstance(loss_box_weighted, Tensor)
+            else loss_box_weighted,
+            "dfl": loss_dfl_weighted.item()
+            if isinstance(loss_dfl_weighted, Tensor)
+            else loss_dfl_weighted,
+            "cls": loss_cls_weighted.item()
+            if isinstance(loss_cls_weighted, Tensor)
+            else loss_cls_weighted,
+            "angle": loss_angle_weighted.item()
+            if isinstance(loss_angle_weighted, Tensor)
+            else loss_angle_weighted,
+            "num_fg": valid_masks.sum().item() / max(bsz, 1),
+        }
+        return loss_dict
+

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -50,9 +50,10 @@ class LibreYOLO9(BaseModel):
     FAMILY = "yolo9"
     FILENAME_PREFIX = "LibreYOLO9"
     INPUT_SIZES = {"t": 640, "s": 640, "m": 640, "c": 640}
-    SUPPORTED_TASKS = ("detect",)
+    SUPPORTED_TASKS = ("detect", "obb")
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,
+        "obb": INPUT_SIZES,
     }
     EXPERIMENTAL_WEIGHT_FILENAMES: frozenset = frozenset()
     TRAIN_CONFIG = YOLO9Config
@@ -140,7 +141,23 @@ class LibreYOLO9(BaseModel):
 
     @classmethod
     def detect_checkpoint_task(cls, weights_dict: dict) -> Optional[str]:
-        """Infer YOLO9 task from task-specific head branches."""
+        """Infer YOLO9 task from task-specific head branches.
+
+        The OBB angle towers live at ``head.cv4.*`` with a single output
+        channel; legacy pose checkpoints used the same towers with
+        ``3 * num_keypoints`` channels, so only the 1-channel case claims obb.
+        """
+        angle_head_channels = []
+        for key, tensor in weights_dict.items():
+            if re.match(r"head\.cv4\.\d+\.2\.weight", key):
+                shape = getattr(tensor, "shape", None)
+                if shape is not None and len(shape) > 0:
+                    angle_head_channels.append(int(shape[0]))
+
+        if angle_head_channels and all(
+            channels == 1 for channels in angle_head_channels
+        ):
+            return "obb"
         return None
 
     # =========================================================================
@@ -173,11 +190,16 @@ class LibreYOLO9(BaseModel):
     # Model lifecycle
     # =========================================================================
 
+    @property
+    def _is_obb(self) -> bool:
+        return self.task == "obb"
+
     def _init_model(self) -> nn.Module:
         return LibreYOLO9Model(
             config=self.size,
             reg_max=self.reg_max,
             nb_classes=self.nb_classes,
+            obb=self._is_obb,
         )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:
@@ -206,6 +228,13 @@ class LibreYOLO9(BaseModel):
         state_dict: dict,
         checkpoint: dict | None = None,
     ) -> None:
+        if self._is_obb:
+            if not any(key.startswith("head.cv4.") for key in state_dict):
+                raise RuntimeError(
+                    "YOLO9 OBB checkpoints must include head.cv4.* angle "
+                    "weights. Detect-to-OBB initialization is only supported "
+                    "through explicit training transfer (pretrained=...)."
+                )
         return
 
     def _prepare_state_dict(
@@ -237,6 +266,8 @@ class LibreYOLO9(BaseModel):
 
         detect._init_bias()
         detect._loss_fn = None
+        if hasattr(detect, "_obb_loss_fn"):
+            detect._obb_loss_fn = None
         detect.to(next(self.model.parameters()).device)
 
     def _rebuild_for_checkpoint_classes(self, new_nc: int, state_dict: dict):
@@ -304,6 +335,8 @@ class LibreYOLO9(BaseModel):
         head.no = self.nb_classes + head.reg_max * 4
         head._init_bias()
         head._loss_fn = None
+        if hasattr(head, "_obb_loss_fn"):
+            head._obb_loss_fn = None
         head.to(next(self.model.parameters()).device)
 
     def _load_transfer_weights(self, weights: str | Path) -> dict[str, int]:
@@ -519,7 +552,8 @@ class LibreYOLO9(BaseModel):
             patience: Early stopping patience.
             pretrained: Optional training initialization weights. Use True to
                 load the matching LibreYOLO9 detect checkpoint for transfer
-                learning, or pass a checkpoint path/name.
+                learning, or pass a checkpoint path/name. Detect-to-OBB
+                transfer is allowed here only as explicit initialization.
             callbacks: Optional training callback or iterable of callbacks.
             loggers: Optional built-in experiment loggers: a name
                 ('tensorboard', 'mlflow', 'wandb'), a configured logger

--- a/libreyolo/models/yolo9/nn.py
+++ b/libreyolo/models/yolo9/nn.py
@@ -16,6 +16,8 @@ LibreYOLO9 checkpoint format, and :mod:`libreyolo.models.yolo9.convert` maps
 upstream checkpoints onto it.
 """
 
+import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -714,6 +716,83 @@ class DDetect(nn.Module):
         )
 
 
+class DDetectOBB(DDetect):
+    """YOLO9 detection head with an oriented-box angle branch.
+
+    Extends the detect head with a per-scale angle tower (``cv4``, same
+    tower shape as the class towers) that emits one logit per anchor. The
+    logit maps to ``[-pi / 2, pi / 2)`` radians via a shifted sigmoid,
+    matching the canonical long-side-width angle range of
+    :mod:`libreyolo.data.obb`. Boxes stay in the detect head's horizontal
+    xyxy encoding and act as the rotated box's width/height proxy; the
+    postprocess recombines them with the angle into ``xywhr``.
+
+    Checkpoint-format contract: the angle towers live at ``head.cv4.*`` with
+    a single output channel — task inference reads that channel count.
+    """
+
+    angle_channels = 1
+
+    def __init__(self, nc=80, ch=(), reg_max=16, stride=(), use_group=True):
+        super().__init__(nc=nc, ch=ch, reg_max=reg_max, stride=stride, use_group=use_group)
+        self._obb_loss_fn = None
+
+        c4 = max(ch[0] // 4, self.angle_channels)
+        self.cv4 = nn.ModuleList(
+            nn.Sequential(
+                Conv(x, c4, 3),
+                Conv(c4, c4, 3),
+                nn.Conv2d(c4, self.angle_channels, 1),
+            )
+            for x in ch
+        )
+
+    def _get_obb_loss_fn(self, device):
+        if self._obb_loss_fn is None:
+            from .loss import YOLO9OBBLoss
+
+            self._obb_loss_fn = YOLO9OBBLoss(
+                num_classes=self.nc,
+                reg_max=self.reg_max,
+                strides=self.stride.tolist(),
+                image_size=None,
+                device=device,
+            )
+        return self._obb_loss_fn
+
+    @staticmethod
+    def _angle_logits_to_radians(angle_logits):
+        return (angle_logits.sigmoid() - 0.5) * math.pi
+
+    def forward(self, x, targets=None, img_size=None):
+        features = list(x)
+        angle_logits = [self.cv4[i](features[i]) for i in range(self.nl)]
+
+        det_outputs = super().forward(features, targets=None, img_size=img_size)
+
+        if self.training:
+            if targets is not None:
+                loss_fn = self._get_obb_loss_fn(angle_logits[0].device)
+                if img_size is not None:
+                    loss_fn.update_anchors(list(img_size))
+                return loss_fn(det_outputs, targets, angle_logits)
+            return det_outputs, angle_logits
+
+        predictions, raw_outputs = det_outputs
+        batch_size = predictions.shape[0]
+        angle = torch.cat(
+            [
+                self._angle_logits_to_radians(a).view(batch_size, 1, -1)
+                for a in angle_logits
+            ],
+            dim=2,
+        )
+        predictions = torch.cat((predictions[:, :4], angle, predictions[:, 4:]), dim=1)
+        if self.export:
+            return predictions
+        return predictions, raw_outputs, angle_logits
+
+
 # =============================================================================
 # Model Architecture Definitions
 # =============================================================================
@@ -1011,6 +1090,7 @@ class LibreYOLO9Model(nn.Module):
         reg_max=16,
         nb_classes=80,
         img_size=640,
+        obb=False,
     ):
         """
         Initialize YOLOv9 model.
@@ -1020,6 +1100,7 @@ class LibreYOLO9Model(nn.Module):
             reg_max: Regression max value for DFL
             nb_classes: Number of classes
             img_size: Input image size
+            obb: Build the oriented-bounding-box head instead of plain detect.
         """
         super().__init__()
 
@@ -1032,6 +1113,7 @@ class LibreYOLO9Model(nn.Module):
         self.nc = nb_classes
         self.reg_max = reg_max
         self.img_size = img_size
+        self.obb = obb
 
         cfg = YOLO9_CONFIGS[config]
 
@@ -1040,7 +1122,8 @@ class LibreYOLO9Model(nn.Module):
 
         # Detection head - use exact channels from config
         head_channels = cfg["head_channels"]
-        self.head = DDetect(
+        head_cls = DDetectOBB if obb else DDetect
+        self.head = head_cls(
             nc=nb_classes,
             ch=head_channels,
             reg_max=reg_max,
@@ -1081,19 +1164,30 @@ class LibreYOLO9Model(nn.Module):
             return output
 
         # Inference mode
-        y, x_list = output
+        if self.obb:
+            # DDetectOBB already folds the angle channel into the prediction
+            # tensor and returns it alone in export mode.
+            if self.head.export:
+                return output
+            y, x_list, angle_logits = output
+        else:
+            y, x_list = output
 
         # Export mode: return only the prediction tensor for ONNX/TorchScript
         if self.head.export:
             return y
 
-        return {
-            "predictions": y,  # (batch, 4+nc, total_anchors)
+        result = {
+            "predictions": y,  # (batch, 4+nc, total_anchors; +1 angle row for OBB)
             "raw_outputs": x_list,
             "x8": {"features": n3},
             "x16": {"features": n4},
             "x32": {"features": n5},
         }
+        if self.obb:
+            result["obb"] = True
+            result["angle_logits"] = angle_logits
+        return result
 
     def fuse(self):
         """Fuse Conv+BN and RepConvN for faster inference."""

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -74,12 +74,15 @@ class YOLO9Trainer(BaseTrainer):
         return groups or super().get_freeze_groups()
 
     def create_transforms(self):
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
         preproc = YOLO9TrainTransform(
             max_labels=getattr(self.config, "max_labels", 100),
             flip_prob=self.config.flip_prob,
             vertical_flip_prob=getattr(self.config, "flipud", 0.0),
             hsv_prob=self.config.hsv_prob,
             rot90_prob=getattr(self.config, "rot90", 0.0),
+            # OBB samples carry [class, x1, y1, x2, y2, angle] labels.
+            output_label_dim=6 if task == "obb" else None,
         )
         return preproc, YOLO9MosaicMixupDataset
 
@@ -110,11 +113,14 @@ class YOLO9Trainer(BaseTrainer):
         def _scalar(v):
             return v.item() if isinstance(v, torch.Tensor) else v
 
-        return {
+        components = {
             "box": _scalar(outputs.get("box", 0)),
             "cls": _scalar(outputs.get("cls", 0)),
             "dfl": _scalar(outputs.get("dfl", 0)),
         }
+        if "angle" in outputs:
+            components["angle"] = _scalar(outputs.get("angle", 0))
+        return components
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         return self.model(imgs, targets=targets)

--- a/libreyolo/validation/obb_validator.py
+++ b/libreyolo/validation/obb_validator.py
@@ -44,6 +44,11 @@ class _OBBValPreprocessor:
         self.base_preprocessor = base_preprocessor
 
     def __getattr__(self, name):
+        # During unpickling (e.g. Windows spawn DataLoader workers) pickle
+        # probes attributes before __dict__ is restored; delegating then would
+        # recurse through this method forever, so fail fast instead.
+        if name == "base_preprocessor":
+            raise AttributeError(name)
         return getattr(self.base_preprocessor, name)
 
     def __call__(self, img: np.ndarray, targets: np.ndarray, input_size: tuple):

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1161,7 +1161,8 @@
   "yolo9": {
     "class": "libreyolo.models.yolo9.model.LibreYOLO9",
     "tasks": [
-      "detect"
+      "detect",
+      "obb"
     ],
     "default_task": "detect",
     "sizes": {
@@ -1178,6 +1179,12 @@
     },
     "task_sizes": {
       "detect": {
+        "t": 640,
+        "s": 640,
+        "m": 640,
+        "c": 640
+      },
+      "obb": {
         "t": 640,
         "s": 640,
         "m": 640,
@@ -1208,6 +1215,12 @@
     },
     "task_sizes": {
       "detect": {
+        "t": 640,
+        "s": 640,
+        "m": 640,
+        "c": 640
+      },
+      "obb": {
         "t": 640,
         "s": 640,
         "m": 640,

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -632,3 +632,72 @@ def test_train_rfdetr_detect_checkpoint_switches_to_obb_architecture(
 
 
 
+
+
+def test_train_dry_run_reports_explicit_yolo9_obb_task():
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        [
+            "data=uav-obb.yaml",
+            "model=yolo9-t",
+            "task=obb",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_family"] == "yolo9"
+    assert data["resolved_config"]["task"] == "obb"
+    assert data["resolved_config"]["scheduler"] == "linear"
+
+
+@pytest.mark.parametrize(
+    "model_args",
+    [
+        ["model=yolo9-t", "task=obb"],
+        ["model=yolo9-t-obb"],
+    ],
+)
+def test_train_yolo9_obb_uses_task_architecture_without_loading_missing_obb_weights(
+    monkeypatch, tmp_path, model_args
+):
+    app = _make_app()
+    captured = {}
+
+    def fail_load(*_args, **_kwargs):
+        raise AssertionError("OBB training should instantiate the task architecture")
+
+    def fake_train(self, data, **kwargs):
+        captured["task"] = self.task
+        captured["size"] = self.size
+        captured["data"] = data
+        captured["kwargs"] = kwargs
+        return {"output_dir": str(tmp_path / "yolo9_obb_exp")}
+
+    monkeypatch.setattr("libreyolo.cli.commands.train.load_model_or_exit", fail_load)
+    monkeypatch.setattr("libreyolo.models.yolo9.model.LibreYOLO9.train", fake_train)
+
+    result = runner.invoke(
+        app,
+        [
+            "data=uav-obb.yaml",
+            *model_args,
+            "epochs=1",
+            "pretrained=false",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["task"] == "obb"
+    assert captured["size"] == "t"
+    assert captured["data"] == "uav-obb.yaml"
+    assert captured["kwargs"]["pretrained"] is False
+    data = json.loads(result.stdout)
+    assert data["model_family"] == "yolo9"
+    assert data["epochs_completed"] == 1

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -300,3 +300,103 @@ def test_factory_routes_onnx_before_native_task_validation(monkeypatch, tmp_path
         "device": "cpu",
         "task": "segment",
     }
+
+
+def test_yolo9_obb_transfer_accepts_same_family_detect_checkpoint(tmp_path):
+    detect_model = LibreYOLO9Model(config="t", nb_classes=80)
+    ckpt_path = tmp_path / "LibreYOLO9t.pt"
+    torch.save(
+        wrap_libreyolo_checkpoint(
+            detect_model.state_dict(),
+            model_family="yolo9",
+            size="t",
+            task="detect",
+            nc=80,
+            imgsz=640,
+        ),
+        ckpt_path,
+    )
+
+    target = LibreYOLO9(None, size="t", task="obb", nb_classes=6, device="cpu")
+    stats = target._load_transfer_weights(ckpt_path)
+
+    assert target.task == "obb"
+    assert target.nb_classes == 6
+    assert target.model.head.cv3[0][0].conv.weight.shape[0] == 80
+    assert hasattr(target.model.head, "cv4")
+    assert stats["loaded"] > 0
+    assert stats["skipped"] > 0
+    torch.testing.assert_close(
+        target.model.state_dict()["backbone.conv0.conv.weight"],
+        detect_model.state_dict()["backbone.conv0.conv.weight"],
+    )
+
+
+def test_yolo9_obb_direct_load_rejects_detect_checkpoint(tmp_path):
+    detect_model = LibreYOLO9Model(config="t", nb_classes=80)
+    ckpt_path = tmp_path / "LibreYOLO9t.pt"
+    torch.save(
+        wrap_libreyolo_checkpoint(
+            detect_model.state_dict(),
+            model_family="yolo9",
+            size="t",
+            task="detect",
+            nc=80,
+            imgsz=640,
+        ),
+        ckpt_path,
+    )
+
+    with pytest.raises(RuntimeError, match="task='detect'"):
+        LibreYOLO9(str(ckpt_path), size="t", task="obb", device="cpu")
+
+
+def test_factory_loads_yolo9_obb_scratch_checkpoint_with_custom_class_width(tmp_path):
+    model = LibreYOLO9Model(config="t", nb_classes=1, obb=True)
+
+    ckpt_path = tmp_path / "LibreYOLO9t-obb.pt"
+    torch.save(
+        wrap_libreyolo_checkpoint(
+            model.state_dict(),
+            model_family="yolo9",
+            size="t",
+            task="obb",
+            nc=1,
+            names={0: "ship"},
+            imgsz=64,
+        ),
+        ckpt_path,
+    )
+
+    loaded = LibreYOLO(str(ckpt_path), device="cpu")
+
+    assert loaded.FAMILY == "yolo9"
+    assert loaded.task == "obb"
+    assert loaded.nb_classes == 1
+    assert loaded.names == {0: "ship"}
+    assert loaded.model.training is False
+    assert loaded.model.head.cv3[0][0].conv.weight.shape[0] == 64
+
+
+def test_factory_resolves_metadata_less_yolo9_obb_from_filename(tmp_path):
+    model = LibreYOLO9Model(config="t", nb_classes=1, obb=True)
+    ckpt_path = tmp_path / "LibreYOLO9t-obb.pt"
+    torch.save(model.state_dict(), ckpt_path)
+
+    loaded = LibreYOLO(str(ckpt_path), device="cpu")
+
+    assert loaded.FAMILY == "yolo9"
+    assert loaded.task == "obb"
+    assert loaded.nb_classes == 1
+
+
+def test_factory_resolves_metadata_less_yolo9_obb_from_angle_head(tmp_path):
+    model = LibreYOLO9Model(config="t", nb_classes=1, obb=True)
+    ckpt_path = tmp_path / "best.pt"
+    torch.save(model.state_dict(), ckpt_path)
+
+    loaded = LibreYOLO(str(ckpt_path), size="t", device="cpu")
+
+    assert loaded.FAMILY == "yolo9"
+    assert loaded.task == "obb"
+    assert loaded.nb_classes == 1

--- a/tests/unit/test_obb_validation.py
+++ b/tests/unit/test_obb_validation.py
@@ -266,3 +266,20 @@ def test_obb_validator_skips_invalid_ground_truth_rows(tmp_path, caplog):
 
     assert metrics["metrics/mAP50"] == pytest.approx(1.0)
     assert "Skipped 1 invalid YOLO OBB label rows" in caplog.text
+
+
+def test_obb_val_preprocessor_survives_pickle_roundtrip():
+    """Windows spawn DataLoader workers pickle the preprocessor; __getattr__
+    must not recurse while __dict__ is still empty during unpickling."""
+    import pickle
+
+    from libreyolo.validation.obb_validator import _OBBValPreprocessor
+
+    preproc = _OBBValPreprocessor(YOLO9ValPreprocessor((32, 32)))
+    restored = pickle.loads(pickle.dumps(preproc))
+
+    assert isinstance(restored.base_preprocessor, YOLO9ValPreprocessor)
+    img = np.zeros((32, 32, 3), dtype=np.uint8)
+    targets = np.zeros((1, 6), dtype=np.float32)
+    out = restored(img, targets, (32, 32))
+    assert out is not None

--- a/tests/unit/test_yolo9_layers.py
+++ b/tests/unit/test_yolo9_layers.py
@@ -21,10 +21,12 @@ from libreyolo.models.yolo9.nn import (
     Concat,
     DFL,
     DDetect,
+    DDetectOBB,
     Backbone9,
     Neck9,
     LibreYOLO9Model,
 )
+from libreyolo.models.yolo9.loss import YOLO9OBBLoss
 from libreyolo.models.yolo9 import utils as yolo9_utils
 from libreyolo.postprocess import yolo9 as yolo9_postprocess_mod
 from libreyolo.models.yolo9.trainer import YOLO9Trainer
@@ -197,6 +199,51 @@ class TestYOLO9DetectionHead:
         assert decoded.shape[0] == 1
         assert decoded.shape[1] == 4 + 80  # 84 (decoded boxes + class scores)
 
+    def test_ddetect_obb_forward(self):
+        """Test oriented-box DDetect head forward pass."""
+        layer = DDetectOBB(nc=2, ch=(64, 128, 256), reg_max=16, stride=(8, 16, 32))
+        layer.eval()
+        x = [
+            torch.randn(1, 64, 8, 8),
+            torch.randn(1, 128, 4, 4),
+            torch.randn(1, 256, 2, 2),
+        ]
+        decoded, raw, angle_logits = layer(x)
+        assert decoded.shape == (1, 7, 84)
+        assert len(raw) == 3
+        assert len(angle_logits) == 3
+        assert angle_logits[0].shape == (1, 1, 8, 8)
+
+    def test_ddetect_obb_angle_row_is_bounded(self):
+        """The decoded angle row stays inside [-pi/2, pi/2)."""
+        layer = DDetectOBB(nc=2, ch=(64, 128, 256), reg_max=16, stride=(8, 16, 32))
+        layer.eval()
+        x = [
+            torch.randn(1, 64, 8, 8) * 100,
+            torch.randn(1, 128, 4, 4) * 100,
+            torch.randn(1, 256, 2, 2) * 100,
+        ]
+        decoded, _, _ = layer(x)
+        angles = decoded[:, 4]
+        assert torch.all(angles >= -torch.pi / 2)
+        assert torch.all(angles <= torch.pi / 2)
+
+    def test_ddetect_obb_export_forward_returns_prediction_tensor(self):
+        """OBB export mode returns a single traceable prediction tensor."""
+        layer = DDetectOBB(nc=2, ch=(64, 128, 256), reg_max=16, stride=(8, 16, 32))
+        layer.eval()
+        layer.export = True
+        x = [
+            torch.randn(1, 64, 8, 8),
+            torch.randn(1, 128, 4, 4),
+            torch.randn(1, 256, 2, 2),
+        ]
+
+        decoded = layer(x)
+
+        assert isinstance(decoded, torch.Tensor)
+        assert decoded.shape == (1, 7, 84)
+
 class TestYOLO9FullModel:
     """Test full model architecture."""
 
@@ -231,6 +278,86 @@ class TestYOLO9FullModel:
         # In eval mode, returns dict with 'predictions' key
         assert isinstance(out, dict)
         assert "predictions" in out
+
+    def test_obb_model_forward(self):
+        """Test full LibreYOLO9 OBB model forward pass."""
+        model = LibreYOLO9Model(config="t", nb_classes=2, obb=True)
+        model.eval()
+        x = torch.randn(1, 3, 64, 64)
+        out = model(x)
+        assert isinstance(out, dict)
+        assert out["obb"] is True
+        assert out["predictions"].shape == (1, 7, 84)
+
+    def test_obb_training_loss(self):
+        """OBB model computes box, class, DFL, and angle losses."""
+        model = LibreYOLO9Model(config="t", nb_classes=2, obb=True)
+        model.train()
+        targets = torch.zeros(2, 100, 6)
+        targets[:, :, 0] = -1
+        targets[0, 0] = torch.tensor([0, 0.2, 0.2, 0.7, 0.7, 0.25])
+        targets[1, 0] = torch.tensor([1, 0.1, 0.1, 0.6, 0.6, -0.25])
+
+        out = model(torch.randn(2, 3, 64, 64), targets=targets)
+
+        assert out["total_loss"].requires_grad
+        assert out["angle_loss"].requires_grad
+        assert out["angle"] >= 0
+
+    def test_obb_training_loss_rejects_five_column_targets(self):
+        """OBB training requires the 6-column [class, box, angle] labels."""
+        model = LibreYOLO9Model(config="t", nb_classes=2, obb=True)
+        model.train()
+        targets = torch.zeros(1, 10, 5)
+        targets[:, :, 0] = -1
+        with pytest.raises(ValueError, match="6"):
+            model(torch.randn(1, 3, 64, 64), targets=targets)
+
+
+def test_yolo9_obb_transform_vertical_flip_updates_box_and_angle():
+    image = np.zeros((10, 20, 3), dtype=np.uint8)
+    targets = np.array([[2.0, 1.0, 10.0, 4.0, 0.0, 0.25]], dtype=np.float32)
+    transform = YOLO9TrainTransform(
+        max_labels=2,
+        flip_prob=0.0,
+        vertical_flip_prob=1.0,
+        hsv_prob=0.0,
+        output_label_dim=6,
+    )
+
+    _, labels = transform(image, targets, (10, 20))
+
+    np.testing.assert_allclose(labels[0], [0.0, 0.1, 0.6, 0.5, 0.9, -0.25])
+    assert labels[1, 0] == -1
+
+
+def test_yolo9_obb_transform_horizontal_flip_updates_box_and_angle():
+    image = np.zeros((10, 20, 3), dtype=np.uint8)
+    targets = np.array([[2.0, 1.0, 10.0, 4.0, 0.0, 0.25]], dtype=np.float32)
+    transform = YOLO9TrainTransform(
+        max_labels=2,
+        flip_prob=1.0,
+        vertical_flip_prob=0.0,
+        hsv_prob=0.0,
+        output_label_dim=6,
+    )
+
+    _, labels = transform(image, targets, (10, 20))
+
+    np.testing.assert_allclose(labels[0], [0.0, 0.5, 0.1, 0.9, 0.4, -0.25])
+    assert labels[1, 0] == -1
+
+
+def test_yolo9_obb_loss_default_angle_weight_is_one():
+    loss = YOLO9OBBLoss(
+        num_classes=2,
+        reg_max=16,
+        strides=[8, 16, 32],
+        image_size=None,
+        device=torch.device("cpu"),
+    )
+
+    assert loss.angle_weight == 1.0
 
 class TestYOLO9Utils:
     """Test utility functions."""

--- a/tests/unit/test_yolo9_obb_export.py
+++ b/tests/unit/test_yolo9_obb_export.py
@@ -1,0 +1,63 @@
+"""Deterministic raw-output parity for YOLO9 OBB exports."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("format", ("onnx", "torchscript"))
+def test_yolo9_obb_raw_parity(tmp_path, format):
+    if format == "onnx":
+        pytest.importorskip("onnx")
+        pytest.importorskip("onnxruntime")
+
+    import libreyolo
+    from libreyolo.export.exporter import OnnxExporter
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    torch.manual_seed(0)
+    imgsz = 320
+    model = LibreYOLO9(None, size="t", nb_classes=3, device="cpu", task="obb")
+    model.model.eval()
+    tensor = torch.rand(1, 3, imgsz, imgsz)
+
+    exporter = OnnxExporter(model)
+    with exporter._model_context("cpu", False, False, 1, (imgsz, imgsz)) as (
+        wrapped,
+        _,
+    ):
+        with torch.no_grad():
+            native = wrapped(tensor)
+    if isinstance(native, torch.Tensor):
+        native = (native,)
+
+    # The OBB prediction tensor carries boxes, one angle row, and class scores.
+    assert native[0].shape == (1, 4 + 1 + 3, native[0].shape[-1])
+
+    artifact = model.export(
+        format=format,
+        imgsz=imgsz,
+        dynamic=False,
+        simplify=False,
+        output_path=str(tmp_path / f"LibreYOLO9t-obb.{format}"),
+    )
+    actual = libreyolo.LibreYOLO(artifact, device="cpu")._run_inference(tensor.numpy())
+
+    assert len(actual) == len(native)
+    rtol, atol = (2e-3, 2e-2) if format == "onnx" else (1e-3, 1e-3)
+    for actual_output, native_output in zip(actual, native):
+        expected = native_output.detach().cpu().numpy()
+        if format == "onnx":
+            element_match = np.isclose(actual_output, expected, rtol=rtol, atol=atol)
+            assert float(element_match.mean()) > 0.95
+            continue
+        np.testing.assert_allclose(
+            actual_output,
+            expected,
+            rtol=rtol,
+            atol=atol,
+        )


### PR DESCRIPTION
# What does this PR do?

Adds oriented bounding boxes (OBB) to YOLO9, closing the YOLO9 half of #320.

The shared OBB infrastructure (dataset parsing, rotated NMS in the YOLO9 postprocess, `OBBValidator`, `Results.obb`, CLI/export/backends plumbing, OBB-aware augmentations) never left dev; only the YOLO9 model-side pieces were removed in #436 (`0d5fe2ba`). This PR restores those pieces from this repository's own history, adapted to the current code structure:

- `DDetectOBB` head: per-scale `cv4` angle towers (1 channel), sigmoid mapped to `[-pi/2, pi/2)`, angle row folded into the prediction tensor.
- `YOLO9OBBLoss`: horizontal proxy-box CIoU/DFL via the existing matcher plus a pi-periodic `0.5 * (1 - cos(2 * delta))` angle loss.
- Task wiring: `SUPPORTED_TASKS`, checkpoint task inference from the 1-channel `cv4` towers, obb state-dict validation, 6-column OBB labels and the angle loss component in the trainer.
- Export: ONNX and TorchScript declared validated for `yolo9`/`obb` with a raw-parity test; inventory and generated tables refreshed.
- Bugfix (pre-existing, affects RF-DETR OBB too): `_OBBValPreprocessor.__getattr__` recursed infinitely when pickled into Windows spawn DataLoader workers, killing every in-training OBB validation on Windows. Fixed with a regression test.

Follow-up (not in this PR): training on a real OBB dataset and publishing `-obb` weights.

# Provenance declaration (required)

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

## Code provenance

All restored code originates from this repository's git history (added in `f2a22821`, review-fixed in `2d72ec52`, removed in `0d5fe2ba`/`69a50d9b`). The underlying detect head and loss machinery it extends is the already-noticed MultimediaTechLab/YOLO (MIT) port; no new third-party code is introduced, so notice files are unchanged.

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

# How was this tested?

- Unit: restored/extended OBB tests across head shapes, angle bounds, export tensor, 6-column target validation, transforms, factory task inference, transfer rules, CLI dry-run, plus a new ONNX/TorchScript raw-parity test and a spawn-pickling regression test. Affected suites: 267 passed.
- End-to-end on a synthetic rotated-bar dataset (48 train / 12 val, imgsz 320, yolo9-t, detect-to-OBB transfer, CUDA): 60 epochs, loss 11.9 -> 1.61 with the angle component falling 0.32 -> 0.08; standalone `val` reports rotated-IoU mAP50 0.874 / mAP50-95 0.545; predictions drawn on val images track the bars' orientation.
- In-training validation verified on Windows after the pickling fix (10-epoch run: epoch-10 validation runs in spawn workers and saves `best.pt` on OBB mAP50-95).
