### PR TITLE
Order the README compatibility table by relevance, not alphabet

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,75 +73,75 @@ Training capabilities are documented per family in
 <!-- export-support:start -->
 | Family | Task | onnx | torchscript | tensorrt | openvino | ncnn | tflite | coreml |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| birefnet | matte | exp | ✓ | exp | exp |  |  |  |
-| clip | classify | ✓ |  |  |  |  |  |  |
-| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| deim | detect | exp | ✓ | exp | exp |  |  |  |
-| deimv2 | detect | exp | ✓ | exp | exp |  |  |  |
-| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  |
-| depth_anything3 | depth |  |  |  |  |  |  |  |
-| dfine | detect | ✓ | ✓ | exp | exp |  |  |  |
-| dfine | segment | ✓ | ✓ | exp | exp |  |  |  |
-| dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |
-| dinov2 | classify | ✓ |  |  |  |  |  |  |
-| ec | detect | ✓ | ✓ | exp | exp |  |  |  |
-| ec | pose | ✓ | ✓ | exp | exp |  |  |  |
-| ec | segment | ✓ | ✓ | exp | exp |  |  |  |
-| edgetam | segment |  |  |  |  |  |  |  |
-| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |
-| eomt | segment |  |  |  |  |  |  |  |
-| eomt | panoptic |  |  |  |  |  |  |  |
-| florence2 | detect |  |  |  |  |  |  |  |
-| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  |
-| grounding_dino | detect |  |  |  |  |  |  |  |
-| internvl3 | detect |  |  |  |  |  |  |  |
-| kosmos2 | detect |  |  |  |  |  |  |  |
-| l2cs | gaze | ✓ |  |  |  |  |  |  |
-| lfm2vl | detect |  |  |  |  |  |  |  |
-| locateanything | detect |  |  |  |  |  |  |  |
-| locateanything | point |  |  |  |  |  |  |  |
-| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| mobilesam | segment |  |  |  |  |  |  |  |
-| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
-| omdet_turbo | detect |  |  |  |  |  |  |  |
-| ov_deim | detect |  |  |  |  |  |  |  |
-| owlv2 | detect |  |  |  |  |  |  |  |
-| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| picosam3 | segment | ✓ |  |  |  |  |  |  |
-| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| ppocr | ocr |  |  |  |  |  |  |  |
-| qwen3vl | detect |  |  |  |  |  |  |  |
-| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
 | rfdetr | detect | ✓ | ✓ | ✓ | ✓ |  | exp | exp |
 | rfdetr | segment | ✓ | ✓ | exp | exp |  |  |  |
 | rfdetr | pose | ✓ | ✓ | exp | exp |  |  |  |
 | rfdetr | obb | ✓ | ✓ | exp | exp |  |  |  |
-| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp |
-| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  |
-| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  |
-| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  |
-| rtmdet | segment |  |  |  |  |  |  |  |
-| sam | segment |  |  |  |  |  |  |  |
-| sam2 | segment |  |  |  |  |  |  |  |
-| sam3 | segment |  |  |  |  |  |  |  |
-| segformer | semantic |  |  |  |  |  |  |  |
-| siglip2 | classify | ✓ |  |  |  |  |  |  |
-| smolvlm2 | detect |  |  |  |  |  |  |  |
-| swinir | restore | exp | exp | exp | exp | exp |  |  |
+| ec | detect | ✓ | ✓ | exp | exp |  |  |  |
+| ec | pose | ✓ | ✓ | exp | exp |  |  |  |
+| ec | segment | ✓ | ✓ | exp | exp |  |  |  |
+| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
+| yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |
+| dfine | detect | ✓ | ✓ | exp | exp |  |  |  |
+| dfine | segment | ✓ | ✓ | exp | exp |  |  |  |
+| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp |
+| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo3 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp |
+| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp |
+| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  |
+| rtmdet | segment |  |  |  |  |  |  |  |
+| deim | detect | exp | ✓ | exp | exp |  |  |  |
+| deimv2 | detect | exp | ✓ | exp | exp |  |  |  |
+| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  |
+| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  |
+| florence2 | detect |  |  |  |  |  |  |  |
+| grounding_dino | detect |  |  |  |  |  |  |  |
+| internvl3 | detect |  |  |  |  |  |  |  |
+| kosmos2 | detect |  |  |  |  |  |  |  |
+| lfm2vl | detect |  |  |  |  |  |  |  |
+| locateanything | detect |  |  |  |  |  |  |  |
+| locateanything | point |  |  |  |  |  |  |  |
+| omdet_turbo | detect |  |  |  |  |  |  |  |
+| ov_deim | detect |  |  |  |  |  |  |  |
+| owlv2 | detect |  |  |  |  |  |  |  |
+| qwen3vl | detect |  |  |  |  |  |  |  |
+| smolvlm2 | detect |  |  |  |  |  |  |  |
+| eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |
+| eomt | segment |  |  |  |  |  |  |  |
+| eomt | panoptic |  |  |  |  |  |  |  |
+| picosam3 | segment | ✓ |  |  |  |  |  |  |
+| edgetam | segment |  |  |  |  |  |  |  |
+| mobilesam | segment |  |  |  |  |  |  |  |
+| sam | segment |  |  |  |  |  |  |  |
+| sam2 | segment |  |  |  |  |  |  |  |
+| sam3 | segment |  |  |  |  |  |  |  |
+| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  |
+| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |
+| dinov2 | classify | ✓ |  |  |  |  |  |  |
+| clip | classify | ✓ |  |  |  |  |  |  |
+| siglip2 | classify | ✓ |  |  |  |  |  |  |
+| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| segformer | semantic |  |  |  |  |  |  |  |
 | zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  |
+| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  |
+| depth_anything3 | depth |  |  |  |  |  |  |  |
+| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
+| swinir | restore | exp | exp | exp | exp | exp |  |  |
+| birefnet | matte | exp | ✓ | exp | exp |  |  |  |
+| ppocr | ocr |  |  |  |  |  |  |  |
+| l2cs | gaze | ✓ |  |  |  |  |  |  |
 <!-- export-support:end -->
 
 ## Depth estimation

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -8,75 +8,75 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 
 | Family | Task | onnx | torchscript | tensorrt | openvino | ncnn | tflite | coreml |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| birefnet | matte | exp | ✓ | exp | exp |  |  |  |
-| clip | classify | ✓ |  |  |  |  |  |  |
-| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| deim | detect | exp | ✓ | exp | exp |  |  |  |
-| deimv2 | detect | exp | ✓ | exp | exp |  |  |  |
-| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  |
-| depth_anything3 | depth |  |  |  |  |  |  |  |
-| dfine | detect | ✓ | ✓ | exp | exp |  |  |  |
-| dfine | segment | ✓ | ✓ | exp | exp |  |  |  |
-| dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |
-| dinov2 | classify | ✓ |  |  |  |  |  |  |
-| ec | detect | ✓ | ✓ | exp | exp |  |  |  |
-| ec | pose | ✓ | ✓ | exp | exp |  |  |  |
-| ec | segment | ✓ | ✓ | exp | exp |  |  |  |
-| edgetam | segment |  |  |  |  |  |  |  |
-| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |
-| eomt | segment |  |  |  |  |  |  |  |
-| eomt | panoptic |  |  |  |  |  |  |  |
-| florence2 | detect |  |  |  |  |  |  |  |
-| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  |
-| grounding_dino | detect |  |  |  |  |  |  |  |
-| internvl3 | detect |  |  |  |  |  |  |  |
-| kosmos2 | detect |  |  |  |  |  |  |  |
-| l2cs | gaze | ✓ |  |  |  |  |  |  |
-| lfm2vl | detect |  |  |  |  |  |  |  |
-| locateanything | detect |  |  |  |  |  |  |  |
-| locateanything | point |  |  |  |  |  |  |  |
-| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| mobilesam | segment |  |  |  |  |  |  |  |
-| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
-| omdet_turbo | detect |  |  |  |  |  |  |  |
-| ov_deim | detect |  |  |  |  |  |  |  |
-| owlv2 | detect |  |  |  |  |  |  |  |
-| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| picosam3 | segment | ✓ |  |  |  |  |  |  |
-| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| ppocr | ocr |  |  |  |  |  |  |  |
-| qwen3vl | detect |  |  |  |  |  |  |  |
-| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
 | rfdetr | detect | ✓ | ✓ | ✓ | ✓ |  | exp | exp |
 | rfdetr | segment | ✓ | ✓ | exp | exp |  |  |  |
 | rfdetr | pose | ✓ | ✓ | exp | exp |  |  |  |
 | rfdetr | obb | ✓ | ✓ | exp | exp |  |  |  |
-| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp |
-| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  |
-| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  |
-| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  |
-| rtmdet | segment |  |  |  |  |  |  |  |
-| sam | segment |  |  |  |  |  |  |  |
-| sam2 | segment |  |  |  |  |  |  |  |
-| sam3 | segment |  |  |  |  |  |  |  |
-| segformer | semantic |  |  |  |  |  |  |  |
-| siglip2 | classify | ✓ |  |  |  |  |  |  |
-| smolvlm2 | detect |  |  |  |  |  |  |  |
-| swinir | restore | exp | exp | exp | exp | exp |  |  |
+| ec | detect | ✓ | ✓ | exp | exp |  |  |  |
+| ec | pose | ✓ | ✓ | exp | exp |  |  |  |
+| ec | segment | ✓ | ✓ | exp | exp |  |  |  |
+| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
+| yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |
+| dfine | detect | ✓ | ✓ | exp | exp |  |  |  |
+| dfine | segment | ✓ | ✓ | exp | exp |  |  |  |
+| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp |
+| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo3 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp |
+| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp |
+| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  |
+| rtmdet | segment |  |  |  |  |  |  |  |
+| deim | detect | exp | ✓ | exp | exp |  |  |  |
+| deimv2 | detect | exp | ✓ | exp | exp |  |  |  |
+| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  |
+| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  |
+| florence2 | detect |  |  |  |  |  |  |  |
+| grounding_dino | detect |  |  |  |  |  |  |  |
+| internvl3 | detect |  |  |  |  |  |  |  |
+| kosmos2 | detect |  |  |  |  |  |  |  |
+| lfm2vl | detect |  |  |  |  |  |  |  |
+| locateanything | detect |  |  |  |  |  |  |  |
+| locateanything | point |  |  |  |  |  |  |  |
+| omdet_turbo | detect |  |  |  |  |  |  |  |
+| ov_deim | detect |  |  |  |  |  |  |  |
+| owlv2 | detect |  |  |  |  |  |  |  |
+| qwen3vl | detect |  |  |  |  |  |  |  |
+| smolvlm2 | detect |  |  |  |  |  |  |  |
+| eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |
+| eomt | segment |  |  |  |  |  |  |  |
+| eomt | panoptic |  |  |  |  |  |  |  |
+| picosam3 | segment | ✓ |  |  |  |  |  |  |
+| edgetam | segment |  |  |  |  |  |  |  |
+| mobilesam | segment |  |  |  |  |  |  |  |
+| sam | segment |  |  |  |  |  |  |  |
+| sam2 | segment |  |  |  |  |  |  |  |
+| sam3 | segment |  |  |  |  |  |  |  |
+| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  |
+| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |
+| dinov2 | classify | ✓ |  |  |  |  |  |  |
+| clip | classify | ✓ |  |  |  |  |  |  |
+| siglip2 | classify | ✓ |  |  |  |  |  |  |
+| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| segformer | semantic |  |  |  |  |  |  |  |
 | zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  |
+| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  |
+| depth_anything3 | depth |  |  |  |  |  |  |  |
+| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
+| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
+| swinir | restore | exp | exp | exp | exp | exp |  |  |
+| birefnet | matte | exp | ✓ | exp | exp |  |  |  |
+| ppocr | ocr |  |  |  |  |  |  |  |
+| l2cs | gaze | ✓ |  |  |  |  |  |  |
 
 ## Parity thresholds
 
@@ -89,47 +89,16 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 
 ## Blocked combinations
 
-- `birefnet` / `matte` / `ncnn`: BiRefNet's decoder requires torchvision deformable convolution, which PNNX/NCNN cannot lower to a runnable graph.
-- `birefnet` / `matte` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `birefnet` / `matte` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `clip` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `clip` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `clip` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `clip` / `classify` / `ncnn`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `clip` / `classify` / `tflite`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `clip` / `classify` / `coreml`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `convnext` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `deim` / `detect` / `ncnn`: NCNN export is not supported for DEIM: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `deim` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `deim` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `deimv2` / `detect` / `ncnn`: NCNN export is not supported for DEIMv2: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `deimv2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `deimv2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `depth_anything` / `depth` / `ncnn`: PNNX 20260526 reports unsupported batch-index reshapes in the DINOv2 transformer graph; the produced NCNN artifact fails numeric parity.
-- `depth_anything` / `depth` / `tflite`: onnx2tf 2.4.x converts the DINOv2 depth graph, but LiteRT rejects a generated FILL node because its dimensions are invalid.
-- `depth_anything` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `depth_anything3` / `depth` / `onnx`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
-- `depth_anything3` / `depth` / `torchscript`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
-- `depth_anything3` / `depth` / `tensorrt`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
-- `depth_anything3` / `depth` / `openvino`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
-- `depth_anything3` / `depth` / `ncnn`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
-- `depth_anything3` / `depth` / `tflite`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
-- `depth_anything3` / `depth` / `coreml`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
-- `dfine` / `detect` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `dfine` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `dfine` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `dfine` / `segment` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `dfine` / `segment` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `dfine` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `dinov2` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
-- `dinov2` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
-- `dinov2` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
-- `dinov2` / `classify` / `torchscript`: LibreDINOv2 classify export currently supports ONNX only.
-- `dinov2` / `classify` / `tensorrt`: LibreDINOv2 classify export currently supports ONNX only.
-- `dinov2` / `classify` / `openvino`: LibreDINOv2 classify export currently supports ONNX only.
-- `dinov2` / `classify` / `ncnn`: LibreDINOv2 classify export currently supports ONNX only.
-- `dinov2` / `classify` / `tflite`: LibreDINOv2 classify export currently supports ONNX only.
-- `dinov2` / `classify` / `coreml`: LibreDINOv2 classify export currently supports ONNX only.
+- `rfdetr` / `detect` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `rfdetr` / `segment` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `rfdetr` / `segment` / `tflite`: onnx2tf 2.4.x assigns an invalid NHWC layout to the segmentation-head Einsum (78 channels versus the required 256), so conversion fails.
+- `rfdetr` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rfdetr` / `pose` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `rfdetr` / `pose` / `tflite`: RF-DETR pose-x TFLite conversion exceeded the CPU timebox and 8 GB working memory without producing an artifact on this toolchain.
+- `rfdetr` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rfdetr` / `obb` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `rfdetr` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `rfdetr` / `obb` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `ec` / `detect` / `ncnn`: NCNN export is not supported for EC: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `ec` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `ec` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
@@ -139,31 +108,56 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `ec` / `segment` / `ncnn`: NCNN export is not supported for EC: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `ec` / `segment` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `ec` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `edgetam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
-- `edgetam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
-- `edgetam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
-- `edgetam` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
-- `edgetam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
-- `edgetam` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
-- `edgetam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
-- `efficientnetv2` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `eomt` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
-- `eomt` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
-- `eomt` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
-- `eomt` / `segment` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `segment` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `segment` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `segment` / `openvino`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `segment` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `segment` / `tflite`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `segment` / `coreml`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `panoptic` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `panoptic` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `panoptic` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `panoptic` / `openvino`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `panoptic` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `panoptic` / `tflite`: EoMT instance and panoptic export do not yet have runtime parsing.
-- `eomt` / `panoptic` / `coreml`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `yolonas` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolonas` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolonas` / `pose` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolonas` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `dfine` / `detect` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `dfine` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `dfine` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `dfine` / `segment` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `dfine` / `segment` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `dfine` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `picodet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `picodet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo1` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolo1` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo2` / `detect` / `tflite`: onnx2tf 2.4.x leaves an unresolved ONNX_CONCAT custom operation; LiteRT cannot prepare the converted detector graph.
+- `yolo2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo3` / `detect` / `tflite`: onnx2tf 2.4.x leaves an unresolved ONNX_CONCAT custom operation; LiteRT cannot prepare the converted detector graph.
+- `yolo3` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo4` / `detect` / `tflite`: onnx2tf 2.4.x produces an invalid CONV_2D channel layout for YOLO4; LiteRT fails while allocating tensors.
+- `yolo4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo7` / `detect` / `tflite`: The converted LiteRT graph changes decoded box coordinates beyond the detector parity tolerance.
+- `yolo7` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo9_e2e` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolo9_e2e` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo9_p2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `yolo9_p2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rtdetr` / `detect` / `ncnn`: NCNN export is not supported for RT-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `rtdetr` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `rtmdet` / `detect` / `ncnn`: PNNX 20260526 reports an unregistered nn.Conv2d layer and leaves the RTMDet NCNN graph without usable input blobs.
+- `rtmdet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `rtmdet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rtmdet` / `segment` / `onnx`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `torchscript`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `tensorrt`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `openvino`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `ncnn`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `tflite`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `coreml`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `deim` / `detect` / `ncnn`: NCNN export is not supported for DEIM: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `deim` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `deim` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `deimv2` / `detect` / `ncnn`: NCNN export is not supported for DEIMv2: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `deimv2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `deimv2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rtdetrv2` / `detect` / `ncnn`: NCNN export is not supported for RT-DETRv2: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `rtdetrv2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `rtdetrv2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rtdetrv4` / `detect` / `ncnn`: NCNN export is not supported for RT-DETRv4: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
+- `rtdetrv4` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `rtdetrv4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `florence2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -171,8 +165,6 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `florence2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
-- `fomo` / `point` / `tflite`: onnx2tf 2.4.x produces an invalid depthwise-convolution graph for the static SAME-padded FOMO backbone on this toolchain.
-- `fomo` / `point` / `coreml`: The CoreML wrapper does not implement the raw point-heatmap contract.
 - `grounding_dino` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
@@ -194,12 +186,6 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `kosmos2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
-- `l2cs` / `gaze` / `torchscript`: The v1 L2CS gaze export contract supports ONNX only.
-- `l2cs` / `gaze` / `tensorrt`: The v1 L2CS gaze export contract supports ONNX only.
-- `l2cs` / `gaze` / `openvino`: The v1 L2CS gaze export contract supports ONNX only.
-- `l2cs` / `gaze` / `ncnn`: The v1 L2CS gaze export contract supports ONNX only.
-- `l2cs` / `gaze` / `tflite`: The v1 L2CS gaze export contract supports ONNX only.
-- `l2cs` / `gaze` / `coreml`: The v1 L2CS gaze export contract supports ONNX only.
 - `lfm2vl` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -221,16 +207,6 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `locateanything` / `point` / `ncnn`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `tflite`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `coreml`: Generative VLM export is out of scope for v1.
-- `mobilenetv4` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `mobilesam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
-- `mobilesam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
-- `mobilesam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
-- `mobilesam` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
-- `mobilesam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
-- `mobilesam` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
-- `mobilesam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
-- `nafnet` / `restore` / `tflite`: onnx2tf 2.4.x converts the fixed-canvas graph, but LiteRT fails at invoke time because an internal input tensor lacks data.
-- `nafnet` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `omdet_turbo` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
@@ -252,22 +228,6 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `owlv2` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `tflite`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
-- `picodet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `picodet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `picosam3` / `segment` / `torchscript`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
-- `picosam3` / `segment` / `tensorrt`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
-- `picosam3` / `segment` / `openvino`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
-- `picosam3` / `segment` / `ncnn`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
-- `picosam3` / `segment` / `tflite`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
-- `picosam3` / `segment` / `coreml`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
-- `pidnet` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
-- `ppocr` / `ocr` / `onnx`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
-- `ppocr` / `ocr` / `torchscript`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
-- `ppocr` / `ocr` / `tensorrt`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
-- `ppocr` / `ocr` / `openvino`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
-- `ppocr` / `ocr` / `ncnn`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
-- `ppocr` / `ocr` / `tflite`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
-- `ppocr` / `ocr` / `coreml`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `qwen3vl` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -275,36 +235,50 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `qwen3vl` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
-- `realesrgan` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `resnet` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rfdetr` / `detect` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `rfdetr` / `segment` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `rfdetr` / `segment` / `tflite`: onnx2tf 2.4.x assigns an invalid NHWC layout to the segmentation-head Einsum (78 channels versus the required 256), so conversion fails.
-- `rfdetr` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rfdetr` / `pose` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `rfdetr` / `pose` / `tflite`: RF-DETR pose-x TFLite conversion exceeded the CPU timebox and 8 GB working memory without producing an artifact on this toolchain.
-- `rfdetr` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rfdetr` / `obb` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `rfdetr` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `rfdetr` / `obb` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rtdetr` / `detect` / `ncnn`: NCNN export is not supported for RT-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `rtdetr` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `rtdetrv2` / `detect` / `ncnn`: NCNN export is not supported for RT-DETRv2: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `rtdetrv2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `rtdetrv2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rtdetrv4` / `detect` / `ncnn`: NCNN export is not supported for RT-DETRv4: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
-- `rtdetrv4` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `rtdetrv4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rtmdet` / `detect` / `ncnn`: PNNX 20260526 reports an unregistered nn.Conv2d layer and leaves the RTMDet NCNN graph without usable input blobs.
-- `rtmdet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `rtmdet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rtmdet` / `segment` / `onnx`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
-- `rtmdet` / `segment` / `torchscript`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
-- `rtmdet` / `segment` / `tensorrt`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
-- `rtmdet` / `segment` / `openvino`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
-- `rtmdet` / `segment` / `ncnn`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
-- `rtmdet` / `segment` / `tflite`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
-- `rtmdet` / `segment` / `coreml`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `smolvlm2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `eomt` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
+- `eomt` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
+- `eomt` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
+- `eomt` / `segment` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `openvino`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `tflite`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `coreml`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `openvino`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `tflite`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `coreml`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `picosam3` / `segment` / `torchscript`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `tensorrt`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `openvino`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `ncnn`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `tflite`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `coreml`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `edgetam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
@@ -326,6 +300,34 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `sam3` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
+- `fomo` / `point` / `tflite`: onnx2tf 2.4.x produces an invalid depthwise-convolution graph for the static SAME-padded FOMO backbone on this toolchain.
+- `fomo` / `point` / `coreml`: The CoreML wrapper does not implement the raw point-heatmap contract.
+- `convnext` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `efficientnetv2` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `mobilenetv4` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `resnet` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `dinov2` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
+- `dinov2` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
+- `dinov2` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
+- `dinov2` / `classify` / `torchscript`: LibreDINOv2 classify export currently supports ONNX only.
+- `dinov2` / `classify` / `tensorrt`: LibreDINOv2 classify export currently supports ONNX only.
+- `dinov2` / `classify` / `openvino`: LibreDINOv2 classify export currently supports ONNX only.
+- `dinov2` / `classify` / `ncnn`: LibreDINOv2 classify export currently supports ONNX only.
+- `dinov2` / `classify` / `tflite`: LibreDINOv2 classify export currently supports ONNX only.
+- `dinov2` / `classify` / `coreml`: LibreDINOv2 classify export currently supports ONNX only.
+- `clip` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `clip` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `clip` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `clip` / `classify` / `ncnn`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `clip` / `classify` / `tflite`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `clip` / `classify` / `coreml`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `siglip2` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `siglip2` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `siglip2` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `siglip2` / `classify` / `ncnn`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `siglip2` / `classify` / `tflite`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `siglip2` / `classify` / `coreml`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `pidnet` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `segformer` / `semantic` / `onnx`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `torchscript`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `tensorrt`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
@@ -333,38 +335,36 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `segformer` / `semantic` / `ncnn`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `tflite`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `coreml`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
-- `siglip2` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `siglip2` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `siglip2` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `siglip2` / `classify` / `ncnn`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `siglip2` / `classify` / `tflite`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `siglip2` / `classify` / `coreml`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
-- `smolvlm2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
-- `smolvlm2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
-- `smolvlm2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
-- `smolvlm2` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
-- `smolvlm2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
-- `smolvlm2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
-- `smolvlm2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
-- `swinir` / `restore` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `swinir` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo1` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `yolo1` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo2` / `detect` / `tflite`: onnx2tf 2.4.x leaves an unresolved ONNX_CONCAT custom operation; LiteRT cannot prepare the converted detector graph.
-- `yolo2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo3` / `detect` / `tflite`: onnx2tf 2.4.x leaves an unresolved ONNX_CONCAT custom operation; LiteRT cannot prepare the converted detector graph.
-- `yolo3` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo4` / `detect` / `tflite`: onnx2tf 2.4.x produces an invalid CONV_2D channel layout for YOLO4; LiteRT fails while allocating tensors.
-- `yolo4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo7` / `detect` / `tflite`: The converted LiteRT graph changes decoded box coordinates beyond the detector parity tolerance.
-- `yolo7` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo9_e2e` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `yolo9_e2e` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo9_p2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `yolo9_p2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolonas` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `yolonas` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolonas` / `pose` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
-- `yolonas` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `zipdepth` / `depth` / `tflite`: onnx2tf 2.4.x flatbuffer-direct conversion does not support the edge-mode Pad operation in ZipDepth's convex upsampler.
 - `zipdepth` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `depth_anything` / `depth` / `ncnn`: PNNX 20260526 reports unsupported batch-index reshapes in the DINOv2 transformer graph; the produced NCNN artifact fails numeric parity.
+- `depth_anything` / `depth` / `tflite`: onnx2tf 2.4.x converts the DINOv2 depth graph, but LiteRT rejects a generated FILL node because its dimensions are invalid.
+- `depth_anything` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `depth_anything3` / `depth` / `onnx`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `torchscript`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `tensorrt`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `openvino`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `ncnn`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `tflite`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `coreml`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `realesrgan` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `nafnet` / `restore` / `tflite`: onnx2tf 2.4.x converts the fixed-canvas graph, but LiteRT fails at invoke time because an internal input tensor lacks data.
+- `nafnet` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `swinir` / `restore` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `swinir` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `birefnet` / `matte` / `ncnn`: BiRefNet's decoder requires torchvision deformable convolution, which PNNX/NCNN cannot lower to a runnable graph.
+- `birefnet` / `matte` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `birefnet` / `matte` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `ppocr` / `ocr` / `onnx`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `torchscript`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `tensorrt`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `openvino`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `ncnn`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `tflite`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `coreml`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `l2cs` / `gaze` / `torchscript`: The v1 L2CS gaze export contract supports ONNX only.
+- `l2cs` / `gaze` / `tensorrt`: The v1 L2CS gaze export contract supports ONNX only.
+- `l2cs` / `gaze` / `openvino`: The v1 L2CS gaze export contract supports ONNX only.
+- `l2cs` / `gaze` / `ncnn`: The v1 L2CS gaze export contract supports ONNX only.
+- `l2cs` / `gaze` / `tflite`: The v1 L2CS gaze export contract supports ONNX only.
+- `l2cs` / `gaze` / `coreml`: The v1 L2CS gaze export contract supports ONNX only.

--- a/tools/gen_compat_table.py
+++ b/tools/gen_compat_table.py
@@ -17,6 +17,57 @@ README_PATH = REPO_ROOT / "README.md"
 DOCS_PATH = REPO_ROOT / "docs" / "export_support.md"
 MARKERS = {"validated": "✓", "experimental": "exp", "blocked": ""}
 
+# The table is a shop window, not an index: readers come for the flagship
+# detectors, so those lead, and the remaining families are grouped by how
+# people scan the library (detection first, niche tasks last) instead of
+# alphabetically — which used to open the table with `birefnet` (matting)
+# while yolo9/yolonas/rfdetr sat at the bottom.
+FLAGSHIP_FAMILIES = ("yolo9", "rfdetr")
+TASK_ORDER = (
+    "detect",
+    "segment",
+    "pose",
+    "obb",
+    "point",
+    "classify",
+    "semantic",
+    "panoptic",
+    "depth",
+    "restore",
+    "matte",
+    "ocr",
+    "gaze",
+)
+
+
+def _family_order(inventory: dict) -> list[str]:
+    """Return inventory families in reader-facing order.
+
+    Flagships lead in their documented order. The rest sort by the earliest
+    task tier they serve (per TASK_ORDER), then by parity-validated export
+    count (most validated first, so heavily tested families outrank
+    export-blocked ones), then by name for determinism.
+    """
+    from libreyolo.export.support import EXPORT_FORMATS, get_support
+
+    def key(family: str) -> tuple:
+        if family in FLAGSHIP_FAMILIES:
+            return (0, FLAGSHIP_FAMILIES.index(family), 0, family)
+        metadata = inventory[family]
+        tiers = [
+            TASK_ORDER.index(task) if task in TASK_ORDER else len(TASK_ORDER)
+            for task in metadata["tasks"]
+        ]
+        validated = sum(
+            1
+            for task in metadata["tasks"]
+            for fmt in EXPORT_FORMATS
+            if get_support(family, task, fmt).tier == "validated"
+        )
+        return (1, min(tiers), -validated, family)
+
+    return sorted(inventory, key=key)
+
 
 def _rows() -> tuple[list[str], list[str]]:
     from libreyolo.export.support import EXPORT_FORMATS, get_support
@@ -34,7 +85,8 @@ def _rows() -> tuple[list[str], list[str]]:
         "| " + " | ".join(["---", "---", *(["---:"] * len(EXPORT_FORMATS))]) + " |",
     ]
     blocked = []
-    for family, metadata in inventory.items():
+    for family in _family_order(inventory):
+        metadata = inventory[family]
         for task in metadata["tasks"]:
             entries = [get_support(family, task, fmt) for fmt in EXPORT_FORMATS]
             readme.append(


### PR DESCRIPTION
## Summary

The README export-compatibility table was emitted in alphabetical inventory order, so it opened with `birefnet` (matting) while the flagship detectors — `yolo9`, `rfdetr`, `yolonas` — sat at the very bottom. First-time visitors scanning the README saw a niche task before any of the models the "Flagship models" section recommends.

`tools/gen_compat_table.py` now orders rows for readers instead of the alphabet:

1. Flagships lead in their documented order (`yolo9`, then `rfdetr`).
2. Remaining families group by the earliest task tier they serve (detection first, then segmentation/pose/OBB, classification, semantic, and finally depth/restoration/matting/OCR/gaze).
3. Within a tier, families with more parity-validated export cells rank higher, so heavily tested families outrank export-blocked stubs (e.g. the VLM detect rows). Name is the final tiebreaker, keeping the order deterministic.

`README.md` and `docs/export_support.md` are regenerated with the new order. No product code changes; the table content (rows, tiers, blocked reasons) is byte-identical modulo ordering.

## Test plan

- `python tools/gen_compat_table.py --check` passes on the regenerated files.
- `pytest tests/unit/test_export_support.py` — 23 passed, including `test_generated_export_docs_are_current`, which runs the generator in check mode against the committed README and docs.

## Code provenance

All changes were written for this PR by the repository maintainer with AI assistance (Cursor). The ordering logic in `tools/gen_compat_table.py` is original work over the project's own inventory/support APIs (`reports/export_inventory.json`, `libreyolo.export.support`); `README.md` and `docs/export_support.md` are mechanical regenerations produced by that script. No code was copied from external projects, and no AGPL or otherwise incompatibly licensed sources were referenced.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Reorders generated export-compatibility documentation by reader relevance.
- Places YOLO9 and RF-DETR first in documented flagship order.
- Groups remaining families by their earliest supported task tier, validated export coverage, and name.
- Regenerates the compatibility tables and blocked-combination lists in README.md and docs/export_support.md.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The generator preserves the existing compatibility data while applying a deterministic reader-facing order, and the generated documentation remains synchronized with that logic.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/gen_compat_table.py | Adds deterministic family ordering based on flagship status, task relevance, validated export coverage, and family name; no actionable defect identified. |
| README.md | Mechanically reorders the generated compatibility table without changing its compatibility data. |
| docs/export_support.md | Mechanically reorders the compatibility table and corresponding blocked-combination entries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Order the README compatibility table by ..."](https://github.com/libreyolo/libreyolo/commit/04d5261b964bcde805e57f9c12e9c571917837dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46962316)</sub>

<!-- /greptile_comment -->