### PR TITLE
Add OV-DEIM real-time open-vocabulary detector (LibreOVDEIM s/m/l)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Training capabilities are documented per family in
 | mobilesam | segment |  |  |  |  |  |  |  |
 | nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
 | omdet_turbo | detect |  |  |  |  |  |  |  |
+| ov_deim | detect |  |  |  |  |  |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |
 | picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | picosam3 | segment | ✓ |  |  |  |  |  |  |

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -40,6 +40,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | mobilesam | segment |  |  |  |  |  |  |  |
 | nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
 | omdet_turbo | detect |  |  |  |  |  |  |  |
+| ov_deim | detect |  |  |  |  |  |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |
 | picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | picosam3 | segment | ✓ |  |  |  |  |  |  |
@@ -237,6 +238,13 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `omdet_turbo` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `tflite`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `openvino`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `tflite`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -177,6 +177,7 @@ Open-vocabulary detector snapshot families use their own size codes:
 | `grounding_dino` | `t` (Swin-T), `b` (Swin-B) |
 | `owlv2` | `b16` (base patch-16 ensemble), `l14` (large patch-14 ensemble) |
 | `omdet_turbo` | `t` (Swin-T, the only released checkpoint) |
+| `ov_deim` | `s`, `m`, `l` (ViT-tiny / ViT-tinyplus / DINOv3-S backbones) |
 
 Notes:
 
@@ -472,6 +473,11 @@ weights/LibreOWLv2l14/
 
 # omdet_turbo - Hugging Face snapshot, no .pt checkpoint filename
 weights/LibreOMDetTurbot/
+
+# ov_deim - Hugging Face snapshot, no .pt checkpoint filename
+weights/LibreOVDEIMs/
+weights/LibreOVDEIMm/
+weights/LibreOVDEIMl/
 ```
 
 ### Gaze (inference-only)

--- a/docs/openvocab_design.md
+++ b/docs/openvocab_design.md
@@ -20,6 +20,7 @@ labels directly.
 | `grounding-dino`, `grounding-dino-tiny`, `grounding-dino-base` | Grounding DINO | tiny | Apache-2.0 |
 | `owlv2`, `owlv2-base`, `owlv2-large` | OWLv2 | base-patch16 ensemble | Apache-2.0 |
 | `omdet-turbo`, `omdet`, `omdet-turbo-swin-tiny` | OMDet-Turbo | Swin-T | Apache-2.0 |
+| `ov-deim`, `ov-deim-s`, `ov-deim-m`, `ov-deim-l` | OV-DEIM | s | code Apache-2.0, weights CC BY-NC 4.0 |
 
 The authoritative alias table is `_ALIASES` in
 `libreyolo/models/openvocab/__init__.py`.
@@ -34,8 +35,29 @@ Grounding DINO). It does not expose `text_threshold=`.
 including its processor and post-processing; LibreYOLO vendors no OMDet-Turbo
 model source. Because that post-processing takes the suppression threshold as
 an argument, OMDet-Turbo is the one family in the tier that honours `iou=`;
-the other two suppress nothing and warn that `iou=` is ignored. Export stays
-unsupported under ADR 0008.
+the other families suppress nothing and warn that `iou=` is ignored. Export
+stays unsupported under ADR 0008.
+
+OV-DEIM is the fastest member of the tier (upstream reports 161/109/91 FPS
+for S/M/L on a T4 with TensorRT at 640). Unlike the other families it is a
+native port, not a `transformers` wrapper: no `transformers` model class
+exists for it, so LibreYOLO vendors the detector modules
+(`libreyolo/models/openvocab/ovdeim/`, Apache-2.0, RT-DETR/DEIMv2 lineage)
+and reuses the DEIMv2 DINOv3 backbone adapter already in the repo. The
+classification branch is region-text alignment: each decoder query is scored
+by cosine similarity against MobileCLIP-B(LT) text embeddings, which
+LibreYOLO computes online with a bundled CLIP-style text tower (reusing
+LibreCLIP's transformer modules and BPE tokenizer), so arbitrary prompts
+work without upstream's precomputed embedding files. Embeddings are cached
+per vocabulary. One-to-one matching, top-K selection, no NMS. The family
+only needs `huggingface_hub` and `safetensors`, not `transformers`.
+
+Licensing is layered for OV-DEIM: the vendored code is Apache-2.0; the
+detector weights are CC BY-NC 4.0 (non-commercial, redistribution and format
+conversion permitted with attribution); the bundled MobileCLIP-B(LT) text
+tower is under the Apple Machine Learning Research Model license (research
+use only); the L backbone derives from DINOv3 weights under Meta's DINOv3
+License. A license notice is logged once at construction.
 
 Weights are loaded from LibreYOLO-owned Hugging Face mirror repositories:
 
@@ -44,6 +66,9 @@ Weights are loaded from LibreYOLO-owned Hugging Face mirror repositories:
 - `LibreYOLO/LibreOWLv2b16`
 - `LibreYOLO/LibreOWLv2l14`
 - `LibreYOLO/LibreOMDetTurbot`
+- `LibreYOLO/LibreOVDEIMs`
+- `LibreYOLO/LibreOVDEIMm`
+- `LibreYOLO/LibreOVDEIMl`
 
 The model cards in those repos record the original upstream source repos.
 

--- a/docs/provenance/ov_deim.md
+++ b/docs/provenance/ov_deim.md
@@ -1,0 +1,106 @@
+# ov_deim (pre-integration audit, family NOT shipped)
+
+- **LibreYOLO module:** none. This is a Phase 0 licensing audit for a proposed
+  port; no OV-DEIM code or weights have entered this repository.
+- **Candidate upstream:** https://github.com/wleilei/OV-DEIM (paper: arXiv
+  2603.07022, "OV-DEIM: Real-time DETR-Style Open-Vocabulary Object Detection
+  with GridSynthetic Augmentation").
+- **Verification status:** verified 2026-07-11. Decision: **blocked (option A)**,
+  see verdict below.
+
+## License status of the upstream repository
+
+Checked 2026-07-11 via the GitHub API and the repository tree:
+
+- The repository has **no LICENSE file** and GitHub reports `license: null`
+  (last upstream push 2026-07-01). Under copyright default this means all
+  rights reserved: the code cannot be ported and the released checkpoints
+  (Google Drive / Baidu) cannot be redistributed or converted.
+- A license clarification issue was opened upstream on 2026-07-11:
+  https://github.com/wleilei/OV-DEIM/issues/4 (asks for a code license, a
+  checkpoint license, and a map of which files derive from which upstream).
+  No answer yet; record the answer here when it arrives.
+
+## Component licenses (verified against each upstream, 2026-07-11)
+
+| Component | License | Notes |
+|---|---|---|
+| DEIMv2 (Intellindust-AI-Lab/DEIMv2) | Apache-2.0 | already ported on dev at `libreyolo/models/deimv2/` |
+| RT-DETR (lyuwenyu/RT-DETR) | Apache-2.0 | |
+| YOLO-World (AILab-CVC/YOLO-World) | GPL-3.0 | |
+| YOLOE (THU-MIG/yoloe) | AGPL-3.0 | |
+| DINOv3 code + weights (facebookresearch/dinov3) | DINOv3 License (Meta custom) | not Apache; redistribution carries Meta's terms |
+| MobileCLIP code (apple/ml-mobileclip) | MIT | code only |
+| MobileCLIP **weights** (LICENSE_MODELS) | Apple ML Research Model license | **research-only**; use, derivatives and redistribution restricted to scientific research |
+| MobileCLIP training data terms (LICENSE_DATA) | CC BY-NC-ND 4.0 | non-commercial, no derivatives |
+
+## File-level provenance map
+
+Method: mechanical line-containment analysis over every `.py` file in the
+OV-DEIM repository against shallow clones of DEIMv2, RT-DETR, YOLO-World,
+YOLOE and dinov3 (fraction of a file's normalized non-trivial source lines
+present in the best-matching reference file, refined with a difflib ratio),
+plus a manual pass over file headers and docstrings. 146 Python files total.
+
+Findings by directory:
+
+- **`dinov3/` (110 files):** wholesale vendored copy of Meta's dinov3
+  repository, containment 0.95 to 1.00 for nearly every file. Governed by the
+  DINOv3 License regardless of what license the OV-DEIM authors adopt. A
+  subset of `dinov3/dinov3/layers/` and `utils/` matches DEIMv2's own vendored
+  `engine/backbone/dinov3/` copy exactly (same Meta lineage via DEIMv2).
+- **`model/` (18 files):** Apache-2.0 lineage plus author-original changes.
+  Backbones are near-identical to DEIMv2/RT-DETR (`hgnetv2.py` 1.00,
+  `vit_tiny.py` 0.98, `presnet.py` 0.97 vs RT-DETR, `dinov3_adapter.py` 0.92),
+  encoder and matcher are DEIMv2-derived (0.88 and 0.81), decoder and
+  criterion are heavier author modifications of the same Apache base (0.44 to
+  0.64). The open-vocab classification head `model/decoder/cls_embed.py` and
+  the top-level `model/ovdeim.py` match no reference (author-original).
+  Copyright headers in these files credit lyuwenyu (RT-DETR, Apache-2.0) and
+  the DEIMv2 authors, consistent with the diff.
+  **No file in `model/` shows meaningful similarity to YOLO-World or YOLOE
+  (all containment at or below 0.03).**
+- **`dataloader/` (3 files):** `transforms.py` states in docstrings that
+  several classes are "adapted from" MMYolo (GPL-3.0) and that
+  `MultiModalMosaic` is "a modified version of" YOLO-World's implementation
+  (GPL-3.0). Line containment vs YOLO-World is low (0.06) because the code was
+  rewritten, but the stated derivation makes these classes derivative works of
+  GPL code. **The GPL surface is confined to this training-only dataloader**;
+  it does not touch the model or inference path.
+- **Training/eval scripts, configs, `optim_tools/`, `dist_tools/`:** original
+  or thin RT-DETR derivations (`optim_tools/ema.py` 0.79 vs RT-DETR,
+  Apache-2.0).
+
+## Checkpoint (weights) analysis
+
+Released S/M/L checkpoints were trained on Objects365v1 + GoldG with text
+embeddings precomputed by MobileCLIP-B(LT):
+
+1. With no upstream license, the checkpoints cannot be redistributed at all
+   today. This alone blocks any HF upload.
+2. Even if the authors add a permissive code license, MobileCLIP **weights**
+   are research-only (Apple ML Research Model license). Shipping an online
+   text tower for arbitrary prompts would mean converting and redistributing
+   MobileCLIP text-encoder weights, which that license does not permit for a
+   commercially usable MIT project. Whether the detector checkpoints
+   themselves count as "Model Derivatives" of MobileCLIP under Apple's terms
+   is an open legal question; treat as needs-check.
+3. Training data terms (Objects365v1 research terms, GoldG mixture including
+   Flickr30k entities): needs-check if weights ever become redistributable.
+
+## Verdict (Phase 0 go/no-go)
+
+- **Option A (blocked): in effect as of 2026-07-11.** No upstream license.
+  Do not port code, do not redistribute or convert weights. Parked pending an
+  answer to upstream issue #4.
+- **Option B (port if licensed):** becomes viable for the inference-side code
+  if the authors add a permissive license: the inference surface is
+  Apache-lineage plus author-original code, and the GPL-derived surface is
+  confined to the training dataloader, which a v1 inference port would not
+  take. Two residual blockers would remain even then: the vendored `dinov3/`
+  tree (avoidable, our port would reuse dev's existing DEIMv2 backbones) and
+  the MobileCLIP weights license for the online text tower (not avoidable
+  without substituting the text encoder and retraining, see point 2 above).
+- **Option C (from-paper reimplementation with our own training):** possible
+  but large (Objects365+GoldG scale training) and still needs a
+  permissively-licensed text tower substitute. Maintainer decision.

--- a/docs/provenance/ov_deim.md
+++ b/docs/provenance/ov_deim.md
@@ -1,12 +1,82 @@
-# ov_deim (pre-integration audit, family NOT shipped)
+# ov_deim
 
-- **LibreYOLO module:** none. This is a Phase 0 licensing audit for a proposed
-  port; no OV-DEIM code or weights have entered this repository.
-- **Candidate upstream:** https://github.com/wleilei/OV-DEIM (paper: arXiv
-  2603.07022, "OV-DEIM: Real-time DETR-Style Open-Vocabulary Object Detection
-  with GridSynthetic Augmentation").
-- **Verification status:** verified 2026-07-11. Decision: **blocked (option A)**,
-  see verdict below.
+- **LibreYOLO module:** `libreyolo/models/openvocab/ov_deim.py` plus vendored
+  architecture modules in `libreyolo/models/openvocab/ovdeim/`; the DINOv3
+  backbone adapter is reused from `libreyolo/models/deimv2/`.
+- **Upstream:** https://github.com/wleilei/OV-DEIM (paper: arXiv 2603.07022,
+  "OV-DEIM: Real-time DETR-Style Open-Vocabulary Object Detection with
+  GridSynthetic Augmentation"), pinned at commit
+  `dfbf394672407b7f837ec08e7d68e8127548b254` (the commit that added the
+  LICENSE files).
+- **Verification status:** Phase 0 audit verified 2026-07-11 (blocked, no
+  license). **Unblocked 2026-07-14**: upstream added LICENSE (Apache-2.0),
+  MODEL_LICENSE (CC BY-NC 4.0) and THIRD_PARTY.md; ported per option B. See
+  "Resolution" below.
+
+## Resolution (2026-07-14)
+
+The repository owner answered the license request
+(https://github.com/wleilei/OV-DEIM/issues/4#issuecomment-4967463647)
+verbatim:
+
+> Hi, thank you for the thoughtful note and for bringing this licensing issue
+> to our attention.
+>
+> We have now added the following files to the repository:
+>
+> * `LICENSE` — The OV-DEIM code is released under the Apache License 2.0.
+> * `MODEL_LICENSE` — The released S/M/L checkpoints are licensed under
+>   CC BY-NC 4.0. Redistribution and format conversion (e.g., ONNX, TensorRT)
+>   are permitted with attribution for non-commercial use.
+> * `THIRD_PARTY.md` — Documents the relationship and licenses of upstream
+>   projects.
+>
+> To clarify the GPL/AGPL concern: OV-DEIM does not directly redistribute
+> source files copied from YOLO-World (GPL-3.0) or YOLOE (AGPL-3.0). These
+> projects were used as research references and architectural inspiration.
+>
+> The codebase includes components adapted from RT-DETR (Apache-2.0) and
+> DEIMv2 (Apache-2.0). MobileCLIP components and the DINOv3 backbone remain
+> under their respective original license terms, as documented in
+> `THIRD_PARTY.md`.
+>
+> We hope this clarifies the licensing status and makes OV-DEIM easier to
+> adopt and integrate. Thank you again for helping us improve the repository
+> documentation.
+
+Ship decisions taken on that basis:
+
+- **Code (port):** the vendored modules (`ovdeim/encoder.py`,
+  `ovdeim/decoder.py`, the `TextAdapter` in `ovdeim/nn.py`) are taken from
+  OV-DEIM under Apache-2.0, RT-DETR headers preserved. The GPL-derived
+  training dataloader identified in the Phase 0 map is **not** ported
+  (inference-only v1); the vendored `dinov3/` tree is avoided by reusing
+  dev's existing DEIMv2 backbone adapter.
+- **Detector weights:** converted S/M/L checkpoints are rehosted on
+  `LibreYOLO/LibreOVDEIM{s,m,l}` under CC BY-NC 4.0 with attribution, as the
+  MODEL_LICENSE explicitly permits. The family is therefore non-commercial;
+  the license notice is logged at model construction.
+- **Text tower:** the online text encoder is MobileCLIP-B(LT)'s text
+  transformer, weights taken unchanged from Apple's own release
+  (`apple/MobileCLIP-B-LT-OpenCLIP`). The Apple Machine Learning Research
+  Model license **permits redistribution** of the model and derivatives with
+  a copy of the agreement, the attribution notice, and disclosure of
+  modifications, but restricts use to research purposes. The weight repos
+  carry the license text verbatim, the attribution notice, and identify the
+  slice (text tower only, unmodified tensors) as required. This is stricter
+  than CC BY-NC; the combined artifact is research-use.
+- **L backbone:** the fine-tuned DINOv3-S weights inside the L checkpoint
+  remain subject to Meta's DINOv3 License; the weight repo documents this,
+  matching the existing DEIMv2 precedent.
+- **Parity evidence:** detector outputs are bit-exact against upstream for
+  all three sizes on identical inputs; the online text tower reproduces
+  upstream's released embedding caches to 2.4e-7 (fp32 storage); the full
+  predict pipeline matches upstream's evaluation flow on real images with
+  100% label agreement across all 300 queries.
+
+The Phase 0 audit below is retained unchanged for the record.
+
+# Phase 0 audit (2026-07-11, superseded by the resolution above)
 
 ## License status of the upstream repository
 

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -677,6 +677,7 @@ _FAMILY_BLOCKS = {
     "grounding_dino": "Open-vocabulary runtime export is out of scope for v1.",
     "owlv2": "Open-vocabulary runtime export is out of scope for v1.",
     "omdet_turbo": "Open-vocabulary runtime export is out of scope for v1.",
+    "ov_deim": "Open-vocabulary runtime export is out of scope for v1.",
     "florence2": "Generative VLM export is out of scope for v1.",
     "kosmos2": "Generative VLM export is out of scope for v1.",
     "lfm2vl": "Generative VLM export is out of scope for v1.",

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -41,6 +41,12 @@ OPTIONAL_MODELS = (
         "openvocab",
         "transformers",
     ),
+    (
+        "libreyolo.models.openvocab.ov_deim",
+        "LibreOVDEIM",
+        "openvocab",
+        "huggingface_hub",
+    ),
 )
 
 

--- a/libreyolo/models/openvocab/__init__.py
+++ b/libreyolo/models/openvocab/__init__.py
@@ -12,6 +12,7 @@ from typing import Dict, Tuple, Type
 from .base import LibreOpenVocabDetector
 from .grounding_dino import LibreGroundingDINO
 from .omdet_turbo import LibreOMDetTurbo
+from .ov_deim import LibreOVDEIM
 from .owlv2 import LibreOWLv2
 
 _ALIASES: Dict[str, Tuple[Type[LibreOpenVocabDetector], str]] = {
@@ -41,6 +42,14 @@ _ALIASES: Dict[str, Tuple[Type[LibreOpenVocabDetector], str]] = {
     "omdet-turbo-tiny": (LibreOMDetTurbo, "t"),
     "omdet-turbo-swin-tiny": (LibreOMDetTurbo, "t"),
     "omdet-turbo-t": (LibreOMDetTurbo, "t"),
+    "ov-deim": (LibreOVDEIM, "s"),
+    "ovdeim": (LibreOVDEIM, "s"),
+    "ov-deim-s": (LibreOVDEIM, "s"),
+    "ovdeim-s": (LibreOVDEIM, "s"),
+    "ov-deim-m": (LibreOVDEIM, "m"),
+    "ovdeim-m": (LibreOVDEIM, "m"),
+    "ov-deim-l": (LibreOVDEIM, "l"),
+    "ovdeim-l": (LibreOVDEIM, "l"),
 }
 
 _DEFAULT_MODEL = "grounding-dino-tiny"
@@ -70,4 +79,5 @@ __all__ = [
     "LibreGroundingDINO",
     "LibreOWLv2",
     "LibreOMDetTurbo",
+    "LibreOVDEIM",
 ]

--- a/libreyolo/models/openvocab/ov_deim.py
+++ b/libreyolo/models/openvocab/ov_deim.py
@@ -120,10 +120,19 @@ class LibreOVDEIM(LibreOpenVocabDetector):
         return self._tokenizer
 
     def _class_text_feats(self) -> torch.Tensor:
-        """L2-normalized text embeddings for the current vocabulary, cached."""
+        """L2-normalized text embeddings for the current vocabulary, cached.
+
+        ``predict(device=...)`` moves the model between calls, so a cache hit
+        must follow the model onto the current device rather than hand back a
+        tensor stranded on the previous one.
+        """
         names = tuple(str(self.names[i]) for i in range(len(self.names)))
         if self._text_feats_cache is not None and self._text_feats_cache[0] == names:
-            return self._text_feats_cache[1]
+            feats = self._text_feats_cache[1]
+            if feats.device != self.device:
+                feats = feats.to(self.device)
+                self._text_feats_cache = (names, feats)
+            return feats
         tokens = self._get_tokenizer()(list(names)).to(self.device)
         with torch.no_grad():
             feats = self.model.encode_texts(tokens)

--- a/libreyolo/models/openvocab/ov_deim.py
+++ b/libreyolo/models/openvocab/ov_deim.py
@@ -1,0 +1,227 @@
+"""OV-DEIM real-time open-vocabulary detector adapter.
+
+Unlike the other families in this tier, OV-DEIM is a native port (no
+``transformers`` model class exists for it). The detector comes from
+https://github.com/wleilei/OV-DEIM (code Apache-2.0, weights CC BY-NC 4.0)
+and classifies queries by cosine similarity against MobileCLIP-B(LT) text
+embeddings, produced online by the bundled text tower for arbitrary prompts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, Optional, Tuple
+
+import numpy as np
+import torch
+
+from .base import LibreOpenVocabDetector
+
+_TEXT_TOWER_LICENSE_NOTICE = (
+    "LibreOVDEIM weights are CC BY-NC 4.0 (non-commercial, upstream: "
+    "wleilei/OV-DEIM); the bundled MobileCLIP-B(LT) text tower is covered by "
+    "the Apple Machine Learning Research Model license (research use only). "
+    "See the LICENSE files in the weight repository."
+)
+
+
+class LibreOVDEIM(LibreOpenVocabDetector):
+    """OV-DEIM: real-time DETR-style open-vocabulary detector (no NMS).
+
+    The classification branch scores each query against the text embedding of
+    every prompt, so ``set_classes([...])`` / ``predict(classes=[...])`` work
+    with arbitrary phrases. Text embeddings are cached per vocabulary.
+    """
+
+    FAMILY = "ov_deim"
+    FILENAME_PREFIX = "LibreOVDEIM"
+    HF_REPOS: ClassVar[Dict[str, str]] = {
+        "s": "LibreYOLO/LibreOVDEIMs",
+        "m": "LibreYOLO/LibreOVDEIMm",
+        "l": "LibreYOLO/LibreOVDEIMl",
+    }
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {"s": 640, "m": 640, "l": 640}
+    DEFAULT_CONF: ClassVar[float] = 0.25
+    # One-to-one matching, top-K selection: no NMS anywhere.
+    NMS_THRESHOLD: ClassVar[float | None] = None
+
+    _LICENSE_NOTICE = _TEXT_TOWER_LICENSE_NOTICE
+
+    # ImageNet statistics (upstream ToTensor defaults).
+    _MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+    _STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+    _PAD_VALUE = 114
+
+    def __init__(self, size: str, **kwargs):
+        self._text_feats_cache: tuple[tuple[str, ...], torch.Tensor] | None = None
+        self._tokenizer = None
+        super().__init__(size, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Weights
+    # ------------------------------------------------------------------
+
+    def _ensure_weights(self) -> str:
+        # Same flow as the base class but without requiring ``transformers``:
+        # this family is a native port and only needs huggingface_hub.
+        import json
+        from pathlib import Path
+
+        from .base import _SNAPSHOT_COMPLETE_MARKER
+
+        repo = self.HF_REPOS[self.size]
+        local_dir = Path("weights") / f"{self.FILENAME_PREFIX}{self.size}"
+        self._notify_license_once()
+        if self._snapshot_complete(local_dir, repo=repo):
+            return str(local_dir)
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            repo,
+            local_dir=str(local_dir),
+            ignore_patterns=list(self.SNAPSHOT_IGNORE_PATTERNS),
+        )
+        (local_dir / _SNAPSHOT_COMPLETE_MARKER).write_text(
+            json.dumps({"repo": repo}) + "\n", encoding="utf-8"
+        )
+        if not self._snapshot_complete(local_dir, repo=repo):
+            (local_dir / _SNAPSHOT_COMPLETE_MARKER).unlink(missing_ok=True)
+            raise FileNotFoundError(
+                f"Downloaded snapshot for {repo} is missing config or weight files in {local_dir}."
+            )
+        return str(local_dir)
+
+    def _load_pretrained(self, snapshot_dir: str):
+        from pathlib import Path
+
+        from safetensors.torch import load_file
+
+        from .ovdeim import LibreOVDEIMModel
+
+        model = LibreOVDEIMModel(self.size)
+        state_dict = load_file(str(Path(snapshot_dir) / "model.safetensors"))
+        model.load_state_dict(state_dict, strict=True)
+        model.eval()
+        return model, None
+
+    # ------------------------------------------------------------------
+    # Text side
+    # ------------------------------------------------------------------
+
+    def set_classes(self, classes: list[str]) -> "LibreOVDEIM":
+        super().set_classes(classes)
+        self._text_feats_cache = None
+        return self
+
+    def _get_tokenizer(self):
+        if self._tokenizer is None:
+            from ..clip.tokenizer import SimpleTokenizer
+
+            self._tokenizer = SimpleTokenizer()
+        return self._tokenizer
+
+    def _class_text_feats(self) -> torch.Tensor:
+        """L2-normalized text embeddings for the current vocabulary, cached."""
+        names = tuple(str(self.names[i]) for i in range(len(self.names)))
+        if self._text_feats_cache is not None and self._text_feats_cache[0] == names:
+            return self._text_feats_cache[1]
+        tokens = self._get_tokenizer()(list(names)).to(self.device)
+        with torch.no_grad():
+            feats = self.model.encode_texts(tokens)
+        self._text_feats_cache = (names, feats)
+        return feats
+
+    # ------------------------------------------------------------------
+    # Image side (mirrors upstream KeepRatioResize + LetterResize + ToTensor)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _letterbox_params(
+        cls, width: int, height: int, target: int
+    ) -> tuple[int, int, int, int]:
+        """Return (new_w, new_h, left_pad, top_pad) for an original size."""
+        scale = min(target / max(height, width), target / min(height, width))
+        new_w = int(np.rint(width * scale))
+        new_h = int(np.rint(height * scale))
+        top = int(np.rint((target - new_h) / 2))
+        left = int(np.rint((target - new_w) / 2))
+        return new_w, new_h, left, top
+
+    def _build_inputs(self, img: Any) -> Dict[str, torch.Tensor]:
+        import cv2
+
+        array = np.asarray(img.convert("RGB") if hasattr(img, "convert") else img)
+        height, width = array.shape[:2]
+        target = self.INPUT_SIZES[self.size]
+        new_w, new_h, left, top = self._letterbox_params(width, height, target)
+
+        if (new_w, new_h) != (width, height):
+            interpolation = cv2.INTER_AREA if new_w < width else cv2.INTER_LINEAR
+            array = cv2.resize(array, (new_w, new_h), interpolation=interpolation)
+        canvas = np.full((target, target, 3), self._PAD_VALUE, dtype=array.dtype)
+        canvas[top : top + new_h, left : left + new_w] = array
+
+        tensor = torch.from_numpy(
+            np.ascontiguousarray(canvas.transpose(2, 0, 1))
+        ).to(torch.float32) / 255.0
+        tensor = (tensor - torch.from_numpy(self._MEAN).view(-1, 1, 1)) / torch.from_numpy(
+            self._STD
+        ).view(-1, 1, 1)
+        return tensor.unsqueeze(0)
+
+    def _forward(self, inputs: torch.Tensor) -> Dict[str, torch.Tensor]:
+        images = inputs.to(self.device, dtype=torch.float32)
+        text_feats = self._class_text_feats().unsqueeze(0)
+        return self.model(images, text_feats)
+
+    # ------------------------------------------------------------------
+    # Postprocess (mirrors upstream OVDEIMPostProcessor)
+    # ------------------------------------------------------------------
+
+    def _postprocess(
+        self,
+        output: Dict[str, torch.Tensor],
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        logits = output["pred_logits"][0]  # (Q, C)
+        boxes = output["pred_boxes"][0]  # (Q, 4) cxcywh in [0, 1]
+        num_classes = logits.shape[-1]
+        num_queries = logits.shape[0]
+        target = self.INPUT_SIZES[self.size]
+
+        scores = torch.sigmoid(logits).flatten()
+        topk = min(num_queries, scores.shape[0])
+        scores, index = torch.topk(scores, topk, dim=-1)
+        labels = index % num_classes
+        query_index = index // num_classes
+        boxes = boxes[query_index]
+
+        # cxcywh (normalized) -> xyxy in letterboxed pixels
+        cxcy, wh = boxes[:, :2] * target, boxes[:, 2:] * target
+        boxes_xyxy = torch.cat([cxcy - wh / 2, cxcy + wh / 2], dim=-1)
+
+        # Undo the letterbox for the original image size.
+        width, height = original_size
+        new_w, new_h, left, top = self._letterbox_params(width, height, target)
+        pad = boxes_xyxy.new_tensor([left, top, left, top])
+        scale = boxes_xyxy.new_tensor(
+            [new_w / width, new_h / height, new_w / width, new_h / height]
+        )
+        boxes_xyxy = (boxes_xyxy - pad) / scale
+
+        return self._detections_to_dict(
+            boxes_xyxy,
+            scores,
+            labels,
+            conf_thres=conf_thres,
+            original_size=original_size,
+            max_det=max_det,
+            classes=kwargs.get("classes"),
+        )
+
+
+__all__ = ["LibreOVDEIM"]

--- a/libreyolo/models/openvocab/ovdeim/__init__.py
+++ b/libreyolo/models/openvocab/ovdeim/__init__.py
@@ -1,0 +1,12 @@
+"""Native OV-DEIM architecture modules (vendored, inference-only).
+
+Ported from OV-DEIM (https://github.com/wleilei/OV-DEIM), Apache-2.0, at
+commit dfbf3946. The encoder/decoder lineage is RT-DETR (Apache-2.0,
+Copyright (c) 2023 lyuwenyu) via DEIMv2 (Apache-2.0); the backbone adapter is
+reused from ``libreyolo.models.deimv2``. Training-only code paths (denoising,
+criterion, GridSynthetic augmentation) are intentionally not ported.
+"""
+
+from .nn import OVDEIM_SIZE_CONFIGS, LibreOVDEIMModel
+
+__all__ = ["LibreOVDEIMModel", "OVDEIM_SIZE_CONFIGS"]

--- a/libreyolo/models/openvocab/ovdeim/decoder.py
+++ b/libreyolo/models/openvocab/ovdeim/decoder.py
@@ -1,0 +1,659 @@
+"""OV-DEIM decoder (vendored, inference-only).
+
+Copyright(c) 2023 lyuwenyu. All Rights Reserved.
+
+Ported from OV-DEIM ``model/decoder/ovdeim_decoder.py``, ``cls_embed.py`` and
+``decoder/utils.py`` (https://github.com/wleilei/OV-DEIM, Apache-2.0). Module
+and attribute names mirror upstream so released checkpoints load with a plain
+key strip. Training-only branches (contrastive denoising, auxiliary losses)
+are removed; construct with ``num_denoising=0``.
+"""
+
+import copy
+import functools
+import math
+from collections import OrderedDict
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.nn.init as init
+
+
+def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
+    x = x.clip(min=0.0, max=1.0)
+    return torch.log(x.clip(min=eps) / (1 - x).clip(min=eps))
+
+
+def bias_init_with_prob(prior_prob=0.01):
+    """initialize conv/fc bias value according to a given probability value."""
+    return float(-math.log((1 - prior_prob) / prior_prob))
+
+
+def deformable_attention_core_func_v2(
+    value: torch.Tensor,
+    value_spatial_shapes,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+    num_points_list: List[int],
+    method="default",
+):
+    """
+    Args:
+        value (Tensor): [bs, value_length, n_head, c]
+        value_spatial_shapes (Tensor|List): [n_levels, 2]
+        sampling_locations (Tensor): [bs, query_length, n_head, n_levels * n_points, 2]
+        attention_weights (Tensor): [bs, query_length, n_head, n_levels * n_points]
+
+    Returns:
+        output (Tensor): [bs, Length_{query}, C]
+    """
+    bs, _, n_head, c = value.shape
+    _, Len_q, _, _, _ = sampling_locations.shape
+
+    split_shape = [h * w for h, w in value_spatial_shapes]
+    value_list = value.permute(0, 2, 3, 1).flatten(0, 1).split(split_shape, dim=-1)
+
+    if method == "default":
+        sampling_grids = 2 * sampling_locations - 1
+    elif method == "discrete":
+        sampling_grids = sampling_locations
+
+    sampling_grids = sampling_grids.permute(0, 2, 1, 3, 4).flatten(0, 1)
+    sampling_locations_list = sampling_grids.split(tuple(num_points_list), dim=-2)
+
+    sampling_value_list = []
+    for level, (h, w) in enumerate(value_spatial_shapes):
+        value_l = value_list[level].reshape(bs * n_head, c, h, w)
+        sampling_grid_l: torch.Tensor = sampling_locations_list[level]
+
+        if method == "default":
+            sampling_value_l = F.grid_sample(
+                value_l, sampling_grid_l, mode="bilinear", padding_mode="zeros", align_corners=False
+            )
+        elif method == "discrete":
+            sampling_coord = (
+                sampling_grid_l * torch.tensor([[w, h]], device=value.device) + 0.5
+            ).to(torch.int64)
+            sampling_coord = sampling_coord.clamp(0, h - 1)
+            sampling_coord = sampling_coord.reshape(bs * n_head, Len_q * num_points_list[level], 2)
+
+            s_idx = (
+                torch.arange(sampling_coord.shape[0], device=value.device)
+                .unsqueeze(-1)
+                .repeat(1, sampling_coord.shape[1])
+            )
+            sampling_value_l: torch.Tensor = value_l[s_idx, :, sampling_coord[..., 1], sampling_coord[..., 0]]
+            sampling_value_l = sampling_value_l.permute(0, 2, 1).reshape(
+                bs * n_head, c, Len_q, num_points_list[level]
+            )
+
+        sampling_value_list.append(sampling_value_l)
+
+    attn_weights = attention_weights.permute(0, 2, 1, 3).reshape(bs * n_head, 1, Len_q, sum(num_points_list))
+    weighted_sample_locs = torch.concat(sampling_value_list, dim=-1) * attn_weights
+    output = weighted_sample_locs.sum(-1).reshape(bs, n_head * c, Len_q)
+
+    return output.permute(0, 2, 1)
+
+
+def get_activation(act, inplace: bool = True):
+    if act is None:
+        return nn.Identity()
+    if isinstance(act, nn.Module):
+        return act
+
+    act = act.lower()
+    if act in ("silu", "swish"):
+        m = nn.SiLU()
+    elif act == "relu":
+        m = nn.ReLU()
+    elif act == "leaky_relu":
+        m = nn.LeakyReLU()
+    elif act == "gelu":
+        m = nn.GELU()
+    elif act == "hardsigmoid":
+        m = nn.Hardsigmoid()
+    else:
+        raise RuntimeError(f"Unsupported activation: {act!r}")
+
+    if hasattr(m, "inplace"):
+        m.inplace = inplace
+    return m
+
+
+class ClassEmbed(nn.Module):
+    """Region-text alignment head: cosine similarity with learned scale/bias."""
+
+    def __init__(self, init_bias: float = 100.0, init_scale: float = 15.0):
+        super().__init__()
+        bias_value = -math.log(init_bias)
+        self.lang_bias = nn.Parameter(torch.full((), bias_value))
+        self.lang_scale = nn.Parameter(torch.tensor(init_scale).log())
+
+    def forward(self, image_embeds, lang_embeds, mask=None):
+        image_norm = F.normalize(image_embeds, p=2, dim=-1)
+        lang_norm = F.normalize(lang_embeds, p=2, dim=-1)
+
+        logits = image_norm @ lang_norm.transpose(2, 1)  # [batch, num_queries, num_classes]
+        logits = logits * torch.exp(self.lang_scale) + self.lang_bias
+
+        if mask is not None:
+            logits = logits.masked_fill(~mask.unsqueeze(1), float("-inf"))
+        return logits
+
+
+class MLP(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int, num_layers: int, act: str = "relu") -> None:
+        super().__init__()
+        self.num_layers = num_layers
+        h = [hidden_dim] * (num_layers - 1)
+        self.layers = nn.ModuleList(nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim]))
+        self.act = get_activation(act)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for i, layer in enumerate(self.layers):
+            x = self.act(layer(x)) if i < self.num_layers - 1 else layer(x)
+        return x
+
+
+class MSDeformableAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int = 256,
+        num_heads: int = 8,
+        num_levels: int = 4,
+        num_points=4,
+        method: str = "default",
+        offset_scale: float = 0.5,
+    ) -> None:
+        """Multi-Scale Deformable Attention"""
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.num_levels = num_levels
+        self.offset_scale = offset_scale
+
+        num_points_list = num_points
+        assert len(num_points_list) == num_levels, (
+            f"Length of num_points_list ({len(num_points_list)}) must match num_levels ({num_levels})"
+        )
+        self.num_points_list = num_points_list
+
+        num_points_scale = [1.0 / n for n in self.num_points_list for _ in range(n)]
+        self.register_buffer("num_points_scale", torch.tensor(num_points_scale, dtype=torch.float32))
+
+        self.total_points = num_heads * sum(num_points_list)
+        self.method = method
+        self.head_dim = embed_dim // num_heads
+        assert self.head_dim * num_heads == self.embed_dim, (
+            f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})"
+        )
+
+        self.sampling_offsets = nn.Linear(embed_dim, self.total_points * 2)
+        self.attention_weights = nn.Linear(embed_dim, self.total_points)
+
+        self.ms_deformable_attn_core = functools.partial(deformable_attention_core_func_v2, method=self.method)
+        self._reset_parameters()
+
+        if method == "discrete":
+            for p in self.sampling_offsets.parameters():
+                p.requires_grad = False
+
+    def _reset_parameters(self) -> None:
+        init.constant_(self.sampling_offsets.weight, 0)
+        thetas = torch.arange(self.num_heads, dtype=torch.float32) * (2.0 * math.pi / self.num_heads)
+        grid_init = torch.stack([thetas.cos(), thetas.sin()], -1)
+        grid_init = grid_init / grid_init.abs().max(-1, keepdim=True).values
+        grid_init = grid_init.reshape(self.num_heads, 1, 2).tile([1, sum(self.num_points_list), 1])
+        scaling = torch.cat(
+            [torch.arange(1, n + 1, dtype=torch.float32) for n in self.num_points_list]
+        ).reshape(1, -1, 1)
+        grid_init *= scaling
+        self.sampling_offsets.bias.data[...] = grid_init.flatten()
+
+        init.constant_(self.attention_weights.weight, 0)
+        init.constant_(self.attention_weights.bias, 0)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        reference_points: torch.Tensor,
+        value: torch.Tensor,
+        value_spatial_shapes: List[Tuple[int, int]],
+        value_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        bs, query_length = query.shape[:2]
+        value_length = value.shape[1]
+
+        if value_mask is not None:
+            value = value * value_mask.to(value.dtype).unsqueeze(-1)
+
+        value = value.view(bs, value_length, self.num_heads, self.head_dim)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, query_length, self.num_heads, sum(self.num_points_list), 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, query_length, self.num_heads, sum(self.num_points_list)
+        )
+        attention_weights = F.softmax(attention_weights, dim=-1)
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.tensor(value_spatial_shapes, device=query.device, dtype=query.dtype)
+            offset_normalizer = offset_normalizer.flip([1]).view(1, 1, 1, self.num_levels, 1, 2)
+            sampling_locations = (
+                reference_points.view(bs, query_length, 1, self.num_levels, 1, 2)
+                + sampling_offsets / offset_normalizer
+            )
+        elif reference_points.shape[-1] == 4:
+            num_points_scale = self.num_points_scale.to(dtype=query.dtype).unsqueeze(-1)
+            offset = sampling_offsets * num_points_scale * reference_points[:, :, None, :, 2:] * self.offset_scale
+            sampling_locations = reference_points[:, :, None, :, :2] + offset
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}"
+            )
+
+        return self.ms_deformable_attn_core(
+            value, value_spatial_shapes, sampling_locations, attention_weights, self.num_points_list
+        )
+
+
+# Taken from: https://github.com/facebookresearch/dinov2/blob/main/dinov2/layers/swiglu_ffn.py#L14-L34
+class SwiGLUFFN(nn.Module):
+    def __init__(self, in_features: int, hidden_features: int, out_features: int, bias: bool = True) -> None:
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.w12 = nn.Linear(in_features, 2 * hidden_features, bias=bias)
+        self.w3 = nn.Linear(hidden_features, out_features, bias=bias)
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        init.xavier_uniform_(self.w12.weight)
+        init.constant_(self.w12.bias, 0)
+        init.xavier_uniform_(self.w3.weight)
+        init.constant_(self.w3.bias, 0)
+
+    def forward(self, x):
+        x12 = self.w12(x)
+        x1, x2 = x12.chunk(2, dim=-1)
+        hidden = F.silu(x1) * x2
+        return self.w3(hidden)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-12):
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.scale = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float()).type_as(x)
+        output = output * self.scale
+        return output
+
+    def extra_repr(self) -> str:
+        return f"dim={self.dim}, eps={self.eps}"
+
+
+class TransformerDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model: int = 256,
+        n_head: int = 8,
+        dim_feedforward: int = 1024,
+        dropout: float = 0.0,
+        activation: str = "relu",
+        n_levels: int = 4,
+        n_points=4,
+        cross_attn_method: str = "default",
+    ) -> None:
+        super().__init__()
+
+        self.self_attn = nn.MultiheadAttention(d_model, n_head, dropout=dropout, batch_first=True)
+        self.dropout1 = nn.Dropout(dropout)
+        self.norm1 = RMSNorm(d_model)
+
+        self.cross_attn = MSDeformableAttention(d_model, n_head, n_levels, n_points, method=cross_attn_method)
+        self.dropout2 = nn.Dropout(dropout)
+        self.norm2 = RMSNorm(d_model)
+
+        self.dropout4 = nn.Dropout(dropout)
+        self.norm3 = RMSNorm(d_model)
+
+        self.ffn = SwiGLUFFN(d_model, dim_feedforward, d_model)
+
+    def with_pos_embed(self, tensor: torch.Tensor, pos: Optional[torch.Tensor]) -> torch.Tensor:
+        return tensor if pos is None else tensor + pos
+
+    def forward(
+        self,
+        target: torch.Tensor,
+        reference_points: torch.Tensor,
+        memory: torch.Tensor,
+        memory_spatial_shapes: List[Tuple[int, int]],
+        attn_mask: Optional[torch.Tensor] = None,
+        memory_mask: Optional[torch.Tensor] = None,
+        query_pos_embed: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        q = k = self.with_pos_embed(target, query_pos_embed)
+        target2, _ = self.self_attn(q, k, value=target, attn_mask=attn_mask)
+        target = target + self.dropout1(target2)
+        target = self.norm1(target)
+
+        target2 = self.cross_attn(
+            self.with_pos_embed(target, query_pos_embed),
+            reference_points,
+            memory,
+            memory_spatial_shapes,
+            memory_mask,
+        )
+        target = target + self.dropout2(target2)
+        target = self.norm2(target)
+
+        target2 = self.ffn(target)
+        target = target + self.dropout4(target2)
+        target = self.norm3(target)
+        return target
+
+
+class TransformerDecoder(nn.Module):
+    def __init__(self, hidden_dim: int, decoder_layer: nn.Module, num_layers: int, eval_idx: int = -1) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([copy.deepcopy(decoder_layer) for _ in range(num_layers)])
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+        self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
+
+    def forward(
+        self,
+        target: torch.Tensor,
+        ref_points_unact: torch.Tensor,
+        memory: torch.Tensor,
+        memory_spatial_shapes: List[Tuple[int, int]],
+        text_feats: torch.Tensor,
+        bbox_head: nn.ModuleList,
+        score_head: nn.ModuleList,
+        query_pos_head: nn.Module,
+        attn_mask: Optional[torch.Tensor] = None,
+        memory_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        dec_out_bboxes = []
+        dec_out_logits = []
+        ref_points_detach = F.sigmoid(ref_points_unact.clamp(min=-500, max=500))
+        query_pos_embed = query_pos_head(ref_points_detach)
+        output = target
+        for i, layer in enumerate(self.layers):
+            ref_points_input = ref_points_detach.unsqueeze(2)
+            output = layer(
+                output, ref_points_input, memory, memory_spatial_shapes, attn_mask, memory_mask, query_pos_embed
+            )
+
+            inter_ref_bbox = F.sigmoid(
+                (bbox_head[i](output) + inverse_sigmoid(ref_points_detach)).clamp(min=-500, max=500)
+            )
+
+            if i == self.eval_idx:
+                dec_out_logits.append(score_head[i](output, text_feats))
+                dec_out_bboxes.append(inter_ref_bbox)
+                break
+            ref_points_detach = inter_ref_bbox.detach()
+
+        return torch.stack(dec_out_bboxes), torch.stack(dec_out_logits)
+
+
+class OVDEIMDecoder(nn.Module):
+    __share__ = ["num_classes", "eval_spatial_size"]
+
+    def __init__(
+        self,
+        num_classes: int = 80,
+        hidden_dim: int = 256,
+        num_queries: int = 300,
+        feat_channels: List[int] = [512, 1024, 2048],
+        feat_strides: List[int] = [8, 16, 32],
+        num_levels: int = 3,
+        num_points=4,
+        nhead: int = 8,
+        num_layers: int = 6,
+        dim_feedforward: int = 1024,
+        dropout: float = 0.0,
+        activation: str = "silu",
+        num_denoising: int = 0,
+        learn_query_content: bool = False,
+        eval_spatial_size: Optional[Tuple[int, int]] = None,
+        eval_idx: int = -1,
+        eps: float = 1e-2,
+        cross_attn_method: str = "default",
+        query_select_method: str = "default",
+        num_enc_queries: int = 0,
+    ) -> None:
+        super().__init__()
+        assert len(feat_channels) <= num_levels
+        assert len(feat_strides) == len(feat_channels)
+        assert query_select_method in ("default", "agnostic")
+        assert cross_attn_method in ("default", "discrete")
+
+        self.hidden_dim = hidden_dim
+        self.nhead = nhead
+        self.feat_strides = feat_strides + [feat_strides[-1] * 2] * (num_levels - len(feat_strides))
+        self.num_levels = num_levels
+        self.num_classes = num_classes
+        self.num_queries = num_queries
+        self.eps = eps
+        self.num_layers = num_layers
+        self.eval_spatial_size = eval_spatial_size
+        self.cross_attn_method = cross_attn_method
+        self.query_select_method = query_select_method
+        self.num_enc_queries = num_enc_queries
+
+        self._build_input_proj_layer(feat_channels)
+
+        decoder_layer = TransformerDecoderLayer(
+            hidden_dim, nhead, dim_feedforward, dropout, activation, num_levels, num_points, cross_attn_method
+        )
+        self.decoder = TransformerDecoder(hidden_dim, decoder_layer, num_layers, eval_idx)
+
+        # Inference port: the contrastive-denoising embedding is training-only
+        # (upstream's own evaluation script skips loading it).
+        self.num_denoising = num_denoising
+        if num_denoising > 0:
+            self.denoising_class_embed = nn.Embedding(num_classes + 1, hidden_dim, padding_idx=num_classes)
+            init.normal_(self.denoising_class_embed.weight[:-1])
+
+        self.learn_query_content = learn_query_content
+        if learn_query_content:
+            self.tgt_embed = nn.Embedding(num_queries, hidden_dim)
+
+        self.query_pos_head = MLP(4, hidden_dim, hidden_dim, 3, act=activation)
+
+        self.enc_output = nn.Identity()
+
+        self.enc_score_head = ClassEmbed() if query_select_method != "agnostic" else nn.Linear(hidden_dim, 1)
+        self.enc_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3, act=activation)
+
+        self.dec_score_head = nn.ModuleList([ClassEmbed() for _ in range(num_layers)])
+        self.dec_bbox_head = nn.ModuleList(
+            [MLP(hidden_dim, hidden_dim, 4, 3, act=activation) for _ in range(num_layers)]
+        )
+
+        if self.eval_spatial_size:
+            anchors, valid_mask = self._generate_anchors()
+            self.register_buffer("anchors", anchors)
+            self.register_buffer("valid_mask", valid_mask)
+        else:
+            self.anchors = None
+            self.valid_mask = None
+
+        self._reset_parameters(feat_channels)
+
+    def _reset_parameters(self, feat_channels) -> None:
+        bias = bias_init_with_prob(0.01)
+        if isinstance(self.enc_score_head, nn.Linear):
+            init.constant_(self.enc_score_head.bias, bias)
+        init.constant_(self.enc_bbox_head.layers[-1].weight, 0)
+        init.constant_(self.enc_bbox_head.layers[-1].bias, 0)
+
+        for cls_head, reg_head in zip(self.dec_score_head, self.dec_bbox_head):
+            if isinstance(cls_head, nn.Linear):
+                init.constant_(cls_head.bias, bias)
+            init.constant_(reg_head.layers[-1].weight, 0)
+            init.constant_(reg_head.layers[-1].bias, 0)
+
+        if self.learn_query_content:
+            init.xavier_uniform_(self.tgt_embed.weight)
+        init.xavier_uniform_(self.query_pos_head.layers[0].weight)
+        init.xavier_uniform_(self.query_pos_head.layers[1].weight)
+        init.xavier_uniform_(self.query_pos_head.layers[-1].weight)
+
+        for m, in_channels in zip(self.input_proj, feat_channels):
+            if in_channels != self.hidden_dim:
+                init.xavier_uniform_(m[0].weight)
+
+    def _build_input_proj_layer(self, feat_channels):
+        self.input_proj = nn.ModuleList()
+        for in_channels in feat_channels:
+            if in_channels == self.hidden_dim:
+                self.input_proj.append(nn.Identity())
+            else:
+                self.input_proj.append(
+                    nn.Sequential(
+                        OrderedDict(
+                            [
+                                ("conv", nn.Conv2d(in_channels, self.hidden_dim, 1, bias=False)),
+                                ("norm", nn.BatchNorm2d(self.hidden_dim)),
+                            ]
+                        )
+                    )
+                )
+
+        in_channels = feat_channels[-1]
+        for _ in range(self.num_levels - len(feat_channels)):
+            if in_channels == self.hidden_dim:
+                self.input_proj.append(nn.Identity())
+            else:
+                self.input_proj.append(
+                    nn.Sequential(
+                        OrderedDict(
+                            [
+                                ("conv", nn.Conv2d(in_channels, self.hidden_dim, 3, 2, padding=1, bias=False)),
+                                ("norm", nn.BatchNorm2d(self.hidden_dim)),
+                            ]
+                        )
+                    )
+                )
+                in_channels = self.hidden_dim
+
+    def _get_encoder_input(self, feats: List[torch.Tensor]):
+        proj_feats = [self.input_proj[i](feat) for i, feat in enumerate(feats)]
+        if self.num_levels > len(proj_feats):
+            len_srcs = len(proj_feats)
+            for i in range(len_srcs, self.num_levels):
+                proj_feats.append(self.input_proj[i](feats[-1] if i == len_srcs else proj_feats[-1]))
+
+        feat_flatten = []
+        spatial_shapes = []
+        for feat in proj_feats:
+            _, _, h, w = feat.shape
+            feat_flatten.append(feat.flatten(2).permute(0, 2, 1))
+            spatial_shapes.append((h, w))
+        return torch.cat(feat_flatten, 1), spatial_shapes
+
+    def _generate_anchors(
+        self,
+        spatial_shapes: Optional[List[Tuple[int, int]]] = None,
+        grid_size: float = 0.05,
+        dtype: torch.dtype = torch.float32,
+        device: torch.device = torch.device("cpu"),
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if spatial_shapes is None:
+            spatial_shapes = [
+                (int(self.eval_spatial_size[0] / s), int(self.eval_spatial_size[1] / s))
+                for s in self.feat_strides
+            ]
+
+        anchors = []
+        for lvl, (h, w) in enumerate(spatial_shapes):
+            grid_y, grid_x = torch.meshgrid(torch.arange(h), torch.arange(w), indexing="ij")
+            grid_xy = torch.stack([grid_x, grid_y], dim=-1).to(dtype=dtype)
+            grid_xy = (grid_xy + 0.5) / torch.tensor([w, h], dtype=dtype)
+            wh = torch.ones_like(grid_xy) * grid_size * (2.0**lvl)
+            lvl_anchors = torch.cat([grid_xy, wh], dim=-1).view(-1, h * w, 4)
+            anchors.append(lvl_anchors)
+
+        anchors = torch.cat(anchors, dim=1).to(device)
+        valid_mask = ((anchors > self.eps) * (anchors < 1 - self.eps)).all(-1, keepdim=True)
+        anchors = torch.log(anchors / (1 - anchors))
+        anchors = torch.where(valid_mask, anchors, torch.inf)
+        return anchors, valid_mask
+
+    def _get_decoder_input(self, memory: torch.Tensor, spatial_shapes, text_feats: torch.Tensor):
+        anchors, valid_mask = (
+            self._generate_anchors(spatial_shapes, device=memory.device)
+            if self.training or self.eval_spatial_size is None
+            else (self.anchors, self.valid_mask)
+        )
+        memory = memory * valid_mask.to(memory.dtype)
+
+        output_memory = self.enc_output(memory)
+        enc_outputs_logits = self.enc_score_head(output_memory, text_feats)
+        if memory.shape[0] > 1:
+            anchors = anchors.repeat(memory.shape[0], 1, 1)
+
+        enc_topk_memory, enc_topk_logits, enc_topk_anchors = self._select_topk(
+            output_memory, enc_outputs_logits, anchors, self.num_queries
+        )
+        enc_topk_bbox_unact = self.enc_bbox_head(enc_topk_memory) + enc_topk_anchors
+
+        content = (
+            self.tgt_embed.weight.unsqueeze(0).repeat(memory.shape[0], 1, 1)
+            if self.learn_query_content
+            else enc_topk_memory.detach()
+        )
+        enc_topk_bbox_unact = enc_topk_bbox_unact.detach()
+
+        return content, enc_topk_bbox_unact
+
+    def _select_topk(self, memory: torch.Tensor, outputs_logits: torch.Tensor, outputs_coords_unact: torch.Tensor, topk: int):
+        if self.query_select_method == "default":
+            scores = outputs_logits.max(-1).values
+        elif self.query_select_method == "agnostic":
+            scores = outputs_logits.squeeze(-1)
+        else:
+            raise ValueError(f"Unknown query_select_method: {self.query_select_method}")
+
+        _, ind_top = torch.topk(scores, topk, dim=-1)
+
+        coords_top = outputs_coords_unact.gather(
+            1, ind_top.unsqueeze(-1).repeat(1, 1, outputs_coords_unact.shape[-1])
+        )
+        logits_top = outputs_logits.gather(1, ind_top.unsqueeze(-1).repeat(1, 1, outputs_logits.shape[-1]))
+        memory_top = memory.gather(1, ind_top.unsqueeze(-1).repeat(1, 1, memory.shape[-1]))
+
+        return memory_top, logits_top, coords_top
+
+    def forward(self, feats: List[torch.Tensor], text_feats: torch.Tensor) -> dict:
+        memory, spatial_shapes = self._get_encoder_input(feats)
+
+        init_ref_contents, init_ref_points_unact = self._get_decoder_input(memory, spatial_shapes, text_feats)
+
+        out_bboxes, out_logits = self.decoder(
+            init_ref_contents,
+            init_ref_points_unact,
+            memory,
+            spatial_shapes,
+            text_feats,
+            self.dec_bbox_head,
+            self.dec_score_head,
+            self.query_pos_head,
+            None,
+            None,
+        )
+
+        return {"pred_logits": out_logits[-1], "pred_boxes": out_bboxes[-1]}

--- a/libreyolo/models/openvocab/ovdeim/encoder.py
+++ b/libreyolo/models/openvocab/ovdeim/encoder.py
@@ -1,0 +1,434 @@
+"""OV-DEIM hybrid encoder (vendored).
+
+Copyright(c) 2023 lyuwenyu. All Rights Reserved.
+
+Ported unmodified (inference-relevant code) from OV-DEIM
+``model/encoder/hybrid_encoder.py`` and ``model/encoder/utils.py``
+(https://github.com/wleilei/OV-DEIM, Apache-2.0). Module and attribute names
+mirror upstream so released checkpoints load with a plain key strip.
+"""
+
+import copy
+from collections import OrderedDict
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = ["HybridEncoder"]
+
+
+def get_activation(act, inplace: bool = True):
+    if act is None:
+        return nn.Identity()
+    if isinstance(act, nn.Module):
+        return act
+
+    act = act.lower()
+    if act in ("silu", "swish"):
+        m = nn.SiLU()
+    elif act == "relu":
+        m = nn.ReLU()
+    elif act == "leaky_relu":
+        m = nn.LeakyReLU()
+    elif act == "gelu":
+        m = nn.GELU()
+    elif act == "hardsigmoid":
+        m = nn.Hardsigmoid()
+    else:
+        raise RuntimeError(f"Unsupported activation: {act!r}")
+
+    if hasattr(m, "inplace"):
+        m.inplace = inplace
+    return m
+
+
+class TransformerEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model,
+        nhead,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+    ):
+        super().__init__()
+        self.normalize_before = normalize_before
+
+        self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout, batch_first=True)
+
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+        self.activation = get_activation(activation)
+
+    @staticmethod
+    def with_pos_embed(tensor, pos_embed):
+        return tensor if pos_embed is None else tensor + pos_embed
+
+    def forward(self, src, src_mask=None, pos_embed=None) -> torch.Tensor:
+        residual = src
+        if self.normalize_before:
+            src = self.norm1(src)
+        q = k = self.with_pos_embed(src, pos_embed)
+        src, _ = self.self_attn(q, k, value=src, attn_mask=src_mask)
+
+        src = residual + self.dropout1(src)
+        if not self.normalize_before:
+            src = self.norm1(src)
+
+        residual = src
+        if self.normalize_before:
+            src = self.norm2(src)
+        src = self.linear2(self.dropout(self.activation(self.linear1(src))))
+        src = residual + self.dropout2(src)
+        if not self.normalize_before:
+            src = self.norm2(src)
+        return src
+
+
+class TransformerEncoder(nn.Module):
+    def __init__(self, encoder_layer, num_layers, norm=None):
+        super().__init__()
+        self.layers = nn.ModuleList([copy.deepcopy(encoder_layer) for _ in range(num_layers)])
+        self.num_layers = num_layers
+        self.norm = norm
+
+    def forward(self, src, src_mask=None, pos_embed=None) -> torch.Tensor:
+        output = src
+        for layer in self.layers:
+            output = layer(output, src_mask=src_mask, pos_embed=pos_embed)
+        if self.norm is not None:
+            output = self.norm(output)
+        return output
+
+
+class ConvNormLayer_fuse(nn.Module):
+    def __init__(self, ch_in, ch_out, kernel_size, stride, g=1, padding=None, bias=False, act=None):
+        super().__init__()
+        padding = (kernel_size - 1) // 2 if padding is None else padding
+        self.conv = nn.Conv2d(
+            ch_in, ch_out, kernel_size, stride, groups=g, padding=padding, bias=bias
+        )
+        self.norm = nn.BatchNorm2d(ch_out)
+        self.act = nn.Identity() if act is None else get_activation(act)
+        self.ch_in, self.ch_out, self.kernel_size, self.stride, self.g, self.padding, self.bias = (
+            ch_in, ch_out, kernel_size, stride, g, padding, bias,
+        )
+
+    def forward(self, x):
+        if hasattr(self, "conv_bn_fused"):
+            y = self.conv_bn_fused(x)
+        else:
+            y = self.norm(self.conv(x))
+        return self.act(y)
+
+    def convert_to_deploy(self):
+        if not hasattr(self, "conv_bn_fused"):
+            self.conv_bn_fused = nn.Conv2d(
+                self.ch_in, self.ch_out, self.kernel_size, self.stride,
+                groups=self.g, padding=self.padding, bias=True,
+            )
+        kernel, bias = self.get_equivalent_kernel_bias()
+        self.conv_bn_fused.weight.data = kernel
+        self.conv_bn_fused.bias.data = bias
+        self.__delattr__("conv")
+        self.__delattr__("norm")
+
+    def get_equivalent_kernel_bias(self):
+        return self._fuse_bn_tensor()
+
+    def _fuse_bn_tensor(self):
+        kernel = self.conv.weight
+        running_mean = self.norm.running_mean
+        running_var = self.norm.running_var
+        gamma = self.norm.weight
+        beta = self.norm.bias
+        eps = self.norm.eps
+        std = (running_var + eps).sqrt()
+        t = (gamma / std).reshape(-1, 1, 1, 1)
+        return kernel * t, beta - running_mean * gamma / std
+
+
+class ConvNormLayer(nn.Module):
+    def __init__(self, ch_in, ch_out, kernel_size, stride, padding=None, bias=False, act=None):
+        super().__init__()
+        self.conv = nn.Conv2d(
+            ch_in, ch_out, kernel_size, stride,
+            padding=(kernel_size - 1) // 2 if padding is None else padding,
+            bias=bias,
+        )
+        self.norm = nn.BatchNorm2d(ch_out)
+        self.act = nn.Identity() if act is None else get_activation(act)
+
+    def forward(self, x):
+        return self.act(self.norm(self.conv(x)))
+
+
+class VGGBlock(nn.Module):
+    def __init__(self, ch_in, ch_out, act="relu"):
+        super().__init__()
+        self.ch_in = ch_in
+        self.ch_out = ch_out
+        self.conv1 = ConvNormLayer(ch_in, ch_out, 3, 1, padding=1, act=None)
+        self.conv2 = ConvNormLayer(ch_in, ch_out, 1, 1, padding=0, act=None)
+        self.act = nn.Identity() if act is None else get_activation(act)
+
+    def forward(self, x):
+        if hasattr(self, "conv"):
+            y = self.conv(x)
+        else:
+            y = self.conv1(x) + self.conv2(x)
+        return self.act(y)
+
+    def convert_to_deploy(self):
+        if not hasattr(self, "conv"):
+            self.conv = nn.Conv2d(self.ch_in, self.ch_out, 3, 1, padding=1)
+        kernel, bias = self.get_equivalent_kernel_bias()
+        self.conv.weight.data = kernel
+        self.conv.bias.data = bias
+        self.__delattr__("conv1")
+        self.__delattr__("conv2")
+
+    def get_equivalent_kernel_bias(self):
+        kernel3x3, bias3x3 = self._fuse_bn_tensor(self.conv1)
+        kernel1x1, bias1x1 = self._fuse_bn_tensor(self.conv2)
+        return kernel3x3 + self._pad_1x1_to_3x3_tensor(kernel1x1), bias3x3 + bias1x1
+
+    def _pad_1x1_to_3x3_tensor(self, kernel1x1):
+        if kernel1x1 is None:
+            return 0
+        return F.pad(kernel1x1, [1, 1, 1, 1])
+
+    def _fuse_bn_tensor(self, branch: ConvNormLayer):
+        if branch is None:
+            return 0, 0
+        kernel = branch.conv.weight
+        running_mean = branch.norm.running_mean
+        running_var = branch.norm.running_var
+        gamma = branch.norm.weight
+        beta = branch.norm.bias
+        eps = branch.norm.eps
+        std = (running_var + eps).sqrt()
+        t = (gamma / std).reshape(-1, 1, 1, 1)
+        return kernel * t, beta - running_mean * gamma / std
+
+
+# This layer is equivalent to RepC3 in YOLO repos.
+class CSPLayer(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        num_blocks=3,
+        expansion=1.0,
+        bias=False,
+        act="silu",
+        bottletype=VGGBlock,
+    ):
+        super().__init__()
+        hidden_channels = int(out_channels * expansion)
+
+        self.conv1 = ConvNormLayer_fuse(in_channels, hidden_channels * 2, 1, 1, bias=bias, act=act)
+        self.bottlenecks = nn.Sequential(
+            *[bottletype(hidden_channels, hidden_channels, act=act) for _ in range(num_blocks)]
+        )
+        if hidden_channels != out_channels:
+            self.conv3 = ConvNormLayer_fuse(hidden_channels, out_channels, 1, 1, bias=bias, act=act)
+        else:
+            self.conv3 = nn.Identity()
+
+    def forward(self, x):
+        y = list(self.conv1(x).chunk(2, 1))
+        y[1] = self.bottlenecks(y[1])
+        return self.conv3(y[0] + y[1])
+
+
+class RepNCSPELAN5(nn.Module):
+    # csp-elan
+    def __init__(self, c1, c2, c3, c4, n=3, bias=False, act="silu"):
+        super().__init__()
+        self.c = c3 // 2
+        self.cv1 = ConvNormLayer_fuse(c1, c3, 1, 1, bias=bias, act=act)
+        self.cv2 = nn.Sequential(CSPLayer(c3 // 2, c4, n, 1, bias=bias, act=act, bottletype=VGGBlock))
+        self.cv3 = nn.Sequential(CSPLayer(c4, c4, n, 1, bias=bias, act=act, bottletype=VGGBlock))
+        self.cv4 = ConvNormLayer_fuse(c3 + (2 * c4), c2, 1, 1, bias=bias, act=act)
+
+    def forward(self, x):
+        y = list(self.cv1(x).split((self.c, self.c), 1))
+        y.extend(m(y[-1]) for m in [self.cv2, self.cv3])
+        return self.cv4(torch.cat(y, 1))
+
+
+class SCDown(nn.Module):
+    def __init__(self, c1, c2, k, s, act=None):
+        super().__init__()
+        self.cv1 = ConvNormLayer_fuse(c1, c2, 1, 1, act=act)
+        self.cv2 = ConvNormLayer_fuse(c2, c2, k, s, c2)
+
+    def forward(self, x):
+        return self.cv2(self.cv1(x))
+
+
+class HybridEncoder(nn.Module):
+    __share__ = ["eval_spatial_size"]
+
+    def __init__(
+        self,
+        in_channels=[512, 1024, 2048],
+        feat_strides=[8, 16, 32],
+        hidden_dim=256,
+        nhead=8,
+        dim_feedforward=1024,
+        dropout=0.0,
+        enc_act="gelu",
+        use_encoder_idx=[2],
+        num_encoder_layers=1,
+        pe_temperature=10000,
+        expansion=1.0,
+        depth_mult=1.0,
+        act="silu",
+        eval_spatial_size=None,
+        version="v2",
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.feat_strides = feat_strides
+        self.hidden_dim = hidden_dim
+        self.use_encoder_idx = use_encoder_idx
+        self.num_encoder_layers = num_encoder_layers
+        self.pe_temperature = pe_temperature
+        self.eval_spatial_size = eval_spatial_size
+        self.out_channels = [hidden_dim for _ in range(len(in_channels))]
+        self.out_strides = feat_strides
+
+        # channel projection
+        self.input_proj = nn.ModuleList()
+        for in_channel in in_channels:
+            if version == "v1":
+                proj = nn.Sequential(
+                    nn.Conv2d(in_channel, hidden_dim, kernel_size=1, bias=False),
+                    nn.BatchNorm2d(hidden_dim),
+                )
+            elif version == "v2":
+                proj = nn.Sequential(
+                    OrderedDict(
+                        [
+                            ("conv", nn.Conv2d(in_channel, hidden_dim, kernel_size=1, bias=False)),
+                            ("norm", nn.BatchNorm2d(hidden_dim)),
+                        ]
+                    )
+                )
+            else:
+                raise AttributeError()
+            self.input_proj.append(proj)
+
+        # encoder transformer
+        encoder_layer = TransformerEncoderLayer(
+            hidden_dim,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            activation=enc_act,
+        )
+        self.encoder = nn.ModuleList(
+            [TransformerEncoder(copy.deepcopy(encoder_layer), num_encoder_layers) for _ in range(len(use_encoder_idx))]
+        )
+
+        # top-down fpn
+        self.lateral_convs = nn.ModuleList()
+        self.fpn_blocks = nn.ModuleList()
+        c1, c2, c3, c4, num_blocks = (
+            hidden_dim,
+            hidden_dim,
+            hidden_dim * 2,
+            round(expansion * hidden_dim // 2),
+            round(3 * depth_mult),
+        )
+        for _ in range(len(in_channels) - 1, 0, -1):
+            self.lateral_convs.append(ConvNormLayer(hidden_dim, hidden_dim, 1, 1, act=act))
+            self.fpn_blocks.append(RepNCSPELAN5(c1=c1, c2=c2, c3=c3, c4=c4, n=num_blocks, act=act))
+
+        # bottom-up pan
+        self.downsample_convs = nn.ModuleList()
+        self.pan_blocks = nn.ModuleList()
+        for _ in range(len(in_channels) - 1):
+            self.downsample_convs.append(SCDown(hidden_dim, hidden_dim, 3, 2, act=act))
+            self.pan_blocks.append(RepNCSPELAN5(c1=c1, c2=c2, c3=c3, c4=c4, n=num_blocks, act=act))
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        if self.eval_spatial_size:
+            for idx in self.use_encoder_idx:
+                stride = self.feat_strides[idx]
+                pos_embed = self.build_2d_sincos_position_embedding(
+                    self.eval_spatial_size[1] // stride,
+                    self.eval_spatial_size[0] // stride,
+                    self.hidden_dim,
+                    self.pe_temperature,
+                )
+                setattr(self, f"pos_embed{idx}", pos_embed)
+
+    @staticmethod
+    def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.0):
+        grid_w = torch.arange(int(w), dtype=torch.float32)
+        grid_h = torch.arange(int(h), dtype=torch.float32)
+        grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij")
+        assert embed_dim % 4 == 0, "Embed dimension must be divisible by 4 for 2D sin-cos position embedding"
+        pos_dim = embed_dim // 4
+        omega = torch.arange(pos_dim, dtype=torch.float32) / pos_dim
+        omega = 1.0 / (temperature**omega)
+
+        out_w = grid_w.flatten()[..., None] @ omega[None]
+        out_h = grid_h.flatten()[..., None] @ omega[None]
+
+        return torch.concat([out_w.sin(), out_w.cos(), out_h.sin(), out_h.cos()], dim=1)[None, :, :]
+
+    def forward(self, feats):
+        assert len(feats) == len(self.in_channels)
+        proj_feats = [self.input_proj[i](feat) for i, feat in enumerate(feats)]
+
+        # encoder
+        if self.num_encoder_layers > 0:
+            for i, enc_ind in enumerate(self.use_encoder_idx):
+                h, w = proj_feats[enc_ind].shape[2:]
+                # flatten [B, C, H, W] to [B, HxW, C]
+                src_flatten = proj_feats[enc_ind].flatten(2).permute(0, 2, 1)
+                if self.training or self.eval_spatial_size is None:
+                    pos_embed = self.build_2d_sincos_position_embedding(
+                        w, h, self.hidden_dim, self.pe_temperature
+                    ).to(src_flatten.device)
+                else:
+                    pos_embed = getattr(self, f"pos_embed{enc_ind}", None).to(src_flatten.device)
+
+                memory: torch.Tensor = self.encoder[i](src_flatten, pos_embed=pos_embed)
+                proj_feats[enc_ind] = memory.permute(0, 2, 1).reshape(-1, self.hidden_dim, h, w).contiguous()
+
+        inner_outs = [proj_feats[-1]]
+        for idx in range(len(self.in_channels) - 1, 0, -1):
+            feat_heigh = inner_outs[0]
+            feat_low = proj_feats[idx - 1]
+            feat_heigh = self.lateral_convs[len(self.in_channels) - 1 - idx](feat_heigh)
+            inner_outs[0] = feat_heigh
+            upsample_feat = F.interpolate(feat_heigh, scale_factor=2.0, mode="nearest")
+            fused_feat = upsample_feat + feat_low
+            inner_out = self.fpn_blocks[len(self.in_channels) - 1 - idx](fused_feat)
+            inner_outs.insert(0, inner_out)
+
+        outs = [inner_outs[0]]
+        for idx in range(len(self.in_channels) - 1):
+            feat_low = outs[-1]
+            feat_height = inner_outs[idx + 1]
+            downsample_feat = self.downsample_convs[idx](feat_low)
+            fused_feat = downsample_feat + feat_height
+            out = self.pan_blocks[idx](fused_feat)
+            outs.append(out)
+
+        return outs

--- a/libreyolo/models/openvocab/ovdeim/nn.py
+++ b/libreyolo/models/openvocab/ovdeim/nn.py
@@ -1,0 +1,269 @@
+"""Top-level OV-DEIM model wiring for LibreYOLO.
+
+The detector (backbone + encoder + decoder + text_adapter) mirrors upstream
+OV-DEIM (https://github.com/wleilei/OV-DEIM, Apache-2.0) attribute names so
+released checkpoints convert with a plain key strip. The online text tower is
+the MobileCLIP-B(LT) text encoder, which is a standard CLIP text transformer;
+it reuses LibreCLIP's open_clip-compatible modules and loads Apple's released
+text-tower weights unchanged.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict
+
+import torch
+import torch.nn as nn
+from torch.nn import init
+
+from ...clip.nn import Transformer as CLIPTextTransformer
+from .decoder import OVDEIMDecoder, RMSNorm
+from .encoder import HybridEncoder
+
+
+# Per-size configuration transcribed from upstream config/dinov3_ori/{dinov3_s,m,l}.py.
+OVDEIM_SIZE_CONFIGS: Dict[str, Dict[str, Any]] = {
+    "s": {
+        "backbone": {
+            "name": "vit_tiny",
+            "embed_dim": 192,
+            "interaction_indexes": [3, 7, 11],
+            "num_heads": 3,
+            "conv_inplane": 16,
+        },
+        "encoder": {
+            "in_channels": [192, 192, 192],
+            "feat_strides": [8, 16, 32],
+            "hidden_dim": 192,
+            "use_encoder_idx": [2],
+            "num_encoder_layers": 1,
+            "nhead": 8,
+            "dim_feedforward": 512,
+            "dropout": 0.0,
+            "enc_act": "gelu",
+            "expansion": 0.34,
+            "depth_mult": 0.67,
+            "act": "silu",
+        },
+        "decoder": {
+            "feat_channels": [192, 192, 192],
+            "feat_strides": [8, 16, 32],
+            "hidden_dim": 192,
+            "dim_feedforward": 512,
+            "num_levels": 3,
+            "num_layers": 4,
+            "num_queries": 300,
+            "learn_query_content": False,
+            "activation": "silu",
+            "eval_idx": -1,
+            "num_points": [4, 6, 4],
+            "cross_attn_method": "default",
+            "query_select_method": "default",
+            "num_enc_queries": 0,
+        },
+        "model": {"img_dim": 192, "text_dim": 512},
+    },
+    "m": {
+        "backbone": {
+            "name": "vit_tinyplus",
+            "embed_dim": 256,
+            "interaction_indexes": [3, 7, 11],
+            "num_heads": 4,
+            "conv_inplane": 16,
+        },
+        "encoder": {
+            "in_channels": [256, 256, 256],
+            "feat_strides": [8, 16, 32],
+            "hidden_dim": 256,
+            "use_encoder_idx": [2],
+            "num_encoder_layers": 1,
+            "nhead": 8,
+            "dim_feedforward": 512,
+            "dropout": 0.0,
+            "enc_act": "gelu",
+            "expansion": 0.67,
+            "depth_mult": 1.0,
+            "act": "silu",
+        },
+        "decoder": {
+            "feat_channels": [256, 256, 256],
+            "feat_strides": [8, 16, 32],
+            "hidden_dim": 256,
+            "dim_feedforward": 512,
+            "num_levels": 3,
+            "num_layers": 4,
+            "num_queries": 300,
+            "learn_query_content": False,
+            "activation": "silu",
+            "eval_idx": -1,
+            "num_points": [4, 6, 4],
+            "cross_attn_method": "default",
+            "query_select_method": "default",
+            "num_enc_queries": 0,
+        },
+        "model": {"img_dim": 256, "text_dim": 512},
+    },
+    "l": {
+        "backbone": {
+            "name": "dinov3_vits16",
+            "embed_dim": 224,
+            "hidden_dim": 224,
+            "conv_inplane": 32,
+            "interaction_indexes": [5, 8, 11],
+            "num_heads": None,
+        },
+        "encoder": {
+            "in_channels": [224, 224, 224],
+            "feat_strides": [8, 16, 32],
+            "hidden_dim": 224,
+            "use_encoder_idx": [2],
+            "num_encoder_layers": 1,
+            "nhead": 8,
+            "dim_feedforward": 896,
+            "dropout": 0.0,
+            "enc_act": "gelu",
+            "expansion": 1.0,
+            "depth_mult": 1.0,
+            "act": "silu",
+        },
+        "decoder": {
+            "feat_channels": [224, 224, 224],
+            "feat_strides": [8, 16, 32],
+            "hidden_dim": 224,
+            "dim_feedforward": 1792,
+            "num_levels": 3,
+            "num_layers": 4,
+            "num_queries": 300,
+            "learn_query_content": False,
+            "activation": "silu",
+            "eval_idx": -1,
+            "num_points": [4, 6, 4],
+            "cross_attn_method": "default",
+            "query_select_method": "default",
+            "num_enc_queries": 0,
+        },
+        "model": {"img_dim": 224, "text_dim": 512},
+    },
+}
+
+
+class GatedFFNBlock(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.w12 = nn.Linear(dim, 2 * dim * 2)
+        self.w3 = nn.Linear(dim * 2, dim)
+        self.norm = RMSNorm(dim)
+
+    def forward(self, x):
+        x1 = self.norm(x)
+        x12 = self.w12(x1)
+        x1, x2 = x12.chunk(2, dim=-1)
+        gated = nn.functional.silu(x1) * x2
+        return x + self.w3(gated)
+
+
+class TextAdapter(nn.Module):
+    """Learned adapter from CLIP text space into the decoder's visual space."""
+
+    def __init__(self, text_dim: int, img_dim: int, num_layers: int = 1):
+        super().__init__()
+        self.layers = nn.ModuleList([GatedFFNBlock(text_dim) for _ in range(num_layers)])
+        self.proj_out = nn.Linear(text_dim, img_dim)
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for layer in self.layers:
+            init.xavier_uniform_(layer.w12.weight)
+            init.constant_(layer.w12.bias, 0)
+            init.xavier_uniform_(layer.w3.weight)
+            init.constant_(layer.w3.bias, 0)
+        init.xavier_uniform_(self.proj_out.weight)
+        init.constant_(self.proj_out.bias, 0)
+
+    def forward(self, text_feats):
+        x = text_feats
+        for layer in self.layers:
+            x = layer(x)
+        return self.proj_out(x)
+
+
+class MobileCLIPTextEncoder(nn.Module):
+    """MobileCLIP-B(LT) text tower: a standard CLIP-B text transformer.
+
+    ``state_dict`` keys mirror open_clip's ``CustomTextCLIP`` text tower with
+    the ``text.`` prefix stripped, so Apple's released weights load unchanged.
+    """
+
+    CONTEXT_LENGTH = 77
+    VOCAB_SIZE = 49408
+    WIDTH = 512
+    HEADS = 8
+    LAYERS = 12
+    EMBED_DIM = 512
+
+    def __init__(self):
+        super().__init__()
+        self.transformer = CLIPTextTransformer(self.WIDTH, self.LAYERS, self.HEADS)
+        self.token_embedding = nn.Embedding(self.VOCAB_SIZE, self.WIDTH)
+        self.positional_embedding = nn.Parameter(torch.empty(self.CONTEXT_LENGTH, self.WIDTH))
+        self.ln_final = nn.LayerNorm(self.WIDTH)
+        self.text_projection = nn.Parameter(torch.empty(self.WIDTH, self.EMBED_DIM))
+        self.register_buffer("attn_mask", self._build_causal_mask(), persistent=False)
+
+        nn.init.normal_(self.positional_embedding, std=0.01)
+        nn.init.normal_(self.text_projection, std=self.WIDTH**-0.5)
+
+    def _build_causal_mask(self) -> torch.Tensor:
+        mask = torch.empty(self.CONTEXT_LENGTH, self.CONTEXT_LENGTH)
+        mask.fill_(float("-inf"))
+        mask.triu_(1)
+        return mask
+
+    def forward(self, text: torch.Tensor) -> torch.Tensor:
+        x = self.token_embedding(text)
+        x = x + self.positional_embedding
+        x = self.transformer(x, attn_mask=self.attn_mask)
+        x = self.ln_final(x)
+        # EOT pooling: the end-of-text token has the highest id in each row.
+        pooled = x[torch.arange(x.shape[0], device=x.device), text.argmax(dim=-1)]
+        return pooled @ self.text_projection
+
+
+class LibreOVDEIMModel(nn.Module):
+    """OV-DEIM detector + online MobileCLIP text tower.
+
+    ``forward(images, text_feats)`` runs the detector against already-encoded
+    (L2-normalized) text embeddings; ``encode_texts`` produces them from token
+    id tensors. Submodule names (``backbone``/``encoder``/``decoder``/
+    ``text_adapter``) match upstream checkpoints; the text tower lives under
+    ``text_encoder``.
+    """
+
+    def __init__(self, size: str):
+        super().__init__()
+        if size not in OVDEIM_SIZE_CONFIGS:
+            raise ValueError(f"Unknown OV-DEIM size {size!r}; choose one of {sorted(OVDEIM_SIZE_CONFIGS)}.")
+        # Imported lazily: the deimv2 backbone package logs at import time.
+        from ...deimv2.engine.backbone.dinov3_adapter import DINOv3STAs
+
+        cfg = copy.deepcopy(OVDEIM_SIZE_CONFIGS[size])
+        self.size = size
+        self.backbone = DINOv3STAs(**cfg["backbone"])
+        self.encoder = HybridEncoder(**cfg["encoder"])
+        self.decoder = OVDEIMDecoder(num_denoising=0, **cfg["decoder"])
+        self.text_adapter = TextAdapter(
+            cfg["model"]["text_dim"], cfg["model"]["img_dim"], num_layers=1
+        )
+        self.text_encoder = MobileCLIPTextEncoder()
+
+    def encode_texts(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Encode tokenized prompts into L2-normalized CLIP text embeddings."""
+        feats = self.text_encoder(token_ids)
+        return nn.functional.normalize(feats, dim=-1)
+
+    def forward(self, x: torch.Tensor, text_feats: torch.Tensor):
+        feats = self.backbone(x)
+        adapted = self.text_adapter(text_feats)
+        feats = self.encoder(feats)
+        return self.decoder(feats, adapted)

--- a/libreyolo/ui/server.py
+++ b/libreyolo/ui/server.py
@@ -201,6 +201,9 @@ def _factory_openvocab_names() -> list[str]:
         "owlv2-b16",
         "owlv2-l14",
         "omdet-turbo",
+        "ov-deim-s",
+        "ov-deim-m",
+        "ov-deim-l",
     ]
 
 

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -584,6 +584,27 @@
     "optional_extra": "openvocab",
     "available": true
   },
+  "ov_deim": {
+    "class": "libreyolo.models.openvocab.ov_deim.LibreOVDEIM",
+    "tasks": [
+      "detect"
+    ],
+    "default_task": "detect",
+    "sizes": {
+      "s": 640,
+      "m": 640,
+      "l": 640
+    },
+    "default_imgsz": {
+      "s": 640,
+      "m": 640,
+      "l": 640
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "openvocab",
+    "available": true
+  },
   "owlv2": {
     "class": "libreyolo.models.openvocab.owlv2.LibreOWLv2",
     "tasks": [

--- a/tests/e2e/test_openvocab_inference.py
+++ b/tests/e2e/test_openvocab_inference.py
@@ -131,6 +131,34 @@ def test_omdet_turbo_replaces_vocabulary_and_can_return_empty(omdet_model):
     assert len(second) == 0
 
 
+def test_ovdeim_small_predict_smoke():
+    pytest.importorskip("huggingface_hub")
+    pytest.importorskip("safetensors")
+    from libreyolo import LibreOpenVocab
+
+    model = LibreOpenVocab("ov-deim-s", device="cpu")
+    model.set_classes(["person", "dog", "skateboard"])
+    result = model.predict(_sample_image(), conf=0.3)
+    _assert_detection_smoke(result, {0: "person", 1: "dog", 2: "skateboard"})
+
+
+def test_ovdeim_replaces_vocabulary_and_can_return_empty():
+    pytest.importorskip("huggingface_hub")
+    pytest.importorskip("safetensors")
+    from libreyolo import LibreOpenVocab
+
+    model = LibreOpenVocab("ov-deim-s", device="cpu")
+    model.set_classes(["person", "building"])
+    first = model.predict(_sample_image(), conf=0.3)
+    assert first.names == {0: "person", 1: "building"}
+    assert len(first) > 0
+
+    model.set_classes(["giraffe"])
+    second = model.predict(_sample_image(), conf=0.5)
+    assert second.names == {0: "giraffe"}
+    assert len(second) == 0
+
+
 def test_openvocab_val_raises_in_v1():
     pytest.importorskip("transformers")
     from libreyolo import LibreOpenVocab

--- a/tests/unit/test_openvocab.py
+++ b/tests/unit/test_openvocab.py
@@ -13,6 +13,7 @@ from libreyolo.models.base.model import BaseModel
 from libreyolo.models.openvocab import LibreOpenVocab
 from libreyolo.models.openvocab.grounding_dino import LibreGroundingDINO
 from libreyolo.models.openvocab.omdet_turbo import LibreOMDetTurbo
+from libreyolo.models.openvocab.ov_deim import LibreOVDEIM
 from libreyolo.models.openvocab.owlv2 import LibreOWLv2
 
 pytestmark = [pytest.mark.unit, pytest.mark.openvocab]
@@ -76,6 +77,8 @@ class TestFactoryAliases:
         assert _ALIASES["omdet-turbo"] == (LibreOMDetTurbo, "t")
         assert _ALIASES["omdet"] == (LibreOMDetTurbo, "t")
         assert _ALIASES["omdet-turbo-swin-tiny"] == (LibreOMDetTurbo, "t")
+        assert _ALIASES["ov-deim"] == (LibreOVDEIM, "s")
+        assert _ALIASES["ovdeim-l"] == (LibreOVDEIM, "l")
 
     def test_unknown_alias_raises_before_loading(self):
         with pytest.raises(ValueError, match="Unknown open-vocabulary detector"):
@@ -547,6 +550,90 @@ class TestOMDetTurboMapping:
         det = m._postprocess(object(), 0.3, 0.45, (20, 20))
         assert det["num_detections"] == 1
         assert det["classes"].tolist() == [1]
+
+
+class TestOVDEIM:
+    def _bare_ovdeim(self, names=("person", "dog")):
+        m = object.__new__(LibreOVDEIM)
+        m.names = {i: n for i, n in enumerate(names)}
+        m.nb_classes = len(names)
+        m._refresh_name_index()
+        m._text_feats_cache = None
+        m._tokenizer = None
+        m.size = "s"
+        return m
+
+    def test_letterbox_params_match_upstream_rounding(self):
+        # 480x640 image into 640: scale 1.0 wide side, rint rounding, centered pad.
+        new_w, new_h, left, top = LibreOVDEIM._letterbox_params(640, 480, 640)
+        assert (new_w, new_h) == (640, 480)
+        assert (left, top) == (0, 80)
+
+        # Non-integer scale: rint, and odd padding splits with rint on top/left.
+        new_w, new_h, left, top = LibreOVDEIM._letterbox_params(500, 375, 640)
+        assert (new_w, new_h) == (640, 480)
+        assert (left, top) == (0, 80)
+
+    def test_postprocess_maps_flat_topk_to_labels_and_queries(self):
+        m = self._bare_ovdeim()
+        logits = torch.full((1, 300, 2), -10.0)
+        boxes = torch.full((1, 300, 4), 0.5)
+        # Query 7 scores high on class 1; centered box covering half the image.
+        logits[0, 7, 1] = 3.0
+        boxes[0, 7] = torch.tensor([0.5, 0.5, 0.5, 0.5])
+        det = m._postprocess(
+            {"pred_logits": logits, "pred_boxes": boxes},
+            conf_thres=0.5,
+            iou_thres=0.45,
+            original_size=(640, 640),
+        )
+        assert det["num_detections"] == 1
+        assert det["classes"].tolist() == [1]
+        assert torch.allclose(
+            det["boxes"][0], torch.tensor([160.0, 160.0, 480.0, 480.0])
+        )
+
+    def test_postprocess_undoes_letterbox_padding(self):
+        m = self._bare_ovdeim()
+        logits = torch.full((1, 300, 2), -10.0)
+        boxes = torch.zeros((1, 300, 4))
+        logits[0, 0, 0] = 3.0
+        # Full-width box in letterbox space for a 640x480 original (80px top pad).
+        boxes[0, 0] = torch.tensor([0.5, 0.5, 1.0, 480.0 / 640.0])
+        det = m._postprocess(
+            {"pred_logits": logits, "pred_boxes": boxes},
+            conf_thres=0.5,
+            iou_thres=0.45,
+            original_size=(640, 480),
+        )
+        assert det["num_detections"] == 1
+        assert torch.allclose(
+            det["boxes"][0], torch.tensor([0.0, 0.0, 640.0, 480.0]), atol=1e-4
+        )
+
+    def test_set_classes_invalidates_text_cache(self):
+        m = self._bare_ovdeim()
+        m._text_feats_cache = (("person", "dog"), torch.zeros(2, 512))
+        m.set_classes(["a red hat"])
+        assert m._text_feats_cache is None
+        assert m.names == {0: "a red hat"}
+
+    def test_no_nms_iou_warns(self):
+        assert LibreOVDEIM.NMS_THRESHOLD is None
+
+    def test_build_inputs_produces_normalized_letterboxed_tensor(self):
+        from PIL import Image
+
+        m = self._bare_ovdeim()
+        img = Image.new("RGB", (320, 240), (114, 114, 114))
+        tensor = m._build_inputs(img)
+        assert tensor.shape == (1, 3, 640, 640)
+        # A uniform 114 image letterboxed with 114 padding stays constant,
+        # so every channel equals (114/255 - mean) / std everywhere.
+        mean = torch.tensor([0.485, 0.456, 0.406]).view(3, 1, 1)
+        std = torch.tensor([0.229, 0.224, 0.225]).view(3, 1, 1)
+        expected = (torch.full((3, 640, 640), 114.0 / 255.0) - mean) / std
+        assert torch.allclose(tensor[0], expected, atol=1e-6)
 
 
 class TestDetectionDict:

--- a/tests/unit/test_openvocab.py
+++ b/tests/unit/test_openvocab.py
@@ -611,6 +611,27 @@ class TestOVDEIM:
             det["boxes"][0], torch.tensor([0.0, 0.0, 640.0, 480.0]), atol=1e-4
         )
 
+    def test_cached_text_feats_follow_the_model_across_devices(self):
+        """predict(device=...) moves the model between calls; a cache hit must
+        not hand back features stranded on the previous device."""
+
+        class _FakeTower:
+            def encode_texts(self, tokens):
+                return torch.zeros(tokens.shape[0], 512, device=tokens.device)
+
+        m = self._bare_ovdeim()
+        m.model = _FakeTower()
+        m.device = torch.device("meta")  # stands in for a second, distinct device
+        m._tokenizer = lambda names: torch.zeros(len(names), 77, dtype=torch.long)
+
+        cached = torch.zeros(2, 512)  # cached on CPU by an earlier call
+        m._text_feats_cache = (("person", "dog"), cached)
+
+        feats = m._class_text_feats()
+        assert feats.device == m.device
+        # The refreshed tensor is written back, so the next hit stays correct.
+        assert m._text_feats_cache[1].device == m.device
+
     def test_set_classes_invalidates_text_cache(self):
         m = self._bare_ovdeim()
         m._text_feats_cache = (("person", "dog"), torch.zeros(2, 512))

--- a/weights/convert_ovdeim_weights.py
+++ b/weights/convert_ovdeim_weights.py
@@ -1,0 +1,113 @@
+"""Convert upstream OV-DEIM checkpoints into LibreOVDEIM HF snapshot repos.
+
+This family lives in the open-vocabulary tier (Hugging Face snapshot repos,
+not ``.pt`` checkpoint files). Each output directory holds ``config.json``
+plus ``model.safetensors`` containing:
+
+* the OV-DEIM detector (``backbone``/``encoder``/``decoder``/``text_adapter``),
+  key-stripped from the released EMA state dict (``module.`` prefix removed,
+  training-only ``decoder.denoising_class_embed`` dropped);
+* the MobileCLIP-B(LT) text tower under ``text_encoder.*``, taken unchanged
+  from Apple's open_clip release (``apple/MobileCLIP-B-LT-OpenCLIP``).
+
+Learned parameters are unchanged; the conversion is a key remap plus merge.
+
+Usage:
+    python weights/convert_ovdeim_weights.py <upstream_dir> <output_dir> --size s
+
+where ``<upstream_dir>`` contains ``ovdeim_{s,m,l}.pth`` and ``<output_dir>``
+receives ``LibreOVDEIM<size>/{config.json,model.safetensors}``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+from _conversion_utils import add_repo_root_to_path
+
+MOBILECLIP_HF_REPO = "apple/MobileCLIP-B-LT-OpenCLIP"
+UPSTREAM_REPO = "https://github.com/wleilei/OV-DEIM"
+UPSTREAM_COMMIT = "dfbf394672407b7f837ec08e7d68e8127548b254"
+
+
+def load_text_tower_state_dict() -> dict[str, torch.Tensor]:
+    """Text-tower weights from Apple's open_clip checkpoint (key strip only)."""
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    path = hf_hub_download(MOBILECLIP_HF_REPO, "open_clip_model.safetensors")
+    full = load_file(path)
+    return {
+        f"text_encoder.{k[len('text.'):]}": v
+        for k, v in full.items()
+        if k.startswith("text.")
+    }
+
+
+def convert(input_dir: str, output_dir: str, size: str) -> Path:
+    add_repo_root_to_path()
+    from libreyolo.models.openvocab.ov_deim import LibreOVDEIM
+    from libreyolo.models.openvocab.ovdeim import LibreOVDEIMModel
+
+    from safetensors.torch import save_file
+
+    ckpt_path = Path(input_dir) / f"ovdeim_{size}.pth"
+    raw = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    if isinstance(raw, dict) and "ema_state_dict" in raw:
+        raw = raw["ema_state_dict"]
+        if "module" in raw:
+            raw = raw["module"]
+    state_dict = {}
+    for key, value in raw.items():
+        if not isinstance(value, torch.Tensor):
+            continue
+        if key.startswith("module."):
+            key = key[len("module."):]
+        if "decoder.denoising_class_embed" in key:
+            continue  # training-only, skipped by upstream's own eval script
+        state_dict[key] = value
+    print(f"{ckpt_path.name}: {len(state_dict)} detector tensors")
+
+    text_sd = load_text_tower_state_dict()
+    print(f"{MOBILECLIP_HF_REPO}: {len(text_sd)} text-tower tensors")
+    state_dict.update(text_sd)
+
+    model = LibreOVDEIMModel(size)
+    model.load_state_dict(state_dict, strict=True)
+    print("strict load into LibreOVDEIMModel: OK")
+
+    repo_name = f"{LibreOVDEIM.FILENAME_PREFIX}{size}"
+    out = Path(output_dir) / repo_name
+    out.mkdir(parents=True, exist_ok=True)
+
+    tmp = out / "model.safetensors.tmp"
+    save_file(state_dict, str(tmp))
+    tmp.rename(out / "model.safetensors")
+
+    config = {
+        "model_type": "ov_deim",
+        "family": "ov_deim",
+        "size": size,
+        "input_size": 640,
+        "text_encoder": "MobileCLIP-B(LT) text tower",
+        "source": {
+            "detector": {"repo": UPSTREAM_REPO, "commit": UPSTREAM_COMMIT},
+            "text_encoder": {"repo": f"https://huggingface.co/{MOBILECLIP_HF_REPO}"},
+        },
+    }
+    (out / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {out}")
+    return out
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_dir", help="Directory containing ovdeim_{s,m,l}.pth")
+    parser.add_argument("output_dir", help="Directory receiving LibreOVDEIM<size>/")
+    parser.add_argument("--size", required=True, choices=["s", "m", "l"])
+    args = parser.parse_args()
+    convert(args.input_dir, args.output_dir, args.size)


### PR DESCRIPTION
## Code provenance

Ported from https://github.com/wleilei/OV-DEIM at commit dfbf3946, licensed Apache-2.0 (upstream RT-DETR/DEIMv2 lineage; copyright headers preserved). Upstream added the license in response to our request: https://github.com/wleilei/OV-DEIM/issues/4#issuecomment-4967463647

The GPL-derived surface found in our audit (training dataloader / MMYolo-derived transforms) is NOT ported: this is an inference-only port. Upstream's vendored dinov3/ tree is avoided by reusing the existing DEIMv2 backbone adapter. Full file-level provenance map and the upstream license answer verbatim: docs/provenance/ov_deim.md

Weights (not code) are non-permissive and are hosted on HF, not in this repo: detector CC BY-NC 4.0 per upstream MODEL_LICENSE (redistribution and format conversion explicitly permitted with attribution), MobileCLIP-B(LT) text tower under Apple's ML Research Model license (research use), L backbone under Meta's DINOv3 License. Each weight repo ships all four license texts; a notice is logged at model construction.

## What

Native port of OV-DEIM into the LibreOpenVocab tier: vendored encoder/decoder, DEIMv2 DINOv3 backbone adapter reused, and an online MobileCLIP-B(LT) text tower built from LibreCLIP modules so arbitrary prompts work without upstream's precomputed embedding files. Registers `LibreOpenVocab("ov-deim-{s,m,l}")`. Weights live on LibreYOLO/LibreOVDEIM{s,m,l}; cold-cache autodownload verified. Inference-only, per ADR 0008.

## Validation

- Detector parity vs upstream: bit-exact (max_abs_diff == 0.0), all three sizes.
- Text tower: exact vs open_clip; 2.4e-7 vs upstream's released embedding caches.
- Full pipeline on real images: 100% label agreement across all 300 queries, scores within 1e-6.
- Zero-shot COCO val2017 through predict(): 45.92 AP (L) vs the paper's 45.9.
- Full unit suite green (3398 passed).
