### PR TITLE
Add BoT-SORT tracker

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -755,6 +755,22 @@ copyright notice and this permission notice. THE SOFTWARE IS PROVIDED "AS IS",
 WITHOUT WARRANTY OF ANY KIND.
 
 --------------------------------------------------------------------
+Roboflow Trackers (BoT-SORT)
+--------------------------------------------------------------------
+Source: https://github.com/roboflow/trackers
+Commit: 3b6d910df78a7ab48d5770b5bc86e043476d2e76
+License: Apache License 2.0
+Copyright (c) 2026 Roboflow. All Rights Reserved.
+Used for: the BoT-SORT tracking lifecycle, scale-aware center-width-height
+          Kalman model, and sparse optical-flow camera-motion compensation in
+          libreyolo/tracking/botsort.py and
+          libreyolo/tracking/kalman_filter.py. The implementation is adapted
+          to LibreYOLO's detector-agnostic Results contract and implements the
+          paper's motion-only BoT-SORT variant (not BoT-SORT-ReID).
+
+The full Apache License 2.0 text is included at licenses/Apache-2.0.txt.
+
+--------------------------------------------------------------------
 Torchreid (deep-person-reid)
 --------------------------------------------------------------------
 Source: https://github.com/KaiyangZhou/deep-person-reid

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -116,6 +116,8 @@ def __getattr__(name):
         "DepthValidator": (".validation", "DepthValidator"),
         "ValidationConfig": (".validation", "ValidationConfig"),
         "ByteTracker": (".tracking", "ByteTracker"),
+        "BoTSortTracker": (".tracking", "BoTSortTracker"),
+        "BoTSortConfig": (".tracking", "BoTSortConfig"),
         "TrackConfig": (".tracking", "TrackConfig"),
         "OCSortTracker": (".tracking", "OCSortTracker"),
         "OCSortConfig": (".tracking", "OCSortConfig"),
@@ -243,6 +245,8 @@ __all__ = [
     "SAMPLE_IMAGE",
     # Tracking
     "ByteTracker",
+    "BoTSortTracker",
+    "BoTSortConfig",
     "TrackConfig",
     "OCSortTracker",
     "OCSortConfig",

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1111,9 +1111,10 @@ class BaseModel(ABC):
         """Track objects across video frames.
 
         Runs detection on each frame and associates detections across time.
-        Three trackers are available via ``tracker``: ByteTrack (default) and
-        OC-SORT are motion-only; Deep OC-SORT adds appearance (ReID)
-        embeddings so identities survive long occlusions and crossing
+        Four trackers are available via ``tracker``: ByteTrack (default) and
+        OC-SORT are motion-only; BoT-SORT adds an improved width/height motion
+        model and camera-motion compensation; Deep OC-SORT adds appearance
+        (ReID) embeddings so identities survive long occlusions and crossing
         targets, at the cost of a small embedding network run per frame (its
         weights are downloaded on first use). Yields one Results per frame
         with ``track_id`` set.
@@ -1121,13 +1122,14 @@ class BaseModel(ABC):
         Args:
             source: Path to a video file.
             track_conf: Confidence threshold for the tracker's first
-                association stage — ``track_high_thresh`` for ByteTrack,
-                ``det_thresh`` for OC-SORT and Deep OC-SORT. For the motion
-                trackers the detector runs at a lower threshold internally so
-                low-confidence detections remain available for recovery. For ByteTrack it must be >=
-                ``track_low_thresh`` (default 0.1). Ignored when *tracker_config*
-                is given, or when the matching key is passed explicitly in
-                ``tracker_kwargs``.
+                association stage — ``track_high_thresh`` for ByteTrack and
+                BoT-SORT, ``det_thresh`` for OC-SORT and Deep OC-SORT. For the
+                motion trackers the detector runs at a lower threshold
+                internally so low-confidence detections remain available for
+                recovery. For ByteTrack and BoT-SORT it must be >=
+                ``track_low_thresh`` (default 0.1). Ignored when
+                *tracker_config* is given, or when the matching key is passed
+                explicitly in ``tracker_kwargs``.
             iou: IoU threshold for NMS during detection.
             imgsz: Override input image size.
             classes: Filter to specific class IDs.
@@ -1137,15 +1139,16 @@ class BaseModel(ABC):
             vid_stride: Process every N-th frame.
             output_path: Path for saved video. Defaults to
                 ``runs/track/<video_stem>.mp4``.
-            tracker: Which tracker to use: ``"bytetrack"``, ``"ocsort"`` or
-                ``"deepocsort"``. Ignored when *tracker_config* is given (the
-                config type selects the tracker).
-            tracker_config: A ``TrackConfig`` (ByteTrack), ``OCSortConfig``
-                (OC-SORT) or ``DeepOCSortConfig`` (Deep OC-SORT) instance, or
-                None to build one from **tracker_kwargs.
+            tracker: Which tracker to use: ``"bytetrack"``, ``"botsort"``,
+                ``"ocsort"`` or ``"deepocsort"``. Ignored when
+                *tracker_config* is given (the config type selects the tracker).
+            tracker_config: A ``TrackConfig`` (ByteTrack), ``BoTSortConfig``
+                (BoT-SORT), ``OCSortConfig`` (OC-SORT), or
+                ``DeepOCSortConfig`` (Deep OC-SORT) instance, or None to build
+                one from **tracker_kwargs.
             **tracker_kwargs: Forwarded to the selected tracker's
-                ``from_kwargs`` (``TrackConfig``, ``OCSortConfig`` or
-                ``DeepOCSortConfig``).
+                ``from_kwargs`` (``TrackConfig``, ``BoTSortConfig``,
+                ``OCSortConfig`` or ``DeepOCSortConfig``).
 
         Yields:
             Results with ``track_id`` attribute set as an (N,) int tensor.
@@ -1190,6 +1193,8 @@ class BaseModel(ABC):
             )
 
         from ...tracking import (
+            BoTSortConfig,
+            BoTSortTracker,
             ByteTracker,
             DeepOCSortConfig,
             DeepOCSortTracker,
@@ -1201,7 +1206,10 @@ class BaseModel(ABC):
         from ...utils.video import run_video_inference
 
         # A provided config picks the tracker; otherwise honour the selector.
-        if isinstance(tracker_config, DeepOCSortConfig):
+        if isinstance(tracker_config, BoTSortConfig):
+            # BoTSortConfig subclasses TrackConfig, so it must be checked first.
+            tracker = "botsort"
+        elif isinstance(tracker_config, DeepOCSortConfig):
             tracker = "deepocsort"
         elif isinstance(tracker_config, OCSortConfig):
             tracker = "ocsort"
@@ -1226,6 +1234,13 @@ class BaseModel(ABC):
             # OC-SORT consumes low-score detections (>0.1) for recovery.
             effective_conf = min(0.1, tracker_config.det_thresh)
             tracker_obj = OCSortTracker(config=tracker_config)
+        elif tracker == "botsort":
+            if tracker_config is None:
+                tracker_kwargs.setdefault("track_high_thresh", track_conf)
+                tracker_config = BoTSortConfig.from_kwargs(**tracker_kwargs)
+            # BoT-SORT keeps ByteTrack's low-confidence recovery stage.
+            effective_conf = tracker_config.track_low_thresh
+            tracker_obj = BoTSortTracker(config=tracker_config)
         elif tracker == "bytetrack":
             if tracker_config is None:
                 tracker_kwargs.setdefault("track_high_thresh", track_conf)
@@ -1236,7 +1251,7 @@ class BaseModel(ABC):
         else:
             raise ValueError(
                 f"Unknown tracker {tracker!r}; "
-                "choose 'bytetrack', 'ocsort' or 'deepocsort'."
+                "choose 'bytetrack', 'botsort', 'ocsort' or 'deepocsort'."
             )
 
         source = Path(source)
@@ -1255,8 +1270,9 @@ class BaseModel(ABC):
                 max_det=max_det,
                 color_format="rgb",
             )
-            if isinstance(tracker_obj, DeepOCSortTracker):
-                # Appearance tracking needs the frame pixels for ReID crops.
+            if isinstance(tracker_obj, (BoTSortTracker, DeepOCSortTracker)):
+                # BoT-SORT needs pixels for camera motion; Deep OC-SORT needs
+                # them for ReID crops.
                 return tracker_obj.update(result, pil_img)
             return tracker_obj.update(result)
 

--- a/libreyolo/tracking/__init__.py
+++ b/libreyolo/tracking/__init__.py
@@ -1,12 +1,15 @@
 """Multi-object tracking for LibreYOLO."""
 
-from .config import DeepOCSortConfig, OCSortConfig, TrackConfig
+from .botsort import BoTSortTracker
+from .config import BoTSortConfig, DeepOCSortConfig, OCSortConfig, TrackConfig
 from .deepocsort import DeepOCSortTracker
 from .ocsort import OCSortTracker
 from .tracker import ByteTracker
 
 __all__ = [
     "ByteTracker",
+    "BoTSortConfig",
+    "BoTSortTracker",
     "DeepOCSortConfig",
     "DeepOCSortTracker",
     "OCSortConfig",

--- a/libreyolo/tracking/botsort.py
+++ b/libreyolo/tracking/botsort.py
@@ -1,0 +1,336 @@
+"""BoT-SORT multi-object tracking with camera-motion compensation.
+
+The implementation is adapted to LibreYOLO's ``Results`` contract from the
+Apache-2.0 clean-room implementation in Roboflow Trackers, pinned at commit
+``3b6d910df78a7ab48d5770b5bc86e043476d2e76``. See
+``THIRD_PARTY_NOTICES.txt`` for provenance and license details.
+
+This module implements the motion-only BoT-SORT variant described by Aharon,
+Orfaig, and Bobrovsky (2022): ByteTrack association with an independent
+width/height Kalman state and camera-motion compensation. The paper names the
+separate appearance-enabled variant ``BoT-SORT-ReID``; no ReID model is run
+here.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from ..utils.results import Results
+from .config import BoTSortConfig
+from .kalman_filter import KalmanFilterXYAH, KalmanFilterXYWH
+from .strack import STrack, TrackState
+from .tracker import ByteTracker
+
+
+def _identity_affine() -> np.ndarray:
+    return np.eye(2, 3, dtype=np.float32)
+
+
+class _SparseOptFlowCameraMotion:
+    """Estimate previous-to-current affine motion from sparse optical flow."""
+
+    def __init__(self, downscale: int = 2):
+        self.downscale = int(downscale)
+        self.frames_failed = 0
+        self.reset()
+
+    def reset(self) -> None:
+        """Forget the previous frame and feature points."""
+        self._initialized = False
+        self.frames_failed = 0
+        self._prev_gray: np.ndarray | None = None
+        self._prev_points: np.ndarray | None = None
+
+    @staticmethod
+    def _to_gray(image) -> np.ndarray:
+        frame = np.asarray(image)
+        if frame.ndim == 2:
+            gray = frame
+        elif frame.ndim == 3 and frame.shape[2] == 3:
+            # BaseModel.track() and the public tracker API use RGB frames.
+            gray = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
+        elif frame.ndim == 3 and frame.shape[2] == 4:
+            gray = cv2.cvtColor(frame, cv2.COLOR_RGBA2GRAY)
+        else:
+            raise ValueError(
+                "BoTSortTracker image must be an RGB/RGBA or grayscale frame; "
+                f"got shape {frame.shape}"
+            )
+        if gray.dtype != np.uint8:
+            if np.issubdtype(gray.dtype, np.floating) and gray.size:
+                finite_max = np.nanmax(gray)
+                if finite_max <= 1.0:
+                    gray = gray * 255.0
+            gray = np.nan_to_num(gray, nan=0.0, posinf=255.0, neginf=0.0)
+            gray = np.clip(gray, 0, 255).astype(np.uint8)
+        return np.ascontiguousarray(gray)
+
+    def _prepare(self, image) -> np.ndarray:
+        gray = self._to_gray(image)
+        if self.downscale > 1:
+            height, width = gray.shape[:2]
+            gray = cv2.resize(
+                gray,
+                (
+                    max(1, width // self.downscale),
+                    max(1, height // self.downscale),
+                ),
+            )
+        return gray
+
+    def _store(self, gray: np.ndarray, points: np.ndarray | None) -> None:
+        self._prev_gray = gray.copy()
+        self._prev_points = None if points is None else points.copy()
+        self._initialized = True
+
+    def estimate(self, image) -> np.ndarray:
+        """Return a 2x3 affine transform mapping the last frame to ``image``.
+
+        The first frame and all recoverable OpenCV failures return identity
+        while refreshing the estimator state, so a bad or textureless frame
+        cannot poison the tracking lifecycle.
+        """
+        gray = self._prepare(image)
+        identity = _identity_affine()
+        try:
+            points = cv2.goodFeaturesToTrack(
+                gray,
+                maxCorners=1000,
+                qualityLevel=0.01,
+                minDistance=1,
+                mask=None,
+                blockSize=3,
+                useHarrisDetector=False,
+                k=0.04,
+            )
+        except cv2.error:
+            self.frames_failed += 1
+            self._store(gray, None)
+            return identity
+
+        if not self._initialized:
+            self._store(gray, points)
+            return identity
+
+        if self._prev_gray is None or self._prev_points is None or points is None:
+            self._store(gray, points)
+            return identity
+
+        try:
+            matched, status, _ = cv2.calcOpticalFlowPyrLK(
+                self._prev_gray, gray, self._prev_points, None
+            )  # ty: ignore[no-matching-overload]
+        except cv2.error:
+            self.frames_failed += 1
+            self._store(gray, points)
+            return identity
+
+        affine = identity
+        if matched is not None and status is not None:
+            valid = status.reshape(-1).astype(bool)
+            previous = self._prev_points.reshape(-1, 2)[valid]
+            current = matched.reshape(-1, 2)[valid]
+            finite = np.isfinite(previous).all(axis=1) & np.isfinite(current).all(
+                axis=1
+            )
+            previous = previous[finite]
+            current = current[finite]
+            if len(previous) >= 5:
+                try:
+                    estimated, _ = cv2.estimateAffinePartial2D(
+                        previous,
+                        current,
+                        method=cv2.RANSAC,
+                        ransacReprojThreshold=3.0,
+                    )
+                except cv2.error:
+                    estimated = None
+                    self.frames_failed += 1
+                if estimated is not None and np.isfinite(estimated).all():
+                    affine = estimated.astype(np.float32)
+                    if self.downscale > 1:
+                        affine[0, 2] *= self.downscale
+                        affine[1, 2] *= self.downscale
+            else:
+                self.frames_failed += 1
+
+        self._store(gray, points)
+        return affine
+
+
+class _BoTSTrack(STrack):
+    """Single BoT-SORT track using ``(cx, cy, w, h, velocities...)``."""
+
+    @staticmethod
+    def xyxy_to_xywh(xyxy: np.ndarray) -> np.ndarray:
+        width = max(float(xyxy[2] - xyxy[0]), 1e-3)
+        height = max(float(xyxy[3] - xyxy[1]), 1e-3)
+        return np.array(
+            [xyxy[0] + width / 2, xyxy[1] + height / 2, width, height],
+            dtype=np.float64,
+        )
+
+    def _measurement(self, xyxy: np.ndarray) -> np.ndarray:
+        return self.xyxy_to_xywh(xyxy)
+
+    @property
+    def xywh(self) -> np.ndarray:
+        """Current ``(center_x, center_y, width, height)`` state."""
+        return self.mean[:4].copy()
+
+    @property
+    def tlwh(self) -> np.ndarray:
+        """Current ``(top-left x, top-left y, width, height)`` state."""
+        ret = self.mean[:4].copy()
+        ret[2:] = np.maximum(ret[2:], 1e-3)
+        ret[:2] -= ret[2:] / 2
+        return ret
+
+    def _clamp_size(self) -> None:
+        self.mean[2:4] = np.maximum(self.mean[2:4], 1e-3)
+
+    def activate(self, kf: KalmanFilterXYAH, frame_id: int, track_id: int):
+        super().activate(kf, frame_id, track_id)
+        self._clamp_size()
+
+    def re_activate(
+        self,
+        kf: KalmanFilterXYAH,
+        new_detection: STrack,
+        frame_id: int,
+        new_id: bool = False,
+        new_track_id: int = 0,
+    ):
+        super().re_activate(kf, new_detection, frame_id, new_id, new_track_id)
+        self._clamp_size()
+
+    def update(self, kf: KalmanFilterXYAH, new_detection: STrack, frame_id: int):
+        super().update(kf, new_detection, frame_id)
+        self._clamp_size()
+
+    def predict(self, kf: KalmanFilterXYAH):
+        # Freeze both size velocities for lost tracks; center motion remains
+        # available for short-gap recovery.
+        if self.state != TrackState.Tracked:
+            self.mean[6:8] = 0
+        super().predict(kf)
+        self._clamp_size()
+
+    def apply_camera_motion(self, affine: np.ndarray) -> None:
+        """Warp center state, center velocity, and their covariance in place."""
+        rotation = np.asarray(affine[:2, :2], dtype=np.float64)
+        translation = np.asarray(affine[:2, 2], dtype=np.float64)
+        self.mean[:2] = rotation @ self.mean[:2] + translation
+        self.mean[4:6] = rotation @ self.mean[4:6]
+
+        transform = np.eye(8, dtype=np.float64)
+        transform[:2, :2] = rotation
+        transform[4:6, 4:6] = rotation
+        self.covariance = transform @ self.covariance @ transform.T
+        self._clamp_size()
+
+
+class BoTSortTracker(ByteTracker):
+    """BoT-SORT tracker with XYWH motion and sparse optical-flow CMC.
+
+    Args:
+        config: BoT-SORT configuration. If None, ``BoTSortConfig`` is built
+            from ``kwargs``.
+        **kwargs: Forwarded to :meth:`BoTSortConfig.from_kwargs` when config
+            is None.
+
+    Example::
+
+        tracker = BoTSortTracker()
+        for frame in frames:  # PIL images or RGB numpy arrays
+            result = model(frame, conf=0.1)
+            tracked = tracker.update(result, frame)
+            print(tracked.track_id)
+    """
+
+    def __init__(self, config: BoTSortConfig | None = None, **kwargs):
+        if config is not None and not isinstance(config, BoTSortConfig):
+            raise TypeError(
+                "BoTSortTracker config must be a BoTSortConfig instance; "
+                f"got {type(config).__name__}"
+            )
+        resolved = config or BoTSortConfig.from_kwargs(**kwargs)
+        super().__init__(config=resolved)
+        self.config: BoTSortConfig = resolved
+        self.kalman_filter = KalmanFilterXYWH()
+        self.camera_motion = _SparseOptFlowCameraMotion(
+            downscale=self.config.cmc_downscale
+        )
+        self._tentative_id_count = 0
+
+    def _make_track(
+        self,
+        xyxy: np.ndarray,
+        score: float,
+        cls: int,
+        detection_index: int,
+    ) -> _BoTSTrack:
+        return _BoTSTrack(xyxy, score, cls, detection_index)
+
+    def _after_predict(self, image) -> None:
+        if not self.config.enable_cmc:
+            return
+        affine = self.camera_motion.estimate(image)
+        seen: set[int] = set()
+        for track in self.tracked_stracks + self.lost_stracks:
+            if id(track) in seen:
+                continue
+            seen.add(id(track))
+            if not isinstance(track, _BoTSTrack):
+                raise TypeError(
+                    "BoTSortTracker encountered a non-BoT-SORT tracklet: "
+                    f"{type(track).__name__}"
+                )
+            track.apply_camera_motion(affine)
+
+    def _activate_new_track(self, track: STrack) -> None:
+        # The reference lifecycle immediately confirms detections in frame 1,
+        # but makes later births survive one association before consuming a
+        # public ID. Unique negative IDs keep tentative tracks distinct inside
+        # ByteTracker's list bookkeeping without leaking into Results.
+        if self._frame_id == 1:
+            track.activate(self.kalman_filter, self._frame_id, self._next_id())
+            return
+        self._tentative_id_count += 1
+        track.activate(self.kalman_filter, self._frame_id, -self._tentative_id_count)
+        track.is_activated = False
+
+    def _after_unconfirmed_match(self, track: STrack) -> None:
+        if track._hits >= self.config.minimum_consecutive_frames:
+            track.track_id = self._next_id()
+            track.is_activated = True
+        else:
+            track.is_activated = False
+
+    def _should_output(self, track: STrack) -> bool:
+        # Frame-one activation is intentionally immediate, matching the
+        # BoT-SORT/ByteTrack reference lifecycle even when the configured
+        # consecutive-frame requirement is greater than one.
+        return track.is_activated and track.track_id > 0
+
+    def update(self, results: Results, image=None) -> Results:
+        """Track one frame and return confirmed detections with stable IDs."""
+        if self.config.enable_cmc and image is None:
+            raise ValueError(
+                "BoTSortTracker.update() needs the frame image when camera-motion "
+                "compensation is enabled; pass update(results, image), or set "
+                "enable_cmc=False."
+            )
+        return super().update(results, image=image)
+
+    def reset(self):
+        """Clear tracks, IDs, and camera-motion history."""
+        super().reset()
+        self._tentative_id_count = 0
+        if hasattr(self, "camera_motion"):
+            self.camera_motion.reset()
+
+
+__all__ = ["BoTSortTracker"]

--- a/libreyolo/tracking/config.py
+++ b/libreyolo/tracking/config.py
@@ -1,4 +1,4 @@
-"""Tracking configuration for ByteTrack."""
+"""Tracking configuration for LibreYOLO's multi-object trackers."""
 
 import warnings
 from dataclasses import dataclass, fields
@@ -80,6 +80,57 @@ class TrackConfig:
         if unknown:
             warnings.warn(
                 f"Unknown tracking config keys (ignored): {sorted(unknown)}",
+                stacklevel=2,
+            )
+        filtered = {k: v for k, v in kwargs.items() if k in valid}
+        return cls(**filtered)
+
+
+@dataclass(kw_only=True)
+class BoTSortConfig(TrackConfig):
+    """Configuration for the BoT-SORT multi-object tracker.
+
+    BoT-SORT keeps ByteTrack's three-stage association lifecycle, but uses a
+    center-width-height Kalman state and compensates predicted tracks for
+    camera motion before matching. This is the paper's motion-only BoT-SORT
+    variant; it does not run an appearance/ReID model.
+
+    The inherited association defaults intentionally match LibreYOLO's
+    :class:`TrackConfig` so detector confidence behaves consistently when
+    switching trackers.
+
+    Args:
+        enable_cmc: Apply camera-motion compensation before association.
+        cmc_method: Camera-motion estimator. ``"sparseOptFlow"`` is the
+            currently supported method.
+        cmc_downscale: Integer image downscale used by the motion estimator.
+            Larger values reduce compute at the cost of small-motion detail.
+    """
+
+    enable_cmc: bool = True
+    cmc_method: str = "sparseOptFlow"
+    cmc_downscale: int = 2
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.cmc_method != "sparseOptFlow":
+            raise ValueError(
+                "cmc_method must be 'sparseOptFlow'; "
+                f"got {self.cmc_method!r}"
+            )
+        if self.cmc_downscale < 1:
+            raise ValueError(
+                f"cmc_downscale must be >= 1, got {self.cmc_downscale}"
+            )
+
+    @classmethod
+    def from_kwargs(cls, **kwargs) -> "BoTSortConfig":
+        """Construct config, warning on unknown keys."""
+        valid = {f.name for f in fields(cls)}
+        unknown = set(kwargs) - valid
+        if unknown:
+            warnings.warn(
+                f"Unknown BoT-SORT config keys (ignored): {sorted(unknown)}",
                 stacklevel=2,
             )
         filtered = {k: v for k, v in kwargs.items() if k in valid}

--- a/libreyolo/tracking/kalman_filter.py
+++ b/libreyolo/tracking/kalman_filter.py
@@ -1,4 +1,4 @@
-"""Kalman filter with constant-velocity model for bounding box tracking.
+"""Kalman filters with constant-velocity models for bounding box tracking.
 
 State space: (cx, cy, aspect_ratio, height, v_cx, v_cy, v_a, v_h)
 Measurement: (cx, cy, aspect_ratio, height)
@@ -175,4 +175,113 @@ class KalmanFilterXYAH:
         innovation = measurement - projected_mean
         new_mean = mean + innovation @ kalman_gain.T
         new_covariance = covariance - kalman_gain @ projected_cov @ kalman_gain.T
+        return new_mean, new_covariance
+
+
+class KalmanFilterXYWH(KalmanFilterXYAH):
+    """BoT-SORT Kalman filter using independent width and height states.
+
+    State space: ``(cx, cy, w, h, vx, vy, vw, vh)``. Process,
+    measurement, and initialization noise scale independently with the box
+    width and height. This avoids coupling width changes to an aspect-ratio
+    state as ByteTrack's XYAH filter does.
+    """
+
+    @staticmethod
+    def _scales(measurement: np.ndarray) -> tuple[float, float]:
+        return max(abs(float(measurement[2])), 1e-2), max(
+            abs(float(measurement[3])), 1e-2
+        )
+
+    def initiate(self, measurement: np.ndarray):
+        """Initialize from a ``(cx, cy, width, height)`` measurement."""
+        mean = np.concatenate([measurement, np.zeros_like(measurement)])
+        w, h = self._scales(measurement)
+        sp = self._std_weight_position
+        sv = self._std_weight_velocity
+        std = np.array(
+            [
+                2 * sp * w,
+                2 * sp * h,
+                2 * sp * w,
+                2 * sp * h,
+                10 * sv * w,
+                10 * sv * h,
+                10 * sv * w,
+                10 * sv * h,
+            ],
+            dtype=np.float64,
+        )
+        return mean, np.diag(np.square(std))
+
+    def predict(self, mean: np.ndarray, covariance: np.ndarray):
+        """Run a scale-aware XYWH prediction step."""
+        w, h = self._scales(mean)
+        sp = self._std_weight_position
+        sv = self._std_weight_velocity
+        std = np.array(
+            [sp * w, sp * h, sp * w, sp * h, sv * w, sv * h, sv * w, sv * h],
+            dtype=np.float64,
+        )
+        motion_cov = np.diag(np.square(std))
+        mean = self._motion_mat @ mean
+        covariance = np.clip(covariance, -1e10, 1e10)
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            covariance = self._motion_mat @ covariance @ self._motion_mat.T
+            covariance += motion_cov
+        return mean, covariance
+
+    def multi_predict(self, mean: np.ndarray, covariance: np.ndarray):
+        """Vectorized scale-aware XYWH prediction."""
+        if len(mean) == 0:
+            return mean, covariance
+        w = np.maximum(np.abs(mean[:, 2]), 1e-2)
+        h = np.maximum(np.abs(mean[:, 3]), 1e-2)
+        sp = self._std_weight_position
+        sv = self._std_weight_velocity
+        std = np.column_stack(
+            [sp * w, sp * h, sp * w, sp * h, sv * w, sv * h, sv * w, sv * h]
+        )
+        motion_cov = np.array([np.diag(np.square(row)) for row in std])
+        mean = np.einsum("ij,nj->ni", self._motion_mat, mean)
+        covariance = np.clip(covariance, -1e10, 1e10)
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            covariance = (
+                np.einsum(
+                    "ij,njk,lk->nil",
+                    self._motion_mat,
+                    covariance,
+                    self._motion_mat,
+                )
+                + motion_cov
+            )
+        return mean, covariance
+
+    def update(self, mean: np.ndarray, covariance: np.ndarray, measurement: np.ndarray):
+        """Correct the state with a ``(cx, cy, width, height)`` measurement."""
+        w, h = self._scales(mean)
+        sp = self._std_weight_position
+        std = np.array([sp * w, sp * h, sp * w, sp * h], dtype=np.float64)
+        innovation_cov = np.diag(np.square(std))
+        projected_mean = self._update_mat @ mean
+        projected_cov = (
+            self._update_mat @ covariance @ self._update_mat.T + innovation_cov
+        )
+        chol_factor, lower = scipy.linalg.cho_factor(
+            projected_cov, lower=True, check_finite=False
+        )
+        kalman_gain = scipy.linalg.cho_solve(
+            (chol_factor, lower),
+            (covariance @ self._update_mat.T).T,
+            check_finite=False,
+        ).T
+        innovation = measurement - projected_mean
+        new_mean = mean + innovation @ kalman_gain.T
+        # Joseph form preserves symmetry and positive semi-definiteness better
+        # over long sequences than the abbreviated P - KSK^T update.
+        identity_minus_gain = np.eye(8) - kalman_gain @ self._update_mat
+        new_covariance = (
+            identity_minus_gain @ covariance @ identity_minus_gain.T
+            + kalman_gain @ innovation_cov @ kalman_gain.T
+        )
         return new_mean, new_covariance

--- a/libreyolo/tracking/strack.py
+++ b/libreyolo/tracking/strack.py
@@ -56,6 +56,10 @@ class STrack:
         a = w / max(h, 1e-6)
         return np.array([cx, cy, a, h], dtype=np.float64)
 
+    def _measurement(self, xyxy: np.ndarray) -> np.ndarray:
+        """Convert an xyxy detection to this track's Kalman measurement."""
+        return self.xyxy_to_xyah(xyxy)
+
     @property
     def xyah(self) -> np.ndarray:
         """Current (cx, cy, aspect_ratio, height) from Kalman state."""
@@ -85,7 +89,7 @@ class STrack:
     def activate(self, kf: KalmanFilterXYAH, frame_id: int, track_id: int):
         """Initialize this track from its first detection."""
         self.track_id = track_id
-        measurement = self.xyxy_to_xyah(self._xyxy)
+        measurement = self._measurement(self._xyxy)
         self.mean, self.covariance = kf.initiate(measurement)
 
         self.state = TrackState.Tracked
@@ -103,7 +107,7 @@ class STrack:
         new_track_id: int = 0,
     ):
         """Re-activate a lost track with a new detection."""
-        measurement = self.xyxy_to_xyah(new_detection._xyxy)
+        measurement = self._measurement(new_detection._xyxy)
         # If covariance has degenerated (NaN/Inf from repeated prediction
         # without updates), reinitialize from the new measurement.
         if np.any(np.isnan(self.covariance)) or np.any(np.isinf(self.covariance)):
@@ -126,7 +130,7 @@ class STrack:
 
     def update(self, kf: KalmanFilterXYAH, new_detection: STrack, frame_id: int):
         """Update a matched track with a new detection."""
-        measurement = self.xyxy_to_xyah(new_detection._xyxy)
+        measurement = self._measurement(new_detection._xyxy)
         self.mean, self.covariance = kf.update(self.mean, self.covariance, measurement)
 
         self.state = TrackState.Tracked

--- a/libreyolo/tracking/tracker.py
+++ b/libreyolo/tracking/tracker.py
@@ -54,7 +54,40 @@ class ByteTracker:
         self.lost_stracks.clear()
         self.removed_stracks.clear()
 
-    def update(self, results: Results) -> Results:
+    def _make_track(
+        self,
+        xyxy: np.ndarray,
+        score: float,
+        cls: int,
+        detection_index: int,
+    ) -> STrack:
+        """Create one detection tracklet.
+
+        Subclasses override this to select a different Kalman state
+        representation while reusing ByteTrack's association lifecycle.
+        """
+        return STrack(xyxy, score, cls, detection_index)
+
+    def _after_predict(self, image) -> None:
+        """Hook for subclasses to transform predicted tracks before matching."""
+
+    def _activate_new_track(self, track: STrack) -> None:
+        """Activate a newly spawned track using ByteTrack's ID semantics."""
+        track.activate(self.kalman_filter, self._frame_id, self._next_id())
+        if self.config.minimum_consecutive_frames > 1:
+            track.is_activated = False
+
+    def _after_unconfirmed_match(self, track: STrack) -> None:
+        """Hook called after an unconfirmed track receives a detection."""
+
+    def _should_output(self, track: STrack) -> bool:
+        """Return whether a currently tracked object is mature enough to emit."""
+        return (
+            track.is_activated
+            and track._hits >= self.config.minimum_consecutive_frames
+        )
+
+    def update(self, results: Results, image=None) -> Results:
         """Run one frame of tracking.
 
         Takes detection results and returns new Results with track IDs
@@ -62,6 +95,8 @@ class ByteTracker:
 
         Args:
             results: Detection results from any detector.
+            image: Optional current frame. Ignored by ByteTrack; used by
+                trackers that extend its lifecycle with image-based motion.
 
         Returns:
             New Results with ``track_id`` matching the input box backend.
@@ -89,11 +124,15 @@ class ByteTracker:
         low_mask = ~high_mask
 
         high_dets = [
-            STrack(boxes_np[i], scores_np[i], classes_np[i], int(original_indices[i]))
+            self._make_track(
+                boxes_np[i], scores_np[i], classes_np[i], int(original_indices[i])
+            )
             for i in np.where(high_mask)[0]
         ]
         low_dets = [
-            STrack(boxes_np[i], scores_np[i], classes_np[i], int(original_indices[i]))
+            self._make_track(
+                boxes_np[i], scores_np[i], classes_np[i], int(original_indices[i])
+            )
             for i in np.where(low_mask)[0]
         ]
 
@@ -108,6 +147,7 @@ class ByteTracker:
             t.predict(self.kalman_filter)
         for t in self.lost_stracks:
             t.predict(self.kalman_filter)
+        self._after_predict(image)
 
         # Split tracked into confirmed and unconfirmed.
         unconfirmed = [t for t in self.tracked_stracks if not t.is_activated]
@@ -175,6 +215,7 @@ class ByteTracker:
             track = unconfirmed[m[0]]
             det = remaining_high_dets[m[1]]
             track.update(self.kalman_filter, det, self._frame_id)
+            self._after_unconfirmed_match(track)
 
         # Remove unmatched unconfirmed tracks.
         for i in u_unconf:
@@ -187,10 +228,7 @@ class ByteTracker:
         for i in u_det_final:
             det = remaining_high_dets[i]
             if det.score >= cfg.new_track_thresh:
-                det.activate(self.kalman_filter, self._frame_id, self._next_id())
-                if cfg.minimum_consecutive_frames > 1:
-                    # Start as unconfirmed — needs more consecutive matches.
-                    det.is_activated = False
+                self._activate_new_track(det)
 
         # ------------------------------------------------------------------
         # 7. Handle lost tracks: mark expired as removed
@@ -248,9 +286,7 @@ class ByteTracker:
         # 9. Build output Results
         # ------------------------------------------------------------------
         output_stracks = [
-            t
-            for t in self.tracked_stracks
-            if t.is_activated and t._hits >= cfg.minimum_consecutive_frames
+            t for t in self.tracked_stracks if self._should_output(t)
         ]
 
         if len(output_stracks) == 0:

--- a/skills/use-libreyolo/SKILL.md
+++ b/skills/use-libreyolo/SKILL.md
@@ -126,11 +126,12 @@ handles every run under the root (`?run=` in the URL selects one).
   model("img.jpg", save=True)        # same predict API as a .pt
   ```
 - **Object tracking** — `model.track(...)` assigns IDs across video frames.
-  Three trackers: **ByteTrack** (`tracker="bytetrack"`, default) and
-  **OC-SORT** are motion-only; **Deep OC-SORT** (`tracker="deepocsort"`)
-  adds appearance ReID (OSNet embeddings, auto-downloaded) so IDs survive
-  occlusions and crossings. IDs come back on `r.boxes.id`. Needs
-  `libreyolo[tracking]`.
+  Four trackers: **ByteTrack** (`tracker="bytetrack"`, default) and
+  **OC-SORT** are motion-only; **BoT-SORT** (`tracker="botsort"`) adds
+  camera-motion compensation and an improved width/height motion model;
+  **Deep OC-SORT** (`tracker="deepocsort"`) adds appearance ReID (OSNet
+  embeddings, auto-downloaded) so IDs survive occlusions and crossings. IDs
+  come back on `r.boxes.id`. Needs `libreyolo[tracking]`.
 - **Tiled inference for large images** — `predict(..., tiling=True,
   overlap_ratio=0.2)` slices high-resolution images so small objects aren't
   lost, then merges detections.

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -2,7 +2,7 @@
 E2E tracking: validate model.track() on a real video with multiple pedestrians.
 
 Downloads a short test video (7.3 MB, 13.6s) from Roboflow's public CDN and
-runs ByteTrack through several LibreYOLO detectors, checking that:
+runs tracking through several LibreYOLO detectors, checking that:
   - track IDs are assigned and consistent across frames
   - the same person keeps the same ID across consecutive frames
   - no duplicate IDs within a single frame
@@ -183,6 +183,21 @@ class TestTrackingYOLOX:
                     stable += 1
         assert stable >= len(frames) // 2, "Deep OC-SORT IDs not stable across frames"
 
+    def test_botsort_tracker_end_to_end(self, model, video_path):
+        """BoT-SORT yields stable IDs while compensating for camera motion."""
+        frames = _run_tracker(model, video_path, n_frames=20, tracker="botsort")
+        assert len(frames) == 20
+        stable = 0
+        for i, frame in enumerate(frames):
+            ids = frame.track_id.tolist() if frame.track_id is not None else []
+            assert len(ids) == len(set(ids)), f"Frame {i}: duplicate IDs: {ids}"
+            if i > 0:
+                previous = _ids(frames[i - 1])
+                current = _ids(frame)
+                if previous and current and len(previous & current) / len(previous) >= 0.5:
+                    stable += 1
+        assert stable >= len(frames) // 2, "BoT-SORT IDs not stable across frames"
+
     def test_save_creates_annotated_video(self, model, video_path, tmp_path):
         """save=True should write an annotated video to output_path."""
         import cv2
@@ -248,6 +263,12 @@ class TestTrackingYOLO9:
         for i, f in enumerate(frames):
             ids = f.track_id.tolist() if f.track_id is not None else []
             assert len(ids) == len(set(ids)), f"Frame {i}: duplicate IDs: {ids}"
+
+    def test_botsort_produces_results(self, model, video_path):
+        """The BoT-SORT path works with flagship YOLO9 detectors."""
+        frames = _run_tracker(model, video_path, n_frames=5, tracker="botsort")
+        assert len(frames) == 5
+        assert all(frame.track_id is not None and len(frame) > 0 for frame in frames)
 
 
 # ── YOLO-NAS ─────────────────────────────────────────────────────────────────
@@ -336,6 +357,12 @@ class TestTrackingRFDETR:
         for i, f in enumerate(frames):
             ids = f.track_id.tolist() if f.track_id is not None else []
             assert len(ids) == len(set(ids)), f"Frame {i}: duplicate IDs: {ids}"
+
+    def test_botsort_produces_results(self, model, video_path):
+        """The BoT-SORT path works with flagship RF-DETR detectors."""
+        frames = _run_tracker(model, video_path, n_frames=5, tracker="botsort")
+        assert len(frames) == 5
+        assert all(frame.track_id is not None and len(frame) > 0 for frame in frames)
 
 
 # ── RF-DETR Segmentation + Tracking ─────────────────────────────────────────

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -1,7 +1,7 @@
 """
 E2E tracking: validate model.track() on a real video with multiple pedestrians.
 
-Downloads a short test video (7.3 MB, 13.6s) from Roboflow's public CDN and
+Downloads official Supervision video assets from Roboflow's public CDN and
 runs tracking through several LibreYOLO detectors, checking that:
   - track IDs are assigned and consistent across frames
   - the same person keeps the same ID across consecutive frames
@@ -34,8 +34,12 @@ from .conftest import (
 pytestmark = [pytest.mark.e2e, requires_cuda]
 
 VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/people-walking.mp4"
+BOTSORT_VIDEO_URL = (
+    "https://media.roboflow.com/supervision/video-examples/basketball-1.mp4"
+)
 VIDEO_CACHE = Path.home() / ".cache" / "libreyolo" / "tracking"
 VIDEO_PATH = VIDEO_CACHE / "people-walking.mp4"
+BOTSORT_VIDEO_PATH = VIDEO_CACHE / "basketball-1.mp4"
 
 OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")
 
@@ -50,6 +54,16 @@ def download_tracking_video():
     print(f"Video cached at {VIDEO_PATH}")
 
 
+def download_botsort_video():
+    """Download the basketball BoT-SORT smoke-test video when not cached."""
+    if BOTSORT_VIDEO_PATH.exists():
+        return
+    print(f"\nDownloading BoT-SORT test video from {BOTSORT_VIDEO_URL} ...")
+    VIDEO_CACHE.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(BOTSORT_VIDEO_URL, str(BOTSORT_VIDEO_PATH))
+    print(f"Video cached at {BOTSORT_VIDEO_PATH}")
+
+
 @pytest.fixture(scope="module")
 def video_path():
     """Download the test video once per module, skip if network unavailable."""
@@ -58,6 +72,16 @@ def video_path():
     except Exception as exc:
         pytest.skip(f"Cannot download test video: {exc}")
     return VIDEO_PATH
+
+
+@pytest.fixture(scope="module")
+def botsort_video_path():
+    """Provide a basketball clip with crossings and similar-looking targets."""
+    try:
+        download_botsort_video()
+    except Exception as exc:
+        pytest.skip(f"Cannot download BoT-SORT test video: {exc}")
+    return BOTSORT_VIDEO_PATH
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -183,10 +207,12 @@ class TestTrackingYOLOX:
                     stable += 1
         assert stable >= len(frames) // 2, "Deep OC-SORT IDs not stable across frames"
 
-    def test_botsort_tracker_end_to_end(self, model, video_path):
-        """BoT-SORT yields stable IDs while compensating for camera motion."""
-        frames = _run_tracker(model, video_path, n_frames=20, tracker="botsort")
-        assert len(frames) == 20
+    def test_botsort_tracker_end_to_end(self, model, botsort_video_path):
+        """BoT-SORT assigns stable, unique IDs on a real basketball clip."""
+        frames = _run_tracker(
+            model, botsort_video_path, n_frames=120, tracker="botsort"
+        )
+        assert len(frames) == 120
         stable = 0
         for i, frame in enumerate(frames):
             ids = frame.track_id.tolist() if frame.track_id is not None else []

--- a/tests/unit/test_botsort.py
+++ b/tests/unit/test_botsort.py
@@ -1,0 +1,471 @@
+"""Behavioral and numerical tests for LibreYOLO's BoT-SORT integration."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.models.base.model import BaseModel
+from libreyolo.tracking import BoTSortConfig, BoTSortTracker
+from libreyolo.tracking.botsort import _BoTSTrack
+from libreyolo.tracking.kalman_filter import KalmanFilterXYWH
+from libreyolo.utils.results import Boxes, Masks, Results
+
+pytestmark = pytest.mark.unit
+
+
+def _make_results(
+    boxes_list,
+    confs,
+    classes,
+    *,
+    orig_shape=(360, 640),
+    backend="torch",
+    masks=False,
+):
+    if backend == "torch":
+        boxes = torch.tensor(boxes_list, dtype=torch.float32).reshape(-1, 4)
+        conf = torch.tensor(confs, dtype=torch.float32).reshape(-1)
+        cls = torch.tensor(classes, dtype=torch.float32).reshape(-1)
+    else:
+        boxes = np.asarray(boxes_list, dtype=np.float32).reshape(-1, 4)
+        conf = np.asarray(confs, dtype=np.float32).reshape(-1)
+        cls = np.asarray(classes, dtype=np.float32).reshape(-1)
+
+    mask_obj = None
+    if masks:
+        h, w = orig_shape
+        data = torch.zeros((len(boxes_list), h, w), dtype=torch.uint8)
+        for i, (x1, y1, x2, y2) in enumerate(boxes_list):
+            data[i, int(y1) : int(y2), int(x1) : int(x2)] = 1
+        mask_obj = Masks(data, orig_shape)
+    return Results(boxes=Boxes(boxes, conf, cls), orig_shape=orig_shape, masks=mask_obj)
+
+
+def _textured_frame(height=360, width=640, seed=7):
+    rng = np.random.default_rng(seed)
+    gray = rng.integers(0, 256, size=(height, width), dtype=np.uint8)
+    return np.repeat(gray[..., None], 3, axis=2)
+
+
+def _box(cx, cy, w=50, h=100):
+    return [cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2]
+
+
+# --------------------------------------------------------------------------
+# Config and public API
+# --------------------------------------------------------------------------
+
+
+def test_config_defaults_and_inherited_association_contract():
+    cfg = BoTSortConfig()
+    assert cfg.track_high_thresh == 0.25
+    assert cfg.track_low_thresh == 0.1
+    assert cfg.match_thresh == 0.8
+    assert cfg.enable_cmc is True
+    assert cfg.cmc_method == "sparseOptFlow"
+    assert cfg.cmc_downscale == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"cmc_downscale": 0},
+        {"cmc_method": "orb"},
+        {"track_high_thresh": 1.1},
+        {"track_low_thresh": -0.1},
+    ],
+)
+def test_config_validation_rejects_invalid_values(kwargs):
+    with pytest.raises(ValueError):
+        BoTSortConfig(**kwargs)
+
+
+def test_config_from_kwargs_warns_unknown():
+    with pytest.warns(UserWarning, match="Unknown BoT-SORT config keys"):
+        cfg = BoTSortConfig.from_kwargs(track_high_thresh=0.6, unknown=1)
+    assert cfg.track_high_thresh == 0.6
+
+
+def test_public_exports_are_available():
+    from libreyolo import BoTSortConfig as TopLevelConfig
+    from libreyolo import BoTSortTracker as TopLevelTracker
+
+    assert TopLevelConfig is BoTSortConfig
+    assert TopLevelTracker is BoTSortTracker
+
+
+# --------------------------------------------------------------------------
+# XYWH Kalman state and affine warping
+# --------------------------------------------------------------------------
+
+
+def test_xywh_kalman_tracks_width_and_height_independently():
+    kf = KalmanFilterXYWH()
+    mean, covariance = kf.initiate(np.array([100.0, 200.0, 40.0, 100.0]))
+    assert mean.tolist() == [100.0, 200.0, 40.0, 100.0, 0.0, 0.0, 0.0, 0.0]
+    assert covariance[0, 0] < covariance[1, 1]
+    assert covariance[2, 2] < covariance[3, 3]
+
+    mean[6] = 5.0
+    mean[7] = -2.0
+    predicted, covariance = kf.predict(mean, covariance)
+    assert predicted[2] == pytest.approx(45.0)
+    assert predicted[3] == pytest.approx(98.0)
+
+    updated, covariance = kf.update(
+        predicted, covariance, np.array([102.0, 201.0, 50.0, 94.0])
+    )
+    assert np.isfinite(updated).all()
+    assert np.isfinite(covariance).all()
+    assert updated[2] > 0 and updated[3] > 0
+
+
+def test_xywh_multi_predict_matches_scalar_predict():
+    kf = KalmanFilterXYWH()
+    states, covariances = zip(
+        *(
+            kf.initiate(np.array(measurement, dtype=float))
+            for measurement in ([100, 200, 40, 100], [300, 150, 80, 30])
+        )
+    )
+    states = np.asarray(states)
+    covariances = np.asarray(covariances)
+    batch_mean, batch_cov = kf.multi_predict(states.copy(), covariances.copy())
+    scalar = [kf.predict(m.copy(), c.copy()) for m, c in zip(states, covariances)]
+    assert np.allclose(batch_mean, np.asarray([item[0] for item in scalar]))
+    assert np.allclose(batch_cov, np.asarray([item[1] for item in scalar]))
+
+
+def test_camera_motion_warps_center_velocity_and_covariance():
+    kf = KalmanFilterXYWH()
+    track = _BoTSTrack(np.array([80, 150, 120, 250]), 0.9, 0, 0)
+    track.activate(kf, frame_id=1, track_id=1)
+    track.mean[4:6] = [3.0, 4.0]
+    before_size = track.mean[2:4].copy()
+    before_cov = track.covariance.copy()
+    affine = np.array([[0.0, -1.0, 10.0], [1.0, 0.0, -5.0]])
+
+    track.apply_camera_motion(affine)
+
+    assert np.allclose(track.mean[:2], [-190.0, 95.0])
+    assert np.allclose(track.mean[4:6], [-4.0, 3.0])
+    assert np.allclose(track.mean[2:4], before_size)
+    # A 90-degree rotation swaps center x/y uncertainty.
+    assert track.covariance[0, 0] == pytest.approx(before_cov[1, 1])
+    assert track.covariance[1, 1] == pytest.approx(before_cov[0, 0])
+
+
+# --------------------------------------------------------------------------
+# Sparse optical-flow camera motion
+# --------------------------------------------------------------------------
+
+
+def test_sparse_optical_flow_recovers_known_translation():
+    tracker = BoTSortTracker(cmc_downscale=1)
+    first = _textured_frame()
+    expected = np.array([[1.0, 0.0, 24.0], [0.0, 1.0, -13.0]], dtype=np.float32)
+    second = cv2.warpAffine(
+        first,
+        expected,
+        (first.shape[1], first.shape[0]),
+        borderMode=cv2.BORDER_REFLECT,
+    )
+
+    initial = tracker.camera_motion.estimate(first)
+    estimated = tracker.camera_motion.estimate(second)
+
+    assert np.allclose(initial, np.eye(2, 3), atol=1e-6)
+    assert np.allclose(estimated[:, :2], expected[:, :2], atol=0.02)
+    assert np.allclose(estimated[:, 2], expected[:, 2], atol=0.75)
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        np.zeros((1, 1), dtype=np.uint8),
+        np.zeros((16, 16, 3), dtype=np.uint8),
+        np.zeros((16, 16, 4), dtype=np.uint8),
+    ],
+)
+def test_camera_motion_textureless_and_tiny_frames_fall_back_to_identity(frame):
+    tracker = BoTSortTracker(cmc_downscale=2)
+    first = tracker.camera_motion.estimate(frame)
+    second = tracker.camera_motion.estimate(frame)
+    assert np.allclose(first, np.eye(2, 3))
+    assert np.allclose(second, np.eye(2, 3))
+
+
+def test_camera_motion_rejects_invalid_frame_shape():
+    tracker = BoTSortTracker()
+    with pytest.raises(ValueError, match="RGB/RGBA or grayscale"):
+        tracker.camera_motion.estimate(np.zeros((10,), dtype=np.uint8))
+
+
+def test_camera_motion_accepts_normalized_float_frames():
+    tracker = BoTSortTracker(cmc_downscale=1)
+    frame = _textured_frame().astype(np.float32) / 255.0
+    assert np.allclose(tracker.camera_motion.estimate(frame), np.eye(2, 3))
+
+
+# --------------------------------------------------------------------------
+# Results adapter and tracker lifecycle
+# --------------------------------------------------------------------------
+
+
+def test_image_is_required_only_when_camera_motion_is_enabled():
+    results = _make_results([_box(100, 150)], [0.9], [0])
+    tracker = BoTSortTracker()
+    with pytest.raises(ValueError, match="needs the frame image"):
+        tracker.update(results)
+    assert tracker._frame_id == 0
+
+    no_cmc = BoTSortTracker(enable_cmc=False)
+    out = no_cmc.update(results)
+    assert out.track_id.tolist() == [1]
+
+
+def test_ids_persist_for_moving_objects():
+    tracker = BoTSortTracker(enable_cmc=False)
+    ids = []
+    for t in range(10):
+        result = _make_results(
+            [_box(100 + 8 * t, 180), _box(500 - 6 * t, 240, 60, 80)],
+            [0.9, 0.85],
+            [0, 0],
+        )
+        out = tracker.update(result)
+        ids.append(out.track_id.tolist())
+    assert ids[0] == ids[-1]
+    assert len(set(ids[-1])) == 2
+
+
+def test_first_frame_is_instant_but_late_birth_obeys_confirmation_count():
+    tracker = BoTSortTracker(enable_cmc=False, minimum_consecutive_frames=3)
+    first = tracker.update(_make_results([_box(100, 150)], [0.9], [0]))
+    assert first.track_id.tolist() == [1]
+
+    # A new object appearing after frame one is tentative for its first two
+    # detections, then receives the next public ID on its third hit.
+    second = tracker.update(
+        _make_results([_box(104, 150), _box(500, 250)], [0.9, 0.9], [0, 0])
+    )
+    third = tracker.update(
+        _make_results([_box(108, 150), _box(504, 250)], [0.9, 0.9], [0, 0])
+    )
+    fourth = tracker.update(
+        _make_results([_box(112, 150), _box(508, 250)], [0.9, 0.9], [0, 0])
+    )
+    assert second.track_id.tolist() == [1]
+    assert third.track_id.tolist() == [1]
+    assert fourth.track_id.tolist() == [1, 2]
+
+
+def test_camera_motion_is_applied_before_association(monkeypatch):
+    tracker = BoTSortTracker(cmc_downscale=1)
+    frame = _textured_frame()
+    first = tracker.update(_make_results([[100, 100, 150, 200]], [0.9], [0]), frame)
+    first_id = first.track_id.item()
+    monkeypatch.setattr(
+        tracker.camera_motion,
+        "estimate",
+        lambda image: np.array([[1, 0, 40], [0, 1, 0]], dtype=np.float32),
+    )
+
+    shifted = tracker.update(_make_results([[140, 100, 190, 200]], [0.9], [0]), frame)
+    assert shifted.track_id.item() == first_id
+
+
+def test_low_confidence_recovery_keeps_id():
+    tracker = BoTSortTracker(
+        enable_cmc=False, track_high_thresh=0.5, track_low_thresh=0.1
+    )
+    first = tracker.update(_make_results([_box(100, 150)], [0.9], [0]))
+    second = tracker.update(_make_results([_box(103, 151)], [0.3], [0]))
+    assert second.track_id.item() == first.track_id.item()
+
+
+def test_pinned_apache_reference_lifecycle_parity_golden():
+    """Match the pinned Roboflow reference's IDs for every input detection.
+
+    The golden rows were generated with Roboflow Trackers commit
+    3b6d910df78a7ab48d5770b5bc86e043476d2e76. They cover first-frame
+    activation, low-confidence association, occlusion recovery, a late birth
+    that must be confirmed, and one-frame false births that must not consume a
+    public ID. LibreYOLO IDs are normalized to its positive, one-based API.
+    """
+    frames = [
+        ([_box(100, 100, 40, 80), _box(400, 200, 40, 80)], [0.9, 0.8]),
+        ([_box(106, 100, 40, 80), _box(394, 200, 40, 80)], [0.9, 0.2]),
+        ([_box(388, 200, 40, 80)], [0.2]),
+        (
+            [
+                _box(118, 100, 40, 80),
+                _box(382, 200, 40, 80),
+                _box(600, 300, 40, 80),
+            ],
+            [0.9, 0.8, 0.9],
+        ),
+        (
+            [
+                _box(124, 100, 40, 80),
+                _box(376, 200, 40, 80),
+                _box(606, 300, 40, 80),
+            ],
+            [0.9, 0.8, 0.9],
+        ),
+        (
+            [
+                _box(130, 100, 40, 80),
+                _box(370, 200, 40, 80),
+                _box(612, 300, 40, 80),
+                _box(800, 100, 40, 80),
+            ],
+            [0.9, 0.8, 0.9, 0.9],
+        ),
+        (
+            [
+                _box(136, 100, 40, 80),
+                _box(364, 200, 40, 80),
+                _box(618, 300, 40, 80),
+            ],
+            [0.9, 0.8, 0.9],
+        ),
+        (
+            [
+                _box(142, 100, 40, 80),
+                _box(358, 200, 40, 80),
+                _box(624, 300, 40, 80),
+                _box(900, 400, 40, 80),
+            ],
+            [0.9, 0.8, 0.9, 0.9],
+        ),
+        (
+            [
+                _box(148, 100, 40, 80),
+                _box(352, 200, 40, 80),
+                _box(630, 300, 40, 80),
+                _box(906, 400, 40, 80),
+            ],
+            [0.9, 0.8, 0.9, 0.9],
+        ),
+    ]
+    expected = [
+        [1, 2],
+        [1, 2],
+        [2],
+        [1, 2, -1],
+        [1, 2, 3],
+        [1, 2, 3, -1],
+        [1, 2, 3],
+        [1, 2, 3, -1],
+        [1, 2, 3, 4],
+    ]
+    tracker = BoTSortTracker(
+        enable_cmc=False,
+        track_buffer=10,
+        track_high_thresh=0.5,
+        track_low_thresh=0.1,
+        new_track_thresh=0.25,
+        minimum_consecutive_frames=1,
+    )
+
+    actual = []
+    for (boxes, scores), expected_ids in zip(frames, expected):
+        output = tracker.update(_make_results(boxes, scores, [0] * len(boxes)))
+        frame_ids = [-1] * len(boxes)
+        output_boxes = output.boxes.xyxy.cpu().numpy()
+        for output_box, track_id in zip(output_boxes, output.track_id.tolist()):
+            distances = np.max(
+                np.abs(np.asarray(boxes, dtype=float) - output_box), axis=1
+            )
+            frame_ids[int(np.argmin(distances))] = int(track_id)
+        actual.append(frame_ids)
+        assert frame_ids == expected_ids
+    assert actual == expected
+
+
+def test_numpy_backend_and_empty_output_are_preserved():
+    tracker = BoTSortTracker(enable_cmc=False)
+    first = tracker.update(_make_results([_box(100, 150)], [0.9], [0], backend="numpy"))
+    empty = tracker.update(_make_results([], [], [], backend="numpy"))
+    assert isinstance(first.track_id, np.ndarray)
+    assert first.track_id.dtype == np.int64
+    assert isinstance(empty.track_id, np.ndarray)
+    assert empty.track_id.shape == (0,)
+
+
+def test_masks_are_sliced_with_tracked_detections():
+    tracker = BoTSortTracker(enable_cmc=False)
+    result = _make_results(
+        [_box(100, 150), _box(450, 230)], [0.9, 0.8], [0, 1], masks=True
+    )
+    tracked = tracker.update(result)
+    assert tracked.masks is not None
+    assert len(tracked.masks) == len(tracked) == 2
+    assert all(tracked.masks.data[i].sum() > 0 for i in range(2))
+
+
+def test_reset_clears_tracks_ids_and_camera_history():
+    tracker = BoTSortTracker()
+    frame = _textured_frame()
+    result = _make_results([_box(100, 150)], [0.9], [0])
+    tracker.update(result, frame)
+    assert tracker.camera_motion._initialized
+
+    tracker.reset()
+
+    assert tracker._frame_id == 0
+    assert tracker.tracked_stracks == []
+    assert not tracker.camera_motion._initialized
+    assert tracker.update(result, frame).track_id.tolist() == [1]
+
+
+# --------------------------------------------------------------------------
+# BaseModel.track selector
+# --------------------------------------------------------------------------
+
+
+def _spy_botsort(monkeypatch):
+    import libreyolo.tracking as tracking
+
+    built = {}
+
+    class SpyBoTSort(tracking.BoTSortTracker):
+        def __init__(self, *args, **kwargs):
+            built["tracker"] = "botsort"
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(tracking, "BoTSortTracker", SpyBoTSort)
+    return built
+
+
+def test_selector_string_builds_botsort(monkeypatch):
+    built = _spy_botsort(monkeypatch)
+    model = type("DetModel", (), {"task": "detect"})()
+    with pytest.raises(FileNotFoundError):
+        next(BaseModel.track(model, "missing.mp4", tracker="botsort"))
+    assert built["tracker"] == "botsort"
+
+
+def test_botsort_config_type_routes_before_trackconfig(monkeypatch):
+    built = _spy_botsort(monkeypatch)
+    model = type("DetModel", (), {"task": "detect"})()
+    with pytest.raises(FileNotFoundError):
+        next(
+            BaseModel.track(
+                model,
+                "missing.mp4",
+                tracker_config=BoTSortConfig(enable_cmc=False),
+            )
+        )
+    assert built["tracker"] == "botsort"
+
+
+def test_tracker_rejects_wrong_config_type():
+    from libreyolo.tracking import TrackConfig
+
+    with pytest.raises(TypeError, match="must be a BoTSortConfig"):
+        BoTSortTracker(config=TrackConfig())


### PR DESCRIPTION
## What does this PR do?

Adds motion-only BoT-SORT tracking support to LibreYOLO.

- Adds `tracker=botsort` to the public `model.track()` API.
- Adds `BoTSortTracker` and `BoTSortConfig`.
- Implements sparse optical-flow camera-motion compensation.
- Adds the scale-aware center-width-height Kalman state used by BoT-SORT.
- Integrates BoT-SORT with LibreYOLO's detector-agnostic `Results` contract.
- Covers the YOLO9 and RF-DETR tracking paths.
- Adds focused unit tests and a real-video GPU smoke test.
- Documents third-party provenance in `THIRD_PARTY_NOTICES.txt`.

This implements motion-only BoT-SORT. It does not include the optional ReID model used by BoT-SORT-ReID.

## Code provenance

The BoT-SORT lifecycle, Kalman model, and camera-motion compensation were adapted from the Apache-2.0-licensed Roboflow Trackers implementation.

| LibreYOLO files | Upstream | Commit | License |
| --- | --- | --- | --- |
| `libreyolo/tracking/botsort.py`, `libreyolo/tracking/kalman_filter.py` | https://github.com/roboflow/trackers | `3b6d910df78a7ab48d5770b5bc86e043476d2e76` | Apache-2.0 |

The implementation was adapted to LibreYOLO's existing tracker lifecycle, configuration API, and detector-agnostic `Results` contract. The remaining API integration and tests were written for this PR.

The upstream attribution and pinned commit are recorded in `THIRD_PARTY_NOTICES.txt`.

## How was this tested?

Focused unit tests:

```text
python -m pytest tests/unit/test_botsort.py -q -m unit
28 passed
```

Real-video GPU smoke test:

```text
python -m pytest tests/e2e/test_tracking.py::TestTrackingYOLOX::test_botsort_tracker_end_to_end -q -m e2e
1 passed
```

Manual validation:

- Rendered all 477 frames of the basketball test video using `LibreYOLO9t`, `tracker=botsort`, and `save=True`.
- Confirmed that the saved 1920x1080 H.264 video was readable and contained tracking annotations.
- The basketball asset is treated as a functional smoke test, not a ground-truth accuracy or camera-motion benchmark.
