### PR TITLE
Fix v1.4.0 release blockers: openvocab deps, v1.3 positional compat, LoRA export order, D-FINE macOS parity

### DIFF
--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -306,6 +306,12 @@ class BaseExporter(ABC):
         Returns:
             Path to the exported model file.
         """
+        # Private plumbing (quantized_export): a callable run at the
+        # post-validation mutation point below, so caller-side mutations
+        # (reconstructing fp32 masters, enabling export mode) also wait for
+        # every request rejection.
+        pre_trace_hook = kwargs.pop("_pre_trace_hook", None)
+
         task = getattr(self.model, "task", "detect")
         if task == "depth":
             # Depth export uses the fixed-resolution dense contract: backends
@@ -383,17 +389,22 @@ class BaseExporter(ABC):
             int8,
         )
 
+        # ---- Post-validation mutation point ------------------------------
+        # Every request rejection above — format support, precision
+        # validation, option preflight, imgsz/path resolution — has fired;
+        # from here on the live model may be mutated.
+        #
         # A model fine-tuned with lora=True carries live PEFT adapter layers.
         # Fold them into dense weights so the traced graph is a plain model
-        # with no peft dependency. Deliberately the last step before the
-        # artifact is produced: the merge is destructive (adapters are folded
-        # and removed), so every request rejection above — format support,
-        # precision validation, option preflight, imgsz/path resolution —
-        # must fire while the adapters are still intact and trainable.
+        # with no peft dependency. The merge is destructive (adapters are
+        # folded and removed), so it must not run any earlier.
         from ..training.lora import merge_lora_adapters, module_has_lora
 
         if module_has_lora(self.model.model):
             merge_lora_adapters(self.model.model)
+
+        if pre_trace_hook is not None:
+            pre_trace_hook()
 
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -383,6 +383,18 @@ class BaseExporter(ABC):
             int8,
         )
 
+        # A model fine-tuned with lora=True carries live PEFT adapter layers.
+        # Fold them into dense weights so the traced graph is a plain model
+        # with no peft dependency. Deliberately the last step before the
+        # artifact is produced: the merge is destructive (adapters are folded
+        # and removed), so every request rejection above — format support,
+        # precision validation, option preflight, imgsz/path resolution —
+        # must fire while the adapters are still intact and trainable.
+        from ..training.lora import merge_lora_adapters, module_has_lora
+
+        if module_has_lora(self.model.model):
+            merge_lora_adapters(self.model.model)
+
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
         precision = _resolve_precision(half, int8)

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1460,20 +1460,25 @@ class BaseModel(ABC):
         # Fold them into dense weights before export so the traced graph is a
         # plain model with no peft dependency. RF-DETR merges via its own
         # export override; this covers the other lora-capable families
-        # (D-FINE, DEIM, DEIMv2, RT-DETR v1/v2/v4, EC, ConvNeXt).
+        # (D-FINE, DEIM, DEIMv2, RT-DETR v1/v2/v4, EC, ConvNeXt). The merge is
+        # destructive (adapters are folded and removed), so validate the
+        # requested format first: a typo'd format must raise while the live
+        # adapters are still intact and trainable.
         from libreyolo.training.lora import merge_lora_adapters, module_has_lora
-
-        if module_has_lora(self.model):
-            merge_lora_adapters(self.model)
 
         if getattr(self, "_quant_manifest", None):
             from libreyolo.quant.api import quantized_export
 
+            if module_has_lora(self.model):
+                merge_lora_adapters(self.model)
             return quantized_export(self, format=format, **kwargs)
 
         from libreyolo.export import BaseExporter
 
-        return BaseExporter.create(format, self)(**kwargs)
+        exporter = BaseExporter.create(format, self)
+        if module_has_lora(self.model):
+            merge_lora_adapters(self.model)
+        return exporter(**kwargs)
 
     def val(
         self,

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1456,29 +1456,20 @@ class BaseModel(ABC):
         Returns:
             Path to the exported model file.
         """
-        # A model fine-tuned with lora=True carries live PEFT adapter layers.
-        # Fold them into dense weights before export so the traced graph is a
-        # plain model with no peft dependency. RF-DETR merges via its own
-        # export override; this covers the other lora-capable families
-        # (D-FINE, DEIM, DEIMv2, RT-DETR v1/v2/v4, EC, ConvNeXt). The merge is
-        # destructive (adapters are folded and removed), so validate the
-        # requested format first: a typo'd format must raise while the live
-        # adapters are still intact and trainable.
-        from libreyolo.training.lora import merge_lora_adapters, module_has_lora
-
+        # Live LoRA adapters are folded into dense weights for export. That
+        # merge is destructive, so it happens only after every request
+        # rejection: BaseExporter.__call__ merges after its preflight for the
+        # float formats, and quantized_export merges after its recipe/format
+        # gates for the format="pt" path (its ONNX path goes through
+        # BaseExporter too).
         if getattr(self, "_quant_manifest", None):
             from libreyolo.quant.api import quantized_export
 
-            # quantized_export merges live adapters itself, after its own
-            # format/recipe validation has accepted the request.
             return quantized_export(self, format=format, **kwargs)
 
         from libreyolo.export import BaseExporter
 
-        exporter = BaseExporter.create(format, self)
-        if module_has_lora(self.model):
-            merge_lora_adapters(self.model)
-        return exporter(**kwargs)
+        return BaseExporter.create(format, self)(**kwargs)
 
     def val(
         self,

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1469,8 +1469,8 @@ class BaseModel(ABC):
         if getattr(self, "_quant_manifest", None):
             from libreyolo.quant.api import quantized_export
 
-            if module_has_lora(self.model):
-                merge_lora_adapters(self.model)
+            # quantized_export merges live adapters itself, after its own
+            # format/recipe validation has accepted the request.
             return quantized_export(self, format=format, **kwargs)
 
         from libreyolo.export import BaseExporter

--- a/libreyolo/models/clip/tokenizer.py
+++ b/libreyolo/models/clip/tokenizer.py
@@ -31,8 +31,10 @@ SOT_TOKEN = "<start_of_text>"
 EOT_TOKEN = "<end_of_text>"
 
 _CLIP_EXTRA_HINT = (
-    "LibreCLIP's text tokenizer needs 'ftfy' and 'regex'. Install them with:\n"
-    '    pip install "libreyolo[clip]"'
+    "The CLIP text tokenizer needs 'ftfy' and 'regex'. Install the extra for "
+    "your model:\n"
+    '    pip install "libreyolo[clip]"       # LibreCLIP\n'
+    '    pip install "libreyolo[openvocab]"  # LibreOVDEIM'
 )
 
 

--- a/libreyolo/models/eomt/model.py
+++ b/libreyolo/models/eomt/model.py
@@ -152,9 +152,11 @@ class LibreEoMT(BaseModel):
         model_path=None,
         size: str = "l",
         nb_classes: int = 150,
-        num_queries: int = 100,
         device: str = "auto",
         task: str | None = None,
+        # New parameters go after the complete v1.3 signature so positional
+        # calls like LibreEoMT(None, "l", 150, "cpu") keep working.
+        num_queries: int = 100,
         **kwargs,
     ) -> None:
         if size is None:

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -626,9 +626,8 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
             "or dequantize() and use the float exporters."
         )
 
-    # Every rejection above has fired; mutation is safe from here on.
-    _merge_live_lora_adapters(wrapper)
-
+    # The ONNX path ends in BaseExporter.__call__, which folds live LoRA
+    # adapters itself after its own preflight; no merge needed here.
     if manifest.get("state") == "finalized":
         # QDQ emission traces fake-quant over fp32 masters; reconstruct them
         # from the packed weights (exact by the packing invariant).

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -490,6 +490,14 @@ def export_finalized_pt(wrapper, out=None, remainder: str = "fp16") -> str:
     # code differently across devices, and the invariant we promise is
     # "finalized scores exactly what you validated on this device".
     model_copy = copy.deepcopy(wrapper.model)
+
+    # Live LoRA adapters are folded on the copy so the checkpoint carries
+    # plain dense weights; the live model keeps its adapters trainable.
+    from ..training.lora import merge_lora_adapters, module_has_lora
+
+    if module_has_lora(model_copy):
+        merge_lora_adapters(model_copy)
+
     with torch.no_grad():
         if recipe not in CAST_RECIPES:
             for _, module in _quant_modules(model_copy):
@@ -573,18 +581,6 @@ def reprepare_model(wrapper):
     return wrapper
 
 
-def _merge_live_lora_adapters(wrapper) -> None:
-    """Fold live LoRA adapters into dense weights before an export mutates.
-
-    Destructive (adapters are folded and removed), so callers must run every
-    validation that can reject the export request *before* calling this.
-    """
-    from ..training.lora import merge_lora_adapters, module_has_lora
-
-    if module_has_lora(wrapper.model):
-        merge_lora_adapters(wrapper.model)
-
-
 def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
     """Export a quantized model.
 
@@ -603,7 +599,8 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
         remainder = kwargs.pop("remainder", "fp16")
         if kwargs:
             logger.info("Ignoring export kwargs for format='pt': %s", sorted(kwargs))
-        _merge_live_lora_adapters(wrapper)
+        # export_finalized_pt works on a deep copy (folding any live LoRA
+        # adapters there); the live model is never mutated on this path.
         return export_finalized_pt(wrapper, out=out, remainder=remainder)
 
     if recipe in CAST_RECIPES:
@@ -626,13 +623,6 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
             "or dequantize() and use the float exporters."
         )
 
-    # The ONNX path ends in BaseExporter.__call__, which folds live LoRA
-    # adapters itself after its own preflight; no merge needed here.
-    if manifest.get("state") == "finalized":
-        # QDQ emission traces fake-quant over fp32 masters; reconstruct them
-        # from the packed weights (exact by the packing invariant).
-        reprepare_model(wrapper)
-
     if kwargs.pop("int8", False):
         logger.info(
             "Model is already int8-quantized; the int8 export flag is "
@@ -649,9 +639,21 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
 
     from ..export import BaseExporter
 
-    _set_export_mode(wrapper.model, True)
+    def _pre_trace():
+        # Invoked by BaseExporter.__call__ after every request rejection
+        # (option preflight, imgsz/path resolution): both steps below mutate
+        # the live model, so a rejected export must leave the finalized
+        # packed state untouched.
+        # QDQ emission traces fake-quant over fp32 masters; reconstruct them
+        # from the packed weights (exact by the packing invariant). No-op
+        # unless the manifest state is "finalized".
+        reprepare_model(wrapper)
+        _set_export_mode(wrapper.model, True)
+
     try:
-        return BaseExporter.create("onnx", wrapper)(**kwargs)
+        return BaseExporter.create("onnx", wrapper)(
+            _pre_trace_hook=_pre_trace, **kwargs
+        )
     finally:
         _set_export_mode(wrapper.model, False)
 

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -573,6 +573,18 @@ def reprepare_model(wrapper):
     return wrapper
 
 
+def _merge_live_lora_adapters(wrapper) -> None:
+    """Fold live LoRA adapters into dense weights before an export mutates.
+
+    Destructive (adapters are folded and removed), so callers must run every
+    validation that can reject the export request *before* calling this.
+    """
+    from ..training.lora import merge_lora_adapters, module_has_lora
+
+    if module_has_lora(wrapper.model):
+        merge_lora_adapters(wrapper.model)
+
+
 def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
     """Export a quantized model.
 
@@ -591,6 +603,7 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
         remainder = kwargs.pop("remainder", "fp16")
         if kwargs:
             logger.info("Ignoring export kwargs for format='pt': %s", sorted(kwargs))
+        _merge_live_lora_adapters(wrapper)
         return export_finalized_pt(wrapper, out=out, remainder=remainder)
 
     if recipe in CAST_RECIPES:
@@ -605,12 +618,6 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
             "PyTorch. Use format='pt' for the crystallized checkpoint, or "
             "dequantize() to use the float exporters."
         )
-
-    if manifest.get("state") == "finalized" and fmt == "onnx":
-        # QDQ emission traces fake-quant over fp32 masters; reconstruct them
-        # from the packed weights (exact by the packing invariant).
-        reprepare_model(wrapper)
-
     if fmt != "onnx":
         raise QuantizationError(
             "int8-quantized export currently supports format='onnx' (QDQ "
@@ -618,6 +625,14 @@ def quantized_export(wrapper, format: str = "onnx", **kwargs) -> str:
             f"'{fmt}'. Export to ONNX and build downstream engines from it, "
             "or dequantize() and use the float exporters."
         )
+
+    # Every rejection above has fired; mutation is safe from here on.
+    _merge_live_lora_adapters(wrapper)
+
+    if manifest.get("state") == "finalized":
+        # QDQ emission traces fake-quant over fp32 masters; reconstruct them
+        # from the packed weights (exact by the packing invariant).
+        reprepare_model(wrapper)
 
     if kwargs.pop("int8", False):
         logger.info(

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -1044,15 +1044,17 @@ class Results:
         gaze: Optional[Gaze] = None,
         points: Optional[Points] = None,
         semantic_mask: Optional[SemanticMask] = None,
-        panoptic: Optional[PanopticSegmentation] = None,
         depth_map: Optional[DepthMap] = None,
         restored: Optional[RestoredImage] = None,
-        matte: Optional[Matte] = None,
-        ocr: Optional[OCRRegions] = None,
-        restore_scale: int = 1,
         speed: Optional[Dict[str, float]] = None,
         track_id: Optional[TensorLike] = None,
         frame_idx: Optional[int] = None,
+        # New parameters go after the complete v1.3 signature so v1.3-era
+        # positional calls keep binding to the same parameters.
+        panoptic: Optional[PanopticSegmentation] = None,
+        matte: Optional[Matte] = None,
+        ocr: Optional[OCRRegions] = None,
+        restore_scale: int = 1,
     ):
         if boxes is not None and boxes.orig_shape is None:
             boxes = boxes.with_orig_shape(orig_shape)
@@ -1164,13 +1166,15 @@ class Results:
         gaze: Optional[Gaze] = None,
         points: Optional[Points] = None,
         semantic_mask: Optional[SemanticMask] = None,
-        panoptic: Optional[PanopticSegmentation] = None,
         depth_map: Optional[DepthMap] = None,
         restored: Optional[RestoredImage] = None,
+        track_id: Optional[TensorLike] = None,
+        # New parameters go after the complete v1.3 signature so v1.3-era
+        # positional calls keep binding to the same parameters.
+        panoptic: Optional[PanopticSegmentation] = None,
         matte: Optional[Matte] = None,
         ocr: Optional[OCRRegions] = None,
         restore_scale: Optional[int] = None,
-        track_id: Optional[TensorLike] = None,
     ) -> "Results":
         if boxes is not None:
             self.boxes = boxes.with_orig_shape(self.orig_shape)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ openvocab = [
     # is instantiated through transformers' TimmBackbone.
     "transformers>=5.1.0",
     "timm>=1.0.0",
+    # OV-DEIM embeds text prompts with the vendored CLIP BPE tokenizer, which
+    # needs these at predict time (Unicode \p{L}/\p{N} classes + ftfy fixing).
+    "regex>=2023.0.0",
+    "ftfy>=6.0.0",
 ]
 sensenova = [
     # SenseNova-Vision (Bagel-MoT): the vendored architecture loads through

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -32,3 +32,17 @@ def test_torch_floor_supports_amp_grad_scaler():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
     deps = pyproject["project"]["dependencies"]
     assert "torch>=2.4.0" in deps
+
+
+def test_openvocab_extra_covers_clip_tokenizer_runtime():
+    """OV-DEIM always embeds prompts with the vendored CLIP BPE tokenizer.
+
+    That tokenizer imports ftfy and regex at predict time, so a clean
+    ``pip install libreyolo[openvocab]`` must ship them or the first
+    LibreOVDEIM prediction raises ImportError (v1.4.0 release blocker).
+    """
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    deps = pyproject["project"]["optional-dependencies"]["openvocab"]
+    names = {dep.split(">=")[0].split("==")[0].strip() for dep in deps}
+    assert "ftfy" in names
+    assert "regex" in names

--- a/tests/unit/test_detr_cpu_export_matrix.py
+++ b/tests/unit/test_detr_cpu_export_matrix.py
@@ -24,6 +24,13 @@ _ONNX_PARITY_GAPS = {
     "LibreRTDETRv2": "9% of selected boxes exceed the ONNX tolerance",
     "LibreRTDETRv4": "7.3% of selected boxes exceed the ONNX tolerance",
 }
+# Families whose ONNX raw outputs are compared after Hungarian query
+# alignment. Their graphs select queries with an in-graph top-k over the
+# near-uniform scores of this test's random-init weights, so tiny host-class
+# float drift (macOS CI vs Linux) reorders a handful of near-tied queries.
+# Alignment removes that ordering sensitivity while keeping the numeric
+# tolerance intact — a genuinely wrong box still fails after alignment.
+_ONNX_QUERY_ALIGNED = {"LibreEC", "LibreDFINE"}
 
 
 def _export_cases():
@@ -101,7 +108,7 @@ def test_detr_detect_raw_parity(tmp_path, class_name, size, imgsz, format):
 
     assert len(actual) == len(native)
     expected_outputs = tuple(output.detach().cpu().numpy() for output in native)
-    if format == "onnx" and class_name == "LibreEC":
+    if format == "onnx" and class_name in _ONNX_QUERY_ALIGNED:
         actual = _align_query_outputs(actual, expected_outputs)
     rtol, atol = (2e-3, 2e-2) if format == "onnx" else (1e-3, 1e-3)
     for actual_output, expected in zip(actual, expected_outputs):

--- a/tests/unit/test_eomt.py
+++ b/tests/unit/test_eomt.py
@@ -209,6 +209,21 @@ class TestEoMTMetadata:
         with pytest.raises(ValueError, match="not supported"):
             LibreEoMT(model_path=None, size="l", task="detect", device="cpu")
 
+    def test_v13_positional_constructor_order(self, fake_eomt_net):
+        """v1.3 called LibreEoMT(model_path, size, nb_classes, device, task).
+
+        New parameters (num_queries) must stay after the complete v1.3
+        signature so old positional calls keep binding device to device.
+        This was a v1.4.0 release blocker — num_queries was inserted before
+        device, so LibreEoMT(None, "l", 150, "cpu") raised on int("cpu").
+        """
+        from libreyolo.models.eomt.model import LibreEoMT
+
+        model = LibreEoMT(None, "l", 150, "cpu", "semantic")
+        assert str(model.device) == "cpu"
+        assert model.nb_classes == 150
+        assert model.num_queries == 100
+
 
 class TestEoMTPredict:
     def test_preprocess_splits_wide_image_like_hf_processor(

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1001,6 +1001,56 @@ class TestExportLoraOrdering:
             BaseModel.export(stub, format="torchscript")
         assert merged == []
 
+    def test_pt_remainder_rejection_leaves_lora_untouched(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from libreyolo.models.base.model import BaseModel
+        from libreyolo.quant import QuantizationError
+
+        merged = []
+        self._record_lora_merges(monkeypatch, merged.append)
+
+        stub = SimpleNamespace(model=nn.Linear(2, 2))
+        stub._quant_manifest = {"recipe": "int8"}
+        with pytest.raises(QuantizationError, match="remainder"):
+            BaseModel.export(stub, format="pt", remainder="int4")
+        assert merged == []
+
+    def test_quantized_pt_export_merges_on_a_copy(self, monkeypatch, tmp_path):
+        from libreyolo.models.base.model import BaseModel
+
+        merged = []
+        self._record_lora_merges(monkeypatch, merged.append)
+
+        wrapper = _make_wrapper()
+        wrapper.task = "detect"
+        wrapper.model_path = None
+        wrapper._quant_manifest = {"recipe": "int8", "state": "prepared"}
+        out = BaseModel.export(wrapper, format="pt", out=str(tmp_path / "q.pt"))
+        assert Path(out).exists()
+        # The fold ran exactly once, on the checkpoint's deep copy — the
+        # live model keeps its adapters trainable.
+        assert len(merged) == 1
+        assert merged[0] is not wrapper.model
+
+    def test_quantized_onnx_rejection_keeps_finalized_state(self, monkeypatch):
+        from libreyolo.quant.api import quantized_export
+
+        merged = []
+        self._record_lora_merges(monkeypatch, merged.append)
+
+        wrapper = _make_wrapper()  # not yolo9 -> embedded NMS is rejected
+        wrapper._quant_manifest = {
+            "recipe": "int8",
+            "state": "finalized",
+            "calibrated": True,
+        }
+        with pytest.raises(NotImplementedError, match="NMS"):
+            quantized_export(wrapper, format="onnx", nms=True)
+        # reprepare_model never ran: the packed finalized state is intact.
+        assert wrapper._quant_manifest["state"] == "finalized"
+        assert merged == []
+
     def test_successful_export_merges_after_preflight(self, monkeypatch, tmp_path):
         events = []
         self._record_lora_merges(monkeypatch, lambda m: events.append("merge"))

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -944,72 +944,81 @@ class TestExporterValidation:
 
 
 class TestExportLoraOrdering:
-    """BaseModel.export folds live LoRA adapters into dense weights.
+    """Live LoRA adapters are folded into dense weights for export.
 
-    That merge is destructive, so an invalid format must raise *before* it
-    happens — otherwise a typo'd export silently strips the adapters from a
-    model the user may keep training (v1.4.0 release blocker).
+    That merge is destructive (adapters are folded and removed), so every
+    request rejection — unknown format, quantized recipe/format gates, the
+    exporter's own option preflight — must raise *before* it happens.
+    Otherwise a rejected export silently strips the adapters from a model
+    the user may keep training (v1.4.0 release blocker).
     """
 
     @staticmethod
-    def _stub(order):
-        from types import SimpleNamespace
-
+    def _record_lora_merges(monkeypatch, on_merge):
         from libreyolo.training import lora as lora_helpers
 
-        stub = SimpleNamespace(model=nn.Linear(2, 2))
-        return stub, lora_helpers
+        monkeypatch.setattr(lora_helpers, "module_has_lora", lambda m: True)
+        monkeypatch.setattr(lora_helpers, "merge_lora_adapters", on_merge)
 
     def test_invalid_format_raises_before_lora_merge(self, monkeypatch):
+        from types import SimpleNamespace
+
         from libreyolo.models.base.model import BaseModel
 
         merged = []
-        stub, lora_helpers = self._stub(merged)
-        monkeypatch.setattr(lora_helpers, "module_has_lora", lambda m: True)
-        monkeypatch.setattr(lora_helpers, "merge_lora_adapters", merged.append)
+        self._record_lora_merges(monkeypatch, merged.append)
 
+        stub = SimpleNamespace(model=nn.Linear(2, 2))
         with pytest.raises(ValueError, match="Unsupported export format"):
             BaseModel.export(stub, format="not-a-format")
         assert merged == []  # adapters untouched by the failed export
 
+    def test_preflight_rejection_leaves_lora_untouched(self, monkeypatch):
+        merged = []
+        self._record_lora_merges(monkeypatch, merged.append)
+
+        # Embedded-NMS ONNX export is YOLO9-only; the preflight rejection
+        # must fire before the destructive adapter merge.
+        wrapper = _make_wrapper()
+        with pytest.raises(NotImplementedError, match="NMS"):
+            OnnxExporter(wrapper)(nms=True)
+        assert merged == []
+
     def test_quantized_export_rejection_leaves_lora_untouched(self, monkeypatch):
+        from types import SimpleNamespace
+
         from libreyolo.models.base.model import BaseModel
         from libreyolo.quant import QuantizationError
 
         merged = []
-        stub, lora_helpers = self._stub(merged)
-        stub._quant_manifest = {"recipe": "int8"}
-        monkeypatch.setattr(lora_helpers, "module_has_lora", lambda m: True)
-        monkeypatch.setattr(lora_helpers, "merge_lora_adapters", merged.append)
+        self._record_lora_merges(monkeypatch, merged.append)
 
+        stub = SimpleNamespace(model=nn.Linear(2, 2))
+        stub._quant_manifest = {"recipe": "int8"}
         # int8 recipe only exports to onnx/pt; torchscript must be rejected
         # before the destructive adapter merge.
         with pytest.raises(QuantizationError, match="format='onnx'"):
             BaseModel.export(stub, format="torchscript")
         assert merged == []
 
-    def test_valid_format_merges_after_validation(self, monkeypatch):
-        from libreyolo.models.base.model import BaseModel
+    def test_successful_export_merges_after_preflight(self, monkeypatch, tmp_path):
+        events = []
+        self._record_lora_merges(monkeypatch, lambda m: events.append("merge"))
 
-        order = []
-        stub, lora_helpers = self._stub(order)
-        monkeypatch.setattr(lora_helpers, "module_has_lora", lambda m: True)
-        monkeypatch.setattr(
-            lora_helpers, "merge_lora_adapters", lambda m: order.append("merge")
+        original_preflight = BaseExporter._preflight
+
+        def spy_preflight(self, **kwargs):
+            events.append("preflight")
+            return original_preflight(self, **kwargs)
+
+        monkeypatch.setattr(BaseExporter, "_preflight", spy_preflight)
+
+        wrapper = _make_wrapper()
+        path = TorchScriptExporter(wrapper)(
+            output_path=str(tmp_path / "model.torchscript")
         )
-
-        class _FakeExporter:
-            def __init__(self, model):
-                order.append("create")
-
-            def __call__(self, **kwargs):
-                order.append("export")
-                return "model.fake"
-
-        monkeypatch.setitem(BaseExporter._registry, "fakefmt", _FakeExporter)
-
-        assert BaseModel.export(stub, format="fakefmt") == "model.fake"
-        assert order == ["create", "merge", "export"]
+        assert Path(path).exists()
+        assert events == ["preflight", "merge"]
 
 
 class TestOutputPathGeneration:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -972,6 +972,22 @@ class TestExportLoraOrdering:
             BaseModel.export(stub, format="not-a-format")
         assert merged == []  # adapters untouched by the failed export
 
+    def test_quantized_export_rejection_leaves_lora_untouched(self, monkeypatch):
+        from libreyolo.models.base.model import BaseModel
+        from libreyolo.quant import QuantizationError
+
+        merged = []
+        stub, lora_helpers = self._stub(merged)
+        stub._quant_manifest = {"recipe": "int8"}
+        monkeypatch.setattr(lora_helpers, "module_has_lora", lambda m: True)
+        monkeypatch.setattr(lora_helpers, "merge_lora_adapters", merged.append)
+
+        # int8 recipe only exports to onnx/pt; torchscript must be rejected
+        # before the destructive adapter merge.
+        with pytest.raises(QuantizationError, match="format='onnx'"):
+            BaseModel.export(stub, format="torchscript")
+        assert merged == []
+
     def test_valid_format_merges_after_validation(self, monkeypatch):
         from libreyolo.models.base.model import BaseModel
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -943,6 +943,59 @@ class TestExporterValidation:
         assert exporter.suffix == ".tflite"
 
 
+class TestExportLoraOrdering:
+    """BaseModel.export folds live LoRA adapters into dense weights.
+
+    That merge is destructive, so an invalid format must raise *before* it
+    happens — otherwise a typo'd export silently strips the adapters from a
+    model the user may keep training (v1.4.0 release blocker).
+    """
+
+    @staticmethod
+    def _stub(order):
+        from types import SimpleNamespace
+
+        from libreyolo.training import lora as lora_helpers
+
+        stub = SimpleNamespace(model=nn.Linear(2, 2))
+        return stub, lora_helpers
+
+    def test_invalid_format_raises_before_lora_merge(self, monkeypatch):
+        from libreyolo.models.base.model import BaseModel
+
+        merged = []
+        stub, lora_helpers = self._stub(merged)
+        monkeypatch.setattr(lora_helpers, "module_has_lora", lambda m: True)
+        monkeypatch.setattr(lora_helpers, "merge_lora_adapters", merged.append)
+
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            BaseModel.export(stub, format="not-a-format")
+        assert merged == []  # adapters untouched by the failed export
+
+    def test_valid_format_merges_after_validation(self, monkeypatch):
+        from libreyolo.models.base.model import BaseModel
+
+        order = []
+        stub, lora_helpers = self._stub(order)
+        monkeypatch.setattr(lora_helpers, "module_has_lora", lambda m: True)
+        monkeypatch.setattr(
+            lora_helpers, "merge_lora_adapters", lambda m: order.append("merge")
+        )
+
+        class _FakeExporter:
+            def __init__(self, model):
+                order.append("create")
+
+            def __call__(self, **kwargs):
+                order.append("export")
+                return "model.fake"
+
+        monkeypatch.setitem(BaseExporter._registry, "fakefmt", _FakeExporter)
+
+        assert BaseModel.export(stub, format="fakefmt") == "model.fake"
+        assert order == ["create", "merge", "export"]
+
+
 class TestOutputPathGeneration:
     def test_auto_path_torchscript(self):
         wrapper = _make_wrapper(model_name="yolo9", size="t")

--- a/tests/unit/test_fomo.py
+++ b/tests/unit/test_fomo.py
@@ -273,6 +273,10 @@ class TestLibreFOMORandomInit:
 
         from libreyolo import LibreYOLO
 
+        # Seed the weight draw: parity across export formats is ordering-
+        # sensitive for near-tied point scores, so an ambient-RNG model makes
+        # this test depend on which tests ran (and drew randoms) before it.
+        torch.manual_seed(0)
         model = _make_random_fomo(size="s", nc=2)
         model.model.eval()
         image = np.random.default_rng(11).integers(

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -598,6 +598,120 @@ class TestSemanticMask:
         assert result.semantic_mask is not None
 
 
+class TestResultsV13PositionalCompat:
+    """v1.4 added panoptic/matte/ocr/restore_scale to Results.
+
+    Those parameters must stay after the complete v1.3 signature: v1.3-era
+    positional calls (e.g. passing depth_map at its old slot) must keep
+    binding to the same parameters. This was a v1.4.0 release blocker —
+    panoptic was inserted before depth_map, silently swallowing it.
+    """
+
+    @staticmethod
+    def _v13_payloads():
+        from libreyolo.utils.results import Gaze, RestoredImage
+
+        shape = (48, 64)
+        return {
+            "boxes": Boxes(
+                torch.tensor([[1.0, 2.0, 10.0, 20.0]]),
+                torch.tensor([0.9]),
+                torch.tensor([0.0]),
+            ),
+            "orig_shape": shape,
+            "masks": Masks(torch.zeros(1, *shape), shape),
+            "keypoints": Keypoints(torch.zeros(1, 5, 3), shape),
+            "probs": Probs(torch.tensor([0.1, 0.9])),
+            "obb": OBB(torch.zeros(1, 7), shape),
+            "gaze": Gaze(torch.zeros(1, 2), shape),
+            "points": Points(torch.zeros(1, 4), shape),
+            "semantic_mask": SemanticMask(torch.zeros(shape, dtype=torch.long), shape),
+            "depth_map": DepthMap(torch.zeros(shape), shape),
+            "restored": RestoredImage(torch.zeros(*shape, 3, dtype=torch.uint8), shape),
+        }
+
+    def test_init_v13_positional_order(self):
+        p = self._v13_payloads()
+        speed = {"inference": 1.0}
+        track_id = torch.tensor([7])
+
+        # Exact v1.3.x positional argument order — must keep working verbatim.
+        result = Results(
+            p["boxes"],
+            p["orig_shape"],
+            "img.jpg",
+            {0: "thing"},
+            p["masks"],
+            p["keypoints"],
+            p["probs"],
+            p["obb"],
+            p["gaze"],
+            p["points"],
+            p["semantic_mask"],
+            p["depth_map"],
+            p["restored"],
+            speed,
+            track_id,
+            3,
+        )
+
+        assert result.path == "img.jpg"
+        assert result.names == {0: "thing"}
+        assert result.masks is p["masks"]
+        assert result.keypoints is p["keypoints"]
+        assert result.probs is p["probs"]
+        assert result.obb is p["obb"]
+        assert result.gaze is p["gaze"]
+        assert result.points is p["points"]
+        assert result.semantic_mask is p["semantic_mask"]
+        assert result.depth_map is p["depth_map"]
+        assert result.restored is p["restored"]
+        assert result.speed == speed
+        assert torch.equal(result.track_id, track_id)
+        assert result.frame_idx == 3
+        # v1.4-only slots must stay at their defaults.
+        assert result.panoptic is None
+        assert result.matte is None
+        assert result.ocr is None
+        assert result.restore_scale == 1
+        # summary() was the reported crash when depth_map bound to panoptic.
+        result.summary()
+
+    def test_update_v13_positional_order(self):
+        p = self._v13_payloads()
+        track_id = torch.tensor([7])
+
+        result = Results(boxes=None, orig_shape=p["orig_shape"])
+        # Exact v1.3.x positional argument order for update().
+        result.update(
+            p["boxes"],
+            p["masks"],
+            p["probs"],
+            p["keypoints"],
+            p["obb"],
+            p["gaze"],
+            p["points"],
+            p["semantic_mask"],
+            p["depth_map"],
+            p["restored"],
+            track_id,
+        )
+
+        assert result.masks is p["masks"]
+        assert result.probs is p["probs"]
+        assert result.keypoints is p["keypoints"]
+        assert result.obb is p["obb"]
+        assert result.gaze is p["gaze"]
+        assert result.points is p["points"]
+        assert result.semantic_mask is p["semantic_mask"]
+        assert result.depth_map is p["depth_map"]
+        assert result.restored is p["restored"]
+        assert torch.equal(result.track_id, track_id)
+        assert result.panoptic is None
+        assert result.matte is None
+        assert result.ocr is None
+
+
 def test_draw_semantic_mask_paints_classes_and_skips_ignore():
     img = Image.new("RGB", (10, 8), color=(0, 0, 0))
     mask = np.full((8, 10), 255, dtype=np.uint8)


### PR DESCRIPTION
## Summary

Fixes the four confirmed blockers from the v1.4.0 release audit of PR #634, plus the recurring macOS D-FINE ONNX parity failure.

### 1. `libreyolo[openvocab]` was broken as advertised
OV-DEIM always embeds prompts with the vendored CLIP BPE tokenizer, which imports `ftfy` and `regex` at predict time — neither was in the `[openvocab]` extra, so a clean openvocab-only install crashed on the first prediction (with a hint telling the user to install `[clip]`). The extra now ships both, the tokenizer hint names the right extra per model, and a dependency tripwire test pins this.

**Verified end-to-end:** built a fresh venv with `pip install -e .[openvocab]` only, downloaded LibreOVDEIM-s, and ran a real `predict()` — works.

### 2. `Results` v1.3 positional compatibility restored
v1.4 had inserted `panoptic` before `depth_map` and `matte`/`ocr`/`restore_scale` before `speed`/`track_id` in both `__init__` and `update()`, so v1.3-era positional calls silently bound `depth_map` to `panoptic` (crashing `summary()`). The new parameters now come after the complete v1.3 signature. All internal call sites pass keywords, so nothing else changes. Compat tests construct `Results` and call `update()` with the exact v1.3 positional argument lists and assert every binding.

### 3. `LibreEoMT` v1.3 positional compatibility restored
`num_queries` had been inserted before `device`, so `LibreEoMT(None, "l", 150, "cpu")` raised on `int("cpu")`. It now comes after the v1.3 parameters. Compat test added.

### 4. Export validates the format before merging LoRA adapters
`BaseModel.export` folded live PEFT adapters into dense weights *before* the format string was validated, so a typo'd format destroyed trainable adapter state and then raised. The exporter is now resolved (which validates the format) before the merge. Tests pin both the failure ordering (invalid format leaves adapters untouched) and the success ordering (validate, merge, export). RF-DETR's override delegates to `super().export()` and inherits the fix.

### 5. D-FINE ONNX macOS parity — aligned, not xfailed
`test_detr_detect_raw_parity[onnx-LibreDFINE]` failed repeatedly on macOS CI at 0.9467 vs the required 0.95 row match. Root cause: the graph selects queries with an in-graph top-k over this test's random-init (near-uniform) scores, so tiny host-class float drift reorders a handful of near-tied queries — whole rows then "mismatch" with no numeric parity loss. The test now applies the file's existing Hungarian query alignment (already used for LibreEC) before the row comparison. The numeric tolerance is unchanged, and a genuinely wrong box still fails after alignment. The strict xfails for the known DEIM/RT-DETRv2/v4 gaps are untouched and still xfail. This supersedes the blanket macOS xfail proposed in #632.

### Also: FOMO export parity test de-flaked
`test_exported_point_parity` built its random model from ambient RNG state, so its pass/fail depended on which tests ran (and drew randoms) before it — adding any test earlier in the suite could flip a near-tied point ordering. The weight draw is now seeded, same as the DETR parity matrix.

## Validation

- Full unit suite locally (Windows, Python 3.12): **3606 passed, 123 skipped, 4 xfailed, 0 failed**.
- Real OV-DEIM prediction in a clean openvocab-only venv (the exact scenario that crashed before).
- DETR CPU export parity matrix: 10 passed, 4 xfailed (strict), including `onnx-LibreDFINE` with alignment.
- New compat tests fail on the unfixed code and pass with the fix.

## Code provenance

All changes are original code written for this PR: dependency declarations in `pyproject.toml`, parameter reordering in existing LibreYOLO signatures, a control-flow reorder in `BaseModel.export`, and new tests. No third-party code was ported, adapted, or derived.
