### PR TITLE
Install the openvocab extra in the Modal nightly env

### DIFF
--- a/tools/ci/modal_nightly.py
+++ b/tools/ci/modal_nightly.py
@@ -311,7 +311,7 @@ def nightly(ref: str, target: str = "test_nightly") -> dict[str, object]:
                 "--group",
                 "dev",
                 "-e",
-                ".[rfdetr,onnx]",
+                ".[rfdetr,onnx,openvocab]",
             ],
             cwd=WORKDIR,
         )


### PR DESCRIPTION
The nightly Modal env installed only `.[rfdetr,onnx]`, so `timm` (declared in the `openvocab` extra for OMDet-Turbo's TimmBackbone Swin backbone) was never installed. `test_omdet_turbo_matches_transformers_postprocessing` errored at setup with `ImportError: TimmBackbone requires the timm library` on the Jul 16 and Jul 17 nightlies (runs 29475843189, 29559159385). Grounding DINO passed only because `transformers` sneaks in through the rfdetr extra.

The bug existed since the test landed in #600 but was masked by the cold-download hang; #613/#614 fixed the hang and exposed it.

One-line fix: install `.[rfdetr,onnx,openvocab]`.

## Code provenance

First-party CI tooling change (one line in tools/ci/modal_nightly.py).
No third-party code involved
