### PR TITLE
Stop a single wedged e2e test from killing the nightly

### DIFF
--- a/.github/workflows/e2e-nightly-dev.yml
+++ b/.github/workflows/e2e-nightly-dev.yml
@@ -79,6 +79,9 @@ jobs:
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # Optional: lifts the Modal container off anonymous Hub rate limits.
+          # Unset is fine, the run stays anonymous as before.
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -uo pipefail
           uvx modal run tools/ci/modal_nightly.py \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 UV := uv run --no-sync
 
+# Per-test wall clock cap for e2e runs, enforced by pytest-timeout. A single
+# wedged test (a stalled weight download, a deadlocked loader) must not be able
+# to burn the whole nightly budget in silence. Override with E2E_TIMEOUT=<s>,
+# or 0 to disable.
+E2E_TIMEOUT ?= 900
+
 .DEFAULT_GOAL := help
 .PHONY: help setup format lint typecheck test test_pr_gate test_install_smoke test_e2e print_nightly_suite test_general_nightly test_flagship_nightly test_nightly test_rf5 build clean
 
@@ -20,6 +26,7 @@ help:
 	@echo "  test_e2e FROM=<file>          - Resume from a test file (e.g. FROM=test_rf1_training.py or FROM=rf1_training)"
 	@echo "  test_e2e MARKERS='<expr>'     - Run only matching e2e markers (e.g. MARKERS='e2e and not experimental_backend')"
 	@echo "  test_e2e MARKER='<expr>'      - Alias for MARKERS=..., also works with FROM=..."
+	@echo "  test_e2e E2E_TIMEOUT=<secs>   - Per-test timeout, default 900 (0 disables)"
 	@echo "  print_nightly_suite           - Print nightly suite version and contract"
 	@echo "  test_general_nightly          - Run broad native inference nightly checks"
 	@echo "  test_flagship_nightly         - Run heavy YOLO9/RF-DETR nightly checks"
@@ -97,7 +104,7 @@ test_e2e:
 		echo "────────────────────────────────────────────────────────────"; \
 		echo "  [$$i/$$total] $$name"; \
 		echo "────────────────────────────────────────────────────────────"; \
-		$(UV) pytest "$$f" -m "$$markers" -v; \
+		PYTEST_TIMEOUT=$(E2E_TIMEOUT) $(UV) pytest "$$f" -m "$$markers" -v; \
 		rc=$$?; \
 		if [ $$rc -eq 0 ]; then passed=$$((passed + 1)); \
 		elif [ $$rc -eq 5 ]; then skipped=$$((skipped + 1)); \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,12 +126,28 @@ and writes runtime, GPU, and estimated GPU cost to the step summary. Exact
 billing remains authoritative in Modal; the GitHub value is a GPU-runtime
 estimate.
 
+Every e2e test also carries a per-test timeout, `E2E_TIMEOUT` (default 900
+seconds, `0` disables), enforced by `pytest-timeout` in thread mode so that a
+test wedged inside a native call, such as a stalled weight download, is killed
+with a stack trace instead of burning the whole nightly budget in silence. The
+suite-level Modal timeout is the last resort, not the first line of defence.
+
+Weight reuse: the Modal volume caches loose weight files, and Hugging Face
+snapshots (open-vocab, SAM, VLM families) as whole directories, since their
+loaders only skip a download when the `.libreyolo_snapshot_complete` marker and
+the config sit beside the weights. Verified snapshots are committed even when
+the suite fails, so a run that dies mid-suite does not leave the next one
+downloading them cold again. Set the `HF_TOKEN` repository secret to lift the
+Modal container off anonymous Hub rate limits; without it the run stays
+anonymous.
+
 Commands:
 
 ```bash
 make test_general_nightly
 make test_flagship_nightly
 make test_nightly
+make test_e2e E2E_TIMEOUT=1800
 ```
 
 V2.1 contract:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-timeout>=2.3.1",
     "pytest-xdist>=3.6",
     "ruff>=0.14.10",
     "ty>=0.0.1",
@@ -305,6 +306,11 @@ unresolved-import = "ignore"
 [tool.pytest.ini_options]
 addopts = "-m unit"
 testpaths = ["tests"]
+# Only the thread method can interrupt a test wedged inside a native call, such
+# as a stalled Hugging Face download; the signal method cannot fire until
+# control returns to Python. The limit itself comes from PYTEST_TIMEOUT, which
+# the e2e target sets, so unit runs stay unbounded.
+timeout_method = "thread"
 markers = [
     "unit: fast tests that avoid external weights or large files",
     "external_data: tests that require external datasets, weights, or staged large files",

--- a/tools/ci/modal_nightly.py
+++ b/tools/ci/modal_nightly.py
@@ -23,9 +23,18 @@ CACHE_VOLUME = os.getenv("LIBREYOLO_MODAL_CACHE_VOLUME", "libreyolo-nightly-cach
 GPU = os.getenv("LIBREYOLO_MODAL_GPU", "L4")
 REPO_URL = "https://github.com/LibreYOLO/libreyolo.git"
 WORKDIR = Path("/workspace/libreyolo")
+CACHE_ROOT = Path("/cache")
+CACHE_WEIGHTS = CACHE_ROOT / "weights"
 
 WEIGHT_SUFFIXES = {".pt", ".pth", ".safetensors"}
 IMAGE_SUFFIXES = {".bmp", ".jpeg", ".jpg", ".png", ".webp"}
+# Written by the model loaders once a Hugging Face snapshot is verified complete
+# (see libreyolo/models/openvocab/base.py). Its absence means the loader will
+# download the snapshot again.
+SNAPSHOT_MARKER = ".libreyolo_snapshot_complete"
+# Requests-based hub downloads hang forever by default; xet transfers may not
+# honour this, which is why the e2e per-test timeout is the real backstop.
+HF_DOWNLOAD_TIMEOUT_S = os.getenv("LIBREYOLO_HF_DOWNLOAD_TIMEOUT", "60")
 GPU_USD_PER_S = {
     "T4": 0.000164,
     "L4": 0.000222,
@@ -34,6 +43,20 @@ GPU_USD_PER_S = {
 
 app = modal.App(APP_NAME)
 cache = modal.Volume.from_name(CACHE_VOLUME, create_if_missing=True)
+
+
+def hf_secrets() -> list[modal.Secret]:
+    """Authenticate to the Hugging Face Hub when the workflow supplies a token.
+
+    Anonymous pulls from a shared datacenter egress are the ones the Hub
+    throttles. A missing token keeps the previous anonymous behaviour instead of
+    failing the run, so this stays optional.
+    """
+    token = os.getenv("HF_TOKEN", "").strip()
+    if not token:
+        return []
+    return [modal.Secret.from_dict({"HF_TOKEN": token})]
+
 
 image = (
     modal.Image.debian_slim(python_version="3.10")
@@ -69,7 +92,7 @@ def replace_with_symlink(link: Path, target: Path) -> None:
 
 
 def prepare_home_cache_links() -> None:
-    cache_root = Path("/cache")
+    cache_root = CACHE_ROOT
     cache_root.mkdir(parents=True, exist_ok=True)
     home_cache = Path.home() / ".cache"
     home_cache.mkdir(parents=True, exist_ok=True)
@@ -79,6 +102,7 @@ def prepare_home_cache_links() -> None:
 
     os.environ["HF_HOME"] = str(cache_root / "huggingface")
     os.environ["LIBREYOLO_DATASETS_DIR"] = str(cache_root / "datasets")
+    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", HF_DOWNLOAD_TIMEOUT_S)
 
 
 def is_weight_file(path: Path) -> bool:
@@ -89,9 +113,33 @@ def is_image_file(path: Path) -> bool:
     return path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES
 
 
+def snapshot_dirs(root: Path) -> list[Path]:
+    """Snapshot directories under ``root`` that the loaders consider complete."""
+    if not root.exists():
+        return []
+    return sorted(marker.parent for marker in root.glob(f"*/{SNAPSHOT_MARKER}"))
+
+
+def link_cached_snapshots() -> None:
+    """Restore Hugging Face snapshots (open-vocab, SAM, VLM) as whole directories.
+
+    A loader only skips the download when the marker file and the config sit
+    beside the weights, and neither is a weight file, so file-level caching left
+    every snapshot family re-downloading its full snapshot on every run.
+    """
+    worktree_weights = WORKDIR / "weights"
+    worktree_weights.mkdir(parents=True, exist_ok=True)
+
+    for src in snapshot_dirs(CACHE_WEIGHTS):
+        dest = worktree_weights / src.name
+        if dest.exists() or dest.is_symlink():
+            continue
+        dest.symlink_to(src, target_is_directory=True)
+
+
 def link_cached_weights() -> None:
     """Expose cached weight files without replacing tracked weights/ helpers."""
-    cache_weights = Path("/cache/weights")
+    cache_weights = CACHE_WEIGHTS
     worktree_weights = WORKDIR / "weights"
     cache_weights.mkdir(parents=True, exist_ok=True)
     worktree_weights.mkdir(parents=True, exist_ok=True)
@@ -107,8 +155,31 @@ def link_cached_weights() -> None:
         dest.symlink_to(src)
 
 
+def sync_snapshots_to_cache() -> None:
+    """Persist snapshots that carry the completion marker.
+
+    The marker is only written after the loader verifies the snapshot, so these
+    are safe to keep even when the suite fails. Publishing through a temporary
+    directory keeps a half-copied snapshot from ever being seen as complete.
+    """
+    cache_weights = CACHE_WEIGHTS
+    worktree_weights = WORKDIR / "weights"
+    cache_weights.mkdir(parents=True, exist_ok=True)
+
+    for snapshot in snapshot_dirs(worktree_weights):
+        if snapshot.is_symlink():
+            continue
+        dest = cache_weights / snapshot.name
+        if dest.exists():
+            continue
+        staging = cache_weights / f".{snapshot.name}.partial"
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.copytree(snapshot, staging)
+        staging.rename(dest)
+
+
 def sync_downloaded_weights_to_cache() -> None:
-    cache_weights = Path("/cache/weights")
+    cache_weights = CACHE_WEIGHTS
     worktree_weights = WORKDIR / "weights"
     if not worktree_weights.exists():
         return
@@ -124,8 +195,9 @@ def sync_downloaded_weights_to_cache() -> None:
 
 
 def prepare_worktree_cache_links() -> None:
+    link_cached_snapshots()
     link_cached_weights()
-    replace_with_symlink(WORKDIR / "downloads", Path("/cache/downloads"))
+    replace_with_symlink(WORKDIR / "downloads", CACHE_ROOT / "downloads")
 
 
 def is_lfs_pointer(path: Path) -> bool:
@@ -199,6 +271,7 @@ def run_test_target(target: str) -> None:
     gpu=GPU,
     timeout=3 * 60 * 60,
     volumes={"/cache": cache},
+    secrets=hf_secrets(),
 )
 def nightly(ref: str, target: str = "test_nightly") -> dict[str, object]:
     started = time.monotonic()
@@ -272,14 +345,21 @@ def nightly(ref: str, target: str = "test_nightly") -> dict[str, object]:
         cache_status = "skipped"
         step = time.monotonic()
         try:
-            if status == "passed" and WORKDIR.exists():
+            if not WORKDIR.exists():
+                cache_status = "workdir-missing"
+            elif status == "passed":
+                sync_snapshots_to_cache()
                 sync_downloaded_weights_to_cache()
                 cache.commit()
                 cache_status = "committed"
-            elif status != "passed":
-                cache_status = "skipped-failed-run"
             else:
-                cache_status = "workdir-missing"
+                # Keep verified snapshots even when the suite fails, so a run
+                # that dies mid-suite does not leave the next one downloading
+                # them cold again. Loose weight files stay out: only snapshots
+                # carry a completeness marker, so only they are provably whole.
+                sync_snapshots_to_cache()
+                cache.commit()
+                cache_status = "committed-snapshots-failed-run"
         except Exception as exc:
             cache_error = repr(exc)
             cache_status = "failed"


### PR DESCRIPTION
The 2026-07-14 nightly hung in the new OMDet-Turbo test until Modal's 3 hour function timeout, with no output and no diagnosis.

- Cap every e2e test with pytest-timeout (E2E_TIMEOUT, default 900s) in thread mode, the only method that can interrupt a native call such as a stalled Hugging Face transfer.
- Cache Hugging Face snapshots as whole directories. Their loaders only skip a download when the completion marker and the config sit beside the weights, and neither is a weight file, so every snapshot family was re-downloading its full snapshot on every run.
- Commit verified snapshots even when the suite fails, so a run that dies mid-suite no longer leaves the next one downloading them cold.
- Pass an optional HF_TOKEN to the Modal container and bound hub downloads; without the secret the run stays anonymous as before.
