### PR TITLE
Add a declarative augmentation spec; warn on ignored knobs and gated mixup

### DIFF
--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -522,16 +522,20 @@ def train_cmd(
             ),
         )
 
-    # RF-DETR: warn and ignore unsupported params
-    rfdetr_warnings = []
+    # Warn when explicitly-set params are ignored by the selected family
+    # (spec-driven; see libreyolo/data/augment/spec.py).
+    ignored_warnings = []
     unsupported_params = get_unsupported_train_params(family)
     if unsupported_params:
         for param_name in unsupported_params:
             if param_name in user_provided:
-                rfdetr_warnings.append(param_name)
-        if rfdetr_warnings:
+                ignored_warnings.append(param_name)
+        if ignored_warnings:
+            from libreyolo.data.augment.spec import display_name
+
             out.progress(
-                f"Warning: RF-DETR ignores these parameters: {', '.join(sorted(rfdetr_warnings))}"
+                f"Warning: {display_name(family)} ignores these parameters: "
+                f"{', '.join(sorted(ignored_warnings))}"
             )
 
     # Dry run: validate and show resolved config

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -13,14 +13,35 @@ from libreyolo.tasks import task_to_suffix
 
 
 def get_unsupported_train_params(family: str | None) -> set[str]:
-    """Return the set of CLI parameters ignored by a model family's trainer."""
+    """Return the set of CLI parameters ignored by a model family's trainer.
+
+    Augmentation knobs come from the declarative spec
+    (``libreyolo.data.augment.spec``), which covers every trainable family.
+    Families may declare additional non-augmentation ignores via an
+    ``UNSUPPORTED_TRAIN_PARAMS`` class attribute (RF-DETR: optimizer/momentum/
+    nesterov/pretrained), which is unioned in.
+    """
+    from libreyolo.data.augment.spec import ignored_aug_params
+
+    from .aliases import TRAIN_ALIASES
+
+    internal_to_cli = {v: k for k, v in TRAIN_ALIASES.items()}
+    unsupported: set[str] = set()
+    for name in ignored_aug_params(family):
+        # Fields whose name collides with a CLI alias key (the classification
+        # ``mixup`` field vs the ``mixup`` -> ``mixup_prob`` alias) have no CLI
+        # spelling of their own; the CLI name belongs to the aliased field.
+        if name in TRAIN_ALIASES:
+            continue
+        unsupported.add(internal_to_cli.get(name, name))
+
     if family == "rfdetr":
         from libreyolo.models import try_ensure_rfdetr
 
         rfcls = try_ensure_rfdetr()
         if rfcls is not None:
-            return getattr(rfcls, "UNSUPPORTED_TRAIN_PARAMS", set())
-    return set()
+            unsupported |= getattr(rfcls, "UNSUPPORTED_TRAIN_PARAMS", set())
+    return unsupported
 
 
 # =========================================================================

--- a/libreyolo/data/augment/spec.py
+++ b/libreyolo/data/augment/spec.py
@@ -1,0 +1,392 @@
+"""Declarative augmentation-knob spec: which family honors which knob.
+
+This module is the single source of truth for how each trainable model family
+treats the augmentation knobs on :class:`~libreyolo.training.config.TrainConfig`.
+It is a plain-Python table (no torch/cv2 imports) derived by reading each
+family's trainer + transform + dataset-wrapper code, and it is pinned to
+reality by ``tests/unit/test_augment_spec.py``, which asserts the claimed
+statuses against the actual pipeline plumbing.
+
+Consumers:
+  - ``libreyolo.cli.config.get_unsupported_train_params`` warns when a user
+    explicitly sets a CLI training parameter that the selected family ignores
+    (previously this existed only for RF-DETR).
+  - ``BaseTrainer._setup_data`` (and FOMO's data setup) warn when
+    ``mixup_prob > 0`` can never fire because the family only applies mixup to
+    mosaic samples and ``mosaic_prob == 0``.
+  - Docs generation can render the support matrix instead of hand-writing it.
+
+Statuses:
+  - ``USED``: the knob reaches the family's train pipeline and changes samples.
+  - ``GATED_BY_MOSAIC``: the knob is only applied to samples that took the
+    mosaic branch (probability ``mosaic_prob``); with ``mosaic_prob == 0`` it
+    never fires. This is how the YOLOX-style wrappers apply affine and mixup.
+  - ``IGNORED``: the knob never reaches the family's train pipeline; setting
+    it silently does nothing.
+
+Keys are TrainConfig field names (``mosaic_prob``, not the CLI alias
+``mosaic``); the CLI consumer maps to CLI spellings via
+``libreyolo.cli.aliases.TRAIN_ALIASES``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, NamedTuple, Optional, Set
+
+USED = "used"
+GATED_BY_MOSAIC = "gated_by_mosaic"
+IGNORED = "ignored"
+
+_VALID_STATUSES = frozenset({USED, GATED_BY_MOSAIC, IGNORED})
+
+
+class Support(NamedTuple):
+    """How one family treats one augmentation knob."""
+
+    status: str
+    note: str = ""
+
+
+# Base TrainConfig augmentation knobs covered by the matrix, with one-line
+# descriptions (config-field names, not CLI aliases).
+AUG_KNOBS: Dict[str, str] = {
+    "mosaic_prob": "Probability of building a 4-image mosaic sample.",
+    "mixup_prob": "Probability of blending in a second sample (MixUp).",
+    "hsv_prob": "Probability of HSV color jitter.",
+    "flip_prob": "Horizontal-flip probability.",
+    "degrees": "Random-rotation range for the affine warp, in degrees.",
+    "translate": "Random-translation fraction for the affine warp.",
+    "mosaic_scale": "Random-scale range for the affine warp.",
+    "mixup_scale": "Jitter-scale range applied to the MixUp partner image.",
+    "shear": "Random-shear range for the affine warp, in degrees.",
+    "perspective": "Projective (perspective) warp magnitude for the affine warp.",
+    "flipud": "Vertical-flip probability.",
+    "no_aug_epochs": "Final epochs trained with strong augmentation disabled.",
+    # Classification-only pack (ImageFolder pipeline; detection families
+    # ignore these).
+    "auto_augment": "Classification AutoAugment policy (randaugment/autoaugment/augmix).",
+    "erasing": "Classification RandomErasing probability.",
+    "mixup": "Classification batch-MixUp probability (soft labels).",
+    "cutmix": "Classification batch-CutMix probability (soft labels).",
+}
+
+# Human-facing family names for warnings and docs.
+FAMILY_DISPLAY_NAMES: Dict[str, str] = {
+    "yolox": "YOLOX",
+    "yolo7": "YOLOv7",
+    "yolo9": "YOLOv9",
+    "yolo9_e2e": "YOLOv9-E2E",
+    "yolo9_p2": "YOLOv9-P2",
+    "yolonas": "YOLO-NAS",
+    "rtdetr": "RT-DETR",
+    "rtdetrv2": "RT-DETRv2",
+    "rtdetrv4": "RT-DETRv4",
+    "dfine": "D-FINE",
+    "deim": "DEIM",
+    "deimv2": "DEIMv2",
+    "ec": "EC",
+    "rtmdet": "RTMDet",
+    "picodet": "PICODET",
+    "rfdetr": "RF-DETR",
+    "fomo": "FOMO",
+    "resnet": "ResNet",
+    "convnext": "ConvNeXt",
+    "mobilenetv4": "MobileNetV4",
+    "efficientnetv2": "EfficientNetV2",
+    "dinov2": "DINOv2",
+    "segformer": "SegFormer",
+    "nafnet": "NAFNet",
+}
+
+
+def _u(note: str = "") -> Support:
+    return Support(USED, note)
+
+
+def _g(note: str = "") -> Support:
+    return Support(GATED_BY_MOSAIC, note)
+
+
+def _i(note: str = "") -> Support:
+    return Support(IGNORED, note)
+
+
+_CLS_KNOBS_IGNORED = {
+    "auto_augment": _i("Classification-only knob."),
+    "erasing": _i("Classification-only knob."),
+    "mixup": _i("Classification-only knob (API-only; the CLI --mixup is the detection mixup_prob alias)."),
+    "cutmix": _i("Classification-only knob."),
+}
+
+# YOLOX-style pipeline: per-sample preproc applies HSV + flips; affine and
+# MixUp run only inside the mosaic branch (probability mosaic_prob).
+_YOLOX_STYLE = {
+    "mosaic_prob": _u(),
+    "mixup_prob": _g("MixUp only applies to mosaic samples."),
+    "hsv_prob": _u(),
+    "flip_prob": _u(),
+    "degrees": _g("Affine runs on the mosaic canvas only."),
+    "translate": _g("Affine runs on the mosaic canvas only."),
+    "mosaic_scale": _g("Affine runs on the mosaic canvas only."),
+    "mixup_scale": _g("MixUp only applies to mosaic samples."),
+    "shear": _g("Affine runs on the mosaic canvas only."),
+    "perspective": _g("Affine runs on the mosaic canvas only."),
+    "flipud": _u(),
+    "no_aug_epochs": _u("Disables mosaic/mixup for the final epochs."),
+    **_CLS_KNOBS_IGNORED,
+}
+
+# DETR-style pass-through pipeline (torchvision-v2 transform, no mosaic):
+# horizontal flip is configurable; photometric distortion / zoom-out /
+# IoU-crop are family recipe constants, so hsv_prob and the geometry knobs
+# never reach the pipeline.
+_DETR_STYLE = {
+    "mosaic_prob": _i("DETR-style pipeline has no mosaic."),
+    "mixup_prob": _i("DETR-style pipeline has no MixUp."),
+    "hsv_prob": _i("Color jitter comes from RandomPhotometricDistort with a fixed recipe probability."),
+    "flip_prob": _u(),
+    "degrees": _i("DETR-style pipeline has no affine warp."),
+    "translate": _i("DETR-style pipeline has no affine warp."),
+    "mosaic_scale": _i("DETR-style pipeline has no affine warp."),
+    "mixup_scale": _i("DETR-style pipeline has no MixUp."),
+    "shear": _i("DETR-style pipeline has no affine warp."),
+    "perspective": _i("DETR-style pipeline has no affine warp."),
+    "flipud": _i("DETR-style pipeline has no vertical flip."),
+    "no_aug_epochs": _u("Stops the strong augs (photometric/zoom-out/IoU-crop) and shapes the LR tail."),
+    **_CLS_KNOBS_IGNORED,
+}
+
+# Classification ImageFolder pipeline: detection knobs never apply; the
+# horizontal flip is a fixed RandomHorizontalFlip(0.5), not flip_prob.
+_CLASSIFY_STYLE = {
+    "mosaic_prob": _i("Classification pipeline has no mosaic."),
+    "mixup_prob": _i("Detection MixUp; classification uses the 'mixup' field instead."),
+    "hsv_prob": _i("Classification pipeline has no HSV jitter."),
+    "flip_prob": _i("Classification flip is a fixed RandomHorizontalFlip(0.5)."),
+    "degrees": _i("Classification pipeline has no affine warp."),
+    "translate": _i("Classification pipeline has no affine warp."),
+    "mosaic_scale": _i("Classification pipeline has no affine warp."),
+    "mixup_scale": _i("Classification pipeline has no detection MixUp."),
+    "shear": _i("Classification pipeline has no affine warp."),
+    "perspective": _i("Classification pipeline has no affine warp."),
+    "flipud": _i("Classification pipeline has no vertical flip."),
+    "no_aug_epochs": _u("Shapes the scheduler's plateau tail."),
+    "auto_augment": _u(),
+    "erasing": _u(),
+    "mixup": _u("API-only: the CLI --mixup is the detection mixup_prob alias."),
+    "cutmix": _u(),
+}
+
+FAMILY_AUG_SUPPORT: Dict[str, Dict[str, Support]] = {
+    # --- YOLOX-style mosaic pipelines -----------------------------------
+    "yolox": dict(_YOLOX_STYLE),
+    "yolo7": dict(_YOLOX_STYLE),
+    "yolo9": dict(_YOLOX_STYLE),
+    "yolo9_e2e": dict(_YOLOX_STYLE),
+    "yolo9_p2": dict(_YOLOX_STYLE),
+    "rtmdet": {
+        **_YOLOX_STYLE,
+        "flipud": _i("RTMDet's transform has no vertical flip."),
+    },
+    "picodet": {
+        **_YOLOX_STYLE,
+        "flipud": _i("PICODET's transform has no vertical flip."),
+    },
+    "rtdetr": {
+        **_YOLOX_STYLE,
+        "flipud": _i("RT-DETR's transform has no vertical flip."),
+    },
+    "rtdetrv2": {
+        **_YOLOX_STYLE,
+        "flipud": _i("RT-DETRv2's transform has no vertical flip."),
+    },
+    "fomo": {
+        **_YOLOX_STYLE,
+        "perspective": _i("FOMO's mosaic wrapper is built without perspective."),
+        "flipud": _i("FOMO's transform has no vertical flip."),
+    },
+    # --- YOLO-NAS: affine always on, mosaic ignored, mixup independent --
+    "yolonas": {
+        "mosaic_prob": _i("YOLO-NAS trains with a per-sample affine instead of mosaic."),
+        "mixup_prob": _u("MixUp is independent of mosaic here."),
+        "hsv_prob": _u(),
+        "flip_prob": _u(),
+        "degrees": _u("Applied by the always-on per-sample affine."),
+        "translate": _u("Applied by the always-on per-sample affine."),
+        "mosaic_scale": _u("Reused as the per-sample affine scale range."),
+        "mixup_scale": _u(),
+        "shear": _u("Applied by the always-on per-sample affine."),
+        "perspective": _u("Applied by the always-on per-sample affine."),
+        "flipud": _u(),
+        "no_aug_epochs": _u("Disables the affine and MixUp for the final epochs."),
+        **_CLS_KNOBS_IGNORED,
+    },
+    # --- DETR-style pass-through pipelines ------------------------------
+    "dfine": dict(_DETR_STYLE),
+    "deim": dict(_DETR_STYLE),
+    "deimv2": dict(_DETR_STYLE),
+    # EC is multi-task (detect/segment/pose). Its pose pipeline honors
+    # hsv_prob/degrees/translate, so those cannot be marked IGNORED for the
+    # family as a whole; the CLI warning must never be wrong for any task.
+    "ec": {
+        **_DETR_STYLE,
+        "hsv_prob": _u("task='pose' only; detect/segment use fixed photometric recipes."),
+        "degrees": _u("task='pose' only (keypoint-aware affine)."),
+        "translate": _u("task='pose' only (keypoint-aware affine)."),
+    },
+    "rtdetrv4": dict(_DETR_STYLE),
+    # --- RF-DETR: native pipeline (flip + scale jitter + crop) ----------
+    "rfdetr": {
+        **_DETR_STYLE,
+        "hsv_prob": _i("RF-DETR's native pipeline has no HSV jitter."),
+        "no_aug_epochs": _u("Shapes the scheduler's plateau tail."),
+    },
+    # --- DINOv2 (multi-task: semantic/classify/detect). Only knobs that
+    # are ignored across ALL of its trainable tasks are marked IGNORED, so
+    # the CLI warning is never wrong for any task. flip_prob reaches the
+    # RF-DETR-style detect pipeline; the classification pack applies to
+    # task='classify'.
+    "dinov2": {
+        **_DETR_STYLE,
+        "hsv_prob": _i("No HSV jitter in any DINOv2 task pipeline."),
+        "no_aug_epochs": _u("Shapes the scheduler's plateau tail."),
+        "auto_augment": _u("task='classify' only."),
+        "erasing": _u("task='classify' only."),
+        "mixup": _u("task='classify' only (API-only knob)."),
+        "cutmix": _u("task='classify' only."),
+    },
+    # --- Classification-only families -----------------------------------
+    "resnet": dict(_CLASSIFY_STYLE),
+    "convnext": dict(_CLASSIFY_STYLE),
+    "mobilenetv4": dict(_CLASSIFY_STYLE),
+    "efficientnetv2": dict(_CLASSIFY_STYLE),
+    # --- Semantic-only: the semantic pipeline reads family class
+    # attributes (semantic_scale_jitter / semantic_hsv_prob), not config
+    # knobs; horizontal flip is a fixed 0.5.
+    "segformer": {
+        "mosaic_prob": _i("Semantic pipeline has no mosaic."),
+        "mixup_prob": _i("Semantic pipeline has no MixUp."),
+        "hsv_prob": _i("Semantic HSV comes from the family's semantic_hsv_prob class attribute."),
+        "flip_prob": _i("Semantic flip is a fixed 0.5."),
+        "degrees": _i("Semantic pipeline has no affine warp."),
+        "translate": _i("Semantic pipeline has no affine warp."),
+        "mosaic_scale": _i("Semantic scale jitter comes from the family's semantic_scale_jitter class attribute."),
+        "mixup_scale": _i("Semantic pipeline has no MixUp."),
+        "shear": _i("Semantic pipeline has no affine warp."),
+        "perspective": _i("Semantic pipeline has no affine warp."),
+        "flipud": _i("Semantic pipeline has no vertical flip."),
+        "no_aug_epochs": _u("Shapes the scheduler's tail."),
+        **_CLS_KNOBS_IGNORED,
+    },
+    # --- Restoration: coupled crop/flip/rot90 with fixed probabilities --
+    "nafnet": {
+        "mosaic_prob": _i("Restore pipeline has no mosaic."),
+        "mixup_prob": _i("Restore pipeline has no MixUp."),
+        "hsv_prob": _i("Restore pipeline has no HSV jitter."),
+        "flip_prob": _i("Restore flips are coupled input/target ops with fixed 0.5 probability."),
+        "degrees": _i("Restore pipeline has no affine warp."),
+        "translate": _i("Restore pipeline has no affine warp."),
+        "mosaic_scale": _i("Restore pipeline has no affine warp."),
+        "mixup_scale": _i("Restore pipeline has no MixUp."),
+        "shear": _i("Restore pipeline has no affine warp."),
+        "perspective": _i("Restore pipeline has no affine warp."),
+        "flipud": _i("Restore vertical flip is a coupled op with fixed 0.5 probability."),
+        "no_aug_epochs": _u("Shapes the scheduler's tail."),
+        **_CLS_KNOBS_IGNORED,
+    },
+}
+
+# Family-specific augmentation knobs that live on the family's TrainConfig
+# subclass rather than the base TrainConfig. Documentation-oriented; the CLI
+# does not expose these.
+FAMILY_EXTRA_AUG_KNOBS: Dict[str, Dict[str, str]] = {
+    "yolo9": {
+        "copy_paste": "Copy-paste instance augmentation probability (task='segment' only).",
+        "copy_paste_mode": "Copy-paste source: 'flip' (same sample mirrored) or 'mixup' (second sample).",
+        "rot90": "Random 90-degree rotation probability (detect/OBB).",
+    },
+    "yolo9_e2e": {
+        "copy_paste": "Copy-paste instance augmentation probability (task='segment' only).",
+        "copy_paste_mode": "Copy-paste source: 'flip' or 'mixup'.",
+        "rot90": "Random 90-degree rotation probability.",
+    },
+    "yolo9_p2": {
+        "copy_paste": "Copy-paste instance augmentation probability (task='segment' only).",
+        "copy_paste_mode": "Copy-paste source: 'flip' or 'mixup'.",
+        "rot90": "Random 90-degree rotation probability.",
+    },
+    "rfdetr": {
+        "copy_paste": "Copy-paste probability for task='segment' ('flip' mode only).",
+        "copy_paste_mode": "Copy-paste source mode for task='segment'.",
+        "crop_resize_prob": "Random crop-resize probability in the native pipeline.",
+    },
+    "dfine": {
+        "crop_resize_prob": "Random crop-resize probability (task='segment').",
+    },
+    "ec": {
+        "crop_resize_prob": "Random crop-resize probability (task='segment').",
+        "brightness_contrast_prob": "Brightness/contrast jitter probability (task='pose').",
+        "affine_prob": "Keypoint-aware affine probability (task='pose').",
+    },
+    "yolonas": {
+        "brightness_contrast_prob": "Brightness/contrast jitter probability (task='pose').",
+        "affine_prob": "Keypoint-aware affine probability (task='pose').",
+    },
+}
+
+
+def aug_support(family: Optional[str]) -> Optional[Dict[str, Support]]:
+    """Return the knob-support table for a family, or None if unknown."""
+    if family is None:
+        return None
+    return FAMILY_AUG_SUPPORT.get(family)
+
+
+def ignored_aug_params(family: Optional[str]) -> Set[str]:
+    """TrainConfig field names of augmentation knobs a family ignores.
+
+    Returns an empty set for unknown families (no spurious warnings for
+    families the spec does not cover yet).
+    """
+    table = aug_support(family)
+    if table is None:
+        return set()
+    return {knob for knob, support in table.items() if support.status == IGNORED}
+
+
+def uses_mosaic_gating(family: Optional[str]) -> bool:
+    """Whether the family's MixUp only fires on mosaic samples."""
+    table = aug_support(family)
+    if table is None:
+        return False
+    return table.get("mixup_prob", Support(IGNORED)).status == GATED_BY_MOSAIC
+
+
+def display_name(family: Optional[str]) -> str:
+    """Human-facing family name for warnings and docs."""
+    if not family:
+        return "This model family"
+    return FAMILY_DISPLAY_NAMES.get(family, family)
+
+
+def mixup_gating_warning(
+    family: Optional[str],
+    mosaic_prob: float,
+    mixup_prob: float,
+) -> Optional[str]:
+    """Warning text when mixup can never fire, or None when it can.
+
+    For families whose MixUp only applies to mosaic samples, ``mixup_prob > 0``
+    with ``mosaic_prob <= 0`` silently disables mixup. Callers log the returned
+    message; this stays a pure function so it is trivially testable and never
+    touches the RNG stream.
+    """
+    if not uses_mosaic_gating(family):
+        return None
+    if float(mixup_prob or 0.0) > 0.0 and float(mosaic_prob or 0.0) <= 0.0:
+        return (
+            f"mixup_prob={mixup_prob} has no effect for {display_name(family)}: "
+            "mixup only applies to mosaic samples and mosaic_prob=0. "
+            "Set mosaic_prob > 0 to enable mixup."
+        )
+    return None

--- a/libreyolo/models/fomo/dataset.py
+++ b/libreyolo/models/fomo/dataset.py
@@ -347,6 +347,13 @@ def build_fomo_datasets(
         from ...training.augment import MosaicMixupDataset
 
         if is_main_process():
+            from ...data.augment.spec import mixup_gating_warning
+
+            gating_msg = mixup_gating_warning(
+                "fomo", config.mosaic_prob, config.mixup_prob
+            )
+            if gating_msg:
+                logger.warning(gating_msg)
             logger.info("FOMO Training: Data augmentation enabled.")
             logger.info(f"  mosaic_prob: {config.mosaic_prob}")
             logger.info(f"  mixup_prob: {config.mixup_prob}")

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -709,6 +709,20 @@ class BaseTrainer(ABC):
                 "OBB augmentation is implemented."
             )
 
+        # Mosaic-gated mixup: for families whose MixUp only fires on mosaic
+        # samples, mixup_prob > 0 with mosaic_prob == 0 silently does nothing.
+        # Say so instead (spec-driven; see libreyolo/data/augment/spec.py).
+        if mosaic_enabled and is_main_process():
+            from ..data.augment.spec import mixup_gating_warning
+
+            gating_msg = mixup_gating_warning(
+                self.get_model_family(),
+                self.config.mosaic_prob,
+                self.config.mixup_prob,
+            )
+            if gating_msg:
+                logger.warning(gating_msg)
+
         train_dataset.enable_image_cache(getattr(self.config, "cache", False))
 
         dataset_kwargs = dict(

--- a/tests/unit/test_augment_spec.py
+++ b/tests/unit/test_augment_spec.py
@@ -139,29 +139,32 @@ _TRAINABLE_WITHOUT_TRAIN_CONFIG = {"dfine", "ec", "yolonas", "segformer"}
 def test_spec_covers_every_trainable_family():
     """Every family the CLI can train must have a spec entry.
 
-    The required set is derived from the model registry (any family whose
-    model class declares TRAIN_CONFIG is trainable by convention), so a newly
-    registered trainable family fails this test until its knobs are classified
-    in the spec. Families that predate the TRAIN_CONFIG convention are listed
-    explicitly in ``_TRAINABLE_WITHOUT_TRAIN_CONFIG``.
+    Families are discovered through the same path the CLI uses
+    (``cli.config._iter_model_classes``: the registry plus the lazy optional
+    families), so anything the CLI can see is enforced here — including a
+    future lazy ``_ensure_*`` family, which must be added to that iterator for
+    the CLI to work and is then automatically required to have a spec entry.
+    The required set is every discovered family whose model class declares
+    TRAIN_CONFIG (the machine-readable trainable flag), plus the explicit
+    ``_TRAINABLE_WITHOUT_TRAIN_CONFIG`` legacy list.
     """
-    import libreyolo.models  # noqa: F401 - populates the registry
-    from libreyolo.models.base.model import BaseModel
+    from libreyolo.cli.config import _iter_model_classes
 
-    registered = {cls.FAMILY for cls in BaseModel._registry if cls.FAMILY}
-    # rfdetr / dinov2 register lazily (optional heavy deps).
+    classes = list(_iter_model_classes())
+    registered = {cls.FAMILY for cls in classes if cls.FAMILY}
+    # rfdetr / dinov2 may be absent when their optional deps are not
+    # installed; tolerate their spec entries in that case (this leniency is
+    # scoped to exactly these known-optional families).
     known = registered | {"rfdetr", "dinov2"}
     unknown = set(FAMILY_AUG_SUPPORT) - known
     assert not unknown, f"Spec families not in the model registry: {sorted(unknown)}"
 
     declared_trainable = {
         cls.FAMILY
-        for cls in BaseModel._registry
+        for cls in classes
         if cls.FAMILY and getattr(cls, "TRAIN_CONFIG", None) is not None
     }
-    required = (
-        declared_trainable | _TRAINABLE_WITHOUT_TRAIN_CONFIG | {"rfdetr", "dinov2"}
-    )
+    required = declared_trainable | _TRAINABLE_WITHOUT_TRAIN_CONFIG
     missing = required - set(FAMILY_AUG_SUPPORT)
     assert not missing, (
         f"Trainable families missing from the augmentation spec: {sorted(missing)}. "

--- a/tests/unit/test_augment_spec.py
+++ b/tests/unit/test_augment_spec.py
@@ -129,8 +129,22 @@ def test_extra_knobs_exist_on_family_configs():
         assert not missing, f"{family}: extra knobs not on config: {sorted(missing)}"
 
 
+# Families that are trainable but predate the TRAIN_CONFIG "machine-readable
+# trainable flag" convention (their model classes don't declare it, so they
+# cannot be discovered from the registry). If you set TRAIN_CONFIG on one of
+# these, remove it here — a test below enforces that this list stays minimal.
+_TRAINABLE_WITHOUT_TRAIN_CONFIG = {"dfine", "ec", "yolonas", "segformer"}
+
+
 def test_spec_covers_every_trainable_family():
-    """Every family the CLI can train must have a spec entry."""
+    """Every family the CLI can train must have a spec entry.
+
+    The required set is derived from the model registry (any family whose
+    model class declares TRAIN_CONFIG is trainable by convention), so a newly
+    registered trainable family fails this test until its knobs are classified
+    in the spec. Families that predate the TRAIN_CONFIG convention are listed
+    explicitly in ``_TRAINABLE_WITHOUT_TRAIN_CONFIG``.
+    """
     import libreyolo.models  # noqa: F401 - populates the registry
     from libreyolo.models.base.model import BaseModel
 
@@ -140,15 +154,28 @@ def test_spec_covers_every_trainable_family():
     unknown = set(FAMILY_AUG_SUPPORT) - known
     assert not unknown, f"Spec families not in the model registry: {sorted(unknown)}"
 
-    expected_trainable = {
-        "yolox", "yolo7", "yolo9", "yolo9_e2e", "yolo9_p2", "yolonas",
-        "rtdetr", "rtdetrv2", "rtdetrv4", "dfine", "deim", "deimv2", "ec",
-        "rtmdet", "picodet", "rfdetr", "fomo",
-        "resnet", "convnext", "mobilenetv4", "efficientnetv2",
-        "dinov2", "segformer", "nafnet",
+    declared_trainable = {
+        cls.FAMILY
+        for cls in BaseModel._registry
+        if cls.FAMILY and getattr(cls, "TRAIN_CONFIG", None) is not None
     }
-    missing = expected_trainable - set(FAMILY_AUG_SUPPORT)
-    assert not missing, f"Trainable families missing from the spec: {sorted(missing)}"
+    required = (
+        declared_trainable | _TRAINABLE_WITHOUT_TRAIN_CONFIG | {"rfdetr", "dinov2"}
+    )
+    missing = required - set(FAMILY_AUG_SUPPORT)
+    assert not missing, (
+        f"Trainable families missing from the augmentation spec: {sorted(missing)}. "
+        "Classify their knobs in libreyolo/data/augment/spec.py."
+    )
+
+    # Self-cleaning: entries in the legacy list must actually lack
+    # TRAIN_CONFIG. When a family gains the flag, drop it from the list so
+    # coverage is registry-derived for it too.
+    stale = _TRAINABLE_WITHOUT_TRAIN_CONFIG & declared_trainable
+    assert not stale, (
+        f"{sorted(stale)} now declare TRAIN_CONFIG; remove them from "
+        "_TRAINABLE_WITHOUT_TRAIN_CONFIG."
+    )
 
 
 # =========================================================================

--- a/tests/unit/test_augment_spec.py
+++ b/tests/unit/test_augment_spec.py
@@ -1,0 +1,573 @@
+"""Pins the declarative augmentation spec to the real pipeline plumbing.
+
+``libreyolo/data/augment/spec.py`` claims, per family, which TrainConfig
+augmentation knobs are used, mosaic-gated, or silently ignored. These tests
+assert those claims against the actual trainers, transforms, and dataset
+wrappers, so the spec (and everything built on it: CLI warnings, docs) cannot
+drift from reality without a test failure.
+
+No training runs here — we construct trainers with sentinel config values and
+inspect what ``create_transforms()`` / the dataset wrappers actually receive.
+"""
+
+import dataclasses
+
+import pytest
+import torch.nn as nn
+
+from libreyolo.data.augment.spec import (
+    AUG_KNOBS,
+    FAMILY_AUG_SUPPORT,
+    FAMILY_DISPLAY_NAMES,
+    FAMILY_EXTRA_AUG_KNOBS,
+    GATED_BY_MOSAIC,
+    IGNORED,
+    USED,
+    ignored_aug_params,
+    mixup_gating_warning,
+    uses_mosaic_gating,
+)
+from libreyolo.training.config import TrainConfig
+
+pytestmark = pytest.mark.unit
+
+
+# Sentinel values no family uses as a default, so a match proves plumbing.
+FLIP = 0.123
+HSV = 0.456
+FLIPUD = 0.789
+DEGREES = 1.5
+TRANSLATE = 0.21
+MOSAIC_SCALE = (0.4, 1.6)
+MIXUP_SCALE = (0.6, 1.4)
+SHEAR = 0.77
+PERSPECTIVE = 0.0003
+
+
+class _DummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 3, 1)
+
+    def forward(self, x):  # pragma: no cover - never called here
+        return self.conv(x)
+
+
+def _make_trainer(trainer_cls, **kwargs):
+    kwargs.setdefault("device", "cpu")
+    return trainer_cls(model=_DummyModel(), **kwargs)
+
+
+class _DummyDataset:
+    """Minimal stand-in for the wrapper constructors (never iterated)."""
+
+    def __len__(self):
+        return 4
+
+
+# =========================================================================
+# Spec self-consistency
+# =========================================================================
+
+
+def test_every_family_table_covers_every_knob_with_valid_statuses():
+    valid = {USED, GATED_BY_MOSAIC, IGNORED}
+    for family, table in FAMILY_AUG_SUPPORT.items():
+        assert set(table) == set(AUG_KNOBS), (
+            f"{family}: spec table must cover exactly the knobs in AUG_KNOBS"
+        )
+        for knob, support in table.items():
+            assert support.status in valid, f"{family}.{knob}: {support.status}"
+
+
+def test_aug_knobs_are_trainconfig_fields():
+    field_names = {f.name for f in dataclasses.fields(TrainConfig)}
+    missing = set(AUG_KNOBS) - field_names
+    assert not missing, f"Spec knobs not on TrainConfig: {sorted(missing)}"
+
+
+def test_spec_families_have_display_names():
+    assert set(FAMILY_AUG_SUPPORT) == set(FAMILY_DISPLAY_NAMES)
+
+
+def test_extra_knobs_exist_on_family_configs():
+    from libreyolo.training.config import (
+        DFINEConfig,
+        ECConfig,
+        YOLO9Config,
+        YOLONASConfig,
+    )
+    from libreyolo.models.yolo9_e2e.config import YOLO9E2EConfig
+    from libreyolo.models.yolo9_p2.config import YOLO9P2Config
+
+    config_classes = {
+        "yolo9": YOLO9Config,
+        "yolo9_e2e": YOLO9E2EConfig,
+        "yolo9_p2": YOLO9P2Config,
+        "dfine": DFINEConfig,
+        "yolonas": YOLONASConfig,
+    }
+    # EC's seg/pose knobs live on the task-specific config subclasses.
+    from libreyolo.training.config import ECPoseConfig, ECSegConfig
+
+    for family, extras in FAMILY_EXTRA_AUG_KNOBS.items():
+        if family == "rfdetr":
+            rf_config = pytest.importorskip("libreyolo.models.rfdetr.config")
+            fields = {f.name for f in dataclasses.fields(rf_config.RFDETRConfig)}
+        elif family == "ec":
+            fields = {f.name for f in dataclasses.fields(ECConfig)}
+            fields |= {f.name for f in dataclasses.fields(ECSegConfig)}
+            fields |= {f.name for f in dataclasses.fields(ECPoseConfig)}
+        elif family == "yolonas":
+            from libreyolo.training.config import YOLONASPoseConfig
+
+            fields = {f.name for f in dataclasses.fields(YOLONASConfig)}
+            fields |= {f.name for f in dataclasses.fields(YOLONASPoseConfig)}
+        else:
+            fields = {f.name for f in dataclasses.fields(config_classes[family])}
+        missing = set(extras) - fields
+        assert not missing, f"{family}: extra knobs not on config: {sorted(missing)}"
+
+
+def test_spec_covers_every_trainable_family():
+    """Every family the CLI can train must have a spec entry."""
+    import libreyolo.models  # noqa: F401 - populates the registry
+    from libreyolo.models.base.model import BaseModel
+
+    registered = {cls.FAMILY for cls in BaseModel._registry if cls.FAMILY}
+    # rfdetr / dinov2 register lazily (optional heavy deps).
+    known = registered | {"rfdetr", "dinov2"}
+    unknown = set(FAMILY_AUG_SUPPORT) - known
+    assert not unknown, f"Spec families not in the model registry: {sorted(unknown)}"
+
+    expected_trainable = {
+        "yolox", "yolo7", "yolo9", "yolo9_e2e", "yolo9_p2", "yolonas",
+        "rtdetr", "rtdetrv2", "rtdetrv4", "dfine", "deim", "deimv2", "ec",
+        "rtmdet", "picodet", "rfdetr", "fomo",
+        "resnet", "convnext", "mobilenetv4", "efficientnetv2",
+        "dinov2", "segformer", "nafnet",
+    }
+    missing = expected_trainable - set(FAMILY_AUG_SUPPORT)
+    assert not missing, f"Trainable families missing from the spec: {sorted(missing)}"
+
+
+# =========================================================================
+# Transform-level plumbing: knobs the spec claims USED must land on the
+# transform; knobs claimed IGNORED must not.
+# =========================================================================
+
+
+def test_yolox_transform_plumbing():
+    from libreyolo.data.augment.yolox import MosaicMixupDataset
+    from libreyolo.models.yolox.trainer import YOLOXTrainer
+
+    trainer = _make_trainer(
+        YOLOXTrainer, flip_prob=FLIP, hsv_prob=HSV, flipud=FLIPUD
+    )
+    preproc, wrapper_cls = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    assert preproc.hsv_prob == HSV
+    assert preproc.flipud == FLIPUD
+    assert wrapper_cls is MosaicMixupDataset
+
+
+def test_yolo9_transform_plumbing():
+    from libreyolo.data.augment.yolo9 import YOLO9MosaicMixupDataset
+    from libreyolo.models.yolo9.trainer import YOLO9Trainer
+
+    trainer = _make_trainer(
+        YOLO9Trainer, flip_prob=FLIP, hsv_prob=HSV, flipud=FLIPUD, rot90=0.25
+    )
+    preproc, wrapper_cls = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    assert preproc.hsv_prob == HSV
+    assert preproc.vertical_flip_prob == FLIPUD
+    assert preproc.rot90_prob == 0.25
+    assert wrapper_cls is YOLO9MosaicMixupDataset
+
+
+def test_yolo7_transform_plumbing():
+    from libreyolo.data.augment.yolo9 import YOLO9MosaicMixupDataset
+    from libreyolo.models.yolo7.trainer import YOLOv7Trainer
+
+    trainer = _make_trainer(
+        YOLOv7Trainer, flip_prob=FLIP, hsv_prob=HSV, flipud=FLIPUD
+    )
+    preproc, wrapper_cls = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    assert preproc.hsv_prob == HSV
+    assert preproc.vertical_flip_prob == FLIPUD
+    assert wrapper_cls is YOLO9MosaicMixupDataset
+
+
+def test_yolonas_transform_plumbing():
+    from libreyolo.data.augment.yolonas import YOLONASAffineMixupDataset
+    from libreyolo.models.yolonas.trainer import YOLONASTrainer
+
+    trainer = _make_trainer(
+        YOLONASTrainer, flip_prob=FLIP, hsv_prob=HSV, flipud=FLIPUD
+    )
+    preproc, wrapper_cls = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    assert preproc.hsv_prob == HSV
+    assert preproc.flipud == FLIPUD
+    assert wrapper_cls is YOLONASAffineMixupDataset
+
+
+def test_rtmdet_ignores_flipud_as_specced():
+    from libreyolo.models.rtmdet.trainer import RTMDetTrainer
+
+    assert FAMILY_AUG_SUPPORT["rtmdet"]["flipud"].status == IGNORED
+    trainer = _make_trainer(
+        RTMDetTrainer, flip_prob=FLIP, hsv_prob=HSV, flipud=FLIPUD
+    )
+    preproc, _ = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    assert preproc.hsv_prob == HSV
+    # flipud never reaches the transform (stays at the class default 0.0).
+    assert preproc.flipud == 0.0
+
+
+def test_picodet_ignores_flipud_as_specced():
+    from libreyolo.models.picodet.trainer import PICODETTrainer
+
+    assert FAMILY_AUG_SUPPORT["picodet"]["flipud"].status == IGNORED
+    trainer = _make_trainer(
+        PICODETTrainer, flip_prob=FLIP, hsv_prob=HSV, flipud=FLIPUD
+    )
+    preproc, _ = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    assert preproc.hsv_prob == HSV
+    assert not hasattr(preproc, "flipud")
+
+
+def test_rtdetr_ignores_flipud_as_specced():
+    from libreyolo.models.rtdetr.trainer import RTDETRTrainer
+
+    assert FAMILY_AUG_SUPPORT["rtdetr"]["flipud"].status == IGNORED
+    trainer = _make_trainer(
+        RTDETRTrainer, flip_prob=FLIP, hsv_prob=HSV, flipud=FLIPUD
+    )
+    preproc, _ = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    assert preproc.hsv_prob == HSV
+    # flipud never reaches the transform (stays at the class default 0.0).
+    assert preproc.vertical_flip_prob == 0.0
+
+
+@pytest.mark.parametrize("family", ["dfine", "deim", "deimv2", "ec"])
+def test_detr_families_use_flip_and_ignore_hsv(family):
+    trainer_cls = {
+        "dfine": ("libreyolo.models.dfine.trainer", "DFINETrainer"),
+        "deim": ("libreyolo.models.deim.trainer", "DEIMTrainer"),
+        "deimv2": ("libreyolo.models.deimv2.trainer", "DEIMv2Trainer"),
+        "ec": ("libreyolo.models.ec.trainer", "ECTrainer"),
+    }[family]
+    module = pytest.importorskip(trainer_cls[0])
+    trainer = _make_trainer(
+        getattr(module, trainer_cls[1]), flip_prob=FLIP, hsv_prob=HSV
+    )
+    preproc, wrapper_cls = trainer.create_transforms()
+    assert preproc.flip_prob == FLIP
+    # The spec says hsv_prob never reaches the DETR-style pipeline (except EC
+    # pose, which is a different trainer): the transform has no such knob.
+    assert not hasattr(preproc, "hsv_prob")
+
+    # The pass-through wrapper drops every mosaic/affine knob it is handed.
+    wrapper = wrapper_cls(
+        dataset=_DummyDataset(),
+        img_size=(64, 64),
+        mosaic=True,
+        preproc=preproc,
+        degrees=DEGREES,
+        translate=TRANSLATE,
+        mosaic_scale=MOSAIC_SCALE,
+        mixup_scale=MIXUP_SCALE,
+        shear=SHEAR,
+        enable_mixup=True,
+        mosaic_prob=0.5,
+        mixup_prob=0.5,
+        perspective=PERSPECTIVE,
+    )
+    for knob in ("degrees", "translate", "shear", "perspective", "mixup_prob",
+                 "mosaic_prob", "enable_mosaic", "enable_mixup"):
+        assert not hasattr(wrapper, knob), f"{family} wrapper kept {knob}"
+
+
+# =========================================================================
+# Wrapper-level plumbing: mosaic gating vs always-on affine
+# =========================================================================
+
+
+def test_yolox_wrapper_receives_geometry_and_gating_knobs():
+    from libreyolo.data.augment.yolox import MosaicMixupDataset
+
+    wrapper = MosaicMixupDataset(
+        dataset=_DummyDataset(),
+        img_size=(64, 64),
+        mosaic=True,
+        preproc=object(),
+        degrees=DEGREES,
+        translate=TRANSLATE,
+        mosaic_scale=MOSAIC_SCALE,
+        mixup_scale=MIXUP_SCALE,
+        shear=SHEAR,
+        enable_mixup=True,
+        mosaic_prob=0.5,
+        mixup_prob=0.25,
+        perspective=PERSPECTIVE,
+    )
+    assert wrapper.degrees == DEGREES
+    assert wrapper.translate == TRANSLATE
+    assert wrapper.scale == MOSAIC_SCALE
+    assert wrapper.mixup_scale == MIXUP_SCALE
+    assert wrapper.shear == SHEAR
+    assert wrapper.perspective == PERSPECTIVE
+    assert wrapper.enable_mosaic is True
+    assert wrapper.mosaic_prob == 0.5
+    assert wrapper.mixup_prob == 0.25
+
+
+def test_yolo9_wrapper_receives_copy_paste():
+    from libreyolo.data.augment.yolo9 import YOLO9MosaicMixupDataset
+
+    wrapper = YOLO9MosaicMixupDataset(
+        dataset=_DummyDataset(),
+        img_size=(64, 64),
+        preproc=object(),
+        copy_paste=0.35,
+        copy_paste_mode="mixup",
+        perspective=PERSPECTIVE,
+    )
+    assert wrapper.copy_paste == 0.35
+    assert wrapper.copy_paste_mode == "mixup"
+    assert wrapper.perspective == PERSPECTIVE
+
+
+def test_yolonas_wrapper_drops_mosaic_but_keeps_affine_and_mixup():
+    from libreyolo.data.augment.yolonas import YOLONASAffineMixupDataset
+
+    wrapper = YOLONASAffineMixupDataset(
+        dataset=_DummyDataset(),
+        img_size=(64, 64),
+        mosaic=True,
+        preproc=object(),
+        degrees=DEGREES,
+        translate=TRANSLATE,
+        mosaic_scale=MOSAIC_SCALE,
+        mixup_scale=MIXUP_SCALE,
+        shear=SHEAR,
+        enable_mixup=True,
+        mosaic_prob=0.5,
+        mixup_prob=0.25,
+        perspective=PERSPECTIVE,
+    )
+    # Spec: mosaic_prob is IGNORED for YOLO-NAS (per-sample affine instead).
+    assert not hasattr(wrapper, "mosaic_prob")
+    assert not hasattr(wrapper, "enable_mosaic")
+    # Spec: affine + mixup knobs are USED, independent of mosaic.
+    assert wrapper.enable_affine is True
+    assert wrapper.degrees == DEGREES
+    assert wrapper.translate == TRANSLATE
+    assert wrapper.scale == MOSAIC_SCALE
+    assert wrapper.shear == SHEAR
+    assert wrapper.perspective == PERSPECTIVE
+    assert wrapper.enable_mixup is True
+    assert wrapper.mixup_prob == 0.25
+
+
+def test_mosaic_gating_flags_match_wrapper_classes():
+    """Families claiming GATED_BY_MOSAIC must use a mosaic-branch wrapper."""
+    from libreyolo.data.augment.yolo9 import YOLO9MosaicMixupDataset
+    from libreyolo.data.augment.yolox import MosaicMixupDataset
+    from libreyolo.models.rtdetr.trainer import RTDETRTrainer
+    from libreyolo.models.rtmdet.trainer import RTMDetTrainer
+    from libreyolo.models.yolo9.trainer import YOLO9Trainer
+    from libreyolo.models.yolonas.trainer import YOLONASTrainer
+    from libreyolo.models.yolox.trainer import YOLOXTrainer
+
+    gated_wrappers = (MosaicMixupDataset, YOLO9MosaicMixupDataset)
+    for family, trainer_cls in {
+        "yolox": YOLOXTrainer,
+        "yolo9": YOLO9Trainer,
+        "rtdetr": RTDETRTrainer,
+        "rtmdet": RTMDetTrainer,
+    }.items():
+        _, wrapper_cls = _make_trainer(trainer_cls).create_transforms()
+        assert uses_mosaic_gating(family), family
+        assert wrapper_cls in gated_wrappers, family
+
+    _, nas_wrapper = _make_trainer(YOLONASTrainer).create_transforms()
+    assert not uses_mosaic_gating("yolonas")
+    assert nas_wrapper not in gated_wrappers
+
+
+# =========================================================================
+# Classification pack plumbing
+# =========================================================================
+
+
+def test_classify_pipeline_accepts_the_classification_pack():
+    from libreyolo.data.classify_dataset import (
+        build_classify_collate,
+        build_classify_transforms,
+        classify_collate_fn,
+    )
+
+    train_tf = build_classify_transforms(
+        64, augment=True, auto_augment="randaugment", erasing=0.4
+    )
+    op_names = [type(op).__name__ for op in train_tf.transforms]
+    assert "RandAugment" in op_names
+    assert "RandomErasing" in op_names
+
+    plain = build_classify_collate(10, mixup=0.0, cutmix=0.0)
+    assert plain is classify_collate_fn
+    mixer = build_classify_collate(10, mixup=0.3, cutmix=0.2)
+    assert mixer is not classify_collate_fn
+
+
+# =========================================================================
+# Spec-driven CLI warnings
+# =========================================================================
+
+
+def test_get_unsupported_train_params_is_spec_driven():
+    from libreyolo.cli.config import get_unsupported_train_params
+
+    dfine = get_unsupported_train_params("dfine")
+    assert {"mosaic", "mixup", "hsv_prob", "degrees", "translate", "shear",
+            "mosaic_scale", "mixup_scale", "flipud", "perspective"} <= dfine
+    assert "flip_prob" not in dfine
+    assert "no_aug_epochs" not in dfine
+
+    yolox = get_unsupported_train_params("yolox")
+    assert "mosaic" not in yolox
+    assert "mixup" not in yolox
+    assert "flip_prob" not in yolox
+
+    yolonas = get_unsupported_train_params("yolonas")
+    assert "mosaic" in yolonas
+    assert "mixup" not in yolonas
+
+    resnet = get_unsupported_train_params("resnet")
+    assert {"mosaic", "mixup", "flip_prob", "hsv_prob"} <= resnet
+
+    assert get_unsupported_train_params(None) == set()
+    assert get_unsupported_train_params("no_such_family") == set()
+
+
+def test_get_unsupported_train_params_rfdetr_keeps_class_level_ignores():
+    from libreyolo.cli.config import get_unsupported_train_params
+    from libreyolo.models import try_ensure_rfdetr
+
+    if try_ensure_rfdetr() is None:
+        pytest.skip("RF-DETR optional dependencies not installed")
+    rf = get_unsupported_train_params("rfdetr")
+    # Spec-derived augmentation ignores plus the class-declared extras.
+    assert {"mosaic", "mixup", "hsv_prob", "degrees", "translate", "shear",
+            "mosaic_scale", "mixup_scale", "optimizer", "momentum",
+            "nesterov", "pretrained"} <= rf
+    assert "flip_prob" not in rf
+
+
+def _make_train_app():
+    import typer
+
+    from libreyolo.cli.commands.train import train_cmd
+    from libreyolo.cli.parsing import KeyValueCommand
+
+    app = typer.Typer()
+    app.command("train", cls=KeyValueCommand)(train_cmd)
+    return app
+
+
+def test_cli_warns_when_family_ignores_an_explicit_param(caplog):
+    import logging
+
+    from typer.testing import CliRunner
+
+    with caplog.at_level(logging.INFO):
+        result = CliRunner().invoke(
+            _make_train_app(),
+            ["data=coco8.yaml", "model=dfine-s", "mosaic=0.5", "--dry-run"],
+        )
+    assert result.exit_code == 0
+    assert "D-FINE ignores these parameters" in caplog.text
+    assert "mosaic" in caplog.text
+
+
+def test_cli_warns_yolonas_ignores_mosaic_but_not_mixup(caplog):
+    import logging
+
+    from typer.testing import CliRunner
+
+    with caplog.at_level(logging.INFO):
+        result = CliRunner().invoke(
+            _make_train_app(),
+            ["data=coco8.yaml", "model=yolonas-s", "mosaic=0.5", "mixup=0.5", "--dry-run"],
+        )
+    assert result.exit_code == 0
+    warn_lines = [
+        line for line in caplog.text.splitlines()
+        if "ignores these parameters" in line
+    ]
+    assert warn_lines, caplog.text
+    assert "YOLO-NAS ignores these parameters: mosaic" in warn_lines[0]
+    assert "mixup" not in warn_lines[0]
+
+
+def test_cli_does_not_warn_when_family_uses_the_param(caplog):
+    import logging
+
+    from typer.testing import CliRunner
+
+    with caplog.at_level(logging.INFO):
+        result = CliRunner().invoke(
+            _make_train_app(),
+            ["data=coco8.yaml", "model=yolox-s", "mosaic=0.5", "mixup=0.5", "--dry-run"],
+        )
+    assert result.exit_code == 0
+    assert "ignores these parameters" not in caplog.text
+
+
+# =========================================================================
+# Mosaic-gated mixup warning
+# =========================================================================
+
+
+def test_mixup_gating_warning_fires_only_when_it_should():
+    # Gated family, mixup on, mosaic off -> warn.
+    msg = mixup_gating_warning("yolox", mosaic_prob=0.0, mixup_prob=1.0)
+    assert msg is not None and "mosaic_prob" in msg and "YOLOX" in msg
+    # Mosaic on -> mixup can fire -> no warning.
+    assert mixup_gating_warning("yolox", 1.0, 1.0) is None
+    # Mixup off -> nothing to warn about.
+    assert mixup_gating_warning("yolo9", 0.0, 0.0) is None
+    # YOLO-NAS mixup is independent of mosaic -> never this warning.
+    assert mixup_gating_warning("yolonas", 0.0, 1.0) is None
+    # DETR-style families have no mixup at all -> never this warning.
+    assert mixup_gating_warning("dfine", 0.0, 1.0) is None
+    # Unknown family -> stay quiet.
+    assert mixup_gating_warning("no_such_family", 0.0, 1.0) is None
+
+
+def test_ignored_aug_params_returns_config_field_names():
+    assert "mosaic_prob" in ignored_aug_params("dfine")
+    assert "flip_prob" not in ignored_aug_params("dfine")
+    assert ignored_aug_params("yolox") == {
+        "auto_augment", "erasing", "mixup", "cutmix"
+    }
+    assert ignored_aug_params(None) == set()
+
+
+def test_spec_module_is_torch_free():
+    """The spec must stay importable without torch (docs/tooling use it)."""
+    import importlib
+    import sys
+
+    spec_module = importlib.import_module("libreyolo.data.augment.spec")
+    source = open(spec_module.__file__, encoding="utf-8").read()
+    assert "import torch" not in source
+    assert "import cv2" not in source
+    assert "libreyolo.data.augment.spec" in sys.modules


### PR DESCRIPTION
## What this does

Augmentation knobs on `TrainConfig` are shared across ~24 trainable families, but each family honors a different subset: DETR-style pipelines ignore `mosaic`/`mixup`/`hsv_prob`/the affine knobs, YOLO-NAS ignores `mosaic` but applies an always-on affine, classification families ignore all detection knobs, and in the YOLOX-style pipelines mixup and the affine knobs only fire on mosaic samples. None of this was machine-readable, so the CLI could only warn for RF-DETR (a hardcoded list), and setting an ignored knob anywhere else silently did nothing (context: the docs complaints in #631).

This PR makes the knob-support surface explicit and enforceable:

- **`libreyolo/data/augment/spec.py`** — a torch-free declarative table: for every trainable family (yolox, yolo7, yolo9/e2e/p2, yolonas, rtdetr/v2/v4, dfine, deim, deimv2, ec, rtmdet, picodet, rfdetr, fomo, resnet, convnext, mobilenetv4, efficientnetv2, dinov2, segformer, nafnet) and every `TrainConfig` augmentation knob, whether it is `used`, `gated_by_mosaic`, or `ignored`, with a note explaining why. Family-specific extras (`copy_paste`, `rot90`, `crop_resize_prob`, pose knobs) are listed separately. Multi-task families (EC, DINOv2) are marked conservatively: a knob is only `ignored` if it is ignored in *every* task, so a warning is never wrong.
- **Spec-driven CLI warnings** — `get_unsupported_train_params()` now derives ignored params from the spec for *all* families instead of returning a hardcoded list only for RF-DETR. `libreyolo train model=dfine-s ... mosaic=0.5` now prints `Warning: D-FINE ignores these parameters: mosaic`; same for YOLO-NAS, classification families, etc. RF-DETR's class-level non-augmentation ignores (`optimizer`, `momentum`, `nesterov`, `pretrained`) are unioned in unchanged.
- **Mosaic-gated mixup warning** — in the YOLOX-style pipelines mixup only applies to mosaic samples, so `mixup_prob>0` with `mosaic_prob=0` silently never fires. `BaseTrainer._setup_data` (and FOMO's data setup) now log a warning explaining exactly that. YOLO-NAS correctly does not warn (its mixup is independent of mosaic).
- **`tests/unit/test_augment_spec.py`** (29 tests) — pins the spec to reality so it cannot drift: sentinel-value plumbing through every family's `create_transforms()` and dataset wrapper (knobs claimed `used` must land on the transform/wrapper; knobs claimed `ignored` must not), wrapper-class checks for the mosaic-gating claims, CLI warning behavior end-to-end via `CliRunner`, spec↔`TrainConfig` field consistency, and registry coverage (every trainable family must have a spec entry, so adding a family without classifying its knobs fails the tests).

## No behavior changes to training

All additions are warning-only pure functions; nothing touches the augmentation math or the RNG stream, so trained results are byte-identical. Proof:

- Full unit suite on this branch: **3600 passed, 123 skipped, 22 deselected, 4 xfailed** (12m43s) — same skip set as `dev` on this machine (the golden `test_augment_parity` fixtures skip here because the local cv2 is 4.10 vs the 4.13 reference environment; they skip identically on unmodified `dev`, and none of the files they cover are touched by this PR).
- `ruff check` clean on all touched files.

## Follow-ups this enables (not in this PR)

Rendering the support matrix into the docs (the actual fix for #631's "which knob does what, where" complaint), and using the spec to generate truthful per-family `--help`/`cfg` output.

## Code provenance

All code in this PR is original, written specifically for this PR by reading LibreYOLO's own trainers, transforms, and dataset wrappers on `dev`. Nothing is ported, adapted, or derived from any third-party repository. In particular, no Ultralytics (AGPL) or other copyleft/unknown-license code was consulted or reproduced; the only overlap with other frameworks is generic knob *names* the codebase already uses (`mosaic`, `flipud`, `copy_paste`).
