### PR TITLE
add tta for panoptic segmentation

### DIFF
--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -757,11 +757,6 @@ class BaseModel(ABC):
                 "Test-time augmentation does not support point-task models yet. "
                 "Use augment=False for point models."
             )
-        if getattr(self, "task", "detect") == "panoptic":
-            raise ValueError(
-                "Test-time augmentation does not support panoptic segmentation yet. "
-                "Use augment=False for panoptic models."
-            )
         if getattr(self, "task", "detect") == "depth":
             raise ValueError(
                 "Test-time augmentation does not support depth estimation yet. "
@@ -788,6 +783,16 @@ class BaseModel(ABC):
 
         if getattr(self, "task", "detect") == "semantic":
             return self._predict_augment_semantic(
+                img_pil,
+                image_path,
+                (orig_w, orig_h),
+                effective_imgsz,
+                color_format,
+                **kwargs,
+            )
+
+        if getattr(self, "task", "detect") == "panoptic":
+            return self._predict_augment_panoptic(
                 img_pil,
                 image_path,
                 (orig_w, orig_h),
@@ -897,6 +902,26 @@ class BaseModel(ABC):
             path=str(image_path) if image_path else None,
             names=self.names,
             semantic_mask=SemanticMask(mask.long(), (orig_h, orig_w)),
+        )
+
+    def _predict_augment_panoptic(
+        self,
+        img_pil,
+        image_path,
+        original_size: Tuple[int, int],
+        effective_imgsz,
+        color_format: str,
+        **kwargs,
+    ) -> Results:
+        """Flip-only TTA for panoptic segmentation. Override per family.
+
+        No family-generic implementation exists (unlike semantic's
+        ``_postprocess_semantic_logits`` hook): panoptic decode is
+        query-based (Mask2Former/MaskFormer-style), and the flip-merge
+        strategy for query outputs is architecture-specific.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement panoptic flip-TTA."
         )
 
     def _merge_classify_tta(
@@ -1356,11 +1381,6 @@ class BaseModel(ABC):
             raise ValueError(
                 "Augmented validation does not support point-task models yet. "
                 "Use augment=False for point models."
-            )
-        if augment and self.task == "panoptic":
-            raise ValueError(
-                "Augmented validation does not support panoptic segmentation "
-                "yet. Use augment=False for panoptic models."
             )
         if augment and self.task == "depth":
             raise ValueError(

--- a/libreyolo/models/eomt/model.py
+++ b/libreyolo/models/eomt/model.py
@@ -692,14 +692,21 @@ class LibreEoMT(BaseModel):
         into it (mask probabilities and scores averaged) instead of
         competing against it separately in the fusion step.
 
-        ``view_ids`` (one int per query, matching ``scores``) restricts
-        merging to pairs from *different* views. Without it, two genuinely
+        ``view_ids`` (one int per query, matching ``scores``) restricts each
+        group to at most one query per view. Without it, two genuinely
         distinct same-class instances the model detected within a single
         view (e.g. two overlapping people in a crowd) could have high enough
         mask IoU to be wrongly folded into one segment — a risk this
         function only exists to dedup cross-view duplicates, not to
-        second-guess a single view's own instance separation. Pass ``None``
-        (the default) to merge on mask IoU alone, ignoring view origin.
+        second-guess a single view's own instance separation. The same cap
+        also stops one broad anchor query from absorbing *two* distinct,
+        correctly-separated queries from the opposite view: greedy
+        clustering otherwise has no limit on how many same-class queries a
+        single anchor can accumulate, so an imprecise mask that happens to
+        overlap two real neighboring instances above the threshold would
+        merge all three into one, silently losing an instance. Pass ``None``
+        (the default) to merge on mask IoU alone, ignoring view origin —
+        including this per-view cap.
         """
         n = mask_probs.shape[0]
         if n <= 1:
@@ -719,10 +726,14 @@ class LibreEoMT(BaseModel):
                 continue
             consumed[idx] = True
             group = [idx]
+            group_views = {int(view_ids[idx])} if view_ids is not None else None
             for jdx in order:
                 if jdx == idx or consumed[jdx] or int(labels[jdx]) != int(labels[idx]):
                     continue
-                if view_ids is not None and int(view_ids[jdx]) == int(view_ids[idx]):
+                jdx_view = int(view_ids[jdx]) if view_ids is not None else None
+                if group_views is not None and jdx_view in group_views:
+                    # Either the anchor's own view, or a view already
+                    # represented in this group — cap one query per view.
                     continue
                 inter = (binary_masks[idx] & binary_masks[jdx]).sum().float()
                 union = areas[idx] + areas[jdx] - inter
@@ -730,6 +741,8 @@ class LibreEoMT(BaseModel):
                 if iou > self.PANOPTIC_TTA_DEDUP_IOU:
                     consumed[jdx] = True
                     group.append(jdx)
+                    if group_views is not None:
+                        group_views.add(jdx_view)
 
             group_t = torch.tensor(group, device=mask_probs.device)
             out_scores.append(scores[group_t].mean())

--- a/libreyolo/models/eomt/model.py
+++ b/libreyolo/models/eomt/model.py
@@ -672,6 +672,7 @@ class LibreEoMT(BaseModel):
         scores: torch.Tensor,
         labels: torch.Tensor,
         mask_probs: torch.Tensor,
+        view_ids: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Merge same-class queries from different flip-TTA views that
         describe the same real instance, before fusion.
@@ -690,6 +691,15 @@ class LibreEoMT(BaseModel):
         ``PANOPTIC_TTA_DEDUP_IOU`` against an already-kept query is folded
         into it (mask probabilities and scores averaged) instead of
         competing against it separately in the fusion step.
+
+        ``view_ids`` (one int per query, matching ``scores``) restricts
+        merging to pairs from *different* views. Without it, two genuinely
+        distinct same-class instances the model detected within a single
+        view (e.g. two overlapping people in a crowd) could have high enough
+        mask IoU to be wrongly folded into one segment — a risk this
+        function only exists to dedup cross-view duplicates, not to
+        second-guess a single view's own instance separation. Pass ``None``
+        (the default) to merge on mask IoU alone, ignoring view origin.
         """
         n = mask_probs.shape[0]
         if n <= 1:
@@ -711,6 +721,8 @@ class LibreEoMT(BaseModel):
             group = [idx]
             for jdx in order:
                 if jdx == idx or consumed[jdx] or int(labels[jdx]) != int(labels[idx]):
+                    continue
+                if view_ids is not None and int(view_ids[jdx]) == int(view_ids[idx]):
                     continue
                 inter = (binary_masks[idx] & binary_masks[jdx]).sum().float()
                 union = areas[idx] + areas[jdx] - inter
@@ -752,6 +764,7 @@ class LibreEoMT(BaseModel):
         scores_views = []
         labels_views = []
         mask_probs_views = []
+        view_ids_views = []
         # Each view's preprocess -> forward -> query-decode runs in sequence,
         # not interleaved: _preprocess stashes per-call instance state
         # (self._last_eomt_content_size) that _panoptic_queries reads back
@@ -774,11 +787,21 @@ class LibreEoMT(BaseModel):
             scores_views.append(scores)
             labels_views.append(labels)
             mask_probs_views.append(mask_probs)
+            # Tags each query with the view it came from, so dedup only ever
+            # merges cross-view duplicates of the same real object — never
+            # two genuinely distinct same-class instances one view detected
+            # on its own (e.g. two overlapping people in a crowd).
+            view_ids_views.append(
+                torch.full((scores.shape[0],), int(is_flipped), dtype=torch.long)
+            )
 
         scores = torch.cat(scores_views, dim=0)
         labels = torch.cat(labels_views, dim=0)
         mask_probs = torch.cat(mask_probs_views, dim=0)
-        scores, labels, mask_probs = self._dedup_panoptic_queries(scores, labels, mask_probs)
+        view_ids = torch.cat(view_ids_views, dim=0)
+        scores, labels, mask_probs = self._dedup_panoptic_queries(
+            scores, labels, mask_probs, view_ids
+        )
         detections = self._fuse_panoptic_queries(scores, labels, mask_probs, original_size)
 
         return Results(

--- a/libreyolo/models/eomt/model.py
+++ b/libreyolo/models/eomt/model.py
@@ -64,6 +64,12 @@ class LibreEoMT(BaseModel):
     PANOPTIC_MASK_THRESHOLD: ClassVar[float] = 0.5
     PANOPTIC_OVERLAP_THRESHOLD: ClassVar[float] = 0.8
 
+    # Flip-TTA only: mask-IoU threshold above which same-class queries from
+    # the two views are treated as the same real instance and merged before
+    # fusion (see _dedup_panoptic_queries). Matches PQ_IOU_THRESHOLD's
+    # convention for "same instance" matching.
+    PANOPTIC_TTA_DEDUP_IOU: ClassVar[float] = 0.5
+
     WEIGHT_VARIANTS: ClassVar[Tuple[str, ...]] = ("1280",)
 
     semantic_resize_mode: ClassVar[str] = "split"
@@ -524,23 +530,17 @@ class LibreEoMT(BaseModel):
             return set()
         return set(range(self.nb_classes)) - set(int(i) for i in thing_ids)
 
-    def _postprocess_panoptic(
-        self,
-        output: Any,
-        conf_thres: float,
-        original_size: Tuple[int, int],
-    ) -> Dict:
-        """Merge per-query classes and masks into one non-overlapping segment map.
+    def _panoptic_queries(
+        self, output: Any, original_size: Tuple[int, int]
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Decode raw panoptic forward output into filtered (score, label,
+        full-resolution mask-probability) queries.
 
-        Implements the standard MaskFormer/Mask2Former panoptic inference recipe:
-        drop no-object and low-confidence queries, assign every pixel to the
-        query with the highest score-weighted mask probability, discard queries
-        whose surviving area falls below ``PANOPTIC_OVERLAP_THRESHOLD`` of their
-        own binarized area, and fuse all stuff segments of the same category.
-
-        Unlike ``_postprocess_segment`` this drops queries whose argmax over the
-        ``C + 1`` logits is the null class, which is what keeps a panoptic map
-        from filling with junk segments.
+        Drops no-object and low-confidence queries (``PANOPTIC_SCORE_THRESHOLD``).
+        Shared by ``_postprocess_panoptic`` (single-view predict/val) and
+        ``LibreEoMT._predict_augment_panoptic`` (flip TTA), which concatenates
+        queries from both views before the shared ``_fuse_panoptic_queries``
+        assignment step. Returns 0-length tensors when nothing survives.
         """
         if not isinstance(output, dict):
             raise ValueError("LibreEoMT panoptic forward must return a dict.")
@@ -558,23 +558,43 @@ class LibreEoMT(BaseModel):
         # The query score threshold is a merge hyperparameter, not a detection
         # confidence, so panoptic ignores predict(conf=...) exactly as semantic
         # does. Tune via PANOPTIC_SCORE_THRESHOLD.
-        score_threshold = self.PANOPTIC_SCORE_THRESHOLD
-
-        empty = {
-            "panoptic": torch.zeros((orig_h, orig_w), dtype=torch.int32),
-            "segments_info": [],
-        }
-
         scores, labels = class_logits[0].softmax(dim=-1).max(-1)  # over C+1
-        keep = (labels != nc) & (scores > score_threshold)
+        keep = (labels != nc) & (scores > self.PANOPTIC_SCORE_THRESHOLD)
         if not keep.any():
-            return empty
+            return scores[keep], labels[keep], mask_logits.new_zeros((0, orig_h, orig_w))
         scores, labels = scores[keep], labels[keep]
 
         # Crop the zero-padded border, resize logits to the image, then sigmoid.
         mask_probs = self._unpad_and_resize_mask_logits(
             mask_logits[0][keep], original_size
         ).sigmoid()
+        return scores, labels, mask_probs
+
+    def _fuse_panoptic_queries(
+        self,
+        scores: torch.Tensor,
+        labels: torch.Tensor,
+        mask_probs: torch.Tensor,
+        original_size: Tuple[int, int],
+    ) -> Dict:
+        """Merge per-query classes and masks into one non-overlapping segment map.
+
+        Implements the standard MaskFormer/Mask2Former panoptic inference recipe:
+        assign every pixel to the query with the highest score-weighted mask
+        probability, discard queries whose surviving area falls below
+        ``PANOPTIC_OVERLAP_THRESHOLD`` of their own binarized area, and fuse
+        all stuff segments of the same category. ``scores``/``labels``/
+        ``mask_probs`` come from ``_panoptic_queries`` — concatenated across
+        views for flip TTA, so this step is agnostic to how many queries
+        there are or which view(s) they came from.
+        """
+        orig_w, orig_h = original_size
+        empty = {
+            "panoptic": torch.zeros((orig_h, orig_w), dtype=torch.int32),
+            "segments_info": [],
+        }
+        if mask_probs.shape[0] == 0:
+            return empty
 
         # Every pixel goes to the query with the highest score-weighted mask
         # probability; a segment is the intersection of the pixels it won with
@@ -625,6 +645,153 @@ class LibreEoMT(BaseModel):
         if not segments_info:
             return empty
         return {"panoptic": segmentation.cpu(), "segments_info": segments_info}
+
+    def _postprocess_panoptic(
+        self,
+        output: Any,
+        conf_thres: float,
+        original_size: Tuple[int, int],
+    ) -> Dict:
+        """Merge per-query classes and masks into one non-overlapping segment map.
+
+        Drops no-object and low-confidence queries, assigns every pixel to
+        the query with the highest score-weighted mask probability, discards
+        mostly-occluded queries, and fuses same-category stuff segments —
+        see ``_panoptic_queries``/``_fuse_panoptic_queries`` for the two
+        halves of this recipe.
+
+        Unlike ``_postprocess_segment`` this drops queries whose argmax over the
+        ``C + 1`` logits is the null class, which is what keeps a panoptic map
+        from filling with junk segments.
+        """
+        scores, labels, mask_probs = self._panoptic_queries(output, original_size)
+        return self._fuse_panoptic_queries(scores, labels, mask_probs, original_size)
+
+    def _dedup_panoptic_queries(
+        self,
+        scores: torch.Tensor,
+        labels: torch.Tensor,
+        mask_probs: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Merge same-class queries from different flip-TTA views that
+        describe the same real instance, before fusion.
+
+        Without this, two views correctly agreeing on the same object each
+        contribute a near-duplicate query. ``_fuse_panoptic_queries``'s
+        per-pixel winner-take-all then splits that object's pixels roughly
+        evenly between the two duplicates, so *each* one's own overlap
+        fraction can fall below ``PANOPTIC_OVERLAP_THRESHOLD`` and get
+        dropped as "mostly occluded" — silently losing an object BOTH views
+        detected correctly (measured empirically: 2 of 7 real segments lost
+        on a real image before this dedup step was added).
+
+        Greedy NMS-style clustering: process queries highest-score first; a
+        lower-score query of the same class with binarized-mask IoU above
+        ``PANOPTIC_TTA_DEDUP_IOU`` against an already-kept query is folded
+        into it (mask probabilities and scores averaged) instead of
+        competing against it separately in the fusion step.
+        """
+        n = mask_probs.shape[0]
+        if n <= 1:
+            return scores, labels, mask_probs
+
+        binary_masks = mask_probs >= self.PANOPTIC_MASK_THRESHOLD
+        areas = binary_masks.flatten(1).sum(dim=1).float()
+        order = torch.argsort(scores, descending=True).tolist()
+
+        consumed = [False] * n
+        out_scores: list[torch.Tensor] = []
+        out_labels: list[torch.Tensor] = []
+        out_masks: list[torch.Tensor] = []
+
+        for idx in order:
+            if consumed[idx]:
+                continue
+            consumed[idx] = True
+            group = [idx]
+            for jdx in order:
+                if jdx == idx or consumed[jdx] or int(labels[jdx]) != int(labels[idx]):
+                    continue
+                inter = (binary_masks[idx] & binary_masks[jdx]).sum().float()
+                union = areas[idx] + areas[jdx] - inter
+                iou = (inter / union) if union > 0 else inter.new_zeros(())
+                if iou > self.PANOPTIC_TTA_DEDUP_IOU:
+                    consumed[jdx] = True
+                    group.append(jdx)
+
+            group_t = torch.tensor(group, device=mask_probs.device)
+            out_scores.append(scores[group_t].mean())
+            out_labels.append(labels[idx])
+            out_masks.append(mask_probs[group_t].mean(dim=0))
+
+        return torch.stack(out_scores), torch.stack(out_labels), torch.stack(out_masks)
+
+    def _predict_augment_panoptic(
+        self,
+        img_pil,
+        image_path,
+        original_size: Tuple[int, int],
+        effective_imgsz,
+        color_format: str,
+        **kwargs,
+    ) -> Any:
+        """Flip-only TTA for panoptic segmentation.
+
+        Concatenates the original and flipped views' surviving (score,
+        label, mask) queries, merges same-instance duplicates across views
+        (``_dedup_panoptic_queries``), and re-runs the existing per-pixel
+        winner-take-all fusion once over the deduplicated set — the same
+        generalization detection TTA uses (concatenate augmented-view
+        boxes, then run NMS once).
+        """
+        from PIL import Image as PILImage
+
+        from ...utils.results import PanopticSegmentation, Results
+
+        orig_w, orig_h = original_size
+        scores_views = []
+        labels_views = []
+        mask_probs_views = []
+        # Each view's preprocess -> forward -> query-decode runs in sequence,
+        # not interleaved: _preprocess stashes per-call instance state
+        # (self._last_eomt_content_size) that _panoptic_queries reads back
+        # via _unpad_and_resize_mask_logits, so a later _preprocess call
+        # must not run before the earlier view's decode has consumed it.
+        for is_flipped in (False, True):
+            src = (
+                img_pil.transpose(PILImage.Transpose.FLIP_LEFT_RIGHT)
+                if is_flipped
+                else img_pil
+            )
+            tensor, _, orig_size, _ = self._preprocess(
+                src, color_format, input_size=effective_imgsz
+            )
+            with torch.no_grad():
+                raw = self._forward(tensor.to(self.device))
+            scores, labels, mask_probs = self._panoptic_queries(raw, orig_size)
+            if is_flipped and mask_probs.shape[0] > 0:
+                mask_probs = mask_probs.flip(-1)
+            scores_views.append(scores)
+            labels_views.append(labels)
+            mask_probs_views.append(mask_probs)
+
+        scores = torch.cat(scores_views, dim=0)
+        labels = torch.cat(labels_views, dim=0)
+        mask_probs = torch.cat(mask_probs_views, dim=0)
+        scores, labels, mask_probs = self._dedup_panoptic_queries(scores, labels, mask_probs)
+        detections = self._fuse_panoptic_queries(scores, labels, mask_probs, original_size)
+
+        return Results(
+            boxes=None,
+            orig_shape=(orig_h, orig_w),
+            path=str(image_path) if image_path else None,
+            names=self.names,
+            panoptic=PanopticSegmentation(
+                detections["panoptic"].long(),
+                detections.get("segments_info") or [],
+                (orig_h, orig_w),
+            ),
+        )
 
     def _postprocess_semantic_logits(
         self, output: Any, original_size: Tuple[int, int], **kwargs

--- a/libreyolo/validation/panoptic_validator.py
+++ b/libreyolo/validation/panoptic_validator.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
+import torch
 from torch.utils.data import DataLoader
 
 from ..data.panoptic_dataset import (
@@ -117,6 +118,59 @@ class PanopticValidator(BaseValidator):
                 "panoptic task?"
             )
         return detections
+
+    def _run_validation_augmented(self) -> None:
+        """Flip TTA, one image at a time (segment maps have per-image
+        resolutions, same as the non-augmented path).
+
+        Reuses ``BaseModel._predict_augment`` — which dispatches to the
+        family's ``_predict_augment_panoptic`` for ``task == "panoptic"`` —
+        the same way ``DetectionValidator._run_validation_augmented`` reuses
+        it for boxes, rather than duplicating the flip/merge logic here.
+        """
+        import sys
+        import time
+
+        from tqdm import tqdm
+
+        # BaseValidator._run_validation already put the model in eval() before
+        # dispatching here.
+        pbar = tqdm(
+            self.dataloader,
+            desc="Validating (TTA x2)",
+            total=len(self.dataloader),
+            disable=not self.config.verbose or not sys.stderr.isatty(),
+            file=sys.stderr,
+        )
+
+        total_start = time.time()
+
+        with torch.no_grad():
+            for batch in pbar:
+                img_paths, seg_maps, segments_infos, infos = batch
+
+                t1 = time.time()
+                result = self.model._predict_augment(
+                    img_paths[0], imgsz=self.config.imgsz
+                )
+                self.speed["inference"] += time.time() - t1
+
+                if result.panoptic is not None:
+                    detections = {
+                        "panoptic": result.panoptic.data,
+                        "segments_info": result.panoptic.segments_info,
+                    }
+                else:
+                    orig_h, orig_w = result.orig_shape
+                    detections = {
+                        "panoptic": torch.zeros((orig_h, orig_w), dtype=torch.int32),
+                        "segments_info": [],
+                    }
+
+                self._update_metrics(detections, seg_maps, infos, segments_infos)
+                self.seen += 1
+
+        self.speed["total"] = time.time() - total_start
 
     def _update_metrics(
         self, preds: Any, targets: Any, img_info: Any, img_ids: Any = None

--- a/tests/unit/test_eomt.py
+++ b/tests/unit/test_eomt.py
@@ -1138,6 +1138,16 @@ def _panoptic_stub(nc: int, thing_class_ids):
     stub._unpad_and_resize_mask_logits = lambda ml, osz: (
         LibreEoMT._unpad_and_resize_mask_logits(stub, ml, osz)
     )
+    stub._panoptic_queries = lambda output, osz: LibreEoMT._panoptic_queries(
+        stub, output, osz
+    )
+    stub._fuse_panoptic_queries = lambda scores, labels, mask_probs, osz: (
+        LibreEoMT._fuse_panoptic_queries(stub, scores, labels, mask_probs, osz)
+    )
+    stub.PANOPTIC_TTA_DEDUP_IOU = LibreEoMT.PANOPTIC_TTA_DEDUP_IOU
+    stub._dedup_panoptic_queries = lambda scores, labels, mask_probs: (
+        LibreEoMT._dedup_panoptic_queries(stub, scores, labels, mask_probs)
+    )
     return stub
 
 
@@ -1242,6 +1252,219 @@ def test_panoptic_merge_empty_when_all_queries_are_null():
     out = LibreEoMT._postprocess_panoptic(stub, output, 0.5, (4, 4))
     assert out["segments_info"] == []
     assert int(out["panoptic"].sum()) == 0
+
+
+def _single_query_panoptic_output(nc, quadrant, cls):
+    """A single high-confidence query occupying one quadrant of a 4x4 canvas."""
+    class_logits = torch.full((1, 1, nc + 1), -10.0)
+    class_logits[0, 0, cls] = 5.0
+    mask_logits = torch.full((1, 1, 4, 4), -4.0)
+    rows, cols = quadrant
+    mask_logits[0, 0, rows, cols] = 4.0
+    return {"class_queries_logits": class_logits, "masks_queries_logits": mask_logits}
+
+
+def _panoptic_tta_stub(nc: int, thing_class_ids, forward_outputs: list):
+    """_panoptic_stub extended with the predict-path hooks _predict_augment_panoptic
+    needs: device, names, _preprocess, _forward (returns forward_outputs[call_idx])."""
+    stub = _panoptic_stub(nc=nc, thing_class_ids=thing_class_ids)
+    stub.device = torch.device("cpu")
+    stub.names = {i: str(i) for i in range(nc)}
+    calls = {"n": 0}
+
+    def _preprocess(image, color_format="auto", input_size=None):
+        return torch.zeros(1, 3, 4, 4), image, (4, 4), 1.0
+
+    def _forward(tensor):
+        out = forward_outputs[calls["n"]]
+        calls["n"] += 1
+        return out
+
+    stub._preprocess = _preprocess
+    stub._forward = _forward
+    return stub
+
+
+TOP_LEFT = (slice(0, 2), slice(0, 2))
+BOTTOM_LEFT = (slice(2, 4), slice(0, 2))
+BOTTOM_RIGHT = (slice(2, 4), slice(2, 4))
+
+
+def test_dedup_panoptic_queries_merges_same_class_overlapping_masks():
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=4, thing_class_ids=[0, 1])
+    scores = torch.tensor([0.9, 0.85])
+    labels = torch.tensor([0, 0])
+    mask_probs = torch.full((2, 4, 4), 0.02)
+    mask_probs[0, 0:2, 0:2] = 0.9
+    mask_probs[1, 0:2, 0:2] = 0.9  # identical quadrant -> IoU 1.0
+
+    out_scores, out_labels, out_masks = LibreEoMT._dedup_panoptic_queries(
+        stub, scores, labels, mask_probs
+    )
+
+    assert out_scores.shape == (1,)
+    assert out_labels.tolist() == [0]
+    assert out_scores.item() == pytest.approx((0.9 + 0.85) / 2)
+    assert torch.allclose(out_masks[0], mask_probs.mean(dim=0))
+
+
+def test_dedup_panoptic_queries_keeps_different_classes_separate():
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=4, thing_class_ids=[0, 1])
+    scores = torch.tensor([0.9, 0.85])
+    labels = torch.tensor([0, 1])  # different classes, identical masks
+    mask_probs = torch.full((2, 4, 4), 0.02)
+    mask_probs[:, 0:2, 0:2] = 0.9
+
+    out_scores, out_labels, _ = LibreEoMT._dedup_panoptic_queries(
+        stub, scores, labels, mask_probs
+    )
+
+    assert out_scores.shape == (2,)
+    assert sorted(out_labels.tolist()) == [0, 1]
+
+
+def test_dedup_panoptic_queries_keeps_non_overlapping_same_class_separate():
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=4, thing_class_ids=[0, 1])
+    scores = torch.tensor([0.9, 0.85])
+    labels = torch.tensor([0, 0])
+    mask_probs = torch.full((2, 4, 4), 0.02)
+    mask_probs[0, 0:2, 0:2] = 0.9  # top-left
+    mask_probs[1, 2:4, 2:4] = 0.9  # bottom-right, disjoint -> IoU 0
+
+    out_scores, _, _ = LibreEoMT._dedup_panoptic_queries(stub, scores, labels, mask_probs)
+
+    assert out_scores.shape == (2,)
+
+
+def test_dedup_prevents_two_agreeing_views_from_losing_to_each_other():
+    """Regression for the exact failure mode measured on a real image: two
+    same-class queries whose masks mostly-but-not-perfectly agree split the
+    per-pixel winner-take-all between them, so *each* one's own overlap
+    ratio can fall below PANOPTIC_OVERLAP_THRESHOLD and get dropped —
+    losing an object both views correctly detected. The canvas here is
+    exactly the 2-pixel competing region (no other "background" pixels):
+    _fuse_panoptic_queries's winner is an argmax with ties resolved to the
+    lowest query index, so any padding pixels where two queries are exactly
+    tied would spuriously hand one of them a free, unbounded won_area and
+    mask the effect under test.
+    """
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=4, thing_class_ids=[0, 1])
+    scores = torch.tensor([0.9, 0.9])
+    labels = torch.tensor([0, 0])
+    # A 2x1 canvas: query A confident on row 0, only-just-over-threshold on
+    # row 1; query B is the mirror image. Both "own" both pixels, but each
+    # only wins the pixel where it's more confident.
+    mask_probs = torch.tensor([[[0.95], [0.62]], [[0.62], [0.95]]])
+
+    undeduped = LibreEoMT._fuse_panoptic_queries(stub, scores, labels, mask_probs, (1, 2))
+    assert undeduped["segments_info"] == []  # both queries lose to each other
+
+    d_scores, d_labels, d_masks = LibreEoMT._dedup_panoptic_queries(
+        stub, scores, labels, mask_probs
+    )
+    deduped = LibreEoMT._fuse_panoptic_queries(stub, d_scores, d_labels, d_masks, (1, 2))
+    assert len(deduped["segments_info"]) == 1
+    assert deduped["segments_info"][0]["category_id"] == 0
+    assert int((deduped["panoptic"] != 0).sum()) == 2
+
+
+def test_predict_augment_panoptic_concatenates_queries_across_views():
+    """The flipped view's bottom-left detection must land at bottom-right
+    after flip-back, and both views' detections must survive into the
+    merged result — the whole point of the concatenate-then-fuse prototype."""
+    from PIL import Image
+
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_tta_stub(
+        nc=4,
+        thing_class_ids=[0, 1],
+        forward_outputs=[
+            _single_query_panoptic_output(nc=4, quadrant=TOP_LEFT, cls=0),
+            _single_query_panoptic_output(nc=4, quadrant=BOTTOM_LEFT, cls=1),
+        ],
+    )
+
+    result = LibreEoMT._predict_augment_panoptic(
+        stub,
+        Image.new("RGB", (4, 4)),
+        image_path=None,
+        original_size=(4, 4),
+        effective_imgsz=4,
+        color_format="auto",
+    )
+
+    seg = result.panoptic.data
+    info = result.panoptic.segments_info
+    assert len(info) == 2
+    assert sorted(e["category_id"] for e in info) == [0, 1]
+
+    top_left_id = next(e["id"] for e in info if e["category_id"] == 0)
+    assert int((seg[0:2, 0:2] == top_left_id).sum()) == 4
+
+    bottom_right_id = next(e["id"] for e in info if e["category_id"] == 1)
+    assert int((seg[2:4, 2:4] == bottom_right_id).sum()) == 4
+    # Nothing survives where the flipped view's raw (pre-flip-back) mask was.
+    assert int((seg[2:4, 0:2] != 0).sum()) == 0
+
+
+def test_predict_augment_panoptic_when_one_view_finds_nothing():
+    """One view surviving 0 queries must not break concatenation with the
+    other view's real detection."""
+    from PIL import Image
+
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    all_null = {
+        "class_queries_logits": torch.full((1, 2, 5), -10.0).index_fill_(
+            -1, torch.tensor([4]), 5.0
+        ),
+        "masks_queries_logits": torch.full((1, 2, 4, 4), 4.0),
+    }
+    stub = _panoptic_tta_stub(
+        nc=4,
+        thing_class_ids=[0, 1],
+        forward_outputs=[
+            all_null,
+            _single_query_panoptic_output(nc=4, quadrant=TOP_LEFT, cls=0),
+        ],
+    )
+
+    result = LibreEoMT._predict_augment_panoptic(
+        stub,
+        Image.new("RGB", (4, 4)),
+        image_path=None,
+        original_size=(4, 4),
+        effective_imgsz=4,
+        color_format="auto",
+    )
+
+    info = result.panoptic.segments_info
+    assert len(info) == 1
+    assert info[0]["category_id"] == 0
+    # The flipped view's top-left query flips back to top-right.
+    seg = result.panoptic.data
+    assert int((seg[0:2, 2:4] == info[0]["id"]).sum()) == 4
+
+
+def test_base_model_predict_augment_panoptic_default_raises():
+    """Families that don't implement panoptic flip-TTA get a clear error,
+    not a silent no-op or an AttributeError."""
+    from types import SimpleNamespace
+
+    from libreyolo.models.base.model import BaseModel
+
+    model = SimpleNamespace(task="panoptic")
+    with pytest.raises(NotImplementedError, match="panoptic flip-TTA"):
+        BaseModel._predict_augment_panoptic(model, None, None, (1, 1), 1, "auto")
 
 
 def test_coco_content_size_matches_upstream_aspect_ratio_rule():

--- a/tests/unit/test_eomt.py
+++ b/tests/unit/test_eomt.py
@@ -1403,6 +1403,37 @@ def test_dedup_panoptic_queries_never_merges_same_view_duplicates():
     assert out_labels.tolist() == [0, 0]
 
 
+def test_dedup_panoptic_queries_caps_one_match_per_view():
+    """A single anchor query must not absorb two distinct queries from the
+    opposite view into the same group. Greedy clustering has no inherent
+    limit on group size, so a broad/imprecise anchor overlapping two
+    correctly-separated same-class queries from the other view (e.g. two
+    people in a crowd) would otherwise merge all three into one, silently
+    losing an instance (reported as a Greptile review finding on this PR).
+
+    Anchor A (view 0, highest score) has identical masks to both B1 and B2
+    (view 1, lower scores) -> IoU 1.0 against each. A must merge with only
+    one of them (the higher-scoring B1), leaving the other as its own group.
+    """
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=4, thing_class_ids=[0, 1])
+    scores = torch.tensor([0.9, 0.8, 0.7])  # A, B1, B2
+    labels = torch.tensor([0, 0, 0])
+    mask_probs = torch.full((3, 4, 4), 0.9)  # identical masks -> IoU 1.0 pairwise
+    view_ids = torch.tensor([0, 1, 1])  # A from view 0; B1, B2 both from view 1
+
+    out_scores, out_labels, _ = LibreEoMT._dedup_panoptic_queries(
+        stub, scores, labels, mask_probs, view_ids
+    )
+
+    assert out_scores.shape == (2,)  # A merges with only one of B1/B2
+    assert out_labels.tolist() == [0, 0]
+    # A (0.9) merges with the higher-scoring B1 (0.8) -> mean 0.85; B2 (0.7)
+    # survives on its own, unmerged.
+    assert sorted(round(s, 4) for s in out_scores.tolist()) == [0.7, 0.85]
+
+
 def test_predict_augment_panoptic_tags_queries_with_their_source_view():
     """Integration check that _predict_augment_panoptic actually wires
     per-query view_ids through to _dedup_panoptic_queries (the unit-level

--- a/tests/unit/test_eomt.py
+++ b/tests/unit/test_eomt.py
@@ -1145,8 +1145,8 @@ def _panoptic_stub(nc: int, thing_class_ids):
         LibreEoMT._fuse_panoptic_queries(stub, scores, labels, mask_probs, osz)
     )
     stub.PANOPTIC_TTA_DEDUP_IOU = LibreEoMT.PANOPTIC_TTA_DEDUP_IOU
-    stub._dedup_panoptic_queries = lambda scores, labels, mask_probs: (
-        LibreEoMT._dedup_panoptic_queries(stub, scores, labels, mask_probs)
+    stub._dedup_panoptic_queries = lambda scores, labels, mask_probs, view_ids=None: (
+        LibreEoMT._dedup_panoptic_queries(stub, scores, labels, mask_probs, view_ids)
     )
     return stub
 
@@ -1363,17 +1363,99 @@ def test_dedup_prevents_two_agreeing_views_from_losing_to_each_other():
     # row 1; query B is the mirror image. Both "own" both pixels, but each
     # only wins the pixel where it's more confident.
     mask_probs = torch.tensor([[[0.95], [0.62]], [[0.62], [0.95]]])
+    view_ids = torch.tensor([0, 1])  # one query per view, as flip-TTA produces
 
     undeduped = LibreEoMT._fuse_panoptic_queries(stub, scores, labels, mask_probs, (1, 2))
     assert undeduped["segments_info"] == []  # both queries lose to each other
 
     d_scores, d_labels, d_masks = LibreEoMT._dedup_panoptic_queries(
-        stub, scores, labels, mask_probs
+        stub, scores, labels, mask_probs, view_ids
     )
     deduped = LibreEoMT._fuse_panoptic_queries(stub, d_scores, d_labels, d_masks, (1, 2))
     assert len(deduped["segments_info"]) == 1
     assert deduped["segments_info"][0]["category_id"] == 0
     assert int((deduped["panoptic"] != 0).sum()) == 2
+
+
+def test_dedup_panoptic_queries_never_merges_same_view_duplicates():
+    """Two distinct, same-class, overlapping-mask queries from the SAME view
+    must stay separate. Dedup exists to merge one real object seen twice
+    across the two flip-TTA views, not to second-guess a single view's own
+    instance separation — e.g. two overlapping people in a crowd, which a
+    single forward pass can legitimately emit as two high-IoU same-class
+    queries. Without the view_ids guard this would wrongly collapse them
+    into one segment (reported as a Greptile review finding on this PR)."""
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    stub = _panoptic_stub(nc=4, thing_class_ids=[0, 1])
+    scores = torch.tensor([0.9, 0.85])
+    labels = torch.tensor([0, 0])
+    mask_probs = torch.full((2, 4, 4), 0.02)
+    mask_probs[0, 0:2, 0:2] = 0.9
+    mask_probs[1, 0:2, 0:2] = 0.9  # identical quadrant -> IoU 1.0
+    view_ids = torch.tensor([0, 0])  # both from the same view
+
+    out_scores, out_labels, _ = LibreEoMT._dedup_panoptic_queries(
+        stub, scores, labels, mask_probs, view_ids
+    )
+
+    assert out_scores.shape == (2,)  # kept separate despite IoU 1.0
+    assert out_labels.tolist() == [0, 0]
+
+
+def test_predict_augment_panoptic_tags_queries_with_their_source_view():
+    """Integration check that _predict_augment_panoptic actually wires
+    per-query view_ids through to _dedup_panoptic_queries (the unit-level
+    fix is tested directly in
+    test_dedup_panoptic_queries_never_merges_same_view_duplicates; this
+    confirms the caller doesn't drop that information on the way in).
+    Two same-class, identical-mask queries both coming from the ORIGINAL
+    view must reach fusion un-merged (2 queries in), not folded into 1 by
+    dedup, even though their mask IoU is 1.0 -- well above
+    PANOPTIC_TTA_DEDUP_IOU."""
+    from PIL import Image
+
+    from libreyolo.models.eomt.model import LibreEoMT
+
+    def _two_overlapping_queries_output(nc=4):
+        class_logits = torch.full((1, 2, nc + 1), -10.0)
+        class_logits[0, :, 0] = 5.0
+        mask_logits = torch.full((1, 2, 4, 4), -4.0)
+        mask_logits[0, :, 0:2, 0:2] = 4.0
+        return {"class_queries_logits": class_logits, "masks_queries_logits": mask_logits}
+
+    all_null = {
+        "class_queries_logits": torch.full((1, 2, 5), -10.0).index_fill_(
+            -1, torch.tensor([4]), 5.0
+        ),
+        "masks_queries_logits": torch.full((1, 2, 4, 4), 4.0),
+    }
+    stub = _panoptic_tta_stub(
+        nc=4,
+        thing_class_ids=[0, 1],
+        forward_outputs=[_two_overlapping_queries_output(nc=4), all_null],
+    )
+    seen_query_count = {}
+    real_fuse = stub._fuse_panoptic_queries
+
+    def _spy_fuse(scores, labels, mask_probs, osz):
+        seen_query_count["n"] = mask_probs.shape[0]
+        return real_fuse(scores, labels, mask_probs, osz)
+
+    stub._fuse_panoptic_queries = _spy_fuse
+
+    LibreEoMT._predict_augment_panoptic(
+        stub,
+        Image.new("RGB", (4, 4)),
+        image_path=None,
+        original_size=(4, 4),
+        effective_imgsz=4,
+        color_format="auto",
+    )
+
+    # Both same-view queries reach fusion un-merged: dedup only collapses
+    # cross-view duplicates.
+    assert seen_query_count["n"] == 2
 
 
 def test_predict_augment_panoptic_concatenates_queries_across_views():

--- a/tests/unit/test_panoptic_scaffold.py
+++ b/tests/unit/test_panoptic_scaffold.py
@@ -131,6 +131,83 @@ def test_panoptic_validator_computes_pq():
     assert metrics["fitness"] == 1.0
 
 
+def test_panoptic_validator_augmented_extracts_result_and_scores_pq():
+    """_run_validation_augmented reuses model._predict_augment (the shared
+    BaseModel dispatch, not a bespoke re-implementation) and must correctly
+    unwrap Results.panoptic back into the {"panoptic", "segments_info"} dict
+    _update_metrics expects."""
+    import torch
+    from types import SimpleNamespace
+
+    from libreyolo.utils.results import PanopticSegmentation, Results
+    from libreyolo.validation import PanopticValidator, ValidationConfig
+
+    class _StubModel:
+        task = "panoptic"
+        nb_classes = 1
+
+        def __init__(self):
+            self.model = SimpleNamespace(eval=lambda: None)
+
+        def _predict_augment(self, path, imgsz=None):
+            seg = torch.tensor([[1, 1], [0, 0]], dtype=torch.int32)
+            return Results(
+                boxes=None,
+                orig_shape=(2, 2),
+                names={0: "a"},
+                panoptic=PanopticSegmentation(
+                    seg, [{"id": 1, "category_id": 0}], (2, 2)
+                ),
+            )
+
+    config = ValidationConfig(data="dummy.yaml", device="cpu", imgsz=2, verbose=False)
+    validator = PanopticValidator(model=_StubModel(), config=config)
+    validator._init_metrics()
+
+    gt_map = np.array([[1, 1], [0, 0]], dtype=np.int64)
+    gt_segments = [{"id": 1, "category_id": 0, "iscrowd": 0}]
+    batch = (["img.jpg"], [torch.from_numpy(gt_map)], [gt_segments], [{}])
+    validator.dataloader = [batch]
+
+    validator._run_validation_augmented()
+
+    metrics = validator._compute_metrics()
+    assert metrics["metrics/PQ"] == 1.0
+    assert validator.seen == 1
+
+
+def test_panoptic_validator_augmented_handles_empty_panoptic_result():
+    """A view with no surviving segments (result.panoptic is None) must not
+    crash — it should score as a fully-void prediction."""
+    import torch
+    from types import SimpleNamespace
+
+    from libreyolo.utils.results import Results
+    from libreyolo.validation import PanopticValidator, ValidationConfig
+
+    class _EmptyModel:
+        task = "panoptic"
+        nb_classes = 1
+
+        def __init__(self):
+            self.model = SimpleNamespace(eval=lambda: None)
+
+        def _predict_augment(self, path, imgsz=None):
+            return Results(boxes=None, orig_shape=(2, 2), names={0: "a"})
+
+    config = ValidationConfig(data="dummy.yaml", device="cpu", imgsz=2, verbose=False)
+    validator = PanopticValidator(model=_EmptyModel(), config=config)
+    validator._init_metrics()
+
+    gt_map = np.zeros((2, 2), dtype=np.int64)
+    batch = (["img.jpg"], [torch.from_numpy(gt_map)], [[]], [{}])
+    validator.dataloader = [batch]
+
+    validator._run_validation_augmented()
+
+    assert validator.seen == 1
+
+
 def test_panoptic_postprocess_without_family_support_fails_loudly():
     """A family that does not implement panoptic must not silently score zero."""
     from libreyolo.validation import PanopticValidator, ValidationConfig


### PR DESCRIPTION
# Add flip-TTA support for panoptic segmentation

## Code provenance

Original code written for this PR. No code was ported or adapted from any
third-party project. The dispatch/hook pattern (`_predict_augment_panoptic`,
the `_postprocess_*` split) follows the structure established by the
semantic segmentation flip-TTA PR (#601) already merged into this repo, not
an external source.

## Summary

Adds horizontal-flip test-time augmentation (`augment=True`) for panoptic
segmentation, following on from the semantic segmentation TTA support merged
in #601. Panoptic decode is query-based (Mask2Former/MaskFormer-style), so
the flip-merge strategy is architecture-specific and cannot reuse the
family-generic semantic hook — this PR adds a dedicated dispatch path plus a
mask-IoU deduplication step needed to make cross-view query fusion safe.

- `BaseModel._predict_augment` gains a `panoptic` dispatch branch and a
  `_predict_augment_panoptic` default hook (raises `NotImplementedError` for
  families that don't implement it, mirroring the semantic hook's pattern).
- Removed the two panoptic TTA rejection guards (`_predict_augment` and
  `val()`) that previously raised `ValueError("... does not support panoptic
  segmentation yet ...")`.
- `LibreEoMT._postprocess_panoptic` split into `_panoptic_queries` (decode
  raw output into filtered score/label/mask-probability queries) and
  `_fuse_panoptic_queries` (the existing winner-take-all per-pixel fusion) —
  behavior-preserving refactor that lets TTA reuse the decode step per view.
- `LibreEoMT._predict_augment_panoptic`: runs original + flipped views
  (atomically preprocess→forward→decode per view, since EoMT stashes
  per-call instance state that must not be interleaved across views), flips
  the flipped view's mask probabilities back into alignment, concatenates
  queries across views, deduplicates, then fuses.
- `LibreEoMT._dedup_panoptic_queries` (new): greedy, highest-score-first,
  mask-IoU-based merge of same-class queries above
  `PANOPTIC_TTA_DEDUP_IOU = 0.5` (mirrors the `PQ_IOU_THRESHOLD` convention).
- `PanopticValidator._run_validation_augmented`: per-image validation path
  for `augment=True`, reusing `model._predict_augment` (same pattern as
  `DetectionValidator`).

## Why the dedup step exists — an empirical finding, not a hypothetical

The naive concatenate-only prototype was measured against real EoMT-S
panoptic weights before the dedup step was added, and it *lost* detections
instead of improving them: 5 segments under `augment=True` vs 7 for
`augment=False` (and for each view fused alone), dropping categories 112 and
116 entirely.

Root cause: near-duplicate queries for the same real object, one from each
view, split the per-pixel winner-take-all roughly evenly. Each query's own
`won_area / own_area` ratio then fell below `PANOPTIC_OVERLAP_THRESHOLD`
(0.8), so *both* competing queries for that object were dropped by the
existing overlap-threshold logic — two views agreeing on an object made that
object disappear, not appear more confidently.

Adding `_dedup_panoptic_queries` (mask-IoU merge before fusion) fixed this:
the single-image sanity check below recovers all 7 segments, matching
`augment=False` exactly.

To confirm this wasn't a one-image fluke, the naive concatenate-only
prototype (dedup step monkeypatched to a no-op) was also run against the
full 5000-image COCO panoptic split. The single-image finding turned out to
understate the problem — without dedup, TTA doesn't just fail to help, it
substantially degrades panoptic quality across the whole validation set:

| metric | augment=False (baseline) | augment=True, no dedup | augment=True, with dedup (shipped) |
|---|---|---|---|
| PQ | 0.4674 | 0.3543 (−0.1131) | **0.4788 (+0.0114)** |
| SQ | 0.8153 | 0.7788 | 0.8147 |
| RQ | 0.5633 | 0.4478 | 0.5777 |
| PQ_things | 0.5015 | 0.3952 | 0.5152 |
| PQ_stuff | 0.4158 | 0.2925 | 0.4240 |

Every metric collapses without dedup, not just PQ_things (where cross-view
duplicate instances would be expected to bite) — PQ_stuff drops even more
in relative terms, since stuff categories are fused per-category and a
flood of near-duplicate low-confidence stuff queries competing in the same
winner-take-all pool degrades that fusion too. This is the concrete
evidence that the dedup step is load-bearing, not defensive-only code.

## Results

### Full COCO panoptic validation (`panoptic_val2017`, all 5000 images)

| metric | augment=False | augment=True | delta |
|---|---|---|---|
| PQ | 0.4674 | **0.4788** | **+0.0114** |
| SQ | 0.8153 | 0.8147 | −0.0006 |
| RQ | 0.5633 | 0.5777 | +0.0144 |
| PQ_things | 0.5015 | 0.5152 | +0.0136 |
| PQ_stuff | 0.4158 | 0.4240 | +0.0082 |
| time | 140.6s | 264.6s | ~1.9x |

RQ moves more than SQ, which is the expected signature of an ensembling
effect improving recall (fewer missed/duplicated instances) more than mask
precision — consistent with the dedup step's role.

### Single-image sanity check (`tests/fixtures/dog.jpg`, EoMT-S panoptic)

`augment=False` and `augment=True` both find **7/7 segments**, identical
categories `[1, 2, 16, 87, 100, 112, 116]`.

## Test plan

- [x] `pytest tests/unit/test_eomt.py tests/unit/test_panoptic_scaffold.py -m unit -q` — 86 passed, 3 skipped
- [x] `pytest tests/unit -m unit -q` (full suite) — 3278 passed, 197 skipped, 0 failures
- [x] New unit tests: `_dedup_panoptic_queries` merge/keep-separate cases (same class overlapping, different classes, non-overlapping same class), a regression test reproducing the exact empirical failure above, `_predict_augment_panoptic` query concatenation across views and single-empty-view handling, and the default `NotImplementedError` for families without an override
- [x] `PanopticValidator._run_validation_augmented` extraction and empty-result-handling tests
- [x] Real single-image sanity check against real EoMT-S panoptic weights
- [x] Full 5000-image COCO panoptic PQ validation, augment on vs off
