### PR TITLE
Pass HF_TOKEN to the nightly Modal container on release

### DIFF
--- a/.github/workflows/e2e-nightly-dev.yml
+++ b/.github/workflows/e2e-nightly-dev.yml
@@ -79,6 +79,9 @@ jobs:
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # Optional: lifts the Modal container off anonymous Hub rate limits.
+          # Unset is fine, the run stays anonymous as before.
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -uo pipefail
           uvx modal run tools/ci/modal_nightly.py \


### PR DESCRIPTION
The scheduled nightly workflow runs from the default branch (release), so the HF_TOKEN env wiring merged to dev in #613 never reaches the run. Add just that one line here so the Modal container authenticates to the Hub instead of pulling anonymously (the source of the OMDet-Turbo download stall). All other nightly fixes already take effect via the dev checkout this workflow performs.
