### PR TITLE
Warn on RF-DETR head reinit and fix distill-config and quant-docs drift

### DIFF
--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -90,8 +90,8 @@ v1 executes quantized arithmetic in **simulation** (fake-quantization with
 straight-through-estimator gradients, computed in fp32 islands even under
 AMP). Simulation is numerics-true: a `val()` score on any device is a real
 claim about the quantized arithmetic. It is not a speed claim; packed
-low-bit kernels are a separate deployment concern. `fp16` is the exception:
-it executes natively.
+low-bit kernels are a separate deployment concern. The `fp16` and `bf16`
+casts are the exception: they execute natively.
 
 `model.quant_info()` reports the recipe, module counts, calibration state,
 and execution tier.

--- a/libreyolo/distillation/configs.py
+++ b/libreyolo/distillation/configs.py
@@ -23,7 +23,7 @@ def get_distill_config(family: str, size: str) -> Dict:
     have a model instance, call ``model.get_distill_config()`` directly.
 
     Args:
-        family: Model family string (e.g., "yolo9", "yolox").
+        family: Model family string (e.g., "yolo9", "yolox", "rfdetr").
         size: Model size string (e.g., "t", "s", "m", "c", "l", "x").
 
     Returns:
@@ -47,6 +47,12 @@ def get_distill_config(family: str, size: str) -> Dict:
         model = LibreYOLOX(model_path=None, size=size)
         return model.get_distill_config()
 
+    elif family == "rfdetr":
+        from ..models.rfdetr.model import LibreRFDETR
+
+        model = LibreRFDETR(model_path=None, size=size)
+        return model.get_distill_config()
+
     else:
         raise ValueError(
             f"Distillation not yet configured for family '{family}'. "
@@ -57,4 +63,4 @@ def get_distill_config(family: str, size: str) -> Dict:
 
 def list_supported() -> List[str]:
     """Return list of model families with distillation support."""
-    return ["yolo9", "yolox"]
+    return ["yolo9", "yolox", "rfdetr"]

--- a/libreyolo/distillation/configs.py
+++ b/libreyolo/distillation/configs.py
@@ -24,7 +24,10 @@ def get_distill_config(family: str, size: str) -> Dict:
 
     Args:
         family: Model family string (e.g., "yolo9", "yolox", "rfdetr").
-        size: Model size string (e.g., "t", "s", "m", "c", "l", "x").
+        size: Model size string (e.g., "t", "s", "m", "c", "l", "x"). Sizes
+            are validated against the family's detect task; for sizes that
+            only exist for another task, instantiate the model with that
+            task and call ``model.get_distill_config()`` directly.
 
     Returns:
         Dict with keys:
@@ -50,7 +53,11 @@ def get_distill_config(family: str, size: str) -> Dict:
     elif family == "rfdetr":
         from ..models.rfdetr.model import LibreRFDETR
 
-        model = LibreRFDETR(model_path=None, size=size)
+        # model_path={} is the build-without-weights sentinel: model_path=None
+        # would resolve and download the default pretrained checkpoint, and
+        # this helper must stay lightweight and offline-safe. The probe that
+        # measures tap shapes only needs the architecture, not the weights.
+        model = LibreRFDETR(model_path={}, size=size)
         return model.get_distill_config()
 
     else:

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -597,15 +597,16 @@ class RFDETRTrainer(BaseTrainer):
                 if task == "pose"
                 else self.config.num_classes + 1
             )
-            logger.warning(
-                "Class count changed (checkpoint head: %d classes, dataset: %d): "
-                "reinitializing the detection head from scratch. The pretrained "
-                "head weights are discarded, so accuracy starts low and short "
-                "fine-tunes underperform the checkpoint; budget enough epochs "
-                "for the new head to converge.",
-                self.model.nb_classes,
-                self.config.num_classes,
-            )
+            if is_main_process():
+                logger.warning(
+                    "Class count changed (checkpoint head: %d classes, dataset: %d): "
+                    "reinitializing the detection head from scratch. The pretrained "
+                    "head weights are discarded, so accuracy starts low and short "
+                    "fine-tunes underperform the checkpoint; budget enough epochs "
+                    "for the new head to converge.",
+                    self.model.nb_classes,
+                    self.config.num_classes,
+                )
             self.model.model.reinitialize_detection_head(head_outputs)
             self.model.nb_classes = self.config.num_classes
             self.model.args.num_classes = (

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -597,6 +597,15 @@ class RFDETRTrainer(BaseTrainer):
                 if task == "pose"
                 else self.config.num_classes + 1
             )
+            logger.warning(
+                "Class count changed (checkpoint head: %d classes, dataset: %d): "
+                "reinitializing the detection head from scratch. The pretrained "
+                "head weights are discarded, so accuracy starts low and short "
+                "fine-tunes underperform the checkpoint; budget enough epochs "
+                "for the new head to converge.",
+                self.model.nb_classes,
+                self.config.num_classes,
+            )
             self.model.model.reinitialize_detection_head(head_outputs)
             self.model.nb_classes = self.config.num_classes
             self.model.args.num_classes = (

--- a/tests/unit/test_distillation.py
+++ b/tests/unit/test_distillation.py
@@ -676,7 +676,7 @@ class TestModelDistillConfig:
         # BaseModel can't be instantiated directly (ABC), so test via the
         # get_distill_config convenience function with an unknown family
         with pytest.raises(ValueError, match="not yet configured"):
-            get_distill_config("rfdetr", "n")
+            get_distill_config("picodet", "n")
 
     def test_model_config_matches_convenience_function(self):
         """Model wrapper and convenience function should return identical configs."""


### PR DESCRIPTION
Three small fixes from the 2026-07-19 quantization viability campaign:

- RF-DETR training now warns loudly when a class-count change reinitializes the detection head: the pretrained head is discarded, so short fine-tunes underperform until the new head converges (measured ~9 mAP points at a 5-epoch budget even in fp32).
- get_distill_config(family=...) now routes "rfdetr" to the model class, which already implemented get_distill_config(); the helper rejected it, and the unsupported-family unit test had fossilized that drift (now uses picodet as the unknown family).
- Quantization docs: fp16 and bf16 casts both execute natively; the wording claimed fp16 only.

Tests: tests/unit/test_distillation*.py and test_rfdetr_lr_contract.py, 79 passed.

## Code provenance

All changes in this PR are original, written for this PR against the existing LibreYOLO codebase. No code was ported, adapted, or derived from any third-party source.
