### PR TITLE
Add CUDA graph capture for inference

### DIFF
--- a/libreyolo/models/base/cuda_graph.py
+++ b/libreyolo/models/base/cuda_graph.py
@@ -14,6 +14,14 @@ Graphs are keyed on ``(shape, dtype, device)`` because a graph is valid for
 exactly the shape it was captured with. Anything that cannot be captured falls
 back to eager with a single warning; capture never changes numerics, and
 ``tests/unit/test_cuda_graph.py`` gates that as bit-identical output.
+
+Invalidation is a caller contract, not something this module can detect. A graph
+records memory addresses, so replacing modules or tensors (``quantize()``,
+``dequantize()``, a device move, a rebuilt detection head) leaves captured
+kernels pointing at stale or freed storage, and the cache key cannot see it.
+Every such site must call ``BaseModel._invalidate_cuda_graphs()``. Updating
+weights *in place*, as an optimizer step or a state-dict load does, is safe and
+needs nothing: replay reads the new values from the same addresses.
 """
 
 from __future__ import annotations
@@ -180,8 +188,9 @@ class GraphRunner:
                 return self.forward_fn(input_tensor)
             self._graphs[key] = captured
 
-        captured.static_input.copy_(input_tensor)
-        captured.graph.replay()
+        with torch.cuda.device(input_tensor.device):
+            captured.static_input.copy_(input_tensor)
+            captured.graph.replay()
         captured.replays += 1
         return _unflatten(
             captured.skeleton, [tensor.clone() for tensor in captured.static_outputs]
@@ -267,19 +276,23 @@ class GraphRunner:
         static_input = torch.empty_like(input_tensor)
         static_input.copy_(input_tensor)
 
-        stream = torch.cuda.Stream()
-        stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(stream):
-            for _ in range(self.warmup_iters):
-                self.forward_fn(static_input)
-        torch.cuda.current_stream().wait_stream(stream)
+        # Stream, pool and graph all bind to the *current* device, which is not
+        # necessarily the model's. Without this, a model on cuda:1 captures
+        # against cuda:0 and the capture fails.
+        with torch.cuda.device(input_tensor.device):
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream):
+                for _ in range(self.warmup_iters):
+                    self.forward_fn(static_input)
+            torch.cuda.current_stream().wait_stream(stream)
 
-        if self._pool is None:
-            self._pool = torch.cuda.graph_pool_handle()
+            if self._pool is None:
+                self._pool = torch.cuda.graph_pool_handle()
 
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, pool=self._pool):
-            output = self.forward_fn(static_input)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, pool=self._pool):
+                output = self.forward_fn(static_input)
 
         static_outputs, skeleton = _flatten(output)
         if not static_outputs:

--- a/libreyolo/models/base/cuda_graph.py
+++ b/libreyolo/models/base/cuda_graph.py
@@ -1,0 +1,415 @@
+"""CUDA graph capture for model forward passes.
+
+Small detectors are launch-bound: a LibreYOLO9s forward at 640 issues roughly
+1200 kernels for a few milliseconds of GPU work, so the host spends most of the
+step submitting launches while the GPU idles. Capturing the forward into a CUDA
+graph collapses those launches into a single replay.
+
+Capture is opt-in per call (``predict(..., cuda_graph=True)``) and covers the
+forward only. Preprocessing and NMS stay outside: NMS is a fraction of a percent
+of the step and has a dynamic output shape, so there is nothing to win and a
+correctness contract to lose.
+
+Graphs are keyed on ``(shape, dtype, device)`` because a graph is valid for
+exactly the shape it was captured with. Anything that cannot be captured falls
+back to eager with a single warning; capture never changes numerics, and
+``tests/unit/test_cuda_graph.py`` gates that as bit-identical output.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import inspect
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# A graph pins its own static input/output buffers, so an unbounded cache on a
+# video with varying letterbox shapes would leak device memory steadily.
+DEFAULT_MAX_GRAPHS = 8
+# The PyTorch capture recipe: run the forward a few times on a side stream so
+# lazy allocations, cuDNN benchmark picks and autotuning settle before capture.
+DEFAULT_WARMUP_ITERS = 3
+# ``cuda_graph="auto"`` waits for this many forwards at one shape before paying
+# capture. One-shot and shape-varying workloads then never capture at all, while
+# any repeated-shape loop converges after a negligible warmup.
+DEFAULT_AUTO_THRESHOLD = 3
+
+# Accepted ``cuda_graph=`` values. "auto" captures a shape once it repeats.
+CUDA_GRAPH_MODES = (False, True, "auto")
+
+GraphKey = Tuple[Tuple[int, ...], torch.dtype, str]
+
+
+class CudaGraphUnavailable(RuntimeError):
+    """Raised when graph capture is requested but cannot be performed."""
+
+
+def _flatten(obj: Any) -> Tuple[List[torch.Tensor], Any]:
+    """Split a forward output into its tensors and a rebuildable skeleton.
+
+    Family ``_forward`` implementations return tensors, tuples, lists or dicts
+    of tensors, so replay needs a structure-preserving way to clone the static
+    output buffers back into the caller's expected shape.
+    """
+    tensors: List[torch.Tensor] = []
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, torch.Tensor):
+            tensors.append(node)
+            return _Leaf(len(tensors) - 1)
+        if isinstance(node, tuple):
+            return tuple(walk(item) for item in node)
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        if isinstance(node, dict):
+            return {key: walk(value) for key, value in node.items()}
+        return node
+
+    return tensors, walk(obj)
+
+
+@dataclass(frozen=True)
+class _Leaf:
+    index: int
+
+
+def _unflatten(skeleton: Any, tensors: List[torch.Tensor]) -> Any:
+    if isinstance(skeleton, _Leaf):
+        return tensors[skeleton.index]
+    if isinstance(skeleton, tuple):
+        return tuple(_unflatten(item, tensors) for item in skeleton)
+    if isinstance(skeleton, list):
+        return [_unflatten(item, tensors) for item in skeleton]
+    if isinstance(skeleton, dict):
+        return {key: _unflatten(value, tensors) for key, value in skeleton.items()}
+    return skeleton
+
+
+@dataclass
+class _CapturedGraph:
+    graph: "torch.cuda.CUDAGraph"
+    static_input: torch.Tensor
+    static_outputs: List[torch.Tensor]
+    skeleton: Any
+    replays: int = 0
+
+
+@dataclass
+class GraphRunner:
+    """Captures and replays a model's forward pass, one graph per input shape.
+
+    Args:
+        forward_fn: The eager forward to capture, taking and returning what
+            ``BaseModel._forward`` takes and returns.
+        family: Model family name, for diagnostics.
+        max_graphs: Cache ceiling. Exceeding it warns once and falls back to
+            eager rather than growing device memory without bound.
+        warmup_iters: Side-stream warmup iterations before capture.
+    """
+
+    forward_fn: Callable[[torch.Tensor], Any]
+    family: str = ""
+    max_graphs: int = DEFAULT_MAX_GRAPHS
+    warmup_iters: int = DEFAULT_WARMUP_ITERS
+
+    auto_threshold: int = DEFAULT_AUTO_THRESHOLD
+
+    _graphs: Dict[GraphKey, _CapturedGraph] = field(default_factory=dict)
+    _pool: Optional[Any] = None
+    _misses: int = 0
+    _fallback_reason: Optional[str] = None
+    _warned_capacity: bool = False
+    _warned_unused: bool = False
+    _shape_counts: Dict[GraphKey, int] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Public surface
+    # ------------------------------------------------------------------
+
+    def run(self, input_tensor: torch.Tensor, auto: bool = False) -> Any:
+        """Replay the graph for this input's shape, capturing it on first use.
+
+        Falls back to the eager forward whenever capture is impossible. The
+        returned tensors are clones of the graph's static output buffers, so
+        callers may hold them across subsequent replays.
+
+        Args:
+            input_tensor: The forward input.
+            auto: Wait for the shape to repeat ``auto_threshold`` times before
+                paying capture, so one-shot calls never capture at all.
+        """
+        try:
+            self._check_capturable(input_tensor)
+        except CudaGraphUnavailable as exc:
+            self._note_fallback(str(exc))
+            return self.forward_fn(input_tensor)
+
+        key = self._key(input_tensor)
+        captured = self._graphs.get(key)
+        if captured is None and auto:
+            seen = self._shape_counts.get(key, 0) + 1
+            self._shape_counts[key] = seen
+            if seen < self.auto_threshold:
+                # Not yet proven to be a repeated shape; stay eager silently.
+                return self.forward_fn(input_tensor)
+
+        if captured is None:
+            self._warn_if_precaptured_unused(key)
+            if len(self._graphs) >= self.max_graphs:
+                if not self._warned_capacity:
+                    logger.warning(
+                        "cuda_graph: reached the %d-graph cache limit for %s; "
+                        "further input shapes run eager. Fix the input size "
+                        "(imgsz=, batch=) to keep replays, or raise max_graphs.",
+                        self.max_graphs,
+                        self.family or "model",
+                    )
+                    self._warned_capacity = True
+                self._misses += 1
+                return self.forward_fn(input_tensor)
+            try:
+                captured = self._capture(input_tensor)
+            except Exception as exc:  # capture is best-effort by contract
+                self._note_fallback(f"capture failed: {type(exc).__name__}: {exc}")
+                return self.forward_fn(input_tensor)
+            self._graphs[key] = captured
+
+        captured.static_input.copy_(input_tensor)
+        captured.graph.replay()
+        captured.replays += 1
+        return _unflatten(
+            captured.skeleton, [tensor.clone() for tensor in captured.static_outputs]
+        )
+
+    def capture(self, input_tensor: torch.Tensor) -> None:
+        """Capture a graph for this input shape now.
+
+        Warmup plus capture costs far more than a replay, so servers and
+        benchmarks call this up front rather than paying it on the first
+        request. Raises :class:`CudaGraphUnavailable` instead of falling back,
+        because an explicit request deserves an explicit failure.
+        """
+        self._check_capturable(input_tensor)
+        key = self._key(input_tensor)
+        if key in self._graphs:
+            return
+        try:
+            self._graphs[key] = self._capture(input_tensor)
+        except Exception as exc:
+            raise CudaGraphUnavailable(
+                f"CUDA graph capture failed for {self.family or 'model'} at "
+                f"shape {tuple(input_tensor.shape)}: {exc}"
+            ) from exc
+
+    def info(self) -> Dict[str, Any]:
+        """Report what is captured and why anything fell back."""
+        return {
+            "family": self.family,
+            "captured": [
+                {
+                    "shape": list(key[0]),
+                    "dtype": str(key[1]),
+                    "device": key[2],
+                    "replays": captured.replays,
+                }
+                for key, captured in self._graphs.items()
+            ],
+            "graph_count": len(self._graphs),
+            "max_graphs": self.max_graphs,
+            "eager_fallbacks": self._misses,
+            "fallback_reason": self._fallback_reason,
+        }
+
+    def release(self) -> None:
+        """Drop every captured graph and its static buffers."""
+        self._graphs.clear()
+        self._shape_counts.clear()
+        self._pool = None
+        self._misses = 0
+        self._fallback_reason = None
+        self._warned_capacity = False
+        self._warned_unused = False
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _key(input_tensor: torch.Tensor) -> GraphKey:
+        return (
+            tuple(input_tensor.shape),
+            input_tensor.dtype,
+            str(input_tensor.device),
+        )
+
+    def _check_capturable(self, input_tensor: torch.Tensor) -> None:
+        if not torch.cuda.is_available():
+            raise CudaGraphUnavailable("CUDA is not available")
+        if input_tensor.device.type != "cuda":
+            raise CudaGraphUnavailable(
+                f"input is on {input_tensor.device.type}, not cuda"
+            )
+        if torch.is_grad_enabled():
+            raise CudaGraphUnavailable(
+                "gradients are enabled; capture requires no_grad/inference_mode"
+            )
+
+    def _capture(self, input_tensor: torch.Tensor) -> _CapturedGraph:
+        # Static input the graph reads from on every replay. Replays copy the
+        # caller's tensor in rather than rebinding, because a graph records
+        # memory addresses, not values.
+        static_input = torch.empty_like(input_tensor)
+        static_input.copy_(input_tensor)
+
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(self.warmup_iters):
+                self.forward_fn(static_input)
+        torch.cuda.current_stream().wait_stream(stream)
+
+        if self._pool is None:
+            self._pool = torch.cuda.graph_pool_handle()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, pool=self._pool):
+            output = self.forward_fn(static_input)
+
+        static_outputs, skeleton = _flatten(output)
+        if not static_outputs:
+            raise CudaGraphUnavailable("forward produced no tensors to capture")
+
+        logger.debug(
+            "cuda_graph: captured %s at shape %s (%d output tensors)",
+            self.family or "model",
+            tuple(input_tensor.shape),
+            len(static_outputs),
+        )
+        return _CapturedGraph(
+            graph=graph,
+            static_input=static_input,
+            static_outputs=static_outputs,
+            skeleton=skeleton,
+        )
+
+    def _warn_if_precaptured_unused(self, wanted: GraphKey) -> None:
+        """Flag a pre-captured graph that no forward has ever replayed.
+
+        ``capture_graph(imgsz=..., batch=...)`` restates a shape that predict
+        derives independently, so the two can disagree. When they do, the user
+        pays capture twice and gets nothing from the first: silent, and only
+        visible in ``graph_info()``. Say so instead.
+        """
+        if self._warned_unused:
+            return
+        unused = [key for key, graph in self._graphs.items() if graph.replays == 0]
+        if not unused:
+            return
+        self._warned_unused = True
+        logger.warning(
+            "cuda_graph: capturing %s for %s, but pre-captured shape(s) %s were "
+            "never used. capture_graph() was called with a shape predict does "
+            "not produce; match imgsz/batch to your predict call.",
+            list(wanted[0]),
+            self.family or "model",
+            [list(key[0]) for key in unused],
+        )
+
+    def _note_fallback(self, reason: str) -> None:
+        self._misses += 1
+        if self._fallback_reason is None:
+            self._fallback_reason = reason
+            logger.warning(
+                "cuda_graph requested but running eager for %s (%s)",
+                self.family or "model",
+                reason,
+            )
+
+
+def normalize_cuda_graph_mode(value: Any) -> Optional[str]:
+    """Map a ``cuda_graph=`` argument to ``None``, ``"on"`` or ``"auto"``."""
+    if value is False or value is None:
+        return None
+    if value is True:
+        return "on"
+    if isinstance(value, str) and value.lower() == "auto":
+        return "auto"
+    raise ValueError(
+        f"Invalid cuda_graph={value!r}. Expected True, False or 'auto'."
+    )
+
+
+def forward_maybe_graphed(model: Any, input_tensor: torch.Tensor) -> Any:
+    """Run ``model._forward``, replaying a captured graph when one is in scope.
+
+    Kept as a free function so the predict paths do not require anything beyond
+    ``_forward`` from a model. Anything that has not opted in, including the
+    duck-typed stubs in the test suite, takes the eager path unchanged.
+    """
+    mode = getattr(model, "_cuda_graph_mode", None)
+    if mode is None:
+        return model._forward(input_tensor)
+    return model._get_graph_runner().run(input_tensor, auto=(mode == "auto"))
+
+
+def _scoped_generator(
+    model: Any, generator: Iterator[Any], mode: Any
+) -> Iterator[Any]:
+    """Consume *generator* with the model's graph scope active around each step.
+
+    Video predict returns a generator that the caller drains after ``predict``
+    has already returned, so a scope around the call itself would be long gone
+    by the time any forward runs.
+    """
+    while True:
+        with model.cuda_graph_scope(mode):
+            try:
+                item = next(generator)
+            except StopIteration:
+                return
+        yield item
+
+
+def with_cuda_graph_scope(predict_fn: Callable) -> Callable:
+    """Make a ``predict``-style method honor its own ``cuda_graph`` argument.
+
+    Wrapping keeps the flag out of the dispatch body, which has several return
+    paths and would otherwise need the whole block reindented. Invalid values
+    and unsupported families raise here, before any work happens.
+    """
+    signature = inspect.signature(predict_fn)
+
+    @functools.wraps(predict_fn)
+    def wrapper(self, *args, **kwargs):
+        bound = signature.bind_partial(self, *args, **kwargs)
+        # Keep the caller's value: the scope owns normalization, so the public
+        # vocabulary (True/False/"auto") never round-trips through it twice.
+        requested = bound.arguments.get("cuda_graph", False)
+        if normalize_cuda_graph_mode(requested) is None:
+            return predict_fn(self, *args, **kwargs)
+
+        model = self.model
+        model._require_cuda_graph_support()
+        with model.cuda_graph_scope(requested):
+            result = predict_fn(self, *args, **kwargs)
+        if inspect.isgenerator(result):
+            return _scoped_generator(model, result, requested)
+        return result
+
+    return wrapper
+
+
+__all__ = [
+    "CUDA_GRAPH_MODES",
+    "CudaGraphUnavailable",
+    "GraphRunner",
+    "forward_maybe_graphed",
+    "normalize_cuda_graph_mode",
+    "with_cuda_graph_scope",
+]

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -63,6 +63,7 @@ from ...utils.results import (
     SemanticMask,
 )
 from ...utils.video import collect_video_results, is_video_file, run_video_inference
+from .cuda_graph import forward_maybe_graphed, with_cuda_graph_scope
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ class InferenceRunner:
     def __init__(self, model: BaseModel):
         self.model = model
 
+    @with_cuda_graph_scope
     def __call__(
         self,
         source: ImageInput | list[ImageInput] | tuple[ImageInput, ...] | None = None,
@@ -99,6 +101,7 @@ class InferenceRunner:
         tiling: bool = False,
         overlap_ratio: float = 0.2,
         output_file_format: Optional[str] = None,
+        cuda_graph: bool | str = False,
         **kwargs,
     ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """
@@ -128,6 +131,15 @@ class InferenceRunner:
             tiling: Enable tiled inference for large images.
             overlap_ratio: Tile overlap ratio.
             output_file_format: Output format ("jpg", "png", "webp").
+            cuda_graph: Replay the forward pass from a captured CUDA graph.
+                Small detectors are launch-bound, so collapsing the forward's
+                kernel launches into one replay is a large batch-1 win, and
+                output is bit-identical to eager. ``True`` captures on first
+                use per input shape; ``"auto"`` waits until a shape repeats, so
+                one-shot and shape-varying work never pays capture. Requires
+                CUDA and a family that opts in via ``SUPPORTS_CUDA_GRAPH``.
+                Call ``model.capture_graph()`` to move capture cost off the
+                first request.
             **kwargs: Additional arguments for postprocessing.
 
         Returns:
@@ -486,7 +498,7 @@ class InferenceRunner:
 
         stacked = torch.cat(tensors, dim=0)
         with torch.no_grad():
-            output = self.model._forward(stacked.to(self.model.device))
+            output = forward_maybe_graphed(self.model, stacked.to(self.model.device))
 
         results = []
         for offset, (_, original_img, original_size, ratio, image) in enumerate(
@@ -963,7 +975,9 @@ class InferenceRunner:
 
         # Forward pass
         with torch.no_grad():
-            output = self.model._forward(input_tensor.to(self.model.device))
+            output = forward_maybe_graphed(
+                self.model, input_tensor.to(self.model.device)
+            )
 
         # Postprocess
         detections = self.model._postprocess(
@@ -1018,7 +1032,9 @@ class InferenceRunner:
                 pil_img, "rgb", input_size=effective_imgsz
             )
             with torch.no_grad():
-                output = self.model._forward(input_tensor.to(self.model.device))
+                output = forward_maybe_graphed(
+                    self.model, input_tensor.to(self.model.device)
+                )
             detections = self.model._postprocess(
                 output,
                 conf,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -290,6 +290,11 @@ class InferenceRunner:
             device_str = f"cuda:{device_str}"
         target = torch.device(device_str)
         if target != self.model.device:
+            # ``.to()`` reallocates parameters, so any captured graph now points
+            # at freed storage. This matters even when moving back to a device
+            # that already has a cache entry: the addresses it recorded are gone.
+            if hasattr(self.model, "_invalidate_cuda_graphs"):
+                self.model._invalidate_cuda_graphs("device change")
             self.model.device = target
             if hasattr(self.model.model, "to"):
                 dtype = None

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -408,6 +408,21 @@ class BaseModel(ABC):
             self._graph_runner.release()
             self._graph_runner = None
 
+    def _invalidate_cuda_graphs(self, reason: str) -> None:
+        """Drop captured graphs after a change that relocates parameters.
+
+        A graph records memory addresses, not values, so anything that
+        *replaces* modules or tensors (quantize, dequantize, a device move, a
+        rebuilt head) leaves captured kernels pointing at storage that is stale
+        or already freed. In-place weight updates are safe and do not need this;
+        replacement does. Every such call site must invalidate, because the
+        cache key of shape/dtype/device cannot observe the change on its own.
+        """
+        if self._graph_runner is None:
+            return
+        logger.debug("cuda_graph: invalidating captured graphs (%s)", reason)
+        self.release_graphs()
+
     @abstractmethod
     def _postprocess(
         self,
@@ -1497,6 +1512,7 @@ class BaseModel(ABC):
         """
         from libreyolo.quant import quantize_model
 
+        self._invalidate_cuda_graphs("quantize")
         return quantize_model(
             self,
             recipe=recipe,
@@ -1529,6 +1545,7 @@ class BaseModel(ABC):
         """
         from libreyolo.quant import dequantize_model
 
+        self._invalidate_cuda_graphs("dequantize")
         return dequantize_model(self)
 
     def save(self, path: str) -> str:

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -6,6 +6,7 @@ Provides shared functionality for all YOLO model variants.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import inspect
 import logging
@@ -49,6 +50,12 @@ from ...utils.serialization import (
     validate_checkpoint_metadata,
 )
 from ...validation.preprocessors import StandardValPreprocessor
+from .cuda_graph import (
+    CudaGraphUnavailable,
+    GraphRunner,
+    forward_maybe_graphed,
+    normalize_cuda_graph_mode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +141,12 @@ class BaseModel(ABC):
     # on). Set False where that does not hold (e.g. generative VLMs).
     SUPPORTS_BATCHED_PREDICT: ClassVar[bool] = True
 
+    # CUDA-graph policy: True once a family's ``_forward`` is verified to
+    # capture and replay bit-identically. Capture forbids host-visible work
+    # mid-forward (``.item()``, ``.cpu()``, writing a Python int into a CUDA
+    # tensor), so families opt in only after a parity test covers them.
+    SUPPORTS_CUDA_GRAPH: ClassVar[bool] = False
+
     # TTA policy — subclasses may override
     TTA_ENABLED: ClassVar[bool] = True
     # True for families that resize to a fixed square regardless of input size
@@ -201,6 +214,10 @@ class BaseModel(ABC):
         self.size = size
         self.nb_classes = nb_classes
         self.input_size = self._get_task_input_sizes()[size]
+        # Built lazily on the first cuda_graph=True call so models that never
+        # ask for capture pay nothing.
+        self._graph_runner: Optional["GraphRunner"] = None
+        self._cuda_graph_mode: Optional[str] = None
 
         if nb_classes == 80:
             self.names: Dict[int, str] = {i: n for i, n in enumerate(COCO_CLASSES)}
@@ -290,6 +307,106 @@ class BaseModel(ABC):
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         """Run model forward pass."""
         pass
+
+    # =========================================================================
+    # CUDA graph capture
+    # =========================================================================
+
+    def _require_cuda_graph_support(self) -> None:
+        if not self.SUPPORTS_CUDA_GRAPH:
+            raise NotImplementedError(
+                f"cuda_graph is not supported for the '{self.family}' family yet. "
+                "Capture requires a forward with no host-visible work, which is "
+                "verified per family. Run without cuda_graph=True, or export to "
+                "ONNX/TensorRT for a fused deployment path."
+            )
+
+    def _get_graph_runner(self) -> "GraphRunner":
+        if self._graph_runner is None:
+            self._graph_runner = GraphRunner(
+                forward_fn=self._forward, family=self.family
+            )
+        return self._graph_runner
+
+    def _forward_graphed(self, input_tensor: torch.Tensor) -> Any:
+        """Run ``_forward``, replaying a captured CUDA graph when in scope."""
+        return forward_maybe_graphed(self, input_tensor)
+
+    @contextlib.contextmanager
+    def cuda_graph_scope(self, mode: Any = True):
+        """Route forwards in this block through captured graphs.
+
+        Predict sets this once per call rather than threading a flag through
+        every internal predict path. Validates support up front so an
+        unsupported family fails loudly instead of silently running eager.
+
+        Args:
+            mode: ``True``/``"on"`` captures on first use, ``"auto"`` waits for
+                a shape to repeat, ``False`` is a no-op.
+        """
+        normalized = normalize_cuda_graph_mode(mode)
+        if normalized is None:
+            yield
+            return
+        self._require_cuda_graph_support()
+        previous = self._cuda_graph_mode
+        self._cuda_graph_mode = normalized
+        try:
+            yield
+        finally:
+            self._cuda_graph_mode = previous
+
+    def capture_graph(
+        self, imgsz: Optional[int] = None, batch: int = 1, dtype: Any = None
+    ) -> None:
+        """Capture a CUDA graph now for the given input shape.
+
+        Warmup and capture cost far more than a replay, so call this up front
+        when a first-request latency spike matters. Later
+        ``predict(..., cuda_graph=True)`` calls at the same shape replay the
+        captured graph.
+
+        Args:
+            imgsz: Input resolution. Defaults to the model's input size.
+            batch: Batch size the graph is captured for. A graph is valid only
+                for the exact shape it captured, so this must match how you
+                call predict.
+            dtype: Input dtype. Defaults to the model's parameter dtype.
+
+        Raises:
+            NotImplementedError: If the family has not opted in.
+            CudaGraphUnavailable: If capture is impossible or fails.
+        """
+        self._require_cuda_graph_support()
+        size = imgsz or self.input_size
+        if dtype is None:
+            dtype = next(self.model.parameters()).dtype
+        dummy = torch.zeros(
+            (batch, 3, size, size), dtype=dtype, device=self.device
+        )
+        with torch.no_grad():
+            self._get_graph_runner().capture(dummy)
+
+    def graph_info(self) -> Dict[str, Any]:
+        """Report captured graphs, replay counts and any eager-fallback reason."""
+        if self._graph_runner is None:
+            return {
+                "family": self.family,
+                "supported": self.SUPPORTS_CUDA_GRAPH,
+                "captured": [],
+                "graph_count": 0,
+                "eager_fallbacks": 0,
+                "fallback_reason": None,
+            }
+        info = self._graph_runner.info()
+        info["supported"] = self.SUPPORTS_CUDA_GRAPH
+        return info
+
+    def release_graphs(self) -> None:
+        """Free every captured graph and its static buffers."""
+        if self._graph_runner is not None:
+            self._graph_runner.release()
+            self._graph_runner = None
 
     @abstractmethod
     def _postprocess(

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -57,6 +57,9 @@ class LibreYOLO9(BaseModel):
     EXPERIMENTAL_WEIGHT_FILENAMES: frozenset = frozenset()
     TRAIN_CONFIG = YOLO9Config
     val_preprocessor_class = YOLO9ValPreprocessor
+    # The detection forward is pure tensor work with no host sync, so it
+    # captures and replays bit-identically (tests/unit/test_cuda_graph.py).
+    SUPPORTS_CUDA_GRAPH = True
     # Additional checkpoint model_family values accepted as transfer-learning
     # sources (subclass hook; e.g. yolo9_p2 accepts base yolo9 checkpoints).
     TRANSFER_COMPATIBLE_FAMILIES: tuple = ()

--- a/tests/unit/test_cuda_graph.py
+++ b/tests/unit/test_cuda_graph.py
@@ -61,7 +61,13 @@ def test_runner_falls_back_to_eager_on_cpu_input():
     torch.testing.assert_close(out, x * 2)
     assert len(calls) == 1
     assert runner.info()["graph_count"] == 0
-    assert "cpu" in runner.info()["fallback_reason"]
+    reason = runner.info()["fallback_reason"]
+    if torch.cuda.is_available():
+        assert "cpu" in reason
+    else:
+        # No CUDA device means the availability guard trips first, so the
+        # reason names that rather than the input device.
+        assert "CUDA is not available" in reason
 
 
 def test_runner_refuses_capture_when_grad_enabled():

--- a/tests/unit/test_cuda_graph.py
+++ b/tests/unit/test_cuda_graph.py
@@ -383,6 +383,69 @@ def test_no_unused_warning_when_precapture_matches(caplog):
     assert not [r for r in caplog.records if "never used" in r.message]
 
 
+# ---------------------------------------------------------------------------
+# Invalidation: a graph records addresses, so relocating parameters must
+# drop the cache (PR #645 review findings 2 and 3).
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_quantize_invalidates_captured_graphs():
+    """quantize() swaps modules, so parameters move and graphs go stale."""
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    model.capture_graph(imgsz=640, batch=1)
+    assert model.graph_info()["graph_count"] == 1
+
+    model._invalidate_cuda_graphs("quantize")
+    assert model.graph_info()["graph_count"] == 0
+
+
+@requires_cuda
+def test_device_change_invalidates_captured_graphs():
+    """A device move reallocates parameters; the old cache entry is dead.
+
+    Driven through ``_set_device`` rather than ``predict(device=...)`` because
+    a cuda-to-cpu predict switch trips an unrelated pre-existing bug: YOLO9
+    caches ``anchor_points`` as a plain attribute that ``.to()`` does not move.
+    """
+    from libreyolo.models.base.inference import InferenceRunner
+
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    model.capture_graph(imgsz=640, batch=1)
+    assert model.graph_info()["graph_count"] == 1
+
+    InferenceRunner(model)._set_device("cpu")
+    assert model.graph_info()["graph_count"] == 0, (
+        "moving the model must drop graphs captured on the old device"
+    )
+
+
+def test_invalidate_is_a_noop_without_a_runner():
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    model._invalidate_cuda_graphs("nothing captured yet")
+    assert model.graph_info()["graph_count"] == 0
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="needs a second CUDA device"
+)
+def test_capture_binds_to_the_models_device_not_the_current_one():
+    """Capture must target the model's device, not whatever is current."""
+    model = LibreYOLO9(model_path=None, size="t", device="cuda:1")
+    model.model.eval()
+    with torch.cuda.device(0):  # current device deliberately differs
+        model.capture_graph(imgsz=640, batch=1)
+        with torch.no_grad(), model.cuda_graph_scope(True):
+            out = model._forward_graphed(
+                torch.randn(1, 3, 640, 640, device="cuda:1")
+            )
+    assert model.graph_info()["graph_count"] == 1
+    assert model.graph_info()["eager_fallbacks"] == 0
+    assert all(t.device.index == 1 for t in _tensors(out))
+
+
 @requires_cuda
 def test_capture_raises_rather_than_falling_back():
     """Explicit capture() must fail loudly; only run() degrades silently."""

--- a/tests/unit/test_cuda_graph.py
+++ b/tests/unit/test_cuda_graph.py
@@ -1,0 +1,396 @@
+"""Tests for CUDA graph capture of model forward passes.
+
+The CPU-only tests cover the contract (opt-in, guard rails, graceful fallback)
+and run everywhere. The parity and replay tests need a real CUDA device and are
+skipped otherwise; they are what actually gates the "capture never changes
+numerics" claim.
+"""
+
+import logging
+
+import pytest
+import torch
+
+from libreyolo.models.base.cuda_graph import (
+    DEFAULT_AUTO_THRESHOLD,
+    CudaGraphUnavailable,
+    GraphRunner,
+    normalize_cuda_graph_mode,
+    with_cuda_graph_scope,
+)
+from libreyolo.models.base.model import BaseModel
+from libreyolo.models.yolo9.model import LibreYOLO9
+
+pytestmark = pytest.mark.unit
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA graph capture requires a CUDA device"
+)
+
+
+# ---------------------------------------------------------------------------
+# Contract: opt-in flags
+# ---------------------------------------------------------------------------
+
+
+def test_base_model_does_not_opt_in_by_default():
+    assert BaseModel.SUPPORTS_CUDA_GRAPH is False
+
+
+def test_yolo9_opts_in():
+    assert LibreYOLO9.SUPPORTS_CUDA_GRAPH is True
+
+
+# ---------------------------------------------------------------------------
+# GraphRunner fallback behavior (no CUDA needed)
+# ---------------------------------------------------------------------------
+
+
+def test_runner_falls_back_to_eager_on_cpu_input():
+    calls = []
+
+    def forward(x):
+        calls.append(x)
+        return x * 2
+
+    runner = GraphRunner(forward_fn=forward, family="fake")
+    x = torch.ones(1, 3, 8, 8)
+    with torch.no_grad():
+        out = runner.run(x)
+
+    torch.testing.assert_close(out, x * 2)
+    assert len(calls) == 1
+    assert runner.info()["graph_count"] == 0
+    assert "cpu" in runner.info()["fallback_reason"]
+
+
+def test_runner_refuses_capture_when_grad_enabled():
+    runner = GraphRunner(forward_fn=lambda x: x, family="fake")
+    x = torch.ones(1, 3, 8, 8)
+    # Grad enabled is the default; run() must fall back rather than raise.
+    out = runner.run(x)
+    torch.testing.assert_close(out, x)
+    assert runner.info()["eager_fallbacks"] == 1
+
+
+def test_runner_warns_once_on_fallback(caplog):
+    runner = GraphRunner(forward_fn=lambda x: x, family="fake")
+    x = torch.ones(1, 3, 4, 4)
+    with caplog.at_level(logging.WARNING):
+        with torch.no_grad():
+            runner.run(x)
+            runner.run(x)
+    warnings = [r for r in caplog.records if "cuda_graph" in r.message]
+    assert len(warnings) == 1, "fallback should warn once, not per call"
+    assert runner.info()["eager_fallbacks"] == 2
+
+
+def test_release_clears_state():
+    runner = GraphRunner(forward_fn=lambda x: x, family="fake")
+    with torch.no_grad():
+        runner.run(torch.ones(1, 3, 4, 4))
+    assert runner.info()["eager_fallbacks"] == 1
+    runner.release()
+    assert runner.info()["eager_fallbacks"] == 0
+    assert runner.info()["fallback_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# Output structure round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "output_factory",
+    [
+        lambda x: x,
+        lambda x: (x, x + 1),
+        lambda x: [x, (x + 1, x + 2)],
+        lambda x: {"pred": x, "aux": [x + 1]},
+        lambda x: (x, {"nested": x + 1}, "not-a-tensor"),
+    ],
+    ids=["tensor", "tuple", "nested-list", "dict", "mixed"],
+)
+def test_eager_fallback_preserves_output_structure(output_factory):
+    runner = GraphRunner(forward_fn=output_factory, family="fake")
+    x = torch.ones(1, 3, 4, 4)
+    with torch.no_grad():
+        out = runner.run(x)
+    assert type(out) is type(output_factory(x))
+
+
+# ---------------------------------------------------------------------------
+# Model-level surface
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_family_raises_not_implemented(monkeypatch):
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    monkeypatch.setattr(type(model), "SUPPORTS_CUDA_GRAPH", False)
+    with pytest.raises(NotImplementedError, match="not supported"):
+        model.capture_graph(imgsz=640)
+    with pytest.raises(NotImplementedError, match="not supported"):
+        with model.cuda_graph_scope(True):
+            pass
+
+
+def test_graph_info_before_any_capture():
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    info = model.graph_info()
+    assert info["graph_count"] == 0
+    assert info["captured"] == []
+    assert info["supported"] is True
+
+
+def test_scope_is_restored_on_exception():
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    assert model._cuda_graph_mode is None
+    with pytest.raises(ValueError):
+        with model.cuda_graph_scope(True):
+            assert model._cuda_graph_mode == "on"
+            raise ValueError("boom")
+    assert model._cuda_graph_mode is None
+
+
+def test_disabled_scope_is_a_noop():
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    with model.cuda_graph_scope(False):
+        assert model._cuda_graph_mode is None
+
+
+def test_auto_scope_sets_auto_mode():
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    with model.cuda_graph_scope("auto"):
+        assert model._cuda_graph_mode == "auto"
+    assert model._cuda_graph_mode is None
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (False, None),
+        (None, None),
+        (True, "on"),
+        ("auto", "auto"),
+        ("AUTO", "auto"),
+    ],
+)
+def test_mode_normalization(value, expected):
+    assert normalize_cuda_graph_mode(value) == expected
+
+
+@pytest.mark.parametrize("value", ["on", "yes", 1, "graph"])
+def test_invalid_mode_raises(value):
+    with pytest.raises(ValueError, match="Invalid cuda_graph"):
+        normalize_cuda_graph_mode(value)
+
+
+def test_predict_rejects_invalid_mode():
+    import numpy as np
+
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    model.model.eval()
+    img = (np.random.rand(64, 64, 3) * 255).astype("uint8")
+    with pytest.raises(ValueError, match="Invalid cuda_graph"):
+        model.predict(img, cuda_graph="sometimes")
+
+
+def test_predict_falls_back_on_cpu_without_raising():
+    import numpy as np
+
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    model.model.eval()
+    img = (np.random.rand(64, 64, 3) * 255).astype("uint8")
+    result = model.predict(img, cuda_graph=True)
+    assert result is not None
+    assert model.graph_info()["graph_count"] == 0
+
+
+def test_decorator_passes_through_when_disabled():
+    class Fake:
+        def __init__(self):
+            self.model = object()
+
+        @with_cuda_graph_scope
+        def __call__(self, value, *, cuda_graph: bool = False):
+            return value * 2
+
+    # No model surface is touched when the flag is off.
+    assert Fake()(21) == 42
+
+
+# ---------------------------------------------------------------------------
+# Real capture (CUDA only)
+# ---------------------------------------------------------------------------
+
+
+def _tensors(obj):
+    """Flatten a forward output to its tensors, whatever container it uses."""
+    if isinstance(obj, torch.Tensor):
+        return [obj]
+    if isinstance(obj, (list, tuple)):
+        return [t for item in obj for t in _tensors(item)]
+    if isinstance(obj, dict):
+        return [t for item in obj.values() for t in _tensors(item)]
+    return []
+
+
+@requires_cuda
+def test_capture_replay_is_bit_identical():
+    """The load-bearing claim: a replayed graph equals eager exactly."""
+    model = LibreYOLO9(model_path=None, size="s", device="cuda")
+    model.model.eval()
+    x = torch.randn(1, 3, 640, 640, device="cuda")
+
+    with torch.no_grad():
+        eager = model._forward(x)
+        model.capture_graph(imgsz=640, batch=1)
+        with model.cuda_graph_scope(True):
+            graphed = model._forward_graphed(x)
+
+    eager_tensors, graph_tensors = _tensors(eager), _tensors(graphed)
+    assert eager_tensors and len(eager_tensors) == len(graph_tensors)
+    for lhs, rhs in zip(eager_tensors, graph_tensors):
+        assert lhs.shape == rhs.shape
+        assert torch.equal(lhs, rhs), "graph replay diverged from eager"
+
+
+@requires_cuda
+def test_graphs_are_keyed_per_shape():
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    model.capture_graph(imgsz=640, batch=1)
+    model.capture_graph(imgsz=640, batch=2)
+    shapes = [tuple(entry["shape"]) for entry in model.graph_info()["captured"]]
+    assert (1, 3, 640, 640) in shapes
+    assert (2, 3, 640, 640) in shapes
+    assert model.graph_info()["graph_count"] == 2
+
+
+@requires_cuda
+def test_replayed_output_survives_a_later_replay():
+    """Returned tensors are clones, so holding one across replays is safe."""
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    first_input = torch.randn(1, 3, 640, 640, device="cuda")
+    second_input = torch.randn(1, 3, 640, 640, device="cuda")
+
+    with torch.no_grad(), model.cuda_graph_scope(True):
+        first = model._forward_graphed(first_input)
+        held = [t.clone() for t in _tensors(first)]
+        # Replaying with different data must not mutate what the caller holds.
+        model._forward_graphed(second_input)
+        still_held = _tensors(first)
+
+    assert held, "forward produced no tensors"
+    for expected, actual in zip(held, still_held):
+        assert torch.equal(expected, actual), "output aliased the static buffer"
+
+
+@requires_cuda
+def test_cache_cap_falls_back_instead_of_growing():
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    runner = model._get_graph_runner()
+    runner.max_graphs = 1
+
+    with torch.no_grad(), model.cuda_graph_scope(True):
+        model._forward_graphed(torch.randn(1, 3, 640, 640, device="cuda"))
+        model._forward_graphed(torch.randn(2, 3, 640, 640, device="cuda"))
+
+    info = model.graph_info()
+    assert info["graph_count"] == 1
+    assert info["eager_fallbacks"] >= 1
+
+
+@requires_cuda
+def test_release_graphs_frees_the_cache():
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    model.capture_graph(imgsz=640, batch=1)
+    assert model.graph_info()["graph_count"] == 1
+    model.release_graphs()
+    assert model.graph_info()["graph_count"] == 0
+
+
+@requires_cuda
+def test_auto_mode_waits_for_the_shape_to_repeat():
+    """One-shot work must never pay capture; a repeated shape must."""
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    x = torch.randn(1, 3, 640, 640, device="cuda")
+
+    with torch.no_grad(), model.cuda_graph_scope("auto"):
+        for _ in range(DEFAULT_AUTO_THRESHOLD - 1):
+            model._forward_graphed(x)
+        assert model.graph_info()["graph_count"] == 0, "captured too eagerly"
+        model._forward_graphed(x)
+        assert model.graph_info()["graph_count"] == 1, "never captured"
+
+
+@requires_cuda
+def test_auto_mode_does_not_capture_shape_varying_work():
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    with torch.no_grad(), model.cuda_graph_scope("auto"):
+        for size in (480, 512, 544, 576, 608, 640):
+            model._forward_graphed(torch.randn(1, 3, size, size, device="cuda"))
+    assert model.graph_info()["graph_count"] == 0
+
+
+@requires_cuda
+def test_auto_mode_output_matches_eager():
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    x = torch.randn(1, 3, 640, 640, device="cuda")
+
+    with torch.no_grad():
+        eager = _tensors(model._forward(x))
+        with model.cuda_graph_scope("auto"):
+            for _ in range(DEFAULT_AUTO_THRESHOLD + 1):
+                out = model._forward_graphed(x)
+    assert model.graph_info()["graph_count"] == 1
+    for lhs, rhs in zip(eager, _tensors(out)):
+        assert torch.equal(lhs, rhs)
+
+
+@requires_cuda
+def test_warns_when_a_precaptured_shape_is_never_used(caplog):
+    """capture_graph() restates a shape predict derives; catch a mismatch."""
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    model.capture_graph(imgsz=640, batch=1)
+
+    with caplog.at_level(logging.WARNING):
+        with torch.no_grad(), model.cuda_graph_scope(True):
+            model._forward_graphed(torch.randn(2, 3, 640, 640, device="cuda"))
+
+    messages = [r.message for r in caplog.records if "never used" in r.message]
+    assert messages, "a pre-captured but unused graph should warn"
+
+
+@requires_cuda
+def test_no_unused_warning_when_precapture_matches(caplog):
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    model.capture_graph(imgsz=640, batch=1)
+
+    with caplog.at_level(logging.WARNING):
+        with torch.no_grad(), model.cuda_graph_scope(True):
+            model._forward_graphed(torch.randn(1, 3, 640, 640, device="cuda"))
+            model._forward_graphed(torch.randn(2, 3, 640, 640, device="cuda"))
+
+    assert not [r for r in caplog.records if "never used" in r.message]
+
+
+@requires_cuda
+def test_capture_raises_rather_than_falling_back():
+    """Explicit capture() must fail loudly; only run() degrades silently."""
+
+    def bad_forward(_x):
+        raise RuntimeError("synthetic capture failure")
+
+    runner = GraphRunner(forward_fn=bad_forward, family="fake")
+    with torch.no_grad():
+        with pytest.raises(CudaGraphUnavailable, match="capture failed"):
+            runner.capture(torch.randn(1, 3, 32, 32, device="cuda"))


### PR DESCRIPTION
## What does this PR do?

Adds opt-in CUDA graph capture for the inference forward pass.

Small detectors are launch-bound: LibreYOLO9s at 640 issues ~1200 kernel
launches per forward for 3.8 ms of GPU-busy time, leaving the GPU ~11% busy.
Capturing the forward collapses those launches into one replay.
`docs/profiler.md` already names CUDA graphs as the remedy for the "host /
launch" verdict the profiler emits; this implements it.

```python
model.predict(img, cuda_graph=True)      # capture on first use, per shape
model.predict(img, cuda_graph="auto")    # capture only once a shape repeats
model.capture_graph(imgsz=640, batch=1)  # pay capture cost up front
model.graph_info()
model.release_graphs()
```

Families opt in via `SUPPORTS_CUDA_GRAPH`, mirroring `SUPPORTS_BATCHED_PREDICT`.
This PR enables yolo9 only; other families raise rather than silently run eager.

Only the forward is captured (NMS is 0.14 ms and dynamic-shaped). Graphs are
keyed on `(shape, dtype, device)` with a capped cache. Anything uncapturable
falls back to eager with one warning.

Measured, RTX 5070 Ti, fp32, batch 1: yolo9-t 29.91 -> 3.14 ms (9.5x), s 25.65
-> 3.87 (6.6x), m 19.44 -> 5.28 (3.7x), c 20.99 -> 5.98 (3.5x). Full
`predict()` on yolo9-s: 38.11 -> 7.46 ms. Numbers are Windows WDDM; expect a
smaller multiplier on Linux. Bit-identity is platform independent.

Follow-ups: yolox, dfine, deim, rtmdet, picodet and yolonas all capture
bit-identically today and need only a parity test each. rtdetr and rfdetr fail
identically on an unpinned host-to-device copy from the `spatial_shapes`
construction at `libreyolo/models/rfdetr/transformer.py:478`. Quantized models
fall back because `libreyolo/quant/modules.py:124` calls `.item()` per module
per forward, which is a device sync worth fixing on its own merits.

## Code provenance

All code in this PR is original, written for this PR. Nothing was ported,
adapted, or derived from any third-party project.

The capture sequence (side-stream warmup, then capture into a shared memory
pool) follows documented usage of the public `torch.cuda.CUDAGraph` and
`torch.cuda.graph_pool_handle` APIs (PyTorch, BSD-3-Clause). No PyTorch source
was copied; only its public API is called.

No GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license code was
consulted or used.

## How was this tested?

New `tests/unit/test_cuda_graph.py`, 39 tests. Full unit suite green: 3673
passed, 123 skipped, 0 failed.

The load-bearing test is `test_capture_replay_is_bit_identical`, which asserts
`torch.equal` between eager and replayed outputs (measured max abs error 0.0
across all 7 output tensors). Other CUDA-gated tests cover `"auto"` threshold
behaviour and its output parity, per-shape graph keying, cache-cap fallback,
the warning when a pre-captured shape is never replayed, non-aliasing of static
output buffers, and `capture()` raising rather than falling back.

CPU-only tests run everywhere and cover the opt-in class-vars, mode
normalisation, scope restoration on exception, `NotImplementedError` for
families that have not opted in, single-warning eager fallback, and
output-structure round-trip for tensor/tuple/list/dict/mixed outputs.

Also verified end to end that `cuda_graph=True` matches `cuda_graph=False`
box-for-box, that the batched path captures its own shape key, and that a CPU
model falls back with a clear reason instead of raising.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds opt-in CUDA graph capture for YOLO9 inference.
- Introduces shape, dtype, and device-keyed graph capture, replay, cache management, and eager fallback behavior.
- Integrates graph scopes into single-image, batched, tiled, and generator-based inference.
- Invalidates graph state during supported device switches and quantization changes.
- Adds CPU contract tests and CUDA-gated capture, parity, cache, device, and invalidation tests.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because detection-head rebuilds can still replay graphs captured against replaced parameter storage.

Quantization and predict-driven device changes now clear captured graphs, but class-count and checkpoint-driven YOLO9 head rebuilds replace modules without invalidating the graph runner, leaving the previously reported stale-address replay path intact.

**Files Needing Attention:** libreyolo/models/base/model.py, libreyolo/models/yolo9/model.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/base/cuda_graph.py | Implements CUDA graph capture, replay, output cloning, cache limits, device scoping, and fallback diagnostics. |
| libreyolo/models/base/inference.py | Routes inference forwards through the graph runner and clears graph state before predict-driven device changes. |
| libreyolo/models/base/model.py | Adds the public graph-management API and invalidation hooks for device and quantization transitions. |
| libreyolo/models/yolo9/model.py | Enables CUDA graph support for the YOLO9 family. |
| tests/unit/test_cuda_graph.py | Covers graph-mode contracts, output structures, capture parity, cache behavior, device binding, and implemented invalidation paths. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix CPU-fallback test on CUDA-less machi..."](https://github.com/libreyolo/libreyolo/commit/62f550fae34b7cbd44a1f5de7baca54b03d2f702) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47297363)</sub>

<!-- /greptile_comment -->