### PR TITLE
Triton kernels for the quantization stack: fused fake-quant and unpack, 2.4x nvfp4 inference, 1.95x healing step

### DIFF
--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -498,19 +498,26 @@ def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
         model_copy = model_copy.cpu()
         new_sd = model_copy.state_dict()
         if remainder == "fp16" and recipe not in CAST_RECIPES:
-            keep_exact = (
-                "_q_w_scale",
-                "_q_w_gscale",
-                "_q_act_lo",
-                "_q_act_hi",
-                "_q_w_amax",
+            # Quant buffers keep their contract dtypes (packed payloads,
+            # scales, exponents, observer state); only the non-quantized
+            # remainder is cast. Collect the buffer names from the
+            # finalized modules themselves so recipes that register new
+            # buffers stay protected without maintaining a name list here.
+            keep_exact = tuple(
+                sorted(
+                    {
+                        "." + name
+                        for _, module in _quant_modules(model_copy)
+                        for name, _ in module.named_buffers(recurse=False)
+                    }
+                )
             )
             new_sd = {
                 key: (
                     value.half()
                     if torch.is_tensor(value)
                     and value.dtype == torch.float32
-                    and not key.endswith(keep_exact)
+                    and not (keep_exact and key.endswith(keep_exact))
                     else value
                 )
                 for key, value in new_sd.items()

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -192,6 +192,27 @@ def _quant_modules(root: nn.Module):
             yield name, module
 
 
+def _cast_finalized_remainder(root: nn.Module, dtype: torch.dtype):
+    """Cast deployment parameters without changing quantized buffer formats."""
+    exact_buffers = {
+        id(buffer)
+        for _, module in _quant_modules(root)
+        for buffer in module.buffers(recurse=False)
+    }
+    with torch.no_grad():
+        for parameter in root.parameters():
+            if parameter.is_floating_point() and parameter.dtype != dtype:
+                parameter.data = parameter.data.to(dtype)
+        for module in root.modules():
+            for buffer in module.buffers(recurse=False):
+                if (
+                    id(buffer) not in exact_buffers
+                    and buffer.is_floating_point()
+                    and buffer.dtype != dtype
+                ):
+                    buffer.data = buffer.data.to(dtype)
+
+
 def _cast_tree(obj, dtype):
     if torch.is_tensor(obj) and obj.is_floating_point():
         return obj.to(dtype)
@@ -477,7 +498,13 @@ def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
         model_copy = model_copy.cpu()
         new_sd = model_copy.state_dict()
         if remainder == "fp16" and recipe not in CAST_RECIPES:
-            keep_exact = ("_q_w_scale", "_q_act_lo", "_q_act_hi", "_q_w_amax")
+            keep_exact = (
+                "_q_w_scale",
+                "_q_w_gscale",
+                "_q_act_lo",
+                "_q_act_hi",
+                "_q_w_amax",
+            )
             new_sd = {
                 key: (
                     value.half()
@@ -529,6 +556,8 @@ def reprepare_model(wrapper):
     manifest = dict(manifest)
     manifest["state"] = "prepared"
     wrapper._quant_manifest = manifest
+    if manifest.get("recipe") not in CAST_RECIPES:
+        wrapper.model.float()
     wrapper.model.to(wrapper.device)
     logger.info(
         "Re-prepared finalized checkpoint: fp32 masters reconstructed from "
@@ -666,6 +695,7 @@ def dequantize_model(wrapper):
                 new.weight = module.weight
             new.bias = module.bias
             _swap_module(root, name, new)
+        root.float()
 
     wrapper._quant_manifest = None
     logger.info("Restored float modules (recipe '%s' removed).", manifest.get("recipe"))
@@ -713,6 +743,14 @@ def apply_quant_structure(wrapper, manifest: Dict):
             for _, module in _quant_modules(wrapper.model):
                 if hasattr(module, "make_finalized"):
                     module.make_finalized()
+            remainder = manifest.get("remainder", "fp32")
+            if remainder == "fp16":
+                _cast_finalized_remainder(wrapper.model, torch.float16)
+            elif remainder != "fp32":
+                raise QuantizationError(
+                    "Finalized checkpoint has unsupported remainder dtype "
+                    f"'{remainder}'."
+                )
         if swapped:
             wrapper.model.to(wrapper.device)
 

--- a/libreyolo/quant/kernels/__init__.py
+++ b/libreyolo/quant/kernels/__init__.py
@@ -77,8 +77,29 @@ def _forced() -> str:
     return os.environ.get("LIBREYOLO_QUANT_KERNELS", "").strip().lower()
 
 
+_INTREE_ATTEMPTED = False
+
+
+def _ensure_intree_loaded():
+    """Lazily import the in-tree Triton kernels on first resolution.
+
+    Lazy so `import libreyolo` never pays the triton import cost, and
+    skipped entirely when the env forces the reference implementations.
+    Absence of triton (e.g. Windows) is the normal fallback case.
+    """
+    global _INTREE_ATTEMPTED
+    if _INTREE_ATTEMPTED or _forced() in ("off", "reference"):
+        return
+    _INTREE_ATTEMPTED = True
+    try:
+        from . import triton  # noqa: F401  (self-registers on import)
+    except Exception as exc:
+        logger.debug("In-tree Triton kernels unavailable: %s", exc)
+
+
 def resolve(op: str) -> Optional[Callable]:
     """Return the active implementation for an op, or None if none eligible."""
+    _ensure_intree_loaded()
     forced = _forced()
     cache_key = f"{op}|{forced}"
     if cache_key in _RESOLVED:
@@ -132,6 +153,17 @@ def _make_proxy(op: str) -> Callable:
 # (always the fallback) and are selectable via the "reference" name.
 for _op in REFERENCE_OPS:
     register(_op, getattr(_reference, _op), name="reference")
+    globals()[_op] = _make_proxy(_op)
+
+# Unpack slots (finalized-checkpoint dequantization): the packing module is
+# the contract and provides the reference implementations; accelerated
+# variants register on top exactly like the fake-quant slots.
+from .. import packing as _packing  # noqa: E402
+
+UNPACK_OPS = ("unpack_int_grouped", "unpack_nvfp4")
+register("unpack_int_grouped", _packing.unpack_int_grouped_weight, name="reference")
+register("unpack_nvfp4", _packing.unpack_nvfp4_weight, name="reference")
+for _op in UNPACK_OPS:
     globals()[_op] = _make_proxy(_op)
 
 

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -1,2 +1,6 @@
-"""Triton kernels (JIT, no build step). Empty scaffold: kernels land here
-with parity tests against the fake_quant reference implementations."""
+"""Triton quantization kernels (JIT, no build step)."""
+
+from .nvfp4_weight import fake_quant_nvfp4_weight
+
+
+__all__ = ["fake_quant_nvfp4_weight"]

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -6,6 +6,7 @@ from .int8_per_channel import fake_quant_int8_per_channel
 from .mxfp4 import fake_quant_mxfp4_dynamic, fake_quant_mxfp4_weight
 from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
 from .nvfp4_weight import fake_quant_nvfp4_weight
+from .unpack_int_grouped import unpack_int_grouped
 
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "fake_quant_mxfp4_weight",
     "fake_quant_nvfp4_dynamic",
     "fake_quant_nvfp4_weight",
+    "unpack_int_grouped",
 ]

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -3,6 +3,7 @@
 from .fp8 import fake_quant_fp8
 from .int_grouped import fake_quant_int_grouped
 from .int8_per_channel import fake_quant_int8_per_channel
+from .mxfp4 import fake_quant_mxfp4_dynamic, fake_quant_mxfp4_weight
 from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
 from .nvfp4_weight import fake_quant_nvfp4_weight
 
@@ -11,6 +12,8 @@ __all__ = [
     "fake_quant_fp8",
     "fake_quant_int_grouped",
     "fake_quant_int8_per_channel",
+    "fake_quant_mxfp4_dynamic",
+    "fake_quant_mxfp4_weight",
     "fake_quant_nvfp4_dynamic",
     "fake_quant_nvfp4_weight",
 ]

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -1,7 +1,12 @@
 """Triton quantization kernels (JIT, no build step)."""
 
+from .int8_per_channel import fake_quant_int8_per_channel
 from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
 from .nvfp4_weight import fake_quant_nvfp4_weight
 
 
-__all__ = ["fake_quant_nvfp4_dynamic", "fake_quant_nvfp4_weight"]
+__all__ = [
+    "fake_quant_int8_per_channel",
+    "fake_quant_nvfp4_dynamic",
+    "fake_quant_nvfp4_weight",
+]

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -1,11 +1,13 @@
 """Triton quantization kernels (JIT, no build step)."""
 
+from .int_grouped import fake_quant_int_grouped
 from .int8_per_channel import fake_quant_int8_per_channel
 from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
 from .nvfp4_weight import fake_quant_nvfp4_weight
 
 
 __all__ = [
+    "fake_quant_int_grouped",
     "fake_quant_int8_per_channel",
     "fake_quant_nvfp4_dynamic",
     "fake_quant_nvfp4_weight",

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -1,6 +1,7 @@
 """Triton quantization kernels (JIT, no build step)."""
 
+from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
 from .nvfp4_weight import fake_quant_nvfp4_weight
 
 
-__all__ = ["fake_quant_nvfp4_weight"]
+__all__ = ["fake_quant_nvfp4_dynamic", "fake_quant_nvfp4_weight"]

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -1,5 +1,6 @@
 """Triton quantization kernels (JIT, no build step)."""
 
+from .fp8 import fake_quant_fp8
 from .int_grouped import fake_quant_int_grouped
 from .int8_per_channel import fake_quant_int8_per_channel
 from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
@@ -7,6 +8,7 @@ from .nvfp4_weight import fake_quant_nvfp4_weight
 
 
 __all__ = [
+    "fake_quant_fp8",
     "fake_quant_int_grouped",
     "fake_quant_int8_per_channel",
     "fake_quant_nvfp4_dynamic",

--- a/libreyolo/quant/kernels/triton/__init__.py
+++ b/libreyolo/quant/kernels/triton/__init__.py
@@ -7,6 +7,7 @@ from .mxfp4 import fake_quant_mxfp4_dynamic, fake_quant_mxfp4_weight
 from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
 from .nvfp4_weight import fake_quant_nvfp4_weight
 from .unpack_int_grouped import unpack_int_grouped
+from .unpack_nvfp4 import unpack_nvfp4
 
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "fake_quant_nvfp4_dynamic",
     "fake_quant_nvfp4_weight",
     "unpack_int_grouped",
+    "unpack_nvfp4",
 ]

--- a/libreyolo/quant/kernels/triton/fp8.py
+++ b/libreyolo/quant/kernels/triton/fp8.py
@@ -1,0 +1,144 @@
+"""Fused Triton FP8 E4M3 fake quantization."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from libreyolo.quant import fake_quant as _reference
+from libreyolo.quant import kernels
+
+
+_FP8_CONFIGS = (
+    triton.Config({"BLOCK_SIZE": 256}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 512}, num_warps=2, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+)
+
+
+@triton.autotune(
+    configs=list(_FP8_CONFIGS),
+    key=["n_elements", "channel_size"],
+)
+@triton.jit
+def _fake_quant_fp8_kernel(
+    input_ptr,
+    scale_ptr,
+    output_ptr,
+    n_elements: tl.constexpr,
+    channel_size: tl.constexpr,
+    PER_CHANNEL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid = offsets < n_elements
+    values = tl.load(input_ptr + offsets, mask=valid).to(tl.float32)
+    if PER_CHANNEL:
+        scale_offsets = offsets // channel_size
+        scale = tl.load(scale_ptr + scale_offsets, mask=valid)
+    else:
+        scale = tl.load(scale_ptr)
+    scale = tl.maximum(scale, 1.0e-12)
+    scaled = libdevice.div_rn(values, scale)
+    scaled = tl.maximum(tl.minimum(scaled, 448.0), -448.0)
+    quantized = scaled.to(tl.float8e4nv).to(tl.float32) * scale
+    tl.store(output_ptr + offsets, quantized, mask=valid)
+
+
+def _launch(inputs: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    per_channel = scale.numel() != 1
+    channel_size = inputs.numel() // inputs.shape[0] if per_channel else 0
+    output = torch.empty_like(inputs)
+
+    def grid(meta):
+        return (triton.cdiv(inputs.numel(), meta["BLOCK_SIZE"]),)
+
+    _fake_quant_fp8_kernel[grid](
+        inputs,
+        scale,
+        output,
+        n_elements=inputs.numel(),
+        channel_size=channel_size,
+        PER_CHANNEL=per_channel,
+    )
+    return output
+
+
+class _FakeQuantFP8(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        _ctx: Any,
+        inputs: torch.Tensor,
+        scale: torch.Tensor,
+    ) -> torch.Tensor:
+        return _launch(inputs, scale)
+
+    @staticmethod
+    def backward(_ctx: Any, grad_output: torch.Tensor):
+        return grad_output, None
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_inputs(inputs: torch.Tensor, scale: torch.Tensor) -> bool:
+    if not (
+        inputs.is_cuda
+        and scale.is_cuda
+        and inputs.device == scale.device
+        and inputs.dtype == torch.float32
+        and scale.dtype == torch.float32
+        and inputs.is_contiguous()
+        and scale.is_contiguous()
+        and inputs.numel() > 0
+        and scale.numel() > 0
+    ):
+        return False
+    if scale.numel() == 1:
+        return True
+    return (
+        inputs.dim() >= 1
+        and scale.dim() == inputs.dim()
+        and scale.shape[0] == inputs.shape[0]
+        and all(dimension == 1 for dimension in scale.shape[1:])
+    )
+
+
+def fake_quant_fp8(inputs: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Apply fused FP8 E4M3 fake quantization or safely use the oracle."""
+    if not _supported_inputs(inputs, scale):
+        return _reference.fake_quant_fp8(inputs, scale)
+    return _FakeQuantFP8.apply(inputs, scale)
+
+
+def autotune_cache() -> list[dict[str, Any]]:
+    """Return configurations selected for every canonical scale layout."""
+    return [
+        {
+            "elements": key[0],
+            "channel_size": key[1],
+            "block_size": config.kwargs["BLOCK_SIZE"],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        for key, config in _fake_quant_fp8_kernel.cache.items()
+    ]
+
+
+kernels.register(
+    "fake_quant_fp8",
+    fake_quant_fp8,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = ["autotune_cache", "fake_quant_fp8"]

--- a/libreyolo/quant/kernels/triton/int8_per_channel.py
+++ b/libreyolo/quant/kernels/triton/int8_per_channel.py
@@ -1,0 +1,250 @@
+"""Fused Triton per-channel symmetric INT8 fake quantization."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from libreyolo.quant import fake_quant as _reference
+from libreyolo.quant import kernels
+
+
+_DYNAMIC_CONFIGS = (
+    triton.Config({}, num_warps=1, num_stages=1),
+    triton.Config({}, num_warps=2, num_stages=1),
+    triton.Config({}, num_warps=4, num_stages=1),
+    triton.Config({}, num_warps=8, num_stages=1),
+)
+
+_FROZEN_CONFIGS = (
+    triton.Config({"BLOCK_SIZE": 256}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 512}, num_warps=2, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+)
+
+
+@triton.autotune(configs=list(_DYNAMIC_CONFIGS), key=["n_channels", "channel_size"])
+@triton.jit
+def _fake_quant_int8_per_channel_dynamic_kernel(
+    weight_ptr,
+    output_ptr,
+    n_channels: tl.constexpr,
+    channel_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    channel = tl.program_id(0)
+    offsets = channel * channel_size + tl.arange(0, BLOCK_SIZE)
+    valid = tl.arange(0, BLOCK_SIZE) < channel_size
+    values = tl.load(weight_ptr + offsets, mask=valid, other=0.0).to(tl.float32)
+    amax = tl.max(tl.abs(values), axis=0)
+    scale = tl.maximum(amax / 127.0, 1.0e-12)
+    inverse_scale = libdevice.div_rn(1.0, scale)
+    codes = libdevice.float2int_rn(values * inverse_scale)
+    codes = tl.maximum(tl.minimum(codes, 127), -128)
+    output = codes.to(tl.float32) * scale
+    tl.store(output_ptr + offsets, output, mask=valid)
+
+
+@triton.autotune(configs=list(_FROZEN_CONFIGS), key=["n_elements", "channel_size"])
+@triton.jit
+def _fake_quant_int8_per_channel_frozen_kernel(
+    weight_ptr,
+    scale_ptr,
+    output_ptr,
+    n_elements: tl.constexpr,
+    channel_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid = offsets < n_elements
+    values = tl.load(weight_ptr + offsets, mask=valid).to(tl.float32)
+    channels = offsets // channel_size
+    scale = tl.maximum(tl.load(scale_ptr + channels, mask=valid), 1.0e-12)
+    inverse_scale = libdevice.div_rn(1.0, scale)
+    codes = libdevice.float2int_rn(values * inverse_scale)
+    codes = tl.maximum(tl.minimum(codes, 127), -128)
+    output = codes.to(tl.float32) * scale
+    tl.store(output_ptr + offsets, output, mask=valid)
+
+
+@triton.autotune(configs=list(_FROZEN_CONFIGS), key=["n_elements", "channel_size"])
+@triton.jit
+def _fake_quant_int8_per_channel_backward_kernel(
+    grad_ptr,
+    weight_ptr,
+    scale_ptr,
+    output_ptr,
+    n_elements: tl.constexpr,
+    channel_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid = offsets < n_elements
+    values = tl.load(weight_ptr + offsets, mask=valid).to(tl.float32)
+    gradients = tl.load(grad_ptr + offsets, mask=valid).to(tl.float32)
+    channels = offsets // channel_size
+    scale = tl.maximum(tl.load(scale_ptr + channels, mask=valid), 1.0e-12)
+    inverse_scale = libdevice.div_rn(1.0, scale)
+    codes = libdevice.float2int_rn(values * inverse_scale)
+    inside = (codes >= -128) & (codes <= 127)
+    tl.store(output_ptr + offsets, tl.where(inside, gradients, 0.0), mask=valid)
+
+
+def _flat_grid(n_elements: int):
+    def grid(meta):
+        return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    return grid
+
+
+def _launch_dynamic(weight: torch.Tensor) -> torch.Tensor:
+    n_channels = weight.shape[0]
+    channel_size = weight.numel() // n_channels
+    block_size = triton.next_power_of_2(channel_size)
+    output = torch.empty_like(weight)
+    _fake_quant_int8_per_channel_dynamic_kernel[(n_channels,)](
+        weight,
+        output,
+        n_channels=n_channels,
+        channel_size=channel_size,
+        BLOCK_SIZE=block_size,
+    )
+    return output
+
+
+def _launch_frozen(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    channel_size = weight.numel() // weight.shape[0]
+    output = torch.empty_like(weight)
+    _fake_quant_int8_per_channel_frozen_kernel[_flat_grid(weight.numel())](
+        weight,
+        scale,
+        output,
+        n_elements=weight.numel(),
+        channel_size=channel_size,
+    )
+    return output
+
+
+def _launch_backward(
+    grad_output: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    gradients = grad_output.contiguous()
+    channel_size = weight.numel() // weight.shape[0]
+    grad_weight = torch.empty_like(weight)
+    _fake_quant_int8_per_channel_backward_kernel[_flat_grid(weight.numel())](
+        gradients,
+        weight,
+        scale,
+        grad_weight,
+        n_elements=weight.numel(),
+        channel_size=channel_size,
+    )
+    return grad_weight
+
+
+class _FakeQuantInt8PerChannel(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: Any,
+        weight: torch.Tensor,
+        scale: torch.Tensor | None,
+    ) -> torch.Tensor:
+        ctx.dynamic_scale = scale is None
+        if scale is None:
+            return _launch_dynamic(weight)
+        ctx.save_for_backward(weight, scale)
+        return _launch_frozen(weight, scale)
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: torch.Tensor):
+        if ctx.dynamic_scale:
+            return grad_output, None
+        weight, scale = ctx.saved_tensors
+        return _launch_backward(grad_output, weight, scale), None
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_inputs(
+    weight: torch.Tensor,
+    ch_axis: int,
+    scale: torch.Tensor | None,
+) -> bool:
+    if not (
+        weight.is_cuda
+        and weight.dtype == torch.float32
+        and weight.is_contiguous()
+        and weight.dim() >= 1
+        and weight.numel() > 0
+        and weight.shape[0] > 0
+        and weight.numel() // weight.shape[0] <= 65536
+        and ch_axis == 0
+    ):
+        return False
+    return scale is None or (
+        scale.is_cuda
+        and scale.device == weight.device
+        and scale.dtype == torch.float32
+        and scale.is_contiguous()
+        and scale.numel() == weight.shape[0]
+    )
+
+
+def fake_quant_int8_per_channel(
+    weight: torch.Tensor,
+    ch_axis: int = 0,
+    scale: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply fused per-channel INT8 fake quantization or use the oracle."""
+    if not _supported_inputs(weight, ch_axis, scale):
+        return _reference.fake_quant_int8_per_channel(weight, ch_axis, scale)
+    return _FakeQuantInt8PerChannel.apply(weight, scale)
+
+
+def _cache_rows(kernel, dynamic: bool = False) -> list[dict[str, Any]]:
+    rows = []
+    for key, config in kernel.cache.items():
+        row = {
+            "elements_or_channels": key[0],
+            "channel_size": key[1],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        if not dynamic:
+            row["block_size"] = config.kwargs["BLOCK_SIZE"]
+        rows.append(row)
+    return rows
+
+
+def autotune_cache() -> dict[str, list[dict[str, Any]]]:
+    """Return dynamic, frozen, and backward configurations used by gates."""
+    return {
+        "dynamic": _cache_rows(
+            _fake_quant_int8_per_channel_dynamic_kernel,
+            dynamic=True,
+        ),
+        "frozen": _cache_rows(_fake_quant_int8_per_channel_frozen_kernel),
+        "backward": _cache_rows(_fake_quant_int8_per_channel_backward_kernel),
+    }
+
+
+kernels.register(
+    "fake_quant_int8_per_channel",
+    fake_quant_int8_per_channel,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = ["autotune_cache", "fake_quant_int8_per_channel"]

--- a/libreyolo/quant/kernels/triton/int_grouped.py
+++ b/libreyolo/quant/kernels/triton/int_grouped.py
@@ -1,0 +1,201 @@
+"""Fused Triton grouped symmetric integer fake quantization."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from libreyolo.quant import fake_quant as _reference
+from libreyolo.quant import kernels
+
+
+_GROUPED_CONFIGS = (
+    triton.Config({}, num_warps=1, num_stages=1),
+    triton.Config({}, num_warps=2, num_stages=1),
+    triton.Config({}, num_warps=4, num_stages=1),
+    triton.Config({}, num_warps=8, num_stages=1),
+)
+
+
+@triton.autotune(configs=list(_GROUPED_CONFIGS), key=["n_rows", "n_cols", "qmax"])
+@triton.jit
+def _fake_quant_int_grouped_dynamic_kernel(
+    weight_ptr,
+    output_ptr,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    n_groups: tl.constexpr,
+    qmin: tl.constexpr,
+    qmax: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+):
+    group_id = tl.program_id(0)
+    row = group_id // n_groups
+    group = group_id % n_groups
+    columns = group * GROUP_SIZE + tl.arange(0, GROUP_SIZE)
+    valid = columns < n_cols
+    offsets = row * n_cols + columns
+    values = tl.load(weight_ptr + offsets, mask=valid, other=0.0).to(tl.float32)
+    amax = tl.max(tl.abs(values), axis=0)
+    scale = tl.maximum(amax / qmax, 1.0e-12)
+    scaled = libdevice.div_rn(values, scale)
+    codes = libdevice.float2int_rn(scaled)
+    codes = tl.maximum(tl.minimum(codes, qmax), qmin)
+    output = codes.to(tl.float32) * scale
+    tl.store(output_ptr + offsets, output, mask=valid)
+
+
+@triton.autotune(configs=list(_GROUPED_CONFIGS), key=["n_rows", "n_cols", "qmax"])
+@triton.jit
+def _fake_quant_int_grouped_frozen_kernel(
+    weight_ptr,
+    scale_ptr,
+    output_ptr,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    n_groups: tl.constexpr,
+    qmin: tl.constexpr,
+    qmax: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+):
+    group_id = tl.program_id(0)
+    row = group_id // n_groups
+    group = group_id % n_groups
+    columns = group * GROUP_SIZE + tl.arange(0, GROUP_SIZE)
+    valid = columns < n_cols
+    offsets = row * n_cols + columns
+    values = tl.load(weight_ptr + offsets, mask=valid).to(tl.float32)
+    scale = tl.maximum(tl.load(scale_ptr + group_id), 1.0e-12)
+    scaled = libdevice.div_rn(values, scale)
+    codes = libdevice.float2int_rn(scaled)
+    codes = tl.maximum(tl.minimum(codes, qmax), qmin)
+    output = codes.to(tl.float32) * scale
+    tl.store(output_ptr + offsets, output, mask=valid)
+
+
+def _parameters(bits: int, group_size: int) -> tuple[int, int]:
+    qmin = -(2 ** (bits - 1))
+    qmax = 2 ** (bits - 1) - 1
+    return qmin, qmax
+
+
+def _launch(
+    weight: torch.Tensor,
+    bits: int,
+    group_size: int,
+    scale: torch.Tensor | None,
+) -> torch.Tensor:
+    n_rows, n_cols = weight.shape
+    n_groups = triton.cdiv(n_cols, group_size)
+    qmin, qmax = _parameters(bits, group_size)
+    output = torch.empty_like(weight)
+    kernel = (
+        _fake_quant_int_grouped_dynamic_kernel
+        if scale is None
+        else _fake_quant_int_grouped_frozen_kernel
+    )
+    arguments = (weight, output) if scale is None else (weight, scale, output)
+    kernel[(n_rows * n_groups,)](
+        *arguments,
+        n_rows=n_rows,
+        n_cols=n_cols,
+        n_groups=n_groups,
+        qmin=qmin,
+        qmax=qmax,
+        GROUP_SIZE=group_size,
+    )
+    return output
+
+
+class _FakeQuantIntGrouped(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        _ctx: Any,
+        weight: torch.Tensor,
+        bits: int,
+        group_size: int,
+        scale: torch.Tensor | None,
+    ) -> torch.Tensor:
+        return _launch(weight, bits, group_size, scale)
+
+    @staticmethod
+    def backward(_ctx: Any, grad_output: torch.Tensor):
+        return grad_output, None, None, None
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_inputs(
+    weight: torch.Tensor,
+    bits: int,
+    group_size: int,
+    scale: torch.Tensor | None,
+) -> bool:
+    if not (
+        weight.is_cuda
+        and weight.dtype == torch.float32
+        and weight.is_contiguous()
+        and weight.dim() == 2
+        and weight.numel() > 0
+        and (bits, group_size) in ((4, 128), (2, 64))
+    ):
+        return False
+    n_groups = triton.cdiv(weight.shape[1], group_size)
+    return scale is None or (
+        scale.is_cuda
+        and scale.device == weight.device
+        and scale.dtype == torch.float32
+        and scale.is_contiguous()
+        and tuple(scale.shape) == (weight.shape[0], n_groups)
+    )
+
+
+def fake_quant_int_grouped(
+    weight: torch.Tensor,
+    bits: int,
+    group_size: int,
+    scale: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply fused W4/W2 grouped fake quantization or safely use the oracle."""
+    if not _supported_inputs(weight, bits, group_size, scale):
+        return _reference.fake_quant_int_grouped(weight, bits, group_size, scale)
+    return _FakeQuantIntGrouped.apply(weight, bits, group_size, scale)
+
+
+def _cache_rows(kernel) -> list[dict[str, Any]]:
+    return [
+        {
+            "rows": key[0],
+            "columns": key[1],
+            "qmax": key[2],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        for key, config in kernel.cache.items()
+    ]
+
+
+def autotune_cache() -> dict[str, list[dict[str, Any]]]:
+    """Return dynamic and frozen configurations selected by the gate."""
+    return {
+        "dynamic": _cache_rows(_fake_quant_int_grouped_dynamic_kernel),
+        "frozen": _cache_rows(_fake_quant_int_grouped_frozen_kernel),
+    }
+
+
+kernels.register(
+    "fake_quant_int_grouped",
+    fake_quant_int_grouped,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = ["autotune_cache", "fake_quant_int_grouped"]

--- a/libreyolo/quant/kernels/triton/mxfp4.py
+++ b/libreyolo/quant/kernels/triton/mxfp4.py
@@ -1,0 +1,159 @@
+"""Fused Triton MXFP4 weight and activation fake quantization."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from libreyolo.quant import fake_quant as _reference
+from libreyolo.quant import kernels
+
+
+_MXFP4_CONFIGS = (
+    triton.Config({"BLOCKS_PER_PROGRAM": 1}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 4}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 8}, num_warps=2, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 16}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 32}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCKS_PER_PROGRAM": 64}, num_warps=8, num_stages=2),
+)
+
+
+@triton.autotune(configs=list(_MXFP4_CONFIGS), key=["n_rows", "n_cols"])
+@triton.jit
+def _fake_quant_mxfp4_kernel(
+    input_ptr,
+    output_ptr,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    BLOCKS_PER_PROGRAM: tl.constexpr,
+):
+    block_width: tl.constexpr = 32
+    blocks_per_row: tl.constexpr = (n_cols + block_width - 1) // block_width
+    total_blocks: tl.constexpr = n_rows * blocks_per_row
+    block_ids = tl.program_id(0) * BLOCKS_PER_PROGRAM + tl.arange(0, BLOCKS_PER_PROGRAM)
+    lanes = tl.arange(0, block_width)
+    rows = block_ids[:, None] // blocks_per_row
+    columns = (block_ids[:, None] % blocks_per_row) * block_width + lanes[None, :]
+    valid = (block_ids[:, None] < total_blocks) & (columns < n_cols)
+    offsets = rows * n_cols + columns
+    values = tl.load(input_ptr + offsets, mask=valid, other=0.0).to(tl.float32)
+
+    block_amax = tl.max(tl.abs(values), axis=1, keep_dims=True)
+    clamped_amax = tl.maximum(block_amax, 1.0e-30)
+    amax_bits = clamped_amax.to(tl.int32, bitcast=True)
+    amax_exponent = ((amax_bits >> 23) & 0xFF) - 127
+    scale_exponent = tl.maximum(tl.minimum(amax_exponent - 2, 127), -127)
+    normal_scale_bits = (scale_exponent + 127) << 23
+    scale_bits = tl.where(scale_exponent == -127, 0x00400000, normal_scale_bits)
+    effective_scale = scale_bits.to(tl.float32, bitcast=True)
+
+    scaled = libdevice.div_rn(values, effective_scale)
+    magnitude = tl.minimum(tl.abs(scaled), 6.0)
+    level = tl.where(magnitude > 0.25, 0.5, 0.0)
+    level = tl.where(magnitude > 0.75, 1.0, level)
+    level = tl.where(magnitude > 1.25, 1.5, level)
+    level = tl.where(magnitude > 1.75, 2.0, level)
+    level = tl.where(magnitude > 2.5, 3.0, level)
+    level = tl.where(magnitude > 3.5, 4.0, level)
+    level = tl.where(magnitude > 5.0, 6.0, level)
+    sign = tl.where(values > 0.0, 1.0, tl.where(values < 0.0, -1.0, 0.0))
+    output = (level * sign) * effective_scale
+    tl.store(output_ptr + offsets, output, mask=valid)
+
+
+def _launch(inputs: torch.Tensor) -> torch.Tensor:
+    matrix = inputs.reshape(-1, inputs.shape[-1])
+    n_rows, n_cols = matrix.shape
+    blocks_per_row = triton.cdiv(n_cols, 32)
+    output = torch.empty_like(matrix)
+
+    def grid(meta):
+        return (triton.cdiv(n_rows * blocks_per_row, meta["BLOCKS_PER_PROGRAM"]),)
+
+    _fake_quant_mxfp4_kernel[grid](
+        matrix,
+        output,
+        n_rows=n_rows,
+        n_cols=n_cols,
+    )
+    return output.reshape_as(inputs)
+
+
+class _FakeQuantMXFP4(torch.autograd.Function):
+    @staticmethod
+    def forward(_ctx: Any, inputs: torch.Tensor) -> torch.Tensor:
+        return _launch(inputs)
+
+    @staticmethod
+    def backward(_ctx: Any, grad_output: torch.Tensor):
+        return grad_output
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_input(inputs: torch.Tensor) -> bool:
+    return (
+        inputs.is_cuda
+        and inputs.dtype == torch.float32
+        and inputs.is_contiguous()
+        and inputs.dim() >= 1
+        and inputs.numel() > 0
+        and inputs.shape[-1] > 0
+    )
+
+
+def fake_quant_mxfp4_weight(weight: torch.Tensor) -> torch.Tensor:
+    """Apply fused MXFP4 weight fake quantization or safely use the oracle."""
+    if not _supported_input(weight):
+        return _reference.fake_quant_mxfp4_weight(weight)
+    return _FakeQuantMXFP4.apply(weight)
+
+
+def fake_quant_mxfp4_dynamic(inputs: torch.Tensor) -> torch.Tensor:
+    """Apply fused dynamic MXFP4 fake quantization or safely use the oracle."""
+    if not _supported_input(inputs):
+        return _reference.fake_quant_mxfp4_dynamic(inputs)
+    return _FakeQuantMXFP4.apply(inputs)
+
+
+def autotune_cache() -> list[dict[str, Any]]:
+    """Return configurations selected across weight and activation shapes."""
+    return [
+        {
+            "rows": key[0],
+            "columns": key[1],
+            "blocks_per_program": config.kwargs["BLOCKS_PER_PROGRAM"],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        for key, config in _fake_quant_mxfp4_kernel.cache.items()
+    ]
+
+
+kernels.register(
+    "fake_quant_mxfp4_weight",
+    fake_quant_mxfp4_weight,
+    name="triton",
+    predicate=_eligible,
+)
+kernels.register(
+    "fake_quant_mxfp4_dynamic",
+    fake_quant_mxfp4_dynamic,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = [
+    "autotune_cache",
+    "fake_quant_mxfp4_dynamic",
+    "fake_quant_mxfp4_weight",
+]

--- a/libreyolo/quant/kernels/triton/nvfp4_dynamic.py
+++ b/libreyolo/quant/kernels/triton/nvfp4_dynamic.py
@@ -1,0 +1,112 @@
+"""Fused Triton NVFP4 dynamic activation fake quantization."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+from libreyolo.quant import fake_quant as _reference
+from libreyolo.quant import kernels
+
+from .nvfp4_weight import _launch as _quantize_with_amax
+from .nvfp4_weight import autotune_cache as _quantize_autotune_cache
+
+
+_AMAX_CONFIGS = (
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 8192}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 16384}, num_warps=8, num_stages=2),
+)
+
+
+@triton.autotune(configs=list(_AMAX_CONFIGS), key=["n_elements"])
+@triton.jit
+def _global_amax_kernel(
+    input_ptr,
+    output_ptr,
+    n_elements: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    values = tl.load(input_ptr + offsets, mask=offsets < n_elements, other=0.0)
+    local_amax = tl.max(tl.abs(values), axis=0)
+    tl.atomic_max(output_ptr, local_amax, sem="relaxed")
+
+
+def _global_amax(inputs: torch.Tensor) -> torch.Tensor:
+    output = torch.zeros(1, device=inputs.device, dtype=torch.float32)
+
+    def grid(meta):
+        return (triton.cdiv(inputs.numel(), meta["BLOCK_SIZE"]),)
+
+    _global_amax_kernel[grid](inputs, output, n_elements=inputs.numel())
+    return output
+
+
+def _launch(inputs: torch.Tensor) -> torch.Tensor:
+    tensor_amax = _global_amax(inputs)
+    matrix = inputs.reshape(-1, inputs.shape[-1])
+    return _quantize_with_amax(matrix, tensor_amax).reshape_as(inputs)
+
+
+class _FakeQuantNVFP4Dynamic(torch.autograd.Function):
+    @staticmethod
+    def forward(_ctx: Any, inputs: torch.Tensor) -> torch.Tensor:
+        return _launch(inputs)
+
+    @staticmethod
+    def backward(_ctx: Any, grad_output: torch.Tensor):
+        return grad_output
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_input(inputs: torch.Tensor) -> bool:
+    return (
+        inputs.is_cuda
+        and inputs.dtype == torch.float32
+        and inputs.dim() >= 1
+        and inputs.is_contiguous()
+        and inputs.numel() > 0
+        and inputs.shape[-1] > 0
+    )
+
+
+def fake_quant_nvfp4_dynamic(inputs: torch.Tensor) -> torch.Tensor:
+    """Apply dynamic NVFP4 fake quantization or safely use the oracle."""
+    if not _supported_input(inputs):
+        return _reference.fake_quant_nvfp4_dynamic(inputs)
+    return _FakeQuantNVFP4Dynamic.apply(inputs)
+
+
+def autotune_cache() -> dict[str, list[dict[str, Any]]]:
+    """Return reduction and quantization configurations used by the gate."""
+    reduction = [
+        {
+            "elements": key[0],
+            "block_size": config.kwargs["BLOCK_SIZE"],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        for key, config in _global_amax_kernel.cache.items()
+    ]
+    return {"amax": reduction, "quantize": _quantize_autotune_cache()}
+
+
+kernels.register(
+    "fake_quant_nvfp4_dynamic",
+    fake_quant_nvfp4_dynamic,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = ["autotune_cache", "fake_quant_nvfp4_dynamic"]

--- a/libreyolo/quant/kernels/triton/nvfp4_weight.py
+++ b/libreyolo/quant/kernels/triton/nvfp4_weight.py
@@ -54,7 +54,7 @@ def _fake_quant_nvfp4_weight_kernel(
     tensor_amax = tl.load(tensor_amax_ptr).to(tl.float32)
     tensor_scale = tl.maximum(tensor_amax / (448.0 * 6.0), 1.0e-12)
     block_amax = tl.max(tl.abs(values), axis=1, keep_dims=True)
-    block_scale = block_amax / (6.0 * tensor_scale)
+    block_scale = libdevice.div_rn(block_amax, 6.0 * tensor_scale)
     block_scale = tl.maximum(tl.minimum(block_scale, 448.0), 1.0e-12)
     block_scale = block_scale.to(tl.float8e4nv).to(tl.float32)
     effective_scale = tl.maximum(block_scale * tensor_scale, 1.0e-12)

--- a/libreyolo/quant/kernels/triton/nvfp4_weight.py
+++ b/libreyolo/quant/kernels/triton/nvfp4_weight.py
@@ -1,0 +1,153 @@
+"""Fused Triton NVFP4 weight fake quantization.
+
+This is a clean-room implementation of LibreYOLO's reference arithmetic in
+``quant.fake_quant``.  It reads each 16-value block once, derives its E4M3
+scale, rounds onto the E2M1 grid, and writes the dequantized values once.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from libreyolo.quant import fake_quant as _reference
+from libreyolo.quant import kernels
+
+
+_NVFP4_CONFIGS = (
+    triton.Config({"BLOCKS_PER_PROGRAM": 1}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 4}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 8}, num_warps=2, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 16}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 32}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCKS_PER_PROGRAM": 64}, num_warps=8, num_stages=2),
+)
+
+
+@triton.autotune(configs=list(_NVFP4_CONFIGS), key=["n_rows", "n_cols"])
+@triton.jit
+def _fake_quant_nvfp4_weight_kernel(
+    weight_ptr,
+    tensor_amax_ptr,
+    output_ptr,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    BLOCKS_PER_PROGRAM: tl.constexpr,
+):
+    block_width: tl.constexpr = 16
+    blocks_per_row: tl.constexpr = (n_cols + block_width - 1) // block_width
+    total_blocks: tl.constexpr = n_rows * blocks_per_row
+
+    block_ids = tl.program_id(0) * BLOCKS_PER_PROGRAM + tl.arange(0, BLOCKS_PER_PROGRAM)
+    lanes = tl.arange(0, block_width)
+    rows = block_ids[:, None] // blocks_per_row
+    columns = (block_ids[:, None] % blocks_per_row) * block_width + lanes[None, :]
+    valid = (block_ids[:, None] < total_blocks) & (columns < n_cols)
+    offsets = rows * n_cols + columns
+    values = tl.load(weight_ptr + offsets, mask=valid, other=0.0).to(tl.float32)
+
+    tensor_amax = tl.load(tensor_amax_ptr).to(tl.float32)
+    tensor_scale = tl.maximum(tensor_amax / (448.0 * 6.0), 1.0e-12)
+    block_amax = tl.max(tl.abs(values), axis=1, keep_dims=True)
+    block_scale = block_amax / (6.0 * tensor_scale)
+    block_scale = tl.maximum(tl.minimum(block_scale, 448.0), 1.0e-12)
+    block_scale = block_scale.to(tl.float8e4nv).to(tl.float32)
+    effective_scale = tl.maximum(block_scale * tensor_scale, 1.0e-12)
+
+    scaled = libdevice.div_rn(values, effective_scale)
+    magnitude = tl.minimum(tl.abs(scaled), 6.0)
+    level = tl.where(magnitude > 0.25, 0.5, 0.0)
+    level = tl.where(magnitude > 0.75, 1.0, level)
+    level = tl.where(magnitude > 1.25, 1.5, level)
+    level = tl.where(magnitude > 1.75, 2.0, level)
+    level = tl.where(magnitude > 2.5, 3.0, level)
+    level = tl.where(magnitude > 3.5, 4.0, level)
+    level = tl.where(magnitude > 5.0, 6.0, level)
+    sign = tl.where(values > 0.0, 1.0, tl.where(values < 0.0, -1.0, 0.0))
+    quantized = (level * sign) * effective_scale
+    tl.store(output_ptr + offsets, quantized, mask=valid)
+
+
+def _launch(weight: torch.Tensor, tensor_amax: torch.Tensor) -> torch.Tensor:
+    rows, columns = weight.shape
+    blocks_per_row = triton.cdiv(columns, 16)
+    output = torch.empty_like(weight)
+
+    def grid(meta):
+        return (triton.cdiv(rows * blocks_per_row, meta["BLOCKS_PER_PROGRAM"]),)
+
+    _fake_quant_nvfp4_weight_kernel[grid](
+        weight,
+        tensor_amax,
+        output,
+        n_rows=rows,
+        n_cols=columns,
+    )
+    return output
+
+
+class _FakeQuantNVFP4Weight(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        _ctx: Any, weight: torch.Tensor, tensor_amax: torch.Tensor
+    ) -> torch.Tensor:
+        return _launch(weight, tensor_amax)
+
+    @staticmethod
+    def backward(_ctx: Any, grad_output: torch.Tensor):
+        return grad_output, None
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_inputs(weight: torch.Tensor, tensor_amax: torch.Tensor) -> bool:
+    return (
+        weight.is_cuda
+        and tensor_amax.is_cuda
+        and weight.dtype == torch.float32
+        and tensor_amax.dtype == torch.float32
+        and weight.dim() == 2
+        and weight.is_contiguous()
+        and tensor_amax.numel() == 1
+    )
+
+
+def fake_quant_nvfp4_weight(
+    weight: torch.Tensor, tensor_amax: torch.Tensor
+) -> torch.Tensor:
+    """Apply fused NVFP4 fake quantization or safely use the oracle."""
+    if not _supported_inputs(weight, tensor_amax):
+        return _reference.fake_quant_nvfp4_weight(weight, tensor_amax)
+    return _FakeQuantNVFP4Weight.apply(weight, tensor_amax)
+
+
+def autotune_cache() -> list[dict[str, Any]]:
+    """Return selected configurations for the rolling benchmark report."""
+    return [
+        {
+            "rows": key[0],
+            "columns": key[1],
+            "blocks_per_program": config.kwargs["BLOCKS_PER_PROGRAM"],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        for key, config in _fake_quant_nvfp4_weight_kernel.cache.items()
+    ]
+
+
+kernels.register(
+    "fake_quant_nvfp4_weight",
+    fake_quant_nvfp4_weight,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = ["autotune_cache", "fake_quant_nvfp4_weight"]

--- a/libreyolo/quant/kernels/triton/unpack_int_grouped.py
+++ b/libreyolo/quant/kernels/triton/unpack_int_grouped.py
@@ -1,0 +1,222 @@
+"""Fused Triton grouped integer weight unpacking."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+from libreyolo.quant import kernels
+from libreyolo.quant import packing as _reference
+
+
+_UNPACK_CONFIGS = (
+    triton.Config({"BLOCK_SIZE": 256}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 512}, num_warps=2, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+)
+
+
+@triton.autotune(
+    configs=list(_UNPACK_CONFIGS),
+    key=["out_features", "payload_cols", "BITS"],
+)
+@triton.jit
+def _unpack_int_grouped_kernel(
+    payload_ptr,
+    scale_ptr,
+    output_ptr,
+    out_features: tl.constexpr,
+    payload_cols: tl.constexpr,
+    in_features: tl.constexpr,
+    n_groups: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    BITS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    per_byte: tl.constexpr = 8 // BITS
+    total_bytes: tl.constexpr = out_features * payload_cols
+    byte_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid_bytes = byte_offsets < total_bytes
+    rows = byte_offsets // payload_cols
+    byte_columns = byte_offsets % payload_cols
+    output_columns = byte_columns * per_byte
+    packed = tl.load(payload_ptr + byte_offsets, mask=valid_bytes).to(tl.int32)
+    groups = output_columns // GROUP_SIZE
+    scale = tl.maximum(
+        tl.load(scale_ptr + rows * n_groups + groups, mask=valid_bytes),
+        1.0e-12,
+    )
+    output_offsets = rows * in_features + output_columns
+
+    if BITS == 4:
+        low = (packed & 0x0F) - 8
+        high = ((packed >> 4) & 0x0F) - 8
+        tl.store(
+            output_ptr + output_offsets,
+            low.to(tl.float32) * scale,
+            mask=valid_bytes & (output_columns < in_features),
+        )
+        tl.store(
+            output_ptr + output_offsets + 1,
+            high.to(tl.float32) * scale,
+            mask=valid_bytes & (output_columns + 1 < in_features),
+        )
+    else:
+        code0 = (packed & 0x03) - 2
+        code1 = ((packed >> 2) & 0x03) - 2
+        code2 = ((packed >> 4) & 0x03) - 2
+        code3 = ((packed >> 6) & 0x03) - 2
+        tl.store(
+            output_ptr + output_offsets,
+            code0.to(tl.float32) * scale,
+            mask=valid_bytes & (output_columns < in_features),
+        )
+        tl.store(
+            output_ptr + output_offsets + 1,
+            code1.to(tl.float32) * scale,
+            mask=valid_bytes & (output_columns + 1 < in_features),
+        )
+        tl.store(
+            output_ptr + output_offsets + 2,
+            code2.to(tl.float32) * scale,
+            mask=valid_bytes & (output_columns + 2 < in_features),
+        )
+        tl.store(
+            output_ptr + output_offsets + 3,
+            code3.to(tl.float32) * scale,
+            mask=valid_bytes & (output_columns + 3 < in_features),
+        )
+
+
+def _launch(
+    payload: torch.Tensor,
+    scale: torch.Tensor,
+    bits: int,
+    group_size: int,
+    in_features: int,
+) -> torch.Tensor:
+    out_features, payload_cols = payload.shape
+    n_groups = triton.cdiv(in_features, group_size)
+    output = torch.empty(
+        (out_features, in_features),
+        device=payload.device,
+        dtype=torch.float32,
+    )
+
+    def grid(meta):
+        return (triton.cdiv(out_features * payload_cols, meta["BLOCK_SIZE"]),)
+
+    _unpack_int_grouped_kernel[grid](
+        payload,
+        scale,
+        output,
+        out_features=out_features,
+        payload_cols=payload_cols,
+        in_features=in_features,
+        n_groups=n_groups,
+        GROUP_SIZE=group_size,
+        BITS=bits,
+    )
+    return output
+
+
+class _UnpackIntGrouped(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        _ctx: Any,
+        payload: torch.Tensor,
+        scale: torch.Tensor,
+        bits: int,
+        group_size: int,
+        in_features: int,
+    ) -> torch.Tensor:
+        return _launch(payload, scale, bits, group_size, in_features)
+
+    @staticmethod
+    def backward(_ctx: Any, _grad_output: torch.Tensor):
+        return None, None, None, None, None
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_inputs(
+    payload: torch.Tensor,
+    scale: torch.Tensor,
+    bits: int,
+    group_size: int,
+    in_features: int,
+) -> bool:
+    if not (
+        payload.is_cuda
+        and scale.is_cuda
+        and payload.device == scale.device
+        and payload.dtype == torch.uint8
+        and scale.dtype == torch.float32
+        and payload.is_contiguous()
+        and scale.is_contiguous()
+        and payload.dim() == 2
+        and scale.dim() == 2
+        and payload.shape[0] == scale.shape[0]
+        and payload.numel() > 0
+        and not scale.requires_grad
+        and (bits, group_size) in ((4, 128), (2, 64))
+        and in_features > 0
+    ):
+        return False
+    per_byte = 8 // bits
+    n_groups = triton.cdiv(in_features, group_size)
+    padded_features = n_groups * group_size
+    return payload.shape[1] * per_byte == padded_features and scale.shape[1] == n_groups
+
+
+def unpack_int_grouped(
+    payload: torch.Tensor,
+    scale: torch.Tensor,
+    bits: int,
+    group_size: int,
+    in_features: int,
+) -> torch.Tensor:
+    """Decode and scale grouped W4/W2 weights, or safely use the oracle."""
+    if not _supported_inputs(payload, scale, bits, group_size, in_features):
+        return _reference.unpack_int_grouped_weight(
+            payload,
+            scale,
+            bits,
+            group_size,
+            in_features,
+        )
+    return _UnpackIntGrouped.apply(payload, scale, bits, group_size, in_features)
+
+
+def autotune_cache() -> list[dict[str, Any]]:
+    """Return configurations selected for every packed format and shape."""
+    return [
+        {
+            "out_features": key[0],
+            "payload_columns": key[1],
+            "bits": key[2],
+            "block_size": config.kwargs["BLOCK_SIZE"],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        for key, config in _unpack_int_grouped_kernel.cache.items()
+    ]
+
+
+kernels.register(
+    "unpack_int_grouped",
+    unpack_int_grouped,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = ["autotune_cache", "unpack_int_grouped"]

--- a/libreyolo/quant/kernels/triton/unpack_nvfp4.py
+++ b/libreyolo/quant/kernels/triton/unpack_nvfp4.py
@@ -1,0 +1,207 @@
+"""Fused Triton NVFP4 weight unpacking."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+from libreyolo.quant import kernels
+from libreyolo.quant import packing as _reference
+
+
+_UNPACK_CONFIGS = (
+    triton.Config({"BLOCK_SIZE": 256}, num_warps=1, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 512}, num_warps=2, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=1),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+)
+
+
+@triton.jit
+def _decode_e2m1(code):
+    index = code & 0x07
+    level = tl.where(index == 0, 0.0, 0.5)
+    level = tl.where(index == 2, 1.0, level)
+    level = tl.where(index == 3, 1.5, level)
+    level = tl.where(index == 4, 2.0, level)
+    level = tl.where(index == 5, 3.0, level)
+    level = tl.where(index == 6, 4.0, level)
+    level = tl.where(index == 7, 6.0, level)
+    sign = tl.where((code & 0x08) != 0, -1.0, 1.0)
+    return level * sign
+
+
+@triton.autotune(
+    configs=list(_UNPACK_CONFIGS),
+    key=["out_features", "payload_cols"],
+)
+@triton.jit
+def _unpack_nvfp4_kernel(
+    payload_ptr,
+    block_scale_ptr,
+    tensor_amax_ptr,
+    output_ptr,
+    out_features: tl.constexpr,
+    payload_cols: tl.constexpr,
+    in_features: tl.constexpr,
+    n_blocks: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    total_bytes: tl.constexpr = out_features * payload_cols
+    byte_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid_bytes = byte_offsets < total_bytes
+    rows = byte_offsets // payload_cols
+    byte_columns = byte_offsets % payload_cols
+    output_columns = byte_columns * 2
+    packed = tl.load(payload_ptr + byte_offsets, mask=valid_bytes).to(tl.int32)
+    block_indices = output_columns // 16
+    block_scale = tl.load(
+        block_scale_ptr + rows * n_blocks + block_indices,
+        mask=valid_bytes,
+    ).to(tl.float32)
+    tensor_scale = tl.maximum(tl.load(tensor_amax_ptr).to(tl.float32) / 2688.0, 1.0e-12)
+    effective_scale = tl.maximum(block_scale * tensor_scale, 1.0e-12)
+    output_offsets = rows * in_features + output_columns
+    low = _decode_e2m1(packed & 0x0F) * effective_scale
+    high = _decode_e2m1((packed >> 4) & 0x0F) * effective_scale
+    tl.store(
+        output_ptr + output_offsets,
+        low,
+        mask=valid_bytes & (output_columns < in_features),
+    )
+    tl.store(
+        output_ptr + output_offsets + 1,
+        high,
+        mask=valid_bytes & (output_columns + 1 < in_features),
+    )
+
+
+def _launch(
+    payload: torch.Tensor,
+    block_scale: torch.Tensor,
+    tensor_amax: torch.Tensor,
+    in_features: int,
+) -> torch.Tensor:
+    out_features, payload_cols = payload.shape
+    n_blocks = triton.cdiv(in_features, 16)
+    output = torch.empty(
+        (out_features, in_features),
+        device=payload.device,
+        dtype=torch.float32,
+    )
+
+    def grid(meta):
+        return (triton.cdiv(out_features * payload_cols, meta["BLOCK_SIZE"]),)
+
+    _unpack_nvfp4_kernel[grid](
+        payload,
+        block_scale,
+        tensor_amax,
+        output,
+        out_features=out_features,
+        payload_cols=payload_cols,
+        in_features=in_features,
+        n_blocks=n_blocks,
+    )
+    return output
+
+
+class _UnpackNVFP4(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        _ctx: Any,
+        payload: torch.Tensor,
+        block_scale: torch.Tensor,
+        tensor_amax: torch.Tensor,
+        in_features: int,
+    ) -> torch.Tensor:
+        return _launch(payload, block_scale, tensor_amax, in_features)
+
+    @staticmethod
+    def backward(_ctx: Any, _grad_output: torch.Tensor):
+        return None, None, None, None
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+def _supported_inputs(
+    payload: torch.Tensor,
+    block_scale: torch.Tensor,
+    tensor_amax: torch.Tensor,
+    in_features: int,
+) -> bool:
+    scale_dtypes = (torch.float32,)
+    if hasattr(torch, "float8_e4m3fn"):
+        scale_dtypes += (torch.float8_e4m3fn,)
+    if not (
+        payload.is_cuda
+        and block_scale.is_cuda
+        and tensor_amax.is_cuda
+        and payload.device == block_scale.device == tensor_amax.device
+        and payload.dtype == torch.uint8
+        and block_scale.dtype in scale_dtypes
+        and tensor_amax.dtype == torch.float32
+        and payload.is_contiguous()
+        and block_scale.is_contiguous()
+        and tensor_amax.is_contiguous()
+        and payload.dim() == 2
+        and block_scale.dim() == 2
+        and payload.shape[0] == block_scale.shape[0]
+        and payload.numel() > 0
+        and tensor_amax.numel() == 1
+        and not block_scale.requires_grad
+        and not tensor_amax.requires_grad
+        and in_features > 0
+    ):
+        return False
+    n_blocks = triton.cdiv(in_features, 16)
+    return payload.shape[1] == n_blocks * 8 and block_scale.shape[1] == n_blocks
+
+
+def unpack_nvfp4(
+    payload: torch.Tensor,
+    block_scale: torch.Tensor,
+    tensor_amax: torch.Tensor,
+    in_features: int,
+) -> torch.Tensor:
+    """Decode and scale NVFP4 weights, or safely use the eager oracle."""
+    if not _supported_inputs(payload, block_scale, tensor_amax, in_features):
+        return _reference.unpack_nvfp4_weight(
+            payload,
+            block_scale,
+            tensor_amax,
+            in_features,
+        )
+    return _UnpackNVFP4.apply(payload, block_scale, tensor_amax, in_features)
+
+
+def autotune_cache() -> list[dict[str, Any]]:
+    """Return configurations selected for every canonical packed shape."""
+    return [
+        {
+            "out_features": key[0],
+            "payload_columns": key[1],
+            "block_size": config.kwargs["BLOCK_SIZE"],
+            "num_warps": config.num_warps,
+            "num_stages": config.num_stages,
+        }
+        for key, config in _unpack_nvfp4_kernel.cache.items()
+    ]
+
+
+kernels.register(
+    "unpack_nvfp4",
+    unpack_nvfp4,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = ["autotune_cache", "unpack_nvfp4"]

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -320,7 +320,9 @@ class NVFP4Linear(nn.Linear):
 
     def _effective_weight(self) -> torch.Tensor:
         if self.is_finalized:
-            return unpack_nvfp4_weight(
+            # Registry slot: accelerated unpack when available, packing
+            # reference otherwise (identical values either way).
+            return K.unpack_nvfp4(
                 self.weight_packed,
                 self.weight_block_scale,
                 self._q_w_amax,
@@ -416,7 +418,9 @@ class GroupQuantLinear(nn.Linear, _ActObserverMixin):
 
     def _effective_weight(self) -> torch.Tensor:
         if self.is_finalized:
-            return unpack_int_grouped_weight(
+            # Registry slot: accelerated unpack when available, packing
+            # reference otherwise (identical values either way).
+            return K.unpack_int_grouped(
                 self.weight_packed,
                 self._q_w_gscale,
                 self._q_bits,

--- a/tests/unit/kernels/__init__.py
+++ b/tests/unit/kernels/__init__.py
@@ -1,0 +1,1 @@
+"""Parity and benchmark support for optional quantization kernels."""

--- a/tests/unit/kernels/harness.py
+++ b/tests/unit/kernels/harness.py
@@ -1,0 +1,309 @@
+"""Mechanical parity and benchmark gates for quantization kernels."""
+
+from __future__ import annotations
+
+import gc
+import json
+import math
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+import torch
+
+from libreyolo.quant import fake_quant, packing
+
+
+SHAPES_PATH = Path(__file__).resolve().parents[3] / "tools" / "shapes.json"
+
+_REFERENCE_NAMES = {
+    "unpack_int_grouped": "unpack_int_grouped_weight",
+    "unpack_nvfp4": "unpack_nvfp4_weight",
+}
+
+_SHAPE_GROUPS = {
+    "fake_quant_nvfp4_weight": ("linear_weights",),
+    "fake_quant_nvfp4_dynamic": ("linear_activations",),
+    "fake_quant_int8_affine": ("linear_activations", "conv_activations"),
+    "fake_quant_int8_per_channel": ("linear_weights", "conv_weights"),
+    "fake_quant_int_grouped": ("linear_weights",),
+    "fake_quant_fp8": (
+        "linear_weights",
+        "conv_weights",
+        "linear_activations",
+        "conv_activations",
+    ),
+    "fake_quant_mxfp4_weight": ("linear_weights",),
+    "fake_quant_mxfp4_dynamic": ("linear_activations",),
+    "unpack_int_grouped": ("linear_weights",),
+    "unpack_nvfp4": ("linear_weights",),
+}
+
+
+@dataclass
+class OpCase:
+    name: str
+    shape: tuple[int, ...]
+    primary: torch.Tensor
+    args: tuple[Any, ...] = ()
+    kwargs: dict[str, Any] | None = None
+    check_gradient: bool = True
+
+    def invoke(self, function: Callable, primary: torch.Tensor):
+        return function(primary, *self.args, **(self.kwargs or {}))
+
+
+def load_shapes(path: str | Path = SHAPES_PATH) -> dict[str, Any]:
+    with Path(path).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _reference(op: str) -> Callable:
+    name = _REFERENCE_NAMES.get(op, op)
+    owner = packing if op.startswith("unpack_") else fake_quant
+    return getattr(owner, name)
+
+
+def _entries(op: str, shapes: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    seen: set[tuple[int, ...]] = set()
+    for group in _SHAPE_GROUPS[op]:
+        for entry in shapes["canonical"][group]:
+            shape = tuple(int(dim) for dim in entry["shape"])
+            if shape in seen:
+                continue
+            seen.add(shape)
+            yield {"group": group, "shape": shape}
+
+
+def _generator(device: torch.device, label: str) -> torch.Generator:
+    seed = zlib.crc32(label.encode("utf-8"))
+    return torch.Generator(device=device).manual_seed(seed)
+
+
+def _random_tensor(
+    shape: tuple[int, ...], device: torch.device, label: str, scale: float = 1.0
+) -> torch.Tensor:
+    return torch.randn(
+        shape,
+        device=device,
+        dtype=torch.float32,
+        generator=_generator(device, label),
+    ).mul_(scale)
+
+
+def _build_cases(
+    op: str, shapes: dict[str, Any], device: torch.device
+) -> Iterable[OpCase]:
+    for index, entry in enumerate(_entries(op, shapes)):
+        shape = entry["shape"]
+        label = f"{op}:{entry['group']}:{shape}:{index}"
+        tensor = _random_tensor(shape, device, label)
+
+        if op == "fake_quant_nvfp4_weight":
+            tensor.mul_(0.05)
+            amax = tensor.abs().amax().reshape(1)
+            yield OpCase(label, shape, tensor, (amax,))
+        elif op == "fake_quant_nvfp4_dynamic":
+            yield OpCase(label, shape, tensor)
+        elif op == "fake_quant_int8_affine":
+            flat = tensor.view(-1)
+            flat[0] = -5.0
+            if flat.numel() > 1:
+                flat[1] = 6.0
+            lo = torch.tensor([-2.5], device=device)
+            hi = torch.tensor([3.25], device=device)
+            yield OpCase(label, shape, tensor, (lo, hi))
+        elif op == "fake_quant_int8_per_channel":
+            yield OpCase(f"{label}:dynamic-scale", shape, tensor)
+            scale = fake_quant.int8_weight_qparams(tensor, 0).mul(0.75)
+            yield OpCase(
+                f"{label}:frozen-scale",
+                shape,
+                tensor,
+                (),
+                {"scale": scale},
+            )
+        elif op == "fake_quant_int_grouped":
+            for bits, group_size in ((4, 128), (2, 64)):
+                suffix = f"bits{bits}-group{group_size}"
+                yield OpCase(
+                    f"{label}:{suffix}:dynamic-scale",
+                    shape,
+                    tensor,
+                    (bits, group_size),
+                )
+                scale = fake_quant.int_group_qparams(tensor, bits, group_size).mul(0.75)
+                yield OpCase(
+                    f"{label}:{suffix}:frozen-scale",
+                    shape,
+                    tensor,
+                    (bits, group_size),
+                    {"scale": scale},
+                )
+        elif op == "fake_quant_fp8":
+            if entry["group"].endswith("weights"):
+                dims = tuple(range(1, tensor.dim()))
+                amax = tensor.abs()
+                if dims:
+                    amax = amax.amax(dim=dims)
+                scale = (amax / fake_quant.E4M3_MAX).clamp(min=1e-12)
+                scale = scale.reshape(-1, *([1] * (tensor.dim() - 1)))
+                variant = "per-channel"
+            else:
+                scale = tensor.abs().amax().reshape(1) / fake_quant.E4M3_MAX
+                variant = "per-tensor"
+            yield OpCase(f"{label}:{variant}", shape, tensor, (scale,))
+        elif op in ("fake_quant_mxfp4_weight", "fake_quant_mxfp4_dynamic"):
+            yield OpCase(label, shape, tensor)
+        elif op == "unpack_int_grouped":
+            for bits, group_size in ((4, 128), (2, 64)):
+                payload, scale = packing.pack_int_grouped_weight(
+                    tensor, bits, group_size
+                )
+                yield OpCase(
+                    f"{label}:bits{bits}-group{group_size}",
+                    tuple(payload.shape),
+                    payload,
+                    (scale, bits, group_size, shape[1]),
+                    check_gradient=False,
+                )
+        elif op == "unpack_nvfp4":
+            amax = tensor.abs().amax().reshape(1)
+            payload, block_scale = packing.pack_nvfp4_weight(tensor, amax)
+            yield OpCase(
+                label,
+                tuple(payload.shape),
+                payload,
+                (block_scale, amax, shape[1]),
+                check_gradient=False,
+            )
+        else:
+            raise KeyError(f"Unsupported harness operation: {op}")
+
+
+def _clone_primary(primary: torch.Tensor, gradient: bool) -> torch.Tensor:
+    clone = primary.detach().clone()
+    if gradient:
+        clone.requires_grad_(True)
+    return clone
+
+
+def check_parity(
+    op: str,
+    impl: Callable,
+    shapes: dict[str, Any] | str | Path,
+    *,
+    device: str | torch.device = "cuda",
+) -> list[dict[str, Any]]:
+    """Check exact forward and reference-gradient parity on every case."""
+    if not isinstance(shapes, dict):
+        shapes = load_shapes(shapes)
+    target = torch.device(device)
+    reference = _reference(op)
+    results = []
+
+    for case in _build_cases(op, shapes, target):
+        ref_input = _clone_primary(case.primary, case.check_gradient)
+        impl_input = _clone_primary(case.primary, case.check_gradient)
+        ref_output = case.invoke(reference, ref_input)
+        impl_output = case.invoke(impl, impl_input)
+
+        if ref_output.dtype != impl_output.dtype:
+            raise AssertionError(
+                f"{case.name}: dtype mismatch {ref_output.dtype} != {impl_output.dtype}"
+            )
+        if not torch.equal(ref_output, impl_output):
+            mismatch = torch.count_nonzero(ref_output != impl_output).item()
+            max_abs = (ref_output.float() - impl_output.float()).abs().max().item()
+            raise AssertionError(
+                f"{case.name}: forward mismatch in {mismatch}/"
+                f"{ref_output.numel()} values (max_abs={max_abs})"
+            )
+
+        grad_max_abs = None
+        if case.check_gradient:
+            ref_output.sum().backward()
+            impl_output.sum().backward()
+            torch.testing.assert_close(
+                impl_input.grad,
+                ref_input.grad,
+                rtol=0.0,
+                atol=1e-6,
+                msg=lambda message: f"{case.name}: gradient mismatch: {message}",
+            )
+            grad_max_abs = (impl_input.grad - ref_input.grad).abs().max().item()
+
+        results.append(
+            {
+                "case": case.name,
+                "shape": list(case.shape),
+                "forward_exact": True,
+                "gradient": "pass" if case.check_gradient else "not-applicable",
+                "gradient_max_abs": grad_max_abs,
+            }
+        )
+        del ref_input, impl_input, ref_output, impl_output
+        gc.collect()
+
+    return results
+
+
+def bench(
+    op: str,
+    impl: Callable,
+    shapes: dict[str, Any] | str | Path,
+    *,
+    device: str | torch.device = "cuda",
+    warmup: int = 25,
+    rep: int = 100,
+    gate: float | None = None,
+) -> list[dict[str, Any]]:
+    """Benchmark implementation and eager oracle with Triton's ``do_bench``."""
+    import triton
+
+    if not isinstance(shapes, dict):
+        shapes = load_shapes(shapes)
+    target = torch.device(device)
+    reference = _reference(op)
+    results = []
+
+    for case in _build_cases(op, shapes, target):
+        primary = case.primary.detach()
+        with torch.no_grad():
+            case.invoke(impl, primary)
+            case.invoke(reference, primary)
+            torch.cuda.synchronize(target)
+            impl_ms = triton.testing.do_bench(
+                lambda: case.invoke(impl, primary), warmup=warmup, rep=rep
+            )
+            reference_ms = triton.testing.do_bench(
+                lambda: case.invoke(reference, primary), warmup=warmup, rep=rep
+            )
+        speedup = reference_ms / impl_ms
+        row = {
+            "case": case.name,
+            "shape": list(case.shape),
+            "reference_ms": reference_ms,
+            "implementation_ms": impl_ms,
+            "speedup": speedup,
+        }
+        results.append(row)
+        print(
+            f"{case.name:72} ref={reference_ms:9.5f} ms "
+            f"impl={impl_ms:9.5f} ms speedup={speedup:7.3f}x"
+        )
+        gc.collect()
+
+    if not results:
+        raise AssertionError(f"No benchmark cases found for {op}")
+    mean = sum(row["speedup"] for row in results) / len(results)
+    minimum = min(row["speedup"] for row in results)
+    print(f"{op}: mean={mean:.3f}x min={minimum:.3f}x cases={len(results)}")
+    if gate is not None and minimum < gate:
+        raise AssertionError(
+            f"{op}: minimum speedup {minimum:.3f}x does not meet {gate:.3f}x"
+        )
+    if not math.isfinite(mean):
+        raise AssertionError(f"{op}: non-finite benchmark result")
+    return results

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -65,6 +65,11 @@ LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
         "libreyolo.quant.kernels.triton.unpack_int_grouped",
         "unpack_int_grouped",
     ),
+    (
+        "unpack_nvfp4",
+        "libreyolo.quant.kernels.triton.unpack_nvfp4",
+        "unpack_nvfp4",
+    ),
 )
 
 

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -60,6 +60,11 @@ LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
         "libreyolo.quant.kernels.triton.mxfp4",
         "fake_quant_mxfp4_dynamic",
     ),
+    (
+        "unpack_int_grouped",
+        "libreyolo.quant.kernels.triton.unpack_int_grouped",
+        "unpack_int_grouped",
+    ),
 )
 
 

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -50,6 +50,16 @@ LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
         "libreyolo.quant.kernels.triton.fp8",
         "fake_quant_fp8",
     ),
+    (
+        "fake_quant_mxfp4_weight",
+        "libreyolo.quant.kernels.triton.mxfp4",
+        "fake_quant_mxfp4_weight",
+    ),
+    (
+        "fake_quant_mxfp4_dynamic",
+        "libreyolo.quant.kernels.triton.mxfp4",
+        "fake_quant_mxfp4_dynamic",
+    ),
 )
 
 

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -1,0 +1,38 @@
+"""GPU parity tests for Triton quantization kernels.
+
+Benchmarks deliberately stay out of pytest.  Each landed implementation is
+added to ``LANDED_KERNELS`` and checked against every canonical shape.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+
+import pytest
+import torch
+
+from .harness import check_parity, load_shapes
+
+
+pytestmark = pytest.mark.unit
+
+HAS_TRITON_CUDA = (
+    importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+)
+
+# (registry slot, module, public implementation)
+LANDED_KERNELS: tuple[tuple[str, str, str], ...] = ()
+
+
+@pytest.mark.skipif(not HAS_TRITON_CUDA, reason="requires CUDA and Triton")
+@pytest.mark.parametrize(
+    ("op", "module_name", "implementation_name"),
+    LANDED_KERNELS,
+)
+def test_triton_kernel_parity(
+    op: str, module_name: str, implementation_name: str
+) -> None:
+    module = importlib.import_module(module_name)
+    implementation = getattr(module, implementation_name)
+    check_parity(op, implementation, load_shapes())

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -35,6 +35,11 @@ LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
         "libreyolo.quant.kernels.triton.nvfp4_dynamic",
         "fake_quant_nvfp4_dynamic",
     ),
+    (
+        "fake_quant_int8_per_channel",
+        "libreyolo.quant.kernels.triton.int8_per_channel",
+        "fake_quant_int8_per_channel",
+    ),
 )
 
 

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -40,6 +40,11 @@ LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
         "libreyolo.quant.kernels.triton.int8_per_channel",
         "fake_quant_int8_per_channel",
     ),
+    (
+        "fake_quant_int_grouped",
+        "libreyolo.quant.kernels.triton.int_grouped",
+        "fake_quant_int_grouped",
+    ),
 )
 
 

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -12,6 +12,8 @@ import importlib.util
 import pytest
 import torch
 
+from libreyolo.quant import kernels
+
 from .harness import check_parity, load_shapes
 
 
@@ -22,7 +24,13 @@ HAS_TRITON_CUDA = (
 )
 
 # (registry slot, module, public implementation)
-LANDED_KERNELS: tuple[tuple[str, str, str], ...] = ()
+LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
+    (
+        "fake_quant_nvfp4_weight",
+        "libreyolo.quant.kernels.triton.nvfp4_weight",
+        "fake_quant_nvfp4_weight",
+    ),
+)
 
 
 @pytest.mark.skipif(not HAS_TRITON_CUDA, reason="requires CUDA and Triton")
@@ -36,3 +44,25 @@ def test_triton_kernel_parity(
     module = importlib.import_module(module_name)
     implementation = getattr(module, implementation_name)
     check_parity(op, implementation, load_shapes())
+
+
+@pytest.mark.skipif(not HAS_TRITON_CUDA, reason="requires CUDA and Triton")
+@pytest.mark.parametrize(
+    ("op", "module_name", "implementation_name"),
+    LANDED_KERNELS,
+)
+def test_triton_kernel_registration_and_escape_hatch(
+    op: str,
+    module_name: str,
+    implementation_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module(module_name)
+    implementation = getattr(module, implementation_name)
+    monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
+    kernels.clear_cache()
+    assert kernels.resolve(op) is implementation
+
+    monkeypatch.setenv("LIBREYOLO_QUANT_KERNELS", "off")
+    kernels.clear_cache()
+    assert kernels.resolve(op) is not implementation

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -30,6 +30,11 @@ LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
         "libreyolo.quant.kernels.triton.nvfp4_weight",
         "fake_quant_nvfp4_weight",
     ),
+    (
+        "fake_quant_nvfp4_dynamic",
+        "libreyolo.quant.kernels.triton.nvfp4_dynamic",
+        "fake_quant_nvfp4_dynamic",
+    ),
 )
 
 

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -45,6 +45,11 @@ LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
         "libreyolo.quant.kernels.triton.int_grouped",
         "fake_quant_int_grouped",
     ),
+    (
+        "fake_quant_fp8",
+        "libreyolo.quant.kernels.triton.fp8",
+        "fake_quant_fp8",
+    ),
 )
 
 

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -590,6 +590,70 @@ def test_finalized_pt_export_roundtrip(tmp_path, yolo9t):
     assert torch.equal(ref, out3)
 
 
+def test_finalized_w4a16_fp16_remainder_preserves_quant_dtypes(tmp_path):
+    from libreyolo.quant import (
+        GroupQuantLinear,
+        apply_quant_structure,
+        export_finalized_pt,
+        quantize_model,
+        reprepare_model,
+    )
+
+    class TinyWrapper:
+        FAMILY = "rfdetr"
+
+        def __init__(self):
+            self.model = nn.Sequential(nn.Linear(130, 7), nn.LayerNorm(7))
+            self.device = torch.device("cpu")
+            self.size = "n"
+            self.task = "detect"
+            self.nb_classes = 1
+            self.names = {0: "class_0"}
+
+        def _get_model_name(self):
+            return "rfdetr"
+
+        def _get_input_size(self):
+            return 640
+
+    source = TinyWrapper()
+    quantize_model(
+        source,
+        recipe="w4a16",
+        calib=None,
+        keep_high_precision=(),
+        verbose=False,
+    )
+    path = export_finalized_pt(
+        source,
+        out=tmp_path / "tiny-w4a16.pt",
+        remainder="fp16",
+    )
+    checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+    state = checkpoint["model"]
+    assert state["0._q_w_gscale"].dtype == torch.float32
+    assert state["0.weight_packed"].dtype == torch.uint8
+    assert state["0.bias"].dtype == torch.float16
+    assert state["1.weight"].dtype == torch.float16
+
+    loaded = TinyWrapper()
+    apply_quant_structure(loaded, checkpoint["quant"])
+    loaded.model.load_state_dict(state)
+    quant_linear = loaded.model[0]
+    assert isinstance(quant_linear, GroupQuantLinear)
+    assert quant_linear.is_finalized
+    assert quant_linear._q_w_gscale.dtype == torch.float32
+    assert quant_linear.weight_packed.dtype == torch.uint8
+    assert quant_linear.bias.dtype == torch.float16
+    assert loaded.model[1].weight.dtype == torch.float16
+
+    reprepare_model(loaded)
+    assert not quant_linear.is_finalized
+    assert quant_linear.weight.dtype == torch.float32
+    assert quant_linear.bias.dtype == torch.float32
+    assert loaded.model[1].weight.dtype == torch.float32
+
+
 def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):
     yolo9t.quantize(recipe="fp16", verbose=False)
     yolo9t.model.eval()

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -203,12 +203,20 @@ def test_nvfp4_linear_finalize_roundtrip():
 # ---------------------------------------------------------------------------
 
 
-def test_kernel_registry_defaults_to_reference():
+def test_kernel_registry_reference_forced_by_env(monkeypatch):
+    # Order-independent: accelerated kernels may already be registered by
+    # other test modules; forcing the env must always yield the reference.
     from libreyolo.quant import fake_quant, kernels
 
-    for op in kernels.REFERENCE_OPS:
-        assert kernels.resolve(op) is getattr(fake_quant, op)
-    assert kernels.active()["fake_quant_int8_per_channel"] == "reference"
+    monkeypatch.setenv("LIBREYOLO_QUANT_KERNELS", "reference")
+    kernels.clear_cache()
+    try:
+        for op in kernels.REFERENCE_OPS:
+            assert kernels.resolve(op) is getattr(fake_quant, op)
+        assert kernels.active()["fake_quant_int8_per_channel"] == "reference"
+    finally:
+        monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
+        kernels.clear_cache()
 
 
 def test_kernel_registry_custom_impl_and_env_override(monkeypatch):
@@ -252,21 +260,35 @@ def test_kernel_registry_custom_impl_and_env_override(monkeypatch):
 
 
 def test_kernel_registry_predicate_gates_selection():
-    from libreyolo.quant import fake_quant, kernels
+    # Order-independent: a failing predicate must never win the slot,
+    # whichever other implementations happen to be registered.
+    from libreyolo.quant import kernels
 
+    never_impl = lambda *a, **k: None  # noqa: E731
     kernels.register(
-        "fake_quant_int8_per_channel", lambda *a, **k: None, name="never",
+        "fake_quant_int8_per_channel", never_impl, name="never",
         predicate=lambda: False,
     )
     try:
         kernels.clear_cache()
-        assert (
-            kernels.resolve("fake_quant_int8_per_channel")
-            is fake_quant.fake_quant_int8_per_channel
-        )
+        assert kernels.resolve("fake_quant_int8_per_channel") is not never_impl
     finally:
         kernels.unregister("fake_quant_int8_per_channel", "never")
         kernels.clear_cache()
+
+
+def test_intree_triton_kernels_activate():
+    # On machines with triton + CUDA the in-tree kernels must self-activate
+    # lazily on first resolution (no explicit import required).
+    import importlib.util
+
+    if importlib.util.find_spec("triton") is None or not torch.cuda.is_available():
+        pytest.skip("triton + CUDA required")
+    from libreyolo.quant import kernels
+
+    kernels.clear_cache()
+    assert kernels.active()["fake_quant_nvfp4_weight"] == "triton"
+    assert kernels.active()["unpack_nvfp4"] == "triton"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -654,6 +654,66 @@ def test_finalized_w4a16_fp16_remainder_preserves_quant_dtypes(tmp_path):
     assert loaded.model[1].weight.dtype == torch.float32
 
 
+@pytest.mark.parametrize(
+    "recipe,scale_buffer,scale_dtype",
+    [
+        ("nvfp4", "weight_block_scale", torch.float8_e4m3fn),
+        ("mxfp4", "weight_block_exp", torch.int8),
+    ],
+)
+def test_finalized_block_recipes_fp16_remainder_preserves_scale_dtypes(
+    tmp_path, recipe, scale_buffer, scale_dtype
+):
+    from libreyolo.quant import (
+        apply_quant_structure,
+        export_finalized_pt,
+        quantize_model,
+    )
+
+    class TinyWrapper:
+        FAMILY = "rfdetr"
+
+        def __init__(self):
+            self.model = nn.Sequential(nn.Linear(130, 7), nn.LayerNorm(7))
+            self.device = torch.device("cpu")
+            self.size = "n"
+            self.task = "detect"
+            self.nb_classes = 1
+            self.names = {0: "class_0"}
+
+        def _get_model_name(self):
+            return "rfdetr"
+
+        def _get_input_size(self):
+            return 640
+
+    source = TinyWrapper()
+    quantize_model(
+        source,
+        recipe=recipe,
+        calib=None,
+        keep_high_precision=(),
+        verbose=False,
+    )
+    path = export_finalized_pt(
+        source,
+        out=tmp_path / f"tiny-{recipe}.pt",
+        remainder="fp16",
+    )
+    checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+    state = checkpoint["model"]
+    assert state[f"0.{scale_buffer}"].dtype == scale_dtype
+    assert state["0.weight_packed"].dtype == torch.uint8
+    assert state["1.weight"].dtype == torch.float16
+
+    loaded = TinyWrapper()
+    apply_quant_structure(loaded, checkpoint["quant"])
+    loaded.model.load_state_dict(state)
+    assert loaded.model[0].is_finalized
+    assert getattr(loaded.model[0], scale_buffer).dtype == scale_dtype
+    assert loaded.model[0].weight_packed.dtype == torch.uint8
+
+
 def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):
     yolo9t.quantize(recipe="fp16", verbose=False)
     yolo9t.model.eval()

--- a/tools/quant_shapes.py
+++ b/tools/quant_shapes.py
@@ -1,0 +1,305 @@
+"""Extract canonical quantization shapes from the flagship live models.
+
+The generated ``shapes.json`` is the shared input for Triton parity and
+benchmark gates.  Module selection intentionally routes through the same
+policy used by ``model.quantize`` so excluded heads and first layers do not
+silently enter the benchmark corpus.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from libreyolo import LibreYOLO
+from libreyolo.quant.api import _select_modules, default_keep_high_precision
+
+
+RFDETR_MODELS = ("LibreRFDETRn.pt", "LibreRFDETRs.pt")
+RFDETR_IMAGE_SIZES = (384, 512, 576)
+YOLO9_MODELS = ("LibreYOLO9s.pt",)
+YOLO9_IMAGE_SIZES = (640,)
+BATCH_SIZES = (1, 8)
+
+
+def _git_commit() -> str:
+    root = Path(__file__).resolve().parents[1]
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+
+def _tensor_arg(args: tuple[Any, ...]) -> torch.Tensor:
+    for arg in args:
+        if torch.is_tensor(arg):
+            return arg
+    raise RuntimeError("Quantizable module received no tensor positional input")
+
+
+def _resolve_module(root: nn.Module, name: str) -> nn.Module:
+    module = root
+    for part in name.split("."):
+        module = getattr(module, part)
+    return module
+
+
+def _complete_modulelist_observations(
+    root: nn.Module,
+    selected: dict[str, nn.Module],
+    observations: dict[tuple[Any, ...], dict[str, Any]],
+) -> None:
+    """Fill inactive cloned branches from an observed peer's live shape.
+
+    RF-DETR's training-only group branches are cloned ``ModuleList`` entries.
+    Evaluation executes group zero, while training executes every clone with
+    that exact input tensor.  Recording the peer relationship preserves every
+    quantizable module without inventing a synthetic token count.
+    """
+    direct: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in observations.values():
+        direct[record["module"]].append(record)
+
+    for name, module in selected.items():
+        if direct[name]:
+            continue
+        parent_name, separator, _index = name.rpartition(".")
+        if not separator:
+            raise RuntimeError(f"No live activation shape observed for {name}")
+        parent = _resolve_module(root, parent_name)
+        if not isinstance(parent, nn.ModuleList):
+            raise RuntimeError(
+                f"No live activation shape observed for non-ModuleList module {name}"
+            )
+
+        peers = []
+        for peer_index, peer in enumerate(parent):
+            peer_name = f"{parent_name}.{peer_index}"
+            if (
+                peer_name in selected
+                and direct[peer_name]
+                and tuple(peer.weight.shape) == tuple(module.weight.shape)
+            ):
+                peers.append(peer_name)
+        if not peers:
+            raise RuntimeError(
+                f"No shape-compatible observed ModuleList peer found for {name}"
+            )
+
+        source_name = peers[0]
+        for source in direct[source_name]:
+            copied = {
+                **source,
+                "module": name,
+                "inferred_from": source_name,
+            }
+            key = (
+                name,
+                copied["imgsz"],
+                copied["batch"],
+                tuple(copied["shape"]),
+            )
+            observations[key] = copied
+
+
+def _canonical(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[int, ...], dict[str, Any]] = {}
+    for record in records:
+        shape = tuple(record["shape"])
+        entry = grouped.setdefault(
+            shape,
+            {
+                "shape": list(shape),
+                "sources": [],
+                "calls": 0,
+            },
+        )
+        source = f"{record['model']}:{record['module']}"
+        if source not in entry["sources"]:
+            entry["sources"].append(source)
+        entry["calls"] += int(record.get("calls", 1))
+    return sorted(grouped.values(), key=lambda item: tuple(item["shape"]))
+
+
+def _extract_model(
+    checkpoint: str,
+    *,
+    recipe: str,
+    image_sizes: tuple[int, ...],
+    batches: tuple[int, ...],
+    device: torch.device,
+) -> dict[str, list[dict[str, Any]]]:
+    wrapper = LibreYOLO(checkpoint, device=str(device))
+    model = wrapper.model.eval()
+    selected = _select_modules(
+        model,
+        recipe,
+        default_keep_high_precision(wrapper.FAMILY),
+    )
+
+    weights: list[dict[str, Any]] = []
+    for name, module in selected.items():
+        kind = "conv" if type(module) is nn.Conv2d else "linear"
+        record: dict[str, Any] = {
+            "model": checkpoint,
+            "module": name,
+            "shape": list(module.weight.shape),
+        }
+        if kind == "linear":
+            record.update(
+                in_features=module.in_features,
+                out_features=module.out_features,
+            )
+        else:
+            record.update(
+                in_channels=module.in_channels,
+                out_channels=module.out_channels,
+                groups=module.groups,
+                kernel_size=list(module.kernel_size),
+            )
+        weights.append({"kind": kind, **record})
+
+    activation_map: dict[tuple[Any, ...], dict[str, Any]] = {}
+    context: dict[str, int] = {}
+    handles = []
+
+    def make_hook(name: str, kind: str):
+        def hook(_module: nn.Module, args: tuple[Any, ...]) -> None:
+            tensor = _tensor_arg(args)
+            shape = tuple(tensor.shape)
+            key = (name, context["imgsz"], context["batch"], shape)
+            record = activation_map.setdefault(
+                key,
+                {
+                    "kind": kind,
+                    "model": checkpoint,
+                    "module": name,
+                    "imgsz": context["imgsz"],
+                    "batch": context["batch"],
+                    "shape": list(shape),
+                    "calls": 0,
+                },
+            )
+            record["calls"] += 1
+
+        return hook
+
+    for name, module in selected.items():
+        kind = "conv" if type(module) is nn.Conv2d else "linear"
+        handles.append(module.register_forward_pre_hook(make_hook(name, kind)))
+
+    try:
+        with torch.inference_mode():
+            for image_size in image_sizes:
+                for batch in batches:
+                    context.update(imgsz=image_size, batch=batch)
+                    inputs = torch.zeros(
+                        batch,
+                        3,
+                        image_size,
+                        image_size,
+                        device=device,
+                    )
+                    model(inputs)
+                    if device.type == "cuda":
+                        torch.cuda.synchronize(device)
+                    del inputs
+            _complete_modulelist_observations(model, selected, activation_map)
+    finally:
+        for handle in handles:
+            handle.remove()
+        del model, wrapper
+        gc.collect()
+        if device.type == "cuda":
+            torch.cuda.empty_cache()
+
+    return {
+        "weights": weights,
+        "activations": list(activation_map.values()),
+    }
+
+
+def extract_shapes(device: str = "cuda") -> dict[str, Any]:
+    target = torch.device(device)
+    if target.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but torch.cuda.is_available() is false")
+
+    all_weights: list[dict[str, Any]] = []
+    all_activations: list[dict[str, Any]] = []
+    model_runs: list[dict[str, Any]] = []
+
+    suites = (
+        (RFDETR_MODELS, "nvfp4", RFDETR_IMAGE_SIZES),
+        (YOLO9_MODELS, "int8", YOLO9_IMAGE_SIZES),
+    )
+    for checkpoints, recipe, image_sizes in suites:
+        for checkpoint in checkpoints:
+            extracted = _extract_model(
+                checkpoint,
+                recipe=recipe,
+                image_sizes=image_sizes,
+                batches=BATCH_SIZES,
+                device=target,
+            )
+            all_weights.extend(extracted["weights"])
+            all_activations.extend(extracted["activations"])
+            model_runs.append(
+                {
+                    "checkpoint": checkpoint,
+                    "selection_recipe": recipe,
+                    "image_sizes": list(image_sizes),
+                    "batches": list(BATCH_SIZES),
+                }
+            )
+
+    by_kind_weights: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    by_kind_activations: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in all_weights:
+        by_kind_weights[record["kind"]].append(record)
+    for record in all_activations:
+        by_kind_activations[record["kind"]].append(record)
+
+    return {
+        "schema_version": 1,
+        "source_commit": _git_commit(),
+        "device": str(target),
+        "models": model_runs,
+        "modules": {
+            "weights": all_weights,
+            "activations": all_activations,
+        },
+        "canonical": {
+            "linear_weights": _canonical(by_kind_weights["linear"]),
+            "linear_activations": _canonical(by_kind_activations["linear"]),
+            "conv_weights": _canonical(by_kind_weights["conv"]),
+            "conv_activations": _canonical(by_kind_activations["conv"]),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).with_name("shapes.json"),
+    )
+    parser.add_argument("--device", default="cuda")
+    args = parser.parse_args()
+
+    shapes = extract_shapes(args.device)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(shapes, indent=2) + "\n", encoding="utf-8")
+    counts = {name: len(items) for name, items in shapes["canonical"].items()}
+    print(f"wrote {args.output}: {counts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/shapes.json
+++ b/tools/shapes.json
@@ -1,0 +1,30662 @@
+{
+  "schema_version": 1,
+  "source_commit": "67e7ee41a0dfd61b3560b0b93bc4ed89529b960f",
+  "device": "cuda",
+  "models": [
+    {
+      "checkpoint": "LibreRFDETRn.pt",
+      "selection_recipe": "nvfp4",
+      "image_sizes": [
+        384,
+        512,
+        576
+      ],
+      "batches": [
+        1,
+        8
+      ]
+    },
+    {
+      "checkpoint": "LibreRFDETRs.pt",
+      "selection_recipe": "nvfp4",
+      "image_sizes": [
+        384,
+        512,
+        576
+      ],
+      "batches": [
+        1,
+        8
+      ]
+    },
+    {
+      "checkpoint": "LibreYOLO9s.pt",
+      "selection_recipe": "int8",
+      "image_sizes": [
+        640
+      ],
+      "batches": [
+        1,
+        8
+      ]
+    }
+  ],
+  "modules": {
+    "weights": [
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "shape": [
+          64,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 64
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "shape": [
+          32,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 32
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "shape": [
+          2048,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 2048
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "shape": [
+          256,
+          2048
+        ],
+        "in_features": 2048,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "shape": [
+          64,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 64
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "shape": [
+          32,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 32
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "shape": [
+          2048,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 2048
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "shape": [
+          256,
+          2048
+        ],
+        "in_features": 2048,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.0",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.1",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.2",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.3",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.4",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.5",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.6",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.7",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.8",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.9",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.10",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.11",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.12",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "shape": [
+          64,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 64
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "shape": [
+          32,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 32
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "shape": [
+          2048,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 2048
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "shape": [
+          256,
+          2048
+        ],
+        "in_features": 2048,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "shape": [
+          64,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 64
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "shape": [
+          32,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 32
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "shape": [
+          2048,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 2048
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "shape": [
+          256,
+          2048
+        ],
+        "in_features": 2048,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+        "shape": [
+          64,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 64
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.attention_weights",
+        "shape": [
+          32,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 32
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.value_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.output_proj",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear1",
+        "shape": [
+          2048,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 2048
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear2",
+        "shape": [
+          256,
+          2048
+        ],
+        "in_features": 2048,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.0",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.1",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.2",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.3",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.4",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.5",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.6",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.7",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.8",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.9",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.10",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.11",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.12",
+        "shape": [
+          256,
+          256
+        ],
+        "in_features": 256,
+        "out_features": 256
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "shape": [
+          384,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 384
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "shape": [
+          1536,
+          384
+        ],
+        "in_features": 384,
+        "out_features": 1536
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "shape": [
+          384,
+          1536
+        ],
+        "in_features": 1536,
+        "out_features": 384
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.conv1.conv",
+        "shape": [
+          64,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv1.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv3.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv4.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down2.cv.conv",
+        "shape": [
+          128,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv1.conv",
+        "shape": [
+          128,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv1.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv2.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv3.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv1.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv2.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv3.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv4.conv",
+        "shape": [
+          128,
+          256,
+          1,
+          1
+        ],
+        "in_channels": 256,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down3.cv.conv",
+        "shape": [
+          192,
+          128,
+          3,
+          3
+        ],
+        "in_channels": 128,
+        "out_channels": 192,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv1.conv",
+        "shape": [
+          192,
+          192,
+          1,
+          1
+        ],
+        "in_channels": 192,
+        "out_channels": 192,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv1.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv2.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv3.conv",
+        "shape": [
+          96,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.1.conv",
+        "shape": [
+          96,
+          96,
+          3,
+          3
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv1.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv2.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv3.conv",
+        "shape": [
+          96,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.1.conv",
+        "shape": [
+          96,
+          96,
+          3,
+          3
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv4.conv",
+        "shape": [
+          192,
+          384,
+          1,
+          1
+        ],
+        "in_channels": 384,
+        "out_channels": 192,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down4.cv.conv",
+        "shape": [
+          256,
+          192,
+          3,
+          3
+        ],
+        "in_channels": 192,
+        "out_channels": 256,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv1.conv",
+        "shape": [
+          256,
+          256,
+          1,
+          1
+        ],
+        "in_channels": 256,
+        "out_channels": 256,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv1.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv2.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv3.conv",
+        "shape": [
+          128,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.1.conv",
+        "shape": [
+          128,
+          128,
+          3,
+          3
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv1.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv2.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv3.conv",
+        "shape": [
+          128,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.1.conv",
+        "shape": [
+          128,
+          128,
+          3,
+          3
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv4.conv",
+        "shape": [
+          256,
+          512,
+          1,
+          1
+        ],
+        "in_channels": 512,
+        "out_channels": 256,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.spp.cv1.conv",
+        "shape": [
+          128,
+          256,
+          1,
+          1
+        ],
+        "in_channels": 256,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.spp.cv5.conv",
+        "shape": [
+          256,
+          512,
+          1,
+          1
+        ],
+        "in_channels": 512,
+        "out_channels": 256,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv1.conv",
+        "shape": [
+          192,
+          448,
+          1,
+          1
+        ],
+        "in_channels": 448,
+        "out_channels": 192,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv1.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv2.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv3.conv",
+        "shape": [
+          96,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.1.conv",
+        "shape": [
+          96,
+          96,
+          3,
+          3
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv1.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv2.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv3.conv",
+        "shape": [
+          96,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.1.conv",
+        "shape": [
+          96,
+          96,
+          3,
+          3
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv4.conv",
+        "shape": [
+          192,
+          384,
+          1,
+          1
+        ],
+        "in_channels": 384,
+        "out_channels": 192,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv1.conv",
+        "shape": [
+          128,
+          320,
+          1,
+          1
+        ],
+        "in_channels": 320,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv1.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv2.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv3.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv1.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv2.conv",
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv3.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv1.conv1.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv1.conv2.conv",
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv2.conv",
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "in_channels": 32,
+        "out_channels": 32,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv4.conv",
+        "shape": [
+          128,
+          256,
+          1,
+          1
+        ],
+        "in_channels": 256,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.down1.cv.conv",
+        "shape": [
+          96,
+          128,
+          3,
+          3
+        ],
+        "in_channels": 128,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv1.conv",
+        "shape": [
+          192,
+          288,
+          1,
+          1
+        ],
+        "in_channels": 288,
+        "out_channels": 192,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv1.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv2.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv3.conv",
+        "shape": [
+          96,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.1.conv",
+        "shape": [
+          96,
+          96,
+          3,
+          3
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv1.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv2.conv",
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv3.conv",
+        "shape": [
+          96,
+          96,
+          1,
+          1
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv1.conv1.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv1.conv2.conv",
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv2.conv",
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "in_channels": 48,
+        "out_channels": 48,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.1.conv",
+        "shape": [
+          96,
+          96,
+          3,
+          3
+        ],
+        "in_channels": 96,
+        "out_channels": 96,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv4.conv",
+        "shape": [
+          192,
+          384,
+          1,
+          1
+        ],
+        "in_channels": 384,
+        "out_channels": 192,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.down2.cv.conv",
+        "shape": [
+          128,
+          192,
+          3,
+          3
+        ],
+        "in_channels": 192,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv1.conv",
+        "shape": [
+          256,
+          384,
+          1,
+          1
+        ],
+        "in_channels": 384,
+        "out_channels": 256,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv1.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv2.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv3.conv",
+        "shape": [
+          128,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.1.conv",
+        "shape": [
+          128,
+          128,
+          3,
+          3
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv1.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv2.conv",
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv3.conv",
+        "shape": [
+          128,
+          128,
+          1,
+          1
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv1.conv1.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv1.conv2.conv",
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv2.conv",
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "in_channels": 64,
+        "out_channels": 64,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.1.conv",
+        "shape": [
+          128,
+          128,
+          3,
+          3
+        ],
+        "in_channels": 128,
+        "out_channels": 128,
+        "groups": 1,
+        "kernel_size": [
+          3,
+          3
+        ]
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv4.conv",
+        "shape": [
+          256,
+          512,
+          1,
+          1
+        ],
+        "in_channels": 512,
+        "out_channels": 256,
+        "groups": 1,
+        "kernel_size": [
+          1,
+          1
+        ]
+      }
+    ],
+    "activations": [
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRn.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.value_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.attention_weights",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.output_proj",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.value_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.attention_weights",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.output_proj",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.0",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.0.linear2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.1.linear2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.value_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.attention_weights",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.cross_attn.output_proj",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.decoder.layers.2.linear2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.1",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.2",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.3",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.4",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.5",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.6",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.7",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.8",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.9",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.10",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.11",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 384,
+        "batch": 1,
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 384,
+        "batch": 8,
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 512,
+        "batch": 1,
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 512,
+        "batch": 8,
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 576,
+        "batch": 1,
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "linear",
+        "model": "LibreRFDETRs.pt",
+        "module": "model.transformer.enc_output.12",
+        "imgsz": 576,
+        "batch": 8,
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "calls": 1,
+        "inferred_from": "model.transformer.enc_output.0"
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          320,
+          320
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down2.cv.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          159,
+          159
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          256,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down3.cv.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          79,
+          79
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          192,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          384,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down4.cv.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          192,
+          39,
+          39
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          256,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          512,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.spp.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          256,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.spp.cv5.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          512,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          448,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          384,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          320,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          256,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.down1.cv.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          79,
+          79
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          288,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          384,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.down2.cv.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          192,
+          39,
+          39
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          384,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv4.conv",
+        "imgsz": 640,
+        "batch": 1,
+        "shape": [
+          1,
+          512,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          320,
+          320
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan1.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          160,
+          160
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down2.cv.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          159,
+          159
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan2.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          256,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down3.cv.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          79,
+          79
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          192,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan3.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          384,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.down4.cv.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          192,
+          39,
+          39
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          256,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.elan4.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          512,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.spp.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          256,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "backbone.spp.cv5.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          512,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          448,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up1.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          384,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          320,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_up2.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          256,
+          80,
+          80
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.down1.cv.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          79,
+          79
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          288,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down1.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          384,
+          40,
+          40
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.down2.cv.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          192,
+          39,
+          39
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          384,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv2.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.1.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv1.conv1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv1.conv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.m.2.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv2.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.0.cv3.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv3.1.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "calls": 1
+      },
+      {
+        "kind": "conv",
+        "model": "LibreYOLO9s.pt",
+        "module": "neck.elan_down2.cv4.conv",
+        "imgsz": 640,
+        "batch": 8,
+        "shape": [
+          8,
+          512,
+          20,
+          20
+        ],
+        "calls": 1
+      }
+    ]
+  },
+  "canonical": {
+    "linear_weights": [
+      {
+        "shape": [
+          32,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.attention_weights",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.attention_weights"
+        ],
+        "calls": 5
+      },
+      {
+        "shape": [
+          64,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.sampling_offsets"
+        ],
+        "calls": 5
+      },
+      {
+        "shape": [
+          256,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.output_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.output_proj",
+          "LibreRFDETRn.pt:model.transformer.enc_output.0",
+          "LibreRFDETRn.pt:model.transformer.enc_output.1",
+          "LibreRFDETRn.pt:model.transformer.enc_output.2",
+          "LibreRFDETRn.pt:model.transformer.enc_output.3",
+          "LibreRFDETRn.pt:model.transformer.enc_output.4",
+          "LibreRFDETRn.pt:model.transformer.enc_output.5",
+          "LibreRFDETRn.pt:model.transformer.enc_output.6",
+          "LibreRFDETRn.pt:model.transformer.enc_output.7",
+          "LibreRFDETRn.pt:model.transformer.enc_output.8",
+          "LibreRFDETRn.pt:model.transformer.enc_output.9",
+          "LibreRFDETRn.pt:model.transformer.enc_output.10",
+          "LibreRFDETRn.pt:model.transformer.enc_output.11",
+          "LibreRFDETRn.pt:model.transformer.enc_output.12",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.enc_output.0",
+          "LibreRFDETRs.pt:model.transformer.enc_output.1",
+          "LibreRFDETRs.pt:model.transformer.enc_output.2",
+          "LibreRFDETRs.pt:model.transformer.enc_output.3",
+          "LibreRFDETRs.pt:model.transformer.enc_output.4",
+          "LibreRFDETRs.pt:model.transformer.enc_output.5",
+          "LibreRFDETRs.pt:model.transformer.enc_output.6",
+          "LibreRFDETRs.pt:model.transformer.enc_output.7",
+          "LibreRFDETRs.pt:model.transformer.enc_output.8",
+          "LibreRFDETRs.pt:model.transformer.enc_output.9",
+          "LibreRFDETRs.pt:model.transformer.enc_output.10",
+          "LibreRFDETRs.pt:model.transformer.enc_output.11",
+          "LibreRFDETRs.pt:model.transformer.enc_output.12"
+        ],
+        "calls": 36
+      },
+      {
+        "shape": [
+          256,
+          2048
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.linear2",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.linear2"
+        ],
+        "calls": 5
+      },
+      {
+        "shape": [
+          384,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense"
+        ],
+        "calls": 96
+      },
+      {
+        "shape": [
+          384,
+          1536
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          1536,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          2048,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.linear1",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.linear1"
+        ],
+        "calls": 5
+      }
+    ],
+    "linear_activations": [
+      {
+        "shape": [
+          1,
+          300,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.attention_weights",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.output_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.linear1",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.attention_weights",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.output_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.linear1"
+        ],
+        "calls": 60
+      },
+      {
+        "shape": [
+          1,
+          300,
+          2048
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.linear2",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.linear2"
+        ],
+        "calls": 15
+      },
+      {
+        "shape": [
+          1,
+          576,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.enc_output.0",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.enc_output.1",
+          "LibreRFDETRn.pt:model.transformer.enc_output.2",
+          "LibreRFDETRn.pt:model.transformer.enc_output.3",
+          "LibreRFDETRn.pt:model.transformer.enc_output.4",
+          "LibreRFDETRn.pt:model.transformer.enc_output.5",
+          "LibreRFDETRn.pt:model.transformer.enc_output.6",
+          "LibreRFDETRn.pt:model.transformer.enc_output.7",
+          "LibreRFDETRn.pt:model.transformer.enc_output.8",
+          "LibreRFDETRn.pt:model.transformer.enc_output.9",
+          "LibreRFDETRn.pt:model.transformer.enc_output.10",
+          "LibreRFDETRn.pt:model.transformer.enc_output.11",
+          "LibreRFDETRn.pt:model.transformer.enc_output.12",
+          "LibreRFDETRs.pt:model.transformer.enc_output.0",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.enc_output.1",
+          "LibreRFDETRs.pt:model.transformer.enc_output.2",
+          "LibreRFDETRs.pt:model.transformer.enc_output.3",
+          "LibreRFDETRs.pt:model.transformer.enc_output.4",
+          "LibreRFDETRs.pt:model.transformer.enc_output.5",
+          "LibreRFDETRs.pt:model.transformer.enc_output.6",
+          "LibreRFDETRs.pt:model.transformer.enc_output.7",
+          "LibreRFDETRs.pt:model.transformer.enc_output.8",
+          "LibreRFDETRs.pt:model.transformer.enc_output.9",
+          "LibreRFDETRs.pt:model.transformer.enc_output.10",
+          "LibreRFDETRs.pt:model.transformer.enc_output.11",
+          "LibreRFDETRs.pt:model.transformer.enc_output.12"
+        ],
+        "calls": 31
+      },
+      {
+        "shape": [
+          1,
+          580,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          1,
+          1024,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.enc_output.0",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.enc_output.1",
+          "LibreRFDETRn.pt:model.transformer.enc_output.2",
+          "LibreRFDETRn.pt:model.transformer.enc_output.3",
+          "LibreRFDETRn.pt:model.transformer.enc_output.4",
+          "LibreRFDETRn.pt:model.transformer.enc_output.5",
+          "LibreRFDETRn.pt:model.transformer.enc_output.6",
+          "LibreRFDETRn.pt:model.transformer.enc_output.7",
+          "LibreRFDETRn.pt:model.transformer.enc_output.8",
+          "LibreRFDETRn.pt:model.transformer.enc_output.9",
+          "LibreRFDETRn.pt:model.transformer.enc_output.10",
+          "LibreRFDETRn.pt:model.transformer.enc_output.11",
+          "LibreRFDETRn.pt:model.transformer.enc_output.12",
+          "LibreRFDETRs.pt:model.transformer.enc_output.0",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.enc_output.1",
+          "LibreRFDETRs.pt:model.transformer.enc_output.2",
+          "LibreRFDETRs.pt:model.transformer.enc_output.3",
+          "LibreRFDETRs.pt:model.transformer.enc_output.4",
+          "LibreRFDETRs.pt:model.transformer.enc_output.5",
+          "LibreRFDETRs.pt:model.transformer.enc_output.6",
+          "LibreRFDETRs.pt:model.transformer.enc_output.7",
+          "LibreRFDETRs.pt:model.transformer.enc_output.8",
+          "LibreRFDETRs.pt:model.transformer.enc_output.9",
+          "LibreRFDETRs.pt:model.transformer.enc_output.10",
+          "LibreRFDETRs.pt:model.transformer.enc_output.11",
+          "LibreRFDETRs.pt:model.transformer.enc_output.12"
+        ],
+        "calls": 31
+      },
+      {
+        "shape": [
+          1,
+          1028,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          1,
+          1296,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.enc_output.0",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.enc_output.1",
+          "LibreRFDETRn.pt:model.transformer.enc_output.2",
+          "LibreRFDETRn.pt:model.transformer.enc_output.3",
+          "LibreRFDETRn.pt:model.transformer.enc_output.4",
+          "LibreRFDETRn.pt:model.transformer.enc_output.5",
+          "LibreRFDETRn.pt:model.transformer.enc_output.6",
+          "LibreRFDETRn.pt:model.transformer.enc_output.7",
+          "LibreRFDETRn.pt:model.transformer.enc_output.8",
+          "LibreRFDETRn.pt:model.transformer.enc_output.9",
+          "LibreRFDETRn.pt:model.transformer.enc_output.10",
+          "LibreRFDETRn.pt:model.transformer.enc_output.11",
+          "LibreRFDETRn.pt:model.transformer.enc_output.12",
+          "LibreRFDETRs.pt:model.transformer.enc_output.0",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.enc_output.1",
+          "LibreRFDETRs.pt:model.transformer.enc_output.2",
+          "LibreRFDETRs.pt:model.transformer.enc_output.3",
+          "LibreRFDETRs.pt:model.transformer.enc_output.4",
+          "LibreRFDETRs.pt:model.transformer.enc_output.5",
+          "LibreRFDETRs.pt:model.transformer.enc_output.6",
+          "LibreRFDETRs.pt:model.transformer.enc_output.7",
+          "LibreRFDETRs.pt:model.transformer.enc_output.8",
+          "LibreRFDETRs.pt:model.transformer.enc_output.9",
+          "LibreRFDETRs.pt:model.transformer.enc_output.10",
+          "LibreRFDETRs.pt:model.transformer.enc_output.11",
+          "LibreRFDETRs.pt:model.transformer.enc_output.12"
+        ],
+        "calls": 31
+      },
+      {
+        "shape": [
+          1,
+          1300,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          4,
+          145,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1"
+        ],
+        "calls": 96
+      },
+      {
+        "shape": [
+          4,
+          145,
+          1536
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          4,
+          257,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1"
+        ],
+        "calls": 96
+      },
+      {
+        "shape": [
+          4,
+          257,
+          1536
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          4,
+          325,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1"
+        ],
+        "calls": 96
+      },
+      {
+        "shape": [
+          4,
+          325,
+          1536
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          8,
+          300,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.attention_weights",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.output_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.linear1",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.attention_weights",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.output_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.linear1",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.sampling_offsets",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.attention_weights",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.output_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.linear1"
+        ],
+        "calls": 60
+      },
+      {
+        "shape": [
+          8,
+          300,
+          2048
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.linear2",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.linear2",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.linear2"
+        ],
+        "calls": 15
+      },
+      {
+        "shape": [
+          8,
+          576,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.enc_output.0",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.enc_output.1",
+          "LibreRFDETRn.pt:model.transformer.enc_output.2",
+          "LibreRFDETRn.pt:model.transformer.enc_output.3",
+          "LibreRFDETRn.pt:model.transformer.enc_output.4",
+          "LibreRFDETRn.pt:model.transformer.enc_output.5",
+          "LibreRFDETRn.pt:model.transformer.enc_output.6",
+          "LibreRFDETRn.pt:model.transformer.enc_output.7",
+          "LibreRFDETRn.pt:model.transformer.enc_output.8",
+          "LibreRFDETRn.pt:model.transformer.enc_output.9",
+          "LibreRFDETRn.pt:model.transformer.enc_output.10",
+          "LibreRFDETRn.pt:model.transformer.enc_output.11",
+          "LibreRFDETRn.pt:model.transformer.enc_output.12",
+          "LibreRFDETRs.pt:model.transformer.enc_output.0",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.enc_output.1",
+          "LibreRFDETRs.pt:model.transformer.enc_output.2",
+          "LibreRFDETRs.pt:model.transformer.enc_output.3",
+          "LibreRFDETRs.pt:model.transformer.enc_output.4",
+          "LibreRFDETRs.pt:model.transformer.enc_output.5",
+          "LibreRFDETRs.pt:model.transformer.enc_output.6",
+          "LibreRFDETRs.pt:model.transformer.enc_output.7",
+          "LibreRFDETRs.pt:model.transformer.enc_output.8",
+          "LibreRFDETRs.pt:model.transformer.enc_output.9",
+          "LibreRFDETRs.pt:model.transformer.enc_output.10",
+          "LibreRFDETRs.pt:model.transformer.enc_output.11",
+          "LibreRFDETRs.pt:model.transformer.enc_output.12"
+        ],
+        "calls": 31
+      },
+      {
+        "shape": [
+          8,
+          580,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          8,
+          1024,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.enc_output.0",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.enc_output.1",
+          "LibreRFDETRn.pt:model.transformer.enc_output.2",
+          "LibreRFDETRn.pt:model.transformer.enc_output.3",
+          "LibreRFDETRn.pt:model.transformer.enc_output.4",
+          "LibreRFDETRn.pt:model.transformer.enc_output.5",
+          "LibreRFDETRn.pt:model.transformer.enc_output.6",
+          "LibreRFDETRn.pt:model.transformer.enc_output.7",
+          "LibreRFDETRn.pt:model.transformer.enc_output.8",
+          "LibreRFDETRn.pt:model.transformer.enc_output.9",
+          "LibreRFDETRn.pt:model.transformer.enc_output.10",
+          "LibreRFDETRn.pt:model.transformer.enc_output.11",
+          "LibreRFDETRn.pt:model.transformer.enc_output.12",
+          "LibreRFDETRs.pt:model.transformer.enc_output.0",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.enc_output.1",
+          "LibreRFDETRs.pt:model.transformer.enc_output.2",
+          "LibreRFDETRs.pt:model.transformer.enc_output.3",
+          "LibreRFDETRs.pt:model.transformer.enc_output.4",
+          "LibreRFDETRs.pt:model.transformer.enc_output.5",
+          "LibreRFDETRs.pt:model.transformer.enc_output.6",
+          "LibreRFDETRs.pt:model.transformer.enc_output.7",
+          "LibreRFDETRs.pt:model.transformer.enc_output.8",
+          "LibreRFDETRs.pt:model.transformer.enc_output.9",
+          "LibreRFDETRs.pt:model.transformer.enc_output.10",
+          "LibreRFDETRs.pt:model.transformer.enc_output.11",
+          "LibreRFDETRs.pt:model.transformer.enc_output.12"
+        ],
+        "calls": 31
+      },
+      {
+        "shape": [
+          8,
+          1028,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          8,
+          1296,
+          256
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.transformer.enc_output.0",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRn.pt:model.transformer.enc_output.1",
+          "LibreRFDETRn.pt:model.transformer.enc_output.2",
+          "LibreRFDETRn.pt:model.transformer.enc_output.3",
+          "LibreRFDETRn.pt:model.transformer.enc_output.4",
+          "LibreRFDETRn.pt:model.transformer.enc_output.5",
+          "LibreRFDETRn.pt:model.transformer.enc_output.6",
+          "LibreRFDETRn.pt:model.transformer.enc_output.7",
+          "LibreRFDETRn.pt:model.transformer.enc_output.8",
+          "LibreRFDETRn.pt:model.transformer.enc_output.9",
+          "LibreRFDETRn.pt:model.transformer.enc_output.10",
+          "LibreRFDETRn.pt:model.transformer.enc_output.11",
+          "LibreRFDETRn.pt:model.transformer.enc_output.12",
+          "LibreRFDETRs.pt:model.transformer.enc_output.0",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.0.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.1.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.decoder.layers.2.cross_attn.value_proj",
+          "LibreRFDETRs.pt:model.transformer.enc_output.1",
+          "LibreRFDETRs.pt:model.transformer.enc_output.2",
+          "LibreRFDETRs.pt:model.transformer.enc_output.3",
+          "LibreRFDETRs.pt:model.transformer.enc_output.4",
+          "LibreRFDETRs.pt:model.transformer.enc_output.5",
+          "LibreRFDETRs.pt:model.transformer.enc_output.6",
+          "LibreRFDETRs.pt:model.transformer.enc_output.7",
+          "LibreRFDETRs.pt:model.transformer.enc_output.8",
+          "LibreRFDETRs.pt:model.transformer.enc_output.9",
+          "LibreRFDETRs.pt:model.transformer.enc_output.10",
+          "LibreRFDETRs.pt:model.transformer.enc_output.11",
+          "LibreRFDETRs.pt:model.transformer.enc_output.12"
+        ],
+        "calls": 31
+      },
+      {
+        "shape": [
+          8,
+          1300,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.attention.output.dense"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          32,
+          145,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1"
+        ],
+        "calls": 96
+      },
+      {
+        "shape": [
+          32,
+          145,
+          1536
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          32,
+          257,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1"
+        ],
+        "calls": 96
+      },
+      {
+        "shape": [
+          32,
+          257,
+          1536
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          32,
+          325,
+          384
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc1",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.query",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.key",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.attention.value",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.attention.output.dense",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc1"
+        ],
+        "calls": 96
+      },
+      {
+        "shape": [
+          32,
+          325,
+          1536
+        ],
+        "sources": [
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRn.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.0.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.1.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.2.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.3.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.4.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.5.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.6.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.7.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.8.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.9.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.10.mlp.fc2",
+          "LibreRFDETRs.pt:model.backbone.0.encoder.encoder.encoder.layer.11.mlp.fc2"
+        ],
+        "calls": 24
+      }
+    ],
+    "conv_weights": [
+      {
+        "shape": [
+          32,
+          32,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv1.conv2.conv"
+        ],
+        "calls": 12
+      },
+      {
+        "shape": [
+          32,
+          32,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan1.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 26
+      },
+      {
+        "shape": [
+          32,
+          64,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv2.conv"
+        ],
+        "calls": 8
+      },
+      {
+        "shape": [
+          48,
+          48,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv1.conv2.conv"
+        ],
+        "calls": 18
+      },
+      {
+        "shape": [
+          48,
+          48,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 36
+      },
+      {
+        "shape": [
+          48,
+          96,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv2.conv"
+        ],
+        "calls": 12
+      },
+      {
+        "shape": [
+          64,
+          32,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.conv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          64,
+          64,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv1.conv2.conv"
+        ],
+        "calls": 17
+      },
+      {
+        "shape": [
+          64,
+          64,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 28
+      },
+      {
+        "shape": [
+          64,
+          128,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv4.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv2.conv"
+        ],
+        "calls": 9
+      },
+      {
+        "shape": [
+          96,
+          96,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv3.conv"
+        ],
+        "calls": 6
+      },
+      {
+        "shape": [
+          96,
+          96,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.1.conv"
+        ],
+        "calls": 6
+      },
+      {
+        "shape": [
+          96,
+          128,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.down1.cv.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          128,
+          64,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down2.cv.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          128,
+          128,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv3.conv"
+        ],
+        "calls": 5
+      },
+      {
+        "shape": [
+          128,
+          128,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.1.conv"
+        ],
+        "calls": 4
+      },
+      {
+        "shape": [
+          128,
+          192,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.down2.cv.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          128,
+          256,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv4.conv",
+          "LibreYOLO9s.pt:backbone.spp.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv4.conv"
+        ],
+        "calls": 3
+      },
+      {
+        "shape": [
+          128,
+          320,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_up2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          192,
+          128,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down3.cv.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          192,
+          192,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          192,
+          288,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_down1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          192,
+          384,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv4.conv"
+        ],
+        "calls": 3
+      },
+      {
+        "shape": [
+          192,
+          448,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_up1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          256,
+          192,
+          3,
+          3
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down4.cv.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          256,
+          256,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          256,
+          384,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_down2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          256,
+          512,
+          1,
+          1
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv4.conv",
+          "LibreYOLO9s.pt:backbone.spp.cv5.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv4.conv"
+        ],
+        "calls": 3
+      }
+    ],
+    "conv_activations": [
+      {
+        "shape": [
+          1,
+          32,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 36
+      },
+      {
+        "shape": [
+          1,
+          32,
+          160,
+          160
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan1.cv3.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          1,
+          32,
+          320,
+          320
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.conv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          48,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 54
+      },
+      {
+        "shape": [
+          1,
+          64,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 36
+      },
+      {
+        "shape": [
+          1,
+          64,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.1.conv"
+        ],
+        "calls": 16
+      },
+      {
+        "shape": [
+          1,
+          64,
+          159,
+          159
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down2.cv.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          64,
+          160,
+          160
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          96,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.1.conv"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          1,
+          128,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.1.conv"
+        ],
+        "calls": 16
+      },
+      {
+        "shape": [
+          1,
+          128,
+          79,
+          79
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down3.cv.conv",
+          "LibreYOLO9s.pt:neck.down1.cv.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          1,
+          128,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          128,
+          160,
+          160
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv4.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          192,
+          39,
+          39
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down4.cv.conv",
+          "LibreYOLO9s.pt:neck.down2.cv.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          1,
+          192,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          256,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv1.conv",
+          "LibreYOLO9s.pt:backbone.spp.cv1.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          1,
+          256,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv4.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          1,
+          288,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_down1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          320,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_up2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          384,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_down2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          384,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv4.conv"
+        ],
+        "calls": 3
+      },
+      {
+        "shape": [
+          1,
+          448,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_up1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          1,
+          512,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv4.conv",
+          "LibreYOLO9s.pt:backbone.spp.cv5.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv4.conv"
+        ],
+        "calls": 3
+      },
+      {
+        "shape": [
+          8,
+          32,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 36
+      },
+      {
+        "shape": [
+          8,
+          32,
+          160,
+          160
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan1.cv3.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          8,
+          32,
+          320,
+          320
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.conv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          48,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 54
+      },
+      {
+        "shape": [
+          8,
+          64,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.m.2.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.1.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv1.conv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv1.conv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.m.2.cv2.conv"
+        ],
+        "calls": 36
+      },
+      {
+        "shape": [
+          8,
+          64,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan2.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv3.1.conv"
+        ],
+        "calls": 16
+      },
+      {
+        "shape": [
+          8,
+          64,
+          159,
+          159
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down2.cv.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          64,
+          160,
+          160
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          96,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan3.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv3.1.conv"
+        ],
+        "calls": 24
+      },
+      {
+        "shape": [
+          8,
+          128,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv2.1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:backbone.elan4.cv3.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv2.1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv1.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv2.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.0.cv3.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv3.1.conv"
+        ],
+        "calls": 16
+      },
+      {
+        "shape": [
+          8,
+          128,
+          79,
+          79
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down3.cv.conv",
+          "LibreYOLO9s.pt:neck.down1.cv.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          8,
+          128,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          128,
+          160,
+          160
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan1.cv4.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          192,
+          39,
+          39
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.down4.cv.conv",
+          "LibreYOLO9s.pt:neck.down2.cv.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          8,
+          192,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          256,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv1.conv",
+          "LibreYOLO9s.pt:backbone.spp.cv1.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          8,
+          256,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan2.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_up2.cv4.conv"
+        ],
+        "calls": 2
+      },
+      {
+        "shape": [
+          8,
+          288,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_down1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          320,
+          80,
+          80
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_up2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          384,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_down2.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          384,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan3.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_up1.cv4.conv",
+          "LibreYOLO9s.pt:neck.elan_down1.cv4.conv"
+        ],
+        "calls": 3
+      },
+      {
+        "shape": [
+          8,
+          448,
+          40,
+          40
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:neck.elan_up1.cv1.conv"
+        ],
+        "calls": 1
+      },
+      {
+        "shape": [
+          8,
+          512,
+          20,
+          20
+        ],
+        "sources": [
+          "LibreYOLO9s.pt:backbone.elan4.cv4.conv",
+          "LibreYOLO9s.pt:backbone.spp.cv5.conv",
+          "LibreYOLO9s.pt:neck.elan_down2.cv4.conv"
+        ],
+        "calls": 3
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What this adds

Triton acceleration for the quantization stack, behind the existing kernel
registry: 10 commits, no changes to model code, reference implementations,
or the packing contract.

- 8 fused Triton kernels in `libreyolo/quant/kernels/triton/`: NVFP4 weight
  and dynamic-activation fake-quant, per-channel INT8 weight fake-quant,
  grouped INT4/INT2 fake-quant, FP8 fake-quant, MXFP4 weight and dynamic
  fake-quant, and fused unpack kernels for finalized w4 and nvfp4
  checkpoints. Every kernel: `@triton.autotune` (no hardcoded tile sizes),
  a `torch.autograd.Function` STE wrapper whose gradients match the
  reference exactly, and a capability predicate (triton + CUDA).
- Registry integration: in-tree kernels self-activate lazily on first op
  resolution (`import libreyolo` cost unchanged; `LIBREYOLO_QUANT_KERNELS=off`
  skips the import and forces the reference path). The packing unpack
  functions register as reference implementations for the two new unpack
  slots, and the finalized GroupQuantLinear/NVFP4Linear hot paths route
  through those slots.
- Harness: `tools/quant_shapes.py` (canonical shape inventory from live
  rfdetr-n/s and yolo9-s models), a reusable parity+bench harness, and
  per-kernel parity tests.
- One queue item deferred by its own gate: a fused int8 activation QDQ
  reached 1.368x against a 1.5x bar (shortest reference chain, least
  fusion headroom); preserved out of tree for a later retry.

## Verification (GPU evidence; note CI runners have no GPU, so the kernel
tests SKIP in CI and the claims below were verified locally)

- Suite: 55 passed, 1 skipped, 0 failed (kernels + quantization suites in
  one process; the two registry tests are now order-independent).
- Independent adversarial audit beyond the in-tree tests: exact forward
  parity AND exact gradient parity against the reference implementations on
  shapes outside the tuning set (including 1x16, 33x257, 128x4099, conv
  shapes, partial groups); all four quantized module classes produce
  bit-identical outputs with kernels on vs `LIBREYOLO_QUANT_KERNELS=off`.
- Model-level, RF-DETR-n on RTX 5070 Ti (sm_120), outputs bit-identical on
  vs off: prepared nvfp4 inference 2.40x faster, QAT/QAD training step
  (forward+backward) 1.95x faster, finalized w4a16 forward 1.10x faster.
- Kernel-level mean speedups vs reference on the canonical shapes range
  from ~5x to ~35x (per-kernel tables in the campaign report).

## Pre-merge checklist

- [ ] Second-architecture verification (parity + bench gates on a non-
  Blackwell CUDA GPU, e.g. a rented Ampere/Ada instance): kernels are
  currently single-architecture-verified. Half-hour run; results will be
  posted on this PR before merge.

## Code provenance

All code in this PR is original, written for this PR against Triton's
public API (`triton.language`, `triton.autotune`, `libdevice`). No code was
ported, adapted, or derived from any third-party kernel implementation
(GPTQ, Marlin, llama.cpp, or others). The reference implementations it is
tested against are LibreYOLO's own (merged in #619). Dependencies used via
public APIs only: torch (BSD-3) and triton (MIT), both already shipped
together by PyTorch; triton remains an optional runtime accelerant, not an
install requirement.
