### PR TITLE
Fix LibreEC ONNX parity matching

### DIFF
--- a/tests/unit/test_detr_cpu_export_matrix.py
+++ b/tests/unit/test_detr_cpu_export_matrix.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import sys
-
 import numpy as np
 import pytest
 import torch
+from scipy.optimize import linear_sum_assignment
 
 pytestmark = pytest.mark.unit
 
@@ -26,15 +25,6 @@ _ONNX_PARITY_GAPS = {
     "LibreRTDETRv4": "7.3% of selected boxes exceed the ONNX tolerance",
 }
 
-# LibreEC ONNX runs deterministically drift past the 0.95 match bar on macOS
-# runners (detect row_match 0.777, segment element_match 0.898) while ubuntu
-# and windows stay above it. Environment-dependent, so not strict.
-_MACOS_LIBREEC_ONNX_DRIFT = pytest.mark.xfail(
-    sys.platform == "darwin",
-    strict=False,
-    reason="macOS onnxruntime drift exceeds the 0.95 match bar for LibreEC",
-)
-
 
 def _export_cases():
     for format in ("onnx", "torchscript"):
@@ -44,8 +34,6 @@ def _export_cases():
                 marks = pytest.mark.xfail(
                     strict=True, reason=_ONNX_PARITY_GAPS[class_name]
                 )
-            elif format == "onnx" and class_name == "LibreEC":
-                marks = _MACOS_LIBREEC_ONNX_DRIFT
             yield pytest.param(
                 class_name,
                 size,
@@ -54,6 +42,29 @@ def _export_cases():
                 marks=marks,
                 id=f"{format}-{class_name}",
             )
+
+
+def _align_query_outputs(actual, expected):
+    """Align unordered DETR queries using their predicted boxes."""
+    box_index = next(
+        (
+            i
+            for i, output in enumerate(expected)
+            if output.ndim == 3 and output.shape[-1] == 4
+        ),
+        None,
+    )
+    assert box_index is not None, "query alignment requires a box output"
+    aligned = [np.empty_like(output) for output in actual]
+    for batch_index, (actual_boxes, expected_boxes) in enumerate(
+        zip(actual[box_index], expected[box_index])
+    ):
+        cost = np.square(actual_boxes[:, None] - expected_boxes[None, :]).sum(axis=-1)
+        actual_indices, expected_indices = linear_sum_assignment(cost)
+        actual_order = actual_indices[np.argsort(expected_indices)]
+        for aligned_output, actual_output in zip(aligned, actual):
+            aligned_output[batch_index] = actual_output[batch_index, actual_order]
+    return tuple(aligned)
 
 
 @pytest.mark.parametrize(
@@ -92,9 +103,11 @@ def test_detr_detect_raw_parity(tmp_path, class_name, size, imgsz, format):
     actual = libreyolo.LibreYOLO(artifact, device="cpu")._run_inference(tensor.numpy())
 
     assert len(actual) == len(native)
+    expected_outputs = tuple(output.detach().cpu().numpy() for output in native)
+    if format == "onnx" and class_name == "LibreEC":
+        actual = _align_query_outputs(actual, expected_outputs)
     rtol, atol = (2e-3, 2e-2) if format == "onnx" else (1e-3, 1e-3)
-    for actual_output, native_output in zip(actual, native):
-        expected = native_output.detach().cpu().numpy()
+    for actual_output, expected in zip(actual, expected_outputs):
         if format == "onnx" and expected.shape[-1] == 4:
             row_match = np.isclose(actual_output, expected, rtol=rtol, atol=atol).all(
                 axis=-1
@@ -120,27 +133,11 @@ _TASK_HEAD_CASES = (
 )
 
 
-def _task_head_cases():
-    for format in ("onnx", "torchscript"):
-        for class_name, size, task, imgsz in _TASK_HEAD_CASES:
-            marks = ()
-            if format == "onnx" and class_name == "LibreEC" and task == "segment":
-                marks = _MACOS_LIBREEC_ONNX_DRIFT
-            yield pytest.param(
-                class_name,
-                size,
-                task,
-                imgsz,
-                format,
-                marks=marks,
-                id=f"{format}-{class_name}-{size}-{task}-{imgsz}",
-            )
-
-
 @pytest.mark.parametrize(
-    ("class_name", "size", "task", "imgsz", "format"),
-    _task_head_cases(),
+    ("class_name", "size", "task", "imgsz"),
+    _TASK_HEAD_CASES,
 )
+@pytest.mark.parametrize("format", ["onnx", "torchscript"])
 def test_detr_task_head_raw_parity(tmp_path, class_name, size, task, imgsz, format):
     if format == "onnx":
         pytest.importorskip("onnx")
@@ -175,9 +172,11 @@ def test_detr_task_head_raw_parity(tmp_path, class_name, size, task, imgsz, form
     actual = libreyolo.LibreYOLO(artifact, device="cpu")._run_inference(tensor.numpy())
 
     assert len(actual) == len(native)
+    expected_outputs = tuple(output.detach().cpu().numpy() for output in native)
+    if format == "onnx" and class_name == "LibreEC" and task == "segment":
+        actual = _align_query_outputs(actual, expected_outputs)
     rtol, atol = (2e-3, 2e-2) if format == "onnx" else (1e-3, 1e-3)
-    for actual_output, native_output in zip(actual, native):
-        expected = native_output.detach().cpu().numpy()
+    for actual_output, expected in zip(actual, expected_outputs):
         if format == "onnx":
             element_match = np.isclose(actual_output, expected, rtol=rtol, atol=atol)
             assert float(element_match.mean()) > 0.95

--- a/tests/unit/test_detr_cpu_export_matrix.py
+++ b/tests/unit/test_detr_cpu_export_matrix.py
@@ -45,21 +45,18 @@ def _export_cases():
 
 
 def _align_query_outputs(actual, expected):
-    """Align unordered DETR queries using their predicted boxes."""
-    box_index = next(
-        (
-            i
-            for i, output in enumerate(expected)
-            if output.ndim == 3 and output.shape[-1] == 4
-        ),
-        None,
-    )
-    assert box_index is not None, "query alignment requires a box output"
+    """Align unordered DETR queries using their predicted geometry."""
+    assert len(actual) > 1, "query alignment requires a geometric output"
+    assert actual[1].shape == expected[1].shape
     aligned = [np.empty_like(output) for output in actual]
-    for batch_index, (actual_boxes, expected_boxes) in enumerate(
-        zip(actual[box_index], expected[box_index])
+    for batch_index, (actual_geometry, expected_geometry) in enumerate(
+        zip(actual[1], expected[1])
     ):
-        cost = np.square(actual_boxes[:, None] - expected_boxes[None, :]).sum(axis=-1)
+        actual_vectors = actual_geometry.reshape(actual_geometry.shape[0], -1)
+        expected_vectors = expected_geometry.reshape(expected_geometry.shape[0], -1)
+        cost = np.square(actual_vectors[:, None] - expected_vectors[None, :]).sum(
+            axis=-1
+        )
         actual_indices, expected_indices = linear_sum_assignment(cost)
         actual_order = actual_indices[np.argsort(expected_indices)]
         for aligned_output, actual_output in zip(aligned, actual):
@@ -173,7 +170,7 @@ def test_detr_task_head_raw_parity(tmp_path, class_name, size, task, imgsz, form
 
     assert len(actual) == len(native)
     expected_outputs = tuple(output.detach().cpu().numpy() for output in native)
-    if format == "onnx" and class_name == "LibreEC" and task == "segment":
+    if format == "onnx" and class_name == "LibreEC":
         actual = _align_query_outputs(actual, expected_outputs)
     rtol, atol = (2e-3, 2e-2) if format == "onnx" else (1e-3, 1e-3)
     for actual_output, expected in zip(actual, expected_outputs):


### PR DESCRIPTION
## What does this PR do?

Fixes #584.

Treats LibreEC DETR queries as an unordered set when checking ONNX parity. The test matches queries by predicted boxes, then compares every query-aligned output with the existing numeric tolerances. This removes the macOS-only xfail without lowering thresholds or changing runtime or export behavior.

## Provenance declaration (required)

All changes are original test code written for LibreYOLO. No third-party code was copied, ported, adapted, or derived, and no weights or external artifacts are included.

## How was this tested?

- Reproduced backend-dependent query ordering on Windows: direct matching misplaced 10/300 detection rows and 6/300 segmentation rows; set alignment restored all outputs to 100% within tolerance, with maximum absolute residual below 6.4e-6.
- Exact LibreEC ONNX regression cases: 2 passed.
- Complete DETR export matrix: 22 passed, 4 pre-existing xfailed.
- Full serial PR gate: 3408 passed, 68 skipped, 73 deselected, 4 pre-existing xfailed.
- GitHub Unit tests run 29400157384: macOS, Windows, Ubuntu, and distributed Linux all passed. The macOS lane reported 3376 passed, 101 skipped, and only the 4 pre-existing xfails.
- Ruff check, Ruff format check, and git diff check passed.

## Code provenance

Original code written for this PR; a bug fix to LibreYOLO's first-party tests. No third-party code was ported, adapted, or introduced, and no GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license material was consulted.
