### PR TITLE
Add PyTorch-native quantization: fp16/int8/nvfp4, QAT/QAD, QDQ ONNX export, finalized checkpoints

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -175,6 +175,15 @@ LibreYOLO backends so they can apply native original-canvas clipping and runtime
 `predict(conf=..., iou=..., max_det=...)` semantics. Third-party consumers that
 want graph-embedded NMS should use the first output.
 
+## Quantized Checkpoints
+
+Quantized models add one optional flat key, `quant`: a small manifest dict
+(`schema`, `recipe`, `keep_high_precision`, `execution`, calibration
+provenance, `module_count`). Loaders that see `quant` rebuild the quantized
+module structure before `load_state_dict`, so the extra `_q_*` scale buffers
+in `model` resolve. Readers without quantization support may ignore the key
+and load the fp32 master weights. See `quantization.md`.
+
 ## Training Checkpoints
 
 Trainer checkpoints use the same required metadata core and may also contain

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -193,11 +193,20 @@ quantized module structure before `load_state_dict`. See `quantization.md`.
   - int8: `weight_packed` (int8, original weight shape) and `_q_w_scale`
     (fp32 per-channel). Dequant: `weight_packed * scale`. Activation range
     buffers (`_q_act_lo`/`_q_act_hi`/`_q_calibrated`) are retained.
+  - fp8: `weight_packed` (float8_e4m3fn, original weight shape) and
+    `_q_w_scale` (fp32 per-channel). Dequant: `weight_packed * scale`.
+  - w4a16 / w4a8: `weight_packed` (uint8, two 4-bit codes per byte, low
+    nibble first; code = q + 8) and `_q_w_gscale` (fp32, [out, ngroups],
+    group 128 along in_features). int2: four 2-bit codes per byte
+    (code = q + 2), group 64.
   - nvfp4: `weight_packed` (uint8, [out, ceil(in/16)*8], two 4-bit codes
     per byte, low nibble first; code = sign<<3 | E2M1 level index),
     `weight_block_scale` (float8_e4m3fn, [out, ceil(in/16)]), and
     `_q_w_amax` (fp32 per-tensor amax). Effective block scale:
     `block_scale * amax / (448 * 6)`.
+  - mxfp4: `weight_packed` as nvfp4 but 32-element blocks, and
+    `weight_block_exp` (int8, [out, ceil(in/32)]) storing the power-of-two
+    block exponent. Effective block scale: `2 ** exponent`.
   The manifest records `remainder` (`"fp16"` or `"fp32"`) for the
   non-quantized tensors. Unpacking reproduces the fake-quant simulation bit
   for bit, so finalized inference matches prepared inference exactly on the

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -179,10 +179,30 @@ want graph-embedded NMS should use the first output.
 
 Quantized models add one optional flat key, `quant`: a small manifest dict
 (`schema`, `recipe`, `keep_high_precision`, `execution`, calibration
-provenance, `module_count`). Loaders that see `quant` rebuild the quantized
-module structure before `load_state_dict`, so the extra `_q_*` scale buffers
-in `model` resolve. Readers without quantization support may ignore the key
-and load the fp32 master weights. See `quantization.md`.
+provenance, `module_count`, `state`). Loaders that see `quant` rebuild the
+quantized module structure before `load_state_dict`. See `quantization.md`.
+
+`state` distinguishes the two artifact forms:
+
+- `"prepared"` (default): fp32 master weights plus `_q_*` scale buffers.
+  Trainable (QAT/QAD). Readers without quantization support may ignore the
+  `quant` key and load the masters as a float model.
+- `"finalized"`: crystallized deployment form written by
+  `export(format="pt")`. Masters are stripped; per quantized module the
+  state dict instead carries:
+  - int8: `weight_packed` (int8, original weight shape) and `_q_w_scale`
+    (fp32 per-channel). Dequant: `weight_packed * scale`. Activation range
+    buffers (`_q_act_lo`/`_q_act_hi`/`_q_calibrated`) are retained.
+  - nvfp4: `weight_packed` (uint8, [out, ceil(in/16)*8], two 4-bit codes
+    per byte, low nibble first; code = sign<<3 | E2M1 level index),
+    `weight_block_scale` (float8_e4m3fn, [out, ceil(in/16)]), and
+    `_q_w_amax` (fp32 per-tensor amax). Effective block scale:
+    `block_scale * amax / (448 * 6)`.
+  The manifest records `remainder` (`"fp16"` or `"fp32"`) for the
+  non-quantized tensors. Unpacking reproduces the fake-quant simulation bit
+  for bit, so finalized inference matches prepared inference exactly on the
+  finalizing device. This layout is the stable contract for external
+  exporters and runtimes.
 
 ## Training Checkpoints
 

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -76,6 +76,25 @@ it executes natively.
 `model.quant_info()` reports the recipe, module counts, calibration state,
 and execution tier.
 
+## Export
+
+Direct export of a quantized model is intentionally rejected: tracing the
+simulation would bake fake-quant arithmetic into the graph, producing an
+artifact that looks fp32 to every runtime and runs slower than the float
+model. The supported bridge to deployment formats today:
+
+```python
+qmodel = LibreYOLO("runs/train/qat-run/weights/best.pt")  # QAT/QAD result
+qmodel.dequantize()   # restore float modules; QAT-trained masters are kept
+qmodel.export(format="onnx", int8=True, data="coco8.yaml")  # real QDQ INT8
+```
+
+The QAT benefit lives mostly in the trained master weights, which this path
+preserves; activation scales are re-derived by the existing calibrated
+exporter. Scale-exact QDQ export (emitting QuantizeLinear/DequantizeLinear
+directly from the model's own calibrated scales) is the planned follow-up.
+`nvfp4` has no standard ONNX representation and stays PyTorch-executed.
+
 ## QAT and QAD mechanics
 
 Quantized modules keep fp32 master weights; fake-quantization applies STE so

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -16,7 +16,7 @@ model = LibreYOLO("LibreYOLO9s.pt")
 
 # Step 1: quantize (structure + calibration). calib is a small UNLABELED
 # image set used forward-only to derive activation ranges and scales.
-qmodel = model.quantize(recipe="int8", calib="coco8.yaml", samples=128)
+qmodel = model.quantize(recipe="int8", calib="coco128.yaml", samples=128)
 
 qmodel.val(data="coco8.yaml")            # honest accuracy, same validators
 qmodel.predict("bus.jpg")
@@ -61,8 +61,21 @@ doing.
 ## Calibration data is not training data
 
 - `calib=` (quantize): a few hundred images, no labels read, forward-only.
-  Purpose: activation ranges and scale generation.
+  Purpose: activation ranges and scale generation. Default: `coco128.yaml`
+  (auto-downloaded); multiple batches matter because ranges are estimated
+  across them.
 - `data=` (train/val): the labeled dataset. Purpose: gradients and metrics.
+
+Activation range estimation (`algorithm=`): the default `minmax` keeps the
+absolute extremes seen across calibration batches; `percentile`
+(experimental) uses the mean of per-batch 0.1/99.9 percentiles. Measured on
+coco128, minmax with a multi-batch calibration set wins for every tested
+model, and percentile clipping collapses DETR-family accuracy because
+transformer activation outliers are functionally load-bearing. What
+actually fixes small-model int8 sensitivity is calibrating on enough
+batches (hence the coco128 default: with it, YOLO9-t lands within about one
+mAP point of fp32). The chosen algorithm is recorded in the checkpoint
+manifest.
 
 ## Execution tiers
 

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -1,0 +1,102 @@
+# PyTorch-Native Quantization
+
+LibreYOLO quantizes models directly in PyTorch. Quantized models keep the
+normal `predict` / `val` / `train` / `save` contract, so accuracy is measured
+with the same validators as float models and accuracy recovery reuses the
+existing training and distillation notation.
+
+## Grammar
+
+Two steps. Step 1 always happens; step 2 is optional accuracy recovery.
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreYOLO9s.pt")
+
+# Step 1: quantize (structure + calibration). calib is a small UNLABELED
+# image set used forward-only to derive activation ranges and scales.
+qmodel = model.quantize(recipe="int8", calib="coco8.yaml", samples=128)
+
+qmodel.val(data="coco8.yaml")            # honest accuracy, same validators
+qmodel.predict("bus.jpg")
+qmodel.save("LibreYOLO9s-int8.pt")       # manifest-carrying checkpoint
+
+# Step 2 (optional): QAT is plain train() on the quantized model.
+qmodel.train(data="coco.yaml", epochs=5)
+
+# QAD: same step plus the existing distillation kwargs.
+qmodel.train(data="coco.yaml", epochs=5, distill_model="LibreYOLO9m.pt")
+```
+
+CLI:
+
+```bash
+libreyolo quantize --model LibreYOLO9s.pt --recipe int8 --calib coco8.yaml
+libreyolo train --model LibreYOLO9s-int8.pt --data coco.yaml --epochs 5
+```
+
+`LibreYOLO("LibreYOLO9s-int8.pt")` restores the quantized structure and
+scales automatically (checkpoints carry a `quant` manifest; see
+`checkpoint_schema.md`). Trainer checkpoints written during QAT/QAD carry the
+manifest too, so `best.pt` from a QAT run is itself a quantized checkpoint.
+
+## Recipes
+
+| Recipe | What it does | Families (v1) | Calibration |
+|---|---|---|---|
+| `fp16` | Casts the model to half precision with a float32 I/O contract. Inference-only. | yolo9, rfdetr | none |
+| `int8` | W8A8 simulation: per-channel symmetric INT8 weights, per-tensor affine INT8 activations, on `Conv2d` and `Linear`. | yolo9, rfdetr | required for activations (skipped with `calib=None`, weights-only) |
+| `nvfp4` | W4A4 NVFP4 simulation on `Linear`: E2M1 elements, 16-element blocks, FP8 E4M3 block scales, FP32 tensor scale. Activations use dynamic block scaling. | rfdetr | not needed (dynamic) |
+
+`nvfp4` is rejected for conv-heavy families such as yolo9 on purpose: FP4
+acceleration is GEMM-only on current hardware, so convolutions stay in higher
+precision. Transformer families (RF-DETR) are the NVFP4 target.
+
+Per-family `keep_high_precision` defaults protect the first layer and the
+heads (and always the YOLO9 DFL conv). Override with
+`quantize(..., keep_high_precision=("head.",))` if you know what you are
+doing.
+
+## Calibration data is not training data
+
+- `calib=` (quantize): a few hundred images, no labels read, forward-only.
+  Purpose: activation ranges and scale generation.
+- `data=` (train/val): the labeled dataset. Purpose: gradients and metrics.
+
+## Execution tiers
+
+v1 executes quantized arithmetic in **simulation** (fake-quantization with
+straight-through-estimator gradients, computed in fp32 islands even under
+AMP). Simulation is numerics-true: a `val()` score on any device is a real
+claim about the quantized arithmetic. It is not a speed claim; packed
+low-bit kernels are a separate deployment concern. `fp16` is the exception:
+it executes natively.
+
+`model.quant_info()` reports the recipe, module counts, calibration state,
+and execution tier.
+
+## QAT and QAD mechanics
+
+Quantized modules keep fp32 master weights; fake-quantization applies STE so
+gradients flow to the masters. The existing trainers work unchanged: EMA,
+AMP, checkpoint resume, and the `distill_*` kwargs (MGD/CWD) all compose.
+`fp16`-quantized models are inference-only; the trainer rejects them with a
+pointer to `amp=True`.
+
+QAT is a finetune of an already-trained model: use finetune learning rates
+(for example `lr0=1e-4` for yolo9), not the from-scratch defaults, or the
+short run will destroy the pretrained weights regardless of quantization.
+
+QAD availability follows family distillation support: it works wherever the
+family implements `get_distill_config()` (yolo9 today). The grammar itself is
+family-independent, so rfdetr QAD activates as soon as that family gains
+distillation support.
+
+Family notes: RF-DETR calibration exercises the inference path, so modules
+that only run during training (denoising branches) keep their activation
+observers open and stay unquantized on activations until QAT runs;
+`quant_info()["calibrated"]` reports this honestly. The RF-DETR trainer also
+reinitializes the detection head when the dataset class count differs from
+the checkpoint head width (COCO checkpoints have a 91-wide head), which
+applies to quantized finetunes exactly as it does to float ones.

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -91,6 +91,30 @@ and execution tier.
 
 ## Export
 
+### Finalized PyTorch checkpoints (`format="pt"`)
+
+A prepared checkpoint keeps fp32 masters because training needs them. When
+you are done, crystallize:
+
+```python
+qmodel.export(format="pt")   # -> <name>-final.pt, packed low-bit weights
+```
+
+Finalized checkpoints store real packed weights (int8 tensors + per-channel
+scales; nvfp4 as two-codes-per-byte E2M1 payload + E4M3 block scales),
+strip the masters, and cast the non-quantized remainder to fp16
+(`remainder="fp32"` keeps it exact). Measured: YOLO9-s int8 29.5 to 9.6 MB,
+RF-DETR-n nvfp4 122 to 26 MB. The packing invariant: unpacking reproduces
+the simulation bit for bit on the device you finalized on, so the finalized
+file scores exactly what you validated. Loading one gives an
+inference-ready model; `train()` on it re-prepares masters from the packed
+weights automatically (QAT-from-PTQ); ONNX export from it re-prepares
+internally and emits the same QDQ graph. The packed layout is documented in
+`checkpoint_schema.md` as the connection contract for external exporters
+and runtimes.
+
+### ONNX (`format="onnx"`)
+
 int8-quantized models export directly to ONNX with in-graph
 QuantizeLinear/DequantizeLinear pairs carrying the model's own calibrated
 (or QAT-trained) scales:

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -78,22 +78,27 @@ and execution tier.
 
 ## Export
 
-Direct export of a quantized model is intentionally rejected: tracing the
-simulation would bake fake-quant arithmetic into the graph, producing an
-artifact that looks fp32 to every runtime and runs slower than the float
-model. The supported bridge to deployment formats today:
+int8-quantized models export directly to ONNX with in-graph
+QuantizeLinear/DequantizeLinear pairs carrying the model's own calibrated
+(or QAT-trained) scales:
 
 ```python
-qmodel = LibreYOLO("runs/train/qat-run/weights/best.pt")  # QAT/QAD result
-qmodel.dequantize()   # restore float modules; QAT-trained masters are kept
-qmodel.export(format="onnx", int8=True, data="coco8.yaml")  # real QDQ INT8
+qmodel = LibreYOLO("LibreYOLO9s-int8.pt")   # PTQ or QAT/QAD checkpoint
+qmodel.export(format="onnx")                # scale-exact QDQ INT8 ONNX
 ```
 
-The QAT benefit lives mostly in the trained master weights, which this path
-preserves; activation scales are re-derived by the existing calibrated
-exporter. Scale-exact QDQ export (emitting QuantizeLinear/DequantizeLinear
-directly from the model's own calibrated scales) is the planned follow-up.
-`nvfp4` has no standard ONNX representation and stays PyTorch-executed.
+ONNX Runtime and TensorRT consume the QDQ graph with real INT8 kernels; on
+coco8 the exported artifact tracks the PyTorch simulation within sub-point
+noise. The CLI equivalent is
+`libreyolo export --model model-int8.pt --format onnx`. Notes:
+
+- `fp16` models: call `dequantize()` and export with `half=True` (the float
+  exporters already own fp16).
+- `nvfp4` has no standard ONNX representation and executes in PyTorch.
+- Other deployment formats for int8 are built downstream from the QDQ ONNX;
+  direct engine export is planned.
+- `dequantize()` remains available to restore float masters (QAT-trained
+  weights are kept) and use any float exporter.
 
 ## QAT and QAD mechanics
 
@@ -108,9 +113,9 @@ QAT is a finetune of an already-trained model: use finetune learning rates
 short run will destroy the pretrained weights regardless of quantization.
 
 QAD availability follows family distillation support: it works wherever the
-family implements `get_distill_config()` (yolo9 today). The grammar itself is
-family-independent, so rfdetr QAD activates as soon as that family gains
-distillation support.
+family implements `get_distill_config()` (yolo9 and rfdetr today; the
+RF-DETR tap point is the stride-16 backbone projector output, probed from
+the live model so future sizes stay correct).
 
 Family notes: RF-DETR calibration exercises the inference path, so modules
 that only run during training (denoising branches) keep their activation

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -45,13 +45,20 @@ manifest too, so `best.pt` from a QAT run is itself a quantized checkpoint.
 
 | Recipe | What it does | Families (v1) | Calibration |
 |---|---|---|---|
-| `fp16` | Casts the model to half precision with a float32 I/O contract. Inference-only. | yolo9, rfdetr | none |
+| `fp16` | Cast to half precision with a float32 I/O contract. Inference-only. | yolo9, rfdetr | none |
+| `bf16` | Cast to bfloat16 (fp32's exponent range at half storage; the fix when fp16 overflows on DETR-style models). Inference-only. | yolo9, rfdetr | none |
+| `fp8` | E4M3 W+A simulation: per-channel weight scales, calibrated per-tensor activation scales, on `Conv2d` and `Linear`. | yolo9, rfdetr | required for activations |
 | `int8` | W8A8 simulation: per-channel symmetric INT8 weights, per-tensor affine INT8 activations, on `Conv2d` and `Linear`. | yolo9, rfdetr | required for activations (skipped with `calib=None`, weights-only) |
-| `nvfp4` | W4A4 NVFP4 simulation on `Linear`: E2M1 elements, 16-element blocks, FP8 E4M3 block scales, FP32 tensor scale. Activations use dynamic block scaling. | rfdetr | not needed (dynamic) |
+| `w4a16` | Grouped symmetric INT4 weights (group 128 along in_features), float activations, on `Linear`. | rfdetr | not needed (weight-only) |
+| `w4a8` | Grouped INT4 weights plus calibrated INT8 activations, on `Linear`. Maps to NPU W4A8 deployments (Hexagon, Hailo `a8_w4`). | rfdetr | required for activations |
+| `nvfp4` | W4A4 NVFP4 simulation on `Linear`: E2M1 elements, 16-element blocks, FP8 E4M3 block scales, FP32 tensor scale. Dynamic activation scaling. | rfdetr | not needed (dynamic) |
+| `mxfp4` | OCP MXFP4 on `Linear`: E2M1 elements, 32-element blocks, power-of-two (E8M0) block scales. Dynamic activation scaling. | rfdetr | not needed (dynamic) |
+| `int2` | Research preview: grouped 2-bit weights (group 64) plus INT8 activations, on `Linear`. PTQ alone is unusable; QAT/QAD required. | rfdetr | required for activations |
 
-`nvfp4` is rejected for conv-heavy families such as yolo9 on purpose: FP4
-acceleration is GEMM-only on current hardware, so convolutions stay in higher
-precision. Transformer families (RF-DETR) are the NVFP4 target.
+Linear-only recipes are rejected for conv-heavy families such as yolo9 on
+purpose: sub-8-bit acceleration is GEMM-only on current hardware, so
+convolutions stay in higher precision. Transformer families (RF-DETR) are
+the target; yolo9 uses `int8` or `fp8`.
 
 Per-family `keep_high_precision` defaults protect the first layer and the
 heads (and always the YOLO9 DFL conv). Override with
@@ -129,9 +136,11 @@ coco8 the exported artifact tracks the PyTorch simulation within sub-point
 noise. The CLI equivalent is
 `libreyolo export --model model-int8.pt --format onnx`. Notes:
 
-- `fp16` models: call `dequantize()` and export with `half=True` (the float
-  exporters already own fp16).
-- `nvfp4` has no standard ONNX representation and executes in PyTorch.
+- Cast recipes (`fp16`/`bf16`): call `dequantize()` and use the float
+  exporters (`half=True` gives fp16 ONNX).
+- Sub-8-bit linear recipes (`w4a16`, `w4a8`, `nvfp4`, `mxfp4`, `int2`) and
+  `fp8` have no deployable ONNX form here yet; they execute in PyTorch and
+  crystallize via `format="pt"`.
 - Other deployment formats for int8 are built downstream from the QDQ ONNX;
   direct engine export is planned.
 - `dequantize()` remains available to restore float masters (QAT-trained

--- a/libreyolo/cli/__init__.py
+++ b/libreyolo/cli/__init__.py
@@ -105,7 +105,7 @@ def entrypoint() -> None:
     logging_argv = _normalize_logging_flags(argv)
     _setup_logging_from_argv(logging_argv)
 
-    from .commands import special, predict, train, val, export, ui, doctor, label, profile, monitor  # noqa: F401
+    from .commands import special, predict, train, val, export, quantize, ui, doctor, label, profile, monitor  # noqa: F401
     from .parsing import KeyValueCommand
 
     # Special commands
@@ -117,6 +117,7 @@ def entrypoint() -> None:
     app.command("train", cls=KeyValueCommand)(train.train_cmd)
     app.command("val", cls=KeyValueCommand)(val.val_cmd)
     app.command("export", cls=KeyValueCommand)(export.export_cmd)
+    app.command("quantize", cls=KeyValueCommand)(quantize.quantize_cmd)
     app.command("ui", cls=KeyValueCommand)(ui.ui_cmd)
     app.command("monitor", cls=KeyValueCommand)(monitor.monitor_cmd)
     app.command("label", cls=KeyValueCommand)(label.label_cmd)

--- a/libreyolo/cli/commands/quantize.py
+++ b/libreyolo/cli/commands/quantize.py
@@ -18,7 +18,9 @@ def quantize_cmd(
     model: str = typer.Option(..., help="Model weights (.pt)"),
     recipe: str = typer.Option(
         "int8",
-        help="Quantization recipe: fp16, int8, or nvfp4 (transformer families)",
+        help="Quantization recipe: fp16, bf16, fp8, int8, w4a16, w4a8, "
+        "nvfp4, mxfp4, int2 (research; w4/nvfp4/mxfp4/int2 target "
+        "transformer families)",
     ),
     calib: Optional[str] = typer.Option(
         "coco128.yaml",

--- a/libreyolo/cli/commands/quantize.py
+++ b/libreyolo/cli/commands/quantize.py
@@ -1,0 +1,96 @@
+"""Quantize command: PyTorch-native model quantization."""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from ..command_utils import (
+    exit_with_error,
+    help_json_callback,
+    load_model_or_exit,
+    resolve_model_or_exit,
+)
+from ..output import OutputHandler
+
+
+def quantize_cmd(
+    model: str = typer.Option(..., help="Model weights (.pt)"),
+    recipe: str = typer.Option(
+        "int8",
+        help="Quantization recipe: fp16, int8, or nvfp4 (transformer families)",
+    ),
+    calib: Optional[str] = typer.Option(
+        "coco8.yaml",
+        help="Calibration images (data.yaml or built-in dataset name); "
+        "unlabeled, forward-only. Use 'none' to skip calibration.",
+    ),
+    samples: int = typer.Option(128, help="Maximum calibration images"),
+    batch: int = typer.Option(8, help="Calibration batch size"),
+    out: Optional[str] = typer.Option(
+        None,
+        help="Output checkpoint path (default: <model>-<recipe>.pt)",
+    ),
+    device: str = typer.Option("auto", help="Device"),
+    allow_download_scripts: bool = typer.Option(
+        False,
+        "--allow-download-scripts",
+        help="Allow embedded Python in dataset YAML download blocks",
+    ),
+    # Agent flags
+    json_output: bool = typer.Option(False, "--json", help="JSON output to stdout"),
+    quiet: bool = typer.Option(False, "--quiet", help="Suppress stderr"),
+    help_json: bool = typer.Option(
+        False,
+        "--help-json",
+        is_eager=True,
+        callback=help_json_callback,
+        help="Dump command schema as JSON",
+    ),
+) -> None:
+    """Quantize a model in PyTorch and save a quantized checkpoint.
+
+    Calibration data is separate from training data: a small unlabeled image
+    set used forward-only to derive scales. To recover accuracy afterwards,
+    run `libreyolo train` on the quantized checkpoint (QAT), optionally with
+    --distill-model for QAD.
+    """
+    out_handler = OutputHandler(json_mode=json_output, quiet=quiet)
+
+    model_path = resolve_model_or_exit(out_handler, model)
+    loaded_model = load_model_or_exit(
+        out_handler, model=model, model_path=model_path, device=device
+    )
+
+    calib_arg = None if calib is None or calib.lower() == "none" else calib
+
+    try:
+        loaded_model.quantize(
+            recipe=recipe,
+            calib=calib_arg,
+            samples=samples,
+            batch=batch,
+            allow_download_scripts=allow_download_scripts,
+        )
+    except Exception as exc:
+        exit_with_error(out_handler, "quantize_failed", f"Quantization failed: {exc}")
+
+    if out is None:
+        src = Path(model_path)
+        out = str(src.with_name(f"{src.stem}-{recipe.lower()}{src.suffix or '.pt'}"))
+
+    try:
+        saved = loaded_model.save(out)
+    except Exception as exc:
+        exit_with_error(out_handler, "save_failed", f"Saving checkpoint failed: {exc}")
+
+    info = loaded_model.quant_info() or {}
+    out_handler.result(
+        {
+            "path": saved,
+            "recipe": recipe.lower(),
+            "execution": info.get("execution"),
+            "calibrated": info.get("calibrated"),
+            "module_counts": info.get("module_counts"),
+        }
+    )

--- a/libreyolo/cli/commands/quantize.py
+++ b/libreyolo/cli/commands/quantize.py
@@ -21,12 +21,17 @@ def quantize_cmd(
         help="Quantization recipe: fp16, int8, or nvfp4 (transformer families)",
     ),
     calib: Optional[str] = typer.Option(
-        "coco8.yaml",
+        "coco128.yaml",
         help="Calibration images (data.yaml or built-in dataset name); "
         "unlabeled, forward-only. Use 'none' to skip calibration.",
     ),
     samples: int = typer.Option(128, help="Maximum calibration images"),
     batch: int = typer.Option(8, help="Calibration batch size"),
+    algorithm: str = typer.Option(
+        "auto",
+        help="Activation range estimation: auto (minmax), minmax, "
+        "percentile (experimental)",
+    ),
     out: Optional[str] = typer.Option(
         None,
         help="Output checkpoint path (default: <model>-<recipe>.pt)",
@@ -70,6 +75,7 @@ def quantize_cmd(
             calib=calib_arg,
             samples=samples,
             batch=batch,
+            algorithm=algorithm,
             allow_download_scripts=allow_download_scripts,
         )
     except Exception as exc:

--- a/libreyolo/cli/commands/quantize.py
+++ b/libreyolo/cli/commands/quantize.py
@@ -71,6 +71,12 @@ def quantize_cmd(
 
     calib_arg = None if calib is None or calib.lower() == "none" else calib
 
+    if allow_download_scripts and calib_arg is not None:
+        out_handler.warning(
+            "Dataset download scripts are enabled. Embedded Python from the "
+            "dataset YAML may execute locally."
+        )
+
     try:
         loaded_model.quantize(
             recipe=recipe,

--- a/libreyolo/cli/errors.py
+++ b/libreyolo/cli/errors.py
@@ -35,6 +35,9 @@ EXIT_CODES: dict[str, int] = {
     "export_dep_missing": 5,
     "format_precision_unsupported": 5,
     "nms_unsupported_format": 5,
+    # Quantization errors
+    "quantize_failed": 5,
+    "save_failed": 5,
 }
 
 

--- a/libreyolo/export/calibration.py
+++ b/libreyolo/export/calibration.py
@@ -71,6 +71,8 @@ class CalibrationDataLoader:
                 Obtained from ``model._get_preprocess_numpy()``.
             allow_download_scripts: Allow embedded Python in dataset YAML downloads.
         """
+        if batch < 1:
+            raise ValueError(f"batch must be >= 1, got {batch}")
         self.imgsz = imgsz
         self.batch = batch
         self.fraction = max(0.0, min(1.0, fraction))

--- a/libreyolo/export/calibration.py
+++ b/libreyolo/export/calibration.py
@@ -165,6 +165,7 @@ def get_calibration_dataloader(
     fraction: float = 1.0,
     preprocess_fn=None,
     allow_download_scripts: bool = False,
+    samples: int | None = None,
 ) -> CalibrationDataLoader:
     """
     Factory function for calibration data loader.
@@ -175,15 +176,18 @@ def get_calibration_dataloader(
         batch: Batch size for calibration.
         fraction: Fraction of dataset to use.
         preprocess_fn: Callable ``(img_rgb_hwc, input_size) -> (chw_float32, ratio)``.
+        allow_download_scripts: Allow embedded Python in dataset YAML downloads.
+        samples: Optional hard cap on the number of calibration images.
 
     Returns:
         CalibrationDataLoader instance.
     """
     return CalibrationDataLoader(
         data,
-        imgsz,
-        batch,
-        fraction,
-        preprocess_fn,
-        allow_download_scripts,
+        imgsz=imgsz,
+        batch=batch,
+        fraction=fraction,
+        samples=samples,
+        preprocess_fn=preprocess_fn,
+        allow_download_scripts=allow_download_scripts,
     )

--- a/libreyolo/export/calibration.py
+++ b/libreyolo/export/calibration.py
@@ -52,6 +52,7 @@ class CalibrationDataLoader:
         imgsz: ImageSize = 640,
         batch: int = 8,
         fraction: float = 1.0,
+        samples: int | None = None,
         preprocess_fn=None,
         allow_download_scripts: bool = False,
     ):
@@ -64,6 +65,8 @@ class CalibrationDataLoader:
             batch: Batch size for calibration.
             fraction: Fraction of dataset to use (0.0-1.0). Use smaller values
                      for faster calibration with slight accuracy tradeoff.
+            samples: Optional hard cap on the number of calibration images,
+                applied after ``fraction``.
             preprocess_fn: Callable ``(img_rgb_hwc, input_size) -> (chw_float32, ratio)``.
                 Obtained from ``model._get_preprocess_numpy()``.
             allow_download_scripts: Allow embedded Python in dataset YAML downloads.
@@ -71,6 +74,7 @@ class CalibrationDataLoader:
         self.imgsz = imgsz
         self.batch = batch
         self.fraction = max(0.0, min(1.0, fraction))
+        self.samples = samples
         self._preprocess_fn = preprocess_fn
 
         # Load dataset config (handles resolve, download, path resolution)
@@ -101,6 +105,8 @@ class CalibrationDataLoader:
 
         total = len(self.img_files)
         self.num_samples = max(1, int(total * self.fraction))
+        if self.samples is not None:
+            self.num_samples = max(1, min(self.num_samples, int(self.samples)))
         self.img_files = self.img_files[: self.num_samples]
         self._num_batches = (self.num_samples + self.batch - 1) // self.batch
 

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -521,7 +521,14 @@ def LibreYOLO(
             "checkpoint with Cityscapes semantic metadata."
         )
 
-    # Auto-detect size
+    # Auto-detect size. Schema v1.0 metadata is authoritative when present;
+    # shape sniffing stays as the legacy fallback (and is required for raw
+    # upstream state dicts). Finalized quantized checkpoints replace some
+    # weight keys with packed payloads, so sniffing alone cannot cover them.
+    if size is None:
+        meta_size = loaded.get("size") if isinstance(loaded, dict) else None
+        if isinstance(meta_size, str) and meta_size:
+            size = meta_size
     if size is None:
         if matched_cls.FAMILY == "rfdetr":
             # RF-DETR needs the full checkpoint for args-based detection

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1321,8 +1321,10 @@ class BaseModel(ABC):
         existing ``distill_model`` kwargs (QAD).
 
         Args:
-            recipe: Quantization recipe: "fp16", "int8", or "nvfp4"
-                (nvfp4 targets transformer families such as rfdetr).
+            recipe: Quantization recipe. Casts: "fp16", "bf16". Conv+Linear:
+                "int8", "fp8". Linear-only (transformer families such as
+                rfdetr): "w4a16", "w4a8", "nvfp4", "mxfp4", and the
+                research preview "int2" (QAT required).
             calib: Calibration images: data.yaml path or built-in dataset
                 name. Pass None to skip calibration (int8 weights-only).
             samples: Maximum number of calibration images.

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -673,6 +673,14 @@ class BaseModel(ABC):
             else:
                 state_dict = self._prepare_state_dict(loaded)
 
+            quant_manifest = (
+                loaded.get("quant") if isinstance(loaded, dict) else None
+            )
+            if quant_manifest:
+                from ...quant import apply_quant_structure
+
+                apply_quant_structure(self, quant_manifest)
+
             self.model.load_state_dict(state_dict, strict=self._strict_loading())
             self.model.to(self.device).eval()
         except Exception as e:
@@ -1292,6 +1300,101 @@ class BaseModel(ABC):
             output_path=track_output,
             annotate_fn=annotate_tracked,
         )
+
+    def quantize(
+        self,
+        recipe: str,
+        calib: str | None = "coco8.yaml",
+        samples: int = 128,
+        batch: int = 8,
+        keep_high_precision: tuple | list | None = None,
+        allow_download_scripts: bool = False,
+        verbose: bool = True,
+    ):
+        """Quantize the loaded model in place (PyTorch execution) and return it.
+
+        Calibration data is separate from training data: it is a small set of
+        images used forward-only to derive activation ranges and scales.
+        Labels are never read. To recover accuracy afterwards, run the normal
+        training step on the returned model (QAT), optionally with the
+        existing ``distill_model`` kwargs (QAD).
+
+        Args:
+            recipe: Quantization recipe: "fp16", "int8", or "nvfp4"
+                (nvfp4 targets transformer families such as rfdetr).
+            calib: Calibration images: data.yaml path or built-in dataset
+                name. Pass None to skip calibration (int8 weights-only).
+            samples: Maximum number of calibration images.
+            batch: Calibration batch size.
+            keep_high_precision: Substring patterns of module names kept in
+                float. Defaults to the family policy (first layer + heads).
+            allow_download_scripts: Allow embedded Python in dataset YAML
+                download blocks.
+            verbose: Log a quantization summary.
+
+        Returns:
+            This model, quantized in place.
+
+        Example::
+
+            >>> model = LibreYOLO("LibreYOLO9s.pt")
+            >>> qmodel = model.quantize(recipe="int8", calib="coco8.yaml")
+            >>> qmodel.val(data="coco8.yaml")
+            >>> qmodel.train(data="coco8.yaml", epochs=5)  # QAT
+            >>> qmodel.save("LibreYOLO9s-int8.pt")
+        """
+        from libreyolo.quant import quantize_model
+
+        return quantize_model(
+            self,
+            recipe=recipe,
+            calib=calib,
+            samples=samples,
+            batch=batch,
+            keep_high_precision=(
+                tuple(keep_high_precision)
+                if keep_high_precision is not None
+                else None
+            ),
+            allow_download_scripts=allow_download_scripts,
+            verbose=verbose,
+        )
+
+    def quant_info(self) -> Optional[Dict[str, Any]]:
+        """Return the quantization state summary, or None for float models."""
+        from libreyolo.quant import quant_info
+
+        return quant_info(self)
+
+    def save(self, path: str) -> str:
+        """Save the current model as a LibreYOLO checkpoint.
+
+        Writes schema v1.0 metadata; quantized models additionally carry the
+        ``quant`` manifest so ``LibreYOLO(path)`` restores the quantized
+        structure and scales.
+        """
+        from libreyolo.utils.serialization import wrap_libreyolo_checkpoint
+
+        state_dict = {k: v.cpu() for k, v in self.model.state_dict().items()}
+        checkpoint = wrap_libreyolo_checkpoint(
+            state_dict,
+            model_family=self._get_model_name(),
+            size=self.size,
+            task=self.task,
+            nc=self.nb_classes,
+            names=self.names,
+            imgsz=int(self._get_input_size()),
+        )
+        quant_manifest = getattr(self, "_quant_manifest", None)
+        if quant_manifest:
+            checkpoint["quant"] = dict(quant_manifest)
+
+        out = Path(path)
+        if out.parent != Path("."):
+            out.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(checkpoint, out)
+        logger.info("Saved checkpoint to %s", out)
+        return str(out)
 
     def export(self, format: str = "onnx", **kwargs) -> str:
         """Export model to deployment format.

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1366,6 +1366,18 @@ class BaseModel(ABC):
 
         return quant_info(self)
 
+    def dequantize(self):
+        """Restore float modules in place, keeping the master weights.
+
+        After QAT/QAD the masters are quantization-trained, so this is the
+        bridge to the deployment exporters: ``model.dequantize()`` then
+        ``model.export(format="onnx", int8=True, data=...)`` produces a real
+        QDQ INT8 artifact from QAT-trained weights.
+        """
+        from libreyolo.quant import dequantize_model
+
+        return dequantize_model(self)
+
     def save(self, path: str) -> str:
         """Save the current model as a LibreYOLO checkpoint.
 
@@ -1408,6 +1420,19 @@ class BaseModel(ABC):
         Returns:
             Path to the exported model file.
         """
+        if getattr(self, "_quant_manifest", None):
+            from libreyolo.quant import QuantizationError
+
+            recipe = self._quant_manifest.get("recipe")
+            raise QuantizationError(
+                f"Export of quantized models is not supported yet "
+                f"(recipe='{recipe}'): tracing would bake simulation "
+                "arithmetic into the graph instead of producing a deployable "
+                "quantized artifact. Call model.dequantize() first (QAT-"
+                "trained master weights are kept), then export, e.g. "
+                "model.export(format='onnx', int8=True, data='coco8.yaml')."
+            )
+
         from libreyolo.export import BaseExporter
 
         return BaseExporter.create(format, self)(**kwargs)

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1421,17 +1421,9 @@ class BaseModel(ABC):
             Path to the exported model file.
         """
         if getattr(self, "_quant_manifest", None):
-            from libreyolo.quant import QuantizationError
+            from libreyolo.quant.api import quantized_export
 
-            recipe = self._quant_manifest.get("recipe")
-            raise QuantizationError(
-                f"Export of quantized models is not supported yet "
-                f"(recipe='{recipe}'): tracing would bake simulation "
-                "arithmetic into the graph instead of producing a deployable "
-                "quantized artifact. Call model.dequantize() first (QAT-"
-                "trained master weights are kept), then export, e.g. "
-                "model.export(format='onnx', int8=True, data='coco8.yaml')."
-            )
+            return quantized_export(self, format=format, **kwargs)
 
         from libreyolo.export import BaseExporter
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1304,9 +1304,10 @@ class BaseModel(ABC):
     def quantize(
         self,
         recipe: str,
-        calib: str | None = "coco8.yaml",
+        calib: str | None = "coco128.yaml",
         samples: int = 128,
         batch: int = 8,
+        algorithm: str = "auto",
         keep_high_precision: tuple | list | None = None,
         allow_download_scripts: bool = False,
         verbose: bool = True,
@@ -1326,6 +1327,11 @@ class BaseModel(ABC):
                 name. Pass None to skip calibration (int8 weights-only).
             samples: Maximum number of calibration images.
             batch: Calibration batch size.
+            algorithm: Activation range estimation: "minmax" (absolute
+                extremes across batches; the measured best default),
+                "percentile" (experimental: mean of per-batch 0.1/99.9
+                percentiles; degrades transformer families), or "auto"
+                (minmax).
             keep_high_precision: Substring patterns of module names kept in
                 float. Defaults to the family policy (first layer + heads).
             allow_download_scripts: Allow embedded Python in dataset YAML
@@ -1351,6 +1357,7 @@ class BaseModel(ABC):
             calib=calib,
             samples=samples,
             batch=batch,
+            algorithm=algorithm,
             keep_high_precision=(
                 tuple(keep_high_precision)
                 if keep_high_precision is not None

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -952,6 +952,14 @@ class LibreRFDETR(BaseModel):
             ):
                 apply_lora_to_rfdetr(self.model.model)
 
+            quant_manifest = loaded.get("quant")
+            if quant_manifest:
+                # Rebuild the quantized module structure first so the _q_*
+                # scale buffers in the checkpoint resolve to real modules.
+                from ...quant import apply_quant_structure
+
+                apply_quant_structure(self, quant_manifest)
+
             missing, unexpected = self.model.load_state_dict(loaded, strict=False)
             if unexpected:
                 raise RuntimeError(

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -615,6 +615,54 @@ class LibreRFDETR(BaseModel):
         """Rebuild the detector head for a new class count."""
         super()._rebuild_for_new_classes(new_nc)
 
+    def get_distill_config(self) -> Dict:
+        """Return distillation config derived from this model's architecture.
+
+        The tap point is the backbone projector output: the single stride-16
+        feature map every RF-DETR size feeds its transformer. All current
+        sizes share the same projector width, so detector-teacher
+        distillation aligns teacher and student without channel adapters.
+        The shape is measured with a one-time probe forward so the config
+        stays correct if a future size changes the projector width.
+        """
+        tap = "model.backbone.0.projector.stages.0"
+        module = self.model
+        for part in tap.split("."):
+            module = module[int(part)] if part.isdigit() else getattr(module, part)
+
+        captured: Dict[str, Tuple[int, ...]] = {}
+
+        def _hook(_mod, _args, out):
+            if torch.is_tensor(out) and out.dim() == 4:
+                captured["shape"] = tuple(out.shape)
+
+        handle = module.register_forward_hook(_hook)
+        was_training = self.model.training
+        self.model.eval()
+        try:
+            with torch.no_grad():
+                device = next(self.model.parameters()).device
+                dummy = torch.zeros(
+                    1, 3, self.input_size, self.input_size, device=device
+                )
+                self.model(dummy)
+        finally:
+            handle.remove()
+            if was_training:
+                self.model.train()
+
+        shape = captured.get("shape")
+        if shape is None:
+            raise NotImplementedError(
+                "Could not probe the RF-DETR projector output for "
+                "distillation; the projector structure is unexpected."
+            )
+        return {
+            "tap_points": [tap],
+            "channels": [int(shape[1])],
+            "strides": [int(self.input_size // shape[2])],
+        }
+
     def _get_available_layers(self) -> Dict[str, nn.Module]:
         layers = {}
         if hasattr(self.model, "model"):

--- a/libreyolo/quant/__init__.py
+++ b/libreyolo/quant/__init__.py
@@ -18,8 +18,10 @@ from .api import (
     apply_quant_structure,
     default_keep_high_precision,
     dequantize_model,
+    export_finalized_pt,
     quant_info,
     quantize_model,
+    reprepare_model,
 )
 from .modules import NVFP4Linear, QuantConv2d, QuantLinear
 
@@ -32,8 +34,10 @@ __all__ = [
     "apply_quant_structure",
     "default_keep_high_precision",
     "dequantize_model",
+    "export_finalized_pt",
     "quant_info",
     "quantize_model",
+    "reprepare_model",
     "NVFP4Linear",
     "QuantConv2d",
     "QuantLinear",

--- a/libreyolo/quant/__init__.py
+++ b/libreyolo/quant/__init__.py
@@ -17,6 +17,7 @@ from .api import (
     SUPPORTED_FAMILIES,
     apply_quant_structure,
     default_keep_high_precision,
+    dequantize_model,
     quant_info,
     quantize_model,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "SUPPORTED_FAMILIES",
     "apply_quant_structure",
     "default_keep_high_precision",
+    "dequantize_model",
     "quant_info",
     "quantize_model",
     "NVFP4Linear",

--- a/libreyolo/quant/__init__.py
+++ b/libreyolo/quant/__init__.py
@@ -23,7 +23,13 @@ from .api import (
     quantize_model,
     reprepare_model,
 )
-from .modules import NVFP4Linear, QuantConv2d, QuantLinear
+from .modules import (
+    GroupQuantLinear,
+    MXFP4Linear,
+    NVFP4Linear,
+    QuantConv2d,
+    QuantLinear,
+)
 
 __all__ = [
     "DEFAULT_CALIB_DATA",
@@ -38,6 +44,8 @@ __all__ = [
     "quant_info",
     "quantize_model",
     "reprepare_model",
+    "GroupQuantLinear",
+    "MXFP4Linear",
     "NVFP4Linear",
     "QuantConv2d",
     "QuantLinear",

--- a/libreyolo/quant/__init__.py
+++ b/libreyolo/quant/__init__.py
@@ -1,0 +1,38 @@
+"""PyTorch-native quantization for LibreYOLO models.
+
+Public grammar::
+
+    model = LibreYOLO("LibreYOLO9s.pt")
+    qmodel = model.quantize(recipe="int8", calib="coco8.yaml", samples=128)
+    qmodel.val(data="coco8.yaml")          # honest accuracy, same validators
+    qmodel.train(data="coco8.yaml", ...)   # QAT (add distill_model=... for QAD)
+    qmodel.save("LibreYOLO9s-int8.pt")     # manifest-carrying checkpoint
+"""
+
+from .api import (
+    DEFAULT_CALIB_DATA,
+    QUANT_SCHEMA_VERSION,
+    QuantizationError,
+    RECIPES,
+    SUPPORTED_FAMILIES,
+    apply_quant_structure,
+    default_keep_high_precision,
+    quant_info,
+    quantize_model,
+)
+from .modules import NVFP4Linear, QuantConv2d, QuantLinear
+
+__all__ = [
+    "DEFAULT_CALIB_DATA",
+    "QUANT_SCHEMA_VERSION",
+    "QuantizationError",
+    "RECIPES",
+    "SUPPORTED_FAMILIES",
+    "apply_quant_structure",
+    "default_keep_high_precision",
+    "quant_info",
+    "quantize_model",
+    "NVFP4Linear",
+    "QuantConv2d",
+    "QuantLinear",
+]

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -158,8 +158,10 @@ def _install_fp16_io_hooks(root: nn.Module):
         return _cast_tree(output, torch.float32)
 
     root.half()
-    root.register_forward_pre_hook(_pre)
-    root.register_forward_hook(_post)
+    root._q_fp16_hooks = [
+        root.register_forward_pre_hook(_pre),
+        root.register_forward_hook(_post),
+    ]
 
 
 def _set_observing(root: nn.Module, flag: bool):
@@ -309,6 +311,62 @@ def quantize_model(
             info.get("execution"),
             info.get("calibrated"),
         )
+    return wrapper
+
+
+def dequantize_model(wrapper):
+    """Restore float modules in place, keeping the master weights.
+
+    After QAT/QAD the fp32 masters are quantization-trained, so the restored
+    float model is the correct input for deployment exporters (for example
+    ``export(format="onnx", int8=True, data=...)``, which re-derives QDQ
+    scales through the existing calibrated exporter). For the ``fp16`` recipe
+    this restores dtype and removes the I/O cast hooks; the mantissa bits
+    lost by the earlier half-cast are not recoverable.
+    """
+    manifest = getattr(wrapper, "_quant_manifest", None)
+    if not manifest:
+        return wrapper
+    root = wrapper.model
+
+    if manifest.get("recipe") == "fp16":
+        for handle in getattr(root, "_q_fp16_hooks", ()):
+            handle.remove()
+        if hasattr(root, "_q_fp16_hooks"):
+            del root._q_fp16_hooks
+        root.float()
+    else:
+        for name, module in list(_quant_modules(root)):
+            if isinstance(module, QuantConv2d):
+                new = nn.Conv2d(
+                    module.in_channels,
+                    module.out_channels,
+                    module.kernel_size,
+                    stride=module.stride,
+                    padding=module.padding,
+                    dilation=module.dilation,
+                    groups=module.groups,
+                    bias=module.bias is not None,
+                    padding_mode=module.padding_mode,
+                    device=module.weight.device,
+                    dtype=module.weight.dtype,
+                )
+            elif isinstance(module, (QuantLinear, NVFP4Linear)):
+                new = nn.Linear(
+                    module.in_features,
+                    module.out_features,
+                    bias=module.bias is not None,
+                    device=module.weight.device,
+                    dtype=module.weight.dtype,
+                )
+            else:
+                continue
+            new.weight = module.weight
+            new.bias = module.bias
+            _swap_module(root, name, new)
+
+    wrapper._quant_manifest = None
+    logger.info("Restored float modules (recipe '%s' removed).", manifest.get("recipe"))
     return wrapper
 
 

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -218,6 +218,7 @@ def quant_info(wrapper) -> Optional[Dict]:
     if not manifest:
         return None
     info = dict(manifest)
+    info.setdefault("state", "prepared")
     counts = {"conv_int8": 0, "linear_int8": 0, "linear_nvfp4": 0}
     calibrated = True
     for _, module in _quant_modules(wrapper.model):
@@ -358,10 +359,108 @@ def quantize_model(
 def _set_export_mode(root: nn.Module, enabled: bool):
     for _, module in _quant_modules(root):
         if isinstance(module, (QuantConv2d, QuantLinear)):
-            if enabled:
+            if enabled and not module.is_finalized:
                 module.freeze_weight_qparams()
             module._q_export_mode = enabled
             module._q_observing = False
+
+
+def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
+    """Write the crystallized quantized checkpoint (deployment artifact).
+
+    Packed low-bit weights + scales + manifest, masters stripped. Unpacking
+    reproduces the simulation bit for bit, so a finalized checkpoint scores
+    exactly what the prepared model scores (with ``remainder="fp32"``;
+    ``"fp16"`` additionally halves every non-quantized float tensor, a
+    near-lossless size win). Loading one yields an inference-ready model;
+    training it re-prepares masters from the packed weights (QAT-from-PTQ).
+    """
+    import copy
+    from pathlib import Path
+
+    from ..utils.serialization import wrap_libreyolo_checkpoint
+
+    manifest = dict(wrapper._quant_manifest)
+    recipe = manifest.get("recipe")
+    remainder = str(remainder).lower()
+    if remainder not in ("fp16", "fp32"):
+        raise QuantizationError(
+            f"remainder must be 'fp16' or 'fp32', got '{remainder}'."
+        )
+
+    # Finalize a deep copy and let the family's own state_dict() produce
+    # the keys (some families re-key their state dicts, so name-based key
+    # surgery would miss them). The live model stays prepared and trainable.
+    # Packing runs on the live device: quantization kernels can round one
+    # code differently across devices, and the invariant we promise is
+    # "finalized scores exactly what you validated on this device".
+    model_copy = copy.deepcopy(wrapper.model)
+    with torch.no_grad():
+        if recipe in ("int8", "nvfp4"):
+            for _, module in _quant_modules(model_copy):
+                if hasattr(module, "make_finalized"):
+                    module.make_finalized()
+        model_copy = model_copy.cpu()
+        new_sd = model_copy.state_dict()
+        if remainder == "fp16" and recipe != "fp16":
+            keep_exact = ("_q_w_scale", "_q_act_lo", "_q_act_hi", "_q_w_amax")
+            new_sd = {
+                key: (
+                    value.half()
+                    if torch.is_tensor(value)
+                    and value.dtype == torch.float32
+                    and not key.endswith(keep_exact)
+                    else value
+                )
+                for key, value in new_sd.items()
+            }
+    del model_copy
+
+    manifest["state"] = "finalized"
+    manifest["remainder"] = remainder if recipe != "fp16" else "fp16"
+
+    checkpoint = wrap_libreyolo_checkpoint(
+        new_sd,
+        model_family=wrapper._get_model_name(),
+        size=wrapper.size,
+        task=wrapper.task,
+        nc=wrapper.nb_classes,
+        names=wrapper.names,
+        imgsz=int(wrapper._get_input_size()),
+    )
+    checkpoint["quant"] = manifest
+
+    if out is None:
+        if wrapper.model_path:
+            src = Path(str(wrapper.model_path))
+            out = src.with_name(f"{src.stem}-final{src.suffix or '.pt'}")
+        else:
+            out = f"{wrapper._get_model_name()}{wrapper.size}-{recipe}-final.pt"
+    out = Path(out)
+    if out.parent != Path("."):
+        out.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(checkpoint, out)
+    logger.info("Finalized %s checkpoint saved to %s", recipe, out)
+    return str(out)
+
+
+def reprepare_model(wrapper):
+    """Reconstruct fp32 masters from a finalized model (QAT-from-PTQ)."""
+    manifest = getattr(wrapper, "_quant_manifest", None)
+    if not manifest or manifest.get("state") != "finalized":
+        return wrapper
+    for _, module in _quant_modules(wrapper.model):
+        if hasattr(module, "make_prepared"):
+            module.make_prepared()
+    manifest = dict(manifest)
+    manifest["state"] = "prepared"
+    wrapper._quant_manifest = manifest
+    wrapper.model.to(wrapper.device)
+    logger.info(
+        "Re-prepared finalized checkpoint: fp32 masters reconstructed from "
+        "packed weights (QAT-from-PTQ)."
+    )
+    return wrapper
 
 
 def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
@@ -376,6 +475,18 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
     manifest = getattr(wrapper, "_quant_manifest", None) or {}
     recipe = manifest.get("recipe")
     fmt = str(format).lower()
+
+    if fmt in ("pt", "pytorch"):
+        out = kwargs.pop("out", None)
+        remainder = kwargs.pop("remainder", "fp16")
+        if kwargs:
+            logger.info("Ignoring export kwargs for format='pt': %s", sorted(kwargs))
+        return export_finalized_pt(wrapper, out=out, remainder=remainder)
+
+    if manifest.get("state") == "finalized" and fmt == "onnx" and recipe == "int8":
+        # QDQ emission traces fake-quant over fp32 masters; reconstruct them
+        # from the packed weights (exact by the packing invariant).
+        reprepare_model(wrapper)
 
     if recipe == "fp16":
         raise QuantizationError(
@@ -447,6 +558,10 @@ def dequantize_model(wrapper):
         root.float()
     else:
         for name, module in list(_quant_modules(root)):
+            finalized = getattr(module, "is_finalized", False)
+            ref = module.bias if module.bias is not None else next(
+                iter(module.buffers())
+            )
             if isinstance(module, QuantConv2d):
                 new = nn.Conv2d(
                     module.in_channels,
@@ -458,20 +573,24 @@ def dequantize_model(wrapper):
                     groups=module.groups,
                     bias=module.bias is not None,
                     padding_mode=module.padding_mode,
-                    device=module.weight.device,
-                    dtype=module.weight.dtype,
+                    device=ref.device,
+                    dtype=torch.float32,
                 )
             elif isinstance(module, (QuantLinear, NVFP4Linear)):
                 new = nn.Linear(
                     module.in_features,
                     module.out_features,
                     bias=module.bias is not None,
-                    device=module.weight.device,
-                    dtype=module.weight.dtype,
+                    device=ref.device,
+                    dtype=torch.float32,
                 )
             else:
                 continue
-            new.weight = module.weight
+            if finalized:
+                with torch.no_grad():
+                    new.weight = nn.Parameter(module._effective_weight())
+            else:
+                new.weight = module.weight
             new.bias = module.bias
             _swap_module(root, name, new)
 
@@ -515,6 +634,12 @@ def apply_quant_structure(wrapper, manifest: Dict):
                 expected,
                 already,
             )
+        if manifest.get("state") == "finalized":
+            # Build the packed-buffer structure so the checkpoint's payload
+            # and scale tensors resolve; load_state_dict fills them next.
+            for _, module in _quant_modules(wrapper.model):
+                if hasattr(module, "make_finalized"):
+                    module.make_finalized()
         if swapped:
             wrapper.model.to(wrapper.device)
 

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -21,14 +21,42 @@ from typing import Dict, Optional, Tuple
 import torch
 import torch.nn as nn
 
-from .modules import NVFP4Linear, QuantConv2d, QuantLinear
+from .modules import (
+    GroupQuantLinear,
+    MXFP4Linear,
+    NVFP4Linear,
+    QUANT_MODULE_TYPES,
+    QuantConv2d,
+    QuantLinear,
+)
 
 logger = logging.getLogger(__name__)
 
 QUANT_SCHEMA_VERSION = "1.0"
-RECIPES = ("fp16", "int8", "nvfp4")
+RECIPES = (
+    "fp16",
+    "bf16",
+    "fp8",
+    "int8",
+    "w4a16",
+    "w4a8",
+    "nvfp4",
+    "mxfp4",
+    "int2",
+)
+# Recipe classes: casts touch dtype only; conv recipes quantize Conv2d and
+# Linear; linear recipes quantize nn.Linear only (transformer families).
+CAST_RECIPES = ("fp16", "bf16")
+CONV_RECIPES = ("int8", "fp8")
+LINEAR_RECIPES = ("w4a16", "w4a8", "nvfp4", "mxfp4", "int2")
+# Recipes whose activations need calibration statistics.
+CALIBRATED_RECIPES = ("int8", "fp8", "w4a8", "int2")
+RESEARCH_RECIPES = ("int2",)
 SUPPORTED_FAMILIES = ("yolo9", "rfdetr")
 CALIB_ALGORITHMS = ("auto", "percentile", "minmax")
+
+GROUP_SIZE = 128  # grouped-int recipes: scale group along in_features
+INT2_GROUP_SIZE = 64
 
 DEFAULT_CALIB_DATA = "coco128.yaml"
 
@@ -69,11 +97,12 @@ def _check_support(family: str, recipe: str):
             f"Quantization is not supported for model family '{family}' yet. "
             f"Supported families: {', '.join(SUPPORTED_FAMILIES)}"
         )
-    if family == "yolo9" and recipe == "nvfp4":
+    if family == "yolo9" and recipe in LINEAR_RECIPES:
         raise QuantizationError(
-            "nvfp4 is not supported for the conv-heavy yolo9 family: FP4 "
-            "acceleration is GEMM-only, so convolutions stay in higher "
-            "precision. Use recipe='int8' for yolo9, or nvfp4 on the "
+            f"'{recipe}' targets nn.Linear layers and is not supported for "
+            "the conv-heavy yolo9 family (sub-8-bit acceleration is "
+            "GEMM-only, so convolutions stay in higher precision). Use "
+            "recipe='int8' or 'fp8' for yolo9, or this recipe on the "
             "transformer-based rfdetr family."
         )
 
@@ -95,10 +124,10 @@ def _select_modules(
     for name, module in root.named_modules():
         if not name or _is_excluded(name, keep):
             continue
-        if recipe == "int8":
+        if recipe in CONV_RECIPES:
             if type(module) is nn.Conv2d or type(module) is nn.Linear:
                 selected[name] = module
-        elif recipe == "nvfp4":
+        elif recipe in LINEAR_RECIPES:
             if type(module) is nn.Linear:
                 selected[name] = module
     return selected
@@ -113,24 +142,53 @@ def _swap_module(root: nn.Module, name: str, new_module: nn.Module):
 
 
 def _swap_selected(root: nn.Module, recipe: str, selected: Dict[str, nn.Module]) -> Dict[str, int]:
-    counts = {"conv_int8": 0, "linear_int8": 0, "linear_nvfp4": 0}
+    counts: Dict[str, int] = {}
+
+    def _count(kind: str):
+        counts[kind] = counts.get(kind, 0) + 1
+
     for name, module in selected.items():
-        if recipe == "int8":
-            if type(module) is nn.Conv2d:
-                _swap_module(root, name, QuantConv2d.from_float(module))
-                counts["conv_int8"] += 1
-            else:
-                _swap_module(root, name, QuantLinear.from_float(module))
-                counts["linear_int8"] += 1
+        if recipe in CONV_RECIPES:
+            is_conv = type(module) is nn.Conv2d
+            new = (
+                QuantConv2d.from_float(module)
+                if is_conv
+                else QuantLinear.from_float(module)
+            )
+            new._q_wformat = recipe  # "int8" | "fp8"
+            new._q_aformat = recipe
+            kind = f"{'conv' if is_conv else 'linear'}_{recipe}"
+            new._q_kind = kind
+            _swap_module(root, name, new)
+            _count(kind)
         elif recipe == "nvfp4":
-            _swap_module(root, name, NVFP4Linear.from_float(module))
-            counts["linear_nvfp4"] += 1
+            new = NVFP4Linear.from_float(module)
+            new._q_kind = "linear_nvfp4"
+            _swap_module(root, name, new)
+            _count("linear_nvfp4")
+        elif recipe == "mxfp4":
+            new = MXFP4Linear.from_float(module)
+            new._q_kind = "linear_mxfp4"
+            _swap_module(root, name, new)
+            _count("linear_mxfp4")
+        elif recipe in ("w4a16", "w4a8", "int2"):
+            bits = 2 if recipe == "int2" else 4
+            group = INT2_GROUP_SIZE if recipe == "int2" else GROUP_SIZE
+            new = GroupQuantLinear.from_float(
+                module,
+                bits=bits,
+                group_size=group,
+                act_int8=recipe in ("w4a8", "int2"),
+            )
+            new._q_kind = f"linear_{recipe}"
+            _swap_module(root, name, new)
+            _count(f"linear_{recipe}")
     return counts
 
 
 def _quant_modules(root: nn.Module):
     for name, module in root.named_modules():
-        if isinstance(module, (QuantConv2d, QuantLinear, NVFP4Linear)):
+        if isinstance(module, QUANT_MODULE_TYPES):
             yield name, module
 
 
@@ -146,23 +204,27 @@ def _cast_tree(obj, dtype):
     return obj
 
 
-def _install_fp16_io_hooks(root: nn.Module):
-    """Half the model and keep the float32 I/O contract at the root."""
+def _install_cast_io_hooks(root: nn.Module, dtype: torch.dtype):
+    """Cast the model to a half-width dtype, keeping float32 I/O at the root."""
 
     def _pre(module, args):
         return tuple(
-            a.half() if torch.is_tensor(a) and a.dtype == torch.float32 else a
+            a.to(dtype) if torch.is_tensor(a) and a.dtype == torch.float32 else a
             for a in args
         )
 
     def _post(module, args, output):
         return _cast_tree(output, torch.float32)
 
-    root.half()
+    root.to(dtype)
     root._q_fp16_hooks = [
         root.register_forward_pre_hook(_pre),
         root.register_forward_hook(_post),
     ]
+
+
+def _cast_dtype(recipe: str) -> torch.dtype:
+    return torch.float16 if recipe == "fp16" else torch.bfloat16
 
 
 def _set_observing(root: nn.Module, flag: bool):
@@ -219,18 +281,18 @@ def quant_info(wrapper) -> Optional[Dict]:
         return None
     info = dict(manifest)
     info.setdefault("state", "prepared")
-    counts = {"conv_int8": 0, "linear_int8": 0, "linear_nvfp4": 0}
+    counts: Dict[str, int] = {}
     calibrated = True
     for _, module in _quant_modules(wrapper.model):
-        if isinstance(module, QuantConv2d):
-            counts["conv_int8"] += 1
-        elif isinstance(module, NVFP4Linear):
-            counts["linear_nvfp4"] += 1
-        elif isinstance(module, QuantLinear):
-            counts["linear_int8"] += 1
-        calibrated = calibrated and module.q_calibrated
+        kind = getattr(module, "_q_kind", type(module).__name__)
+        counts[kind] = counts.get(kind, 0) + 1
+        needs_act_calib = not (
+            isinstance(module, GroupQuantLinear) and not module._q_act_enabled
+        )
+        if needs_act_calib:
+            calibrated = calibrated and module.q_calibrated
     info["module_counts"] = counts
-    if manifest.get("recipe") != "fp16":
+    if manifest.get("recipe") not in CAST_RECIPES:
         info["calibrated"] = calibrated
     return info
 
@@ -295,13 +357,22 @@ def quantize_model(
         "module_count": 0,
     }
 
-    if recipe == "fp16":
+    if recipe in CAST_RECIPES:
         if wrapper.device.type == "cpu":
-            logger.warning("fp16 on CPU is functional but slow; use a GPU device.")
-        _install_fp16_io_hooks(wrapper.model)
+            logger.warning(
+                "%s on CPU is functional but slow; use a GPU device.", recipe
+            )
+        _install_cast_io_hooks(wrapper.model, _cast_dtype(recipe))
         manifest["execution"] = "native"
         manifest["calibrated"] = True
     else:
+        if recipe in RESEARCH_RECIPES:
+            logger.warning(
+                "'%s' is a research preview: PTQ at this bit width is not "
+                "usable on its own. Run train() on the quantized model "
+                "(QAT, or QAD with distill_model=) to recover accuracy.",
+                recipe,
+            )
         selected = _select_modules(wrapper.model, recipe, keep)
         if not selected:
             raise QuantizationError(
@@ -311,7 +382,7 @@ def quantize_model(
         counts = _swap_selected(wrapper.model, recipe, selected)
         manifest["module_count"] = sum(counts.values())
 
-        if recipe == "int8":
+        if recipe in CALIBRATED_RECIPES:
             if calib is not None:
                 seen = _run_calibration(
                     wrapper,
@@ -327,14 +398,17 @@ def quantize_model(
                 manifest["calib_algorithm"] = algorithm
             else:
                 logger.warning(
-                    "int8 quantization without calibration: activations stay "
-                    "in float (W8 simulation only). Pass calib= to calibrate."
+                    "%s quantization without calibration: activations stay "
+                    "in float (weight-only simulation). Pass calib= to "
+                    "calibrate.",
+                    recipe,
                 )
-        elif recipe == "nvfp4":
+        else:
             if calib is not None and calib != DEFAULT_CALIB_DATA:
                 logger.info(
-                    "nvfp4 activations use dynamic block scaling; calibration "
-                    "data is not needed and was ignored."
+                    "'%s' needs no activation calibration (dynamic or "
+                    "weight-only scaling); calibration data was ignored.",
+                    recipe,
                 )
             manifest["calibrated"] = True
 
@@ -396,13 +470,13 @@ def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
     # "finalized scores exactly what you validated on this device".
     model_copy = copy.deepcopy(wrapper.model)
     with torch.no_grad():
-        if recipe in ("int8", "nvfp4"):
+        if recipe not in CAST_RECIPES:
             for _, module in _quant_modules(model_copy):
                 if hasattr(module, "make_finalized"):
                     module.make_finalized()
         model_copy = model_copy.cpu()
         new_sd = model_copy.state_dict()
-        if remainder == "fp16" and recipe != "fp16":
+        if remainder == "fp16" and recipe not in CAST_RECIPES:
             keep_exact = ("_q_w_scale", "_q_act_lo", "_q_act_hi", "_q_w_amax")
             new_sd = {
                 key: (
@@ -417,7 +491,7 @@ def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
     del model_copy
 
     manifest["state"] = "finalized"
-    manifest["remainder"] = remainder if recipe != "fp16" else "fp16"
+    manifest["remainder"] = recipe if recipe in CAST_RECIPES else remainder
 
     checkpoint = wrap_libreyolo_checkpoint(
         new_sd,
@@ -483,27 +557,24 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
             logger.info("Ignoring export kwargs for format='pt': %s", sorted(kwargs))
         return export_finalized_pt(wrapper, out=out, remainder=remainder)
 
-    if manifest.get("state") == "finalized" and fmt == "onnx" and recipe == "int8":
+    if recipe in CAST_RECIPES:
+        raise QuantizationError(
+            f"{recipe}-quantized models do not need a quantized exporter: "
+            "call model.dequantize() and export with the float exporters "
+            "(half=True gives fp16 ONNX), or use format='pt'."
+        )
+    if recipe != "int8":
+        raise QuantizationError(
+            f"'{recipe}' has no deployable ONNX form yet; it executes in "
+            "PyTorch. Use format='pt' for the crystallized checkpoint, or "
+            "dequantize() to use the float exporters."
+        )
+
+    if manifest.get("state") == "finalized" and fmt == "onnx":
         # QDQ emission traces fake-quant over fp32 masters; reconstruct them
         # from the packed weights (exact by the packing invariant).
         reprepare_model(wrapper)
 
-    if recipe == "fp16":
-        raise QuantizationError(
-            "fp16-quantized models do not need a quantized exporter: call "
-            "model.dequantize() and export with half=True, e.g. "
-            "model.export(format='onnx', half=True)."
-        )
-    if recipe == "nvfp4":
-        raise QuantizationError(
-            "nvfp4 has no standard ONNX representation and executes in "
-            "PyTorch. Deploy the PyTorch model directly, or dequantize() and "
-            "use the float exporters."
-        )
-    if recipe != "int8":
-        raise QuantizationError(
-            f"Export is not supported for quantization recipe '{recipe}'."
-        )
     if fmt != "onnx":
         raise QuantizationError(
             "int8-quantized export currently supports format='onnx' (QDQ "
@@ -550,7 +621,7 @@ def dequantize_model(wrapper):
         return wrapper
     root = wrapper.model
 
-    if manifest.get("recipe") == "fp16":
+    if manifest.get("recipe") in CAST_RECIPES:
         for handle in getattr(root, "_q_fp16_hooks", ()):
             handle.remove()
         if hasattr(root, "_q_fp16_hooks"):
@@ -576,7 +647,9 @@ def dequantize_model(wrapper):
                     device=ref.device,
                     dtype=torch.float32,
                 )
-            elif isinstance(module, (QuantLinear, NVFP4Linear)):
+            elif isinstance(
+                module, (QuantLinear, NVFP4Linear, MXFP4Linear, GroupQuantLinear)
+            ):
                 new = nn.Linear(
                     module.in_features,
                     module.out_features,
@@ -612,9 +685,9 @@ def apply_quant_structure(wrapper, manifest: Dict):
         )
     _check_support(wrapper.FAMILY, recipe)
 
-    if recipe == "fp16":
+    if recipe in CAST_RECIPES:
         if not getattr(wrapper, "_quant_manifest", None):
-            _install_fp16_io_hooks(wrapper.model)
+            _install_cast_io_hooks(wrapper.model, _cast_dtype(recipe))
     else:
         keep_raw = manifest.get("keep_high_precision")
         keep = (

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -1,0 +1,354 @@
+"""PyTorch-native quantization API.
+
+Grammar:
+
+- ``model.quantize(recipe, calib=...)`` transforms the loaded model in place
+  (structure swap + calibration) and returns it. No gradients are involved.
+- QAT is plain ``model.train(...)`` on a quantized model: the swapped modules
+  carry fp32 master weights and STE fake-quant, so the existing trainers work
+  unchanged.
+- QAD is the same training step with the existing ``distill_model`` kwargs.
+
+Everything runs in PyTorch (simulation tier: numerics-true on any device).
+Checkpoints written by ``model.save()`` and by the trainer carry a ``quant``
+manifest so ``LibreYOLO(path)`` can rebuild the quantized structure before
+loading weights.
+"""
+
+import logging
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from .modules import NVFP4Linear, QuantConv2d, QuantLinear
+
+logger = logging.getLogger(__name__)
+
+QUANT_SCHEMA_VERSION = "1.0"
+RECIPES = ("fp16", "int8", "nvfp4")
+SUPPORTED_FAMILIES = ("yolo9", "rfdetr")
+
+DEFAULT_CALIB_DATA = "coco8.yaml"
+
+# Per-family keep-high-precision defaults (substring match on qualified module
+# names). First layers and heads stay in float: standard practice, and the
+# YOLO9 DFL conv is a fixed integral-expectation operator that must never be
+# quantized.
+_FAMILY_KEEP_HIGH_PRECISION: Dict[str, Tuple[str, ...]] = {
+    "yolo9": ("head.", "backbone.conv0."),
+    "rfdetr": (
+        "class_embed",
+        "bbox_embed",
+        "angle_embed",
+        "keypoint_head",
+        "segmentation_head",
+        "embeddings",
+        "ref_point",
+    ),
+}
+_ALWAYS_KEEP = ("dfl",)
+
+
+class QuantizationError(ValueError):
+    """Raised for unsupported or invalid quantization requests."""
+
+
+def default_keep_high_precision(family: str) -> Tuple[str, ...]:
+    return _FAMILY_KEEP_HIGH_PRECISION.get(family, ())
+
+
+def _check_support(family: str, recipe: str):
+    if recipe not in RECIPES:
+        raise QuantizationError(
+            f"Unknown quantization recipe '{recipe}'. Available: {', '.join(RECIPES)}"
+        )
+    if family not in SUPPORTED_FAMILIES:
+        raise QuantizationError(
+            f"Quantization is not supported for model family '{family}' yet. "
+            f"Supported families: {', '.join(SUPPORTED_FAMILIES)}"
+        )
+    if family == "yolo9" and recipe == "nvfp4":
+        raise QuantizationError(
+            "nvfp4 is not supported for the conv-heavy yolo9 family: FP4 "
+            "acceleration is GEMM-only, so convolutions stay in higher "
+            "precision. Use recipe='int8' for yolo9, or nvfp4 on the "
+            "transformer-based rfdetr family."
+        )
+
+
+def _is_excluded(name: str, keep: Tuple[str, ...]) -> bool:
+    for pattern in (*keep, *_ALWAYS_KEEP):
+        if pattern and pattern in name:
+            return True
+    return False
+
+
+def _select_modules(
+    root: nn.Module,
+    recipe: str,
+    keep: Tuple[str, ...],
+) -> Dict[str, nn.Module]:
+    """Deterministically select float modules to swap for a recipe."""
+    selected: Dict[str, nn.Module] = {}
+    for name, module in root.named_modules():
+        if not name or _is_excluded(name, keep):
+            continue
+        if recipe == "int8":
+            if type(module) is nn.Conv2d or type(module) is nn.Linear:
+                selected[name] = module
+        elif recipe == "nvfp4":
+            if type(module) is nn.Linear:
+                selected[name] = module
+    return selected
+
+
+def _swap_module(root: nn.Module, name: str, new_module: nn.Module):
+    parent = root
+    *parents, attr = name.split(".")
+    for part in parents:
+        parent = getattr(parent, part)
+    setattr(parent, attr, new_module)
+
+
+def _swap_selected(root: nn.Module, recipe: str, selected: Dict[str, nn.Module]) -> Dict[str, int]:
+    counts = {"conv_int8": 0, "linear_int8": 0, "linear_nvfp4": 0}
+    for name, module in selected.items():
+        if recipe == "int8":
+            if type(module) is nn.Conv2d:
+                _swap_module(root, name, QuantConv2d.from_float(module))
+                counts["conv_int8"] += 1
+            else:
+                _swap_module(root, name, QuantLinear.from_float(module))
+                counts["linear_int8"] += 1
+        elif recipe == "nvfp4":
+            _swap_module(root, name, NVFP4Linear.from_float(module))
+            counts["linear_nvfp4"] += 1
+    return counts
+
+
+def _quant_modules(root: nn.Module):
+    for name, module in root.named_modules():
+        if isinstance(module, (QuantConv2d, QuantLinear, NVFP4Linear)):
+            yield name, module
+
+
+def _cast_tree(obj, dtype):
+    if torch.is_tensor(obj) and obj.is_floating_point():
+        return obj.to(dtype)
+    if isinstance(obj, dict):
+        return {k: _cast_tree(v, dtype) for k, v in obj.items()}
+    if isinstance(obj, tuple):
+        return tuple(_cast_tree(v, dtype) for v in obj)
+    if isinstance(obj, list):
+        return [_cast_tree(v, dtype) for v in obj]
+    return obj
+
+
+def _install_fp16_io_hooks(root: nn.Module):
+    """Half the model and keep the float32 I/O contract at the root."""
+
+    def _pre(module, args):
+        return tuple(
+            a.half() if torch.is_tensor(a) and a.dtype == torch.float32 else a
+            for a in args
+        )
+
+    def _post(module, args, output):
+        return _cast_tree(output, torch.float32)
+
+    root.half()
+    root.register_forward_pre_hook(_pre)
+    root.register_forward_hook(_post)
+
+
+def _set_observing(root: nn.Module, flag: bool):
+    for _, module in _quant_modules(root):
+        if hasattr(module, "_q_observing"):
+            module._q_observing = flag
+
+
+def _run_calibration(wrapper, calib: str, samples: int, batch: int, allow_download_scripts: bool):
+    from ..export.calibration import CalibrationDataLoader
+
+    loader = CalibrationDataLoader(
+        data=calib,
+        imgsz=wrapper._get_input_size(),
+        batch=batch,
+        fraction=1.0,
+        samples=samples,
+        preprocess_fn=wrapper._get_preprocess_numpy(),
+        allow_download_scripts=allow_download_scripts,
+    )
+    root = wrapper.model
+    was_training = root.training
+    root.eval()
+    _set_observing(root, True)
+    seen = 0
+    with torch.no_grad():
+        for np_batch in loader:
+            x = torch.from_numpy(np_batch).to(wrapper.device)
+            root(x)
+            seen += x.shape[0]
+    _set_observing(root, False)
+    if was_training:
+        root.train()
+    return seen
+
+
+def quant_info(wrapper) -> Optional[Dict]:
+    """Summary of the model's quantization state, or None if float."""
+    manifest = getattr(wrapper, "_quant_manifest", None)
+    if not manifest:
+        return None
+    info = dict(manifest)
+    counts = {"conv_int8": 0, "linear_int8": 0, "linear_nvfp4": 0}
+    calibrated = True
+    for _, module in _quant_modules(wrapper.model):
+        if isinstance(module, QuantConv2d):
+            counts["conv_int8"] += 1
+        elif isinstance(module, NVFP4Linear):
+            counts["linear_nvfp4"] += 1
+        elif isinstance(module, QuantLinear):
+            counts["linear_int8"] += 1
+        calibrated = calibrated and module.q_calibrated
+    info["module_counts"] = counts
+    if manifest.get("recipe") != "fp16":
+        info["calibrated"] = calibrated
+    return info
+
+
+def quantize_model(
+    wrapper,
+    recipe: str,
+    calib: Optional[str] = DEFAULT_CALIB_DATA,
+    samples: int = 128,
+    batch: int = 8,
+    keep_high_precision: Optional[Tuple[str, ...]] = None,
+    allow_download_scripts: bool = False,
+    verbose: bool = True,
+):
+    """Quantize a loaded LibreYOLO model in place and return it."""
+    if getattr(wrapper, "_quant_manifest", None):
+        raise QuantizationError(
+            "Model is already quantized "
+            f"(recipe='{wrapper._quant_manifest.get('recipe')}'). Load a float "
+            "checkpoint to quantize with a different recipe."
+        )
+
+    family = wrapper.FAMILY
+    recipe = str(recipe).lower()
+    _check_support(family, recipe)
+
+    keep = (
+        tuple(keep_high_precision)
+        if keep_high_precision is not None
+        else default_keep_high_precision(family)
+    )
+
+    manifest = {
+        "schema": QUANT_SCHEMA_VERSION,
+        "recipe": recipe,
+        "keep_high_precision": list(keep),
+        "execution": "simulated",
+        "calibrated": False,
+        "calib_data": None,
+        "calib_samples": 0,
+        "module_count": 0,
+    }
+
+    if recipe == "fp16":
+        if wrapper.device.type == "cpu":
+            logger.warning("fp16 on CPU is functional but slow; use a GPU device.")
+        _install_fp16_io_hooks(wrapper.model)
+        manifest["execution"] = "native"
+        manifest["calibrated"] = True
+    else:
+        selected = _select_modules(wrapper.model, recipe, keep)
+        if not selected:
+            raise QuantizationError(
+                f"No quantizable modules found for recipe '{recipe}' on family "
+                f"'{family}' with keep_high_precision={list(keep)}."
+            )
+        counts = _swap_selected(wrapper.model, recipe, selected)
+        manifest["module_count"] = sum(counts.values())
+
+        if recipe == "int8":
+            if calib is not None:
+                seen = _run_calibration(
+                    wrapper, calib, samples, batch, allow_download_scripts
+                )
+                manifest["calibrated"] = True
+                manifest["calib_data"] = str(calib)
+                manifest["calib_samples"] = int(seen)
+            else:
+                logger.warning(
+                    "int8 quantization without calibration: activations stay "
+                    "in float (W8 simulation only). Pass calib= to calibrate."
+                )
+        elif recipe == "nvfp4":
+            if calib is not None and calib != DEFAULT_CALIB_DATA:
+                logger.info(
+                    "nvfp4 activations use dynamic block scaling; calibration "
+                    "data is not needed and was ignored."
+                )
+            manifest["calibrated"] = True
+
+    wrapper._quant_manifest = manifest
+    wrapper.model.to(wrapper.device)
+
+    if verbose:
+        info = quant_info(wrapper)
+        counts = info.get("module_counts", {})
+        described = ", ".join(f"{v} {k}" for k, v in counts.items() if v) or "cast only"
+        logger.info(
+            "Quantized %s to %s (%s; execution=%s, calibrated=%s)",
+            wrapper._get_model_name(),
+            recipe,
+            described,
+            info.get("execution"),
+            info.get("calibrated"),
+        )
+    return wrapper
+
+
+def apply_quant_structure(wrapper, manifest: Dict):
+    """Re-apply a checkpoint's quantized structure before loading weights.
+
+    Idempotent: already-swapped modules are left alone. Calibration state is
+    restored from the checkpoint buffers by the subsequent load_state_dict.
+    """
+    recipe = manifest.get("recipe")
+    if recipe not in RECIPES:
+        raise QuantizationError(
+            f"Checkpoint has unknown quantization recipe '{recipe}'."
+        )
+    _check_support(wrapper.FAMILY, recipe)
+
+    if recipe == "fp16":
+        if not getattr(wrapper, "_quant_manifest", None):
+            _install_fp16_io_hooks(wrapper.model)
+    else:
+        keep_raw = manifest.get("keep_high_precision")
+        keep = (
+            tuple(keep_raw)
+            if keep_raw is not None
+            else default_keep_high_precision(wrapper.FAMILY)
+        )
+        selected = _select_modules(wrapper.model, recipe, keep)
+        counts = _swap_selected(wrapper.model, recipe, selected)
+        swapped = sum(counts.values())
+        expected = int(manifest.get("module_count") or 0)
+        already = sum(1 for _ in _quant_modules(wrapper.model))
+        if expected and already != expected:
+            logger.warning(
+                "Quantized checkpoint expected %d quantized modules but the "
+                "rebuilt model has %d; scales may not fully load.",
+                expected,
+                already,
+            )
+        if swapped:
+            wrapper.model.to(wrapper.device)
+
+    wrapper._quant_manifest = dict(manifest)
+    return wrapper

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -314,6 +314,75 @@ def quantize_model(
     return wrapper
 
 
+def _set_export_mode(root: nn.Module, enabled: bool):
+    for _, module in _quant_modules(root):
+        if isinstance(module, (QuantConv2d, QuantLinear)):
+            if enabled:
+                module.freeze_weight_qparams()
+            module._q_export_mode = enabled
+            module._q_observing = False
+
+
+def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
+    """Export a quantized model.
+
+    int8 models export to ONNX with in-graph QuantizeLinear/DequantizeLinear
+    pairs carrying the model's own calibrated (or QAT-trained) scales, so
+    ONNX Runtime and TensorRT run real INT8 kernels with exactly the
+    arithmetic that was validated in PyTorch. Other recipes are rejected
+    with instructions.
+    """
+    manifest = getattr(wrapper, "_quant_manifest", None) or {}
+    recipe = manifest.get("recipe")
+    fmt = str(format).lower()
+
+    if recipe == "fp16":
+        raise QuantizationError(
+            "fp16-quantized models do not need a quantized exporter: call "
+            "model.dequantize() and export with half=True, e.g. "
+            "model.export(format='onnx', half=True)."
+        )
+    if recipe == "nvfp4":
+        raise QuantizationError(
+            "nvfp4 has no standard ONNX representation and executes in "
+            "PyTorch. Deploy the PyTorch model directly, or dequantize() and "
+            "use the float exporters."
+        )
+    if recipe != "int8":
+        raise QuantizationError(
+            f"Export is not supported for quantization recipe '{recipe}'."
+        )
+    if fmt != "onnx":
+        raise QuantizationError(
+            "int8-quantized export currently supports format='onnx' (QDQ "
+            "graph, consumable by ONNX Runtime and TensorRT). Requested: "
+            f"'{fmt}'. Export to ONNX and build downstream engines from it, "
+            "or dequantize() and use the float exporters."
+        )
+
+    if kwargs.pop("int8", False):
+        logger.info(
+            "Model is already int8-quantized; the int8 export flag is "
+            "ignored (Q/DQ scales come from the model itself)."
+        )
+    if kwargs.pop("half", False):
+        logger.warning("half=True is ignored for int8-quantized export.")
+    if not manifest.get("calibrated"):
+        logger.warning(
+            "Exporting an int8 model whose activations were never "
+            "calibrated: the graph carries weight Q/DQ only. Pass calib= to "
+            "quantize() for full W8A8 deployment."
+        )
+
+    from ..export import BaseExporter
+
+    _set_export_mode(wrapper.model, True)
+    try:
+        return BaseExporter.create("onnx", wrapper)(**kwargs)
+    finally:
+        _set_export_mode(wrapper.model, False)
+
+
 def dequantize_model(wrapper):
     """Restore float modules in place, keeping the master weights.
 

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -28,8 +28,9 @@ logger = logging.getLogger(__name__)
 QUANT_SCHEMA_VERSION = "1.0"
 RECIPES = ("fp16", "int8", "nvfp4")
 SUPPORTED_FAMILIES = ("yolo9", "rfdetr")
+CALIB_ALGORITHMS = ("auto", "percentile", "minmax")
 
-DEFAULT_CALIB_DATA = "coco8.yaml"
+DEFAULT_CALIB_DATA = "coco128.yaml"
 
 # Per-family keep-high-precision defaults (substring match on qualified module
 # names). First layers and heads stay in float: standard practice, and the
@@ -170,7 +171,14 @@ def _set_observing(root: nn.Module, flag: bool):
             module._q_observing = flag
 
 
-def _run_calibration(wrapper, calib: str, samples: int, batch: int, allow_download_scripts: bool):
+def _run_calibration(
+    wrapper,
+    calib: str,
+    samples: int,
+    batch: int,
+    allow_download_scripts: bool,
+    algorithm: str = "percentile",
+):
     from ..export.calibration import CalibrationDataLoader
 
     loader = CalibrationDataLoader(
@@ -185,6 +193,8 @@ def _run_calibration(wrapper, calib: str, samples: int, batch: int, allow_downlo
     root = wrapper.model
     was_training = root.training
     root.eval()
+    for _, module in _quant_modules(root):
+        module._q_obs_method = algorithm
     _set_observing(root, True)
     seen = 0
     with torch.no_grad():
@@ -193,6 +203,10 @@ def _run_calibration(wrapper, calib: str, samples: int, batch: int, allow_downlo
             root(x)
             seen += x.shape[0]
     _set_observing(root, False)
+    for _, module in _quant_modules(root):
+        if hasattr(module, "finalize_observation"):
+            module.finalize_observation()
+        module._q_obs_method = "minmax"
     if was_training:
         root.train()
     return seen
@@ -226,6 +240,7 @@ def quantize_model(
     calib: Optional[str] = DEFAULT_CALIB_DATA,
     samples: int = 128,
     batch: int = 8,
+    algorithm: str = "auto",
     keep_high_precision: Optional[Tuple[str, ...]] = None,
     allow_download_scripts: bool = False,
     verbose: bool = True,
@@ -242,6 +257,25 @@ def quantize_model(
     recipe = str(recipe).lower()
     _check_support(family, recipe)
 
+    algorithm = str(algorithm).lower()
+    if algorithm not in CALIB_ALGORITHMS:
+        raise QuantizationError(
+            f"Unknown calibration algorithm '{algorithm}'. "
+            f"Available: {', '.join(CALIB_ALGORITHMS)}"
+        )
+    if algorithm == "auto":
+        # Measured on coco128: multi-batch min/max beats percentile clipping
+        # for every tested model, and percentile collapses transformer
+        # activations (their outliers are load-bearing). minmax is the
+        # default; percentile stays available as an experimental estimator.
+        algorithm = "minmax"
+    if algorithm == "percentile" and family == "rfdetr":
+        logger.warning(
+            "percentile calibration clips transformer activation outliers, "
+            "which measurably degrades DETR-family accuracy; prefer "
+            "algorithm='minmax' for rfdetr."
+        )
+
     keep = (
         tuple(keep_high_precision)
         if keep_high_precision is not None
@@ -256,6 +290,7 @@ def quantize_model(
         "calibrated": False,
         "calib_data": None,
         "calib_samples": 0,
+        "calib_algorithm": None,
         "module_count": 0,
     }
 
@@ -278,11 +313,17 @@ def quantize_model(
         if recipe == "int8":
             if calib is not None:
                 seen = _run_calibration(
-                    wrapper, calib, samples, batch, allow_download_scripts
+                    wrapper,
+                    calib,
+                    samples,
+                    batch,
+                    allow_download_scripts,
+                    algorithm=algorithm,
                 )
                 manifest["calibrated"] = True
                 manifest["calib_data"] = str(calib)
                 manifest["calib_samples"] = int(seen)
+                manifest["calib_algorithm"] = algorithm
             else:
                 logger.warning(
                     "int8 quantization without calibration: activations stay "

--- a/libreyolo/quant/fake_quant.py
+++ b/libreyolo/quant/fake_quant.py
@@ -61,28 +61,67 @@ def fake_quant_e2m1(x: torch.Tensor) -> torch.Tensor:
     return _ste(quant, x)
 
 
-def fake_quant_int8_per_channel(weight: torch.Tensor, ch_axis: int = 0) -> torch.Tensor:
-    """Symmetric per-channel INT8 fake-quantization of a weight tensor."""
+def int8_weight_qparams(weight: torch.Tensor, ch_axis: int = 0) -> torch.Tensor:
+    """Per-channel symmetric INT8 scale for a weight tensor."""
     dims = [d for d in range(weight.dim()) if d != ch_axis]
-    amax = weight.abs().amax(dim=dims, keepdim=True).detach()
-    scale = (amax / 127.0).clamp(min=_EPS)
-    quant = torch.clamp(torch.round(weight / scale), -127, 127) * scale
-    return _ste(quant, weight)
+    amax = weight.detach().abs()
+    if dims:
+        amax = amax.amax(dim=dims)
+    return (amax / 127.0).clamp(min=_EPS)
+
+
+def fake_quant_int8_per_channel(
+    weight: torch.Tensor,
+    ch_axis: int = 0,
+    scale: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Symmetric per-channel INT8 fake-quantization of a weight tensor.
+
+    Uses ``torch.fake_quantize_per_channel_affine`` so ``torch.onnx.export``
+    emits QuantizeLinear/DequantizeLinear pairs carrying these exact scales.
+    The (-128, 127) range is required by the ONNX symbolic; with symmetric
+    ``amax/127`` scales the -128 code is unreachable, so results match the
+    (-127, 127) convention bit for bit.
+    """
+    if scale is None:
+        scale = int8_weight_qparams(weight, ch_axis)
+    scale = scale.to(device=weight.device, dtype=torch.float32)
+    zero_point = torch.zeros(scale.shape, dtype=torch.int32, device=weight.device)
+    return torch.fake_quantize_per_channel_affine(
+        weight, scale, zero_point, ch_axis, -128, 127
+    )
+
+
+def int8_act_qparams(lo: torch.Tensor, hi: torch.Tensor):
+    """Per-tensor affine INT8 (scale, zero_point) from calibrated [lo, hi]."""
+    lo = torch.minimum(lo, torch.zeros_like(lo))
+    hi = torch.maximum(hi, torch.zeros_like(hi))
+    scale = ((hi - lo) / 255.0).clamp(min=_EPS).reshape(1)
+    zero_point = (
+        torch.clamp(torch.round(-128.0 - lo / scale), -128, 127)
+        .to(torch.int32)
+        .reshape(1)
+    )
+    return scale, zero_point
 
 
 def fake_quant_int8_affine(
     x: torch.Tensor,
     lo: torch.Tensor,
     hi: torch.Tensor,
+    scalars: bool = False,
 ) -> torch.Tensor:
-    """Per-tensor affine INT8 fake-quantization with calibrated [lo, hi]."""
-    lo = torch.minimum(lo, torch.zeros_like(lo))
-    hi = torch.maximum(hi, torch.zeros_like(hi))
-    scale = ((hi - lo) / 255.0).clamp(min=_EPS)
-    zero_point = torch.round(-128.0 - lo / scale)
-    quant = torch.clamp(torch.round(x / scale) + zero_point, -128, 127)
-    quant = (quant - zero_point) * scale
-    return _ste(quant, x)
+    """Per-tensor affine INT8 fake-quantization with calibrated [lo, hi].
+
+    With ``scalars=True`` the qparams are passed as python scalars so ONNX
+    tracing bakes them as constants (export mode).
+    """
+    scale, zero_point = int8_act_qparams(lo, hi)
+    if scalars:
+        return torch.fake_quantize_per_tensor_affine(
+            x, float(scale.item()), int(zero_point.item()), -128, 127
+        )
+    return torch.fake_quantize_per_tensor_affine(x, scale, zero_point, -128, 127)
 
 
 def _blockwise_nvfp4(x: torch.Tensor, tensor_scale: torch.Tensor) -> torch.Tensor:

--- a/libreyolo/quant/fake_quant.py
+++ b/libreyolo/quant/fake_quant.py
@@ -1,0 +1,128 @@
+"""Quantization arithmetic primitives.
+
+All functions here simulate low-precision arithmetic in float32 with
+straight-through-estimator (STE) gradients, so the same code path serves
+post-training quantization, quantization-aware training, and quantization-
+aware distillation. Simulation is numerics-true: a validation score computed
+through these ops is a real claim about the quantized arithmetic.
+
+Formats:
+- INT8: per-channel symmetric weights, per-tensor affine activations.
+- NVFP4: E2M1 elements in 16-element blocks, one FP8 E4M3 scale per block,
+  one FP32 scale per tensor. Implemented from the publicly documented format
+  definition.
+"""
+
+from contextlib import nullcontext
+
+import torch
+
+# E2M1 representable magnitudes (sign handled separately): subnormal 0.5,
+# then normals 1, 1.5, 2, 3, 4, 6.
+_E2M1_LEVELS = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+# Decision midpoints between consecutive levels for nearest-value rounding.
+_E2M1_MIDPOINTS = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0])
+
+E2M1_MAX = 6.0
+E4M3_MAX = 448.0
+NVFP4_BLOCK = 16
+
+_EPS = 1e-12
+
+
+def autocast_off(device_type: str):
+    """Context manager disabling autocast so quantized ops run in fp32."""
+    if device_type in ("cuda", "cpu"):
+        return torch.autocast(device_type=device_type, enabled=False)
+    return nullcontext()
+
+
+def _ste(x_fake: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    """Straight-through estimator: forward x_fake, backward identity to x."""
+    return x + (x_fake - x).detach()
+
+
+def quantize_e4m3(x: torch.Tensor) -> torch.Tensor:
+    """Round a positive tensor to the FP8 E4M3 grid (returned as fp32)."""
+    x = x.clamp(min=_EPS, max=E4M3_MAX)
+    if hasattr(torch, "float8_e4m3fn"):
+        return x.to(torch.float8_e4m3fn).to(torch.float32)
+    return x
+
+
+def fake_quant_e2m1(x: torch.Tensor) -> torch.Tensor:
+    """Round to the nearest E2M1 value. Input must already be scaled so the
+    representable range is [-6, 6]. STE gradient."""
+    midpoints = _E2M1_MIDPOINTS.to(device=x.device, dtype=x.dtype)
+    levels = _E2M1_LEVELS.to(device=x.device, dtype=x.dtype)
+    mag = x.abs().clamp(max=E2M1_MAX)
+    idx = torch.bucketize(mag, midpoints)
+    quant = levels[idx] * torch.sign(x)
+    return _ste(quant, x)
+
+
+def fake_quant_int8_per_channel(weight: torch.Tensor, ch_axis: int = 0) -> torch.Tensor:
+    """Symmetric per-channel INT8 fake-quantization of a weight tensor."""
+    dims = [d for d in range(weight.dim()) if d != ch_axis]
+    amax = weight.abs().amax(dim=dims, keepdim=True).detach()
+    scale = (amax / 127.0).clamp(min=_EPS)
+    quant = torch.clamp(torch.round(weight / scale), -127, 127) * scale
+    return _ste(quant, weight)
+
+
+def fake_quant_int8_affine(
+    x: torch.Tensor,
+    lo: torch.Tensor,
+    hi: torch.Tensor,
+) -> torch.Tensor:
+    """Per-tensor affine INT8 fake-quantization with calibrated [lo, hi]."""
+    lo = torch.minimum(lo, torch.zeros_like(lo))
+    hi = torch.maximum(hi, torch.zeros_like(hi))
+    scale = ((hi - lo) / 255.0).clamp(min=_EPS)
+    zero_point = torch.round(-128.0 - lo / scale)
+    quant = torch.clamp(torch.round(x / scale) + zero_point, -128, 127)
+    quant = (quant - zero_point) * scale
+    return _ste(quant, x)
+
+
+def _blockwise_nvfp4(x: torch.Tensor, tensor_scale: torch.Tensor) -> torch.Tensor:
+    """NVFP4 fake-quantization along the last dim in blocks of 16.
+
+    tensor_scale is the FP32 per-tensor scale; each 16-element block gets an
+    E4M3 scale chosen so the block maximum maps to the E2M1 maximum (6).
+    """
+    orig_shape = x.shape
+    last = orig_shape[-1]
+    pad = (-last) % NVFP4_BLOCK
+    if pad:
+        x = torch.nn.functional.pad(x, (0, pad))
+    blocks = x.reshape(*x.shape[:-1], x.shape[-1] // NVFP4_BLOCK, NVFP4_BLOCK)
+
+    block_amax = blocks.abs().amax(dim=-1, keepdim=True).detach()
+    tensor_scale = tensor_scale.clamp(min=_EPS)
+    block_scale = quantize_e4m3(block_amax / (E2M1_MAX * tensor_scale))
+    eff_scale = (block_scale * tensor_scale).clamp(min=_EPS)
+
+    quant = fake_quant_e2m1(blocks / eff_scale) * eff_scale
+    quant = quant.reshape(*x.shape)
+    if pad:
+        quant = quant[..., :last]
+    return quant
+
+
+def fake_quant_nvfp4_weight(
+    weight: torch.Tensor,
+    tensor_amax: torch.Tensor,
+) -> torch.Tensor:
+    """NVFP4 fake-quantization of a [out, in] weight with a fixed per-tensor
+    amax captured at quantize time (so QAT trains against stable scaling)."""
+    tensor_scale = tensor_amax / (E4M3_MAX * E2M1_MAX)
+    return _blockwise_nvfp4(weight, tensor_scale)
+
+
+def fake_quant_nvfp4_dynamic(x: torch.Tensor) -> torch.Tensor:
+    """NVFP4 fake-quantization of activations with dynamic per-tensor scale,
+    blocked along the last (feature) dimension."""
+    tensor_amax = x.abs().amax().detach()
+    tensor_scale = tensor_amax / (E4M3_MAX * E2M1_MAX)
+    return _blockwise_nvfp4(x, tensor_scale)

--- a/libreyolo/quant/fake_quant.py
+++ b/libreyolo/quant/fake_quant.py
@@ -26,6 +26,7 @@ _E2M1_MIDPOINTS = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0])
 E2M1_MAX = 6.0
 E4M3_MAX = 448.0
 NVFP4_BLOCK = 16
+MXFP4_BLOCK = 32
 
 _EPS = 1e-12
 
@@ -122,6 +123,96 @@ def fake_quant_int8_affine(
             x, float(scale.item()), int(zero_point.item()), -128, 127
         )
     return torch.fake_quantize_per_tensor_affine(x, scale, zero_point, -128, 127)
+
+
+def fp8_weight_qparams(weight: torch.Tensor, ch_axis: int = 0) -> torch.Tensor:
+    """Per-channel symmetric FP8 E4M3 scale for a weight tensor."""
+    dims = [d for d in range(weight.dim()) if d != ch_axis]
+    amax = weight.detach().abs()
+    if dims:
+        amax = amax.amax(dim=dims)
+    return (amax / E4M3_MAX).clamp(min=_EPS)
+
+
+def fake_quant_fp8(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Symmetric FP8 E4M3 fake-quantization with a broadcastable scale."""
+    scale = scale.clamp(min=_EPS)
+    scaled = (x / scale).clamp(-E4M3_MAX, E4M3_MAX)
+    quant = scaled.to(torch.float8_e4m3fn).to(torch.float32) * scale
+    return _ste(quant, x)
+
+
+def int_group_qparams(
+    weight: torch.Tensor, bits: int, group_size: int
+) -> torch.Tensor:
+    """Per-group symmetric scales for grouped integer weight quantization.
+
+    Returns [out, ngroups] scales with qmax = 2**(bits-1) - 1.
+    """
+    out_features, in_features = weight.shape
+    pad = (-in_features) % group_size
+    w = weight.detach().float()
+    if pad:
+        w = torch.nn.functional.pad(w, (0, pad))
+    groups = w.reshape(out_features, -1, group_size)
+    qmax = float(2 ** (bits - 1) - 1)
+    return (groups.abs().amax(dim=-1) / qmax).clamp(min=_EPS)
+
+
+def fake_quant_int_grouped(
+    weight: torch.Tensor,
+    bits: int,
+    group_size: int,
+    scale: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Grouped symmetric integer weight fake-quantization (W4/W2 style)."""
+    out_features, in_features = weight.shape
+    if scale is None:
+        scale = int_group_qparams(weight, bits, group_size)
+    pad = (-in_features) % group_size
+    w = weight.float()
+    if pad:
+        w = torch.nn.functional.pad(w, (0, pad))
+    groups = w.reshape(out_features, -1, group_size)
+    qmin = -(2 ** (bits - 1))
+    qmax = 2 ** (bits - 1) - 1
+    s = scale.unsqueeze(-1).clamp(min=_EPS)
+    quant = torch.clamp(torch.round(groups / s), qmin, qmax) * s
+    quant = quant.reshape(out_features, -1)[:, :in_features]
+    return _ste(quant, weight)
+
+
+def _e8m0_scale(amax: torch.Tensor) -> torch.Tensor:
+    """OCP MX power-of-two block scale: 2^(floor(log2(amax)) - emax(E2M1))."""
+    exp = torch.floor(torch.log2(amax.clamp(min=1e-30))) - 2.0
+    return torch.exp2(exp.clamp(-127.0, 127.0))
+
+
+def _blockwise_mxfp4(x: torch.Tensor) -> torch.Tensor:
+    orig_shape = x.shape
+    last = orig_shape[-1]
+    pad = (-last) % MXFP4_BLOCK
+    if pad:
+        x = torch.nn.functional.pad(x, (0, pad))
+    blocks = x.reshape(*x.shape[:-1], x.shape[-1] // MXFP4_BLOCK, MXFP4_BLOCK)
+    block_amax = blocks.abs().amax(dim=-1, keepdim=True).detach()
+    eff = _e8m0_scale(block_amax)
+    quant = fake_quant_e2m1(blocks / eff) * eff
+    quant = quant.reshape(*x.shape)
+    if pad:
+        quant = quant[..., :last]
+    return quant
+
+
+def fake_quant_mxfp4_weight(weight: torch.Tensor) -> torch.Tensor:
+    """OCP MXFP4 weight fake-quantization: E2M1 elements, 32-element blocks,
+    power-of-two (E8M0) block scales, no second-level tensor scale."""
+    return _blockwise_mxfp4(weight)
+
+
+def fake_quant_mxfp4_dynamic(x: torch.Tensor) -> torch.Tensor:
+    """MXFP4 activation fake-quantization with dynamic block scaling."""
+    return _blockwise_mxfp4(x)
 
 
 def _blockwise_nvfp4(x: torch.Tensor, tensor_scale: torch.Tensor) -> torch.Tensor:

--- a/libreyolo/quant/kernels/__init__.py
+++ b/libreyolo/quant/kernels/__init__.py
@@ -1,0 +1,144 @@
+"""Kernel registry: pluggable accelerated implementations for quant ops.
+
+Architecture (vLLM-shaped, scaled down to a library that rents its runtime):
+
+- The reference implementations in ``fake_quant.py`` are always registered
+  and always available. They are the numerical oracle: any accelerated
+  implementation must match them (parity tests gate in-tree kernels, and
+  ``packing.py`` never has variants because it is the checkpoint contract).
+- Triton kernels live under ``kernels/triton/`` as plain Python (JIT
+  compiled at runtime, no build step, no wheels).
+- Compiled kernels ship out-of-tree in the optional ``libreyolo-kernels``
+  package. If installed, it is imported here and self-registers via
+  :func:`register`; the core package never grows a build dependency.
+- Selection is per-op: implementations are tried newest-first and the first
+  one whose predicate passes wins, falling back to the reference. The
+  ``LIBREYOLO_QUANT_KERNELS`` environment variable overrides selection:
+  ``off``/``reference`` forces the reference implementations; any other
+  value selects only implementations registered under that name.
+
+Registered op slots (callables with the reference signatures):
+``fake_quant_int8_per_channel``, ``fake_quant_int8_affine``,
+``fake_quant_fp8``, ``fake_quant_int_grouped``, ``fake_quant_nvfp4_weight``,
+``fake_quant_nvfp4_dynamic``, ``fake_quant_mxfp4_weight``,
+``fake_quant_mxfp4_dynamic``. GEMM slots (``nvfp4_gemm``, ...) may be
+registered by external packages; they have no reference implementation and
+callers must check :func:`resolve` returns non-None before use.
+"""
+
+import importlib.util
+import logging
+import os
+from typing import Callable, Dict, List, Optional
+
+from .. import fake_quant as _reference
+
+logger = logging.getLogger(__name__)
+
+REFERENCE_OPS = (
+    "fake_quant_int8_per_channel",
+    "fake_quant_int8_affine",
+    "fake_quant_fp8",
+    "fake_quant_int_grouped",
+    "fake_quant_nvfp4_weight",
+    "fake_quant_nvfp4_dynamic",
+    "fake_quant_mxfp4_weight",
+    "fake_quant_mxfp4_dynamic",
+)
+
+_REGISTRY: Dict[str, List[dict]] = {}
+_RESOLVED: Dict[str, Callable] = {}
+
+
+def register(
+    op: str,
+    impl: Callable,
+    *,
+    name: str,
+    predicate: Optional[Callable[[], bool]] = None,
+):
+    """Register an implementation for an op slot (newest wins when eligible)."""
+    _REGISTRY.setdefault(op, []).insert(
+        0, {"name": name, "impl": impl, "predicate": predicate}
+    )
+    _RESOLVED.pop(op, None)
+
+
+def unregister(op: str, name: str):
+    _REGISTRY[op] = [e for e in _REGISTRY.get(op, []) if e["name"] != name]
+    _RESOLVED.pop(op, None)
+
+
+def clear_cache():
+    _RESOLVED.clear()
+
+
+def _forced() -> str:
+    return os.environ.get("LIBREYOLO_QUANT_KERNELS", "").strip().lower()
+
+
+def resolve(op: str) -> Optional[Callable]:
+    """Return the active implementation for an op, or None if none eligible."""
+    forced = _forced()
+    cache_key = f"{op}|{forced}"
+    if cache_key in _RESOLVED:
+        return _RESOLVED[cache_key]
+
+    impl = None
+    for entry in _REGISTRY.get(op, ()):
+        if forced in ("off", "reference") and entry["name"] != "reference":
+            continue
+        if forced and forced not in ("off", "reference") and entry["name"] not in (
+            forced,
+            "reference",
+        ):
+            continue
+        predicate = entry["predicate"]
+        try:
+            if predicate is None or predicate():
+                impl = entry["impl"]
+                break
+        except Exception as exc:  # a broken predicate must never break inference
+            logger.warning(
+                "Kernel predicate failed for %s/%s: %s", op, entry["name"], exc
+            )
+    _RESOLVED[cache_key] = impl
+    return impl
+
+
+def active() -> Dict[str, str]:
+    """Map of op slot to the name of the implementation currently selected."""
+    out = {}
+    for op, entries in _REGISTRY.items():
+        impl = resolve(op)
+        out[op] = next(
+            (e["name"] for e in entries if e["impl"] is impl), "unavailable"
+        )
+    return out
+
+
+def _make_proxy(op: str) -> Callable:
+    def proxy(*args, **kwargs):
+        impl = resolve(op)
+        if impl is None:
+            raise RuntimeError(f"No implementation available for quant op '{op}'.")
+        return impl(*args, **kwargs)
+
+    proxy.__name__ = op
+    return proxy
+
+
+# Reference implementations: registered first so they sit last in the list
+# (always the fallback) and are selectable via the "reference" name.
+for _op in REFERENCE_OPS:
+    register(_op, getattr(_reference, _op), name="reference")
+    globals()[_op] = _make_proxy(_op)
+
+
+# Optional out-of-tree compiled kernels (e.g. the CUTLASS NVFP4 GEMM).
+# The package self-registers on import; absence is the normal case.
+if importlib.util.find_spec("libreyolo_kernels") is not None:
+    try:
+        import libreyolo_kernels  # noqa: F401
+    except Exception as exc:
+        logger.warning("libreyolo_kernels present but failed to import: %s", exc)

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -1,0 +1,2 @@
+"""Triton kernels (JIT, no build step). Empty scaffold: kernels land here
+with parity tests against the fake_quant reference implementations."""

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -1,0 +1,172 @@
+"""Quantized module variants.
+
+Each class subclasses its float counterpart so the module keeps the same
+state_dict key layout (``weight`` / ``bias`` stay where checkpoints expect
+them) and remains a drop-in inside existing architectures, trainers, and
+optimizers. Quantization state lives in extra ``_q_*`` buffers so it
+round-trips through checkpoints.
+
+Weights are fake-quantized from the fp32 master copy on every forward, which
+keeps the modules correct for QAT (gradients flow to the masters through the
+straight-through estimator). Computation runs in an fp32 island even under
+autocast so the simulated arithmetic is exactly the declared scheme.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .fake_quant import (
+    autocast_off,
+    fake_quant_int8_affine,
+    fake_quant_int8_per_channel,
+    fake_quant_nvfp4_dynamic,
+    fake_quant_nvfp4_weight,
+)
+
+
+class _ActObserverMixin:
+    """Shared INT8 activation observer / fake-quant state."""
+
+    def _init_act_state(self):
+        self.register_buffer("_q_act_lo", torch.zeros(1))
+        self.register_buffer("_q_act_hi", torch.zeros(1))
+        self.register_buffer("_q_calibrated", torch.zeros(1, dtype=torch.uint8))
+        self._q_observing = False
+
+    @property
+    def q_calibrated(self) -> bool:
+        return bool(self._q_calibrated.item())
+
+    def _observe(self, x: torch.Tensor):
+        with torch.no_grad():
+            lo = x.amin().float().reshape(1)
+            hi = x.amax().float().reshape(1)
+            if self.q_calibrated:
+                torch.minimum(self._q_act_lo, lo, out=self._q_act_lo)
+                torch.maximum(self._q_act_hi, hi, out=self._q_act_hi)
+            else:
+                self._q_act_lo.copy_(lo)
+                self._q_act_hi.copy_(hi)
+                self._q_calibrated.fill_(1)
+
+    def _maybe_quant_input(self, x: torch.Tensor) -> torch.Tensor:
+        if self._q_observing:
+            self._observe(x)
+            return x
+        if self.q_calibrated:
+            return fake_quant_int8_affine(x, self._q_act_lo, self._q_act_hi)
+        return x
+
+
+class QuantConv2d(nn.Conv2d, _ActObserverMixin):
+    """INT8 W8A8 simulated convolution (per-channel weights, affine input)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._init_act_state()
+
+    @classmethod
+    def from_float(cls, conv: nn.Conv2d) -> "QuantConv2d":
+        mod = cls(
+            conv.in_channels,
+            conv.out_channels,
+            conv.kernel_size,
+            stride=conv.stride,
+            padding=conv.padding,
+            dilation=conv.dilation,
+            groups=conv.groups,
+            bias=conv.bias is not None,
+            padding_mode=conv.padding_mode,
+            device=conv.weight.device,
+            dtype=conv.weight.dtype,
+        )
+        mod.weight = conv.weight
+        mod.bias = conv.bias
+        return mod
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        with autocast_off(x.device.type):
+            x = x.float()
+            x = self._maybe_quant_input(x)
+            weight = fake_quant_int8_per_channel(self.weight.float())
+            bias = self.bias.float() if self.bias is not None else None
+            out = self._conv_forward(x, weight, bias)
+        return out.to(in_dtype) if in_dtype != out.dtype else out
+
+
+class QuantLinear(nn.Linear, _ActObserverMixin):
+    """INT8 W8A8 simulated linear (per-channel weights, affine input)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._init_act_state()
+
+    @classmethod
+    def from_float(cls, linear: nn.Linear) -> "QuantLinear":
+        mod = cls(
+            linear.in_features,
+            linear.out_features,
+            bias=linear.bias is not None,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+        )
+        mod.weight = linear.weight
+        mod.bias = linear.bias
+        return mod
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        with autocast_off(x.device.type):
+            x = x.float()
+            x = self._maybe_quant_input(x)
+            weight = fake_quant_int8_per_channel(self.weight.float())
+            bias = self.bias.float() if self.bias is not None else None
+            out = F.linear(x, weight, bias)
+        return out.to(in_dtype) if in_dtype != out.dtype else out
+
+
+class NVFP4Linear(nn.Linear):
+    """NVFP4 W4A4 simulated linear.
+
+    Weights: E2M1 in 16-element blocks with E4M3 block scales and a fixed
+    fp32 per-tensor scale captured at quantize time. Activations: dynamically
+    scaled per forward (two-level scaling), so no calibration is required.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.register_buffer("_q_w_amax", torch.zeros(1))
+        self._q_observing = False  # accepted for API symmetry; unused
+
+    @classmethod
+    def from_float(cls, linear: nn.Linear) -> "NVFP4Linear":
+        mod = cls(
+            linear.in_features,
+            linear.out_features,
+            bias=linear.bias is not None,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+        )
+        mod.weight = linear.weight
+        mod.bias = linear.bias
+        with torch.no_grad():
+            mod._q_w_amax.copy_(linear.weight.detach().abs().amax().float().reshape(1))
+        return mod
+
+    @property
+    def q_calibrated(self) -> bool:
+        return bool((self._q_w_amax > 0).item())
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        with autocast_off(x.device.type):
+            x = fake_quant_nvfp4_dynamic(x.float())
+            weight = fake_quant_nvfp4_weight(self.weight.float(), self._q_w_amax)
+            bias = self.bias.float() if self.bias is not None else None
+            out = F.linear(x, weight, bias)
+        return out.to(in_dtype) if in_dtype != out.dtype else out
+
+
+QUANT_MODULE_TYPES = (QuantConv2d, QuantLinear, NVFP4Linear)

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -24,6 +24,12 @@ from .fake_quant import (
     fake_quant_nvfp4_weight,
     int8_weight_qparams,
 )
+from .packing import (
+    pack_int8_weight,
+    pack_nvfp4_weight,
+    unpack_int8_weight,
+    unpack_nvfp4_weight,
+)
 
 
 class _ActObserverMixin:
@@ -52,6 +58,41 @@ class _ActObserverMixin:
 
     def _weight_scale(self):
         return self._q_w_scale if self._q_export_mode else None
+
+    @property
+    def is_finalized(self) -> bool:
+        return "weight_packed" in self._buffers
+
+    def make_finalized(self):
+        """Crystallize: replace the fp32 master weight with packed int8.
+
+        Unpacking reproduces the simulation's weight values bit for bit, so
+        finalized inference matches prepared inference exactly.
+        """
+        if self.is_finalized:
+            return
+        self.freeze_weight_qparams()
+        with torch.no_grad():
+            packed = pack_int8_weight(self.weight.detach(), self._q_w_scale)
+        del self._parameters["weight"]
+        self.register_buffer("weight_packed", packed)
+        self._q_export_mode = False
+
+    def make_prepared(self):
+        """Reconstruct fp32 masters from packed weights (QAT-from-PTQ)."""
+        if not self.is_finalized:
+            return
+        with torch.no_grad():
+            weight = unpack_int8_weight(self.weight_packed, self._q_w_scale)
+        del self._buffers["weight_packed"]
+        self.weight = nn.Parameter(weight)
+
+    def _effective_weight(self) -> torch.Tensor:
+        if self.is_finalized:
+            return unpack_int8_weight(self.weight_packed, self._q_w_scale)
+        return fake_quant_int8_per_channel(
+            self.weight.float(), scale=self._weight_scale()
+        )
 
     @property
     def q_calibrated(self) -> bool:
@@ -149,9 +190,7 @@ class QuantConv2d(nn.Conv2d, _ActObserverMixin):
         with autocast_off(x.device.type):
             x = x.float()
             x = self._maybe_quant_input(x)
-            weight = fake_quant_int8_per_channel(
-                self.weight.float(), scale=self._weight_scale()
-            )
+            weight = self._effective_weight()
             bias = self.bias.float() if self.bias is not None else None
             out = self._conv_forward(x, weight, bias)
         return out.to(in_dtype) if in_dtype != out.dtype else out
@@ -182,9 +221,7 @@ class QuantLinear(nn.Linear, _ActObserverMixin):
         with autocast_off(x.device.type):
             x = x.float()
             x = self._maybe_quant_input(x)
-            weight = fake_quant_int8_per_channel(
-                self.weight.float(), scale=self._weight_scale()
-            )
+            weight = self._effective_weight()
             bias = self.bias.float() if self.bias is not None else None
             out = F.linear(x, weight, bias)
         return out.to(in_dtype) if in_dtype != out.dtype else out
@@ -222,11 +259,52 @@ class NVFP4Linear(nn.Linear):
     def q_calibrated(self) -> bool:
         return bool((self._q_w_amax > 0).item())
 
+    @property
+    def is_finalized(self) -> bool:
+        return "weight_packed" in self._buffers
+
+    def make_finalized(self):
+        """Crystallize: replace fp32 masters with packed E2M1 + E4M3 scales."""
+        if self.is_finalized:
+            return
+        with torch.no_grad():
+            payload, block_scale = pack_nvfp4_weight(
+                self.weight.detach(), self._q_w_amax
+            )
+        del self._parameters["weight"]
+        self.register_buffer("weight_packed", payload)
+        self.register_buffer("weight_block_scale", block_scale)
+
+    def make_prepared(self):
+        """Reconstruct fp32 masters from packed weights (QAT-from-PTQ)."""
+        if not self.is_finalized:
+            return
+        with torch.no_grad():
+            weight = unpack_nvfp4_weight(
+                self.weight_packed,
+                self.weight_block_scale,
+                self._q_w_amax,
+                self.in_features,
+            )
+        del self._buffers["weight_packed"]
+        del self._buffers["weight_block_scale"]
+        self.weight = nn.Parameter(weight)
+
+    def _effective_weight(self) -> torch.Tensor:
+        if self.is_finalized:
+            return unpack_nvfp4_weight(
+                self.weight_packed,
+                self.weight_block_scale,
+                self._q_w_amax,
+                self.in_features,
+            )
+        return fake_quant_nvfp4_weight(self.weight.float(), self._q_w_amax)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         in_dtype = x.dtype
         with autocast_off(x.device.type):
             x = fake_quant_nvfp4_dynamic(x.float())
-            weight = fake_quant_nvfp4_weight(self.weight.float(), self._q_w_amax)
+            weight = self._effective_weight()
             bias = self.bias.float() if self.bias is not None else None
             out = F.linear(x, weight, bias)
         return out.to(in_dtype) if in_dtype != out.dtype else out

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -57,8 +57,31 @@ class _ActObserverMixin:
     def q_calibrated(self) -> bool:
         return bool(self._q_calibrated.item())
 
+    _Q_PERCENTILE = 0.999
+    _Q_OBS_SAMPLE_CAP = 1_000_000
+
     def _observe(self, x: torch.Tensor):
         with torch.no_grad():
+            if getattr(self, "_q_obs_method", "minmax") == "percentile":
+                # Mean of per-batch (0.1%, 99.9%) quantiles: robust to the
+                # activation outliers that make pure min/max ranges crush
+                # int8 resolution (worst on the smallest models). Strided
+                # subsampling keeps torch.quantile within its size limits.
+                flat = x.detach().reshape(-1).float()
+                if flat.numel() > self._Q_OBS_SAMPLE_CAP:
+                    step = (flat.numel() + self._Q_OBS_SAMPLE_CAP - 1) // self._Q_OBS_SAMPLE_CAP
+                    flat = flat[::step]
+                qs = torch.quantile(
+                    flat,
+                    torch.tensor(
+                        [1.0 - self._Q_PERCENTILE, self._Q_PERCENTILE],
+                        device=flat.device,
+                    ),
+                )
+                self._q_obs_lo_sum = getattr(self, "_q_obs_lo_sum", 0.0) + float(qs[0])
+                self._q_obs_hi_sum = getattr(self, "_q_obs_hi_sum", 0.0) + float(qs[1])
+                self._q_obs_n = getattr(self, "_q_obs_n", 0) + 1
+                return
             lo = x.amin().float().reshape(1).to(self._q_act_lo.device)
             hi = x.amax().float().reshape(1).to(self._q_act_hi.device)
             if self.q_calibrated:
@@ -68,6 +91,18 @@ class _ActObserverMixin:
                 self._q_act_lo.copy_(lo)
                 self._q_act_hi.copy_(hi)
                 self._q_calibrated.fill_(1)
+
+    def finalize_observation(self):
+        """Write percentile statistics into the calibrated range buffers."""
+        n = getattr(self, "_q_obs_n", 0)
+        if n:
+            with torch.no_grad():
+                self._q_act_lo.fill_(self._q_obs_lo_sum / n)
+                self._q_act_hi.fill_(self._q_obs_hi_sum / n)
+                self._q_calibrated.fill_(1)
+        for attr in ("_q_obs_lo_sum", "_q_obs_hi_sum", "_q_obs_n"):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
     def _maybe_quant_input(self, x: torch.Tensor) -> torch.Tensor:
         if self._q_observing:

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -16,17 +16,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from . import kernels as K
 from .fake_quant import (
     E4M3_MAX,
     autocast_off,
-    fake_quant_fp8,
-    fake_quant_int8_affine,
-    fake_quant_int8_per_channel,
-    fake_quant_int_grouped,
-    fake_quant_mxfp4_dynamic,
-    fake_quant_mxfp4_weight,
-    fake_quant_nvfp4_dynamic,
-    fake_quant_nvfp4_weight,
     fp8_weight_qparams,
     int8_weight_qparams,
     int_group_qparams,
@@ -116,13 +109,13 @@ class _ActObserverMixin:
                 return unpack_fp8_weight(self.weight_packed, self._q_w_scale)
             return unpack_int8_weight(self.weight_packed, self._q_w_scale)
         if fp8:
-            return fake_quant_fp8(
+            return K.fake_quant_fp8(
                 self.weight.float(),
                 fp8_weight_qparams(self.weight.float()).reshape(
                     -1, *([1] * (self.weight.dim() - 1))
                 ),
             )
-        return fake_quant_int8_per_channel(
+        return K.fake_quant_int8_per_channel(
             self.weight.float(), scale=self._weight_scale()
         )
 
@@ -185,8 +178,8 @@ class _ActObserverMixin:
             return x
         if getattr(self, "_q_aformat", "int8") == "fp8":
             amax = torch.maximum(self._q_act_lo.abs(), self._q_act_hi.abs())
-            return fake_quant_fp8(x, (amax / E4M3_MAX).reshape(1))
-        return fake_quant_int8_affine(
+            return K.fake_quant_fp8(x, (amax / E4M3_MAX).reshape(1))
+        return K.fake_quant_int8_affine(
             x,
             self._q_act_lo,
             self._q_act_hi,
@@ -333,12 +326,12 @@ class NVFP4Linear(nn.Linear):
                 self._q_w_amax,
                 self.in_features,
             )
-        return fake_quant_nvfp4_weight(self.weight.float(), self._q_w_amax)
+        return K.fake_quant_nvfp4_weight(self.weight.float(), self._q_w_amax)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         in_dtype = x.dtype
         with autocast_off(x.device.type):
-            x = fake_quant_nvfp4_dynamic(x.float())
+            x = K.fake_quant_nvfp4_dynamic(x.float())
             weight = self._effective_weight()
             bias = self.bias.float() if self.bias is not None else None
             out = F.linear(x, weight, bias)
@@ -430,7 +423,7 @@ class GroupQuantLinear(nn.Linear, _ActObserverMixin):
                 self._q_group,
                 self.in_features,
             )
-        return fake_quant_int_grouped(
+        return K.fake_quant_int_grouped(
             self.weight.float(), self._q_bits, self._q_group
         )
 
@@ -500,12 +493,12 @@ class MXFP4Linear(nn.Linear):
             return unpack_mxfp4_weight(
                 self.weight_packed, self.weight_block_exp, self.in_features
             )
-        return fake_quant_mxfp4_weight(self.weight.float())
+        return K.fake_quant_mxfp4_weight(self.weight.float())
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         in_dtype = x.dtype
         with autocast_off(x.device.type):
-            x = fake_quant_mxfp4_dynamic(x.float())
+            x = K.fake_quant_mxfp4_dynamic(x.float())
             weight = self._effective_weight()
             bias = self.bias.float() if self.bias is not None else None
             out = F.linear(x, weight, bias)

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -22,17 +22,29 @@ from .fake_quant import (
     fake_quant_int8_per_channel,
     fake_quant_nvfp4_dynamic,
     fake_quant_nvfp4_weight,
+    int8_weight_qparams,
 )
 
 
 class _ActObserverMixin:
     """Shared INT8 activation observer / fake-quant state."""
 
-    def _init_act_state(self):
+    def _init_act_state(self, out_channels: int):
         self.register_buffer("_q_act_lo", torch.zeros(1))
         self.register_buffer("_q_act_hi", torch.zeros(1))
         self.register_buffer("_q_calibrated", torch.zeros(1, dtype=torch.uint8))
+        self.register_buffer("_q_w_scale", torch.zeros(out_channels))
         self._q_observing = False
+        self._q_export_mode = False
+
+    def freeze_weight_qparams(self):
+        """Bake the current per-channel weight scales into a buffer so ONNX
+        tracing emits them as constants (export mode)."""
+        with torch.no_grad():
+            self._q_w_scale.copy_(int8_weight_qparams(self.weight.float()))
+
+    def _weight_scale(self):
+        return self._q_w_scale if self._q_export_mode else None
 
     @property
     def q_calibrated(self) -> bool:
@@ -55,7 +67,12 @@ class _ActObserverMixin:
             self._observe(x)
             return x
         if self.q_calibrated:
-            return fake_quant_int8_affine(x, self._q_act_lo, self._q_act_hi)
+            return fake_quant_int8_affine(
+                x,
+                self._q_act_lo,
+                self._q_act_hi,
+                scalars=getattr(self, "_q_export_mode", False),
+            )
         return x
 
 
@@ -64,7 +81,7 @@ class QuantConv2d(nn.Conv2d, _ActObserverMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._init_act_state()
+        self._init_act_state(self.out_channels)
 
     @classmethod
     def from_float(cls, conv: nn.Conv2d) -> "QuantConv2d":
@@ -90,7 +107,9 @@ class QuantConv2d(nn.Conv2d, _ActObserverMixin):
         with autocast_off(x.device.type):
             x = x.float()
             x = self._maybe_quant_input(x)
-            weight = fake_quant_int8_per_channel(self.weight.float())
+            weight = fake_quant_int8_per_channel(
+                self.weight.float(), scale=self._weight_scale()
+            )
             bias = self.bias.float() if self.bias is not None else None
             out = self._conv_forward(x, weight, bias)
         return out.to(in_dtype) if in_dtype != out.dtype else out
@@ -101,7 +120,7 @@ class QuantLinear(nn.Linear, _ActObserverMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._init_act_state()
+        self._init_act_state(self.out_features)
 
     @classmethod
     def from_float(cls, linear: nn.Linear) -> "QuantLinear":
@@ -121,7 +140,9 @@ class QuantLinear(nn.Linear, _ActObserverMixin):
         with autocast_off(x.device.type):
             x = x.float()
             x = self._maybe_quant_input(x)
-            weight = fake_quant_int8_per_channel(self.weight.float())
+            weight = fake_quant_int8_per_channel(
+                self.weight.float(), scale=self._weight_scale()
+            )
             bias = self.bias.float() if self.bias is not None else None
             out = F.linear(x, weight, bias)
         return out.to(in_dtype) if in_dtype != out.dtype else out

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -17,17 +17,30 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .fake_quant import (
+    E4M3_MAX,
     autocast_off,
+    fake_quant_fp8,
     fake_quant_int8_affine,
     fake_quant_int8_per_channel,
+    fake_quant_int_grouped,
+    fake_quant_mxfp4_dynamic,
+    fake_quant_mxfp4_weight,
     fake_quant_nvfp4_dynamic,
     fake_quant_nvfp4_weight,
+    fp8_weight_qparams,
     int8_weight_qparams,
+    int_group_qparams,
 )
 from .packing import (
+    pack_fp8_weight,
     pack_int8_weight,
+    pack_int_grouped_weight,
+    pack_mxfp4_weight,
     pack_nvfp4_weight,
+    unpack_fp8_weight,
     unpack_int8_weight,
+    unpack_int_grouped_weight,
+    unpack_mxfp4_weight,
     unpack_nvfp4_weight,
 )
 
@@ -54,7 +67,10 @@ class _ActObserverMixin:
         """Bake the current per-channel weight scales into a buffer so ONNX
         tracing emits them as constants (export mode)."""
         with torch.no_grad():
-            self._q_w_scale.copy_(int8_weight_qparams(self.weight.float()))
+            if getattr(self, "_q_wformat", "int8") == "fp8":
+                self._q_w_scale.copy_(fp8_weight_qparams(self.weight.float()))
+            else:
+                self._q_w_scale.copy_(int8_weight_qparams(self.weight.float()))
 
     def _weight_scale(self):
         return self._q_w_scale if self._q_export_mode else None
@@ -64,7 +80,7 @@ class _ActObserverMixin:
         return "weight_packed" in self._buffers
 
     def make_finalized(self):
-        """Crystallize: replace the fp32 master weight with packed int8.
+        """Crystallize: replace the fp32 master weight with packed low bits.
 
         Unpacking reproduces the simulation's weight values bit for bit, so
         finalized inference matches prepared inference exactly.
@@ -73,7 +89,10 @@ class _ActObserverMixin:
             return
         self.freeze_weight_qparams()
         with torch.no_grad():
-            packed = pack_int8_weight(self.weight.detach(), self._q_w_scale)
+            if getattr(self, "_q_wformat", "int8") == "fp8":
+                packed = pack_fp8_weight(self.weight.detach(), self._q_w_scale)
+            else:
+                packed = pack_int8_weight(self.weight.detach(), self._q_w_scale)
         del self._parameters["weight"]
         self.register_buffer("weight_packed", packed)
         self._q_export_mode = False
@@ -83,13 +102,26 @@ class _ActObserverMixin:
         if not self.is_finalized:
             return
         with torch.no_grad():
-            weight = unpack_int8_weight(self.weight_packed, self._q_w_scale)
+            if getattr(self, "_q_wformat", "int8") == "fp8":
+                weight = unpack_fp8_weight(self.weight_packed, self._q_w_scale)
+            else:
+                weight = unpack_int8_weight(self.weight_packed, self._q_w_scale)
         del self._buffers["weight_packed"]
         self.weight = nn.Parameter(weight)
 
     def _effective_weight(self) -> torch.Tensor:
+        fp8 = getattr(self, "_q_wformat", "int8") == "fp8"
         if self.is_finalized:
+            if fp8:
+                return unpack_fp8_weight(self.weight_packed, self._q_w_scale)
             return unpack_int8_weight(self.weight_packed, self._q_w_scale)
+        if fp8:
+            return fake_quant_fp8(
+                self.weight.float(),
+                fp8_weight_qparams(self.weight.float()).reshape(
+                    -1, *([1] * (self.weight.dim() - 1))
+                ),
+            )
         return fake_quant_int8_per_channel(
             self.weight.float(), scale=self._weight_scale()
         )
@@ -149,14 +181,17 @@ class _ActObserverMixin:
         if self._q_observing:
             self._observe(x)
             return x
-        if self.q_calibrated:
-            return fake_quant_int8_affine(
-                x,
-                self._q_act_lo,
-                self._q_act_hi,
-                scalars=getattr(self, "_q_export_mode", False),
-            )
-        return x
+        if not self.q_calibrated:
+            return x
+        if getattr(self, "_q_aformat", "int8") == "fp8":
+            amax = torch.maximum(self._q_act_lo.abs(), self._q_act_hi.abs())
+            return fake_quant_fp8(x, (amax / E4M3_MAX).reshape(1))
+        return fake_quant_int8_affine(
+            x,
+            self._q_act_lo,
+            self._q_act_hi,
+            scalars=getattr(self, "_q_export_mode", False),
+        )
 
 
 class QuantConv2d(nn.Conv2d, _ActObserverMixin):
@@ -310,4 +345,177 @@ class NVFP4Linear(nn.Linear):
         return out.to(in_dtype) if in_dtype != out.dtype else out
 
 
-QUANT_MODULE_TYPES = (QuantConv2d, QuantLinear, NVFP4Linear)
+class GroupQuantLinear(nn.Linear, _ActObserverMixin):
+    """Grouped symmetric integer weight quantization (W4/W2 style linears).
+
+    Weights: per-group symmetric int codes (``_q_bits`` in {2, 4}, group size
+    along in_features). Activations: optional calibrated INT8 (W4A8/W2A8) or
+    untouched float (W4A16 style).
+    """
+
+    def __init__(self, *args, bits: int = 4, group_size: int = 128, act_int8: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._q_bits = int(bits)
+        self._q_group = int(group_size)
+        self._q_act_enabled = bool(act_int8)
+        self._init_act_state(self.out_features)
+        ngroups = (self.in_features + self._q_group - 1) // self._q_group
+        self.register_buffer(
+            "_q_w_gscale",
+            torch.zeros(self.out_features, ngroups, device=self.weight.device),
+        )
+
+    @classmethod
+    def from_float(
+        cls,
+        linear: nn.Linear,
+        bits: int = 4,
+        group_size: int = 128,
+        act_int8: bool = False,
+    ) -> "GroupQuantLinear":
+        mod = cls(
+            linear.in_features,
+            linear.out_features,
+            bias=linear.bias is not None,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+            bits=bits,
+            group_size=group_size,
+            act_int8=act_int8,
+        )
+        mod.weight = linear.weight
+        mod.bias = linear.bias
+        return mod
+
+    def freeze_weight_qparams(self):
+        with torch.no_grad():
+            self._q_w_gscale.copy_(
+                int_group_qparams(self.weight.float(), self._q_bits, self._q_group)
+            )
+
+    def make_finalized(self):
+        if self.is_finalized:
+            return
+        self.freeze_weight_qparams()
+        with torch.no_grad():
+            payload, _ = pack_int_grouped_weight(
+                self.weight.detach().float(),
+                self._q_bits,
+                self._q_group,
+                scale=self._q_w_gscale,
+            )
+        del self._parameters["weight"]
+        self.register_buffer("weight_packed", payload)
+
+    def make_prepared(self):
+        if not self.is_finalized:
+            return
+        with torch.no_grad():
+            weight = unpack_int_grouped_weight(
+                self.weight_packed,
+                self._q_w_gscale,
+                self._q_bits,
+                self._q_group,
+                self.in_features,
+            )
+        del self._buffers["weight_packed"]
+        self.weight = nn.Parameter(weight)
+
+    def _effective_weight(self) -> torch.Tensor:
+        if self.is_finalized:
+            return unpack_int_grouped_weight(
+                self.weight_packed,
+                self._q_w_gscale,
+                self._q_bits,
+                self._q_group,
+                self.in_features,
+            )
+        return fake_quant_int_grouped(
+            self.weight.float(), self._q_bits, self._q_group
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        with autocast_off(x.device.type):
+            x = x.float()
+            if self._q_act_enabled or self._q_observing:
+                x = self._maybe_quant_input(x)
+            weight = self._effective_weight()
+            bias = self.bias.float() if self.bias is not None else None
+            out = F.linear(x, weight, bias)
+        return out.to(in_dtype) if in_dtype != out.dtype else out
+
+
+class MXFP4Linear(nn.Linear):
+    """OCP MXFP4 W4A4 simulated linear: E2M1 elements, 32-element blocks,
+    power-of-two (E8M0) block scales, dynamic activation scaling."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._q_observing = False  # API symmetry; unused
+
+    @classmethod
+    def from_float(cls, linear: nn.Linear) -> "MXFP4Linear":
+        mod = cls(
+            linear.in_features,
+            linear.out_features,
+            bias=linear.bias is not None,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+        )
+        mod.weight = linear.weight
+        mod.bias = linear.bias
+        return mod
+
+    @property
+    def q_calibrated(self) -> bool:
+        return True  # dynamic activation scaling: nothing to calibrate
+
+    @property
+    def is_finalized(self) -> bool:
+        return "weight_packed" in self._buffers
+
+    def make_finalized(self):
+        if self.is_finalized:
+            return
+        with torch.no_grad():
+            payload, exponents = pack_mxfp4_weight(self.weight.detach().float())
+        del self._parameters["weight"]
+        self.register_buffer("weight_packed", payload)
+        self.register_buffer("weight_block_exp", exponents)
+
+    def make_prepared(self):
+        if not self.is_finalized:
+            return
+        with torch.no_grad():
+            weight = unpack_mxfp4_weight(
+                self.weight_packed, self.weight_block_exp, self.in_features
+            )
+        del self._buffers["weight_packed"]
+        del self._buffers["weight_block_exp"]
+        self.weight = nn.Parameter(weight)
+
+    def _effective_weight(self) -> torch.Tensor:
+        if self.is_finalized:
+            return unpack_mxfp4_weight(
+                self.weight_packed, self.weight_block_exp, self.in_features
+            )
+        return fake_quant_mxfp4_weight(self.weight.float())
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        with autocast_off(x.device.type):
+            x = fake_quant_mxfp4_dynamic(x.float())
+            weight = self._effective_weight()
+            bias = self.bias.float() if self.bias is not None else None
+            out = F.linear(x, weight, bias)
+        return out.to(in_dtype) if in_dtype != out.dtype else out
+
+
+QUANT_MODULE_TYPES = (
+    QuantConv2d,
+    QuantLinear,
+    NVFP4Linear,
+    MXFP4Linear,
+    GroupQuantLinear,
+)

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -30,10 +30,17 @@ class _ActObserverMixin:
     """Shared INT8 activation observer / fake-quant state."""
 
     def _init_act_state(self, out_channels: int):
-        self.register_buffer("_q_act_lo", torch.zeros(1))
-        self.register_buffer("_q_act_hi", torch.zeros(1))
-        self.register_buffer("_q_calibrated", torch.zeros(1, dtype=torch.uint8))
-        self.register_buffer("_q_w_scale", torch.zeros(out_channels))
+        # Buffers must live on the weight's device from the start: modules are
+        # built with device=weight.device by from_float, and a CPU-born buffer
+        # would survive until the post-quantize .to() call, crashing
+        # multi-batch calibration on GPU.
+        device = self.weight.device
+        self.register_buffer("_q_act_lo", torch.zeros(1, device=device))
+        self.register_buffer("_q_act_hi", torch.zeros(1, device=device))
+        self.register_buffer(
+            "_q_calibrated", torch.zeros(1, dtype=torch.uint8, device=device)
+        )
+        self.register_buffer("_q_w_scale", torch.zeros(out_channels, device=device))
         self._q_observing = False
         self._q_export_mode = False
 
@@ -52,8 +59,8 @@ class _ActObserverMixin:
 
     def _observe(self, x: torch.Tensor):
         with torch.no_grad():
-            lo = x.amin().float().reshape(1)
-            hi = x.amax().float().reshape(1)
+            lo = x.amin().float().reshape(1).to(self._q_act_lo.device)
+            hi = x.amax().float().reshape(1).to(self._q_act_hi.device)
             if self.q_calibrated:
                 torch.minimum(self._q_act_lo, lo, out=self._q_act_lo)
                 torch.maximum(self._q_act_hi, hi, out=self._q_act_hi)
@@ -158,7 +165,7 @@ class NVFP4Linear(nn.Linear):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.register_buffer("_q_w_amax", torch.zeros(1))
+        self.register_buffer("_q_w_amax", torch.zeros(1, device=self.weight.device))
         self._q_observing = False  # accepted for API symmetry; unused
 
     @classmethod

--- a/libreyolo/quant/packing.py
+++ b/libreyolo/quant/packing.py
@@ -21,9 +21,12 @@ import torch
 from .fake_quant import (
     _E2M1_LEVELS,
     _E2M1_MIDPOINTS,
+    _e8m0_scale,
     E2M1_MAX,
     E4M3_MAX,
+    MXFP4_BLOCK,
     NVFP4_BLOCK,
+    int_group_qparams,
     quantize_e4m3,
 )
 
@@ -57,6 +60,127 @@ def unpack_int8_weight(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tenso
     """Dequantize; bit-identical to fake_quant_int8_per_channel(masters)."""
     s = _scale_view(scale.float(), packed.dim()).clamp(min=_EPS)
     return packed.float() * s
+
+
+def pack_fp8_weight(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Store the weight as a real float8_e4m3fn tensor (native dtype)."""
+    s = _scale_view(scale.float().clamp(min=_EPS), weight.dim())
+    return (weight.float() / s).clamp(-E4M3_MAX, E4M3_MAX).to(torch.float8_e4m3fn)
+
+
+def unpack_fp8_weight(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Dequantize; bit-identical to fake_quant_fp8(masters, scale)."""
+    s = _scale_view(scale.float().clamp(min=_EPS), packed.dim())
+    return packed.to(torch.float32) * s
+
+
+def pack_int_grouped_weight(
+    weight: torch.Tensor,
+    bits: int,
+    group_size: int,
+    scale: torch.Tensor | None = None,
+):
+    """Pack grouped symmetric integer weights into unsigned codes.
+
+    4-bit: two codes per byte (low nibble first). 2-bit: four codes per byte
+    (lowest crumb first). Codes are offset by 2**(bits-1).
+    """
+    assert bits in (2, 4), bits
+    out_features, in_features = weight.shape
+    if scale is None:
+        scale = int_group_qparams(weight, bits, group_size)
+    pad = (-in_features) % group_size
+    w = weight.detach().float()
+    if pad:
+        w = torch.nn.functional.pad(w, (0, pad))
+    groups = w.reshape(out_features, -1, group_size)
+    qmin = -(2 ** (bits - 1))
+    qmax = 2 ** (bits - 1) - 1
+    s = scale.unsqueeze(-1).clamp(min=_EPS)
+    q = torch.clamp(torch.round(groups / s), qmin, qmax).to(torch.int64)
+    codes = (q - qmin).reshape(out_features, -1).to(torch.uint8)
+    if bits == 4:
+        payload = codes[:, 0::2] | (codes[:, 1::2] << 4)
+    else:
+        payload = (
+            codes[:, 0::4]
+            | (codes[:, 1::4] << 2)
+            | (codes[:, 2::4] << 4)
+            | (codes[:, 3::4] << 6)
+        )
+    return payload.contiguous(), scale.contiguous().float()
+
+
+def unpack_int_grouped_weight(
+    payload: torch.Tensor,
+    scale: torch.Tensor,
+    bits: int,
+    group_size: int,
+    in_features: int,
+) -> torch.Tensor:
+    """Dequantize; bit-identical to fake_quant_int_grouped(masters)."""
+    assert bits in (2, 4), bits
+    out_features = payload.shape[0]
+    per_byte = 8 // bits
+    codes = torch.empty(
+        (out_features, payload.shape[1] * per_byte),
+        dtype=torch.uint8,
+        device=payload.device,
+    )
+    if bits == 4:
+        codes[:, 0::2] = payload & 0x0F
+        codes[:, 1::2] = payload >> 4
+    else:
+        codes[:, 0::4] = payload & 0x03
+        codes[:, 1::4] = (payload >> 2) & 0x03
+        codes[:, 2::4] = (payload >> 4) & 0x03
+        codes[:, 3::4] = (payload >> 6) & 0x03
+    qmin = -(2 ** (bits - 1))
+    q = codes.float() + qmin
+    s = scale.float().clamp(min=_EPS).unsqueeze(-1)
+    groups = q.reshape(out_features, -1, group_size) * s
+    return groups.reshape(out_features, -1)[:, :in_features].contiguous()
+
+
+def pack_mxfp4_weight(weight: torch.Tensor):
+    """Pack an fp32 [out, in] weight into (payload uint8, block exponents)."""
+    out_features, in_features = weight.shape
+    w = weight.detach().float()
+    pad = (-in_features) % MXFP4_BLOCK
+    if pad:
+        w = torch.nn.functional.pad(w, (0, pad))
+    blocks = w.reshape(out_features, -1, MXFP4_BLOCK)
+    block_amax = blocks.abs().amax(dim=-1, keepdim=True)
+    eff = _e8m0_scale(block_amax)
+    scaled = blocks / eff
+    midpoints = _E2M1_MIDPOINTS.to(device=weight.device, dtype=torch.float32)
+    idx = torch.bucketize(scaled.abs().clamp(max=E2M1_MAX), midpoints).to(torch.uint8)
+    sign = (scaled < 0).to(torch.uint8)
+    codes = (idx | (sign << 3)).reshape(out_features, -1)
+    payload = codes[:, 0::2] | (codes[:, 1::2] << 4)
+    exponents = torch.log2(eff.squeeze(-1)).round().to(torch.int8)
+    return payload.contiguous(), exponents.contiguous()
+
+
+def unpack_mxfp4_weight(
+    payload: torch.Tensor,
+    exponents: torch.Tensor,
+    in_features: int,
+) -> torch.Tensor:
+    """Dequantize; bit-identical to fake_quant_mxfp4_weight(masters)."""
+    out_features = payload.shape[0]
+    codes = torch.empty(
+        (out_features, payload.shape[1] * 2), dtype=torch.uint8, device=payload.device
+    )
+    codes[:, 0::2] = payload & 0x0F
+    codes[:, 1::2] = payload >> 4
+    idx = (codes & 0x07).long()
+    sign = torch.where((codes & 0x08).bool(), -1.0, 1.0)
+    levels = _E2M1_LEVELS.to(device=payload.device, dtype=torch.float32)
+    values = levels[idx] * sign
+    eff = torch.exp2(exponents.float()).unsqueeze(-1)
+    blocks = values.reshape(out_features, -1, MXFP4_BLOCK) * eff
+    return blocks.reshape(out_features, -1)[:, :in_features].contiguous()
 
 
 def _nvfp4_eff_scales(weight2d: torch.Tensor, tensor_amax: torch.Tensor):

--- a/libreyolo/quant/packing.py
+++ b/libreyolo/quant/packing.py
@@ -1,0 +1,111 @@
+"""Packed storage for finalized quantized checkpoints.
+
+The invariant that keeps finalized checkpoints explainable: unpacking a
+packed weight reproduces bit for bit the values the fake-quant simulation
+computes from the fp32 masters. Finalized inference is therefore numerically
+identical to prepared inference; only the storage changes.
+
+Layouts (documented for external consumers in docs/checkpoint_schema.md):
+
+- int8: ``weight_packed`` int8 tensor in the original weight shape, plus the
+  per-channel fp32 scale in ``_q_w_scale``. Dequant: ``packed * scale``.
+- nvfp4: ``weight_packed`` uint8 tensor of shape [out, ceil(in/16)*8], two
+  4-bit codes per byte (low nibble first; code = sign<<3 | level index into
+  the E2M1 magnitude table), ``weight_block_scale`` float8_e4m3fn tensor of
+  shape [out, ceil(in/16)], and the fp32 per-tensor amax in ``_q_w_amax``.
+  Effective block scale: ``block_scale * amax / (448 * 6)``.
+"""
+
+import torch
+
+from .fake_quant import (
+    _E2M1_LEVELS,
+    _E2M1_MIDPOINTS,
+    E2M1_MAX,
+    E4M3_MAX,
+    NVFP4_BLOCK,
+    quantize_e4m3,
+)
+
+_EPS = 1e-12
+
+
+def _scale_view(scale: torch.Tensor, ndim: int) -> torch.Tensor:
+    return scale.reshape(-1, *([1] * (ndim - 1)))
+
+
+def pack_int8_weight(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Quantize an fp32 weight onto the int8 grid used by the simulation.
+
+    Routes through torch.fake_quantize so the integer codes come from the
+    exact same kernel arithmetic the simulation uses (CUDA's fast division
+    can differ from a plain divide by one code at rounding boundaries);
+    unpacking therefore reproduces the simulation bit for bit on every
+    device.
+    """
+    weight = weight.float()
+    scale = scale.float().clamp(min=_EPS)
+    zero_point = torch.zeros(scale.shape, dtype=torch.int32, device=weight.device)
+    fq = torch.fake_quantize_per_channel_affine(
+        weight, scale, zero_point, 0, -128, 127
+    )
+    s = _scale_view(scale, weight.dim())
+    return torch.round(fq / s).to(torch.int8)
+
+
+def unpack_int8_weight(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Dequantize; bit-identical to fake_quant_int8_per_channel(masters)."""
+    s = _scale_view(scale.float(), packed.dim()).clamp(min=_EPS)
+    return packed.float() * s
+
+
+def _nvfp4_eff_scales(weight2d: torch.Tensor, tensor_amax: torch.Tensor):
+    """Blocked view plus the (e4m3 block scales, effective scales) pair."""
+    out_features, in_features = weight2d.shape
+    pad = (-in_features) % NVFP4_BLOCK
+    if pad:
+        weight2d = torch.nn.functional.pad(weight2d, (0, pad))
+    blocks = weight2d.reshape(out_features, -1, NVFP4_BLOCK)
+    tensor_scale = (tensor_amax.float() / (E4M3_MAX * E2M1_MAX)).clamp(min=_EPS)
+    block_amax = blocks.abs().amax(dim=-1, keepdim=True)
+    block_scale = quantize_e4m3(block_amax / (E2M1_MAX * tensor_scale))
+    eff = (block_scale * tensor_scale).clamp(min=_EPS)
+    return blocks, block_scale.squeeze(-1), eff
+
+
+def pack_nvfp4_weight(weight: torch.Tensor, tensor_amax: torch.Tensor):
+    """Pack an fp32 [out, in] weight into (payload uint8, block scales f8)."""
+    blocks, block_scale, eff = _nvfp4_eff_scales(weight.float(), tensor_amax)
+    scaled = blocks / eff
+    midpoints = _E2M1_MIDPOINTS.to(device=weight.device, dtype=torch.float32)
+    idx = torch.bucketize(scaled.abs().clamp(max=E2M1_MAX), midpoints).to(torch.uint8)
+    sign = (scaled < 0).to(torch.uint8)
+    codes = (idx | (sign << 3)).reshape(weight.shape[0], -1)  # [out, padded_in]
+    payload = codes[:, 0::2] | (codes[:, 1::2] << 4)
+    if hasattr(torch, "float8_e4m3fn"):
+        block_scale = block_scale.to(torch.float8_e4m3fn)
+    return payload.contiguous(), block_scale.contiguous()
+
+
+def unpack_nvfp4_weight(
+    payload: torch.Tensor,
+    block_scale: torch.Tensor,
+    tensor_amax: torch.Tensor,
+    in_features: int,
+) -> torch.Tensor:
+    """Dequantize; bit-identical to fake_quant_nvfp4_weight(masters)."""
+    out_features = payload.shape[0]
+    codes = torch.empty(
+        (out_features, payload.shape[1] * 2), dtype=torch.uint8, device=payload.device
+    )
+    codes[:, 0::2] = payload & 0x0F
+    codes[:, 1::2] = payload >> 4
+    idx = (codes & 0x07).long()
+    sign = torch.where((codes & 0x08).bool(), -1.0, 1.0)
+    levels = _E2M1_LEVELS.to(device=payload.device, dtype=torch.float32)
+    values = levels[idx] * sign
+
+    tensor_scale = (tensor_amax.float() / (E4M3_MAX * E2M1_MAX)).clamp(min=_EPS)
+    eff = (block_scale.float() * tensor_scale).clamp(min=_EPS)
+    blocks = values.reshape(out_features, -1, NVFP4_BLOCK) * eff.unsqueeze(-1)
+    return blocks.reshape(out_features, -1)[:, :in_features].contiguous()

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1246,11 +1246,12 @@ class BaseTrainer(ABC):
             return
 
         quant_manifest = getattr(self.wrapper_model, "_quant_manifest", None)
-        if quant_manifest and quant_manifest.get("recipe") == "fp16":
+        if quant_manifest and quant_manifest.get("recipe") in ("fp16", "bf16"):
             raise ValueError(
-                "fp16-quantized models are inference-only. Train the float "
-                "model with amp=True instead, or use recipe='int8'/'nvfp4' "
-                "for quantization-aware training."
+                "Cast-precision quantized models (fp16/bf16) are "
+                "inference-only. Train the float model with amp=True "
+                "instead, or use a quantizing recipe (int8/fp8/w4a8/nvfp4/"
+                "...) for quantization-aware training."
             )
         if quant_manifest and quant_manifest.get("state") == "finalized":
             from ..quant.api import reprepare_model

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1252,6 +1252,10 @@ class BaseTrainer(ABC):
                 "model with amp=True instead, or use recipe='int8'/'nvfp4' "
                 "for quantization-aware training."
             )
+        if quant_manifest and quant_manifest.get("state") == "finalized":
+            from ..quant.api import reprepare_model
+
+            reprepare_model(self.wrapper_model)
 
         if getattr(self.config, "lora", False) and not self.supports_lora:
             family = self.get_model_family() if hasattr(self, "get_model_family") else "this model"

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1245,6 +1245,14 @@ class BaseTrainer(ABC):
         if self._is_setup:
             return
 
+        quant_manifest = getattr(self.wrapper_model, "_quant_manifest", None)
+        if quant_manifest and quant_manifest.get("recipe") == "fp16":
+            raise ValueError(
+                "fp16-quantized models are inference-only. Train the float "
+                "model with amp=True instead, or use recipe='int8'/'nvfp4' "
+                "for quantization-aware training."
+            )
+
         if getattr(self.config, "lora", False) and not self.supports_lora:
             family = self.get_model_family() if hasattr(self, "get_model_family") else "this model"
             raise ValueError(
@@ -2736,6 +2744,11 @@ class BaseTrainer(ABC):
             is_ema_weights=self.ema_model is not None,
         )
         checkpoint.update(self._checkpoint_extra_metadata())
+        quant_manifest = getattr(self.wrapper_model, "_quant_manifest", None)
+        if quant_manifest:
+            # QAT/QAD checkpoints must be self-describing so LibreYOLO(path)
+            # rebuilds the quantized structure before loading scales.
+            checkpoint["quant"] = dict(quant_manifest)
         checkpoint["best_metric"] = self.best_mAP50_95
         checkpoint["best_metric_name"] = checkpoint["best_metric_key"]
         if self.ema_model is not None:

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -199,6 +199,77 @@ def test_nvfp4_linear_finalize_roundtrip():
 
 
 # ---------------------------------------------------------------------------
+# Kernel registry
+# ---------------------------------------------------------------------------
+
+
+def test_kernel_registry_defaults_to_reference():
+    from libreyolo.quant import fake_quant, kernels
+
+    for op in kernels.REFERENCE_OPS:
+        assert kernels.resolve(op) is getattr(fake_quant, op)
+    assert kernels.active()["fake_quant_int8_per_channel"] == "reference"
+
+
+def test_kernel_registry_custom_impl_and_env_override(monkeypatch):
+    from libreyolo.quant import fake_quant, kernels
+
+    calls = {}
+
+    def custom(weight, ch_axis=0, scale=None):
+        calls["hit"] = True
+        return fake_quant.fake_quant_int8_per_channel(weight, ch_axis, scale)
+
+    kernels.register(
+        "fake_quant_int8_per_channel", custom, name="testkern",
+        predicate=lambda: True,
+    )
+    try:
+        kernels.clear_cache()
+        assert kernels.resolve("fake_quant_int8_per_channel") is custom
+        out = kernels.fake_quant_int8_per_channel(torch.randn(4, 8))
+        assert calls.get("hit") and out.shape == (4, 8)
+        assert kernels.active()["fake_quant_int8_per_channel"] == "testkern"
+
+        # A quantized module transparently uses the registered kernel.
+        calls.clear()
+        conv = QuantConv2d.from_float(nn.Conv2d(3, 8, 3, padding=1))
+        with torch.no_grad():
+            conv(torch.randn(1, 3, 8, 8))
+        assert calls.get("hit")
+
+        # Env override forces the reference implementation.
+        monkeypatch.setenv("LIBREYOLO_QUANT_KERNELS", "off")
+        kernels.clear_cache()
+        assert (
+            kernels.resolve("fake_quant_int8_per_channel")
+            is fake_quant.fake_quant_int8_per_channel
+        )
+    finally:
+        monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
+        kernels.unregister("fake_quant_int8_per_channel", "testkern")
+        kernels.clear_cache()
+
+
+def test_kernel_registry_predicate_gates_selection():
+    from libreyolo.quant import fake_quant, kernels
+
+    kernels.register(
+        "fake_quant_int8_per_channel", lambda *a, **k: None, name="never",
+        predicate=lambda: False,
+    )
+    try:
+        kernels.clear_cache()
+        assert (
+            kernels.resolve("fake_quant_int8_per_channel")
+            is fake_quant.fake_quant_int8_per_channel
+        )
+    finally:
+        kernels.unregister("fake_quant_int8_per_channel", "never")
+        kernels.clear_cache()
+
+
+# ---------------------------------------------------------------------------
 # New precision recipes: arithmetic + module roundtrips
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -18,6 +18,13 @@ from libreyolo.quant.fake_quant import (
     fake_quant_int8_affine,
     fake_quant_int8_per_channel,
     fake_quant_nvfp4_weight,
+    int8_weight_qparams,
+)
+from libreyolo.quant.packing import (
+    pack_int8_weight,
+    pack_nvfp4_weight,
+    unpack_int8_weight,
+    unpack_nvfp4_weight,
 )
 
 
@@ -148,6 +155,47 @@ def test_quant_buffers_live_on_weight_device():
         lin = lin.cuda()
     qlin = NVFP4Linear.from_float(lin)
     assert qlin._q_w_amax.device == qlin.weight.device
+
+
+# ---------------------------------------------------------------------------
+# Packing (finalized checkpoints)
+# ---------------------------------------------------------------------------
+
+
+def test_int8_pack_unpack_matches_simulation():
+    torch.manual_seed(0)
+    w = torch.randn(16, 8, 3, 3)
+    scale = int8_weight_qparams(w)
+    packed = pack_int8_weight(w, scale)
+    assert packed.dtype == torch.int8
+    assert torch.equal(unpack_int8_weight(packed, scale), fake_quant_int8_per_channel(w))
+
+
+def test_nvfp4_pack_unpack_matches_simulation():
+    torch.manual_seed(0)
+    for in_features in (48, 20):  # multiple and non-multiple of the 16-block
+        w = torch.randn(8, in_features) * 0.05
+        amax = w.abs().amax().reshape(1)
+        payload, block_scale = pack_nvfp4_weight(w, amax)
+        assert payload.dtype == torch.uint8
+        assert payload.shape == (8, ((in_features + 15) // 16) * 8)
+        out = unpack_nvfp4_weight(payload, block_scale, amax, in_features)
+        assert torch.equal(out, fake_quant_nvfp4_weight(w, amax))
+
+
+def test_nvfp4_linear_finalize_roundtrip():
+    torch.manual_seed(0)
+    lin = nn.Linear(64, 32)
+    q = NVFP4Linear.from_float(lin)
+    x = torch.randn(4, 64)
+    with torch.no_grad():
+        ref = q(x)
+        q.make_finalized()
+        assert q.is_finalized and "weight" not in dict(q.named_parameters())
+        assert torch.equal(q(x), ref)
+        q.make_prepared()
+        assert not q.is_finalized
+        assert torch.equal(q(x), ref)
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +337,51 @@ def test_fp16_dequantize_restores_float_dtype(yolo9t):
     while isinstance(leaf, (tuple, list)):
         leaf = leaf[0]
     assert leaf.dtype == torch.float32
+
+
+def _leaf(out):
+    leaf = next(iter(out.values())) if isinstance(out, dict) else out
+    while isinstance(leaf, (tuple, list)):
+        leaf = leaf[0]
+    return leaf
+
+
+def test_finalized_pt_export_roundtrip(tmp_path, yolo9t):
+    from libreyolo.quant import reprepare_model
+
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    yolo9t.model.eval()
+    x = torch.randn(1, 3, 640, 640)
+    with torch.no_grad():
+        ref = _leaf(yolo9t.model(x))
+
+    prepared = tmp_path / "prep.pt"
+    yolo9t.save(str(prepared))
+    final = yolo9t.export(format="pt", out=str(tmp_path / "final.pt"), remainder="fp32")
+
+    import os
+    assert os.path.getsize(final) < os.path.getsize(prepared)
+
+    ckpt = torch.load(final, map_location="cpu", weights_only=False)
+    sd = ckpt["model"]
+    assert ckpt["quant"]["state"] == "finalized"
+    assert "backbone.conv1.conv.weight_packed" in sd
+    assert "backbone.conv1.conv.weight" not in sd
+    assert sd["backbone.conv1.conv.weight_packed"].dtype == torch.int8
+
+    m2 = LibreYOLO9(final, size="t", device="cpu")
+    assert m2.quant_info()["state"] == "finalized"
+    m2.model.eval()
+    with torch.no_grad():
+        out2 = _leaf(m2.model(x))
+    assert torch.equal(ref, out2)
+
+    reprepare_model(m2)
+    assert m2.quant_info()["state"] == "prepared"
+    m2.model.eval()
+    with torch.no_grad():
+        out3 = _leaf(m2.model(x))
+    assert torch.equal(ref, out3)
 
 
 def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -1,0 +1,184 @@
+"""Unit tests for the PyTorch-native quantization API."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = pytest.mark.unit
+
+from libreyolo.models.yolo9.model import LibreYOLO9
+from libreyolo.quant import (
+    NVFP4Linear,
+    QuantConv2d,
+    QuantizationError,
+)
+from libreyolo.quant.fake_quant import (
+    E2M1_MAX,
+    fake_quant_e2m1,
+    fake_quant_int8_affine,
+    fake_quant_int8_per_channel,
+    fake_quant_nvfp4_weight,
+)
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic primitives
+# ---------------------------------------------------------------------------
+
+
+def test_e2m1_rounds_to_codebook():
+    vals = torch.tensor([0.0, 0.24, 0.26, 0.5, 1.2, 1.6, 2.4, 3.4, 4.9, 5.1, 7.5, -2.6])
+    expected = torch.tensor([0.0, 0.0, 0.5, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 6.0, -3.0])
+    assert torch.equal(fake_quant_e2m1(vals), expected)
+
+
+def test_e2m1_clamps_to_max():
+    out = fake_quant_e2m1(torch.tensor([100.0, -100.0]))
+    assert out.abs().max().item() == E2M1_MAX
+
+
+def test_int8_per_channel_error_is_small():
+    torch.manual_seed(0)
+    w = torch.randn(32, 16, 3, 3)
+    wq = fake_quant_int8_per_channel(w)
+    rel = (w - wq).norm() / w.norm()
+    assert rel < 0.01
+
+
+def test_int8_affine_respects_range():
+    x = torch.linspace(-1.0, 3.0, 1000)
+    lo = torch.tensor([-1.0])
+    hi = torch.tensor([3.0])
+    xq = fake_quant_int8_affine(x, lo, hi)
+    assert (x - xq).abs().max() < (4.0 / 255.0)
+
+
+def test_nvfp4_weight_error_reasonable():
+    torch.manual_seed(0)
+    w = torch.randn(64, 128) * 0.02
+    wq = fake_quant_nvfp4_weight(w, w.abs().amax().reshape(1))
+    rel = (w - wq).norm() / w.norm()
+    assert rel < 0.15
+
+
+def test_ste_gradients_flow():
+    w = torch.randn(8, 16, requires_grad=True)
+    out = fake_quant_int8_per_channel(w)
+    out.sum().backward()
+    assert w.grad is not None
+    assert torch.isfinite(w.grad).all()
+
+
+# ---------------------------------------------------------------------------
+# Quantized modules
+# ---------------------------------------------------------------------------
+
+
+def test_nvfp4_linear_matches_float_approximately():
+    torch.manual_seed(0)
+    lin = nn.Linear(64, 32)
+    qlin = NVFP4Linear.from_float(lin)
+    x = torch.randn(4, 64)
+    rel = (lin(x) - qlin(x)).norm() / lin(x).norm()
+    assert rel < 0.25
+
+
+def test_quant_conv_preserves_state_dict_keys():
+    conv = nn.Conv2d(8, 16, 3, padding=1)
+    qconv = QuantConv2d.from_float(conv)
+    keys = set(qconv.state_dict().keys())
+    assert {"weight", "bias"} <= keys
+    assert qconv.weight is conv.weight
+
+
+# ---------------------------------------------------------------------------
+# Model-level API (fresh yolo9-t, no downloads)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def yolo9t():
+    return LibreYOLO9(None, size="t", device="cpu")
+
+
+def test_quantize_int8_swaps_and_keeps_keys(yolo9t):
+    keys_before = set(yolo9t.model.state_dict().keys())
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    info = yolo9t.quant_info()
+    assert info["recipe"] == "int8"
+    assert info["module_counts"]["conv_int8"] > 0
+    assert keys_before <= set(yolo9t.model.state_dict().keys())
+    # Head and stem stay float per the family default policy.
+    for name, module in yolo9t.model.named_modules():
+        if name.startswith("head.") or name.startswith("backbone.conv0."):
+            assert not isinstance(module, QuantConv2d), name
+
+
+def test_quantize_twice_raises(yolo9t):
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    with pytest.raises(QuantizationError):
+        yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+
+
+def test_yolo9_nvfp4_rejected(yolo9t):
+    with pytest.raises(QuantizationError, match="GEMM-only"):
+        yolo9t.quantize(recipe="nvfp4")
+
+
+def test_unknown_recipe_rejected(yolo9t):
+    with pytest.raises(QuantizationError, match="Unknown quantization recipe"):
+        yolo9t.quantize(recipe="int3")
+
+
+def test_quantized_forward_and_qat_gradients(yolo9t):
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    yolo9t.model.train()
+    out = yolo9t.model(torch.randn(1, 3, 640, 640))
+    tensors = out.values() if isinstance(out, dict) else out
+    loss = sum(
+        t.float().abs().mean()
+        for t in tensors
+        if torch.is_tensor(t) and t.is_floating_point()
+    )
+    loss.backward()
+    qmod = next(
+        m for m in yolo9t.model.modules() if isinstance(m, QuantConv2d)
+    )
+    assert qmod.weight.grad is not None
+    assert torch.isfinite(qmod.weight.grad).all()
+
+
+def test_save_load_roundtrip(tmp_path, yolo9t):
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    path = tmp_path / "LibreYOLO9t-int8.pt"
+    yolo9t.save(str(path))
+
+    reloaded = LibreYOLO9(str(path), size="t", device="cpu")
+    info = reloaded.quant_info()
+    assert info["recipe"] == "int8"
+    n_quant = sum(1 for m in reloaded.model.modules() if isinstance(m, QuantConv2d))
+    assert n_quant == info["module_count"]
+
+    # Weights and quant buffers survive the roundtrip bit-exactly.
+    src = yolo9t.model.state_dict()
+    dst = reloaded.model.state_dict()
+    assert set(src.keys()) == set(dst.keys())
+    for key in src:
+        assert torch.equal(src[key].cpu(), dst[key].cpu()), key
+
+
+def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):
+    yolo9t.quantize(recipe="fp16", verbose=False)
+    yolo9t.model.eval()
+    with torch.no_grad():
+        out = yolo9t.model(torch.randn(1, 3, 640, 640))
+    leaf = next(iter(out.values())) if isinstance(out, dict) else out
+    while isinstance(leaf, (tuple, list)):
+        leaf = leaf[0]
+    assert leaf.dtype == torch.float32
+
+    path = tmp_path / "LibreYOLO9t-fp16.pt"
+    yolo9t.save(str(path))
+    reloaded = LibreYOLO9(str(path), size="t", device="cpu")
+    assert reloaded.quant_info()["recipe"] == "fp16"
+    assert next(reloaded.model.parameters()).dtype == torch.float16

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -167,6 +167,47 @@ def test_save_load_roundtrip(tmp_path, yolo9t):
         assert torch.equal(src[key].cpu(), dst[key].cpu()), key
 
 
+def test_export_rejected_on_quantized_model(yolo9t):
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    with pytest.raises(QuantizationError, match="dequantize"):
+        yolo9t.export(format="onnx")
+
+
+def test_dequantize_restores_exact_float_forward(yolo9t):
+    yolo9t.model.eval()
+    x = torch.randn(1, 3, 640, 640)
+    with torch.no_grad():
+        ref = yolo9t.model(x)
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    yolo9t.dequantize()
+    assert yolo9t.quant_info() is None
+    assert not any(
+        isinstance(m, QuantConv2d) for m in yolo9t.model.modules()
+    )
+    yolo9t.model.eval()
+    with torch.no_grad():
+        out = yolo9t.model(x)
+    ref_leaf = next(iter(ref.values())) if isinstance(ref, dict) else ref
+    out_leaf = next(iter(out.values())) if isinstance(out, dict) else out
+    while isinstance(ref_leaf, (tuple, list)):
+        ref_leaf, out_leaf = ref_leaf[0], out_leaf[0]
+    assert torch.equal(ref_leaf, out_leaf)
+
+
+def test_fp16_dequantize_restores_float_dtype(yolo9t):
+    yolo9t.quantize(recipe="fp16", verbose=False)
+    yolo9t.dequantize()
+    assert yolo9t.quant_info() is None
+    assert next(yolo9t.model.parameters()).dtype == torch.float32
+    yolo9t.model.eval()
+    with torch.no_grad():
+        out = yolo9t.model(torch.randn(1, 3, 640, 640))
+    leaf = next(iter(out.values())) if isinstance(out, dict) else out
+    while isinstance(leaf, (tuple, list)):
+        leaf = leaf[0]
+    assert leaf.dtype == torch.float32
+
+
 def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):
     yolo9t.quantize(recipe="fp16", verbose=False)
     yolo9t.model.eval()

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -91,6 +91,34 @@ def test_quant_conv_preserves_state_dict_keys():
     assert qconv.weight is conv.weight
 
 
+def test_percentile_observation_rejects_outliers():
+    conv = nn.Conv2d(3, 8, 3, padding=1)
+
+    def calibrate(method):
+        q = QuantConv2d.from_float(conv)
+        q._q_obs_method = method
+        q._q_observing = True
+        torch.manual_seed(0)
+        with torch.no_grad():
+            for _ in range(4):
+                x = torch.randn(2, 3, 16, 16)
+                x[0, 0, 0, 0] = 100.0  # single extreme outlier per batch
+                q(x)
+        q._q_observing = False
+        q.finalize_observation()
+        return float(q._q_act_hi)
+
+    hi_minmax = calibrate("minmax")
+    hi_pct = calibrate("percentile")
+    assert hi_minmax >= 100.0
+    assert hi_pct < 10.0, f"percentile should clip the outlier, got {hi_pct}"
+
+
+def test_invalid_calibration_algorithm_rejected(yolo9t):
+    with pytest.raises(QuantizationError, match="calibration algorithm"):
+        yolo9t.quantize(recipe="int8", calib=None, algorithm="entropy")
+
+
 def test_multi_batch_observation_widens_ranges():
     # Regression: the min/max merge branch only fires from the second
     # calibration batch onwards (coco8's single batch never exercised it).

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -91,6 +91,37 @@ def test_quant_conv_preserves_state_dict_keys():
     assert qconv.weight is conv.weight
 
 
+def test_multi_batch_observation_widens_ranges():
+    # Regression: the min/max merge branch only fires from the second
+    # calibration batch onwards (coco8's single batch never exercised it).
+    conv = nn.Conv2d(3, 8, 3, padding=1)
+    qconv = QuantConv2d.from_float(conv)
+    qconv._q_observing = True
+    with torch.no_grad():
+        qconv(torch.full((1, 3, 8, 8), 0.5))
+        qconv(torch.full((1, 3, 8, 8), -2.0))
+        qconv(torch.full((1, 3, 8, 8), 3.0))
+    qconv._q_observing = False
+    assert qconv.q_calibrated
+    assert qconv._q_act_lo.item() <= -2.0
+    assert qconv._q_act_hi.item() >= 3.0
+
+
+def test_quant_buffers_live_on_weight_device():
+    # Regression: CPU-born buffers crashed multi-batch GPU calibration.
+    conv = nn.Conv2d(3, 8, 3, padding=1)
+    if torch.cuda.is_available():
+        conv = conv.cuda()
+    qconv = QuantConv2d.from_float(conv)
+    assert qconv._q_act_lo.device == qconv.weight.device
+    assert qconv._q_w_scale.device == qconv.weight.device
+    lin = nn.Linear(8, 4)
+    if torch.cuda.is_available():
+        lin = lin.cuda()
+    qlin = NVFP4Linear.from_float(lin)
+    assert qlin._q_w_amax.device == qlin.weight.device
+
+
 # ---------------------------------------------------------------------------
 # Model-level API (fresh yolo9-t, no downloads)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -167,10 +167,34 @@ def test_save_load_roundtrip(tmp_path, yolo9t):
         assert torch.equal(src[key].cpu(), dst[key].cpu()), key
 
 
-def test_export_rejected_on_quantized_model(yolo9t):
+def test_export_rejected_for_fp16_and_wrong_formats(yolo9t):
     yolo9t.quantize(recipe="int8", calib=None, verbose=False)
-    with pytest.raises(QuantizationError, match="dequantize"):
-        yolo9t.export(format="onnx")
+    with pytest.raises(QuantizationError, match="format='onnx'"):
+        yolo9t.export(format="torchscript")
+
+
+def test_export_rejected_for_fp16_recipe():
+    m = LibreYOLO9(None, size="t", device="cpu")
+    m.quantize(recipe="fp16", verbose=False)
+    with pytest.raises(QuantizationError, match="half=True"):
+        m.export(format="onnx")
+
+
+def test_quantized_onnx_export_emits_qdq(tmp_path, yolo9t):
+    onnx = pytest.importorskip("onnx")
+    yolo9t.quantize(recipe="int8", calib=None, verbose=False)
+    ckpt = tmp_path / "LibreYOLO9t-int8.pt"
+    yolo9t.save(str(ckpt))
+    reloaded = LibreYOLO9(str(ckpt), size="t", device="cpu")
+    path = reloaded.export(format="onnx", simplify=False)
+    graph = onnx.load(path).graph
+    n_q = sum(1 for n in graph.node if n.op_type == "QuantizeLinear")
+    n_dq = sum(1 for n in graph.node if n.op_type == "DequantizeLinear")
+    assert n_q > 100, f"expected weight QDQ pairs, got {n_q}"
+    assert n_dq >= n_q
+    # Export mode must be reset afterwards.
+    q_modules = [m for m in reloaded.model.modules() if isinstance(m, QuantConv2d)]
+    assert q_modules and all(not m._q_export_mode for m in q_modules)
 
 
 def test_dequantize_restores_exact_float_forward(yolo9t):

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -199,6 +199,119 @@ def test_nvfp4_linear_finalize_roundtrip():
 
 
 # ---------------------------------------------------------------------------
+# New precision recipes: arithmetic + module roundtrips
+# ---------------------------------------------------------------------------
+
+
+def test_fp8_fake_quant_and_packing():
+    from libreyolo.quant.fake_quant import fake_quant_fp8, fp8_weight_qparams
+    from libreyolo.quant.packing import pack_fp8_weight, unpack_fp8_weight
+
+    torch.manual_seed(0)
+    w = torch.randn(16, 8, 3, 3)
+    scale = fp8_weight_qparams(w)
+    view = scale.reshape(-1, 1, 1, 1)
+    fq = fake_quant_fp8(w, view)
+    rel = (w - fq).norm() / w.norm()
+    assert rel < 0.05
+    packed = pack_fp8_weight(w, scale)
+    assert packed.dtype == torch.float8_e4m3fn
+    assert torch.equal(unpack_fp8_weight(packed, scale), fq)
+
+
+def test_grouped_int_fake_quant_and_packing():
+    from libreyolo.quant.fake_quant import fake_quant_int_grouped
+    from libreyolo.quant.packing import (
+        pack_int_grouped_weight,
+        unpack_int_grouped_weight,
+    )
+
+    torch.manual_seed(0)
+    for bits, group, in_features in ((4, 128, 300), (2, 64, 100)):
+        w = torch.randn(8, in_features) * 0.05
+        fq = fake_quant_int_grouped(w, bits, group)
+        payload, scale = pack_int_grouped_weight(w, bits, group)
+        assert payload.dtype == torch.uint8
+        out = unpack_int_grouped_weight(payload, scale, bits, group, in_features)
+        assert torch.equal(out, fq)
+        levels = torch.unique(torch.round(out / scale.unsqueeze(-1).clamp(min=1e-12)
+                                          .expand(-1, -1, group)
+                                          .reshape(8, -1)[:, :in_features]))
+        assert levels.numel() <= 2 ** bits
+
+
+def test_mxfp4_fake_quant_and_packing():
+    from libreyolo.quant.fake_quant import fake_quant_mxfp4_weight
+    from libreyolo.quant.packing import pack_mxfp4_weight, unpack_mxfp4_weight
+
+    torch.manual_seed(0)
+    for in_features in (64, 40):
+        w = torch.randn(8, in_features) * 0.05
+        fq = fake_quant_mxfp4_weight(w)
+        rel = (w - fq).norm() / w.norm()
+        assert rel < 0.2
+        payload, exponents = pack_mxfp4_weight(w)
+        assert exponents.dtype == torch.int8
+        out = unpack_mxfp4_weight(payload, exponents, in_features)
+        assert torch.equal(out, fq)
+
+
+def test_group_and_mxfp4_linear_finalize_roundtrips():
+    from libreyolo.quant import GroupQuantLinear, MXFP4Linear
+
+    torch.manual_seed(0)
+    x = torch.randn(4, 200)
+    for mod in (
+        GroupQuantLinear.from_float(nn.Linear(200, 32), bits=4, group_size=128),
+        GroupQuantLinear.from_float(
+            nn.Linear(200, 32), bits=2, group_size=64, act_int8=True
+        ),
+        MXFP4Linear.from_float(nn.Linear(200, 32)),
+    ):
+        with torch.no_grad():
+            ref = mod(x)
+            mod.make_finalized()
+            assert mod.is_finalized
+            assert torch.equal(mod(x), ref)
+            mod.make_prepared()
+            assert not mod.is_finalized
+            assert torch.equal(mod(x), ref)
+
+
+def test_new_recipe_wiring_on_models(yolo9t):
+    from libreyolo.quant import QuantizationError as QErr
+
+    # Linear-only recipes rejected on the conv-heavy family
+    for recipe in ("w4a16", "w4a8", "mxfp4", "int2"):
+        with pytest.raises(QErr, match="GEMM-only"):
+            LibreYOLO9(None, size="t", device="cpu").quantize(recipe=recipe)
+
+    # fp8 quantizes convs on yolo9 and round-trips through save/load
+    yolo9t.quantize(recipe="fp8", calib=None, verbose=False)
+    info = yolo9t.quant_info()
+    assert info["recipe"] == "fp8"
+    assert info["module_counts"].get("conv_fp8", 0) > 0
+    yolo9t.model.eval()
+    with torch.no_grad():
+        out = yolo9t.model(torch.randn(1, 3, 640, 640))
+    assert torch.isfinite(_leaf(out)).all()
+
+
+def test_bf16_recipe_roundtrip(tmp_path):
+    m = LibreYOLO9(None, size="t", device="cpu")
+    m.quantize(recipe="bf16", verbose=False)
+    m.model.eval()
+    with torch.no_grad():
+        out = m.model(torch.randn(1, 3, 640, 640))
+    assert _leaf(out).dtype == torch.float32
+    path = tmp_path / "LibreYOLO9t-bf16.pt"
+    m.save(str(path))
+    m2 = LibreYOLO9(str(path), size="t", device="cpu")
+    assert m2.quant_info()["recipe"] == "bf16"
+    assert next(m2.model.parameters()).dtype == torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
 # Model-level API (fresh yolo9-t, no downloads)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this adds

PyTorch-native quantization for the flagship families (yolo9, rfdetr), with a two-step grammar: quantization is a model transform, accuracy recovery reuses the existing training notation.

- `model.quantize(recipe, calib=...)` quantizes in place and keeps the normal predict/val/train/export contract. Recipes: `fp16`, `int8` (W8A8 simulation: per-channel weights, calibrated per-tensor activations), `nvfp4` (W4A4 simulation for transformer families: E2M1 elements, 16-element blocks, FP8 E4M3 block scales).
- Calibration data is separate from training data: small, unlabeled, forward-only (`calib=`, default coco128; `algorithm=minmax|percentile`). Provenance is recorded in the checkpoint manifest.
- QAT is plain `train()` on a quantized model (fp32 masters + STE); QAD is the same step plus the existing `distill_*` kwargs. RF-DETR gains `get_distill_config()` (stride-16 backbone projector tap, probed from the live model), enabling detector-teacher distillation for the family.
- Checkpoints carry a `quant` manifest; `LibreYOLO(path)` rebuilds the quantized structure before loading. Trainer checkpoints are self-describing, so `best.pt` from a QAT run loads standalone.
- Export: `export(format="onnx")` on int8 models emits scale-exact QDQ (QuantizeLinear/DequantizeLinear carrying the model's own calibrated or QAT-trained scales). `export(format="pt")` writes finalized checkpoints: packed low-bit weights, masters stripped, inference bit-identical to the prepared model (yolo9-s int8: 29.5 to 9.6 MB; rfdetr-n nvfp4: 122 to 26 MB). Training a finalized checkpoint re-prepares masters automatically (QAT-from-PTQ).
- CLI: `libreyolo quantize`; predict/val/train/export all work on quantized checkpoints.
- Docs: `docs/quantization.md`; packed layout contract in `docs/checkpoint_schema.md`. 28 unit tests; trainer/calibration/rfdetr/cli/smoke suites pass.

## Measured (coco8/coco128, RTX 5070 Ti)

- yolo9s: fp32 0.7449, int8 sim 0.7400, int8 ONNX artifact 0.7372 mAP50-95; QAT lifts int8 to 0.7651 and the artifact tracks it.
- coco128 int8 gaps vs fp32: yolo9c -0.12, rfdetr-n -0.22, yolo9t -1.2 mAP50-95 (multi-batch calibration is the small-model fix).
- rfdetr-n nvfp4 PTQ: -4.9 mAP50-95 on coco128 (the QAT/QAD recovery target); a 60-epoch nvfp4 QAT run tracks the float control.
- Finalized checkpoints score identically to prepared ones (max abs diff 0.0 on-device).

## Notes

- Execution is the simulation tier: accuracy claims are real on any device; speed comes from exported artifacts (ONNX Runtime and TensorRT consume the QDQ graph with real INT8 kernels). nvfp4 executes in PyTorch (no standard ONNX form).
- `nvfp4` is rejected on conv-heavy yolo9 by design (FP4 acceleration is GEMM-only); unsupported families raise a clear error naming the supported set.

## Code provenance

All code in this PR is original, written for this PR. The NVFP4 arithmetic (E2M1 codebook, 16-element blocks, FP8 E4M3 block scales, fp32 per-tensor scale) is implemented from NVIDIA's public format description; INT8 QDQ uses PyTorch's public fake-quantize ops and the ONNX QuantizeLinear/DequantizeLinear convention. No third-party code was ported, adapted, or derived. Dependencies are used through their public APIs only: torch (BSD-3), onnx/onnxruntime (Apache-2.0/MIT), opencv (Apache-2.0).
