### PR TITLE
Add Core AI export with trained parity for YOLO9, D-FINE, and RF-DETR

### DIFF
--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -6,78 +6,78 @@ Do not edit the matrix by hand.
 `✓` means parity-validated, `exp` means conversion is available without a
 numeric parity guarantee, and an empty cell is blocked in preflight.
 
-| Family | Task | onnx | torchscript | tensorrt | openvino | ncnn | tflite | coreml |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| birefnet | matte | exp | ✓ | exp | exp |  |  |  |
-| clip | classify | ✓ |  |  |  |  |  |  |
-| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| deim | detect | exp | ✓ | exp | exp |  |  |  |
-| deimv2 | detect | exp | ✓ | exp | exp |  |  |  |
-| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  |
-| depth_anything3 | depth |  |  |  |  |  |  |  |
-| dfine | detect | ✓ | ✓ | exp | exp |  |  |  |
-| dfine | segment | ✓ | ✓ | exp | exp |  |  |  |
-| dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |
-| dinov2 | classify | ✓ |  |  |  |  |  |  |
-| ec | detect | ✓ | ✓ | exp | exp |  |  |  |
-| ec | pose | ✓ | ✓ | exp | exp |  |  |  |
-| ec | segment | ✓ | ✓ | exp | exp |  |  |  |
-| edgetam | segment |  |  |  |  |  |  |  |
-| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |
-| eomt | segment |  |  |  |  |  |  |  |
-| eomt | panoptic |  |  |  |  |  |  |  |
-| florence2 | detect |  |  |  |  |  |  |  |
-| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  |
-| grounding_dino | detect |  |  |  |  |  |  |  |
-| internvl3 | detect |  |  |  |  |  |  |  |
-| kosmos2 | detect |  |  |  |  |  |  |  |
-| l2cs | gaze | ✓ |  |  |  |  |  |  |
-| lfm2vl | detect |  |  |  |  |  |  |  |
-| lingbotvision | semantic | ✓ | ✓ | exp | exp |  |  |  |
-| locateanything | detect |  |  |  |  |  |  |  |
-| locateanything | point |  |  |  |  |  |  |  |
-| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| mobilesam | segment |  |  |  |  |  |  |  |
-| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  |
-| omdet_turbo | detect |  |  |  |  |  |  |  |
-| ov_deim | detect |  |  |  |  |  |  |  |
-| owlv2 | detect |  |  |  |  |  |  |  |
-| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| picosam3 | segment | ✓ |  |  |  |  |  |  |
-| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| ppocr | ocr |  |  |  |  |  |  |  |
-| qwen3vl | detect |  |  |  |  |  |  |  |
-| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  |
-| rfdetr | detect | ✓ | ✓ | ✓ | ✓ |  | exp | exp |
-| rfdetr | segment | ✓ | ✓ | exp | exp |  |  |  |
-| rfdetr | pose | ✓ | ✓ | exp | exp |  |  |  |
-| rfdetr | obb | ✓ | ✓ | exp | exp |  |  |  |
-| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp |
-| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  |
-| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  |
-| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  |
-| rtmdet | segment |  |  |  |  |  |  |  |
-| sam | segment |  |  |  |  |  |  |  |
-| sam2 | segment |  |  |  |  |  |  |  |
-| sam3 | segment |  |  |  |  |  |  |  |
-| segformer | semantic |  |  |  |  |  |  |  |
-| siglip2 | classify | ✓ |  |  |  |  |  |  |
-| smolvlm2 | detect |  |  |  |  |  |  |  |
-| swinir | restore | exp | exp | exp | exp | exp |  |  |
-| yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo3 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp |
-| yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |
-| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp |
-| zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  |
+| Family | Task | onnx | torchscript | tensorrt | openvino | ncnn | tflite | coreml | coreai |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| birefnet | matte | exp | ✓ | exp | exp |  |  |  |  |
+| clip | classify | ✓ |  |  |  |  |  |  | exp |
+| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| deim | detect | exp | ✓ | exp | exp |  |  |  | exp |
+| deimv2 | detect | exp | ✓ | exp | exp |  |  |  | exp |
+| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  | exp |
+| depth_anything3 | depth |  |  |  |  |  |  |  |  |
+| dfine | detect | ✓ | ✓ | exp | exp |  |  |  | ✓ |
+| dfine | segment | ✓ | ✓ | exp | exp |  |  |  |  |
+| dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |  |
+| dinov2 | classify | ✓ |  |  |  |  |  |  | exp |
+| ec | detect | ✓ | ✓ | exp | exp |  |  |  | exp |
+| ec | pose | ✓ | ✓ | exp | exp |  |  |  |  |
+| ec | segment | ✓ | ✓ | exp | exp |  |  |  |  |
+| edgetam | segment |  |  |  |  |  |  |  |  |
+| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |  |
+| eomt | segment |  |  |  |  |  |  |  |  |
+| eomt | panoptic |  |  |  |  |  |  |  |  |
+| florence2 | detect |  |  |  |  |  |  |  |  |
+| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| grounding_dino | detect |  |  |  |  |  |  |  |  |
+| internvl3 | detect |  |  |  |  |  |  |  |  |
+| kosmos2 | detect |  |  |  |  |  |  |  |  |
+| l2cs | gaze | ✓ |  |  |  |  |  |  |  |
+| lfm2vl | detect |  |  |  |  |  |  |  |  |
+| lingbotvision | semantic | ✓ | ✓ | exp | exp |  |  |  | exp |
+| locateanything | detect |  |  |  |  |  |  |  |  |
+| locateanything | point |  |  |  |  |  |  |  |  |
+| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| mobilesam | segment |  |  |  |  |  |  |  |  |
+| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| omdet_turbo | detect |  |  |  |  |  |  |  |  |
+| ov_deim | detect |  |  |  |  |  |  |  |  |
+| owlv2 | detect |  |  |  |  |  |  |  |  |
+| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| picosam3 | segment | ✓ |  |  |  |  |  |  |  |
+| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| ppocr | ocr |  |  |  |  |  |  |  |  |
+| qwen3vl | detect |  |  |  |  |  |  |  |  |
+| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| rfdetr | detect | ✓ | ✓ | ✓ | ✓ |  | exp | exp | ✓ |
+| rfdetr | segment | ✓ | ✓ | exp | exp |  |  |  |  |
+| rfdetr | pose | ✓ | ✓ | exp | exp |  |  |  |  |
+| rfdetr | obb | ✓ | ✓ | exp | exp |  |  |  |  |
+| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp | exp |
+| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  | exp |
+| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  | exp |
+| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  | exp |
+| rtmdet | segment |  |  |  |  |  |  |  |  |
+| sam | segment |  |  |  |  |  |  |  |  |
+| sam2 | segment |  |  |  |  |  |  |  |  |
+| sam3 | segment |  |  |  |  |  |  |  |  |
+| segformer | semantic |  |  |  |  |  |  |  |  |
+| siglip2 | classify | ✓ |  |  |  |  |  |  | exp |
+| smolvlm2 | detect |  |  |  |  |  |  |  |  |
+| swinir | restore | exp | exp | exp | exp | exp |  |  |  |
+| yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolo2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolo3 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |  |
+| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
+| yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |  |
+| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp | exp |
+| zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
 
 ## Parity thresholds
 
@@ -93,6 +93,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `birefnet` / `matte` / `ncnn`: BiRefNet's decoder requires torchvision deformable convolution, which PNNX/NCNN cannot lower to a runnable graph.
 - `birefnet` / `matte` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `birefnet` / `matte` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `birefnet` / `matte` / `coreai`: The decoder needs torchvision deform_conv2d, which the Core AI converter cannot lower ('unable to handle call function op: deform_conv2d.default'). The same operator already blocks the NCNN path. An encoder-only contract is the realistic route, matching the seam the CUDA graph work used.
 - `clip` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `clip` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `clip` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
@@ -116,15 +117,18 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `depth_anything3` / `depth` / `ncnn`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `tflite`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `coreml`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `coreai`: The model raises NotImplementedError for every format: depth export is out of scope per ADR 0006, the depth task contract. Depth Anything V2 exports and validates at 5.2e-06, so this is specific to the V3 family and not a Core AI limitation.
 - `dfine` / `detect` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `dfine` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `dfine` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `dfine` / `segment` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `dfine` / `segment` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `dfine` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `dfine` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
 - `dinov2` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `dinov2` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `dinov2` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
+- `dinov2` / `semantic` / `coreai`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `dinov2` / `classify` / `torchscript`: LibreDINOv2 classify export currently supports ONNX only.
 - `dinov2` / `classify` / `tensorrt`: LibreDINOv2 classify export currently supports ONNX only.
 - `dinov2` / `classify` / `openvino`: LibreDINOv2 classify export currently supports ONNX only.
@@ -137,9 +141,11 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `ec` / `pose` / `ncnn`: NCNN export is not supported for EC: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `ec` / `pose` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `ec` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `ec` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
 - `ec` / `segment` / `ncnn`: NCNN export is not supported for EC: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `ec` / `segment` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `ec` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `ec` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
 - `edgetam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
@@ -147,10 +153,12 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `edgetam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `efficientnetv2` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `eomt` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `eomt` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `eomt` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
+- `eomt` / `semantic` / `coreai`: torch.export refuses the graph: GuardOnDataDependentSymNode, 'Could not guard on data-dependent expression Eq(u0, 1)'. Something in the mask path reads a value off a tensor and branches on it, which becomes an unbacked symbol with no hint the tracer can resolve. This is a real capture failure, not a missing operator and not the task gate: it was measured with the gate open. Fixing it means finding the host read and making the shape static for a fixed export canvas, the same shape of fix as the rfdetr torch._assert.
 - `eomt` / `segment` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
@@ -158,6 +166,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `eomt` / `segment` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `tflite`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `coreml`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `coreai`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
@@ -165,6 +174,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `eomt` / `panoptic` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `tflite`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `coreml`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `coreai`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `florence2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -172,6 +182,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `florence2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `florence2` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `fomo` / `point` / `tflite`: onnx2tf 2.4.x produces an invalid depthwise-convolution graph for the static SAME-padded FOMO backbone on this toolchain.
 - `fomo` / `point` / `coreml`: The CoreML wrapper does not implement the raw point-heatmap contract.
 - `grounding_dino` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
@@ -181,6 +192,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `grounding_dino` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `tflite`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
+- `grounding_dino` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `internvl3` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -188,6 +200,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `internvl3` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `internvl3` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -195,12 +208,14 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `kosmos2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `kosmos2` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `l2cs` / `gaze` / `torchscript`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `tensorrt`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `openvino`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `ncnn`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `tflite`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `coreml`: The v1 L2CS gaze export contract supports ONNX only.
+- `l2cs` / `gaze` / `coreai`: The model itself refuses: 'LibreL2CS export to coreai is not implemented. The v1 gaze export contract supports ONNX only.' That is a model-side decision, unchanged by opening the support gate, so nothing about Core AI is being tested here. Wiring the gaze contract beyond ONNX comes first.
 - `lfm2vl` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -208,6 +223,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `lfm2vl` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `lfm2vl` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `lingbotvision` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `lingbotvision` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `lingbotvision` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
@@ -218,6 +234,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `locateanything` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `locateanything` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `locateanything` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `locateanything` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `onnx`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `torchscript`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -225,6 +242,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `locateanything` / `point` / `ncnn`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `tflite`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `coreml`: Generative VLM export is out of scope for v1.
+- `locateanything` / `point` / `coreai`: Generative VLM export is out of scope for v1.
 - `mobilenetv4` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `mobilesam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
@@ -233,6 +251,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `mobilesam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `nafnet` / `restore` / `tflite`: onnx2tf 2.4.x converts the fixed-canvas graph, but LiteRT fails at invoke time because an internal input tensor lacks data.
 - `nafnet` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `omdet_turbo` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
@@ -242,6 +261,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `omdet_turbo` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `tflite`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
+- `omdet_turbo` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
@@ -249,6 +269,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `ov_deim` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `tflite`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
@@ -256,6 +277,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `owlv2` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `tflite`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
+- `owlv2` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `picodet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `picodet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `picosam3` / `segment` / `torchscript`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
@@ -264,6 +286,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `picosam3` / `segment` / `ncnn`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `tflite`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `coreml`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `coreai`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `pidnet` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `ppocr` / `ocr` / `onnx`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `torchscript`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
@@ -272,6 +295,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `ppocr` / `ocr` / `ncnn`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `tflite`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `coreml`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `coreai`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `qwen3vl` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
@@ -279,18 +303,22 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `qwen3vl` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `qwen3vl` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `realesrgan` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `resnet` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `rfdetr` / `detect` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `segment` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `segment` / `tflite`: onnx2tf 2.4.x assigns an invalid NHWC layout to the segmentation-head Einsum (78 channels versus the required 256), so conversion fails.
 - `rfdetr` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rfdetr` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
 - `rfdetr` / `pose` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `pose` / `tflite`: RF-DETR pose-x TFLite conversion exceeded the CPU timebox and 8 GB working memory without producing an artifact on this toolchain.
 - `rfdetr` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rfdetr` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
 - `rfdetr` / `obb` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `rfdetr` / `obb` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rfdetr` / `obb` / `coreai`: This family and task have not been validated for Core AI export.
 - `rtdetr` / `detect` / `ncnn`: NCNN export is not supported for RT-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rtdetr` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `rtdetrv2` / `detect` / `ncnn`: NCNN export is not supported for RT-DETRv2: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
@@ -309,6 +337,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `rtmdet` / `segment` / `ncnn`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `rtmdet` / `segment` / `tflite`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `rtmdet` / `segment` / `coreml`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `coreai`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `sam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
@@ -316,6 +345,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `sam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
+- `sam` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
@@ -323,6 +353,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `sam2` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
+- `sam2` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
@@ -330,6 +361,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `sam3` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `tflite`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
+- `sam3` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `segformer` / `semantic` / `onnx`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `torchscript`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `tensorrt`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
@@ -337,6 +369,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `segformer` / `semantic` / `ncnn`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `tflite`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `coreml`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
+- `segformer` / `semantic` / `coreai`: LibreSegformer implements no export path at all ('Export is not implemented for LibreSegformer yet'), so this is not a Core AI limitation. Note its weights are non-commercial regardless.
 - `siglip2` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `siglip2` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `siglip2` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
@@ -350,8 +383,10 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `smolvlm2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `swinir` / `restore` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `swinir` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `swinir` / `restore` / `coreai`: The export process DIES rather than hangs, and the kill point moves between runs, which is the signature of memory exhaustion rather than a stuck loop. One run reached 'Step 3/3: Optimizing and writing the asset' before stopping; a later run of the same graph at the same 128 canvas died inside to_coreai() before returning, in both cases with a leaked-semaphore warning and no traceback. Window attention unrolls into a very large number of small ops, so the converter's peak memory is the prime suspect on a 16 GB machine. Next steps: watch RSS during conversion, try the smallest available size at a 64 canvas, and check the system log for a memory kill. Do NOT assume optimize() is at fault; an earlier note said so on the strength of a single run and the second run contradicted it.
 - `yolo1` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `yolo1` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo2` / `detect` / `tflite`: onnx2tf 2.4.x leaves an unresolved ONNX_CONCAT custom operation; LiteRT cannot prepare the converted detector graph.
@@ -362,6 +397,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `yolo4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo7` / `detect` / `tflite`: The converted LiteRT graph changes decoded box coordinates beyond the detector parity tolerance.
 - `yolo7` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolo7` / `detect` / `coreai`: WITHDRAWN from validated. This family was recorded at 1.4e-07 on random initialisation. With trained weights, where the reference actually moves (input-sensitivity 1.3e-01), the same comparison gives 2.9e-01: the artifact does not reproduce the model. The earlier number was two near-constant tensors agreeing, not a correct conversion. yolo7 is the one family where the trained-weight re-measurement turned a pass into a failure rather than confirming it, so whatever it does differently from yolo9 and yolox, which pass the identical check at 1.9e-06 and 2.4e-06, is the place to look. Only the b size exists, so a second size cannot be used to narrow it.
 - `yolo9_e2e` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `yolo9_e2e` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo9_p2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
@@ -370,5 +406,6 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `yolonas` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolonas` / `pose` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `yolonas` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `yolonas` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
 - `zipdepth` / `depth` / `tflite`: onnx2tf 2.4.x flatbuffer-direct conversion does not support the edge-mode Pad operation in ZipDepth's convex upsampler.
 - `zipdepth` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -19,7 +19,10 @@ def export_cmd(
     model: str = typer.Option(..., help="Model weights (.pt)"),
     format: str = typer.Option(
         "onnx",
-        help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite (alias: litert), coreml",
+        help=(
+            "Export format: onnx, torchscript, tensorrt, openvino, ncnn, "
+            "tflite (alias: litert), coreml, coreai (Apple, macOS only)"
+        ),
     ),
     imgsz: Optional[str] = typer.Option(None, help="Input image size (e.g. 640 or 640,480)"),
     batch: int = typer.Option(1, help="Export batch size"),

--- a/libreyolo/export/coreai.py
+++ b/libreyolo/export/coreai.py
@@ -1,0 +1,679 @@
+"""Core AI (``.aimodel``) export.
+
+Core AI is Apple's on-device inference stack, the successor generation to
+Core ML. Unlike the Core ML path, which records a single trace through
+``torch.jit.trace``, this converter goes through ``torch.export``: a real
+graph capture with guards. That is stricter (host scalar reads and
+data-dependent control flow are rejected rather than silently baked in) and
+removes the need for the static-eval monkey patches the Core ML path carries.
+
+Pipeline::
+
+    torch.export.export -> run_decompositions -> TorchConverter -> optimize
+                        -> AIProgram.save_asset(.aimodel)
+
+Artifacts declare ``minimum_os = OSVersion.v27``; that is the only value the
+Core AI toolchain offers, and it gates *deployment*, not conversion. Both
+conversion and Python-side execution work on earlier macOS through the
+runtime shipped inside the ``coreai`` wheel, but numerics differ between OS
+versions, so parity must be recorded on macOS 27.
+
+SCOPE: EXPORT, NOT INFERENCE
+----------------------------
+There is no Core AI entry in ``libreyolo/backends``. This module converts a
+model and the support matrix records numeric parity against a reference
+artifact, but nothing in the library loads an ``.aimodel`` back for inference
+the way ``backends/onnx.py`` loads an ONNX graph. A ``validated`` row here is
+a claim that the exported graph computes the same numbers as the reference,
+not that ``predict`` will run it. Consumers use the Core AI runtime directly.
+
+OUTPUT ORDERING CONTRACT
+------------------------
+Core AI returns a **named dict**, and its key order matches neither the eager
+forward's tuple order nor anything a caller can guess. Consumers must map by
+name. The exported output names are recorded in the artifact metadata under
+``coreai_output_names`` so a backend can rebuild the canonical ordering
+without re-deriving it. Never pair Core AI outputs with eager outputs
+positionally.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+from .coreml import _prepare_rtdetr_static_eval, _wrap_for_family
+
+logger = logging.getLogger(__name__)
+
+# Only value the toolchain exposes; kept named so the reason is greppable.
+_MINIMUM_OS = "v27"
+_ANCHOR_FREEZE_FAMILIES = {
+    "yolo9",
+    "yolo9_e2e",
+    "yolo9_p2",
+    "yolox",
+    "yolo1",
+    "yolo2",
+    "yolo3",
+    "yolo4",
+    "yolo7",
+    "yolonas",
+    "picodet",
+    "rtmdet",
+}
+_RTDETR_STATIC_FAMILIES = {
+    "rtdetr",
+    "rtdetrv2",
+    "rtdetrv4",
+    "dfine",
+    "deim",
+    "deimv2",
+    "ec",
+}
+
+
+def _freeze_anchor_grid(nn_model: nn.Module, dummy: torch.Tensor):
+    """Bake a detection head's anchor grid as constants for the export canvas.
+
+    The shared exporter sets ``head.export = True`` before handing the model
+    over. In that branch the head rebuilds its anchor grid from live feature
+    shapes every forward, and ``torch.export`` turns the ``h * w`` products
+    into unbacked symbols and refuses the graph. Core AI artifacts are
+    fixed-canvas, so the grid is a constant and can be frozen.
+
+    This deliberately does NOT reuse ``coreml._prepare_yolo9_static_eval``.
+    That helper runs its warm-up forward with ``export`` already ``True``, and
+    in that branch ``_grid`` returns early *without* populating
+    ``head.anchors`` / ``head.strides``. It therefore freezes whatever those
+    attributes held at construction, and transposing an unpopulated tensor
+    raises ``IndexError: Dimension out of range``. The fix is to warm up with
+    ``export`` temporarily disabled so the cache is genuinely filled.
+
+    Returns a callable restoring the original state.
+    """
+    target = nn_model
+    head = getattr(target, "head", None)
+    while head is None and isinstance(getattr(target, "model", None), nn.Module):
+        target = target.model
+        head = getattr(target, "head", None)
+    if head is None or not hasattr(head, "_anchor_grid"):
+        return lambda: None
+
+    was_export = getattr(head, "export", False)
+    previous_anchors = getattr(head, "anchors", None)
+    previous_strides = getattr(head, "strides", None)
+    previous_shape = getattr(head, "shape", None)
+    had_instance_override = "_anchor_grid" in head.__dict__
+    previous_anchor_grid = head.__dict__.get("_anchor_grid")
+
+    def _restore_cache():
+        if hasattr(head, "anchors"):
+            head.anchors = previous_anchors
+        if hasattr(head, "strides"):
+            head.strides = previous_strides
+        if hasattr(head, "shape"):
+            head.shape = previous_shape
+
+    try:
+        # Warm up in NON-export mode so _grid populates the anchor cache.
+        # Input values are irrelevant; anchors depend only on feature geometry,
+        # which dummy's H/W fixes.
+        head.export = False
+        with torch.no_grad():
+            nn_model(dummy)
+        anchors = getattr(head, "anchors", None)
+        strides = getattr(head, "strides", None)
+        if anchors is None or strides is None or anchors.ndim < 2:
+            logger.warning(
+                "Could not freeze the anchor grid for this head; export may "
+                "fail on data-dependent shapes."
+            )
+            _restore_cache()
+            return lambda: None
+        frozen_anchors = anchors.detach().clone()
+        frozen_strides = strides.detach().clone()
+    except Exception:
+        _restore_cache()
+        raise
+    finally:
+        head.export = was_export
+
+    def _const_anchor_grid(feats):
+        del feats  # geometry is fixed by the export canvas
+        # The export branch of _grid transposes whatever this returns, so
+        # pre-transpose to survive the round trip unchanged.
+        return frozen_anchors.transpose(0, 1), frozen_strides.transpose(0, 1)
+
+    head._anchor_grid = _const_anchor_grid
+
+    def _restore():
+        _restore_cache()
+        if had_instance_override:
+            head._anchor_grid = previous_anchor_grid
+        else:
+            head.__dict__.pop("_anchor_grid", None)
+
+    return _restore
+
+
+class _YoloNASDecodedOnly(nn.Module):
+    """Expose only YOLO-NAS's decoded predictions, matching the ONNX contract.
+
+    In export mode the head returns ``(decoded_predictions, raw_predictions)``
+    (see models/yolonas/nn.py). The ONNX path ships the decoded pair alone, so
+    an artifact that also carries the raw per-level maps disagrees on arity
+    with every other backend and cannot be parity-checked against them.
+    """
+
+    def __init__(self, model: nn.Module) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(self, x):
+        out = self.model(x)
+        if isinstance(out, (list, tuple)) and len(out) == 2:
+            decoded = out[0]
+            if isinstance(decoded, (list, tuple)):
+                return tuple(decoded)
+        return out
+
+
+def _rebake_rfdetr_pos_embed(nn_model: nn.Module, dummy: torch.Tensor):
+    """Re-bake RF-DETR's position embedding for the actual export canvas.
+
+    The RF-DETR backbone already carries the right idea: ``export()``
+    interpolates the pretrained position-embedding grid once, eagerly, stores
+    the result as a Parameter, and swaps ``interpolate_pos_encoding`` for a
+    version that returns that Parameter whenever the token count matches.
+
+    It bakes for the backbone's CONFIGURED shape, though, which is 384 for the
+    nano size. Export at any other canvas and the token counts no longer match
+    (640 needs 40x40 = 1600 patches against the baked 24x24 = 576), so the fast
+    path is skipped and the fallback runs a bicubic *with antialiasing* inside
+    the traced graph. The converter has no lowering for
+    ``aten._upsample_bicubic2d_aa`` and refuses the program.
+
+    Pointing the backbone at the export canvas and re-running its own bake
+    moves that interpolation back out of the graph. The numbers are unchanged:
+    the eager fallback resizes the baked grid to the canvas with an
+    antialiased bicubic, and re-baking performs exactly that resize, just
+    ahead of capture instead of during it.
+
+    This is deliberately NOT a general interception of ``F.interpolate``. An
+    earlier attempt did that, replaying results by call order, and it silently
+    changed model outputs by up to 9.5e-01 whenever the call sequence did not
+    line up. Reusing the model's own baking path keeps the correctness
+    argument local and checkable.
+
+    Returns a callable restoring the original state.
+    """
+    h, w = int(dummy.shape[-2]), int(dummy.shape[-1])
+
+    targets = [
+        mod
+        for mod in nn_model.modules()
+        if hasattr(mod, "_export")
+        and callable(getattr(mod, "export", None))
+        and isinstance(getattr(mod, "shape", None), (tuple, list))
+    ]
+    if not targets:
+        return lambda: None
+
+    undo = []
+    for mod in targets:
+        if tuple(mod.shape)[:2] == (h, w):
+            continue  # already baked for this canvas
+        embeddings = getattr(getattr(mod, "encoder", None), "embeddings", None)
+        if embeddings is None:
+            continue
+        prev_shape = mod.shape
+        prev_export = mod._export
+        prev_pe = embeddings.position_embeddings
+        prev_interp = embeddings.__dict__.get("interpolate_pos_encoding")
+
+        mod.shape = (h, w)
+        mod._export = False
+        try:
+            mod.export()
+        except Exception as exc:  # noqa: BLE001 - leave the graph to fail loudly
+            logger.warning(
+                "Could not re-bake the RF-DETR position embedding for %dx%d "
+                "(%s); the antialiased bicubic will stay in the graph.",
+                h,
+                w,
+                exc,
+            )
+            mod.shape = prev_shape
+            mod._export = prev_export
+            embeddings.position_embeddings = prev_pe
+            if prev_interp is None:
+                embeddings.__dict__.pop("interpolate_pos_encoding", None)
+            else:
+                embeddings.interpolate_pos_encoding = prev_interp
+            continue
+        logger.info(
+            "Re-baked the RF-DETR position embedding for the %dx%d export "
+            "canvas (was %s).",
+            h,
+            w,
+            tuple(prev_shape)[:2],
+        )
+        undo.append((mod, embeddings, prev_shape, prev_export, prev_pe, prev_interp))
+
+    def _restore():
+        for mod, embeddings, prev_shape, prev_export, prev_pe, prev_interp in undo:
+            mod.shape = prev_shape
+            mod._export = prev_export
+            embeddings.position_embeddings = prev_pe
+            if prev_interp is None:
+                embeddings.__dict__.pop("interpolate_pos_encoding", None)
+            else:
+                embeddings.interpolate_pos_encoding = prev_interp
+
+    return _restore
+
+
+def _replace_adaptive_avg_pool(nn_model: nn.Module):
+    """Replace ``AdaptiveAvgPool2d(1)`` with an exact spatial mean.
+
+    ``AdaptiveAvgPool2d`` decomposes to ``aten.as_strided``, which the Core AI
+    converter cannot lower. ``as_strided`` is a primitive with no
+    decomposition, so it cannot be expanded away.
+
+    When the target output is 1x1 the operation is exactly a mean over the
+    spatial dimensions, so substituting one changes nothing numerically while
+    removing the operator entirely. Any other output size is left alone: the
+    equivalence does not hold there, and a conversion error is better than a
+    silent approximation.
+
+    Returns a callable restoring the original modules.
+    """
+
+    class _SpatialMean(nn.Module):
+        def forward(self, x):
+            return x.mean(dim=(-2, -1), keepdim=True)
+
+    def _is_global(mod):
+        size = getattr(mod, "output_size", None)
+        return size == 1 or size == (1, 1) or size == [1, 1]
+
+    swapped = []
+    for parent in nn_model.modules():
+        for name, child in list(parent.named_children()):
+            if isinstance(child, nn.AdaptiveAvgPool2d) and _is_global(child):
+                setattr(parent, name, _SpatialMean())
+                swapped.append((parent, name, child))
+    if swapped:
+        logger.info(
+            "Replaced %d AdaptiveAvgPool2d(1) with an exact spatial mean "
+            "(avoids aten.as_strided).",
+            len(swapped),
+        )
+
+    def _restore():
+        for parent, name, child in swapped:
+            setattr(parent, name, child)
+
+    return _restore
+
+
+def _require_coreai():
+    """Import the Core AI toolchain with an actionable message if absent."""
+    try:
+        from coreai_torch import TorchConverter, get_decomp_table
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise ImportError(
+            "Core AI export requires the 'coreai-torch' package. Install it "
+            "with `pip install libreyolo[coreai]`. Note that coreai-torch "
+            "pins torch to 2.11.x, and that Core AI artifacts can only be "
+            "produced and executed on macOS."
+        ) from exc
+    return TorchConverter, get_decomp_table
+
+
+def _minimum_os():
+    """The OS version the asset declares.
+
+    Passed explicitly rather than left to the toolchain default, so the value
+    the module docstring promises is the value the artifact carries even if
+    that default moves.
+    """
+    from coreai.authoring import OSVersion
+
+    return getattr(OSVersion, _MINIMUM_OS)
+
+
+def _stringify_metadata_value(value: Any) -> str:
+    """Encode structured metadata without Python-repr-only values."""
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return str(value)
+
+
+def _asset_metadata(values: dict[str, Any]):
+    """Build the asset metadata record, or ``None`` when there is nothing to say.
+
+    Everything the exporter knows goes in as creator-defined metadata, keyed
+    and stringified, because the asset format stores custom entries as strings.
+    """
+    if not values:
+        return None
+    from coreai.authoring.asset import AIModelAssetMetadata
+
+    record = AIModelAssetMetadata()
+    for key, value in values.items():
+        if value is None:
+            continue
+        record.set_custom(str(key), _stringify_metadata_value(value))
+    return record
+
+
+def _snapshot_rtdetr_static_eval(nn_model: nn.Module):
+    """Snapshot what ``_prepare_rtdetr_static_eval`` is about to overwrite.
+
+    That helper bakes resolution-specific tensors straight onto the live
+    encoder and decoder (``eval_spatial_size``, one ``pos_embed{idx}`` per
+    encoder index, and the ``anchors`` / ``valid_mask`` buffers) and returns
+    nothing, so without this the caller's model keeps export-only state
+    afterwards and quietly misbehaves at any other resolution.
+
+    Returns a callable restoring the previous state.
+    """
+    target = nn_model
+    while (
+        getattr(target, "encoder", None) is None
+        and getattr(target, "decoder", None) is None
+        and getattr(target, "model", None) is not None
+    ):
+        target = target.model
+
+    missing = object()
+    saved: list = []
+    encoder = getattr(target, "encoder", None)
+    if encoder is not None and hasattr(encoder, "build_2d_sincos_position_embedding"):
+        saved.append(
+            (
+                encoder,
+                "eval_spatial_size",
+                getattr(encoder, "eval_spatial_size", missing),
+            )
+        )
+        for idx in getattr(encoder, "use_encoder_idx", []):
+            name = f"pos_embed{idx}"
+            saved.append((encoder, name, getattr(encoder, name, missing)))
+
+    decoder = getattr(target, "decoder", None)
+    if decoder is not None and hasattr(decoder, "_generate_anchors"):
+        saved.append(
+            (
+                decoder,
+                "eval_spatial_size",
+                getattr(decoder, "eval_spatial_size", missing),
+            )
+        )
+        # Buffers are restored through _buffers so a name that was absent
+        # before export does not linger as a registered buffer afterwards.
+        for name in ("anchors", "valid_mask"):
+            value = decoder._buffers.get(name, missing)
+            saved.append((decoder, f"_buffer:{name}", value))
+
+    def _restore():
+        for owner, name, value in saved:
+            if name.startswith("_buffer:"):
+                key = name.split(":", 1)[1]
+                if value is missing:
+                    owner._buffers.pop(key, None)
+                else:
+                    owner._buffers[key] = value
+            else:
+                if value is missing:
+                    try:
+                        delattr(owner, name)
+                    except AttributeError:
+                        pass
+                else:
+                    setattr(owner, name, value)
+
+    return _restore
+
+
+def _force_manual_grid_sample():
+    """Enable the repository's gather-based deformable sampler temporarily."""
+    tokens = []
+    try:
+        from ..models.dfine import ms_deform as _dfine_ms
+
+        tokens.append(
+            (
+                _dfine_ms._FORCE_MANUAL_GRID_SAMPLE,
+                _dfine_ms._FORCE_MANUAL_GRID_SAMPLE.set(True),
+            )
+        )
+    except ImportError:
+        pass
+
+    def _restore():
+        for flag, token in reversed(tokens):
+            flag.reset(token)
+
+    return _restore
+
+
+@contextmanager
+def _prepare_coreai_graph(
+    nn_model: nn.Module,
+    dummy: torch.Tensor,
+    model_family: str | None,
+):
+    """Apply fixed-canvas graph preparation and always restore live state."""
+    family = (model_family or "").lower()
+    with ExitStack() as stack:
+        if family in _ANCHOR_FREEZE_FAMILIES:
+            stack.callback(_freeze_anchor_grid(nn_model, dummy))
+
+        if family in _RTDETR_STATIC_FAMILIES:
+            # Snapshot first: preparation mutates resolution-specific buffers
+            # and can itself fail.
+            stack.callback(_snapshot_rtdetr_static_eval(nn_model))
+            _prepare_rtdetr_static_eval(nn_model, dummy.shape[-2], dummy.shape[-1])
+
+        stack.callback(_force_manual_grid_sample())
+        stack.callback(_rebake_rfdetr_pos_embed(nn_model, dummy))
+        stack.callback(_replace_adaptive_avg_pool(nn_model))
+        yield nn_model
+
+
+def _exported_output_names(exported_program) -> list[str]:
+    """Declared output names of the exported graph, in graph order.
+
+    These are the keys the runtime hands back. They are graph node names
+    (``cat_33``, ``silu_120``, ...) and carry no semantic meaning, which is
+    exactly why they have to be recorded rather than inferred.
+    """
+    try:
+        return [str(name) for name in exported_program.graph_signature.user_outputs]
+    except AttributeError:  # pragma: no cover - signature shape changed upstream
+        logger.warning(
+            "Could not read output names from the exported program; the "
+            "Core AI artifact will not carry an output-name mapping."
+        )
+    return []
+
+
+def prepare_frozen_classifier_export(
+    model,
+    kwargs: dict[str, Any],
+    *,
+    default_output: str,
+) -> tuple[int, str, dict[str, Any]]:
+    """Validate a frozen CLIP-style export and build standard metadata."""
+    from .exporter import CoreAIExporter
+
+    options = dict(kwargs)
+    imgsz = options.pop("imgsz", None)
+    output_path = options.pop("output_path", None) or default_output
+    half = bool(options.pop("half", False))
+    int8 = bool(options.pop("int8", False))
+    data = options.pop("data", None)
+    dynamic = bool(options.pop("dynamic", False))
+    batch = int(options.pop("batch", 1))
+    nms = bool(options.pop("nms", False))
+    device = options.pop("device", None)
+
+    # Accepted by the shared public export signature but irrelevant to the
+    # direct torch.export path used by frozen vision-language classifiers.
+    for name in (
+        "opset",
+        "simplify",
+        "verbose",
+        "fraction",
+        "allow_download_scripts",
+        "_pre_trace_hook",
+    ):
+        options.pop(name, None)
+    if options:
+        names = ", ".join(sorted(options))
+        raise TypeError(f"Unsupported Core AI export options: {names}")
+    if dynamic:
+        raise NotImplementedError(
+            "Core AI frozen-class export uses a fixed input shape; "
+            "dynamic=True is not supported."
+        )
+    if batch != 1:
+        raise NotImplementedError(
+            "Core AI frozen-class export currently requires batch=1."
+        )
+    if device not in (None, "cpu", torch.device("cpu")):
+        raise NotImplementedError(
+            "Core AI conversion runs on CPU; pass device='cpu' or omit device."
+        )
+
+    if imgsz is None:
+        height = width = int(model.input_size)
+    elif isinstance(imgsz, (tuple, list)):
+        if len(imgsz) != 2:
+            raise ValueError(f"imgsz must be an int or (height, width), got {imgsz}")
+        height, width = (int(imgsz[0]), int(imgsz[1]))
+    else:
+        height = width = int(imgsz)
+    if height <= 0 or width <= 0:
+        raise ValueError(f"imgsz values must be positive, got {(height, width)}")
+    if height != width:
+        raise NotImplementedError(
+            "Frozen CLIP-style Core AI export requires a square input."
+        )
+
+    exporter = CoreAIExporter(model)
+    half, int8 = exporter._validate(half, int8, data)
+    exporter._preflight(
+        half=half,
+        int8=int8,
+        data=data,
+        nms=nms,
+    )
+    metadata = exporter._build_metadata("fp32", False, None, imgsz=(height, width))
+    return height, str(output_path), metadata
+
+
+def export_coreai(
+    nn_model: nn.Module,
+    dummy: torch.Tensor,
+    *,
+    output_path: str | Path,
+    precision: str = "fp32",
+    metadata: dict[str, Any] | None = None,
+    model_family: str | None = None,
+    dynamic: bool = False,
+    **kwargs: Any,
+) -> str:
+    """Convert *nn_model* to a Core AI ``.aimodel`` asset and return its path.
+
+    ``dummy`` fixes the export resolution. Core AI artifacts are static-shape
+    in v1, matching the Core ML precedent, so the canvas the caller passes is
+    the canvas the artifact runs at.
+    """
+    if kwargs:
+        names = ", ".join(sorted(kwargs))
+        raise TypeError(f"Unsupported Core AI conversion options: {names}")
+    if dynamic:
+        raise NotImplementedError(
+            "Core AI export uses a fixed input shape; dynamic=True is not supported."
+        )
+    if precision != "fp32":
+        raise NotImplementedError("Core AI export currently supports FP32 only.")
+    TorchConverter, get_decomp_table = _require_coreai()
+
+    # Third-party defect workarounds; see coreai_compat for what and why.
+    from .coreai_compat import apply as _apply_coreai_shims
+
+    _apply_coreai_shims()
+
+    output_path = Path(output_path)
+    if output_path.suffix != ".aimodel":
+        output_path = output_path.with_suffix(".aimodel")
+
+    # Reuse the Core ML family wrappers verbatim: they ARE the per-family
+    # output contract, and a Core AI artifact must emit the same tensors as
+    # the other backends for the same family or downstream consumers cannot
+    # swap formats.
+    wrapped = _wrap_for_family(nn_model, model_family)
+    wrapped.eval()
+
+    # YOLO-NAS returns (decoded, raw) in export mode; the other
+    # backends ship the decoded pair alone. Match them so the
+    # artifact can be parity-checked against ONNX.
+    if (model_family or "").lower() == "yolonas":
+        wrapped = _YoloNASDecodedOnly(wrapped).eval()
+
+    # Fixed-canvas preparation is scoped so both successful conversion and any
+    # capture/lowering failure leave the caller's live model unchanged.
+    with _prepare_coreai_graph(wrapped, dummy, model_family):
+        logger.info("Step 1/3: Capturing the graph with torch.export")
+        exported = torch.export.export(wrapped, args=(dummy,))
+
+        logger.info("Step 2/3: Lowering to Core AI IR")
+        table = dict(get_decomp_table())
+        from torch._decomp import get_decompositions
+
+        # The Core AI converter has no lowering for aten.grid_sampler_2d
+        # (the deformable-attention sampler in the DETR families).
+        # PyTorch core ships a reference decomposition; folding it into the
+        # table lowers the op inside the exported graph into primitives the
+        # converter already supports.
+        table.update(get_decompositions([torch.ops.aten.grid_sampler_2d]))
+        exported = exported.run_decompositions(table)
+        program = TorchConverter().add_exported_program(exported).to_coreai()
+
+    logger.info("Step 3/3: Optimizing and writing the asset")
+    program.optimize()
+
+    output_names = _exported_output_names(exported)
+    meta = dict(metadata or {})
+    if output_names:
+        # Recorded so a backend can restore canonical ordering. See the
+        # OUTPUT ORDERING CONTRACT note in the module docstring. This has to
+        # reach the asset: the ordering contract is the one thing a consumer
+        # cannot re-derive, and an earlier version of this function built the
+        # dictionary and then dropped it, documenting a guarantee the artifact
+        # did not carry.
+        meta["coreai_output_names"] = output_names
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    program.save_asset(
+        output_path, metadata=_asset_metadata(meta), minimum_os=_minimum_os()
+    )
+
+    logger.info("Core AI export complete: %s", output_path)
+    if output_names:
+        logger.info("Core AI output names (in graph order): %s", output_names)
+    return str(output_path)
+
+
+__all__ = ["export_coreai", "prepare_frozen_classifier_export"]

--- a/libreyolo/export/coreai_compat.py
+++ b/libreyolo/export/coreai_compat.py
@@ -1,0 +1,111 @@
+"""Compatibility shims for third-party Core AI toolchain defects.
+
+Follows the same discipline as ``libreyolo/models/sam/transformers_compat.py``:
+patch from our side rather than editing site-packages, verify the defect is
+actually present before touching anything, and decline quietly if upstream
+restructures so a future release cannot be silently broken by a stale shim.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import PackageNotFoundError, version
+
+logger = logging.getLogger(__name__)
+
+# aten.avg_pool2d signature:
+#   (input, kernel_size, stride, padding, ceil_mode, count_include_pad,
+#    divisor_override)
+_AVG_POOL2D_ARITY = 7
+_AFFECTED_COREAI_TORCH_VERSIONS = {"0.4.1"}
+
+
+def _patch_avg_pool2d() -> bool:
+    """Work around an off-by-one in coreai-torch's avg_pool2d resolver.
+
+    ``coreai_torch/_aten_to_core.py`` reads ``count_include_pad`` as::
+
+        node.args[5] if len(node.args) > 4 and node.args[4] is not None else True
+
+    The guard tests element 4 but the read is element 5, so a node carrying
+    exactly five arguments passes the guard and then raises ``IndexError:
+    tuple index out of range``. RT-DETR emits avg_pool2d with five arguments,
+    which killed conversion for the whole family before a single tensor was
+    compared.
+
+    Rather than reimplement the resolver, this normalises the node's argument
+    tuple to full arity using PyTorch's documented defaults before handing it
+    over, which keeps upstream's implementation in charge of the maths.
+    """
+    try:
+        installed = version("coreai-torch")
+    except PackageNotFoundError:
+        return False
+    if installed not in _AFFECTED_COREAI_TORCH_VERSIONS:
+        # Never carry a private upstream patch into an unverified release.
+        return False
+
+    try:
+        from coreai_torch import _aten_to_core as mod
+    except ImportError:
+        return False
+
+    original = getattr(mod, "replace_avg_pool2d", None)
+    if original is None or getattr(original, "_libreyolo_patched", False):
+        return False
+
+    def replace_avg_pool2d(values_map, node, loc, *args, **kwargs):
+        current = tuple(node.args)
+        if len(current) < _AVG_POOL2D_ARITY:
+            kernel_size = current[1] if len(current) > 1 else None
+            defaults = (
+                None,  # 0 input, always present
+                None,  # 1 kernel_size, always present
+                kernel_size,  # 2 stride defaults to kernel_size
+                [0, 0],  # 3 padding
+                False,  # 4 ceil_mode
+                True,  # 5 count_include_pad
+                None,  # 6 divisor_override
+            )
+            node.args = current + defaults[len(current) :]
+        try:
+            return original(values_map, node, loc, *args, **kwargs)
+        finally:
+            node.args = current
+
+    replace_avg_pool2d._libreyolo_patched = True
+
+    mod.replace_avg_pool2d = replace_avg_pool2d
+    # The resolver table captured the function by value at import time, so the
+    # module attribute alone is not enough.
+    table = getattr(mod, "_aten_to_core_resolver", None)
+    if isinstance(table, dict):
+        for key, value in list(table.items()):
+            if value is original:
+                table[key] = replace_avg_pool2d
+    try:
+        from coreai_torch import converter as conv
+
+        conv_table = getattr(conv, "_aten_to_core_resolver", None)
+        if isinstance(conv_table, dict):
+            for key, value in list(conv_table.items()):
+                if value is original:
+                    conv_table[key] = replace_avg_pool2d
+    except ImportError:
+        pass
+    return True
+
+
+def apply() -> bool:
+    """Apply every shim; returns True if any patch was installed."""
+    try:
+        patched = _patch_avg_pool2d()
+    except Exception as exc:  # noqa: BLE001 - never break export over a shim
+        logger.debug("Core AI compatibility shim declined: %s", exc)
+        return False
+    if patched:
+        logger.debug("Applied Core AI avg_pool2d compatibility shim.")
+    return patched
+
+
+__all__ = ["apply"]

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -17,6 +17,8 @@ from typing import Optional, Tuple, Union
 
 import torch
 
+from ..tasks import task_to_suffix
+from ..utils.serialization import SCHEMA_VERSION
 from .onnx import (
     _get_version,
     _requires_onnx_opset17,
@@ -24,10 +26,8 @@ from .onnx import (
     export_onnx,
     quantize_onnx_int8,
 )
-from .torchscript import export_torchscript
 from .support import get_support, validated_alternatives
-from ..tasks import task_to_suffix
-from ..utils.serialization import SCHEMA_VERSION
+from .torchscript import export_torchscript
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +157,7 @@ _RECTANGULAR_EXPORT_FAMILIES = {
     "realesrgan",
 }
 _RECTANGULAR_EXPORT_FORMATS = {
+    "coreai",
     "coreml",
     "ncnn",
     "onnx",
@@ -374,6 +375,8 @@ class BaseExporter(ABC):
         if getattr(self.model, "task", "detect") == "matte":
             from ..models.birefnet.export import (
                 MIN_OPSET as _MATTE_MIN_OPSET,
+            )
+            from ..models.birefnet.export import (
                 register_deform_conv2d_onnx_symbolic,
             )
 
@@ -504,6 +507,10 @@ class BaseExporter(ABC):
                 stacklevel=2,
             )
             half = False
+        if half and not self.supports_fp16:
+            raise NotImplementedError(
+                f"{self.format_name.upper()} FP16 export is not supported."
+            )
         if int8 and not self.supports_int8:
             raise NotImplementedError(
                 f"{self.format_name.upper()} INT8 export is not supported."
@@ -1458,6 +1465,80 @@ class TFLiteExporter(BaseExporter):
             verbose=verbose,
             onnx2tf_args=onnx2tf_args,
             metadata=metadata,
+        )
+
+
+class CoreAIExporter(BaseExporter):
+    """Apple Core AI (``.aimodel``) export via ``torch.export``.
+
+    Unlike the Core ML path this uses a real graph capture rather than a
+    single recorded trace, so the static-eval monkey patches that path needs
+    are not required here. Artifacts are static-shape in v1 and declare a
+    minimum OS of v27, which is the only value the toolchain offers.
+    """
+
+    format_name = "coreai"
+    suffix = ".aimodel"
+    requires_onnx = False
+    supports_int8 = False
+    supports_fp16 = False
+    apply_model_half = False
+    supports_embedded_nms = False
+
+    def __call__(self, *, dynamic: bool = False, **kwargs) -> str:
+        """Export a fixed-canvas Core AI artifact.
+
+        The base exporter defaults ``dynamic=True`` for ONNX. Core AI has no
+        dynamic-shape contract in v1, so its format-specific default is false
+        and an explicit request is rejected rather than mislabeled.
+        """
+        if dynamic:
+            raise NotImplementedError(
+                "Core AI export uses a fixed input shape; dynamic=True is not "
+                "supported."
+            )
+        return super().__call__(dynamic=False, **kwargs)
+
+    def _preflight(self, **kwargs):
+        # Support policy is checked before optional dependencies, as required
+        # by ADR 0011. Dependency validation still happens before the
+        # destructive LoRA merge in BaseExporter.__call__.
+        super()._preflight(**kwargs)
+
+        # Check the optional dependency HERE, not at conversion time. Preflight
+        # runs before __call__ merges any live LoRA adapters, and that merge is
+        # destructive. Discovering the missing package afterwards would leave
+        # the caller's model permanently modified with no artifact to show for
+        # it.
+        from .coreai import _require_coreai
+
+        _require_coreai()
+
+    def _build_metadata(self, precision, dynamic, onnx_path, imgsz=None):
+        # v1 artifacts are fixed-canvas, mirroring the CoreML/NCNN overrides.
+        meta = super()._build_metadata(precision, dynamic, onnx_path, imgsz=imgsz)
+        meta["dynamic"] = False
+        return meta
+
+    def _export(
+        self,
+        nn_model,
+        dummy,
+        *,
+        output_path,
+        precision,
+        metadata,
+        **kwargs,
+    ):
+        from .coreai import export_coreai
+
+        return export_coreai(
+            nn_model,
+            dummy,
+            output_path=output_path,
+            precision=precision,
+            metadata=metadata,
+            model_family=self.model._get_model_name(),
         )
 
 

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -7,7 +7,6 @@ from typing import Iterator, Literal
 
 from ..tasks import TASKS
 
-
 Tier = Literal["validated", "experimental", "blocked"]
 EXPORT_FORMATS = (
     "onnx",
@@ -17,6 +16,7 @@ EXPORT_FORMATS = (
     "ncnn",
     "tflite",
     "coreml",
+    "coreai",
 )
 
 
@@ -134,7 +134,7 @@ _add(
     "blocked",
     ("clip", "siglip2"),
     ("classify",),
-    tuple(fmt for fmt in EXPORT_FORMATS if fmt != "onnx"),
+    tuple(fmt for fmt in EXPORT_FORMATS if fmt not in {"onnx", "coreai"}),
     reason=(
         "Frozen-class vision-language export is ONNX-only in v1; re-export "
         "the frozen ONNX graph for a different deployment runtime."
@@ -144,7 +144,7 @@ _add(
     "blocked",
     ("dinov2",),
     ("classify",),
-    tuple(fmt for fmt in EXPORT_FORMATS if fmt != "onnx"),
+    tuple(fmt for fmt in EXPORT_FORMATS if fmt not in {"onnx", "coreai"}),
     reason="LibreDINOv2 classify export currently supports ONNX only.",
 )
 _add(
@@ -650,6 +650,341 @@ _add(
 )
 
 
+# Conversion has been observed for the families below, but a validated tier
+# requires a reproducible trained-weight parity test in this repository.
+_add(
+    "experimental",
+    (
+        "yolo1",
+        "deim",
+        "deimv2",
+        "rtdetr",
+        "rtdetrv2",
+        "rtdetrv4",
+        "yolo9_e2e",
+        "yolox",
+        "rtmdet",
+        "picodet",
+        "yolonas",
+    ),
+    ("detect",),
+    ("coreai",),
+    reason=(
+        "Conversion has been measured, but no reproducible trained-weight "
+        "Core AI parity test is committed for this family yet."
+    ),
+)
+_add(
+    "experimental",
+    (
+        "resnet",
+        "mobilenetv4",
+        "efficientnetv2",
+        "clip",
+        "siglip2",
+        "convnext",
+        "dinov2",
+    ),
+    ("classify",),
+    ("coreai",),
+    reason=(
+        "Conversion has been measured, but no reproducible trained-weight "
+        "Core AI parity test is committed for this family yet."
+    ),
+)
+_add(
+    "experimental",
+    ("zipdepth", "depth_anything"),
+    ("depth",),
+    ("coreai",),
+    reason=(
+        "Conversion has been measured, but no reproducible trained-weight "
+        "Core AI parity test is committed for this family yet."
+    ),
+)
+_add(
+    "experimental",
+    ("nafnet", "realesrgan"),
+    ("restore",),
+    ("coreai",),
+    reason=(
+        "Conversion has been measured, but no reproducible trained-weight "
+        "Core AI parity test is committed for this family yet."
+    ),
+)
+
+# HOW THE Core AI NUMBERS BELOW WERE MEASURED, and why an earlier set of them
+# was withdrawn.
+#
+# Every figure is the worst relative error against a reference graph, using
+# TRAINED weights, with each artifact fed the input ITS OWN contract expects,
+# and reported alongside the reference's own input-sensitivity.
+#
+# All three qualifiers were learned the hard way.
+#
+# Trained weights: a randomly initialised detection head emits nearly the same
+# tensor whatever it is shown, because the constant anchor grid dominates its
+# output. Measured on the ONNX reference between two very different probes,
+# random-init yolox moved by 1.5e-09 and rtmdet by 8.9e-12. Agreement at 1e-08
+# against a reference that moves 1.5e-09 certifies nothing. picodet was caught
+# because it hit exactly zero and was recorded as blocked; its neighbours
+# failed the same way by degrees and were recorded as validated.
+#
+# Input contract: _wrap_for_family wraps some families in a preprocessing
+# module for the Apple formats, so a Core AI graph takes canonical RGB[0,1] and
+# converts internally (YOLOX scales by 255 and swaps to BGR, RF-DETR applies
+# ImageNet normalization). The ONNX exporter applies no such wrapper. Handing
+# both the same tensor compares two different functions and reads ~0.5 however
+# correct the conversion is.
+#
+# Sensitivity margin: a result counts only if parity is at least 100x below
+# how far the reference itself moves between probes. Otherwise the honest
+# answer is that the measurement cannot support a verdict.
+_add(
+    "validated",
+    ("dfine",),
+    ("detect",),
+    ("coreai",),
+    since="1.5",
+    constraint=(
+        "fixed export canvas; trained LibreDFINEn weights are covered on "
+        "macOS 27 by direct named-output parity with a 3e-04 tolerance and "
+        "a 100x input-sensitivity margin"
+    ),
+)
+
+
+_add(
+    "validated",
+    ("yolo9",),
+    ("detect",),
+    ("coreai",),
+    since="1.5",
+    constraint=(
+        "fixed export canvas; trained LibreYOLO9t weights are covered on "
+        "macOS 27 by direct named-output parity with a 3e-04 tolerance and "
+        "a 100x input-sensitivity margin"
+    ),
+)
+_add(
+    "experimental",
+    ("yolo9_p2",),
+    ("detect",),
+    ("coreai",),
+    reason=(
+        "Converts, and agrees with its ONNX export at 7.1e-08, but that number "
+        "cannot be relied on: no weights are published for this family, so it "
+        "was measured with random initialisation, and the reference then moves "
+        "only 1.9e-06 between two very different probes. Parity of 7.1e-08 "
+        "against a reference that barely responds to its input is not "
+        "evidence. Publish or point at trained weights and this resolves in "
+        "one run; every sibling that could be measured that way passed."
+    ),
+)
+_add(
+    "blocked",
+    ("yolo7",),
+    ("detect",),
+    ("coreai",),
+    reason=(
+        "WITHDRAWN from validated. This family was recorded at 1.4e-07 on "
+        "random initialisation. With trained weights, where the reference "
+        "actually moves (input-sensitivity 1.3e-01), the same comparison gives "
+        "2.9e-01: the artifact does not reproduce the model. The earlier "
+        "number was two near-constant tensors agreeing, not a correct "
+        "conversion. "
+        "yolo7 is the one family where the trained-weight re-measurement "
+        "turned a pass into a failure rather than confirming it, so whatever "
+        "it does differently from yolo9 and yolox, which pass the identical "
+        "check at 1.9e-06 and 2.4e-06, is the place to look. Only the b size "
+        "exists, so a second size cannot be used to narrow it."
+    ),
+)
+_add(
+    "experimental",
+    ("ec",),
+    ("detect",),
+    ("coreai",),
+    reason=(
+        "Just over the line. Trained weights give 1.08e-04 against a "
+        "reference input-sensitivity of 9.9e-01, versus a 1e-04 gate: a factor "
+        "of 1.08, not an order of magnitude. Its five siblings in the DETR "
+        "group pass the identical check between 2.8e-06 and 4.6e-05, so this "
+        "is a marginal numeric residual rather than a structural fault. Worth "
+        "one look at the highest-error output before either tightening the "
+        "conversion or accepting it."
+    ),
+)
+_add(
+    "experimental",
+    ("yolo2", "yolo3", "yolo4"),
+    ("detect",),
+    ("coreai",),
+    reason=(
+        "Not close. Random initialisation put these at 2.4e-04 and the note "
+        "here said to re-measure with real weights before reading anything "
+        "into it. Done: with trained weights they are 1.5e-01 (yolo2), "
+        "1.1e-01 (yolo3) and 1.6e-01 (yolo4) against reference "
+        "input-sensitivities of 0.18 to 0.37. The residual is structural, not "
+        "numeric drift, and it is shared with yolo7, which fails the same way "
+        "at 2.9e-01. All four are darknet-lineage models sharing "
+        "models/darknet, so one cause probably explains all four. yolo1 sits "
+        "in the same lineage and passes, which makes it the useful control."
+    ),
+)
+_add(
+    "blocked",
+    ("birefnet",),
+    ("matte",),
+    ("coreai",),
+    reason=(
+        "The decoder needs torchvision deform_conv2d, which the Core AI "
+        "converter cannot lower ('unable to handle call function op: "
+        "deform_conv2d.default'). The same operator already blocks the NCNN "
+        "path. An encoder-only contract is the realistic route, matching the "
+        "seam the CUDA graph work used."
+    ),
+)
+_add(
+    "validated",
+    ("rfdetr",),
+    ("detect",),
+    ("coreai",),
+    since="1.5",
+    constraint=(
+        "fixed export canvas; trained LibreRFDETRn weights are covered on "
+        "macOS 27 against the graph the exporter itself prepares, using "
+        "direct named-output parity with a 3e-04 tolerance and a 100x "
+        "input-sensitivity margin. "
+        "Conversion needed _rebake_rfdetr_pos_embed in export/coreai.py: the "
+        "backbone bakes its position embedding for its configured 384 canvas, "
+        "so exporting at any other size left an antialiased bicubic in the "
+        "graph and the converter has no lowering for "
+        "aten._upsample_bicubic2d_aa. The rebake re-runs the model's OWN "
+        "baking path for the actual canvas, so the interpolation happens "
+        "eagerly, outside the graph, computing exactly what it computed "
+        "before. "
+        "NOTE the reference. This family is verified against the exporter's "
+        "prepared graph, not against ONNX, and the difference is not a "
+        "detail: at a 640 canvas the rfdetr ONNX artifact disagrees with that "
+        "same prepared graph by 9.3e-01. Core AI's rebake preserves the "
+        "antialiased resize the eager "
+        "model performs, whereas the ONNX path disables antialiasing (the "
+        "model checks torch.onnx.is_in_onnx_export). Which artifact is right "
+        "is an ONNX question and is not settled here, but ONNX cannot be used "
+        "as the reference for this family at a non-native canvas."
+    ),
+)
+_add(
+    "blocked",
+    ("swinir",),
+    ("restore",),
+    ("coreai",),
+    reason=(
+        "The export process DIES rather than hangs, and the kill point moves "
+        "between runs, which is the signature of memory exhaustion rather "
+        "than a stuck loop. One run reached 'Step 3/3: Optimizing and writing "
+        "the asset' before stopping; a later run of the same graph at the "
+        "same 128 canvas died inside to_coreai() before returning, in both "
+        "cases with a leaked-semaphore warning and no traceback. Window "
+        "attention unrolls into a very large number of small ops, so the "
+        "converter's peak memory is the prime suspect on a 16 GB machine. "
+        "Next steps: watch RSS during conversion, try the smallest available "
+        "size at a 64 canvas, and check the system log for a memory kill. Do "
+        "NOT assume optimize() is at fault; an earlier note said so on the "
+        "strength of a single run and the second run contradicted it."
+    ),
+)
+
+_add(
+    "experimental",
+    ("pidnet", "lingbotvision"),
+    ("semantic",),
+    ("coreai",),
+    reason=(
+        "The conversion is correct and measured: against the eager contract "
+        "graph, pidnet is 6.7e-05 and lingbotvision 7.8e-07, both inside the "
+        "1e-04 gate. Eager rather than ONNX because ONNX is itself blocked "
+        "for the semantic task, so there is no ONNX artifact to compare with; "
+        "an earlier 2.3e-04 for pidnet came from comparing two gate-forced "
+        "exports and is superseded. "
+        "Held at experimental rather than promoted, because _TASK_BLOCKS "
+        "refuses semantic for EVERY format: the shared dense-logits and "
+        "backend argmax decode contract does not exist yet. The artifact "
+        "carries raw logits and nothing downstream knows how to read them. "
+        "What stands between these two and validated is that cross-format "
+        "task contract, not anything about Core AI."
+    ),
+)
+_add(
+    "blocked",
+    ("segformer",),
+    ("semantic",),
+    ("coreai",),
+    reason=(
+        "LibreSegformer implements no export path at all ('Export is not "
+        "implemented for LibreSegformer yet'), so this is not a Core AI "
+        "limitation. Note its weights are non-commercial regardless."
+    ),
+)
+_add(
+    "blocked",
+    ("eomt",),
+    ("semantic",),
+    ("coreai",),
+    reason=(
+        "torch.export refuses the graph: GuardOnDataDependentSymNode, "
+        "'Could not guard on data-dependent expression Eq(u0, 1)'. Something "
+        "in the mask path reads a value off a tensor and branches on it, "
+        "which becomes an unbacked symbol with no hint the tracer can "
+        "resolve. This is a real capture failure, not a missing operator and "
+        "not the task gate: it was measured with the gate open. Fixing it "
+        "means finding the host read and making the shape static for a fixed "
+        "export canvas, the same shape of fix as the rfdetr torch._assert."
+    ),
+)
+_add(
+    "experimental",
+    ("fomo",),
+    ("point",),
+    ("coreai",),
+    reason=(
+        "Converts and matches the eager contract graph at 4.3e-07, measured "
+        "at the family's native 96 canvas. An earlier attempt at 640 said "
+        "nothing useful: 96 is the size this model is built for. "
+        "Held at experimental for the same reason as the semantic families: "
+        "_TASK_BLOCKS refuses point for every format because the shared "
+        "heatmap and backend peak-decoding contract does not exist, so the "
+        "artifact emits a raw heatmap that nothing downstream can decode."
+    ),
+)
+_add(
+    "blocked",
+    ("l2cs",),
+    ("gaze",),
+    ("coreai",),
+    reason=(
+        "The model itself refuses: 'LibreL2CS export to coreai is not "
+        "implemented. The v1 gaze export contract supports ONNX only.' That "
+        "is a model-side decision, unchanged by opening the support gate, so "
+        "nothing about Core AI is being tested here. Wiring the gaze contract "
+        "beyond ONNX comes first."
+    ),
+)
+_add(
+    "blocked",
+    ("depth_anything3",),
+    ("depth",),
+    ("coreai",),
+    reason=(
+        "The model raises NotImplementedError for every format: depth export "
+        "is out of scope per ADR 0006, the depth task contract. Depth Anything "
+        "V2 exports and validates at 5.2e-06, so this is specific to the V3 "
+        "family and not a Core AI limitation."
+    ),
+)
+
+
 _TASK_BLOCKS = {
     "ocr": (
         "OCR uses two networks for detection and recognition with dynamic "
@@ -743,6 +1078,11 @@ def get_support(family: str, task: str, fmt: str) -> SupportEntry:
         return SupportEntry(
             "blocked",
             "This family and task have not been validated through the ONNX-to-TFLite path.",
+        )
+    if fmt == "coreai":
+        return SupportEntry(
+            "blocked",
+            "This family and task have not been validated for Core AI export.",
         )
     if fmt == "coreml":
         return SupportEntry(

--- a/libreyolo/models/clip/model.py
+++ b/libreyolo/models/clip/model.py
@@ -71,7 +71,9 @@ class LibreCLIP(BaseModel):
     # the model resizes to a fixed square; keep predict to a single forward.
     TTA_ENABLED: ClassVar[bool] = False
 
-    validator_class: ClassVar[Optional[type]] = None  # set lazily (see _resolve_validator)
+    validator_class: ClassVar[Optional[type]] = (
+        None  # set lazily (see _resolve_validator)
+    )
 
     # =========================================================================
     # Registry classmethods
@@ -141,10 +143,14 @@ class LibreCLIP(BaseModel):
         else:
             # Zero-config: pick a default size and autodownload its checkpoint.
             size = size or "b32"
-            weight_source = self._resolve_weights_path(f"{self.FILENAME_PREFIX}{size}-cls.pt")
+            weight_source = self._resolve_weights_path(
+                f"{self.FILENAME_PREFIX}{size}-cls.pt"
+            )
         size = size or "b32"
 
-        self._default_templates = list(templates) if templates else list(DEFAULT_TEMPLATES)
+        self._default_templates = (
+            list(templates) if templates else list(DEFAULT_TEMPLATES)
+        )
         self._text_embeds: Optional[torch.Tensor] = None
         self.tokenizer = None  # built after super().__init__
 
@@ -248,8 +254,9 @@ class LibreCLIP(BaseModel):
         }
 
     def _build_transform(self, imgsz: int):
-        from ...data.classify_dataset import build_classify_transforms
         from torchvision.transforms import InterpolationMode
+
+        from ...data.classify_dataset import build_classify_transforms
 
         return build_classify_transforms(
             imgsz,
@@ -262,15 +269,20 @@ class LibreCLIP(BaseModel):
 
     @staticmethod
     def _get_preprocess_numpy():
-        from ...data.classify_dataset import build_classify_transforms
-        from torchvision.transforms import InterpolationMode
         import numpy as _np
+        from torchvision.transforms import InterpolationMode
+
+        from ...data.classify_dataset import build_classify_transforms
 
         def _preprocess_numpy(img_rgb_hwc, input_size=224):
             res = input_size if isinstance(input_size, int) else input_size[0]
             transform = build_classify_transforms(
-                res, augment=False, mean=CLIP_MEAN, std=CLIP_STD,
-                interpolation=InterpolationMode.BICUBIC, crop_pct=1.0,
+                res,
+                augment=False,
+                mean=CLIP_MEAN,
+                std=CLIP_STD,
+                interpolation=InterpolationMode.BICUBIC,
+                crop_pct=1.0,
             )
             pil = Image.fromarray(_np.asarray(img_rgb_hwc).astype("uint8"))
             return transform(pil).numpy(), 1.0
@@ -409,14 +421,48 @@ class LibreCLIP(BaseModel):
         inference). The ONNX is fixed to the labels set at export time and to a
         fixed input resolution; re-export to change either.
         """
-        if format.lower() != "onnx":
+        if format.lower() not in {"onnx", "coreai"}:
             raise NotImplementedError(
                 f"LibreCLIP export to {format!r} is not implemented; only 'onnx' "
-                "(frozen-class) is supported. Open-vocabulary export (two towers "
+                "and 'coreai' (frozen-class) are supported. Open-vocabulary export (two towers "
                 "+ tokenizer) is out of scope for v1."
             )
         if self._text_embeds is None:
             raise RuntimeError("No classes set; call set_classes() before export().")
+
+        if format.lower() == "coreai":
+            # LibreCLIP is a two-tower module with no single forward(x), which
+            # is why the ONNX path builds its graph by hand. Reuse the very
+            # same frozen-class module here rather than duplicating it, then
+            # hand it to the shared Core AI converter.
+            import torch as _torch
+
+            from ...export.coreai import (
+                export_coreai,
+                prepare_frozen_classifier_export,
+            )
+            from .export import _FrozenCLIPClassifier
+
+            size, output_path, metadata = prepare_frozen_classifier_export(
+                self, kwargs, default_output="clip_coreai"
+            )
+            scale = float(self.model.logit_scale.exp().detach().cpu())
+            weight = (scale * self._text_embeds).detach().cpu()
+            device = next(self.model.visual.parameters()).device
+            was_training = self.model.visual.training
+            visual = self.model.visual.to("cpu").eval()
+            try:
+                frozen = _FrozenCLIPClassifier(visual, weight).eval()
+                dummy = _torch.randn(1, 3, size, size)
+                return export_coreai(
+                    frozen,
+                    dummy,
+                    output_path=output_path,
+                    metadata=metadata,
+                    model_family="clip",
+                )
+            finally:
+                self.model.visual.to(device).train(was_training)
 
         from .export import export_frozen_onnx
 

--- a/libreyolo/models/dfine/ms_deform.py
+++ b/libreyolo/models/dfine/ms_deform.py
@@ -10,6 +10,7 @@ keeps ONNX export portable (opset >= 16).
 """
 
 import math
+from contextvars import ContextVar
 from typing import List
 
 import torch
@@ -50,6 +51,16 @@ def get_activation(act, inpace: bool = True):
     if hasattr(m, "inplace"):
         m.inplace = inpace
     return m
+
+
+# Set by the Core AI exporter for the duration of graph capture. A ContextVar
+# keeps nested or concurrent exports from resetting another export's state.
+# That converter has no lowering for aten.grid_sampler_2d, and the
+# manual gather-based path below emits no GridSample op, so it is the
+# same escape hatch the ONNX path already uses.
+_FORCE_MANUAL_GRID_SAMPLE: ContextVar[bool] = ContextVar(
+    "_FORCE_MANUAL_GRID_SAMPLE", default=False
+)
 
 
 def _grid_sample_bilinear_manual(feat, grid, padding_mode="zeros", align_corners=False):
@@ -148,7 +159,7 @@ def deformable_attention_core_func_v2(
         sampling_grid_l = sampling_locations_list[level]
 
         if method == "default":
-            if torch.onnx.is_in_onnx_export():
+            if torch.onnx.is_in_onnx_export() or _FORCE_MANUAL_GRID_SAMPLE.get():
                 sampling_value_l = _grid_sample_bilinear_manual(
                     value_l, sampling_grid_l, padding_mode="zeros", align_corners=False
                 )

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -693,10 +693,10 @@ class LibreDINOv2(BaseModel):
     # =========================================================================
 
     def export(self, format: str = "onnx", *, opset: int = 17, **kwargs) -> str:
-        if self.task == "classify" and format.lower() == "onnx":
+        if self.task == "classify" and format.lower() in {"onnx", "coreai"}:
             return super().export(format=format, opset=opset, **kwargs)
         if self.task == "semantic":
             return super().export(format=format, opset=opset, **kwargs)
         raise NotImplementedError(
-            "LibreDINOv2 classify export currently supports ONNX only."
+            "LibreDINOv2 classify export currently supports ONNX and Core AI only."
         )

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -272,12 +272,29 @@ class MSDeformAttn(nn.Module):
         """
         batch_size, len_query, _ = query.shape
         batch_size, len_input, _ = input_flatten.shape
-        expected_len_in = (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum()
         error_msg = "input_spatial_shapes must match the flattened input length"
-        if self._export:
+        # torch.export captures torch._assert on a tensor comparison as an
+        # aten.item call, which produces an unbacked symbol and makes the
+        # graph unguardable ("Could not guard on data-dependent expression
+        # Eq(u0, 1)"). The check is a developer sanity check over spatial
+        # shapes that are constant for a fixed export canvas, so evaluate it
+        # in Python when the shapes are concrete and skip the tensor path.
+        if not torch.jit.is_tracing() and not isinstance(
+            input_spatial_shapes, torch.fx.Proxy
+        ):
+            try:
+                expected_len_in = int(
+                    (input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]).sum()
+                )
+            except Exception:  # noqa: BLE001 - symbolic shapes under export
+                expected_len_in = None
+            if expected_len_in is not None and not isinstance(len_input, torch.Tensor):
+                assert expected_len_in == len_input, error_msg
+        elif self._export:
+            expected_len_in = (
+                input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]
+            ).sum()
             torch._assert(expected_len_in == len_input, error_msg)
-        else:
-            assert expected_len_in == len_input, error_msg
 
         value = self.value_proj(input_flatten)
         if input_padding_mask is not None:

--- a/libreyolo/models/siglip2/model.py
+++ b/libreyolo/models/siglip2/model.py
@@ -46,7 +46,12 @@ from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.serialization import load_trusted_torch_file
 from ..base.model import BaseModel
-from .labels import DEFAULT_TEMPLATES, humanize_labels, imagenet1k_classnames, openai_imagenet_templates
+from .labels import (
+    DEFAULT_TEMPLATES,
+    humanize_labels,
+    imagenet1k_classnames,
+    openai_imagenet_templates,
+)
 from .nn import SIGLIP2_CONFIGS, build_siglip2_model
 
 logger = logging.getLogger(__name__)
@@ -69,9 +74,13 @@ def siglip2_logits(
     L2-normalized class matrix ``[K, D]``. Returns ``[B, K]`` logits.
     """
     image_features = F.normalize(image_features, dim=-1)
-    scale = logit_scale.exp().to(device=image_features.device, dtype=image_features.dtype)
+    scale = logit_scale.exp().to(
+        device=image_features.device, dtype=image_features.dtype
+    )
     bias = logit_bias.to(device=image_features.device, dtype=image_features.dtype)
-    text_embeds = text_embeds.to(device=image_features.device, dtype=image_features.dtype)
+    text_embeds = text_embeds.to(
+        device=image_features.device, dtype=image_features.dtype
+    )
     return scale * (image_features @ text_embeds.t()) + bias
 
 
@@ -110,7 +119,9 @@ class LibreSigLIP2(BaseModel):
     # Attention pooling + fixed square resize make multi-scale TTA meaningless.
     TTA_ENABLED: ClassVar[bool] = False
 
-    validator_class: ClassVar[Optional[type]] = None  # set lazily (see _resolve_validator)
+    validator_class: ClassVar[Optional[type]] = (
+        None  # set lazily (see _resolve_validator)
+    )
 
     # =========================================================================
     # Registry classmethods
@@ -165,7 +176,9 @@ class LibreSigLIP2(BaseModel):
     ) -> None:
         resolved_task = normalize_task(task) if task is not None else "classify"
         if resolved_task != "classify":
-            raise ValueError(f"LibreSigLIP2 only supports task='classify'; got {task!r}.")
+            raise ValueError(
+                f"LibreSigLIP2 only supports task='classify'; got {task!r}."
+            )
 
         if isinstance(model_path, dict):
             weight_source: str | dict = model_path
@@ -177,10 +190,14 @@ class LibreSigLIP2(BaseModel):
                 size = self.detect_size_from_filename(model_path)
         else:
             size = size or "b16"
-            weight_source = self._resolve_weights_path(f"{self.FILENAME_PREFIX}{size}-cls.pt")
+            weight_source = self._resolve_weights_path(
+                f"{self.FILENAME_PREFIX}{size}-cls.pt"
+            )
         size = size or "b16"
 
-        self._default_templates = list(templates) if templates else list(DEFAULT_TEMPLATES)
+        self._default_templates = (
+            list(templates) if templates else list(DEFAULT_TEMPLATES)
+        )
         self._multi_label = bool(multi_label)
         self._text_embeds: Optional[torch.Tensor] = None
         self.tokenizer = None  # built after super().__init__
@@ -296,8 +313,9 @@ class LibreSigLIP2(BaseModel):
         }
 
     def _build_transform(self, imgsz: int):
-        from ...data.classify_dataset import build_classify_transforms
         from torchvision.transforms import InterpolationMode
+
+        from ...data.classify_dataset import build_classify_transforms
 
         return build_classify_transforms(
             imgsz,
@@ -311,15 +329,21 @@ class LibreSigLIP2(BaseModel):
 
     @staticmethod
     def _get_preprocess_numpy():
-        from ...data.classify_dataset import build_classify_transforms
-        from torchvision.transforms import InterpolationMode
         import numpy as _np
+        from torchvision.transforms import InterpolationMode
+
+        from ...data.classify_dataset import build_classify_transforms
 
         def _preprocess_numpy(img_rgb_hwc, input_size=224):
             res = input_size if isinstance(input_size, int) else input_size[0]
             transform = build_classify_transforms(
-                res, augment=False, mean=SIGLIP_MEAN, std=SIGLIP_STD,
-                interpolation=InterpolationMode.BILINEAR, crop_pct=1.0, square_resize=True,
+                res,
+                augment=False,
+                mean=SIGLIP_MEAN,
+                std=SIGLIP_STD,
+                interpolation=InterpolationMode.BILINEAR,
+                crop_pct=1.0,
+                square_resize=True,
             )
             pil = Image.fromarray(_np.asarray(img_rgb_hwc).astype("uint8"))
             return transform(pil).numpy(), 1.0
@@ -398,7 +422,10 @@ class LibreSigLIP2(BaseModel):
             )
 
         state = self._extract_state(loaded)
-        if "logit_bias" not in state or "vision_model.embeddings.patch_embedding.weight" not in state:
+        if (
+            "logit_bias" not in state
+            or "vision_model.embeddings.patch_embedding.weight" not in state
+        ):
             raise RuntimeError(
                 "Checkpoint does not look like a LibreSigLIP2 model (missing "
                 "'logit_bias'/'vision_model.embeddings.patch_embedding.weight')."
@@ -458,14 +485,50 @@ class LibreSigLIP2(BaseModel):
         the labels and input resolution set at export time; re-export to change
         either.
         """
-        if format.lower() != "onnx":
+        if format.lower() not in {"onnx", "coreai"}:
             raise NotImplementedError(
                 f"LibreSigLIP2 export to {format!r} is not implemented; only 'onnx' "
-                "(frozen-class) is supported. Open-vocabulary export (two towers "
+                "and 'coreai' (frozen-class) are supported. Open-vocabulary export (two towers "
                 "+ tokenizer) is out of scope for v1."
             )
         if self._text_embeds is None:
             raise RuntimeError("No classes set; call set_classes() before export().")
+
+        if format.lower() == "coreai":
+            # LibreSigLIP2 is a two-tower module with no single forward(x),
+            # which is why the ONNX path builds its graph by hand. Reuse that
+            # same frozen-class module rather than duplicating it, then hand
+            # it to the shared Core AI converter. The logit_bias matters here:
+            # without it the exported logits do not match native.
+            import torch as _torch
+
+            from ...export.coreai import (
+                export_coreai,
+                prepare_frozen_classifier_export,
+            )
+            from .export import _FrozenSigLIP2Classifier
+
+            size, output_path, metadata = prepare_frozen_classifier_export(
+                self, kwargs, default_output="siglip2_coreai"
+            )
+            scale = float(self.model.logit_scale.exp().detach().cpu())
+            weight = (scale * self._text_embeds).detach().cpu()
+            bias = self.model.logit_bias.detach().to("cpu", _torch.float32).reshape(())
+            device = next(self.model.vision_model.parameters()).device
+            was_training = self.model.vision_model.training
+            vision = self.model.vision_model.to("cpu").eval()
+            try:
+                frozen = _FrozenSigLIP2Classifier(vision, weight, bias).eval()
+                dummy = _torch.randn(1, 3, size, size)
+                return export_coreai(
+                    frozen,
+                    dummy,
+                    output_path=output_path,
+                    metadata=metadata,
+                    model_family="siglip2",
+                )
+            finally:
+                self.model.vision_model.to(device).train(was_training)
 
         from .export import export_frozen_onnx
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,13 @@ onnx = [
     "onnxsim>=0.4.0",
     "onnxruntime>=1.16.0",
 ]
+coreai = [
+    # Core AI (.aimodel) export, macOS only: the toolchain neither converts
+    # nor runs elsewhere. Kept out of every aggregate extra on purpose,
+    # because coreai-torch pins torch to 2.11.x and would drag the whole
+    # environment onto that version.
+    "coreai-torch>=0.4.1; sys_platform == 'darwin'",
+]
 rfdetr = [
     "transformers>=5.1.0",
 ]

--- a/tests/e2e/test_coreai.py
+++ b/tests/e2e/test_coreai.py
@@ -1,0 +1,184 @@
+"""Trained-weight Core AI parity on real Apple hardware.
+
+The test compares the public ``.aimodel`` export with the exact fixed-canvas
+PyTorch graph prepared by the exporter. Two probes establish both numeric
+agreement and meaningful input sensitivity. Multi-output DETR tensors are
+compared in the graph's declared order without independently sorting or
+matching rows, so the gate cannot hide a broken box/logit association.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = [
+    pytest.mark.general_nightly,
+    pytest.mark.export_backend,
+    pytest.mark.supported_backend,
+]
+
+coreai_runtime = pytest.importorskip(
+    "coreai.runtime",
+    reason="Core AI export requires the coreai toolchain (macOS only)",
+)
+
+if sys.platform != "darwin":  # pragma: no cover - platform gate
+    pytest.skip("Core AI artifacts only run on macOS", allow_module_level=True)
+
+
+REL_TOL = 3e-4
+MIN_SENSITIVITY_MARGIN = 100.0
+CASES = [
+    ("LibreYOLO9t.pt", "yolo9", 640),
+    ("LibreDFINEn.pt", "dfine", 640),
+    ("LibreRFDETRn.pt", "rfdetr", 384),
+]
+
+
+def _run(value):
+    return asyncio.run(value) if inspect.isawaitable(value) else value
+
+
+def _flatten(value):
+    if torch.is_tensor(value):
+        return [value.detach().cpu().numpy()]
+    if isinstance(value, (list, tuple)):
+        return [tensor for item in value for tensor in _flatten(item)]
+    if isinstance(value, dict):
+        return [tensor for key in sorted(value) for tensor in _flatten(value[key])]
+    return []
+
+
+def _input_name(function) -> str:
+    desc = getattr(function, "desc", None)
+    for attr in ("inputs", "input_names", "input_descriptors"):
+        values = getattr(desc, attr, None) if desc is not None else None
+        if not values:
+            continue
+        first = next(iter(values))
+        return str(getattr(first, "name", first))
+    return "x"
+
+
+def _prepared_reference(model, family, imgsz, x1, x2):
+    from coreai_torch import get_decomp_table
+
+    from libreyolo.export.coreai import (
+        _exported_output_names,
+        _prepare_coreai_graph,
+    )
+    from libreyolo.export.coreml import _wrap_for_family
+    from libreyolo.export.exporter import CoreAIExporter
+
+    exporter = CoreAIExporter(model)
+    with exporter._model_context(
+        torch.device("cpu"),
+        False,
+        False,
+        1,
+        (imgsz, imgsz),
+    ) as (nn_model, _):
+        wrapped = _wrap_for_family(nn_model, family).eval()
+        with _prepare_coreai_graph(wrapped, x1, family):
+            # The eager prepared graph is the semantic reference. Running the
+            # decomposed ExportedProgram as a module is not equivalent for
+            # these DETR graphs: functionalization replays mutation-sensitive
+            # buffers differently and can be nearly 1.0 relative off before
+            # Core AI conversion is involved.
+            with torch.no_grad():
+                ref1 = _flatten(wrapped(x1))
+                ref2 = _flatten(wrapped(x2))
+            exported = torch.export.export(wrapped, args=(x1,))
+            from torch._decomp import get_decompositions
+
+            table = dict(get_decomp_table())
+            table.update(get_decompositions([torch.ops.aten.grid_sampler_2d]))
+            exported = exported.run_decompositions(table)
+    return _exported_output_names(exported), ref1, ref2
+
+
+@pytest.mark.parametrize("weights,family,imgsz", CASES)
+def test_coreai_artifact_matches_prepared_trained_model(
+    weights, family, imgsz, tmp_path
+):
+    from libreyolo import LibreYOLO
+
+    if family == "rfdetr":
+        pytest.importorskip(
+            "transformers",
+            reason="RF-DETR parity requires the rfdetr extra",
+        )
+
+    model = LibreYOLO(weights, device="cpu")
+    artifact = model.export(
+        format="coreai",
+        imgsz=imgsz,
+        output_path=str(tmp_path / family),
+    )
+
+    generator = torch.Generator().manual_seed(20260728)
+    # The public export contract is canonical RGB float input in [0, 1].
+    # Out-of-contract Gaussian/extreme probes exercise unspecified runtime
+    # behaviour and previously produced false failures in DETR activations.
+    x1 = torch.rand(1, 3, imgsz, imgsz, generator=generator)
+    x2 = torch.rand(1, 3, imgsz, imgsz, generator=generator)
+    output_names, ref1, ref2 = _prepared_reference(model, family, imgsz, x1, x2)
+    assert len(output_names) == len(ref1)
+
+    loaded = _run(coreai_runtime.AIModel.load(artifact))
+    function = _run(loaded.load_function(next(iter(loaded.function_names))))
+    input_name = _input_name(function)
+
+    def call(tensor):
+        result = _run(
+            function(
+                {input_name: coreai_runtime.NDArray(tensor.detach().cpu().numpy())}
+            )
+        )
+        assert isinstance(result, dict), "Core AI output contract must be named"
+        assert set(output_names) == set(result), (
+            f"runtime names {sorted(result)} != graph names {sorted(output_names)}"
+        )
+        return [
+            np.asarray(
+                result[name].numpy() if hasattr(result[name], "numpy") else result[name]
+            )
+            for name in output_names
+        ]
+
+    got1 = call(x1)
+    got2 = call(x2)
+    assert [array.shape for array in got1] == [array.shape for array in ref1]
+
+    for index, (expected1, expected2, actual1, actual2) in enumerate(
+        zip(ref1, ref2, got1, got2)
+    ):
+        scale = max(
+            float(np.abs(expected1).max()),
+            float(np.abs(expected2).max()),
+            1e-12,
+        )
+        error = (
+            max(
+                float(np.abs(actual1 - expected1).max()),
+                float(np.abs(actual2 - expected2).max()),
+            )
+            / scale
+        )
+        sensitivity = float(np.abs(expected2 - expected1).max()) / scale
+        margin = float("inf") if error == 0 else sensitivity / error
+        assert error <= REL_TOL, (
+            f"out[{index}] ({output_names[index]}) relative error "
+            f"{error:.3e} exceeds {REL_TOL:.0e}"
+        )
+        assert margin >= MIN_SENSITIVITY_MARGIN, (
+            f"out[{index}] parity margin {margin:.1f}x is below "
+            f"{MIN_SENSITIVITY_MARGIN:.0f}x "
+            f"(error={error:.3e}, sensitivity={sensitivity:.3e})"
+        )

--- a/tests/unit/test_export_coreai.py
+++ b/tests/unit/test_export_coreai.py
@@ -1,0 +1,252 @@
+"""Core AI exporter contracts that do not require Apple hardware."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from libreyolo.export import coreai, coreai_compat
+from libreyolo.export.exporter import BaseExporter, CoreAIExporter
+
+pytestmark = pytest.mark.unit
+
+
+class _Wrapper:
+    task = "detect"
+
+    def __init__(self, family="yolo9"):
+        self.family = family
+
+    def _get_model_name(self):
+        return self.family
+
+
+def test_coreai_format_defaults_static_and_rejects_dynamic(monkeypatch):
+    calls = []
+
+    def fake_call(self, **kwargs):
+        calls.append(kwargs)
+        return "model.aimodel"
+
+    monkeypatch.setattr(BaseExporter, "__call__", fake_call)
+    exporter = CoreAIExporter(_Wrapper())
+
+    assert exporter() == "model.aimodel"
+    assert calls == [{"dynamic": False}]
+    with pytest.raises(NotImplementedError, match="dynamic=True"):
+        exporter(dynamic=True)
+
+
+def test_coreai_rejects_unsupported_precision():
+    exporter = CoreAIExporter(_Wrapper())
+    with pytest.raises(NotImplementedError, match="FP16"):
+        exporter._validate(True, False, None)
+    with pytest.raises(NotImplementedError, match="INT8"):
+        exporter._validate(False, True, None)
+
+
+def test_low_level_coreai_rejects_dynamic_and_precision_before_import():
+    model = nn.Identity()
+    dummy = torch.zeros(1, 3, 8, 8)
+    with pytest.raises(NotImplementedError, match="dynamic=True"):
+        coreai.export_coreai(model, dummy, output_path="unused", dynamic=True)
+    with pytest.raises(NotImplementedError, match="FP32 only"):
+        coreai.export_coreai(model, dummy, output_path="unused", precision="fp16")
+
+
+def test_blocked_support_is_checked_before_dependency(monkeypatch):
+    def dependency_must_not_run():
+        raise AssertionError("dependency check ran before support policy")
+
+    monkeypatch.setattr(coreai, "_require_coreai", dependency_must_not_run)
+    exporter = CoreAIExporter(_Wrapper("unwired_family"))
+    with pytest.raises(NotImplementedError, match="coreai"):
+        exporter._preflight(half=False, int8=False, data=None)
+
+
+def test_structured_metadata_uses_json():
+    assert coreai._stringify_metadata_value(["a", "b"]) == '["a","b"]'
+    assert coreai._stringify_metadata_value({1: "one"}) == '{"1":"one"}'
+    assert coreai._stringify_metadata_value(("x", 2)) == '["x",2]'
+
+
+def test_frozen_classifier_helper_runs_shared_validation(monkeypatch):
+    calls = []
+
+    def fake_validate(self, half, int8, data):
+        calls.append(("validate", half, int8, data))
+        return half, int8
+
+    def fake_preflight(self, **kwargs):
+        calls.append(("preflight", kwargs))
+
+    def fake_metadata(self, precision, dynamic, onnx_path, imgsz=None):
+        calls.append(("metadata", precision, dynamic, onnx_path, imgsz))
+        return {"precision": precision, "imgsz": imgsz}
+
+    monkeypatch.setattr(CoreAIExporter, "_validate", fake_validate)
+    monkeypatch.setattr(CoreAIExporter, "_preflight", fake_preflight)
+    monkeypatch.setattr(CoreAIExporter, "_build_metadata", fake_metadata)
+    owner = SimpleNamespace(input_size=224)
+
+    size, output, metadata = coreai.prepare_frozen_classifier_export(
+        owner,
+        {"imgsz": (192, 192), "output_path": "frozen", "device": "cpu"},
+        default_output="unused",
+    )
+    assert (size, output) == (192, "frozen")
+    assert metadata == {"precision": "fp32", "imgsz": (192, 192)}
+    assert calls == [
+        ("validate", False, False, None),
+        (
+            "preflight",
+            {"half": False, "int8": False, "data": None, "nms": False},
+        ),
+        ("metadata", "fp32", False, None, (192, 192)),
+    ]
+
+
+def test_compat_shim_declines_unverified_toolchain_version(monkeypatch):
+    monkeypatch.setattr(coreai_compat, "version", lambda package: "0.4.2")
+    assert coreai_compat._patch_avg_pool2d() is False
+
+
+def test_manual_grid_sample_flag_is_nestable():
+    from libreyolo.models.dfine.ms_deform import _FORCE_MANUAL_GRID_SAMPLE
+
+    assert _FORCE_MANUAL_GRID_SAMPLE.get() is False
+    restore_outer = coreai._force_manual_grid_sample()
+    assert _FORCE_MANUAL_GRID_SAMPLE.get() is True
+    restore_inner = coreai._force_manual_grid_sample()
+    restore_inner()
+    assert _FORCE_MANUAL_GRID_SAMPLE.get() is True
+    restore_outer()
+    assert _FORCE_MANUAL_GRID_SAMPLE.get() is False
+
+
+def test_graph_preparation_restores_snapshot_when_prepare_fails(monkeypatch):
+    restored = []
+    monkeypatch.setattr(
+        coreai,
+        "_snapshot_rtdetr_static_eval",
+        lambda model: lambda: restored.append(model),
+    )
+
+    def fail_prepare(*args):
+        raise RuntimeError("preparation failed")
+
+    monkeypatch.setattr(coreai, "_prepare_rtdetr_static_eval", fail_prepare)
+    model = nn.Identity()
+    dummy = torch.zeros(1, 3, 8, 8)
+    with (
+        pytest.raises(RuntimeError, match="preparation failed"),
+        coreai._prepare_coreai_graph(model, dummy, "dfine"),
+    ):
+        pass
+    assert restored == [model]
+
+
+def test_graph_preparation_restores_replaced_pool_after_capture_error():
+    model = nn.Sequential(nn.AdaptiveAvgPool2d(1))
+    original = model[0]
+    dummy = torch.zeros(1, 3, 8, 8)
+    with (
+        pytest.raises(RuntimeError, match="capture failed"),
+        coreai._prepare_coreai_graph(model, dummy, "resnet"),
+    ):
+        assert model[0] is not original
+        raise RuntimeError("capture failed")
+    assert model[0] is original
+
+
+def test_anchor_freeze_reaches_wrapped_model_and_restores_cache():
+    class Head(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.export = True
+            self.anchors = torch.tensor([])
+            self.strides = torch.tensor([])
+            self.shape = None
+
+        def _anchor_grid(self, features):
+            return self.anchors, self.strides
+
+    class Detector(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.head = Head()
+
+        def forward(self, tensor):
+            self.head.anchors = torch.ones(2, 4)
+            self.head.strides = torch.full((2, 4), 8.0)
+            self.head.shape = tuple(tensor.shape)
+            return tensor
+
+    class Wrapper(nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+
+        def forward(self, tensor):
+            return self.model(tensor)
+
+    detector = Detector()
+    wrapped = Wrapper(detector)
+    old_anchors = detector.head.anchors
+    old_strides = detector.head.strides
+    restore = coreai._freeze_anchor_grid(wrapped, torch.zeros(1, 3, 8, 8))
+    assert "_anchor_grid" in detector.head.__dict__
+    restore()
+
+    assert detector.head.anchors is old_anchors
+    assert detector.head.strides is old_strides
+    assert detector.head.shape is None
+    assert "_anchor_grid" not in detector.head.__dict__
+    assert detector.head.export is True
+
+
+def test_rtdetr_snapshot_removes_new_attributes_and_buffers():
+    class Encoder(nn.Module):
+        use_encoder_idx = (0,)
+
+        def build_2d_sincos_position_embedding(self):
+            pass
+
+    class Decoder(nn.Module):
+        def _generate_anchors(self):
+            pass
+
+    model = SimpleNamespace(encoder=Encoder(), decoder=Decoder())
+    restore = coreai._snapshot_rtdetr_static_eval(model)
+    model.encoder.eval_spatial_size = (8, 8)
+    model.encoder.pos_embed0 = torch.ones(1)
+    model.decoder.eval_spatial_size = (8, 8)
+    model.decoder.register_buffer("anchors", torch.ones(1))
+    model.decoder.register_buffer("valid_mask", torch.ones(1))
+    restore()
+
+    assert not hasattr(model.encoder, "eval_spatial_size")
+    assert not hasattr(model.encoder, "pos_embed0")
+    assert not hasattr(model.decoder, "eval_spatial_size")
+    assert "anchors" not in model.decoder._buffers
+    assert "valid_mask" not in model.decoder._buffers
+
+
+def test_rtdetr_snapshot_preserves_existing_none_buffer():
+    class Decoder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("anchors", None)
+
+        def _generate_anchors(self):
+            pass
+
+    model = SimpleNamespace(encoder=None, decoder=Decoder())
+    restore = coreai._snapshot_rtdetr_static_eval(model)
+    model.decoder.anchors = torch.ones(1)
+    restore()
+    assert "anchors" in model.decoder._buffers
+    assert model.decoder.anchors is None

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import json
 import importlib
+import json
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,9 +15,7 @@ import pytest
 from libreyolo.export.exporter import NcnnExporter, OnnxExporter
 from libreyolo.export.support import EXPORT_FORMATS, SUPPORT, get_support
 from libreyolo.models.inventory import collect_model_inventory
-from libreyolo.tasks import TASKS
-from libreyolo.tasks import task_to_suffix
-
+from libreyolo.tasks import TASKS, task_to_suffix
 
 pytestmark = pytest.mark.unit
 
@@ -115,6 +113,19 @@ def test_observed_cpu_toolchain_blocks_are_explicit():
     fomo_tflite = get_support("fomo", "point", "tflite")
     assert depth_ncnn.tier == "blocked" and "reshape" in depth_ncnn.reason
     assert fomo_tflite.tier == "blocked" and "depthwise" in fomo_tflite.reason
+
+
+def test_coreai_validated_tier_has_trained_weight_parity_coverage():
+    validated = {
+        (family, task)
+        for (family, task, fmt), entry in SUPPORT.items()
+        if fmt == "coreai" and entry.tier == "validated"
+    }
+    assert validated == {
+        ("dfine", "detect"),
+        ("rfdetr", "detect"),
+        ("yolo9", "detect"),
+    }
 
 
 def test_fallback_reasons_describe_project_support_not_developer_environment():


### PR DESCRIPTION
## What does this PR do?

Adds Apple Core AI `.aimodel` export using `torch.export` and `coreai-torch`.

The validated tier is deliberately limited to three trained-weight detector families:

- YOLO9 detect (`LibreYOLO9t.pt`, 640 px)
- D-FINE detect (`LibreDFINEn.pt`, 640 px)
- RF-DETR detect (`LibreRFDETRn.pt`, native 384 px)

The support matrix marks another 30 combinations as experimental and 10 as blocked. Non-Core-AI support rows are unchanged from `dev`.

The exporter now:

- rejects unsupported models before importing the optional Core AI dependency;
- uses a fixed input canvas and rejects dynamic, FP16, and INT8 requests instead of silently misrepresenting the artifact;
- writes structured JSON metadata and preserves declared output names;
- restores graph and model state on both success and failure, with a scoped, nested-safe manual grid sampler;
- applies the same preflight, metadata, and state-restoration rules to frozen CLIP and SigLIP exports;
- limits the compatibility shim to the affected `coreai-torch==0.4.1` release; and
- replaces the old random-weight/order-insensitive comparison path with a trained-weight parity gate that compares named outputs directly, uses two probes, enforces a `3e-4` tolerance, and verifies that a 100x-tightened threshold fails.

This PR adds export support only; it does not add a LibreYOLO `.aimodel` inference backend.

## Code provenance

The implementation is original code written for this PR. No third-party source code was copied, adapted, or derived. It calls Apple's optional `coreai-torch==0.4.1` and Core AI packages and reuses existing LibreYOLO in-repository family wrappers and frozen-classifier modules. The narrowly version-gated `avg_pool2d` resolver shim was independently derived from observed package behavior and PyTorch's documented operator defaults; no upstream implementation was copied.

## How was this tested?

- The squashed SHA `cf1f73bd266fec3099b1510c17d2244b83a20226` has the identical Git tree (`ed76932c9481401f979ea7ee17b36b5efbc3308d`) as the pre-squash SHA tested on an Apple M4 Mac mini (macOS 27.0 arm64, `coreai-torch 0.4.1`, `coreai-core 1.0.0b2`): all three trained-weight end-to-end parity cases passed (`3 passed` in 17.51 s).
- Full local unit suite after syncing `dev`: `3779 passed, 123 skipped, 1151 deselected, 4 xfailed`.
- Focused exporter tests: `212 passed`.
- GitHub CI passed on Ubuntu, Windows, and macOS, including install smoke, distributed, provenance, and automated review checks.
- The generated support matrix was checked against `dev`: every non-Core-AI row is unchanged.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds fixed-canvas Apple Core AI export support and trained-weight parity validation.
- Registers Core AI in the export API, CLI help, dependency extras, and support matrix.
- Exports structured metadata and declared output names with scoped model-state restoration.
- Adds compatibility handling and graph preparation for YOLO9, D-FINE, RF-DETR, and frozen classifiers.
- Adds unit coverage and macOS end-to-end parity tests for the three validated detector families.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/export/coreai.py | Implements fixed-canvas graph preparation, conversion, metadata persistence, and scoped restoration for Core AI assets. |
| libreyolo/export/coreai_compat.py | Adds a version-restricted compatibility shim for the affected Core AI avg-pool resolver. |
| libreyolo/export/exporter.py | Registers Core AI and performs support and dependency preflight before destructive export mutations. |
| libreyolo/export/support.py | Defines validated, experimental, and blocked Core AI family/task combinations. |
| libreyolo/models/dfine/ms_deform.py | Adds a nested-safe context flag for the gather-based deformable-attention sampling path. |
| libreyolo/models/rfdetr/transformer.py | Avoids a data-dependent tensor assertion during fixed-shape torch.export capture. |
| tests/e2e/test_coreai.py | Validates named-output parity and input sensitivity with trained YOLO9, D-FINE, and RF-DETR weights. |
| pyproject.toml | Defines the macOS Core AI optional dependency group referenced by exporter errors. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Public export request] --> B[Validate support and options]
  B --> C[Check Core AI dependency]
  C --> D[Prepare fixed-canvas model graph]
  D --> E[torch.export capture]
  E --> F[Run decompositions]
  F --> G[Convert and optimize Core AI program]
  G --> H[Attach metadata and output names]
  H --> I[Save .aimodel asset]
  D -. scoped cleanup .-> J[Restore live model state]
  G -. failure cleanup .-> J
  I --> J
```
</details>

<sub>Reviews (46): Last reviewed commit: ["Add Core AI export"](https://github.com/libreyolo/libreyolo/commit/cf1f73bd266fec3099b1510c17d2244b83a20226) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47542775)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
</details>

<!-- /greptile_comment -->