### PR TITLE
Add OBB task to YOLO9 with an oriented head and Gaussian loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Training capabilities are documented per family in
 | yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
+| yolo9 | obb | ✓ | ✓ | exp | exp | exp |  |  |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |

--- a/docs/dataset_schema.md
+++ b/docs/dataset_schema.md
@@ -366,9 +366,12 @@ their own training tensors, but public results should expose OBB detections as
 `xywhr, conf, cls` rows.
 
 YOLO9 OBB currently uses a family-private training adapter that stores targets
-as `class, x1, y1, x2, y2, angle`, where `xyxy` is a horizontal proxy box for
-assignment and DFL, and `angle` is trained with a separate periodic loss. Do
-not treat that proxy tensor as the general OBB contract for other families.
+as `class, x1, y1, x2, y2, angle`. The `xyxy` columns are a *proxy* box: the
+oriented rectangle's own width and height, axis-aligned about its center. They
+are an encoding of the side lengths, not the spatial envelope of the rotated
+box, so they must never be clipped or corner-warped as if they were one.
+Assignment and DFL regress that proxy; the orientation is carried in `angle`.
+Do not treat that proxy tensor as the general OBB contract for other families.
 
 Native COCO JSON OBB loading accepts annotations in this priority order:
 
@@ -378,8 +381,11 @@ Native COCO JSON OBB loading accepts annotations in this priority order:
 - COCO `bbox: [x, y, w, h]`, interpreted as an axis-aligned rectangle and
   canonicalized to LibreYOLO `xywhr`.
 
-Mosaic and mixup are disabled for OBB training until corner-aware OBB
-augmentation is implemented.
+Mosaic and mixup run for OBB. The geometric augmentations are orientation
+aware: flips and quarter turns transform the angle, and the affine applies
+rotation, uniform scale and translation exactly (the center rides the matrix
+and the side directions carry the rotation and scale). Shear and perspective
+are suppressed for OBB because neither maps a rectangle to a rectangle.
 
 ## classify
 

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -71,6 +71,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
+| yolo9 | obb | ✓ | ✓ | exp | exp | exp |  |  |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
@@ -358,6 +359,8 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `yolo4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo7` / `detect` / `tflite`: The converted LiteRT graph changes decoded box coordinates beyond the detector parity tolerance.
 - `yolo7` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo9` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolo9` / `obb` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo9_e2e` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `yolo9_e2e` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo9_p2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -294,7 +294,7 @@ Detector-factory family support follows:
 | `yolo3`     | `("detect",)` (default)             | detect | YOLOv3 (Darknet, public domain); inference-only in LibreYOLO |
 | `yolo4`     | `("detect",)` (default)             | detect | YOLOv4 (Darknet, public domain); inference-only in LibreYOLO |
 | `yolo7`     | `("detect",)` (default)             | detect | YOLOv7 (MIT MultimediaTechLab/YOLO); trainable via SimOTA loss |
-| `yolo9`     | `("detect",)`                       | detect | detect-only (non-detect flagship variants removed in #436) |
+| `yolo9`     | `("detect", "obb")`                 | detect | OBB via the oriented head (#320, docs/provenance/yolo9_obb.md); other non-detect variants removed in #436 |
 | `yolo9_e2e` | `("detect",)` (default)             | detect | detect-only |
 | `yolo9_p2`  | `("detect",)`                       | detect | detect-only |
 | `dfine`     | `("detect", "segment")`             | detect | segment uses the D-FINE-seg mask head; same sizes as detect; COCO `-seg` weights on HF (detect-to-segment fine-tune needs an explicit transfer flag) |
@@ -376,6 +376,10 @@ LibreRFDETRn.pt            # detect
 LibreRFDETRn-seg.pt        # segment
 LibreRFDETRx-pose.pt       # pose (preview; only size x ships)
 LibreRFDETRn-obb.pt        # obb
+
+# yolo9 - detect + obb
+LibreYOLO9t.pt             # detect (default)
+LibreYOLO9t-obb.pt         # obb
 
 # dinov2 — DINOv2 backbone + task head (NOT the RF-DETR detector)
 LibreDINOv2n.pt            # semantic (default task; dense head at 518)

--- a/docs/provenance/yolo9_obb.md
+++ b/docs/provenance/yolo9_obb.md
@@ -50,10 +50,10 @@ divergence checklist in section 9.
 | Task registry: `obb` name, aliases, `-obb` suffix | `libreyolo/tasks.py` | live |
 | YOLO OBB label parsing (9-field rows), canonical `xywhr`, proxy conversion | `libreyolo/data/obb.py` (`parse_yolo_obb_label_line`, `canonicalize_xywhr`, `corners_to_xywhr`, `xywhr_to_proxy_xyxy`, `xywhr_iou`) | live |
 | Dataset loading: `load_obb`, rows emitted as `[x1, y1, x2, y2, cls, theta]` (pixel proxy box + radians) | `libreyolo/data/dataset.py` (~line 448) | live |
-| Train transforms: 6-column labels, angle-aware hflip/vflip/rot90, mosaic disabled for OBB | `libreyolo/data/augment/yolo9.py`, `libreyolo/training/trainer.py:705` | live |
+| Train transforms: 6-column labels, angle-aware hflip/vflip/rot90, mosaic/mixup with the corner-aware affine (`apply_affine_to_obb`; shear and perspective suppressed) | `libreyolo/data/augment/yolo9.py`, `libreyolo/data/augment/geometry.py` | live |
 | Training targets contract: `[class, x1, y1, x2, y2, theta]`, normalized | `docs/dataset_schema.md` (OBB section) | live |
 | Inference postprocess contract: predictions `(B, 4+1+nc, A)` with rows `[proxy xyxy in input pixels, theta, sigmoided class scores]`, dict flag `obb: True`; exact rotated NMS | `libreyolo/postprocess/yolo9.py:176-321` | live |
-| Rotated IoU (exact, OpenCV) | `libreyolo/data/obb.py:xywhr_iou` | live |
+| Rotated IoU: exact, vectorized (axis-aligned envelope gate, then convex-polygon intersection); the OpenCV scalar form remains the reference | `libreyolo/utils/box_ops.py` (`rotated_iou_matrix`, `rotated_iou_pairwise`), `libreyolo/data/obb.py:xywhr_iou` | live |
 | OBB validator (rotated-IoU AP) | `libreyolo/validation/obb_validator.py` | live |
 | Results container `OBB` (xywhr/conf/cls) and drawing | `libreyolo/utils/results.py:846`, `libreyolo/utils/drawing.py:draw_obb` | live |
 | CLI train/val/predict OBB plumbing, backends, export metadata | `libreyolo/cli/commands/*.py`, `libreyolo/backends/base.py`, `libreyolo/export/exporter.py` | live |
@@ -357,9 +357,54 @@ review is treated as a bug.
 | `libreyolo/models/yolo9/loss.py` | Gaussian helpers (`_rbox_gaussian`, `_gaussian_kld`, `_bhattacharyya_score`), `RotatedBoxMatcher`, `YOLO9OrientedLoss` |
 | `libreyolo/models/yolo9/model.py` | task wiring per section 6 |
 | `libreyolo/models/yolo9/trainer.py` | 6-column labels, angle logging |
-| `libreyolo/validation/obb_validator.py` | pickling fix |
+| `libreyolo/validation/obb_validator.py` | pickling fix; per-class cached vectorized IoU |
+| `libreyolo/utils/box_ops.py` | `rotated_iou_pairwise` / `rotated_iou_matrix` (section 11) |
+| `libreyolo/postprocess/yolo9.py` | rotated NMS rebuilt on the vectorized IoU (section 11) |
+| `libreyolo/data/augment/geometry.py` | `apply_affine_to_obb`, `obb` flag on `random_affine` (section 12) |
+| `libreyolo/data/augment/yolo9.py`, `libreyolo/training/trainer.py` | mosaic/mixup enabled for OBB (section 12) |
 | `libreyolo/export/support.py` + generated tables | obb rows |
 | `docs/nomenclature.md` | family table + filename example |
 | `tests/unit/...` | per section 8 |
+
+## 11. Vectorized rotated IoU
+
+Rotated NMS evaluated one OpenCV polygon intersection per candidate pair from
+a Python loop, and the OBB validator repeated the same per-pair calls once per
+mAP threshold. Both now go through an exact vectorized IoU.
+
+Two convex polygons intersect in the convex hull of: each polygon's vertices
+that lie inside the other, plus every edge-edge crossing. For two rectangles
+that is at most eight of twenty-four candidate points; they are ordered by
+angle about their centroid and the area follows from the shoelace formula.
+Pairs are gated first on their axis-aligned envelopes, which cannot miss when
+the rotated boxes overlap, so on dense imagery only a small fraction of the
+matrix reaches the polygon stage.
+
+Greedy suppression order, the threshold comparison and the resulting keep
+indices are unchanged; the tests assert bit-identical output against the
+OpenCV implementation, which remains the reference.
+
+Source: classical computational geometry (convex-polygon intersection,
+shoelace area, axis-aligned rejection). `Source: original` for the
+formulation and for reusing the same primitive in both NMS and validation.
+
+## 12. Orientation-aware mosaic
+
+Mosaic was disabled for OBB because the shared affine warps the corners of the
+xyxy columns and rewrites them as an envelope, which for the OBB proxy box
+(section 3.1) both discards the rotation and corrupts the side lengths.
+
+A rectangle stays a rectangle under rotation, uniform scale and translation,
+so the OBB affine is exact: the center rides the matrix, and the two side
+directions are carried through the matrix's linear part, which yields the new
+orientation and the new side lengths without reading an angle out of the
+matrix (and so without depending on any sign or handedness convention).
+Shear and perspective are suppressed for OBB, as neither maps a rectangle to a
+rectangle. Mosaic tile placement needed no change: uniform scale and
+translation of all four proxy coordinates scale the center and the sides
+consistently and cannot rotate the box.
+
+Source: classical linear algebra. `Source: original` for the proxy-box
+transform and for the decision to suppress shear rather than refit it.
 
 Estimated new code: ~450 lines library, ~400 lines tests.

--- a/docs/provenance/yolo9_obb.md
+++ b/docs/provenance/yolo9_obb.md
@@ -1,0 +1,365 @@
+# YOLO9 OBB design and provenance
+
+Status: approved for implementation. Branch: `yolo9-obb-v2`. Target: `dev`.
+Closes the YOLO9 half of issue #320.
+
+## 0. Provenance rules for this plan
+
+Every design element below carries a `Source:` line. Allowed sources:
+
+1. **In-tree code on current dev** (commit `f039d382` or later), cited by file
+   and line. The live OBB groundwork (task registry, dataset, augmentations,
+   rotated NMS, validator, results container, CLI/export plumbing) was audited
+   on 2026-07-14 and is used as-is.
+2. **Published papers**, cited by name. Only the math is taken, transcribed
+   into formulas in this plan; no code from paper repos is read or ported
+   unless the repo is explicitly listed under 3.
+3. **Permissively licensed repositories** already attributed in
+   `THIRD_PARTY_NOTICES.txt` (MultimediaTechLab/YOLO, MIT; Deci-AI
+   super-gradients, Apache-2.0). No new third-party code is ported in this
+   plan.
+4. **Classical mathematics** (trigonometric identities, multivariate normal
+   formulas), cited as such.
+5. **Original design decisions**, explicitly marked `Source: original`.
+
+Banned sources: the AGPL detection framework and any code derived from it;
+the removed June 2026 YOLO9 task heads (`f2a22821`, `2d5fe2ba` history) and
+the withdrawn PR #606 branch. Two exceptions from that branch are re-landed
+because they were authored in-repo before any AGPL exposure and are
+self-contained: the OBB validator spawn-pickling fix and the export
+raw-parity test skeleton (both listed in section 8).
+
+Implementation discipline: the implementer works by transcribing the formulas
+and structures written in this plan, not from memory of any external
+implementation. After implementation, the diff is checked against the
+divergence checklist in section 9.
+
+## 1. Goal and scope
+
+- New task `obb` for the `yolo9` family (sizes t/s/m/c): training, validation,
+  prediction, ONNX/TorchScript export.
+- `yolo9_e2e` and `yolo9_p2` stay detect-only (out of scope).
+- User-facing surface follows the existing task conventions: `task=obb`,
+  `-obb` weight suffix, `Results.obb` container, OBB metrics. All of these
+  already exist on dev and are consumed today by the RF-DETR OBB task.
+
+## 2. Current-code inventory (what this plan builds on, all live on dev)
+
+| Surface | Location | Status |
+|---|---|---|
+| Task registry: `obb` name, aliases, `-obb` suffix | `libreyolo/tasks.py` | live |
+| YOLO OBB label parsing (9-field rows), canonical `xywhr`, proxy conversion | `libreyolo/data/obb.py` (`parse_yolo_obb_label_line`, `canonicalize_xywhr`, `corners_to_xywhr`, `xywhr_to_proxy_xyxy`, `xywhr_iou`) | live |
+| Dataset loading: `load_obb`, rows emitted as `[x1, y1, x2, y2, cls, theta]` (pixel proxy box + radians) | `libreyolo/data/dataset.py` (~line 448) | live |
+| Train transforms: 6-column labels, angle-aware hflip/vflip/rot90, mosaic disabled for OBB | `libreyolo/data/augment/yolo9.py`, `libreyolo/training/trainer.py:705` | live |
+| Training targets contract: `[class, x1, y1, x2, y2, theta]`, normalized | `docs/dataset_schema.md` (OBB section) | live |
+| Inference postprocess contract: predictions `(B, 4+1+nc, A)` with rows `[proxy xyxy in input pixels, theta, sigmoided class scores]`, dict flag `obb: True`; exact rotated NMS | `libreyolo/postprocess/yolo9.py:176-321` | live |
+| Rotated IoU (exact, OpenCV) | `libreyolo/data/obb.py:xywhr_iou` | live |
+| OBB validator (rotated-IoU AP) | `libreyolo/validation/obb_validator.py` | live |
+| Results container `OBB` (xywhr/conf/cls) and drawing | `libreyolo/utils/results.py:846`, `libreyolo/utils/drawing.py:draw_obb` | live |
+| CLI train/val/predict OBB plumbing, backends, export metadata | `libreyolo/cli/commands/*.py`, `libreyolo/backends/base.py`, `libreyolo/export/exporter.py` | live |
+| Detect head: towers `cv2`/`cv3`, DFL integral, grid helpers `_anchor_grid`/`_grid`/`_decode_inference` | `libreyolo/models/yolo9/nn.py` | live (`f039d382`) |
+| Training decode and assignment: `Vec2Box`, `BoxMatcher`, `BCELoss`, `DFLoss` | `libreyolo/models/yolo9/loss.py` | live |
+
+The plan adds exactly four new pieces of substance: an oriented head variant,
+a rotated matcher variant, an oriented loss, and the task wiring.
+
+## 3. Geometry representation
+
+### 3.1 Internal box parameterization (unchanged)
+
+The rotated box is carried as the canonical `xywhr` of `data/obb.py`: center
+`(cx, cy)`, long side `w`, short side `h` (so `w >= h`), angle
+`theta in [-pi/2, pi/2)` measured as the rotation of the `w` side. For the
+regression head the box is represented by its **proxy rectangle**: the
+axis-aligned rectangle of size `(w, h)` centered at `(cx, cy)`, encoded as
+LTRB distances from the anchor and regressed through the existing DFL
+machinery, exactly as the dataset and postprocess already expect.
+
+Source: in-tree contract (`data/obb.py`, `docs/dataset_schema.md`,
+`postprocess/yolo9.py`).
+
+### 3.2 Orientation encoding: the double-angle vector
+
+The head does not regress `theta` as a scalar. It predicts a 2-channel vector
+
+```
+v = (v_c, v_s)   with target   t = w_ar * (cos 2*theta, sin 2*theta)
+```
+
+Decode at inference: `theta_hat = 0.5 * atan2(v_s, v_c)`, which lands in
+`(-pi/2, pi/2]`, matching the canonical range.
+
+Why the double angle: a rectangle is invariant under rotation by pi, and
+`(cos 2t, sin 2t)` is exactly pi-periodic, so the two equivalent descriptions
+of the same box map to the same target. The angular boundary discontinuity
+(a box at 89 degrees vs -89 degrees) disappears by construction instead of
+being patched in the loss.
+
+`w_ar` is an aspect-ratio weight (section 5.3): elongated boxes carry a
+full-length target vector, near-squares carry a near-zero one, because a
+square's orientation is undefined under the canonical convention. As a side
+effect the norm of the predicted vector becomes a learned "orientedness"
+signal (not exposed in `Results` for now; the container contract is frozen).
+
+Sources: trigonometric double-angle identities (classical); encoding angles
+in trigonometric/phase components for rotated detection appears in the
+Phase-Shifting Coder paper (Yu and Da, CVPR 2023) and Circular Smooth Label
+(Yang and Yan, ECCV 2020) motivates the square-ambiguity treatment. The
+specific combination (2-channel double-angle vector, aspect-weighted target
+length, norm as orientedness) is `Source: original`.
+
+### 3.3 Gaussian form of a rotated box
+
+For the joint loss the box `(cx, cy, w, h, theta)` maps to a 2D Gaussian
+`N(mu, Sigma)` with `mu = (cx, cy)` and
+
+```
+Sigma = R(theta) * diag(w^2/4, h^2/4) * R(theta)^T
+```
+
+Written with half-angle identities (`cos^2 t = (1 + cos 2t)/2` etc.) the
+covariance components are **linear in the double-angle vector**:
+
+```
+p = (w^2 + h^2) / 8        q = (w^2 - h^2) / 8
+a = p + q * cos 2*theta    (var x)
+b = p - q * cos 2*theta    (var y)
+c = q * sin 2*theta        (cov xy)
+```
+
+This is the key structural fit of the design: the head's raw `(v_c, v_s)`,
+normalized to unit length, plugs directly into `(a, b, c)`. The training loss
+never computes `atan2`; it is smooth everywhere, including at the square
+degeneracy where `q -> 0` erases the angle from the Gaussian entirely, which
+is the mathematically correct behavior.
+
+Sources: box-to-Gaussian mapping from the Gaussian Wasserstein Distance paper
+(Yang et al., ICML 2021) and the ProbIoU paper (Murrugarra-Llerena et al.,
+2021); the half-angle expansion making `Sigma` linear in the double-angle
+vector is `Source: classical identities, derivation original to this plan`.
+
+## 4. Head: `OrientedDDetect(DDetect)`
+
+File: `libreyolo/models/yolo9/nn.py`.
+
+### 4.1 Structure
+
+- Inherits everything from the current `DDetect` (`f039d382`): towers,
+  bias init, `_anchor_grid`, `_grid`, `_decode_bboxes`.
+- Adds one `nn.ModuleList` named `ang`: per scale, a single
+  `nn.Conv2d(box_hidden, 2, 1)` applied to the output of the **first box
+  tower conv** (`cv2[i][0]`), i.e. the ungrouped hidden geometry features.
+  There is no separate multi-layer angle tower; orientation is read from the
+  same representation that produces the distances. Bias initialized to zero
+  (weights default init) so the initial orientation claim is near-neutral.
+- Checkpoint keys: `head.ang.{i}.weight/bias`. Task inference reads the
+  presence of `head.ang.` keys. The `cv2`/`cv3`/`dfl` layout is untouched, so
+  detect-to-OBB transfer partial-loads the entire detect head and only the
+  `ang` convs start fresh.
+
+Source: `DDetect` is in-tree; the shared-geometry tap (angle from the box
+tower's hidden features via one 1x1 conv) is `Source: original`.
+
+### 4.2 Forward
+
+Training with targets: per-level towers run once; `preds` (the usual
+`cat(cv2_i, cv3_i)` maps) plus per-level angle maps `ang_i(hidden_i)` of
+shape `(B, 2, H, W)` go to `YOLO9OrientedLoss` (section 5). Training targets
+are `[B, N, 6]`; a shape guard raises on 5-column labels.
+
+Inference: reuse the base per-level decode (`_decode_inference` from
+`f039d382`, our own expression) with one extension: flatten the per-level
+angle maps to `(B, 2, A)`, compute `theta_hat = 0.5 * atan2(v_s, v_c)` as a
+`(B, 1, A)` row, and emit
+
+```
+y = cat([proxy_boxes_pixels, theta_hat, scores.sigmoid()], dim=1)   # (B, 4+1+nc, A)
+```
+
+which is exactly the live postprocess contract. Export mode returns `y`
+alone. `LibreYOLO9Model.forward` sets `result["obb"] = True` when built with
+`obb=True` so the postprocess selects the rotated branch.
+
+Source: decode structure in-tree (`f039d382`); output layout dictated by
+in-tree `postprocess/yolo9.py`; `atan2` decode classical.
+
+## 5. Loss: `YOLO9OrientedLoss(YOLO9Loss)`
+
+File: `libreyolo/models/yolo9/loss.py`. Components and weighting follow the
+in-tree normalization scheme (`cls_norm`, `box_norm`, weighted sums) of
+`YOLO9Loss` verbatim, with the CIoU box loss replaced by the Gaussian loss:
+
+```
+total = box_weight * L_kld  +  dfl_weight * L_dfl  +  cls_weight * L_bce  +  vec_weight * L_vec
+```
+
+Defaults: `box_weight=7.5`, `dfl_weight=1.5`, `cls_weight=0.5` (in-tree
+values), `vec_weight=0.5` (original, tunable). Loss dict keys mirror the
+detect loss plus `angle_loss`/`angle` so the trainer logging picks them up.
+
+### 5.1 Assignment: `RotatedBoxMatcher(BoxMatcher)`
+
+- `get_valid_matrix` unchanged: it gates which anchors can represent the
+  **proxy** LTRB distances inside `reg_max` bins, which is precisely the
+  quantity DFL regresses. Source: in-tree.
+- Similarity replaces the CIoU matrix: the Bhattacharyya coefficient between
+  the target Gaussian and the (detached) predicted Gaussian,
+
+```
+Sigma_m = (Sigma_p + Sigma_t) / 2,   d = mu_p - mu_t
+B_D = (1/8) * d^T Sigma_m^{-1} d + (1/2) * ln( det Sigma_m / sqrt(det Sigma_p * det Sigma_t) )
+score = exp(-B_D)  in (0, 1]
+```
+
+  computed in closed 2x2 form (`det = a*b - c^2` clamped at `1e-7`,
+  `Sigma^{-1} = [[b, -c], [-c, a]] / det`). The score is IoU-like (1 at
+  identity), so it plugs into the existing task-aligned target
+  `score^iou_factor * cls^cls_factor` unchanged.
+- `__call__` accepts 6-column targets, splits `[1, 4, 1]`, and additionally
+  gathers the matched `theta` (and matched `w, h` implied by the proxy box)
+  per anchor, following the same gather pattern the parent uses for boxes.
+
+Sources: matcher body in-tree (MIT-derived); Bhattacharyya distance between
+Gaussians classical statistics; its use as a rotated-box similarity is the
+ProbIoU paper. Applying it as the TAL metric inside our matcher is
+`Source: original` (consequence of reusing in-tree assignment).
+
+### 5.2 Gaussian regression loss (KLD)
+
+For each matched anchor, target Gaussian `(mu_t, Sigma_t)` from the matched
+proxy box and `theta_t`; predicted Gaussian `(mu_p, Sigma_p)` from the
+decoded proxy box and the **normalized** predicted vector
+`(c_hat, s_hat) = v / max(||v||, 1e-6)` via section 3.3. Kullback-Leibler
+divergence in the direction that only ever inverts the exact target
+covariance (numerically safe; predictions never get inverted):
+
+```
+D = 1/2 * [ tr(Sigma_t^{-1} Sigma_p) + d^T Sigma_t^{-1} d - 2 + ln(det Sigma_t / det Sigma_p) ]
+L_kld = 1 - 1 / (1 + ln(1 + D))
+```
+
+`L_kld in [0, 1)` behaves like an IoU-style loss and takes the in-tree
+`box_norm`/`cls_norm` weighting. Computed in fp32 under AMP (in-tree
+precedent: the fp32-loss guard added for picodet/rtmdet).
+
+Sources: multivariate normal KL closed form classical; using KL between box
+Gaussians with a `1 - 1/(tau + f(D))` normalization is the KLD paper (Yang et
+al., NeurIPS 2021); the inversion-direction choice is
+`Source: original (numerical-stability argument stated above)`.
+
+### 5.3 Orientation vector loss
+
+```
+w_ar = clamp( ln(w_t / h_t) / ln(3), 0, 1 )        (w_t >= h_t canonical)
+t = w_ar * (cos 2*theta_t, sin 2*theta_t)
+L_vec = mean over matched anchors of || v - t ||^2, weighted like the box terms
+```
+
+Near-squares (`w_t ~ h_t`) get `w_ar ~ 0`: their target vector is zero, the
+network learns to output short vectors there, and no gradient fights the
+undefined orientation. Aspect 3 and beyond gets full supervision. The KLD
+term already couples orientation for everything in between, so `L_vec` is an
+auxiliary sharpener, not the main angle signal.
+
+Source: original (motivated by the square-ambiguity discussion in the CSL and
+KLD papers; threshold `ln(3)` is a tunable original default).
+
+### 5.4 What is deliberately absent
+
+- No tiny-box filtering inside the loss: degenerate rows are already rejected
+  or clamped at parse/transform time in-tree.
+- No separate scalar-angle regression, no periodic trig penalty on a scalar
+  angle, no angle classification bins in v1 (CSL-style distributional angle
+  is noted as a possible v2 under the same DFL philosophy).
+- No changes to `BoxMatcher`, `Vec2Box`, `DFLoss`, `BCELoss` for the detect
+  path.
+
+## 6. Task wiring
+
+All following the current file conventions on dev (each item is glue in the
+style of the surrounding code; `Source: in-tree patterns`):
+
+- `nn.LibreYOLO9Model`: `obb=False` kwarg; selects `OrientedDDetect`;
+  inference dict gains `"obb": True`.
+- `model.LibreYOLO9`: `SUPPORTED_TASKS = ("detect", "obb")`,
+  `TASK_INPUT_SIZES["obb"]`, `_is_obb` property, `_init_model(obb=...)`,
+  `detect_checkpoint_task` returns `"obb"` iff `head.ang.` keys present,
+  `_validate_loaded_state_dict_for_task` requires `head.ang.` for `task=obb`
+  direct loads (transfer path exempt). No extra loss-cache resets needed: the
+  oriented loss lives in the standard `_loss_fn` slot that the rebuild
+  helpers already clear.
+- `trainer.YOLO9Trainer.create_transforms`: `output_label_dim=6` when the
+  wrapper task is `obb`; `get_loss_components` logs the `angle` component.
+- Validator: re-land the `_OBBValPreprocessor.__getattr__` spawn-pickling fix
+  (raise `AttributeError` for `base_preprocessor`) plus its regression test.
+- Docs: nomenclature family table row, dataset schema pointer already exists.
+- Export support (`libreyolo/export/support.py`): `yolo9`/`obb` validated for
+  `onnx`, `torchscript` with the raw-parity test; regenerate inventory and
+  tables with the existing tools.
+
+## 7. Hyperparameters and numerics
+
+| Knob | Default | Rationale |
+|---|---|---|
+| `box_weight` (KLD) | 7.5 | in-tree box slot, `L_kld` is IoU-like |
+| `dfl_weight` | 1.5 | in-tree |
+| `cls_weight` | 0.5 | in-tree |
+| `vec_weight` | 0.5 | original default, aux term |
+| aspect threshold | `ln(3)` | full angle supervision from aspect 3 |
+| det clamp | `1e-7` | 2x2 inversions |
+| vector norm floor | `1e-6` | normalization guard |
+| KLD normalization | `1 - 1/(1 + ln(1+D))` | KLD paper form |
+| AMP | Gaussian terms in fp32 | in-tree precedent |
+
+## 8. Verification ladder
+
+1. **Unit tests** (`tests/unit/test_yolo9_layers.py` + factory/CLI files):
+   head forward shapes `(B, 4+1+nc, A)`, theta row bounded in
+   `(-pi/2, pi/2]`, export single-tensor mode, encode/decode roundtrip
+   `theta -> v -> theta` over a grid of angles, Gaussian helper identities
+   (`L_kld(x, x) = 0`, Bhattacharyya score 1 at identity, monotone decrease
+   under center offset), square-invariance (rotating a square target changes
+   the loss by < 1e-5), 6-column target guard, gradient-flow to `ang`,
+   detect-to-OBB transfer stats, checkpoint task inference from `head.ang.`,
+   scratch checkpoint round-trip via the factory, CLI dry-run and
+   task-architecture selection, validator pickle roundtrip.
+2. **Export parity**: ONNX + TorchScript raw outputs vs the eager head
+   (adapting the pre-exposure parity test skeleton from 2026-07-14).
+3. **Synthetic overfit smoke** (same generator as the 2026-07-14 run:
+   rotated bars, 48 train / 12 val, imgsz 320, yolo9-t, detect transfer,
+   60 epochs): quality bar is the June design's measured result,
+   rotated-IoU mAP50 >= 0.87 on val, angles visually aligned.
+4. **In-training validation** on Windows spawn workers (exercises the
+   pickling fix), `best.pt` selected on OBB mAP50-95.
+5. **Real-data run** (follow-up, not gating this PR): DOTA-v1.0 split at
+   1024, compare against the literature deltas for Gaussian losses; weights
+   publication is a separate maintainer decision (dataset is academic-use).
+
+## 9. Divergence checklist (checked against the final diff)
+
+The AGPL implementation is characterized by: a separate multi-layer angle
+tower on the FPN features with a specific width formula; a single
+sigmoid-scalar angle mapped by a fixed affine to a three-quarter-pi range; a
+rotated task-aligned assigner ported alongside the loss; a Gaussian-IoU
+fast-NMS; corner conversions with while-loop range normalization. The
+implementation of this plan must contain none of those: angle as a 2-channel
+double-angle vector from a single 1x1 conv on the box tower's hidden
+features; `atan2` decode; assignment through the in-tree `BoxMatcher` with a
+Bhattacharyya score; the existing exact OpenCV NMS; covariance built linearly
+from the vector with no angle normalization code at all. Any overlap found in
+review is treated as a bug.
+
+## 10. Implementation map
+
+| File | Change |
+|---|---|
+| `libreyolo/models/yolo9/nn.py` | `OrientedDDetect`, `obb` kwarg in `LibreYOLO9Model`, obb inference dict flag |
+| `libreyolo/models/yolo9/loss.py` | Gaussian helpers (`_rbox_gaussian`, `_gaussian_kld`, `_bhattacharyya_score`), `RotatedBoxMatcher`, `YOLO9OrientedLoss` |
+| `libreyolo/models/yolo9/model.py` | task wiring per section 6 |
+| `libreyolo/models/yolo9/trainer.py` | 6-column labels, angle logging |
+| `libreyolo/validation/obb_validator.py` | pickling fix |
+| `libreyolo/export/support.py` + generated tables | obb rows |
+| `docs/nomenclature.md` | family table + filename example |
+| `tests/unit/...` | per section 8 |
+
+Estimated new code: ~450 lines library, ~400 lines tests.

--- a/libreyolo/data/augment/geometry.py
+++ b/libreyolo/data/augment/geometry.py
@@ -146,6 +146,60 @@ def apply_affine_to_bboxes(targets, target_size, M, scale):
     return targets
 
 
+def apply_affine_to_obb(targets, M):
+    """Warp oriented boxes through a 2x3 affine matrix.
+
+    ``targets`` rows are ``[x1, y1, x2, y2, class, angle]``. The xyxy columns
+    are the OBB *proxy* box — the oriented rectangle's own width and height,
+    axis-aligned about its center (see
+    :func:`libreyolo.data.obb.xywhr_to_proxy_xyxy`) — so they are an encoding,
+    not a spatial envelope, and warping their corners the way
+    :func:`apply_affine_to_bboxes` does would silently discard the rotation.
+
+    Under rotation, uniform scale and translation a rectangle stays a
+    rectangle, so the transform is exact: the center rides the matrix, and
+    each side direction picks up the rotation and scale. Mapping the side
+    directions through the linear part rather than reading an angle out of
+    the matrix keeps this free of any sign or handedness convention.
+    """
+    linear = M[:, :2]
+    centers = np.stack(
+        (
+            (targets[:, 0] + targets[:, 2]) * 0.5,
+            (targets[:, 1] + targets[:, 3]) * 0.5,
+        ),
+        axis=1,
+    )
+    widths = targets[:, 2] - targets[:, 0]
+    heights = targets[:, 3] - targets[:, 1]
+    angles = targets[:, 5]
+
+    moved = centers @ linear.T + M[:, 2]
+    width_axis = np.stack((np.cos(angles), np.sin(angles)), axis=1) @ linear.T
+    height_axis = np.stack((-np.sin(angles), np.cos(angles)), axis=1) @ linear.T
+
+    new_widths = widths * np.linalg.norm(width_axis, axis=1)
+    new_heights = heights * np.linalg.norm(height_axis, axis=1)
+    new_angles = np.arctan2(width_axis[:, 1], width_axis[:, 0])
+
+    # Canonical form: the long side is the width, angle in [-pi/2, pi/2).
+    swap = new_heights > new_widths
+    new_widths, new_heights = (
+        np.where(swap, new_heights, new_widths),
+        np.where(swap, new_widths, new_heights),
+    )
+    new_angles = np.where(swap, new_angles + np.pi / 2, new_angles)
+    new_angles = (new_angles + np.pi / 2) % np.pi - np.pi / 2
+
+    warped = targets.copy()
+    warped[:, 0] = moved[:, 0] - new_widths / 2
+    warped[:, 1] = moved[:, 1] - new_heights / 2
+    warped[:, 2] = moved[:, 0] + new_widths / 2
+    warped[:, 3] = moved[:, 1] + new_heights / 2
+    warped[:, 5] = new_angles
+    return warped
+
+
 def random_affine(
     img,
     targets=(),
@@ -155,8 +209,19 @@ def random_affine(
     scales=0.1,
     shear=10,
     perspective=0.0,
+    obb=False,
 ):
-    """Random affine (or projective, when ``perspective != 0``) on image + boxes."""
+    """Random affine (or projective, when ``perspective != 0``) on image + boxes.
+
+    With ``obb`` the targets carry an orientation column and shear and
+    perspective are suppressed: both turn a rectangle into a shape an oriented
+    box cannot represent, whereas rotation, scale and translation keep it a
+    rectangle and are applied exactly.
+    """
+    if obb:
+        shear = 0.0
+        perspective = 0.0
+
     M, scale = get_affine_matrix(
         target_size, degrees, translate, scales, shear, perspective
     )
@@ -169,7 +234,10 @@ def random_affine(
         img = cv2.warpAffine(img, M, dsize=target_size, borderValue=(114, 114, 114))
 
     if len(targets) > 0:
-        targets = apply_affine_to_bboxes(targets, target_size, M, scale)
+        if obb:
+            targets = apply_affine_to_obb(targets, M)
+        else:
+            targets = apply_affine_to_bboxes(targets, target_size, M, scale)
 
     return img, targets
 

--- a/libreyolo/data/augment/yolo9.py
+++ b/libreyolo/data/augment/yolo9.py
@@ -541,15 +541,21 @@ class YOLO9MosaicMixupDataset:
                     )
                     mosaic_segments.extend(tile_segments or [[] for _ in labels])
 
+        label_dim = getattr(self.preproc, "output_label_dim", None) or 5
+        is_obb = label_dim == 6
+
         if len(mosaic_labels) > 0:
             mosaic_labels = np.concatenate(mosaic_labels, 0)
-            # Clip to mosaic bounds
-            np.clip(mosaic_labels[:, 0], 0, 2 * input_w, out=mosaic_labels[:, 0])
-            np.clip(mosaic_labels[:, 1], 0, 2 * input_h, out=mosaic_labels[:, 1])
-            np.clip(mosaic_labels[:, 2], 0, 2 * input_w, out=mosaic_labels[:, 2])
-            np.clip(mosaic_labels[:, 3], 0, 2 * input_h, out=mosaic_labels[:, 3])
+            if not is_obb:
+                # Clip to mosaic bounds. Skipped for OBB: there the xyxy columns
+                # are the oriented rectangle's own width and height about its
+                # center, so clipping them would shrink the box rather than
+                # trim it. Out-of-frame OBBs are dropped by center below.
+                np.clip(mosaic_labels[:, 0], 0, 2 * input_w, out=mosaic_labels[:, 0])
+                np.clip(mosaic_labels[:, 1], 0, 2 * input_h, out=mosaic_labels[:, 1])
+                np.clip(mosaic_labels[:, 2], 0, 2 * input_w, out=mosaic_labels[:, 2])
+                np.clip(mosaic_labels[:, 3], 0, 2 * input_h, out=mosaic_labels[:, 3])
         else:
-            label_dim = getattr(self.preproc, "output_label_dim", None) or 5
             mosaic_labels = np.zeros((0, label_dim))
 
         if has_segments:
@@ -578,6 +584,7 @@ class YOLO9MosaicMixupDataset:
                 scales=self.scale,
                 shear=self.shear,
                 perspective=self.perspective,
+                obb=is_obb,
             )
 
         # Filter small boxes
@@ -585,6 +592,17 @@ class YOLO9MosaicMixupDataset:
             w = mosaic_labels[:, 2] - mosaic_labels[:, 0]
             h = mosaic_labels[:, 3] - mosaic_labels[:, 1]
             mask = (w > 2) & (h > 2)
+            if is_obb:
+                # The proxy box does not track where the rectangle actually
+                # sits, so keep the ones whose center still lands in frame.
+                center_x = (mosaic_labels[:, 0] + mosaic_labels[:, 2]) * 0.5
+                center_y = (mosaic_labels[:, 1] + mosaic_labels[:, 3]) * 0.5
+                mask &= (
+                    (center_x >= 0)
+                    & (center_x < input_w)
+                    & (center_y >= 0)
+                    & (center_y < input_h)
+                )
             mosaic_labels = mosaic_labels[mask]
             if has_segments:
                 mosaic_segments = _filter_segments(mosaic_segments, mask)

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -86,6 +86,13 @@ _add(
     EXPORT_FORMATS,
     reason="YOLO9 segmentation export is not supported; YOLO9 is detection-only in LibreYOLO.",
 )
+_add(
+    "validated",
+    ("yolo9",),
+    ("obb",),
+    ("onnx", "torchscript"),
+    since="1.4",
+)
 _add("validated", ("yolo9_p2",), ("detect",), ("onnx",), since="1.3")
 _add(
     "validated",

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -827,8 +827,14 @@ class BaseModel(ABC):
                 )
                 with torch.no_grad():
                     raw = self._forward(tensor.to(self.device))
+                # The views were preprocessed at effective_imgsz; postprocess
+                # must un-scale against that same size, not the model's default
+                # input size (they differ whenever val runs at a non-default
+                # imgsz, e.g. OBB at 1024 vs a 640 default).
+                pp_kwargs = dict(kwargs)
+                pp_kwargs.setdefault("input_size", effective_imgsz)
                 det = self._postprocess(
-                    raw, conf, iou, orig_size, max_det=max_det, ratio=ratio, **kwargs
+                    raw, conf, iou, orig_size, max_det=max_det, ratio=ratio, **pp_kwargs
                 )
                 aug_dets.append((det, orig_size, is_flipped, scale))
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -145,6 +145,15 @@ class BaseModel(ABC):
     # Ignored when TTA_FIXED_SIZE is True.
     TTA_SCALES: ClassVar[Tuple[float, ...]] = (1.0,)
 
+    def _tta_scales(self) -> Tuple[float, ...]:
+        """TTA scale factors for this instance.
+
+        Defaults to the class-level ``TTA_SCALES``; families whose scale set
+        depends on the loaded task (e.g. multi-scale for OBB but flip-only for
+        detect) override this rather than the class variable.
+        """
+        return self.TTA_SCALES
+
     # Model registry — auto-populated by __init_subclass__
     _registry: ClassVar[List[Type["BaseModel"]]] = []
 
@@ -742,11 +751,6 @@ class BaseModel(ABC):
         Scales are read from TTA_SCALES (class variable); each scale x 2 flips
         = one batch of passes. TTA_FIXED_SIZE models always use flip-only.
         """
-        if getattr(self, "task", "detect") == "obb":
-            raise ValueError(
-                "Test-time augmentation does not support oriented boxes yet. "
-                "Use augment=False for OBB models."
-            )
         if getattr(self, "task", "detect") == "pose":
             raise ValueError(
                 "Test-time augmentation does not support pose keypoints yet. "
@@ -801,7 +805,7 @@ class BaseModel(ABC):
                 **kwargs,
             )
 
-        scales = (1.0,) if self.TTA_FIXED_SIZE else self.TTA_SCALES
+        scales = (1.0,) if self.TTA_FIXED_SIZE else self._tta_scales()
 
         aug_dets = []
         for scale in scales:
@@ -830,6 +834,11 @@ class BaseModel(ABC):
 
         if getattr(self, "task", "detect") == "classify":
             return self._merge_classify_tta(aug_dets, image_path, (orig_w, orig_h))
+
+        if getattr(self, "task", "detect") == "obb":
+            return self._merge_tta_obb(
+                aug_dets, iou, image_path, (orig_w, orig_h), max_det, classes
+            )
 
         return self._merge_tta(aug_dets, iou, image_path, (orig_w, orig_h), classes)
 
@@ -950,6 +959,96 @@ class BaseModel(ABC):
             path=str(image_path) if image_path else None,
             names=self.names,
             probs=Probs(avg_probs),
+        )
+
+    def _merge_tta_obb(
+        self,
+        aug_dets: list,
+        iou_thres: float,
+        image_path,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        classes: Optional[List[int]] = None,
+    ) -> Results:
+        """Merge oriented-box TTA views via class-aware rotated NMS.
+
+        Each view's ``xywhr`` predictions are mapped back to the original
+        frame (a horizontal flip mirrors the center x and negates the angle;
+        a rectangle's orientation is invariant mod pi, so no separate vertical
+        handling is needed), then all views are pooled and de-duplicated with
+        the same exact rotated NMS the single-view postprocess uses.
+        """
+        from ...utils.box_ops import rotated_nms
+        from ...utils.results import OBB, Results
+
+        orig_w, orig_h = original_size
+        orig_shape = (orig_h, orig_w)
+
+        rects: List[torch.Tensor] = []
+        scores: List[torch.Tensor] = []
+        cls_ids: List[torch.Tensor] = []
+        for det, view_size, is_flipped, scale in aug_dets:
+            raw = det.get("obb")
+            if not det.get("num_detections") or raw is None:
+                continue
+            rows = (
+                raw.float().cpu()
+                if isinstance(raw, torch.Tensor)
+                else torch.as_tensor(raw, dtype=torch.float32)
+            )
+            if rows.numel() == 0:
+                continue
+            xywhr = rows[:, :5].clone()
+            if is_flipped:
+                xywhr[:, 0] = view_size[0] - xywhr[:, 0]
+                xywhr[:, 4] = -xywhr[:, 4]
+            if scale != 1.0:
+                xywhr[:, :4] = xywhr[:, :4] / scale
+            rects.append(xywhr)
+            scores.append(rows[:, 5])
+            cls_ids.append(rows[:, 6])
+
+        def _empty() -> Results:
+            return Results(
+                boxes=None,
+                orig_shape=orig_shape,
+                path=str(image_path) if image_path else None,
+                names=self.names,
+                obb=OBB(torch.zeros((0, 7), dtype=torch.float32), orig_shape),
+            )
+
+        if not rects:
+            return _empty()
+
+        xywhr = torch.cat(rects, dim=0)
+        scores_cat = torch.cat(scores, dim=0)
+        cls_cat = torch.cat(cls_ids, dim=0)
+
+        if classes is not None:
+            keep_cls = torch.zeros(cls_cat.shape[0], dtype=torch.bool)
+            for c in classes:
+                keep_cls |= cls_cat == c
+            xywhr, scores_cat, cls_cat = (
+                xywhr[keep_cls],
+                scores_cat[keep_cls],
+                cls_cat[keep_cls],
+            )
+            if xywhr.numel() == 0:
+                return _empty()
+
+        keep = rotated_nms(xywhr, scores_cat, cls_cat.long(), iou_thres, max_det)
+        if len(keep) == 0:
+            return _empty()
+
+        merged = torch.cat(
+            (xywhr[keep], scores_cat[keep, None], cls_cat[keep, None]), dim=1
+        )
+        return Results(
+            boxes=None,
+            orig_shape=orig_shape,
+            path=str(image_path) if image_path else None,
+            names=self.names,
+            obb=OBB(merged, orig_shape),
         )
 
     def _merge_tta(
@@ -1367,11 +1466,6 @@ class BaseModel(ABC):
             imgsz = self._get_input_size()
         if plots is not None and "save_plots" not in kwargs:
             kwargs["save_plots"] = plots
-        if augment and self.task == "obb":
-            raise ValueError(
-                "Augmented validation does not support oriented boxes yet. "
-                "Use augment=False for OBB models."
-            )
         if augment and self.task == "pose":
             raise ValueError(
                 "Augmented validation does not support pose keypoints yet. "

--- a/libreyolo/models/yolo9/loss.py
+++ b/libreyolo/models/yolo9/loss.py
@@ -497,6 +497,8 @@ class YOLO9Loss:
     - Classification loss (BCE)
     """
 
+    matcher_class = BoxMatcher
+
     def __init__(
         self,
         num_classes: int,
@@ -548,7 +550,7 @@ class YOLO9Loss:
             device=self.device,
         )
         # Initialize matcher with new anchors
-        self.matcher = BoxMatcher(
+        self.matcher = self.matcher_class(
             num_classes=self.num_classes,
             anchor_grid=self.vec2box.anchor_grid,
             scaler=self.vec2box.scaler,
@@ -672,3 +674,341 @@ class YOLO9Loss:
 
         return loss_dict
 
+
+
+# =============================================================================
+# Oriented boxes (OBB): Gaussian geometry helpers and loss
+# =============================================================================
+
+
+def _rbox_covariance(
+    wh: Tensor, cos2t: Tensor, sin2t: Tensor
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Covariance components of the Gaussian form of a rotated box.
+
+    ``Sigma = R(t) diag(w^2/4, h^2/4) R(t)^T`` expanded with half-angle
+    identities so the components are linear in the double-angle vector:
+    ``a = p + q cos2t``, ``b = p - q cos2t``, ``c = q sin2t`` with
+    ``p = (w^2 + h^2) / 8`` and ``q = (w^2 - h^2) / 8``. Derivation and
+    sources in docs/provenance/yolo9_obb.md.
+    """
+    quarter = wh.square() / 4.0
+    p = (quarter[..., 0] + quarter[..., 1]) / 2.0
+    q = (quarter[..., 0] - quarter[..., 1]) / 2.0
+    return p + q * cos2t, p - q * cos2t, q * sin2t
+
+
+def _gaussian_kld(
+    mu_p: Tensor,
+    cov_p: Tuple[Tensor, Tensor, Tensor],
+    mu_t: Tensor,
+    cov_t: Tuple[Tensor, Tensor, Tensor],
+    eps: float = 1e-7,
+) -> Tensor:
+    """Closed-form ``KL(N_p || N_t)`` between 2D Gaussians.
+
+    Only the exact target covariance is ever inverted, so degenerate
+    predictions cannot destabilize the term. Classical multivariate normal
+    formula written out for 2x2 covariances ``[[a, c], [c, b]]``.
+    """
+    a_p, b_p, c_p = cov_p
+    a_t, b_t, c_t = cov_t
+    det_t = (a_t * b_t - c_t.square()).clamp_min(eps)
+    det_p = (a_p * b_p - c_p.square()).clamp_min(eps)
+    dx = mu_p[..., 0] - mu_t[..., 0]
+    dy = mu_p[..., 1] - mu_t[..., 1]
+    trace = (b_t * a_p - 2.0 * c_t * c_p + a_t * b_p) / det_t
+    maha = (b_t * dx.square() - 2.0 * c_t * dx * dy + a_t * dy.square()) / det_t
+    kld = 0.5 * (trace + maha - 2.0) + 0.5 * (det_t / det_p).log()
+    return kld.clamp_min(0.0)
+
+
+def _bhattacharyya_score(
+    mu_p: Tensor,
+    cov_p: Tuple[Tensor, Tensor, Tensor],
+    mu_t: Tensor,
+    cov_t: Tuple[Tensor, Tensor, Tensor],
+    eps: float = 1e-7,
+) -> Tensor:
+    """IoU-like similarity ``exp(-B_D)`` between rotated-box Gaussians.
+
+    ``B_D`` is the classical Bhattacharyya distance; its use as a rotated-box
+    similarity follows the ProbIoU paper (see docs/provenance/yolo9_obb.md). Returns
+    values in ``(0, 1]`` with 1 at identity.
+    """
+    a_p, b_p, c_p = cov_p
+    a_t, b_t, c_t = cov_t
+    a_m = (a_p + a_t) / 2.0
+    b_m = (b_p + b_t) / 2.0
+    c_m = (c_p + c_t) / 2.0
+    det_m = (a_m * b_m - c_m.square()).clamp_min(eps)
+    det_p = (a_p * b_p - c_p.square()).clamp_min(eps)
+    det_t = (a_t * b_t - c_t.square()).clamp_min(eps)
+    dx = mu_p[..., 0] - mu_t[..., 0]
+    dy = mu_p[..., 1] - mu_t[..., 1]
+    maha = (b_m * dx.square() - 2.0 * c_m * dx * dy + a_m * dy.square()) / det_m
+    distance = 0.125 * maha + 0.5 * (
+        det_m / (det_p * det_t).sqrt().clamp_min(eps)
+    ).log()
+    return distance.clamp(0.0, 50.0).neg().exp()
+
+
+class RotatedBoxMatcher(BoxMatcher):
+    """Task-aligned assignment for oriented boxes.
+
+    Keeps the proxy-box validity gating of :class:`BoxMatcher` (it bounds the
+    LTRB distances the DFL branch must represent) and replaces the CIoU
+    metric with the Bhattacharyya similarity between the Gaussian forms of
+    the rotated boxes, so assignment sees orientation.
+    """
+
+    def get_similarity_matrix(
+        self, predict_rbox: Tensor, target_rbox: Tensor
+    ) -> Tensor:
+        """Similarity in (0, 1] between all targets and all anchors.
+
+        Args:
+            predict_rbox: [B, anchors, 6] as (cx, cy, w, h, cos2t, sin2t)
+            target_rbox: [B, targets, 5] as (cx, cy, w, h, theta)
+        """
+        pred = predict_rbox[:, None]
+        target = target_rbox[:, :, None]
+        two_theta = 2.0 * target[..., 4]
+        target_cov = _rbox_covariance(
+            target[..., 2:4], two_theta.cos(), two_theta.sin()
+        )
+        pred_cov = _rbox_covariance(pred[..., 2:4], pred[..., 4], pred[..., 5])
+        return _bhattacharyya_score(
+            pred[..., :2], pred_cov, target[..., :2], target_cov
+        )
+
+    def __call__(
+        self,
+        target: Tensor,
+        predict: Tuple[Tensor, Tensor],
+    ) -> Tuple[Tensor, Tensor]:
+        """
+        Match 6-column oriented targets to anchors.
+
+        Args:
+            target: Ground truth [B, targets, 6] with
+                [class_id, x1, y1, x2, y2, theta] (proxy box in pixels)
+            predict: Tuple of (pred_cls, pred_rbox)
+                - pred_cls: [B, anchors, num_classes] class logits
+                - pred_rbox: [B, anchors, 6] as (cx, cy, w, h, cos2t, sin2t)
+
+        Returns:
+            anchor_matched_targets: [B, anchors, num_classes + 4 + 1]
+            valid_mask: [B, anchors] boolean mask
+        """
+        predict_cls, predict_rbox = predict
+
+        n_targets = target.shape[1]
+        if n_targets == 0:
+            device = predict_rbox.device
+            align_cls = torch.zeros_like(predict_cls, device=device)
+            align_box = torch.zeros(
+                *predict_rbox.shape[:2], 5, device=device, dtype=predict_rbox.dtype
+            )
+            valid_mask = torch.zeros(predict_cls.shape[:2], dtype=bool, device=device)
+            return torch.cat([align_cls, align_box], dim=-1), valid_mask
+
+        target_cls, target_bbox, target_theta = target.split([1, 4, 1], dim=-1)
+        target_cls = target_cls.long().clamp(0)
+
+        # Valid matrix gates the proxy LTRB distances (unchanged semantics)
+        grid_mask = self.get_valid_matrix(target_bbox)
+
+        centers = (target_bbox[..., :2] + target_bbox[..., 2:]) / 2.0
+        sides = (target_bbox[..., 2:] - target_bbox[..., :2]).clamp_min(0.0)
+        target_rbox = torch.cat([centers, sides, target_theta], dim=-1)
+        iou_mat = self.get_similarity_matrix(predict_rbox, target_rbox)
+
+        cls_mat = self.get_cls_matrix(predict_cls.sigmoid(), target_cls)
+
+        target_matrix = (iou_mat**self.iou_factor) * (cls_mat**self.cls_factor)
+
+        topk_targets, topk_mask = self.filter_topk(
+            target_matrix, grid_mask, topk=self.topk
+        )
+        topk_mask = self.ensure_one_anchor(target_matrix, topk_mask)
+        unique_indices, valid_mask, topk_mask = self.filter_duplicates(
+            iou_mat, topk_mask
+        )
+
+        align_bbox = torch.gather(target_bbox, 1, unique_indices.repeat(1, 1, 4))
+        align_theta = torch.gather(target_theta, 1, unique_indices)
+        align_cls_indices = torch.gather(target_cls, 1, unique_indices)
+        align_cls = torch.zeros_like(align_cls_indices, dtype=torch.bool).repeat(
+            1, 1, self.num_classes
+        )
+        align_cls.scatter_(-1, index=align_cls_indices, src=~align_cls)
+
+        iou_mat *= topk_mask
+        target_matrix *= topk_mask
+        max_target = target_matrix.amax(dim=-1, keepdim=True)
+        max_iou = iou_mat.amax(dim=-1, keepdim=True)
+        normalize_term = (target_matrix / (max_target + 1e-9)) * max_iou
+        normalize_term = normalize_term.permute(0, 2, 1).gather(2, unique_indices)
+        align_cls = align_cls * normalize_term * valid_mask[:, :, None]
+
+        anchor_matched_targets = torch.cat(
+            [align_cls, align_bbox, align_theta], dim=-1
+        )
+        return anchor_matched_targets, valid_mask
+
+
+class YOLO9OrientedLoss(YOLO9Loss):
+    """YOLO9 loss for the obb task.
+
+    Keeps the in-tree DFL and BCE terms on the proxy rectangle and replaces
+    the CIoU box term with a Gaussian Kullback-Leibler loss that couples
+    center, sides, and orientation, plus an aspect-weighted auxiliary loss on
+    the double-angle orientation vector. Derivations, sources, and defaults:
+    docs/provenance/yolo9_obb.md.
+    """
+
+    matcher_class = RotatedBoxMatcher
+
+    def __init__(
+        self,
+        *args,
+        vec_weight: float = 0.5,
+        aspect_full: float = 3.0,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.vec_weight = vec_weight
+        self._log_aspect_full = math.log(aspect_full)
+
+    def __call__(
+        self,
+        predictions: List[Tensor],
+        targets: Tensor,
+        angle_maps: List[Tensor],
+    ) -> Dict[str, float]:
+        if targets.shape[-1] != 6:
+            raise ValueError(
+                "YOLO9 OBB training requires targets shaped "
+                "[B, max_targets, 6]: class, x1, y1, x2, y2, theta."
+            )
+        if self.vec2box is None:
+            raise RuntimeError("Vec2Box not initialized. Call update_anchors() first.")
+
+        preds_cls, preds_anc, preds_box = self.vec2box(predictions)
+
+        vec_levels = []
+        for level in angle_maps:
+            bsz, channels, height, width = level.shape
+            if channels != 2:
+                raise ValueError(
+                    f"OBB orientation branch must emit 2 channels, got {channels}"
+                )
+            vec_levels.append(
+                level.permute(0, 2, 3, 1).reshape(bsz, height * width, 2)
+            )
+        preds_vec = torch.cat(vec_levels, dim=1)
+        preds_unit = preds_vec / preds_vec.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+
+        B = targets.shape[0]
+        W, H = self.vec2box.image_size
+        scale = torch.tensor(
+            [1, W, H, W, H, 1], device=targets.device, dtype=targets.dtype
+        )
+        targets_scaled = targets * scale
+
+        pred_centers = (preds_box[..., :2] + preds_box[..., 2:]) / 2.0
+        pred_sides = (preds_box[..., 2:] - preds_box[..., :2]).clamp_min(0.0)
+        pred_rbox = torch.cat([pred_centers, pred_sides, preds_unit], dim=-1)
+
+        align_targets, valid_masks = self.matcher(
+            targets_scaled, (preds_cls.detach(), pred_rbox.detach())
+        )
+        targets_cls, targets_bbox, targets_theta = torch.split(
+            align_targets, (self.num_classes, 4, 1), dim=-1
+        )
+
+        preds_box_norm = preds_box / self.vec2box.scaler[None, :, None]
+        targets_bbox_norm = targets_bbox / self.vec2box.scaler[None, :, None]
+
+        cls_norm = self._global_cls_norm(targets_cls)
+        box_norm = targets_cls.sum(-1)[valid_masks]
+
+        loss_cls = self.cls_loss(preds_cls, targets_cls, cls_norm)
+        if valid_masks.any():
+            anchors_norm = (self.vec2box.anchor_grid / self.vec2box.scaler[:, None])[
+                None
+            ]
+            loss_dfl = self.dfl_loss(
+                preds_anc,
+                targets_bbox_norm,
+                anchors_norm,
+                valid_masks,
+                box_norm,
+                cls_norm,
+            )
+
+            # Gaussian terms in fp32 under AMP (in-tree precedent).
+            m_pred_mu = pred_centers[valid_masks].float()
+            m_pred_wh = pred_sides[valid_masks].float()
+            m_unit = preds_unit[valid_masks].float()
+            m_t_bbox = targets_bbox[valid_masks].float()
+            m_theta = targets_theta[valid_masks].squeeze(-1).float()
+            m_t_mu = (m_t_bbox[..., :2] + m_t_bbox[..., 2:]) / 2.0
+            m_t_wh = (m_t_bbox[..., 2:] - m_t_bbox[..., :2]).clamp_min(1e-6)
+
+            two_theta = 2.0 * m_theta
+            pred_cov = _rbox_covariance(m_pred_wh, m_unit[..., 0], m_unit[..., 1])
+            target_cov = _rbox_covariance(
+                m_t_wh, two_theta.cos(), two_theta.sin()
+            )
+            kld = _gaussian_kld(m_pred_mu, pred_cov, m_t_mu, target_cov)
+            loss_box = (
+                (1.0 - 1.0 / (1.0 + torch.log1p(kld))) * box_norm
+            ).sum() / cls_norm
+
+            aspect = (m_t_wh[..., 0] / m_t_wh[..., 1].clamp_min(1e-6)).clamp_min(1.0)
+            weight_ar = (aspect.log() / self._log_aspect_full).clamp(0.0, 1.0)
+            target_vec = weight_ar[..., None] * torch.stack(
+                [two_theta.cos(), two_theta.sin()], dim=-1
+            )
+            vec_err = (preds_vec[valid_masks].float() - target_vec).square().sum(-1)
+            loss_vec = (vec_err * box_norm).sum() / cls_norm
+        else:
+            loss_dfl = preds_anc.sum() * 0.0
+            loss_box = preds_box_norm.sum() * 0.0
+            loss_vec = preds_vec.sum() * 0.0
+
+        loss_box_weighted = self.box_weight * loss_box
+        loss_dfl_weighted = self.dfl_weight * loss_dfl
+        loss_cls_weighted = self.cls_weight * loss_cls
+        loss_vec_weighted = self.vec_weight * loss_vec
+
+        total_loss = (
+            loss_box_weighted
+            + loss_dfl_weighted
+            + loss_cls_weighted
+            + loss_vec_weighted
+        )
+
+        loss_dict = {
+            "total_loss": total_loss,
+            "box_loss": loss_box_weighted,
+            "dfl_loss": loss_dfl_weighted,
+            "cls_loss": loss_cls_weighted,
+            "angle_loss": loss_vec_weighted,
+            "box": loss_box_weighted.item()
+            if isinstance(loss_box_weighted, Tensor)
+            else loss_box_weighted,
+            "dfl": loss_dfl_weighted.item()
+            if isinstance(loss_dfl_weighted, Tensor)
+            else loss_dfl_weighted,
+            "cls": loss_cls_weighted.item()
+            if isinstance(loss_cls_weighted, Tensor)
+            else loss_cls_weighted,
+            "angle": loss_vec_weighted.item()
+            if isinstance(loss_vec_weighted, Tensor)
+            else loss_vec_weighted,
+            "num_fg": valid_masks.sum().item() / max(B, 1),
+        }
+        return loss_dict

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -58,6 +58,12 @@ class LibreYOLO9(BaseModel):
     EXPERIMENTAL_WEIGHT_FILENAMES: frozenset = frozenset()
     TRAIN_CONFIG = YOLO9Config
     val_preprocessor_class = YOLO9ValPreprocessor
+    # Multi-scale TTA for oriented boxes (aerial imagery spans object scales);
+    # detection keeps the flip-only default so its behavior is unchanged.
+    OBB_TTA_SCALES = (0.83, 1.0, 1.2)
+
+    def _tta_scales(self):
+        return self.OBB_TTA_SCALES if self.task == "obb" else self.TTA_SCALES
     # Additional checkpoint model_family values accepted as transfer-learning
     # sources (subclass hook; e.g. yolo9_p2 accepts base yolo9 checkpoints).
     TRANSFER_COMPATIBLE_FAMILIES: tuple = ()

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -50,9 +50,10 @@ class LibreYOLO9(BaseModel):
     FAMILY = "yolo9"
     FILENAME_PREFIX = "LibreYOLO9"
     INPUT_SIZES = {"t": 640, "s": 640, "m": 640, "c": 640}
-    SUPPORTED_TASKS = ("detect",)
+    SUPPORTED_TASKS = ("detect", "obb")
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,
+        "obb": INPUT_SIZES,
     }
     EXPERIMENTAL_WEIGHT_FILENAMES: frozenset = frozenset()
     TRAIN_CONFIG = YOLO9Config
@@ -140,7 +141,14 @@ class LibreYOLO9(BaseModel):
 
     @classmethod
     def detect_checkpoint_task(cls, weights_dict: dict) -> Optional[str]:
-        """Infer YOLO9 task from task-specific head branches."""
+        """Infer YOLO9 task from task-specific head branches.
+
+        The OBB orientation convs live at ``head.ang.*`` (two output
+        channels, see ``OrientedDDetect``); their presence claims the obb
+        task.
+        """
+        if any(re.match(r"head\.ang\.\d+\.weight", key) for key in weights_dict):
+            return "obb"
         return None
 
     # =========================================================================
@@ -173,11 +181,16 @@ class LibreYOLO9(BaseModel):
     # Model lifecycle
     # =========================================================================
 
+    @property
+    def _is_obb(self) -> bool:
+        return self.task == "obb"
+
     def _init_model(self) -> nn.Module:
         return LibreYOLO9Model(
             config=self.size,
             reg_max=self.reg_max,
             nb_classes=self.nb_classes,
+            obb=self._is_obb,
         )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:
@@ -206,6 +219,13 @@ class LibreYOLO9(BaseModel):
         state_dict: dict,
         checkpoint: dict | None = None,
     ) -> None:
+        if self._is_obb:
+            if not any(key.startswith("head.ang.") for key in state_dict):
+                raise RuntimeError(
+                    "YOLO9 OBB checkpoints must include head.ang.* orientation "
+                    "weights. Detect-to-OBB initialization is only supported "
+                    "through explicit training transfer (pretrained=...)."
+                )
         return
 
     def _prepare_state_dict(
@@ -519,7 +539,8 @@ class LibreYOLO9(BaseModel):
             patience: Early stopping patience.
             pretrained: Optional training initialization weights. Use True to
                 load the matching LibreYOLO9 detect checkpoint for transfer
-                learning, or pass a checkpoint path/name.
+                learning, or pass a checkpoint path/name. Detect-to-OBB
+                transfer is allowed here only as explicit initialization.
             callbacks: Optional training callback or iterable of callbacks.
             loggers: Optional built-in experiment loggers: a name
                 ('tensorboard', 'mlflow', 'wandb'), a configured logger

--- a/libreyolo/models/yolo9/nn.py
+++ b/libreyolo/models/yolo9/nn.py
@@ -710,6 +710,87 @@ class DDetect(nn.Module):
         )
 
 
+class OrientedDDetect(DDetect):
+    """Oriented-box (OBB) variant of the detect head.
+
+    Orientation is read from the geometry the box towers already compute: a
+    single 1x1 convolution per scale (``ang``) maps the first box-tower
+    conv's hidden features to a two-channel double-angle vector
+    ``(cos 2*theta, sin 2*theta)``, decoded with ``0.5 * atan2`` at
+    inference. Boxes stay in the detect head's horizontal proxy encoding and
+    the live postprocess recombines them with the angle row into ``xywhr``.
+    Design rationale and sources: ``docs/provenance/yolo9_obb.md``.
+
+    Checkpoint contract: the orientation convs live at ``head.ang.*`` and
+    task inference keys on their presence. ``cv2``/``cv3``/``dfl`` are
+    unchanged, so detect checkpoints transfer into everything but ``ang``.
+    """
+
+    def __init__(self, nc=80, ch=(), reg_max=16, stride=(), use_group=True):
+        super().__init__(
+            nc=nc, ch=ch, reg_max=reg_max, stride=stride, use_group=use_group
+        )
+        self.ang = nn.ModuleList(
+            nn.Conv2d(self._box_hidden_channels, 2, 1) for _ in ch
+        )
+        # Zero bias keeps the initial orientation claim near-neutral: short
+        # vectors mean "no confident orientation" under the norm semantics.
+        for conv in self.ang:
+            nn.init.zeros_(conv.bias)
+
+    def _get_loss_fn(self, device):
+        """Lazily initialize the oriented loss (standard ``_loss_fn`` slot)."""
+        if self._loss_fn is None:
+            from .loss import YOLO9OrientedLoss
+
+            self._loss_fn = YOLO9OrientedLoss(
+                num_classes=self.nc,
+                reg_max=self.reg_max,
+                strides=self.stride.tolist(),
+                image_size=None,
+                device=device,
+            )
+        return self._loss_fn
+
+    def forward(self, x, targets=None, img_size=None):
+        preds = []
+        angles = []
+        for i, feat in enumerate(x):
+            hidden = self.cv2[i][0](feat)
+            box_out = self.cv2[i][2](self.cv2[i][1](hidden))
+            preds.append(torch.cat((box_out, self.cv3[i](feat)), 1))
+            angles.append(self.ang[i](hidden))
+
+        if self.training:
+            if targets is not None:
+                loss_fn = self._get_loss_fn(preds[0].device)
+                if img_size is not None:
+                    loss_fn.update_anchors(list(img_size))
+                return loss_fn(preds, targets, angles)
+            return preds, angles
+
+        return self._decode_oriented(preds, angles), preds
+
+    def _decode_oriented(self, preds, angles):
+        anchor_points, stride_scale = self._grid(preds)
+        box_levels = []
+        score_levels = []
+        for pred in preds:
+            box_level, score_level = pred.flatten(2).split(
+                (4 * self.reg_max, self.nc), 1
+            )
+            box_levels.append(box_level)
+            score_levels.append(score_level)
+        distances = self.dfl(torch.cat(box_levels, 2))
+        boxes = (
+            self._decode_bboxes(distances, anchor_points.unsqueeze(0)) * stride_scale
+        )
+        vec = torch.cat([level.flatten(2) for level in angles], 2)
+        theta = 0.5 * torch.atan2(vec[:, 1:2], vec[:, 0:1])
+        scores = torch.cat(score_levels, 2).sigmoid()
+        return torch.cat((boxes, theta, scores), 1)
+
+
 # =============================================================================
 # Model Architecture Definitions
 # =============================================================================
@@ -1007,6 +1088,7 @@ class LibreYOLO9Model(nn.Module):
         reg_max=16,
         nb_classes=80,
         img_size=640,
+        obb=False,
     ):
         """
         Initialize YOLOv9 model.
@@ -1016,6 +1098,7 @@ class LibreYOLO9Model(nn.Module):
             reg_max: Regression max value for DFL
             nb_classes: Number of classes
             img_size: Input image size
+            obb: Build the oriented-bounding-box head instead of plain detect.
         """
         super().__init__()
 
@@ -1028,6 +1111,7 @@ class LibreYOLO9Model(nn.Module):
         self.nc = nb_classes
         self.reg_max = reg_max
         self.img_size = img_size
+        self.obb = obb
 
         cfg = YOLO9_CONFIGS[config]
 
@@ -1036,7 +1120,8 @@ class LibreYOLO9Model(nn.Module):
 
         # Detection head - use exact channels from config
         head_channels = cfg["head_channels"]
-        self.head = DDetect(
+        head_cls = OrientedDDetect if obb else DDetect
+        self.head = head_cls(
             nc=nb_classes,
             ch=head_channels,
             reg_max=reg_max,
@@ -1083,13 +1168,16 @@ class LibreYOLO9Model(nn.Module):
         if self.head.export:
             return y
 
-        return {
-            "predictions": y,  # (batch, 4+nc, total_anchors)
+        result = {
+            "predictions": y,  # (batch, 4+nc, total_anchors; +1 angle row for OBB)
             "raw_outputs": x_list,
             "x8": {"features": n3},
             "x16": {"features": n4},
             "x32": {"features": n5},
         }
+        if self.obb:
+            result["obb"] = True
+        return result
 
     def fuse(self):
         """Fuse Conv+BN and RepConvN for faster inference."""

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -74,12 +74,15 @@ class YOLO9Trainer(BaseTrainer):
         return groups or super().get_freeze_groups()
 
     def create_transforms(self):
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
         preproc = YOLO9TrainTransform(
             max_labels=getattr(self.config, "max_labels", 100),
             flip_prob=self.config.flip_prob,
             vertical_flip_prob=getattr(self.config, "flipud", 0.0),
             hsv_prob=self.config.hsv_prob,
             rot90_prob=getattr(self.config, "rot90", 0.0),
+            # OBB samples carry [class, x1, y1, x2, y2, theta] labels.
+            output_label_dim=6 if task == "obb" else None,
         )
         return preproc, YOLO9MosaicMixupDataset
 
@@ -110,11 +113,14 @@ class YOLO9Trainer(BaseTrainer):
         def _scalar(v):
             return v.item() if isinstance(v, torch.Tensor) else v
 
-        return {
+        components = {
             "box": _scalar(outputs.get("box", 0)),
             "cls": _scalar(outputs.get("cls", 0)),
             "dfl": _scalar(outputs.get("dfl", 0)),
         }
+        if "angle" in outputs:
+            components["angle"] = _scalar(outputs.get("angle", 0))
+        return components
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         return self.model(imgs, targets=targets)

--- a/libreyolo/postprocess/yolo9.py
+++ b/libreyolo/postprocess/yolo9.py
@@ -9,7 +9,7 @@ import torch
 from torchvision.ops import batched_nms
 from typing import Dict, Tuple, Union
 
-from ..data.obb import xywhr_iou
+from ..utils.box_ops import _aabb_overlap, rotated_iou_pairwise
 
 
 _YOLO9_MAX_NMS_CANDIDATES = 30000
@@ -116,6 +116,13 @@ def _rotated_nms_keep_indices(
     iou_thres: float,
     max_det: int,
 ) -> torch.Tensor:
+    """Class-aware greedy NMS over rotated boxes.
+
+    The suppression order and threshold semantics are the textbook greedy
+    ones, but the geometry is evaluated as a single vectorized IoU matrix on
+    the tensors' own device (:func:`rotated_iou_matrix`) instead of one
+    OpenCV call per candidate pair.
+    """
     if xywhr.numel() == 0:
         return torch.zeros(0, dtype=torch.long, device=xywhr.device)
 
@@ -131,25 +138,40 @@ def _rotated_nms_keep_indices(
         valid_indices = None
 
     order = torch.argsort(scores, descending=True)
-    rects = xywhr.detach().cpu().numpy().astype(np.float32)
-    classes = class_ids.detach().cpu().numpy().astype(np.int64)
-    ordered = order.detach().cpu().numpy().astype(np.int64).tolist()
+    ranked = xywhr[order]
+    ranked_classes = class_ids[order]
+    count = ranked.shape[0]
 
+    # Ranked by score, so a suppressor always precedes its victim: only the
+    # upper triangle can suppress. Same-class and axis-aligned-envelope
+    # overlap are both prerequisites, and both are far cheaper than the
+    # polygon intersection, so they gate which pairs are evaluated at all.
+    candidates = (
+        _aabb_overlap(ranked, ranked)
+        & (ranked_classes[:, None] == ranked_classes[None, :])
+    ).triu(diagonal=1)
+    rows, cols = candidates.nonzero(as_tuple=True)
+
+    suppresses = np.zeros((count, count), dtype=bool)
+    if rows.numel():
+        overlapping = (
+            rotated_iou_pairwise(ranked[rows], ranked[cols]) > iou_thres
+        )
+        suppresses[
+            rows[overlapping].cpu().numpy(), cols[overlapping].cpu().numpy()
+        ] = True
+
+    alive = np.ones(count, dtype=bool)
     keep_local: list[int] = []
-    while ordered and len(keep_local) < max_det:
-        current = ordered.pop(0)
-        keep_local.append(current)
+    for candidate in range(count):
+        if not alive[candidate]:
+            continue
+        keep_local.append(candidate)
+        if len(keep_local) >= max_det:
+            break
+        alive &= ~suppresses[candidate]
 
-        remaining = []
-        for candidate in ordered:
-            if classes[candidate] != classes[current]:
-                remaining.append(candidate)
-                continue
-            if xywhr_iou(rects[current], rects[candidate]) <= iou_thres:
-                remaining.append(candidate)
-        ordered = remaining
-
-    keep = torch.as_tensor(keep_local, dtype=torch.long, device=xywhr.device)
+    keep = order[torch.as_tensor(keep_local, dtype=torch.long, device=xywhr.device)]
     if valid_indices is not None:
         keep = valid_indices[keep]
     return keep

--- a/libreyolo/postprocess/yolo9.py
+++ b/libreyolo/postprocess/yolo9.py
@@ -4,12 +4,11 @@ Moved verbatim from ``libreyolo/models/yolo9/utils.py``, which re-exports
 everything here for backward compatibility.
 """
 
-import numpy as np
 import torch
 from torchvision.ops import batched_nms
 from typing import Dict, Tuple, Union
 
-from ..utils.box_ops import _aabb_overlap, rotated_iou_pairwise
+from ..utils.box_ops import rotated_nms
 
 
 _YOLO9_MAX_NMS_CANDIDATES = 30000
@@ -116,65 +115,8 @@ def _rotated_nms_keep_indices(
     iou_thres: float,
     max_det: int,
 ) -> torch.Tensor:
-    """Class-aware greedy NMS over rotated boxes.
-
-    The suppression order and threshold semantics are the textbook greedy
-    ones, but the geometry is evaluated as a single vectorized IoU matrix on
-    the tensors' own device (:func:`rotated_iou_matrix`) instead of one
-    OpenCV call per candidate pair.
-    """
-    if xywhr.numel() == 0:
-        return torch.zeros(0, dtype=torch.long, device=xywhr.device)
-
-    finite_mask = torch.isfinite(xywhr).all(dim=1) & torch.isfinite(scores)
-    if not finite_mask.all():
-        valid_indices = torch.where(finite_mask)[0]
-        if len(valid_indices) == 0:
-            return torch.zeros(0, dtype=torch.long, device=xywhr.device)
-        xywhr = xywhr[finite_mask]
-        scores = scores[finite_mask]
-        class_ids = class_ids[finite_mask]
-    else:
-        valid_indices = None
-
-    order = torch.argsort(scores, descending=True)
-    ranked = xywhr[order]
-    ranked_classes = class_ids[order]
-    count = ranked.shape[0]
-
-    # Ranked by score, so a suppressor always precedes its victim: only the
-    # upper triangle can suppress. Same-class and axis-aligned-envelope
-    # overlap are both prerequisites, and both are far cheaper than the
-    # polygon intersection, so they gate which pairs are evaluated at all.
-    candidates = (
-        _aabb_overlap(ranked, ranked)
-        & (ranked_classes[:, None] == ranked_classes[None, :])
-    ).triu(diagonal=1)
-    rows, cols = candidates.nonzero(as_tuple=True)
-
-    suppresses = np.zeros((count, count), dtype=bool)
-    if rows.numel():
-        overlapping = (
-            rotated_iou_pairwise(ranked[rows], ranked[cols]) > iou_thres
-        )
-        suppresses[
-            rows[overlapping].cpu().numpy(), cols[overlapping].cpu().numpy()
-        ] = True
-
-    alive = np.ones(count, dtype=bool)
-    keep_local: list[int] = []
-    for candidate in range(count):
-        if not alive[candidate]:
-            continue
-        keep_local.append(candidate)
-        if len(keep_local) >= max_det:
-            break
-        alive &= ~suppresses[candidate]
-
-    keep = order[torch.as_tensor(keep_local, dtype=torch.long, device=xywhr.device)]
-    if valid_indices is not None:
-        keep = valid_indices[keep]
-    return keep
+    """Class-aware greedy rotated NMS (thin alias over the shared op)."""
+    return rotated_nms(xywhr, scores, class_ids, iou_thres, max_det)
 
 
 def _obb_prefilter_keep_indices(

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -702,12 +702,7 @@ class BaseTrainer(ABC):
 
         self.config.num_classes = int(self.num_classes)
 
-        mosaic_enabled = not load_obb
-        if load_obb and is_main_process():
-            logger.info(
-                "Disabling mosaic/mixup for OBB training until corner-aware "
-                "OBB augmentation is implemented."
-            )
+        mosaic_enabled = True
 
         train_dataset.enable_image_cache(getattr(self.config, "cache", False))
 

--- a/libreyolo/utils/box_ops.py
+++ b/libreyolo/utils/box_ops.py
@@ -2,6 +2,7 @@
 
 import math
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -286,3 +287,68 @@ def rotated_iou_matrix(boxes1: Tensor, boxes2: Tensor, eps: float = 1e-7) -> Ten
         return iou
     iou[rows, cols] = rotated_iou_pairwise(boxes1[rows], boxes2[cols], eps)
     return iou
+
+
+def rotated_nms(
+    xywhr: Tensor,
+    scores: Tensor,
+    class_ids: Tensor,
+    iou_thres: float,
+    max_det: int,
+) -> Tensor:
+    """Class-aware greedy NMS over rotated ``xywhr`` boxes.
+
+    The suppression order and threshold semantics are the textbook greedy
+    ones; the geometry is the exact vectorized rotated IoU
+    (:func:`rotated_iou_pairwise`). Ranking by score means a suppressor
+    always precedes its victim, so only the upper triangle can suppress, and
+    same-class plus axis-aligned-envelope overlap gate which pairs reach the
+    polygon intersection at all. Shared by the YOLO9 postprocess and the
+    oriented-box TTA merge so both de-duplicate identically.
+    """
+    if xywhr.numel() == 0:
+        return torch.zeros(0, dtype=torch.long, device=xywhr.device)
+
+    finite_mask = torch.isfinite(xywhr).all(dim=1) & torch.isfinite(scores)
+    if not finite_mask.all():
+        valid_indices = torch.where(finite_mask)[0]
+        if len(valid_indices) == 0:
+            return torch.zeros(0, dtype=torch.long, device=xywhr.device)
+        xywhr = xywhr[finite_mask]
+        scores = scores[finite_mask]
+        class_ids = class_ids[finite_mask]
+    else:
+        valid_indices = None
+
+    order = torch.argsort(scores, descending=True)
+    ranked = xywhr[order]
+    ranked_classes = class_ids[order]
+    count = ranked.shape[0]
+
+    candidates = (
+        _aabb_overlap(ranked, ranked)
+        & (ranked_classes[:, None] == ranked_classes[None, :])
+    ).triu(diagonal=1)
+    rows, cols = candidates.nonzero(as_tuple=True)
+
+    suppresses = np.zeros((count, count), dtype=bool)
+    if rows.numel():
+        overlapping = rotated_iou_pairwise(ranked[rows], ranked[cols]) > iou_thres
+        suppresses[
+            rows[overlapping].cpu().numpy(), cols[overlapping].cpu().numpy()
+        ] = True
+
+    alive = np.ones(count, dtype=bool)
+    keep_local: list[int] = []
+    for candidate in range(count):
+        if not alive[candidate]:
+            continue
+        keep_local.append(candidate)
+        if len(keep_local) >= max_det:
+            break
+        alive &= ~suppresses[candidate]
+
+    keep = order[torch.as_tensor(keep_local, dtype=torch.long, device=xywhr.device)]
+    if valid_indices is not None:
+        keep = valid_indices[keep]
+    return keep

--- a/libreyolo/utils/box_ops.py
+++ b/libreyolo/utils/box_ops.py
@@ -116,3 +116,173 @@ def compute_iou(
         alpha = v / (v - iou + 1 + EPS)
     ciou = diou - alpha * v
     return ciou.to(dtype)
+
+
+# =============================================================================
+# Oriented (rotated) boxes
+# =============================================================================
+
+
+def rbox_corners(boxes: Tensor) -> Tensor:
+    """Convert ``xywhr`` rotated boxes to their four corners.
+
+    Matches the corner order of :func:`libreyolo.data.obb.xywhr_to_corners`.
+
+    Args:
+        boxes: ``(..., 5)`` as ``(cx, cy, w, h, angle)``, angle in radians.
+
+    Returns:
+        ``(..., 4, 2)`` corners.
+    """
+    cx, cy, w, h, angle = boxes.unbind(-1)
+    cos, sin = angle.cos(), angle.sin()
+    wx, wy = cos * w / 2, sin * w / 2
+    hx, hy = -sin * h / 2, cos * h / 2
+    return torch.stack(
+        (
+            torch.stack((cx - wx - hx, cy - wy - hy), -1),
+            torch.stack((cx + wx - hx, cy + wy - hy), -1),
+            torch.stack((cx + wx + hx, cy + wy + hy), -1),
+            torch.stack((cx - wx + hx, cy - wy + hy), -1),
+        ),
+        dim=-2,
+    )
+
+
+def _convex_quad_intersection_area(
+    poly_a: Tensor, poly_b: Tensor, eps: float = 1e-7
+) -> Tensor:
+    """Exact intersection area of paired convex quadrilaterals.
+
+    The intersection of two convex polygons is the convex hull of: each
+    polygon's vertices that lie inside the other, plus every edge-edge
+    crossing. Both inputs are rectangles, so at most eight of the twenty-four
+    candidate points survive. They are ordered by angle about their centroid
+    and the area follows from the shoelace formula; rejected slots collapse
+    onto the first surviving vertex, where they enclose no area.
+
+    Args:
+        poly_a: ``(K, 4, 2)`` corners.
+        poly_b: ``(K, 4, 2)`` corners.
+
+    Returns:
+        ``(K,)`` intersection areas.
+    """
+
+    def _vertices_inside(points: Tensor, polygon: Tensor) -> Tensor:
+        edge_start = polygon[:, None, :, :]
+        edge_end = polygon.roll(-1, dims=-2)[:, None, :, :]
+        probe = points[:, :, None, :]
+        edge = edge_end - edge_start
+        offset = probe - edge_start
+        cross = edge[..., 0] * offset[..., 1] - edge[..., 1] * offset[..., 0]
+        # Convex and consistently wound: inside means every cross product agrees.
+        return (cross >= -eps).all(-1) | (cross <= eps).all(-1)
+
+    inside_a = _vertices_inside(poly_a, poly_b)
+    inside_b = _vertices_inside(poly_b, poly_a)
+
+    a_start = poly_a[:, :, None, :]
+    a_dir = (poly_a.roll(-1, dims=-2) - poly_a)[:, :, None, :]
+    b_start = poly_b[:, None, :, :]
+    b_dir = (poly_b.roll(-1, dims=-2) - poly_b)[:, None, :, :]
+
+    denom = a_dir[..., 0] * b_dir[..., 1] - a_dir[..., 1] * b_dir[..., 0]
+    parallel = denom.abs() < eps
+    safe = torch.where(parallel, torch.ones_like(denom), denom)
+    delta = b_start - a_start
+    t = (delta[..., 0] * b_dir[..., 1] - delta[..., 1] * b_dir[..., 0]) / safe
+    u = (delta[..., 0] * a_dir[..., 1] - delta[..., 1] * a_dir[..., 0]) / safe
+    hit = ~parallel & (t >= 0) & (t <= 1) & (u >= 0) & (u <= 1)
+    crossings = a_start + t[..., None] * a_dir
+
+    points = torch.cat((poly_a, poly_b, crossings.flatten(1, 2)), dim=1)
+    valid = torch.cat((inside_a, inside_b, hit.flatten(1, 2)), dim=1)
+
+    count = valid.sum(-1, keepdim=True)
+    centroid = (points * valid[..., None]).sum(-2, keepdim=True) / count.clamp_min(
+        1
+    ).unsqueeze(-1)
+    offset = points - centroid
+    angle = torch.atan2(offset[..., 1], offset[..., 0]).masked_fill(
+        ~valid, float("inf")
+    )
+
+    order = angle.argsort(-1)
+    points = points.gather(-2, order[..., None].expand_as(points))
+    valid = valid.gather(-1, order)
+    points = torch.where(valid[..., None], points, points[:, 0:1, :])
+
+    following = points.roll(-1, dims=-2)
+    area = 0.5 * (
+        points[..., 0] * following[..., 1] - following[..., 0] * points[..., 1]
+    ).sum(-1).abs()
+    return torch.where(count.squeeze(-1) >= 3, area, torch.zeros_like(area))
+
+
+def rotated_iou_pairwise(boxes1: Tensor, boxes2: Tensor, eps: float = 1e-7) -> Tensor:
+    """Exact IoU of rotated boxes, one pair per row.
+
+    Args:
+        boxes1: ``(K, 5)`` ``xywhr`` boxes.
+        boxes2: ``(K, 5)`` ``xywhr`` boxes.
+
+    Returns:
+        ``(K,)`` IoU values.
+    """
+    if boxes1.numel() == 0:
+        return boxes1.new_zeros((boxes1.shape[0],))
+    intersection = _convex_quad_intersection_area(
+        rbox_corners(boxes1), rbox_corners(boxes2), eps
+    )
+    area1 = (boxes1[:, 2] * boxes1[:, 3]).clamp_min(0)
+    area2 = (boxes2[:, 2] * boxes2[:, 3]).clamp_min(0)
+    union = area1 + area2 - intersection
+    return (intersection / union.clamp_min(eps)).clamp(0.0, 1.0)
+
+
+def _aabb_overlap(boxes1: Tensor, boxes2: Tensor) -> Tensor:
+    """Which ``(i, j)`` pairs have overlapping axis-aligned envelopes.
+
+    Rotated boxes can only intersect when their axis-aligned envelopes do, so
+    this cheap test discards the overwhelming majority of pairs before any
+    polygon work is attempted.
+    """
+    corners1 = rbox_corners(boxes1)
+    corners2 = rbox_corners(boxes2)
+    lo1, hi1 = corners1.amin(-2), corners1.amax(-2)
+    lo2, hi2 = corners2.amin(-2), corners2.amax(-2)
+    return (
+        (lo1[:, None, 0] < hi2[None, :, 0])
+        & (lo2[None, :, 0] < hi1[:, None, 0])
+        & (lo1[:, None, 1] < hi2[None, :, 1])
+        & (lo2[None, :, 1] < hi1[:, None, 1])
+    )
+
+
+def rotated_iou_matrix(boxes1: Tensor, boxes2: Tensor, eps: float = 1e-7) -> Tensor:
+    """Exact pairwise IoU between two sets of rotated boxes.
+
+    Vectorized equivalent of :func:`libreyolo.data.obb.xywhr_iou`, which
+    evaluates a single pair at a time through OpenCV. Pairs whose axis-aligned
+    envelopes miss are known to have zero IoU, so only the surviving pairs
+    reach the polygon intersection; on dense aerial imagery that is a small
+    fraction of the matrix.
+
+    Args:
+        boxes1: ``(N, 5)`` ``xywhr`` boxes.
+        boxes2: ``(M, 5)`` ``xywhr`` boxes.
+
+    Returns:
+        ``(N, M)`` IoU matrix.
+    """
+    n, m = boxes1.shape[0], boxes2.shape[0]
+    iou = boxes1.new_zeros((n, m))
+    if n == 0 or m == 0:
+        return iou
+
+    rows, cols = _aabb_overlap(boxes1, boxes2).nonzero(as_tuple=True)
+    if rows.numel() == 0:
+        return iou
+    iou[rows, cols] = rotated_iou_pairwise(boxes1[rows], boxes2[cols], eps)
+    return iou

--- a/libreyolo/validation/obb_validator.py
+++ b/libreyolo/validation/obb_validator.py
@@ -23,8 +23,8 @@ from libreyolo.data.dataset import COCODataset, YOLODataset
 from libreyolo.data.obb import (
     corners_to_xywhr,
     parse_yolo_obb_label_line,
-    xywhr_iou,
 )
+from libreyolo.utils.box_ops import rotated_iou_matrix
 
 from ..postprocess.slicing import slice_batch_outputs
 from .base import BaseValidator
@@ -77,6 +77,7 @@ class OBBValidator(BaseValidator):
         self._gt_by_class: Dict[int, Dict[int, List[np.ndarray]]] = {}
         self._num_gt_by_class: Dict[int, int] = {}
         self._predictions_by_class: Dict[int, List[dict]] = {}
+        self._iou_rows_by_class: Dict[int, List[np.ndarray | None]] = {}
 
     def _resolve_imgsz(self) -> int:
         if self.config.imgsz is not None:
@@ -308,6 +309,7 @@ class OBBValidator(BaseValidator):
         self._predictions_by_class = {i: [] for i in range(self.nc)}
         self._gt_by_class = {i: {} for i in range(self.nc)}
         self._num_gt_by_class = {i: 0 for i in range(self.nc)}
+        self._iou_rows_by_class = {}
         for img_id, rows in self._gt_by_image.items():
             for cls_id, xywhr in rows:
                 self._gt_by_class.setdefault(cls_id, {}).setdefault(img_id, []).append(xywhr)
@@ -391,6 +393,42 @@ class OBBValidator(BaseValidator):
         ]
         return float(np.mean(values))
 
+    def _class_iou_rows(self, cls_id: int, preds: List[dict]) -> List[np.ndarray | None]:
+        """Rotated IoU of each prediction against its own image's ground truth.
+
+        The geometry does not depend on the matching threshold, so it is
+        computed once per class as a vectorized IoU matrix per image and
+        reused across every mAP threshold.
+        """
+        cache = getattr(self, "_iou_rows_by_class", None)
+        if cache is None:
+            cache = self._iou_rows_by_class = {}
+        cached = cache.get(cls_id)
+        if cached is not None and len(cached) == len(preds):
+            return cached
+
+        gt_by_image = self._gt_by_class.get(cls_id, {})
+        preds_by_image: Dict[int, List[int]] = {}
+        for index, pred in enumerate(preds):
+            preds_by_image.setdefault(pred["image_id"], []).append(index)
+
+        rows: List[np.ndarray | None] = [None] * len(preds)
+        for image_id, pred_indices in preds_by_image.items():
+            gt_rows = gt_by_image.get(image_id, [])
+            if not gt_rows:
+                continue
+            pred_boxes = torch.as_tensor(
+                np.stack([preds[i]["xywhr"] for i in pred_indices]),
+                dtype=torch.float32,
+            )
+            gt_boxes = torch.as_tensor(np.stack(gt_rows), dtype=torch.float32)
+            iou = rotated_iou_matrix(pred_boxes, gt_boxes).numpy()
+            for local, index in enumerate(pred_indices):
+                rows[index] = iou[local]
+
+        cache[cls_id] = rows
+        return rows
+
     def _evaluate_class(self, cls_id: int, iou_threshold: float) -> tuple[float, float, float] | None:
         n_gt = self._num_gt_by_class.get(cls_id, 0)
         if n_gt == 0:
@@ -408,18 +446,16 @@ class OBBValidator(BaseValidator):
         tp = np.zeros(len(preds), dtype=np.float32)
         fp = np.zeros(len(preds), dtype=np.float32)
 
+        iou_rows = self._class_iou_rows(cls_id, preds)
+
         for pred_idx, pred in enumerate(preds):
             image_id = pred["image_id"]
-            gt_rows = self._gt_by_class.get(cls_id, {}).get(image_id, [])
-            if not gt_rows:
+            ious = iou_rows[pred_idx]
+            if ious is None or ious.size == 0:
                 fp[pred_idx] = 1.0
                 continue
 
-            ious = np.asarray(
-                [xywhr_iou(pred["xywhr"], gt) for gt in gt_rows],
-                dtype=np.float32,
-            )
-            best_idx = int(ious.argmax()) if ious.size else -1
+            best_idx = int(ious.argmax())
             if (
                 best_idx >= 0
                 and float(ious[best_idx]) >= iou_threshold

--- a/libreyolo/validation/obb_validator.py
+++ b/libreyolo/validation/obb_validator.py
@@ -185,6 +185,9 @@ class OBBValidator(BaseValidator):
         if dataset is None:
             img_files = [Path(p) for p in img_files]
             label_files = [Path(p) for p in (label_files or img2label_paths(img_files))]
+            # img_id == position in img_files (see val_collate_fn / dataset build),
+            # so this list resolves the per-image path for TTA validation.
+            self._val_img_files = img_files
             self.val_preproc = _OBBValPreprocessor(
                 self.model._get_val_preprocessor(img_size=actual_imgsz)
             )
@@ -381,6 +384,64 @@ class OBBValidator(BaseValidator):
                         "xywhr": np.asarray(row[:5], dtype=np.float32),
                     }
                 )
+
+    def _run_validation_augmented(self) -> None:
+        """Test-time augmentation validation for oriented boxes.
+
+        Runs the model's multi-scale + horizontal-flip TTA per image
+        (``_predict_augment`` -> rotated-NMS merge) and feeds the merged
+        oriented boxes through the same metric accumulation as the plain
+        path, so the only difference is inference.
+        """
+        import sys
+        import time
+
+        from tqdm import tqdm
+
+        img_files = getattr(self, "_val_img_files", None)
+        if not img_files:
+            raise RuntimeError(
+                "OBB TTA validation needs a YOLO-format image list; the COCO-JSON "
+                "path is not supported for augment=True."
+            )
+
+        self.model.model.eval()
+        conf_thres = self.config.conf_thres
+
+        pbar = tqdm(
+            self.dataloader,
+            desc="Validating (OBB TTA)",
+            total=len(self.dataloader),
+            disable=not self.config.verbose or not sys.stderr.isatty(),
+            file=sys.stderr,
+        )
+        total_start = time.time()
+
+        with torch.no_grad():
+            for batch in pbar:
+                _images, targets, img_info, img_ids = batch
+                detections = []
+                t0 = time.time()
+                for img_id in img_ids:
+                    idx = int(img_id.item()) if hasattr(img_id, "item") else int(img_id)
+                    result = self.model._predict_augment(
+                        str(img_files[idx]),
+                        conf=conf_thres,
+                        iou=self.config.iou_thres,
+                        imgsz=self._actual_imgsz,
+                        max_det=self.config.max_det,
+                    )
+                    if result.obb is not None and len(result.obb) > 0:
+                        obb = result.obb.data.to(self.device).float()
+                    else:
+                        obb = torch.zeros((0, 7), dtype=torch.float32, device=self.device)
+                    detections.append({"obb": obb})
+
+                self.speed["inference"] += time.time() - t0
+                self._update_metrics(detections, targets, img_info, img_ids)
+                self.seen += len(img_ids)
+
+        self.speed["total"] = time.time() - total_start
 
     @staticmethod
     def _average_precision(recall: np.ndarray, precision: np.ndarray) -> float:

--- a/libreyolo/validation/obb_validator.py
+++ b/libreyolo/validation/obb_validator.py
@@ -44,6 +44,11 @@ class _OBBValPreprocessor:
         self.base_preprocessor = base_preprocessor
 
     def __getattr__(self, name):
+        # During unpickling (e.g. Windows spawn DataLoader workers) pickle
+        # probes attributes before __dict__ is restored; delegating then would
+        # recurse through this method forever, so fail fast instead.
+        if name == "base_preprocessor":
+            raise AttributeError(name)
         return getattr(self.base_preprocessor, name)
 
     def __call__(self, img: np.ndarray, targets: np.ndarray, input_size: tuple):

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1182,7 +1182,8 @@
   "yolo9": {
     "class": "libreyolo.models.yolo9.model.LibreYOLO9",
     "tasks": [
-      "detect"
+      "detect",
+      "obb"
     ],
     "default_task": "detect",
     "sizes": {
@@ -1199,6 +1200,12 @@
     },
     "task_sizes": {
       "detect": {
+        "t": 640,
+        "s": 640,
+        "m": 640,
+        "c": 640
+      },
+      "obb": {
         "t": 640,
         "s": 640,
         "m": 640,
@@ -1229,6 +1236,12 @@
     },
     "task_sizes": {
       "detect": {
+        "t": 640,
+        "s": 640,
+        "m": 640,
+        "c": 640
+      },
+      "obb": {
         "t": 640,
         "s": 640,
         "m": 640,

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -632,3 +632,69 @@ def test_train_rfdetr_detect_checkpoint_switches_to_obb_architecture(
 
 
 
+
+
+def test_train_dry_run_reports_explicit_yolo9_obb_task():
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        [
+            "data=uav-obb.yaml",
+            "model=yolo9-t",
+            "task=obb",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_family"] == "yolo9"
+    assert data["resolved_config"]["task"] == "obb"
+
+
+@pytest.mark.parametrize(
+    "model_args",
+    [
+        ["model=yolo9-t", "task=obb"],
+        ["model=yolo9-t-obb"],
+    ],
+)
+def test_train_yolo9_obb_uses_task_architecture_without_loading_missing_obb_weights(
+    monkeypatch, tmp_path, model_args
+):
+    app = _make_app()
+    captured = {}
+
+    def fail_load(*_args, **_kwargs):
+        raise AssertionError("OBB training should instantiate the task architecture")
+
+    def fake_train(self, data, **kwargs):
+        captured["task"] = self.task
+        captured["size"] = self.size
+        captured["data"] = data
+        captured["kwargs"] = kwargs
+        return {"output_dir": str(tmp_path / "yolo9_obb_exp")}
+
+    monkeypatch.setattr("libreyolo.cli.commands.train.load_model_or_exit", fail_load)
+    monkeypatch.setattr("libreyolo.models.yolo9.model.LibreYOLO9.train", fake_train)
+
+    result = runner.invoke(
+        app,
+        [
+            "data=uav-obb.yaml",
+            *model_args,
+            "epochs=1",
+            "pretrained=false",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["task"] == "obb"
+    assert captured["size"] == "t"
+    assert captured["kwargs"]["pretrained"] is False
+    data = json.loads(result.stdout)
+    assert data["model_family"] == "yolo9"

--- a/tests/unit/test_augment_geometry.py
+++ b/tests/unit/test_augment_geometry.py
@@ -160,3 +160,91 @@ def test_obb_rot90_matches_bruteforce_corner_rotation(k):
     assert model_xywhr[0] == pytest.approx(brute_xywhr[0], abs=1e-3)
     assert model_xywhr[1] == pytest.approx(brute_xywhr[1], abs=1e-3)
     assert xywhr_iou(model_xywhr, brute_xywhr) > 0.999
+
+
+def test_apply_affine_to_obb_is_exact_for_similarity_transforms():
+    """A rectangle stays a rectangle under rotation + uniform scale +
+    translation, so the OBB affine must reproduce the result of warping the
+    real corners and refitting -- not merely approximate it."""
+    import cv2
+
+    from libreyolo.data.augment.geometry import apply_affine_to_obb
+
+    rng = np.random.default_rng(0)
+    worst = 0.0
+    for _ in range(100):
+        cx, cy = rng.uniform(100, 400, 2)
+        width, height = rng.uniform(40, 120), rng.uniform(10, 39)
+        angle = rng.uniform(-math.pi / 2, math.pi / 2)
+
+        matrix = cv2.getRotationMatrix2D(
+            (0.0, 0.0), float(rng.uniform(-180, 180)), float(rng.uniform(0.5, 1.5))
+        )
+        matrix[:, 2] += rng.uniform(-50, 50, 2)
+
+        target = np.array(
+            [[cx - width / 2, cy - height / 2, cx + width / 2, cy + height / 2, 0, angle]]
+        )
+        warped = apply_affine_to_obb(target, matrix)[0]
+        actual = xywhr_to_corners(
+            np.array(
+                [
+                    (warped[0] + warped[2]) / 2,
+                    (warped[1] + warped[3]) / 2,
+                    warped[2] - warped[0],
+                    warped[3] - warped[1],
+                    warped[5],
+                ],
+                dtype=np.float32,
+            )
+        )
+
+        corners = xywhr_to_corners(
+            np.array([cx, cy, width, height, angle], dtype=np.float32)
+        )
+        expected = xywhr_to_corners(
+            corners_to_xywhr(
+                (corners @ matrix[:, :2].T + matrix[:, 2]).astype(np.float32)
+            )
+        )
+        worst = max(
+            worst, float(np.abs(np.sort(actual, axis=0) - np.sort(expected, axis=0)).max())
+        )
+
+    assert worst < 1e-2
+
+
+def test_apply_affine_to_obb_identity_is_a_no_op():
+    from libreyolo.data.augment.geometry import apply_affine_to_obb
+
+    identity = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    target = np.array([[160.0, 140.0, 240.0, 160.0, 0.0, 0.7]])
+
+    np.testing.assert_allclose(apply_affine_to_obb(target, identity), target, atol=1e-6)
+
+
+def test_random_affine_obb_suppresses_shear_and_updates_angle():
+    """Shear would turn the rectangle into a parallelogram, so the OBB path
+    must disable it; a rotation must reach the angle column."""
+    from libreyolo.data.augment.geometry import random_affine
+
+    image = np.zeros((256, 256, 3), dtype=np.uint8)
+    target = np.array([[100.0, 120.0, 180.0, 140.0, 0.0, 0.0]])
+
+    random.seed(0)
+    _, plain = random_affine(
+        image, target.copy(), target_size=(256, 256), degrees=0.0,
+        translate=0.0, scales=0.0, shear=45.0, perspective=0.0, obb=True,
+    )
+    # Shear suppressed and no rotation drawn: geometry is untouched.
+    np.testing.assert_allclose(plain, target, atol=1e-6)
+
+    random.seed(1)
+    _, rotated = random_affine(
+        image, target.copy(), target_size=(256, 256), degrees=30.0,
+        translate=0.0, scales=0.0, shear=0.0, perspective=0.0, obb=True,
+    )
+    assert abs(float(rotated[0, 5])) > 1e-3  # the angle column moved
+    # Side lengths are intrinsic: a rotation cannot change them.
+    assert float(rotated[0, 2] - rotated[0, 0]) == pytest.approx(80.0, abs=1e-3)
+    assert float(rotated[0, 3] - rotated[0, 1]) == pytest.approx(20.0, abs=1e-3)

--- a/tests/unit/test_merge_tta.py
+++ b/tests/unit/test_merge_tta.py
@@ -21,11 +21,21 @@ def _model():
     return SimpleNamespace(names={0: "a", 1: "b"})
 
 
-def test_obb_rejects_tta_before_axis_aligned_merge():
-    model = SimpleNamespace(task="obb")
+def test_obb_tta_merge_is_rotation_nms_not_axis_aligned():
+    """OBB TTA is supported and routes to the rotated-NMS merge, never the
+    axis-aligned ``_merge_tta`` used by detection."""
+    from libreyolo.models.yolo9.model import LibreYOLO9
 
-    with pytest.raises(ValueError, match="oriented boxes"):
-        BaseModel._predict_augment(model, image=None)
+    model = LibreYOLO9(None, size="t", task="obb", nb_classes=3, device="cpu")
+    # A single 1.0x, unflipped view with one box: it must survive as-is,
+    # proving the merge runs and preserves oriented geometry.
+    box = [30.0, 40.0, 20.0, 10.0, 0.3, 0.9, 1.0]
+    aug_dets = [({"obb": [box], "num_detections": 1}, (100.0, 100.0), False, 1.0)]
+    merged = model._merge_tta_obb(
+        aug_dets, iou_thres=0.5, image_path=None, original_size=(100, 100), max_det=50
+    )
+    assert merged.obb is not None and len(merged.obb) == 1
+    assert abs(float(merged.obb.data[0][4]) - 0.3) < 1e-6  # angle preserved
 
 
 def test_pose_rejects_tta_before_keypoint_merge():

--- a/tests/unit/test_obb_labels.py
+++ b/tests/unit/test_obb_labels.py
@@ -120,3 +120,90 @@ def test_xywhr_iou_is_pi_periodic():
 def test_parse_yolo_obb_label_line_rejects_invalid_rows(line, message):
     with pytest.raises(ValueError, match=message):
         parse_yolo_obb_label_line(line, num_classes=2)
+
+
+def test_rotated_iou_matrix_matches_opencv_reference():
+    """The vectorized IoU must stay exact: it replaces the OpenCV path in
+    rotated NMS and OBB validation, so any drift silently moves mAP."""
+    import torch
+
+    from libreyolo.utils.box_ops import rotated_iou_matrix
+
+    rng = np.random.default_rng(0)
+
+    def sample(n):
+        boxes = np.empty((n, 5), dtype=np.float32)
+        boxes[:, 0:2] = rng.uniform(0, 200, (n, 2))
+        boxes[:, 2:4] = rng.uniform(10, 70, (n, 2))
+        boxes[:, 4] = rng.uniform(-math.pi / 2, math.pi / 2, n)
+        return boxes
+
+    a, b = sample(40), sample(30)
+    actual = rotated_iou_matrix(torch.from_numpy(a), torch.from_numpy(b)).numpy()
+    expected = np.array(
+        [[xywhr_iou(box_a, box_b) for box_b in b] for box_a in a], dtype=np.float32
+    )
+
+    assert (expected > 1e-6).any()  # the sample must actually contain overlaps
+    np.testing.assert_allclose(actual, expected, atol=1e-4)
+
+
+def test_rotated_iou_matrix_edge_cases():
+    import torch
+
+    from libreyolo.utils.box_ops import rotated_iou_matrix
+
+    box = torch.tensor([[50.0, 50.0, 40.0, 20.0, 0.3]])
+    assert float(rotated_iou_matrix(box, box)) == pytest.approx(1.0, abs=1e-5)
+
+    half_turn = box + torch.tensor([[0.0, 0.0, 0.0, 0.0, math.pi]])
+    assert float(rotated_iou_matrix(box, half_turn)) == pytest.approx(1.0, abs=1e-5)
+
+    far_away = torch.tensor([[900.0, 900.0, 40.0, 20.0, 0.3]])
+    assert float(rotated_iou_matrix(box, far_away)) == pytest.approx(0.0, abs=1e-6)
+
+    empty = torch.zeros((0, 5))
+    assert rotated_iou_matrix(empty, box).shape == (0, 1)
+    assert rotated_iou_matrix(box, empty).shape == (1, 0)
+
+
+def test_rotated_nms_is_greedy_and_class_aware():
+    """Greedy semantics: the highest-scoring box suppresses same-class
+    overlaps and never suppresses a different class."""
+    import torch
+
+    from libreyolo.postprocess.yolo9 import _rotated_nms_keep_indices
+
+    boxes = torch.tensor(
+        [
+            [50.0, 50.0, 40.0, 20.0, 0.0],  # best of its class
+            [51.0, 50.0, 40.0, 20.0, 0.0],  # near-duplicate, same class -> dropped
+            [50.0, 50.0, 40.0, 20.0, 0.0],  # same box, different class -> kept
+            [200.0, 200.0, 40.0, 20.0, 0.0],  # far away -> kept
+        ]
+    )
+    scores = torch.tensor([0.9, 0.8, 0.7, 0.6])
+    classes = torch.tensor([0, 0, 1, 0])
+
+    keep = _rotated_nms_keep_indices(boxes, scores, classes, 0.45, 300)
+
+    assert keep.tolist() == [0, 2, 3]
+
+
+def test_rotated_nms_respects_max_det():
+    import torch
+
+    from libreyolo.postprocess.yolo9 import _rotated_nms_keep_indices
+
+    boxes = torch.stack(
+        [
+            torch.tensor([100.0 * i, 100.0 * i, 20.0, 10.0, 0.0])
+            for i in range(1, 8)
+        ]
+    )
+    scores = torch.linspace(0.9, 0.3, 7)
+    classes = torch.zeros(7, dtype=torch.long)
+
+    keep = _rotated_nms_keep_indices(boxes, scores, classes, 0.45, max_det=3)
+
+    assert keep.tolist() == [0, 1, 2]

--- a/tests/unit/test_obb_validation.py
+++ b/tests/unit/test_obb_validation.py
@@ -139,9 +139,22 @@ def test_obb_validator_metrics_are_perfect_for_exact_prediction():
     assert metrics["metrics/mAP50-95"] == pytest.approx(1.0)
 
 
-def test_obb_validation_rejects_augmented_validation_before_base_tta():
-    with pytest.raises(ValueError, match="oriented boxes"):
-        BaseModel.val(_DummyOBBModel(), data="unused.yaml", imgsz=64, augment=True)
+def test_obb_predict_augment_merges_flipped_views():
+    """OBB TTA is supported: flipped-view boxes must un-transform back onto
+    the plain-view boxes (mirror center x, negate angle) so the rotated-NMS
+    merge combines them rather than duplicating them."""
+    import numpy as np
+
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", task="obb", nb_classes=3, device="cpu")
+    model.model.eval()
+
+    # A deterministic image so plain and flipped views see the same content.
+    rng = np.random.default_rng(0)
+    img = (rng.random((256, 256, 3)) * 255).astype("uint8")
+    result = model._predict_augment(img, conf=0.001, iou=0.5, imgsz=256, max_det=100)
+    assert result.obb is not None  # returns an OBB container, does not raise
 
 
 def test_pose_validation_rejects_augmented_validation_before_base_tta():

--- a/tests/unit/test_yolo9_obb.py
+++ b/tests/unit/test_yolo9_obb.py
@@ -392,3 +392,34 @@ def test_merge_tta_obb_rescales_scaled_views():
     row = merged.obb.data[0]
     assert float(row[0]) == pytest.approx(40.0, abs=0.5)   # 50 / 1.25
     assert float(row[2]) == pytest.approx(20.0, abs=0.5)   # 25 / 1.25
+
+
+def test_predict_augment_uses_effective_imgsz_not_model_default():
+    """Regression: TTA postprocess must un-scale against the imgsz the views
+    were preprocessed at, not the model's default input size. When they
+    differ (OBB val at 1024 vs a 640 default) the boxes must still land in
+    the original frame, not be shrunk by default/effective."""
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", task="obb", nb_classes=3, device="cpu")
+    model.model.eval()
+    default = model._get_input_size()
+
+    rng = np.random.default_rng(0)
+    # An imgsz deliberately different from the model default.
+    imgsz = default * 2
+    img = (rng.random((imgsz, imgsz, 3)) * 255).astype("uint8")
+
+    plain = model(img, conf=0.01, imgsz=imgsz, save=False)
+    plain = plain[0] if isinstance(plain, list) else plain
+    tta = model._predict_augment(img, conf=0.01, iou=0.5, imgsz=imgsz, max_det=300)
+
+    # Both should decode into the same imgsz-sized frame; a wrong input_size
+    # in TTA would scale every box by default/imgsz and misplace them.
+    if plain.obb is not None and len(plain.obb) and tta.obb is not None and len(tta.obb):
+        plain_c = plain.obb.xywhr[:, :2].cpu().numpy()
+        tta_c = tta.obb.xywhr[:, :2].cpu().numpy()
+        dist = np.min(
+            np.linalg.norm(plain_c[:, None] - tta_c[None, :], axis=2), axis=1
+        )
+        assert float(np.median(dist)) < imgsz * 0.05

--- a/tests/unit/test_yolo9_obb.py
+++ b/tests/unit/test_yolo9_obb.py
@@ -345,3 +345,50 @@ def test_obb_val_preprocessor_survives_pickle_roundtrip():
     img = np.zeros((32, 32, 3), dtype=np.uint8)
     targets = np.zeros((1, 6), dtype=np.float32)
     assert restored(img, targets, (32, 32)) is not None
+
+
+def test_merge_tta_obb_unflips_and_dedups():
+    """The OBB TTA merge must map a flipped view's boxes back onto the plain
+    view (mirror center x, negate angle) so rotated NMS de-duplicates them
+    into one box rather than keeping both."""
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", task="obb", nb_classes=3, device="cpu")
+
+    view_w = 100.0
+    # cx, cy, w, h, angle, score, cls
+    plain_box = [30.0, 40.0, 20.0, 10.0, 0.3, 0.9, 1.0]
+    # Same object seen in the horizontally-flipped view: x mirrored, angle negated.
+    flipped_box = [view_w - 30.0, 40.0, 20.0, 10.0, -0.3, 0.85, 1.0]
+
+    aug_dets = [
+        ({"obb": [plain_box], "num_detections": 1}, (view_w, 100.0), False, 1.0),
+        ({"obb": [flipped_box], "num_detections": 1}, (view_w, 100.0), True, 1.0),
+    ]
+    merged = model._merge_tta_obb(
+        aug_dets, iou_thres=0.5, image_path=None,
+        original_size=(int(view_w), 100), max_det=100,
+    )
+    # The two views describe the same box -> exactly one survives NMS,
+    # sitting at the plain-view location.
+    assert len(merged.obb) == 1
+    row = merged.obb.data[0]
+    assert float(row[0]) == pytest.approx(30.0, abs=1.0)   # center x, not mirrored
+    assert abs(float(row[4]) - 0.3) < 1e-3                  # angle, not negated
+    assert int(row[6]) == 1
+
+
+def test_merge_tta_obb_rescales_scaled_views():
+    """A view rendered at scale s must have its boxes divided by s."""
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", task="obb", nb_classes=3, device="cpu")
+    # One 1.25x view only; box coords should come back divided by 1.25.
+    scaled = [50.0, 60.0, 25.0, 10.0, 0.2, 0.9, 2.0]
+    aug_dets = [({"obb": [scaled], "num_detections": 1}, (125.0, 125.0), False, 1.25)]
+    merged = model._merge_tta_obb(
+        aug_dets, 0.5, None, original_size=(100, 100), max_det=100
+    )
+    row = merged.obb.data[0]
+    assert float(row[0]) == pytest.approx(40.0, abs=0.5)   # 50 / 1.25
+    assert float(row[2]) == pytest.approx(20.0, abs=0.5)   # 25 / 1.25

--- a/tests/unit/test_yolo9_obb.py
+++ b/tests/unit/test_yolo9_obb.py
@@ -1,0 +1,347 @@
+"""Unit tests for the YOLO9 oriented-bounding-box (OBB) task.
+
+Covers the design contracts of PLAN_obb_yolo9.md: head shapes and decode
+bounds, the double-angle encode/decode roundtrip, the Gaussian geometry
+helpers, the rotated matcher, loss composition and gradients, and the
+factory/transfer rules.
+"""
+
+import math
+import pickle
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo import LibreYOLO
+from libreyolo.models.yolo9.loss import (
+    RotatedBoxMatcher,
+    YOLO9OrientedLoss,
+    _bhattacharyya_score,
+    _gaussian_kld,
+    _rbox_covariance,
+)
+from libreyolo.models.yolo9.model import LibreYOLO9
+from libreyolo.models.yolo9.nn import LibreYOLO9Model, OrientedDDetect
+from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+from libreyolo.validation.preprocessors import YOLO9ValPreprocessor
+
+pytestmark = pytest.mark.unit
+
+
+class TestOrientedHead:
+    def _head(self, nc=2):
+        return OrientedDDetect(
+            nc=nc, ch=(64, 128, 256), reg_max=16, stride=(8, 16, 32)
+        )
+
+    def _feats(self, hw=8):
+        return [
+            torch.randn(1, 64, hw, hw),
+            torch.randn(1, 128, hw // 2, hw // 2),
+            torch.randn(1, 256, hw // 4, hw // 4),
+        ]
+
+    def test_eval_forward_shapes(self):
+        head = self._head()
+        head.eval()
+        y, preds = head(self._feats())
+        assert y.shape == (1, 4 + 1 + 2, 84)
+        assert len(preds) == 3
+
+    def test_theta_row_is_bounded(self):
+        head = self._head()
+        head.eval()
+        feats = [f * 100 for f in self._feats()]
+        y, _ = head(feats)
+        theta = y[:, 4]
+        assert torch.all(theta >= -math.pi / 2 - 1e-6)
+        assert torch.all(theta <= math.pi / 2 + 1e-6)
+
+    def test_export_mode_returns_single_tensor(self):
+        model = LibreYOLO9Model(config="t", nb_classes=2, obb=True)
+        model.eval()
+        model.head.export = True
+        y = model(torch.randn(1, 3, 64, 64))
+        assert isinstance(y, torch.Tensor)
+        assert y.shape == (1, 7, 84)
+
+    def test_detect_towers_are_reused_unchanged(self):
+        """The oriented head must produce the same box/class maps as the
+        detect head with identical tower weights (the hidden-feature tap
+        cannot change the values)."""
+        torch.manual_seed(3)
+        from libreyolo.models.yolo9.nn import DDetect
+
+        det = DDetect(nc=2, ch=(64, 128, 256), reg_max=16, stride=(8, 16, 32))
+        obb = self._head()
+        obb.load_state_dict(det.state_dict(), strict=False)
+        det.train()
+        obb.train()
+        feats = self._feats()
+        det_preds = det(feats)
+        obb_preds, _angles = obb(feats)
+        for a, b in zip(det_preds, obb_preds):
+            torch.testing.assert_close(a, b)
+
+    def test_orientation_bias_starts_at_zero(self):
+        head = self._head()
+        for conv in head.ang:
+            assert torch.all(conv.bias == 0)
+
+
+def test_double_angle_roundtrip():
+    for theta in np.linspace(-math.pi / 2, math.pi / 2, 37):
+        vec = (math.cos(2 * theta), math.sin(2 * theta))
+        recovered = 0.5 * math.atan2(vec[1], vec[0])
+        canon = (theta + math.pi / 2) % math.pi - math.pi / 2
+        recovered = (recovered + math.pi / 2) % math.pi - math.pi / 2
+        assert abs(recovered - canon) < 1e-9
+
+
+class TestGaussianHelpers:
+    def _cov(self, w, h, theta):
+        wh = torch.tensor([[float(w), float(h)]])
+        tt = torch.tensor([2.0 * theta])
+        return _rbox_covariance(wh, tt.cos(), tt.sin())
+
+    def test_kld_zero_at_identity(self):
+        mu = torch.tensor([[10.0, 20.0]])
+        cov = self._cov(60, 20, 0.5)
+        assert float(_gaussian_kld(mu, cov, mu, cov)) == pytest.approx(0.0, abs=1e-5)
+
+    def test_bhattacharyya_one_at_identity_and_monotone(self):
+        mu = torch.tensor([[10.0, 20.0]])
+        cov = self._cov(60, 20, 0.5)
+        assert float(_bhattacharyya_score(mu, cov, mu, cov)) == pytest.approx(
+            1.0, abs=1e-5
+        )
+        previous = 1.0
+        for offset in (5.0, 15.0, 40.0):
+            score = float(
+                _bhattacharyya_score(mu + torch.tensor([[offset, 0.0]]), cov, mu, cov)
+            )
+            assert score < previous
+            previous = score
+
+    def test_square_targets_are_rotation_invariant(self):
+        """A square's Gaussian is isotropic: rotating the target must not
+        change the loss against any fixed prediction."""
+        mu = torch.tensor([[0.0, 0.0]])
+        pred_cov = self._cov(40, 25, 0.3)
+        base = float(_gaussian_kld(mu, pred_cov, mu, self._cov(30, 30, 0.0)))
+        for theta in (0.3, -0.9, 1.2):
+            rotated = float(
+                _gaussian_kld(mu, pred_cov, mu, self._cov(30, 30, theta))
+            )
+            assert rotated == pytest.approx(base, abs=1e-5)
+
+    def test_kld_sees_orientation_of_elongated_boxes(self):
+        mu = torch.tensor([[0.0, 0.0]])
+        target = self._cov(80, 20, 0.0)
+        aligned = float(_gaussian_kld(mu, self._cov(80, 20, 0.0), mu, target))
+        crossed = float(_gaussian_kld(mu, self._cov(80, 20, math.pi / 2 - 0.01), mu, target))
+        assert crossed > aligned + 1.0
+
+
+class TestRotatedMatcher:
+    def _matcher(self, nc=2):
+        from libreyolo.models.yolo9.loss import generate_anchors
+
+        anchor_grid, scaler = generate_anchors([64, 64], [8, 16, 32])
+        return RotatedBoxMatcher(
+            num_classes=nc,
+            anchor_grid=anchor_grid,
+            scaler=scaler,
+            reg_max=16,
+        )
+
+    def test_matched_targets_carry_theta(self):
+        matcher = self._matcher()
+        n_anchors = matcher.anchor_grid.shape[0]
+        target = torch.tensor([[[0.0, 8.0, 8.0, 46.0, 26.0, 0.7]]])
+        pred_cls = torch.zeros(1, n_anchors, 2)
+        pred_rbox = torch.zeros(1, n_anchors, 6)
+        pred_rbox[..., :2] = matcher.anchor_grid[None]
+        pred_rbox[..., 2:4] = 20.0
+        pred_rbox[..., 4] = 1.0
+        matched, valid = matcher(target, (pred_cls, pred_rbox))
+        assert matched.shape == (1, n_anchors, 2 + 4 + 1)
+        assert valid.any()
+        matched_theta = matched[0, valid[0], -1]
+        torch.testing.assert_close(
+            matched_theta, torch.full_like(matched_theta, 0.7)
+        )
+
+    def test_empty_targets(self):
+        matcher = self._matcher()
+        n_anchors = matcher.anchor_grid.shape[0]
+        target = torch.zeros(1, 0, 6)
+        matched, valid = matcher(
+            (target), (torch.zeros(1, n_anchors, 2), torch.zeros(1, n_anchors, 6))
+        )
+        assert matched.shape == (1, n_anchors, 7)
+        assert not valid.any()
+
+
+class TestOrientedLoss:
+    def _loss(self, nc=2):
+        return YOLO9OrientedLoss(
+            num_classes=nc,
+            reg_max=16,
+            strides=[8, 16, 32],
+            image_size=[64, 64],
+            device=torch.device("cpu"),
+        )
+
+    def test_rejects_five_column_targets(self):
+        model = LibreYOLO9Model(config="t", nb_classes=2, obb=True)
+        model.train()
+        targets = torch.zeros(1, 10, 5)
+        targets[:, :, 0] = -1
+        with pytest.raises(ValueError, match="6"):
+            model(torch.randn(1, 3, 64, 64), targets=targets)
+
+    def test_components_and_gradients(self):
+        model = LibreYOLO9Model(config="t", nb_classes=2, obb=True)
+        model.train()
+        targets = torch.zeros(2, 100, 6)
+        targets[:, :, 0] = -1
+        targets[0, 0] = torch.tensor([0, 0.20, 0.30, 0.70, 0.48, 0.9])
+        targets[1, 0] = torch.tensor([1, 0.10, 0.10, 0.60, 0.28, -0.6])
+
+        out = model(torch.randn(2, 3, 64, 64), targets=targets)
+
+        assert out["total_loss"].requires_grad
+        assert out["angle_loss"].requires_grad
+        assert out["box"] >= 0 and out["angle"] >= 0
+        out["total_loss"].backward()
+        assert model.head.ang[0].weight.grad is not None
+        assert model.head.ang[0].weight.grad.abs().sum() > 0
+        assert model.head.cv2[0][0].conv.weight.grad is not None
+
+    def test_square_targets_get_no_directional_supervision(self):
+        """Aspect weighting: a square target's vector target is zero, so the
+        angle loss must be invariant to the direction of the predicted
+        vector (it only pulls its norm down). Elongated targets must prefer
+        the correct direction."""
+        loss_fn = self._loss(nc=1)
+
+        def angle_loss(box_row, direction):
+            torch.manual_seed(0)
+            preds = [
+                torch.randn(1, 1 + 64, 64 // s, 64 // s) for s in (8, 16, 32)
+            ]
+            angles = [
+                torch.full((1, 2, 64 // s, 64 // s), 0.0) for s in (8, 16, 32)
+            ]
+            for level in angles:
+                level[0, 0] = direction[0]
+                level[0, 1] = direction[1]
+            targets = torch.zeros(1, 1, 6)
+            targets[0, 0] = box_row
+            return float(loss_fn(preds, targets, angles)["angle_loss"])
+
+        square = torch.tensor([0, 0.25, 0.25, 0.75, 0.75, 0.8])
+        elongated = torch.tensor([0, 0.10, 0.35, 0.90, 0.55, 0.0])
+
+        sq_a = angle_loss(square, (1.0, 0.0))
+        sq_b = angle_loss(square, (0.0, 1.0))
+        assert sq_a == pytest.approx(sq_b, rel=1e-5)
+
+        el_right = angle_loss(elongated, (1.0, 0.0))
+        el_wrong = angle_loss(elongated, (-1.0, 0.0))
+        assert el_right < el_wrong
+
+
+class TestOBBFactoryAndTransfer:
+    def test_scratch_checkpoint_roundtrip(self, tmp_path):
+        model = LibreYOLO9Model(config="t", nb_classes=1, obb=True)
+        ckpt = tmp_path / "LibreYOLO9t-obb.pt"
+        torch.save(
+            wrap_libreyolo_checkpoint(
+                model.state_dict(),
+                model_family="yolo9",
+                size="t",
+                task="obb",
+                nc=1,
+                names={0: "ship"},
+                imgsz=64,
+            ),
+            ckpt,
+        )
+        loaded = LibreYOLO(str(ckpt), device="cpu")
+        assert loaded.FAMILY == "yolo9"
+        assert loaded.task == "obb"
+        assert loaded.names == {0: "ship"}
+        assert isinstance(loaded.model.head, OrientedDDetect)
+
+    def test_metadata_less_task_inference_from_ang_keys(self, tmp_path):
+        model = LibreYOLO9Model(config="t", nb_classes=1, obb=True)
+        ckpt = tmp_path / "best.pt"
+        torch.save(model.state_dict(), ckpt)
+        loaded = LibreYOLO(str(ckpt), size="t", device="cpu")
+        assert loaded.task == "obb"
+
+    def test_transfer_accepts_detect_checkpoint(self, tmp_path):
+        detect = LibreYOLO9Model(config="t", nb_classes=80)
+        ckpt = tmp_path / "LibreYOLO9t.pt"
+        torch.save(
+            wrap_libreyolo_checkpoint(
+                detect.state_dict(),
+                model_family="yolo9",
+                size="t",
+                task="detect",
+                nc=80,
+                imgsz=640,
+            ),
+            ckpt,
+        )
+        target = LibreYOLO9(None, size="t", task="obb", nb_classes=6, device="cpu")
+        stats = target._load_transfer_weights(ckpt)
+        assert stats["loaded"] > 0
+        # Only the fresh orientation convs are skipped (weight+bias per scale).
+        assert stats["skipped"] == 6
+        torch.testing.assert_close(
+            target.model.state_dict()["backbone.conv0.conv.weight"],
+            detect.state_dict()["backbone.conv0.conv.weight"],
+        )
+
+    def test_direct_load_rejects_detect_checkpoint(self, tmp_path):
+        detect = LibreYOLO9Model(config="t", nb_classes=80)
+        ckpt = tmp_path / "LibreYOLO9t.pt"
+        torch.save(
+            wrap_libreyolo_checkpoint(
+                detect.state_dict(),
+                model_family="yolo9",
+                size="t",
+                task="detect",
+                nc=80,
+                imgsz=640,
+            ),
+            ckpt,
+        )
+        with pytest.raises(RuntimeError, match="task='detect'"):
+            LibreYOLO9(str(ckpt), size="t", task="obb", device="cpu")
+
+    def test_predict_returns_obb_container(self):
+        model = LibreYOLO9(None, size="t", task="obb", nb_classes=2, device="cpu")
+        model.model.eval()
+        img = (np.random.rand(96, 128, 3) * 255).astype("uint8")
+        result = model(img, conf=0.0001, save=False)
+        result = result[0] if isinstance(result, list) else result
+        assert result.obb is not None or result.boxes is not None
+
+
+def test_obb_val_preprocessor_survives_pickle_roundtrip():
+    """Windows spawn DataLoader workers pickle the preprocessor; __getattr__
+    must not recurse while __dict__ is still empty during unpickling."""
+    from libreyolo.validation.obb_validator import _OBBValPreprocessor
+
+    preproc = _OBBValPreprocessor(YOLO9ValPreprocessor((32, 32)))
+    restored = pickle.loads(pickle.dumps(preproc))
+
+    assert isinstance(restored.base_preprocessor, YOLO9ValPreprocessor)
+    img = np.zeros((32, 32, 3), dtype=np.uint8)
+    targets = np.zeros((1, 6), dtype=np.float32)
+    assert restored(img, targets, (32, 32)) is not None

--- a/tests/unit/test_yolo9_obb_export.py
+++ b/tests/unit/test_yolo9_obb_export.py
@@ -1,0 +1,63 @@
+"""Deterministic raw-output parity for YOLO9 OBB exports."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("format", ("onnx", "torchscript"))
+def test_yolo9_obb_raw_parity(tmp_path, format):
+    if format == "onnx":
+        pytest.importorskip("onnx")
+        pytest.importorskip("onnxruntime")
+
+    import libreyolo
+    from libreyolo.export.exporter import OnnxExporter
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    torch.manual_seed(0)
+    imgsz = 320
+    model = LibreYOLO9(None, size="t", nb_classes=3, device="cpu", task="obb")
+    model.model.eval()
+    tensor = torch.rand(1, 3, imgsz, imgsz)
+
+    exporter = OnnxExporter(model)
+    with exporter._model_context("cpu", False, False, 1, (imgsz, imgsz)) as (
+        wrapped,
+        _,
+    ):
+        with torch.no_grad():
+            native = wrapped(tensor)
+    if isinstance(native, torch.Tensor):
+        native = (native,)
+
+    # The OBB prediction tensor carries boxes, one angle row, and class scores.
+    assert native[0].shape == (1, 4 + 1 + 3, native[0].shape[-1])
+
+    artifact = model.export(
+        format=format,
+        imgsz=imgsz,
+        dynamic=False,
+        simplify=False,
+        output_path=str(tmp_path / f"LibreYOLO9t-obb.{format}"),
+    )
+    actual = libreyolo.LibreYOLO(artifact, device="cpu")._run_inference(tensor.numpy())
+
+    assert len(actual) == len(native)
+    rtol, atol = (2e-3, 2e-2) if format == "onnx" else (1e-3, 1e-3)
+    for actual_output, native_output in zip(actual, native):
+        expected = native_output.detach().cpu().numpy()
+        if format == "onnx":
+            element_match = np.isclose(actual_output, expected, rtol=rtol, atol=atol)
+            assert float(element_match.mean()) > 0.95
+            continue
+        np.testing.assert_allclose(
+            actual_output,
+            expected,
+            rtol=rtol,
+            atol=atol,
+        )


### PR DESCRIPTION
# What does this PR do?

Adds the `obb` task to YOLO9 (the YOLO9 half of #320) with an original design built on the current in-tree machinery. The full design document with the per-component source ledger is committed as `docs/provenance/yolo9_obb.md`.

- `OrientedDDetect`: orientation as a two-channel double-angle vector `(cos 2t, sin 2t)` read from the box tower's hidden features through a single 1x1 conv per scale (`head.ang.*`), decoded with `0.5 * atan2`. No separate angle tower; the pi-periodicity of rectangles is handled by the encoding itself.
- `YOLO9OrientedLoss`: keeps the in-tree DFL and BCE terms on the proxy rectangle and replaces CIoU with a Gaussian Kullback-Leibler term that couples center, sides, and orientation (covariance built linearly from the double-angle vector via half-angle identities, so there is no angle-wrapping code anywhere), plus an aspect-weighted auxiliary vector loss that gives near-square boxes no directional supervision.
- `RotatedBoxMatcher`: the in-tree task-aligned matcher with the CIoU metric swapped for the Bhattacharyya similarity between box Gaussians, so assignment sees orientation.
- Task wiring: `SUPPORTED_TASKS`, checkpoint task inference from `head.ang.*`, detect-to-OBB training transfer (only the 6 orientation tensors start fresh), 6-column labels, angle loss logging.
- Bugfix: OBB validation preprocessor recursed infinitely when pickled into Windows spawn DataLoader workers (pre-existing; killed in-training OBB validation on Windows).
- Export: ONNX and TorchScript declared validated with a raw-parity test; generated tables refreshed.

All shared OBB infrastructure (dataset parsing, augmentations, rotated NMS, validator, results container, CLI/backends) is the live in-tree code and is unchanged.

# Provenance declaration (required)

- [x] All code in this PR was written by the author(s), OR every ported or
      adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial,
      proprietary, or unknown-license code, including rewrites, paraphrases,
      or renamed adaptations of such code.
- [x] Notice files are updated if this PR ports third-party code
      (`THIRD_PARTY_NOTICES.txt`, per-family `NOTICE`).

## Code provenance

No third-party code is ported. Every component has an explicit source recorded in `docs/provenance/yolo9_obb.md`: in-tree code on current dev (the MIT-derived matcher/DFL/BCE machinery and the live OBB groundwork), classical mathematics transcribed as formulas in the design document (multivariate normal KL divergence, Bhattacharyya distance, half-angle identities), published papers for the applications of that math (GWD/KLD/ProbIoU/CSL/PSC papers, cited by name in the document), and explicitly marked original design decisions. The design document also contains a divergence checklist against the AGPL implementation's known design, and the implementation was checked against it.

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

# How was this tested?

- 21 new unit tests: head shapes and theta bounds, export single-tensor mode, tower-reuse equivalence against the detect head, double-angle encode/decode roundtrip, Gaussian identities (KL zero at identity, Bhattacharyya 1 at identity and monotone under offset, exact square-rotation invariance, orientation sensitivity for elongated boxes), rotated matcher theta gathering, loss composition/gradients, square-vs-elongated directional supervision, factory/transfer/task-inference rules, CLI dry-run and task-architecture selection, validator pickle-roundtrip regression.
- ONNX + TorchScript raw parity: 2 passed.
- Affected suites (yolo9 layers/e2e, factory, obb validation/labels, rfdetr obb, export, CLI train, batch predict): 250+ passed.
- Full unit tier and a synthetic-bars overfit training run (quality bar: rotated-IoU mAP50 >= 0.87 measured for the previous design) are running; results will be posted on this PR.
