### PR TITLE
Add LoRA fine-tuning for D-FINE, DEIM, DEIMv2, RT-DETR, EC and ConvNeXt

### DIFF
--- a/docs/lora.md
+++ b/docs/lora.md
@@ -1,12 +1,16 @@
 # LoRA fine-tuning
 
-Parameter-efficient fine-tuning for RF-DETR on low-VRAM GPUs. Freezes the DINOv2
-backbone and trains small adapters on it plus the projector, decoder, and head.
+Parameter-efficient fine-tuning for transformer-based detectors on low-VRAM
+GPUs. Freezes the pretrained heavy parts and trains small low-rank adapters
+plus the layers that must stay dense (heads, projections).
 
 ## Use
 
 ```python
 model = LibreYOLO("LibreRFDETRn.pt")
+model.train(data="data.yaml", lora=True)
+
+model = LibreYOLO("LibreDFINEs.pt")
 model.train(data="data.yaml", lora=True)
 ```
 
@@ -16,19 +20,82 @@ model.train(data="data.yaml", lora=True)
 pip install "libreyolo[lora]"
 ```
 
-## Recipe
+## Recipes
 
-DoRA, rank 16, alpha 16, on the backbone attention `query`/`key`/`value`. Matches
-the RF-DETR reference. Adapters merge into dense weights on `export()`, so exported
-models have no `peft` dependency.
+Fixed per family, not user-facing knobs.
 
-Training checkpoints (`best.pt` and `last.pt`) keep the adapter tensors so they
-can be resumed or inspected. Loading those checkpoints requires the `lora` extra.
-Use `export()` when you need a dense inference artifact without `peft`.
+### RF-DETR
+
+DoRA, rank 16, alpha 16, on the DINOv2 backbone attention
+`query`/`key`/`value`. Matches the RF-DETR reference. The ViT backbone is
+frozen; the projector, decoder, and detection head keep training normally.
+
+### D-FINE / DEIM / RT-DETR (v1, v2, v4)
+
+These pair a CNN (HGNetv2 or PResNet) backbone with a transformer hybrid
+encoder + deformable decoder, so the recipe differs:
+
+- The CNN backbone is frozen entirely. It is the first stage, so no gradient
+  flows through it at all and its backward pass is skipped.
+- The transformer blocks (AIFI encoder layers, decoder layers) freeze their
+  base weights and train plain LoRA adapters (rank 16, alpha 16) on their
+  `nn.Linear` layers: FFN `linear1`/`linear2`, the gate, and the deformable
+  attention projections.
+- Decoder self-attention (`nn.MultiheadAttention`) stays frozen without
+  adapters: PyTorch's MHA reads `out_proj.weight` directly, which would
+  silently bypass an injected adapter.
+- Everything else trains normally: encoder conv fusion, input projections,
+  prediction heads, query embeddings.
+
+Plain LoRA instead of DoRA because several decoder Linears are zero-init by
+design and DoRA's magnitude normalization divides by the weight norm.
+
+RT-DETRv4 reuses the D-FINE architecture and trainer, so it takes this
+recipe by inheritance.
+
+### EC (EdgeCrafter)
+
+EC is a DETR whose backbone is a ViTAdapter: a plain ViT with fused `qkv`
+attention under `backbone.backbone`, surrounded by a trainable conv projector
+pyramid. The ViT base freezes and its `qkv` Linears get adapters, the
+transformer encoder/decoder blocks take the shared DETR recipe, and the
+projector plus heads keep training. Detection only (seg/pose raise).
+
+### ConvNeXt (classification)
+
+ConvNeXt blocks carry channels-last `nn.Linear` MLPs (`fc1`/`fc2`); those
+take plain LoRA adapters while the depthwise convs, norms, and layer-scale
+parameters freeze. The classification head stays dense-trainable so custom
+class counts keep working.
+
+### DEIMv2
+
+Same DETR recipe as above (its SwiGLU FFN `w12`/`w3` Linears are targeted
+instead of `linear1`/`linear2`), with one addition for the S/M/L/X sizes,
+which carry a DINOv3 ViT backbone: the ViT base weights freeze and its fused
+attention `qkv` Linears get adapters (the same `qkv` target the RF-DETR
+reference lists for fused layouts), while the Spatial Tuning Adapter conv
+pyramid keeps training as the projector analog. The `qkv` adapters are
+injected even when the config shipped the ViT frozen: adapting a frozen
+backbone is the point of LoRA. Sub-S sizes use HGNetv2 and take the plain
+DETR recipe.
+
+## Checkpoints and export
+
+Training checkpoints (`best.pt` and `last.pt`) keep the adapter tensors so
+they can be resumed or inspected. Loading those checkpoints requires the
+`lora` extra; the loader replays the adapter injection so the peft keys line
+up. RF-DETR merges adapters into dense weights on `export()`;
+`libreyolo.training.lora.merge_lora_adapters` does the same for injected
+D-FINE/DEIM models.
 
 ## Scope
 
-- RF-DETR only. Other families raise instead of silently ignoring `lora=True`.
-- The detection head always stays trainable (custom class counts need it).
-- Saves optimizer/gradient memory, not activations. For the tightest VRAM, lower
-  `batch` or `imgsz`.
+- RF-DETR, D-FINE, DEIM, DEIMv2, RT-DETR v1/v2/v4, EC, and ConvNeXt. Other
+  families raise instead of silently ignoring `lora=True`.
+- Detection tasks only for D-FINE and EC (segment/pose raise); RF-DETR
+  semantic raises.
+- The detection heads always stay trainable (custom class counts need them).
+- Saves optimizer/gradient memory and skips the frozen backbone's backward;
+  activation memory is unchanged. For the tightest VRAM, lower `batch` or
+  `imgsz`.

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -25,7 +25,17 @@ from ..output import OutputHandler
 from ...training.freezing import normalize_freeze_selectors, parse_freeze_spec
 
 
-_LORA_TRAIN_FAMILIES = {"rfdetr"}
+_LORA_TRAIN_FAMILIES = {
+    "rfdetr",
+    "dfine",
+    "deim",
+    "deimv2",
+    "rtdetr",
+    "rtdetrv2",
+    "rtdetrv4",
+    "ec",
+    "convnext",
+}
 
 
 def _model_ref_exists(model_path: str) -> bool:
@@ -506,7 +516,10 @@ def train_cmd(
             out,
             "config_unsupported",
             f"LoRA fine-tuning (lora=True) is not supported for {family}.",
-            suggestion="Use an RF-DETR model or remove --lora.",
+            suggestion=(
+                "Use a supported family (RF-DETR, D-FINE, DEIM, DEIMv2, "
+                "RT-DETR v1/v2/v4, EC, ConvNeXt) or remove --lora."
+            ),
         )
 
     # RF-DETR: warn and ignore unsupported params
@@ -536,6 +549,8 @@ def train_cmd(
         }
         if params.get("freeze") is not None:
             resolved_config["freeze"] = params["freeze"]
+        if params.get("lora"):
+            resolved_config["lora"] = True
         if params.get("distill_model"):
             resolved_config["distill_model"] = params["distill_model"]
             resolved_config["distill_loss_type"] = params["distill_loss_type"]

--- a/libreyolo/data/augment/detr.py
+++ b/libreyolo/data/augment/detr.py
@@ -72,7 +72,8 @@ def resolve_aug_stop_epoch(epochs: int, ratio: float, no_aug_epochs: int) -> int
     run.
     """
     epochs = int(epochs)
-    stop_epoch = int(epochs * float(ratio))
+    # ratio may be None on a config whose size recipe did not set it.
+    stop_epoch = int(epochs * float(ratio if ratio is not None else 1.0))
     no_aug = int(no_aug_epochs or 0)
     if no_aug > 0:
         stop_epoch = min(stop_epoch, max(1, epochs - no_aug))

--- a/libreyolo/data/augment/detr.py
+++ b/libreyolo/data/augment/detr.py
@@ -60,6 +60,25 @@ def _labels_at_index_2(inputs):
     return inputs[2]
 
 
+def resolve_aug_stop_epoch(epochs: int, ratio: float, no_aug_epochs: int) -> int:
+    """Epoch at which the strong augs (ZoomOut/IoUCrop/Photometric) shut off.
+
+    Strong augs must stop early enough to leave the no-aug LR tail clean:
+    ``min(ratio-based stop, epochs - no_aug_epochs)``. Published recipes
+    already satisfy this (DEIM 132ep: 120 both ways; DEIMv2 tables encode
+    ``ratio == (epochs - no_aug)/epochs`` exactly; D-FINE's 0.85 stops even
+    earlier), so they are unchanged. Short fine-tune runs stop augmenting in
+    time to consolidate at low LR instead of augmenting through ~90% of the
+    run.
+    """
+    epochs = int(epochs)
+    stop_epoch = int(epochs * float(ratio))
+    no_aug = int(no_aug_epochs or 0)
+    if no_aug > 0:
+        stop_epoch = min(stop_epoch, max(1, epochs - no_aug))
+    return stop_epoch
+
+
 def _generate_scales(base_size: int, base_size_repeat: int) -> List[int]:
     """Mirror of the upstream ports' ``generate_scales``.
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -681,6 +681,7 @@ class BaseModel(ABC):
 
                 apply_quant_structure(self, quant_manifest)
 
+            self._prepare_model_for_state_dict(state_dict)
             self.model.load_state_dict(state_dict, strict=self._strict_loading())
             self.model.to(self.device).eval()
         except Exception as e:
@@ -691,6 +692,16 @@ class BaseModel(ABC):
     def _allow_checkpoint_task_mismatch(self, checkpoint_task: str) -> bool:
         """Return whether a family permits loading a checkpoint from another task."""
         return False
+
+    def _prepare_model_for_state_dict(self, state_dict: dict) -> None:
+        """Family hook: adapt the live module graph to an incoming state dict.
+
+        Runs after any class-count rebuild and right before
+        ``load_state_dict``. Families that support ``lora=True`` and rely on
+        the base loader override this to replay adapter injection when the
+        checkpoint carries LoRA keys; the default is a no-op.
+        """
+        return None
 
     # =========================================================================
     # Public API

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1456,6 +1456,16 @@ class BaseModel(ABC):
         Returns:
             Path to the exported model file.
         """
+        # A model fine-tuned with lora=True carries live PEFT adapter layers.
+        # Fold them into dense weights before export so the traced graph is a
+        # plain model with no peft dependency. RF-DETR merges via its own
+        # export override; this covers the other lora-capable families
+        # (D-FINE, DEIM, DEIMv2, RT-DETR v1/v2/v4, EC, ConvNeXt).
+        from libreyolo.training.lora import merge_lora_adapters, module_has_lora
+
+        if module_has_lora(self.model):
+            merge_lora_adapters(self.model)
+
         if getattr(self, "_quant_manifest", None):
             from libreyolo.quant.api import quantized_export
 

--- a/libreyolo/models/convnext/model.py
+++ b/libreyolo/models/convnext/model.py
@@ -127,6 +127,19 @@ class LibreConvNeXt(BaseModel):
         self.model.reset_classifier(new_nb_classes)
         self.model.to(self.device)
 
+    def _prepare_model_for_state_dict(self, state_dict: dict) -> None:
+        """Replay LoRA injection for adapter checkpoints (lora=True training
+        saves block MLPs under peft keys; rebuild the adapted graph so the
+        keys line up before the strict load)."""
+        from ...training.lora import (
+            apply_lora_to_convnext,
+            module_has_lora,
+            state_dict_has_lora,
+        )
+
+        if state_dict_has_lora(state_dict) and not module_has_lora(self.model):
+            apply_lora_to_convnext(self.model)
+
     # ---- inference -------------------------------------------------------
 
     def _get_preprocess_numpy(self):

--- a/libreyolo/models/convnext/trainer.py
+++ b/libreyolo/models/convnext/trainer.py
@@ -25,6 +25,11 @@ class ConvNeXtTrainer(BaseTrainer):
     # Non-detect task: select the best checkpoint by top-1 accuracy.
     best_metric_key = "metrics/accuracy_top1"
 
+    # ConvNeXt blocks carry channels-last nn.Linear MLPs (fc1/fc2), so LoRA
+    # adapts those while the convs/norms freeze and the head keeps training
+    # (see libreyolo/training/lora.py).
+    supports_lora = True
+
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:
         return ConvNeXtConfig
@@ -34,6 +39,19 @@ class ConvNeXtTrainer(BaseTrainer):
 
     def get_model_tag(self) -> str:
         return f"ConvNeXt-{self.config.size}"
+
+    def preserve_freeze_param(self, name: str, param: torch.nn.Parameter) -> bool:
+        if not getattr(self.config, "lora", False):
+            return False
+        from ...training.lora import is_lora_parameter_name
+
+        return is_lora_parameter_name(name)
+
+    def on_setup(self):
+        if getattr(self.config, "lora", False):
+            from ...training.lora import apply_lora_to_convnext
+
+            apply_lora_to_convnext(self.model)
 
     def create_transforms(self):
         # Classification uses the ImageFolder pipeline in ``_setup_classify_data``,

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -330,6 +330,19 @@ class LibreDEIM(BaseModel):
                 if ckpt_names is not None:
                     self.names = self._sanitize_names(ckpt_names, effective_nc)
 
+            # Replay LoRA injection for adapter checkpoints. A model trained
+            # with lora=True saves its transformer Linears under peft keys
+            # (``.base_layer.``/``lora_A``/``lora_B``); rebuild the adapted
+            # graph before loading so those keys line up.
+            from ...training.lora import (
+                apply_lora_to_detr,
+                module_has_lora,
+                state_dict_has_lora,
+            )
+
+            if state_dict_has_lora(state_dict) and not module_has_lora(self.model):
+                apply_lora_to_detr(self.model)
+
             missing, unexpected = self.model.load_state_dict(
                 state_dict, strict=self._strict_loading()
             )

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -58,6 +58,12 @@ from .transforms import (
 
 
 class DEIMTrainer(BaseTrainer):
+    # DEIM shares D-FINE's architecture shape: CNN (HGNetv2) backbone plus a
+    # transformer encoder/decoder with nn.Linear projections. lora=True
+    # freezes the backbone and the transformer base weights and trains LoRA
+    # adapters on the transformer Linears (see libreyolo/training/lora.py).
+    supports_lora = True
+
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:
         return DEIMConfig
@@ -67,6 +73,13 @@ class DEIMTrainer(BaseTrainer):
 
     def get_model_tag(self) -> str:
         return f"DEIM-{self.config.size}"
+
+    def preserve_freeze_param(self, name: str, param: torch.nn.Parameter) -> bool:
+        if not getattr(self.config, "lora", False):
+            return False
+        from ...training.lora import is_lora_parameter_name
+
+        return is_lora_parameter_name(name)
 
     def create_transforms(self):
         preproc = DEIMTrainTransform(
@@ -132,6 +145,11 @@ class DEIMTrainer(BaseTrainer):
         self._sync_wrapped_model_num_classes(num_classes)
 
     def on_setup(self):
+        if getattr(self.config, "lora", False):
+            from ...training.lora import apply_lora_to_detr
+
+            apply_lora_to_detr(self.model)
+
         matcher = HungarianMatcher(
             weight_dict={"cost_class": 2.0, "cost_bbox": 5.0, "cost_giou": 2.0},
             use_focal_loss=True,
@@ -402,10 +420,14 @@ class DEIMTrainer(BaseTrainer):
         )
 
         # Wire stop_epoch on the dataset wrapper so set_epoch can disable
-        # strong augs at the right moment.
-        stop_epoch = int(
-            self.config.epochs
-            * float(getattr(self.config, "aug_stop_epoch_ratio", 1.0))
+        # strong augs at the right moment (never later than the start of the
+        # no-aug LR tail; see resolve_aug_stop_epoch).
+        from ...data.augment.detr import resolve_aug_stop_epoch
+
+        stop_epoch = resolve_aug_stop_epoch(
+            self.config.epochs,
+            getattr(self.config, "aug_stop_epoch_ratio", 1.0),
+            getattr(self.config, "no_aug_epochs", 0),
         )
         if hasattr(train_dataset, "set_stop_epoch"):
             train_dataset.set_stop_epoch(stop_epoch)

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -443,6 +443,19 @@ class LibreDEIMv2(BaseModel):
                 if ckpt_names is not None:
                     self.names = self._sanitize_names(ckpt_names, effective_nc)
 
+            # Replay LoRA injection for adapter checkpoints. A model trained
+            # with lora=True saves its transformer Linears under peft keys
+            # (``.base_layer.``/``lora_A``/``lora_B``); rebuild the adapted
+            # graph before loading so those keys line up.
+            from ...training.lora import (
+                apply_lora_to_deimv2,
+                module_has_lora,
+                state_dict_has_lora,
+            )
+
+            if state_dict_has_lora(state_dict) and not module_has_lora(self.model):
+                apply_lora_to_deimv2(self.model)
+
             self._load_state_dict_checked(state_dict)
         except RuntimeError:
             raise

--- a/libreyolo/models/deimv2/trainer.py
+++ b/libreyolo/models/deimv2/trainer.py
@@ -41,14 +41,28 @@ class DEIMv2FlatCosineScheduler:
     ):
         self.lr = lr
         self.total_iters = iters_per_epoch * total_epochs
-        self.warmup_iters = int(warmup_iters)
+        # Budget guards for short fine-tune runs. The released DEIMv2 recipes
+        # express warmup in ITERATIONS (e.g. 2000) and flat in EPOCHS (e.g.
+        # 64/132) sized for full COCO training; on a small custom dataset a
+        # 15-epoch run can be shorter than the warmup alone, leaving the
+        # whole run as a quadratic ramp that never reaches the base LR. Caps:
+        # warmup <= 10% of the run, the min-LR tail <= 20%, and the cosine
+        # decay keeps >= 30% of the run. None of them bite when the recipe
+        # fits its budget (COCO-scale runs are unchanged).
+        self.warmup_iters = min(int(warmup_iters), int(0.1 * self.total_iters))
         self.warmup_lr_start = warmup_lr_start
-        self.flat_iters = (
+        self.no_aug_iters = min(
+            int(iters_per_epoch * no_aug_epochs), int(0.2 * self.total_iters)
+        )
+        requested_flat = (
             int(iters_per_epoch * flat_epochs)
             if flat_epochs is not None
             else self.total_iters - int(iters_per_epoch * no_aug_epochs)
         )
-        self.no_aug_iters = int(iters_per_epoch * no_aug_epochs)
+        max_flat = (
+            self.total_iters - self.no_aug_iters - max(1, int(0.3 * self.total_iters))
+        )
+        self.flat_iters = max(self.warmup_iters, min(requested_flat, max_flat))
         self.min_lr = lr * min_lr_ratio
 
     def update_lr(self, iters: int) -> float:
@@ -133,6 +147,13 @@ class DEIMv2Trainer(DEIMTrainer):
         )
 
     def on_setup(self):
+        # DEIMv2 needs its own recipe (SwiGLU FFN names, DINOv3 backbone on
+        # S/M/L/X), so this override must not rely on DEIMTrainer's hook.
+        if getattr(self.config, "lora", False):
+            from ...training.lora import apply_lora_to_deimv2
+
+            apply_lora_to_deimv2(self.model)
+
         decoder_reg_max = getattr(getattr(self.model, "decoder", None), "reg_max", None)
         if decoder_reg_max is not None and int(self.config.reg_max) != int(
             decoder_reg_max

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -431,6 +431,19 @@ class LibreDFINE(BaseModel):
                 if ckpt_names is not None:
                     self.names = self._sanitize_names(ckpt_names, effective_nc)
 
+            # Replay LoRA injection for adapter checkpoints. A model trained
+            # with lora=True saves its transformer Linears under peft keys
+            # (``.base_layer.``/``lora_A``/``lora_B``); rebuild the adapted
+            # graph before loading so those keys line up.
+            from ...training.lora import (
+                apply_lora_to_detr,
+                module_has_lora,
+                state_dict_has_lora,
+            )
+
+            if state_dict_has_lora(state_dict) and not module_has_lora(self.model):
+                apply_lora_to_detr(self.model)
+
             missing, unexpected = self.model.load_state_dict(
                 state_dict, strict=self._strict_loading()
             )

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -64,6 +64,12 @@ logger = logging.getLogger(__name__)
 
 
 class DFINETrainer(BaseTrainer):
+    # D-FINE pairs a CNN (HGNetv2) backbone with a transformer encoder/decoder
+    # whose projections are nn.Linear layers. lora=True freezes the backbone
+    # and the transformer base weights and trains LoRA adapters on the
+    # transformer Linears (see libreyolo/training/lora.py).
+    supports_lora = True
+
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:
         return DFINEConfig
@@ -73,6 +79,13 @@ class DFINETrainer(BaseTrainer):
 
     def get_model_tag(self) -> str:
         return f"DFINE-{self.config.size}"
+
+    def preserve_freeze_param(self, name: str, param: torch.nn.Parameter) -> bool:
+        if not getattr(self.config, "lora", False):
+            return False
+        from ...training.lora import is_lora_parameter_name
+
+        return is_lora_parameter_name(name)
 
     def _is_segment(self) -> bool:
         return (
@@ -155,6 +168,20 @@ class DFINETrainer(BaseTrainer):
         self._sync_wrapped_model_num_classes(num_classes)
 
     def on_setup(self):
+        if getattr(self.config, "lora", False):
+            if self._is_segment():
+                # The mask head path is untested with adapters; silently
+                # training it fully while config says LoRA would misrepresent
+                # the run.
+                raise ValueError(
+                    "D-FINE segment training does not support lora=True yet. "
+                    "Use freeze='backbone' for parameter-efficient segment "
+                    "fine-tuning."
+                )
+            from ...training.lora import apply_lora_to_detr
+
+            apply_lora_to_detr(self.model)
+
         matcher_weights = {"cost_class": 2.0, "cost_bbox": 5.0, "cost_giou": 2.0}
         loss_weights = {
             "loss_vfl": 1.0,
@@ -445,10 +472,14 @@ class DFINETrainer(BaseTrainer):
         )
 
         # Wire stop_epoch on the dataset wrapper so set_epoch can disable
-        # strong augs at the right moment.
-        stop_epoch = int(
-            self.config.epochs
-            * float(getattr(self.config, "aug_stop_epoch_ratio", 1.0))
+        # strong augs at the right moment (never later than the start of the
+        # no-aug LR tail; see resolve_aug_stop_epoch).
+        from ...data.augment.detr import resolve_aug_stop_epoch
+
+        stop_epoch = resolve_aug_stop_epoch(
+            self.config.epochs,
+            getattr(self.config, "aug_stop_epoch_ratio", 1.0),
+            getattr(self.config, "no_aug_epochs", 0),
         )
         if hasattr(train_dataset, "set_stop_epoch"):
             train_dataset.set_stop_epoch(stop_epoch)

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -637,6 +637,19 @@ class LibreEC(BaseModel):
                     if ckpt_names is not None:
                         self.names = self._sanitize_names(ckpt_names, effective_nc)
 
+            # Replay LoRA injection for adapter checkpoints. A model trained
+            # with lora=True saves its transformer Linears under peft keys
+            # (``.base_layer.``/``lora_A``/``lora_B``); rebuild the adapted
+            # graph before loading so those keys line up.
+            from ...training.lora import (
+                apply_lora_to_ec,
+                module_has_lora,
+                state_dict_has_lora,
+            )
+
+            if state_dict_has_lora(state_dict) and not module_has_lora(self.model):
+                apply_lora_to_ec(self.model)
+
             missing, unexpected = self.model.load_state_dict(
                 state_dict, strict=self._strict_loading()
             )

--- a/libreyolo/models/ec/trainer.py
+++ b/libreyolo/models/ec/trainer.py
@@ -101,6 +101,20 @@ class ECTrainer(DFINETrainer):
         }
 
     def on_setup(self):
+        # This override does not call super().on_setup(), so the LoRA hook
+        # inherited from DFINETrainer must be replayed here with EC's own
+        # recipe (ViTAdapter backbone: frozen ViT + qkv adapters).
+        if getattr(self.config, "lora", False):
+            task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+            if task != "detect":
+                raise ValueError(
+                    f"EC {task} training does not support lora=True yet. "
+                    "Use freeze='backbone' for parameter-efficient fine-tuning."
+                )
+            from ...training.lora import apply_lora_to_ec
+
+            apply_lora_to_ec(self.model)
+
         matcher = HungarianMatcher(
             weight_dict={"cost_class": 2.0, "cost_bbox": 5.0, "cost_giou": 2.0},
             use_focal_loss=True,

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -377,6 +377,22 @@ class LibreRTDETR(BaseModel):
         """RTDETR uses non-strict loading to handle variable layer counts."""
         return False
 
+    def _prepare_model_for_state_dict(self, state_dict: dict) -> None:
+        """Replay LoRA injection for adapter checkpoints.
+
+        RT-DETR loads non-strictly, so without the replay a lora=True
+        checkpoint's adapter tensors would be dropped silently instead of
+        erroring. Rebuild the adapted graph so the peft keys line up.
+        """
+        from ...training.lora import (
+            apply_lora_to_detr,
+            module_has_lora,
+            state_dict_has_lora,
+        )
+
+        if state_dict_has_lora(state_dict) and not module_has_lora(self.model):
+            apply_lora_to_detr(self.model)
+
     @classmethod
     def _get_trainer_class(cls):
         """Hook for sibling families to override; defaults to v1's trainer."""

--- a/libreyolo/models/rtdetr/trainer.py
+++ b/libreyolo/models/rtdetr/trainer.py
@@ -80,9 +80,29 @@ def convert_targets_for_detr(
 class RTDETRTrainer(BaseTrainer):
     """RT-DETR-specific trainer."""
 
+    # RT-DETR pairs a CNN (PResNet/HGNetv2) backbone with a transformer
+    # encoder/decoder whose projections are nn.Linear layers. lora=True
+    # freezes the backbone and the transformer base weights and trains LoRA
+    # adapters on the transformer Linears (see libreyolo/training/lora.py).
+    supports_lora = True
+
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:
         return RTDETRConfig
+
+    def preserve_freeze_param(self, name: str, param: torch.nn.Parameter) -> bool:
+        if not getattr(self.config, "lora", False):
+            return False
+        from ...training.lora import is_lora_parameter_name
+
+        return is_lora_parameter_name(name)
+
+    def _maybe_apply_lora(self) -> None:
+        """Inject adapters when lora=True. Called by every on_setup override."""
+        if getattr(self.config, "lora", False):
+            from ...training.lora import apply_lora_to_detr
+
+            apply_lora_to_detr(self.model)
 
     def _ddp_find_unused_parameters(self) -> bool:
         # RT-DETR's denoising_class_embed is skipped when a batch has no GT
@@ -193,6 +213,7 @@ class RTDETRTrainer(BaseTrainer):
 
     def on_setup(self):
         """Initialize the loss criterion."""
+        self._maybe_apply_lora()
         self.criterion = RTDETRLoss(num_classes=self.config.num_classes)
         self.criterion.to(self.device)
 

--- a/libreyolo/models/rtdetrv2/trainer.py
+++ b/libreyolo/models/rtdetrv2/trainer.py
@@ -20,6 +20,7 @@ class RTDETRv2Trainer(RTDETRTrainer):
         """
         from .loss import RTDETRv2Loss
 
+        self._maybe_apply_lora()
         self.criterion = RTDETRv2Loss(num_classes=self.config.num_classes)
         self.criterion.to(self.device)
 

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -511,7 +511,9 @@ DEIMV2_SIZE_DEFAULTS = {
         "lr0": 8e-4,
         "weight_decay": 1e-4,
         "warmup_iters": 2000,
-        "flat_epochs": 7800,
+        # Epoch-scale, like every other size (flat ~= 0.49*epochs). The prior
+        # 7800 was the iteration count (160 epochs * ~49 it/ep) mis-placed here.
+        "flat_epochs": 78,
         "no_aug_epochs": 12,
         "min_lr_ratio": 1.0,
         "backbone_lr_mult": 0.5,

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -125,9 +125,11 @@ class TrainConfig:
     # freezes matching module/parameter names.
     freeze: Optional[Union[int, str, List[Union[int, str]]]] = None
     # Parameter-efficient fine-tuning. ``lora=True`` injects LoRA adapters into
-    # the backbone of supported transformer families (currently RF-DETR) and
-    # trains only the adapters plus the projector/decoder/head, for low-VRAM
-    # fine-tuning on a custom dataset. Requires the optional ``peft`` dependency
+    # the transformer components of supported families (RF-DETR: DINOv2
+    # backbone attention; D-FINE/DEIM: encoder/decoder Linears with the CNN
+    # backbone frozen) and trains only the adapters plus the parts that must
+    # stay dense (heads, projections), for low-VRAM fine-tuning on a custom
+    # dataset. Requires the optional ``peft`` dependency
     # (``pip install "libreyolo[lora]"``). Families that do not support LoRA
     # raise a clear error rather than silently ignoring the flag.
     lora: bool = False
@@ -389,14 +391,20 @@ class DEIMConfig(TrainConfig):
     """
 
     optimizer: str = "adamw"
-    lr0: float = 4e-4
+    # Fine-tune defaults, per the class docstring. Upstream's published COCO
+    # recipe uses lr0=4e-4 with min_lr_ratio=0.5 (its lr_gamma) at total batch
+    # 32 over 132 epochs; at practical fine-tune batches (8-16) on small
+    # datasets that keeps the whole run between 4e-4 and 2e-4 and measurably
+    # degrades transfer (aquarium/bccd bench, 2026-07). Pass the recipe values
+    # explicitly to reproduce upstream COCO training.
+    lr0: float = 1e-4
     weight_decay: float = 1e-4
 
     scheduler: str = "flat_cosine"
     warmup_epochs: int = 2
     warmup_lr_start: float = 1e-6
     no_aug_epochs: int = 12
-    min_lr_ratio: float = 0.5  # DEIM's lr_gamma in upstream
+    min_lr_ratio: float = 0.05
 
     mosaic_prob: float = 0.0
     mixup_prob: float = 0.0

--- a/libreyolo/training/lora.py
+++ b/libreyolo/training/lora.py
@@ -559,6 +559,15 @@ def merge_lora_adapters(module: nn.Module) -> int:
         )
         setattr(parent, name.rsplit(".", 1)[-1], sub.get_base_layer())
         merged += 1
+
+    # inject_adapter_in_model stamps ``peft_config`` on the model; drop it once
+    # every tuner layer is folded back so ``module_has_lora`` reflects the now
+    # fully-dense graph (and a second export is a no-op).
+    if merged and hasattr(module, "peft_config"):
+        try:
+            del module.peft_config
+        except AttributeError:
+            pass
     return merged
 
 

--- a/libreyolo/training/lora.py
+++ b/libreyolo/training/lora.py
@@ -163,14 +163,422 @@ def apply_lora_to_rfdetr(core_model: nn.Module) -> nn.Module:
     return wrapped
 
 
+# ---------------------------------------------------------------------------
+# D-FINE / DEIM (DETR decoder) recipe
+# ---------------------------------------------------------------------------
+# These families pair a CNN (HGNetv2) backbone with a transformer hybrid
+# encoder + deformable decoder. The CNN backbone has no nn.Linear layers to
+# adapt, so the recipe differs from RF-DETR's ViT-backbone recipe:
+#   - the backbone is frozen entirely (no gradients flow through it at all,
+#     which also skips its backward pass),
+#   - the transformer blocks (AIFI encoder layers + decoder layers) freeze
+#     their base weights and train LoRA adapters on their nn.Linear layers,
+#   - everything else (encoder conv fusion, input projections, prediction
+#     heads, query embeddings) keeps training normally, since custom class
+#     counts require freshly trained heads.
+#
+# Plain LoRA, not DoRA: several decoder Linears (Gate.gate, MSDeformableAttention
+# sampling_offsets / attention_weights) are zero-init by design, and DoRA's
+# magnitude normalization divides by the weight norm, which is 0 for a
+# freshly built model. Rank/alpha match the RF-DETR recipe.
+DETR_LORA_RANK = 16
+DETR_LORA_ALPHA = 16
+DETR_LORA_DROPOUT = 0.0
+
+# Module classes that delimit the frozen+adapted transformer zone. Both
+# D-FINE and DEIM define their own copies of these classes with identical
+# names (as does RT-DETR, for future adoption).
+DETR_BLOCK_CLASSES = ("TransformerEncoderLayer", "TransformerDecoderLayer")
+
+# Leaf names of nn.Linear layers adapted inside those blocks. ``value_proj``
+# and ``output_proj`` are inert for D-FINE/DEIM (their deformable attention
+# has neither) but kept for parity with other deformable-DETR decoders.
+# nn.MultiheadAttention is intentionally NOT adapted: its forward reads
+# ``out_proj.weight`` directly, so a swapped-in LoRA layer would be silently
+# bypassed. Self-attention stays frozen instead.
+DETR_TARGET_LINEAR_NAMES = (
+    "linear1",
+    "linear2",
+    "gate",
+    "sampling_offsets",
+    "attention_weights",
+    "value_proj",
+    "output_proj",
+    # DEIMv2's decoder swaps the classic linear1/linear2 FFN for SwiGLU:
+    "w12",
+    "w3",
+)
+
+# DEIMv2 S/M/L/X carry a ViT backbone under ``backbone.dinov3``, in one of two
+# vendorings: the DINOv3 ``SelfAttentionBlock`` or the ViT-Tiny ``Block``
+# (vit_tiny.py). Both use one fused ``qkv`` Linear per block; adapting it
+# mirrors the RF-DETR reference recipe, which lists ``qkv`` for exactly this
+# fused layout. The attention output ``proj`` is not adapted (the reference
+# does not adapt output projections either). ``Block`` is generic, so ViT
+# block discovery is scoped to the ``backbone.dinov3`` subtree.
+DINOV3_BLOCK_CLASSES = ("SelfAttentionBlock", "Block")
+DINOV3_TARGET_LINEAR_NAMES = ("qkv",)
+
+
+def apply_lora_to_detr(core_model: nn.Module) -> nn.Module:
+    """Inject LoRA adapters into a D-FINE/DEIM style DETR core model, in place.
+
+    Uses ``peft.inject_adapter_in_model`` (no PeftModel wrapper) so the module
+    tree, attribute surface, and checkpoint key layout stay put; only the
+    targeted ``nn.Linear`` layers become ``lora.Linear`` (their dense weight
+    moves under ``.base_layer.``). After injection the trainability policy is
+    applied explicitly:
+
+    - ``lora_*`` adapter params: trainable
+    - ``backbone.*`` and all params inside transformer blocks: frozen
+    - everything else: left exactly as it was (heads/neck stay trainable,
+      intentionally fixed params like D-FINE's ``decoder.up`` stay fixed)
+
+    Args:
+        core_model: a model exposing ``backbone``/``encoder``/``decoder``
+            (``LibreDFINEModel`` / ``LibreDEIMModel``).
+
+    Returns:
+        *core_model*, modified in place.
+
+    Raises:
+        ImportError: if ``peft`` is not installed.
+        ValueError: if the model does not look like a DETR core or no target
+            module matched.
+    """
+    _require_detr_layout(core_model)
+    if module_has_lora(core_model):
+        return core_model
+
+    block_roots = _discover_block_roots(core_model, DETR_BLOCK_CLASSES)
+    if not block_roots:
+        raise ValueError(
+            "No transformer encoder/decoder blocks found; expected "
+            f"{DETR_BLOCK_CLASSES} classes in the model."
+        )
+    target_modules = _collect_linear_targets(
+        core_model, block_roots, DETR_TARGET_LINEAR_NAMES, skip_frozen=True
+    )
+    frozen_prefixes = ("backbone.",) + tuple(f"{root}." for root in block_roots)
+    return _inject_lora(
+        core_model, target_modules, frozen_prefixes, label="DETR transformer blocks"
+    )
+
+
+def apply_lora_to_deimv2(core_model: nn.Module) -> nn.Module:
+    """Inject LoRA adapters into a DEIMv2 core model, in place.
+
+    Same contract as :func:`apply_lora_to_detr`, with two DEIMv2 additions:
+
+    - The decoder FFN is SwiGLU (``w12``/``w3``), covered by the shared
+      target list.
+    - S/M/L/X sizes carry a DINOv3 ViT backbone under ``backbone.dinov3``.
+      There, the ViT base is frozen and its fused attention ``qkv`` Linears
+      get adapters (as in the RF-DETR reference, which targets ``qkv`` for
+      fused layouts), while the Spatial Tuning Adapter (STA) conv pyramid
+      around it keeps training as the projector analog. The ``qkv`` layers
+      are adapted even when the config shipped the ViT frozen
+      (``finetune=False``): adapting a frozen backbone is the point of LoRA.
+      HGNetv2 sizes fall back to the plain DETR recipe (backbone frozen
+      entirely).
+    """
+    _require_detr_layout(core_model)
+    if module_has_lora(core_model):
+        return core_model
+
+    detr_roots = _discover_block_roots(core_model, DETR_BLOCK_CLASSES)
+    if not detr_roots:
+        raise ValueError(
+            "No transformer encoder/decoder blocks found; expected "
+            f"{DETR_BLOCK_CLASSES} classes in the model."
+        )
+    target_modules = _collect_linear_targets(
+        core_model, detr_roots, DETR_TARGET_LINEAR_NAMES, skip_frozen=True
+    )
+
+    frozen_roots = list(detr_roots)
+    dinov3 = getattr(core_model.backbone, "dinov3", None)
+    if dinov3 is not None:
+        # Scoped to the ViT subtree: "Block" is too generic a class name to
+        # match across the whole model.
+        vit_roots = [
+            f"backbone.dinov3.{name}"
+            for name, module in dinov3.named_modules()
+            if name and type(module).__name__ in DINOV3_BLOCK_CLASSES
+        ]
+        if not vit_roots:
+            raise ValueError(
+                "backbone.dinov3 present but no SelfAttentionBlock modules "
+                "found; the DINOv3 vendoring may have changed."
+            )
+        target_modules += _collect_linear_targets(
+            core_model, vit_roots, DINOV3_TARGET_LINEAR_NAMES, skip_frozen=False
+        )
+        frozen_roots += vit_roots
+        backbone_prefix = "backbone.dinov3."
+    else:
+        backbone_prefix = "backbone."
+
+    frozen_prefixes = (backbone_prefix,) + tuple(f"{root}." for root in frozen_roots)
+    return _inject_lora(
+        core_model, target_modules, frozen_prefixes, label="DEIMv2 transformer blocks"
+    )
+
+
+def apply_lora_to_ec(core_model: nn.Module) -> nn.Module:
+    """Inject LoRA adapters into an EC (EdgeCrafter) core model, in place.
+
+    EC is a DETR whose backbone is a ViTAdapter: a plain ViT (fused ``qkv``
+    attention ``Block``s, same layout as DEIMv2's tiny ViT) under
+    ``backbone.backbone``, surrounded by a trainable conv projector pyramid.
+    Recipe: freeze the ViT base and adapt its ``qkv`` Linears, freeze the
+    transformer encoder/decoder block bases and adapt their Linears, keep the
+    ViTAdapter projector, input projections, and heads dense-trainable.
+    """
+    _require_detr_layout(core_model)
+    if module_has_lora(core_model):
+        return core_model
+
+    detr_roots = _discover_block_roots(core_model, DETR_BLOCK_CLASSES)
+    if not detr_roots:
+        raise ValueError(
+            "No transformer encoder/decoder blocks found; expected "
+            f"{DETR_BLOCK_CLASSES} classes in the model."
+        )
+    target_modules = _collect_linear_targets(
+        core_model, detr_roots, DETR_TARGET_LINEAR_NAMES, skip_frozen=True
+    )
+
+    vit = getattr(core_model.backbone, "backbone", None)
+    if vit is None:
+        raise ValueError(
+            "EC model has no backbone.backbone ViT; the ViTAdapter layout "
+            "may have changed."
+        )
+    # Scoped to the ViT subtree: "Block" is too generic a class name to match
+    # across the whole model.
+    vit_roots = [
+        f"backbone.backbone.{name}"
+        for name, module in vit.named_modules()
+        if name and type(module).__name__ in DINOV3_BLOCK_CLASSES
+    ]
+    if not vit_roots:
+        raise ValueError(
+            "backbone.backbone present but no ViT Block modules found; "
+            "the EC backbone vendoring may have changed."
+        )
+    target_modules += _collect_linear_targets(
+        core_model, vit_roots, DINOV3_TARGET_LINEAR_NAMES, skip_frozen=False
+    )
+
+    frozen_prefixes = ("backbone.backbone.",) + tuple(
+        f"{root}." for root in detr_roots + vit_roots
+    )
+    return _inject_lora(
+        core_model, target_modules, frozen_prefixes, label="EC transformer blocks"
+    )
+
+
+# ConvNeXt: a conv classifier whose blocks nonetheless carry channels-last
+# nn.Linear MLPs (timm layout, ``fc1``/``fc2``). Those take the adapters; the
+# depthwise convs, norms, and layer-scale gammas freeze; the classification
+# head stays dense-trainable (custom class counts rebuild it).
+CONVNEXT_BLOCK_CLASSES = ("ConvNeXtBlock",)
+CONVNEXT_TARGET_LINEAR_NAMES = ("fc1", "fc2")
+
+
+def apply_lora_to_convnext(core_model: nn.Module) -> nn.Module:
+    """Inject LoRA adapters into a ConvNeXt classifier core, in place."""
+    for attr in ("stages", "head"):
+        if not hasattr(core_model, attr):
+            raise ValueError(
+                f"Model has no .{attr}; cannot apply the ConvNeXt LoRA recipe."
+            )
+    if module_has_lora(core_model):
+        return core_model
+
+    block_roots = _discover_block_roots(core_model, CONVNEXT_BLOCK_CLASSES)
+    if not block_roots:
+        raise ValueError(
+            "No ConvNeXtBlock modules found; the ConvNeXt vendoring may have "
+            "changed."
+        )
+    target_modules = _collect_linear_targets(
+        core_model, block_roots, CONVNEXT_TARGET_LINEAR_NAMES, skip_frozen=True
+    )
+
+    # Freeze every top-level child except the classification head.
+    frozen_prefixes = tuple(
+        f"{name}." for name, _ in core_model.named_children() if name != "head"
+    )
+    return _inject_lora(
+        core_model, target_modules, frozen_prefixes, label="ConvNeXt block MLPs"
+    )
+
+
+def _require_detr_layout(core_model: nn.Module) -> None:
+    for attr in ("backbone", "encoder", "decoder"):
+        if not hasattr(core_model, attr):
+            raise ValueError(
+                f"Model has no .{attr}; cannot apply the DETR LoRA recipe."
+            )
+
+
+def _discover_block_roots(
+    core_model: nn.Module, block_classes: tuple[str, ...]
+) -> list[str]:
+    return [
+        name
+        for name, module in core_model.named_modules()
+        if type(module).__name__ in block_classes
+    ]
+
+
+def _collect_linear_targets(
+    core_model: nn.Module,
+    block_roots: list[str],
+    leaf_names: tuple[str, ...],
+    *,
+    skip_frozen: bool,
+) -> list[str]:
+    """Fully-qualified names of the nn.Linear layers to adapt inside blocks.
+
+    ``skip_frozen=True`` respects layers frozen by design (e.g.
+    ``cross_attn_method="discrete"`` freezes sampling_offsets): no adapter
+    there. ViT backbone passes set it False, because a config-frozen backbone
+    is exactly where adapters belong.
+    """
+    targets = []
+    for root in block_roots:
+        block = core_model.get_submodule(root)
+        for sub_name, sub in block.named_modules():
+            if not isinstance(sub, nn.Linear):
+                continue
+            if sub_name.rsplit(".", 1)[-1] not in leaf_names:
+                continue
+            params = list(sub.parameters())
+            if skip_frozen and params and all(not p.requires_grad for p in params):
+                continue
+            targets.append(f"{root}.{sub_name}")
+    return targets
+
+
+def _inject_lora(
+    core_model: nn.Module,
+    target_modules: list[str],
+    frozen_prefixes: tuple[str, ...],
+    *,
+    label: str,
+) -> nn.Module:
+    """Inject plain LoRA (r16/a16) on *target_modules* and apply the
+    trainability policy: adapters train, *frozen_prefixes* freeze, everything
+    else is restored to its pre-injection state."""
+    if not target_modules:
+        raise ValueError(
+            f"LoRA injection matched zero modules in the {label}. "
+            f"Expected Linear leaf names {DETR_TARGET_LINEAR_NAMES}; "
+            "the module naming may have changed."
+        )
+
+    try:
+        from peft import LoraConfig, inject_adapter_in_model
+    except ImportError as exc:
+        raise ImportError(_PEFT_INSTALL_HINT) from exc
+
+    # Snapshot trainability before injection so the policy below can restore
+    # everything outside the frozen zones no matter what peft toggled.
+    pre_requires_grad = {
+        name: p.requires_grad for name, p in core_model.named_parameters()
+    }
+
+    lora_config = LoraConfig(
+        r=DETR_LORA_RANK,
+        lora_alpha=DETR_LORA_ALPHA,
+        lora_dropout=DETR_LORA_DROPOUT,
+        use_dora=False,
+        target_modules=target_modules,
+        bias="none",
+    )
+    inject_adapter_in_model(lora_config, core_model, adapter_name="default")
+
+    n_adapted = sum(
+        1
+        for name, _ in core_model.named_modules()
+        if name.endswith(".lora_A.default")
+    )
+    if n_adapted == 0:
+        raise ValueError(
+            "peft matched the target list but created no adapters; "
+            f"targets were {target_modules[:5]}..."
+        )
+
+    for name, p in core_model.named_parameters():
+        if "lora_" in name:
+            p.requires_grad = True
+        elif name.startswith(frozen_prefixes):
+            p.requires_grad = False
+        elif name in pre_requires_grad:
+            p.requires_grad = pre_requires_grad[name]
+
+    trainable, total = count_trainable_parameters(core_model)
+    logger.info(
+        "Applied LoRA to %s: %d adapted modules, "
+        "%d/%d trainable params (%.2f%%).",
+        label,
+        n_adapted,
+        trainable,
+        total,
+        100.0 * trainable / max(1, total),
+    )
+    return core_model
+
+
+def merge_lora_adapters(module: nn.Module) -> int:
+    """Merge injected LoRA layers back into dense weights, in place.
+
+    For models adapted with :func:`apply_lora_to_detr` (peft injection without
+    a PeftModel wrapper), folds every adapter into its base ``nn.Linear`` and
+    swaps the original layer back in, so the module carries no peft dependency
+    afterwards.
+
+    Returns:
+        Number of merged adapter layers.
+    """
+    try:
+        from peft.tuners.tuners_utils import BaseTunerLayer
+    except ImportError as exc:
+        raise ImportError(_PEFT_INSTALL_HINT) from exc
+
+    merged = 0
+    for name, sub in list(module.named_modules()):
+        if not isinstance(sub, BaseTunerLayer):
+            continue
+        sub.merge(safe_merge=True)
+        parent = (
+            module.get_submodule(name.rsplit(".", 1)[0]) if "." in name else module
+        )
+        setattr(parent, name.rsplit(".", 1)[-1], sub.get_base_layer())
+        merged += 1
+    return merged
+
+
 __all__ = [
     "apply_lora_to_rfdetr",
+    "apply_lora_to_detr",
+    "apply_lora_to_deimv2",
+    "apply_lora_to_ec",
+    "apply_lora_to_convnext",
+    "merge_lora_adapters",
     "is_peft_available",
     "is_lora_parameter_name",
     "state_dict_has_lora",
     "module_has_lora",
     "count_trainable_parameters",
     "DINOV2_TARGET_MODULES",
+    "DETR_BLOCK_CLASSES",
+    "DETR_TARGET_LINEAR_NAMES",
+    "DETR_LORA_RANK",
+    "DETR_LORA_ALPHA",
     "LORA_RANK",
     "LORA_ALPHA",
     "USE_DORA",

--- a/libreyolo/training/scheduler.py
+++ b/libreyolo/training/scheduler.py
@@ -163,7 +163,13 @@ class FlatCosineScheduler(BaseScheduler):
         super().__init__(lr, iters_per_epoch, total_epochs)
         self.warmup_iters = iters_per_epoch * warmup_epochs
         self.warmup_lr_start = _clamp_warmup_lr_start(lr, warmup_lr_start)
-        self.cosine_iters = iters_per_epoch * no_aug_epochs
+        # Budget guard: on runs shorter than the configured tail, the cosine
+        # window must not extend back into warmup. Recipes that fit their
+        # budget are unaffected.
+        self.cosine_iters = min(
+            iters_per_epoch * no_aug_epochs,
+            max(0, self.total_iters - self.warmup_iters),
+        )
         self.min_lr = lr * min_lr_ratio
 
     def update_lr(self, iters: int) -> float:

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1262,7 +1262,8 @@ class BaseTrainer(ABC):
             family = self.get_model_family() if hasattr(self, "get_model_family") else "this model"
             raise ValueError(
                 f"LoRA fine-tuning (lora=True) is not supported for {family}. "
-                "LoRA targets transformer backbones with nn.Linear layers (e.g. RF-DETR)."
+                "LoRA targets transformer components with nn.Linear layers "
+                "(e.g. RF-DETR, D-FINE, DEIM)."
             )
 
         if is_main_process():

--- a/tests/e2e/test_dfine_deim_lora.py
+++ b/tests/e2e/test_dfine_deim_lora.py
@@ -1,0 +1,286 @@
+"""D-FINE / DEIM LoRA fine-tuning tests.
+
+Exercise the real user path (``lora=True``) through both trainers: ``on_setup``
+injects plain LoRA adapters into the transformer encoder/decoder Linears, the
+CNN backbone and the transformer base weights are frozen, the optimizer only
+collects trainable params, and a forward + backward step updates adapters while
+leaving the base weights untouched. Models build offline (random init, no
+downloads).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.deim.model import LibreDEIM
+from libreyolo.models.deim.trainer import DEIMTrainer
+from libreyolo.models.dfine.model import LibreDFINE
+from libreyolo.models.dfine.trainer import DFINETrainer
+from libreyolo.training.lora import (
+    apply_lora_to_detr,
+    count_trainable_parameters,
+    merge_lora_adapters,
+    module_has_lora,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.dfine, pytest.mark.deim, pytest.mark.slow]
+
+pytest.importorskip("peft")
+
+IMGSZ = 640
+
+_FAMILIES = {
+    "dfine": (LibreDFINE, DFINETrainer),
+    "deim": (LibreDEIM, DEIMTrainer),
+}
+
+
+def _build_trainer(family: str, lora: bool = True):
+    model_cls, trainer_cls = _FAMILIES[family]
+    # None model_path -> random init, no downloads. num_classes matches the
+    # default 80-class heads so no data-driven rebuild is needed.
+    wrapper = model_cls(None, size="n", device="cpu")
+    wrapper.model.train()
+    trainer = trainer_cls(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="n",
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=2,
+        imgsz=IMGSZ,
+        device="cpu",
+        amp=False,
+        ema=False,
+        eval_interval=-1,
+        lora=lora,
+    )
+    return trainer, wrapper
+
+
+def _synthetic_batch() -> tuple[torch.Tensor, torch.Tensor]:
+    imgs = torch.randn(2, 3, IMGSZ, IMGSZ)
+    # padded targets (B, max_labels, 5) = [cls, cx, cy, w, h] in pixels
+    targets = torch.zeros(2, 120, 5)
+    targets[0, 0] = torch.tensor([0.0, 320.0, 320.0, 120.0, 90.0])
+    targets[0, 1] = torch.tensor([1.0, 180.0, 150.0, 60.0, 60.0])
+    targets[1, 0] = torch.tensor([1.0, 400.0, 330.0, 90.0, 75.0])
+    return imgs, targets
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_injects_freezes_zones_and_reduces_trainable_params(family):
+    trainer, wrapper = _build_trainer(family)
+    core = wrapper.model
+
+    trainable_before = sum(p.numel() for p in core.parameters() if p.requires_grad)
+    trainer.on_setup()
+    trainable_after = sum(p.numel() for p in core.parameters() if p.requires_grad)
+
+    assert module_has_lora(core)
+    assert trainable_after < trainable_before
+
+    names = dict(core.named_parameters())
+    lora_params = {n: p for n, p in names.items() if "lora_" in n}
+    assert lora_params, "no LoRA adapters were created"
+    assert all(p.requires_grad for p in lora_params.values())
+
+    # CNN backbone: frozen entirely
+    backbone = [(n, p) for n, p in names.items() if n.startswith("backbone.")]
+    assert backbone
+    assert all(not p.requires_grad for _, p in backbone)
+
+    # transformer block base weights: frozen (dense weight moved under
+    # .base_layer. by the injection)
+    base_in_blocks = [
+        (n, p) for n, p in names.items() if ".base_layer." in n
+    ]
+    assert base_in_blocks
+    assert all(not p.requires_grad for _, p in base_in_blocks)
+
+    # heads and encoder conv fusion: still trainable
+    assert any(
+        p.requires_grad for n, p in names.items() if "dec_score_head" in n
+    ), "detection head must stay trainable"
+    assert any(
+        p.requires_grad
+        for n, p in names.items()
+        if n.startswith("encoder.") and "encoder.encoder" not in n
+    ), "encoder conv fusion must stay trainable"
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_recipe_targets_transformer_linears_only(family):
+    trainer, wrapper = _build_trainer(family)
+    trainer.on_setup()
+    names = [n for n, _ in wrapper.model.named_parameters()]
+
+    # FFN, gate, and deformable-attention projections are adapted
+    assert any(".linear1.lora_A" in n for n in names)
+    assert any(".linear2.lora_A" in n for n in names)
+    assert any("gateway.gate.lora_A" in n for n in names)
+    assert any("sampling_offsets.lora_A" in n for n in names)
+    # MHA self-attention is NOT adapted (out_proj would be silently bypassed)
+    assert not any("self_attn" in n and "lora_" in n for n in names)
+    # heads and backbone are NOT adapted
+    assert not any("dec_score_head" in n and "lora_" in n for n in names)
+    assert not any(n.startswith("backbone.") and "lora_" in n for n in names)
+    # plain LoRA, not DoRA (zero-init decoder Linears break DoRA's norm)
+    assert not any("lora_magnitude" in n for n in names)
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_optimizer_only_collects_trainable_params(family):
+    trainer, wrapper = _build_trainer(family)
+    trainer.on_setup()
+    optimizer = trainer._setup_optimizer()
+
+    opt_params = [p for g in optimizer.param_groups for p in g["params"]]
+    assert all(p.requires_grad for p in opt_params)
+
+    core = wrapper.model
+    opt_ids = {id(p) for p in opt_params}
+    lora_ids = {id(p) for n, p in core.named_parameters() if "lora_" in n}
+    assert opt_ids & lora_ids, "no LoRA params landed in the optimizer"
+    frozen_ids = {id(p) for p in core.parameters() if not p.requires_grad}
+    assert not (opt_ids & frozen_ids), "frozen params leaked into optimizer"
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_backward_updates_adapters_and_leaves_base_frozen(family):
+    torch.manual_seed(0)
+    trainer, wrapper = _build_trainer(family)
+    trainer.on_setup()
+    core = wrapper.model
+    params = dict(core.named_parameters())
+
+    base_name = next(n for n in params if n.endswith("linear1.base_layer.weight"))
+    base_ref = params[base_name].detach().clone()
+    lora_B_name = next(n for n in params if "lora_B" in n)
+    assert torch.count_nonzero(params[lora_B_name]) == 0
+
+    optimizer = trainer._setup_optimizer()
+    imgs, targets = _synthetic_batch()
+    out = trainer.on_forward(imgs, targets)
+    loss = out["total_loss"]
+    assert torch.isfinite(loss)
+    optimizer.zero_grad()
+    loss.backward()
+    assert params[lora_B_name].grad is not None
+    optimizer.step()
+
+    assert torch.count_nonzero(params[lora_B_name]) > 0
+    assert torch.allclose(params[base_name].detach(), base_ref)
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_merge_preserves_layer_math_and_removes_adapters(family):
+    """Merging must fold adapters into dense weights exactly.
+
+    Layer equivalence is asserted per adapted Linear: full-model output
+    equality is not a usable oracle for DETRs, whose top-k query selection
+    reorders under any epsilon-level numeric change.
+    """
+    torch.manual_seed(0)
+    trainer, wrapper = _build_trainer(family)
+    trainer.on_setup()
+    core = wrapper.model
+
+    # one optimizer step so the adapters are non-trivial before merging
+    optimizer = trainer._setup_optimizer()
+    imgs, targets = _synthetic_batch()
+    out = trainer.on_forward(imgs, targets)
+    out["total_loss"].backward()
+    optimizer.step()
+
+    core.eval()
+    from peft.tuners.tuners_utils import BaseTunerLayer
+
+    probes = {}
+    with torch.no_grad():
+        for name, sub in core.named_modules():
+            if isinstance(sub, BaseTunerLayer):
+                x = torch.randn(4, sub.get_base_layer().in_features)
+                probes[name] = (x, sub(x))
+    assert probes, "no adapted layers found to probe"
+
+    n_merged = merge_lora_adapters(core)
+    assert n_merged == len(probes)
+    assert not any("lora_" in n for n, _ in core.named_parameters())
+    assert not any(".base_layer." in n for n, _ in core.named_parameters())
+
+    with torch.no_grad():
+        for name, (x, expected) in probes.items():
+            dense = core.get_submodule(name)
+            assert isinstance(dense, torch.nn.Linear)
+            assert not isinstance(dense, BaseTunerLayer)
+            torch.testing.assert_close(dense(x), expected, atol=1e-5, rtol=1e-5)
+
+    # the merged model still runs end to end and produces finite outputs
+    with torch.no_grad():
+        outputs = core(torch.randn(1, 3, IMGSZ, IMGSZ))
+    assert torch.isfinite(outputs["pred_logits"]).all()
+    assert torch.isfinite(outputs["pred_boxes"]).all()
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_checkpoint_reloads_into_fresh_model(family, tmp_path):
+    """A lora=True checkpoint must load into a fresh model: the loader replays
+    the adapter injection so the peft keys line up instead of being rejected as
+    unexpected."""
+    model_cls, _ = _FAMILIES[family]
+
+    w1 = model_cls(None, size="n", device="cpu")
+    apply_lora_to_detr(w1.model)
+    sd = dict(w1.model.state_dict())
+    assert any("lora_" in k for k in sd), "checkpoint should carry adapter keys"
+    ckpt_path = tmp_path / "last.pt"
+    torch.save({"model": sd}, ckpt_path)
+
+    w2 = model_cls(None, size="n", device="cpu")
+    assert not module_has_lora(w2.model)
+    w2._load_weights(str(ckpt_path))  # must not raise on the adapter keys
+    assert module_has_lora(w2.model), (
+        "loader did not replay LoRA injection for an adapter checkpoint"
+    )
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_apply_is_idempotent(family):
+    model_cls, _ = _FAMILIES[family]
+    wrapper = model_cls(None, size="n", device="cpu")
+    apply_lora_to_detr(wrapper.model)
+    n_before = sum(1 for n, _ in wrapper.model.named_parameters() if "lora_" in n)
+    trainable_before, _ = count_trainable_parameters(wrapper.model)
+
+    result = apply_lora_to_detr(wrapper.model)
+
+    assert result is wrapper.model
+    n_after = sum(1 for n, _ in wrapper.model.named_parameters() if "lora_" in n)
+    trainable_after, _ = count_trainable_parameters(wrapper.model)
+    assert n_after == n_before
+    assert trainable_after == trainable_before
+
+
+def test_lora_rejected_for_dfine_segment_task():
+    """The mask head path is untested with adapters; segment must hard-error."""
+    wrapper = LibreDFINE(None, size="n", device="cpu", task="segment")
+    trainer = DFINETrainer(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="n",
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=2,
+        imgsz=IMGSZ,
+        device="cpu",
+        amp=False,
+        ema=False,
+        eval_interval=-1,
+        lora=True,
+    )
+    with pytest.raises(ValueError, match="segment.*lora|lora.*segment"):
+        trainer.on_setup()

--- a/tests/e2e/test_ec_convnext_lora.py
+++ b/tests/e2e/test_ec_convnext_lora.py
@@ -1,0 +1,274 @@
+"""EC (EdgeCrafter) and ConvNeXt LoRA fine-tuning tests.
+
+EC: DETR with a ViTAdapter backbone (plain ViT with fused ``qkv`` under
+``backbone.backbone`` plus a trainable projector pyramid). ConvNeXt: conv
+classifier whose blocks carry channels-last ``fc1``/``fc2`` Linears. Both
+build offline (random init, no downloads).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.convnext.model import LibreConvNeXt
+from libreyolo.models.convnext.trainer import ConvNeXtTrainer
+from libreyolo.models.ec.model import LibreEC
+from libreyolo.models.ec.trainer import ECTrainer
+from libreyolo.training.lora import (
+    apply_lora_to_convnext,
+    apply_lora_to_ec,
+    merge_lora_adapters,
+    module_has_lora,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+pytest.importorskip("peft")
+
+EC_IMGSZ = 640
+CNX_IMGSZ = 224
+
+
+def _build_ec_trainer(lora: bool = True):
+    wrapper = LibreEC(None, size="s", device="cpu")
+    wrapper.model.train()
+    trainer = ECTrainer(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="s",
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=2,
+        imgsz=EC_IMGSZ,
+        device="cpu",
+        amp=False,
+        ema=False,
+        eval_interval=-1,
+        lora=lora,
+    )
+    return trainer, wrapper
+
+
+def _build_cnx_trainer(lora: bool = True):
+    wrapper = LibreConvNeXt(None, size="t", device="cpu")
+    wrapper.model.train()
+    trainer = ConvNeXtTrainer(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="t",
+        num_classes=wrapper.nb_classes,
+        data=None,
+        epochs=1,
+        batch=2,
+        imgsz=CNX_IMGSZ,
+        device="cpu",
+        amp=False,
+        ema=False,
+        eval_interval=-1,
+        lora=lora,
+    )
+    return trainer, wrapper
+
+
+def test_ec_lora_injects_and_freezes_zones():
+    trainer, wrapper = _build_ec_trainer()
+    core = wrapper.model
+
+    before = sum(p.numel() for p in core.parameters() if p.requires_grad)
+    trainer.on_setup()
+    after = sum(p.numel() for p in core.parameters() if p.requires_grad)
+
+    assert module_has_lora(core)
+    assert after < before
+    names = dict(core.named_parameters())
+    # ViT base frozen, qkv adapted inside it
+    vit_base = [
+        p for n, p in names.items()
+        if n.startswith("backbone.backbone.") and "lora_" not in n
+    ]
+    assert vit_base and all(not p.requires_grad for p in vit_base)
+    assert any(
+        "backbone.backbone." in n and ".qkv.lora_A" in n for n in names
+    ), "ViT qkv must carry adapters"
+    # ViTAdapter projector pyramid stays trainable
+    projector = [
+        p for n, p in names.items()
+        if n.startswith("backbone.") and not n.startswith("backbone.backbone.")
+    ]
+    assert projector and any(p.requires_grad for p in projector)
+    # decoder blocks: base frozen, adapters trainable, heads dense-trainable
+    assert any(".base_layer." in n and "decoder" in n for n in names)
+    assert any(p.requires_grad for n, p in names.items() if "dec_score_head" in n)
+    # attention output proj and MHA are NOT adapted
+    assert not any(".proj.lora_A" in n for n in names)
+    assert not any("self_attn" in n and "lora_" in n for n in names)
+
+
+def test_ec_lora_backward_updates_adapters_and_leaves_base_frozen():
+    torch.manual_seed(0)
+    trainer, wrapper = _build_ec_trainer()
+    trainer.on_setup()
+    core = wrapper.model
+    params = dict(core.named_parameters())
+
+    base_name = next(n for n in params if ".base_layer.weight" in n)
+    base_ref = params[base_name].detach().clone()
+    lora_B_name = next(n for n in params if "lora_B" in n)
+    assert torch.count_nonzero(params[lora_B_name]) == 0
+
+    optimizer = trainer._setup_optimizer()
+    imgs = torch.randn(2, 3, EC_IMGSZ, EC_IMGSZ)
+    targets = torch.zeros(2, 120, 5)
+    targets[0, 0] = torch.tensor([0.0, 320.0, 320.0, 120.0, 90.0])
+    targets[1, 0] = torch.tensor([1.0, 400.0, 330.0, 90.0, 75.0])
+
+    out = trainer.on_forward(imgs, targets)
+    assert torch.isfinite(out["total_loss"])
+    optimizer.zero_grad()
+    out["total_loss"].backward()
+    assert params[lora_B_name].grad is not None
+    optimizer.step()
+
+    assert torch.count_nonzero(params[lora_B_name]) > 0
+    assert torch.allclose(params[base_name].detach(), base_ref)
+
+
+def test_ec_lora_checkpoint_reloads_into_fresh_model(tmp_path):
+    w1 = LibreEC(None, size="s", device="cpu")
+    apply_lora_to_ec(w1.model)
+    sd = dict(w1.model.state_dict())
+    assert any("lora_" in k for k in sd)
+    ckpt_path = tmp_path / "last.pt"
+    torch.save({"model": sd}, ckpt_path)
+
+    w2 = LibreEC(None, size="s", device="cpu")
+    assert not module_has_lora(w2.model)
+    w2._load_weights(str(ckpt_path))
+    assert module_has_lora(w2.model)
+
+
+def test_ec_lora_rejected_for_non_detect_tasks():
+    trainer, wrapper = _build_ec_trainer()
+    wrapper.task = "segment"
+    with pytest.raises(ValueError, match="lora"):
+        trainer.on_setup()
+
+
+def test_convnext_lora_injects_freezes_backbone_and_keeps_head():
+    trainer, wrapper = _build_cnx_trainer()
+    core = wrapper.model
+
+    before = sum(p.numel() for p in core.parameters() if p.requires_grad)
+    trainer.on_setup()
+    after = sum(p.numel() for p in core.parameters() if p.requires_grad)
+
+    assert module_has_lora(core)
+    assert after < before
+    names = dict(core.named_parameters())
+    assert any(".fc1.lora_A" in n for n in names)
+    assert any(".fc2.lora_A" in n for n in names)
+    # convs, norms, layer scale frozen
+    stages_base = [
+        p for n, p in names.items()
+        if n.startswith("stages.") and "lora_" not in n
+    ]
+    assert stages_base and all(not p.requires_grad for p in stages_base)
+    stem = [p for n, p in names.items() if n.startswith("stem.")]
+    assert stem and all(not p.requires_grad for p in stem)
+    # classification head stays trainable
+    head = [p for n, p in names.items() if n.startswith("head.")]
+    assert head and all(p.requires_grad for p in head)
+    # no adapters outside the block MLPs
+    assert not any("conv_dw" in n and "lora_" in n for n in names)
+    assert not any(n.startswith("head.") and "lora_" in n for n in names)
+
+
+def test_convnext_lora_backward_updates_adapters_and_leaves_base_frozen():
+    torch.manual_seed(0)
+    trainer, wrapper = _build_cnx_trainer()
+    trainer.on_setup()
+    core = wrapper.model
+    params = dict(core.named_parameters())
+
+    base_name = next(n for n in params if ".base_layer.weight" in n)
+    base_ref = params[base_name].detach().clone()
+    lora_B_name = next(n for n in params if "lora_B" in n)
+    assert torch.count_nonzero(params[lora_B_name]) == 0
+
+    optimizer = trainer._setup_optimizer()
+    imgs = torch.randn(2, 3, CNX_IMGSZ, CNX_IMGSZ)
+    labels = torch.tensor([1, 3])
+    out = trainer.on_forward(imgs, labels)
+    assert torch.isfinite(out["total_loss"])
+    optimizer.zero_grad()
+    out["total_loss"].backward()
+    assert params[lora_B_name].grad is not None
+    optimizer.step()
+
+    assert torch.count_nonzero(params[lora_B_name]) > 0
+    assert torch.allclose(params[base_name].detach(), base_ref)
+
+
+def test_convnext_lora_merge_preserves_layer_math_and_model_runs():
+    torch.manual_seed(0)
+    trainer, wrapper = _build_cnx_trainer()
+    trainer.on_setup()
+    core = wrapper.model
+
+    optimizer = trainer._setup_optimizer()
+    out = trainer.on_forward(torch.randn(2, 3, CNX_IMGSZ, CNX_IMGSZ), torch.tensor([0, 2]))
+    out["total_loss"].backward()
+    optimizer.step()
+
+    core.eval()
+    from peft.tuners.tuners_utils import BaseTunerLayer
+
+    probes = {}
+    with torch.no_grad():
+        for name, sub in core.named_modules():
+            if isinstance(sub, BaseTunerLayer):
+                x = torch.randn(4, sub.get_base_layer().in_features)
+                probes[name] = (x, sub(x))
+    assert probes
+
+    n_merged = merge_lora_adapters(core)
+    assert n_merged == len(probes)
+    assert not any("lora_" in n for n, _ in core.named_parameters())
+    with torch.no_grad():
+        for name, (x, expected) in probes.items():
+            dense = core.get_submodule(name)
+            torch.testing.assert_close(dense(x), expected, atol=1e-5, rtol=1e-5)
+        logits = core(torch.randn(1, 3, CNX_IMGSZ, CNX_IMGSZ))
+    assert torch.isfinite(logits).all()
+
+
+def test_convnext_lora_checkpoint_reloads_into_fresh_model(tmp_path):
+    w1 = LibreConvNeXt(None, size="t", device="cpu")
+    apply_lora_to_convnext(w1.model)
+    sd = dict(w1.model.state_dict())
+    assert any("lora_" in k for k in sd)
+    ckpt_path = tmp_path / "last.pt"
+    torch.save({"model": sd}, ckpt_path)
+
+    w2 = LibreConvNeXt(None, size="t", device="cpu")
+    assert not module_has_lora(w2.model)
+    w2._load_weights(str(ckpt_path))
+    assert module_has_lora(w2.model)
+
+
+@pytest.mark.parametrize("family", ["ec", "convnext"])
+def test_lora_apply_is_idempotent(family):
+    if family == "ec":
+        wrapper = LibreEC(None, size="s", device="cpu")
+        fn = apply_lora_to_ec
+    else:
+        wrapper = LibreConvNeXt(None, size="t", device="cpu")
+        fn = apply_lora_to_convnext
+    fn(wrapper.model)
+    n_before = sum(1 for n, _ in wrapper.model.named_parameters() if "lora_" in n)
+    result = fn(wrapper.model)
+    assert result is wrapper.model
+    n_after = sum(1 for n, _ in wrapper.model.named_parameters() if "lora_" in n)
+    assert n_after == n_before

--- a/tests/e2e/test_ec_convnext_lora.py
+++ b/tests/e2e/test_ec_convnext_lora.py
@@ -258,6 +258,34 @@ def test_convnext_lora_checkpoint_reloads_into_fresh_model(tmp_path):
     assert module_has_lora(w2.model)
 
 
+def test_export_merges_lora_adapters_for_new_families(monkeypatch):
+    """export() must fold live PEFT adapters into dense weights before tracing,
+    so the exported graph carries no adapter modules / peft dependency."""
+    import libreyolo.export as export_mod
+
+    wrapper = LibreConvNeXt(None, size="t", device="cpu")
+    apply_lora_to_convnext(wrapper.model)
+    assert module_has_lora(wrapper.model)
+
+    # Stub the actual exporter: we only assert the pre-export merge ran.
+    captured = {}
+
+    class _StubExporter:
+        @staticmethod
+        def create(fmt, model):
+            captured["had_lora_at_export"] = module_has_lora(model.model)
+            return lambda **kw: "stub.onnx"
+
+    monkeypatch.setattr(export_mod, "BaseExporter", _StubExporter)
+
+    out = wrapper.export(format="onnx")
+    assert out == "stub.onnx"
+    # merged before the exporter saw the model, and no adapters remain
+    assert captured["had_lora_at_export"] is False
+    assert not module_has_lora(wrapper.model)
+    assert not any(".base_layer." in n for n, _ in wrapper.model.named_parameters())
+
+
 @pytest.mark.parametrize("family", ["ec", "convnext"])
 def test_lora_apply_is_idempotent(family):
     if family == "ec":

--- a/tests/e2e/test_rfdetr_lora.py
+++ b/tests/e2e/test_rfdetr_lora.py
@@ -361,14 +361,14 @@ def test_lora_checkpoint_continue_train_does_not_reapply_adapters():
 
 def test_lora_rejected_on_unsupported_family():
     """A pure-CNN family must hard-error on lora=True rather than silently ignore it."""
-    from libreyolo import LibreDFINE
-    from libreyolo.models.dfine.trainer import DFINETrainer
+    from libreyolo import LibreYOLO9
+    from libreyolo.models.yolo9.trainer import YOLO9Trainer
 
-    wrapper = LibreDFINE(None, size="n", device="cpu")
-    trainer = DFINETrainer(
+    wrapper = LibreYOLO9(None, size="t", device="cpu")
+    trainer = YOLO9Trainer(
         model=wrapper.model,
         wrapper_model=wrapper,
-        size="n",
+        size="t",
         num_classes=80,
         data=None,
         epochs=1,
@@ -380,6 +380,6 @@ def test_lora_rejected_on_unsupported_family():
         eval_interval=-1,
         lora=True,
     )
-    assert DFINETrainer.supports_lora is False
+    assert YOLO9Trainer.supports_lora is False
     with pytest.raises(ValueError, match="LoRA fine-tuning"):
         trainer.setup()

--- a/tests/e2e/test_rtdetr_deimv2_lora.py
+++ b/tests/e2e/test_rtdetr_deimv2_lora.py
@@ -1,0 +1,222 @@
+"""RT-DETR (v1/v2/v4) and DEIMv2 LoRA fine-tuning tests.
+
+Wave-2 coverage for ``lora=True``: the shared DETR recipe drops into the
+RT-DETR family, RT-DETRv4 takes it by inheritance (its trainer subclasses
+DEIMTrainer and its core is the D-FINE architecture), and DEIMv2 gets its own
+recipe (SwiGLU ``w12``/``w3`` FFN targets, plus DINOv3 ``qkv`` adapters with a
+frozen ViT on the S/M/L/X sizes). Models build offline (random init).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.deimv2.model import LibreDEIMv2
+from libreyolo.models.deimv2.trainer import DEIMv2Trainer
+from libreyolo.models.rtdetr.model import LibreRTDETR
+from libreyolo.models.rtdetr.trainer import RTDETRTrainer
+from libreyolo.models.rtdetrv2.model import LibreRTDETRv2
+from libreyolo.models.rtdetrv2.trainer import RTDETRv2Trainer
+from libreyolo.models.rtdetrv4.model import LibreRTDETRv4
+from libreyolo.models.rtdetrv4.trainer import RTDETRv4Trainer
+from libreyolo.training.lora import (
+    apply_lora_to_deimv2,
+    apply_lora_to_detr,
+    module_has_lora,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.rtdetr,
+    pytest.mark.deimv2,
+    pytest.mark.slow,
+]
+
+pytest.importorskip("peft")
+
+IMGSZ = 640
+
+# family -> (wrapper cls, trainer cls, size, apply fn)
+_FAMILIES = {
+    "rtdetr": (LibreRTDETR, RTDETRTrainer, "r18", apply_lora_to_detr),
+    "rtdetrv2": (LibreRTDETRv2, RTDETRv2Trainer, "r18", apply_lora_to_detr),
+    "rtdetrv4": (LibreRTDETRv4, RTDETRv4Trainer, "s", apply_lora_to_detr),
+    "deimv2-pico": (LibreDEIMv2, DEIMv2Trainer, "pico", apply_lora_to_deimv2),
+    "deimv2-s": (LibreDEIMv2, DEIMv2Trainer, "s", apply_lora_to_deimv2),
+}
+
+
+def _build_trainer(family: str, lora: bool = True):
+    model_cls, trainer_cls, size, _ = _FAMILIES[family]
+    wrapper = model_cls(None, size=size, device="cpu")
+    wrapper.model.train()
+    trainer = trainer_cls(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size=size,
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=2,
+        imgsz=IMGSZ,
+        device="cpu",
+        amp=False,
+        ema=False,
+        eval_interval=-1,
+        lora=lora,
+    )
+    return trainer, wrapper
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_lora_injects_freezes_zones_and_reduces_trainable_params(family):
+    trainer, wrapper = _build_trainer(family)
+    core = wrapper.model
+
+    trainable_before = sum(p.numel() for p in core.parameters() if p.requires_grad)
+    trainer.on_setup()
+    trainable_after = sum(p.numel() for p in core.parameters() if p.requires_grad)
+
+    assert module_has_lora(core)
+    assert trainable_after < trainable_before
+
+    names = dict(core.named_parameters())
+    lora_params = {n: p for n, p in names.items() if "lora_" in n}
+    assert lora_params, "no LoRA adapters were created"
+    assert all(p.requires_grad for p in lora_params.values())
+
+    # transformer block base weights: frozen
+    base_in_blocks = [(n, p) for n, p in names.items() if ".base_layer." in n]
+    assert base_in_blocks
+    assert all(not p.requires_grad for _, p in base_in_blocks)
+
+    # detection head: still trainable
+    assert any(p.requires_grad for n, p in names.items() if "dec_score_head" in n)
+
+    if family == "deimv2-s":
+        # DINOv3 ViT base: frozen; STA conv pyramid around it: trainable
+        dinov3 = [
+            (n, p)
+            for n, p in names.items()
+            if n.startswith("backbone.dinov3.") and "lora_" not in n
+        ]
+        assert dinov3
+        assert all(not p.requires_grad for _, p in dinov3)
+        sta = [
+            (n, p)
+            for n, p in names.items()
+            if n.startswith("backbone.") and not n.startswith("backbone.dinov3.")
+        ]
+        assert sta, "expected STA params outside backbone.dinov3"
+        assert any(p.requires_grad for _, p in sta), "STA must stay trainable"
+    else:
+        backbone = [(n, p) for n, p in names.items() if n.startswith("backbone.")]
+        assert backbone
+        assert all(not p.requires_grad for _, p in backbone)
+
+
+def test_deimv2_dino_recipe_targets_qkv_and_swiglu():
+    trainer, wrapper = _build_trainer("deimv2-s")
+    trainer.on_setup()
+    names = [n for n, _ in wrapper.model.named_parameters()]
+
+    # DINOv3 fused attention qkv is adapted inside the frozen ViT
+    assert any("backbone.dinov3." in n and ".qkv.lora_A" in n for n in names)
+    # SwiGLU FFN Linears are adapted in the decoder
+    assert any(".w12.lora_A" in n for n in names)
+    assert any(".w3.lora_A" in n for n in names)
+    # attention output proj and MHA self-attention are NOT adapted
+    assert not any(".proj.lora_A" in n for n in names)
+    assert not any("self_attn" in n and "lora_" in n for n in names)
+    # plain LoRA, not DoRA
+    assert not any("lora_magnitude" in n for n in names)
+
+
+def test_rtdetrv4_supports_lora_by_inheritance():
+    """RTDETRv4Trainer subclasses DEIMTrainer and the core is the D-FINE
+    architecture, so lora=True must work through plain inheritance."""
+    assert RTDETRv4Trainer.supports_lora is True
+    trainer, wrapper = _build_trainer("rtdetrv4")
+    trainer.on_setup()
+    assert module_has_lora(wrapper.model)
+
+
+@pytest.mark.parametrize("family", ["rtdetrv2", "deimv2-s"])
+def test_lora_backward_updates_adapters_and_leaves_base_frozen(family):
+    torch.manual_seed(0)
+    trainer, wrapper = _build_trainer(family)
+    trainer.on_setup()
+    core = wrapper.model
+    params = dict(core.named_parameters())
+
+    base_name = next(n for n in params if ".base_layer.weight" in n)
+    base_ref = params[base_name].detach().clone()
+    lora_B_name = next(n for n in params if "lora_B" in n)
+    assert torch.count_nonzero(params[lora_B_name]) == 0
+
+    optimizer = trainer._setup_optimizer()
+    imgs = torch.randn(2, 3, IMGSZ, IMGSZ)
+    targets = torch.zeros(2, 120, 5)
+    if family.startswith("rtdetr"):
+        # RT-DETR targets are [cls, x1, y1, x2, y2] in pixels
+        targets[0, 0] = torch.tensor([0.0, 100.0, 100.0, 300.0, 260.0])
+        targets[1, 0] = torch.tensor([1.0, 200.0, 180.0, 420.0, 400.0])
+    else:
+        # DEIM-style targets are [cls, cx, cy, w, h] in pixels
+        targets[0, 0] = torch.tensor([0.0, 320.0, 320.0, 120.0, 90.0])
+        targets[1, 0] = torch.tensor([1.0, 400.0, 330.0, 90.0, 75.0])
+
+    out = trainer.on_forward(imgs, targets)
+    loss = out["total_loss"]
+    assert torch.isfinite(loss)
+    optimizer.zero_grad()
+    loss.backward()
+    assert params[lora_B_name].grad is not None
+    optimizer.step()
+
+    assert torch.count_nonzero(params[lora_B_name]) > 0
+    assert torch.allclose(params[base_name].detach(), base_ref)
+
+
+@pytest.mark.parametrize("family", ["rtdetr", "deimv2-s"])
+def test_lora_checkpoint_reloads_into_fresh_model(family, tmp_path):
+    """A lora=True checkpoint must load into a fresh model: the loader replays
+    the adapter injection so the peft keys line up (RT-DETR loads non-strictly,
+    so without the replay the adapters would be dropped silently)."""
+    model_cls, _, size, apply_fn = _FAMILIES[family]
+
+    w1 = model_cls(None, size=size, device="cpu")
+    apply_fn(w1.model)
+    sd = dict(w1.model.state_dict())
+    assert any("lora_" in k for k in sd), "checkpoint should carry adapter keys"
+    ckpt_path = tmp_path / "last.pt"
+    torch.save({"model": sd}, ckpt_path)
+
+    w2 = model_cls(None, size=size, device="cpu")
+    assert not module_has_lora(w2.model)
+    w2._load_weights(str(ckpt_path))
+    assert module_has_lora(w2.model), (
+        "loader did not replay LoRA injection for an adapter checkpoint"
+    )
+    # the replayed adapters must carry the trained values, not fresh zeros:
+    # non-strict loading would silently drop them otherwise
+    loaded = dict(w2.model.named_parameters())
+    src_A_name, src_A = next(
+        (n, p) for n, p in w1.model.named_parameters() if "lora_A" in n
+    )
+    assert torch.equal(loaded[src_A_name].detach(), src_A.detach())
+
+
+@pytest.mark.parametrize("family", ["rtdetrv2", "deimv2-pico", "deimv2-s"])
+def test_lora_apply_is_idempotent(family):
+    model_cls, _, size, apply_fn = _FAMILIES[family]
+    wrapper = model_cls(None, size=size, device="cpu")
+    apply_fn(wrapper.model)
+    n_before = sum(1 for n, _ in wrapper.model.named_parameters() if "lora_" in n)
+
+    result = apply_fn(wrapper.model)
+
+    assert result is wrapper.model
+    n_after = sum(1 for n, _ in wrapper.model.named_parameters() if "lora_" in n)
+    assert n_after == n_before

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -208,6 +208,34 @@ def test_train_dry_run_distill_model_is_visible():
     assert data["resolved_config"]["dis"] == 2.0
 
 
+def test_train_dry_run_accepts_lora_for_dfine_and_deim():
+    app = _make_app()
+    for model_name, family in (
+        ("LibreDFINEs.pt", "dfine"),
+        ("LibreDEIMs.pt", "deim"),
+        ("LibreDEIMv2s.pt", "deimv2"),
+        ("LibreRTDETRr18.pt", "rtdetr"),
+        ("LibreRTDETRv2r18.pt", "rtdetrv2"),
+        ("LibreRTDETRv4s.pt", "rtdetrv4"),
+        ("LibreECs.pt", "ec"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "data=coco8.yaml",
+                f"model={model_name}",
+                "--lora",
+                "--dry-run",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        data = json.loads(result.stdout)
+        assert data["model_family"] == family
+        assert data["resolved_config"]["lora"] is True
+
+
 def test_train_dry_run_rejects_lora_for_unsupported_family():
     app = _make_app()
     result = runner.invoke(

--- a/tests/unit/test_lora_helpers.py
+++ b/tests/unit/test_lora_helpers.py
@@ -32,6 +32,19 @@ def test_module_has_lora_detects_wrapped_or_adapter_modules():
     assert not lora_helpers.module_has_lora(plain)
 
 
+def test_apply_lora_to_detr_rejects_non_detr_models():
+    # Raises before any peft import, so this stays inside the PR gate.
+    with pytest.raises(ValueError, match=r"no \.backbone"):
+        lora_helpers.apply_lora_to_detr(torch.nn.Linear(4, 4))
+
+
+def test_detr_recipe_constants_are_exported():
+    assert lora_helpers.DETR_LORA_RANK == 16
+    assert lora_helpers.DETR_LORA_ALPHA == 16
+    assert "linear1" in lora_helpers.DETR_TARGET_LINEAR_NAMES
+    assert "TransformerDecoderLayer" in lora_helpers.DETR_BLOCK_CLASSES
+
+
 def test_missing_peft_error_mentions_lora_extra(monkeypatch):
     real_import = builtins.__import__
 

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -195,3 +195,6 @@ def test_aug_stop_epoch_leaves_no_aug_tail_clean_on_short_runs():
     assert resolve_aug_stop_epoch(8, 0.91, 12) == 1
     # No tail configured: pure ratio semantics.
     assert resolve_aug_stop_epoch(100, 0.85, 0) == 85
+    # ratio=None (a config whose size recipe did not set it) must not crash;
+    # treated as 1.0, then clamped by the no-aug tail.
+    assert resolve_aug_stop_epoch(60, None, 12) == 48

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -129,3 +129,69 @@ def test_warmup_start_is_clamped_to_target_lr_for_low_lr_finetunes(
 
     assert max(warmup_lrs) <= 1e-5 + 1e-12
     assert sched.update_lr(0) == pytest.approx(1e-5)
+
+
+def test_flat_cosine_tail_cannot_extend_into_warmup_on_short_runs():
+    """A run shorter than the configured no-aug tail must still warm up
+    first and end at min lr, not cosine-decay from iteration zero."""
+    sched = FlatCosineScheduler(
+        lr=1e-4, iters_per_epoch=10, total_epochs=8,
+        warmup_epochs=2, no_aug_epochs=12, min_lr_ratio=0.05,
+    )
+    # cosine window is clamped to the post-warmup budget
+    assert sched.cosine_iters == 8 * 10 - 2 * 10
+    # end of run sits at the floor
+    assert sched.update_lr(80) == pytest.approx(1e-4 * 0.05, rel=1e-6)
+    # warmup still ramps up from the start value
+    assert sched.update_lr(1) < 1e-4
+
+
+def test_deimv2_flat_cosine_clamps_recipe_phases_to_short_budgets():
+    """DEIMv2 recipes use iteration-based warmup (2000) and epoch-based flat
+    (64) sized for COCO; a 15-epoch small-dataset run must not spend its
+    whole budget warming up."""
+    from libreyolo.models.deimv2.trainer import DEIMv2FlatCosineScheduler
+
+    ips, total = 56, 15
+    sched = DEIMv2FlatCosineScheduler(
+        lr=5e-4, iters_per_epoch=ips, total_epochs=total,
+        warmup_iters=2000, flat_epochs=64, no_aug_epochs=12, min_lr_ratio=0.5,
+    )
+    budget = ips * total
+    assert sched.warmup_iters <= int(0.1 * budget)
+    assert sched.no_aug_iters <= int(0.2 * budget)
+    assert sched.flat_iters < budget - sched.no_aug_iters
+    # base LR is actually reached during the flat phase
+    mid_flat = (sched.warmup_iters + sched.flat_iters) // 2
+    assert sched.update_lr(mid_flat) == pytest.approx(5e-4, rel=1e-6)
+    # and the run ends at the floor
+    assert sched.update_lr(budget) == pytest.approx(5e-4 * 0.5, rel=1e-6)
+
+
+def test_deimv2_flat_cosine_leaves_coco_scale_recipes_untouched():
+    """None of the budget guards may alter a recipe that fits its budget."""
+    from libreyolo.models.deimv2.trainer import DEIMv2FlatCosineScheduler
+
+    ips, total = 3600, 132
+    sched = DEIMv2FlatCosineScheduler(
+        lr=5e-4, iters_per_epoch=ips, total_epochs=total,
+        warmup_iters=2000, flat_epochs=64, no_aug_epochs=12, min_lr_ratio=0.5,
+    )
+    assert sched.warmup_iters == 2000
+    assert sched.flat_iters == 64 * ips
+    assert sched.no_aug_iters == 12 * ips
+
+
+def test_aug_stop_epoch_leaves_no_aug_tail_clean_on_short_runs():
+    from libreyolo.data.augment.detr import resolve_aug_stop_epoch
+
+    # Published recipes are unchanged (equality for DEIM/DEIMv2, earlier for
+    # D-FINE's independent 0.85 ratio).
+    assert resolve_aug_stop_epoch(132, 0.91, 12) == 120
+    assert resolve_aug_stop_epoch(500, 468 / 500, 32) == 468
+    assert resolve_aug_stop_epoch(72, 0.85, 4) == 61
+    # Short fine-tunes stop strong augs before the no-aug LR tail begins.
+    assert resolve_aug_stop_epoch(15, 0.91, 12) == 3
+    assert resolve_aug_stop_epoch(8, 0.91, 12) == 1
+    # No tail configured: pure ratio semantics.
+    assert resolve_aug_stop_epoch(100, 0.85, 0) == 85


### PR DESCRIPTION
Extend lora=True (previously RF-DETR only) to the CNN-backbone DETR families and the EC and ConvNeXt families, plus a short-fine-tune schedule fix so DEIM-family runs anneal within their epoch budget.
