### PR TITLE
Stop promising published weights are MIT or Apache-2.0 when some of them are not

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -25,8 +25,11 @@ SOFTWARE.
 NOTE ON WEIGHTS: No pretrained weight files are shipped with this source
 repository. Pretrained LibreYOLO weights are published separately on
 Hugging Face under https://huggingface.co/LibreYOLO and carry their own
-per-family licenses (MIT or Apache-2.0, reflecting each upstream).
-See `weights/LICENSE_NOTICE.txt` and the LICENSE / NOTICE files on each
+per-family licenses, reflecting each upstream. Those licenses vary and
+are not all permissive: some published weights are non-commercial or
+otherwise restricted, and this MIT License does not extend to them.
+Choosing a model means choosing its license. See
+`weights/LICENSE_NOTICE.txt` and the LICENSE / NOTICE files on each
 Hugging Face model card for the authoritative terms.
 
 NOTE ON THIRD-PARTY CODE: Portions of this repository are derived from


### PR DESCRIPTION
The root `LICENSE` promised that published LibreYOLO weights carry "per-family licenses (MIT or Apache-2.0, reflecting each upstream)". That is not true.

Checked against the Hugging Face organization on 2026-07-26: **35 of 202 published repositories are neither MIT nor Apache-2.0.**

| Terms | Count | Families |
| --- | --- | --- |
| CC BY-NC-4.0 (non-commercial) | 6 | `LibreOVDEIM{s,m,l}`, `LibreDepthAnythingV2{b,l}-depth`, `SenseNovaVision7b` |
| CC BY-NC-SA-3.0 (non-commercial) | 1 | `LibreYOLO9P2s-visdrone` |
| NVIDIA Source Code License (research / evaluation only) | 6 | `LibreSegformer{b0..b5}-sem` |
| CC BY-4.0 (attribution) | 4 | `LibreRFDETR{n,s,m,l}-obb` |
| BSD-3-Clause | 3 | `LibreRealESRGAN{x2,x4,x4t}-restore` |
| Custom upstream terms | 15 | `LibreDEIMv2{s,m,l,x}`, `LibrePAGE*-gazetarget`, `LibreYOLO{1,2,3,4}*` |

The claim sat in the file GitHub renders on the repository landing page, so the most visible license statement in the project was also the wrong one. It could reasonably be read as permission to ship a non-commercial checkpoint in a commercial product.

LibreYOLO is a meta-library: picking a model means picking its license. This says that instead, and keeps pointing at the model repository as authoritative.

Scope is deliberately minimal: one file, +5/-2. The MIT grant over the source code is untouched, so GitHub still detects the repository as MIT. `README.md` already said the right thing, and `weights/LICENSE_NOTICE.txt` already flagged SegFormer as non-commercial.

Note: this targets `dev`, but visitors land on `release`, so the corrected text is not public until it reaches release.

## Code provenance

Original prose written for this PR. There is no code in this change at all: the diff edits the `NOTE ON WEIGHTS` paragraph of the root `LICENSE` file. The license facts were read from the public Hugging Face API listing for the LibreYOLO organization

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Corrects the root license notice to distinguish the MIT-licensed source code from separately licensed pretrained weights.
- Removes the inaccurate claim that all published weights use MIT or Apache-2.0.
- Warns that some weights are non-commercial or otherwise restricted.
- Directs users to the per-model LICENSE and NOTICE files for authoritative terms.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the corrected licensing notice.

The new wording removes an inaccurate blanket licensing claim, preserves the source-code MIT grant, and points readers to valid authoritative per-model license information.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| LICENSE | The revised weights notice accurately clarifies license variability and remains consistent with the repository's existing licensing guidance. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Stop promising published weights are MIT..."](https://github.com/libreyolo/libreyolo/commit/ca981ba3862c4dff58aae3e9fc1f5e37435568fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47400753)</sub>

<!-- /greptile_comment -->