### PR TITLE
Add facial recognition (embed task): embeddings, verification, gallery identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ selects the task. These families are extras on top of the core library.
 - **Background removal (matting):** BiRefNet
 - **OCR:** PP-OCR
 - **Gaze estimation:** L2CS
+- **Facial recognition (face embedding):** LibreFaceRec (verification + gallery identification)
 - **Open-vocabulary & VLM detection:** Grounding DINO, OWLv2, OmDet-Turbo, OV-DEIM, Florence-2, Kosmos-2, Qwen3-VL, InternVL3, LFM2-VL, SmolVLM2, LocateAnything
 
 </details>

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -899,3 +899,25 @@ Model weights (sensenova/SenseNova-Vision-7B-MoT, CC BY-NC 4.0,
 non-commercial) are mirrored byte-identically with attribution at
 huggingface.co/LibreYOLO/SenseNovaVision7b; mirroring does not change the
 license. See libreyolo/models/sensenova/NOTICE for the full provenance chain.
+
+--------------------------------------------------------------------
+AuraFace-v1 (fal.ai)
+--------------------------------------------------------------------
+Source: https://huggingface.co/fal/AuraFace-v1
+License: Apache-2.0 (weights)
+Used for: the librefacerec-l face-embedding ONNX weights (single file
+glintr100.onnx, mirrored unmodified to the LibreYOLO Hugging Face org
+as librefacerec-l.onnx). No code is ported; the graph is consumed
+opaquely via onnxruntime. Upstream training data is undisclosed; only
+this single Apache-2.0 file is mirrored, none of the other artifacts
+in the upstream repository.
+
+--------------------------------------------------------------------
+YuNet face detector (OpenCV Zoo)
+--------------------------------------------------------------------
+Source: https://github.com/opencv/opencv_zoo/tree/main/models/face_detection_yunet
+License: MIT (weights), Copyright (c) Shiqi Yu
+Used for: the librefacerec-det default face-detector ONNX weights
+(face_detection_yunet_2023mar.onnx, mirrored unmodified to the
+LibreYOLO Hugging Face org as librefacerec-det.onnx). Consumed via
+OpenCV's bundled cv2.FaceDetectorYN; no code is ported.

--- a/docs/adr/0013-embed-task-contract.md
+++ b/docs/adr/0013-embed-task-contract.md
@@ -1,0 +1,96 @@
+# ADR 0013: Embed (Facial Recognition) Task Contract
+
+## Status
+
+Accepted.
+
+## Context
+
+Face verification ("are these two photos the same person?") and identification
+("who is this, out of the people I enrolled?") are among the most requested
+vision capabilities, and no existing task carries them. The output primitive
+that serves both is an identity embedding: a unit-length vector per face whose
+cosine similarity with another vector measures identity agreement.
+
+No existing contract fits it. `detect` and `pose` describe where things are,
+not who they are. `classify` assigns a fixed label set, but identity is an
+open set: the people a deployment cares about are enrolled at runtime, not at
+training time, and a model that could only recognize its training identities
+would be useless. An embedding is a distinct output primitive, so a new task is
+warranted (the same test that promoted `point` in ADR 0003, `depth` in ADR
+0006, and `matte` in ADR 0010).
+
+The task is two-stage by nature: a detector locates faces and five landmarks,
+each face is warped onto a canonical 112x112 template, and a recognition head
+emits the embedding. This mirrors the `gaze` (L2CS) shape, and reuses its
+face-detector protocol rather than inventing a second one.
+
+Recognition heads are consumed as opaque ONNX graphs. No third-party
+architecture code is ported, and the family carries no training path, which is
+the accepted single-purpose exception to "new features cover the flagships"
+(as with `gaze` and `matte`).
+
+## Decision
+
+LibreYOLO defines a canonical `embed` task (suffix `-embed`; aliases
+`facial-recognition`, `face-recognition`, `recognition`, `face`, `faceid`,
+`embedding`, `reid`). The single-word canonical name matches the other task
+names and the short filename suffix; the human-facing spellings resolve to it.
+
+Its prediction primitive is `Results.embeddings`: an `(N, D)` float32 payload
+of L2-normalized rows, row-aligned with `Results.boxes` (the face boxes), where
+`D` is the head's embedding dimension. Cosine similarity is therefore a dot
+product, and verification is a threshold on it.
+
+Identification is arithmetic on that primitive rather than a second model
+output. `FaceGallery` holds named reference embeddings and is matched against
+query embeddings to produce `Results.identities`: an `(N,)` payload of matched
+names and scores, row-aligned with the boxes.
+
+Contract decisions worth stating, because each rules out a plausible
+alternative:
+
+- **Per-reference storage, max-cosine scoring.** Enrolling K images of a person
+  stores K vectors and the identity scores as the best cosine over them.
+  Averaging references into a centroid discards pose, age, and lighting
+  variance, which is precisely the variance multiple references exist to cover.
+- **Unknown is a first-class outcome.** Below threshold, `identities.name[i]`
+  is `None`, never the nearest enrolled person. The best score stays visible in
+  `identities.score[i]` so callers can inspect a near miss. A recognition API
+  whose worst case is confidently naming the wrong human is not acceptable.
+- **Galleries are bound to their embedder.** `save()` records the embedding
+  dimension and a fingerprint of the weights file; matching against a different
+  model raises rather than silently comparing incompatible vector spaces.
+- **Brute-force matching only.** Cosine against a few thousand identities is a
+  single matmul. No ANN index and no vector-store dependency: callers at larger
+  scale export `results.embeddings` to their own store.
+- **Thresholds are model-specific and documented, not hidden.** The shipped
+  default is stated with the benchmark it came from, because a threshold
+  transplanted between embedders is meaningless.
+
+Embedding vectors are omitted from `summary()` and JSON output by default (a
+512-float vector is roughly 2 KB per face); `summary(embeddings=True)` opts in.
+
+Out of scope in v1: training, dataset validation, and re-export
+(`model.train()`, `.val()`, `.export()` raise), because the family wraps an
+existing ONNX graph. Also out of scope: face attribute prediction (age, gender,
+emotion), which is a different ethical surface, and clustering of unlabeled
+collections, which callers can do from the raw embeddings.
+
+## Consequences
+
+- Embed results always carry face boxes row-aligned with the embeddings, so the
+  ADR 0001 alignment rule holds and `Results.__getitem__` slices both together.
+- Any ArcFace-convention ONNX (aligned 112x112 in, `(N, D)` out) works as a
+  bring-your-own-weights model, which covers recognition heads whose licenses
+  do not permit LibreYOLO to redistribute them.
+- The detector is swappable: any LibreYOLO detector, a callable, or an OpenCV
+  face-detector ONNX, and detection can be bypassed entirely with `face_boxes=`.
+  A default detector is auto-downloaded when none is supplied.
+- Hosted weights state their license and training-data provenance on the model
+  card, and accuracy claims on those cards must be reproducible from a
+  documented protocol rather than asserted.
+- The task documentation carries a responsible-use section: these are biometric
+  identifiers, the intended uses are consent-based, and remote biometric
+  identification is restricted in several jurisdictions. That is a
+  documentation obligation, not a runtime gate.

--- a/docs/facial_recognition.md
+++ b/docs/facial_recognition.md
@@ -1,0 +1,101 @@
+# Facial recognition (`embed` task)
+
+Face embedding, 1:1 verification, and 1:N identification. Two-stage and
+inference-only: a face detector locates faces and 5 landmarks, each face is
+aligned to a canonical 112x112 crop, and an ONNX recognition head emits an
+L2-normalized identity embedding. Verification and identification are cosine
+similarity on those embeddings.
+
+Canonical task name: `embed`. Aliases: `facial-recognition`, `face`,
+`faceid`, `recognition`, `embedding`.
+
+## Quickstart
+
+```python
+from libreyolo import LibreYOLO, FaceGallery
+
+model = LibreYOLO("librefacerec-l")   # auto-downloads embedder + default detector
+
+# Embeddings
+results = model("group.jpg")
+results.embeddings                     # (N, 512) unit vectors, row-aligned with boxes
+
+# 1:1 verification
+model.verify("a.jpg", "b.jpg", threshold=0.4)
+# {'similarity': 0.72, 'same_person': True, 'threshold': 0.4}
+
+# 1:N identification
+gallery = FaceGallery(embedder=model)
+gallery.enroll("alice", ["alice1.jpg", "alice2.jpg"])
+gallery.save("team.gallery.npz")
+
+results = model("group.jpg", gallery=gallery, threshold=0.4)
+results.identities.name                # ["alice", None, ...] (None = unknown)
+results.identities.score               # best gallery cosine per face
+```
+
+```bash
+libreyolo compare model=facerec-l source=a.jpg source2=b.jpg
+libreyolo enroll  model=facerec-l source=people/ gallery=team.gallery.npz
+libreyolo predict model=facerec-l source=group.jpg gallery=team.gallery.npz save=true
+```
+
+`enroll` expects a folder-per-person tree (`people/<identity>/*.jpg`, folder
+name becomes the identity), the same convention as classification datasets.
+
+## Models
+
+| Name | Role | Dim | Weights license | Notes |
+|---|---|---|---|---|
+| `librefacerec-l` | embedder (default) | 512 | Apache-2.0 | iResNet100, mirrored from AuraFace-v1; LFW ROC-AUC 0.998 through this pipeline |
+| `librefacerec-det` | default detector | - | MIT | YuNet with 5 landmarks, runs on OpenCV's bundled `cv2.FaceDetectorYN` |
+
+Weights carry their own licenses on their Hugging Face model cards; review
+them for your use case.
+
+### Bring your own weights
+
+Any ArcFace-convention ONNX (aligned 112x112 RGB in, `(N, D)` embeddings
+out) loads directly:
+
+```python
+model = LibreYOLO("path/to/recognition.onnx", task="facial-recognition")
+```
+
+This covers third-party recognition heads whose licenses do not allow
+LibreYOLO to redistribute them (for example InsightFace `w600k_r50.onnx`
+from the buffalo_l pack, or OpenCV SFace with `preproc="raw_bgr"`). The
+detector is also swappable: pass `face_detector=` any LibreYOLO detector, an
+OpenCV face-detector ONNX path, or a callable; or bypass detection entirely
+with `face_boxes=[...]`.
+
+## Design notes
+
+- **Per-reference storage, max-cosine scoring.** Enrolling K images of one
+  person keeps K vectors; an identity's score is the best cosine over its
+  references. References survive pose and age variance better than a
+  centroid.
+- **Unknown is a first-class outcome.** Faces below the threshold get
+  `name=None`, never the nearest wrong person. The raw best score stays
+  visible in `identities.score`.
+- **Galleries are bound to their embedder.** `save()` records the embedding
+  dim and a fingerprint of the model file; matching against a different
+  model raises instead of silently comparing incompatible vector spaces.
+- **Brute-force matching only.** Thousands of identities cost one matmul.
+  For larger scale, export `results.embeddings` to a dedicated vector
+  store.
+- **Thresholds are model-specific.** The 0.4 default was chosen on labeled
+  LFW pairs for `librefacerec-l`; recalibrate for other embedders and for
+  your population.
+- Training, validation, and export raise `NotImplementedError`: like gaze,
+  this is an inference product consuming opaque ONNX graphs.
+
+## Responsible use
+
+Face embeddings are biometric identifiers. The task is intended for
+consent-based applications: device unlock, photo-library organization,
+opt-in event galleries. Remote biometric identification of people in public
+spaces is prohibited or heavily restricted in several jurisdictions (EU AI
+Act, BIPA and similar state laws), and compliance is the deployer's
+responsibility. Recognition accuracy varies across demographics; calibrate
+thresholds on data representative of your deployment.

--- a/docs/facial_recognition.md
+++ b/docs/facial_recognition.md
@@ -47,7 +47,7 @@ name becomes the identity), the same convention as classification datasets.
 
 | Name | Role | Dim | Weights license | Notes |
 |---|---|---|---|---|
-| `librefacerec-l` | embedder (default) | 512 | Apache-2.0 | iResNet100, mirrored from AuraFace-v1; LFW ROC-AUC 0.998 through this pipeline |
+| `librefacerec-l` | embedder (default) | 512 | Apache-2.0 | iResNet100, mirrored from AuraFace-v1; LFW dev-test ROC-AUC 0.980, 96.9% accuracy through this pipeline |
 | `librefacerec-det` | default detector | - | MIT | YuNet with 5 landmarks, runs on OpenCV's bundled `cv2.FaceDetectorYN` |
 
 Weights carry their own licenses on their Hugging Face model cards; review
@@ -84,9 +84,15 @@ with `face_boxes=[...]`.
 - **Brute-force matching only.** Thousands of identities cost one matmul.
   For larger scale, export `results.embeddings` to a dedicated vector
   store.
-- **Thresholds are model-specific.** The 0.4 default was chosen on labeled
-  LFW pairs for `librefacerec-l`; recalibrate for other embedders and for
-  your population.
+- **Thresholds are model-specific.** Measured on the LFW dev pairs with
+  `librefacerec-l` (threshold picked on the train split, scored on the
+  held-out test split): ROC-AUC 0.980, 96.9% accuracy at threshold 0.227,
+  95.6% at the 0.4 default. No different-person pair scored above 0.30 in
+  that split, so 0.4 is a conservative default that trades recall for
+  near-zero false accepts; lower it toward 0.3 when missed matches cost
+  more than false ones. Recalibrate for other embedders and for your
+  population, and note LFW is a saturated, frontal, celebrity-photo
+  benchmark where leading models report roughly 99.5% and above.
 - Training, validation, and export raise `NotImplementedError`: like gaze,
   this is an inference product consuming opaque ONNX graphs.
 

--- a/docs/facial_recognition.md
+++ b/docs/facial_recognition.md
@@ -96,6 +96,9 @@ with `face_boxes=[...]`.
 - Training, validation, and export raise `NotImplementedError`: like gaze,
   this is an inference product consuming opaque ONNX graphs.
 
+The full contract, including the alternatives these decisions rule out, is
+recorded in [`adr/0013-embed-task-contract.md`](adr/0013-embed-task-contract.md).
+
 ## Responsible use
 
 Face embeddings are biometric identifiers. The task is intended for

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -70,6 +70,7 @@ instance, and panoptic segmentation; the `mobilenetv4` / `convnext` /
 | `zipdepth`  | `LibreZipDepth` | CamelCase preserved (`ZipDepth` brand casing); depth-only lightweight CNN (speed/edge tier) |
 | `birefnet`  | `LibreBiRefNet` | CamelCase preserved (Bilateral Reference); matte-only background-removal family |
 | `ppocr`     | `LibrePPOCR`    | All-caps acronym (PP-OCR brand, hyphen dropped); ocr-only two-stage text detection + recognition family |
+| `facerec`   | `LibreFaceEmbedder` | Descriptive family name (no upstream brand): embed-only two-stage face detection + identity-embedding family, inference-only |
 
 Casing rules observed in the table:
 
@@ -208,6 +209,7 @@ From `libreyolo/tasks.py`:
 | `restore`     | `-restore` |
 | `matte`       | `-matte` |
 | `ocr`         | `-ocr` |
+| `embed`       | `-embed` |
 
 The factory accepts selected upstream-style aliases (`detection`, `det`,
 `segmentation`, `keypoints`, `cls`, …) at the API boundary; only the canonical
@@ -267,6 +269,17 @@ Detection quads are genuine polygons (rotated text) and do not populate
 `Results.boxes`. Canonical ocr filenames must carry the `-ocr` suffix; task
 aliases `text`, `text-recognition`, and `text_recognition` resolve to `ocr` at
 the API boundary.
+
+`embed` is the task for face identity embeddings (facial recognition). Models
+expose `Results.embeddings`, an `(N, D)` payload of L2-normalized identity
+vectors row-aligned with the face boxes, so cosine similarity is a dot product.
+Supplying a `FaceGallery` of enrolled identities adds `Results.identities`
+(matched name and score per face, `None` when below threshold). The task is
+two-stage and inference-only: training, validation, and re-export raise.
+Canonical embed filenames must carry the `-embed` suffix; task aliases
+`facial-recognition`, `face-recognition`, `recognition`, `face`, `faceid`,
+`embedding`, and `reid` resolve to `embed` at the API boundary. See ADR 0013
+for the full contract.
 
 Dataset and label contracts are documented in
 [`dataset_schema.md`](dataset_schema.md). A task is supported by a model family

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -62,6 +62,7 @@ from .utils.results import (
     Matte,
     OCRRegions,
     Embeddings,
+    Identities,
 )
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
@@ -148,6 +149,8 @@ def __getattr__(name):
         "check_dataset": (".data", "check_dataset"),
         "Distiller": (".distillation", "Distiller"),
         "get_distill_config": (".distillation", "get_distill_config"),
+        "LibreFaceEmbedder": (".models.facerec", "LibreFaceEmbedder"),
+        "FaceGallery": (".models.facerec", "FaceGallery"),
     }
     if name in ("LibreRFDETR", "LibreDINOv2"):
         # RF-DETR and DINOv2 share the same transformers dependency check.
@@ -245,6 +248,9 @@ __all__ = [
     "Matte",
     "OCRRegions",
     "Embeddings",
+    "Identities",
+    "FaceGallery",
+    "LibreFaceEmbedder",
     # Assets
     "SAMPLE_IMAGE",
     # Tracking

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -61,6 +61,7 @@ from .utils.results import (
     RestoredImage,
     Matte,
     OCRRegions,
+    Embeddings,
 )
 
 SAMPLE_IMAGE = str(_Path(__file__).parent / "assets" / "parkour.jpg")
@@ -243,6 +244,7 @@ __all__ = [
     "RestoredImage",
     "Matte",
     "OCRRegions",
+    "Embeddings",
     # Assets
     "SAMPLE_IMAGE",
     # Tracking

--- a/libreyolo/cli/__init__.py
+++ b/libreyolo/cli/__init__.py
@@ -115,6 +115,8 @@ def entrypoint() -> None:
     # Face-embedding verification (facial-recognition): compare two images.
     app.command("compare", cls=KeyValueCommand)(special.compare_cmd)
     app.command("verify", cls=KeyValueCommand)(special.compare_cmd)
+    # Face identification: build a gallery from a folder-per-person tree.
+    app.command("enroll", cls=KeyValueCommand)(special.enroll_cmd)
 
     # Core mode commands
     app.command("predict", cls=KeyValueCommand)(predict.predict_cmd)

--- a/libreyolo/cli/__init__.py
+++ b/libreyolo/cli/__init__.py
@@ -112,6 +112,10 @@ def entrypoint() -> None:
     for cmd_name in ("version", "checks", "models", "formats", "cfg", "info", "metadata"):
         app.command(cmd_name, cls=KeyValueCommand)(getattr(special, f"{cmd_name}_cmd"))
 
+    # Face-embedding verification (facial-recognition): compare two images.
+    app.command("compare", cls=KeyValueCommand)(special.compare_cmd)
+    app.command("verify", cls=KeyValueCommand)(special.compare_cmd)
+
     # Core mode commands
     app.command("predict", cls=KeyValueCommand)(predict.predict_cmd)
     app.command("train", cls=KeyValueCommand)(train.train_cmd)

--- a/libreyolo/cli/commands/predict.py
+++ b/libreyolo/cli/commands/predict.py
@@ -132,6 +132,15 @@ def predict_cmd(
         "--face-detector",
         help="Face detector model (path or CLI name); required for gaze models",
     ),
+    gallery: Optional[str] = typer.Option(
+        None,
+        "--gallery",
+        help="Face gallery (.npz from `libreyolo enroll`) to identify faces "
+        "against; facial-recognition models only",
+    ),
+    gallery_threshold: float = typer.Option(
+        0.4, help="Cosine threshold for a gallery identity match"
+    ),
     project: str = typer.Option("runs/detect", help="Output directory root"),
     name: str = typer.Option("predict", help="Experiment name"),
     exist_ok: bool = typer.Option(False, help="Reuse existing output directory"),
@@ -189,6 +198,39 @@ def predict_cmd(
         from libreyolo.models.l2cs.face import resolve_face_detector
 
         loaded_model.face_detector = resolve_face_detector(fd_model)
+
+    # Face-embedding models: optional --face-detector override (the family
+    # otherwise falls back to its auto-downloaded default detector) and
+    # optional --gallery for 1:N identification.
+    gallery_obj = None
+    if getattr(loaded_model, "task", None) == "embed":
+        if face_detector is not None:
+            from .special import _resolve_embed_face_detector
+
+            loaded_model.face_detector = _resolve_embed_face_detector(
+                out, face_detector, device
+            )
+        if gallery is not None:
+            if not Path(gallery).exists():
+                exit_with_error(
+                    out,
+                    "source_not_found",
+                    f"Gallery not found: {gallery}. Build one with "
+                    "`libreyolo enroll model=... source=people/ gallery=...`.",
+                )
+            from libreyolo.models.facerec import FaceGallery
+
+            try:
+                gallery_obj = FaceGallery.load(gallery, embedder=loaded_model)
+            except ValueError as exc:
+                exit_with_error(out, "config_unsupported", str(exc))
+    elif gallery is not None:
+        exit_with_error(
+            out,
+            "config_unsupported",
+            "--gallery is only supported for facial-recognition models "
+            "(e.g. model=facerec-l).",
+        )
 
     # FP16 (half) precision: exported runtimes (ONNX, TensorRT, ...) accept the
     # flag and run in FP16, so forward it there. For native PyTorch inference it
@@ -251,6 +293,9 @@ def predict_cmd(
     )
     if half and is_exported_backend:
         predict_kwargs["half"] = half
+    if gallery_obj is not None:
+        predict_kwargs["gallery"] = gallery_obj
+        predict_kwargs["threshold"] = gallery_threshold
     results = loaded_model(source, **predict_kwargs)
     elapsed = time.time() - t0
 
@@ -418,8 +463,14 @@ def predict_cmd(
                         kp["confidence"] = round(float(kp_conf[i, k]), 4)
                     keypoints.append(kp)
                 det["keypoints"] = keypoints
+            identities = getattr(r, "identities", None)
+            if identities is not None and i < len(identities):
+                det["identity"] = identities.name[i]
+                score = float(identities.score[i])
+                det["identity_score"] = round(score, 4) if score == score else None
             detections.append(det)
-            class_counts[cls_name] = class_counts.get(cls_name, 0) + 1
+            count_key = det.get("identity") or cls_name
+            class_counts[count_key] = class_counts.get(count_key, 0) + 1
 
         result_data = {
             "path": r.path or str(source),

--- a/libreyolo/cli/commands/special.py
+++ b/libreyolo/cli/commands/special.py
@@ -6,7 +6,12 @@ from typing import Any, Optional
 
 import typer
 
-from ..command_utils import load_model_or_exit, resolve_model_or_exit
+from ..command_utils import (
+    exit_stage_error,
+    exit_with_error,
+    load_model_or_exit,
+    resolve_model_or_exit,
+)
 from ..errors import CLIError
 from ..output import OutputHandler
 from ...utils.model_info import build_model_info, format_model_info
@@ -17,6 +22,88 @@ from ...utils.model_info import build_model_info, format_model_info
 # =========================================================================
 def _get_output(json_output: bool, quiet: bool) -> OutputHandler:
     return OutputHandler(json_mode=json_output, quiet=quiet)
+
+
+def _resolve_embed_face_detector(out: OutputHandler, face_detector: Optional[str], device: str):
+    """Resolve a face detector for the two-stage face-embedding task.
+
+    Accepts an OpenCV face-detector ``.onnx`` (wrapped as a 5-landmark
+    ``OpenCVFaceDetector``) or a LibreYOLO detector checkpoint/name (wrapped via
+    ``resolve_face_detector``).
+    """
+    if face_detector is None:
+        exit_with_error(
+            out,
+            "config_unsupported",
+            "Face-embedding (facial-recognition) is two-stage and needs a face "
+            "detector. Pass --face-detector <model> (an OpenCV face-detector .onnx "
+            "or a LibreYOLO detector trained on faces).",
+            suggestion="e.g. --face-detector path/to/facedet.onnx",
+        )
+    if str(face_detector).lower().endswith(".onnx"):
+        from libreyolo.models.facerec import OpenCVFaceDetector
+
+        return OpenCVFaceDetector(face_detector)
+    fd_path = resolve_model_or_exit(out, face_detector)
+    fd_model = load_model_or_exit(
+        out, model=face_detector, model_path=fd_path, device=device
+    )
+    from libreyolo.models.l2cs.face import resolve_face_detector
+
+    return resolve_face_detector(fd_model)
+
+
+def compare_cmd(
+    model: str = typer.Option(..., help="Face-embedding model (path or name)"),
+    source: str = typer.Option(..., help="First image"),
+    source2: str = typer.Option(..., help="Second image to compare against"),
+    face_detector: Optional[str] = typer.Option(
+        None, "--face-detector", help="Face detector (YuNet .onnx or LibreYOLO detector)"
+    ),
+    threshold: float = typer.Option(
+        0.4, help="Cosine-similarity threshold for the same-identity decision"
+    ),
+    device: str = typer.Option("auto", help="Device: 0, cpu, mps, auto"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output to stdout"),
+    quiet: bool = typer.Option(False, "--quiet", help="Suppress stderr"),
+) -> None:
+    """Verify whether two face images are the same identity (cosine similarity)."""
+    out = _get_output(json_output, quiet)
+
+    for label, src in (("source", source), ("source2", source2)):
+        if not Path(src).exists() and not str(src).startswith(("http://", "https://")):
+            exit_with_error(out, "source_not_found", f"{label} not found: {src}")
+
+    model_path = resolve_model_or_exit(out, model)
+    loaded = load_model_or_exit(
+        out, model=model, model_path=model_path, device=device, task="facial-recognition"
+    )
+    if getattr(loaded, "task", None) != "embed":
+        exit_with_error(
+            out,
+            "config_unsupported",
+            "compare requires a face-embedding model (task=facial-recognition).",
+        )
+    loaded.face_detector = _resolve_embed_face_detector(out, face_detector, device)
+
+    try:
+        res = loaded.verify(source, source2, threshold=threshold)
+    except Exception as exc:  # no face / runtime error
+        exit_stage_error(out, stage="compare", detail=exc, code="config_unsupported")
+
+    similarity = round(float(res["similarity"]), 4)
+    data = {
+        "similarity": similarity,
+        "same_person": bool(res["same_person"]),
+        "threshold": threshold,
+    }
+    if not json_output:
+        verdict = "SAME person" if data["same_person"] else "DIFFERENT people"
+        data["_human_text"] = (
+            f"cosine similarity: {similarity:.4f}  ->  {verdict} "
+            f"(threshold {threshold})"
+        )
+    out.result(data)
 
 
 def _metadata_value_for_cli(value: Any) -> Any:

--- a/libreyolo/cli/commands/special.py
+++ b/libreyolo/cli/commands/special.py
@@ -101,6 +101,110 @@ def compare_cmd(
     out.result(data)
 
 
+def enroll_cmd(
+    model: str = typer.Option(..., help="Face-embedding model (path or name)"),
+    source: str = typer.Option(
+        ..., help="Folder-per-person tree: source/<identity>/*.jpg"
+    ),
+    gallery: str = typer.Option(
+        ..., help="Output gallery file (.npz); extended in place if it exists"
+    ),
+    face_detector: Optional[str] = typer.Option(
+        None, "--face-detector", help="Face detector (YuNet .onnx or LibreYOLO detector)"
+    ),
+    device: str = typer.Option("auto", help="Device: 0, cpu, mps, auto"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output to stdout"),
+    quiet: bool = typer.Option(False, "--quiet", help="Suppress stderr"),
+) -> None:
+    """Enroll identities into a face gallery from a folder-per-person tree."""
+    from libreyolo.utils.image_loader import ImageLoader
+
+    out = _get_output(json_output, quiet)
+
+    source_dir = Path(source)
+    if not source_dir.is_dir():
+        exit_with_error(
+            out,
+            "source_not_found",
+            f"source must be a directory laid out as <identity>/<images>: {source}",
+        )
+    identity_dirs = sorted(d for d in source_dir.iterdir() if d.is_dir())
+    if not identity_dirs:
+        exit_with_error(
+            out,
+            "config_unsupported",
+            f"No identity subfolders found under {source}. Expected "
+            "source/<identity_name>/*.jpg (the folder name becomes the identity).",
+        )
+
+    model_path = resolve_model_or_exit(out, model)
+    loaded = load_model_or_exit(
+        out, model=model, model_path=model_path, device=device, task="facial-recognition"
+    )
+    if getattr(loaded, "task", None) != "embed":
+        exit_with_error(
+            out,
+            "config_unsupported",
+            "enroll requires a face-embedding model (task=facial-recognition).",
+        )
+    loaded.face_detector = _resolve_embed_face_detector(out, face_detector, device)
+
+    from libreyolo.models.facerec import FaceGallery
+
+    gallery_path = Path(gallery)
+    if gallery_path.exists():
+        book = FaceGallery.load(gallery_path, embedder=loaded)
+    else:
+        book = FaceGallery(embedder=loaded)
+
+    enrolled: dict[str, int] = {}
+    skipped: list[str] = []
+    for identity_dir in identity_dirs:
+        images = ImageLoader.collect_images(identity_dir)
+        if not images:
+            skipped.append(identity_dir.name)
+            continue
+        count = 0
+        for image in images:
+            try:
+                count += book.enroll(identity_dir.name, image)
+            except ValueError as exc:  # e.g. no face found in one reference
+                if not quiet:
+                    typer.echo(f"skip {image}: {exc}", err=True)
+        if count:
+            enrolled[identity_dir.name] = count
+        else:
+            skipped.append(identity_dir.name)
+
+    if not enrolled:
+        exit_stage_error(
+            out,
+            stage="enroll",
+            detail="no faces found in any identity folder",
+            code="config_unsupported",
+        )
+
+    try:
+        book.save(gallery_path)
+    except Exception as exc:
+        exit_stage_error(out, stage="enroll", detail=exc, code="io_error")
+
+    data = {
+        "gallery": str(gallery_path),
+        "identities": len(book),
+        "references": sum(enrolled.values()),
+        "enrolled": enrolled,
+        "skipped": skipped,
+    }
+    if not json_output:
+        data["_human_text"] = (
+            f"enrolled {sum(enrolled.values())} reference faces for "
+            f"{len(enrolled)} identities -> {gallery_path}"
+            + (f" (skipped: {', '.join(skipped)})" if skipped else "")
+        )
+    out.result(data)
+
+
 def _metadata_value_for_cli(value: Any) -> Any:
     """Return a compact JSON-safe representation for raw checkpoint metadata."""
     if value is None or isinstance(value, (str, int, float, bool)):

--- a/libreyolo/cli/commands/special.py
+++ b/libreyolo/cli/commands/special.py
@@ -32,14 +32,9 @@ def _resolve_embed_face_detector(out: OutputHandler, face_detector: Optional[str
     ``resolve_face_detector``).
     """
     if face_detector is None:
-        exit_with_error(
-            out,
-            "config_unsupported",
-            "Face-embedding (facial-recognition) is two-stage and needs a face "
-            "detector. Pass --face-detector <model> (an OpenCV face-detector .onnx "
-            "or a LibreYOLO detector trained on faces).",
-            suggestion="e.g. --face-detector path/to/facedet.onnx",
-        )
+        # The runner falls back to the family's default detector
+        # (auto-downloaded on first use).
+        return None
     if str(face_detector).lower().endswith(".onnx"):
         from libreyolo.models.facerec import OpenCVFaceDetector
 

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -112,6 +112,15 @@ def _build_name_map() -> None:
     for cls in BaseModel._registry:
         _register_cli_names_for_class(cls)
 
+    # The face-embedding (facial-recognition) family is ONNX-only and lives
+    # outside BaseModel._registry; register its embedder names explicitly.
+    from libreyolo.models.facerec.weights import FACEREC_SIZES
+
+    for size_code in FACEREC_SIZES:
+        weight_name = f"librefacerec-{size_code}.onnx"
+        _CLI_NAME_TO_WEIGHTS[f"facerec-{size_code}"] = weight_name
+        _CLI_NAME_TO_WEIGHTS[f"librefacerec-{size_code}"] = weight_name
+
 
 def get_all_cli_names() -> list[str]:
     """Return all valid CLI model names (e.g. ['yolox-n', 'yolox-s', ...])."""

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -256,6 +256,21 @@ def LibreYOLO(
     ensure_default_logging()
     model_path = _resolve_weights_path(model_path)
 
+    # librefacerec-* names route to the face-embedding family regardless of
+    # extension: the family is ONNX-only, auto-downloads from the LibreYOLO
+    # HF org, and infers task=embed from the name.
+    if Path(model_path).name.lower().startswith("librefacerec-"):
+        from ..tasks import normalize_task
+
+        if task is not None and normalize_task(task) != "embed":
+            raise ValueError(
+                f"librefacerec weights only support the 'embed' "
+                f"(facial-recognition) task, got task={task!r}."
+            )
+        from .facerec import LibreFaceEmbedder
+
+        return LibreFaceEmbedder(model_path, device=device)
+
     # Non-PyTorch formats: delegate to inference backends
     if model_path.endswith(".onnx"):
         # Face embedding (facial-recognition) is an inference-only, two-stage

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -258,6 +258,16 @@ def LibreYOLO(
 
     # Non-PyTorch formats: delegate to inference backends
     if model_path.endswith(".onnx"):
+        # Face embedding (facial-recognition) is an inference-only, two-stage
+        # ONNX task with no detection-shaped output, so it routes to its own
+        # runner rather than the detection ONNX backend.
+        from ..tasks import normalize_task
+
+        if task is not None and normalize_task(task) == "embed":
+            from .facerec import LibreFaceEmbedder
+
+            return LibreFaceEmbedder(model_path, device=device)
+
         from ..backends.onnx import OnnxBackend
 
         return OnnxBackend(
@@ -702,5 +712,16 @@ __all__ = [
     "LibreCLIP",
     "LibreSigLIP2",
     "LibrePPOCR",
+    "LibreFaceEmbedder",
     "try_ensure_rfdetr",
 ]
+
+
+def __getattr__(name):
+    # Lazy export so importing the face-embedding family (and its optional
+    # onnxruntime dependency) only happens on first use.
+    if name == "LibreFaceEmbedder":
+        from .facerec import LibreFaceEmbedder
+
+        return LibreFaceEmbedder
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libreyolo/models/facerec/__init__.py
+++ b/libreyolo/models/facerec/__init__.py
@@ -1,0 +1,19 @@
+"""Face-embedding / facial-recognition task (inference only).
+
+Two-stage, ONNX-backed: a face detector locates faces (+5 landmarks), each is
+aligned to a canonical 112x112 crop, and a recognition head emits an
+L2-normalized identity embedding. Verification is cosine similarity.
+"""
+
+from .align import ARCFACE_DST_112, align_face, estimate_norm
+from .model import LibreFaceEmbedder, OpenCVFaceDetector
+from .preprocess import PreprocCfg
+
+__all__ = [
+    "LibreFaceEmbedder",
+    "OpenCVFaceDetector",
+    "PreprocCfg",
+    "align_face",
+    "estimate_norm",
+    "ARCFACE_DST_112",
+]

--- a/libreyolo/models/facerec/__init__.py
+++ b/libreyolo/models/facerec/__init__.py
@@ -6,14 +6,19 @@ L2-normalized identity embedding. Verification is cosine similarity.
 """
 
 from .align import ARCFACE_DST_112, align_face, estimate_norm
+from .gallery import FaceGallery
 from .model import LibreFaceEmbedder, OpenCVFaceDetector
 from .preprocess import PreprocCfg
+from .weights import FACEREC_WEIGHT_URLS, resolve_facerec_weight
 
 __all__ = [
     "LibreFaceEmbedder",
     "OpenCVFaceDetector",
+    "FaceGallery",
     "PreprocCfg",
     "align_face",
     "estimate_norm",
     "ARCFACE_DST_112",
+    "FACEREC_WEIGHT_URLS",
+    "resolve_facerec_weight",
 ]

--- a/libreyolo/models/facerec/align.py
+++ b/libreyolo/models/facerec/align.py
@@ -1,0 +1,115 @@
+"""5-point face alignment for the embedding (face-recognition) task.
+
+ArcFace-style recognition heads expect a face warped onto a canonical 112x112
+template via a *similarity* transform (rotation + uniform scale + translation,
+no shear) estimated from 5 facial landmarks. We implement Umeyama's closed-form
+least-squares similarity estimate in pure numpy and warp with cv2 — no
+scikit-image dependency. When landmarks are unavailable we fall back to a
+center-square crop of the face box, which is lower quality but keeps the
+pipeline running.
+
+The Umeyama algorithm (S. Umeyama, IEEE PAMI 1991) and the canonical 5-point
+template are standard published math/data, implemented here from first
+principles.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy as np
+
+# Canonical ArcFace destination landmarks for a 112x112 aligned crop, in the
+# standard 5-point order: [right-eye, left-eye, nose, right-mouth, left-mouth]
+# expressed in image coordinates (index 0 sits on the image's left).
+ARCFACE_DST_112 = np.array(
+    [
+        [38.2946, 51.6963],
+        [73.5318, 51.5014],
+        [56.0252, 71.7366],
+        [41.5493, 92.3655],
+        [70.7299, 92.2041],
+    ],
+    dtype=np.float64,
+)
+
+
+def umeyama_similarity(src: np.ndarray, dst: np.ndarray) -> np.ndarray:
+    """Least-squares similarity transform mapping ``src`` onto ``dst``.
+
+    Returns a ``(2, 3)`` affine matrix ``M`` (uniform scale + rotation +
+    translation) such that ``dst ~= src @ M[:, :2].T + M[:, 2]``.
+    """
+    src = np.asarray(src, dtype=np.float64)
+    dst = np.asarray(dst, dtype=np.float64)
+    n, dim = src.shape
+
+    src_mean = src.mean(axis=0)
+    dst_mean = dst.mean(axis=0)
+    src_demean = src - src_mean
+    dst_demean = dst - dst_mean
+
+    cov = dst_demean.T @ src_demean / n
+    U, S, Vt = np.linalg.svd(cov)
+
+    d = np.ones(dim)
+    if np.linalg.det(U) * np.linalg.det(Vt) < 0:
+        d[-1] = -1.0
+    R = U @ np.diag(d) @ Vt
+
+    var_src = (src_demean ** 2).sum() / n
+    scale = (S * d).sum() / var_src if var_src > 0 else 1.0
+
+    M = np.zeros((2, 3), dtype=np.float64)
+    M[:, :2] = scale * R
+    M[:, 2] = dst_mean - scale * (R @ src_mean)
+    return M
+
+
+def estimate_norm(landmarks5: np.ndarray, image_size: int = 112) -> np.ndarray:
+    """Affine ``(2, 3)`` mapping 5 landmarks onto the canonical template."""
+    template = ARCFACE_DST_112.copy()
+    if image_size != 112:
+        template = template * (image_size / 112.0)
+    return umeyama_similarity(np.asarray(landmarks5, dtype=np.float64), template)
+
+
+def _center_crop_resize(image_rgb: np.ndarray, box: Sequence[float], size: int) -> np.ndarray:
+    """Fallback when no landmarks: square-crop the face box and resize."""
+    import cv2
+
+    h, w = image_rgb.shape[:2]
+    x1, y1, x2, y2 = box
+    cx, cy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+    half = max(x2 - x1, y2 - y1) / 2.0
+    x1 = int(max(0, round(cx - half)))
+    y1 = int(max(0, round(cy - half)))
+    x2 = int(min(w, round(cx + half)))
+    y2 = int(min(h, round(cy + half)))
+    if x2 <= x1 or y2 <= y1:
+        raise ValueError(f"Degenerate face box for crop: {(x1, y1, x2, y2)}")
+    crop = image_rgb[y1:y2, x1:x2]
+    return cv2.resize(crop, (size, size))
+
+
+def align_face(
+    image_rgb: np.ndarray,
+    box: Sequence[float],
+    landmarks: Optional[np.ndarray] = None,
+    image_size: int = 112,
+) -> np.ndarray:
+    """Return a canonical ``image_size`` aligned face crop (RGB uint8).
+
+    Uses a 5-point similarity warp when ``landmarks`` of shape ``(5, 2)`` are
+    given, otherwise a center-square crop of ``box``.
+    """
+    import cv2
+
+    if landmarks is not None:
+        lm = np.asarray(landmarks, dtype=np.float64)
+        if lm.shape == (5, 2):
+            M = estimate_norm(lm, image_size)
+            return cv2.warpAffine(
+                image_rgb, M.astype(np.float32), (image_size, image_size), borderValue=0
+            )
+    return _center_crop_resize(image_rgb, box, image_size)

--- a/libreyolo/models/facerec/gallery.py
+++ b/libreyolo/models/facerec/gallery.py
@@ -1,0 +1,285 @@
+"""Identity gallery for 1:N face identification (``embed`` task).
+
+A :class:`FaceGallery` holds named reference embeddings. Identification is a
+cosine match of query embeddings against every reference: per-reference
+storage with max-cosine scoring (enrolling K images of one person keeps K
+vectors; a person's score is the best of their references). Below-threshold
+queries resolve to *unknown* (``None``), never to the nearest wrong person.
+
+Galleries are bound to the embedder that produced them: ``save()`` records
+the embedding dimension and a fingerprint of the model file, and matching
+with a different model raises instead of silently comparing incompatible
+vector spaces.
+
+Scale note: matching is a single dense matmul, comfortably microseconds for
+thousands of identities. Larger deployments should export raw embeddings
+(``results.embeddings``) to a dedicated vector store instead.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+_FINGERPRINT_CHUNK = 1024 * 1024
+
+
+def model_file_fingerprint(model_path: str | Path) -> str:
+    """Stable content fingerprint (sha256) of a weights file."""
+    h = hashlib.sha256()
+    with open(model_path, "rb") as f:
+        while True:
+            chunk = f.read(_FINGERPRINT_CHUNK)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def _unit(vec: np.ndarray) -> np.ndarray:
+    vec = np.asarray(vec, dtype=np.float32).reshape(-1)
+    norm = float(np.linalg.norm(vec))
+    if norm <= 1e-10:
+        raise ValueError("Cannot enroll an all-zero embedding.")
+    return vec / norm
+
+
+class FaceGallery:
+    """Named reference embeddings for face identification.
+
+    Args:
+        embedder: Optional ``LibreFaceEmbedder`` used by :meth:`enroll` to
+            embed reference images and to stamp the gallery's model
+            fingerprint. Precomputed vectors can always be added with
+            :meth:`enroll_embedding`, embedder or not.
+    """
+
+    def __init__(self, embedder: Any = None):
+        self._names: List[str] = []
+        self._vectors: List[np.ndarray] = []
+        self._dim: Optional[int] = None
+        self._model_fingerprint: Optional[str] = None
+        self.embedder = embedder
+        if embedder is not None:
+            self._model_fingerprint = _embedder_fingerprint(embedder)
+
+    # ------------------------------------------------------------------
+    # Enrollment
+    # ------------------------------------------------------------------
+    def enroll(self, name: str, sources, *, embedder: Any = None) -> int:
+        """Enroll one identity from one or more reference images.
+
+        ``sources`` is an image or a sequence of images (paths, URLs, arrays,
+        PIL images). Each image contributes the embedding of its most
+        prominent face. Returns the number of references added.
+        """
+        model = embedder or self.embedder
+        if model is None:
+            raise ValueError(
+                "FaceGallery.enroll needs an embedder: construct the gallery "
+                "with FaceGallery(embedder=model) or pass embedder=model. For "
+                "precomputed vectors use enroll_embedding()."
+            )
+        if self._model_fingerprint is None:
+            self._model_fingerprint = _embedder_fingerprint(model)
+
+        if isinstance(sources, (str, Path)) or not isinstance(sources, Sequence):
+            sources = [sources]
+
+        added = 0
+        for source in sources:
+            result = model(source)
+            emb = result.embeddings
+            if emb is None or len(emb) == 0:
+                raise ValueError(f"No face found in enrollment image: {source!r}")
+            data = np.asarray(_to_numpy(emb.data), dtype=np.float32)
+            idx = 0
+            if result.boxes is not None and len(result.boxes) == len(data):
+                conf = np.asarray(_to_numpy(result.boxes.conf), dtype=np.float32)
+                if conf.size:
+                    idx = int(np.argmax(conf))
+            self.enroll_embedding(name, data[idx])
+            added += 1
+        return added
+
+    def enroll_embedding(self, name: str, vector) -> None:
+        """Enroll one identity reference from a precomputed embedding."""
+        vec = _unit(_to_numpy(vector))
+        if self._dim is None:
+            self._dim = int(vec.shape[0])
+        elif int(vec.shape[0]) != self._dim:
+            raise ValueError(
+                f"Embedding dim mismatch: gallery holds {self._dim}-d vectors, "
+                f"got {int(vec.shape[0])}-d."
+            )
+        self._names.append(str(name))
+        self._vectors.append(vec)
+
+    def remove(self, name: str) -> int:
+        """Remove every reference of an identity. Returns how many."""
+        keep = [(n, v) for n, v in zip(self._names, self._vectors) if n != name]
+        removed = len(self._names) - len(keep)
+        self._names = [n for n, _ in keep]
+        self._vectors = [v for _, v in keep]
+        return removed
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    @property
+    def identities(self) -> List[str]:
+        """Unique enrolled identity names, in first-enrolled order."""
+        seen: Dict[str, None] = {}
+        for n in self._names:
+            seen.setdefault(n)
+        return list(seen)
+
+    @property
+    def dim(self) -> Optional[int]:
+        return self._dim
+
+    def __len__(self) -> int:
+        return len(self.identities)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._names
+
+    def __repr__(self) -> str:
+        return (
+            f"FaceGallery(identities={len(self)}, references={len(self._names)}, "
+            f"dim={self._dim})"
+        )
+
+    # ------------------------------------------------------------------
+    # Matching
+    # ------------------------------------------------------------------
+    def match(
+        self,
+        embeddings,
+        *,
+        top_k: int = 1,
+        threshold: float = 0.4,
+        model: Any = None,
+    ) -> List[List[Tuple[str, float]]]:
+        """Match query embeddings against the gallery.
+
+        Accepts an ``Embeddings`` payload or an ``(N, D)`` array. Returns, per
+        query row, up to ``top_k`` ``(name, score)`` pairs with score >=
+        ``threshold``, best first. Scores are max-cosine over each identity's
+        references.
+        """
+        if model is not None:
+            self._check_model(model)
+        data = embeddings.data if hasattr(embeddings, "data") else embeddings
+        queries = np.asarray(_to_numpy(data), dtype=np.float32)
+        if queries.ndim == 1:
+            queries = queries[None, :]
+        if not self._names or queries.size == 0:
+            return [[] for _ in range(queries.shape[0])]
+        if self._dim is not None and queries.shape[1] != self._dim:
+            raise ValueError(
+                f"Embedding dim mismatch: gallery holds {self._dim}-d vectors, "
+                f"queries are {queries.shape[1]}-d. Was this gallery built "
+                f"with a different embedding model?"
+            )
+
+        refs = np.stack(self._vectors)  # (R, D), unit rows
+        norms = np.linalg.norm(queries, axis=1, keepdims=True)
+        queries = queries / np.clip(norms, 1e-10, None)
+        sims = queries @ refs.T  # (N, R)
+
+        names = np.asarray(self._names)
+        out: List[List[Tuple[str, float]]] = []
+        for row in sims:
+            best: Dict[str, float] = {}
+            for name, s in zip(names, row):
+                s = float(s)
+                if s > best.get(name, -2.0):
+                    best[name] = s
+            ranked = sorted(best.items(), key=lambda kv: kv[1], reverse=True)
+            out.append([(n, s) for n, s in ranked[:top_k] if s >= threshold])
+        return out
+
+    def _check_model(self, model: Any) -> None:
+        fp = _embedder_fingerprint(model)
+        if (
+            fp is not None
+            and self._model_fingerprint is not None
+            and fp != self._model_fingerprint
+        ):
+            raise ValueError(
+                "This gallery was built with a different embedding model "
+                f"(gallery fingerprint {self._model_fingerprint}, model "
+                f"fingerprint {fp}). Re-enroll with the current model or load "
+                "the matching gallery."
+            )
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> str:
+        """Save to an ``.npz`` archive (vectors + names + metadata)."""
+        path = Path(path)
+        if not self._names:
+            raise ValueError("Cannot save an empty gallery.")
+        meta = {
+            "format": "libreyolo-face-gallery-v1",
+            "dim": self._dim,
+            "model_fingerprint": self._model_fingerprint,
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(
+            path,
+            vectors=np.stack(self._vectors),
+            names=np.asarray(self._names),
+            meta=np.asarray(json.dumps(meta)),
+        )
+        return str(path)
+
+    @classmethod
+    def load(cls, path: str | Path, *, embedder: Any = None) -> "FaceGallery":
+        """Load a gallery previously written by :meth:`save`."""
+        with np.load(Path(path), allow_pickle=False) as archive:
+            try:
+                meta = json.loads(str(archive["meta"]))
+                vectors = archive["vectors"]
+                names = archive["names"]
+            except KeyError as e:
+                raise ValueError(f"Not a LibreYOLO face gallery: {path}") from e
+        if meta.get("format") != "libreyolo-face-gallery-v1":
+            raise ValueError(f"Not a LibreYOLO face gallery: {path}")
+
+        gallery = cls()
+        gallery._model_fingerprint = meta.get("model_fingerprint")
+        for name, vec in zip(names.tolist(), vectors):
+            gallery.enroll_embedding(str(name), vec)
+        if embedder is not None:
+            gallery.embedder = embedder
+            gallery._check_model(embedder)
+        return gallery
+
+
+def _to_numpy(data):
+    if hasattr(data, "detach"):
+        return data.detach().cpu().numpy()
+    return np.asarray(data)
+
+
+def _embedder_fingerprint(model: Any) -> Optional[str]:
+    """Best-effort fingerprint of an embedder's weight file (cached on it)."""
+    cached = getattr(model, "_weights_fingerprint", None)
+    if cached is not None:
+        return cached
+    model_path = getattr(model, "model_path", None)
+    if not model_path or not Path(model_path).exists():
+        return None
+    fp = model_file_fingerprint(model_path)
+    try:
+        model._weights_fingerprint = fp
+    except AttributeError:
+        pass
+    return fp

--- a/libreyolo/models/facerec/gallery.py
+++ b/libreyolo/models/facerec/gallery.py
@@ -84,8 +84,13 @@ class FaceGallery:
                 "with FaceGallery(embedder=model) or pass embedder=model. For "
                 "precomputed vectors use enroll_embedding()."
             )
+        # A gallery is only meaningful within one embedding space, so an
+        # enrolment through a different model has to fail here rather than
+        # append a vector that silently will not compare.
         if self._model_fingerprint is None:
             self._model_fingerprint = _embedder_fingerprint(model)
+        else:
+            self._check_model(model)
 
         if isinstance(sources, (str, Path)) or not isinstance(sources, Sequence):
             sources = [sources]

--- a/libreyolo/models/facerec/inference.py
+++ b/libreyolo/models/facerec/inference.py
@@ -1,0 +1,179 @@
+"""Inference orchestrator for the face-embedding (``embed``) task.
+
+Wraps the two-stage pipeline (face detection -> 5-pt align -> recognition head
+-> L2-normalized embedding) behind the same ``__call__`` shape the detection
+runner provides, so ``LibreFaceEmbedder`` integrates with the rest of the
+framework. Mirrors ``GazeInferenceRunner``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Sequence
+
+import numpy as np
+import torch
+
+from ...utils.general import log_saved_result, resolve_save_path
+from ...utils.image_loader import ImageInput, ImageLoader
+from ...utils.results import Boxes, Embeddings, Results
+from ..l2cs.face import FaceBox, FaceDetector, resolve_face_detector
+from .align import align_face
+
+if TYPE_CHECKING:
+    from .model import LibreFaceEmbedder
+
+logger = logging.getLogger(__name__)
+
+
+class FaceEmbedRunner:
+    """Runs face-embedding inference for a ``LibreFaceEmbedder``."""
+
+    def __init__(self, model: "LibreFaceEmbedder"):
+        self.model = model
+
+    # ------------------------------------------------------------------
+    def __call__(
+        self,
+        source: ImageInput | None = None,
+        *,
+        face_boxes: Optional[Sequence] = None,
+        face_detector: Optional[FaceDetector] = None,
+        face_conf: float = 0.5,
+        save: bool = False,
+        output_path: Optional[str] = None,
+        color_format: str = "auto",
+        show: bool = False,
+        output_file_format: Optional[str] = None,
+        augment: bool = False,
+        tiling: bool = False,
+        **_: object,
+    ):
+        if augment:
+            raise ValueError("TTA (augment=True) is not meaningful for face embedding.")
+        if tiling:
+            raise ValueError("Tiled inference is not supported for face embedding.")
+
+        detector = self._resolve_runtime_detector(face_detector, face_boxes)
+
+        if isinstance(source, (str, Path)) and Path(source).is_dir():
+            return [
+                self._predict_single(
+                    p, detector=detector, face_boxes=None, face_conf=face_conf,
+                    save=save, output_path=output_path, color_format=color_format,
+                    output_file_format=output_file_format,
+                )
+                for p in ImageLoader.collect_images(source)
+            ]
+
+        return self._predict_single(
+            source, detector=detector, face_boxes=face_boxes, face_conf=face_conf,
+            save=save, output_path=output_path, color_format=color_format,
+            output_file_format=output_file_format,
+        )
+
+    # ------------------------------------------------------------------
+    def _predict_single(
+        self,
+        image: ImageInput,
+        *,
+        detector: Optional[FaceDetector],
+        face_boxes: Optional[Sequence],
+        face_conf: float,
+        save: bool,
+        output_path: Optional[str],
+        color_format: str,
+        output_file_format: Optional[str],
+    ) -> Results:
+        image_path = image if isinstance(image, (str, Path)) else None
+        pil = ImageLoader.load(image, color_format=color_format)
+        rgb_np = np.asarray(pil)
+        h, w = rgb_np.shape[:2]
+
+        faces = self._collect_faces(rgb_np, detector, face_boxes, face_conf)
+        result = self._run_embed(rgb_np, faces, (h, w), image_path)
+
+        if save:
+            ext = (output_file_format or "jpg").lower().lstrip(".")
+            save_path = resolve_save_path(output_path, image_path, ext=ext)
+            annotated = self._annotate(pil, result)
+            annotated.save(save_path)
+            log_saved_result(result, save_path)
+        return result
+
+    # ------------------------------------------------------------------
+    def _resolve_runtime_detector(self, explicit, face_boxes):
+        if face_boxes is not None:
+            return None
+        if explicit is not None:
+            return resolve_face_detector(explicit)
+        return self.model.face_detector
+
+    def _collect_faces(self, image_rgb, detector, face_boxes, face_conf) -> List[FaceBox]:
+        if face_boxes is not None:
+            from ..l2cs.face import _normalize_boxes
+
+            return _normalize_boxes(face_boxes, min_score=0.0)
+        if detector is None:
+            raise RuntimeError(
+                "LibreFaceEmbedder has no face source. Pass face_boxes=[...] for BYO "
+                "boxes, or face_detector=... (a callable, a LibreYOLO model, or an "
+                "OpenCVFaceDetector) when constructing or calling the model."
+            )
+        return [f for f in detector(image_rgb) if f.score >= face_conf]
+
+    def _run_embed(self, rgb_np, faces, orig_shape, image_path) -> Results:
+        def _empty() -> Results:
+            dim = self.model.dim or 0
+            return Results(
+                boxes=Boxes(
+                    torch.zeros((0, 4), dtype=torch.float32),
+                    torch.zeros((0,), dtype=torch.float32),
+                    torch.zeros((0,), dtype=torch.float32),
+                ),
+                orig_shape=orig_shape,
+                path=str(image_path) if image_path else None,
+                names=self.model.names,
+                embeddings=Embeddings(np.zeros((0, dim), dtype=np.float32), orig_shape),
+            )
+
+        if not faces:
+            return _empty()
+
+        crops, kept = [], []
+        for f in faces:
+            try:
+                crops.append(align_face(rgb_np, f.xyxy, f.landmarks, image_size=112))
+                kept.append(f)
+            except ValueError as e:
+                logger.warning("Skipping degenerate face crop: %s", e)
+        if not crops:
+            return _empty()
+
+        emb = self.model.embed_aligned(crops)  # (N, D) L2-normalized float32
+
+        xyxy = torch.tensor([list(f.xyxy) for f in kept], dtype=torch.float32)
+        conf = torch.tensor([f.score for f in kept], dtype=torch.float32)
+        cls = torch.zeros(len(kept), dtype=torch.float32)
+        return Results(
+            boxes=Boxes(xyxy, conf, cls),
+            orig_shape=orig_shape,
+            path=str(image_path) if image_path else None,
+            names=self.model.names,
+            embeddings=Embeddings(emb, orig_shape),
+        )
+
+    # ------------------------------------------------------------------
+    def _annotate(self, pil_img, result):
+        if result.boxes is None or len(result.boxes) == 0:
+            return pil_img
+        from ...utils.drawing import draw_boxes
+
+        return draw_boxes(
+            pil_img,
+            result.boxes.xyxy.tolist(),
+            result.boxes.conf.tolist(),
+            result.boxes.cls.tolist(),
+            class_names=result.names,
+        )

--- a/libreyolo/models/facerec/inference.py
+++ b/libreyolo/models/facerec/inference.py
@@ -66,6 +66,7 @@ class FaceEmbedRunner:
             gen = self._predict_video(
                 source,
                 detector=detector,
+                face_boxes=face_boxes,
                 face_conf=face_conf,
                 gallery=gallery,
                 threshold=threshold,
@@ -207,6 +208,7 @@ class FaceEmbedRunner:
         source,
         *,
         detector: Optional[FaceDetector],
+        face_boxes: Optional[Sequence],
         face_conf: float,
         gallery,
         threshold: float,
@@ -215,12 +217,17 @@ class FaceEmbedRunner:
         vid_stride: int,
         output_path: Optional[str],
     ):
-        """Embed (and optionally identify) faces frame by frame."""
+        """Embed (and optionally identify) faces frame by frame.
+
+        Caller-supplied ``face_boxes`` apply to every frame (a fixed region on
+        a static camera); dropping them here would leave the frame callback
+        with neither a detector nor boxes.
+        """
 
         def predict_frame(pil_img):
             rgb_np = np.asarray(pil_img)
             h, w = rgb_np.shape[:2]
-            faces = self._collect_faces(rgb_np, detector, None, face_conf)
+            faces = self._collect_faces(rgb_np, detector, face_boxes, face_conf)
             result = self._run_embed(rgb_np, faces, (h, w), str(source))
             if gallery is not None:
                 self._identify(result, gallery, threshold)

--- a/libreyolo/models/facerec/inference.py
+++ b/libreyolo/models/facerec/inference.py
@@ -108,7 +108,17 @@ class FaceEmbedRunner:
             return None
         if explicit is not None:
             return resolve_face_detector(explicit)
-        return self.model.face_detector
+        if self.model.face_detector is not None:
+            return self.model.face_detector
+        try:
+            return self.model.default_face_detector()
+        except Exception as e:
+            raise RuntimeError(
+                "LibreFaceEmbedder could not obtain its default face detector "
+                f"({e}). Pass face_boxes=[...] for BYO boxes, or "
+                "face_detector=... (a callable, a LibreYOLO model, or an "
+                "OpenCVFaceDetector) when constructing or calling the model."
+            ) from e
 
     def _collect_faces(self, image_rgb, detector, face_boxes, face_conf) -> List[FaceBox]:
         if face_boxes is not None:

--- a/libreyolo/models/facerec/inference.py
+++ b/libreyolo/models/facerec/inference.py
@@ -41,6 +41,8 @@ class FaceEmbedRunner:
         face_boxes: Optional[Sequence] = None,
         face_detector: Optional[FaceDetector] = None,
         face_conf: float = 0.5,
+        gallery=None,
+        threshold: float = 0.4,
         save: bool = False,
         output_path: Optional[str] = None,
         color_format: str = "auto",
@@ -61,6 +63,7 @@ class FaceEmbedRunner:
             return [
                 self._predict_single(
                     p, detector=detector, face_boxes=None, face_conf=face_conf,
+                    gallery=gallery, threshold=threshold,
                     save=save, output_path=output_path, color_format=color_format,
                     output_file_format=output_file_format,
                 )
@@ -69,6 +72,7 @@ class FaceEmbedRunner:
 
         return self._predict_single(
             source, detector=detector, face_boxes=face_boxes, face_conf=face_conf,
+            gallery=gallery, threshold=threshold,
             save=save, output_path=output_path, color_format=color_format,
             output_file_format=output_file_format,
         )
@@ -85,6 +89,8 @@ class FaceEmbedRunner:
         output_path: Optional[str],
         color_format: str,
         output_file_format: Optional[str],
+        gallery=None,
+        threshold: float = 0.4,
     ) -> Results:
         image_path = image if isinstance(image, (str, Path)) else None
         pil = ImageLoader.load(image, color_format=color_format)
@@ -93,6 +99,8 @@ class FaceEmbedRunner:
 
         faces = self._collect_faces(rgb_np, detector, face_boxes, face_conf)
         result = self._run_embed(rgb_np, faces, (h, w), image_path)
+        if gallery is not None:
+            self._identify(result, gallery, threshold)
 
         if save:
             ext = (output_file_format or "jpg").lower().lstrip(".")
@@ -175,10 +183,48 @@ class FaceEmbedRunner:
         )
 
     # ------------------------------------------------------------------
+    def _identify(self, result: Results, gallery, threshold: float) -> None:
+        """Attach an Identities payload by matching against ``gallery``."""
+        from ...utils.results import Identities
+
+        if result.embeddings is None or len(result.embeddings) == 0:
+            result.identities = Identities([], np.zeros((0,), dtype=np.float32))
+            return
+        if len(gallery) == 0:
+            raise ValueError(
+                "Cannot identify against an empty FaceGallery — enroll at "
+                "least one identity first."
+            )
+        # Match unthresholded to keep the best score visible for unknowns,
+        # then apply the threshold to the name only.
+        matches = gallery.match(
+            result.embeddings, top_k=1, threshold=-1.0, model=self.model
+        )
+        names, scores = [], []
+        for m in matches:
+            best_name, best_score = m[0] if m else (None, float("nan"))
+            names.append(best_name if best_score >= threshold else None)
+            scores.append(best_score)
+        result.identities = Identities(names, np.asarray(scores, dtype=np.float32))
+
+    # ------------------------------------------------------------------
     def _annotate(self, pil_img, result):
         if result.boxes is None or len(result.boxes) == 0:
             return pil_img
         from ...utils.drawing import draw_boxes
+
+        if result.identities is not None and len(result.identities) == len(result.boxes):
+            # Label each face with its matched identity (or "unknown"),
+            # colored per identity, with the match score as the confidence.
+            labels = [n if n is not None else "unknown" for n in result.identities.name]
+            palette = {label: i for i, label in enumerate(dict.fromkeys(labels))}
+            return draw_boxes(
+                pil_img,
+                result.boxes.xyxy.tolist(),
+                [max(float(s), 0.0) for s in result.identities.score],
+                [palette[label] for label in labels],
+                class_names={i: label for label, i in palette.items()},
+            )
 
         return draw_boxes(
             pil_img,

--- a/libreyolo/models/facerec/inference.py
+++ b/libreyolo/models/facerec/inference.py
@@ -18,6 +18,7 @@ import torch
 from ...utils.general import log_saved_result, resolve_save_path
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.results import Boxes, Embeddings, Results
+from ...utils.video import collect_video_results, is_video_file, run_video_inference
 from ..l2cs.face import FaceBox, FaceDetector, resolve_face_detector
 from .align import align_face
 
@@ -50,6 +51,8 @@ class FaceEmbedRunner:
         output_file_format: Optional[str] = None,
         augment: bool = False,
         tiling: bool = False,
+        stream: bool = False,
+        vid_stride: int = 1,
         **_: object,
     ):
         if augment:
@@ -58,6 +61,22 @@ class FaceEmbedRunner:
             raise ValueError("Tiled inference is not supported for face embedding.")
 
         detector = self._resolve_runtime_detector(face_detector, face_boxes)
+
+        if is_video_file(source):
+            gen = self._predict_video(
+                source,
+                detector=detector,
+                face_conf=face_conf,
+                gallery=gallery,
+                threshold=threshold,
+                save=save,
+                show=show,
+                vid_stride=vid_stride,
+                output_path=output_path,
+            )
+            if stream:
+                return gen
+            return collect_video_results(gen, source, vid_stride)
 
         if isinstance(source, (str, Path)) and Path(source).is_dir():
             return [
@@ -180,6 +199,41 @@ class FaceEmbedRunner:
             path=str(image_path) if image_path else None,
             names=self.model.names,
             embeddings=Embeddings(emb, orig_shape),
+        )
+
+    # ------------------------------------------------------------------
+    def _predict_video(
+        self,
+        source,
+        *,
+        detector: Optional[FaceDetector],
+        face_conf: float,
+        gallery,
+        threshold: float,
+        save: bool,
+        show: bool,
+        vid_stride: int,
+        output_path: Optional[str],
+    ):
+        """Embed (and optionally identify) faces frame by frame."""
+
+        def predict_frame(pil_img):
+            rgb_np = np.asarray(pil_img)
+            h, w = rgb_np.shape[:2]
+            faces = self._collect_faces(rgb_np, detector, None, face_conf)
+            result = self._run_embed(rgb_np, faces, (h, w), str(source))
+            if gallery is not None:
+                self._identify(result, gallery, threshold)
+            return result
+
+        yield from run_video_inference(
+            source,
+            predict_frame,
+            vid_stride=vid_stride,
+            save=save,
+            show=show,
+            output_path=output_path,
+            annotate_fn=self._annotate,
         )
 
     # ------------------------------------------------------------------

--- a/libreyolo/models/facerec/model.py
+++ b/libreyolo/models/facerec/model.py
@@ -63,7 +63,14 @@ class LibreFaceEmbedder:
             ) from e
 
         if not Path(model_path).exists():
-            raise FileNotFoundError(f"Face-embedding ONNX model not found: {model_path}")
+            from .weights import is_facerec_weight_name, resolve_facerec_weight
+
+            if is_facerec_weight_name(model_path):
+                model_path = resolve_facerec_weight(model_path)
+            else:
+                raise FileNotFoundError(
+                    f"Face-embedding ONNX model not found: {model_path}"
+                )
 
         available = ort.get_available_providers()
         if device in ("auto", "cuda", "gpu") and "CUDAExecutionProvider" in available:
@@ -86,6 +93,7 @@ class LibreFaceEmbedder:
         self.face_detector = (
             resolve_face_detector(face_detector) if face_detector is not None else None
         )
+        self._default_detector_instance = None
 
         out_dim = self.session.get_outputs()[0].shape[-1]
         self._dim = int(out_dim) if isinstance(out_dim, int) else None
@@ -108,6 +116,14 @@ class LibreFaceEmbedder:
         emb = np.concatenate(outs, axis=0)
         self._dim = emb.shape[1]
         return l2_normalize(emb, axis=1)
+
+    def default_face_detector(self):
+        """The family's default detector (auto-downloaded on first use)."""
+        if self._default_detector_instance is None:
+            from .weights import default_face_detector
+
+            self._default_detector_instance = default_face_detector()
+        return self._default_detector_instance
 
     # ------------------------------------------------------------------
     @property

--- a/libreyolo/models/facerec/model.py
+++ b/libreyolo/models/facerec/model.py
@@ -1,0 +1,233 @@
+"""LibreYOLO face-embedding model (task ``embed`` / facial-recognition).
+
+Inference-only, two-stage and ONNX-backed — structurally a sibling of the gaze
+(L2CS) task: a face detector locates faces (and ideally 5 landmarks), each face
+is aligned to a canonical 112x112 crop, and a recognition head produces an
+L2-normalized identity embedding. Verification/identification is then a cosine
+similarity (== dot product of unit vectors).
+
+The recognition head is consumed as an opaque ONNX graph via onnxruntime, so no
+third-party architecture code is ported. Training and dataset validation are out
+of scope here (exactly like L2CS) — embeddings are an inference product.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, List, Optional
+
+import numpy as np
+
+from ..l2cs.face import FaceBox, FaceDetector, resolve_face_detector
+from .preprocess import PreprocCfg, l2_normalize, preprocess_aligned, resolve_preproc
+
+logger = logging.getLogger(__name__)
+
+
+class LibreFaceEmbedder:
+    """Face-embedding model: image -> per-face (box + L2-normalized embedding).
+
+    Args:
+        model_path: Path to a face-recognition ONNX model that maps an
+            ``(N, 3, 112, 112)`` aligned-face batch to ``(N, D)`` embeddings.
+        preproc: A ``PreprocCfg``, a preset name (``"arcface"`` | ``"raw_bgr"``),
+            or ``None`` (defaults to the ArcFace convention: RGB,
+            ``(x-127.5)/127.5``).
+        device: ``"auto"`` | ``"cpu"`` | ``"cuda"``.
+        face_detector: Optional default detector (a callable, a LibreYOLO
+            detection model, or a ``FaceDetector``). May also be supplied per
+            call, or bypassed entirely with ``face_boxes=...``.
+    """
+
+    FAMILY = "facerec"
+    SUPPORTED_TASKS = ("embed",)
+    DEFAULT_TASK = "embed"
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        preproc: "PreprocCfg | str | None" = None,
+        device: str = "auto",
+        face_detector: Any = None,
+        names: Optional[dict] = None,
+        task: str | None = "embed",
+    ):
+        try:
+            import onnxruntime as ort
+        except ImportError as e:  # pragma: no cover - env dependent
+            raise ImportError(
+                "Face embedding requires onnxruntime. "
+                'Install with: pip install "libreyolo[onnx]"'
+            ) from e
+
+        if not Path(model_path).exists():
+            raise FileNotFoundError(f"Face-embedding ONNX model not found: {model_path}")
+
+        available = ort.get_available_providers()
+        if device in ("auto", "cuda", "gpu") and "CUDAExecutionProvider" in available:
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            self.device = "cuda"
+        else:
+            providers = ["CPUExecutionProvider"]
+            self.device = "cpu"
+
+        so = ort.SessionOptions()
+        so.log_severity_level = 3  # silence "initializer in graph inputs" spam
+        self.session = ort.InferenceSession(model_path, sess_options=so, providers=providers)
+        self.input_name = self.session.get_inputs()[0].name
+
+        self.model_path = model_path
+        self.family = self.FAMILY
+        self.task = "embed"
+        self.cfg = resolve_preproc(preproc)
+        self.names = names or {0: "face"}
+        self.face_detector = (
+            resolve_face_detector(face_detector) if face_detector is not None else None
+        )
+
+        out_dim = self.session.get_outputs()[0].shape[-1]
+        self._dim = int(out_dim) if isinstance(out_dim, int) else None
+
+    # ------------------------------------------------------------------
+    @property
+    def dim(self) -> Optional[int]:
+        """Embedding dimension (``None`` if the ONNX graph declares it dynamic)."""
+        return self._dim
+
+    def embed_aligned(self, aligned_crops: List[np.ndarray]) -> np.ndarray:
+        """List of aligned HxWx3 RGB uint8 crops -> ``(N, D)`` L2-normalized."""
+        if not aligned_crops:
+            return np.zeros((0, self._dim or 0), dtype=np.float32)
+        outs = []
+        for crop in aligned_crops:
+            blob = preprocess_aligned(crop, self.cfg)
+            out = self.session.run(None, {self.input_name: blob})[0]
+            outs.append(np.asarray(out, dtype=np.float32).reshape(1, -1))
+        emb = np.concatenate(outs, axis=0)
+        self._dim = emb.shape[1]
+        return l2_normalize(emb, axis=1)
+
+    # ------------------------------------------------------------------
+    @property
+    def _runner(self):
+        if getattr(self, "_runner_instance", None) is None:
+            from .inference import FaceEmbedRunner
+
+            self._runner_instance = FaceEmbedRunner(self)
+        return self._runner_instance
+
+    def __call__(self, source=None, **kwargs):
+        return self._runner(source, **kwargs)
+
+    def predict(self, *args, **kwargs):
+        return self(*args, **kwargs)
+
+    def verify(
+        self,
+        image_a,
+        image_b,
+        *,
+        threshold: float = 0.4,
+        face_detector: Any = None,
+        face_boxes_a: Any = None,
+        face_boxes_b: Any = None,
+    ) -> dict:
+        """Compare the most prominent face in two images.
+
+        Returns ``{'similarity', 'same_person', 'threshold'}`` where similarity
+        is cosine similarity in ``[-1, 1]``.
+        """
+        ra = self(image_a, face_detector=face_detector, face_boxes=face_boxes_a)
+        rb = self(image_b, face_detector=face_detector, face_boxes=face_boxes_b)
+        ea = _top_embedding(ra)
+        eb = _top_embedding(rb)
+        if ea is None or eb is None:
+            raise RuntimeError(
+                "verify() needs at least one face in each image "
+                f"(image_a faces={0 if ea is None else 1}, image_b faces={0 if eb is None else 1})."
+            )
+        sim = float(np.dot(ea, eb))
+        return {"similarity": sim, "same_person": sim >= threshold, "threshold": threshold}
+
+    # ------------------------------------------------------------------
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Training is out of scope for LibreFaceEmbedder (inference-only). "
+            "Train a recognition head upstream and export it to ONNX."
+        )
+
+    def val(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Dataset validation is out of scope for LibreFaceEmbedder. Evaluate "
+            "verification accuracy with the `compare` API on labeled pairs."
+        )
+
+    def export(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreFaceEmbedder already wraps an ONNX graph; re-export is not supported."
+        )
+
+
+def _top_embedding(result) -> Optional[np.ndarray]:
+    """Highest-confidence face embedding from a Results, or None."""
+    emb = getattr(result, "embeddings", None)
+    if emb is None or len(emb) == 0:
+        return None
+    data = emb.numpy().data if hasattr(emb, "numpy") else emb.data
+    data = np.asarray(data, dtype=np.float32)
+    boxes = result.boxes
+    if boxes is not None and len(boxes) == len(data):
+        conf = np.asarray(boxes.numpy().conf, dtype=np.float32)
+        idx = int(np.argmax(conf)) if conf.size else 0
+    else:
+        idx = 0
+    return l2_normalize(data[idx])
+
+
+class OpenCVFaceDetector:
+    """Face detector + 5 landmarks via OpenCV's bundled ``cv2.FaceDetectorYN``.
+
+    Returns ``FaceBox`` with 5-point landmarks, ready for canonical alignment.
+    The detector API ships with OpenCV (a core dependency, Apache-2.0); the
+    ``.onnx`` model file is supplied by the caller. Lazy — cv2/model are only
+    touched on first use.
+    """
+
+    def __init__(self, model_path: str, score_threshold: float = 0.6, nms_threshold: float = 0.3):
+        self.model_path = str(model_path)
+        self.score_threshold = score_threshold
+        self.nms_threshold = nms_threshold
+        self._impl = None
+
+    def _load(self):
+        if self._impl is None:
+            import cv2
+
+            if not Path(self.model_path).exists():
+                raise FileNotFoundError(f"Face-detector model not found: {self.model_path}")
+            self._impl = cv2.FaceDetectorYN.create(
+                self.model_path, "", (320, 320),
+                score_threshold=self.score_threshold, nms_threshold=self.nms_threshold,
+            )
+
+    def __call__(self, image_rgb: np.ndarray) -> List[FaceBox]:
+        self._load()
+        bgr = np.ascontiguousarray(image_rgb[:, :, ::-1])
+        h, w = bgr.shape[:2]
+        self._impl.setInputSize((w, h))
+        _, faces = self._impl.detect(bgr)
+        if faces is None:
+            return []
+        out: List[FaceBox] = []
+        for f in faces:
+            x, y, bw, bh = f[:4]
+            out.append(
+                FaceBox(
+                    xyxy=(float(x), float(y), float(x + bw), float(y + bh)),
+                    score=float(f[-1]),
+                    landmarks=f[4:14].reshape(5, 2).astype(np.float32),
+                )
+            )
+        return out

--- a/libreyolo/models/facerec/preprocess.py
+++ b/libreyolo/models/facerec/preprocess.py
@@ -1,0 +1,68 @@
+"""Per-model preprocessing for face-embedding ONNX heads.
+
+Face-recognition heads differ only in a small preprocessing contract applied to
+an already-aligned 112x112 crop (channel order, mean, scale, layout). Getting
+this wrong silently yields garbage embeddings, so each known head pins its
+convention explicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class PreprocCfg:
+    """Preprocessing contract for an aligned face crop."""
+
+    size: int = 112
+    color_order: str = "RGB"      # "RGB" or "BGR"
+    mean: float = 127.5           # subtracted per channel
+    scale: float = 1.0 / 127.5    # multiplied after mean subtraction
+    layout: str = "NCHW"          # "NCHW" or "NHWC"
+
+    @classmethod
+    def arcface(cls) -> "PreprocCfg":
+        # ArcFace / iResNet convention (e.g. the AuraFace 512-d head):
+        # RGB, (x-127.5)/127.5 -> [-1, 1].
+        return cls(size=112, color_order="RGB", mean=127.5, scale=1.0 / 127.5)
+
+    @classmethod
+    def raw_bgr(cls) -> "PreprocCfg":
+        # Raw BGR convention (e.g. some MobileFaceNet-style 128-d heads):
+        # BGR, [0, 255], no normalization.
+        return cls(size=112, color_order="BGR", mean=0.0, scale=1.0)
+
+
+_NAMED = {"arcface": PreprocCfg.arcface, "raw_bgr": PreprocCfg.raw_bgr}
+
+
+def resolve_preproc(spec) -> PreprocCfg:
+    """Coerce ``None`` / a name / a PreprocCfg into a PreprocCfg (default ArcFace)."""
+    if spec is None:
+        return PreprocCfg.arcface()
+    if isinstance(spec, PreprocCfg):
+        return spec
+    if isinstance(spec, str):
+        key = spec.strip().lower()
+        if key in _NAMED:
+            return _NAMED[key]()
+        raise ValueError(f"Unknown preprocessing preset: {spec!r}. Known: {sorted(_NAMED)}.")
+    raise TypeError(f"Unsupported preproc spec: {type(spec).__name__}")
+
+
+def preprocess_aligned(crop_rgb_uint8: np.ndarray, cfg: PreprocCfg) -> np.ndarray:
+    """Aligned HxWx3 RGB uint8 -> (1, 3, H, W) or (1, H, W, 3) float32 per cfg."""
+    img = crop_rgb_uint8.astype(np.float32)
+    if cfg.color_order == "BGR":
+        img = img[:, :, ::-1]
+    img = (img - cfg.mean) * cfg.scale
+    if cfg.layout == "NCHW":
+        img = np.transpose(img, (2, 0, 1))
+    return np.ascontiguousarray(img[None, ...], dtype=np.float32)
+
+
+def l2_normalize(x: np.ndarray, axis: int = -1, eps: float = 1e-10) -> np.ndarray:
+    return x / np.clip(np.linalg.norm(x, axis=axis, keepdims=True), eps, None)

--- a/libreyolo/models/facerec/weights.py
+++ b/libreyolo/models/facerec/weights.py
@@ -1,0 +1,72 @@
+"""Named weights and auto-download for the face-embedding (``embed``) task.
+
+The family ships two ONNX artifacts on the LibreYOLO Hugging Face org:
+
+- ``librefacerec-l.onnx``   — iResNet100 recognition head, 512-d embeddings
+  (mirrored single-file from an Apache-2.0 upstream release).
+- ``librefacerec-det.onnx`` — lightweight face detector with 5 landmarks
+  (MIT-licensed artifact from the OpenCV zoo), used as the default detector.
+
+Any other ArcFace-convention ONNX (aligned 112x112 in, ``(N, D)`` out) can be
+used by passing its file path directly (bring-your-own-weights).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HF_BASE = "https://huggingface.co/LibreYOLO"
+
+#: Canonical downloadable artifacts: filename -> HF resolve URL.
+FACEREC_WEIGHT_URLS = {
+    "librefacerec-l.onnx": f"{_HF_BASE}/librefacerec-l/resolve/main/librefacerec-l.onnx",
+    "librefacerec-det.onnx": f"{_HF_BASE}/librefacerec-det/resolve/main/librefacerec-det.onnx",
+}
+
+#: Embedder sizes the factory accepts as ``librefacerec-<size>``.
+FACEREC_SIZES = ("l",)
+
+
+def is_facerec_weight_name(model_path: str) -> bool:
+    """True for ``librefacerec-*`` names/paths (with or without ``.onnx``)."""
+    return Path(model_path).name.lower().startswith("librefacerec-")
+
+
+def resolve_facerec_weight(model_path: str) -> str:
+    """Resolve a ``librefacerec-*`` name to a local path, downloading if needed.
+
+    Bare names resolve into the standard ``weights/`` directory. Existing
+    file paths are returned unchanged.
+    """
+    path = Path(model_path)
+    name = path.name.lower()
+    if not name.endswith(".onnx"):
+        name += ".onnx"
+
+    if path.exists():
+        return str(path)
+
+    if name not in FACEREC_WEIGHT_URLS:
+        known = ", ".join(sorted(FACEREC_WEIGHT_URLS))
+        raise FileNotFoundError(
+            f"Unknown face-embedding weight '{path.name}'. Known downloadable "
+            f"names: {known}. For third-party recognition models, pass the "
+            f"path to a local ArcFace-convention ONNX file instead."
+        )
+
+    # Bare name (or weights/-prefixed name from the factory resolver).
+    dest = path if path.parent != Path(".") else Path("weights") / name
+    dest = dest.with_name(name)
+    if not dest.exists():
+        from ...utils.download import download_url_to_path
+
+        download_url_to_path(FACEREC_WEIGHT_URLS[name], dest)
+    return str(dest)
+
+
+def default_face_detector():
+    """Build the default face detector, downloading its weights if needed."""
+    from .model import OpenCVFaceDetector
+
+    det_path = resolve_facerec_weight("librefacerec-det.onnx")
+    return OpenCVFaceDetector(det_path)

--- a/libreyolo/tasks.py
+++ b/libreyolo/tasks.py
@@ -21,6 +21,7 @@ TaskType = Literal[
     "restore",
     "matte",
     "ocr",
+    "embed",
 ]
 TASKS = (
     "detect",
@@ -36,6 +37,7 @@ TASKS = (
     "restore",
     "matte",
     "ocr",
+    "embed",
 )
 
 TASK_ALIASES = {
@@ -91,6 +93,20 @@ TASK_ALIASES = {
     "text": "ocr",
     "text-recognition": "ocr",
     "text_recognition": "ocr",
+    # Face-embedding / facial recognition. Canonical is the single-word
+    # ``embed`` (matching the family's other single-word task names and the
+    # short filename suffix), with the human-facing terms routed to it.
+    "embed": "embed",
+    "embedding": "embed",
+    "embeddings": "embed",
+    "facial-recognition": "embed",
+    "facial_recognition": "embed",
+    "face-recognition": "embed",
+    "face_recognition": "embed",
+    "recognition": "embed",
+    "face": "embed",
+    "faceid": "embed",
+    "reid": "embed",
 }
 
 TASK_TO_SUFFIX = {
@@ -106,6 +122,7 @@ TASK_TO_SUFFIX = {
     "restore": "restore",
     "matte": "matte",
     "ocr": "ocr",
+    "embed": "embed",
 }
 
 SUFFIX_TO_TASK = {v: k for k, v in TASK_TO_SUFFIX.items()}

--- a/libreyolo/ui/server.py
+++ b/libreyolo/ui/server.py
@@ -63,6 +63,21 @@ def _summarize_result(result) -> tuple[str, str]:
     if gaze is not None:
         return "gaze", _plural(len(gaze), "face")
 
+    # Embeddings for the same reason: embed results also carry face boxes.
+    embeddings = getattr(result, "embeddings", None)
+    if embeddings is not None:
+        identities = getattr(result, "identities", None)
+        if identities is not None and len(identities) == len(embeddings):
+            known = list(dict.fromkeys(n for n in identities.name if n is not None))
+            unknown = sum(1 for n in identities.name if n is None)
+            if known:
+                label = ", ".join(known)
+                if unknown:
+                    label += f" (+{_plural(unknown, 'unknown face')})"
+                return "embed", label
+            return "embed", _plural(len(identities), "unknown face")
+        return "embed", _plural(len(embeddings), "face")
+
     boxes = getattr(result, "boxes", None)
     if boxes is not None:
         n = len(boxes)
@@ -149,6 +164,14 @@ def _resolve_download_url(name: str) -> str | None:
     from libreyolo.models.base.model import BaseModel
 
     filename = Path(resolve_model_name(name)).name
+
+    # The face-embedding family is ONNX-only and lives outside the model
+    # registry, so it publishes its download URLs directly.
+    from libreyolo.models.facerec.weights import FACEREC_WEIGHT_URLS
+
+    if filename in FACEREC_WEIGHT_URLS:
+        return FACEREC_WEIGHT_URLS[filename]
+
     classes = list(BaseModel._registry)
     rf = try_ensure_rfdetr()
     if rf is not None and rf not in classes:

--- a/libreyolo/utils/download.py
+++ b/libreyolo/utils/download.py
@@ -298,9 +298,18 @@ def download_weights(model_path: str, size: str):
     if notice:
         logger.warning(notice)
 
+    download_url_to_path(url, path, verify=cls.verify_downloaded_file)
+
+
+def download_url_to_path(url: str, path: Path, *, verify=None) -> None:
+    """Download ``url`` to ``path`` with locking, resume, retries and verify.
+
+    ``verify`` is an optional ``(local_path, source_url) -> None`` hook run on
+    the temporary file before it is atomically published at ``path``.
+    """
     logger.info(
         "Model weights not found at %s. Attempting download from %s...",
-        model_path,
+        path,
         url,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -355,11 +364,12 @@ def download_weights(model_path: str, size: str):
                 time.sleep(_DOWNLOAD_BACKOFF_SECONDS * (2**attempt))
 
         # Verify the temporary file before publishing it at the final path.
-        try:
-            cls.verify_downloaded_file(str(partial), url)
-        except Exception:
-            _reset_partial(partial)
-            raise
+        if verify is not None:
+            try:
+                verify(str(partial), url)
+            except Exception:
+                _reset_partial(partial)
+                raise
         os.replace(partial, path)
         _partial_metadata_path(partial).unlink(missing_ok=True)
         logger.info("Download complete.")

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -1082,6 +1082,73 @@ class Embeddings(_TensorPayload):
         )
 
 
+class Identities:
+    """Per-face identification outcome, row-aligned with ``Results.boxes``.
+
+    Produced by the ``embed`` task when a ``FaceGallery`` is supplied.
+    ``name`` is ``None`` for faces below the match threshold (*unknown*):
+    an unidentified face is never assigned the nearest wrong person.
+    """
+
+    def __init__(
+        self,
+        names: List[Optional[str]],
+        scores: TensorLike,
+    ):
+        self._names = list(names)
+        self._scores = np.asarray(_numpy(scores), dtype=np.float32).reshape(-1)
+        if len(self._names) != self._scores.shape[0]:
+            raise ValueError(
+                f"names ({len(self._names)}) and scores "
+                f"({self._scores.shape[0]}) must be row-aligned"
+            )
+
+    @property
+    def name(self) -> List[Optional[str]]:
+        """Matched identity per face, ``None`` for unknown."""
+        return list(self._names)
+
+    @property
+    def score(self) -> np.ndarray:
+        """Best gallery cosine similarity per face."""
+        return self._scores
+
+    @property
+    def data(self) -> List[Tuple[Optional[str], float]]:
+        return [(n, float(s)) for n, s in zip(self._names, self._scores)]
+
+    # Container protocol used by Results._apply — identity labels are
+    # device-less, so tensor movement is a no-op.
+    def to(self, *args, **kwargs) -> "Identities":
+        return self
+
+    def cpu(self) -> "Identities":
+        return self
+
+    def cuda(self) -> "Identities":
+        return self
+
+    def numpy(self) -> "Identities":
+        return self
+
+    def __getitem__(self, idx) -> "Identities":
+        if isinstance(idx, (int, np.integer)):
+            return Identities([self._names[idx]], self._scores[idx : idx + 1])
+        if isinstance(idx, slice):
+            return Identities(self._names[idx], self._scores[idx])
+        idx = np.asarray(idx)
+        if idx.dtype == bool:
+            idx = np.flatnonzero(idx)
+        return Identities([self._names[i] for i in idx], self._scores[idx])
+
+    def __len__(self) -> int:
+        return len(self._names)
+
+    def __repr__(self) -> str:
+        known = sum(1 for n in self._names if n is not None)
+        return f"Identities(n={len(self)}, known={known})"
+
+
 class Results:
     """Single-image result with flat detection/segmentation slots."""
 
@@ -1100,6 +1167,7 @@ class Results:
         "matte",
         "ocr",
         "embeddings",
+        "identities",
     )
 
     def __init__(
@@ -1127,6 +1195,7 @@ class Results:
         ocr: Optional[OCRRegions] = None,
         restore_scale: int = 1,
         embeddings: Optional[Embeddings] = None,
+        identities: Optional[Identities] = None,
     ):
         if boxes is not None and boxes.orig_shape is None:
             boxes = boxes.with_orig_shape(orig_shape)
@@ -1161,6 +1230,7 @@ class Results:
         # deblur/denoise and every non-restore task.
         self.restore_scale = int(restore_scale) if restore_scale else 1
         self.embeddings = embeddings
+        self.identities = identities
         self.orig_shape = orig_shape
         self.path = path
         self.names = names or {}
@@ -1188,6 +1258,7 @@ class Results:
             "ocr": self.ocr,
             "restore_scale": self.restore_scale,
             "embeddings": self.embeddings,
+            "identities": self.identities,
             "speed": dict(self.speed),
             "track_id": self.track_id,
             "frame_idx": self.frame_idx,
@@ -1250,6 +1321,7 @@ class Results:
         ocr: Optional[OCRRegions] = None,
         restore_scale: Optional[int] = None,
         embeddings: Optional[Embeddings] = None,
+        identities: Optional[Identities] = None,
     ) -> "Results":
         if boxes is not None:
             self.boxes = boxes.with_orig_shape(self.orig_shape)
@@ -1285,6 +1357,8 @@ class Results:
             self.restore_scale = int(restore_scale) if restore_scale else 1
         if embeddings is not None:
             self.embeddings = embeddings
+        if identities is not None:
+            self.identities = identities
         if track_id is not None:
             self.track_id = track_id
             if self.boxes is not None:
@@ -1537,6 +1611,9 @@ class Results:
                 row["embedding_dim"] = int(emb.dim)
                 if embeddings:
                     row["embedding"] = [round(float(v), decimals) for v in emb.data[i]]
+            if self.identities is not None and i < len(self.identities):
+                row["identity"] = self.identities.name[i]
+                row["identity_score"] = round(float(self.identities.score[i]), decimals)
             if track_ids is not None:
                 row["track_id"] = int(track_ids[i])
             rows.append(row)

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -1012,6 +1012,76 @@ class Gaze(_TensorPayload):
         )
 
 
+class Embeddings(_TensorPayload):
+    """Per-face L2-normalized identity embeddings for a single image.
+
+    Data shape: ``(N, D)`` where ``D`` is the model's embedding dimension
+    (e.g. 512 for an ArcFace/iResNet head, 128 for a MobileFaceNet-style head).
+    Each row is L2-normalized by the
+    inference runner and aligned row-by-row with the parent ``Results.boxes``
+    (the face boxes), exactly like ``Gaze``. Cosine similarity between two
+    normalized rows is their dot product, so identity verification is a
+    threshold on ``.similarity(...)``.
+    """
+
+    def __init__(self, data: TensorLike, orig_shape: Tuple[int, int] | None = None):
+        if data.ndim == 1:
+            if isinstance(data, torch.Tensor):
+                data = data.unsqueeze(0)
+            else:
+                data = data[None, :]
+        if data.ndim != 2:
+            raise ValueError(
+                f"expected (N, D) embeddings, got shape {tuple(data.shape)}"
+            )
+        super().__init__(data, orig_shape)
+
+    @property
+    def dim(self) -> int:
+        return int(self.data.shape[-1])
+
+    @property
+    def normalized(self) -> TensorLike:
+        """Defensive re-L2-normalization of each row."""
+        d = self.data
+        if isinstance(d, torch.Tensor):
+            return d / d.norm(dim=-1, keepdim=True).clamp_min(1e-10)
+        norm = np.linalg.norm(d, axis=-1, keepdims=True)
+        return d / np.clip(norm, 1e-10, None)
+
+    def similarity(self, other: "Embeddings | TensorLike") -> TensorLike:
+        """Cosine similarity of these rows against ``other``.
+
+        Returns ``(N, M)`` for an ``(M, D)`` gallery (or another Embeddings),
+        or ``(N,)`` for a single ``(D,)`` vector.
+        """
+        a = self.normalized
+        b = other.normalized if isinstance(other, Embeddings) else other
+        single = getattr(b, "ndim", 2) == 1
+        if isinstance(a, torch.Tensor):
+            b = b if isinstance(b, torch.Tensor) else torch.as_tensor(b, dtype=a.dtype, device=a.device)
+            b = b.reshape(1, -1) if single else b
+            b = b / b.norm(dim=-1, keepdim=True).clamp_min(1e-10)
+            sim = a @ b.T
+        else:
+            b = b if isinstance(b, np.ndarray) else _numpy(b)
+            b = b.reshape(1, -1) if single else b
+            b = b / np.clip(np.linalg.norm(b, axis=-1, keepdims=True), 1e-10, None)
+            sim = a @ b.T
+        return sim[:, 0] if single else sim
+
+    def verify(self, i: int, j: int, threshold: float = 0.4) -> bool:
+        """Whether face rows ``i`` and ``j`` are the same identity."""
+        sim = self.similarity(self.data[j])
+        return bool(float(sim[i]) >= threshold)
+
+    def __repr__(self) -> str:
+        return (
+            f"Embeddings(n={len(self)}, dim={self.dim}, "
+            f"shape={tuple(self.data.shape)})"
+        )
+
+
 class Results:
     """Single-image result with flat detection/segmentation slots."""
 
@@ -1029,6 +1099,7 @@ class Results:
         "restored",
         "matte",
         "ocr",
+        "embeddings",
     )
 
     def __init__(
@@ -1055,6 +1126,7 @@ class Results:
         matte: Optional[Matte] = None,
         ocr: Optional[OCRRegions] = None,
         restore_scale: int = 1,
+        embeddings: Optional[Embeddings] = None,
     ):
         if boxes is not None and boxes.orig_shape is None:
             boxes = boxes.with_orig_shape(orig_shape)
@@ -1088,6 +1160,7 @@ class Results:
         # restored canvas is ``restore_scale`` times the input. 1 for
         # deblur/denoise and every non-restore task.
         self.restore_scale = int(restore_scale) if restore_scale else 1
+        self.embeddings = embeddings
         self.orig_shape = orig_shape
         self.path = path
         self.names = names or {}
@@ -1114,6 +1187,7 @@ class Results:
             "matte": self.matte,
             "ocr": self.ocr,
             "restore_scale": self.restore_scale,
+            "embeddings": self.embeddings,
             "speed": dict(self.speed),
             "track_id": self.track_id,
             "frame_idx": self.frame_idx,
@@ -1175,6 +1249,7 @@ class Results:
         matte: Optional[Matte] = None,
         ocr: Optional[OCRRegions] = None,
         restore_scale: Optional[int] = None,
+        embeddings: Optional[Embeddings] = None,
     ) -> "Results":
         if boxes is not None:
             self.boxes = boxes.with_orig_shape(self.orig_shape)
@@ -1208,6 +1283,8 @@ class Results:
             )
         if restore_scale is not None:
             self.restore_scale = int(restore_scale) if restore_scale else 1
+        if embeddings is not None:
+            self.embeddings = embeddings
         if track_id is not None:
             self.track_id = track_id
             if self.boxes is not None:
@@ -1273,7 +1350,12 @@ class Results:
         Image.fromarray(rgba, mode="RGBA").save(out)
         return str(out)
 
-    def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, Any]]:
+    def summary(
+        self,
+        normalize: bool = False,
+        decimals: int = 5,
+        embeddings: bool = False,
+    ) -> List[Dict[str, Any]]:
         if self.boxes is None:
             if self.ocr is not None:
                 ocr_np = self.ocr.numpy()
@@ -1448,6 +1530,13 @@ class Results:
                     "pitch_deg": round(float(gaze_np.data[i, 0]) * 180.0 / math.pi, decimals),
                     "yaw_deg": round(float(gaze_np.data[i, 1]) * 180.0 / math.pi, decimals),
                 }
+            if self.embeddings is not None and i < len(self.embeddings):
+                emb = self.embeddings.numpy() if isinstance(self.embeddings.data, torch.Tensor) else self.embeddings
+                # A 512-float vector is ~2 KB/face — omit it from summaries by
+                # default and surface only its dimension; opt in with embeddings=True.
+                row["embedding_dim"] = int(emb.dim)
+                if embeddings:
+                    row["embedding"] = [round(float(v), decimals) for v in emb.data[i]]
             if track_ids is not None:
                 row["track_id"] = int(track_ids[i])
             rows.append(row)
@@ -1461,6 +1550,8 @@ class Results:
             return len(self.boxes)
         if self.points is not None:
             return len(self.points)
+        if self.embeddings is not None:
+            return len(self.embeddings)
         if self.probs is not None:
             return 1
         if self.semantic_mask is not None:

--- a/tests/unit/cli/commands/test_compare.py
+++ b/tests/unit/cli/commands/test_compare.py
@@ -1,0 +1,103 @@
+"""Behavior tests for the `compare` (face-verification) command."""
+
+import json
+
+import pytest
+import typer
+from PIL import Image
+from typer.testing import CliRunner
+
+from libreyolo.cli.commands import special as special_module
+from libreyolo.cli.commands.special import compare_cmd
+from libreyolo.cli.parsing import KeyValueCommand
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+def _make_app() -> typer.Typer:
+    app = typer.Typer()
+    app.command("compare", cls=KeyValueCommand)(compare_cmd)
+    return app
+
+
+class _FakeEmbedModel:
+    task = "embed"
+    family = "facerec"
+
+    def __init__(self, sim: float):
+        self._sim = sim
+        self.face_detector = None
+
+    def verify(self, a, b, *, threshold: float = 0.4, **_):
+        return {
+            "similarity": self._sim,
+            "same_person": self._sim >= threshold,
+            "threshold": threshold,
+        }
+
+
+def _patch(monkeypatch, fake):
+    monkeypatch.setattr(special_module, "resolve_model_or_exit", lambda out, m: m)
+    monkeypatch.setattr(
+        special_module,
+        "load_model_or_exit",
+        lambda out, *, model, model_path, device, task=None: fake,
+    )
+
+
+def _imgs(tmp_path):
+    a, b = tmp_path / "a.jpg", tmp_path / "b.jpg"
+    Image.new("RGB", (20, 20)).save(a)
+    Image.new("RGB", (20, 20)).save(b)
+    det = tmp_path / "facedet.onnx"        # lazy OpenCVFaceDetector — never loaded here
+    det.write_bytes(b"stub")
+    return a, b, det
+
+
+def test_compare_same_person(monkeypatch, tmp_path):
+    a, b, det = _imgs(tmp_path)
+    _patch(monkeypatch, _FakeEmbedModel(sim=0.82))
+    result = runner.invoke(
+        _make_app(),
+        [f"model={a}", f"source={a}", f"source2={b}",
+         "--face-detector", str(det), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["same_person"] is True
+    assert data["similarity"] == pytest.approx(0.82, abs=1e-4)
+
+
+def test_compare_different_people(monkeypatch, tmp_path):
+    a, b, det = _imgs(tmp_path)
+    _patch(monkeypatch, _FakeEmbedModel(sim=0.05))
+    result = runner.invoke(
+        _make_app(),
+        [f"model={a}", f"source={a}", f"source2={b}",
+         "--face-detector", str(det), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["same_person"] is False
+
+
+def test_compare_requires_face_detector(monkeypatch, tmp_path):
+    a, b, _ = _imgs(tmp_path)
+    _patch(monkeypatch, _FakeEmbedModel(sim=0.82))
+    result = runner.invoke(
+        _make_app(),
+        [f"model={a}", f"source={a}", f"source2={b}", "--json"],
+    )
+    assert result.exit_code != 0
+
+
+def test_compare_missing_source(monkeypatch, tmp_path):
+    a, _, det = _imgs(tmp_path)
+    _patch(monkeypatch, _FakeEmbedModel(sim=0.82))
+    result = runner.invoke(
+        _make_app(),
+        [f"model={a}", f"source={a}",
+         f"source2={tmp_path / 'missing.jpg'}", "--face-detector", str(det), "--json"],
+    )
+    assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_compare.py
+++ b/tests/unit/cli/commands/test_compare.py
@@ -82,14 +82,19 @@ def test_compare_different_people(monkeypatch, tmp_path):
     assert json.loads(result.stdout)["same_person"] is False
 
 
-def test_compare_requires_face_detector(monkeypatch, tmp_path):
+def test_compare_face_detector_optional(monkeypatch, tmp_path):
+    """Omitting --face-detector falls back to the family default detector."""
     a, b, _ = _imgs(tmp_path)
-    _patch(monkeypatch, _FakeEmbedModel(sim=0.82))
+    model = _FakeEmbedModel(sim=0.82)
+    _patch(monkeypatch, model)
     result = runner.invoke(
         _make_app(),
         [f"model={a}", f"source={a}", f"source2={b}", "--json"],
     )
-    assert result.exit_code != 0
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["same_person"] is True
+    # The CLI leaves the detector unset so the runner resolves the default.
+    assert model.face_detector is None
 
 
 def test_compare_missing_source(monkeypatch, tmp_path):

--- a/tests/unit/cli/commands/test_enroll.py
+++ b/tests/unit/cli/commands/test_enroll.py
@@ -1,0 +1,126 @@
+"""Behavior tests for the `enroll` (face-gallery build) command."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import typer
+from PIL import Image
+from typer.testing import CliRunner
+
+from libreyolo.cli.commands import special as special_module
+from libreyolo.cli.commands.special import enroll_cmd
+from libreyolo.cli.parsing import KeyValueCommand
+from libreyolo.utils.results import Embeddings
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+def _make_app() -> typer.Typer:
+    app = typer.Typer()
+    app.command("enroll", cls=KeyValueCommand)(enroll_cmd)
+    return app
+
+
+class _FakeEmbedModel:
+    """Embeds each image as a deterministic unit vector per identity folder."""
+
+    task = "embed"
+    family = "facerec"
+    model_path = None
+
+    def __init__(self):
+        self.face_detector = None
+
+    def __call__(self, source, **_):
+        identity = Path(source).parent.name
+        rng = np.random.RandomState(abs(hash(identity)) % (2**31))
+        vec = rng.rand(8).astype(np.float32)
+        return SimpleNamespace(
+            embeddings=Embeddings(vec[None, :]), boxes=None
+        )
+
+
+def _patch(monkeypatch, fake):
+    monkeypatch.setattr(special_module, "resolve_model_or_exit", lambda out, m: m)
+    monkeypatch.setattr(
+        special_module,
+        "load_model_or_exit",
+        lambda out, *, model, model_path, device, task=None: fake,
+    )
+
+
+def _people_tree(tmp_path):
+    people = tmp_path / "people"
+    for identity, count in (("alice", 2), ("bob", 1)):
+        d = people / identity
+        d.mkdir(parents=True)
+        for i in range(count):
+            Image.new("RGB", (20, 20)).save(d / f"{i}.jpg")
+    (people / "carol").mkdir()  # no images -> skipped
+    return people
+
+
+def test_enroll_builds_gallery(monkeypatch, tmp_path):
+    from libreyolo.models.facerec import FaceGallery
+
+    people = _people_tree(tmp_path)
+    gallery_path = tmp_path / "team.gallery.npz"
+    _patch(monkeypatch, _FakeEmbedModel())
+
+    result = runner.invoke(
+        _make_app(),
+        [f"model=facerec-l", f"source={people}", f"gallery={gallery_path}", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["identities"] == 2
+    assert data["references"] == 3
+    assert data["enrolled"] == {"alice": 2, "bob": 1}
+    assert data["skipped"] == ["carol"]
+
+    loaded = FaceGallery.load(gallery_path)
+    assert sorted(loaded.identities) == ["alice", "bob"]
+
+
+def test_enroll_appends_to_existing_gallery(monkeypatch, tmp_path):
+    from libreyolo.models.facerec import FaceGallery
+
+    people = _people_tree(tmp_path)
+    gallery_path = tmp_path / "team.gallery.npz"
+    _patch(monkeypatch, _FakeEmbedModel())
+    app = _make_app()
+
+    first = runner.invoke(
+        app, [f"model=facerec-l", f"source={people}", f"gallery={gallery_path}", "--json"]
+    )
+    assert first.exit_code == 0, first.output
+
+    dave = people / "dave"
+    dave.mkdir()
+    Image.new("RGB", (20, 20)).save(dave / "0.jpg")
+    second = runner.invoke(
+        app, [f"model=facerec-l", f"source={people}", f"gallery={gallery_path}", "--json"]
+    )
+    assert second.exit_code == 0, second.output
+
+    loaded = FaceGallery.load(gallery_path)
+    assert "dave" in loaded.identities
+    assert len(loaded.identities) == 3
+
+
+def test_enroll_rejects_flat_folder(monkeypatch, tmp_path):
+    flat = tmp_path / "flat"
+    flat.mkdir()
+    Image.new("RGB", (20, 20)).save(flat / "img.jpg")
+    _patch(monkeypatch, _FakeEmbedModel())
+
+    result = runner.invoke(
+        _make_app(),
+        [f"model=facerec-l", f"source={flat}", f"gallery={tmp_path / 'g.npz'}", "--json"],
+    )
+    assert result.exit_code != 0

--- a/tests/unit/test_facerec.py
+++ b/tests/unit/test_facerec.py
@@ -1,0 +1,228 @@
+"""Unit tests for the face-embedding (facial-recognition / ``embed``) task.
+
+Hermetic — no network, no large weights. ONNX-dependent tests build a tiny
+synthetic recognition graph; everything else (task aliases, the Embeddings
+payload, alignment math) is pure numpy/torch.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.tasks import (
+    SUFFIX_TO_TASK,
+    normalize_task,
+    suffix_to_task,
+    task_to_suffix,
+)
+from libreyolo.models.facerec.align import (
+    ARCFACE_DST_112,
+    align_face,
+    estimate_norm,
+)
+from libreyolo.utils.results import Boxes, Embeddings, Results
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Task registration / aliases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["embed", "embedding", "embeddings", "facial-recognition", "facial_recognition",
+     "face-recognition", "face_recognition", "recognition", "face", "faceid", "reid"],
+)
+def test_aliases_resolve_to_embed(alias):
+    assert normalize_task(alias) == "embed"
+
+
+def test_embed_suffix_roundtrip():
+    assert task_to_suffix("embed") == "embed"
+    assert suffix_to_task("embed") == "embed"
+    assert SUFFIX_TO_TASK["embed"] == "embed"
+
+
+# ---------------------------------------------------------------------------
+# Embeddings payload
+# ---------------------------------------------------------------------------
+
+
+def test_embeddings_basic_and_dim():
+    e = Embeddings(torch.randn(3, 8))
+    assert e.dim == 8
+    assert len(e) == 3
+    norms = torch.linalg.vector_norm(e.normalized, dim=-1)
+    assert torch.allclose(norms, torch.ones(3), atol=1e-5)
+
+
+def test_embeddings_promotes_1d():
+    e = Embeddings(np.random.rand(16).astype(np.float32))
+    assert e.data.shape == (1, 16)
+
+
+def test_embeddings_rejects_wrong_rank():
+    with pytest.raises(ValueError):
+        Embeddings(torch.randn(2, 3, 4))
+
+
+def test_embeddings_similarity_single_and_matrix():
+    a = Embeddings(np.eye(4, dtype=np.float32)[:2])  # two orthonormal rows
+    # vs a single vector
+    sim_vec = a.similarity(np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32))
+    assert np.asarray(sim_vec).shape == (2,)
+    assert sim_vec[0] == pytest.approx(1.0, abs=1e-5)
+    assert sim_vec[1] == pytest.approx(0.0, abs=1e-5)
+    # vs a gallery matrix
+    sim_mat = a.similarity(a)
+    assert np.asarray(sim_mat).shape == (2, 2)
+    assert np.allclose(np.diag(np.asarray(sim_mat)), 1.0, atol=1e-5)
+
+
+def test_embeddings_verify():
+    data = np.stack([[1, 0, 0], [1, 0, 0], [0, 1, 0]]).astype(np.float32)
+    e = Embeddings(data)
+    assert e.verify(0, 1, threshold=0.9) is True   # identical rows
+    assert e.verify(0, 2, threshold=0.5) is False  # orthogonal rows
+
+
+def test_embeddings_device_roundtrip_and_index():
+    e = Embeddings(torch.randn(2, 8))
+    e_np = e.numpy()
+    assert isinstance(e_np.data, np.ndarray)
+    first = e[0]
+    assert first.data.shape == (1, 8)
+
+
+def test_results_carries_embeddings_slot():
+    boxes = Boxes(torch.zeros((2, 4)), torch.tensor([0.9, 0.8]), torch.tensor([0.0, 0.0]))
+    e = Embeddings(torch.randn(2, 8))
+    r = Results(boxes=boxes, orig_shape=(100, 100), embeddings=e, names={0: "face"})
+    assert r.embeddings is e
+    assert "embeddings" in r._keys
+    # survives device-move / slicing through _apply
+    assert r.numpy().embeddings.data.shape == (2, 8)
+    assert r[0].embeddings.data.shape == (1, 8)
+
+
+def test_summary_omits_vector_by_default():
+    boxes = Boxes(torch.zeros((1, 4)), torch.tensor([0.9]), torch.tensor([0.0]))
+    e = Embeddings(torch.randn(1, 8))
+    r = Results(boxes=boxes, orig_shape=(50, 50), embeddings=e, names={0: "face"})
+    row = r.summary()[0]
+    assert row["embedding_dim"] == 8
+    assert "embedding" not in row          # raw vector omitted by default
+    row_full = r.summary(embeddings=True)[0]
+    assert len(row_full["embedding"]) == 8  # opt-in includes it
+
+
+# ---------------------------------------------------------------------------
+# Alignment
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_norm_recovers_template():
+    theta = np.deg2rad(23.0)
+    R = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
+    src = 1.37 * (ARCFACE_DST_112 @ R.T) + np.array([40.0, -15.0])
+    M = estimate_norm(src, 112)
+    recovered = src @ M[:, :2].T + M[:, 2]
+    assert np.abs(recovered - ARCFACE_DST_112).max() < 1e-6
+
+
+def test_align_face_landmarks_and_fallback():
+    img = (np.random.rand(200, 200, 3) * 255).astype(np.uint8)
+    lm = ARCFACE_DST_112 + np.array([40.0, 30.0])  # template shifted into the image
+    aligned = align_face(img, (40, 30, 152, 142), lm, 112)
+    assert aligned.shape == (112, 112, 3)
+    # no landmarks -> center-crop fallback still yields a 112 crop
+    fallback = align_face(img, (10, 10, 110, 110), None, 112)
+    assert fallback.shape == (112, 112, 3)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with a synthetic ONNX recognition head
+# ---------------------------------------------------------------------------
+
+
+def _build_tiny_face_onnx(path: str, dim: int = 8) -> None:
+    onnx = pytest.importorskip("onnx")
+    from onnx import TensorProto, helper, numpy_helper
+
+    inp = helper.make_tensor_value_info("data", TensorProto.FLOAT, [None, 3, 112, 112])
+    out = helper.make_tensor_value_info("emb", TensorProto.FLOAT, [None, dim])
+    gap = helper.make_node("GlobalAveragePool", ["data"], ["gap"])
+    newshape = numpy_helper.from_array(np.array([-1, 3], dtype=np.int64), name="newshape")
+    reshape = helper.make_node("Reshape", ["gap", "newshape"], ["flat"])
+    rng = np.random.RandomState(0)
+    W = numpy_helper.from_array(rng.rand(3, dim).astype(np.float32), name="W")
+    matmul = helper.make_node("MatMul", ["flat", "W"], ["emb"])
+    graph = helper.make_graph([gap, reshape, matmul], "tiny_face",
+                              [inp], [out], initializer=[newshape, W])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    onnx.save(model, path)
+
+
+@pytest.fixture
+def tiny_onnx(tmp_path):
+    pytest.importorskip("onnxruntime")
+    p = tmp_path / "tiny_face.onnx"
+    _build_tiny_face_onnx(str(p), dim=8)
+    return str(p)
+
+
+def test_end_to_end_byo_boxes(tiny_onnx):
+    from libreyolo.models.facerec import LibreFaceEmbedder
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    assert model.task == "embed"
+    assert model.names == {0: "face"}
+
+    img = Image.fromarray((np.random.rand(96, 96, 3) * 255).astype(np.uint8))
+    res = model(img, face_boxes=[(0, 0, 96, 96)])
+    assert isinstance(res, Results)
+    assert res.embeddings is not None
+    assert res.embeddings.data.shape == (1, 8)
+    assert float(np.linalg.norm(res.embeddings.numpy().data[0])) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_verify_same_image_is_one(tiny_onnx):
+    from libreyolo.models.facerec import LibreFaceEmbedder
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    img = Image.fromarray((np.random.rand(96, 96, 3) * 255).astype(np.uint8))
+    out = model.verify(img, img, threshold=0.5, face_boxes_a=[(0, 0, 96, 96)],
+                       face_boxes_b=[(0, 0, 96, 96)])
+    assert out["similarity"] == pytest.approx(1.0, abs=1e-4)
+    assert out["same_person"] is True
+
+
+def test_factory_routes_onnx_embed_task(tiny_onnx):
+    from libreyolo import LibreYOLO
+    from libreyolo.models.facerec import LibreFaceEmbedder
+
+    model = LibreYOLO(tiny_onnx, task="facial-recognition")
+    assert isinstance(model, LibreFaceEmbedder)
+    assert model.task == "embed"
+
+
+def test_inference_only_guards(tiny_onnx):
+    from libreyolo.models.facerec import LibreFaceEmbedder
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    for verb in ("train", "val", "export"):
+        with pytest.raises(NotImplementedError):
+            getattr(model, verb)()
+
+    img = Image.fromarray((np.random.rand(64, 64, 3) * 255).astype(np.uint8))
+    with pytest.raises(ValueError):
+        model(img, face_boxes=[(0, 0, 64, 64)], augment=True)
+    with pytest.raises(RuntimeError):
+        model(img)  # no detector, no boxes

--- a/tests/unit/test_facerec.py
+++ b/tests/unit/test_facerec.py
@@ -213,7 +213,7 @@ def test_factory_routes_onnx_embed_task(tiny_onnx):
     assert model.task == "embed"
 
 
-def test_inference_only_guards(tiny_onnx):
+def test_inference_only_guards(tiny_onnx, monkeypatch):
     from libreyolo.models.facerec import LibreFaceEmbedder
 
     model = LibreFaceEmbedder(tiny_onnx, device="cpu")
@@ -224,5 +224,79 @@ def test_inference_only_guards(tiny_onnx):
     img = Image.fromarray((np.random.rand(64, 64, 3) * 255).astype(np.uint8))
     with pytest.raises(ValueError):
         model(img, face_boxes=[(0, 0, 64, 64)], augment=True)
+    # No detector, no boxes, and the default detector unobtainable (kept
+    # hermetic: the real fallback would try an auto-download here).
+    monkeypatch.setattr(
+        model, "default_face_detector",
+        lambda: (_ for _ in ()).throw(FileNotFoundError("offline")),
+    )
     with pytest.raises(RuntimeError):
-        model(img)  # no detector, no boxes
+        model(img)
+
+
+# ---------------------------------------------------------------------------
+# Named weights + auto-download wiring
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_facerec_weight_existing_path(tiny_onnx):
+    from libreyolo.models.facerec.weights import resolve_facerec_weight
+
+    assert resolve_facerec_weight(tiny_onnx) == tiny_onnx
+
+
+def test_resolve_facerec_weight_downloads_bare_name(monkeypatch, tmp_path):
+    from pathlib import Path as P
+
+    from libreyolo.models.facerec.weights import resolve_facerec_weight
+
+    calls = {}
+
+    def fake_download(url, dest, **kwargs):
+        calls["url"] = url
+        P(dest).parent.mkdir(parents=True, exist_ok=True)
+        P(dest).write_bytes(b"stub")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "libreyolo.utils.download.download_url_to_path", fake_download
+    )
+    got = resolve_facerec_weight("librefacerec-l")
+    assert P(got) == P("weights") / "librefacerec-l.onnx"
+    assert P(got).exists()
+    assert calls["url"].endswith("librefacerec-l/resolve/main/librefacerec-l.onnx")
+
+
+def test_resolve_facerec_weight_unknown_name(tmp_path, monkeypatch):
+    from libreyolo.models.facerec.weights import resolve_facerec_weight
+
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(FileNotFoundError, match="Known downloadable"):
+        resolve_facerec_weight("librefacerec-zz.onnx")
+
+
+def test_factory_routes_librefacerec_name(monkeypatch, tmp_path):
+    import shutil
+
+    from libreyolo import LibreYOLO
+    from libreyolo.models.facerec import LibreFaceEmbedder
+
+    pytest.importorskip("onnxruntime")
+    monkeypatch.chdir(tmp_path)
+    wdir = tmp_path / "weights"
+    wdir.mkdir()
+    _build_tiny_face_onnx(str(wdir / "librefacerec-l.onnx"), dim=8)
+
+    model = LibreYOLO("librefacerec-l")
+    assert isinstance(model, LibreFaceEmbedder)
+    assert model.task == "embed"
+
+    with pytest.raises(ValueError, match="embed"):
+        LibreYOLO("librefacerec-l", task="detect")
+
+
+def test_cli_names_resolve_facerec():
+    from libreyolo.cli.config import resolve_model_name
+
+    assert resolve_model_name("facerec-l") == "librefacerec-l.onnx"
+    assert resolve_model_name("librefacerec-l") == "librefacerec-l.onnx"

--- a/tests/unit/test_facerec.py
+++ b/tests/unit/test_facerec.py
@@ -443,3 +443,56 @@ def test_identities_payload_slicing_and_results_plumbing():
     assert sliced.identities.name == ["alice"]
     r2 = r.update(identities=Identities(["carol"] * 3, np.ones(3)))
     assert r2.identities.name == ["carol", "carol", "carol"]
+
+
+# ---------------------------------------------------------------------------
+# Review follow-ups (PR #654)
+# ---------------------------------------------------------------------------
+
+
+def test_enroll_through_a_different_model_raises(tiny_onnx, tmp_path):
+    """A gallery holds one embedding space; enrolling via another model fails.
+
+    Without this guard the gallery keeps the first model's fingerprint and
+    silently appends a vector that will never compare correctly.
+    """
+    from libreyolo.models.facerec import FaceGallery, LibreFaceEmbedder
+
+    model_a = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    other_path = tmp_path / "other.onnx"
+    _build_tiny_face_onnx(str(other_path), dim=8)
+    model_b = LibreFaceEmbedder(str(other_path), device="cpu")
+    model_b._weights_fingerprint = "deadbeefdeadbeef"
+
+    img = Image.fromarray((np.random.rand(96, 96, 3) * 255).astype(np.uint8))
+    path = tmp_path / "face.jpg"
+    img.save(path)
+
+    gallery = FaceGallery(embedder=model_a)
+    gallery.enroll_embedding("alice", _vec(8, 0))
+
+    with pytest.raises(ValueError, match="different embedding model"):
+        gallery.enroll("bob", str(path), embedder=model_b)
+
+
+def test_video_source_routes_to_video_inference(tiny_onnx, monkeypatch):
+    """A video path must go through the video runner, not ImageLoader."""
+    from libreyolo.models.facerec import LibreFaceEmbedder
+    from libreyolo.models.facerec import inference as inference_module
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    called = {}
+
+    def fake_run_video_inference(source, predict_frame, **kwargs):
+        called["source"] = str(source)
+        called["stride"] = kwargs.get("vid_stride")
+        return iter(())
+
+    monkeypatch.setattr(
+        inference_module, "run_video_inference", fake_run_video_inference
+    )
+    monkeypatch.setattr(
+        inference_module, "collect_video_results", lambda gen, src, stride: list(gen)
+    )
+    model("clip.mp4", face_boxes=[(0, 0, 10, 10)])
+    assert called["source"] == "clip.mp4"

--- a/tests/unit/test_facerec.py
+++ b/tests/unit/test_facerec.py
@@ -476,17 +476,22 @@ def test_enroll_through_a_different_model_raises(tiny_onnx, tmp_path):
 
 
 def test_video_source_routes_to_video_inference(tiny_onnx, monkeypatch):
-    """A video path must go through the video runner, not ImageLoader."""
+    """A video path routes to the video runner AND its frames actually embed.
+
+    The fake driver invokes the frame callback the way the real one does; a
+    fake that only records the call would pass even when every frame raises.
+    """
     from libreyolo.models.facerec import LibreFaceEmbedder
     from libreyolo.models.facerec import inference as inference_module
 
     model = LibreFaceEmbedder(tiny_onnx, device="cpu")
     called = {}
+    frame = Image.fromarray((np.random.rand(96, 96, 3) * 255).astype(np.uint8))
 
     def fake_run_video_inference(source, predict_frame, **kwargs):
         called["source"] = str(source)
         called["stride"] = kwargs.get("vid_stride")
-        return iter(())
+        yield predict_frame(frame)
 
     monkeypatch.setattr(
         inference_module, "run_video_inference", fake_run_video_inference
@@ -494,5 +499,37 @@ def test_video_source_routes_to_video_inference(tiny_onnx, monkeypatch):
     monkeypatch.setattr(
         inference_module, "collect_video_results", lambda gen, src, stride: list(gen)
     )
-    model("clip.mp4", face_boxes=[(0, 0, 10, 10)])
+
+    # Caller-supplied boxes must survive into every frame: with no detector,
+    # dropping them left the frame callback with no face source at all.
+    results = model("clip.mp4", face_boxes=[(0, 0, 96, 96)], vid_stride=2)
     assert called["source"] == "clip.mp4"
+    assert called["stride"] == 2
+    assert len(results) == 1
+    assert results[0].embeddings.data.shape == (1, 8)
+
+
+def test_video_with_gallery_identifies_each_frame(tiny_onnx, monkeypatch):
+    from libreyolo.models.facerec import FaceGallery, LibreFaceEmbedder
+    from libreyolo.models.facerec import inference as inference_module
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    frame = Image.fromarray((np.random.rand(96, 96, 3) * 255).astype(np.uint8))
+
+    reference = model(frame, face_boxes=[(0, 0, 96, 96)])
+    gallery = FaceGallery(embedder=model)
+    gallery.enroll_embedding("alice", reference.embeddings.data[0])
+
+    monkeypatch.setattr(
+        inference_module,
+        "run_video_inference",
+        lambda source, predict_frame, **kw: iter([predict_frame(frame)]),
+    )
+    monkeypatch.setattr(
+        inference_module, "collect_video_results", lambda gen, src, stride: list(gen)
+    )
+
+    results = model(
+        "clip.mp4", face_boxes=[(0, 0, 96, 96)], gallery=gallery, threshold=0.9
+    )
+    assert results[0].identities.name == ["alice"]

--- a/tests/unit/test_facerec.py
+++ b/tests/unit/test_facerec.py
@@ -300,3 +300,146 @@ def test_cli_names_resolve_facerec():
 
     assert resolve_model_name("facerec-l") == "librefacerec-l.onnx"
     assert resolve_model_name("librefacerec-l") == "librefacerec-l.onnx"
+
+
+# ---------------------------------------------------------------------------
+# FaceGallery + identification
+# ---------------------------------------------------------------------------
+
+
+def _vec(dim, hot):
+    v = np.zeros(dim, dtype=np.float32)
+    v[hot] = 1.0
+    return v
+
+
+def test_gallery_enroll_embedding_and_match():
+    from libreyolo.models.facerec import FaceGallery
+
+    g = FaceGallery()
+    g.enroll_embedding("alice", _vec(8, 0))
+    g.enroll_embedding("alice", _vec(8, 1))  # second reference, different pose
+    g.enroll_embedding("bob", _vec(8, 2))
+    assert len(g) == 2
+    assert g.identities == ["alice", "bob"]
+    assert "alice" in g and "carol" not in g
+
+    # max-cosine over references: a query near alice's 2nd ref still hits alice
+    matches = g.match(_vec(8, 1), top_k=2, threshold=0.3)
+    assert matches[0][0] == ("alice", pytest.approx(1.0))
+    # below-threshold queries return no name, never the nearest wrong person
+    q = np.full(8, 0.1, dtype=np.float32)
+    assert g.match(_vec(8, 5), threshold=0.5) == [[]]
+
+    assert g.remove("bob") == 1
+    assert g.identities == ["alice"]
+
+
+def test_gallery_dim_mismatch_raises():
+    from libreyolo.models.facerec import FaceGallery
+
+    g = FaceGallery()
+    g.enroll_embedding("alice", _vec(8, 0))
+    with pytest.raises(ValueError, match="dim mismatch"):
+        g.enroll_embedding("bob", _vec(16, 0))
+    with pytest.raises(ValueError, match="dim mismatch"):
+        g.match(_vec(16, 0))
+
+
+def test_gallery_save_load_roundtrip(tmp_path):
+    from libreyolo.models.facerec import FaceGallery
+
+    g = FaceGallery()
+    g.enroll_embedding("alice", _vec(8, 0))
+    g.enroll_embedding("bob", _vec(8, 2))
+    p = tmp_path / "team.gallery.npz"
+    g.save(p)
+
+    loaded = FaceGallery.load(p)
+    assert loaded.identities == ["alice", "bob"]
+    assert loaded.dim == 8
+    assert loaded.match(_vec(8, 2))[0][0][0] == "bob"
+
+    with pytest.raises(ValueError):
+        FaceGallery().save(tmp_path / "empty.npz")
+
+
+def test_gallery_model_fingerprint_guard(tmp_path, tiny_onnx):
+    from libreyolo.models.facerec import FaceGallery, LibreFaceEmbedder
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    g = FaceGallery(embedder=model)
+    g.enroll_embedding("alice", _vec(8, 0))
+    p = tmp_path / "team.gallery.npz"
+    g.save(p)
+
+    # same model loads fine
+    FaceGallery.load(p, embedder=model)
+
+    # different weights file -> fingerprint mismatch
+    other_path = tmp_path / "other.onnx"
+    _build_tiny_face_onnx(str(other_path), dim=8)
+    other = LibreFaceEmbedder(str(other_path), device="cpu")
+    other._weights_fingerprint = "deadbeefdeadbeef"
+    with pytest.raises(ValueError, match="different embedding model"):
+        FaceGallery.load(p, embedder=other)
+
+
+def test_gallery_enroll_from_images_and_identify(tiny_onnx, tmp_path):
+    from libreyolo.models.facerec import FaceGallery, LibreFaceEmbedder
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    rng = np.random.RandomState(7)
+    img_a = Image.fromarray((rng.rand(96, 96, 3) * 255).astype(np.uint8))
+    path_a = tmp_path / "alice.jpg"
+    img_a.save(path_a)
+
+    g = FaceGallery(embedder=model)
+    # enroll needs a face source; the tiny graph has no detector, so BYO boxes
+    res = model(img_a, face_boxes=[(0, 0, 96, 96)])
+    g.enroll_embedding("alice", res.embeddings.data[0])
+    assert len(g) == 1
+
+    # identify the same face -> alice at ~1.0 cosine
+    out = model(img_a, face_boxes=[(0, 0, 96, 96)], gallery=g, threshold=0.9)
+    assert out.identities is not None
+    assert out.identities.name == ["alice"]
+    assert float(out.identities.score[0]) == pytest.approx(1.0, abs=1e-5)
+    assert out.summary()[0]["identity"] == "alice"
+
+    # impossible threshold -> unknown, but the raw best score stays visible
+    out2 = model(img_a, face_boxes=[(0, 0, 96, 96)], gallery=g, threshold=1.1)
+    assert out2.identities.name == [None]
+    assert float(out2.identities.score[0]) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_identify_empty_gallery_raises(tiny_onnx):
+    from libreyolo.models.facerec import FaceGallery, LibreFaceEmbedder
+
+    model = LibreFaceEmbedder(tiny_onnx, device="cpu")
+    img = Image.fromarray((np.random.rand(64, 64, 3) * 255).astype(np.uint8))
+    with pytest.raises(ValueError, match="empty FaceGallery"):
+        model(img, face_boxes=[(0, 0, 64, 64)], gallery=FaceGallery())
+
+
+def test_identities_payload_slicing_and_results_plumbing():
+    from libreyolo.utils.results import Identities
+
+    ids = Identities(["alice", None, "bob"], np.array([0.9, 0.2, 0.7]))
+    assert len(ids) == 3
+    assert ids.name[1] is None
+    assert ids[0].name == ["alice"]
+    assert ids[1:].name == [None, "bob"]
+    assert ids[[0, 2]].name == ["alice", "bob"]
+    assert ids.numpy() is ids and ids.cpu() is ids
+
+    boxes = Boxes(
+        torch.tensor([[0, 0, 10, 10], [5, 5, 20, 20], [8, 8, 30, 30]], dtype=torch.float32),
+        torch.tensor([0.9, 0.8, 0.7]),
+        torch.zeros(3),
+    )
+    r = Results(boxes=boxes, orig_shape=(64, 64), identities=ids)
+    sliced = r[0]
+    assert sliced.identities.name == ["alice"]
+    r2 = r.update(identities=Identities(["carol"] * 3, np.ones(3)))
+    assert r2.identities.name == ["carol", "carol", "carol"]

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -79,6 +79,7 @@ def test_task_type_literal_is_public():
         "restore",
         "matte",
         "ocr",
+        "embed",
     }
 
 

--- a/tests/unit/ui/test_ui_summary.py
+++ b/tests/unit/ui/test_ui_summary.py
@@ -131,3 +131,63 @@ def test_self_managed_download_l2cs_only_r50():
     assert _self_managed_download("LibreL2CSr50.pt") is True
     assert _self_managed_download("LibreL2CSr18.pt") is False
     assert _self_managed_download("definitely-not-a-weight.pt") is False
+
+
+# ---------------------------------------------------------------------------
+# Embed (facial recognition)
+# ---------------------------------------------------------------------------
+
+
+class _Identities(list):
+    """Minimal stand-in with the .name/.score surface the UI reads."""
+
+    def __init__(self, names, scores):
+        super().__init__(names)
+        self.name = list(names)
+        self.score = list(scores)
+
+
+@pytest.mark.parametrize(
+    ("item", "expected"),
+    [
+        # Embed results carry face boxes; they must not read as detection.
+        (
+            result(boxes=[object(), object()], embeddings=[object(), object()]),
+            ("embed", "2 faces"),
+        ),
+        (
+            result(
+                boxes=[object()],
+                embeddings=[object()],
+                identities=_Identities(["alice"], [0.8]),
+            ),
+            ("embed", "alice"),
+        ),
+        (
+            result(
+                boxes=[object(), object()],
+                embeddings=[object(), object()],
+                identities=_Identities(["alice", None], [0.8, 0.1]),
+            ),
+            ("embed", "alice (+1 unknown face)"),
+        ),
+        (
+            result(
+                boxes=[object(), object()],
+                embeddings=[object(), object()],
+                identities=_Identities([None, None], [0.1, 0.2]),
+            ),
+            ("embed", "2 unknown faces"),
+        ),
+    ],
+)
+def test_summarize_embed(item, expected):
+    assert _summarize_result(item) == expected
+
+
+def test_embed_download_url_resolves():
+    """The UI availability probe must find a URL for the ONNX-only family."""
+    from libreyolo.ui.server import _resolve_download_url
+
+    url = _resolve_download_url("facerec-l")
+    assert url is not None and url.endswith("librefacerec-l.onnx")


### PR DESCRIPTION
Adds facial recognition to LibreYOLO as a new inference-only `embed` task:
face embeddings, 1:1 verification, and 1:N identification against an enrolled
gallery.

The task is two-stage and reuses the gaze family's face-detector protocol
rather than inventing a second one: a detector locates faces and five
landmarks, each face is warped onto the canonical 112x112 template, and an
ONNX recognition head emits an L2-normalized identity vector. Recognition
heads are consumed as opaque ONNX graphs, so no third-party architecture code
is ported and there is no training path. ADR 0013 records the contract.

## What it adds

`Results.embeddings` is an `(N, D)` payload of unit vectors row-aligned with
the face boxes, so cosine similarity is a dot product. `FaceGallery` holds
named reference embeddings, and matching against it produces
`Results.identities` (name and score per face). Weights auto-download from the
HF org: `librefacerec-l` for the embedder and `librefacerec-det` for the
default detector.

```python
from libreyolo import LibreYOLO, FaceGallery

model = LibreYOLO("librefacerec-l")
model.verify("a.jpg", "b.jpg")

gallery = FaceGallery(embedder=model)
gallery.enroll("alice", ["alice1.jpg", "alice2.jpg"])
results = model("group.jpg", gallery=gallery)
results.identities.name
```

CLI: `compare` / `verify` for 1:1, `enroll` to build a gallery from a
folder-per-person tree, and `predict --gallery` for identification.

## Design decisions worth reviewing

Enrolling K images of a person stores K vectors and scores by the best cosine
over them, rather than averaging into a centroid, which would discard the
pose and lighting variance that multiple references exist to capture. Faces
below threshold resolve to `name=None`, never the nearest enrolled person,
with the best score still exposed for inspection. Galleries record the
embedding dimension and a fingerprint of the weights file, so matching against
a different model raises instead of silently comparing incompatible vector
spaces. Matching is a single dense matmul with no ANN index or vector-store
dependency.

## Accuracy

Measured through the shipped pipeline on the standard LFW dev pairs, with the
threshold selected on `pairsDevTrain` and accuracy reported on the held-out
`pairsDevTest` (1000 pairs): ROC-AUC 0.980, 96.9% accuracy at threshold 0.227,
95.6% at the 0.4 library default. No different-person pair scored above 0.30
in that split, so the default is deliberately conservative. LFW is a
saturated, frontal benchmark where leading models report roughly 99.5% and
above; the model cards say so rather than implying state of the art.

A known follow-up, not in this PR: the alignment stage is the accuracy
bottleneck, not the weights. On the same pairs a plain centre crop of the
pre-aligned image scores 0.9981 / 99.00% against our 0.9756 / 97.00%. The
template is byte-correct against the canonical ArcFace one, the landmark
ordering is correct (deliberately swapping it collapses AUC to 0.59), and
rescaling the template does not help, which points at landmark precision from
the detector. Worth roughly two points if a sharper landmark source is wired
in later.

## Documentation and safety

`docs/facial_recognition.md` covers usage, the model table, bring-your-own
weights, and the design decisions above. It carries a short responsible-use
section: these are biometric identifiers, the intended uses are consent-based,
and remote biometric identification is prohibited or restricted in several
jurisdictions, which is the deployer's responsibility. That is documentation,
not a runtime gate, matching how established open libraries handle it.

## Code provenance

Original code written for this PR. The task module, the alignment maths, the
gallery, the result payloads, the CLI commands, and the tests are first-party
code written for LibreYOLO. Umeyama's similarity estimate (S. Umeyama, IEEE
PAMI 1991) and the canonical ArcFace 5-point template are standard published
maths and data, implemented from first principles in numpy; no third-party
implementation was copied or adapted. Recognition and detection models are
consumed as opaque ONNX graphs at runtime, so no upstream architecture code is
ported, adapted, or introduced. No GPL, AGPL, LGPL, non-commercial, or
unknown-license material is involved.

Two weight files are mirrored to the LibreYOLO Hugging Face org, unmodified
and verified byte-identical to their upstreams, with provenance and license
recorded in `THIRD_PARTY_NOTICES.txt` and on the model cards: the
`librefacerec-l` embedder from AuraFace-v1 (`glintr100.onnx`, Apache-2.0;
only that single file is mirrored, since other files in that upstream
repository carry different terms), and the `librefacerec-det` detector from
the OpenCV Zoo YuNet release (MIT, copyright Shiqi Yu).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an inference-only facial-recognition task with embedding, verification, and gallery identification workflows.
- Introduces the ONNX-backed face embedding pipeline, face alignment, model resolution, and downloadable recognition and detector weights.
- Adds model-bound gallery enrollment, persistence, cosine matching, and identity result payloads.
- Exposes Python, CLI, and prediction UI integrations for comparison, enrollment, and gallery-backed identification.
- Documents the task contract, model provenance, accuracy, usage, and responsible-use considerations.
- Adds unit coverage for task resolution, gallery behavior, CLI commands, result summaries, and video inference.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported mixed-model enrollment and video inference issues are fixed in the current code.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/facerec/inference.py | Implements image, batch, and video orchestration for face detection, alignment, embedding, and optional gallery identification; the previously reported video-routing and face-box propagation defects are fixed. |
| libreyolo/models/facerec/gallery.py | Implements gallery enrollment, persistence, model fingerprint validation, and max-cosine identity matching; the previously reported mixed-model enrollment path now validates the embedder. |
| libreyolo/models/facerec/model.py | Defines the inference-only face embedder and OpenCV detector integration around the recognition ONNX graph. |
| libreyolo/models/facerec/align.py | Adds canonical five-landmark similarity alignment with a center-crop fallback. |
| libreyolo/cli/commands/special.py | Adds face comparison and folder-based gallery enrollment commands with structured CLI error handling. |
| libreyolo/cli/commands/predict.py | Adds gallery loading, threshold forwarding, and identity fields to facial-recognition prediction output. |
| libreyolo/utils/results.py | Adds row-aligned embedding and identity payload support to inference results. |
| tests/unit/test_facerec.py | Covers alignment, embedding, gallery matching and persistence, model compatibility, and video inference behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Embedder as LibreFaceEmbedder
    participant Detector as Face detector
    participant Head as ONNX recognition head
    participant Gallery as FaceGallery
    User->>Embedder: predict(image, gallery?)
    Embedder->>Detector: detect faces and landmarks
    Detector-->>Embedder: boxes and 5-point landmarks
    Embedder->>Head: aligned 112x112 face crops
    Head-->>Embedder: normalized embeddings
    opt Gallery identification
        Embedder->>Gallery: match embeddings and model fingerprint
        Gallery-->>Embedder: identity names and scores
    end
    Embedder-->>User: Results(boxes, embeddings, identities?)
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Honour caller-supplied face boxes on vid..."](https://github.com/libreyolo/libreyolo/commit/f9c60bfbeb21ca8f89475edca499e8275fa07481) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48133011)</sub>

<!-- /greptile_comment -->