### PR TITLE
Expand Core AI validation to remaining model families

### DIFF
--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -28,13 +28,13 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | eomt | segment |  |  |  |  |  |  |  |  |
 | eomt | panoptic |  |  |  |  |  |  |  |  |
 | florence2 | detect |  |  |  |  |  |  |  |  |
-| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | grounding_dino | detect |  |  |  |  |  |  |  |  |
 | internvl3 | detect |  |  |  |  |  |  |  |  |
 | kosmos2 | detect |  |  |  |  |  |  |  |  |
 | l2cs | gaze | ✓ |  |  |  |  |  |  |  |
 | lfm2vl | detect |  |  |  |  |  |  |  |  |
-| lingbotvision | semantic | ✓ | ✓ | exp | exp |  |  |  | exp |
+| lingbotvision | semantic | ✓ | ✓ | exp | exp |  |  |  | ✓ |
 | locateanything | detect |  |  |  |  |  |  |  |  |
 | locateanything | point |  |  |  |  |  |  |  |  |
 | mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
@@ -45,7 +45,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | owlv2 | detect |  |  |  |  |  |  |  |  |
 | picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | picosam3 | segment | ✓ |  |  |  |  |  |  |  |
-| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  | exp |
+| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | ppocr | ocr |  |  |  |  |  |  |  |  |
 | qwen3vl | detect |  |  |  |  |  |  |  |  |
 | realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
@@ -66,15 +66,15 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | siglip2 | classify | ✓ |  |  |  |  |  |  | ✓ |
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |
 | swinir | restore | exp | exp | exp | exp | exp |  |  |  |
-| yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
-| yolo2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
-| yolo3 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
-| yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
-| yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  |  |
+| yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo3 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
-| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  | exp |
+| yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |  |
 | yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp | ✓ |
 | zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
@@ -87,6 +87,77 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - Classification: logits cosine above 0.999 and equal top-1 class.
 - Depth and restoration: PSNR above 40 dB against native output.
 - Point: peak locations equal within one output cell.
+
+## Validated constraints
+
+A check mark applies only under any constraint listed here.
+
+- `birefnet` / `matte` / `torchscript`: fixed 1024x1024 input
+- `clip` / `classify` / `onnx`: frozen-class labels and fixed input resolution
+- `clip` / `classify` / `coreai`: frozen class set and fixed export canvas; permissively licensed trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `convnext` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `deim` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `deimv2` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `depth_anything` / `depth` / `coreai`: fixed export canvas; permissively licensed trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `dfine` / `detect` / `coreai`: fixed export canvas; trained LibreDFINEn weights are covered on macOS 27 by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `dinov2` / `semantic` / `onnx`: fixed 518x518 input
+- `dinov2` / `semantic` / `torchscript`: fixed 518x518 input
+- `dinov2` / `classify` / `onnx`: fixed 224x224 input
+- `ec` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `ec` / `pose` / `onnx`: fixed 640x640 input
+- `ec` / `pose` / `torchscript`: fixed 640x640 input
+- `ec` / `segment` / `onnx`: fixed 640x640 input
+- `ec` / `segment` / `torchscript`: fixed 640x640 input
+- `efficientnetv2` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `eomt` / `semantic` / `onnx`: fixed 512x512 input
+- `eomt` / `semantic` / `torchscript`: fixed 512x512 input
+- `fomo` / `point` / `coreai`: native 96 canvas; a deterministic model state trained from scratch for eight steps on synthetic tensors is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; this validates conversion and the existing heatmap contract, not point-localization accuracy
+- `l2cs` / `gaze` / `onnx`: head-only contract: each input image is one face crop
+- `lingbotvision` / `semantic` / `onnx`: fixed 512x512 input
+- `lingbotvision` / `semantic` / `torchscript`: fixed 512x512 input
+- `lingbotvision` / `semantic` / `coreai`: fixed family-native canvases (PIDNet 1024, LingBotVision 512); trained LibrePIDNets-sem and LibreLingBotVisions-sem checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; exported backends already implement the shared dense-logit resize and argmax contract
+- `mobilenetv4` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `nafnet` / `restore` / `onnx`: fixed-resolution export canvas
+- `nafnet` / `restore` / `torchscript`: fixed-resolution export canvas
+- `nafnet` / `restore` / `ncnn`: fixed-resolution export canvas
+- `nafnet` / `restore` / `coreai`: fixed export canvas; permissively licensed trained restoration checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `picodet` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `picosam3` / `segment` / `onnx`: raw fixed-96 ROI contract: roi_image -> mask_logits
+- `pidnet` / `semantic` / `coreai`: fixed family-native canvases (PIDNet 1024, LingBotVision 512); trained LibrePIDNets-sem and LibreLingBotVisions-sem checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; exported backends already implement the shared dense-logit resize and argmax contract
+- `realesrgan` / `restore` / `onnx`: ONNX supports dynamic spatial input; TorchScript and NCNN are fixed-canvas
+- `realesrgan` / `restore` / `torchscript`: ONNX supports dynamic spatial input; TorchScript and NCNN are fixed-canvas
+- `realesrgan` / `restore` / `ncnn`: ONNX supports dynamic spatial input; TorchScript and NCNN are fixed-canvas
+- `realesrgan` / `restore` / `tflite`: fixed-resolution export canvas
+- `realesrgan` / `restore` / `coreai`: fixed export canvas; permissively licensed trained restoration checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `resnet` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `rfdetr` / `detect` / `coreai`: fixed export canvas; trained LibreRFDETRn weights are covered on macOS 27 against the graph the exporter itself prepares, using direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin. Conversion needed _rebake_rfdetr_pos_embed in export/coreai.py: the backbone bakes its position embedding for its configured 384 canvas, so exporting at any other size left an antialiased bicubic in the graph and the converter has no lowering for aten._upsample_bicubic2d_aa. The rebake re-runs the model's OWN baking path for the actual canvas, so the interpolation happens eagerly, outside the graph, computing exactly what it computed before. NOTE the reference. This family is verified against the exporter's prepared graph, not against ONNX, and the difference is not a detail: at a 640 canvas the rfdetr ONNX artifact disagrees with that same prepared graph by 9.3e-01. Core AI's rebake preserves the antialiased resize the eager model performs, whereas the ONNX path disables antialiasing (the model checks torch.onnx.is_in_onnx_export). Which artifact is right is an ONNX question and is not settled here, but ONNX cannot be used as the reference for this family at a non-native canvas.
+- `rfdetr` / `segment` / `onnx`: fixed task-native input resolution
+- `rfdetr` / `segment` / `torchscript`: fixed task-native input resolution
+- `rfdetr` / `pose` / `onnx`: fixed task-native input resolution
+- `rfdetr` / `pose` / `torchscript`: fixed task-native input resolution
+- `rfdetr` / `obb` / `onnx`: fixed task-native input resolution
+- `rfdetr` / `obb` / `torchscript`: fixed task-native input resolution
+- `rtdetr` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `rtdetrv2` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `rtdetrv4` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `rtmdet` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `siglip2` / `classify` / `onnx`: frozen-class labels and fixed input resolution
+- `siglip2` / `classify` / `coreai`: frozen class set and fixed export canvas; permissively licensed trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `yolo1` / `detect` / `ncnn`: fixed 448x448 input
+- `yolo1` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo2` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo3` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo4` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo7` / `detect` / `coreai`: fixed 640x640 export canvas; trained LibreYOLO7b weights are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; the export decoder uses direct arange grids because Core AI 0.4.1 mislowers the equivalent cumulative-sum expression
+- `yolo9` / `detect` / `coreai`: fixed export canvas; trained LibreYOLO9t weights are covered on macOS 27 by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `yolo9_e2e` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `yolo9_p2` / `detect` / `coreai`: fixed 640x640 export canvas; a deterministic YOLO9-P2-T model initialized from the SHA-256-pinned, permissively licensed trained LibreYOLO9t checkpoint is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; this validates conversion, not P2 task accuracy, and does not depend on the restricted VisDrone research-preview checkpoint
+- `yolonas` / `detect` / `coreai`: fixed 96x96 export canvas with pre-shaped canonical RGB tensors; a deterministic, license-clean synthetic YOLO-NAS-S state is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; the state receives 12 native training steps and a 20x regression-head scale to make both exported outputs non-degenerate; this validates conversion, not detection accuracy, raw-image preprocessing, or native-640 behavior, and does not convert restricted official weights
+- `yolox` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `zipdepth` / `depth` / `onnx`: fixed-resolution export canvas
+- `zipdepth` / `depth` / `torchscript`: fixed-resolution export canvas
+- `zipdepth` / `depth` / `ncnn`: fixed-resolution export canvas
+- `zipdepth` / `depth` / `coreai`: fixed export canvas; permissively licensed trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 
 ## Blocked combinations
 
@@ -397,7 +468,6 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 - `yolo4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo7` / `detect` / `tflite`: The converted LiteRT graph changes decoded box coordinates beyond the detector parity tolerance.
 - `yolo7` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolo7` / `detect` / `coreai`: WITHDRAWN from validated. This family was recorded at 1.4e-07 on random initialisation. With trained weights, where the reference actually moves (input-sensitivity 1.3e-01), the same comparison gives 2.9e-01: the artifact does not reproduce the model. The earlier number was two near-constant tensors agreeing, not a correct conversion. yolo7 is the one family where the trained-weight re-measurement turned a pass into a failure rather than confirming it, so whatever it does differently from yolo9 and yolox, which pass the identical check at 1.9e-06 and 2.4e-06, is the place to look. Only the b size exists, so a second size cannot be used to narrow it.
 - `yolo9_e2e` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `yolo9_e2e` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo9_p2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.

--- a/libreyolo/cli/commands/special.py
+++ b/libreyolo/cli/commands/special.py
@@ -270,9 +270,7 @@ def formats_cmd(
             "requires_onnx": cls.requires_onnx,
         }
         aliases = sorted(
-            alias
-            for alias, target in BaseExporter._aliases.items()
-            if target == name
+            alias for alias, target in BaseExporter._aliases.items() if target == name
         )
         if aliases:
             info["aliases"] = aliases
@@ -296,6 +294,8 @@ def formats_cmd(
             )
             if "tier" in f:
                 lines.append(f"    Tier: {f['tier']} ({f['reason']})")
+                if f.get("constraint"):
+                    lines.append(f"    Constraint: {f['constraint']}")
         data["_human_text"] = "\n".join(lines)
 
     out.result(data)

--- a/libreyolo/export/coreai.py
+++ b/libreyolo/export/coreai.py
@@ -68,6 +68,7 @@ _ANCHOR_FREEZE_FAMILIES = {
     "picodet",
     "rtmdet",
 }
+_DARKNET_FAMILIES = {"yolo1", "yolo2", "yolo3", "yolo4"}
 _RTDETR_STATIC_FAMILIES = {
     "rtdetr",
     "rtdetrv2",
@@ -77,6 +78,74 @@ _RTDETR_STATIC_FAMILIES = {
     "deimv2",
     "ec",
 }
+
+
+def _fuse_darknet_batchnorm(nn_model: nn.Module):
+    """Fold exact Darknet inference BN into its preceding convolution.
+
+    Core AI 0.4.1 does not preserve Darknet's normalization formula,
+    ``(x - mean) / (sqrt(var) + eps) * weight + bias``. In particular,
+    Darknet adds epsilon after the square root, unlike ``nn.BatchNorm2d``.
+    Folding the frozen inference parameters into the convolution is
+    algebraically equivalent and removes the converter-sensitive expression.
+
+    The swap is scoped to Core AI graph preparation and restored afterwards.
+    """
+    from ..models.darknet.blocks import DarknetConv
+
+    prepared: list[tuple[DarknetConv, nn.Conv2d, nn.Conv2d, nn.Module]] = []
+    for module in nn_model.modules():
+        if not isinstance(module, DarknetConv) or module.bn is None:
+            continue
+
+        conv = module.conv
+        bn = module.bn
+        replacement = nn.Conv2d(
+            conv.in_channels,
+            conv.out_channels,
+            conv.kernel_size,
+            stride=conv.stride,
+            padding=conv.padding,
+            dilation=conv.dilation,
+            groups=conv.groups,
+            bias=True,
+            padding_mode=conv.padding_mode,
+            device=conv.weight.device,
+            dtype=conv.weight.dtype,
+        )
+        with torch.no_grad():
+            scale = bn.weight / (torch.sqrt(bn.running_var) + bn.eps)
+            replacement.weight.copy_(conv.weight * scale[:, None, None, None])
+            conv_bias = (
+                conv.bias
+                if conv.bias is not None
+                else torch.zeros_like(bn.running_mean)
+            )
+            replacement.bias.copy_((conv_bias - bn.running_mean) * scale + bn.bias)
+
+        prepared.append((module, replacement, conv, bn))
+
+    # Do not mutate the live graph until every replacement has been allocated
+    # and populated. A failure on a later layer must leave earlier layers
+    # untouched, before the caller has had a chance to register our restore
+    # callback.
+    for module, replacement, _, _ in prepared:
+        module.conv = replacement
+        module.bn = None
+
+    if prepared:
+        logger.info(
+            "Folded %d exact Darknet batch-normalization layers into their "
+            "convolutions for Core AI conversion.",
+            len(prepared),
+        )
+
+    def _restore():
+        for module, _, conv, bn in prepared:
+            module.conv = conv
+            module.bn = bn
+
+    return _restore
 
 
 def _freeze_anchor_grid(nn_model: nn.Module, dummy: torch.Tensor):
@@ -183,6 +252,31 @@ class _YoloNASDecodedOnly(nn.Module):
             if isinstance(decoded, (list, tuple)):
                 return tuple(decoded)
         return out
+
+
+class _FOMOPreprocess(nn.Module):
+    """Map canonical RGB[0,1] input to FOMO's RGB[-1,1] contract."""
+
+    def __init__(self, model: nn.Module) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(self, x):
+        return self.model((x - 0.5) / 0.5)
+
+
+def _wrap_coreai_contract(
+    nn_model: nn.Module,
+    model_family: str | None,
+) -> nn.Module:
+    """Apply the complete per-family Core AI input/output contract."""
+    family = (model_family or "").lower()
+    wrapped = _wrap_for_family(nn_model, family)
+    if family == "fomo":
+        wrapped = _FOMOPreprocess(wrapped)
+    if family == "yolonas":
+        wrapped = _YoloNASDecodedOnly(wrapped)
+    return wrapped.eval()
 
 
 def _rebake_rfdetr_pos_embed(nn_model: nn.Module, dummy: torch.Tensor):
@@ -475,6 +569,9 @@ def _prepare_coreai_graph(
     """Apply fixed-canvas graph preparation and always restore live state."""
     family = (model_family or "").lower()
     with ExitStack() as stack:
+        if family in _DARKNET_FAMILIES:
+            stack.callback(_fuse_darknet_batchnorm(nn_model))
+
         if family in _ANCHOR_FREEZE_FAMILIES:
             stack.callback(_freeze_anchor_grid(nn_model, dummy))
 
@@ -623,14 +720,9 @@ def export_coreai(
     # output contract, and a Core AI artifact must emit the same tensors as
     # the other backends for the same family or downstream consumers cannot
     # swap formats.
-    wrapped = _wrap_for_family(nn_model, model_family)
-    wrapped.eval()
-
-    # YOLO-NAS returns (decoded, raw) in export mode; the other
-    # backends ship the decoded pair alone. Match them so the
-    # artifact can be parity-checked against ONNX.
-    if (model_family or "").lower() == "yolonas":
-        wrapped = _YoloNASDecodedOnly(wrapped).eval()
+    # Reuse one wrapper function in conversion and parity tests so the
+    # reference cannot accidentally retain YOLO-NAS's raw training maps.
+    wrapped = _wrap_coreai_contract(nn_model, model_family)
 
     # Fixed-canvas preparation is scoped so both successful conversion and any
     # capture/lowering failure leave the caller's live model unchanged.

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -651,26 +651,36 @@ _add(
 
 
 _add(
-    "experimental",
-    ("yolo1",),
+    "validated",
+    ("yolo1", "yolo2", "yolo3", "yolo4"),
     ("detect",),
     ("coreai",),
-    reason=(
-        "The published trained LibreYOLO1b checkpoint converts and runs, but "
-        "its Core AI output differs from the prepared PyTorch graph by "
-        "3.02e-01 at the native 448 canvas. This is a real numeric failure, "
-        "not a missing checkpoint or a random-weight measurement."
+    since="1.5",
+    constraint=(
+        "fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, "
+        "YOLO4 608); representative published trained checkpoints are covered "
+        "on Apple hardware by direct named-output parity with a 3e-04 "
+        "tolerance and a 100x input-sensitivity margin; Core AI graph "
+        "preparation exactly folds Darknet inference batch normalization into "
+        "the preceding convolutions because Core AI 0.4.1 does not preserve "
+        "Darknet's epsilon-after-square-root formula"
     ),
 )
 _add(
-    "experimental",
+    "validated",
     ("yolonas",),
     ("detect",),
     ("coreai",),
-    reason=(
-        "Conversion has been measured, but no permissively licensed "
-        "LibreYOLO trained checkpoint is published for a reproducible Core AI "
-        "parity gate."
+    since="1.5",
+    constraint=(
+        "fixed 96x96 export canvas with pre-shaped canonical RGB tensors; a "
+        "deterministic, license-clean synthetic "
+        "YOLO-NAS-S state is covered on Apple hardware by direct named-output "
+        "parity with a 3e-04 tolerance and a 100x input-sensitivity margin; "
+        "the state receives 12 native training steps and a 20x regression-head "
+        "scale to make both exported outputs non-degenerate; this validates "
+        "conversion, not detection accuracy, raw-image preprocessing, or "
+        "native-640 behavior, and does not convert restricted official weights"
     ),
 )
 _add(
@@ -763,13 +773,16 @@ _add(
 # HOW THE Core AI NUMBERS BELOW WERE MEASURED, and why an earlier set of them
 # was withdrawn.
 #
-# Every figure is the worst relative error against a reference graph, using
-# TRAINED weights, with each artifact fed the input ITS OWN contract expects,
-# and reported alongside the reference's own input-sensitivity.
+# Every figure is the worst relative error against a reference graph, with each
+# artifact fed the input ITS OWN contract expects and reported alongside the
+# reference's own input-sensitivity. Published trained weights are used where a
+# permissive checkpoint exists. The FOMO, YOLO-NAS, and YOLO9-P2 entries state
+# their license-clean synthetic or transfer fixture explicitly and make no
+# accuracy claim.
 #
 # All three qualifiers were learned the hard way.
 #
-# Trained weights: a randomly initialised detection head emits nearly the same
+# Non-degenerate weights: a randomly initialised detection head emits nearly the same
 # tensor whatever it is shown, because the constant anchor grid dominates its
 # output. Measured on the ONNX reference between two very different probes,
 # random-init yolox moved by 1.5e-09 and rtmdet by 8.9e-12. Agreement at 1e-08
@@ -814,54 +827,33 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "validated",
     ("yolo9_p2",),
     ("detect",),
     ("coreai",),
-    reason=(
-        "The published LibreYOLO9P2s-visdrone checkpoint passes the trained "
-        "Core AI parity gate at 640. It remains experimental because the only "
-        "published checkpoint is a non-commercial VisDrone research preview; "
-        "LibreYOLO's permissive validation gate must not depend on that "
-        "restricted artifact. A permissively licensed trained checkpoint "
-        "would make this promotable."
+    since="1.5",
+    constraint=(
+        "fixed 640x640 export canvas; a deterministic YOLO9-P2-T model "
+        "initialized from the SHA-256-pinned, permissively licensed trained "
+        "LibreYOLO9t checkpoint is covered on Apple hardware by direct "
+        "named-output parity with a 3e-04 tolerance and a 100x "
+        "input-sensitivity margin; this validates conversion, not P2 task "
+        "accuracy, and does not depend on the restricted VisDrone "
+        "research-preview checkpoint"
     ),
 )
 _add(
-    "blocked",
+    "validated",
     ("yolo7",),
     ("detect",),
     ("coreai",),
-    reason=(
-        "WITHDRAWN from validated. This family was recorded at 1.4e-07 on "
-        "random initialisation. With trained weights, where the reference "
-        "actually moves (input-sensitivity 1.3e-01), the same comparison gives "
-        "2.9e-01: the artifact does not reproduce the model. The earlier "
-        "number was two near-constant tensors agreeing, not a correct "
-        "conversion. "
-        "yolo7 is the one family where the trained-weight re-measurement "
-        "turned a pass into a failure rather than confirming it, so whatever "
-        "it does differently from yolo9 and yolox, which pass the identical "
-        "check at 1.9e-06 and 2.4e-06, is the place to look. Only the b size "
-        "exists, so a second size cannot be used to narrow it."
-    ),
-)
-_add(
-    "experimental",
-    ("yolo2", "yolo3", "yolo4"),
-    ("detect",),
-    ("coreai",),
-    reason=(
-        "Not close. Random initialisation put these at 2.4e-04 and the note "
-        "here said to re-measure with real weights before reading anything "
-        "into it. Done: with trained weights they are 1.5e-01 (yolo2), "
-        "1.1e-01 (yolo3) and 1.6e-01 (yolo4) against reference "
-        "input-sensitivities of 0.18 to 0.37. The residual is structural, not "
-        "numeric drift, and it is shared with yolo7, which fails the same way "
-        "at 2.9e-01. All four are darknet-lineage models sharing "
-        "models/darknet, so one cause probably explains all four. The "
-        "published trained YOLO1-B checkpoint now fails the same direct gate "
-        "at 3.0e-01, strengthening the shared-lineage diagnosis."
+    since="1.5",
+    constraint=(
+        "fixed 640x640 export canvas; trained LibreYOLO7b weights are covered on "
+        "Apple hardware by direct named-output parity with a 3e-04 tolerance "
+        "and a 100x input-sensitivity margin; the export decoder uses direct "
+        "arange grids because Core AI 0.4.1 mislowers the equivalent "
+        "cumulative-sum expression"
     ),
 )
 _add(
@@ -929,23 +921,17 @@ _add(
 )
 
 _add(
-    "experimental",
+    "validated",
     ("pidnet", "lingbotvision"),
     ("semantic",),
     ("coreai",),
-    reason=(
-        "The conversion is correct and measured: against the eager contract "
-        "graph, pidnet is 6.7e-05 and lingbotvision 7.8e-07, both inside the "
-        "1e-04 gate. Eager rather than ONNX because ONNX is itself blocked "
-        "for the semantic task, so there is no ONNX artifact to compare with; "
-        "an earlier 2.3e-04 for pidnet came from comparing two gate-forced "
-        "exports and is superseded. "
-        "Held at experimental rather than promoted, because _TASK_BLOCKS "
-        "refuses semantic for EVERY format: the shared dense-logits and "
-        "backend argmax decode contract does not exist yet. The artifact "
-        "carries raw logits and nothing downstream knows how to read them. "
-        "What stands between these two and validated is that cross-format "
-        "task contract, not anything about Core AI."
+    since="1.5",
+    constraint=(
+        "fixed family-native canvases (PIDNet 1024, LingBotVision 512); trained "
+        "LibrePIDNets-sem and LibreLingBotVisions-sem checkpoints are covered "
+        "on Apple hardware by direct named-output parity with a 3e-04 "
+        "tolerance and a 100x input-sensitivity margin; exported backends "
+        "already implement the shared dense-logit resize and argmax contract"
     ),
 )
 _add(
@@ -976,18 +962,17 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "validated",
     ("fomo",),
     ("point",),
     ("coreai",),
-    reason=(
-        "Converts and matches the eager contract graph at 4.3e-07, measured "
-        "at the family's native 96 canvas. An earlier attempt at 640 said "
-        "nothing useful: 96 is the size this model is built for. "
-        "Held at experimental for the same reason as the semantic families: "
-        "_TASK_BLOCKS refuses point for every format because the shared "
-        "heatmap and backend peak-decoding contract does not exist, so the "
-        "artifact emits a raw heatmap that nothing downstream can decode."
+    since="1.5",
+    constraint=(
+        "native 96 canvas; a deterministic model state trained from scratch "
+        "for eight steps on synthetic tensors is covered on Apple hardware "
+        "by direct named-output parity with a 3e-04 tolerance and a 100x "
+        "input-sensitivity margin; this validates conversion and the existing "
+        "heatmap contract, not point-localization accuracy"
     ),
 )
 _add(

--- a/libreyolo/postprocess/darknet_yolo.py
+++ b/libreyolo/postprocess/darknet_yolo.py
@@ -179,7 +179,7 @@ def _decode_detection_export(output: torch.Tensor, spec) -> torch.Tensor:
     if spec.softmax:
         class_block = torch.softmax(class_block, dim=-1)
 
-    grid = output.new_ones(cells).cumsum(0) - 1.0  # 0..cells-1
+    grid = torch.arange(cells, device=output.device, dtype=output.dtype)
     rows_idx = (grid // s).view(1, cells, 1)
     cols_idx = (grid - (grid // s) * s).view(1, cells, 1)
 
@@ -227,10 +227,10 @@ def decode_export(
         a = len(spec.anchors)
         x = output.view(b, a, 5 + nc, h, w).permute(0, 1, 3, 4, 2)  # B,A,H,W,5+nc
 
-        # Grids from ``output`` (new_ones/cumsum) follow the input device at
-        # runtime; anchors come in as device-tracked buffers for the same reason.
-        col = (output.new_ones(w).cumsum(0) - 1.0).view(1, 1, 1, w)
-        row = (output.new_ones(h).cumsum(0) - 1.0).view(1, 1, h, 1)
+        # Build the fixed-canvas grid directly. Core AI 0.4.1 mislowers the
+        # equivalent ``new_ones(...).cumsum(0) - 1`` expression.
+        col = torch.arange(w, device=output.device, dtype=output.dtype).view(1, 1, 1, w)
+        row = torch.arange(h, device=output.device, dtype=output.dtype).view(1, 1, h, 1)
         aw = anchors[:, 0].view(1, a, 1, 1)
         ah = anchors[:, 1].view(1, a, 1, 1)
 

--- a/libreyolo/postprocess/yolo7.py
+++ b/libreyolo/postprocess/yolo7.py
@@ -72,9 +72,10 @@ def decode_export(
         a = anc.shape[0]
         x = output.view(b, a, 5 + num_classes, h, w).permute(0, 1, 3, 4, 2).sigmoid()
 
-        # Device-agnostic grids (new_ones/cumsum); anchors are buffers.
-        col = (output.new_ones(w).cumsum(0) - 1.0).view(1, 1, 1, w)
-        row = (output.new_ones(h).cumsum(0) - 1.0).view(1, 1, h, 1)
+        # Build the fixed-canvas grid directly. Core AI 0.4.1 mislowers the
+        # equivalent ``new_ones(...).cumsum(0) - 1`` expression.
+        col = torch.arange(w, device=output.device, dtype=output.dtype).view(1, 1, 1, w)
+        row = torch.arange(h, device=output.device, dtype=output.dtype).view(1, 1, h, 1)
         aw = anc[:, 0].view(1, a, 1, 1)
         ah = anc[:, 1].view(1, a, 1, 1)
 

--- a/tests/e2e/test_coreai.py
+++ b/tests/e2e/test_coreai.py
@@ -1,4 +1,4 @@
-"""Trained-weight Core AI parity on real Apple hardware.
+"""Core AI artifact parity on real Apple hardware.
 
 The test compares the public ``.aimodel`` export with the exact fixed-canvas
 PyTorch graph prepared by the exporter. Two probes establish both numeric
@@ -12,12 +12,15 @@ so the gate cannot hide a broken box/logit association.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
 import torch
+import torch.nn.functional as F
 from scipy.optimize import linear_sum_assignment
 
 pytestmark = [
@@ -37,6 +40,7 @@ if sys.platform != "darwin":  # pragma: no cover - platform gate
 
 REL_TOL = 3e-4
 MIN_SENSITIVITY_MARGIN = 100.0
+MIN_REL_SENSITIVITY = 1e-6
 CASES = [
     ("LibreYOLO9t.pt", "yolo9", 640),
     ("LibreDFINEn.pt", "dfine", 640),
@@ -51,6 +55,13 @@ CASES = [
     ("LibreRTDETRv4s.pt", "rtdetrv4", 640),
     ("LibreRTMDett.pt", "rtmdet", 640),
     ("LibreYOLO9E2Et.pt", "yolo9_e2e", 640),
+    ("LibreYOLO1b.pt", "yolo1", 448),
+    ("LibreYOLO2b.pt", "yolo2", 608),
+    ("LibreYOLO3b.pt", "yolo3", 416),
+    ("LibreYOLO4b.pt", "yolo4", 608),
+    ("LibreYOLO7b.pt", "yolo7", 640),
+    ("LibrePIDNets-sem.pt", "pidnet", 1024),
+    ("LibreLingBotVisions-sem.pt", "lingbotvision", 512),
     ("LibreResNet18-cls.pt", "resnet", 224),
     ("LibreMobileNetV4s-cls.pt", "mobilenetv4", 224),
     ("LibreEfficientNetV2b0-cls.pt", "efficientnetv2", 224),
@@ -97,8 +108,8 @@ def _prepared_reference(model, family, imgsz, x1, x2):
     from libreyolo.export.coreai import (
         _exported_output_names,
         _prepare_coreai_graph,
+        _wrap_coreai_contract,
     )
-    from libreyolo.export.coreml import _wrap_for_family
     from libreyolo.export.exporter import CoreAIExporter
 
     exporter = CoreAIExporter(model)
@@ -109,7 +120,7 @@ def _prepared_reference(model, family, imgsz, x1, x2):
         1,
         (imgsz, imgsz),
     ) as (nn_model, _):
-        wrapped = _wrap_for_family(nn_model, family).eval()
+        wrapped = _wrap_coreai_contract(nn_model, family)
         with _prepare_coreai_graph(wrapped, x1, family):
             # The eager prepared graph is the semantic reference. Running the
             # decomposed ExportedProgram as a module is not equivalent for
@@ -182,6 +193,10 @@ def _assert_parity(output_names, ref1, ref2, got1, got2):
             f"out[{index}] ({output_names[index]}) relative error "
             f"{error:.3e} exceeds {REL_TOL:.0e}"
         )
+        assert sensitivity >= MIN_REL_SENSITIVITY, (
+            f"out[{index}] ({output_names[index]}) relative input sensitivity "
+            f"{sensitivity:.3e} is below {MIN_REL_SENSITIVITY:.0e}"
+        )
         assert margin >= MIN_SENSITIVITY_MARGIN, (
             f"out[{index}] parity margin {margin:.1f}x is below "
             f"{MIN_SENSITIVITY_MARGIN:.0f}x "
@@ -212,19 +227,7 @@ def _align_unordered_queries(reference, candidate):
     return [array[:, order, ...] for array in candidate]
 
 
-@pytest.mark.parametrize("weights,family,imgsz", CASES)
-def test_coreai_artifact_matches_prepared_trained_model(
-    weights, family, imgsz, tmp_path
-):
-    from libreyolo import LibreYOLO
-
-    if family == "rfdetr":
-        pytest.importorskip(
-            "transformers",
-            reason="RF-DETR parity requires the rfdetr extra",
-        )
-
-    model = LibreYOLO(weights, device="cpu")
+def _assert_model_artifact_parity(model, family, imgsz, tmp_path):
     artifact = model.export(
         format="coreai",
         imgsz=imgsz,
@@ -249,6 +252,102 @@ def test_coreai_artifact_matches_prepared_trained_model(
         got1 = _align_unordered_queries(ref1, got1)
         got2 = _align_unordered_queries(ref2, got2)
     _assert_parity(output_names, ref1, ref2, got1, got2)
+
+
+@pytest.mark.parametrize("weights,family,imgsz", CASES)
+def test_coreai_artifact_matches_prepared_trained_model(
+    weights, family, imgsz, tmp_path
+):
+    from libreyolo import LibreYOLO
+
+    if family == "rfdetr":
+        pytest.importorskip(
+            "transformers",
+            reason="RF-DETR parity requires the rfdetr extra",
+        )
+
+    model = LibreYOLO(weights, device="cpu")
+    _assert_model_artifact_parity(model, family, imgsz, tmp_path)
+
+
+def test_coreai_fomo_synthetic_trained_parity(tmp_path):
+    from libreyolo import LibreFOMO
+
+    torch.manual_seed(20260728)
+    model = LibreFOMO(None, size="s", nb_classes=2, device="cpu")
+    network = model.model.train()
+    optimizer = torch.optim.SGD(network.parameters(), lr=0.02, momentum=0.9)
+
+    for step in range(8):
+        images = torch.rand(4, 3, 96, 96)
+        logits = network(images)
+        targets = torch.zeros(
+            logits.shape[0],
+            *logits.shape[-2:],
+            dtype=torch.long,
+        )
+        targets[:, 2 + step % 4, 3 + step % 5] = 1
+        targets[:, 7 - step % 4, 8 - step % 5] = 2
+        loss = F.cross_entropy(logits, targets)
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+
+    network.eval()
+    _assert_model_artifact_parity(model, "fomo", 96, tmp_path)
+
+
+def test_coreai_yolonas_synthetic_trained_parity(tmp_path):
+    from libreyolo import LibreYOLONAS
+    from libreyolo.models.yolonas.loss import PPYoloELoss
+
+    torch.manual_seed(20260728)
+    model = LibreYOLONAS(None, size="s", nb_classes=2, device="cpu")
+    network = model.model.train()
+    loss_fn = PPYoloELoss(num_classes=2)
+    optimizer = torch.optim.SGD(network.parameters(), lr=0.01, momentum=0.9)
+
+    for step in range(12):
+        images = torch.rand(2, 3, 96, 96)
+        targets = torch.zeros(2, 10, 5)
+        targets[0, 0] = torch.tensor([float(step % 2), 36.0 + step, 42.0, 24.0, 30.0])
+        targets[1, 0] = torch.tensor([float((step + 1) % 2), 64.0, 52.0, 20.0, 26.0])
+        outputs = network(images)
+        loss, _ = loss_fn(outputs, targets)
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+
+    network.eval()
+    # A randomly initialized detector's decoded boxes are dominated by its
+    # fixed anchor grid. Scaling only the owned synthetic regression heads
+    # makes the conversion gate sensitive to both outputs without asserting
+    # anything about detection accuracy.
+    with torch.no_grad():
+        for head in (
+            network.heads.head1,
+            network.heads.head2,
+            network.heads.head3,
+        ):
+            head.reg_pred.weight.mul_(20.0)
+
+    _assert_model_artifact_parity(model, "yolonas", 96, tmp_path)
+
+
+def test_coreai_yolo9_p2_permissive_transfer_parity(tmp_path):
+    from libreyolo import LibreYOLO9P2
+    from libreyolo.utils.download import download_weights
+
+    torch.manual_seed(20260728)
+    model = LibreYOLO9P2(None, size="t", device="cpu")
+    weights_path = Path(model._resolve_weights_path("LibreYOLO9t.pt"))
+    if not weights_path.exists():
+        download_weights(str(weights_path), model.size)
+    with weights_path.open("rb") as weights_file:
+        digest = hashlib.file_digest(weights_file, "sha256").hexdigest()
+    assert digest == "b4d7e93f9e0393830fb42e6135c0e3464b2673b05e5ecf4b7f2374ec18e39eb2"
+    model._load_transfer_weights(weights_path)
+    _assert_model_artifact_parity(model, "yolo9_p2", 640, tmp_path)
 
 
 @pytest.mark.parametrize("weights,family,imgsz", FROZEN_CLASS_CASES)

--- a/tests/unit/test_export_coreai.py
+++ b/tests/unit/test_export_coreai.py
@@ -162,6 +162,96 @@ def test_graph_preparation_restores_replaced_pool_after_capture_error():
     assert model[0] is original
 
 
+def test_yolonas_contract_wrapper_keeps_only_decoded_outputs():
+    class _SyntheticYoloNAS(nn.Module):
+        def forward(self, x):
+            return ((x + 1, x + 2), (x + 3, x + 4))
+
+    x = torch.zeros(1, 1, 2, 2)
+    wrapped = coreai._wrap_coreai_contract(_SyntheticYoloNAS(), "yolonas")
+    boxes, scores = wrapped(x)
+    torch.testing.assert_close(boxes, x + 1)
+    torch.testing.assert_close(scores, x + 2)
+
+
+def test_fomo_contract_wrapper_applies_native_normalization():
+    x = torch.tensor([[[[0.0, 0.5, 1.0]]]]).expand(1, 3, 1, 3)
+    wrapped = coreai._wrap_coreai_contract(nn.Identity(), "fomo")
+    torch.testing.assert_close(wrapped(x), (x - 0.5) / 0.5)
+
+
+def test_graph_preparation_fuses_exact_darknet_batchnorm_and_restores():
+    from libreyolo.models.darknet.blocks import DarknetConv
+
+    torch.manual_seed(7)
+    model = DarknetConv(
+        3,
+        4,
+        size=3,
+        stride=1,
+        batch_normalize=True,
+        activation="leaky",
+    ).eval()
+    with torch.no_grad():
+        model.bn.running_mean.copy_(torch.randn(4))
+        model.bn.running_var.copy_(torch.rand(4) + 0.2)
+        model.bn.weight.copy_(torch.randn(4))
+        model.bn.bias.copy_(torch.randn(4))
+
+    dummy = torch.randn(1, 3, 8, 8)
+    original_conv = model.conv
+    original_bn = model.bn
+    expected = model(dummy)
+
+    with coreai._prepare_coreai_graph(model, dummy, "yolo1"):
+        assert model.conv is not original_conv
+        assert model.bn is None
+        torch.testing.assert_close(model(dummy), expected, rtol=2e-6, atol=2e-6)
+
+    assert model.conv is original_conv
+    assert model.bn is original_bn
+    torch.testing.assert_close(model(dummy), expected, rtol=0, atol=0)
+
+
+def test_darknet_batchnorm_fusion_failure_is_atomic(monkeypatch):
+    from libreyolo.models.darknet.blocks import DarknetConv
+
+    model = nn.Sequential(
+        DarknetConv(
+            3,
+            4,
+            size=3,
+            stride=1,
+            batch_normalize=True,
+            activation="leaky",
+        ),
+        DarknetConv(
+            4,
+            5,
+            size=3,
+            stride=1,
+            batch_normalize=True,
+            activation="leaky",
+        ),
+    ).eval()
+    original = [(block.conv, block.bn) for block in model]
+    conv2d = nn.Conv2d
+    calls = 0
+
+    def fail_second_replacement(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("synthetic allocation failure")
+        return conv2d(*args, **kwargs)
+
+    monkeypatch.setattr(coreai.nn, "Conv2d", fail_second_replacement)
+    with pytest.raises(RuntimeError, match="synthetic allocation failure"):
+        coreai._fuse_darknet_batchnorm(model)
+
+    assert [(block.conv, block.bn) for block in model] == original
+
+
 def test_anchor_freeze_reaches_wrapped_model_and_restores_cache():
     class Head(nn.Module):
         def __init__(self):

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -115,7 +115,7 @@ def test_observed_cpu_toolchain_blocks_are_explicit():
     assert fomo_tflite.tier == "blocked" and "depthwise" in fomo_tflite.reason
 
 
-def test_coreai_validated_tier_has_trained_weight_parity_coverage():
+def test_coreai_validated_tier_has_hardware_parity_coverage():
     validated = {
         (family, task)
         for (family, task, fmt), entry in SUPPORT.items()
@@ -130,9 +130,12 @@ def test_coreai_validated_tier_has_trained_weight_parity_coverage():
         ("dfine", "detect"),
         ("ec", "detect"),
         ("efficientnetv2", "classify"),
+        ("fomo", "point"),
+        ("lingbotvision", "semantic"),
         ("mobilenetv4", "classify"),
         ("nafnet", "restore"),
         ("picodet", "detect"),
+        ("pidnet", "semantic"),
         ("realesrgan", "restore"),
         ("resnet", "classify"),
         ("rfdetr", "detect"),
@@ -141,8 +144,15 @@ def test_coreai_validated_tier_has_trained_weight_parity_coverage():
         ("rtdetrv4", "detect"),
         ("rtmdet", "detect"),
         ("siglip2", "classify"),
+        ("yolo1", "detect"),
+        ("yolo2", "detect"),
+        ("yolo3", "detect"),
+        ("yolo4", "detect"),
+        ("yolo7", "detect"),
         ("yolo9", "detect"),
         ("yolo9_e2e", "detect"),
+        ("yolo9_p2", "detect"),
+        ("yolonas", "detect"),
         ("yolox", "detect"),
         ("zipdepth", "depth"),
     }
@@ -165,7 +175,7 @@ def test_compat_table_paths_do_not_depend_on_working_directory(tmp_path, monkeyp
 
     monkeypatch.chdir(tmp_path)
     assert gen_compat_table.INVENTORY_PATH.exists()
-    rows, _ = gen_compat_table._rows()
+    rows, _, _ = gen_compat_table._rows()
     assert rows
     # The full matrix lives in docs/export_support.md; the README is curated.
     assert gen_compat_table.render_docs().startswith("# Export support")
@@ -255,3 +265,12 @@ def test_generated_export_docs_are_current():
         env=env,
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_generated_docs_expose_validated_constraints():
+    from tools.gen_compat_table import render_docs
+
+    docs = render_docs()
+    assert "## Validated constraints" in docs
+    assert "`yolonas` / `detect` / `coreai`" in docs
+    assert "raw-image preprocessing" in docs

--- a/tests/unit/test_pidnet.py
+++ b/tests/unit/test_pidnet.py
@@ -212,6 +212,11 @@ class TestPIDNetForwardAndPredict:
         from libreyolo import LibreYOLO
         from libreyolo.models.pidnet.model import LibrePIDNet
 
+        # Random untrained logits can be almost tied, making a tiny backend
+        # rounding difference flip many argmax pixels and turn this parity
+        # check into an ambient-RNG failure. Fix the draw so the test measures
+        # the export path rather than whichever tests happened to run first.
+        torch.manual_seed(0)
         model = LibrePIDNet(
             model_path=None, size="s", task="semantic", nb_classes=3, device="cpu"
         )

--- a/tools/gen_compat_table.py
+++ b/tools/gen_compat_table.py
@@ -20,7 +20,7 @@ DOCS_PATH = REPO_ROOT / "docs" / "export_support.md"
 MARKERS = {"validated": "✓", "experimental": "exp", "blocked": ""}
 
 
-def _rows() -> tuple[list[str], list[str]]:
+def _rows() -> tuple[list[str], list[str], list[str]]:
     from libreyolo.export.support import EXPORT_FORMATS, get_support
 
     if not INVENTORY_PATH.exists():
@@ -35,6 +35,7 @@ def _rows() -> tuple[list[str], list[str]]:
         "| " + " | ".join(header) + " |",
         "| " + " | ".join(["---", "---", *(["---:"] * len(EXPORT_FORMATS))]) + " |",
     ]
+    validated_constraints = []
     blocked = []
     for family, metadata in inventory.items():
         for task in metadata["tasks"]:
@@ -47,13 +48,17 @@ def _rows() -> tuple[list[str], list[str]]:
                 + " |"
             )
             for fmt, entry in zip(EXPORT_FORMATS, entries):
+                if entry.tier == "validated" and entry.constraint:
+                    validated_constraints.append(
+                        f"- `{family}` / `{task}` / `{fmt}`: {entry.constraint}"
+                    )
                 if entry.tier == "blocked":
                     blocked.append(f"- `{family}` / `{task}` / `{fmt}`: {entry.reason}")
-    return rows, blocked
+    return rows, validated_constraints, blocked
 
 
 def render_docs() -> str:
-    rows, blocked = _rows()
+    rows, validated_constraints, blocked = _rows()
     return "\n".join(
         [
             "# Export support",
@@ -74,6 +79,12 @@ def render_docs() -> str:
             "- Classification: logits cosine above 0.999 and equal top-1 class.",
             "- Depth and restoration: PSNR above 40 dB against native output.",
             "- Point: peak locations equal within one output cell.",
+            "",
+            "## Validated constraints",
+            "",
+            "A check mark applies only under any constraint listed here.",
+            "",
+            *validated_constraints,
             "",
             "## Blocked combinations",
             "",


### PR DESCRIPTION
<!--
Write your PR description however you like. Structure it your own way.
Only the "Code provenance" section below is required (CI checks it exists and
is filled). Everything else is up to you.
-->

## What does this PR do?

Expands hardware-backed Core AI coverage to YOLO1, YOLO2, YOLO3, YOLO4, YOLO7, FOMO, PIDNet, LingBotVision, YOLO-NAS detection, and YOLO9-P2.

- Folds Darknet's exact inference batch-normalization formula into preceding convolutions during scoped Core AI graph preparation, with atomic failure/restoration handling.
- Replaces converter-sensitive cumulative-sum grid construction in the Darknet and YOLO7 export decoders with direct `arange` grids.
- Adds FOMO's canonical RGB `[0,1]` to native RGB `[-1,1]` preprocessing contract.
- Reuses the complete Core AI wrapper in conversion and parity references, including YOLO-NAS decoded-output selection.
- Strengthens the hardware gate with a minimum relative input-sensitivity floor so constant outputs cannot pass.
- Adds deterministic, license-clean conversion-only fixtures for FOMO and YOLO-NAS, plus a SHA-256-pinned LibreYOLO9t transfer fixture for YOLO9-P2.
- Promotes the passing family/task combinations in the support matrix and exposes validated constraints in generated documentation and human CLI output.

YOLO-NAS validation is deliberately limited to a fixed 96x96, pre-shaped tensor contract and does not claim native-640 preprocessing or detection accuracy. YOLO9-P2 validation is fixed at 640x640 and proves conversion fidelity, not P2 task accuracy.

## Code provenance

All implementation, tests, and documentation changes in this PR are original work written for LibreYOLO. No code was copied, ported, adapted, paraphrased, or derived from a third-party project.

No pretrained weights are added to the repository. Existing published LibreYOLO checkpoints are used only as external validation inputs under their existing project notices. The YOLO-NAS fixture starts from `None` and trains only on generated tensors; it does not download or convert restricted official YOLO-NAS weights. The YOLO9-P2 fixture transfers from the existing MIT-licensed LibreYOLO9t checkpoint and verifies SHA-256 `b4d7e93f9e0393830fb42e6135c0e3464b2673b05e5ecf4b7f2374ec18e39eb2` before use; it does not use the restricted VisDrone research-preview checkpoint.

## How was this tested?

- Mac Mini M4, macOS 27.0, Core AI 0.4.1: `33 passed` in the complete `tests/e2e/test_coreai.py` hardware parity suite.
- Windows full unit suite: `3781 passed, 122 skipped, 27 deselected, 4 xfailed`.
- Final affected Windows regression set: `109 passed, 1 skipped`.
- Focused Core AI contract/support tests: `41 passed`.
- Ruff checks, formatting checks, `git diff --check`, and generated compatibility-document checks passed.

The Mac gate compares named artifact outputs against the prepared eager graph at relative tolerance `3e-4`, requires at least a `100x` input-sensitivity margin, and rejects outputs below the absolute relative-sensitivity floor.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Expands parity-validated Core AI coverage across additional detection, semantic, and point-model families.
- Adds scoped Darknet batch-normalization folding, FOMO preprocessing, and shared Core AI contract wrapping.
- Replaces converter-sensitive Darknet and YOLO7 cumulative grid construction with direct arange grids.
- Adds hardware parity fixtures, sensitivity checks, support constraints, generated documentation, and CLI constraint output.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until newly validated Core AI entries reject or downgrade export configurations outside their parity-tested constraints.

Export preflight treats each promoted entry as unconditionally validated, so users can reach unvalidated canvases such as normal-size YOLO-NAS export despite the support contract being limited to 96x96.

**Files Needing Attention:** libreyolo/export/support.py and libreyolo/export/exporter.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/export/coreai.py | Adds scoped and restorable graph preparation plus FOMO and YOLO-NAS contract wrappers; no independent defect was established in these transformations. |
| libreyolo/export/support.py | Promotes several narrowly constrained Core AI configurations to validated even though runtime preflight does not enforce those constraints. |
| libreyolo/postprocess/darknet_yolo.py | Replaces cumulative grid generation with numerically equivalent device- and dtype-preserving arange grids. |
| libreyolo/postprocess/yolo7.py | Uses the same arange grid construction as the existing native decoder to avoid converter mislowering. |
| tests/e2e/test_coreai.py | Extends hardware parity coverage and rejects insensitive outputs, but fixtures exercise only the documented canvases and therefore do not catch unconstrained preflight. |
| libreyolo/cli/commands/special.py | Displays support constraints in human-readable format output without changing JSON behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    User[Core AI export request] --> Support[get_support tier lookup]
    Support --> Preflight[Exporter preflight]
    Preflight --> Resolve[Resolve image size]
    Resolve --> Wrap[Apply family contract wrapper]
    Wrap --> Prepare[Scoped graph preparation]
    Prepare --> Capture[torch.export capture]
    Capture --> Convert[Core AI conversion]
    Convert --> Artifact[Named-output artifact]
    Constraint[Documented validation constraint] -. displayed but not enforced .-> Support
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fexport%2Fsupport.py%3A670-684%0A**Validated%20constraints%20remain%20unenforced**%0A%0AWhen%20a%20user%20exports%20a%20newly%20validated%20family%20outside%20its%20documented%20canvas%2C%20%60get_support%60%20still%20returns%20%60validated%60%20because%20preflight%20checks%20only%20the%20tier%20and%20never%20evaluates%20the%20constraint%20against%20the%20resolved%20image%20size.%20This%20allows%20configurations%20such%20as%20normal-size%20YOLO-NAS%20export%20even%20though%20this%20entry%20validates%20only%20a%20pre-shaped%2096x96%20contract%20and%20explicitly%20excludes%20native-640%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=655&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22fix%2Fcoreai-remaining-families%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcoreai-remaining-families%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fexport%2Fsupport.py%3A670-684%0A**Validated%20constraints%20remain%20unenforced**%0A%0AWhen%20a%20user%20exports%20a%20newly%20validated%20family%20outside%20its%20documented%20canvas%2C%20%60get_support%60%20still%20returns%20%60validated%60%20because%20preflight%20checks%20only%20the%20tier%20and%20never%20evaluates%20the%20constraint%20against%20the%20resolved%20image%20size.%20This%20allows%20configurations%20such%20as%20normal-size%20YOLO-NAS%20export%20even%20though%20this%20entry%20validates%20only%20a%20pre-shaped%2096x96%20contract%20and%20explicitly%20excludes%20native-640%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=655&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Expand Core AI model coverage"](https://github.com/libreyolo/libreyolo/commit/5d45b8c6d333f1fc17309f1d32bb8c7f57baccbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48138657)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)
- Knowledge Base — [Postprocess pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/postprocess-pipeline.md)

<!-- /greptile_comment -->