### PR TITLE
Fix non-detection CLI model resolution

### DIFF
--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -75,8 +75,16 @@ def _task_sizes_for_cli(cls, task: str) -> dict[str, int]:
 def _register_cli_names_for_class(cls) -> None:
     default_task = getattr(cls, "DEFAULT_TASK", "detect")
     for size_code in _task_sizes_for_cli(cls, default_task):
+        weight_name = _weight_filename_for_cli(cls, size_code)
         cli_name = f"{cls.FAMILY}-{size_code}"
-        _CLI_NAME_TO_WEIGHTS[cli_name] = _weight_filename_for_cli(cls, size_code)
+        _CLI_NAME_TO_WEIGHTS[cli_name] = weight_name
+
+        # ``libreyolo models`` prints the explicit task suffix for every
+        # non-detection task. Keep the shorter default-task alias too, but make
+        # the advertised spelling resolve to the same canonical checkpoint.
+        suffix = task_to_suffix(default_task)
+        if suffix:
+            _CLI_NAME_TO_WEIGHTS[f"{cli_name}-{suffix}"] = weight_name
 
     for task in getattr(cls, "SUPPORTED_TASKS", ("detect",)):
         if task == default_task:
@@ -94,17 +102,15 @@ def _build_name_map() -> None:
     """Populate CLI name → weight filename mapping from model registry."""
     if _CLI_NAME_TO_WEIGHTS:
         return
+    from libreyolo.models import try_ensure_rfdetr
     from libreyolo.models.base.model import BaseModel
 
+    # RF-DETR and DINOv2 register together when their optional dependency is
+    # available. Trigger that registration before walking the registry so both
+    # families receive CLI aliases.
+    try_ensure_rfdetr()
     for cls in BaseModel._registry:
         _register_cli_names_for_class(cls)
-
-    # Also try RF-DETR (lazily registered)
-    from libreyolo.models import try_ensure_rfdetr
-
-    rfcls = try_ensure_rfdetr()
-    if rfcls is not None:
-        _register_cli_names_for_class(rfcls)
 
 
 def get_all_cli_names() -> list[str]:

--- a/libreyolo/models/clip/model.py
+++ b/libreyolo/models/clip/model.py
@@ -64,6 +64,7 @@ class LibreCLIP(BaseModel):
     }
     SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("classify",)
     DEFAULT_TASK: ClassVar[str] = "classify"
+    REQUIRE_TASK_SUFFIX: ClassVar[bool] = True
     TRAIN_CONFIG = None
 
     # The text->image attention pooling makes multi-scale TTA meaningless and

--- a/libreyolo/models/depth_anything/model.py
+++ b/libreyolo/models/depth_anything/model.py
@@ -51,6 +51,7 @@ class LibreDepthAnythingV2(BaseModel):
     }
     SUPPORTED_TASKS = ("depth",)
     DEFAULT_TASK = "depth"
+    REQUIRE_TASK_SUFFIX = True
 
     # DINOv2 patch grid; the depth dataset and validator enforce divisibility.
     depth_imgsz_divisor = 14

--- a/libreyolo/models/fomo/model.py
+++ b/libreyolo/models/fomo/model.py
@@ -38,6 +38,7 @@ class LibreFOMO(BaseModel):
 
     SUPPORTED_TASKS = ("point",)
     DEFAULT_TASK = "point"
+    REQUIRE_TASK_SUFFIX = True
     TRAIN_CONFIG = FOMOConfig
     val_preprocessor_class = FOMOValPreprocessor
     validator_class = FOMOValidator

--- a/libreyolo/models/siglip2/model.py
+++ b/libreyolo/models/siglip2/model.py
@@ -104,6 +104,7 @@ class LibreSigLIP2(BaseModel):
     }
     SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("classify",)
     DEFAULT_TASK: ClassVar[str] = "classify"
+    REQUIRE_TASK_SUFFIX: ClassVar[bool] = True
     TRAIN_CONFIG = None
 
     # Attention pooling + fixed square resize make multi-scale TTA meaningless.

--- a/libreyolo/models/zipdepth/model.py
+++ b/libreyolo/models/zipdepth/model.py
@@ -59,6 +59,7 @@ class LibreZipDepth(BaseModel):
     }
     SUPPORTED_TASKS = ("depth",)
     DEFAULT_TASK = "depth"
+    REQUIRE_TASK_SUFFIX = True
 
     # Encoder stride; the depth dataset and validator enforce divisibility.
     depth_imgsz_divisor = IMGSZ_DIVISOR

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -4,6 +4,7 @@ import pytest
 
 from dataclasses import fields as dc_fields
 
+import libreyolo.cli.config as cli_config
 from libreyolo.cli.config import (
     build_train_kwargs,
     detect_family_from_name,
@@ -44,6 +45,69 @@ class TestResolveModelName:
         assert resolve_model_name("rfdetr-n-seg") == "LibreRFDETRn-seg.pt"
         assert resolve_model_name("rfdetr-x-seg") == "LibreRFDETRx-seg.pt"
         assert resolve_model_name("rfdetr-xx-seg") == "LibreRFDETRxx-seg.pt"
+
+    @pytest.mark.parametrize(
+        ("short_name", "advertised_name", "weight_name"),
+        [
+            ("clip-b32", "clip-b32-cls", "LibreCLIPb32-cls.pt"),
+            (
+                "depth_anything-s",
+                "depth_anything-s-depth",
+                "LibreDepthAnythingV2s-depth.pt",
+            ),
+            ("fomo-s", "fomo-s-point", "LibreFOMOs-point.pt"),
+            ("siglip2-b16", "siglip2-b16-cls", "LibreSigLIP2b16-cls.pt"),
+            ("zipdepth-b", "zipdepth-b-depth", "LibreZipDepthb-depth.pt"),
+        ],
+    )
+    def test_non_detection_default_aliases_use_canonical_suffix(
+        self, short_name, advertised_name, weight_name
+    ):
+        assert resolve_model_name(short_name) == weight_name
+        assert resolve_model_name(advertised_name) == weight_name
+
+    def test_suffix_optional_family_keeps_unsuffixed_checkpoint(self):
+        assert resolve_model_name("l2cs-r50") == "LibreL2CSr50.pt"
+        assert resolve_model_name("l2cs-r50-gaze") == "LibreL2CSr50.pt"
+
+    def test_lazily_registered_family_receives_default_task_aliases(self, monkeypatch):
+        import libreyolo.models as models
+        from libreyolo.models.base.model import BaseModel
+
+        class EagerFamily:
+            FAMILY = "eager"
+            FILENAME_PREFIX = "LibreEager"
+            WEIGHT_EXT = ".pt"
+            INPUT_SIZES = {"s": 64}
+            TASK_INPUT_SIZES = {}
+            SUPPORTED_TASKS = ("detect",)
+            DEFAULT_TASK = "detect"
+            REQUIRE_TASK_SUFFIX = False
+
+        class LazyFamily:
+            FAMILY = "lazy"
+            FILENAME_PREFIX = "LibreLazy"
+            WEIGHT_EXT = ".pt"
+            INPUT_SIZES = {"s": 64}
+            TASK_INPUT_SIZES = {}
+            SUPPORTED_TASKS = ("semantic",)
+            DEFAULT_TASK = "semantic"
+            REQUIRE_TASK_SUFFIX = False
+
+        registry = [EagerFamily]
+
+        def register_lazy_family():
+            registry.append(LazyFamily)
+            return LazyFamily
+
+        monkeypatch.setattr(BaseModel, "_registry", registry)
+        monkeypatch.setattr(models, "try_ensure_rfdetr", register_lazy_family)
+        monkeypatch.setattr(cli_config, "_CLI_NAME_TO_WEIGHTS", {})
+
+        cli_config._build_name_map()
+
+        assert cli_config.resolve_model_name("lazy-s") == "LibreLazys.pt"
+        assert cli_config.resolve_model_name("lazy-s-sem") == "LibreLazys.pt"
 
     def test_case_insensitive(self):
         assert resolve_model_name("YOLOX-S") == "LibreYOLOXs.pt"


### PR DESCRIPTION
# What does this PR do?

Fixes CLI model-name resolution for families whose default task is not detection.

The CLI now accepts both the short default-task alias and the explicit task-suffixed name advertised by `libreyolo models`. It also uses canonical suffixed checkpoint filenames for CLIP, Depth Anything V2, FOMO, SigLIP2, and ZipDepth.

Lazy registration now adds aliases for both RF-DETR and DINOv2 when their optional dependency is available.

# Provenance declaration (required)

- [x] All code in this PR was written by the author(s), OR every ported or adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license code.
- [x] Notice files are updated if this PR ports third-party code.

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

## Code provenance

This PR is an original, first-party implementation written for LibreYOLO. No code was ported or adapted from another project.

# How was this tested?

- Affected unit suites: 219 passed, 6 skipped.
- Verified all 66 installed non-detection default-task aliases resolve.
- Ruff and `git diff --check` passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes CLI resolution for model families whose default task is not detection.
- Registers both short and explicit task-suffixed CLI aliases for non-detection default tasks.
- Uses canonical task-suffixed checkpoint filenames for CLIP, Depth Anything V2, FOMO, SigLIP2, and ZipDepth.
- Registers RF-DETR and DINOv2 aliases after optional lazy registration.
- Adds focused resolution and lazy-registration unit coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed aliases consistently resolving to canonical checkpoint filenames.

The name map now registers optional families before traversal and maps both accepted spellings to the same family-derived filename, while preserving unsuffixed filenames for families where task suffixes remain optional.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/cli/config.py | Adds default-task suffix aliases and moves optional model registration before registry traversal so all lazily registered families are included. |
| libreyolo/models/clip/model.py | Marks CLIP checkpoints as requiring the canonical classification suffix. |
| libreyolo/models/depth_anything/model.py | Marks Depth Anything V2 checkpoints as requiring the canonical depth suffix. |
| libreyolo/models/fomo/model.py | Marks FOMO checkpoints as requiring the canonical point-task suffix. |
| libreyolo/models/siglip2/model.py | Marks SigLIP2 checkpoints as requiring the canonical classification suffix. |
| libreyolo/models/zipdepth/model.py | Marks ZipDepth checkpoints as requiring the canonical depth suffix. |
| tests/unit/cli/test_config.py | Covers short and advertised aliases, suffix-optional behavior, and aliases for lazily registered families. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Input[CLI model name] --> Build[Build name map]
  Build --> Lazy[Attempt RF-DETR and DINOv2 registration]
  Lazy --> Registry[Walk BaseModel registry]
  Registry --> Short[Register short default-task alias]
  Registry --> Explicit[Register explicit task-suffixed alias]
  Short --> Canonical[Canonical checkpoint filename]
  Explicit --> Canonical
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix non-detection CLI model names"](https://github.com/libreyolo/libreyolo/commit/441985e3c4400b8f81bfda296d350ca854978454) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47248668)</sub>

**Context used:**

- Knowledge Base ? [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
- Knowledge Base ? [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->
