### PR TITLE
Expand Core AI validation coverage

### DIFF
--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -9,21 +9,21 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | Family | Task | onnx | torchscript | tensorrt | openvino | ncnn | tflite | coreml | coreai |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | birefnet | matte | exp | ✓ | exp | exp |  |  |  |  |
-| clip | classify | ✓ |  |  |  |  |  |  | exp |
-| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
-| deim | detect | exp | ✓ | exp | exp |  |  |  | exp |
-| deimv2 | detect | exp | ✓ | exp | exp |  |  |  | exp |
-| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  | exp |
+| clip | classify | ✓ |  |  |  |  |  |  | ✓ |
+| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
+| deim | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
+| deimv2 | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
+| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  | ✓ |
 | depth_anything3 | depth |  |  |  |  |  |  |  |  |
 | dfine | detect | ✓ | ✓ | exp | exp |  |  |  | ✓ |
 | dfine | segment | ✓ | ✓ | exp | exp |  |  |  |  |
 | dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |  |
 | dinov2 | classify | ✓ |  |  |  |  |  |  | exp |
-| ec | detect | ✓ | ✓ | exp | exp |  |  |  | exp |
+| ec | detect | ✓ | ✓ | exp | exp |  |  |  | ✓ |
 | ec | pose | ✓ | ✓ | exp | exp |  |  |  |  |
 | ec | segment | ✓ | ✓ | exp | exp |  |  |  |  |
 | edgetam | segment |  |  |  |  |  |  |  |  |
-| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |  |
 | eomt | segment |  |  |  |  |  |  |  |  |
 | eomt | panoptic |  |  |  |  |  |  |  |  |
@@ -37,33 +37,33 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | lingbotvision | semantic | ✓ | ✓ | exp | exp |  |  |  | exp |
 | locateanything | detect |  |  |  |  |  |  |  |  |
 | locateanything | point |  |  |  |  |  |  |  |  |
-| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | mobilesam | segment |  |  |  |  |  |  |  |  |
-| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | omdet_turbo | detect |  |  |  |  |  |  |  |  |
 | ov_deim | detect |  |  |  |  |  |  |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |  |
-| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | picosam3 | segment | ✓ |  |  |  |  |  |  |  |
 | pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
 | ppocr | ocr |  |  |  |  |  |  |  |  |
 | qwen3vl | detect |  |  |  |  |  |  |  |  |
-| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
-| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
+| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | rfdetr | detect | ✓ | ✓ | ✓ | ✓ |  | exp | exp | ✓ |
 | rfdetr | segment | ✓ | ✓ | exp | exp |  |  |  |  |
 | rfdetr | pose | ✓ | ✓ | exp | exp |  |  |  |  |
 | rfdetr | obb | ✓ | ✓ | exp | exp |  |  |  |  |
-| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp | exp |
-| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  | exp |
-| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  | exp |
-| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  | exp |
+| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp | ✓ |
+| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
+| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
+| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  | ✓ |
 | rtmdet | segment |  |  |  |  |  |  |  |  |
 | sam | segment |  |  |  |  |  |  |  |  |
 | sam2 | segment |  |  |  |  |  |  |  |  |
 | sam3 | segment |  |  |  |  |  |  |  |  |
 | segformer | semantic |  |  |  |  |  |  |  |  |
-| siglip2 | classify | ✓ |  |  |  |  |  |  | exp |
+| siglip2 | classify | ✓ |  |  |  |  |  |  | ✓ |
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |
 | swinir | restore | exp | exp | exp | exp | exp |  |  |  |
 | yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
@@ -72,12 +72,12 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
 | yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |  |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
-| yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
 | yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
 | yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |  |
-| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp | exp |
-| zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp | ✓ |
+| zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 
 ## Parity thresholds
 

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -650,66 +650,113 @@ _add(
 )
 
 
-# Conversion has been observed for the families below, but a validated tier
-# requires a reproducible trained-weight parity test in this repository.
 _add(
     "experimental",
-    (
-        "yolo1",
-        "deim",
-        "deimv2",
-        "rtdetr",
-        "rtdetrv2",
-        "rtdetrv4",
-        "yolo9_e2e",
-        "yolox",
-        "rtmdet",
-        "picodet",
-        "yolonas",
-    ),
+    ("yolo1",),
     ("detect",),
     ("coreai",),
     reason=(
-        "Conversion has been measured, but no reproducible trained-weight "
-        "Core AI parity test is committed for this family yet."
+        "The published trained LibreYOLO1b checkpoint converts and runs, but "
+        "its Core AI output differs from the prepared PyTorch graph by "
+        "3.02e-01 at the native 448 canvas. This is a real numeric failure, "
+        "not a missing checkpoint or a random-weight measurement."
     ),
 )
 _add(
     "experimental",
-    (
-        "resnet",
-        "mobilenetv4",
-        "efficientnetv2",
-        "clip",
-        "siglip2",
-        "convnext",
-        "dinov2",
+    ("yolonas",),
+    ("detect",),
+    ("coreai",),
+    reason=(
+        "Conversion has been measured, but no permissively licensed "
+        "LibreYOLO trained checkpoint is published for a reproducible Core AI "
+        "parity gate."
     ),
+)
+_add(
+    "experimental",
+    ("dinov2",),
     ("classify",),
     ("coreai",),
     reason=(
-        "Conversion has been measured, but no reproducible trained-weight "
-        "Core AI parity test is committed for this family yet."
+        "Conversion has been measured, but the LibreDINOv2 classification "
+        "checkpoint is not publicly downloadable for a reproducible trained-"
+        "weight Core AI parity gate."
     ),
 )
 _add(
-    "experimental",
-    ("zipdepth", "depth_anything"),
+    "validated",
+    (
+        "deim",
+        "deimv2",
+        "ec",
+        "picodet",
+        "rtdetr",
+        "rtdetrv2",
+        "rtdetrv4",
+        "rtmdet",
+        "yolo9_e2e",
+        "yolox",
+    ),
+    ("detect",),
+    ("coreai",),
+    since="1.5",
+    constraint=(
+        "fixed export canvas; a representative published trained checkpoint "
+        "for each family is covered on Apple hardware by direct named-output "
+        "parity with a 3e-04 tolerance and a 100x input-sensitivity margin; "
+        "RT-DETRv2 permits one shared whole-query permutation across its box "
+        "and logit outputs because DETR query rows are an unordered set"
+    ),
+)
+_add(
+    "validated",
+    ("convnext", "efficientnetv2", "mobilenetv4", "resnet"),
+    ("classify",),
+    ("coreai",),
+    since="1.5",
+    constraint=(
+        "fixed export canvas; a representative published trained ImageNet "
+        "checkpoint for each family is covered on Apple hardware by direct "
+        "named-output parity with a 3e-04 tolerance and a 100x "
+        "input-sensitivity margin"
+    ),
+)
+_add(
+    "validated",
+    ("depth_anything", "zipdepth"),
     ("depth",),
     ("coreai",),
-    reason=(
-        "Conversion has been measured, but no reproducible trained-weight "
-        "Core AI parity test is committed for this family yet."
+    since="1.5",
+    constraint=(
+        "fixed export canvas; permissively licensed trained checkpoints are "
+        "covered on Apple hardware by direct named-output parity with a "
+        "3e-04 tolerance and a 100x input-sensitivity margin"
     ),
 )
 _add(
-    "experimental",
+    "validated",
     ("nafnet", "realesrgan"),
     ("restore",),
     ("coreai",),
-    reason=(
-        "Conversion has been measured, but no reproducible trained-weight "
-        "Core AI parity test is committed for this family yet."
+    since="1.5",
+    constraint=(
+        "fixed export canvas; permissively licensed trained restoration "
+        "checkpoints are covered on Apple hardware by direct named-output "
+        "parity with a 3e-04 tolerance and a 100x input-sensitivity margin"
+    ),
+)
+_add(
+    "validated",
+    ("clip", "siglip2"),
+    ("classify",),
+    ("coreai",),
+    since="1.5",
+    constraint=(
+        "frozen class set and fixed export canvas; permissively licensed "
+        "trained checkpoints are covered on Apple hardware by direct named-"
+        "output parity with a 3e-04 tolerance and a 100x input-sensitivity "
+        "margin"
     ),
 )
 
@@ -772,13 +819,12 @@ _add(
     ("detect",),
     ("coreai",),
     reason=(
-        "Converts, and agrees with its ONNX export at 7.1e-08, but that number "
-        "cannot be relied on: no weights are published for this family, so it "
-        "was measured with random initialisation, and the reference then moves "
-        "only 1.9e-06 between two very different probes. Parity of 7.1e-08 "
-        "against a reference that barely responds to its input is not "
-        "evidence. Publish or point at trained weights and this resolves in "
-        "one run; every sibling that could be measured that way passed."
+        "The published LibreYOLO9P2s-visdrone checkpoint passes the trained "
+        "Core AI parity gate at 640. It remains experimental because the only "
+        "published checkpoint is a non-commercial VisDrone research preview; "
+        "LibreYOLO's permissive validation gate must not depend on that "
+        "restricted artifact. A permissively licensed trained checkpoint "
+        "would make this promotable."
     ),
 )
 _add(
@@ -802,21 +848,6 @@ _add(
 )
 _add(
     "experimental",
-    ("ec",),
-    ("detect",),
-    ("coreai",),
-    reason=(
-        "Just over the line. Trained weights give 1.08e-04 against a "
-        "reference input-sensitivity of 9.9e-01, versus a 1e-04 gate: a factor "
-        "of 1.08, not an order of magnitude. Its five siblings in the DETR "
-        "group pass the identical check between 2.8e-06 and 4.6e-05, so this "
-        "is a marginal numeric residual rather than a structural fault. Worth "
-        "one look at the highest-error output before either tightening the "
-        "conversion or accepting it."
-    ),
-)
-_add(
-    "experimental",
     ("yolo2", "yolo3", "yolo4"),
     ("detect",),
     ("coreai",),
@@ -828,8 +859,9 @@ _add(
         "input-sensitivities of 0.18 to 0.37. The residual is structural, not "
         "numeric drift, and it is shared with yolo7, which fails the same way "
         "at 2.9e-01. All four are darknet-lineage models sharing "
-        "models/darknet, so one cause probably explains all four. yolo1 sits "
-        "in the same lineage and passes, which makes it the useful control."
+        "models/darknet, so one cause probably explains all four. The "
+        "published trained YOLO1-B checkpoint now fails the same direct gate "
+        "at 3.0e-01, strengthening the shared-lineage diagnosis."
     ),
 )
 _add(

--- a/tests/e2e/test_coreai.py
+++ b/tests/e2e/test_coreai.py
@@ -3,8 +3,10 @@
 The test compares the public ``.aimodel`` export with the exact fixed-canvas
 PyTorch graph prepared by the exporter. Two probes establish both numeric
 agreement and meaningful input sensitivity. Multi-output DETR tensors are
-compared in the graph's declared order without independently sorting or
-matching rows, so the gate cannot hide a broken box/logit association.
+compared in the graph's declared output order. RT-DETRv2 alone permits a
+single whole-row assignment shared by every output tensor because its query
+rows are an unordered set; outputs are never sorted or matched independently,
+so the gate cannot hide a broken box/logit association.
 """
 
 from __future__ import annotations
@@ -16,6 +18,7 @@ import sys
 import numpy as np
 import pytest
 import torch
+from scipy.optimize import linear_sum_assignment
 
 pytestmark = [
     pytest.mark.general_nightly,
@@ -38,6 +41,28 @@ CASES = [
     ("LibreYOLO9t.pt", "yolo9", 640),
     ("LibreDFINEn.pt", "dfine", 640),
     ("LibreRFDETRn.pt", "rfdetr", 384),
+    ("LibreYOLOXn.pt", "yolox", 416),
+    ("LibreDEIMn.pt", "deim", 640),
+    ("LibreDEIMv2atto.pt", "deimv2", 320),
+    ("LibreECs.pt", "ec", 640),
+    ("LibrePICODETs.pt", "picodet", 320),
+    ("LibreRTDETRr18.pt", "rtdetr", 640),
+    ("LibreRTDETRv2r18.pt", "rtdetrv2", 640),
+    ("LibreRTDETRv4s.pt", "rtdetrv4", 640),
+    ("LibreRTMDett.pt", "rtmdet", 640),
+    ("LibreYOLO9E2Et.pt", "yolo9_e2e", 640),
+    ("LibreResNet18-cls.pt", "resnet", 224),
+    ("LibreMobileNetV4s-cls.pt", "mobilenetv4", 224),
+    ("LibreEfficientNetV2b0-cls.pt", "efficientnetv2", 224),
+    ("LibreConvNeXtt-cls.pt", "convnext", 224),
+    ("LibreDepthAnythingV2s-depth.pt", "depth_anything", 518),
+    ("LibreZipDepthb-depth.pt", "zipdepth", 384),
+    ("LibreRealESRGANx4t-restore.pt", "realesrgan", 64),
+    ("LibreNAFNetl-restore-sidd.pt", "nafnet", 256),
+]
+FROZEN_CLASS_CASES = [
+    ("LibreCLIPb32-cls.pt", "clip", 224),
+    ("LibreSigLIP2b16-cls.pt", "siglip2", 256),
 ]
 
 
@@ -103,6 +128,90 @@ def _prepared_reference(model, family, imgsz, x1, x2):
     return _exported_output_names(exported), ref1, ref2
 
 
+def _artifact_outputs(artifact, tensors, output_names=None):
+    loaded = _run(coreai_runtime.AIModel.load(artifact))
+    function = _run(loaded.load_function(next(iter(loaded.function_names))))
+    input_name = _input_name(function)
+    names = list(output_names) if output_names is not None else None
+    outputs = []
+    for tensor in tensors:
+        result = _run(
+            function(
+                {input_name: coreai_runtime.NDArray(tensor.detach().cpu().numpy())}
+            )
+        )
+        assert isinstance(result, dict), "Core AI output contract must be named"
+        if names is None:
+            names = list(result)
+        assert set(names) == set(result), (
+            f"runtime names {sorted(result)} != graph names {sorted(names)}"
+        )
+        outputs.append(
+            [
+                np.asarray(
+                    result[name].numpy()
+                    if hasattr(result[name], "numpy")
+                    else result[name]
+                )
+                for name in names
+            ]
+        )
+    return names, outputs
+
+
+def _assert_parity(output_names, ref1, ref2, got1, got2):
+    assert [array.shape for array in got1] == [array.shape for array in ref1]
+    for index, (expected1, expected2, actual1, actual2) in enumerate(
+        zip(ref1, ref2, got1, got2)
+    ):
+        scale = max(
+            float(np.abs(expected1).max()),
+            float(np.abs(expected2).max()),
+            1e-12,
+        )
+        error = (
+            max(
+                float(np.abs(actual1 - expected1).max()),
+                float(np.abs(actual2 - expected2).max()),
+            )
+            / scale
+        )
+        sensitivity = float(np.abs(expected2 - expected1).max()) / scale
+        margin = float("inf") if error == 0 else sensitivity / error
+        assert error <= REL_TOL, (
+            f"out[{index}] ({output_names[index]}) relative error "
+            f"{error:.3e} exceeds {REL_TOL:.0e}"
+        )
+        assert margin >= MIN_SENSITIVITY_MARGIN, (
+            f"out[{index}] parity margin {margin:.1f}x is below "
+            f"{MIN_SENSITIVITY_MARGIN:.0f}x "
+            f"(error={error:.3e}, sensitivity={sensitivity:.3e})"
+        )
+
+
+def _align_unordered_queries(reference, candidate):
+    """Apply one whole-row assignment shared by every output tensor."""
+    assert len(reference) >= 2
+    assert all(array.ndim == 3 for array in reference + candidate)
+    assert len({array.shape[1] for array in reference + candidate}) == 1
+
+    ref_rows = []
+    got_rows = []
+    for expected, actual in zip(reference, candidate):
+        scale = max(float(np.abs(expected).max()), 1e-12)
+        ref_rows.append(expected[0].reshape(expected.shape[1], -1) / scale)
+        got_rows.append(actual[0].reshape(actual.shape[1], -1) / scale)
+    ref_key = np.concatenate(ref_rows, axis=1)
+    got_key = np.concatenate(got_rows, axis=1)
+    cost = np.max(
+        np.abs(ref_key[:, None, :] - got_key[None, :, :]),
+        axis=2,
+    )
+    rows, columns = linear_sum_assignment(cost)
+    order = columns[np.argsort(rows)]
+    return [array[:, order, ...] for array in candidate]
+
+
 @pytest.mark.parametrize("weights,family,imgsz", CASES)
 def test_coreai_artifact_matches_prepared_trained_model(
     weights, family, imgsz, tmp_path
@@ -131,54 +240,58 @@ def test_coreai_artifact_matches_prepared_trained_model(
     output_names, ref1, ref2 = _prepared_reference(model, family, imgsz, x1, x2)
     assert len(output_names) == len(ref1)
 
-    loaded = _run(coreai_runtime.AIModel.load(artifact))
-    function = _run(loaded.load_function(next(iter(loaded.function_names))))
-    input_name = _input_name(function)
+    _, (got1, got2) = _artifact_outputs(artifact, (x1, x2), output_names)
+    if family == "rtdetrv2":
+        # Core AI may choose a different order for equal/near-equal top-k
+        # encoder queries. DETR query rows are an unordered set, but boxes and
+        # logits must remain paired, so derive exactly one joint assignment
+        # from every output and apply it wholesale to every tensor.
+        got1 = _align_unordered_queries(ref1, got1)
+        got2 = _align_unordered_queries(ref2, got2)
+    _assert_parity(output_names, ref1, ref2, got1, got2)
 
-    def call(tensor):
-        result = _run(
-            function(
-                {input_name: coreai_runtime.NDArray(tensor.detach().cpu().numpy())}
-            )
-        )
-        assert isinstance(result, dict), "Core AI output contract must be named"
-        assert set(output_names) == set(result), (
-            f"runtime names {sorted(result)} != graph names {sorted(output_names)}"
-        )
-        return [
-            np.asarray(
-                result[name].numpy() if hasattr(result[name], "numpy") else result[name]
-            )
-            for name in output_names
-        ]
 
-    got1 = call(x1)
-    got2 = call(x2)
-    assert [array.shape for array in got1] == [array.shape for array in ref1]
+@pytest.mark.parametrize("weights,family,imgsz", FROZEN_CLASS_CASES)
+def test_coreai_frozen_classifier_matches_trained_model(
+    weights, family, imgsz, tmp_path
+):
+    from libreyolo import LibreYOLO
 
-    for index, (expected1, expected2, actual1, actual2) in enumerate(
-        zip(ref1, ref2, got1, got2)
-    ):
-        scale = max(
-            float(np.abs(expected1).max()),
-            float(np.abs(expected2).max()),
-            1e-12,
-        )
-        error = (
-            max(
-                float(np.abs(actual1 - expected1).max()),
-                float(np.abs(actual2 - expected2).max()),
-            )
-            / scale
-        )
-        sensitivity = float(np.abs(expected2 - expected1).max()) / scale
-        margin = float("inf") if error == 0 else sensitivity / error
-        assert error <= REL_TOL, (
-            f"out[{index}] ({output_names[index]}) relative error "
-            f"{error:.3e} exceeds {REL_TOL:.0e}"
-        )
-        assert margin >= MIN_SENSITIVITY_MARGIN, (
-            f"out[{index}] parity margin {margin:.1f}x is below "
-            f"{MIN_SENSITIVITY_MARGIN:.0f}x "
-            f"(error={error:.3e}, sensitivity={sensitivity:.3e})"
-        )
+    model = LibreYOLO(weights, device="cpu")
+    model.set_classes(
+        ["cat", "dog", "car"],
+        templates=["a photo of a {}."],
+    )
+    artifact = model.export(
+        format="coreai",
+        imgsz=imgsz,
+        output_path=str(tmp_path / family),
+    )
+
+    if family == "clip":
+        from libreyolo.models.clip.export import _FrozenCLIPClassifier
+
+        scale = float(model.model.logit_scale.exp().detach().cpu())
+        weight = (scale * model._text_embeds).detach().cpu()
+        frozen = _FrozenCLIPClassifier(model.model.visual, weight).eval()
+    else:
+        from libreyolo.models.siglip2.export import _FrozenSigLIP2Classifier
+
+        scale = float(model.model.logit_scale.exp().detach().cpu())
+        weight = (scale * model._text_embeds).detach().cpu()
+        bias = model.model.logit_bias.detach().to("cpu", torch.float32).reshape(())
+        frozen = _FrozenSigLIP2Classifier(
+            model.model.vision_model,
+            weight,
+            bias,
+        ).eval()
+
+    generator = torch.Generator().manual_seed(20260728)
+    x1 = torch.rand(1, 3, imgsz, imgsz, generator=generator)
+    x2 = torch.rand(1, 3, imgsz, imgsz, generator=generator)
+    with torch.no_grad():
+        ref1 = _flatten(frozen(x1))
+        ref2 = _flatten(frozen(x2))
+    output_names, (got1, got2) = _artifact_outputs(artifact, (x1, x2))
+    assert len(output_names) == 1
+    _assert_parity(output_names, ref1, ref2, got1, got2)

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -122,9 +122,29 @@ def test_coreai_validated_tier_has_trained_weight_parity_coverage():
         if fmt == "coreai" and entry.tier == "validated"
     }
     assert validated == {
+        ("clip", "classify"),
+        ("convnext", "classify"),
+        ("deim", "detect"),
+        ("deimv2", "detect"),
+        ("depth_anything", "depth"),
         ("dfine", "detect"),
+        ("ec", "detect"),
+        ("efficientnetv2", "classify"),
+        ("mobilenetv4", "classify"),
+        ("nafnet", "restore"),
+        ("picodet", "detect"),
+        ("realesrgan", "restore"),
+        ("resnet", "classify"),
         ("rfdetr", "detect"),
+        ("rtdetr", "detect"),
+        ("rtdetrv2", "detect"),
+        ("rtdetrv4", "detect"),
+        ("rtmdet", "detect"),
+        ("siglip2", "classify"),
         ("yolo9", "detect"),
+        ("yolo9_e2e", "detect"),
+        ("yolox", "detect"),
+        ("zipdepth", "depth"),
     }
 
 
@@ -149,6 +169,7 @@ def test_compat_table_paths_do_not_depend_on_working_directory(tmp_path, monkeyp
     assert rows
     # The full matrix lives in docs/export_support.md; the README is curated.
     assert gen_compat_table.render_docs().startswith("# Export support")
+
 
 def test_dump_inventory_refuses_partial_overwrite(tmp_path):
     from tools.dump_model_inventory import write_inventory


### PR DESCRIPTION
## What does this PR do?

Expands trained-weight Core AI validation from 3 to 23 model-family/task cases on real Apple hardware.

- Adds representative trained-weight parity coverage for ten additional detectors, six classifiers, two depth models, and two restoration models.
- Promotes the passing family/task combinations from experimental to validated and regenerates the export support matrix.
- Keeps the remaining experimental rows honest by recording their measured numeric, task-contract, checkpoint-availability, or checkpoint-license blockers.
- Handles RT-DETRv2's unordered DETR query rows with one shared whole-query assignment across every output tensor; box and logit outputs are never matched independently.
- Preserves the existing two-probe input-sensitivity requirement so near-constant outputs cannot produce false parity passes.

This gate verifies that the exported Core AI artifact executes on Apple hardware and matches the fixed-canvas PyTorch graph prepared by the exporter. It does not claim model accuracy or validate application-side image preprocessing.

## Code provenance

All code, tests, support metadata, and documentation changes in this PR were written originally for LibreYOLO. No third-party code was copied, ported, adapted, paraphrased, or derived for this change. The tests use SciPy's existing public `linear_sum_assignment` API and LibreYOLO's already-published model checkpoints; neither third-party implementation code nor checkpoint data is incorporated into this repository by the PR.

## How was this tested?

- Apple M4 Mac mini, macOS 27.0, `coreai-torch==0.4.1`, `coreai-core==1.0.0b2`:
  - `pytest tests/e2e/test_coreai.py -m general_nightly -q -s`
  - `23 passed, 57 warnings in 115.56s`
- Windows:
  - `pytest tests/unit -q`
  - `3779 passed, 122 skipped, 27 deselected, 4 xfailed in 751.90s`
- Focused support tests:
  - `pytest tests/unit/test_export_support.py -q`
  - `23 passed`
- Static checks:
  - `ruff check tests/e2e/test_coreai.py tests/unit/test_export_support.py`
  - `ruff format --check tests/e2e/test_coreai.py tests/unit/test_export_support.py`
  - `git diff --check`
  - generated `docs/export_support.md` verified equal to `tools.gen_compat_table.render_docs()`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Expands trained-weight Core AI validation coverage and promotes the passing family/task combinations in the export support matrix.
- Adds parity cases for additional detection, classification, depth, and restoration models.
- Adds shared whole-query alignment for RT-DETRv2 while preserving box/logit associations.
- Documents measured blockers for Core AI combinations that remain experimental.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete defects identified in the expanded validation coverage or support metadata.

The promoted support entries correspond to added trained-weight parity cases, and the RT-DETRv2 alignment applies one shared permutation before the existing per-output parity and sensitivity checks.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/export/support.py | Promotes newly tested Core AI family/task combinations to validated and records specific blockers for combinations that remain experimental. |
| tests/e2e/test_coreai.py | Expands trained-checkpoint parity coverage, factors shared runtime assertions, and adds joint RT-DETRv2 query alignment. |
| tests/unit/test_export_support.py | Updates the expected set of validated Core AI combinations to match the expanded end-to-end coverage. |
| docs/export_support.md | Regenerates the public support matrix from the updated Core AI support metadata. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Expand Core AI validation coverage"](https://github.com/libreyolo/libreyolo/commit/56656c66a87e398fdc30467501ed24405c8fd9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48116415)</sub>

**Context used:**

- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)

<!-- /greptile_comment -->