### PR TITLE
Add resumable weight downloads

### DIFF
--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -325,6 +325,7 @@ def LibreYOLO(
                 break
 
     # Download if missing
+    download_error: Exception | None = None
     if not Path(model_path).exists():
         if size is None:
             for cls in BaseModel._registry:
@@ -355,9 +356,15 @@ def LibreYOLO(
         try:
             download_weights(model_path, size)
         except Exception as e:
+            download_error = e
             logger.warning("Auto-download failed: %s", e)
 
     if not Path(model_path).exists():
+        if download_error is not None:
+            raise FileNotFoundError(
+                f"Model weights file not found: {model_path}\n"
+                f"Auto-download failed: {download_error}"
+            ) from download_error
         raise FileNotFoundError(f"Model weights file not found: {model_path}")
 
     # Load weights once

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -1,9 +1,11 @@
 """Download helpers for LibreYOLO model weights."""
 
+import json
 import logging
 import os
 import re
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -15,6 +17,8 @@ _DOWNLOAD_RETRIES = 3
 _DOWNLOAD_BACKOFF_SECONDS = 1.0
 _DOWNLOAD_TIMEOUT = (10, 60)
 _DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+_DOWNLOAD_LOCK_TIMEOUT = 6 * 60 * 60
+_DOWNLOAD_LOCK_POLL_SECONDS = 0.1
 logger = logging.getLogger(__name__)
 
 
@@ -74,12 +78,116 @@ def _response_total_size(response, offset: int) -> int:
     return content_length
 
 
+def _partial_metadata_path(partial: Path) -> Path:
+    return partial.with_name(partial.name + ".json")
+
+
+def _reset_partial(partial: Path) -> None:
+    partial.unlink(missing_ok=True)
+    _partial_metadata_path(partial).unlink(missing_ok=True)
+
+
+def _response_validator(response) -> str | None:
+    """Return a validator suitable for an If-Range request."""
+    etag = response.headers.get("etag")
+    if etag and not etag.lstrip().lower().startswith("w/"):
+        return etag
+    return response.headers.get("last-modified")
+
+
+def _load_partial_validator(partial: Path, url: str) -> str | None:
+    metadata = _partial_metadata_path(partial)
+    try:
+        state = json.loads(metadata.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError, TypeError):
+        return None
+    if state.get("url") != url:
+        return None
+    validator = state.get("validator")
+    return validator if isinstance(validator, str) and validator else None
+
+
+def _save_partial_validator(partial: Path, url: str, validator: str | None) -> None:
+    metadata = _partial_metadata_path(partial)
+    if validator is None:
+        metadata.unlink(missing_ok=True)
+        return
+    temporary = metadata.with_name(metadata.name + ".tmp")
+    temporary.write_text(
+        json.dumps({"url": url, "validator": validator}),
+        encoding="utf-8",
+    )
+    os.replace(temporary, metadata)
+
+
+def _try_lock_file(lock_file) -> None:
+    lock_file.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_file(lock_file) -> None:
+    lock_file.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _download_lock(path: Path):
+    """Serialize downloads targeting the same final weights path."""
+    lock_path = path.with_name(path.name + ".download.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+b") as lock_file:
+        if lock_file.seek(0, os.SEEK_END) == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+
+        deadline = time.monotonic() + _DOWNLOAD_LOCK_TIMEOUT
+        while True:
+            try:
+                _try_lock_file(lock_file)
+                break
+            except OSError as e:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out waiting for download lock: {lock_path}"
+                    ) from e
+                time.sleep(_DOWNLOAD_LOCK_POLL_SECONDS)
+
+        try:
+            yield
+        finally:
+            _unlock_file(lock_file)
+
+
 def _download_once(url: str, partial: Path, headers: dict[str, str]) -> None:
     """Stream one request, resuming a partial file when the server permits it."""
     offset = partial.stat().st_size if partial.exists() else 0
+    validator = _load_partial_validator(partial, url) if offset else None
+    if offset and validator is None:
+        logger.warning(
+            "Partial download has no matching HTTP validator; restarting from byte 0."
+        )
+        _reset_partial(partial)
+        offset = 0
+
     request_headers = dict(headers)
     if offset:
+        assert validator is not None
         request_headers["Range"] = f"bytes={offset}-"
+        request_headers["If-Range"] = validator
 
     response = requests.get(
         url,
@@ -89,31 +197,45 @@ def _download_once(url: str, partial: Path, headers: dict[str, str]) -> None:
     )
     try:
         if response.status_code == 416 and offset:
+            response_validator = _response_validator(response)
             complete_range = re.match(
                 r"bytes\s+\*/(\d+)",
                 response.headers.get("content-range", ""),
                 re.IGNORECASE,
             )
-            if complete_range and int(complete_range.group(1)) == offset:
+            same_object = response_validator == validator
+            if (
+                same_object
+                and complete_range
+                and int(complete_range.group(1)) == offset
+            ):
                 return
 
             # The saved offset is invalid for this object. Remove only this
             # download's temporary file so the retry starts cleanly.
-            partial.unlink(missing_ok=True)
+            _reset_partial(partial)
 
         response.raise_for_status()
 
         append = offset > 0 and response.status_code == 206
+        response_validator = _response_validator(response)
+        if append and response_validator not in {None, validator}:
+            _reset_partial(partial)
+            raise IOError("Download object changed while resuming")
+
         if offset and not append:
             logger.warning(
                 "Download server ignored the resume request; restarting from byte 0."
             )
             offset = 0
+            _reset_partial(partial)
 
         total_size = _response_total_size(response, offset)
         downloaded = offset
         last_logged = -1
         mode = "ab" if append else "wb"
+        if not append:
+            _save_partial_validator(partial, url, response_validator)
         with open(partial, mode) as f:
             for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
                 if chunk:
@@ -142,7 +264,11 @@ def download_weights(model_path: str, size: str):
     """Download weights from Hugging Face if not found locally."""
     path = Path(model_path)
     if path.exists():
-        return
+        # A concurrent downloader may have atomically placed the file but still
+        # be running its family-specific verification hook.
+        with _download_lock(path):
+            if path.exists():
+                return
 
     from libreyolo.models.base.model import BaseModel
 
@@ -199,40 +325,41 @@ def download_weights(model_path: str, size: str):
     # never leave a truncated weight at the final path (loading one fails
     # with an opaque zip error and requires a manual delete).
     partial = path.with_name(path.name + ".part")
-    last_error: Exception | None = None
-    for attempt in range(_DOWNLOAD_RETRIES + 1):
-        try:
-            _download_once(url, partial, headers)
-            os.replace(partial, path)
-            logger.info("Download complete.")
-            break
-        except Exception as e:
-            last_error = e
-            if attempt == _DOWNLOAD_RETRIES:
+    with _download_lock(path):
+        # Another process may have completed the same download while this
+        # process waited for the lock.
+        if path.exists():
+            return
+
+        for attempt in range(_DOWNLOAD_RETRIES + 1):
+            try:
+                _download_once(url, partial, headers)
+                break
+            except Exception as e:
+                if attempt == _DOWNLOAD_RETRIES:
+                    partial_size = partial.stat().st_size if partial.exists() else 0
+                    raise RuntimeError(
+                        f"Failed to download weights from {url} after "
+                        f"{_DOWNLOAD_RETRIES + 1} attempts: {e}. "
+                        f"Partial download kept at {partial} ({partial_size} bytes)."
+                    ) from e
+
                 partial_size = partial.stat().st_size if partial.exists() else 0
-                raise RuntimeError(
-                    f"Failed to download weights from {url} after "
-                    f"{_DOWNLOAD_RETRIES + 1} attempts: {e}. "
-                    f"Partial download kept at {partial} ({partial_size} bytes)."
-                ) from e
+                logger.warning(
+                    "Download interrupted (%s). Retrying %d/%d from byte %d.",
+                    e,
+                    attempt + 1,
+                    _DOWNLOAD_RETRIES,
+                    partial_size,
+                )
+                time.sleep(_DOWNLOAD_BACKOFF_SECONDS * (2**attempt))
 
-            partial_size = partial.stat().st_size if partial.exists() else 0
-            logger.warning(
-                "Download interrupted (%s). Retrying %d/%d from byte %d.",
-                e,
-                attempt + 1,
-                _DOWNLOAD_RETRIES,
-                partial_size,
-            )
-            time.sleep(_DOWNLOAD_BACKOFF_SECONDS * (2**attempt))
-
-    if last_error is not None and not path.exists():
-        # Defensive guard for type checkers and unusual filesystem races.
-        raise RuntimeError(f"Failed to download weights from {url}") from last_error
-
-    # Let the matched family verify the freshly downloaded file before anything
-    # loads it (e.g. checksum-pin a third-party CDN object). This runs for every
-    # download path — the LibreYOLO(...) factory and the per-family loaders all
-    # funnel through here — so the check cannot be bypassed. HF-hosted LibreYOLO
-    # weights use the trusting default and this is a no-op.
-    cls.verify_downloaded_file(str(path), url)
+        # Verify the temporary file before publishing it at the final path.
+        try:
+            cls.verify_downloaded_file(str(partial), url)
+        except Exception:
+            _reset_partial(partial)
+            raise
+        os.replace(partial, path)
+        _partial_metadata_path(partial).unlink(missing_ok=True)
+        logger.info("Download complete.")

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -10,6 +11,10 @@ from urllib.parse import urlparse
 import requests
 
 _YOLONAS_LICENSE_NOTICE_SHOWN = False
+_DOWNLOAD_RETRIES = 3
+_DOWNLOAD_BACKOFF_SECONDS = 1.0
+_DOWNLOAD_TIMEOUT = (10, 60)
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 logger = logging.getLogger(__name__)
 
 
@@ -52,6 +57,85 @@ def _detect_family_from_filename(filename: str) -> Optional[str]:
     if re.search(r"libreyolo9", fl):
         return "yolo9"
     return None
+
+
+def _response_total_size(response, offset: int) -> int:
+    """Return the complete object size for a full or ranged response."""
+    content_range = response.headers.get("content-range", "")
+    match = re.match(r"bytes\s+\d+-\d+/(\d+|\*)", content_range, re.IGNORECASE)
+    if match and match.group(1) != "*":
+        return int(match.group(1))
+
+    content_length = int(response.headers.get("content-length", 0))
+    if content_length <= 0:
+        return 0
+    if response.status_code == 206:
+        return offset + content_length
+    return content_length
+
+
+def _download_once(url: str, partial: Path, headers: dict[str, str]) -> None:
+    """Stream one request, resuming a partial file when the server permits it."""
+    offset = partial.stat().st_size if partial.exists() else 0
+    request_headers = dict(headers)
+    if offset:
+        request_headers["Range"] = f"bytes={offset}-"
+
+    response = requests.get(
+        url,
+        stream=True,
+        headers=request_headers,
+        timeout=_DOWNLOAD_TIMEOUT,
+    )
+    try:
+        if response.status_code == 416 and offset:
+            complete_range = re.match(
+                r"bytes\s+\*/(\d+)",
+                response.headers.get("content-range", ""),
+                re.IGNORECASE,
+            )
+            if complete_range and int(complete_range.group(1)) == offset:
+                return
+
+            # The saved offset is invalid for this object. Remove only this
+            # download's temporary file so the retry starts cleanly.
+            partial.unlink(missing_ok=True)
+
+        response.raise_for_status()
+
+        append = offset > 0 and response.status_code == 206
+        if offset and not append:
+            logger.warning(
+                "Download server ignored the resume request; restarting from byte 0."
+            )
+            offset = 0
+
+        total_size = _response_total_size(response, offset)
+        downloaded = offset
+        last_logged = -1
+        mode = "ab" if append else "wb"
+        with open(partial, mode) as f:
+            for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
+                if chunk:
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if total_size > 0:
+                        percent = int(100 * downloaded / total_size)
+                        if percent % 25 == 0 and percent != last_logged:
+                            last_logged = percent
+                            logger.info(
+                                "Downloading: %d%% (%.1f/%.1f MB)",
+                                percent,
+                                downloaded / 1024 / 1024,
+                                total_size / 1024 / 1024,
+                            )
+
+        if total_size > 0 and downloaded != total_size:
+            raise IOError(
+                f"Incomplete download: got {downloaded} of {total_size} bytes"
+            )
+    finally:
+        response.close()
 
 
 def download_weights(model_path: str, size: str):
@@ -115,38 +199,36 @@ def download_weights(model_path: str, size: str):
     # never leave a truncated weight at the final path (loading one fails
     # with an opaque zip error and requires a manual delete).
     partial = path.with_name(path.name + ".part")
-    try:
-        response = requests.get(url, stream=True, headers=headers)
-        response.raise_for_status()
-        total_size = int(response.headers.get("content-length", 0))
+    last_error: Exception | None = None
+    for attempt in range(_DOWNLOAD_RETRIES + 1):
+        try:
+            _download_once(url, partial, headers)
+            os.replace(partial, path)
+            logger.info("Download complete.")
+            break
+        except Exception as e:
+            last_error = e
+            if attempt == _DOWNLOAD_RETRIES:
+                partial_size = partial.stat().st_size if partial.exists() else 0
+                raise RuntimeError(
+                    f"Failed to download weights from {url} after "
+                    f"{_DOWNLOAD_RETRIES + 1} attempts: {e}. "
+                    f"Partial download kept at {partial} ({partial_size} bytes)."
+                ) from e
 
-        with open(partial, "wb") as f:
-            downloaded = 0
-            last_logged = -1
-            for chunk in response.iter_content(chunk_size=1024 * 1024):
-                if chunk:
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if total_size > 0:
-                        percent = int(100 * downloaded / total_size)
-                        if percent % 25 == 0 and percent != last_logged:
-                            last_logged = percent
-                            logger.info(
-                                "Downloading: %d%% (%.1f/%.1f MB)",
-                                percent,
-                                downloaded / 1024 / 1024,
-                                total_size / 1024 / 1024,
-                            )
-        if total_size > 0 and downloaded != total_size:
-            raise IOError(
-                f"Incomplete download: got {downloaded} of {total_size} bytes"
+            partial_size = partial.stat().st_size if partial.exists() else 0
+            logger.warning(
+                "Download interrupted (%s). Retrying %d/%d from byte %d.",
+                e,
+                attempt + 1,
+                _DOWNLOAD_RETRIES,
+                partial_size,
             )
-        os.replace(partial, path)
-        logger.info("Download complete.")
-    except Exception as e:
-        if partial.exists():
-            partial.unlink()
-        raise RuntimeError(f"Failed to download weights from {url}: {e}") from e
+            time.sleep(_DOWNLOAD_BACKOFF_SECONDS * (2**attempt))
+
+    if last_error is not None and not path.exists():
+        # Defensive guard for type checkers and unusual filesystem races.
+        raise RuntimeError(f"Failed to download weights from {url}") from last_error
 
     # Let the matched family verify the freshly downloaded file before anything
     # loads it (e.g. checksum-pin a third-party CDN object). This runs for every

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,0 +1,163 @@
+"""Tests for retrying and resumable weight downloads."""
+
+import requests
+import pytest
+
+from libreyolo.models.base.model import BaseModel
+from libreyolo.utils import download
+
+pytestmark = pytest.mark.unit
+
+
+class _DownloadFamily:
+    @classmethod
+    def get_download_url(cls, _filename):
+        return "https://huggingface.co/LibreYOLO/test/resolve/model.pt"
+
+    @classmethod
+    def get_download_notice(cls, _filename, _url):
+        return None
+
+    @classmethod
+    def verify_downloaded_file(cls, _path, _url):
+        return None
+
+
+class _Response:
+    def __init__(self, chunks, *, status_code=200, headers=None):
+        self._chunks = chunks
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.closed = False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size):
+        assert chunk_size == download._DOWNLOAD_CHUNK_SIZE
+        for chunk in self._chunks:
+            if isinstance(chunk, Exception):
+                raise chunk
+            yield chunk
+
+    def close(self):
+        self.closed = True
+
+
+def _prepare(monkeypatch):
+    monkeypatch.setattr(BaseModel, "_registry", [_DownloadFamily])
+    monkeypatch.setattr(download, "_get_hf_token", lambda: None)
+    monkeypatch.setattr(download.time, "sleep", lambda _seconds: None)
+
+
+def test_interrupted_download_retries_from_partial(monkeypatch, tmp_path):
+    _prepare(monkeypatch)
+    responses = [
+        _Response(
+            [b"abcd", requests.ConnectionError("connection dropped")],
+            headers={"content-length": "10"},
+        ),
+        _Response(
+            [b"efghij"],
+            status_code=206,
+            headers={"content-length": "6", "content-range": "bytes 4-9/10"},
+        ),
+    ]
+    calls = []
+
+    def fake_get(url, *, stream, headers, timeout):
+        calls.append(
+            {"url": url, "stream": stream, "headers": headers, "timeout": timeout}
+        )
+        return responses.pop(0)
+
+    monkeypatch.setattr(download.requests, "get", fake_get)
+    target = tmp_path / "model.pt"
+
+    download.download_weights(str(target), "s")
+
+    assert target.read_bytes() == b"abcdefghij"
+    assert calls[0]["headers"].get("Range") is None
+    assert calls[1]["headers"]["Range"] == "bytes=4-"
+    assert calls[1]["timeout"] == download._DOWNLOAD_TIMEOUT
+    assert not target.with_name("model.pt.part").exists()
+
+
+def test_server_ignoring_range_restarts_partial(monkeypatch, tmp_path):
+    _prepare(monkeypatch)
+    target = tmp_path / "model.pt"
+    partial = target.with_name("model.pt.part")
+    partial.write_bytes(b"stale")
+    response = _Response([b"complete"], headers={"content-length": "8"})
+
+    monkeypatch.setattr(
+        download.requests,
+        "get",
+        lambda _url, **_kwargs: response,
+    )
+
+    download.download_weights(str(target), "s")
+
+    assert target.read_bytes() == b"complete"
+
+
+def test_complete_partial_is_finalized_after_range_416(monkeypatch, tmp_path):
+    _prepare(monkeypatch)
+    target = tmp_path / "model.pt"
+    partial = target.with_name("model.pt.part")
+    partial.write_bytes(b"complete")
+    response = _Response(
+        [],
+        status_code=416,
+        headers={"content-range": "bytes */8"},
+    )
+
+    monkeypatch.setattr(
+        download.requests,
+        "get",
+        lambda _url, **_kwargs: response,
+    )
+
+    download.download_weights(str(target), "s")
+
+    assert target.read_bytes() == b"complete"
+
+
+def test_exhausted_download_keeps_partial(monkeypatch, tmp_path):
+    _prepare(monkeypatch)
+    monkeypatch.setattr(download, "_DOWNLOAD_RETRIES", 0)
+    response = _Response(
+        [b"partial", requests.ConnectionError("still offline")],
+        headers={"content-length": "20"},
+    )
+    monkeypatch.setattr(
+        download.requests,
+        "get",
+        lambda _url, **_kwargs: response,
+    )
+    target = tmp_path / "model.pt"
+
+    with pytest.raises(RuntimeError, match="Partial download kept"):
+        download.download_weights(str(target), "s")
+
+    assert target.with_name("model.pt.part").read_bytes() == b"partial"
+
+
+def test_factory_reports_and_chains_download_failure(monkeypatch, tmp_path):
+    import libreyolo.models as models
+
+    failure = RuntimeError("connection reset while fetching checkpoint")
+
+    def fail_download(_model_path, _size):
+        raise failure
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(models, "download_weights", fail_download)
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="Auto-download failed: connection reset while fetching checkpoint",
+    ) as exc_info:
+        models.LibreYOLO("LibreYOLO9t.pt")
+
+    assert exc_info.value.__cause__ is failure

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,5 +1,10 @@
 """Tests for retrying and resumable weight downloads."""
 
+import multiprocessing
+import queue
+import time
+from pathlib import Path
+
 import requests
 import pytest
 
@@ -31,7 +36,8 @@ class _Response:
         self.closed = False
 
     def raise_for_status(self):
-        return None
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
 
     def iter_content(self, chunk_size):
         assert chunk_size == download._DOWNLOAD_CHUNK_SIZE
@@ -50,17 +56,27 @@ def _prepare(monkeypatch):
     monkeypatch.setattr(download.time, "sleep", lambda _seconds: None)
 
 
+def _hold_download_lock(target, entered, release):
+    with download._download_lock(Path(target)):
+        entered.put(time.monotonic())
+        release.wait(timeout=10)
+
+
 def test_interrupted_download_retries_from_partial(monkeypatch, tmp_path):
     _prepare(monkeypatch)
     responses = [
         _Response(
             [b"abcd", requests.ConnectionError("connection dropped")],
-            headers={"content-length": "10"},
+            headers={"content-length": "10", "etag": '"version-1"'},
         ),
         _Response(
             [b"efghij"],
             status_code=206,
-            headers={"content-length": "6", "content-range": "bytes 4-9/10"},
+            headers={
+                "content-length": "6",
+                "content-range": "bytes 4-9/10",
+                "etag": '"version-1"',
+            },
         ),
     ]
     calls = []
@@ -79,26 +95,60 @@ def test_interrupted_download_retries_from_partial(monkeypatch, tmp_path):
     assert target.read_bytes() == b"abcdefghij"
     assert calls[0]["headers"].get("Range") is None
     assert calls[1]["headers"]["Range"] == "bytes=4-"
+    assert calls[1]["headers"]["If-Range"] == '"version-1"'
     assert calls[1]["timeout"] == download._DOWNLOAD_TIMEOUT
     assert not target.with_name("model.pt.part").exists()
+    assert not target.with_name("model.pt.part.json").exists()
 
 
-def test_server_ignoring_range_restarts_partial(monkeypatch, tmp_path):
+def test_partial_without_validator_restarts(monkeypatch, tmp_path):
     _prepare(monkeypatch)
     target = tmp_path / "model.pt"
     partial = target.with_name("model.pt.part")
     partial.write_bytes(b"stale")
     response = _Response([b"complete"], headers={"content-length": "8"})
+    calls = []
 
-    monkeypatch.setattr(
-        download.requests,
-        "get",
-        lambda _url, **_kwargs: response,
-    )
+    def fake_get(_url, **kwargs):
+        calls.append(kwargs)
+        return response
+
+    monkeypatch.setattr(download.requests, "get", fake_get)
 
     download.download_weights(str(target), "s")
 
     assert target.read_bytes() == b"complete"
+    assert "Range" not in calls[0]["headers"]
+
+
+def test_changed_object_restarts_instead_of_mixing_bytes(monkeypatch, tmp_path):
+    _prepare(monkeypatch)
+    responses = [
+        _Response(
+            [b"old-", requests.ConnectionError("connection dropped")],
+            headers={"content-length": "8", "etag": '"version-1"'},
+        ),
+        # A conforming server ignores Range and returns the complete new object
+        # when If-Range does not match.
+        _Response(
+            [b"new-data"],
+            headers={"content-length": "8", "etag": '"version-2"'},
+        ),
+    ]
+    calls = []
+
+    def fake_get(_url, **kwargs):
+        calls.append(kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(download.requests, "get", fake_get)
+    target = tmp_path / "model.pt"
+
+    download.download_weights(str(target), "s")
+
+    assert calls[1]["headers"]["Range"] == "bytes=4-"
+    assert calls[1]["headers"]["If-Range"] == '"version-1"'
+    assert target.read_bytes() == b"new-data"
 
 
 def test_complete_partial_is_finalized_after_range_416(monkeypatch, tmp_path):
@@ -106,21 +156,60 @@ def test_complete_partial_is_finalized_after_range_416(monkeypatch, tmp_path):
     target = tmp_path / "model.pt"
     partial = target.with_name("model.pt.part")
     partial.write_bytes(b"complete")
+    download._save_partial_validator(
+        partial,
+        _DownloadFamily.get_download_url(target.name),
+        '"version-1"',
+    )
     response = _Response(
         [],
         status_code=416,
-        headers={"content-range": "bytes */8"},
+        headers={"content-range": "bytes */8", "etag": '"version-1"'},
     )
+    calls = []
 
-    monkeypatch.setattr(
-        download.requests,
-        "get",
-        lambda _url, **_kwargs: response,
-    )
+    def fake_get(_url, **kwargs):
+        calls.append(kwargs)
+        return response
+
+    monkeypatch.setattr(download.requests, "get", fake_get)
 
     download.download_weights(str(target), "s")
 
     assert target.read_bytes() == b"complete"
+    assert calls[0]["headers"]["If-Range"] == '"version-1"'
+
+
+def test_range_416_with_changed_validator_restarts(monkeypatch, tmp_path):
+    _prepare(monkeypatch)
+    target = tmp_path / "model.pt"
+    partial = target.with_name("model.pt.part")
+    partial.write_bytes(b"old-data")
+    download._save_partial_validator(
+        partial,
+        _DownloadFamily.get_download_url(target.name),
+        '"version-1"',
+    )
+    responses = [
+        _Response(
+            [],
+            status_code=416,
+            headers={"content-range": "bytes */8", "etag": '"version-2"'},
+        ),
+        _Response(
+            [b"new-data"],
+            headers={"content-length": "8", "etag": '"version-2"'},
+        ),
+    ]
+    monkeypatch.setattr(
+        download.requests,
+        "get",
+        lambda _url, **_kwargs: responses.pop(0),
+    )
+
+    download.download_weights(str(target), "s")
+
+    assert target.read_bytes() == b"new-data"
 
 
 def test_exhausted_download_keeps_partial(monkeypatch, tmp_path):
@@ -128,7 +217,7 @@ def test_exhausted_download_keeps_partial(monkeypatch, tmp_path):
     monkeypatch.setattr(download, "_DOWNLOAD_RETRIES", 0)
     response = _Response(
         [b"partial", requests.ConnectionError("still offline")],
-        headers={"content-length": "20"},
+        headers={"content-length": "20", "etag": '"version-1"'},
     )
     monkeypatch.setattr(
         download.requests,
@@ -141,6 +230,72 @@ def test_exhausted_download_keeps_partial(monkeypatch, tmp_path):
         download.download_weights(str(target), "s")
 
     assert target.with_name("model.pt.part").read_bytes() == b"partial"
+    assert target.with_name("model.pt.part.json").exists()
+
+
+def test_failed_verification_removes_final_file(monkeypatch, tmp_path):
+    _prepare(monkeypatch)
+
+    def fail_verification(_cls, _path, _url):
+        raise ValueError("checksum mismatch")
+
+    monkeypatch.setattr(
+        _DownloadFamily,
+        "verify_downloaded_file",
+        classmethod(fail_verification),
+    )
+    monkeypatch.setattr(
+        download.requests,
+        "get",
+        lambda _url, **_kwargs: _Response(
+            [b"complete"],
+            headers={"content-length": "8", "etag": '"version-1"'},
+        ),
+    )
+    target = tmp_path / "model.pt"
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        download.download_weights(str(target), "s")
+
+    assert not target.exists()
+
+
+def test_download_lock_serializes_processes(tmp_path):
+    ctx = multiprocessing.get_context("spawn")
+    entered = ctx.Queue()
+    release_first = ctx.Event()
+    release_second = ctx.Event()
+    target = tmp_path / "model.pt"
+    first = ctx.Process(
+        target=_hold_download_lock,
+        args=(str(target), entered, release_first),
+    )
+    second = ctx.Process(
+        target=_hold_download_lock,
+        args=(str(target), entered, release_second),
+    )
+
+    try:
+        first.start()
+        entered.get(timeout=10)
+        second.start()
+        with pytest.raises(queue.Empty):
+            entered.get(timeout=0.3)
+
+        release_first.set()
+        entered.get(timeout=10)
+        release_second.set()
+        first.join(timeout=10)
+        second.join(timeout=10)
+        assert first.exitcode == 0
+        assert second.exitcode == 0
+    finally:
+        release_first.set()
+        release_second.set()
+        for process in (first, second):
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
 
 
 def test_factory_reports_and_chains_download_failure(monkeypatch, tmp_path):


### PR DESCRIPTION
# What does this PR do?

Makes weight downloads resilient to interrupted connections.

Downloads now retry three times with exponential backoff and resume retained `.part` files using HTTP range requests. If a server ignores the range request, the download restarts safely. Completed partial files can also be finalized after HTTP 416.

After retries are exhausted, the partial download remains available. Factory errors now include and chain the underlying download failure.

# Provenance declaration (required)

- [x] All code in this PR was written by the author(s), OR every ported or adapted part is listed in the table below.
- [x] No part of this PR is derived from GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license code.
- [x] Notice files are updated if this PR ports third-party code.

Ported or adapted code (leave the table empty if none):

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
|  |  |  |  |

## Code provenance

This PR is an original, first-party implementation written for LibreYOLO. No code was ported or adapted from another project.

# How was this tested?

- 30 affected unit tests passed after the review fixes.
- Tests cover interrupted-transfer resume, HTTP object identity, changed validators, cross-process locking, ignored range requests, completed partial files, retained partials, verification failure, and factory error chaining.
- Ruff and `git diff --check` passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Resumable weight downloads now preserve object identity and serialize concurrent access.
- Persists strong ETag or Last-Modified validators and sends `If-Range` when resuming retained partial files.
- Restarts safely when a server ignores a range request or returns evidence that the remote object changed.
- Uses a per-target cross-process lock around partial-file mutation, verification, and atomic publication.
- Retries interrupted transfers with exponential backoff and retains partial data after exhaustion.
- Chains download failures through the model factory’s final `FileNotFoundError`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; validator-bound range requests address stale-object mixing and the target-specific lock covers partial mutation, verification, and final publication across concurrent processes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/utils/download.py | Adds validator-bound resumable transfers, bounded retries, per-target process locking, temporary-file verification, and atomic publication; the two previously reported failure paths are addressed. |
| libreyolo/models/__init__.py | Preserves the underlying auto-download exception and chains it into the factory’s missing-weights error. |
| tests/unit/test_download.py | Covers interrupted resume, object changes, ignored ranges, HTTP 416 completion, retained partials, verification failure, process serialization, and factory error chaining. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Missing model weights] --> B[Acquire target download lock]
    B --> C{Final file now exists?}
    C -->|Yes| D[Return]
    C -->|No| E[Load retained partial and validator]
    E --> F[Request full object or Range plus If-Range]
    F --> G{Response permits safe resume?}
    G -->|206 with matching validator| H[Append bytes]
    G -->|Range ignored or identity changed| I[Reset partial]
    I --> F
    G -->|416 confirms same object and size| J[Use completed partial]
    H --> K{Transfer complete?}
    K -->|No| L[Backoff and retry]
    L --> F
    K -->|Yes| J
    J --> M[Verify temporary weights]
    M --> N[Atomically replace final path]
    N --> O[Release lock]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Harden resumable weight downloads"](https://github.com/libreyolo/libreyolo/commit/934190b2c9b07c965e4259d7d85e64a863546b2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47248678)</sub>

<!-- /greptile_comment -->