### PR TITLE
Fix finalized quant remainder dtypes

### DIFF
--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -498,19 +498,26 @@ def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
         model_copy = model_copy.cpu()
         new_sd = model_copy.state_dict()
         if remainder == "fp16" and recipe not in CAST_RECIPES:
-            keep_exact = (
-                "_q_w_scale",
-                "_q_w_gscale",
-                "_q_act_lo",
-                "_q_act_hi",
-                "_q_w_amax",
+            # Quant buffers keep their contract dtypes (packed payloads,
+            # scales, exponents, observer state); only the non-quantized
+            # remainder is cast. Collect the buffer names from the
+            # finalized modules themselves so recipes that register new
+            # buffers stay protected without maintaining a name list here.
+            keep_exact = tuple(
+                sorted(
+                    {
+                        "." + name
+                        for _, module in _quant_modules(model_copy)
+                        for name, _ in module.named_buffers(recurse=False)
+                    }
+                )
             )
             new_sd = {
                 key: (
                     value.half()
                     if torch.is_tensor(value)
                     and value.dtype == torch.float32
-                    and not key.endswith(keep_exact)
+                    and not (keep_exact and key.endswith(keep_exact))
                     else value
                 )
                 for key, value in new_sd.items()

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -192,6 +192,27 @@ def _quant_modules(root: nn.Module):
             yield name, module
 
 
+def _cast_finalized_remainder(root: nn.Module, dtype: torch.dtype):
+    """Cast deployment parameters without changing quantized buffer formats."""
+    exact_buffers = {
+        id(buffer)
+        for _, module in _quant_modules(root)
+        for buffer in module.buffers(recurse=False)
+    }
+    with torch.no_grad():
+        for parameter in root.parameters():
+            if parameter.is_floating_point() and parameter.dtype != dtype:
+                parameter.data = parameter.data.to(dtype)
+        for module in root.modules():
+            for buffer in module.buffers(recurse=False):
+                if (
+                    id(buffer) not in exact_buffers
+                    and buffer.is_floating_point()
+                    and buffer.dtype != dtype
+                ):
+                    buffer.data = buffer.data.to(dtype)
+
+
 def _cast_tree(obj, dtype):
     if torch.is_tensor(obj) and obj.is_floating_point():
         return obj.to(dtype)
@@ -477,7 +498,13 @@ def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
         model_copy = model_copy.cpu()
         new_sd = model_copy.state_dict()
         if remainder == "fp16" and recipe not in CAST_RECIPES:
-            keep_exact = ("_q_w_scale", "_q_act_lo", "_q_act_hi", "_q_w_amax")
+            keep_exact = (
+                "_q_w_scale",
+                "_q_w_gscale",
+                "_q_act_lo",
+                "_q_act_hi",
+                "_q_w_amax",
+            )
             new_sd = {
                 key: (
                     value.half()
@@ -529,6 +556,8 @@ def reprepare_model(wrapper):
     manifest = dict(manifest)
     manifest["state"] = "prepared"
     wrapper._quant_manifest = manifest
+    if manifest.get("recipe") not in CAST_RECIPES:
+        wrapper.model.float()
     wrapper.model.to(wrapper.device)
     logger.info(
         "Re-prepared finalized checkpoint: fp32 masters reconstructed from "
@@ -666,6 +695,7 @@ def dequantize_model(wrapper):
                 new.weight = module.weight
             new.bias = module.bias
             _swap_module(root, name, new)
+        root.float()
 
     wrapper._quant_manifest = None
     logger.info("Restored float modules (recipe '%s' removed).", manifest.get("recipe"))
@@ -713,6 +743,14 @@ def apply_quant_structure(wrapper, manifest: Dict):
             for _, module in _quant_modules(wrapper.model):
                 if hasattr(module, "make_finalized"):
                     module.make_finalized()
+            remainder = manifest.get("remainder", "fp32")
+            if remainder == "fp16":
+                _cast_finalized_remainder(wrapper.model, torch.float16)
+            elif remainder != "fp32":
+                raise QuantizationError(
+                    "Finalized checkpoint has unsupported remainder dtype "
+                    f"'{remainder}'."
+                )
         if swapped:
             wrapper.model.to(wrapper.device)
 

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -590,6 +590,70 @@ def test_finalized_pt_export_roundtrip(tmp_path, yolo9t):
     assert torch.equal(ref, out3)
 
 
+def test_finalized_w4a16_fp16_remainder_preserves_quant_dtypes(tmp_path):
+    from libreyolo.quant import (
+        GroupQuantLinear,
+        apply_quant_structure,
+        export_finalized_pt,
+        quantize_model,
+        reprepare_model,
+    )
+
+    class TinyWrapper:
+        FAMILY = "rfdetr"
+
+        def __init__(self):
+            self.model = nn.Sequential(nn.Linear(130, 7), nn.LayerNorm(7))
+            self.device = torch.device("cpu")
+            self.size = "n"
+            self.task = "detect"
+            self.nb_classes = 1
+            self.names = {0: "class_0"}
+
+        def _get_model_name(self):
+            return "rfdetr"
+
+        def _get_input_size(self):
+            return 640
+
+    source = TinyWrapper()
+    quantize_model(
+        source,
+        recipe="w4a16",
+        calib=None,
+        keep_high_precision=(),
+        verbose=False,
+    )
+    path = export_finalized_pt(
+        source,
+        out=tmp_path / "tiny-w4a16.pt",
+        remainder="fp16",
+    )
+    checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+    state = checkpoint["model"]
+    assert state["0._q_w_gscale"].dtype == torch.float32
+    assert state["0.weight_packed"].dtype == torch.uint8
+    assert state["0.bias"].dtype == torch.float16
+    assert state["1.weight"].dtype == torch.float16
+
+    loaded = TinyWrapper()
+    apply_quant_structure(loaded, checkpoint["quant"])
+    loaded.model.load_state_dict(state)
+    quant_linear = loaded.model[0]
+    assert isinstance(quant_linear, GroupQuantLinear)
+    assert quant_linear.is_finalized
+    assert quant_linear._q_w_gscale.dtype == torch.float32
+    assert quant_linear.weight_packed.dtype == torch.uint8
+    assert quant_linear.bias.dtype == torch.float16
+    assert loaded.model[1].weight.dtype == torch.float16
+
+    reprepare_model(loaded)
+    assert not quant_linear.is_finalized
+    assert quant_linear.weight.dtype == torch.float32
+    assert quant_linear.bias.dtype == torch.float32
+    assert loaded.model[1].weight.dtype == torch.float32
+
+
 def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):
     yolo9t.quantize(recipe="fp16", verbose=False)
     yolo9t.model.eval()

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -654,6 +654,66 @@ def test_finalized_w4a16_fp16_remainder_preserves_quant_dtypes(tmp_path):
     assert loaded.model[1].weight.dtype == torch.float32
 
 
+@pytest.mark.parametrize(
+    "recipe,scale_buffer,scale_dtype",
+    [
+        ("nvfp4", "weight_block_scale", torch.float8_e4m3fn),
+        ("mxfp4", "weight_block_exp", torch.int8),
+    ],
+)
+def test_finalized_block_recipes_fp16_remainder_preserves_scale_dtypes(
+    tmp_path, recipe, scale_buffer, scale_dtype
+):
+    from libreyolo.quant import (
+        apply_quant_structure,
+        export_finalized_pt,
+        quantize_model,
+    )
+
+    class TinyWrapper:
+        FAMILY = "rfdetr"
+
+        def __init__(self):
+            self.model = nn.Sequential(nn.Linear(130, 7), nn.LayerNorm(7))
+            self.device = torch.device("cpu")
+            self.size = "n"
+            self.task = "detect"
+            self.nb_classes = 1
+            self.names = {0: "class_0"}
+
+        def _get_model_name(self):
+            return "rfdetr"
+
+        def _get_input_size(self):
+            return 640
+
+    source = TinyWrapper()
+    quantize_model(
+        source,
+        recipe=recipe,
+        calib=None,
+        keep_high_precision=(),
+        verbose=False,
+    )
+    path = export_finalized_pt(
+        source,
+        out=tmp_path / f"tiny-{recipe}.pt",
+        remainder="fp16",
+    )
+    checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+    state = checkpoint["model"]
+    assert state[f"0.{scale_buffer}"].dtype == scale_dtype
+    assert state["0.weight_packed"].dtype == torch.uint8
+    assert state["1.weight"].dtype == torch.float16
+
+    loaded = TinyWrapper()
+    apply_quant_structure(loaded, checkpoint["quant"])
+    loaded.model.load_state_dict(state)
+    assert loaded.model[0].is_finalized
+    assert getattr(loaded.model[0], scale_buffer).dtype == scale_dtype
+    assert loaded.model[0].weight_packed.dtype == torch.uint8
+
+
 def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):
     yolo9t.quantize(recipe="fp16", verbose=False)
     yolo9t.model.eval()


### PR DESCRIPTION
Found during the tier-2 kernel campaign: two dtype bugs in the finalized-checkpoint path.

- A finalized manifest with remainder="fp16" rebuilt fp32 destination parameters, so load_state_dict silently promoted the saved fp16 tensors (and the W4A16 kernel path fell back to reference).
- Export cast _q_w_gscale to fp16 despite the frozen checkpoint schema requiring fp32 group scales.

The loader now casts only the non-quantized remainder before load, quant buffers keep their contract dtypes, export preserves _q_w_gscale as fp32, and re-preparing restores ordinary parameters to fp32. Adds a focused CPU round-trip test. Full suite: 56 passed, 1 skipped.

Note: stacked on kernels/tier1-4 (#623); the deferred fused-GEMM kernel itself is intentionally NOT in this PR (evidence and scratch kernel live outside the repo).

## Code provenance

All changes are original, written for this PR against the existing LibreYOLO codebase. No third-party code was ported, adapted, or derived. The frozen W4 packing contract is unchanged.
