### PR TITLE
Fix CLIP tokenizer unit tests failing on missing optional deps

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,9 @@ jobs:
         # The onnx extra keeps the ONNX-dependent unit tests (raw export
         # contract, picodet/classification round-trips) from silently
         # skipping in this gate — they importorskip onnx/onnxruntime.
-        run: uv pip install --no-sources --torch-backend cpu --group dev -e ".[rfdetr,onnx]"
+        # The clip extra (ftfy + regex) keeps the LibreCLIP tokenizer tests
+        # from erroring on a missing optional tokenizer dependency.
+        run: uv pip install --no-sources --torch-backend cpu --group dev -e ".[rfdetr,onnx,clip]"
 
       - name: Run PR gate tests
         env:

--- a/tests/unit/test_clip.py
+++ b/tests/unit/test_clip.py
@@ -12,6 +12,11 @@ import pytest
 import torch
 from PIL import Image
 
+# LibreCLIP's tokenizer needs the optional ``clip`` extra (ftfy + regex).
+# Skip cleanly instead of erroring when it isn't installed.
+pytest.importorskip("ftfy", reason="LibreCLIP tokenizer needs the 'clip' extra")
+pytest.importorskip("regex", reason="LibreCLIP tokenizer needs the 'clip' extra")
+
 from libreyolo.models.base.model import BaseModel
 from libreyolo.models.clip import nn as clip_nn
 from libreyolo.models.clip.model import LibreCLIP


### PR DESCRIPTION
## Summary
- Skips the CLIP tokenizer unit tests cleanly when the optional ftfy/regex dependencies (the [clip] extra) are not installed, instead of erroring at collection.
- Found while running the v1.4.0 GPU e2e gate on a fresh environment; no product code changes.
