### PR TITLE
Add SenseNova-Vision unified multimodal family (7 tasks, LibreVLM tier)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -32,6 +32,22 @@ DINOv3 (Meta DINOv3 License Agreement)
     These terms apply only to the DINOv3 subtree listed above. The
     rest of LibreYOLO remains under the MIT License.
 
+SenseNova-Vision / Bagel (Apache License 2.0 code; CC BY-NC 4.0 weights,
+not redistributed)
+    Path:    libreyolo/models/sensenova/
+    License: libreyolo/models/sensenova/NOTICE  (Apache-2.0 code sources)
+    Source:  https://github.com/OpenSenseNova/SenseNova-Vision
+
+    The SenseNova-Vision family vendors an inference-only port of the
+    upstream Apache-2.0 implementation (SenseTime 2026, building on
+    ByteDance's Bagel, Hugging Face transformers, and the Black Forest
+    Labs FLUX autoencoder, all Apache-2.0). The upstream file
+    modeling/bagel/modeling_utils.py is CC BY-NC 4.0 (DiT-derived) and is
+    NOT ported; its standard components are re-derived from Apache/MIT
+    sources in modeling/layers.py (see the family NOTICE). Model weights
+    are CC BY-NC 4.0 and are downloaded at runtime from the upstream
+    Hugging Face repository, never redistributed by LibreYOLO.
+
 MobileNetV4 / timm (Apache License 2.0)
     Path:    libreyolo/models/mobilenetv4/
     License: libreyolo/models/mobilenetv4/NOTICE  (Apache-2.0)

--- a/NOTICE
+++ b/NOTICE
@@ -45,8 +45,9 @@ not redistributed)
     modeling/bagel/modeling_utils.py is CC BY-NC 4.0 (DiT-derived) and is
     NOT ported; its standard components are re-derived from Apache/MIT
     sources in modeling/layers.py (see the family NOTICE). Model weights
-    are CC BY-NC 4.0 and are downloaded at runtime from the upstream
-    Hugging Face repository, never redistributed by LibreYOLO.
+    are CC BY-NC 4.0, mirrored byte-identically with attribution at
+    huggingface.co/LibreYOLO/SenseNovaVision7b; the loader prints the
+    non-commercial notice before every automatic download.
 
 MobileNetV4 / timm (Apache License 2.0)
     Path:    libreyolo/models/mobilenetv4/

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -840,3 +840,25 @@ Used for: the Transformers-backed LibreEdgeTAM adapter in
           independently and then checked exactly against it.
 
 The full Apache License 2.0 text is included at licenses/Apache-2.0.txt.
+
+--------------------------------------------------------------------
+SenseNova-Vision / Bagel (SenseTime; ByteDance; Hugging Face; BFL)
+--------------------------------------------------------------------
+Source: https://github.com/OpenSenseNova/SenseNova-Vision
+        (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c)
+License: Apache License 2.0 (see licenses/Apache-2.0.txt)
+Copyright (c) 2026 SenseTime Group Inc.; (c) 2025 Bytedance Ltd.;
+          (c) 2024 The Qwen Team and The HuggingFace Inc. team;
+          (c) 2024 Black Forest Labs
+Citation: SenseNova-Vision team. "Vision as Unified Multimodal
+          Generation." arXiv:2607.06560, 2026.
+Used for: the LibreSenseNovaVision family (libreyolo/models/sensenova/), an
+inference-only port of the Bagel-MoT unified multimodal architecture, its
+interleaved inferencer, image transforms, task prompts, and structured-output
+parsers. The upstream file modeling/bagel/modeling_utils.py is CC BY-NC 4.0
+(DiT-derived) and is NOT ported; its standard components are re-derived from
+Hugging Face transformers (ViT-MAE sincos table, Apache-2.0) and
+openai/guided-diffusion (timestep embedding, MIT) in modeling/layers.py.
+Model weights (sensenova/SenseNova-Vision-7B-MoT) are CC BY-NC 4.0,
+downloaded at runtime from upstream, and never redistributed by LibreYOLO.
+See libreyolo/models/sensenova/NOTICE for the full provenance chain.

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -859,6 +859,7 @@ parsers. The upstream file modeling/bagel/modeling_utils.py is CC BY-NC 4.0
 (DiT-derived) and is NOT ported; its standard components are re-derived from
 Hugging Face transformers (ViT-MAE sincos table, Apache-2.0) and
 openai/guided-diffusion (timestep embedding, MIT) in modeling/layers.py.
-Model weights (sensenova/SenseNova-Vision-7B-MoT) are CC BY-NC 4.0,
-downloaded at runtime from upstream, and never redistributed by LibreYOLO.
-See libreyolo/models/sensenova/NOTICE for the full provenance chain.
+Model weights (sensenova/SenseNova-Vision-7B-MoT, CC BY-NC 4.0,
+non-commercial) are mirrored byte-identically with attribution at
+huggingface.co/LibreYOLO/SenseNovaVision7b; mirroring does not change the
+license. See libreyolo/models/sensenova/NOTICE for the full provenance chain.

--- a/docs/adr/0012-sensenova-unified-multimodal.md
+++ b/docs/adr/0012-sensenova-unified-multimodal.md
@@ -1,0 +1,84 @@
+# ADR 0012: Unified Multimodal Families In The LibreVLM Tier
+
+- Status: Proposed
+- Date: 2026-07-17
+- Scope: First multi-task generative family (SenseNova-Vision) and the tier
+  contract changes it introduces
+
+## Context
+
+ADR 0002 established the LibreVLM tier for generative models used as
+open-vocabulary detectors, and LocateAnything already stretched it to two
+tasks (`detect`, `point`). A new class of unified multimodal models goes much
+further: SenseNova-Vision (SenseTime, arXiv:2607.06560) casts vision as
+prompted generation on a Bagel-MoT backbone, with no task heads at all.
+Symbolic outputs (boxes, points, keypoints, OCR words, camera poses) are
+generated as tagged text; dense outputs (depth maps, binary and panoptic
+segmentation masks, surface normals) are generated as images that a frozen
+VAE decodes. One checkpoint covers more than a dozen tasks with competitive
+accuracy (56.6 COCO-Com mAP, 4.0 AbsRel NYUv2 depth, 81.3 cIoU RefCOCO).
+
+The question was whether this needs a new tier, new task names, or new result
+types. It needs none of them: the capability set maps onto tasks LibreYOLO
+already defines, with the same `Results` payloads specialist families return.
+
+## Decision
+
+1. **Unified multimodal models join the LibreVLM tier as multi-task
+   families.** `LibreVLM("sensenova-vision", task="depth")` loads the same
+   class as `task="detect"`; `SUPPORTED_TASKS` declares what the family
+   serves. No new tier, no parallel task vocabulary.
+
+2. **Tasks keep their canonical LibreYOLO names and Results payloads.**
+   SenseNova-Vision v1 serves `detect`, `point`, `pose`, `ocr`, `depth`,
+   `segment` (referring segmentation: the "class" list is free text such as
+   "person furthest to the right"), and `panoptic`. Each returns exactly the
+   payload the specialist family for that task returns (`Boxes`, `Points`,
+   `Keypoints`, `OCRRegions`, `DepthMap`, `Masks`, `PanopticSegmentation`),
+   so swapping a specialist for the generalist is a one-line change.
+
+3. **`set_task()` joins the tier base.** Prompt-driven families serve every
+   task from one set of weights, so the task is sticky state like the
+   vocabulary, switchable without reloading. Checkpoint families outside the
+   tier keep task fixed at load time, unchanged.
+
+4. **Capabilities without a canonical task stay behind the raw escape
+   hatches.** `chat()` (visual QA) and `generate()` (any upstream mode:
+   surface normals, grounded-conversation segmentation, editing, generation)
+   expose the full model. Surface normals, 3D reconstruction, and camera pose
+   get public task names only when a second family or real demand justifies
+   the shared surface.
+
+5. **The architecture is vendored, not remote-loaded.** Unlike previous VLM
+   families, the model is not loadable through transformers and its Hugging
+   Face repo carries no remote code, so the Apache-2.0 implementation is
+   ported into `libreyolo/models/sensenova/modeling/` with per-file
+   provenance (Bagel/ByteDance, Qwen2 and SigLIP/Hugging Face, FLUX
+   autoencoder/Black Forest Labs). The port is inference-only, and flash-attn
+   is optional behind a numerically equivalent SDPA fallback. The one
+   CC BY-NC upstream file (DiT-derived helpers) is not ported; its standard
+   components are re-derived from the original permissive sources
+   (transformers ViT-MAE, openai/guided-diffusion) in `modeling/layers.py`.
+
+6. **Weights are never redistributed.** The checkpoint is CC BY-NC 4.0 and
+   downloads at runtime from the upstream repository after a one-time license
+   notice, following the LocateAnything precedent.
+
+## Consequences
+
+- The tier's honest-confidence rules extend unchanged: generated outputs
+  carry the placeholder score, `val()` stays unsupported, and `track()`
+  degrades as documented in ADR 0002.
+- Dense tasks pay one diffusion decode (50 denoising steps) per image; this
+  is a capability model, not a real-time one. `dtype="auto"` picks bf16 on
+  large GPUs and NF4 quantization (bitsandbytes) on consumer GPUs; the
+  14.7B-parameter checkpoint is ~29.6 GB in bf16 and ~9 GB in NF4.
+- Referring segmentation arrives as a `segment`-task capability with one mask
+  per query rather than per-instance masks; the contract is documented on the
+  family.
+- Panoptic output is open-vocabulary: phrases the model returns beyond the
+  configured category list register new entries in `Results.names` instead of
+  being dropped.
+- The vendored port adds ~5k lines under `models/sensenova/`. Structural
+  parity with the released checkpoint was verified tensor-by-tensor (1223
+  names and shapes) against the safetensors header.

--- a/docs/adr/0012-sensenova-unified-multimodal.md
+++ b/docs/adr/0012-sensenova-unified-multimodal.md
@@ -60,9 +60,13 @@ already defines, with the same `Results` payloads specialist families return.
    components are re-derived from the original permissive sources
    (transformers ViT-MAE, openai/guided-diffusion) in `modeling/layers.py`.
 
-6. **Weights are never redistributed.** The checkpoint is CC BY-NC 4.0 and
-   downloads at runtime from the upstream repository after a one-time license
-   notice, following the LocateAnything precedent.
+6. **Weights are mirrored under their original license.** The checkpoint is
+   CC BY-NC 4.0 (non-commercial); by maintainer decision (2026-07-18,
+   following the OV-DEIM precedent) LibreYOLO hosts a byte-identical,
+   attribution-carrying mirror at `LibreYOLO/SenseNovaVision7b` with the
+   revision and SHA-256 pins on the card. Mirroring does not change the
+   license, and the loader prints the non-commercial notice before every
+   automatic download.
 
 ## Consequences
 

--- a/docs/librevlm_design.md
+++ b/docs/librevlm_design.md
@@ -238,7 +238,8 @@ weights, which matters at 29.6 GB. Two family-specific notes: this is the
 one family whose architecture is vendored rather than loaded through
 transformers (no upstream remote code exists; the port carries per-file
 Apache-2.0 provenance and an SDPA fallback so flash-attn is optional), and
-its weights are CC BY-NC 4.0, downloaded at runtime from upstream under a
+its weights are CC BY-NC 4.0 (non-commercial), auto-downloaded from the
+byte-identical LibreYOLO mirror (`LibreYOLO/SenseNovaVision7b`) under a
 one-time license notice. Capabilities without a canonical LibreYOLO task
 (surface normals, grounded-conversation segmentation, editing, multi-view
 reconstruction) stay behind `chat()`/`generate()`. See

--- a/docs/librevlm_design.md
+++ b/docs/librevlm_design.md
@@ -36,6 +36,7 @@ size marked with `*`. The authoritative list is `_ALIASES` in
 | `kosmos-2`*                                   | Kosmos-2  | MIT                 | 2023 grounder; loads clean, coarse boxes |
 | `smolvlm2`, `-2.2b`*, `-500m`                | SmolVLM2  | Apache-2.0          | tiny; weak detector, zero-code family    |
 | `locate-anything`, `-3b`*                     | LocateAnything | NVIDIA non-commercial | remote-code grounder; boxes and points |
+| `sensenova-vision`, `-7b`*                    | SenseNova-Vision | Apache-2.0 code, CC BY-NC 4.0 weights | unified multimodal; 7 tasks, vendored port, heavy |
 
 Florence-2 and Kosmos-2 do not use a chat template: they are driven by task /
 grounding prompts and decode boxes via the processor's `post_process_generation`,
@@ -211,6 +212,37 @@ downloads do not execute mutable upstream code.
 LibreYOLO contributes only adapter code. It does not redistribute VLM weights or
 remote-code model repositories; those are downloaded at runtime under the
 upstream model repository's terms when a user chooses that model.
+
+## Multi-task families: SenseNova-Vision
+
+The tier's "VLM as detector" framing was v1 scoping, not a ceiling. The
+LocateAnything family already served two tasks (`detect`, `point`); the
+SenseNova-Vision family extends the same mechanics to seven: `detect`,
+`point`, `pose`, `ocr`, `depth`, `segment` (referring segmentation with
+free-text queries), and `panoptic`. Symbolic tasks come back as tagged text
+the family parses; dense tasks come back as generated images a frozen VAE
+decodes. Every task returns the same `Results` payload the specialist
+families return, so the generalist and the specialists are interchangeable
+call sites.
+
+```python
+model = LibreVLM("sensenova-vision", task="depth")
+result = model.predict("image.jpg")            # Results.depth_map
+model.set_task("segment").set_classes(["person furthest to the right"])
+result = model.predict("image.jpg")            # Results.masks, one referred mask
+model.set_task("panoptic")                      # COCO-panoptic vocabulary default
+```
+
+`set_task()` (on the tier base) switches the active task without reloading
+weights, which matters at 29.6 GB. Two family-specific notes: this is the
+one family whose architecture is vendored rather than loaded through
+transformers (no upstream remote code exists; the port carries per-file
+Apache-2.0 provenance and an SDPA fallback so flash-attn is optional), and
+its weights are CC BY-NC 4.0, downloaded at runtime from upstream under a
+one-time license notice. Capabilities without a canonical LibreYOLO task
+(surface normals, grounded-conversation segmentation, editing, multi-view
+reconstruction) stay behind `chat()`/`generate()`. See
+[`adr/0012-sensenova-unified-multimodal.md`](adr/0012-sensenova-unified-multimodal.md).
 
 ## Known limitations (v1)
 

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -127,6 +127,7 @@ def __getattr__(name):
         "LibreFlorence2": (".models.vlm", "LibreFlorence2"),
         "LibreKosmos2": (".models.vlm", "LibreKosmos2"),
         "LibreLocateAnything": (".models.vlm", "LibreLocateAnything"),
+        "LibreSenseNovaVision": (".models.sensenova", "LibreSenseNovaVision"),
         "LibreSAM": (".models.sam", "LibreSAM"),
         "LibreSAM1": (".models.sam", "LibreSAM1"),
         "LibreSAM2": (".models.sam", "LibreSAM2"),

--- a/libreyolo/models/sensenova/NOTICE
+++ b/libreyolo/models/sensenova/NOTICE
@@ -44,10 +44,17 @@ sources instead:
   * The MLP connector and frozen-buffer wrappers follow the parameter
     names/shapes fixed by the released checkpoint.
 
-Model weights are NOT redistributed by LibreYOLO. The upstream checkpoint
+Model weights are CC BY-NC 4.0 (non-commercial use only) and are mirrored,
+byte-identical and with attribution, at:
 
-    Repository: sensenova/SenseNova-Vision-7B-MoT (Hugging Face)
-    License:    CC BY-NC 4.0 (non-commercial use only)
+    Mirror:     LibreYOLO/SenseNovaVision7b (Hugging Face)
+    Upstream:   sensenova/SenseNova-Vision-7B-MoT
+    Revision:   79548fcc5b954598799b9317f8d3ec5e347d5c0e
+    SHA-256:    ema.safetensors
+                96f29abd98791288c5a24087322e964bb9bcabfc2f185ece71543f827bc2b11e
+                ae.safetensors
+                afc8e28272cd15db3919bacdb6918ce9c1ed22e96cb12c4d5ed0fba823529e38
 
-is downloaded at runtime from the upstream repository after a one-time
-license notice; users are responsible for complying with its terms.
+Mirroring does not change the license; the loader prints the
+non-commercial notice before every automatic download, and users are
+responsible for complying with the upstream terms.

--- a/libreyolo/models/sensenova/NOTICE
+++ b/libreyolo/models/sensenova/NOTICE
@@ -1,0 +1,53 @@
+LibreSenseNovaVision - third-party attribution
+==============================================
+
+The SenseNova-Vision family vendors an inference-only port of the upstream
+model implementation. All ported files retain their upstream copyright
+headers and per-file provenance notes.
+
+    Project:  SenseNova-Vision
+    Upstream: https://github.com/OpenSenseNova/SenseNova-Vision
+    Commit:   12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c
+    License:  Apache License 2.0 (repository code)
+    Copyright (c) 2026 SenseTime Group Inc. and/or its affiliates
+
+The upstream implementation itself derives from Apache-2.0 projects, and the
+ported files keep those lineage headers:
+
+  * Bagel (Qwen2-NaViT MoT decoder, SigLIP-NaViT tower, inferencer):
+    Copyright (c) 2025 Bytedance Ltd., Apache-2.0
+    https://github.com/ByteDance-Seed/Bagel
+  * Qwen2 / SigLIP leaf modules and configurations:
+    Copyright (c) 2024 The Qwen Team and The HuggingFace Inc. team, Apache-2.0
+    https://github.com/huggingface/transformers
+  * FLUX autoencoder (modeling/autoencoder.py):
+    Copyright (c) 2024 Black Forest Labs, Apache-2.0
+    https://github.com/black-forest-labs/flux
+
+LibreYOLO adaptations (documented in each file header): the training-only
+forward paths are removed, flash-attn is optional behind a numerically
+equivalent SDPA fallback, einops rearranges are rewritten as plain torch ops,
+and imports are made relative.
+
+NOT ported: upstream modeling/bagel/modeling_utils.py is marked
+CC BY-NC 4.0 (it derives from facebookresearch/DiT) and is incompatible with
+LibreYOLO. The small standard components it provided are re-derived in
+libreyolo/models/sensenova/modeling/layers.py from the original permissive
+sources instead:
+
+  * 2D sine-cosine position table: Hugging Face transformers
+    (models/vit_mae/modeling_vit_mae.py, Apache-2.0, Meta copyright under
+    Apache in that file), which predates DiT's non-commercial fork of the
+    same routine.
+  * Sinusoidal timestep embedding: openai/guided-diffusion
+    (guided_diffusion/nn.py, MIT), the source DiT itself credits.
+  * The MLP connector and frozen-buffer wrappers follow the parameter
+    names/shapes fixed by the released checkpoint.
+
+Model weights are NOT redistributed by LibreYOLO. The upstream checkpoint
+
+    Repository: sensenova/SenseNova-Vision-7B-MoT (Hugging Face)
+    License:    CC BY-NC 4.0 (non-commercial use only)
+
+is downloaded at runtime from the upstream repository after a one-time
+license notice; users are responsible for complying with its terms.

--- a/libreyolo/models/sensenova/__init__.py
+++ b/libreyolo/models/sensenova/__init__.py
@@ -1,0 +1,12 @@
+"""SenseNova-Vision: one generative checkpoint serving many LibreYOLO tasks.
+
+The user-facing entry point is the ``LibreVLM`` factory
+(``LibreVLM("sensenova-vision", task=...)``) or the ``LibreSenseNovaVision``
+class directly. See ``docs/adr/0012-sensenova-unified-multimodal.md`` for the
+contract and ``libreyolo/models/sensenova/modeling`` for the vendored
+architecture provenance.
+"""
+
+from .model import LibreSenseNovaVision
+
+__all__ = ["LibreSenseNovaVision"]

--- a/libreyolo/models/sensenova/data_utils.py
+++ b/libreyolo/models/sensenova/data_utils.py
@@ -1,0 +1,97 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# data/data_utils.py, trimmed to the helpers the inference path uses.
+
+import torch
+from PIL import Image
+
+
+def patchify(image, patch_size):
+    p = patch_size
+    c, h, w = image.shape
+    assert h % p == 0 and w % p == 0
+    image = image.reshape(c, h // p, p, w // p, p)
+    image = torch.einsum("chpwq->hwpqc", image)
+    image = image.reshape(-1, p**2 * c)
+    return image
+
+
+def get_flattened_position_ids_extrapolate(
+    img_h, img_w, patch_size, max_num_patches_per_side
+):
+    num_patches_h, num_patches_w = img_h // patch_size, img_w // patch_size
+    coords_h = torch.arange(0, num_patches_h)
+    coords_w = torch.arange(0, num_patches_w)
+    pos_ids = (coords_h[:, None] * max_num_patches_per_side + coords_w).flatten()
+    return pos_ids
+
+
+def get_flattened_position_ids_interpolate(
+    img_h, img_w, patch_size, max_num_patches_per_side
+):
+    num_patches_h, num_patches_w = img_h // patch_size, img_w // patch_size
+    boundaries = torch.arange(
+        1 / max_num_patches_per_side, 1.0, 1 / max_num_patches_per_side
+    )
+    fractional_coords_h = torch.arange(0, 1 - 1e-6, 1 / num_patches_h)
+    fractional_coords_w = torch.arange(0, 1 - 1e-6, 1 / num_patches_w)
+    bucket_coords_h = torch.bucketize(fractional_coords_h, boundaries, right=True)
+    bucket_coords_w = torch.bucketize(fractional_coords_w, boundaries, right=True)
+    pos_ids = (
+        bucket_coords_h[:, None] * max_num_patches_per_side + bucket_coords_w
+    ).flatten()
+    return pos_ids
+
+
+def pil_img2rgb(image):
+    if image.mode == "RGBA" or image.info.get("transparency", None) is not None:
+        image = image.convert("RGBA")
+        white = Image.new(mode="RGB", size=image.size, color=(255, 255, 255))
+        white.paste(image, mask=image.split()[3])
+        image = white
+    else:
+        image = image.convert("RGB")
+
+    return image
+
+
+def add_special_tokens(tokenizer):
+    all_special_tokens = []
+    for k, v in tokenizer.special_tokens_map.items():
+        if isinstance(v, str):
+            all_special_tokens.append(v)
+        elif isinstance(v, list):
+            all_special_tokens += v
+
+    new_tokens = []
+
+    if "<|im_start|>" not in all_special_tokens:
+        new_tokens.append("<|im_start|>")
+
+    if "<|im_end|>" not in all_special_tokens:
+        new_tokens.append("<|im_end|>")
+
+    if "<|vision_start|>" not in all_special_tokens:
+        new_tokens.append("<|vision_start|>")
+
+    if "<|vision_end|>" not in all_special_tokens:
+        new_tokens.append("<|vision_end|>")
+
+    num_new_tokens = tokenizer.add_tokens(new_tokens)
+    bos_token_id = tokenizer.convert_tokens_to_ids("<|im_start|>")
+    eos_token_id = tokenizer.convert_tokens_to_ids("<|im_end|>")
+    start_of_image = tokenizer.convert_tokens_to_ids("<|vision_start|>")
+    end_of_image = tokenizer.convert_tokens_to_ids("<|vision_end|>")
+
+    new_token_ids = dict(
+        bos_token_id=bos_token_id,
+        eos_token_id=eos_token_id,
+        start_of_image=start_of_image,
+        end_of_image=end_of_image,
+    )
+
+    return tokenizer, new_token_ids, num_new_tokens

--- a/libreyolo/models/sensenova/data_utils.py
+++ b/libreyolo/models/sensenova/data_utils.py
@@ -5,9 +5,88 @@
 # Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
 # (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
 # data/data_utils.py, trimmed to the helpers the inference path uses.
+# CheckpointTokenizer is a LibreYOLO addition; see its docstring.
+
+import re
 
 import torch
 from PIL import Image
+
+
+class CheckpointTokenizer:
+    """Applies the checkpoint's trained added-token layout over a base BPE.
+
+    The released SenseNova-Vision repo ships two conflicting tokenizer
+    definitions. ``tokenizer.json`` (the fast backend) places the chat/vision
+    specials and ~2k structured tokens (camera-pose tags, coordinate bins)
+    at ids 151644-153675, beyond the checkpoint's 152064-row embedding, so
+    using it as-is trips a CUDA device-side assert on the first embedding
+    lookup. ``tokenizer_config.json``'s ``added_tokens_decoder`` records the
+    layout the model was trained with: the same tokens overriding ids
+    149632-151664 (repurposed rare base-vocab ids), which upstream's legacy
+    slow tokenizer applied. transformers 5.x no longer builds slow
+    tokenizers, so this wrapper reproduces that layout: encode splits text
+    on the override literals before delegating to the base BPE, and decode
+    maps override ids back to their literals.
+    """
+
+    def __init__(self, base, id_to_token):
+        self._base = base
+        self._id_to_token = {int(i): str(t) for i, t in id_to_token.items()}
+        self._token_to_id = {t: i for i, t in self._id_to_token.items()}
+        literals = sorted(self._token_to_id, key=len, reverse=True)
+        self._split_re = re.compile("(" + "|".join(re.escape(t) for t in literals) + ")")
+
+    # -- surface used by add_special_tokens() ------------------------------
+    @property
+    def special_tokens_map(self):
+        return {}
+
+    def add_tokens(self, tokens):
+        missing = [t for t in tokens if t not in self._token_to_id]
+        if missing:
+            raise ValueError(
+                f"Tokens {missing} are not part of the checkpoint layout; "
+                "refusing to add ids beyond the embedding table."
+            )
+        return 0
+
+    def convert_tokens_to_ids(self, token):
+        return self._token_to_id[token]
+
+    def __len__(self):
+        return max(self._id_to_token) + 1
+
+    # -- encode / decode ---------------------------------------------------
+    def encode(self, text):
+        ids = []
+        for part in self._split_re.split(str(text)):
+            if not part:
+                continue
+            override = self._token_to_id.get(part)
+            if override is not None:
+                ids.append(override)
+            else:
+                ids.extend(self._base.encode(part, add_special_tokens=False))
+        return ids
+
+    def decode(self, ids):
+        if hasattr(ids, "tolist"):
+            ids = ids.tolist()
+        pieces, run = [], []
+        for token_id in ids:
+            token_id = int(token_id)
+            literal = self._id_to_token.get(token_id)
+            if literal is None:
+                run.append(token_id)
+                continue
+            if run:
+                pieces.append(self._base.decode(run))
+                run = []
+            pieces.append(literal)
+        if run:
+            pieces.append(self._base.decode(run))
+        return "".join(pieces)
 
 
 def patchify(image, patch_size):

--- a/libreyolo/models/sensenova/inferencer.py
+++ b/libreyolo/models/sensenova/inferencer.py
@@ -1,0 +1,420 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# inference/inferencer.py. LibreYOLO adaptation: autocast follows the model
+# device so the CPU fallback works, instead of hardcoding CUDA.
+
+from copy import deepcopy
+from typing import List, Dict, Optional, Union, Any
+
+from PIL import Image
+import torch
+
+from .data_utils import pil_img2rgb
+from .modeling.qwen2_navit import NaiveCache
+
+
+
+VLM_THINK_SYSTEM_PROMPT = '''You should first think about the reasoning process in the mind and then provide the user with the answer. 
+The reasoning process is enclosed within <think> </think> tags, i.e. <think> reasoning process here </think> answer here'''
+
+GEN_THINK_SYSTEM_PROMPT = '''You should first think about the planning process in the mind and then generate the image. 
+The planning process is enclosed within <think> </think> tags, i.e. <think> planning process here </think> image here'''
+
+def move_generation_input_to_device(generation_input, device):
+    # Utility to move all tensors in generation_input to device
+    for k, v in generation_input.items():
+        if isinstance(v, torch.Tensor):
+            generation_input[k] = v.to(device)
+    return generation_input
+
+class InterleaveInferencer:
+    def __init__(
+        self,
+        model,
+        vae_model,
+        tokenizer,
+        vae_transform,
+        vit_transform,
+        new_token_ids,
+        device="cuda",
+    ):
+        self.model = model
+        self.vae_model = vae_model
+        self.tokenizer = tokenizer
+        self.vae_transform = vae_transform
+        self.vit_transform = vit_transform
+        self.new_token_ids = new_token_ids
+        self.device = device
+
+        model_dtype = next(self.model.parameters()).dtype
+
+        if not hasattr(self.model, "hf_device_map"):
+            self.model = self.model.to(self.device)
+
+        self.vae_model = self.vae_model.to(device=self.device, dtype=model_dtype)
+        self.vae_dtype = next(self.vae_model.parameters()).dtype
+
+    def init_gen_context(self): 
+        gen_context = {
+            'kv_lens': [0],
+            'ropes': [0],
+            'past_key_values': NaiveCache(self.model.config.llm_config.num_hidden_layers),
+        }
+        return gen_context
+
+    @torch.no_grad()
+    def update_context_text(self, text, gen_context):
+        # used for interleave data, currently only support 1 data inference, 
+
+        past_key_values = gen_context['past_key_values']
+        kv_lens = gen_context['kv_lens']
+        ropes = gen_context['ropes']
+        generation_input, kv_lens, ropes = self.model.prepare_prompts(
+            curr_kvlens=kv_lens,
+            curr_rope=ropes, 
+            prompts=[text],
+            tokenizer=self.tokenizer, 
+            new_token_ids=self.new_token_ids,
+        )
+        generation_input = move_generation_input_to_device(generation_input, self.device)
+        past_key_values = self.model.forward_cache_update_text(past_key_values, **generation_input)        
+        gen_context['kv_lens'] = kv_lens
+        gen_context['ropes'] = ropes
+        gen_context['past_key_values'] = past_key_values
+        
+        return gen_context
+
+    @torch.no_grad()
+    def update_context_image(
+        self,
+        image,
+        gen_context,
+        vae=True,
+        vit=True,
+        vae_transform=None,
+        vit_transform=None,
+    ):
+        # used for interleave data, currently only support 1 data inference, 
+
+        assert vae or vit
+        past_key_values = gen_context['past_key_values']
+        kv_lens = gen_context['kv_lens']
+        ropes =  gen_context['ropes']
+        vae_transform = vae_transform or self.vae_transform
+        vit_transform = vit_transform or self.vit_transform
+
+        if vae:
+            ## update vae
+            generation_input, kv_lens, ropes = self.model.prepare_vae_images(
+                curr_kvlens=kv_lens,
+                curr_rope=ropes, 
+                images=[image],
+                transforms=vae_transform,
+                new_token_ids=self.new_token_ids,
+            )
+            generation_input = move_generation_input_to_device(generation_input, self.device)
+            past_key_values = self.model.forward_cache_update_vae(self.vae_model, past_key_values, **generation_input)
+        
+        if vit:
+            ## update vit
+            generation_input, kv_lens, ropes = self.model.prepare_vit_images(
+                curr_kvlens=kv_lens,
+                curr_rope=ropes, 
+                images=[image],
+                transforms=vit_transform,
+                new_token_ids=self.new_token_ids,
+            )
+            generation_input = move_generation_input_to_device(generation_input, self.device)
+            past_key_values = self.model.forward_cache_update_vit(past_key_values, **generation_input)
+
+        gen_context['kv_lens'] = kv_lens
+        gen_context['ropes'] = ropes
+        gen_context['past_key_values'] = past_key_values
+        
+        return gen_context
+
+    @torch.no_grad()
+    def gen_image(
+        self, 
+        image_shape, 
+        gen_context, 
+        cfg_text_scale=4.0,
+        cfg_img_scale=1.5,
+
+        cfg_text_precontext=None, 
+        cfg_img_precontext=None, 
+        cfg_interval=(0.4, 1.0),
+        cfg_renorm_min=0.0,
+        cfg_renorm_type="global",
+        
+        num_timesteps=50, 
+        timestep_shift=3.0,
+        num_output_vae=1,
+        output_raw_tensor=False,
+    ):
+        # print(cfg_renorm_type)
+        past_key_values = gen_context['past_key_values']
+        kv_lens = gen_context['kv_lens']
+        ropes = gen_context['ropes']
+        generation_input = self.model.prepare_vae_latent(
+            curr_kvlens=kv_lens + [0] * (num_output_vae - 1),
+            curr_rope=list(ropes[0] + x for x in range(num_output_vae)),
+            image_sizes=[image_shape] * num_output_vae,
+            new_token_ids=self.new_token_ids,
+        ) 
+        generation_input = move_generation_input_to_device(generation_input, self.device)
+        packed_seqlens = generation_input["packed_seqlens"]
+        generation_input["packed_seqlens"] = torch.sum(generation_input["packed_seqlens"], dim=0, keepdim=True, dtype=generation_input["packed_seqlens"].dtype)
+        generation_input["key_values_lens"] = torch.sum(generation_input["key_values_lens"], dim=0, keepdim=True, dtype=generation_input["key_values_lens"].dtype)
+
+        # text cfg
+        cfg_text_past_key_values = cfg_text_precontext['past_key_values']
+        kv_lens_cfg = cfg_text_precontext['kv_lens']
+        ropes_cfg = cfg_text_precontext['ropes']
+        generation_input_cfg_text = self.model.prepare_vae_latent_cfg(
+            curr_kvlens=kv_lens_cfg + [0] * (num_output_vae - 1),
+            curr_rope=list(ropes_cfg[0] + x for x in range(num_output_vae)),
+            image_sizes=[image_shape] * num_output_vae,
+        )
+        generation_input_cfg_text = move_generation_input_to_device(generation_input_cfg_text, self.device)
+        generation_input_cfg_text["cfg_key_values_lens"] = torch.sum(
+            generation_input_cfg_text["cfg_key_values_lens"],
+            dim=0,
+            keepdim=True,
+            dtype=generation_input_cfg_text["cfg_key_values_lens"].dtype,
+        )
+
+        # img cfg
+        cfg_img_past_key_values = cfg_img_precontext['past_key_values']
+        kv_lens_cfg = cfg_img_precontext['kv_lens']
+        ropes_cfg = cfg_img_precontext['ropes']
+        generation_input_cfg_img = self.model.prepare_vae_latent_cfg(
+            curr_kvlens=kv_lens_cfg + [0] * (num_output_vae - 1),
+            curr_rope=list(ropes_cfg[0] + x for x in range(num_output_vae)),
+            image_sizes=[image_shape] * num_output_vae,
+        )
+        generation_input_cfg_img = move_generation_input_to_device(generation_input_cfg_img, self.device)
+        generation_input_cfg_img["cfg_key_values_lens"] = torch.sum(
+            generation_input_cfg_img["cfg_key_values_lens"],
+            dim=0,
+            keepdim=True,
+            dtype=generation_input_cfg_img["cfg_key_values_lens"].dtype,
+        )
+
+
+        x_0 = self.model.generate_image(
+            past_key_values=past_key_values,
+            cfg_text_past_key_values=cfg_text_past_key_values,
+            cfg_img_past_key_values=cfg_img_past_key_values,
+            num_timesteps=num_timesteps,
+            cfg_text_scale=cfg_text_scale,
+            cfg_img_scale=cfg_img_scale,
+            cfg_interval=cfg_interval,
+            cfg_renorm_min=cfg_renorm_min,
+            cfg_renorm_type=cfg_renorm_type,
+            timestep_shift=timestep_shift,
+            **generation_input,
+            cfg_text_packed_position_ids=generation_input_cfg_text['cfg_packed_position_ids'],
+            cfg_text_packed_query_indexes=generation_input_cfg_text['cfg_packed_query_indexes'],
+            cfg_text_key_values_lens=generation_input_cfg_text['cfg_key_values_lens'],
+            cfg_text_packed_key_value_indexes=generation_input_cfg_text['cfg_packed_key_value_indexes'],
+            cfg_img_packed_position_ids=generation_input_cfg_img['cfg_packed_position_ids'],
+            cfg_img_packed_query_indexes=generation_input_cfg_img['cfg_packed_query_indexes'],
+            cfg_img_key_values_lens=generation_input_cfg_img['cfg_key_values_lens'],
+            cfg_img_packed_key_value_indexes=generation_input_cfg_img['cfg_packed_key_value_indexes'],
+            return_raw_latent=True,
+        )
+        unpacked_latent = x_0.split((packed_seqlens - 2).tolist())
+
+        images = [
+            self.decode_image(latent, image_shape, output_raw_tensor)
+            for latent in unpacked_latent
+        ]
+        return images
+
+
+    def decode_image(self, latent, image_shape, output_raw_tensor=False):
+        H, W = image_shape
+        h, w = H // self.model.latent_downsample, W // self.model.latent_downsample
+
+        latent = latent.reshape(1, h, w, self.model.latent_patch_size, self.model.latent_patch_size, self.model.latent_channel)
+        latent = torch.einsum("nhwpqc->nchpwq", latent)
+        latent = latent.reshape(1, self.model.latent_channel, h * self.model.latent_patch_size, w * self.model.latent_patch_size)
+        latent = latent.to(dtype=self.vae_dtype)
+        image = self.vae_model.decode(latent)
+
+        if output_raw_tensor:
+            image = image[0].permute(1, 2, 0).float().cpu().numpy()
+        else:
+            image = (image * 0.5 + 0.5).clamp(0, 1)[0].permute(1, 2, 0) * 255
+            image = Image.fromarray((image).to(torch.uint8).cpu().numpy())
+
+        return image
+
+    @torch.no_grad()
+    def gen_text(self, gen_context, max_length: int = 500, do_sample: bool = True, temperature: float = 1.0):
+        gen_context = deepcopy(gen_context)
+        past_key_values = gen_context['past_key_values']
+        kv_lens = gen_context['kv_lens']
+        ropes = gen_context['ropes']
+
+        generation_input = self.model.prepare_start_tokens(kv_lens, ropes, self.new_token_ids)
+        generation_input = move_generation_input_to_device(generation_input, self.device)
+        unpacked_latent = self.model.generate_text(
+            past_key_values=past_key_values,
+            max_length=max_length,
+            do_sample=do_sample,
+            temperature=temperature,
+            end_token_id=self.new_token_ids['eos_token_id'],
+            **generation_input,
+        )
+        output = self.tokenizer.decode(unpacked_latent[:,0])
+        output = output.split('<|im_end|>')[0].split('<|im_start|>')[1]
+        return output
+        
+    @torch.no_grad()
+    def interleave_inference(
+        self,
+        input_lists: List[Union[str, Image.Image]],
+        think=False,
+        understanding_output=False,
+        caption=False,
+        output_multiple_vae=False,
+        output_raw_tensor=False,
+        return_preprocessed_input=False,
+
+        max_think_token_n=1000,
+        do_sample=False,
+        text_temperature=0.3,
+        cfg_text_scale=3.0,
+        cfg_img_scale=1.5,
+        cfg_interval=[0.4, 1.0],
+        timestep_shift=3.0,
+        num_timesteps=50,
+        cfg_renorm_min=0.0,
+        cfg_renorm_type="global",
+        image_shapes=(1024, 1024),
+        vae_transform=None,
+        vit_transform=None,
+    ) -> List[Union[str, Image.Image]]:
+
+        output_list = []
+        gen_context = self.init_gen_context()
+        cfg_text_context = deepcopy(gen_context)
+        cfg_img_context = deepcopy(gen_context)
+        preprocessed_inputs = [] if return_preprocessed_input else None
+        vae_transform = vae_transform or self.vae_transform
+        vit_transform = vit_transform or self.vit_transform
+
+        autocast_device = "cuda" if str(self.device).startswith("cuda") else "cpu"
+        with torch.autocast(device_type=autocast_device, enabled=True, dtype=torch.bfloat16):
+            if think:
+                if understanding_output:
+                    system_prompt = VLM_THINK_SYSTEM_PROMPT 
+                else:
+                    system_prompt = GEN_THINK_SYSTEM_PROMPT
+                gen_context = self.update_context_text(system_prompt, gen_context)
+                cfg_img_context = self.update_context_text(system_prompt, cfg_img_context)
+
+            for input_term in input_lists:
+                if isinstance(input_term, str):
+                    cfg_text_context = deepcopy(gen_context)
+                    gen_context = self.update_context_text(input_term, gen_context)
+                    cfg_img_context = self.update_context_text(input_term, cfg_img_context)
+                    if return_preprocessed_input:
+                        preprocessed_inputs.append(input_term)
+
+                elif isinstance(input_term, Image.Image):
+                    input_term = vae_transform.resize_transform(pil_img2rgb(input_term))
+                    gen_context = self.update_context_image(
+                        input_term,
+                        gen_context,
+                        vae=not understanding_output,
+                        vae_transform=vae_transform,
+                        vit_transform=vit_transform,
+                    )
+
+                    image_shapes = input_term.size[::-1]
+                    cfg_text_context = deepcopy(gen_context)
+                    if return_preprocessed_input:
+                        preprocessed_inputs.append(input_term)
+
+                else:
+                    raise ValueError(f"Unsupported input type: {type(input_term)}")
+
+            if understanding_output:
+                gen_text = self.gen_text(gen_context, do_sample=do_sample, temperature=text_temperature, max_length=max_think_token_n)
+                output_list.append(gen_text)
+
+            else:
+                if think or caption:
+                    gen_text = self.gen_text(gen_context, do_sample=do_sample, temperature=text_temperature, max_length=max_think_token_n)
+                    gen_context = self.update_context_text(gen_text, gen_context)
+                    output_list.append(gen_text)
+
+                input_image_count = sum(
+                    isinstance(item, Image.Image)
+                    for item in input_lists
+                )
+                num_output_vae = (
+                    max(input_image_count, 1)
+                    if output_multiple_vae
+                    else 1
+                )
+
+                imgs = self.gen_image(
+                    image_shapes, 
+                    gen_context, 
+                    cfg_text_precontext=cfg_text_context, 
+                    cfg_img_precontext=cfg_img_context,
+
+                    cfg_text_scale=cfg_text_scale, 
+                    cfg_img_scale=cfg_img_scale, 
+                    cfg_interval=cfg_interval, 
+                    timestep_shift=timestep_shift, 
+                    num_timesteps=num_timesteps,
+                    cfg_renorm_min=cfg_renorm_min,
+                    cfg_renorm_type=cfg_renorm_type,
+                    num_output_vae=num_output_vae,
+                    output_raw_tensor=output_raw_tensor,
+                )
+
+                output_list.extend(imgs)
+
+        if return_preprocessed_input:
+            return output_list, preprocessed_inputs
+
+        return output_list
+    
+    def __call__(
+        self, 
+        image: Optional[Union[Image.Image, List[Image.Image]]] = None,
+        text: Optional[str] = None, 
+        **kargs
+    ) -> Dict[str, Any]:
+        output_dict = {'image': None, 'text': None}
+
+        if image is None and text is None:
+            print('Please provide at least one input: either an image or text.')
+            return output_dict
+
+        input_list = []
+        if image is not None:
+            if isinstance(image, Image.Image):
+                input_list.append(image)
+            else:
+                input_list.extend(image)
+        if text is not None:
+            input_list.append(text)
+
+        output_list = self.interleave_inference(input_list, **kargs)
+
+        for i in output_list:
+            if isinstance(i, Image.Image):
+                output_dict['image'] = i
+            elif isinstance(i, str):
+                output_dict['text'] = i
+        return output_dict

--- a/libreyolo/models/sensenova/model.py
+++ b/libreyolo/models/sensenova/model.py
@@ -248,10 +248,20 @@ class LibreSenseNovaVision(LibreVLMModel):
         self._max_memory_per_gpu = max_memory_per_gpu
         self.noise_seed = noise_seed
         self._user_vocab = False
+        # The configured vocabulary, kept separate from ``self.names`` because
+        # a panoptic prediction rewrites ``names`` with its (possibly
+        # open-vocabulary-extended) label table for Results naming; prompts
+        # must keep building from what the caller configured.
+        self._vocab: Optional[Dict[int, str]] = None
         # Filled by _init_model.
         self.inferencer = None
         self.tokenizer = None
         super().__init__(size=size, **kwargs)
+        if self._vocab is None:
+            self._vocab = dict(self.names)
+        # A prompt= override is written against the task active at
+        # construction; it must not leak into other tasks after set_task().
+        self._custom_prompt_task = self.task if self._custom_prompt else None
 
     # =========================================================================
     # Task and vocabulary surface
@@ -259,21 +269,26 @@ class LibreSenseNovaVision(LibreVLMModel):
 
     def set_classes(self, classes: list) -> "LibreSenseNovaVision":
         self._user_vocab = True
-        return super().set_classes(classes)
+        result = super().set_classes(classes)
+        self._vocab = dict(self.names)
+        return result
 
     def _task_names(self) -> Dict[int, str]:
         """The effective vocabulary for the active task.
 
-        Unless the user set one, panoptic falls back to the COCO panoptic
-        categories the model was tuned on, and pose falls back to ``person``.
+        Reads the configured vocabulary (``_vocab``), never ``self.names``,
+        so a panoptic prediction's label-table rewrite cannot leak into later
+        prompts. Unless the user set a vocabulary, panoptic falls back to the
+        COCO panoptic categories the model was tuned on, and pose falls back
+        to ``person``.
         """
         if self._user_vocab:
-            return self.names
+            return dict(self._vocab)
         if self.task == "panoptic":
             return {i: name for i, name in enumerate(COCO_PANOPTIC_NAMES)}
         if self.task == "pose":
             return {0: "person"}
-        return self.names
+        return dict(self._vocab)
 
     def _require_user_vocab(self) -> None:
         if not self._user_vocab:
@@ -306,7 +321,7 @@ class LibreSenseNovaVision(LibreVLMModel):
 
     def _task_prompt(self) -> str:
         """Build the exact instruction the checkpoint expects for the task."""
-        if self._custom_prompt:
+        if self._custom_prompt and self.task == self._custom_prompt_task:
             return self._custom_prompt
         names = self._task_names()
         if self.task == "detect":
@@ -675,6 +690,11 @@ class LibreSenseNovaVision(LibreVLMModel):
         mode = _TASK_TO_MODE[self.task]
         params = dict(BASE_PARAMS[mode])
         inputs = _SenseNovaInputs(img, self._task_prompt(), mode, params)
+        # Re-derive the Results label table from the active task's vocabulary
+        # so a previous panoptic prediction's rewrite does not mislabel this
+        # prediction's class ids.
+        self.names = dict(self._task_names())
+        self.nb_classes = len(self.names)
         return inputs, img, img.size, 1.0
 
     def _forward(self, inputs: _SenseNovaInputs) -> Dict[str, Any]:

--- a/libreyolo/models/sensenova/model.py
+++ b/libreyolo/models/sensenova/model.py
@@ -1,0 +1,869 @@
+"""LibreYOLO wrapper for SenseNova-Vision, a unified multimodal vision model.
+
+SenseNova-Vision (SenseTime, Apache-2.0 code) casts vision tasks as prompted
+generation on a Bagel-MoT backbone: symbolic outputs (boxes, points,
+keypoints, OCR words) are generated as tagged text, and dense outputs (depth
+maps, segmentation masks, panoptic color maps) are generated as images that a
+frozen VAE decodes. One checkpoint therefore serves many LibreYOLO tasks; this
+family is the first LibreVLM member whose ``task=`` spans the dense tasks.
+
+    from libreyolo import LibreVLM
+    model = LibreVLM("sensenova-vision", task="depth")
+    result = model.predict("image.jpg")          # -> Results.depth_map
+    model.set_task("detect").set_classes(["bird", "boat"])
+    result = model.predict("image.jpg")          # -> Results.boxes
+
+The model is heavy (14.7B parameters, ~29.6 GB in bf16) and runs one diffusion
+decode per dense prediction; it is a capability model, not a real-time one.
+``dtype="auto"`` picks bf16 on large GPUs and 4-bit NF4 quantization (via
+bitsandbytes) on consumer GPUs.
+
+Weights are downloaded at runtime from the upstream Hugging Face repository
+under its CC BY-NC 4.0 terms; LibreYOLO does not redistribute them.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+
+from ...utils.image_loader import ImageInput, ImageLoader
+from ..vlm.base import LibreVLMModel
+from ..vlm.parsing import build_detection_dict
+from . import parsing
+from .prompts import (
+    BBOX_DETECTION_PROMPT_TEMPLATE,
+    CAPTION_QUESTION_TEMPLATE,
+    COCO_PANOPTIC_NAMES,
+    DEPTH_PROMPT,
+    HUMAN_KEYPOINT_CATEGORIES,
+    KEYPOINT_PROMPT_TEMPLATES,
+    MASK_QUESTION_TEMPLATE,
+    OCR_PROMPT,
+    POINT_DETECTION_PROMPT_TEMPLATE,
+)
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "LibreSenseNovaVision requires the 'sensenova' extra. Install with:\n"
+    "    pip install 'libreyolo[sensenova]'"
+)
+
+# Per-mode generation parameters, ported from inference/sensenova_vision.py
+# BASE_PARAMS (Apache-2.0). The released checkpoint was tuned against these
+# exact schedules; recon3d is intentionally not ported in v1.
+BASE_PARAMS: Dict[str, Dict[str, Any]] = {
+    "generate": dict(
+        cfg_text_scale=4.0,
+        cfg_img_scale=1.0,
+        cfg_interval=[0.4, 1.0],
+        timestep_shift=3.0,
+        num_timesteps=50,
+        cfg_renorm_min=1.0,
+        cfg_renorm_type="global",
+    ),
+    "think_generate": dict(
+        max_think_token_n=1000,
+        do_sample=False,
+        cfg_text_scale=4.0,
+        cfg_img_scale=1.0,
+        cfg_interval=[0.4, 1.0],
+        timestep_shift=3.0,
+        num_timesteps=50,
+        cfg_renorm_min=1.0,
+        cfg_renorm_type="global",
+        think=True,
+    ),
+    "caption_generate": dict(
+        max_think_token_n=8192,
+        do_sample=False,
+        cfg_text_scale=4.0,
+        cfg_img_scale=1.0,
+        cfg_interval=[0.0, 1.0],
+        timestep_shift=4.0,
+        num_timesteps=50,
+        cfg_renorm_min=1.0,
+        cfg_renorm_type="global",
+        caption=True,
+    ),
+    "dense_perception": dict(
+        cfg_text_scale=4.0,
+        cfg_img_scale=1.0,
+        cfg_interval=[0.0, 1.0],
+        timestep_shift=4.0,
+        num_timesteps=50,
+        cfg_renorm_min=1.0,
+        cfg_renorm_type="text_channel",
+    ),
+    "edit": dict(
+        cfg_text_scale=4.0,
+        cfg_img_scale=2.0,
+        cfg_interval=[0.0, 1.0],
+        timestep_shift=4.0,
+        num_timesteps=50,
+        cfg_renorm_min=1.0,
+        cfg_renorm_type="text_channel",
+    ),
+    "think_edit": dict(
+        max_think_token_n=1000,
+        do_sample=False,
+        cfg_text_scale=4.0,
+        cfg_img_scale=2.0,
+        cfg_interval=[0.4, 1.0],
+        timestep_shift=3.0,
+        num_timesteps=50,
+        cfg_renorm_min=0.0,
+        cfg_renorm_type="text_channel",
+        think=True,
+    ),
+    "understanding": dict(
+        max_think_token_n=8192,
+        do_sample=False,
+        understanding_output=True,
+    ),
+    "think_understanding": dict(
+        max_think_token_n=8192,
+        do_sample=False,
+        understanding_output=True,
+        think=True,
+    ),
+    "dense_detection": dict(
+        max_think_token_n=8192,
+        do_sample=False,
+        understanding_output=True,
+    ),
+    "dense_OCR": dict(
+        max_think_token_n=20000,
+        do_sample=False,
+        understanding_output=True,
+    ),
+}
+
+IMAGE_OUTPUT_MODES = {
+    "generate",
+    "think_generate",
+    "caption_generate",
+    "dense_perception",
+    "edit",
+    "think_edit",
+}
+
+# LibreYOLO task -> (inference mode, needs a class vocabulary in the prompt)
+_TASK_TO_MODE = {
+    "detect": "dense_detection",
+    "point": "dense_detection",
+    "pose": "dense_detection",
+    "ocr": "dense_OCR",
+    "depth": "dense_perception",
+    "segment": "dense_perception",
+    "panoptic": "caption_generate",
+}
+
+
+class _SenseNovaInputs:
+    """Preprocessed inputs for one predict call.
+
+    The shared InferenceRunner calls ``inputs.to(device)`` before forwarding;
+    device placement is owned by the accelerate-dispatched model, so ``to`` is
+    a no-op.
+    """
+
+    def __init__(self, image: Image.Image, prompt: str, mode: str, params: Dict[str, Any]):
+        self.image = image
+        self.prompt = prompt
+        self.mode = mode
+        self.params = params
+
+    def to(self, _device):
+        return self
+
+
+def _set_seed(seed: Optional[int]) -> None:
+    """Seed diffusion noise for reproducible dense generations."""
+    if seed is None:
+        return
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+class LibreSenseNovaVision(LibreVLMModel):
+    """SenseNova-Vision as a multi-task LibreVLM family."""
+
+    FAMILY = "sensenovavision"
+    FILENAME_PREFIX = "SenseNovaVision"
+
+    HF_REPOS: ClassVar[Dict[str, str]] = {
+        "7b": "sensenova/SenseNova-Vision-7B-MoT",
+    }
+    # Weight-only repo (no remote code); the pin still keeps downloads
+    # reproducible across releases.
+    HF_REVISIONS: ClassVar[Dict[str, str]] = {}
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {
+        "7b": 1024,
+    }
+
+    SUPPORTED_TASKS = ("detect", "segment", "panoptic", "pose", "point", "depth", "ocr")
+    DEFAULT_TASK = "detect"
+
+    # The upstream repo also ships showcase images; only weights/configs are
+    # needed to run.
+    SNAPSHOT_IGNORE_PATTERNS: ClassVar[tuple] = LibreVLMModel.SNAPSHOT_IGNORE_PATTERNS + (
+        "assets/*",
+    )
+
+    _LICENSE_NOTICE = (
+        "\n"
+        "----------------------------------------------------------------\n"
+        "SenseNova-Vision-7B-MoT weights are provided by SenseTime under\n"
+        "CC BY-NC 4.0 (non-commercial use only). LibreYOLO does not\n"
+        "redistribute these weights; they are downloaded from the upstream\n"
+        "Hugging Face repository and you are responsible for complying with\n"
+        "their terms:\n"
+        "  https://huggingface.co/sensenova/SenseNova-Vision-7B-MoT\n"
+        "----------------------------------------------------------------\n"
+    )
+
+    def __init__(
+        self,
+        size: str = "7b",
+        *,
+        dtype: str = "auto",
+        max_memory_per_gpu: Optional[str] = None,
+        noise_seed: Optional[int] = 42,
+        **kwargs,
+    ):
+        self._requested_dtype = str(dtype).lower()
+        self._max_memory_per_gpu = max_memory_per_gpu
+        self.noise_seed = noise_seed
+        self._user_vocab = False
+        # Filled by _init_model.
+        self.inferencer = None
+        self.tokenizer = None
+        super().__init__(size=size, **kwargs)
+
+    # =========================================================================
+    # Task and vocabulary surface
+    # =========================================================================
+
+    def set_classes(self, classes: list) -> "LibreSenseNovaVision":
+        self._user_vocab = True
+        return super().set_classes(classes)
+
+    def _task_names(self) -> Dict[int, str]:
+        """The effective vocabulary for the active task.
+
+        Unless the user set one, panoptic falls back to the COCO panoptic
+        categories the model was tuned on, and pose falls back to ``person``.
+        """
+        if self._user_vocab:
+            return self.names
+        if self.task == "panoptic":
+            return {i: name for i, name in enumerate(COCO_PANOPTIC_NAMES)}
+        if self.task == "pose":
+            return {0: "person"}
+        return self.names
+
+    def _require_user_vocab(self) -> None:
+        if not self._user_vocab:
+            raise ValueError(
+                "Referring segmentation needs a target phrase. Call "
+                'set_classes(["<phrase>"]) first, e.g. '
+                'set_classes(["person furthest to the right"]).'
+            )
+
+    # =========================================================================
+    # Prompts
+    # =========================================================================
+
+    @staticmethod
+    def _format_categories(names: Dict[int, str]) -> str:
+        return ", ".join(f"<p>{names[i]}</p>" for i in range(len(names)))
+
+    def _keypoint_prompt(self, names: Dict[int, str]) -> str:
+        categories = self._format_categories(names)
+        labels = [str(v).strip().lower() for v in names.values()]
+        has_human = any(label in HUMAN_KEYPOINT_CATEGORIES for label in labels)
+        has_animal = any(label not in HUMAN_KEYPOINT_CATEGORIES for label in labels)
+        if has_human and has_animal:
+            kind = "mixed"
+        elif has_human:
+            kind = "human"
+        else:
+            kind = "animal"
+        return KEYPOINT_PROMPT_TEMPLATES[kind].format(categories=categories)
+
+    def _task_prompt(self) -> str:
+        """Build the exact instruction the checkpoint expects for the task."""
+        if self._custom_prompt:
+            return self._custom_prompt
+        names = self._task_names()
+        if self.task == "detect":
+            return BBOX_DETECTION_PROMPT_TEMPLATE.format(
+                categories=self._format_categories(names)
+            )
+        if self.task == "point":
+            return POINT_DETECTION_PROMPT_TEMPLATE.format(
+                categories=self._format_categories(names)
+            )
+        if self.task == "pose":
+            return self._keypoint_prompt(names)
+        if self.task == "ocr":
+            return OCR_PROMPT
+        if self.task == "depth":
+            return DEPTH_PROMPT
+        if self.task == "segment":
+            self._require_user_vocab()
+            return MASK_QUESTION_TEMPLATE.format(
+                categories=self._format_categories(names), task_type="binary"
+            )
+        if self.task == "panoptic":
+            category_prompt = MASK_QUESTION_TEMPLATE.format(
+                categories=self._format_categories(names), task_type="panoptic"
+            )
+            caption_prompt = CAPTION_QUESTION_TEMPLATE.format(task_type="panoptic")
+            return f"{category_prompt} {caption_prompt}"
+        raise ValueError(f"Unsupported task: {self.task!r}")
+
+    # =========================================================================
+    # Loading
+    # =========================================================================
+
+    def _select_dtype(self) -> str:
+        if self._requested_dtype != "auto":
+            return self._requested_dtype
+        if self.device.type != "cuda":
+            # The checkpoint is stored in bf16; fp32 would double memory.
+            return "bf16"
+        total = torch.cuda.get_device_properties(self.device.index or 0).total_memory
+        if total >= 35 * 1024**3:
+            return "bf16"
+        try:
+            import bitsandbytes  # noqa: F401
+
+            logger.info(
+                "LibreSenseNovaVision: GPU has %.0f GiB; loading NF4-quantized "
+                "(pass dtype='bf16' to override).",
+                total / 1024**3,
+            )
+            return "nf4"
+        except ImportError as exc:
+            raise ImportError(
+                "SenseNova-Vision needs ~30 GiB of VRAM in bf16, and this GPU "
+                f"has {total / 1024**3:.0f} GiB. Install bitsandbytes for 4-bit "
+                "loading (pip install bitsandbytes) or pass dtype='bf16' with a "
+                "larger GPU."
+            ) from exc
+
+    def _max_memory(self) -> Dict[Any, str]:
+        if self.device.type != "cuda":
+            return {"cpu": "128GiB"}
+        if self._max_memory_per_gpu is not None:
+            budget = self._max_memory_per_gpu
+            return {i: budget for i in range(torch.cuda.device_count())}
+        max_memory = {}
+        for i in range(torch.cuda.device_count()):
+            total = torch.cuda.get_device_properties(i).total_memory
+            # Leave headroom for activations and the VAE decode.
+            max_memory[i] = f"{int(total * 0.9 / 1024**3)}GiB"
+        return max_memory
+
+    def _load_pretrained(self, snapshot_dir: str):
+        """Build the Bagel skeleton and load the checkpoint through accelerate."""
+        try:
+            from accelerate import (
+                infer_auto_device_map,
+                init_empty_weights,
+                load_checkpoint_and_dispatch,
+            )
+            from transformers import AutoTokenizer
+        except ImportError as exc:
+            raise ImportError(_INSTALL_HINT) from exc
+
+        import os
+
+        from .modeling.autoencoder import load_ae
+        from .modeling.bagel import Bagel, BagelConfig
+        from .modeling.qwen2_navit import Qwen2Config, Qwen2ForCausalLM
+        from .modeling.siglip_navit import SiglipVisionConfig, SiglipVisionModel
+        from .data_utils import add_special_tokens
+        from .inferencer import InterleaveInferencer
+        from .transforms import ImageTransform
+
+        llm_config = Qwen2Config.from_json_file(os.path.join(snapshot_dir, "llm_config.json"))
+        llm_config.qk_norm = True
+        llm_config.tie_word_embeddings = False
+        llm_config.layer_module = "Qwen2MoTDecoderLayer"
+
+        vit_config = SiglipVisionConfig.from_json_file(
+            os.path.join(snapshot_dir, "vit_config.json")
+        )
+        vit_config.rope = False
+        vit_config.num_hidden_layers = vit_config.num_hidden_layers - 1
+
+        vae_model, vae_config = load_ae(
+            local_path=os.path.join(snapshot_dir, "ae.safetensors")
+        )
+
+        tokenizer = AutoTokenizer.from_pretrained(snapshot_dir)
+        tokenizer, new_token_ids, _ = add_special_tokens(tokenizer)
+
+        bagel_config = BagelConfig(
+            visual_gen=True,
+            visual_und=True,
+            llm_config=llm_config,
+            vit_config=vit_config,
+            vae_config=vae_config,
+            latent_patch_size=2,
+            max_latent_size=64,
+            vit_max_num_patch_per_side=70,
+            connector_act="gelu_pytorch_tanh",
+        )
+
+        with init_empty_weights():
+            language_model = Qwen2ForCausalLM(llm_config)
+            vit_model = SiglipVisionModel(vit_config)
+            model = Bagel(language_model, vit_model, bagel_config)
+            model.vit_model.vision_model.embeddings.convert_conv2d_to_linear(
+                vit_config, meta=True
+            )
+
+        device_map = infer_auto_device_map(
+            model,
+            max_memory=self._max_memory(),
+            no_split_module_classes=["Bagel", "Qwen2MoTDecoderLayer"],
+        )
+        # Keep the shared embedding/connector modules on one device.
+        same_device_modules = [
+            "language_model.model.embed_tokens",
+            "time_embedder",
+            "latent_pos_embed",
+            "vae2llm",
+            "llm2vae",
+            "connector",
+            "vit_pos_embed",
+        ]
+        first_device = device_map.get(
+            same_device_modules[0],
+            str(self.device) if self.device.type == "cuda" else "cpu",
+        )
+        for key in same_device_modules:
+            device_map[key] = device_map.get(key, first_device)
+
+        checkpoint_path = os.path.join(snapshot_dir, "ema.safetensors")
+        selected_dtype = self._select_dtype()
+
+        if selected_dtype in ("nf4", "int8"):
+            from accelerate.utils import BnbQuantizationConfig, load_and_quantize_model
+
+            if selected_dtype == "nf4":
+                quant_config = BnbQuantizationConfig(
+                    load_in_4bit=True,
+                    bnb_4bit_compute_dtype=torch.bfloat16,
+                    bnb_4bit_use_double_quant=False,
+                    bnb_4bit_quant_type="nf4",
+                )
+            else:
+                quant_config = BnbQuantizationConfig(
+                    load_in_8bit=True, torch_dtype=torch.float32
+                )
+            model = load_and_quantize_model(
+                model,
+                weights_location=checkpoint_path,
+                bnb_quantization_config=quant_config,
+                device_map=device_map,
+                offload_folder=None,
+            ).eval()
+        else:
+            torch_dtype = {
+                "bf16": torch.bfloat16,
+                "bfloat16": torch.bfloat16,
+                "fp16": torch.float16,
+                "float16": torch.float16,
+                "fp32": torch.float32,
+                "float32": torch.float32,
+            }.get(selected_dtype)
+            if torch_dtype is None:
+                raise ValueError(
+                    f"Unsupported dtype {selected_dtype!r}. Use auto, bf16, fp16, "
+                    "fp32, nf4 or int8."
+                )
+            model = load_checkpoint_and_dispatch(
+                model,
+                checkpoint=checkpoint_path,
+                device_map=device_map,
+                offload_buffers=True,
+                dtype=torch_dtype,
+                force_hooks=True,
+            ).eval()
+
+        # Record the dispatch layout; the inferencer (and transformers) use it
+        # to skip whole-model device moves. When part of the checkpoint is
+        # offloaded to CPU, a later ``.to(device)`` (BaseModel moves the model
+        # after init) would break the accelerate hooks, so neutralize it.
+        model.hf_device_map = device_map
+        if any(str(target) in ("cpu", "disk") for target in device_map.values()):
+            import types
+
+            model.to = types.MethodType(lambda module, *args, **kwargs: module, model)
+
+        vae_device = str(self.device)
+        vae_model = vae_model.to(device=vae_device).eval()
+
+        self.tokenizer = tokenizer
+        self._new_token_ids = new_token_ids
+        self._vae_model = vae_model
+        self._vae_transform = ImageTransform(1024, 512, 16)
+        self._vit_transform = ImageTransform(980, 224, 14)
+        self.inferencer = InterleaveInferencer(
+            model=model,
+            vae_model=vae_model,
+            tokenizer=tokenizer,
+            vae_transform=self._vae_transform,
+            vit_transform=self._vit_transform,
+            new_token_ids=new_token_ids,
+            device=vae_device,
+        )
+        # No HF processor for this family; the inferencer owns preprocessing.
+        return model, None
+
+    def _init_model(self):
+        snapshot_dir = self._ensure_weights()
+        model, _ = self._load_pretrained(snapshot_dir)
+        self.processor = None
+        self._model_dtype = next(
+            (p.dtype for p in model.parameters() if p.is_floating_point()),
+            torch.bfloat16,
+        )
+        return model
+
+    # =========================================================================
+    # Raw escape hatches
+    # =========================================================================
+
+    def generate(
+        self,
+        prompt: str,
+        images: Optional[List[ImageInput]] = None,
+        mode: str = "understanding",
+        max_new_tokens: Optional[int] = None,
+        noise_seed: Optional[int] = None,
+        **overrides,
+    ):
+        """Run one raw SenseNova-Vision request: images plus prompt in, text or
+        image out.
+
+        ``mode`` selects the upstream inference schedule (understanding,
+        dense_perception, dense_detection, dense_OCR, caption_generate,
+        generate, edit, and their think variants). Image-output modes return a
+        ``PIL.Image``; text modes return ``str``; modes that produce both
+        return ``{"image": ..., "text": ...}``.
+        """
+        if self.inferencer is None:
+            raise RuntimeError("Model is not loaded.")
+        if mode not in BASE_PARAMS:
+            raise ValueError(
+                f"Invalid mode {mode!r}. Supported modes: {sorted(BASE_PARAMS)}"
+            )
+        params = dict(BASE_PARAMS[mode])
+        params.update(overrides)
+        if max_new_tokens is not None:
+            params["max_think_token_n"] = max_new_tokens
+        think = params.pop("think", False)
+        understanding_output = params.pop("understanding_output", False)
+
+        input_lists: List[Any] = []
+        for image in images or []:
+            input_lists.append(ImageLoader.load(image, color_format="auto"))
+        text = str(prompt).strip()
+        if text:
+            input_lists.append(text)
+        if not input_lists:
+            raise ValueError("generate() needs a prompt and/or at least one image.")
+
+        _set_seed(self.noise_seed if noise_seed is None else noise_seed)
+        with torch.no_grad():
+            outputs = self.inferencer.interleave_inference(
+                input_lists,
+                think=think,
+                understanding_output=understanding_output,
+                **params,
+            )
+
+        images_out = [item for item in outputs if isinstance(item, Image.Image)]
+        texts_out = [item for item in outputs if isinstance(item, str)]
+        if mode in IMAGE_OUTPUT_MODES and images_out and not texts_out:
+            return images_out[0]
+        if not images_out and texts_out:
+            return texts_out[0]
+        return {
+            "image": images_out[0] if images_out else None,
+            "text": texts_out[0] if texts_out else None,
+        }
+
+    def chat(
+        self,
+        image: ImageInput,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+        color_format: str = "auto",
+    ) -> str:
+        """Free-form visual question answering on one image."""
+        img = ImageLoader.load(image, color_format=color_format)
+        result = self.generate(
+            prompt, images=[img], mode="understanding", max_new_tokens=max_new_tokens
+        )
+        return result if isinstance(result, str) else str(result.get("text") or "")
+
+    # =========================================================================
+    # InferenceRunner hooks
+    # =========================================================================
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[Any, Any, Tuple[int, int], float]:
+        img = ImageLoader.load(image, color_format=color_format)
+        mode = _TASK_TO_MODE[self.task]
+        params = dict(BASE_PARAMS[mode])
+        inputs = _SenseNovaInputs(img, self._task_prompt(), mode, params)
+        return inputs, img, img.size, 1.0
+
+    def _forward(self, inputs: _SenseNovaInputs) -> Dict[str, Any]:
+        params = dict(inputs.params)
+        think = params.pop("think", False)
+        understanding_output = params.pop("understanding_output", False)
+        _set_seed(self.noise_seed)
+        outputs = self.inferencer.interleave_inference(
+            [inputs.image, inputs.prompt],
+            think=think,
+            understanding_output=understanding_output,
+            **params,
+        )
+        result = {"image": None, "text": None}
+        for item in outputs:
+            if isinstance(item, Image.Image) and result["image"] is None:
+                result["image"] = item
+            elif isinstance(item, str) and result["text"] is None:
+                result["text"] = item
+        return result
+
+    def _postprocess(
+        self,
+        output: Dict[str, Any],
+        conf_thres: float,
+        iou_thres: float,
+        original_size: Tuple[int, int],
+        max_det: int = 300,
+        ratio: float = 1.0,
+        **kwargs,
+    ) -> Dict:
+        text = output.get("text") or ""
+        image = output.get("image")
+        classes = kwargs.get("classes")
+
+        if self.task == "detect":
+            return self._postprocess_detect(text, conf_thres, iou_thres, original_size, max_det, classes)
+        if self.task == "point":
+            return self._postprocess_point(text, conf_thres, original_size, max_det, classes)
+        if self.task == "pose":
+            return self._postprocess_pose(text, conf_thres, original_size, max_det, classes)
+        if self.task == "ocr":
+            return self._postprocess_ocr(text, original_size, max_det)
+        if self.task == "depth":
+            return self._postprocess_depth(image, original_size)
+        if self.task == "segment":
+            return self._postprocess_segment(image, conf_thres, original_size)
+        if self.task == "panoptic":
+            return self._postprocess_panoptic(image, text, original_size)
+        raise ValueError(f"Unsupported task: {self.task!r}")
+
+    # ---- symbolic tasks ----
+
+    def _postprocess_detect(self, text, conf_thres, iou_thres, original_size, max_det, classes):
+        parsed = parsing.parse_tagged_boxes(text)
+        items = [
+            {"label": label, "bbox": box}
+            for label, boxes in parsed.items()
+            for box in boxes
+        ]
+        name_to_id = {
+            parsing.normalize_category(v): k for k, v in self._task_names().items()
+        }
+        return build_detection_dict(
+            items,
+            name_to_id,
+            original_size,
+            conf_thres=conf_thres,
+            max_det=max_det,
+            classes=classes,
+            default_score=self._score_detections(items),
+            bbox_key="bbox",
+            coord_divisor=1.0,
+            box_format="xyxy",
+            iou_thres=iou_thres,
+        )
+
+    def _postprocess_point(self, text, conf_thres, original_size, max_det, classes):
+        width, height = original_size
+        parsed = parsing.parse_tagged_points(text)
+        name_to_id = {
+            parsing.normalize_category(v): k for k, v in self._task_names().items()
+        }
+        allowed = set(classes) if classes is not None else None
+        score = self._score_detections(parsed)
+        rows: List[List[float]] = []
+        seen = set()
+        if score >= conf_thres and max_det > 0:
+            for label, points in parsed.items():
+                class_id = name_to_id.get(label)
+                if class_id is None:
+                    continue
+                if allowed is not None and class_id not in allowed:
+                    continue
+                for x, y in points:
+                    key = (class_id, round(x, 3), round(y, 3))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    rows.append([x * width, y * height, float(class_id), score])
+                    if len(rows) >= max_det:
+                        break
+                if len(rows) >= max_det:
+                    break
+        return {"points": rows, "num_detections": len(rows)}
+
+    def _postprocess_pose(self, text, conf_thres, original_size, max_det, classes):
+        width, height = original_size
+        parsed = parsing.parse_tagged_keypoints(text)
+        names = self._task_names()
+        name_to_id = {parsing.normalize_category(v): k for k, v in names.items()}
+        allowed = set(classes) if classes is not None else None
+        score = self._score_detections(parsed)
+
+        boxes, scores, class_ids, keypoints = [], [], [], []
+        if score >= conf_thres and max_det > 0:
+            for label, instances in parsed.items():
+                class_id = name_to_id.get(label)
+                if class_id is None:
+                    continue
+                if allowed is not None and class_id not in allowed:
+                    continue
+                skeleton = (
+                    parsing.HUMAN_KEYPOINT_NAMES
+                    if label in HUMAN_KEYPOINT_CATEGORIES
+                    else parsing.ANIMAL_KEYPOINT_NAMES
+                )
+                for instance in instances:
+                    kpts = parsing.keypoint_instance_to_array(
+                        instance, skeleton, width, height
+                    )
+                    bbox = instance.get("bbox")
+                    if bbox is not None:
+                        x0, y0, x1, y1 = bbox
+                        box = [x0 * width, y0 * height, x1 * width, y1 * height]
+                    else:
+                        visible = kpts[kpts[:, 2] > 0][:, :2]
+                        if len(visible) == 0:
+                            continue
+                        box = [
+                            float(visible[:, 0].min()),
+                            float(visible[:, 1].min()),
+                            float(visible[:, 0].max()),
+                            float(visible[:, 1].max()),
+                        ]
+                    boxes.append(box)
+                    scores.append(score)
+                    class_ids.append(class_id)
+                    keypoints.append(kpts)
+                    if len(boxes) >= max_det:
+                        break
+                if len(boxes) >= max_det:
+                    break
+
+        detections = {
+            "boxes": boxes,
+            "scores": scores,
+            "classes": class_ids,
+            "num_detections": len(boxes),
+        }
+        if keypoints:
+            detections["keypoints"] = np.stack(keypoints, axis=0)
+        return detections
+
+    def _postprocess_ocr(self, text, original_size, max_det):
+        width, height = original_size
+        parsed = parsing.parse_tagged_boxes(text, normalize_labels=False)
+        polygons, texts = [], []
+        for word, boxes in parsed.items():
+            for x0, y0, x1, y1 in boxes:
+                if len(polygons) >= max_det:
+                    break
+                polygons.append(
+                    [
+                        [x0 * width, y0 * height],
+                        [x1 * width, y0 * height],
+                        [x1 * width, y1 * height],
+                        [x0 * width, y1 * height],
+                    ]
+                )
+                texts.append(word)
+        return {
+            "ocr": {
+                "polygons": polygons,
+                "texts": texts,
+                "confidences": [self.DEFAULT_SCORE] * len(texts),
+                "det_confidences": [self.DEFAULT_SCORE] * len(texts),
+            }
+        }
+
+    # ---- dense tasks ----
+
+    def _postprocess_depth(self, image, original_size):
+        width, height = original_size
+        if image is None:
+            depth = np.zeros((height, width), dtype=np.float32)
+        else:
+            depth = parsing.depth_from_image(image, original_size)
+        return {"depth": depth}
+
+    def _postprocess_segment(self, image, conf_thres, original_size):
+        empty = {"boxes": [], "scores": [], "classes": [], "num_detections": 0}
+        if image is None or self.DEFAULT_SCORE < conf_thres:
+            return empty
+        mask = parsing.binary_mask_from_image(image, original_size)
+        box = parsing.mask_to_xyxy(mask)
+        if box is None:
+            return empty
+        return {
+            "boxes": [box],
+            "scores": [self.DEFAULT_SCORE],
+            "classes": [0],
+            "num_detections": 1,
+            "masks": mask[None, :, :].astype(np.uint8),
+        }
+
+    def _postprocess_panoptic(self, image, text, original_size):
+        width, height = original_size
+        if image is None:
+            return {
+                "panoptic": np.zeros((height, width), dtype=np.int64),
+                "segments_info": [],
+            }
+        id_map, segments_info, names = parsing.panoptic_from_mask_and_caption(
+            image, text, self._task_names(), original_size
+        )
+        # Registered open-vocabulary phrases extend the label table so
+        # Results can name every returned segment.
+        self.names = names
+        return {"panoptic": id_map, "segments_info": segments_info}

--- a/libreyolo/models/sensenova/model.py
+++ b/libreyolo/models/sensenova/model.py
@@ -18,8 +18,9 @@ decode per dense prediction; it is a capability model, not a real-time one.
 ``dtype="auto"`` picks bf16 on large GPUs and 4-bit NF4 quantization (via
 bitsandbytes) on consumer GPUs.
 
-Weights are downloaded at runtime from the upstream Hugging Face repository
-under its CC BY-NC 4.0 terms; LibreYOLO does not redistribute them.
+Weights are CC BY-NC 4.0 (non-commercial) and download at runtime from the
+byte-identical LibreYOLO mirror of the upstream release, after a one-time
+license notice.
 """
 
 from __future__ import annotations
@@ -202,7 +203,9 @@ class LibreSenseNovaVision(LibreVLMModel):
     FILENAME_PREFIX = "SenseNovaVision"
 
     HF_REPOS: ClassVar[Dict[str, str]] = {
-        "7b": "sensenova/SenseNova-Vision-7B-MoT",
+        # Byte-identical mirror of sensenova/SenseNova-Vision-7B-MoT at
+        # revision 79548fcc (SHA-256 pins in the repo card and family NOTICE).
+        "7b": "LibreYOLO/SenseNovaVision7b",
     }
     # Weight-only repo (no remote code); the pin still keeps downloads
     # reproducible across releases.
@@ -224,11 +227,11 @@ class LibreSenseNovaVision(LibreVLMModel):
         "\n"
         "----------------------------------------------------------------\n"
         "SenseNova-Vision-7B-MoT weights are provided by SenseTime under\n"
-        "CC BY-NC 4.0 (non-commercial use only). LibreYOLO does not\n"
-        "redistribute these weights; they are downloaded from the upstream\n"
-        "Hugging Face repository and you are responsible for complying with\n"
-        "their terms:\n"
-        "  https://huggingface.co/sensenova/SenseNova-Vision-7B-MoT\n"
+        "CC BY-NC 4.0: NON-COMMERCIAL use only. LibreYOLO mirrors the\n"
+        "unmodified weights with attribution; the license is unchanged and\n"
+        "you are responsible for complying with its terms.\n"
+        "  Mirror:   https://huggingface.co/LibreYOLO/SenseNovaVision7b\n"
+        "  Upstream: https://huggingface.co/sensenova/SenseNova-Vision-7B-MoT\n"
         "----------------------------------------------------------------\n"
     )
 

--- a/libreyolo/models/sensenova/model.py
+++ b/libreyolo/models/sensenova/model.py
@@ -363,17 +363,26 @@ class LibreSenseNovaVision(LibreVLMModel):
                 "larger GPU."
             ) from exc
 
-    def _max_memory(self) -> Dict[Any, str]:
+    def _max_memory(self, plan_scale: float = 1.0) -> Dict[Any, Any]:
+        """Per-device budgets for the dispatch planner, in bytes.
+
+        The planner sizes modules at their checkpoint (bf16) width, but a
+        quantized load shrinks them ~3.5x on the GPU, so quantized paths pass
+        ``plan_scale`` > 1 to let the planner place modules that will fit
+        after quantization.
+        """
         if self.device.type != "cuda":
-            return {"cpu": "128GiB"}
-        if self._max_memory_per_gpu is not None:
-            budget = self._max_memory_per_gpu
-            return {i: budget for i in range(torch.cuda.device_count())}
+            return {"cpu": 128 * 1024**3}
         max_memory = {}
         for i in range(torch.cuda.device_count()):
-            total = torch.cuda.get_device_properties(i).total_memory
-            # Leave headroom for activations and the VAE decode.
-            max_memory[i] = f"{int(total * 0.9 / 1024**3)}GiB"
+            if self._max_memory_per_gpu is not None:
+                from accelerate.utils import convert_file_size_to_int
+
+                budget = convert_file_size_to_int(self._max_memory_per_gpu)
+            else:
+                # Leave headroom for activations and the VAE decode.
+                budget = int(torch.cuda.get_device_properties(i).total_memory * 0.9)
+            max_memory[i] = int(budget * plan_scale)
         return max_memory
 
     def _load_pretrained(self, snapshot_dir: str):
@@ -390,11 +399,13 @@ class LibreSenseNovaVision(LibreVLMModel):
 
         import os
 
+        import json
+
         from .modeling.autoencoder import load_ae
         from .modeling.bagel import Bagel, BagelConfig
         from .modeling.qwen2_navit import Qwen2Config, Qwen2ForCausalLM
         from .modeling.siglip_navit import SiglipVisionConfig, SiglipVisionModel
-        from .data_utils import add_special_tokens
+        from .data_utils import CheckpointTokenizer, add_special_tokens
         from .inferencer import InterleaveInferencer
         from .transforms import ImageTransform
 
@@ -413,8 +424,25 @@ class LibreSenseNovaVision(LibreVLMModel):
             local_path=os.path.join(snapshot_dir, "ae.safetensors")
         )
 
-        tokenizer = AutoTokenizer.from_pretrained(snapshot_dir)
+        # The released tokenizer.json disagrees with the trained added-token
+        # layout recorded in tokenizer_config.json; CheckpointTokenizer
+        # overlays the trained layout (see its docstring).
+        base_tokenizer = AutoTokenizer.from_pretrained(snapshot_dir)
+        with open(
+            os.path.join(snapshot_dir, "tokenizer_config.json"), encoding="utf-8"
+        ) as f:
+            added_tokens = json.load(f).get("added_tokens_decoder", {})
+        tokenizer = CheckpointTokenizer(
+            base_tokenizer,
+            {int(i): t["content"] for i, t in added_tokens.items()},
+        )
         tokenizer, new_token_ids, _ = add_special_tokens(tokenizer)
+        if max(new_token_ids.values()) >= llm_config.vocab_size:
+            raise RuntimeError(
+                "Special token ids exceed the checkpoint vocabulary "
+                f"({new_token_ids}); the tokenizer files are inconsistent "
+                "with the model weights."
+            )
 
         bagel_config = BagelConfig(
             visual_gen=True,
@@ -436,9 +464,13 @@ class LibreSenseNovaVision(LibreVLMModel):
                 vit_config, meta=True
             )
 
+        selected_dtype = self._select_dtype()
+        # NF4 stores 4-bit weights plus norms/embeddings in bf16 (~3.5x
+        # smaller than the bf16 checkpoint the planner measures); int8 is ~1.8x.
+        plan_scale = {"nf4": 3.5, "int8": 1.8}.get(selected_dtype, 1.0)
         device_map = infer_auto_device_map(
             model,
-            max_memory=self._max_memory(),
+            max_memory=self._max_memory(plan_scale),
             no_split_module_classes=["Bagel", "Qwen2MoTDecoderLayer"],
         )
         # Keep the shared embedding/connector modules on one device.
@@ -459,7 +491,9 @@ class LibreSenseNovaVision(LibreVLMModel):
             device_map[key] = device_map.get(key, first_device)
 
         checkpoint_path = os.path.join(snapshot_dir, "ema.safetensors")
-        selected_dtype = self._select_dtype()
+        # Last-resort spill target when a small machine cannot hold the model
+        # across GPU and CPU memory.
+        offload_folder = os.path.join(snapshot_dir, "offload")
 
         if selected_dtype in ("nf4", "int8"):
             from accelerate.utils import BnbQuantizationConfig, load_and_quantize_model
@@ -480,7 +514,7 @@ class LibreSenseNovaVision(LibreVLMModel):
                 weights_location=checkpoint_path,
                 bnb_quantization_config=quant_config,
                 device_map=device_map,
-                offload_folder=None,
+                offload_folder=offload_folder,
             ).eval()
         else:
             torch_dtype = {
@@ -500,6 +534,7 @@ class LibreSenseNovaVision(LibreVLMModel):
                 model,
                 checkpoint=checkpoint_path,
                 device_map=device_map,
+                offload_folder=offload_folder,
                 offload_buffers=True,
                 dtype=torch_dtype,
                 force_hooks=True,

--- a/libreyolo/models/sensenova/modeling/__init__.py
+++ b/libreyolo/models/sensenova/modeling/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Inference-only port of the Bagel-MoT architecture used by SenseNova-Vision.
+# See the per-file headers for upstream provenance and the LibreYOLO
+# adaptations (SDPA fallback, training-path removal, clean-source layers).
+
+from .bagel import Bagel, BagelConfig
+from .qwen2_navit import Qwen2Config, Qwen2ForCausalLM, Qwen2Model
+from .siglip_navit import SiglipVisionConfig, SiglipVisionModel
+
+__all__ = [
+    "Bagel",
+    "BagelConfig",
+    "Qwen2Config",
+    "Qwen2ForCausalLM",
+    "Qwen2Model",
+    "SiglipVisionConfig",
+    "SiglipVisionModel",
+]

--- a/libreyolo/models/sensenova/modeling/autoencoder.py
+++ b/libreyolo/models/sensenova/modeling/autoencoder.py
@@ -1,0 +1,366 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright (c) 2024 Black Forest Labs.
+# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file has been modified by ByteDance Ltd. and/or its affiliates. on 2025-05-20.
+#
+# Original file was released under Apache-2.0, with the full license text
+# available at https://github.com/black-forest-labs/flux/blob/main/LICENSE.
+#
+# This modified file is released under the same license.
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# modeling/autoencoder.py (the FLUX autoencoder). LibreYOLO adaptation: the
+# einops rearranges in the attention block are rewritten as plain
+# reshape/transpose so the port adds no einops dependency.
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor, nn
+from safetensors.torch import load_file as load_sft
+
+
+@dataclass
+class AutoEncoderParams:
+    resolution: int
+    in_channels: int
+    downsample: int
+    ch: int
+    out_ch: int
+    ch_mult: list[int]
+    num_res_blocks: int
+    z_channels: int
+    scale_factor: float
+    shift_factor: float
+
+
+def swish(x: Tensor) -> Tensor:
+    return x * torch.sigmoid(x)
+
+
+class AttnBlock(nn.Module):
+    def __init__(self, in_channels: int):
+        super().__init__()
+        self.in_channels = in_channels
+
+        self.norm = nn.GroupNorm(num_groups=32, num_channels=in_channels, eps=1e-6, affine=True)
+
+        self.q = nn.Conv2d(in_channels, in_channels, kernel_size=1)
+        self.k = nn.Conv2d(in_channels, in_channels, kernel_size=1)
+        self.v = nn.Conv2d(in_channels, in_channels, kernel_size=1)
+        self.proj_out = nn.Conv2d(in_channels, in_channels, kernel_size=1)
+
+    def attention(self, h_: Tensor) -> Tensor:
+        h_ = self.norm(h_)
+        q = self.q(h_)
+        k = self.k(h_)
+        v = self.v(h_)
+
+        b, c, h, w = q.shape
+        q = q.reshape(b, c, h * w).transpose(1, 2).unsqueeze(1).contiguous()
+        k = k.reshape(b, c, h * w).transpose(1, 2).unsqueeze(1).contiguous()
+        v = v.reshape(b, c, h * w).transpose(1, 2).unsqueeze(1).contiguous()
+        h_ = nn.functional.scaled_dot_product_attention(q, k, v)
+
+        return h_.squeeze(1).transpose(1, 2).reshape(b, c, h, w)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x + self.proj_out(self.attention(x))
+
+
+class ResnetBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+        self.in_channels = in_channels
+        out_channels = in_channels if out_channels is None else out_channels
+        self.out_channels = out_channels
+
+        self.norm1 = nn.GroupNorm(num_groups=32, num_channels=in_channels, eps=1e-6, affine=True)
+        self.conv1 = nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=1, padding=1)
+        self.norm2 = nn.GroupNorm(num_groups=32, num_channels=out_channels, eps=1e-6, affine=True)
+        self.conv2 = nn.Conv2d(out_channels, out_channels, kernel_size=3, stride=1, padding=1)
+        if self.in_channels != self.out_channels:
+            self.nin_shortcut = nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=1, padding=0)
+
+    def forward(self, x):
+        h = x
+        h = self.norm1(h)
+        h = swish(h)
+        h = self.conv1(h)
+
+        h = self.norm2(h)
+        h = swish(h)
+        h = self.conv2(h)
+
+        if self.in_channels != self.out_channels:
+            x = self.nin_shortcut(x)
+
+        return x + h
+
+
+class Downsample(nn.Module):
+    def __init__(self, in_channels: int):
+        super().__init__()
+        # no asymmetric padding in torch conv, must do it ourselves
+        self.conv = nn.Conv2d(in_channels, in_channels, kernel_size=3, stride=2, padding=0)
+
+    def forward(self, x: Tensor):
+        pad = (0, 1, 0, 1)
+        x = nn.functional.pad(x, pad, mode="constant", value=0)
+        x = self.conv(x)
+        return x
+
+
+class Upsample(nn.Module):
+    def __init__(self, in_channels: int):
+        super().__init__()
+        self.conv = nn.Conv2d(in_channels, in_channels, kernel_size=3, stride=1, padding=1)
+
+    def forward(self, x: Tensor):
+        x = nn.functional.interpolate(x, scale_factor=2.0, mode="nearest")
+        x = self.conv(x)
+        return x
+
+
+class Encoder(nn.Module):
+    def __init__(
+        self,
+        resolution: int,
+        in_channels: int,
+        ch: int,
+        ch_mult: list[int],
+        num_res_blocks: int,
+        z_channels: int,
+    ):
+        super().__init__()
+        self.ch = ch
+        self.num_resolutions = len(ch_mult)
+        self.num_res_blocks = num_res_blocks
+        self.resolution = resolution
+        self.in_channels = in_channels
+        # downsampling
+        self.conv_in = nn.Conv2d(in_channels, self.ch, kernel_size=3, stride=1, padding=1)
+
+        curr_res = resolution
+        in_ch_mult = (1,) + tuple(ch_mult)
+        self.in_ch_mult = in_ch_mult
+        self.down = nn.ModuleList()
+        block_in = self.ch
+        for i_level in range(self.num_resolutions):
+            block = nn.ModuleList()
+            attn = nn.ModuleList()
+            block_in = ch * in_ch_mult[i_level]
+            block_out = ch * ch_mult[i_level]
+            for _ in range(self.num_res_blocks):
+                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out))
+                block_in = block_out
+            down = nn.Module()
+            down.block = block
+            down.attn = attn
+            if i_level != self.num_resolutions - 1:
+                down.downsample = Downsample(block_in)
+                curr_res = curr_res // 2
+            self.down.append(down)
+
+        # middle
+        self.mid = nn.Module()
+        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+        self.mid.attn_1 = AttnBlock(block_in)
+        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+
+        # end
+        self.norm_out = nn.GroupNorm(num_groups=32, num_channels=block_in, eps=1e-6, affine=True)
+        self.conv_out = nn.Conv2d(block_in, 2 * z_channels, kernel_size=3, stride=1, padding=1)
+
+    def forward(self, x: Tensor) -> Tensor:
+        # downsampling
+        hs = [self.conv_in(x)]
+        for i_level in range(self.num_resolutions):
+            for i_block in range(self.num_res_blocks):
+                h = self.down[i_level].block[i_block](hs[-1])
+                if len(self.down[i_level].attn) > 0:
+                    h = self.down[i_level].attn[i_block](h)
+                hs.append(h)
+            if i_level != self.num_resolutions - 1:
+                hs.append(self.down[i_level].downsample(hs[-1]))
+
+        # middle
+        h = hs[-1]
+        h = self.mid.block_1(h)
+        h = self.mid.attn_1(h)
+        h = self.mid.block_2(h)
+        # end
+        h = self.norm_out(h)
+        h = swish(h)
+        h = self.conv_out(h)
+        return h
+
+
+class Decoder(nn.Module):
+    def __init__(
+        self,
+        ch: int,
+        out_ch: int,
+        ch_mult: list[int],
+        num_res_blocks: int,
+        in_channels: int,
+        resolution: int,
+        z_channels: int,
+    ):
+        super().__init__()
+        self.ch = ch
+        self.num_resolutions = len(ch_mult)
+        self.num_res_blocks = num_res_blocks
+        self.resolution = resolution
+        self.in_channels = in_channels
+        self.ffactor = 2 ** (self.num_resolutions - 1)
+
+        # compute in_ch_mult, block_in and curr_res at lowest res
+        block_in = ch * ch_mult[self.num_resolutions - 1]
+        curr_res = resolution // 2 ** (self.num_resolutions - 1)
+        self.z_shape = (1, z_channels, curr_res, curr_res)
+
+        # z to block_in
+        self.conv_in = nn.Conv2d(z_channels, block_in, kernel_size=3, stride=1, padding=1)
+
+        # middle
+        self.mid = nn.Module()
+        self.mid.block_1 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+        self.mid.attn_1 = AttnBlock(block_in)
+        self.mid.block_2 = ResnetBlock(in_channels=block_in, out_channels=block_in)
+
+        # upsampling
+        self.up = nn.ModuleList()
+        for i_level in reversed(range(self.num_resolutions)):
+            block = nn.ModuleList()
+            attn = nn.ModuleList()
+            block_out = ch * ch_mult[i_level]
+            for _ in range(self.num_res_blocks + 1):
+                block.append(ResnetBlock(in_channels=block_in, out_channels=block_out))
+                block_in = block_out
+            up = nn.Module()
+            up.block = block
+            up.attn = attn
+            if i_level != 0:
+                up.upsample = Upsample(block_in)
+                curr_res = curr_res * 2
+            self.up.insert(0, up)  # prepend to get consistent order
+
+        # end
+        self.norm_out = nn.GroupNorm(num_groups=32, num_channels=block_in, eps=1e-6, affine=True)
+        self.conv_out = nn.Conv2d(block_in, out_ch, kernel_size=3, stride=1, padding=1)
+
+    def forward(self, z: Tensor) -> Tensor:
+        # z to block_in
+        h = self.conv_in(z)
+
+        # middle
+        h = self.mid.block_1(h)
+        h = self.mid.attn_1(h)
+        h = self.mid.block_2(h)
+
+        # upsampling
+        for i_level in reversed(range(self.num_resolutions)):
+            for i_block in range(self.num_res_blocks + 1):
+                h = self.up[i_level].block[i_block](h)
+                if len(self.up[i_level].attn) > 0:
+                    h = self.up[i_level].attn[i_block](h)
+            if i_level != 0:
+                h = self.up[i_level].upsample(h)
+
+        # end
+        h = self.norm_out(h)
+        h = swish(h)
+        h = self.conv_out(h)
+        return h
+
+
+class DiagonalGaussian(nn.Module):
+    def __init__(self, sample: bool = True, chunk_dim: int = 1):
+        super().__init__()
+        self.sample = sample
+        self.chunk_dim = chunk_dim
+
+    def forward(self, z: Tensor) -> Tensor:
+        mean, logvar = torch.chunk(z, 2, dim=self.chunk_dim)
+        if self.sample:
+            std = torch.exp(0.5 * logvar)
+            return mean + std * torch.randn_like(mean)
+        else:
+            return mean
+
+
+class AutoEncoder(nn.Module):
+    def __init__(self, params: AutoEncoderParams):
+        super().__init__()
+        self.encoder = Encoder(
+            resolution=params.resolution,
+            in_channels=params.in_channels,
+            ch=params.ch,
+            ch_mult=params.ch_mult,
+            num_res_blocks=params.num_res_blocks,
+            z_channels=params.z_channels,
+        )
+        self.decoder = Decoder(
+            resolution=params.resolution,
+            in_channels=params.in_channels,
+            ch=params.ch,
+            out_ch=params.out_ch,
+            ch_mult=params.ch_mult,
+            num_res_blocks=params.num_res_blocks,
+            z_channels=params.z_channels,
+        )
+        self.reg = DiagonalGaussian()
+
+        self.scale_factor = params.scale_factor
+        self.shift_factor = params.shift_factor
+
+    def encode(self, x: Tensor) -> Tensor:
+        z = self.reg(self.encoder(x))
+        z = self.scale_factor * (z - self.shift_factor)
+        return z
+
+    def decode(self, z: Tensor) -> Tensor:
+        z = z / self.scale_factor + self.shift_factor
+        return self.decoder(z)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.decode(self.encode(x))
+
+
+def print_load_warning(missing: list[str], unexpected: list[str]) -> None:
+    if len(missing) > 0 and len(unexpected) > 0:
+        print(f"Got {len(missing)} missing keys:\n\t" + "\n\t".join(missing))
+        print("\n" + "-" * 79 + "\n")
+        print(f"Got {len(unexpected)} unexpected keys:\n\t" + "\n\t".join(unexpected))
+    elif len(missing) > 0:
+        print(f"Got {len(missing)} missing keys:\n\t" + "\n\t".join(missing))
+    elif len(unexpected) > 0:
+        print(f"Got {len(unexpected)} unexpected keys:\n\t" + "\n\t".join(unexpected))
+
+
+def load_ae(local_path: str | None) -> tuple[AutoEncoder, AutoEncoderParams]:
+    ae_params = AutoEncoderParams(
+            resolution=256,
+            in_channels=3,
+            downsample=8,
+            ch=128,
+            out_ch=3,
+            ch_mult=[1, 2, 4, 4],
+            num_res_blocks=2,
+            z_channels=16,
+            scale_factor=0.3611,
+            shift_factor=0.1159,
+    )
+
+    # Loading the autoencoder
+    ae = AutoEncoder(ae_params)
+
+    if local_path is not None:
+        sd = load_sft(local_path)
+        missing, unexpected = ae.load_state_dict(sd, strict=False, assign=True)
+        print_load_warning(missing, unexpected)
+    return ae, ae_params

--- a/libreyolo/models/sensenova/modeling/bagel.py
+++ b/libreyolo/models/sensenova/modeling/bagel.py
@@ -1,0 +1,916 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# modeling/bagel/bagel.py. LibreYOLO adaptations: the training forward pass
+# (flex-attention sparse block masks) is removed because this port is
+# inference-only, and the CC BY-NC modeling_utils helpers are replaced by the
+# clean-source re-implementations in `layers.py`.
+
+from typing import List, Tuple, Optional
+
+import torch
+from torch import nn
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_utils import PreTrainedModel
+
+from ..data_utils import (
+    get_flattened_position_ids_extrapolate,
+    get_flattened_position_ids_interpolate,
+    patchify,
+)
+from .qwen2_navit import NaiveCache
+from .layers import MLPconnector, TimestepEmbedder, PositionEmbedding
+
+from tqdm import tqdm
+
+
+class BagelConfig(PretrainedConfig):
+    def __init__(
+        self,
+        visual_gen=True,
+        visual_und=True,
+        llm_config=None,
+        vit_config=None,
+        vae_config=None,
+        latent_patch_size=2,
+        max_latent_size=32,
+        vit_max_num_patch_per_side=70,
+        connector_act="gelu_pytorch_tanh",
+        interpolate_pos=False,
+        timestep_shift=1.0,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.visual_gen = visual_gen
+        self.visual_und = visual_und
+        self.llm_config = llm_config
+        self.vit_config = vit_config
+        self.vae_config = vae_config
+        self.latent_patch_size = latent_patch_size
+        self.max_latent_size = max_latent_size
+        self.vit_max_num_patch_per_side = vit_max_num_patch_per_side
+        self.connector_act = connector_act
+        self.interpolate_pos = interpolate_pos
+        self.timestep_shift = timestep_shift
+
+
+class Bagel(PreTrainedModel):
+    config_class = BagelConfig
+    base_model_prefix = 'bagel'
+
+    def __init__(self, language_model, vit_model, config: BagelConfig):
+        super().__init__(config)    
+        self.language_model = language_model
+        
+        if config.llm_config is None:
+            raise ValueError("llm_config cannot be None")
+            
+        self.hidden_size = config.llm_config.hidden_size
+        self.use_moe = "Mo" in config.llm_config.layer_module
+        self.num_heads = config.llm_config.num_attention_heads
+
+        if config.visual_gen:
+            if config.vae_config is None:
+                raise ValueError("vae_config cannot be None when visual_gen is True")
+            self.latent_patch_size = config.latent_patch_size
+            self.timestep_shift = config.timestep_shift
+            self.latent_downsample = config.vae_config.downsample * config.latent_patch_size
+            self.max_latent_size = config.max_latent_size
+            self.latent_channel = config.vae_config.z_channels
+            self.patch_latent_dim = self.latent_patch_size ** 2 * self.latent_channel
+            self.time_embedder = TimestepEmbedder(self.hidden_size)
+            self.vae2llm = nn.Linear(self.patch_latent_dim, self.hidden_size)
+            self.llm2vae = nn.Linear(self.hidden_size, self.patch_latent_dim)
+            self.latent_pos_embed = PositionEmbedding(self.max_latent_size, self.hidden_size)
+
+        if config.visual_und:
+            if config.vit_config is None:
+                raise ValueError("vit_config cannot be None when visual_und is True")
+            self.vit_model = vit_model
+            self.vit_patch_size = config.vit_config.patch_size
+            self.vit_max_num_patch_per_side = config.vit_max_num_patch_per_side
+            self.vit_hidden_size = config.vit_config.hidden_size
+            self.connector = MLPconnector(self.vit_hidden_size, self.hidden_size, config.connector_act)
+            self.vit_pos_embed = PositionEmbedding(self.vit_max_num_patch_per_side, self.hidden_size)
+
+        if config.interpolate_pos:
+            self.get_flattened_position_ids = get_flattened_position_ids_interpolate
+        else:
+            self.get_flattened_position_ids = get_flattened_position_ids_extrapolate
+
+        self.config = config
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.config.visual_gen:
+            nn.init.constant_(self.llm2vae.weight, 0)
+            nn.init.constant_(self.llm2vae.bias, 0)
+
+    def prepare_prompts(self, curr_kvlens, curr_rope, prompts, tokenizer, new_token_ids):
+        packed_text_ids = list()
+        packed_text_position_ids = list()
+        text_token_lens = list()
+        packed_text_indexes = list()
+        packed_key_value_indexes = list()
+
+        curr = 0
+        newlens, new_rope = list(), list()
+        for prompt, curr_kvlen, curr_position_id in zip(prompts, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            text_ids = tokenizer.encode(prompt)
+            text_ids = [new_token_ids['bos_token_id']] + text_ids + [new_token_ids['eos_token_id']]
+            text_token_lens.append(len(text_ids))
+            packed_text_ids.extend(text_ids)
+            packed_text_position_ids.extend(range(curr_position_id, curr_position_id + len(text_ids)))
+            packed_text_indexes.extend(range(curr, curr + len(text_ids)))
+            newlens.append(curr_kvlen + len(text_ids))
+            new_rope.append(curr_position_id + len(text_ids))
+            curr += len(text_ids)
+
+        generation_input = {
+            "text_token_lens": torch.tensor(text_token_lens, dtype=torch.int),
+            "packed_text_ids": torch.tensor(packed_text_ids, dtype=torch.long),
+            "packed_text_position_ids": torch.tensor(packed_text_position_ids, dtype=torch.long),
+            "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+        }
+
+        return generation_input, newlens, new_rope
+
+    @torch.no_grad
+    def forward_cache_update_text(
+        self,
+        past_key_values: NaiveCache,
+        packed_text_ids: torch.IntTensor,
+        packed_text_position_ids: torch.LongTensor,
+        text_token_lens: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+    ):
+        packed_text_embedding = self.language_model.model.embed_tokens(packed_text_ids)
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs = {"mode": "und"}
+
+        output = self.language_model.forward_inference(
+            packed_query_sequence=packed_text_embedding,
+            query_lens=text_token_lens,
+            packed_query_position_ids=packed_text_position_ids,
+            packed_query_indexes=packed_text_indexes,
+            past_key_values=past_key_values,
+            packed_key_value_indexes=packed_key_value_indexes,
+            key_values_lens=key_values_lens,
+            update_past_key_values=True,
+            is_causal=True,
+            **extra_inputs,
+        )
+        past_key_values = output.past_key_values
+
+        return past_key_values
+
+    def prepare_vit_images(self, curr_kvlens, curr_rope, images, transforms, new_token_ids):
+        packed_vit_token_indexes = list()
+        vit_token_seqlens, packed_vit_tokens, packed_vit_position_ids = list(), list(), list()
+        packed_text_ids, packed_text_indexes = list(), list()
+        packed_seqlens, packed_position_ids, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
+
+        _curr = curr = 0
+        newlens, new_rope = list(), list()
+        for image, curr_kvlen, curr_position_id in zip(images, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_text_ids.append(new_token_ids['start_of_image'])
+            packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            _curr += 1
+
+            image_tensor = transforms(image)
+            vit_position_ids = self.get_flattened_position_ids(
+                image_tensor.size(1), image_tensor.size(2), 
+                self.vit_patch_size, 
+                max_num_patches_per_side=self.vit_max_num_patch_per_side
+            )
+            vit_tokens = patchify(image_tensor, self.vit_patch_size)
+            packed_vit_tokens.append(vit_tokens)
+            num_img_tokens = vit_tokens.shape[0]
+            packed_vit_position_ids.append(vit_position_ids)
+            vit_token_seqlens.append(num_img_tokens)
+            packed_vit_token_indexes.extend(range(_curr, _curr + num_img_tokens))
+            packed_indexes.extend(range(curr, curr + num_img_tokens))
+            curr += num_img_tokens
+            _curr += num_img_tokens
+
+            packed_text_ids.append(new_token_ids['end_of_image'])
+            packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            _curr += 1
+
+            packed_position_ids.extend([curr_position_id] * (num_img_tokens + 2))
+            packed_seqlens.append(num_img_tokens + 2)
+            newlens.append(curr_kvlen + num_img_tokens + 2)
+            new_rope.append(curr_position_id + 1)
+
+        generation_input = {
+            "packed_text_ids": torch.tensor(packed_text_ids, dtype=torch.long),
+            "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
+            "vit_token_seqlens": torch.tensor(vit_token_seqlens, dtype=torch.int),
+            "packed_vit_tokens": torch.cat(packed_vit_tokens, dim=0),
+            "packed_vit_position_ids": torch.cat(packed_vit_position_ids, dim=0),
+            "packed_vit_token_indexes": torch.tensor(packed_vit_token_indexes, dtype=torch.long),
+            "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+        }
+
+        return generation_input, newlens, new_rope
+
+    @torch.no_grad
+    def forward_cache_update_vit(
+        self,
+        past_key_values: NaiveCache,
+        packed_text_ids: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_vit_tokens: torch.Tensor,
+        packed_vit_token_indexes: torch.LongTensor,
+        packed_vit_position_ids: torch.LongTensor,
+        vit_token_seqlens: torch.IntTensor,
+        packed_position_ids: torch.LongTensor,
+        packed_seqlens: torch.IntTensor,
+        packed_indexes: torch.LongTensor,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+    ):
+        packed_text_embedding = self.language_model.model.embed_tokens(packed_text_ids)
+        packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
+        packed_sequence[packed_text_indexes] = packed_text_embedding
+
+        cu_seqlens = torch.nn.functional.pad(torch.cumsum(vit_token_seqlens, dim=0), (1, 0))
+        cu_seqlens = cu_seqlens.to(torch.int32)
+        max_seqlen = torch.max(vit_token_seqlens).item()
+        packed_vit_token_embed = self.vit_model(
+            packed_pixel_values=packed_vit_tokens, 
+            packed_flattened_position_ids=packed_vit_position_ids,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        packed_vit_token_embed = self.connector(packed_vit_token_embed)
+        pos_emb = self.vit_pos_embed(packed_vit_position_ids)
+        packed_vit_token_embed = packed_vit_token_embed + pos_emb
+        if packed_vit_token_embed.dtype != packed_sequence.dtype:
+            packed_vit_token_embed = packed_vit_token_embed.to(packed_sequence.dtype)
+        packed_sequence[packed_vit_token_indexes] = packed_vit_token_embed
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs = {"mode": "und"}
+
+        output = self.language_model.forward_inference(
+            packed_query_sequence=packed_sequence,
+            query_lens=packed_seqlens,
+            packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
+            past_key_values=past_key_values,
+            packed_key_value_indexes=packed_key_value_indexes,
+            key_values_lens=key_values_lens,
+            update_past_key_values=True,
+            is_causal=False,
+            **extra_inputs,
+        )
+        past_key_values = output.past_key_values
+
+        return past_key_values
+
+    def prepare_vae_images(self, curr_kvlens, curr_rope, images, transforms, new_token_ids, timestep=0):
+        patchified_vae_latent_shapes, packed_vae_position_ids = list(), list()
+        packed_vae_token_indexes = list()
+        packed_text_ids, packed_text_indexes = list(), list()
+        packed_seqlens, packed_position_ids, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
+
+        _curr = curr = 0
+        vae_image_tensors = list()
+        newlens, new_rope = list(), list()
+        for image, curr_kvlen, curr_position_id in zip(images, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_text_ids.append(new_token_ids['start_of_image'])
+            packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            _curr += 1
+
+            image_tensor = transforms(image)
+            vae_image_tensors.append(image_tensor)
+            vae_posiiton_ids = self.get_flattened_position_ids(
+                image_tensor.size(1), image_tensor.size(2),
+                self.latent_downsample, 
+                max_num_patches_per_side=self.max_latent_size
+            )
+            packed_vae_position_ids.append(vae_posiiton_ids)
+            H, W = image_tensor.shape[1:]
+            h = H // self.latent_downsample
+            w = W // self.latent_downsample
+            patchified_vae_latent_shapes.append((h, w))
+
+            num_img_tokens = w * h
+            packed_vae_token_indexes.extend(range(_curr, _curr + num_img_tokens))
+            packed_indexes.extend(range(curr, curr + num_img_tokens))
+            curr += num_img_tokens
+            _curr += num_img_tokens
+
+            packed_text_ids.append(new_token_ids['end_of_image'])
+            packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            _curr += 1
+
+            packed_position_ids.extend([curr_position_id] * (num_img_tokens + 2))
+            packed_seqlens.append(num_img_tokens + 2)
+            newlens.append(curr_kvlen + num_img_tokens + 2)
+            new_rope.append(curr_position_id + 1)
+
+        image_sizes = [item.shape for item in vae_image_tensors]
+        max_image_size = [max(item) for item in list(zip(*image_sizes))]
+        padded_images = torch.zeros(size=(len(vae_image_tensors), *max_image_size))
+        for i, image_tensor in enumerate(vae_image_tensors):
+            padded_images[i, :, :image_tensor.shape[1], :image_tensor.shape[2]] = image_tensor
+
+        generation_input = {
+            "padded_images": padded_images,
+            "patchified_vae_latent_shapes": patchified_vae_latent_shapes,
+            "packed_vae_position_ids": torch.cat(packed_vae_position_ids, dim=0),
+            "packed_timesteps": torch.tensor([timestep]),
+            "packed_vae_token_indexes": torch.tensor(packed_vae_token_indexes, dtype=torch.long),
+            "packed_text_ids": torch.tensor(packed_text_ids, dtype=torch.long),
+            "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
+            "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+        }
+
+        return generation_input, newlens, new_rope
+
+    @torch.no_grad
+    def forward_cache_update_vae(
+        self,
+        vae_model,
+        past_key_values: NaiveCache,
+        padded_images: torch.Tensor,
+        patchified_vae_latent_shapes: List,
+        packed_vae_position_ids: torch.LongTensor,
+        packed_timesteps: torch.Tensor,
+        packed_vae_token_indexes: torch.LongTensor,
+        packed_text_ids: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_position_ids: torch.LongTensor,
+        packed_seqlens: torch.IntTensor,
+        packed_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+        packed_key_value_indexes: torch.Tensor,
+    ):
+        packed_text_embedding = self.language_model.model.embed_tokens(packed_text_ids)
+        packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
+        packed_sequence[packed_text_indexes] = packed_text_embedding
+
+        padded_latent = vae_model.encode(padded_images)
+
+        p = self.latent_patch_size
+        packed_latent = list()
+        for latent, (h, w) in zip(padded_latent, patchified_vae_latent_shapes):
+            latent = latent[:, :h * p, :w * p].reshape(self.latent_channel, h, p, w, p)
+            latent = torch.einsum("chpwq->hwpqc", latent).reshape(-1, p * p * self.latent_channel)
+            packed_latent.append(latent)
+        packed_latent = torch.cat(packed_latent, dim=0)
+        packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
+        packed_timestep_embeds = self.time_embedder(packed_timesteps)
+        packed_latent = self.vae2llm(packed_latent) + packed_timestep_embeds + packed_pos_embed
+        if packed_latent.dtype != packed_sequence.dtype:
+            packed_latent = packed_latent.to(packed_sequence.dtype)
+        packed_sequence[packed_vae_token_indexes] = packed_latent
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs = {
+                "mode": "gen",
+                "packed_vae_token_indexes": packed_vae_token_indexes,
+                "packed_text_indexes": packed_text_indexes
+            }
+
+        output = self.language_model.forward_inference(
+            packed_query_sequence=packed_sequence,
+            query_lens=packed_seqlens,
+            packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
+            past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
+            update_past_key_values=True,
+            is_causal=False,
+            **extra_inputs,
+        )
+        past_key_values = output.past_key_values
+
+        return past_key_values
+
+    def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids):
+        packed_text_ids, packed_text_indexes = list(), list()
+        packed_vae_position_ids, packed_vae_token_indexes, packed_init_noises = list(), list(), list()
+        packed_position_ids, packed_seqlens, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
+
+        query_curr = curr = 0
+        for (H, W), curr_kvlen, curr_position_id in zip(image_sizes, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_text_ids.append(new_token_ids['start_of_image'])
+            packed_text_indexes.append(query_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            vae_posiiton_ids = self.get_flattened_position_ids(
+                H, W,
+                self.latent_downsample, 
+                max_num_patches_per_side=self.max_latent_size
+            )
+            packed_vae_position_ids.append(vae_posiiton_ids)
+
+            h, w = H // self.latent_downsample, W // self.latent_downsample
+            num_image_tokens = h * w
+            packed_init_noises.append(
+                torch.randn(num_image_tokens, self.latent_channel * self.latent_patch_size ** 2)
+            )
+            packed_vae_token_indexes.extend(range(query_curr, query_curr + num_image_tokens))
+            packed_indexes.extend(range(curr, curr + num_image_tokens))
+            curr += num_image_tokens
+            query_curr += num_image_tokens
+
+            packed_text_ids.append(new_token_ids['end_of_image'])
+            packed_text_indexes.append(query_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            packed_position_ids.extend([curr_position_id] * (num_image_tokens + 2))
+            packed_seqlens.append(num_image_tokens + 2)
+
+        generation_input = {
+            "packed_text_ids": torch.tensor(packed_text_ids, dtype=torch.long),
+            "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
+            "packed_init_noises": torch.cat(packed_init_noises, dim=0),
+            "packed_vae_position_ids": torch.cat(packed_vae_position_ids, dim=0),
+            "packed_vae_token_indexes": torch.tensor(packed_vae_token_indexes, dtype=torch.long),
+            "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
+            "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+        }
+
+        return generation_input
+
+    def prepare_vae_latent_cfg(self, curr_kvlens, curr_rope, image_sizes):
+        packed_position_ids, packed_indexes, packed_key_value_indexes = list(), list(), list()
+
+        query_curr = curr = 0
+        for (H, W), curr_kvlen, curr_position_id in zip(image_sizes, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            h, w = H // self.latent_downsample, W // self.latent_downsample
+            num_image_tokens = h * w
+            packed_indexes.extend(range(curr, curr + num_image_tokens))
+            curr += num_image_tokens
+            query_curr += num_image_tokens
+
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            packed_position_ids.extend([curr_position_id] * (num_image_tokens + 2))
+
+        generation_input = {
+            "cfg_packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "cfg_key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "cfg_packed_query_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "cfg_packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+        }
+
+        return generation_input
+
+    @torch.no_grad
+    def generate_image(
+        self,
+        packed_text_ids: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_init_noises: torch.Tensor,
+        packed_vae_position_ids: torch.LongTensor,
+        packed_vae_token_indexes: torch.LongTensor,
+        packed_seqlens: torch.IntTensor,
+        packed_position_ids: torch.LongTensor,
+        packed_indexes: torch.LongTensor,
+        past_key_values: NaiveCache,
+        key_values_lens: torch.IntTensor,
+        packed_key_value_indexes: torch.LongTensor,
+        num_timesteps: int = 24,
+        timestep_shift: float = 1.0,
+        cfg_renorm_min: float = 0.0,
+        cfg_renorm_type: str = "global",
+        cfg_interval: Optional[Tuple[float, float]] = [0, 1],
+        return_raw_latent=False,
+        # cfg_text
+        cfg_text_scale: float = 1.0,
+        cfg_text_packed_query_indexes: Optional[torch.LongTensor] = None,
+        cfg_text_packed_position_ids: Optional[torch.LongTensor] = None,
+        cfg_text_past_key_values: Optional[NaiveCache] = None,
+        cfg_text_key_values_lens: Optional[torch.IntTensor] = None,
+        cfg_text_packed_key_value_indexes: Optional[torch.LongTensor] = None,
+        # cfg_img
+        cfg_img_scale: float = 1.0,
+        cfg_img_packed_query_indexes: Optional[torch.LongTensor] = None,
+        cfg_img_packed_position_ids: Optional[torch.LongTensor] = None,
+        cfg_img_past_key_values: Optional[NaiveCache] = None,
+        cfg_img_key_values_lens: Optional[torch.IntTensor] = None,
+        cfg_img_packed_key_value_indexes: Optional[torch.LongTensor] = None,
+        cfg_type: str = "parallel",
+    ):
+        x_t = packed_init_noises
+
+        timesteps = torch.linspace(1, 0, num_timesteps, device=x_t.device)
+        timesteps = timestep_shift * timesteps / (1 + (timestep_shift - 1) * timesteps)
+        dts =  timesteps[:-1] - timesteps[1:]
+        timesteps = timesteps[:-1]
+
+        for i, t in tqdm(enumerate(timesteps), total=len(timesteps)):
+
+            timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
+            if t > cfg_interval[0] and t <= cfg_interval[1]:
+                cfg_text_scale_ = cfg_text_scale
+                cfg_img_scale_ = cfg_img_scale
+            else:
+                cfg_text_scale_ = 1.0
+                cfg_img_scale_ = 1.0
+            v_t = self._forward_flow(
+                x_t=x_t,
+                timestep=timestep, 
+                packed_vae_token_indexes=packed_vae_token_indexes,
+                packed_vae_position_ids=packed_vae_position_ids,
+                packed_text_ids=packed_text_ids,
+                packed_text_indexes=packed_text_indexes,
+                packed_position_ids=packed_position_ids,
+                packed_indexes=packed_indexes,
+                packed_seqlens=packed_seqlens,
+                key_values_lens=key_values_lens,
+                past_key_values=past_key_values,
+                packed_key_value_indexes=packed_key_value_indexes,
+                cfg_renorm_min=cfg_renorm_min,
+                cfg_renorm_type=cfg_renorm_type,
+                # cfg_text
+                cfg_text_scale=cfg_text_scale_,
+                cfg_text_packed_position_ids=cfg_text_packed_position_ids,
+                cfg_text_packed_query_indexes=cfg_text_packed_query_indexes,
+                cfg_text_key_values_lens=cfg_text_key_values_lens,
+                cfg_text_past_key_values=cfg_text_past_key_values,
+                cfg_text_packed_key_value_indexes=cfg_text_packed_key_value_indexes,
+                # cfg_img
+                cfg_img_scale=cfg_img_scale_,
+                cfg_img_packed_position_ids=cfg_img_packed_position_ids,
+                cfg_img_packed_query_indexes=cfg_img_packed_query_indexes,
+                cfg_img_key_values_lens=cfg_img_key_values_lens,
+                cfg_img_past_key_values=cfg_img_past_key_values,
+                cfg_img_packed_key_value_indexes=cfg_img_packed_key_value_indexes,
+                cfg_type=cfg_type,
+            )
+
+            x_t = x_t - v_t.to(x_t.device) * dts[i] # velocity pointing from data to noise
+
+        if return_raw_latent:
+            return x_t
+        unpacked_latent = x_t.split((packed_seqlens - 2).tolist())
+        return unpacked_latent
+
+    @torch.no_grad
+    def _forward_flow(
+        self,
+        x_t: torch.Tensor,
+        timestep: torch.LongTensor,
+        packed_vae_token_indexes: torch.LongTensor,
+        packed_vae_position_ids: torch.LongTensor,
+        packed_text_ids: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_indexes: torch.LongTensor,
+        packed_position_ids: torch.LongTensor,
+        packed_seqlens: torch.IntTensor,
+        key_values_lens: torch.IntTensor,
+        past_key_values: NaiveCache,
+        packed_key_value_indexes: torch.LongTensor,
+        cfg_renorm_min: float = 0.0,
+        cfg_renorm_type: str = "global",
+        # cfg_text
+        cfg_text_scale: float = 1.0,
+        cfg_text_packed_position_ids: Optional[torch.LongTensor] = None,
+        cfg_text_packed_query_indexes: Optional[torch.LongTensor] = None,
+        cfg_text_key_values_lens: Optional[torch.Tensor] = None,
+        cfg_text_past_key_values: Optional[NaiveCache] = None,
+        cfg_text_packed_key_value_indexes: Optional[torch.LongTensor] = None,
+        # cfg_img
+        cfg_img_scale: float = 1.0,
+        cfg_img_packed_position_ids: Optional[torch.LongTensor] = None,
+        cfg_img_packed_query_indexes: Optional[torch.LongTensor] = None,
+        cfg_img_key_values_lens: Optional[torch.Tensor] = None,
+        cfg_img_past_key_values: Optional[NaiveCache] = None,
+        cfg_img_packed_key_value_indexes: Optional[torch.LongTensor] = None,
+        cfg_type: str = "parallel",
+    ):
+        packed_text_embedding = self.language_model.model.embed_tokens(packed_text_ids)
+        packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
+        packed_sequence[packed_text_indexes] = packed_text_embedding
+
+        assert timestep.unique().shape[0] == 1
+        packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
+        packed_timestep_embeds = self.time_embedder(timestep)
+        x_t = self.vae2llm(x_t) + packed_timestep_embeds + packed_pos_embed
+        if x_t.dtype != packed_sequence.dtype:
+            x_t = x_t.to(packed_sequence.dtype)
+        packed_sequence[packed_vae_token_indexes] = x_t
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs = {
+                "mode": "gen",
+                "packed_vae_token_indexes": packed_vae_token_indexes,
+                "packed_text_indexes": packed_text_indexes
+            }
+
+        output = self.language_model.forward_inference(
+            packed_query_sequence=packed_sequence,
+            query_lens=packed_seqlens,
+            packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
+            past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
+            update_past_key_values=False,
+            is_causal=False,
+            **extra_inputs,
+        )
+        v_t = self.llm2vae(output.packed_query_sequence)
+        v_t = v_t[packed_vae_token_indexes]
+
+        if cfg_text_scale > 1.0:
+            cfg_text_output = self.language_model.forward_inference(
+                packed_query_sequence=packed_sequence,
+                query_lens=packed_seqlens,
+                packed_query_position_ids=cfg_text_packed_position_ids,
+                packed_query_indexes=cfg_text_packed_query_indexes,
+                past_key_values=cfg_text_past_key_values,
+                key_values_lens=cfg_text_key_values_lens,
+                packed_key_value_indexes=cfg_text_packed_key_value_indexes,
+                update_past_key_values=False,
+                is_causal=False,
+                **extra_inputs,
+            )
+            cfg_text_v_t = self.llm2vae(cfg_text_output.packed_query_sequence)
+            cfg_text_v_t = cfg_text_v_t[packed_vae_token_indexes]
+
+        if cfg_img_scale > 1.0:
+            cfg_img_output = self.language_model.forward_inference(
+                packed_query_sequence=packed_sequence,
+                query_lens=packed_seqlens,
+                packed_query_position_ids=cfg_img_packed_position_ids,
+                packed_query_indexes=cfg_img_packed_query_indexes,
+                past_key_values=cfg_img_past_key_values,
+                key_values_lens=cfg_img_key_values_lens,
+                packed_key_value_indexes=cfg_img_packed_key_value_indexes,
+                update_past_key_values=False,
+                is_causal=False,
+                **extra_inputs,
+            )
+            cfg_img_v_t = self.llm2vae(cfg_img_output.packed_query_sequence)
+            cfg_img_v_t = cfg_img_v_t[packed_vae_token_indexes]
+
+        if cfg_text_scale > 1.0:
+            if cfg_renorm_type == "text_channel":
+                v_t_text_ = cfg_text_v_t + cfg_text_scale * (v_t - cfg_text_v_t)
+                norm_v_t = torch.norm(v_t, dim=-1, keepdim=True)
+                norm_v_t_text_ = torch.norm(v_t_text_, dim=-1, keepdim=True)
+                scale = (norm_v_t / (norm_v_t_text_ + 1e-8)).clamp(min=cfg_renorm_min, max=1.0)
+                v_t_text = v_t_text_ * scale
+                if cfg_img_scale > 1.0:
+                    v_t = cfg_img_v_t + cfg_img_scale * (v_t_text - cfg_img_v_t)
+                else:
+                    v_t = v_t_text
+            else:
+                v_t_text_ = cfg_text_v_t + cfg_text_scale * (v_t - cfg_text_v_t)
+                
+                if cfg_img_scale > 1.0:
+                    v_t_ = cfg_img_v_t + cfg_img_scale * (v_t_text_ - cfg_img_v_t)
+                else:
+                    v_t_ = v_t_text_
+
+                # NOTE norm is computed over all dimensions, thus currently only supports batch_size = 1 with navit
+                if cfg_renorm_type == "global":
+                    norm_v_t = torch.norm(v_t)
+                    norm_v_t_ = torch.norm(v_t_)
+                elif cfg_renorm_type == "channel":
+                    norm_v_t = torch.norm(v_t, dim=-1, keepdim=True)
+                    norm_v_t_ = torch.norm(v_t_, dim=-1, keepdim=True)
+                else:
+                    raise NotImplementedError(f"{cfg_renorm_type} is not suppoprted")
+                scale = (norm_v_t / (norm_v_t_ + 1e-8)).clamp(min=cfg_renorm_min, max=1.0)
+                v_t = v_t_ * scale
+        else:
+            # No CFG
+            pass
+
+        return v_t
+
+    def prepare_start_tokens(self, curr_kvlens, curr_rope, new_token_ids):
+        packed_start_tokens, packed_key_value_indexes = list(), list()
+        packed_query_position_ids = list()
+
+        curr = 0
+        for curr_kvlen, curr_position_id in zip(curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            packed_start_tokens.append(new_token_ids['bos_token_id'])
+            packed_query_position_ids.append(curr_position_id)
+            curr += curr_kvlen
+
+        generation_input = {
+            "packed_start_tokens": torch.tensor(packed_start_tokens, dtype=torch.long),
+            "packed_query_position_ids": torch.tensor(packed_query_position_ids, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+        }
+
+        return generation_input
+
+    @torch.no_grad
+    def generate_text(
+        self,
+        past_key_values: NaiveCache,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+        packed_start_tokens: torch.LongTensor,
+        packed_query_position_ids: torch.LongTensor,
+        max_length: int,
+        do_sample: bool = False,
+        temperature: float = 1.0,
+        end_token_id: int = None,
+    ):
+        step = 0
+        generated_sequence = []
+        curr_tokens = packed_start_tokens
+        while step < max_length:
+            generated_sequence.append(curr_tokens)
+            packed_text_embedding = self.language_model.model.embed_tokens(curr_tokens)
+            query_lens = torch.ones_like(curr_tokens)
+            packed_query_indexes = torch.cumsum(key_values_lens, dim=0) + torch.arange(
+                0, len(key_values_lens), 
+                device=key_values_lens.device, 
+                dtype=key_values_lens.dtype
+            )
+
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for i in range(len(uppacked)):
+                uppacked[i] += i
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
+
+            extra_inputs = {}
+            if self.use_moe:
+                extra_inputs = {"mode": "und"}
+
+            output = self.language_model.forward_inference(
+                packed_query_sequence=packed_text_embedding,
+                query_lens=query_lens,
+                packed_query_position_ids=packed_query_position_ids,
+                packed_query_indexes=packed_query_indexes,
+                past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
+                update_past_key_values=True,
+                is_causal=True,
+                **extra_inputs,
+            )
+            past_key_values = output.past_key_values
+            packed_query_sequence = output.packed_query_sequence
+            pred_logits = self.language_model.lm_head(packed_query_sequence)
+
+            if do_sample:
+                probs = nn.functional.softmax(pred_logits / temperature, dim=-1)
+                curr_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
+            else:
+                curr_tokens = torch.argmax(pred_logits, dim=-1)
+
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for i in range(len(uppacked)):
+                uppacked[i] = torch.cat(
+                    [uppacked[i], torch.tensor([uppacked[i][-1] + 1], device=uppacked[i].device)], dim=0
+                )
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
+            key_values_lens = key_values_lens + 1
+            packed_query_position_ids = packed_query_position_ids + 1
+            step += 1
+
+            if end_token_id is not None and curr_tokens[0] == end_token_id: # only support batch=1
+                break
+
+        output_device = generated_sequence[0].device
+        return torch.stack([i.to(output_device) for i in generated_sequence], dim=0)
+
+    # for evaluation
+    @torch.no_grad()
+    def chat(
+        self,
+        tokenizer,
+        new_token_ids,
+        image_transform,
+        images,
+        prompt,
+        max_length: int,
+        do_sample: bool = False,
+        temperature: float = 1.0,
+    ):
+        device = next(self.parameters()).device
+
+        if isinstance(new_token_ids, dict):
+            for k, v in new_token_ids.items():
+                if torch.is_tensor(v):
+                    new_token_ids[k] = v.to(device)
+        elif torch.is_tensor(new_token_ids):
+            new_token_ids = new_token_ids.to(device)
+
+        # prefill
+        past_key_values = NaiveCache(self.config.llm_config.num_hidden_layers)
+        newlens = [0]
+        new_rope = [0]
+
+        # add images
+        for image in images:
+            generation_input, newlens, new_rope = self.prepare_vit_images(
+                curr_kvlens=newlens,
+                curr_rope=new_rope, 
+                images=[image], 
+                transforms=image_transform,
+                new_token_ids=new_token_ids,
+            )
+            for k, v in generation_input.items():
+                if torch.is_tensor(v):
+                    generation_input[k] = v.to(device)
+            with torch.amp.autocast("cuda", enabled=True, dtype=torch.bfloat16):
+                past_key_values = self.forward_cache_update_vit(past_key_values, **generation_input)
+
+        # add text
+        generation_input, newlens, new_rope = self.prepare_prompts(
+            curr_kvlens=newlens,
+            curr_rope=new_rope, 
+            prompts=[prompt],
+            tokenizer=tokenizer, 
+            new_token_ids=new_token_ids,
+        )
+        for k, v in generation_input.items():
+            if torch.is_tensor(v):
+                generation_input[k] = v.to(device)
+        with torch.amp.autocast("cuda", enabled=True, dtype=torch.bfloat16):
+            past_key_values = self.forward_cache_update_text(past_key_values, **generation_input)
+
+        # decode
+        generation_input = self.prepare_start_tokens(newlens, new_rope, new_token_ids)
+        for k, v in generation_input.items():
+            if torch.is_tensor(v):
+                generation_input[k] = v.to(device)
+        with torch.amp.autocast("cuda", enabled=True, dtype=torch.bfloat16):
+            unpacked_latent = self.generate_text(
+                past_key_values=past_key_values,
+                max_length=max_length,
+                do_sample=do_sample,
+                temperature=temperature,
+                end_token_id=new_token_ids['eos_token_id'],
+                **generation_input,
+            )
+        output = tokenizer.decode(unpacked_latent[:,0])
+        output = output.split('<|im_end|>')[0].split('<|im_start|>')[1]
+
+        return output

--- a/libreyolo/models/sensenova/modeling/layers.py
+++ b/libreyolo/models/sensenova/modeling/layers.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+#
+# Clean-source implementations of the small embedding/connector layers the
+# Bagel-MoT architecture expects. The corresponding file in the upstream
+# SenseNova-Vision repository (modeling/bagel/modeling_utils.py) is marked
+# CC BY-NC 4.0 because it derives from facebookresearch/DiT, so it is NOT
+# ported into LibreYOLO. This file re-derives the same standard components
+# from their original permissive sources instead:
+#
+# - The 2D sine-cosine position table follows the Apache-2.0 implementation
+#   in Hugging Face transformers (models/vit_mae/modeling_vit_mae.py,
+#   `get_2d_sincos_pos_embed`), which carries Meta's copyright under
+#   Apache-2.0 and predates DiT's non-commercial fork of the same routine.
+# - The sinusoidal timestep embedding follows openai/guided-diffusion
+#   (guided_diffusion/nn.py, `timestep_embedding`, MIT), the source DiT
+#   itself credits.
+# - Module structure and parameter names (mlp.0/mlp.2, fc1/fc2, pos_embed)
+#   are fixed by the released SenseNova-Vision-7B-MoT checkpoint's state
+#   dict and carry no expression beyond that interface.
+
+import math
+
+import torch
+from torch import nn
+
+from transformers.activations import ACT2FN
+
+
+def sincos_position_embedding_1d(embed_dim: int, positions: torch.Tensor) -> torch.Tensor:
+    """Sine-cosine table for one axis: [sin(p*w), cos(p*w)] per position.
+
+    Frequencies follow the transformer convention 1/10000^(2i/d). Returns a
+    float32 tensor of shape (len(positions), embed_dim).
+    """
+    if embed_dim % 2 != 0:
+        raise ValueError(f"embed_dim must be even, got {embed_dim}")
+    omega = torch.arange(embed_dim // 2, dtype=torch.float64) / (embed_dim / 2.0)
+    omega = 1.0 / torch.pow(torch.tensor(10000.0, dtype=torch.float64), omega)
+    out = positions.reshape(-1).to(torch.float64)[:, None] * omega[None, :]
+    return torch.cat([torch.sin(out), torch.cos(out)], dim=1).float()
+
+
+def sincos_position_embedding_2d(embed_dim: int, grid_size: int) -> torch.Tensor:
+    """2D sine-cosine position table over a square grid, flattened row-major.
+
+    Position p = row * grid_size + col maps to the concatenation of the
+    1D table over the column index (first half) and the row index (second
+    half), matching the axis order of the transformers ViTMAE reference so
+    the table is interchangeable with released checkpoints.
+    """
+    if embed_dim % 2 != 0:
+        raise ValueError(f"embed_dim must be even, got {embed_dim}")
+    rows = torch.arange(grid_size, dtype=torch.float64)
+    cols = torch.arange(grid_size, dtype=torch.float64)
+    grid_rows = rows[:, None].expand(grid_size, grid_size)
+    grid_cols = cols[None, :].expand(grid_size, grid_size)
+    emb_cols = sincos_position_embedding_1d(embed_dim // 2, grid_cols)
+    emb_rows = sincos_position_embedding_1d(embed_dim // 2, grid_rows)
+    return torch.cat([emb_cols, emb_rows], dim=1)
+
+
+class PositionEmbedding(nn.Module):
+    """Frozen sine-cosine position table indexed by flattened position ids."""
+
+    def __init__(self, max_num_patch_per_side: int, hidden_size: int):
+        super().__init__()
+        self.max_num_patch_per_side = max_num_patch_per_side
+        self.hidden_size = hidden_size
+        self.pos_embed = nn.Parameter(
+            torch.zeros(max_num_patch_per_side**2, hidden_size),
+            requires_grad=False,
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        table = sincos_position_embedding_2d(self.hidden_size, self.max_num_patch_per_side)
+        self.pos_embed.data.copy_(table)
+
+    def forward(self, position_ids):
+        return self.pos_embed[position_ids]
+
+
+class TimestepEmbedder(nn.Module):
+    """Embeds scalar diffusion timesteps into hidden-size vectors."""
+
+    def __init__(self, hidden_size: int, frequency_embedding_size: int = 256):
+        super().__init__()
+        # Layout (Linear, SiLU, Linear) is fixed by the checkpoint keys
+        # time_embedder.mlp.0.* / time_embedder.mlp.2.*.
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        )
+        self.frequency_embedding_size = frequency_embedding_size
+
+    @staticmethod
+    def timestep_embedding(t: torch.Tensor, dim: int, max_period: int = 10000) -> torch.Tensor:
+        """Sinusoidal timestep embedding: [cos(t*f), sin(t*f)] per frequency.
+
+        Frequencies decay geometrically from 1 to 1/max_period, following the
+        guided-diffusion reference; cos comes first, and an odd `dim` gets one
+        zero pad column.
+        """
+        half = dim // 2
+        freqs = torch.exp(
+            -math.log(max_period)
+            * torch.arange(start=0, end=half, dtype=torch.float32)
+            / half
+        ).to(device=t.device)
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+        return embedding
+
+    def forward(self, t):
+        t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
+        return self.mlp(t_freq)
+
+
+class MLPconnector(nn.Module):
+    """Two-layer projector between the vision tower and the language model."""
+
+    def __init__(self, in_dim: int, out_dim: int, hidden_act: str):
+        super().__init__()
+        # fc1/fc2 names are fixed by the checkpoint keys connector.fc1.* /
+        # connector.fc2.*.
+        self.activation_fn = ACT2FN[hidden_act]
+        self.fc1 = nn.Linear(in_dim, out_dim)
+        self.fc2 = nn.Linear(out_dim, out_dim)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states

--- a/libreyolo/models/sensenova/modeling/qwen2_base.py
+++ b/libreyolo/models/sensenova/modeling/qwen2_base.py
@@ -1,0 +1,201 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright 2024 The Qwen Team and The HuggingFace Inc. team.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# modeling/qwen2/modeling_qwen2.py, itself derived from Hugging Face
+# transformers (Apache-2.0). Trimmed to the leaf modules the packed NaViT
+# decoder actually instantiates: the eager/flash full-model classes and the
+# training-only machinery of the upstream file are not ported. Qwen2Attention
+# keeps only its constructor; its forward is never called because
+# PackedAttention overrides it.
+
+import torch
+from torch import nn
+
+from transformers.activations import ACT2FN
+from transformers.modeling_utils import PreTrainedModel
+
+from .qwen2_config import Qwen2Config
+
+try:
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+except ImportError:  # pragma: no cover - depends on transformers version
+    ROPE_INIT_FUNCTIONS = None
+
+
+class Qwen2RMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """Qwen2RMSNorm is equivalent to T5LayerNorm."""
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+def _default_rope_init(config, device=None):
+    """Default RoPE inverse frequencies (rope_type="default").
+
+    Matches transformers' ROPE_INIT_FUNCTIONS["default"]; kept inline so the
+    vendored model does not depend on a private transformers module path.
+    """
+    base = config.rope_theta
+    dim = config.hidden_size // config.num_attention_heads
+    inv_freq = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.int64).float().to(device) / dim)
+    )
+    return inv_freq, 1.0
+
+
+class Qwen2RotaryEmbedding(nn.Module):
+    def __init__(self, config: Qwen2Config, device=None):
+        super().__init__()
+        if config.rope_scaling is not None:
+            self.rope_type = config.rope_scaling.get(
+                "rope_type", config.rope_scaling.get("type")
+            )
+        else:
+            self.rope_type = "default"
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        if self.rope_type == "default" or ROPE_INIT_FUNCTIONS is None:
+            if self.rope_type != "default":
+                raise ValueError(
+                    f"rope_type {self.rope_type!r} requires transformers' rope init "
+                    "functions, which this transformers version does not expose."
+                )
+            self.rope_init_fn = _default_rope_init
+        else:
+            self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+
+        inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    @torch.no_grad()
+    def forward(self, x, position_ids):
+        # Core RoPE block (static frequencies; the released checkpoints use
+        # rope_type="default", which never triggers dynamic updates).
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        )
+        position_ids_expanded = position_ids[:, None, :].float()
+        device_type = x.device.type
+        device_type = (
+            device_type
+            if isinstance(device_type, str) and device_type != "mps"
+            else "cpu"
+        )
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (
+                inv_freq_expanded.float().to(x.device) @ position_ids_expanded.float()
+            ).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+
+        cos = cos * self.attention_scaling
+        sin = sin * self.attention_scaling
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors."""
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class Qwen2MLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_state):
+        return self.down_proj(
+            self.act_fn(self.gate_proj(hidden_state)) * self.up_proj(hidden_state)
+        )
+
+
+class Qwen2Attention(nn.Module):
+    """Projection layout of Qwen2 multi-headed attention.
+
+    Only the constructor is used: PackedAttention subclasses this for the
+    q/k/v/o projections and head bookkeeping, and overrides forward with the
+    packed-sequence implementation.
+    """
+
+    def __init__(self, config: Qwen2Config, layer_idx=None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_theta = config.rope_theta
+        self.is_causal = config.is_causal
+        self.attention_dropout = config.attention_dropout
+
+        if (self.head_dim * self.num_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: "
+                f"{self.hidden_size} and `num_heads`: {self.num_heads})."
+            )
+        self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=True)
+        self.k_proj = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
+
+
+class Qwen2PreTrainedModel(PreTrainedModel):
+    config_class = Qwen2Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Qwen2DecoderLayer"]
+    _skip_keys_device_placement = "past_key_values"
+    _supports_cache_class = True
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()

--- a/libreyolo/models/sensenova/modeling/qwen2_config.py
+++ b/libreyolo/models/sensenova/modeling/qwen2_config.py
@@ -1,0 +1,187 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright 2024 The Qwen Team and The HuggingFace Inc. team.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen2 model configuration"""
+
+from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import logging
+
+try:
+    from transformers.modeling_rope_utils import rope_config_validation
+except ImportError:  # pragma: no cover - depends on transformers version
+
+    def rope_config_validation(config):
+        return None
+
+
+
+logger = logging.get_logger(__name__)
+
+
+class Qwen2Config(PretrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of a [`Qwen2Model`]. It is used to instantiate a
+    Qwen2 model according to the specified arguments, defining the model architecture. Instantiating a configuration
+    with the defaults will yield a similar configuration to that of
+    Qwen2-7B-beta [Qwen/Qwen2-7B-beta](https://huggingface.co/Qwen/Qwen2-7B-beta).
+
+    Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PretrainedConfig`] for more information.
+
+
+    Args:
+        vocab_size (`int`, *optional*, defaults to 151936):
+            Vocabulary size of the Qwen2 model. Defines the number of different tokens that can be represented by the
+            `inputs_ids` passed when calling [`Qwen2Model`]
+        hidden_size (`int`, *optional*, defaults to 4096):
+            Dimension of the hidden representations.
+        intermediate_size (`int`, *optional*, defaults to 22016):
+            Dimension of the MLP representations.
+        num_hidden_layers (`int`, *optional*, defaults to 32):
+            Number of hidden layers in the Transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 32):
+            Number of attention heads for each attention layer in the Transformer encoder.
+        num_key_value_heads (`int`, *optional*, defaults to 32):
+            This is the number of key_value heads that should be used to implement Grouped Query Attention. If
+            `num_key_value_heads=num_attention_heads`, the model will use Multi Head Attention (MHA), if
+            `num_key_value_heads=1` the model will use Multi Query Attention (MQA) otherwise GQA is used. When
+            converting a multi-head checkpoint to a GQA checkpoint, each group key and value head should be constructed
+            by meanpooling all the original heads within that group. For more details checkout [this
+            paper](https://arxiv.org/pdf/2305.13245.pdf). If it is not specified, will default to `32`.
+        hidden_act (`str` or `function`, *optional*, defaults to `"silu"`):
+            The non-linear activation function (function or string) in the decoder.
+        max_position_embeddings (`int`, *optional*, defaults to 32768):
+            The maximum sequence length that this model might ever be used with.
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
+        rms_norm_eps (`float`, *optional*, defaults to 1e-06):
+            The epsilon used by the rms normalization layers.
+        use_cache (`bool`, *optional*, defaults to `True`):
+            Whether or not the model should return the last key/values attentions (not used by all models). Only
+            relevant if `config.is_decoder=True`.
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether the model's input and output word embeddings should be tied.
+        rope_theta (`float`, *optional*, defaults to 10000.0):
+            The base period of the RoPE embeddings.
+        rope_scaling (`Dict`, *optional*):
+            Dictionary containing the scaling configuration for the RoPE embeddings. NOTE: if you apply new rope type
+            and you expect the model to work on longer `max_position_embeddings`, we recommend you to update this value
+            accordingly.
+            Expected contents:
+                `rope_type` (`str`):
+                    The sub-variant of RoPE to use. Can be one of ['default', 'linear', 'dynamic', 'yarn', 'longrope',
+                    'llama3'], with 'default' being the original RoPE implementation.
+                `factor` (`float`, *optional*):
+                    Used with all rope types except 'default'. The scaling factor to apply to the RoPE embeddings. In
+                    most scaling types, a `factor` of x will enable the model to handle sequences of length x *
+                    original maximum pre-trained length.
+                `original_max_position_embeddings` (`int`, *optional*):
+                    Used with 'dynamic', 'longrope' and 'llama3'. The original max position embeddings used during
+                    pretraining.
+                `attention_factor` (`float`, *optional*):
+                    Used with 'yarn' and 'longrope'. The scaling factor to be applied on the attention
+                    computation. If unspecified, it defaults to value recommended by the implementation, using the
+                    `factor` field to infer the suggested value.
+                `beta_fast` (`float`, *optional*):
+                    Only used with 'yarn'. Parameter to set the boundary for extrapolation (only) in the linear
+                    ramp function. If unspecified, it defaults to 32.
+                `beta_slow` (`float`, *optional*):
+                    Only used with 'yarn'. Parameter to set the boundary for interpolation (only) in the linear
+                    ramp function. If unspecified, it defaults to 1.
+                `short_factor` (`List[float]`, *optional*):
+                    Only used with 'longrope'. The scaling factor to be applied to short contexts (<
+                    `original_max_position_embeddings`). Must be a list of numbers with the same length as the hidden
+                    size divided by the number of attention heads divided by 2
+                `long_factor` (`List[float]`, *optional*):
+                    Only used with 'longrope'. The scaling factor to be applied to long contexts (<
+                    `original_max_position_embeddings`). Must be a list of numbers with the same length as the hidden
+                    size divided by the number of attention heads divided by 2
+                `low_freq_factor` (`float`, *optional*):
+                    Only used with 'llama3'. Scaling factor applied to low frequency components of the RoPE
+                `high_freq_factor` (`float`, *optional*):
+                    Only used with 'llama3'. Scaling factor applied to high frequency components of the RoPE
+        use_sliding_window (`bool`, *optional*, defaults to `False`):
+            Whether to use sliding window attention.
+        sliding_window (`int`, *optional*, defaults to 4096):
+            Sliding window attention (SWA) window size. If not specified, will default to `4096`.
+        max_window_layers (`int`, *optional*, defaults to 28):
+            The number of layers that use SWA (Sliding Window Attention). The bottom layers use SWA while the top use full attention.
+        attention_dropout (`float`, *optional*, defaults to 0.0):
+            The dropout ratio for the attention probabilities.
+
+    ```python
+    >>> from transformers import Qwen2Model, Qwen2Config
+
+    >>> # Initializing a Qwen2 style configuration
+    >>> configuration = Qwen2Config()
+
+    >>> # Initializing a model from the Qwen2-7B style configuration
+    >>> model = Qwen2Model(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```"""
+
+    model_type = "qwen2"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size=151936,
+        hidden_size=4096,
+        intermediate_size=22016,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        num_key_value_heads=32,
+        hidden_act="silu",
+        max_position_embeddings=32768,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        tie_word_embeddings=False,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        use_sliding_window=False,
+        sliding_window=4096,
+        max_window_layers=28,
+        attention_dropout=0.0,
+        is_causal=True,
+        _attn_implementation="flash_attention_2",
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.use_sliding_window = use_sliding_window
+        self.sliding_window = sliding_window if use_sliding_window else None
+        self.max_window_layers = max_window_layers
+
+        # for backward compatibility
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.attention_dropout = attention_dropout
+        self.is_causal = is_causal
+        self._attn_implementation = _attn_implementation
+
+        # Validate the correctness of rotary position embeddings parameters
+        # BC: if there is a 'type' field, move it to 'rope_type'.
+        if self.rope_scaling is not None and "type" in self.rope_scaling:
+            self.rope_scaling["rope_type"] = self.rope_scaling["type"]
+        rope_config_validation(self)
+
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/libreyolo/models/sensenova/modeling/qwen2_navit.py
+++ b/libreyolo/models/sensenova/modeling/qwen2_navit.py
@@ -1,0 +1,932 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright (c) 2024 The Qwen Team and The HuggingFace Inc. team.
+# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file has been modified by ByteDance Ltd. and/or its affiliates. on 2025-05-20.
+#
+# Original file was released under Apache-2.0, with the full license text
+# available at https://github.com/huggingface/transformers/blob/main/LICENSE.
+#
+# This modified file is released under the same license.
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# modeling/bagel/qwen2_navit.py. LibreYOLO adaptations: the training-only
+# forward paths (flex-attention block masks, import-time torch.compile) are
+# removed because this port is inference-only, and flash-attn becomes an
+# optional accelerator with a numerically equivalent SDPA fallback in
+# `_varlen_attention` so the model runs where flash-attn wheels do not.
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from torch.nn.functional import scaled_dot_product_attention
+from transformers.utils import ModelOutput
+
+from .qwen2_base import (
+    Qwen2Attention,
+    Qwen2MLP,
+    Qwen2PreTrainedModel,
+    Qwen2RMSNorm,
+    Qwen2RotaryEmbedding,
+    apply_rotary_pos_emb,
+)
+
+from .qwen2_config import Qwen2Config as _Qwen2Config
+
+try:
+    from flash_attn import flash_attn_varlen_func
+
+    _HAS_FLASH_ATTN = True
+except ImportError:  # pragma: no cover - depends on environment
+    flash_attn_varlen_func = None
+    _HAS_FLASH_ATTN = False
+
+
+def _varlen_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    causal: bool,
+) -> torch.Tensor:
+    """Variable-length packed attention: flash-attn when available, SDPA otherwise.
+
+    Inputs and output are packed as ``[total_tokens, heads, head_dim]``. The
+    fallback iterates the (at inference, one or two) packed sequences and
+    reproduces flash-attn's bottom-right-aligned causal semantics, where the
+    last query row attends to every key.
+    """
+    if _HAS_FLASH_ATTN:
+        return flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            causal=causal,
+        )
+
+    num_heads = q.shape[1]
+    num_kv_heads = k.shape[1]
+    outputs = []
+    for i in range(int(cu_seqlens_q.numel()) - 1):
+        qs, qe = int(cu_seqlens_q[i]), int(cu_seqlens_q[i + 1])
+        ks, ke = int(cu_seqlens_k[i]), int(cu_seqlens_k[i + 1])
+        qi = q[qs:qe].transpose(0, 1)
+        ki = k[ks:ke].transpose(0, 1)
+        vi = v[ks:ke].transpose(0, 1)
+        if num_kv_heads != num_heads:
+            rep = num_heads // num_kv_heads
+            ki = ki.repeat_interleave(rep, dim=0)
+            vi = vi.repeat_interleave(rep, dim=0)
+        n, m = qi.shape[1], ki.shape[1]
+        attn_mask = None
+        if causal and n > 1:
+            attn_mask = torch.ones(n, m, dtype=torch.bool, device=q.device).tril_(m - n)
+        out = scaled_dot_product_attention(
+            qi.unsqueeze(0), ki.unsqueeze(0), vi.unsqueeze(0), attn_mask=attn_mask
+        )
+        outputs.append(out.squeeze(0).transpose(0, 1))
+    return torch.cat(outputs, dim=0)
+
+
+class Qwen2Config(_Qwen2Config):
+    r"""
+    This is the configuration class to store the configuration of a [`Qwen2Model`]. It is used to instantiate a
+    Qwen2 model according to the specified arguments, defining the model architecture. Instantiating a configuration
+    with the defaults will yield a similar configuration to that of
+    Qwen2-7B-beta [Qwen/Qwen2-7B-beta](https://huggingface.co/Qwen/Qwen2-7B-beta).
+
+    Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PretrainedConfig`] for more information.
+
+    Args:
+        vocab_size (`int`, *optional*, defaults to 151936):
+            Vocabulary size of the Qwen2 model. Defines the number of different tokens that can be represented by the
+            `inputs_ids` passed when calling [`Qwen2Model`]
+        hidden_size (`int`, *optional*, defaults to 4096):
+            Dimension of the hidden representations.
+        intermediate_size (`int`, *optional*, defaults to 22016):
+            Dimension of the MLP representations.
+        num_hidden_layers (`int`, *optional*, defaults to 32):
+            Number of hidden layers in the Transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 32):
+            Number of attention heads for each attention layer in the Transformer encoder.
+        num_key_value_heads (`int`, *optional*, defaults to 32):
+            This is the number of key_value heads that should be used to implement Grouped Query Attention. If
+            `num_key_value_heads=num_attention_heads`, the model will use Multi Head Attention (MHA), if
+            `num_key_value_heads=1` the model will use Multi Query Attention (MQA) otherwise GQA is used. When
+            converting a multi-head checkpoint to a GQA checkpoint, each group key and value head should be constructed
+            by meanpooling all the original heads within that group. For more details checkout [this
+            paper](https://arxiv.org/pdf/2305.13245.pdf). If it is not specified, will default to `32`.
+        hidden_act (`str` or `function`, *optional*, defaults to `"silu"`):
+            The non-linear activation function (function or string) in the decoder.
+        max_position_embeddings (`int`, *optional*, defaults to 32768):
+            The maximum sequence length that this model might ever be used with.
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
+        rms_norm_eps (`float`, *optional*, defaults to 1e-06):
+            The epsilon used by the rms normalization layers.
+        use_cache (`bool`, *optional*, defaults to `True`):
+            Whether or not the model should return the last key/values attentions (not used by all models). Only
+            relevant if `config.is_decoder=True`.
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether the model's input and output word embeddings should be tied.
+        rope_theta (`float`, *optional*, defaults to 10000.0):
+            The base period of the RoPE embeddings.
+        rope_scaling (`Dict`, *optional*):
+            Dictionary containing the scaling configuration for the RoPE embeddings. NOTE: if you apply new rope type
+            and you expect the model to work on longer `max_position_embeddings`, we recommend you to update this value
+            accordingly.
+            Expected contents:
+                `rope_type` (`str`):
+                    The sub-variant of RoPE to use. Can be one of ['default', 'linear', 'dynamic', 'yarn', 'longrope',
+                    'llama3'], with 'default' being the original RoPE implementation.
+                `factor` (`float`, *optional*):
+                    Used with all rope types except 'default'. The scaling factor to apply to the RoPE embeddings. In
+                    most scaling types, a `factor` of x will enable the model to handle sequences of length x *
+                    original maximum pre-trained length.
+                `original_max_position_embeddings` (`int`, *optional*):
+                    Used with 'dynamic', 'longrope' and 'llama3'. The original max position embeddings used during
+                    pretraining.
+                `attention_factor` (`float`, *optional*):
+                    Used with 'yarn' and 'longrope'. The scaling factor to be applied on the attention
+                    computation. If unspecified, it defaults to value recommended by the implementation, using the
+                    `factor` field to infer the suggested value.
+                `beta_fast` (`float`, *optional*):
+                    Only used with 'yarn'. Parameter to set the boundary for extrapolation (only) in the linear
+                    ramp function. If unspecified, it defaults to 32.
+                `beta_slow` (`float`, *optional*):
+                    Only used with 'yarn'. Parameter to set the boundary for interpolation (only) in the linear
+                    ramp function. If unspecified, it defaults to 1.
+                `short_factor` (`List[float]`, *optional*):
+                    Only used with 'longrope'. The scaling factor to be applied to short contexts (<
+                    `original_max_position_embeddings`). Must be a list of numbers with the same length as the hidden
+                    size divided by the number of attention heads divided by 2
+                `long_factor` (`List[float]`, *optional*):
+                    Only used with 'longrope'. The scaling factor to be applied to long contexts (<
+                    `original_max_position_embeddings`). Must be a list of numbers with the same length as the hidden
+                    size divided by the number of attention heads divided by 2
+                `low_freq_factor` (`float`, *optional*):
+                    Only used with 'llama3'. Scaling factor applied to low frequency components of the RoPE
+                `high_freq_factor` (`float`, *optional*):
+                    Only used with 'llama3'. Scaling factor applied to high frequency components of the RoPE
+        use_sliding_window (`bool`, *optional*, defaults to `False`):
+            Whether to use sliding window attention.
+        sliding_window (`int`, *optional*, defaults to 4096):
+            Sliding window attention (SWA) window size. If not specified, will default to `4096`.
+        max_window_layers (`int`, *optional*, defaults to 28):
+            The number of layers that use SWA (Sliding Window Attention). The bottom layers use SWA while the top use full attention.
+        attention_dropout (`float`, *optional*, defaults to 0.0):
+            The dropout ratio for the attention probabilities.
+
+    ```python
+    >>> from transformers import Qwen2Model, Qwen2Config
+
+    >>> # Initializing a Qwen2 style configuration
+    >>> configuration = Qwen2Config()
+
+    >>> # Initializing a model from the Qwen2-7B style configuration
+    >>> model = Qwen2Model(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```"""
+
+    model_type = "qwen2"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size=151936,
+        hidden_size=4096,
+        intermediate_size=22016,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        num_key_value_heads=32,
+        hidden_act="silu",
+        max_position_embeddings=32768,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        tie_word_embeddings=False,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        use_sliding_window=False,
+        sliding_window=4096,
+        max_window_layers=28,
+        attention_dropout=0.0,
+        is_causal=True,
+        _attn_implementation="flash_attention_2",
+        qk_norm=True,
+        layer_module="Qwen2DecoderLayer",
+        freeze_und=False,
+        **kwargs,
+    ):
+        super().__init__(
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            hidden_act=hidden_act,
+            max_position_embeddings=max_position_embeddings,
+            initializer_range=initializer_range,
+            rms_norm_eps=rms_norm_eps,
+            use_cache=use_cache,
+            tie_word_embeddings=tie_word_embeddings,
+            rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
+            use_sliding_window=use_sliding_window,
+            sliding_window=sliding_window,
+            max_window_layers=max_window_layers,
+            attention_dropout=attention_dropout,
+            is_causal=is_causal,
+            _attn_implementation=_attn_implementation,
+            **kwargs,
+        )
+        self.qk_norm = qk_norm
+        self.layer_module = layer_module
+        self.freeze_und = freeze_und
+
+
+class NaiveCache:
+    def __init__(self, num_layers):
+        self.key_cache = {k: None for k in range(num_layers)}
+        self.value_cache = {k: None for k in range(num_layers)}
+
+    @property
+    def num_layers(self):
+        return len(self.key_cache)
+
+    @property
+    def seq_lens(self):
+        if self.key_cache[0] is not None:
+            return self.key_cache[0].shape[0]
+        else:
+            return 0
+
+
+@dataclass
+class BaseNavitOutputWithPast(ModelOutput):
+    packed_query_sequence: torch.FloatTensor = None
+    past_key_values: Optional[NaiveCache] = None
+
+
+class PackedAttention(Qwen2Attention):
+    def __init__(self, config, layer_idx: Optional[int] = None):
+        super().__init__(config, layer_idx)
+        if self.config.qk_norm:
+            self.q_norm = Qwen2RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.k_norm = Qwen2RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        else:
+            self.q_norm = nn.Identity()
+            self.k_norm = nn.Identity()
+
+    def forward(self, *args, **kwargs):
+        return self.forward_inference(*args, **kwargs)
+
+    def forward_inference(
+        self,
+        packed_query_sequence: torch.Tensor,
+        query_lens: torch.Tensor,
+        packed_query_position_embeddings: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
+        past_key_values: Optional[NaiveCache] = None,
+        key_values_lens: Optional[torch.Tensor] = None,
+        packed_key_value_indexes: Optional[torch.Tensor] = None,
+        update_past_key_values=True,
+        is_causal=True,
+    ):
+        packed_query_states = self.q_proj(packed_query_sequence).view(
+            -1, self.num_heads, self.head_dim
+        )
+        packed_key_states = self.k_proj(packed_query_sequence).view(
+            -1, self.num_key_value_heads, self.head_dim
+        )
+        packed_value_states = self.v_proj(packed_query_sequence).view(
+            -1, self.num_key_value_heads, self.head_dim
+        )
+
+        packed_query_states = self.q_norm(packed_query_states)
+        packed_key_states = self.k_norm(packed_key_states)
+
+        packed_cos, packed_sin = packed_query_position_embeddings
+        packed_query_states, packed_key_states = apply_rotary_pos_emb(
+            packed_query_states, packed_key_states, packed_cos, packed_sin, unsqueeze_dim=1
+        )
+
+        packed_query_states = packed_query_states.to(torch.bfloat16)
+        packed_key_states = packed_key_states.to(torch.bfloat16)
+        packed_value_states = packed_value_states.to(torch.bfloat16)
+
+        if past_key_values is not None and past_key_values.key_cache[self.layer_idx] is not None:
+            past_key_states = past_key_values.key_cache[self.layer_idx]
+            past_value_states = past_key_values.value_cache[self.layer_idx]
+
+            seqlens = sum(query_lens) + sum(key_values_lens)
+            merged_key_states = past_key_states.new_zeros(
+                (seqlens, self.num_key_value_heads, self.head_dim)
+            )
+            merged_value_states = past_key_states.new_zeros(
+                (seqlens, self.num_key_value_heads, self.head_dim)
+            )
+            merged_key_states[packed_query_indexes] = packed_key_states
+            merged_key_states[packed_key_value_indexes] = past_key_states
+            merged_value_states[packed_query_indexes] = packed_value_states
+            merged_value_states[packed_key_value_indexes] = past_value_states
+            key_values_lens = key_values_lens + query_lens
+        else:
+            merged_key_states = packed_key_states
+            merged_value_states = packed_value_states
+            key_values_lens = query_lens
+
+        cu_seqlens_q = torch.nn.functional.pad(torch.cumsum(query_lens, dim=0), (1, 0))
+        cu_seqlens_k = torch.nn.functional.pad(torch.cumsum(key_values_lens, dim=0), (1, 0))
+
+        packed_attn_output = _varlen_attention(
+            q=packed_query_states,
+            k=merged_key_states,
+            v=merged_value_states,
+            cu_seqlens_q=cu_seqlens_q.to(torch.int32),
+            cu_seqlens_k=cu_seqlens_k.to(torch.int32),
+            max_seqlen_q=max(query_lens).item(),
+            max_seqlen_k=max(key_values_lens).item(),
+            causal=is_causal,
+        )
+        packed_attn_output = packed_attn_output.reshape(-1, self.hidden_size)
+        packed_attn_output = self.o_proj(packed_attn_output)
+
+        if update_past_key_values:
+            past_key_values.key_cache[self.layer_idx] = merged_key_states
+            past_key_values.value_cache[self.layer_idx] = merged_value_states
+
+        return packed_attn_output, past_key_values
+
+
+class PackedAttentionMoT(Qwen2Attention):
+    def __init__(self, config, layer_idx: Optional[int] = None):
+        super().__init__(config, layer_idx)
+        if self.config.qk_norm:
+            self.q_norm = Qwen2RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.k_norm = Qwen2RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.q_norm_moe_gen = Qwen2RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.k_norm_moe_gen = Qwen2RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        else:
+            self.q_norm = nn.Identity()
+            self.k_norm = nn.Identity()
+            self.q_norm_moe_gen = nn.Identity()
+            self.k_norm_moe_gen = nn.Identity()
+
+        self.q_proj_moe_gen = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=True)
+        self.k_proj_moe_gen = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.v_proj_moe_gen = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.o_proj_moe_gen = nn.Linear(
+            self.num_heads * self.head_dim, self.hidden_size, bias=False
+        )
+
+    def forward(self, *args, **kwargs):
+        return self.forward_inference(*args, **kwargs)
+
+    def forward_inference(
+        self,
+        packed_query_sequence: torch.Tensor,
+        query_lens: torch.Tensor,
+        packed_query_position_embeddings: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
+        past_key_values: Optional[NaiveCache] = None,
+        key_values_lens: Optional[torch.Tensor] = None,
+        packed_key_value_indexes: Optional[torch.Tensor] = None,
+        update_past_key_values=True,
+        is_causal=True,
+        mode="und",
+        packed_vae_token_indexes=None,
+        packed_text_indexes=None,
+    ):
+        if mode == 'und':
+            packed_query_states = self.q_proj(packed_query_sequence).view(
+                -1, self.num_heads, self.head_dim
+            )
+            packed_key_states = self.k_proj(packed_query_sequence).view(
+                -1, self.num_key_value_heads, self.head_dim
+            )
+            packed_value_states = self.v_proj(packed_query_sequence).view(
+                -1, self.num_key_value_heads, self.head_dim
+            )
+            packed_query_states = self.q_norm(packed_query_states)
+            packed_key_states = self.k_norm(packed_key_states)
+        elif mode == 'gen':
+            packed_query_sequence = packed_query_sequence.to(torch.bfloat16)
+            packed_query_states = packed_query_sequence.new_zeros(
+                (packed_query_sequence.shape[0], self.num_heads * self.head_dim)
+            )
+            packed_key_states = packed_query_sequence.new_zeros(
+                (packed_query_sequence.shape[0], self.num_key_value_heads * self.head_dim)
+            )
+            packed_value_states = packed_query_sequence.new_zeros(
+                (packed_query_sequence.shape[0], self.num_key_value_heads * self.head_dim)
+            )
+
+            packed_text_query_sequence = packed_query_sequence[packed_text_indexes]
+            packed_vae_query_sequence = packed_query_sequence[packed_vae_token_indexes]
+
+            packed_query_states[packed_text_indexes] = self.q_proj(packed_text_query_sequence)
+            packed_query_states[packed_vae_token_indexes] = self.q_proj_moe_gen(
+                packed_vae_query_sequence
+            )
+
+            packed_key_states[packed_text_indexes] = self.k_proj(packed_text_query_sequence)
+            packed_key_states[packed_vae_token_indexes] = self.k_proj_moe_gen(
+                packed_vae_query_sequence
+            )
+
+            packed_value_states[packed_text_indexes] = self.v_proj(packed_text_query_sequence)
+            packed_value_states[packed_vae_token_indexes] = self.v_proj_moe_gen(
+                packed_vae_query_sequence
+            )
+
+            packed_query_states = packed_query_states.view(-1, self.num_heads, self.head_dim)
+            packed_key_states = packed_key_states.view(-1, self.num_key_value_heads, self.head_dim)
+            packed_value_states = packed_value_states.view(
+                -1, self.num_key_value_heads, self.head_dim
+            )
+
+            packed_query_states = packed_query_states.to(torch.float32)
+            packed_query_states[packed_text_indexes] = self.q_norm(
+                packed_query_states[packed_text_indexes]
+            )
+            packed_query_states[packed_vae_token_indexes] = self.q_norm_moe_gen(
+                packed_query_states[packed_vae_token_indexes]
+            )
+
+            packed_key_states = packed_key_states.to(torch.float32)
+            packed_key_states[packed_text_indexes] = self.k_norm(
+                packed_key_states[packed_text_indexes]
+            )
+            packed_key_states[packed_vae_token_indexes] = self.k_norm_moe_gen(
+                packed_key_states[packed_vae_token_indexes]
+            )
+
+        packed_cos, packed_sin = packed_query_position_embeddings
+        packed_query_states, packed_key_states = apply_rotary_pos_emb(
+            packed_query_states, packed_key_states, packed_cos, packed_sin, unsqueeze_dim=1
+        )
+
+        packed_query_states = packed_query_states.to(torch.bfloat16)
+        packed_key_states = packed_key_states.to(torch.bfloat16)
+        packed_value_states = packed_value_states.to(torch.bfloat16)
+
+        if past_key_values is not None and past_key_values.key_cache[self.layer_idx] is not None:
+            past_key_states = past_key_values.key_cache[self.layer_idx]
+            past_value_states = past_key_values.value_cache[self.layer_idx]
+
+            seqlens = sum(query_lens) + sum(key_values_lens)
+            merged_key_states = past_key_states.new_zeros(
+                size=[seqlens, self.num_key_value_heads, self.head_dim]
+            )
+            merged_value_states = past_key_states.new_zeros(
+                size=[seqlens, self.num_key_value_heads, self.head_dim]
+            )
+            merged_key_states[packed_query_indexes] = packed_key_states
+            merged_key_states[packed_key_value_indexes] = past_key_states
+            merged_value_states[packed_query_indexes] = packed_value_states
+            merged_value_states[packed_key_value_indexes] = past_value_states
+            key_values_lens = key_values_lens + query_lens
+        else:
+            merged_key_states = packed_key_states
+            merged_value_states = packed_value_states
+            key_values_lens = query_lens
+
+        cu_seqlens_q = torch.nn.functional.pad(torch.cumsum(query_lens, dim=0), (1, 0))
+        cu_seqlens_k = torch.nn.functional.pad(torch.cumsum(key_values_lens, dim=0), (1, 0))
+
+        packed_attn_output = _varlen_attention(
+            q=packed_query_states,
+            k=merged_key_states,
+            v=merged_value_states,
+            cu_seqlens_q=cu_seqlens_q.to(torch.int32),
+            cu_seqlens_k=cu_seqlens_k.to(torch.int32),
+            max_seqlen_q=max(query_lens).item(),
+            max_seqlen_k=max(key_values_lens).item(),
+            causal=is_causal,
+        )
+        packed_attn_output = packed_attn_output.reshape(-1, self.hidden_size)
+        if mode == 'und':
+            packed_attn_output = self.o_proj(packed_attn_output)
+        elif mode == 'gen':
+            packed_attn_output[packed_text_indexes] = self.o_proj(
+                packed_attn_output[packed_text_indexes]
+            )
+            packed_attn_output[packed_vae_token_indexes] = self.o_proj_moe_gen(
+                packed_attn_output[packed_vae_token_indexes]
+            )
+
+        if update_past_key_values:
+            past_key_values.key_cache[self.layer_idx] = merged_key_states
+            past_key_values.value_cache[self.layer_idx] = merged_value_states
+
+        return packed_attn_output, past_key_values
+
+
+class Qwen2DecoderLayer(nn.Module):
+    def __init__(self, config, layer_idx: Optional[int] = None):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        self.self_attn = PackedAttention(config, layer_idx)
+
+        self.mlp = Qwen2MLP(config)
+        self.input_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(self, *args, **kwargs):
+        return self.forward_inference(*args, **kwargs)
+
+    def forward_inference(
+        self,
+        packed_query_sequence: torch.Tensor,
+        query_lens: torch.Tensor,
+        packed_query_position_embeddings: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
+        past_key_values: Optional[NaiveCache] = None,
+        key_values_lens: Optional[torch.Tensor] = None,
+        packed_key_value_indexes: Optional[torch.Tensor] = None,
+        update_past_key_values=True,
+        is_causal=True,
+    ) -> BaseNavitOutputWithPast:
+
+        residual = packed_query_sequence
+        packed_query_sequence = self.input_layernorm(packed_query_sequence)
+
+        # Self Attention
+        packed_query_sequence, past_key_values = self.self_attn(
+            packed_query_sequence=packed_query_sequence,
+            query_lens=query_lens,
+            packed_query_position_embeddings=packed_query_position_embeddings,
+            packed_query_indexes=packed_query_indexes,
+            past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
+            update_past_key_values=update_past_key_values,
+            is_causal=is_causal,
+        )
+        packed_query_sequence = residual + packed_query_sequence
+
+        # Fully Connected
+        residual = packed_query_sequence
+        packed_query_sequence = self.post_attention_layernorm(packed_query_sequence)
+        packed_query_sequence = self.mlp(packed_query_sequence)
+        packed_query_sequence = residual + packed_query_sequence
+
+        return packed_query_sequence, past_key_values
+
+
+class Qwen2MoTDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config,
+        layer_idx: Optional[int] = None,
+        attn_module: Optional[Qwen2Attention] = PackedAttentionMoT,
+    ):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.freeze_und = config.freeze_und
+
+        self.self_attn = attn_module(config, layer_idx)
+
+        self.mlp = Qwen2MLP(config)
+        self.mlp_moe_gen = Qwen2MLP(config)
+        self.input_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.input_layernorm_moe_gen = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm_moe_gen = Qwen2RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(self, *args, **kwargs):
+        return self.forward_inference(*args, **kwargs)
+
+    def forward_inference(
+        self,
+        packed_query_sequence: torch.Tensor,
+        query_lens: torch.Tensor,
+        packed_query_position_embeddings: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
+        past_key_values: Optional[NaiveCache] = None,
+        key_values_lens: Optional[torch.Tensor] = None,
+        packed_key_value_indexes: Optional[torch.Tensor] = None,
+        update_past_key_values=True,
+        is_causal=True,
+        mode="und",
+        packed_vae_token_indexes=None,
+        packed_text_indexes=None,
+    ) -> BaseNavitOutputWithPast:
+
+        residual = packed_query_sequence
+        if mode == "und":
+            packed_query_sequence = self.input_layernorm(packed_query_sequence)
+        elif mode == "gen":
+            packed_query_sequence_ = torch.zeros_like(packed_query_sequence)
+            packed_query_sequence_[packed_text_indexes] = self.input_layernorm(
+                packed_query_sequence[packed_text_indexes]
+            )
+            packed_query_sequence_[packed_vae_token_indexes] = self.input_layernorm_moe_gen(
+                packed_query_sequence[packed_vae_token_indexes]
+            )
+            packed_query_sequence = packed_query_sequence_
+
+        # Self Attention
+        packed_query_sequence, past_key_values = self.self_attn(
+            packed_query_sequence=packed_query_sequence,
+            query_lens=query_lens,
+            packed_query_position_embeddings=packed_query_position_embeddings,
+            packed_query_indexes=packed_query_indexes,
+            past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
+            update_past_key_values=update_past_key_values,
+            is_causal=is_causal,
+            mode=mode,
+            packed_vae_token_indexes=packed_vae_token_indexes,
+            packed_text_indexes=packed_text_indexes,
+        )
+        packed_query_sequence = residual + packed_query_sequence
+
+        # Fully Connected
+        residual = packed_query_sequence
+        if mode == "und":
+            packed_query_sequence = self.post_attention_layernorm(packed_query_sequence)
+            packed_query_sequence = self.mlp(packed_query_sequence)
+        elif mode == "gen":
+            packed_text_query_sequence = packed_query_sequence[packed_text_indexes]
+            packed_vae_query_sequence = packed_query_sequence[packed_vae_token_indexes]
+            packed_text_query_sequence = self.post_attention_layernorm(
+                packed_text_query_sequence
+            ).to(torch.bfloat16)
+            packed_vae_query_sequence = self.post_attention_layernorm_moe_gen(
+                packed_vae_query_sequence
+            ).to(torch.bfloat16)
+
+            packed_query_sequence_ = torch.zeros_like(packed_query_sequence).to(torch.bfloat16)
+            packed_query_sequence_[packed_text_indexes] = self.mlp(packed_text_query_sequence)
+            packed_query_sequence_[packed_vae_token_indexes] = self.mlp_moe_gen(
+                packed_vae_query_sequence
+            )
+            packed_query_sequence = packed_query_sequence_
+
+        packed_query_sequence = residual + packed_query_sequence
+        return packed_query_sequence, past_key_values
+
+
+class Qwen2MoEDecoderLayer(nn.Module):
+    def __init__(self, config, layer_idx: Optional[int] = None):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        self.self_attn = PackedAttention(config, layer_idx)
+
+        self.mlp = Qwen2MLP(config)
+        self.mlp_moe_gen = Qwen2MLP(config)
+        self.input_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(self, *args, **kwargs):
+        return self.forward_inference(*args, **kwargs)
+
+    def forward_inference(
+        self,
+        packed_query_sequence: torch.Tensor,
+        query_lens: torch.Tensor,
+        packed_query_position_embeddings: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
+        past_key_values: Optional[NaiveCache] = None,
+        key_values_lens: Optional[torch.Tensor] = None,
+        packed_key_value_indexes: Optional[torch.Tensor] = None,
+        update_past_key_values=True,
+        is_causal=True,
+        mode="und",
+        packed_vae_token_indexes=None,
+        packed_text_indexes=None,
+    ) -> BaseNavitOutputWithPast:
+
+        residual = packed_query_sequence
+        packed_query_sequence = self.input_layernorm(packed_query_sequence)
+
+        # Self Attention
+        packed_query_sequence, past_key_values = self.self_attn(
+            packed_query_sequence=packed_query_sequence,
+            query_lens=query_lens,
+            packed_query_position_embeddings=packed_query_position_embeddings,
+            packed_query_indexes=packed_query_indexes,
+            past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
+            update_past_key_values=update_past_key_values,
+            is_causal=is_causal,
+        )
+        packed_query_sequence = residual + packed_query_sequence
+
+        # Fully Connected
+        residual = packed_query_sequence
+        packed_query_sequence = self.post_attention_layernorm(packed_query_sequence)
+        if mode == "und":
+            packed_query_sequence = self.mlp(packed_query_sequence)
+        elif mode == "gen":
+            packed_query_sequence_ = torch.zeros_like(packed_query_sequence).to(torch.bfloat16)
+            packed_query_sequence_[packed_text_indexes] = self.mlp(
+                packed_query_sequence[packed_text_indexes]
+            )
+            packed_query_sequence_[packed_vae_token_indexes] = self.mlp_moe_gen(
+                packed_query_sequence[packed_vae_token_indexes]
+            )
+            packed_query_sequence = packed_query_sequence_
+        packed_query_sequence = residual + packed_query_sequence
+
+        return packed_query_sequence, past_key_values
+
+
+Decoder_layer_dict = {
+    "Qwen2DecoderLayer": Qwen2DecoderLayer,
+    "Qwen2MoEDecoderLayer": Qwen2MoEDecoderLayer,
+    "Qwen2MoTDecoderLayer": Qwen2MoTDecoderLayer,
+}
+
+
+class Qwen2Model(Qwen2PreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        # transformers 5.x configs no longer default pad_token_id to None.
+        self.padding_idx = getattr(config, "pad_token_id", None)
+        self.vocab_size = config.vocab_size
+        self.use_moe = 'Mo' in config.layer_module
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        layer_module = Decoder_layer_dict[config.layer_module]
+        self.layers = nn.ModuleList(
+            [layer_module(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+
+        self.norm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        if self.use_moe:
+            self.norm_moe_gen = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Qwen2RotaryEmbedding(config=config)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def forward(self, *args, **kwargs):
+        return self.forward_inference(*args, **kwargs)
+
+    def forward_inference(
+        self,
+        packed_query_sequence: torch.Tensor,
+        query_lens: torch.Tensor,
+        packed_query_position_ids: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
+        past_key_values: Optional[NaiveCache] = None,
+        key_values_lens: Optional[torch.Tensor] = None,
+        packed_key_value_indexes: Optional[torch.Tensor] = None,
+        update_past_key_values=True,
+        is_causal=True,
+        mode="und",
+        packed_vae_token_indexes=None,
+        packed_text_indexes=None,
+    ) -> BaseNavitOutputWithPast:
+
+        # create position embeddings to be shared across the decoder layers
+        cos, sin = self.rotary_emb(packed_query_sequence, packed_query_position_ids.unsqueeze(0))
+        cos = cos.squeeze(0)
+        sin = sin.squeeze(0)
+        packed_query_position_embeddings = (cos, sin)
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs.update(mode=mode)
+            if mode == 'gen':
+                assert packed_vae_token_indexes is not None
+                assert packed_text_indexes is not None
+                extra_inputs.update(
+                    packed_vae_token_indexes=packed_vae_token_indexes,
+                    packed_text_indexes=packed_text_indexes,
+                )
+
+        for decoder_layer in self.layers:
+            packed_query_sequence, past_key_values = decoder_layer(
+                packed_query_sequence=packed_query_sequence,
+                query_lens=query_lens,
+                packed_query_position_embeddings=packed_query_position_embeddings,
+                packed_query_indexes=packed_query_indexes,
+                past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
+                update_past_key_values=update_past_key_values,
+                is_causal=is_causal,
+                **extra_inputs,
+            )
+
+        if self.use_moe:
+            if mode == "und":
+                packed_query_sequence = self.norm(packed_query_sequence)
+            elif mode == "gen":
+                packed_query_sequence_ = torch.zeros_like(packed_query_sequence)
+                packed_query_sequence_[packed_text_indexes] = self.norm(
+                    packed_query_sequence[packed_text_indexes]
+                )
+                packed_query_sequence_[packed_vae_token_indexes] = self.norm_moe_gen(
+                    packed_query_sequence[packed_vae_token_indexes]
+                )
+                packed_query_sequence = packed_query_sequence_
+        else:
+            packed_query_sequence = self.norm(packed_query_sequence)
+
+        return BaseNavitOutputWithPast(
+            packed_query_sequence=packed_query_sequence,
+            past_key_values=past_key_values,
+        )
+
+
+class Qwen2ForCausalLM(Qwen2PreTrainedModel):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = Qwen2Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def init_moe(self):
+        for name, param in self.named_parameters():
+            if "moe_gen" in name:
+                original_name = name.replace("_moe_gen", "")
+                param.data.copy_(self.state_dict()[original_name].data)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(self, *args, **kwargs):
+        return self.forward_inference(*args, **kwargs)
+
+    def forward_inference(
+        self,
+        packed_query_sequence: torch.Tensor,
+        query_lens: torch.Tensor,
+        packed_query_position_ids: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
+        past_key_values: Optional[NaiveCache] = None,
+        key_values_lens: Optional[torch.Tensor] = None,
+        packed_key_value_indexes: Optional[torch.Tensor] = None,
+        update_past_key_values=True,
+        is_causal=True,
+        mode="und",
+        packed_vae_token_indexes=None,
+        packed_text_indexes=None,
+    ) -> BaseNavitOutputWithPast:
+
+        outputs = self.model(
+            packed_query_sequence=packed_query_sequence,
+            query_lens=query_lens,
+            packed_query_position_ids=packed_query_position_ids,
+            packed_query_indexes=packed_query_indexes,
+            past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
+            update_past_key_values=update_past_key_values,
+            is_causal=is_causal,
+            mode=mode,
+            packed_vae_token_indexes=packed_vae_token_indexes,
+            packed_text_indexes=packed_text_indexes,
+        )
+
+        return outputs

--- a/libreyolo/models/sensenova/modeling/siglip_base.py
+++ b/libreyolo/models/sensenova/modeling/siglip_base.py
@@ -1,0 +1,97 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright 2024 The HuggingFace Inc. team.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), files
+# modeling/siglip/modeling_siglip.py and configuration_siglip.py, themselves
+# derived from Hugging Face transformers (Apache-2.0). Trimmed to what the
+# packed NaViT vision tower instantiates: SiglipAttention keeps only its
+# constructor (the NaViT subclass overrides forward), and the text/pooling
+# branches of the upstream weight init are dropped because this port only
+# ever loads released checkpoints on top of a meta-initialized skeleton.
+
+from torch import nn
+
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_utils import PreTrainedModel
+
+
+class SiglipVisionConfigBase(PretrainedConfig):
+    """Vision-tower configuration (upstream ``SiglipVisionConfig``)."""
+
+    model_type = "siglip_vision_model"
+
+    def __init__(
+        self,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        num_channels=3,
+        image_size=224,
+        patch_size=16,
+        hidden_act="gelu_pytorch_tanh",
+        layer_norm_eps=1e-6,
+        attention_dropout=0.0,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_channels = num_channels
+        self.patch_size = patch_size
+        self.image_size = image_size
+        self.attention_dropout = attention_dropout
+        self.layer_norm_eps = layer_norm_eps
+        self.hidden_act = hidden_act
+
+
+class SiglipAttention(nn.Module):
+    """Projection layout of SigLIP multi-headed attention.
+
+    Only the constructor is used: the NaViT flash/SDPA subclass overrides
+    forward with the packed-sequence implementation.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(
+                f"embed_dim must be divisible by num_heads (got `embed_dim`: "
+                f"{self.embed_dim} and `num_heads`: {self.num_heads})."
+            )
+        self.scale = self.head_dim**-0.5
+        self.dropout = config.attention_dropout
+
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+
+class SiglipPreTrainedModel(PreTrainedModel):
+    """Abstract class wiring config/meta-init for the vendored vision tower."""
+
+    config_class = SiglipVisionConfigBase
+    base_model_prefix = "siglip"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["SiglipVisionEmbeddings", "SiglipEncoderLayer"]
+
+    def _init_weights(self, module):
+        """Generic init; real checkpoints always overwrite these values."""
+        if isinstance(module, (nn.Linear, nn.Conv2d)):
+            nn.init.normal_(module.weight, std=0.02)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, std=0.02)
+        elif isinstance(module, nn.LayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(1.0)

--- a/libreyolo/models/sensenova/modeling/siglip_navit.py
+++ b/libreyolo/models/sensenova/modeling/siglip_navit.py
@@ -1,0 +1,433 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright (c) 2024 The HuggingFace Inc. team.
+# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file has been modified by ByteDance Ltd. and/or its affiliates. on 2025-05-20.
+#
+# Original file was released under Apache-2.0, with the full license text
+# available at https://github.com/huggingface/transformers/blob/main/LICENSE.
+#
+# This modified file is released under the same license.
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# modeling/bagel/siglip_navit.py. LibreYOLO adaptation: flash-attn becomes an
+# optional accelerator with an SDPA fallback (the vision tower's packed
+# attention is non-causal self-attention over per-image sequences).
+
+import torch
+from torch import nn
+from torch.nn.functional import scaled_dot_product_attention
+
+from transformers.activations import ACT2FN
+
+from .siglip_base import (
+    SiglipAttention,
+    SiglipPreTrainedModel,
+    SiglipVisionConfigBase as _SiglipVisionConfig,
+)
+
+try:
+    from flash_attn import flash_attn_varlen_func
+
+    _HAS_FLASH_ATTN = True
+except ImportError:  # pragma: no cover - depends on environment
+    flash_attn_varlen_func = None
+    _HAS_FLASH_ATTN = False
+
+
+class SiglipVisionConfig(_SiglipVisionConfig):
+    r"""
+    This is the configuration class to store the configuration of a [`SiglipVisionModel`]. It is used to instantiate a
+    Siglip vision encoder according to the specified arguments, defining the model architecture. Instantiating a
+    configuration with the defaults will yield a similar configuration to that of the vision encoder of the Siglip
+    [google/siglip-base-patch16-224](https://huggingface.co/google/siglip-base-patch16-224) architecture.
+
+    Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PretrainedConfig`] for more information.
+
+    Args:
+        hidden_size (`int`, *optional*, defaults to 768):
+            Dimensionality of the encoder layers and the pooler layer.
+        intermediate_size (`int`, *optional*, defaults to 3072):
+            Dimensionality of the "intermediate" (i.e., feed-forward) layer in the Transformer encoder.
+        num_hidden_layers (`int`, *optional*, defaults to 12):
+            Number of hidden layers in the Transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 12):
+            Number of attention heads for each attention layer in the Transformer encoder.
+        num_channels (`int`, *optional*, defaults to 3):
+            Number of channels in the input images.
+        image_size (`int`, *optional*, defaults to 224):
+            The size (resolution) of each image.
+        patch_size (`int`, *optional*, defaults to 16):
+            The size (resolution) of each patch.
+        hidden_act (`str` or `function`, *optional*, defaults to `"gelu_pytorch_tanh"`):
+            The non-linear activation function (function or string) in the encoder and pooler. If string, `"gelu"`,
+            `"relu"`, `"selu"` and `"gelu_new"` `"quick_gelu"` are supported.
+        layer_norm_eps (`float`, *optional*, defaults to 1e-06):
+            The epsilon used by the layer normalization layers.
+        attention_dropout (`float`, *optional*, defaults to 0.0):
+            The dropout ratio for the attention probabilities.
+
+    Example:
+
+    ```python
+    >>> from transformers import SiglipVisionConfig, SiglipVisionModel
+
+    >>> # Initializing a SiglipVisionConfig with google/siglip-base-patch16-224 style configuration
+    >>> configuration = SiglipVisionConfig()
+
+    >>> # Initializing a SiglipVisionModel (with random weights) from the google/siglip-base-patch16-224 style configuration
+    >>> model = SiglipVisionModel(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```"""
+
+    model_type = "siglip_vision_model"
+
+    def __init__(
+        self,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        num_channels=3,
+        image_size=224,
+        patch_size=16,
+        hidden_act="gelu_pytorch_tanh",
+        layer_norm_eps=1e-6,
+        attention_dropout=0.0,
+        rope=True,
+        **kwargs,
+    ):
+        super().__init__(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_channels=num_channels,
+            image_size=image_size,
+            patch_size=patch_size,
+            hidden_act=hidden_act,
+            layer_norm_eps=layer_norm_eps,
+            attention_dropout=attention_dropout,
+            **kwargs)
+        
+        self.rope = rope
+
+
+class RotaryEmbedding2D(torch.nn.Module):
+    def __init__(self, dim, max_h, max_w, base=10000):
+        super().__init__()
+        freq = torch.arange(0, dim, 2, dtype=torch.int64).float() / dim
+        inv_freq = 1.0 / (base ** freq)
+
+        grid_h = torch.arange(0, max_h)
+        grid_h = grid_h.to(inv_freq.dtype)
+        grid_h = grid_h[:, None].repeat(1, max_w)
+
+        grid_w = torch.arange(0, max_w)
+        grid_w = grid_w.to(inv_freq.dtype)
+        grid_w = grid_w[None, :].repeat(max_h, 1)
+
+        cos_h, sin_h = self._forward_one_side(grid_h, inv_freq)
+        cos_w, sin_w = self._forward_one_side(grid_w, inv_freq)
+
+        self.register_buffer("cos_h", cos_h)
+        self.register_buffer("sin_h", sin_h)
+        self.register_buffer("cos_w", cos_w)
+        self.register_buffer("sin_w", sin_w)
+
+    def _forward_one_side(self, grid, inv_freq):
+        freqs = grid[..., None] * inv_freq[None, None, :]
+        emb = torch.cat((freqs, freqs), dim=-1).flatten(0, 1)
+        return emb.cos(), emb.sin()
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin):
+    # unsqueeze due to the head dimension
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class SiglipVisionEmbeddings(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            padding="valid",
+        )
+
+        self.num_patches_per_side = self.image_size // self.patch_size
+        self.num_patches = self.num_patches_per_side**2
+        self.num_positions = self.num_patches
+        if not config.rope:
+            self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
+
+    def convert_conv2d_to_linear(self, config, meta=False):
+        if meta:
+            linear_patch_embedding = nn.Linear(
+                config.num_channels * self.patch_size ** 2, self.embed_dim, bias=True, device='meta'
+            )
+        else:
+            linear_patch_embedding = nn.Linear(
+                config.num_channels * self.patch_size ** 2, self.embed_dim, bias=True
+            )
+        W = self.patch_embedding.weight.permute(0, 2, 3, 1).reshape(
+            self.embed_dim, config.num_channels * self.patch_size ** 2
+        )
+        linear_patch_embedding.weight.data = W
+        linear_patch_embedding.bias.data = self.patch_embedding.bias.data
+        del self.patch_embedding
+        self.patch_embedding = linear_patch_embedding
+
+    def forward(
+        self, 
+        packed_pixel_values: torch.FloatTensor, 
+        packed_flattened_position_ids: torch.LongTensor
+    ) -> torch.Tensor:
+
+        patch_embeds = self.patch_embedding(packed_pixel_values)
+        if not self.config.rope:
+            embeddings = patch_embeds + self.position_embedding(packed_flattened_position_ids)
+        else:
+            embeddings = patch_embeds
+        return embeddings
+
+
+class SiglipFlashAttention2(SiglipAttention):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.IntTensor,
+        max_seqlen: int,
+        cos_h: torch.Tensor = None,
+        sin_h: torch.Tensor = None,
+        cos_w: torch.Tensor = None,
+        sin_w: torch.Tensor = None,
+        **kwargs,
+    ) -> torch.Tensor:
+
+        total_q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(total_q_len, self.num_heads, self.head_dim)
+        key_states = key_states.view(total_q_len, self.num_heads, self.head_dim)
+        value_states = value_states.view(total_q_len, self.num_heads, self.head_dim)
+
+        if self.config.rope:
+            qh, qw = query_states[:, :, :self.head_dim // 2], query_states[:, :, self.head_dim // 2:] 
+            kh, kw = key_states[:, :, :self.head_dim // 2], key_states[:, :, self.head_dim // 2:]
+            qh, kh = apply_rotary_pos_emb(qh, kh, cos_h, sin_h)
+            qw, kw = apply_rotary_pos_emb(qw, kw, cos_w, sin_w)
+            query_states = torch.cat([qh, qw], dim=-1)
+            key_states = torch.cat([kh, kw], dim=-1)
+
+        if _HAS_FLASH_ATTN:
+            attn_output = flash_attn_varlen_func(
+                query_states.to(torch.bfloat16),
+                key_states.to(torch.bfloat16),
+                value_states.to(torch.bfloat16),
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=False,
+            )
+        else:
+            outputs = []
+            for i in range(int(cu_seqlens.numel()) - 1):
+                start, end = int(cu_seqlens[i]), int(cu_seqlens[i + 1])
+                out = scaled_dot_product_attention(
+                    query_states[start:end].to(torch.bfloat16).transpose(0, 1).unsqueeze(0),
+                    key_states[start:end].to(torch.bfloat16).transpose(0, 1).unsqueeze(0),
+                    value_states[start:end].to(torch.bfloat16).transpose(0, 1).unsqueeze(0),
+                )
+                outputs.append(out.squeeze(0).transpose(0, 1))
+            attn_output = torch.cat(outputs, dim=0)
+
+        attn_output = self.out_proj(attn_output.reshape(total_q_len, -1))
+        return attn_output
+
+
+class SiglipMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.activation_fn = ACT2FN[config.hidden_act]
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states
+
+
+class SiglipEncoderLayer(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.self_attn = SiglipFlashAttention2(config)
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+        self.mlp = SiglipMLP(config)
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.IntTensor,
+        max_seqlen: int,
+        cos_h: torch.Tensor = None,
+        sin_h: torch.Tensor = None,
+        cos_w: torch.Tensor = None,
+        sin_w: torch.Tensor = None
+    ) -> torch.Tensor:
+        residual = hidden_states
+
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            cos_h=cos_h,
+            sin_h=sin_h,
+            cos_w=cos_w,
+            sin_w=sin_w
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class SiglipEncoder(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.config = config
+        self.layers = nn.ModuleList(
+            [SiglipEncoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        cu_seqlens: torch.IntTensor,
+        max_seqlen: int,
+        cos_h: torch.Tensor = None,
+        sin_h: torch.Tensor = None,
+        cos_w: torch.Tensor = None,
+        sin_w: torch.Tensor = None,
+    ) -> torch.Tensor:
+
+        hidden_states = inputs_embeds
+        for encoder_layer in self.layers:
+            hidden_states = encoder_layer(hidden_states, cu_seqlens, max_seqlen,
+                                          cos_h=cos_h, sin_h=sin_h, cos_w=cos_w, sin_w=sin_w)
+
+        return hidden_states
+
+
+class SiglipVisionTransformer(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.config = config
+        embed_dim = config.hidden_size
+
+        self.embeddings = SiglipVisionEmbeddings(config)
+        if config.rope:
+            max_size = config.image_size // config.patch_size
+            dim_head = config.hidden_size // config.num_attention_heads
+            self.rope = RotaryEmbedding2D(dim_head // 2, max_size, max_size)
+
+        self.encoder = SiglipEncoder(config)
+        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+
+    def forward(
+        self,
+        packed_pixel_values: torch.Tensor,
+        packed_flattened_position_ids: torch.LongTensor,
+        cu_seqlens: torch.IntTensor,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        hidden_states = self.embeddings(
+            packed_pixel_values=packed_pixel_values, 
+            packed_flattened_position_ids=packed_flattened_position_ids
+        )
+
+        extra_inputs = {}
+        if self.config.rope:
+            extra_inputs.update(
+                cos_h = self.rope.cos_h[packed_flattened_position_ids],
+                sin_h = self.rope.sin_h[packed_flattened_position_ids],
+                cos_w = self.rope.cos_w[packed_flattened_position_ids],
+                sin_w = self.rope.sin_w[packed_flattened_position_ids]
+            )
+
+        last_hidden_state = self.encoder(
+            inputs_embeds=hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen, 
+            **extra_inputs
+        )
+        last_hidden_state = self.post_layernorm(last_hidden_state)
+        return last_hidden_state
+
+
+class SiglipVisionModel(SiglipPreTrainedModel):
+    config_class = SiglipVisionConfig
+    main_input_name = "packed_pixel_values"
+
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__(config)
+
+        self.vision_model = SiglipVisionTransformer(config)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.vision_model.embeddings.patch_embedding
+
+    def forward(
+        self,
+        packed_pixel_values: torch.Tensor,
+        packed_flattened_position_ids: torch.LongTensor,
+        cu_seqlens: torch.IntTensor,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+
+        return self.vision_model(
+            packed_pixel_values=packed_pixel_values,
+            packed_flattened_position_ids=packed_flattened_position_ids,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )

--- a/libreyolo/models/sensenova/parsing.py
+++ b/libreyolo/models/sensenova/parsing.py
@@ -1,0 +1,385 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), files
+# utils/parsing_output.py, utils/__init__.py and utils/mask.py, trimmed and
+# adapted to emit the LibreYOLO detection-dict shapes. Everything here is pure
+# (no torch, no model) so it can be unit-tested offline.
+#
+# Output grammars decoded here:
+# - boxes:     ``<p>label</p><bbox>[x0,y0,x1,y1]</bbox>`` (normalized [0, 1])
+# - points:    ``<p>label</p><point>[x,y]</point>``
+# - keypoints: ``<p>label</p><bbox>...</bbox>name<kpt>[x,y]</kpt>...`` with
+#              optional ``<ins>...</ins>`` instance spans and
+#              ``<kpt>unvisible</kpt>`` for occluded joints
+# - panoptic:  an RGB mask image plus a rich caption of
+#              ``<p>phrase-idx<color>(R,G,B)</color></p>`` tags
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from PIL import Image
+
+HUMAN_KEYPOINT_NAMES = [
+    "nose",
+    "left eye",
+    "right eye",
+    "left ear",
+    "right ear",
+    "left shoulder",
+    "right shoulder",
+    "left elbow",
+    "right elbow",
+    "left wrist",
+    "right wrist",
+    "left hip",
+    "right hip",
+    "left knee",
+    "right knee",
+    "left ankle",
+    "right ankle",
+]
+ANIMAL_KEYPOINT_NAMES = [
+    "left eye",
+    "right eye",
+    "nose",
+    "neck",
+    "root of tail",
+    "left shoulder",
+    "left elbow",
+    "left front paw",
+    "right shoulder",
+    "right elbow",
+    "right front paw",
+    "left hip",
+    "left knee",
+    "left back paw",
+    "right hip",
+    "right knee",
+    "right back paw",
+]
+
+_COLOR_TAG = re.compile(
+    r"<p>\s*(.*?)\s*<color>\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*</color>\s*</p>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+def normalize_category(category: str) -> str:
+    """Normalize category names for matching."""
+    return (
+        str(category)
+        .replace("-merged", "")
+        .replace("-other", "")
+        .replace("-stuff", "")
+        .replace("-negative", "")
+        .replace("-", " ")
+        .lower()
+        .strip()
+    )
+
+
+def clip_normalized(values) -> List[float]:
+    """Clip normalized coordinate values into the half-open visual range."""
+    return [max(0.0, min(0.999, float(v))) for v in values]
+
+
+def _iter_label_blocks(text: str):
+    """Yield (label, rest) for each ``<p>label</p>...`` block in the text."""
+    s = str(text or "").strip().rstrip(" .\n")
+    for part in s.split("<p>")[1:]:
+        if "</p>" not in part:
+            continue
+        cat_end = part.find("</p>")
+        yield part[:cat_end].strip(), part[cat_end + len("</p>") :]
+
+
+def parse_tagged_boxes(text: str, normalize_labels: bool = True) -> Dict[str, List[List[float]]]:
+    """Parse ``<p>label</p><bbox>[x0,y0,x1,y1]</bbox>`` detection text.
+
+    Returns ``{label: [[x0, y0, x1, y1], ...]}`` with coordinates kept in
+    normalized space and clipped to ``[0, 0.999]``. OCR keeps original label
+    case via ``normalize_labels=False``.
+    """
+    results: Dict[str, List[List[float]]] = {}
+    for category, rest in _iter_label_blocks(text):
+        boxes = []
+        while "<bbox>[" in rest:
+            start = rest.find("<bbox>[")
+            end = rest.find("]</bbox>")
+            if start == -1 or end == -1:
+                break
+            coord_str = rest[start + len("<bbox>[") : end]
+            rest = rest[end + len("]</bbox>") :]
+            try:
+                coords = [float(x.strip()) for x in coord_str.split(",")]
+            except ValueError:
+                continue
+            if len(coords) == 4:
+                boxes.append(clip_normalized(coords))
+        if boxes:
+            label = normalize_category(category) if normalize_labels else category
+            results.setdefault(label, []).extend(boxes)
+    return results
+
+
+def parse_tagged_points(text: str) -> Dict[str, List[List[float]]]:
+    """Parse ``<p>label</p><point>[x,y]</point>`` point-detection text."""
+    results: Dict[str, List[List[float]]] = {}
+    for category, rest in _iter_label_blocks(text):
+        points = []
+        while "<point>[" in rest:
+            start = rest.find("<point>[")
+            end = rest.find("]</point>")
+            if start == -1 or end == -1:
+                break
+            coord_str = rest[start + len("<point>[") : end]
+            rest = rest[end + len("]</point>") :]
+            try:
+                coords = [float(x.strip()) for x in coord_str.split(",")]
+            except ValueError:
+                continue
+            if len(coords) == 2:
+                points.append(clip_normalized(coords))
+        if points:
+            results.setdefault(normalize_category(category), []).extend(points)
+    return results
+
+
+def parse_tagged_keypoints(text: str) -> Dict[str, List[dict]]:
+    """Parse keypoint text grouped by category and instance.
+
+    Expected structure per instance:
+    ``<p>person</p><bbox>[...]</bbox>left shoulder<kpt>[x,y]</kpt>...``.
+    ``<ins>...</ins>`` wrappers are tolerated and stripped. Invisible keypoints
+    encoded as ``<kpt>unvisible</kpt>`` are stored as ``[-1, -1]``.
+
+    Returns ``{category: [{"bbox": [...] or missing, "keypoints": {name: [x, y]}}]}``
+    with all coordinates normalized.
+    """
+    results: Dict[str, List[dict]] = {}
+    for category, rest in _iter_label_blocks(text):
+        rest = rest.replace("<ins>", "").replace("</ins>", "")
+
+        bbox = None
+        if "<bbox>[" in rest:
+            start = rest.find("<bbox>[")
+            end = rest.find("]</bbox>")
+            if start != -1 and end != -1:
+                coord_str = rest[start + len("<bbox>[") : end]
+                try:
+                    coords = [float(x.strip()) for x in coord_str.split(",")]
+                    if len(coords) == 4:
+                        bbox = clip_normalized(coords)
+                except ValueError:
+                    pass
+                rest = rest[:start] + rest[end + len("]</bbox>") :]
+
+        keypoints: Dict[str, List[float]] = {}
+        while "<kpt>" in rest:
+            start = rest.find("<kpt>")
+            end = rest.find("</kpt>", start)
+            if start == -1 or end == -1:
+                break
+            keypoint_name = rest[:start].strip().strip(",.;:").strip().lower()
+            content = rest[start + len("<kpt>") : end].strip()
+            rest = rest[end + len("</kpt>") :]
+            if not keypoint_name:
+                continue
+            if content == "unvisible":
+                keypoints[keypoint_name] = [-1.0, -1.0]
+                continue
+            try:
+                coords = [float(x.strip()) for x in content.strip("[]").split(",")]
+            except ValueError:
+                continue
+            if len(coords) == 2:
+                keypoints[keypoint_name] = clip_normalized(coords)
+
+        if category:
+            instance = {"keypoints": keypoints}
+            if bbox is not None:
+                instance["bbox"] = bbox
+            results.setdefault(normalize_category(category), []).append(instance)
+    return results
+
+
+def keypoint_instance_to_array(
+    instance: dict, skeleton: List[str], width: int, height: int
+) -> np.ndarray:
+    """Convert one parsed keypoint instance into a ``(K, 3)`` pixel array.
+
+    Rows follow ``skeleton`` order as ``(x, y, visibility)``, with missing or
+    invisible joints emitted as ``(0, 0, 0)`` in the LibreYOLO keypoint
+    convention.
+    """
+    arr = np.zeros((len(skeleton), 3), dtype=np.float32)
+    keypoints = instance.get("keypoints", {})
+    for idx, name in enumerate(skeleton):
+        coords = keypoints.get(name)
+        if coords is None:
+            continue
+        x, y = float(coords[0]), float(coords[1])
+        if x < 0 or y < 0:
+            continue
+        arr[idx] = (x * width, y * height, 1.0)
+    return arr
+
+
+def get_clean_caption(caption: str) -> str:
+    """Strip color/markup tags from a rich caption, keeping the prose."""
+    caption = re.sub(r"<.*?>", "", str(caption or ""))
+    caption = re.sub(r"\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)", "", caption)
+    return " ".join(caption.split()).strip("'").strip()
+
+
+def extract_caption_instances(caption: str) -> List[Tuple[str, Tuple[int, int, int]]]:
+    """Return ordered (phrase, rgb) entries from colored caption tags.
+
+    Preserves repeated phrases, such as multiple instances of the same
+    category, unlike a phrase-to-color dict.
+    """
+    instances = []
+    for match in _COLOR_TAG.finditer(str(caption or "")):
+        phrase = re.sub(r"<.*?>", "", match.group(1)).strip()
+        rgb = tuple(int(match.group(i)) for i in range(2, 5))
+        instances.append((phrase, rgb))
+    return instances
+
+
+def nearest_color_class_mask(image: Image.Image, class_colors: np.ndarray) -> np.ndarray:
+    """Convert an RGB mask to a class-index mask by nearest prompt color.
+
+    Black pixels are always assigned to the background index
+    ``len(class_colors)``.
+    """
+    img_np = np.array(image.convert("RGB"), dtype=np.float32)
+    class_colors = np.asarray(class_colors, dtype=np.float32)
+    if class_colors.ndim != 2 or class_colors.shape[1] != 3:
+        raise ValueError(f"class_colors must have shape [N, 3], got {class_colors.shape}")
+
+    mask_black = np.all(img_np == 0, axis=-1)
+    h, w, _ = img_np.shape
+    pixels = img_np.reshape(-1, 3)
+
+    pred_class = np.empty((pixels.shape[0],), dtype=np.int32)
+    chunk_size = 262144
+    for start in range(0, pixels.shape[0], chunk_size):
+        end = min(start + chunk_size, pixels.shape[0])
+        diff = pixels[start:end, None, :] - class_colors[None, :, :]
+        dist = np.sum(diff * diff, axis=-1)
+        pred_class[start:end] = np.argmin(dist, axis=1)
+
+    mask = pred_class.reshape(h, w)
+    mask[mask_black] = len(class_colors)
+    return mask.astype(np.int32, copy=False)
+
+
+def panoptic_from_mask_and_caption(
+    mask_image: Image.Image,
+    caption: str,
+    names: Dict[int, str],
+    image_size: Tuple[int, int],
+) -> Tuple[np.ndarray, List[dict], Dict[int, str]]:
+    """Assemble a panoptic id map from a generated color mask and rich caption.
+
+    The model emits an RGB mask plus caption tags such as
+    ``<p>person-0<color>(255,0,0)</color></p>``; each color keys one segment.
+    Segment ids are ``(category_id + 1) * 1000 + local_instance_index``; the
+    +1 keeps id 0 reserved for void pixels even though LibreYOLO category ids
+    are 0-based. Phrases outside ``names`` are registered as new categories so
+    open-vocabulary output is not dropped.
+
+    Returns ``(id_map, segments_info, names)`` where ``names`` includes any
+    newly registered categories.
+    """
+    width, height = image_size
+    if mask_image.size != (width, height):
+        mask_image = mask_image.resize((width, height), resample=Image.NEAREST)
+
+    instances = extract_caption_instances(caption)
+    phrases = [phrase for phrase, _ in instances]
+    if instances:
+        class_colors = np.array([rgb for _, rgb in instances], dtype=np.float32)
+    else:
+        class_colors = np.array([(255, 255, 255)], dtype=np.float32)
+    class_mask = nearest_color_class_mask(mask_image, class_colors)
+
+    names = dict(names)
+    name_to_id = {normalize_category(v): int(k) for k, v in names.items()}
+    max_category_id = max((int(k) for k in names), default=-1)
+
+    id_map = np.zeros((height, width), dtype=np.int64)
+    segments_info: List[dict] = []
+    occurrence: Dict[int, int] = {}
+    used_ids = set()
+
+    for instance_idx, phrase in enumerate(phrases):
+        base_name, separator, suffix = phrase.rpartition("-")
+        if separator and suffix.isdigit():
+            local_idx: Optional[int] = int(suffix)
+        else:
+            base_name = phrase
+            local_idx = None
+
+        normalized = normalize_category(base_name)
+        if not normalized:
+            continue
+        category_id = name_to_id.get(normalized)
+        if category_id is None:
+            max_category_id += 1
+            category_id = max_category_id
+            names[category_id] = base_name
+            name_to_id[normalized] = category_id
+
+        segment_mask = class_mask == instance_idx
+        if not np.any(segment_mask):
+            continue
+        if local_idx is None:
+            local_idx = occurrence.get(category_id, 0)
+        panoptic_id = (category_id + 1) * 1000 + local_idx
+        while panoptic_id in used_ids:
+            local_idx += 1
+            panoptic_id = (category_id + 1) * 1000 + local_idx
+        occurrence[category_id] = max(occurrence.get(category_id, 0), local_idx + 1)
+        used_ids.add(panoptic_id)
+        id_map[segment_mask] = panoptic_id
+        segments_info.append({"id": panoptic_id, "category_id": category_id, "score": 1.0})
+
+    return id_map, segments_info, names
+
+
+def binary_mask_from_image(
+    mask_image: Image.Image, image_size: Tuple[int, int], threshold: int = 127
+) -> np.ndarray:
+    """Threshold a generated mask image into a boolean array at image size."""
+    width, height = image_size
+    if mask_image.size != (width, height):
+        mask_image = mask_image.resize((width, height), resample=Image.NEAREST)
+    arr = np.array(mask_image.convert("L"), dtype=np.uint8)
+    return arr > threshold
+
+
+def depth_from_image(depth_image: Image.Image, image_size: Tuple[int, int]) -> np.ndarray:
+    """Convert a generated grayscale depth image into a relative map in [0, 1].
+
+    The model draws closer pixels brighter, which matches LibreYOLO's
+    relative inverse-depth convention directly (larger value = closer).
+    """
+    width, height = image_size
+    if depth_image.size != (width, height):
+        depth_image = depth_image.resize((width, height), resample=Image.BILINEAR)
+    arr = np.asarray(depth_image.convert("L"), dtype=np.float32)
+    return arr / 255.0
+
+
+def mask_to_xyxy(mask: np.ndarray) -> Optional[List[float]]:
+    """Tight pixel bounding box of a boolean mask, or None when empty."""
+    ys, xs = np.nonzero(mask)
+    if xs.size == 0:
+        return None
+    return [float(xs.min()), float(ys.min()), float(xs.max() + 1), float(ys.max() + 1)]

--- a/libreyolo/models/sensenova/parsing.py
+++ b/libreyolo/models/sensenova/parsing.py
@@ -251,11 +251,17 @@ def extract_caption_instances(caption: str) -> List[Tuple[str, Tuple[int, int, i
     return instances
 
 
-def nearest_color_class_mask(image: Image.Image, class_colors: np.ndarray) -> np.ndarray:
+def nearest_color_class_mask(
+    image: Image.Image,
+    class_colors: np.ndarray,
+    black_is_background: bool = True,
+) -> np.ndarray:
     """Convert an RGB mask to a class-index mask by nearest prompt color.
 
-    Black pixels are always assigned to the background index
-    ``len(class_colors)``.
+    Black pixels are assigned to the background index ``len(class_colors)``
+    (the model's trained void convention) unless ``black_is_background`` is
+    False, which callers pass when the caption explicitly declared black as
+    an instance color.
     """
     img_np = np.array(image.convert("RGB"), dtype=np.float32)
     class_colors = np.asarray(class_colors, dtype=np.float32)
@@ -275,7 +281,8 @@ def nearest_color_class_mask(image: Image.Image, class_colors: np.ndarray) -> np
         pred_class[start:end] = np.argmin(dist, axis=1)
 
     mask = pred_class.reshape(h, w)
-    mask[mask_black] = len(class_colors)
+    if black_is_background:
+        mask[mask_black] = len(class_colors)
     return mask.astype(np.int32, copy=False)
 
 
@@ -307,7 +314,10 @@ def panoptic_from_mask_and_caption(
         class_colors = np.array([rgb for _, rgb in instances], dtype=np.float32)
     else:
         class_colors = np.array([(255, 255, 255)], dtype=np.float32)
-    class_mask = nearest_color_class_mask(mask_image, class_colors)
+    black_declared = any(rgb == (0, 0, 0) for _, rgb in instances)
+    class_mask = nearest_color_class_mask(
+        mask_image, class_colors, black_is_background=not black_declared
+    )
 
     names = dict(names)
     name_to_id = {normalize_category(v): int(k) for k, v in names.items()}

--- a/libreyolo/models/sensenova/prompts.py
+++ b/libreyolo/models/sensenova/prompts.py
@@ -1,0 +1,109 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Task prompt templates ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), files
+# inference/inference_demo.py and data/prompts.py. The prompts are the exact
+# instructions the released checkpoint was trained/evaluated with; paraphrasing
+# them degrades output quality, so they are kept verbatim.
+
+DEPTH_PROMPT = (
+    "Estimate relative depth for each pixel in the image, with closer objects "
+    "appearing brighter and distant objects appearing darker. Output is a "
+    "grayscale image with pixel values ranging from 0-255."
+)
+
+NORMAL_PROMPT = (
+    "Estimate surface normals and encode as an RGB image. Each channel "
+    "corresponds to a direction component (X, Y, Z) with continuous value "
+    "variations, creating smooth color gradients distinct from other task outputs."
+)
+
+OCR_PROMPT = (
+    "Perform word-level text detection and recognition on the entire image. "
+    "Output a structured text list containing every detected word, its bounding "
+    "box coordinates with <bbox> format, and the recognized text content."
+)
+
+BBOX_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all instances of {categories} in the image. Output the results "
+    "as a structured text list with each detection including category and "
+    "bounding box coordinates in <bbox> format."
+)
+
+POINT_DETECTION_PROMPT_TEMPLATE = (
+    "Locate and identify {categories} within the scene. Output detection "
+    "results as text entries, each containing the object class and pixel "
+    "coordinates defining the object point location."
+)
+
+KEYPOINT_PROMPT_TEMPLATES = {
+    "human": (
+        "Detect all instances of {categories} in the image. For each instance, "
+        "output a bounding box in <bbox> format and the coordinates of its "
+        "nose, left eye, right eye, left ear, right ear, left shoulder, right "
+        "shoulder, left elbow, right elbow, left wrist, right wrist, left hip, "
+        "right hip, left knee, right knee, left ankle, right ankle in "
+        "<kpt>[x,y]</kpt> format. Return results as a structured list."
+    ),
+    "animal": (
+        "Detect all instances of {categories} in the image. For each instance, "
+        "output a bounding box in <bbox> format and the coordinates of its "
+        "left eye, right eye, nose, neck, root of tail, left shoulder, left "
+        "elbow, left front paw, right shoulder, right elbow, right front paw, "
+        "left hip, left knee, left back paw, right hip, right knee, right back "
+        "paw in <kpt>[x,y]</kpt> format. Return results as a structured list."
+    ),
+    "mixed": (
+        "Detect all instances of {categories} in the image. For human "
+        "instances, output a bounding box in <bbox> format and the COCO human "
+        "keypoints: nose, left eye, right eye, left ear, right ear, left "
+        "shoulder, right shoulder, left elbow, right elbow, left wrist, right "
+        "wrist, left hip, right hip, left knee, right knee, left ankle, right "
+        "ankle. For animal instances, output a bounding box in <bbox> format "
+        "and the AP-10K animal keypoints: left eye, right eye, nose, neck, "
+        "root of tail, left shoulder, left elbow, left front paw, right "
+        "shoulder, right elbow, right front paw, left hip, left knee, left back "
+        "paw, right hip, right knee, right back paw. Use <kpt>[x,y]</kpt> "
+        "format for every keypoint and return results as a structured list."
+    ),
+}
+
+HUMAN_KEYPOINT_CATEGORIES = {"human", "person", "people", "pedestrian"}
+
+MASK_QUESTION_TEMPLATE = 'Can you segment the image based on the following categories: {categories}? Please output the {task_type} segmentation masks.'
+
+CAPTION_QUESTION_TEMPLATE = 'Please find all instances in the image and assign color to each instance in the EXACT format: <p>instance-no<color>(R,G,B)</color></p>, then respond with {task_type} segmentation masks.'
+
+# COCO panoptic category names (things + stuff, dataset-suffixes stripped),
+# the default vocabulary for panoptic segmentation when set_classes() was
+# not called. Factual dataset metadata from data/prompts.py.
+COCO_PANOPTIC_NAMES = [
+    'person', 'bicycle', 'car', 'motorcycle', 'airplane',
+    'bus', 'train', 'truck', 'boat', 'traffic light',
+    'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird',
+    'cat', 'dog', 'horse', 'sheep', 'cow',
+    'elephant', 'bear', 'zebra', 'giraffe', 'backpack',
+    'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+    'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat',
+    'baseball glove', 'skateboard', 'surfboard', 'tennis racket', 'bottle',
+    'wine glass', 'cup', 'fork', 'knife', 'spoon',
+    'bowl', 'banana', 'apple', 'sandwich', 'orange',
+    'broccoli', 'carrot', 'hot dog', 'pizza', 'donut',
+    'cake', 'chair', 'couch', 'potted plant', 'bed',
+    'dining table', 'toilet', 'tv', 'laptop', 'mouse',
+    'remote', 'keyboard', 'cell phone', 'microwave', 'oven',
+    'toaster', 'sink', 'refrigerator', 'book', 'clock',
+    'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush',
+    'banner', 'blanket', 'bridge', 'cardboard', 'counter',
+    'curtain', 'door', 'floor-wood', 'flower', 'fruit',
+    'gravel', 'house', 'light', 'mirror', 'net',
+    'pillow', 'platform', 'playingfield', 'railroad', 'river',
+    'road', 'roof', 'sand', 'sea', 'shelf',
+    'snow', 'stairs', 'tent', 'towel', 'wall-brick',
+    'wall-stone', 'wall-tile', 'wall-wood', 'water', 'window-blind',
+    'window', 'tree', 'fence', 'ceiling', 'sky',
+    'cabinet', 'table', 'floor', 'pavement', 'mountain',
+    'grass', 'dirt', 'paper', 'food', 'building',
+    'rock', 'wall', 'rug',
+]

--- a/libreyolo/models/sensenova/transforms.py
+++ b/libreyolo/models/sensenova/transforms.py
@@ -1,0 +1,119 @@
+# Copyright 2026 SenseTime Group Inc. and/or its affiliates.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported for LibreYOLO from OpenSenseNova/SenseNova-Vision
+# (commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0), file
+# data/transforms.py, trimmed to the transforms the inference path uses.
+
+import torch
+from torchvision import transforms
+from torchvision.transforms import functional as F
+from torchvision.transforms import InterpolationMode
+
+
+class MaxLongEdgeMinShortEdgeResize(torch.nn.Module):
+    """Resize the input image so that its longest side and shortest side are within a specified range,
+    ensuring that both sides are divisible by a specified stride.
+
+    Args:
+        max_size (int): Maximum size for the longest edge of the image.
+        min_size (int): Minimum size for the shortest edge of the image.
+        stride (int): Value by which the height and width of the image must be divisible.
+        max_pixels (int): Maximum pixels for the full image.
+        interpolation (InterpolationMode): Desired interpolation enum defined by
+            :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.BILINEAR``.
+            If input is Tensor, only ``InterpolationMode.NEAREST``, ``InterpolationMode.NEAREST_EXACT``,
+            ``InterpolationMode.BILINEAR``, and ``InterpolationMode.BICUBIC`` are supported.
+            The corresponding Pillow integer constants, e.g., ``PIL.Image.BILINEAR`` are also accepted.
+        antialias (bool, optional): Whether to apply antialiasing (default is True).
+    """
+
+    def __init__(
+        self,
+        max_size: int,
+        min_size: int,
+        stride: int,
+        max_pixels: int,
+        interpolation=InterpolationMode.BICUBIC,
+        antialias=True,
+    ):
+        super().__init__()
+        self.max_size = max_size
+        self.min_size = min_size
+        self.stride = stride
+        self.max_pixels = max_pixels
+        self.interpolation = interpolation
+        self.antialias = antialias
+
+    def _make_divisible(self, value, stride):
+        """Ensure the value is divisible by the stride."""
+        return max(stride, int(round(value / stride) * stride))
+
+    def _apply_scale(self, width, height, scale):
+        new_width = round(width * scale)
+        new_height = round(height * scale)
+        new_width = self._make_divisible(new_width, self.stride)
+        new_height = self._make_divisible(new_height, self.stride)
+        return new_width, new_height
+
+    def forward(self, img, img_num=1):
+        """
+        Args:
+            img (PIL Image): Image to be resized.
+            img_num (int): Number of images, used to change max_tokens.
+        Returns:
+            PIL Image or Tensor: Rescaled image with divisible dimensions.
+        """
+        if isinstance(img, torch.Tensor):
+            height, width = img.shape[-2:]
+        else:
+            width, height = img.size
+
+        scale = min(self.max_size / max(width, height), 1.0)
+        scale = max(scale, self.min_size / min(width, height))
+        new_width, new_height = self._apply_scale(width, height, scale)
+
+        # Ensure the number of pixels does not exceed max_pixels
+        if new_width * new_height > self.max_pixels / img_num:
+            scale = self.max_pixels / img_num / (new_width * new_height)
+            new_width, new_height = self._apply_scale(new_width, new_height, scale)
+
+        # Ensure longest edge does not exceed max_size
+        if max(new_width, new_height) > self.max_size:
+            scale = self.max_size / max(new_width, new_height)
+            new_width, new_height = self._apply_scale(new_width, new_height, scale)
+
+        return F.resize(img, (new_height, new_width), self.interpolation, antialias=self.antialias)
+
+
+class ImageTransform:
+    def __init__(
+        self,
+        max_image_size,
+        min_image_size,
+        image_stride,
+        max_pixels=14 * 14 * 9 * 1024,
+        image_mean=[0.5, 0.5, 0.5],
+        image_std=[0.5, 0.5, 0.5],
+    ):
+        self.stride = image_stride
+
+        self.resize_transform = MaxLongEdgeMinShortEdgeResize(
+            max_size=max_image_size,
+            min_size=min_image_size,
+            stride=image_stride,
+            max_pixels=max_pixels,
+        )
+        self.to_tensor_transform = transforms.ToTensor()
+        self.normalize_transform = transforms.Normalize(
+            mean=image_mean, std=image_std, inplace=True
+        )
+
+    def __call__(self, img, img_num=1):
+        img = self.resize_transform(img, img_num=img_num)
+        img = self.to_tensor_transform(img)
+        img = self.normalize_transform(img)
+        return img
+
+

--- a/libreyolo/models/vlm/__init__.py
+++ b/libreyolo/models/vlm/__init__.py
@@ -56,6 +56,15 @@ _ALIASES: Dict[str, Tuple[Type[LibreVLMModel], str]] = {
     "locateanything-3b": (LibreLocateAnything, "3b"),
 }
 
+# SenseNova-Vision lives in ``models/sensenova`` (it vendors its own
+# architecture) and imports this package's base class, so its aliases resolve
+# lazily to avoid a circular import at package-init time.
+_LAZY_ALIASES: Dict[str, str] = {
+    "sensenova-vision": "7b",
+    "sensenova-vision-7b": "7b",
+    "sensenovavision": "7b",
+}
+
 _DEFAULT_MODEL = "qwen3-vl-4b"
 
 
@@ -73,14 +82,26 @@ def LibreVLM(model: str = _DEFAULT_MODEL, **kwargs) -> LibreVLMModel:
         A ``LibreVLMModel`` instance with the standard predict/track surface.
     """
     key = str(model).strip().lower()
+    if key in _LAZY_ALIASES:
+        from ..sensenova import LibreSenseNovaVision
+
+        return LibreSenseNovaVision(size=_LAZY_ALIASES[key], **kwargs)
     match = _ALIASES.get(key)
     if match is None:
         raise ValueError(
             f"Unknown VLM model {model!r}. Known aliases: "
-            f"{', '.join(sorted(_ALIASES))}."
+            f"{', '.join(sorted(set(_ALIASES) | set(_LAZY_ALIASES)))}."
         )
     family_cls, size = match
     return family_cls(size=size, **kwargs)
+
+
+def __getattr__(name: str):
+    if name == "LibreSenseNovaVision":
+        from ..sensenova import LibreSenseNovaVision
+
+        return LibreSenseNovaVision
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [
@@ -93,4 +114,5 @@ __all__ = [
     "LibreFlorence2",
     "LibreKosmos2",
     "LibreLocateAnything",
+    "LibreSenseNovaVision",
 ]

--- a/libreyolo/models/vlm/base.py
+++ b/libreyolo/models/vlm/base.py
@@ -180,6 +180,18 @@ class LibreVLMModel(BaseModel):
         self._name_to_id = {v.strip().lower(): k for k, v in self.names.items()}
         return self
 
+    def set_task(self, task: str) -> "LibreVLMModel":
+        """Switch the active task without reloading the model.
+
+        Prompt-driven families serve every task from the same weights, so
+        unlike checkpoint families the task is not fixed at load time. The
+        task is validated against ``SUPPORTED_TASKS`` and, like
+        ``set_classes``, is sticky across later ``predict()``/``track()``
+        calls. Returns ``self`` so calls can chain.
+        """
+        self.task = self._resolve_task(task)
+        return self
+
     def chat(
         self,
         image: ImageInput,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,15 @@ openvocab = [
     "transformers>=5.1.0",
     "timm>=1.0.0",
 ]
+sensenova = [
+    # SenseNova-Vision (Bagel-MoT): the vendored architecture loads through
+    # accelerate's big-model dispatch; the tokenizer and activation registry
+    # come from transformers. flash-attn is optional (SDPA fallback built in).
+    "transformers>=5.1.0",
+    "accelerate>=1.7.0",
+    # 4-bit NF4 loading on consumer GPUs; no macOS wheels.
+    "bitsandbytes>=0.45.0; sys_platform != 'darwin'",
+]
 label = [
     # AI-assist for `libreyolo label`: SAM click-to-mask via the LibreSAM tier.
     # The manual labeller and model-assisted box auto-label work without this.
@@ -187,6 +196,7 @@ all = [
     "libreyolo[sam]",
     "libreyolo[label]",
     "libreyolo[openvocab]",
+    "libreyolo[sensenova]",
     "libreyolo[tensorboard]",
     "libreyolo[mlflow]",
     "libreyolo[wandb]",
@@ -350,6 +360,7 @@ markers = [
     "vlm: tests covering the LibreVLM (VLM-as-detector) tier",
     "sam: tests covering the LibreSAM (promptable-segmentation) tier",
     "openvocab: tests covering the LibreOpenVocab detector tier",
+    "sensenova: tests covering the LibreSenseNovaVision unified multimodal family",
     "clip: tests covering the LibreCLIP zero-shot open-vocabulary classifier family",
     "siglip2: tests covering the LibreSigLIP2 zero-shot open-vocabulary classifier family",
     "distributed: multi-rank gloo tests that mp.spawn a process group. Linux-only in the PR gate: they exercise distributed-training math, which is platform-independent, while dist.init_process_group(backend='gloo') costs ~105s per test on the macOS runner (a bare 2-rank scalar all-reduce takes 109s there vs 3.9s on Linux). They also compare a parent-process reference gradient against child-process gradients at a BLAS-sensitive tolerance, so running them on every OS yields flakes rather than coverage. The spawn-plumbing tests are deliberately NOT marked: they cover spawn-only failure modes that Linux's fork never hits.",

--- a/tests/unit/test_sensenova.py
+++ b/tests/unit/test_sensenova.py
@@ -1,0 +1,475 @@
+"""Offline tests for the SenseNova-Vision multi-task VLM family.
+
+Everything here runs without weights: the tagged-text and generated-image
+parsers are pure, and the adapter's postprocess hooks are exercised on bare
+instances following the LocateAnything test pattern.
+"""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from libreyolo.models.sensenova import parsing
+from libreyolo.models.sensenova.model import (
+    _TASK_TO_MODE,
+    BASE_PARAMS,
+    LibreSenseNovaVision,
+)
+from libreyolo.models.sensenova.modeling.layers import (
+    TimestepEmbedder,
+    sincos_position_embedding_2d,
+)
+from libreyolo.models.sensenova.prompts import COCO_PANOPTIC_NAMES
+
+pytestmark = pytest.mark.unit
+
+
+def _bare(task="detect", names=None, user_vocab=False):
+    m = object.__new__(LibreSenseNovaVision)
+    names = names or ["person", "car"]
+    m.names = {i: name for i, name in enumerate(names)}
+    m.nb_classes = len(m.names)
+    m._name_to_id = {name.lower(): i for i, name in m.names.items()}
+    m.task = task
+    m._custom_prompt = None
+    m._user_vocab = user_vocab
+    m.noise_seed = 42
+    return m
+
+
+class TestTaggedTextParsing:
+    def test_parses_labeled_boxes_normalized(self):
+        text = (
+            "<p>person</p><bbox>[0.1, 0.2, 0.5, 0.9]</bbox>"
+            "<bbox>[0.6,0.1,0.8,0.4]</bbox><p>car</p><bbox>[0.0,0.0,0.3,0.3]</bbox>"
+        )
+        parsed = parsing.parse_tagged_boxes(text)
+        assert parsed["person"] == [[0.1, 0.2, 0.5, 0.9], [0.6, 0.1, 0.8, 0.4]]
+        assert parsed["car"] == [[0.0, 0.0, 0.3, 0.3]]
+
+    def test_clips_out_of_range_coordinates(self):
+        parsed = parsing.parse_tagged_boxes("<p>dog</p><bbox>[-0.2, 0.5, 1.4, 0.9]</bbox>")
+        assert parsed["dog"] == [[0.0, 0.5, 0.999, 0.9]]
+
+    def test_ignores_malformed_fragments(self):
+        assert parsing.parse_tagged_boxes("<p>cat</p><bbox>[a, b, c, d]</bbox>") == {}
+        assert parsing.parse_tagged_boxes("no tags at all") == {}
+
+    def test_parses_points(self):
+        parsed = parsing.parse_tagged_points(
+            "<p>bird</p><point>[0.25, 0.75]</point><point>[0.5,0.5]</point>"
+        )
+        assert parsed["bird"] == [[0.25, 0.75], [0.5, 0.5]]
+
+    def test_parses_keypoints_with_instances_and_unvisible(self):
+        text = (
+            "<p>person</p><bbox>[0.1,0.1,0.9,0.9]</bbox>"
+            "nose<kpt>[0.5,0.2]</kpt>left eye<kpt>unvisible</kpt>"
+        )
+        parsed = parsing.parse_tagged_keypoints(text)
+        assert len(parsed["person"]) == 1
+        instance = parsed["person"][0]
+        assert instance["bbox"] == [0.1, 0.1, 0.9, 0.9]
+        assert instance["keypoints"]["nose"] == [0.5, 0.2]
+        assert instance["keypoints"]["left eye"] == [-1.0, -1.0]
+
+    def test_keypoint_array_orders_by_skeleton(self):
+        instance = {"keypoints": {"nose": [0.5, 0.2], "left ankle": [-1.0, -1.0]}}
+        arr = parsing.keypoint_instance_to_array(
+            instance, parsing.HUMAN_KEYPOINT_NAMES, 100, 200
+        )
+        assert arr.shape == (17, 3)
+        assert arr[0].tolist() == [50.0, 40.0, 1.0]  # nose is index 0
+        assert arr[15].tolist() == [0.0, 0.0, 0.0]  # invisible left ankle
+        assert arr[16].tolist() == [0.0, 0.0, 0.0]  # missing right ankle
+
+    def test_normalize_category_strips_dataset_suffixes(self):
+        assert parsing.normalize_category("tree-merged") == "tree"
+        assert parsing.normalize_category("wall-other") == "wall"
+        assert parsing.normalize_category("Traffic-Light") == "traffic light"
+
+
+class TestGeneratedImageParsing:
+    def test_binary_mask_resizes_and_thresholds(self):
+        img = Image.new("L", (10, 10), 0)
+        for x in range(5):
+            for y in range(10):
+                img.putpixel((x, y), 255)
+        mask = parsing.binary_mask_from_image(img, (20, 20))
+        assert mask.shape == (20, 20)
+        assert mask[:, :10].all() and not mask[:, 10:].any()
+
+    def test_mask_to_xyxy(self):
+        mask = np.zeros((10, 10), dtype=bool)
+        mask[2:5, 3:8] = True
+        assert parsing.mask_to_xyxy(mask) == [3.0, 2.0, 8.0, 5.0]
+        assert parsing.mask_to_xyxy(np.zeros((4, 4), dtype=bool)) is None
+
+    def test_depth_map_scales_to_unit_range(self):
+        img = Image.new("L", (8, 8), 255)
+        depth = parsing.depth_from_image(img, (8, 8))
+        assert depth.shape == (8, 8)
+        assert float(depth.max()) == 1.0
+
+    def test_panoptic_assembly_from_colors_and_caption(self):
+        img = Image.new("RGB", (20, 20), (0, 0, 0))
+        for x in range(10):
+            for y in range(20):
+                img.putpixel((x, y), (255, 0, 0))
+        for x in range(10, 20):
+            for y in range(10):
+                img.putpixel((x, y), (0, 0, 255))
+        caption = (
+            "A person stands under the sky. "
+            "<p>person-0<color>(255,0,0)</color></p> "
+            "<p>sky<color>(0,0,255)</color></p>"
+        )
+        id_map, segments, names = parsing.panoptic_from_mask_and_caption(
+            img, caption, {0: "person"}, (20, 20)
+        )
+        assert id_map.shape == (20, 20)
+        # person: category 0 -> segment id 1000; sky registered as category 1.
+        assert segments[0] == {"id": 1000, "category_id": 0, "score": 1.0}
+        assert segments[1]["category_id"] == 1
+        assert names[1] == "sky"
+        assert (id_map[:, :10] == 1000).all()
+        # Bottom-right quadrant stayed black -> void id 0.
+        assert (id_map[10:, 10:] == 0).all()
+
+    def test_panoptic_repeated_phrase_gets_new_instance_ids(self):
+        img = Image.new("RGB", (4, 4), (255, 0, 0))
+        for x in range(2):
+            for y in range(4):
+                img.putpixel((x, y), (0, 255, 0))
+        caption = (
+            "<p>car-0<color>(0,255,0)</color></p><p>car-0<color>(255,0,0)</color></p>"
+        )
+        _, segments, _ = parsing.panoptic_from_mask_and_caption(
+            img, caption, {0: "car"}, (4, 4)
+        )
+        assert [s["id"] for s in segments] == [1000, 1001]
+
+
+class TestCleanSourceLayers:
+    def test_sincos_table_matches_reference_convention(self):
+        table = sincos_position_embedding_2d(8, 3)
+        assert table.shape == (9, 8)
+        # Position 0 encodes sin(0)=0 in each half's first slot, cos(0)=1 after.
+        assert table[0, 0] == pytest.approx(0.0)
+        assert table[0, 2] == pytest.approx(1.0)
+        # Position p = row*grid+col: first half varies with col, second with row.
+        col_half = table[:, :4]
+        row_half = table[:, 4:]
+        assert np.allclose(col_half[0], col_half[3])  # positions 0 and 3 share col 0
+        assert np.allclose(row_half[0], row_half[1])  # positions 0 and 1 share row 0
+        assert not np.allclose(col_half[0], col_half[1])  # different cols differ
+
+    def test_timestep_embedding_is_cos_first(self):
+        import torch
+
+        emb = TimestepEmbedder.timestep_embedding(torch.zeros(2), 8)
+        assert emb.shape == (2, 8)
+        assert torch.allclose(emb[:, :4], torch.ones(2, 4))  # cos(0) = 1
+        assert torch.allclose(emb[:, 4:], torch.zeros(2, 4))  # sin(0) = 0
+
+    def test_position_embedding_module_matches_table(self):
+        import torch
+
+        from libreyolo.models.sensenova.modeling.layers import PositionEmbedding
+
+        mod = PositionEmbedding(4, 8)
+        table = sincos_position_embedding_2d(8, 4)
+        assert torch.allclose(mod.pos_embed.data, table)
+        assert not mod.pos_embed.requires_grad
+
+
+class TestPrompts:
+    def test_detect_prompt_wraps_classes_in_p_tags(self):
+        prompt = _bare("detect", ["bird", "pink car"])._task_prompt()
+        assert "<p>bird</p>, <p>pink car</p>" in prompt
+        assert "<bbox>" in prompt
+
+    def test_pose_prompt_selects_human_skeleton(self):
+        prompt = _bare("pose", ["person"])._task_prompt()
+        assert "left wrist" in prompt and "root of tail" not in prompt
+
+    def test_pose_prompt_selects_animal_skeleton(self):
+        prompt = _bare("pose", ["cat"], user_vocab=True)._task_prompt()
+        assert "root of tail" in prompt and "left wrist" not in prompt
+
+    def test_pose_prompt_mixed(self):
+        prompt = _bare("pose", ["person", "dog"], user_vocab=True)._task_prompt()
+        assert "AP-10K" in prompt
+
+    def test_pose_defaults_to_person_without_user_vocab(self):
+        model = _bare("pose", ["person", "car"], user_vocab=False)
+        assert model._task_names() == {0: "person"}
+
+    def test_segment_requires_user_vocabulary(self):
+        with pytest.raises(ValueError, match="set_classes"):
+            _bare("segment")._task_prompt()
+        prompt = _bare(
+            "segment", ["person furthest to the right"], user_vocab=True
+        )._task_prompt()
+        assert "<p>person furthest to the right</p>" in prompt
+        assert "binary" in prompt
+
+    def test_panoptic_defaults_to_coco_panoptic_names(self):
+        model = _bare("panoptic")
+        assert len(COCO_PANOPTIC_NAMES) == 133
+        prompt = model._task_prompt()
+        assert "<p>person</p>" in prompt and "panoptic" in prompt
+        assert "<color>(R,G,B)</color>" in prompt
+
+    def test_every_supported_task_has_a_mode(self):
+        for task in LibreSenseNovaVision.SUPPORTED_TASKS:
+            assert task in _TASK_TO_MODE
+            assert _TASK_TO_MODE[task] in BASE_PARAMS
+
+    def test_custom_prompt_wins(self):
+        model = _bare("detect")
+        model._custom_prompt = "my prompt"
+        assert model._task_prompt() == "my prompt"
+
+
+class TestPostprocess:
+    def test_detect_maps_labels_and_scales_boxes(self):
+        det = _bare("detect")._postprocess(
+            {"text": "<p>person</p><bbox>[0.1,0.2,0.5,0.4]</bbox>", "image": None},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(1000, 500),
+        )
+        assert det["num_detections"] == 1
+        assert det["boxes"] == [[100.0, 100.0, 500.0, 200.0]]
+        assert det["classes"] == [0]
+
+    def test_detect_drops_out_of_vocabulary_labels(self):
+        det = _bare("detect")._postprocess(
+            {"text": "<p>zebra</p><bbox>[0.1,0.2,0.5,0.4]</bbox>", "image": None},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(100, 100),
+        )
+        assert det["num_detections"] == 0
+
+    def test_point_task_returns_point_rows(self):
+        det = _bare("point")._postprocess(
+            {"text": "<p>car</p><point>[0.5,0.5]</point>", "image": None},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(200, 100),
+        )
+        assert det["points"] == [[100.0, 50.0, 1.0, 1.0]]
+
+    def test_pose_task_builds_keypoint_tensor(self):
+        text = (
+            "<p>person</p><bbox>[0.0,0.0,1.0,1.0]</bbox>"
+            "nose<kpt>[0.5,0.25]</kpt>left shoulder<kpt>[0.4,0.5]</kpt>"
+        )
+        det = _bare("pose", ["person"], user_vocab=True)._postprocess(
+            {"text": text, "image": None},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(100, 100),
+        )
+        assert det["num_detections"] == 1
+        assert det["keypoints"].shape == (1, 17, 3)
+        assert det["keypoints"][0, 0].tolist() == [50.0, 25.0, 1.0]
+
+    def test_ocr_returns_polygons_and_texts(self):
+        det = _bare("ocr")._postprocess(
+            {"text": "<p>STOP</p><bbox>[0.1,0.1,0.3,0.2]</bbox>", "image": None},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(100, 100),
+        )
+        assert det["ocr"]["texts"] == ["STOP"]
+        assert det["ocr"]["polygons"][0][0] == [10.0, 10.0]
+
+    def test_depth_returns_dense_map(self):
+        det = _bare("depth")._postprocess(
+            {"text": None, "image": Image.new("L", (10, 10), 128)},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(20, 40),
+        )
+        assert det["depth"].shape == (40, 20)
+        assert det["depth"].max() == pytest.approx(128 / 255)
+
+    def test_segment_returns_single_mask_instance(self):
+        mask_img = Image.new("L", (10, 10), 0)
+        for x in range(3, 7):
+            for y in range(3, 7):
+                mask_img.putpixel((x, y), 255)
+        det = _bare("segment", ["the box"], user_vocab=True)._postprocess(
+            {"text": None, "image": mask_img},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(10, 10),
+        )
+        assert det["num_detections"] == 1
+        assert det["masks"].shape == (1, 10, 10)
+        assert det["boxes"] == [[3.0, 3.0, 7.0, 7.0]]
+
+    def test_panoptic_extends_names_with_registered_phrases(self):
+        model = _bare("panoptic", ["person"], user_vocab=True)
+        img = Image.new("RGB", (10, 10), (255, 0, 0))
+        caption = "<p>surfboard<color>(255,0,0)</color></p>"
+        det = model._postprocess(
+            {"text": caption, "image": img},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(10, 10),
+        )
+        assert det["segments_info"][0]["category_id"] == 1
+        assert model.names[1] == "surfboard"
+
+    def test_missing_image_output_degrades_gracefully(self):
+        det = _bare("depth")._postprocess(
+            {"text": None, "image": None},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(4, 6),
+        )
+        assert det["depth"].shape == (6, 4)
+        seg = _bare("segment", ["x"], user_vocab=True)._postprocess(
+            {"text": None, "image": None},
+            conf_thres=0.0,
+            iou_thres=0.5,
+            original_size=(4, 4),
+        )
+        assert seg["num_detections"] == 0
+
+
+class _FakeInferencer:
+    """Stands in for InterleaveInferencer, returning canned generations."""
+
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.calls = []
+
+    def interleave_inference(self, input_lists, **kwargs):
+        self.calls.append((input_lists, kwargs))
+        return list(self.outputs)
+
+
+def _loaded(task, names, outputs, user_vocab=True):
+    import torch
+
+    m = _bare(task, names, user_vocab=user_vocab)
+    m.device = torch.device("cpu")
+    m.input_size = 1024
+    m.model = torch.nn.Identity()
+    m.inferencer = _FakeInferencer(outputs)
+    return m
+
+
+class TestPredictEndToEnd:
+    """Full predict-path smoke through the shared InferenceRunner."""
+
+    def test_detect_predict_returns_boxes_results(self):
+        model = _loaded(
+            "detect",
+            ["person", "car"],
+            ["<p>person</p><bbox>[0.1,0.2,0.5,0.4]</bbox>"],
+        )
+        result = model.predict(Image.new("RGB", (200, 100)))
+        assert result.boxes is not None
+        assert result.boxes.xyxy.tolist() == [[20.0, 20.0, 100.0, 40.0]]
+        assert result.names[int(result.boxes.cls[0])] == "person"
+        # The prompt sent to the model carries the vocabulary.
+        sent = model.inferencer.calls[0][0]
+        assert any("<p>person</p>" in str(item) for item in sent)
+
+    def test_depth_predict_returns_depth_map(self):
+        model = _loaded("depth", ["person"], [Image.new("RGB", (64, 32), (200, 200, 200))])
+        result = model.predict(Image.new("RGB", (64, 32)))
+        assert result.depth_map is not None
+        assert tuple(result.depth_map.data.shape) == (32, 64)
+
+    def test_panoptic_predict_returns_panoptic_results(self):
+        mask = Image.new("RGB", (20, 20), (255, 0, 0))
+        caption = "<p>person-0<color>(255,0,0)</color></p>"
+        model = _loaded("panoptic", ["person"], [caption, mask])
+        result = model.predict(Image.new("RGB", (20, 20)))
+        assert result.panoptic is not None
+        assert result.panoptic.segments_info[0]["category_id"] == 0
+
+    def test_pose_predict_returns_keypoints(self):
+        text = (
+            "<p>person</p><bbox>[0.0,0.0,1.0,1.0]</bbox>nose<kpt>[0.5,0.5]</kpt>"
+        )
+        model = _loaded("pose", ["person"], [text])
+        result = model.predict(Image.new("RGB", (100, 100)))
+        assert result.keypoints is not None
+        assert tuple(result.keypoints.data.shape) == (1, 17, 3)
+
+    def test_segment_predict_returns_masks(self):
+        mask_img = Image.new("L", (10, 10), 0)
+        for x in range(2, 8):
+            for y in range(2, 8):
+                mask_img.putpixel((x, y), 255)
+        model = _loaded("segment", ["the thing"], [mask_img.convert("RGB")])
+        result = model.predict(Image.new("RGB", (10, 10)))
+        assert result.masks is not None
+        assert result.boxes.xyxy.tolist() == [[2.0, 2.0, 8.0, 8.0]]
+
+    def test_ocr_predict_returns_regions(self):
+        model = _loaded("ocr", ["person"], ["<p>EXIT</p><bbox>[0.0,0.0,0.5,0.2]</bbox>"])
+        result = model.predict(Image.new("RGB", (100, 100)))
+        assert result.ocr is not None
+        assert result.ocr.texts == ["EXIT"]
+
+
+class TestFamilySurface:
+    def test_import_order_does_not_break(self):
+        # Regression: importing the family package before the vlm package used
+        # to raise a circular-import error.
+        import importlib
+        import sys
+
+        for name in [
+            "libreyolo.models.sensenova",
+            "libreyolo.models.sensenova.model",
+            "libreyolo.models.vlm",
+        ]:
+            sys.modules.pop(name, None)
+        sensenova = importlib.import_module("libreyolo.models.sensenova")
+        vlm = importlib.import_module("libreyolo.models.vlm")
+        assert vlm.LibreSenseNovaVision is sensenova.LibreSenseNovaVision
+
+    def test_factory_knows_the_alias(self):
+        from libreyolo.models.vlm import _LAZY_ALIASES, LibreVLM
+
+        assert _LAZY_ALIASES["sensenova-vision"] == "7b"
+        with pytest.raises(ValueError, match="sensenova-vision"):
+            LibreVLM("definitely-not-a-model")
+
+    def test_set_task_switches_without_reload(self):
+        model = _bare("detect")
+        assert model.set_task("depth") is model
+        assert model.task == "depth"
+        with pytest.raises(ValueError):
+            model.set_task("classify")
+
+    def test_supported_tasks_are_canonical(self):
+        from libreyolo.tasks import TASKS
+
+        for task in LibreSenseNovaVision.SUPPORTED_TASKS:
+            assert task in TASKS
+
+    def test_notice_names_the_license_and_upstream(self):
+        notice = LibreSenseNovaVision._LICENSE_NOTICE
+        assert "CC BY-NC 4.0" in notice
+        assert "huggingface.co/sensenova/SenseNova-Vision-7B-MoT" in notice
+        assert "does not\nredistribute" in notice or "does not redistribute" in notice
+
+    def test_default_score_below_conf_threshold_drops_everything(self):
+        det = _bare("detect")._postprocess(
+            {"text": "<p>person</p><bbox>[0.1,0.2,0.5,0.4]</bbox>", "image": None},
+            conf_thres=1.5,
+            iou_thres=0.5,
+            original_size=(100, 100),
+        )
+        assert det["num_detections"] == 0

--- a/tests/unit/test_sensenova.py
+++ b/tests/unit/test_sensenova.py
@@ -516,11 +516,12 @@ class TestFamilySurface:
         for task in LibreSenseNovaVision.SUPPORTED_TASKS:
             assert task in TASKS
 
-    def test_notice_names_the_license_and_upstream(self):
+    def test_notice_names_the_license_mirror_and_upstream(self):
         notice = LibreSenseNovaVision._LICENSE_NOTICE
         assert "CC BY-NC 4.0" in notice
+        assert "NON-COMMERCIAL" in notice
+        assert "huggingface.co/LibreYOLO/SenseNovaVision7b" in notice
         assert "huggingface.co/sensenova/SenseNova-Vision-7B-MoT" in notice
-        assert "does not\nredistribute" in notice or "does not redistribute" in notice
 
     def test_default_score_below_conf_threshold_drops_everything(self):
         det = _bare("detect")._postprocess(

--- a/tests/unit/test_sensenova.py
+++ b/tests/unit/test_sensenova.py
@@ -342,6 +342,63 @@ class TestPostprocess:
         assert seg["num_detections"] == 0
 
 
+class _FakeBaseTokenizer:
+    """Byte-per-char stand-in for the base BPE."""
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(c) % 1000 for c in text]
+
+    def decode(self, ids):
+        return "".join(chr(i) if 31 < i < 127 else "?" for i in ids)
+
+
+class TestCheckpointTokenizer:
+    def _tok(self):
+        from libreyolo.models.sensenova.data_utils import CheckpointTokenizer
+
+        overrides = {
+            2000: "<|im_start|>",
+            2001: "<|im_end|>",
+            2002: "<|vision_start|>",
+            2003: "<|vision_end|>",
+            2004: "<quat>",
+        }
+        return CheckpointTokenizer(_FakeBaseTokenizer(), overrides)
+
+    def test_override_literals_encode_to_trained_ids(self):
+        tok = self._tok()
+        assert tok.encode("<|im_start|>hi<quat>") == [2000, ord("h"), ord("i"), 2004]
+
+    def test_decode_maps_override_ids_back_to_literals(self):
+        tok = self._tok()
+        text = tok.decode([2000, ord("h"), ord("i"), 2001])
+        assert text == "<|im_start|>hi<|im_end|>"
+        assert text.split("<|im_end|>")[0].split("<|im_start|>")[1] == "hi"
+
+    def test_decode_accepts_tensors(self):
+        import torch
+
+        tok = self._tok()
+        assert tok.decode(torch.tensor([2000, ord("a")])) == "<|im_start|>a"
+
+    def test_add_special_tokens_resolves_trained_ids(self):
+        from libreyolo.models.sensenova.data_utils import add_special_tokens
+
+        tok, ids, n_new = add_special_tokens(self._tok())
+        assert n_new == 0
+        assert ids == {
+            "bos_token_id": 2000,
+            "eos_token_id": 2001,
+            "start_of_image": 2002,
+            "end_of_image": 2003,
+        }
+
+    def test_refuses_unknown_token_registration(self):
+        tok = self._tok()
+        with pytest.raises(ValueError, match="checkpoint layout"):
+            tok.add_tokens(["<|brand-new|>"])
+
+
 class _FakeInferencer:
     """Stands in for InterleaveInferencer, returning canned generations."""
 

--- a/tests/unit/test_sensenova.py
+++ b/tests/unit/test_sensenova.py
@@ -30,8 +30,10 @@ def _bare(task="detect", names=None, user_vocab=False):
     m.names = {i: name for i, name in enumerate(names)}
     m.nb_classes = len(m.names)
     m._name_to_id = {name.lower(): i for i, name in m.names.items()}
+    m._vocab = dict(m.names)
     m.task = task
     m._custom_prompt = None
+    m._custom_prompt_task = None
     m._user_vocab = user_vocab
     m.noise_seed = 42
     return m
@@ -136,6 +138,26 @@ class TestGeneratedImageParsing:
         # Bottom-right quadrant stayed black -> void id 0.
         assert (id_map[10:, 10:] == 0).all()
 
+    def test_panoptic_black_survives_when_declared_as_instance_color(self):
+        # Regression (Greptile #618): black is the trained void convention,
+        # but a caption that explicitly assigns (0,0,0) to an instance keeps
+        # that segment.
+        img = Image.new("RGB", (4, 4), (0, 0, 0))
+        caption = "<p>cat<color>(0,0,0)</color></p>"
+        id_map, segments, _ = parsing.panoptic_from_mask_and_caption(
+            img, caption, {0: "cat"}, (4, 4)
+        )
+        assert len(segments) == 1
+        assert (id_map == segments[0]["id"]).all()
+
+    def test_panoptic_black_stays_void_when_undeclared(self):
+        img = Image.new("RGB", (4, 4), (0, 0, 0))
+        caption = "<p>cat<color>(255,0,0)</color></p>"
+        id_map, segments, _ = parsing.panoptic_from_mask_and_caption(
+            img, caption, {0: "cat"}, (4, 4)
+        )
+        assert segments == [] and (id_map == 0).all()
+
     def test_panoptic_repeated_phrase_gets_new_instance_ids(self):
         img = Image.new("RGB", (4, 4), (255, 0, 0))
         for x in range(2):
@@ -226,10 +248,20 @@ class TestPrompts:
             assert task in _TASK_TO_MODE
             assert _TASK_TO_MODE[task] in BASE_PARAMS
 
-    def test_custom_prompt_wins(self):
+    def test_custom_prompt_wins_for_its_own_task(self):
         model = _bare("detect")
         model._custom_prompt = "my prompt"
+        model._custom_prompt_task = "detect"
         assert model._task_prompt() == "my prompt"
+
+    def test_custom_prompt_does_not_leak_into_other_tasks(self):
+        from libreyolo.models.sensenova.prompts import DEPTH_PROMPT
+
+        model = _bare("detect")
+        model._custom_prompt = "my detect prompt"
+        model._custom_prompt_task = "detect"
+        model.set_task("depth")
+        assert model._task_prompt() == DEPTH_PROMPT
 
 
 class TestPostprocess:
@@ -477,6 +509,25 @@ class TestPredictEndToEnd:
         result = model.predict(Image.new("RGB", (100, 100)))
         assert result.ocr is not None
         assert result.ocr.texts == ["EXIT"]
+
+    def test_panoptic_does_not_poison_later_detect(self):
+        # Regression (Greptile #618): the panoptic label-table rewrite must
+        # not leak into the vocabulary used by later tasks on the same model.
+        model = _loaded(
+            "panoptic",
+            ["bird"],
+            ["<p>sky<color>(255,0,0)</color></p>", Image.new("RGB", (10, 10), (255, 0, 0))],
+        )
+        result = model.predict(Image.new("RGB", (10, 10)))
+        assert "sky" in result.names.values()
+
+        model.set_task("detect")
+        model.inferencer = _FakeInferencer(["<p>bird</p><bbox>[0.1,0.1,0.5,0.5]</bbox>"])
+        result = model.predict(Image.new("RGB", (10, 10)))
+        assert result.names == {0: "bird"}
+        assert result.names[int(result.boxes.cls[0])] == "bird"
+        prompt_sent = [i for i in model.inferencer.calls[0][0] if isinstance(i, str)][0]
+        assert "<p>bird</p>" in prompt_sent and "sky" not in prompt_sent
 
 
 class TestFamilySurface:

--- a/tests/unit/test_sensenova_modeling.py
+++ b/tests/unit/test_sensenova_modeling.py
@@ -1,0 +1,170 @@
+"""Offline integration test for the vendored SenseNova (Bagel-MoT) stack.
+
+Builds a miniature random-weight Bagel and drives the real
+InterleaveInferencer through all three generation modes on CPU. This
+exercises the packed SDPA attention fallback (both MoT modes), KV-cache
+merging, rotary embeddings, CFG flow sampling, and VAE decode, none of which
+the parser-level tests touch.
+"""
+
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.sensenova.inferencer import InterleaveInferencer
+from libreyolo.models.sensenova.modeling.autoencoder import AutoEncoder, AutoEncoderParams
+from libreyolo.models.sensenova.modeling.bagel import Bagel, BagelConfig
+from libreyolo.models.sensenova.modeling.qwen2_navit import Qwen2Config, Qwen2ForCausalLM
+from libreyolo.models.sensenova.modeling.siglip_navit import (
+    SiglipVisionConfig,
+    SiglipVisionModel,
+)
+from libreyolo.models.sensenova.transforms import ImageTransform
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer surface the inferencer and Bagel.prepare_* use."""
+
+    special_tokens_map = {}
+
+    def add_tokens(self, tokens):
+        self._extra = {t: 500 + i for i, t in enumerate(tokens)}
+        return len(tokens)
+
+    def convert_tokens_to_ids(self, token):
+        return self._extra[token]
+
+    def encode(self, text):
+        return [(7 + ord(c)) % 400 for c in text[:12]]
+
+    def decode(self, ids):
+        return "<|im_start|>tiny output text<|im_end|>"
+
+
+@pytest.fixture(scope="module")
+def tiny_inferencer():
+    llm_config = Qwen2Config(
+        vocab_size=512,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=2048,
+        rope_theta=10000.0,
+        tie_word_embeddings=False,
+        qk_norm=True,
+        layer_module="Qwen2MoTDecoderLayer",
+    )
+    vit_config = SiglipVisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        image_size=64,
+        patch_size=16,
+        rope=False,
+    )
+    vae_params = AutoEncoderParams(
+        resolution=64,
+        in_channels=3,
+        downsample=8,
+        ch=32,
+        out_ch=3,
+        ch_mult=[1, 2, 2, 2],
+        num_res_blocks=1,
+        z_channels=4,
+        scale_factor=0.3611,
+        shift_factor=0.1159,
+    )
+    bagel_config = BagelConfig(
+        visual_gen=True,
+        visual_und=True,
+        llm_config=llm_config,
+        vit_config=vit_config,
+        vae_config=vae_params,
+        latent_patch_size=2,
+        max_latent_size=64,
+        # Must equal image_size // patch_size so flattened position ids stay
+        # in range of the tower's embedding table (real model: 980 // 14 = 70).
+        vit_max_num_patch_per_side=4,
+        connector_act="gelu_pytorch_tanh",
+    )
+
+    torch.manual_seed(0)
+    language_model = Qwen2ForCausalLM(llm_config)
+    vit_model = SiglipVisionModel(vit_config)
+    model = Bagel(language_model, vit_model, bagel_config)
+    model.vit_model.vision_model.embeddings.convert_conv2d_to_linear(vit_config)
+    model = model.to(torch.bfloat16).eval()
+    vae = AutoEncoder(vae_params).to(torch.bfloat16).eval()
+
+    tokenizer = _FakeTokenizer()
+    tokenizer.add_tokens(
+        ["<|im_start|>", "<|im_end|>", "<|vision_start|>", "<|vision_end|>"]
+    )
+    new_token_ids = dict(
+        bos_token_id=500, eos_token_id=501, start_of_image=502, end_of_image=503
+    )
+
+    return InterleaveInferencer(
+        model=model,
+        vae_model=vae,
+        tokenizer=tokenizer,
+        vae_transform=ImageTransform(64, 32, 16),
+        vit_transform=ImageTransform(64, 32, 16),
+        new_token_ids=new_token_ids,
+        device="cpu",
+    )
+
+
+@pytest.fixture()
+def image():
+    return Image.new("RGB", (64, 64), (120, 40, 200))
+
+
+def test_understanding_mode_generates_text(tiny_inferencer, image):
+    out = tiny_inferencer.interleave_inference(
+        [image, "describe"],
+        understanding_output=True,
+        max_think_token_n=5,
+        do_sample=False,
+    )
+    assert any(isinstance(o, str) for o in out)
+
+
+def test_dense_perception_mode_generates_image(tiny_inferencer, image):
+    out = tiny_inferencer.interleave_inference(
+        [image, "estimate depth"],
+        understanding_output=False,
+        cfg_text_scale=4.0,
+        cfg_img_scale=1.0,
+        cfg_interval=[0.0, 1.0],
+        timestep_shift=4.0,
+        num_timesteps=4,
+        cfg_renorm_min=1.0,
+        cfg_renorm_type="text_channel",
+    )
+    images = [o for o in out if isinstance(o, Image.Image)]
+    assert images and images[0].size == (64, 64)
+
+
+def test_caption_generate_mode_yields_text_then_image(tiny_inferencer, image):
+    out = tiny_inferencer.interleave_inference(
+        [image, "caption then mask"],
+        understanding_output=False,
+        caption=True,
+        max_think_token_n=5,
+        do_sample=False,
+        cfg_text_scale=4.0,
+        cfg_img_scale=1.0,
+        cfg_interval=[0.0, 1.0],
+        timestep_shift=4.0,
+        num_timesteps=4,
+        cfg_renorm_min=1.0,
+        cfg_renorm_type="global",
+    )
+    assert any(isinstance(o, str) for o in out)
+    assert any(isinstance(o, Image.Image) for o in out)


### PR DESCRIPTION
Adds SenseNova-Vision (arXiv:2607.06560), a unified multimodal generation model, as the first multi-task family in the LibreVLM tier. `LibreVLM("sensenova-vision", task=...)` serves detect, point, pose, ocr, depth, segment (referring, free-text queries) and panoptic from one checkpoint, returning the same Results payloads as the specialist families. `set_task()` (new on the tier base) switches tasks without reloading. Capabilities without a canonical task (normals, GCG, editing, 3D) stay behind the chat()/generate() escape hatches. Contract in ADR 0012.

Weights are CC BY-NC 4.0, mirrored byte-identically with attribution at LibreYOLO/SenseNovaVision7b (revision and SHA-256 pins on the card); the loader prints the non-commercial notice before every download.

## Code provenance

- Ported (inference-only) from OpenSenseNova/SenseNova-Vision at commit 12ccd96e32b32967a11cacb6c5bd5fe3a555fc0c, Apache-2.0: `libreyolo/models/sensenova/modeling/{bagel,qwen2_navit,siglip_navit,autoencoder,qwen2_config,qwen2_base,siglip_base}.py`, `inferencer.py`, `transforms.py`, `data_utils.py`, plus the task prompts and output parsers (`prompts.py`, `parsing.py`). Upstream lineages retained in the file headers: Bagel (ByteDance, Apache-2.0), Qwen2/SigLIP modules (Hugging Face transformers, Apache-2.0), FLUX autoencoder (Black Forest Labs, Apache-2.0). Adaptations documented per file: training paths removed, flash-attn optional behind an SDPA fallback, relative imports.
- NOT ported: upstream `modeling/bagel/modeling_utils.py` is CC BY-NC 4.0 (derives from facebookresearch/DiT) and is excluded. Its standard components are re-derived in `modeling/layers.py` from the original permissive sources instead: the 2D sincos position table from Hugging Face transformers (models/vit_mae, Apache-2.0) and the sinusoidal timestep embedding from openai/guided-diffusion (MIT), with parameter names fixed by the released checkpoint. Maintainer sign-off on this remedy is part of merging this PR.
- Original code written for this PR: the family adapter (`libreyolo/models/sensenova/model.py`), `CheckpointTokenizer`, `set_task()` on the VLM tier base, tests, docs, notices.
- Structural parity with the released checkpoint verified tensor-by-tensor (1223/1223 names and shapes) against the safetensors header.

## How was this tested?

- 53 offline unit tests (parsers, prompts, postprocess routing, tokenizer overlay, full mocked predict path per task, tiny-Bagel CPU run of all three generation modes through the real inferencer).
- Real-weights end-to-end on an RTX 5070 Ti (NF4, no flash-attn): all 7 tasks plus chat produced correct Results on the bundled test image (detect 6 boxes, pose 3x17x3 keypoints, 852x1280 depth map, referring mask, panoptic 4 person instances + open-vocab sky segment).
- Autodownload path exercised against upstream before the mirror flip; mirror verified byte-identical (same SHA-256s) via the HF API.
