### PR TITLE
Fix two quantization API state bugs: MXFP4 dequantize crash and leaked observing mode

### DIFF
--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -15,6 +15,7 @@ manifest so ``LibreYOLO(path)`` can rebuild the quantized structure before
 loading weights.
 """
 
+import itertools
 import logging
 from typing import Dict, Optional, Tuple
 
@@ -192,6 +193,26 @@ def _quant_modules(root: nn.Module):
             yield name, module
 
 
+def _reference_tensor(module: nn.Module) -> torch.Tensor:
+    """Return any tensor the module owns, to read its device from.
+
+    Quant modules differ in what they hold depending on their state, so no
+    single attribute is always present: a prepared MXFP4Linear owns only the
+    weight parameter and registers no buffers, while a finalized one deletes
+    that parameter and owns packed buffers instead. Bias is absent on many
+    modules. Look at parameters and buffers together.
+    """
+    for tensor in itertools.chain(
+        module.parameters(recurse=False), module.buffers(recurse=False)
+    ):
+        if tensor is not None:
+            return tensor
+    raise RuntimeError(
+        f"{type(module).__name__} owns no parameters or buffers, so its "
+        "device cannot be determined"
+    )
+
+
 def _cast_finalized_remainder(root: nn.Module, dtype: torch.dtype):
     """Cast deployment parameters without changing quantized buffer formats."""
     exact_buffers = {
@@ -280,18 +301,23 @@ def _run_calibration(
         module._q_obs_method = algorithm
     _set_observing(root, True)
     seen = 0
-    with torch.no_grad():
-        for np_batch in loader:
-            x = torch.from_numpy(np_batch).to(wrapper.device)
-            root(x)
-            seen += x.shape[0]
-    _set_observing(root, False)
+    try:
+        with torch.no_grad():
+            for np_batch in loader:
+                x = torch.from_numpy(np_batch).to(wrapper.device)
+                root(x)
+                seen += x.shape[0]
+    finally:
+        # Restore on every exit path. A batch that raises (bad sample, OOM,
+        # interrupt) would otherwise leave every observer live, so each later
+        # forward keeps widening the ranges and silently corrupts calibration.
+        _set_observing(root, False)
+        if was_training:
+            root.train()
     for _, module in _quant_modules(root):
         if hasattr(module, "finalize_observation"):
             module.finalize_observation()
         module._q_obs_method = "minmax"
-    if was_training:
-        root.train()
     return seen
 
 
@@ -682,9 +708,7 @@ def dequantize_model(wrapper):
     else:
         for name, module in list(_quant_modules(root)):
             finalized = getattr(module, "is_finalized", False)
-            ref = module.bias if module.bias is not None else next(
-                iter(module.buffers())
-            )
+            ref = _reference_tensor(module)
             if isinstance(module, QuantConv2d):
                 new = nn.Conv2d(
                     module.in_channels,

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -431,14 +431,22 @@ def quantize_model(
 
         if recipe in CALIBRATED_RECIPES:
             if calib is not None:
-                seen = _run_calibration(
-                    wrapper,
-                    calib,
-                    samples,
-                    batch,
-                    allow_download_scripts,
-                    algorithm=algorithm,
-                )
+                try:
+                    seen = _run_calibration(
+                        wrapper,
+                        calib,
+                        samples,
+                        batch,
+                        allow_download_scripts,
+                        algorithm=algorithm,
+                    )
+                except BaseException:
+                    # Calibration may already have written partial observer
+                    # ranges. Restore the original float modules so the call
+                    # is transactional and the caller can safely retry.
+                    for name, module in selected.items():
+                        _swap_module(wrapper.model, name, module)
+                    raise
                 manifest["calibrated"] = True
                 manifest["calib_data"] = str(calib)
                 manifest["calib_samples"] = int(seen)

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -791,15 +791,25 @@ class _Boom(RuntimeError):
 class _TinyQuantWrapper:
     """Minimal stand-in for a model wrapper, holding real quant modules."""
 
-    def __init__(self):
-        self.model = nn.Sequential(QuantConv2d(3, 4, 3, padding=1))
-        self.device = "cpu"
+    FAMILY = "yolo9"
+
+    def __init__(self, quantized=True):
+        module = (
+            QuantConv2d(3, 4, 3, padding=1)
+            if quantized
+            else nn.Conv2d(3, 4, 3, padding=1, bias=False)
+        )
+        self.model = nn.Sequential(module)
+        self.device = torch.device("cpu")
 
     def _get_input_size(self):
         return 32
 
     def _get_preprocess_numpy(self):
         return None
+
+    def _get_model_name(self):
+        return "tiny"
 
 
 @pytest.mark.parametrize("fails", [True, False])
@@ -819,9 +829,9 @@ def test_calibration_always_clears_observing_mode(monkeypatch, fails):
 
     class _Loader:
         def __iter__(self):
+            yield np.zeros((1, 3, 32, 32), dtype=np.float32)
             if fails:
                 raise _Boom("bad calibration sample")
-            yield np.zeros((1, 3, 32, 32), dtype=np.float32)
 
     monkeypatch.setattr(
         "libreyolo.export.calibration.CalibrationDataLoader",
@@ -841,3 +851,55 @@ def test_calibration_always_clears_observing_mode(monkeypatch, fails):
         )
 
     assert not any(getattr(m, "_q_observing", False) for m in quant_modules)
+    assert wrapper.model.training
+
+
+def test_failed_calibration_rolls_back_and_allows_retry(monkeypatch):
+    """A partial calibration must not leave an untracked quantized model."""
+    import numpy as np
+
+    from libreyolo.quant import api as quant_api
+
+    wrapper = _TinyQuantWrapper(quantized=False)
+    original = wrapper.model[0]
+    state = {"fail": True, "after_batch": False}
+
+    class _Loader:
+        def __iter__(self):
+            yield np.ones((1, 3, 32, 32), dtype=np.float32)
+            if state["fail"]:
+                state["after_batch"] = True
+                raise _Boom("interrupted after one batch")
+
+    monkeypatch.setattr(
+        "libreyolo.export.calibration.CalibrationDataLoader",
+        lambda **kwargs: _Loader(),
+    )
+
+    def quantize():
+        return quant_api.quantize_model(
+            wrapper,
+            recipe="int8",
+            calib="x",
+            batch=1,
+            samples=2,
+            keep_high_precision=(),
+            verbose=False,
+        )
+
+    with pytest.raises(_Boom):
+        quantize()
+
+    assert state["after_batch"]
+    assert wrapper.model[0] is original
+    assert wrapper.model.training
+    assert getattr(wrapper, "_quant_manifest", None) is None
+    assert not any(
+        isinstance(module, QuantConv2d) for module in wrapper.model.modules()
+    )
+
+    state["fail"] = False
+    quantize()
+    assert isinstance(wrapper.model[0], QuantConv2d)
+    assert wrapper._quant_manifest["calibrated"]
+    assert not wrapper.model[0]._q_observing

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -729,3 +729,115 @@ def test_fp16_roundtrip_keeps_float32_io(tmp_path, yolo9t):
     reloaded = LibreYOLO9(str(path), size="t", device="cpu")
     assert reloaded.quant_info()["recipe"] == "fp16"
     assert next(reloaded.model.parameters()).dtype == torch.float16
+
+
+# ---------------------------------------------------------------------------
+# Robustness of the quant API state machine
+# ---------------------------------------------------------------------------
+
+
+def test_reference_tensor_handles_every_module_state():
+    """Device lookup must work whatever tensors a quant module owns.
+
+    A prepared MXFP4Linear without bias owns only its weight parameter and
+    registers no buffers, so a buffers-only lookup raised StopIteration and
+    crashed dequantize on the ordinary quantize -> train -> dequantize path.
+    """
+    from libreyolo.quant import MXFP4Linear
+    from libreyolo.quant.api import _reference_tensor
+
+    prepared = MXFP4Linear.from_float(nn.Linear(64, 32, bias=False))
+    assert not list(prepared.buffers())          # the condition that broke it
+    assert _reference_tensor(prepared).device == prepared.weight.device
+
+    finalized = MXFP4Linear.from_float(nn.Linear(64, 32, bias=False))
+    finalized.make_finalized()
+    assert "weight" not in dict(finalized.named_parameters())
+    assert _reference_tensor(finalized) is not None
+
+    with_bias = MXFP4Linear.from_float(nn.Linear(64, 32, bias=True))
+    assert _reference_tensor(with_bias) is not None
+
+
+def test_dequantize_survives_bias_free_mxfp4_in_prepared_state(yolo9t):
+    """dequantize_model must not crash on a bias-free prepared MXFP4Linear."""
+    from libreyolo.quant import MXFP4Linear
+    from libreyolo.quant.api import dequantize_model
+
+    root = yolo9t.model
+    parent = None
+    for module in root.modules():
+        for child_name, child in list(module.named_children()):
+            if isinstance(child, nn.Linear) and child.bias is None:
+                parent, name, original = module, child_name, child
+                break
+        if parent is not None:
+            break
+    if parent is None:  # graft one so the test is not architecture-dependent
+        parent, name = root, "_probe_linear"
+        original = nn.Linear(8, 8, bias=False)
+    setattr(parent, name, MXFP4Linear.from_float(
+        original if isinstance(original, nn.Linear) else nn.Linear(8, 8, bias=False)
+    ))
+    yolo9t._quant_manifest = {"recipe": "mxfp4", "state": "prepared"}
+
+    dequantize_model(yolo9t)  # previously raised StopIteration
+
+
+class _Boom(RuntimeError):
+    pass
+
+
+class _TinyQuantWrapper:
+    """Minimal stand-in for a model wrapper, holding real quant modules."""
+
+    def __init__(self):
+        self.model = nn.Sequential(QuantConv2d(3, 4, 3, padding=1))
+        self.device = "cpu"
+
+    def _get_input_size(self):
+        return 32
+
+    def _get_preprocess_numpy(self):
+        return None
+
+
+@pytest.mark.parametrize("fails", [True, False])
+def test_calibration_always_clears_observing_mode(monkeypatch, fails):
+    """Observing must be cleared on the failure path as well as the happy one.
+
+    Left set, every later forward keeps widening the observed ranges and
+    silently corrupts the calibration that follows.
+    """
+    import numpy as np
+
+    from libreyolo.quant import api as quant_api
+
+    wrapper = _TinyQuantWrapper()
+    quant_modules = [m for _, m in quant_api._quant_modules(wrapper.model)]
+    assert quant_modules, "fixture must contain quant modules"
+
+    class _Loader:
+        def __iter__(self):
+            if fails:
+                raise _Boom("bad calibration sample")
+            yield np.zeros((1, 3, 32, 32), dtype=np.float32)
+
+    monkeypatch.setattr(
+        "libreyolo.export.calibration.CalibrationDataLoader",
+        lambda **kwargs: _Loader(),
+    )
+
+    if fails:
+        with pytest.raises(_Boom):
+            quant_api._run_calibration(
+                wrapper, calib="x", batch=1, samples=1, algorithm="minmax",
+                allow_download_scripts=False,
+            )
+    else:
+        quant_api._run_calibration(
+            wrapper, calib="x", batch=1, samples=1, algorithm="minmax",
+            allow_download_scripts=False,
+        )
+
+    assert not any(getattr(m, "_q_observing", False) for m in quant_modules)


### PR DESCRIPTION
Fixes two state-handling bugs in the quantization API. Both were surfaced by
a review pass while working on an unrelated branch, and both are reachable
from ordinary use rather than edge cases.

## `dequantize_model` crashes on a bias-free MXFP4 linear

When picking a tensor to read a module's device from, the code fell back to
the module's first buffer if there was no bias:

```python
ref = module.bias if module.bias is not None else next(iter(module.buffers()))
```

A prepared `MXFP4Linear` owns only its `weight` parameter and registers no
buffers, so for a bias-free one that `next()` raises `StopIteration` and takes
down the entire `dequantize_model` call. This is the normal state during the
quantize, train, dequantize workflow, since the model stays prepared
throughout training, so the mxfp4 recipe hits it on the common path.
`NVFP4Linear` is unaffected because it registers `_q_w_amax` in `__init__`.

The two states own different tensors, which is why no single attribute works:
prepared holds the `weight` parameter with no buffers, and `make_finalized`
deletes that parameter and registers packed buffers instead. The fix looks at
parameters and buffers together, so it is correct in either state, and raises
a clear error rather than `StopIteration` if a module somehow owns neither.

## Interrupted calibration leaves every observer running

`_run_calibration` enabled observing, ran the calibration batches, then
disabled it. Any exception in the loop, a malformed sample, an out-of-memory
error, a keyboard interrupt, skipped the cleanup, so every quant module stayed
in observing mode and the training-mode restore was skipped too. Each
subsequent forward then keeps widening the observed ranges, silently
corrupting whatever calibration runs next, with nothing in the failure message
to suggest the model is now in a bad state.

Observing and training mode are now restored in a `finally` block. Observation
finalization stays on the success path, since finalizing ranges gathered from
a partial run would be wrong.

## Tests

Three regression tests, each verified to fail when the corresponding fix is
reverted:

- `_reference_tensor` returns a usable tensor for a prepared bias-free module
  (the state with no buffers at all), a finalized one (where the weight
  parameter is gone), and one with a bias.
- `dequantize_model` completes on a bias-free prepared `MXFP4Linear` instead
  of raising `StopIteration`.
- Calibration clears observing mode on both the failure and success paths;
  the failure case fails without the `finally`, and the success case passes
  either way, which is the expected signature.

Full quantization suite: 44 passed, 1 skipped.

## Code provenance

Original code written for this PR. Bug fixes to LibreYOLO's own first-party
code, no third-party code ported, adapted, or introduced, and no GPL, AGPL,
LGPL, non-commercial, or unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves quantization state handling.
- Selects a device-reference tensor from direct parameters or buffers so prepared, bias-free MXFP4 modules can be dequantized.
- Restores observation and training modes when calibration exits exceptionally.
- Adds regression coverage for MXFP4 tensor lookup, dequantization, and observer cleanup.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until failed calibration rolls back or invalidates partially accumulated observer state.

An exception after one or more calibration batches leaves modules marked calibrated with incomplete ranges, causing incorrect fake quantization and contaminating later calibration attempts; the added failure test raises before reaching that state.

**Files Needing Attention:** libreyolo/quant/api.py, tests/unit/test_quantize.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/quant/api.py | Fixes MXFP4 device lookup and basic exception cleanup, but failed calibration still preserves partial observer state that affects inference and retries. |
| tests/unit/test_quantize.py | Adds focused regression tests, though the failure-path test raises before observing any batch and therefore misses partial calibration-state contamination. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start calibration] --> B[Enable observation]
    B --> C[Process batch and update ranges]
    C --> D{Another batch?}
    D -->|Yes| C
    D -->|No| E[Finalize observation]
    E --> F[Disable observation and restore mode]
    C -->|Exception| G[Disable observation and restore mode]
    G --> H[Partial ranges remain marked calibrated]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fquant%2Fapi.py%3A310-316%0A**Partial%20calibration%20remains%20active**%0A%0AWhen%20calibration%20processes%20at%20least%20one%20batch%20and%20then%20raises%2C%20this%20cleanup%20disables%20observation%20but%20leaves%20the%20partial%20ranges%20marked%20calibrated.%20Subsequent%20inference%20fake-quantizes%20against%20incomplete%20ranges%2C%20and%20a%20later%20calibration%20attempt%20merges%20with%20stale%20min%2Fmax%20ranges%20or%20percentile%20accumulators.%0A%0A%23%23%23%20Issue%202%0Atests%2Funit%2Ftest_quantize.py%3A820-824%0A**Failure%20test%20skips%20partial%20state**%0A%0AThe%20failing%20loader%20raises%20before%20yielding%20any%20batch%2C%20so%20this%20regression%20test%20never%20exercises%20cleanup%20after%20observers%20have%20accumulated%20and%20marked%20partial%20ranges%20as%20calibrated.%20Yield%20one%20batch%20before%20raising%20so%20the%20test%20covers%20the%20state%20corruption%20that%20occurs%20after%20an%20interrupted%20multi-batch%20calibration.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22fix-quant-api-robustness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-quant-api-robustness%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fquant%2Fapi.py%3A310-316%0A**Partial%20calibration%20remains%20active**%0A%0AWhen%20calibration%20processes%20at%20least%20one%20batch%20and%20then%20raises%2C%20this%20cleanup%20disables%20observation%20but%20leaves%20the%20partial%20ranges%20marked%20calibrated.%20Subsequent%20inference%20fake-quantizes%20against%20incomplete%20ranges%2C%20and%20a%20later%20calibration%20attempt%20merges%20with%20stale%20min%2Fmax%20ranges%20or%20percentile%20accumulators.%0A%0A%23%23%23%20Issue%202%0Atests%2Funit%2Ftest_quantize.py%3A820-824%0A**Failure%20test%20skips%20partial%20state**%0A%0AThe%20failing%20loader%20raises%20before%20yielding%20any%20batch%2C%20so%20this%20regression%20test%20never%20exercises%20cleanup%20after%20observers%20have%20accumulated%20and%20marked%20partial%20ranges%20as%20calibrated.%20Yield%20one%20batch%20before%20raising%20so%20the%20test%20covers%20the%20state%20corruption%20that%20occurs%20after%20an%20interrupted%20multi-batch%20calibration.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix two quantization API state bugs"](https://github.com/libreyolo/libreyolo/commit/74d6ab6667e4b700275fb72a2849c8b1e8b80018) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48145780)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->