### PR TITLE
Support dynamic eval sizes across the DETR families

### DIFF
--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -551,6 +551,12 @@ class BaseExporter(ABC):
             imgsz = (int(imgsz), int(imgsz))
         if imgsz[0] <= 0 or imgsz[1] <= 0:
             raise ValueError(f"imgsz values must be positive, got {imgsz}.")
+        imgsz_divisor = int(getattr(self.model, "IMGSZ_DIVISOR", 1) or 1)
+        if imgsz[0] % imgsz_divisor or imgsz[1] % imgsz_divisor:
+            raise ValueError(
+                f"{model_name} export imgsz must be divisible by "
+                f"{imgsz_divisor}, got {imgsz}."
+            )
         if model_name == "nafnet":
             padder_size = int(getattr(self.model.model, "padder_size", 16))
             if imgsz[0] % padder_size or imgsz[1] % padder_size:

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -551,14 +551,6 @@ class BaseExporter(ABC):
             imgsz = (int(imgsz), int(imgsz))
         if imgsz[0] <= 0 or imgsz[1] <= 0:
             raise ValueError(f"imgsz values must be positive, got {imgsz}.")
-        if model_name == "deimv2" and imgsz != (
-            int(native_imgsz),
-            int(native_imgsz),
-        ):
-            raise ValueError(
-                "DEIMv2 export uses fixed decoder anchors; imgsz must match "
-                f"the native size {native_imgsz}, got {imgsz}."
-            )
         if model_name == "nafnet":
             padder_size = int(getattr(self.model.model, "padder_size", 16))
             if imgsz[0] % padder_size or imgsz[1] % padder_size:

--- a/libreyolo/models/deim/decoder.py
+++ b/libreyolo/models/deim/decoder.py
@@ -38,6 +38,8 @@ from .ms_deform import (
     inverse_sigmoid,
 )
 
+EVAL_CONSTANT_CACHE_LIMIT = 16
+
 
 class MLP(nn.Module):
     def __init__(self, input_dim, hidden_dim, output_dim, num_layers, act="relu"):
@@ -589,10 +591,22 @@ class DEIMTransformer(nn.Module):
         )
         self.integral = Integral(self.reg_max)
 
+        self._anchor_cache = OrderedDict()
         if self.eval_spatial_size:
             anchors, valid_mask = self._generate_anchors()
             self.register_buffer("anchors", anchors)
             self.register_buffer("valid_mask", valid_mask)
+            self._eval_spatial_shape_key = self._spatial_shape_key(
+                [
+                    [
+                        int(self.eval_spatial_size[0] / s),
+                        int(self.eval_spatial_size[1] / s),
+                    ]
+                    for s in self.feat_strides
+                ]
+            )
+        else:
+            self._eval_spatial_shape_key = None
 
         self._reset_parameters(feat_channels)
 
@@ -734,6 +748,34 @@ class DEIMTransformer(nn.Module):
 
         return anchors, valid_mask
 
+    @staticmethod
+    def _spatial_shape_key(spatial_shapes):
+        return tuple((int(h), int(w)) for h, w in spatial_shapes)
+
+    def _cache_anchors(self, key, anchors, valid_mask):
+        self._anchor_cache[key] = (anchors, valid_mask)
+        self._anchor_cache.move_to_end(key)
+        while len(self._anchor_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._anchor_cache.popitem(last=False)
+
+    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
+        shape_key = self._spatial_shape_key(spatial_shapes)
+        key = (shape_key, memory.device, memory.dtype)
+        cached = self._anchor_cache.get(key)
+        if cached is None:
+            if shape_key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
+                anchors = self.anchors.to(device=memory.device, dtype=memory.dtype)
+                valid_mask = self.valid_mask.to(device=memory.device)
+            else:
+                anchors, valid_mask = self._generate_anchors(
+                    spatial_shapes, dtype=memory.dtype, device=memory.device
+                )
+            self._cache_anchors(key, anchors, valid_mask)
+        else:
+            self._anchor_cache.move_to_end(key)
+            anchors, valid_mask = cached
+        return anchors, valid_mask
+
     def _get_decoder_input(
         self,
         memory: torch.Tensor,
@@ -746,8 +788,9 @@ class DEIMTransformer(nn.Module):
                 spatial_shapes, device=memory.device
             )
         else:
-            anchors = self.anchors
-            valid_mask = self.valid_mask
+            anchors, valid_mask = self._get_anchors_for_spatial_shapes(
+                spatial_shapes, memory
+            )
         if memory.shape[0] > 1:
             anchors = anchors.repeat(memory.shape[0], 1, 1)
 

--- a/libreyolo/models/deim/encoder.py
+++ b/libreyolo/models/deim/encoder.py
@@ -19,6 +19,8 @@ import torch.nn.functional as F
 
 from .ms_deform import get_activation
 
+EVAL_CONSTANT_CACHE_LIMIT = 16
+
 
 class ConvNormLayer_fuse(nn.Module):
     def __init__(
@@ -328,6 +330,7 @@ class HybridEncoder(nn.Module):
         self.num_encoder_layers = num_encoder_layers
         self.pe_temperature = pe_temperature
         self.eval_spatial_size = eval_spatial_size
+        self._pos_embed_cache = OrderedDict()
         self.out_channels = [hidden_dim for _ in range(len(self.in_channels))]
         self.out_strides = self.feat_strides
 
@@ -410,6 +413,49 @@ class HybridEncoder(nn.Module):
                     self.pe_temperature,
                 )
                 setattr(self, f"pos_embed{idx}", pos_embed)
+                self._cache_pos_embed(
+                    (
+                        idx,
+                        self.eval_spatial_size[0] // stride,
+                        self.eval_spatial_size[1] // stride,
+                        pos_embed.device,
+                        pos_embed.dtype,
+                    ),
+                    pos_embed,
+                )
+
+    def _cache_pos_embed(self, key, pos_embed):
+        self._pos_embed_cache[key] = pos_embed
+        self._pos_embed_cache.move_to_end(key)
+        while len(self._pos_embed_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._pos_embed_cache.popitem(last=False)
+
+    def _get_pos_embed(self, enc_ind, h, w, src_flatten):
+        key = (enc_ind, h, w, src_flatten.device, src_flatten.dtype)
+        pos_embed = self._pos_embed_cache.get(key)
+        if pos_embed is None:
+            base = getattr(self, f"pos_embed{enc_ind}", None)
+            # Compare grid shapes, not token counts: a rectangular grid can
+            # match the native token count (e.g. 16x25 vs 20x20, both 400)
+            # while laying positions out on the wrong grid.
+            stride = self.feat_strides[enc_ind]
+            base_hw = (
+                (
+                    self.eval_spatial_size[0] // stride,
+                    self.eval_spatial_size[1] // stride,
+                )
+                if self.eval_spatial_size
+                else None
+            )
+            if base is None or (h, w) != base_hw:
+                base = self.build_2d_sincos_position_embedding(
+                    w, h, self.hidden_dim, self.pe_temperature
+                )
+            pos_embed = base.to(device=src_flatten.device, dtype=src_flatten.dtype)
+            self._cache_pos_embed(key, pos_embed)
+        else:
+            self._pos_embed_cache.move_to_end(key)
+        return pos_embed
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.0):
@@ -443,9 +489,7 @@ class HybridEncoder(nn.Module):
                         w, h, self.hidden_dim, self.pe_temperature
                     ).to(src_flatten.device)
                 else:
-                    pos_embed = getattr(self, f"pos_embed{enc_ind}", None).to(
-                        src_flatten.device
-                    )
+                    pos_embed = self._get_pos_embed(enc_ind, h, w, src_flatten)
 
                 memory = self.encoder[i](src_flatten, pos_embed=pos_embed)
                 proj_feats[enc_ind] = (

--- a/libreyolo/models/deimv2/engine/deim/deim_decoder.py
+++ b/libreyolo/models/deimv2/engine/deim/deim_decoder.py
@@ -17,7 +17,11 @@ import torch.nn.functional as F
 import torch.nn.init as init
 from typing import List
 
-from libreyolo.models.deim.decoder import LQE, MSDeformableAttention
+from libreyolo.models.deim.decoder import (
+    EVAL_CONSTANT_CACHE_LIMIT,
+    LQE,
+    MSDeformableAttention,
+)
 from libreyolo.models.deim.denoising import get_contrastive_denoising_training_group
 from libreyolo.models.deim.fdr import Integral, distance2bbox, weighting_function
 from libreyolo.models.deim.ms_deform import bias_init_with_prob, inverse_sigmoid
@@ -439,10 +443,22 @@ class DEIMTransformer(nn.Module):
         )
 
         # init encoder output anchors and valid_mask
+        self._anchor_cache = OrderedDict()
         if self.eval_spatial_size:
             anchors, valid_mask = self._generate_anchors()
             self.register_buffer("anchors", anchors)
             self.register_buffer("valid_mask", valid_mask)
+            self._eval_spatial_shape_key = self._spatial_shape_key(
+                [
+                    [
+                        int(self.eval_spatial_size[0] / s),
+                        int(self.eval_spatial_size[1] / s),
+                    ]
+                    for s in self.feat_strides
+                ]
+            )
+        else:
+            self._eval_spatial_shape_key = None
         # init encoder output anchors and valid_mask
         if self.eval_spatial_size:
             self.anchors, self.valid_mask = self._generate_anchors()
@@ -597,6 +613,34 @@ class DEIMTransformer(nn.Module):
 
         return anchors, valid_mask
 
+    @staticmethod
+    def _spatial_shape_key(spatial_shapes):
+        return tuple((int(h), int(w)) for h, w in spatial_shapes)
+
+    def _cache_anchors(self, key, anchors, valid_mask):
+        self._anchor_cache[key] = (anchors, valid_mask)
+        self._anchor_cache.move_to_end(key)
+        while len(self._anchor_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._anchor_cache.popitem(last=False)
+
+    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
+        shape_key = self._spatial_shape_key(spatial_shapes)
+        key = (shape_key, memory.device, memory.dtype)
+        cached = self._anchor_cache.get(key)
+        if cached is None:
+            if shape_key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
+                anchors = self.anchors.to(device=memory.device, dtype=memory.dtype)
+                valid_mask = self.valid_mask.to(device=memory.device)
+            else:
+                anchors, valid_mask = self._generate_anchors(
+                    spatial_shapes, dtype=memory.dtype, device=memory.device
+                )
+            self._cache_anchors(key, anchors, valid_mask)
+        else:
+            self._anchor_cache.move_to_end(key)
+            anchors, valid_mask = cached
+        return anchors, valid_mask
+
     def _get_decoder_input(
         self,
         memory: torch.Tensor,
@@ -611,8 +655,9 @@ class DEIMTransformer(nn.Module):
                 spatial_shapes, device=memory.device
             )
         else:
-            anchors = self.anchors
-            valid_mask = self.valid_mask
+            anchors, valid_mask = self._get_anchors_for_spatial_shapes(
+                spatial_shapes, memory
+            )
         if memory.shape[0] > 1:
             anchors = anchors.repeat(memory.shape[0], 1, 1)
 

--- a/libreyolo/models/deimv2/engine/deim/hybrid_encoder.py
+++ b/libreyolo/models/deimv2/engine/deim/hybrid_encoder.py
@@ -15,6 +15,8 @@ import torch.nn.functional as F
 
 from libreyolo.models.deim.ms_deform import get_activation
 
+EVAL_CONSTANT_CACHE_LIMIT = 16
+
 __all__ = ["HybridEncoder"]
 
 
@@ -438,6 +440,7 @@ class HybridEncoder(nn.Module):
         self.num_encoder_layers = num_encoder_layers
         self.pe_temperature = pe_temperature
         self.eval_spatial_size = eval_spatial_size
+        self._pos_embed_cache = OrderedDict()
         self.out_channels = [hidden_dim for _ in range(len(in_channels))]
         self.out_strides = feat_strides
         self.fuse_op = fuse_op
@@ -539,6 +542,49 @@ class HybridEncoder(nn.Module):
                 )
                 setattr(self, f"pos_embed{idx}", pos_embed)
                 # self.register_buffer(f'pos_embed{idx}', pos_embed)
+                self._cache_pos_embed(
+                    (
+                        idx,
+                        self.eval_spatial_size[0] // stride,
+                        self.eval_spatial_size[1] // stride,
+                        pos_embed.device,
+                        pos_embed.dtype,
+                    ),
+                    pos_embed,
+                )
+
+    def _cache_pos_embed(self, key, pos_embed):
+        self._pos_embed_cache[key] = pos_embed
+        self._pos_embed_cache.move_to_end(key)
+        while len(self._pos_embed_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._pos_embed_cache.popitem(last=False)
+
+    def _get_pos_embed(self, enc_ind, h, w, src_flatten):
+        key = (enc_ind, h, w, src_flatten.device, src_flatten.dtype)
+        pos_embed = self._pos_embed_cache.get(key)
+        if pos_embed is None:
+            base = getattr(self, f"pos_embed{enc_ind}", None)
+            # Compare grid shapes, not token counts: a rectangular grid can
+            # match the native token count (e.g. 16x25 vs 20x20, both 400)
+            # while laying positions out on the wrong grid.
+            stride = self.feat_strides[enc_ind]
+            base_hw = (
+                (
+                    self.eval_spatial_size[0] // stride,
+                    self.eval_spatial_size[1] // stride,
+                )
+                if self.eval_spatial_size
+                else None
+            )
+            if base is None or (h, w) != base_hw:
+                base = self.build_2d_sincos_position_embedding(
+                    w, h, self.hidden_dim, self.pe_temperature
+                )
+            pos_embed = base.to(device=src_flatten.device, dtype=src_flatten.dtype)
+            self._cache_pos_embed(key, pos_embed)
+        else:
+            self._pos_embed_cache.move_to_end(key)
+        return pos_embed
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.0):
@@ -575,9 +621,7 @@ class HybridEncoder(nn.Module):
                         w, h, self.hidden_dim, self.pe_temperature
                     ).to(src_flatten.device)
                 else:
-                    pos_embed = getattr(self, f"pos_embed{enc_ind}", None).to(
-                        src_flatten.device
-                    )
+                    pos_embed = self._get_pos_embed(enc_ind, h, w, src_flatten)
 
                 memory: torch.Tensor = self.encoder[i](src_flatten, pos_embed=pos_embed)
                 proj_feats[enc_ind] = (

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -42,6 +42,17 @@ class LibreDEIMv2(BaseModel):
     TRAIN_CONFIG = DEIMv2Config
     val_preprocessor_class = DEIMv2ValPreprocessor
     TTA_FIXED_SIZE = True  # resizes to a fixed square; multi-scale TTA is a no-op
+    IMGSZ_DIVISOR = 32
+
+    @classmethod
+    def _validate_imgsz(cls, imgsz: int, *, context: str = "DEIMv2 imgsz") -> int:
+        imgsz = int(imgsz)
+        if imgsz <= 0 or imgsz % cls.IMGSZ_DIVISOR:
+            raise ValueError(
+                f"{context} must be a positive multiple of "
+                f"{cls.IMGSZ_DIVISOR}, got {imgsz}."
+            )
+        return imgsz
 
     @classmethod
     def can_load(cls, weights_dict: dict) -> bool:
@@ -149,6 +160,7 @@ class LibreDEIMv2(BaseModel):
     def _get_val_preprocessor(self, img_size: int | None = None):
         if img_size is None:
             img_size = self._get_input_size()
+        img_size = self._validate_imgsz(img_size, context="DEIMv2 validation imgsz")
         cls = (
             DEIMv2DINOValPreprocessor
             if self.size in DINO_SIZES
@@ -163,6 +175,9 @@ class LibreDEIMv2(BaseModel):
         input_size: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Any, Tuple[int, int], float]:
         effective_size = input_size if input_size is not None else self.input_size
+        effective_size = self._validate_imgsz(
+            effective_size, context="DEIMv2 prediction imgsz"
+        )
         return preprocess_image(
             image,
             input_size=effective_size,
@@ -243,6 +258,8 @@ class LibreDEIMv2(BaseModel):
         from .trainer import DEIMv2Trainer
 
         kwargs.pop("pretrained", None)
+        if imgsz is not None:
+            imgsz = self._validate_imgsz(imgsz, context="DEIMv2 training imgsz")
 
         try:
             data_config = load_data_config(data, autodownload=True)

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -41,7 +41,7 @@ class LibreDEIMv2(BaseModel):
     INPUT_SIZES = {size: int(cfg["input_size"]) for size, cfg in SIZE_CONFIGS.items()}
     TRAIN_CONFIG = DEIMv2Config
     val_preprocessor_class = DEIMv2ValPreprocessor
-    TTA_FIXED_SIZE = True  # fixed decoder anchors require a fixed size; multi-scale TTA is invalid
+    TTA_FIXED_SIZE = True  # resizes to a fixed square; multi-scale TTA is a no-op
 
     @classmethod
     def can_load(cls, weights_dict: dict) -> bool:
@@ -163,11 +163,6 @@ class LibreDEIMv2(BaseModel):
         input_size: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Any, Tuple[int, int], float]:
         effective_size = input_size if input_size is not None else self.input_size
-        if effective_size != self.input_size:
-            raise ValueError(
-                "DEIMv2 uses fixed decoder anchors; input_size must match "
-                f"the native size {self.input_size}, got {effective_size}."
-            )
         return preprocess_image(
             image,
             input_size=effective_size,

--- a/libreyolo/models/dfine/encoder.py
+++ b/libreyolo/models/dfine/encoder.py
@@ -483,7 +483,19 @@ class HybridEncoder(nn.Module):
         pos_embed = self._pos_embed_cache.get(key)
         if pos_embed is None:
             base = getattr(self, f"pos_embed{enc_ind}", None)
-            if base is None or base.shape[1] != h * w:
+            # Compare grid shapes, not token counts: a rectangular grid can
+            # match the native token count (e.g. 16x25 vs 20x20, both 400)
+            # while laying positions out on the wrong grid.
+            stride = self.feat_strides[enc_ind]
+            base_hw = (
+                (
+                    self.eval_spatial_size[0] // stride,
+                    self.eval_spatial_size[1] // stride,
+                )
+                if self.eval_spatial_size
+                else None
+            )
+            if base is None or (h, w) != base_hw:
                 base = self.build_2d_sincos_position_embedding(
                     w, h, self.hidden_dim, self.pe_temperature
                 )

--- a/libreyolo/models/ec/decoder.py
+++ b/libreyolo/models/ec/decoder.py
@@ -26,6 +26,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.init as init
 
+from ..dfine.decoder import EVAL_CONSTANT_CACHE_LIMIT
 from ..dfine.denoising import get_contrastive_denoising_training_group
 from .utils import (
     _grid_sample_bilinear_manual,
@@ -622,10 +623,22 @@ class ECTransformer(nn.Module):
             ]
         )
 
+        self._anchor_cache = OrderedDict()
         if self.eval_spatial_size:
             anchors, valid_mask = self._generate_anchors()
             self.register_buffer("anchors", anchors)
             self.register_buffer("valid_mask", valid_mask)
+            self._eval_spatial_shape_key = self._spatial_shape_key(
+                [
+                    [
+                        int(self.eval_spatial_size[0] / s),
+                        int(self.eval_spatial_size[1] / s),
+                    ]
+                    for s in self.feat_strides
+                ]
+            )
+        else:
+            self._eval_spatial_shape_key = None
 
         self._reset_parameters(feat_channels)
 
@@ -756,6 +769,34 @@ class ECTransformer(nn.Module):
         invalid_fill = torch.full_like(anchors, 1e4)
         return torch.where(valid_mask, anchors, invalid_fill), valid_mask
 
+    @staticmethod
+    def _spatial_shape_key(spatial_shapes):
+        return tuple((int(h), int(w)) for h, w in spatial_shapes)
+
+    def _cache_anchors(self, key, anchors, valid_mask):
+        self._anchor_cache[key] = (anchors, valid_mask)
+        self._anchor_cache.move_to_end(key)
+        while len(self._anchor_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._anchor_cache.popitem(last=False)
+
+    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
+        shape_key = self._spatial_shape_key(spatial_shapes)
+        key = (shape_key, memory.device, memory.dtype)
+        cached = self._anchor_cache.get(key)
+        if cached is None:
+            if shape_key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
+                anchors = self.anchors.to(device=memory.device, dtype=memory.dtype)
+                valid_mask = self.valid_mask.to(device=memory.device)
+            else:
+                anchors, valid_mask = self._generate_anchors(
+                    spatial_shapes, dtype=memory.dtype, device=memory.device
+                )
+            self._cache_anchors(key, anchors, valid_mask)
+        else:
+            self._anchor_cache.move_to_end(key)
+            anchors, valid_mask = cached
+        return anchors, valid_mask
+
     def _get_decoder_input(
         self, memory, spatial_shapes, denoising_logits=None, denoising_bbox_unact=None
     ):
@@ -764,8 +805,9 @@ class ECTransformer(nn.Module):
                 spatial_shapes, device=memory.device
             )
         else:
-            anchors = self.anchors
-            valid_mask = self.valid_mask
+            anchors, valid_mask = self._get_anchors_for_spatial_shapes(
+                spatial_shapes, memory
+            )
         if memory.shape[0] > 1:
             anchors = anchors.repeat(memory.shape[0], 1, 1)
 
@@ -1737,10 +1779,22 @@ class ECPoseTransformer(nn.Module):
 
         self._reset_parameters()
 
+        self._anchor_cache = OrderedDict()
         if self.eval_spatial_size:
             anchors, valid_mask = self._generate_anchors()
             self.register_buffer("anchors", anchors)
             self.register_buffer("valid_mask", valid_mask)
+            self._eval_spatial_shape_key = self._spatial_shape_key(
+                [
+                    [
+                        int(self.eval_spatial_size[0] / s),
+                        int(self.eval_spatial_size[1] / s),
+                    ]
+                    for s in self.feat_strides
+                ]
+            )
+        else:
+            self._eval_spatial_shape_key = None
 
     def _reset_parameters(self):
         for p in self.parameters():
@@ -1749,6 +1803,34 @@ class ECPoseTransformer(nn.Module):
         for m in self.modules():
             if isinstance(m, MSDeformAttnPose):
                 m._reset_parameters()
+
+    @staticmethod
+    def _spatial_shape_key(spatial_shapes):
+        return tuple((int(h), int(w)) for h, w in spatial_shapes)
+
+    def _cache_anchors(self, key, anchors, valid_mask):
+        self._anchor_cache[key] = (anchors, valid_mask)
+        self._anchor_cache.move_to_end(key)
+        while len(self._anchor_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._anchor_cache.popitem(last=False)
+
+    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
+        shape_key = self._spatial_shape_key(spatial_shapes)
+        key = (shape_key, memory.device)
+        cached = self._anchor_cache.get(key)
+        if cached is None:
+            if shape_key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
+                anchors = self.anchors.to(device=memory.device)
+                valid_mask = self.valid_mask.to(device=memory.device)
+            else:
+                anchors, valid_mask = self._generate_anchors(
+                    spatial_shapes, memory.device
+                )
+            self._cache_anchors(key, anchors, valid_mask)
+        else:
+            self._anchor_cache.move_to_end(key)
+            anchors, valid_mask = cached
+        return anchors, valid_mask
 
     def _generate_anchors(self, spatial_shapes=None, device="cpu"):
         if spatial_shapes is None:
@@ -1804,8 +1886,11 @@ class ECPoseTransformer(nn.Module):
             output_memory = memory.masked_fill(valid_mask, 0.0)
             output_proposals = output_proposals.repeat(memory.size(0), 1, 1)
         else:
-            output_proposals = self.anchors.repeat(memory.size(0), 1, 1)
-            output_memory = memory.masked_fill(self.valid_mask, 0.0)
+            anchors, valid_mask = self._get_anchors_for_spatial_shapes(
+                spatial_shapes, memory
+            )
+            output_proposals = anchors.repeat(memory.size(0), 1, 1)
+            output_memory = memory.masked_fill(valid_mask, 0.0)
 
         output_memory = self.enc_output_norm(self.enc_output(output_memory))
 

--- a/libreyolo/models/ec/decoder.py
+++ b/libreyolo/models/ec/decoder.py
@@ -1816,15 +1816,15 @@ class ECPoseTransformer(nn.Module):
 
     def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
         shape_key = self._spatial_shape_key(spatial_shapes)
-        key = (shape_key, memory.device)
+        key = (shape_key, memory.device, memory.dtype)
         cached = self._anchor_cache.get(key)
         if cached is None:
             if shape_key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
-                anchors = self.anchors.to(device=memory.device)
+                anchors = self.anchors.to(device=memory.device, dtype=memory.dtype)
                 valid_mask = self.valid_mask.to(device=memory.device)
             else:
                 anchors, valid_mask = self._generate_anchors(
-                    spatial_shapes, memory.device
+                    spatial_shapes, device=memory.device, dtype=memory.dtype
                 )
             self._cache_anchors(key, anchors, valid_mask)
         else:
@@ -1832,7 +1832,7 @@ class ECPoseTransformer(nn.Module):
             anchors, valid_mask = cached
         return anchors, valid_mask
 
-    def _generate_anchors(self, spatial_shapes=None, device="cpu"):
+    def _generate_anchors(self, spatial_shapes=None, device="cpu", dtype=torch.float32):
         if spatial_shapes is None:
             spatial_shapes = []
             eval_h, eval_w = self.eval_spatial_size
@@ -1841,13 +1841,13 @@ class ECPoseTransformer(nn.Module):
         anchors = []
         for h, w in spatial_shapes:
             grid_y, grid_x = torch.meshgrid(
-                torch.linspace(0, h - 1, h, dtype=torch.float32, device=device),
-                torch.linspace(0, w - 1, w, dtype=torch.float32, device=device),
+                torch.linspace(0, h - 1, h, dtype=dtype, device=device),
+                torch.linspace(0, w - 1, w, dtype=dtype, device=device),
                 indexing="ij",
             )
             grid = torch.stack([grid_x, grid_y], -1)
             grid = (grid.unsqueeze(0) + 0.5) / torch.tensor(
-                [w, h], dtype=torch.float32, device=device
+                [w, h], dtype=dtype, device=device
             )
             anchors.append(grid.view(1, -1, 2))
         anchors = torch.cat(anchors, 1)
@@ -1881,7 +1881,7 @@ class ECPoseTransformer(nn.Module):
 
         if self.training:
             output_proposals, valid_mask = self._generate_anchors(
-                spatial_shapes, memory.device
+                spatial_shapes, device=memory.device, dtype=memory.dtype
             )
             output_memory = memory.masked_fill(valid_mask, 0.0)
             output_proposals = output_proposals.repeat(memory.size(0), 1, 1)

--- a/libreyolo/models/ec/encoder.py
+++ b/libreyolo/models/ec/encoder.py
@@ -10,12 +10,14 @@ Differs from D-FINE's HybridEncoder in three ways:
 from __future__ import annotations
 
 import copy
+from collections import OrderedDict
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 from ..dfine.encoder import (
+    EVAL_CONSTANT_CACHE_LIMIT,
     ConvNormLayer_fuse,
     SCDown,
     TransformerEncoder,
@@ -121,6 +123,7 @@ class HybridEncoder(nn.Module):
         self.num_encoder_layers = num_encoder_layers
         self.pe_temperature = pe_temperature
         self.eval_spatial_size = eval_spatial_size
+        self._pos_embed_cache = OrderedDict()
         self.out_channels = [hidden_dim] * len(self.in_channels)
         self.out_strides = self.feat_strides
         self.fuse_op = fuse_op
@@ -176,6 +179,49 @@ class HybridEncoder(nn.Module):
                     self.pe_temperature,
                 )
                 setattr(self, f"pos_embed{idx}", pos_embed)
+                self._cache_pos_embed(
+                    (
+                        idx,
+                        self.eval_spatial_size[0] // stride,
+                        self.eval_spatial_size[1] // stride,
+                        pos_embed.device,
+                        pos_embed.dtype,
+                    ),
+                    pos_embed,
+                )
+
+    def _cache_pos_embed(self, key, pos_embed):
+        self._pos_embed_cache[key] = pos_embed
+        self._pos_embed_cache.move_to_end(key)
+        while len(self._pos_embed_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._pos_embed_cache.popitem(last=False)
+
+    def _get_pos_embed(self, enc_ind, h, w, src_flatten):
+        key = (enc_ind, h, w, src_flatten.device, src_flatten.dtype)
+        pos_embed = self._pos_embed_cache.get(key)
+        if pos_embed is None:
+            base = getattr(self, f"pos_embed{enc_ind}", None)
+            # Compare grid shapes, not token counts: a rectangular grid can
+            # match the native token count (e.g. 16x25 vs 20x20, both 400)
+            # while laying positions out on the wrong grid.
+            stride = self.feat_strides[enc_ind]
+            base_hw = (
+                (
+                    self.eval_spatial_size[0] // stride,
+                    self.eval_spatial_size[1] // stride,
+                )
+                if self.eval_spatial_size
+                else None
+            )
+            if base is None or (h, w) != base_hw:
+                base = self.build_2d_sincos_position_embedding(
+                    w, h, self.hidden_dim, self.pe_temperature
+                )
+            pos_embed = base.to(device=src_flatten.device, dtype=src_flatten.dtype)
+            self._cache_pos_embed(key, pos_embed)
+        else:
+            self._pos_embed_cache.move_to_end(key)
+        return pos_embed
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.0):
@@ -205,9 +251,7 @@ class HybridEncoder(nn.Module):
                         w, h, self.hidden_dim, self.pe_temperature
                     ).to(src_flatten.device)
                 else:
-                    pos_embed = getattr(self, f"pos_embed{enc_ind}", None).to(
-                        src_flatten.device
-                    )
+                    pos_embed = self._get_pos_embed(enc_ind, h, w, src_flatten)
                 memory = self.encoder[i](src_flatten, pos_embed=pos_embed)
                 proj_feats[enc_ind] = (
                     memory.permute(0, 2, 1)

--- a/libreyolo/models/rtdetr/nn.py
+++ b/libreyolo/models/rtdetr/nn.py
@@ -29,6 +29,8 @@ from .utils import (
 )
 from .denoising import get_contrastive_denoising_training_group
 
+EVAL_CONSTANT_CACHE_LIMIT = 16
+
 
 # =============================================================================
 # Encoder Building Blocks
@@ -243,6 +245,7 @@ class HybridEncoder(nn.Module):
         self.num_encoder_layers = num_encoder_layers
         self.pe_temperature = pe_temperature
         self.eval_spatial_size = eval_spatial_size
+        self._pos_embed_cache = OrderedDict()
 
         # Channel projection
         self.input_proj = nn.ModuleList()
@@ -316,6 +319,49 @@ class HybridEncoder(nn.Module):
                     self.pe_temperature,
                 )
                 setattr(self, f"pos_embed{idx}", pos_embed)
+                self._cache_pos_embed(
+                    (
+                        idx,
+                        self.eval_spatial_size[0] // stride,
+                        self.eval_spatial_size[1] // stride,
+                        pos_embed.device,
+                        pos_embed.dtype,
+                    ),
+                    pos_embed,
+                )
+
+    def _cache_pos_embed(self, key, pos_embed):
+        self._pos_embed_cache[key] = pos_embed
+        self._pos_embed_cache.move_to_end(key)
+        while len(self._pos_embed_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._pos_embed_cache.popitem(last=False)
+
+    def _get_pos_embed(self, enc_ind, h, w, src_flatten):
+        key = (enc_ind, h, w, src_flatten.device, src_flatten.dtype)
+        pos_embed = self._pos_embed_cache.get(key)
+        if pos_embed is None:
+            base = getattr(self, f"pos_embed{enc_ind}", None)
+            # Compare grid shapes, not token counts: a rectangular grid can
+            # match the native token count (e.g. 16x25 vs 20x20, both 400)
+            # while laying positions out on the wrong grid.
+            stride = self.feat_strides[enc_ind]
+            base_hw = (
+                (
+                    self.eval_spatial_size[0] // stride,
+                    self.eval_spatial_size[1] // stride,
+                )
+                if self.eval_spatial_size
+                else None
+            )
+            if base is None or (h, w) != base_hw:
+                base = self.build_2d_sincos_position_embedding(
+                    w, h, self.hidden_dim, self.pe_temperature
+                )
+            pos_embed = base.to(device=src_flatten.device, dtype=src_flatten.dtype)
+            self._cache_pos_embed(key, pos_embed)
+        else:
+            self._pos_embed_cache.move_to_end(key)
+        return pos_embed
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.0):
@@ -351,9 +397,7 @@ class HybridEncoder(nn.Module):
                         w, h, self.hidden_dim, self.pe_temperature
                     ).to(src_flatten.device)
                 else:
-                    pos_embed = getattr(self, f"pos_embed{enc_ind}", None).to(
-                        src_flatten.device
-                    )
+                    pos_embed = self._get_pos_embed(enc_ind, h, w, src_flatten)
 
                 memory = self.encoder[i](src_flatten, pos_embed=pos_embed)
                 proj_feats[enc_ind] = (

--- a/libreyolo/models/rtdetrv2/decoder.py
+++ b/libreyolo/models/rtdetrv2/decoder.py
@@ -32,6 +32,8 @@ from .utils import (
 
 __all__ = ["RTDETRTransformerv2"]
 
+EVAL_CONSTANT_CACHE_LIMIT = 16
+
 
 class MLP(nn.Module):
     def __init__(self, input_dim, hidden_dim, output_dim, num_layers, act="relu"):
@@ -423,10 +425,22 @@ class RTDETRTransformerv2(nn.Module):
             [MLP(hidden_dim, hidden_dim, 4, 3) for _ in range(num_layers)]
         )
 
+        self._anchor_cache = OrderedDict()
         if self.eval_spatial_size:
             anchors, valid_mask = self._generate_anchors()
             self.register_buffer("anchors", anchors)
             self.register_buffer("valid_mask", valid_mask)
+            self._eval_spatial_shape_key = self._spatial_shape_key(
+                [
+                    [
+                        int(self.eval_spatial_size[0] / s),
+                        int(self.eval_spatial_size[1] / s),
+                    ]
+                    for s in self.feat_strides
+                ]
+            )
+        else:
+            self._eval_spatial_shape_key = None
 
         self._reset_parameters()
 
@@ -530,6 +544,34 @@ class RTDETRTransformerv2(nn.Module):
         anchors = torch.where(valid_mask, anchors, torch.inf)
         return anchors, valid_mask
 
+    @staticmethod
+    def _spatial_shape_key(spatial_shapes):
+        return tuple((int(h), int(w)) for h, w in spatial_shapes)
+
+    def _cache_anchors(self, key, anchors, valid_mask):
+        self._anchor_cache[key] = (anchors, valid_mask)
+        self._anchor_cache.move_to_end(key)
+        while len(self._anchor_cache) > EVAL_CONSTANT_CACHE_LIMIT:
+            self._anchor_cache.popitem(last=False)
+
+    def _get_anchors_for_spatial_shapes(self, spatial_shapes, memory):
+        shape_key = self._spatial_shape_key(spatial_shapes)
+        key = (shape_key, memory.device, memory.dtype)
+        cached = self._anchor_cache.get(key)
+        if cached is None:
+            if shape_key == self._eval_spatial_shape_key and hasattr(self, "anchors"):
+                anchors = self.anchors.to(device=memory.device, dtype=memory.dtype)
+                valid_mask = self.valid_mask.to(device=memory.device)
+            else:
+                anchors, valid_mask = self._generate_anchors(
+                    spatial_shapes, dtype=memory.dtype, device=memory.device
+                )
+            self._cache_anchors(key, anchors, valid_mask)
+        else:
+            self._anchor_cache.move_to_end(key)
+            anchors, valid_mask = cached
+        return anchors, valid_mask
+
     def _get_decoder_input(
         self, memory, spatial_shapes, denoising_logits=None, denoising_bbox_unact=None
     ):
@@ -538,8 +580,9 @@ class RTDETRTransformerv2(nn.Module):
                 spatial_shapes, device=memory.device
             )
         else:
-            anchors = self.anchors
-            valid_mask = self.valid_mask
+            anchors, valid_mask = self._get_anchors_for_spatial_shapes(
+                spatial_shapes, memory
+            )
 
         memory = valid_mask.to(memory.dtype) * memory
 

--- a/tests/unit/test_deim_endtoend_shapes.py
+++ b/tests/unit/test_deim_endtoend_shapes.py
@@ -1,0 +1,52 @@
+"""Eval-time dynamic-size tests for DEIM.
+
+The DEIM wrapper builds its model with a concrete ``eval_spatial_size``, so
+eval-mode forwards must rebuild the precomputed encoder pos-embed and decoder
+anchors whenever the runtime input size differs from the native one.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.deim.nn import LibreDEIMModel
+
+pytestmark = pytest.mark.unit
+
+
+def _make(eval_spatial_size):
+    return LibreDEIMModel(
+        config="s", nb_classes=2, eval_spatial_size=eval_spatial_size
+    ).eval()
+
+
+def test_eval_forward_accepts_runtime_size_different_from_eval_spatial_size():
+    """Eval must rebuild fixed-size encoder/decoder constants for runtime imgsz."""
+    model = _make((640, 640))
+
+    for hw in ((320, 320), (800, 800)):
+        x = torch.randn(1, 3, *hw)
+        with torch.no_grad():
+            out = model(x)
+        assert out["pred_boxes"].shape[-1] == 4
+
+
+def test_eval_rectangular_size_with_native_token_count_matches_dynamic():
+    """A rect grid can share the native buffer's token count (16x25 == 20x20).
+
+    Constants must be rebuilt from the grid shape, not the token count, or
+    the encoder/decoder silently apply wrong-grid embeddings and anchors.
+    """
+    fixed = _make((640, 640))
+    dynamic = _make(None)
+    dynamic.load_state_dict(fixed.state_dict(), strict=False)
+
+    x = torch.randn(1, 3, 512, 800)
+    with torch.no_grad():
+        out_fixed = fixed(x)
+        out_dynamic = dynamic(x)
+    for key in ("pred_logits", "pred_boxes"):
+        torch.testing.assert_close(
+            out_fixed[key], out_dynamic[key], rtol=1e-4, atol=1e-5
+        )

--- a/tests/unit/test_deimv2.py
+++ b/tests/unit/test_deimv2.py
@@ -148,3 +148,15 @@ def test_deimv2_val_preprocessor_matches_upstream_pil_resize():
     assert targets.shape == (preproc.max_labels, 5)
     assert not issubclass(DFINEValPreprocessor, DEIMv2ValPreprocessor)
     assert not issubclass(DEIMValPreprocessor, DEIMv2ValPreprocessor)
+
+
+def test_deimv2_public_preprocessors_reject_unaligned_imgsz():
+    from libreyolo import LibreDEIMv2
+
+    model = LibreDEIMv2(None, size="atto", device="cpu")
+    image = np.zeros((32, 32, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="positive multiple of 32"):
+        model._preprocess(image, input_size=513)
+    with pytest.raises(ValueError, match="positive multiple of 32"):
+        model._get_val_preprocessor(img_size=513)

--- a/tests/unit/test_deimv2_endtoend_shapes.py
+++ b/tests/unit/test_deimv2_endtoend_shapes.py
@@ -1,0 +1,55 @@
+"""Eval-time dynamic-size tests for DEIMv2.
+
+DEIMv2 configs bake a per-size native ``eval_spatial_size`` (320 for atto),
+so eval-mode forwards must rebuild the precomputed encoder pos-embed and
+decoder anchors whenever the runtime input size differs from the native one.
+The validator letterboxes to the requested imgsz and calls the model
+directly, so this path must not rely on any preprocess-level guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.deimv2.nn import LibreDEIMv2Model
+
+pytestmark = pytest.mark.unit
+
+
+def test_eval_forward_accepts_runtime_size_different_from_eval_spatial_size():
+    """Eval must rebuild fixed-size encoder/decoder constants for runtime imgsz."""
+    model = LibreDEIMv2Model(config="atto", nb_classes=2).eval()
+
+    for hw in ((320, 320), (640, 640)):
+        x = torch.randn(1, 3, *hw)
+        with torch.no_grad():
+            out = model(x)
+        assert out["pred_boxes"].shape[-1] == 4
+
+
+def test_eval_rectangular_size_with_native_token_count_matches_dynamic():
+    """A rect grid can share the native buffer's token count (5x20 == 10x10).
+
+    Constants must be rebuilt from the grid shape, not the token count, or
+    the encoder/decoder silently apply wrong-grid embeddings and anchors.
+    Native atto size is 320 (stride-32 grid 10x10 = 100 tokens); 160x640
+    gives a 5x20 grid whose 100 tokens collide with the native count
+    exactly, while 384x512 (12x16 = 192) exercises the plain non-native
+    rebuild. Sizes must stay divisible by 32.
+    """
+    fixed = LibreDEIMv2Model(config="atto", nb_classes=2).eval()
+    dynamic = LibreDEIMv2Model(config="atto", nb_classes=2).eval()
+    dynamic.load_state_dict(fixed.state_dict(), strict=False)
+    dynamic.encoder.eval_spatial_size = None
+    dynamic.decoder.eval_spatial_size = None
+
+    for hw in ((160, 640), (384, 512)):
+        x = torch.randn(1, 3, *hw)
+        with torch.no_grad():
+            out_fixed = fixed(x)
+            out_dynamic = dynamic(x)
+        for key in ("pred_logits", "pred_boxes"):
+            torch.testing.assert_close(
+                out_fixed[key], out_dynamic[key], rtol=1e-4, atol=1e-5
+            )

--- a/tests/unit/test_deimv2_export.py
+++ b/tests/unit/test_deimv2_export.py
@@ -192,14 +192,16 @@ def test_deimv2_ncnn_export_is_blocked(tmp_path):
         model.export("ncnn", output_path=str(tmp_path / "deimv2_ncnn"))
 
 
-def test_deimv2_export_rejects_non_native_imgsz(tmp_path):
+def test_deimv2_export_accepts_non_native_square_imgsz():
     from libreyolo import LibreDEIMv2
+    from libreyolo.export.exporter import OnnxExporter
 
     model = LibreDEIMv2(None, size="atto", device="cpu")
-    with pytest.raises(ValueError, match="fixed decoder anchors"):
-        model.export(
-            "onnx",
-            output_path=str(tmp_path / "bad.onnx"),
-            imgsz=640,
-            simplify=False,
-        )
+    imgsz, _, _ = OnnxExporter(model)._resolve_params(
+        output_path=None,
+        imgsz=640,
+        device="cpu",
+        half=False,
+        int8=False,
+    )
+    assert imgsz == (640, 640)

--- a/tests/unit/test_deimv2_export.py
+++ b/tests/unit/test_deimv2_export.py
@@ -205,3 +205,18 @@ def test_deimv2_export_accepts_non_native_square_imgsz():
         int8=False,
     )
     assert imgsz == (640, 640)
+
+
+def test_deimv2_export_rejects_unaligned_square_imgsz():
+    from libreyolo import LibreDEIMv2
+    from libreyolo.export.exporter import OnnxExporter
+
+    model = LibreDEIMv2(None, size="atto", device="cpu")
+    with pytest.raises(ValueError, match="divisible by 32"):
+        OnnxExporter(model)._resolve_params(
+            output_path=None,
+            imgsz=513,
+            device="cpu",
+            half=False,
+            int8=False,
+        )

--- a/tests/unit/test_dfine_endtoend_shapes.py
+++ b/tests/unit/test_dfine_endtoend_shapes.py
@@ -93,6 +93,27 @@ def test_eval_forward_accepts_runtime_size_different_from_eval_spatial_size():
     assert out["pred_boxes"].shape == (1, 300, 4)
 
 
+def test_eval_rectangular_size_with_native_token_count_matches_dynamic():
+    """A rect grid can share the native buffer's token count (16x25 == 20x20).
+
+    The pos-embed must be rebuilt from the grid shape, not the token count,
+    or the encoder silently applies a wrong-grid embedding.
+    """
+    fixed = LibreDFINEModel("n", nb_classes=2, eval_spatial_size=(640, 640)).eval()
+    dynamic = LibreDFINEModel("n", nb_classes=2, eval_spatial_size=None).eval()
+    dynamic.load_state_dict(fixed.state_dict(), strict=False)
+
+    for hw in ((512, 800), (320, 1280)):
+        x = torch.randn(1, 3, *hw)
+        with torch.no_grad():
+            out_fixed = fixed(x)
+            out_dynamic = dynamic(x)
+        for key in ("pred_logits", "pred_boxes"):
+            torch.testing.assert_close(
+                out_fixed[key], out_dynamic[key], rtol=1e-4, atol=1e-5
+            )
+
+
 def test_eval_pos_embed_cache_is_bounded_and_reuses_moved_tensor():
     encoder = HybridEncoder(
         in_channels=(16,),

--- a/tests/unit/test_ec_endtoend_shapes.py
+++ b/tests/unit/test_ec_endtoend_shapes.py
@@ -58,3 +58,58 @@ def test_full_pipeline_random_weights(size):
     assert set(out.keys()) == {"pred_logits", "pred_boxes"}
     assert out["pred_logits"].shape == (1, 300, 80)
     assert out["pred_boxes"].shape == (1, 300, 4)
+
+
+def _load_twin(fixed, cls, **kwargs):
+    from libreyolo.models.ec import nn as ec_nn
+
+    dynamic = getattr(ec_nn, cls)(config="s", eval_spatial_size=None, **kwargs)
+    dynamic.load_state_dict(fixed.state_dict(), strict=False)
+    return dynamic.eval()
+
+
+@pytest.mark.parametrize(
+    "cls,kwargs",
+    [
+        ("LibreECModel", {"nb_classes": 2}),
+        ("LibreECSegModel", {"nb_classes": 2}),
+        ("LibreECPoseModel", {}),
+    ],
+)
+def test_eval_forward_accepts_runtime_size_different_from_eval_spatial_size(
+    cls, kwargs
+):
+    """Eval must rebuild fixed-size encoder/decoder constants for runtime imgsz."""
+    from libreyolo.models.ec import nn as ec_nn
+
+    model = getattr(ec_nn, cls)(
+        config="s", eval_spatial_size=(640, 640), **kwargs
+    ).eval()
+
+    for hw in ((320, 320), (800, 800)):
+        x = torch.randn(1, 3, *hw)
+        with torch.no_grad():
+            model(x)
+
+
+def test_eval_rectangular_size_with_native_token_count_matches_dynamic():
+    """A rect grid can share the native buffer's token count (16x25 == 20x20).
+
+    Constants must be rebuilt from the grid shape, not the token count, or
+    the encoder/decoder silently apply wrong-grid embeddings and anchors.
+    """
+    from libreyolo.models.ec.nn import LibreECModel
+
+    fixed = LibreECModel(
+        config="s", nb_classes=2, eval_spatial_size=(640, 640)
+    ).eval()
+    dynamic = _load_twin(fixed, "LibreECModel", nb_classes=2)
+
+    x = torch.randn(1, 3, 512, 800)
+    with torch.no_grad():
+        out_fixed = fixed(x)
+        out_dynamic = dynamic(x)
+    for key in ("pred_logits", "pred_boxes"):
+        torch.testing.assert_close(
+            out_fixed[key], out_dynamic[key], rtol=1e-4, atol=1e-5
+        )

--- a/tests/unit/test_ec_endtoend_shapes.py
+++ b/tests/unit/test_ec_endtoend_shapes.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from libreyolo.models.ec.backbone import ViTAdapter
-from libreyolo.models.ec.decoder import ECTransformer
+from libreyolo.models.ec.decoder import ECTransformer, ECPoseTransformer
 from libreyolo.models.ec.encoder import HybridEncoder
 from libreyolo.models.ec.nn import SIZE_CONFIGS
 
@@ -113,3 +113,27 @@ def test_eval_rectangular_size_with_native_token_count_matches_dynamic():
         torch.testing.assert_close(
             out_fixed[key], out_dynamic[key], rtol=1e-4, atol=1e-5
         )
+
+
+def test_pose_anchor_cache_tracks_memory_dtype():
+    """A warmed float cache must not survive a later half-precision cast."""
+    decoder = ECPoseTransformer(
+        hidden_dim=32,
+        nhead=4,
+        num_queries=5,
+        num_decoder_layers=1,
+        dim_feedforward=64,
+        eval_spatial_size=(64, 64),
+    ).eval()
+    spatial_shapes = [[8, 8], [4, 4], [2, 2]]
+    memory = torch.empty(1, 84, 32)
+
+    anchors_float, _ = decoder._get_anchors_for_spatial_shapes(spatial_shapes, memory)
+    decoder.half()
+    anchors_half, _ = decoder._get_anchors_for_spatial_shapes(
+        spatial_shapes, memory.half()
+    )
+
+    assert anchors_float.dtype == torch.float32
+    assert anchors_half.dtype == torch.float16
+    assert anchors_float.data_ptr() != anchors_half.data_ptr()

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -596,7 +596,7 @@ class TestExporterFormats:
 
     @pytest.mark.parametrize(
         "family",
-        ["dfine", "deim", "ec", "rfdetr", "rtdetr", "rtdetrv2", "rtdetrv4"],
+        ["dfine", "deim", "deimv2", "ec", "rfdetr", "rtdetr", "rtdetrv2", "rtdetrv4"],
     )
     def test_rectangular_imgsz_rejected_for_fixed_square_families(self, family):
         wrapper = _make_wrapper(model_name=family, input_size=32)
@@ -610,17 +610,17 @@ class TestExporterFormats:
                 int8=False,
             )
 
-    def test_deimv2_tuple_imgsz_must_match_native(self):
+    def test_deimv2_accepts_non_native_square_imgsz(self):
         wrapper = _make_wrapper(model_name="deimv2", input_size=320)
 
-        with pytest.raises(ValueError, match="fixed decoder anchors"):
-            OnnxExporter(wrapper)._resolve_params(
-                output_path=None,
-                imgsz=(320, 640),
-                device="cpu",
-                half=False,
-                int8=False,
-            )
+        imgsz, _, _ = OnnxExporter(wrapper)._resolve_params(
+            output_path=None,
+            imgsz=(640, 640),
+            device="cpu",
+            half=False,
+            int8=False,
+        )
+        assert imgsz == (640, 640)
 
     def test_rectangular_onnx_export_writes_shape_metadata_without_onnx(
         self, monkeypatch, tmp_path

--- a/tests/unit/test_rtdetrv2_endtoend_shapes.py
+++ b/tests/unit/test_rtdetrv2_endtoend_shapes.py
@@ -1,0 +1,72 @@
+"""Eval-time dynamic-size tests for RT-DETRv2 (and the shared RT-DETR encoder).
+
+The RT-DETRv2 wrapper builds its model with a concrete ``eval_spatial_size``,
+so eval-mode forwards must rebuild the precomputed encoder pos-embed and
+decoder anchors whenever the runtime input size differs from the native one.
+RT-DETR v1 passes no ``eval_spatial_size`` and must stay dynamic-by-default.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.rtdetr.nn import RTDETRModel
+from libreyolo.models.rtdetrv2.nn import RTDETRv2Model
+
+pytestmark = pytest.mark.unit
+
+
+def _make_v2(eval_spatial_size):
+    return RTDETRv2Model(
+        num_classes=2, eval_spatial_size=eval_spatial_size
+    ).eval()
+
+
+def test_eval_forward_accepts_runtime_size_different_from_eval_spatial_size():
+    """Eval must rebuild fixed-size encoder/decoder constants for runtime imgsz."""
+    model = _make_v2((640, 640))
+
+    for hw in ((320, 320), (800, 800)):
+        x = torch.randn(1, 3, *hw)
+        with torch.no_grad():
+            out = model(x)
+        assert out["pred_logits"].shape == (1, 300, 2)
+        assert out["pred_boxes"].shape == (1, 300, 4)
+
+
+def test_eval_rectangular_size_with_native_token_count_matches_dynamic():
+    """A rect grid can share the native buffer's token count (16x25 == 20x20).
+
+    Constants must be rebuilt from the grid shape, not the token count, or
+    the encoder/decoder silently apply wrong-grid embeddings and anchors.
+    """
+    fixed = _make_v2((640, 640))
+    dynamic = _make_v2(None)
+    dynamic.load_state_dict(fixed.state_dict(), strict=False)
+
+    x = torch.randn(1, 3, 512, 800)
+    with torch.no_grad():
+        out_fixed = fixed(x)
+        out_dynamic = dynamic(x)
+    for key in ("pred_logits", "pred_boxes"):
+        torch.testing.assert_close(
+            out_fixed[key], out_dynamic[key], rtol=1e-4, atol=1e-5
+        )
+
+
+def test_rtdetr_v1_default_stays_dynamic_with_no_extra_buffers():
+    """v1 never sets eval_spatial_size; behavior and state-dict must not change."""
+    model = RTDETRModel(num_classes=2).eval()
+
+    assert model.decoder.eval_spatial_size is None
+    assert not any(
+        key.endswith(("anchors", "valid_mask")) for key in model.state_dict()
+    )
+
+    for hw in ((320, 320), (512, 800)):
+        x = torch.randn(1, 3, *hw)
+        with torch.no_grad():
+            out = model(x)
+        assert out["pred_logits"].shape[0] == 1
+        assert out["pred_boxes"].shape[-1] == 4


### PR DESCRIPTION
Fixes the eval-size crash class reported on r/LibreYOLO for the EC model ("Validation failed: the size of tensor a (1024) must match the size of tensor b (400) at non-singleton dimension 1" when training at imgsz != 640), and closes the same defect in every sibling family that shares the pattern.

DETR-family models precompute the encoder sin-cos pos-embed and the decoder anchors/valid_mask at construction for `eval_spatial_size` and used them in eval mode regardless of the actual input size, so any predict/val/train-time-validation at a non-native imgsz crashed. PR #541 fixed this for D-FINE only; this PR ports that dynamic rebuild (with the same bounded LRU caches) to:

- EC detect, segment, and pose (encoder + ECTransformer + ECPoseTransformer)
- RT-DETRv2 (shared rtdetr HybridEncoder + v2 decoder; RT-DETR v1 keeps passing no eval_spatial_size and is covered by a no-regression test)
- DEIM (encoder + decoder)
- DEIMv2 (engine hybrid encoder + decoder), removing its now-obsolete preprocess/export imgsz guards, which only protected predict anyway — validators call the model directly, so val() and train-time validation still crashed

It also fixes a hole in #541 itself: the encoder rebuilt the pos-embed only when the token count differed, so a rectangular grid colliding with the native count (16x25 vs 20x20, both 400 tokens at stride 32, e.g. a 512x800 input) silently ran with a wrong-grid embedding (~0.8 max output divergence). The rebuild condition now compares grid shapes. The decoder half already keyed on exact spatial shapes and was safe.

Tests: new/extended endtoend-shape unit tests per family, covering non-native square sizes, the equal-token-count rectangular collision (fixed model must match an eval_spatial_size=None twin loaded with the same weights), the RT-DETR v1 no-regression case, and DEIMv2 export accepting non-native square imgsz (rectangular export stays blocked by the fixed-square export contract, now also parametrized for deimv2). State-dict keys are unchanged everywhere: the caches are plain attributes, and the registered anchors/valid_mask/pos_embed buffers keep their names.

## Code provenance

Original code written for this PR; it ports LibreYOLO's own first-party D-FINE fix pattern (PR #541) to sibling family copies within this repository. No third-party code ported, adapted, or introduced; no GPL/AGPL/LGPL/non-commercial/unknown-license material involved.
