### PR TITLE
Parsing error when training models with YOLO format dataset with rectangular modelsize

### DIFF
--- a/libreyolo/cli/command_utils.py
+++ b/libreyolo/cli/command_utils.py
@@ -7,6 +7,8 @@ from typing import Any, NoReturn, Optional, Set, Tuple, Union
 import click
 import typer
 
+from libreyolo.utils.image_size import normalize_imgsz
+
 from .errors import CLIError
 from .output import OutputHandler
 
@@ -87,40 +89,20 @@ def parse_imgsz_str(imgsz: str | int | None) -> int | tuple[int, int] | None:
         "640"      -> 640
         "480x640"  -> (480, 640)
         "480X640"  -> (480, 640)
+        "480,640"  -> (480, 640), legacy alias
         None       -> None
         int        -> int (pass-through)
     """
     if imgsz is None:
         return None
-    if isinstance(imgsz, int):
-        if imgsz <= 0:
-            raise ValueError(f"imgsz must be positive, got {imgsz}.")
-        return imgsz
-    s = str(imgsz).strip()
-    if not s:
+    if isinstance(imgsz, str) and not imgsz.strip():
         return None
-    if "x" in s.lower():
-        parts = s.lower().split("x", 1)
-        try:
-            h, w = int(parts[0]), int(parts[1])
-        except (ValueError, IndexError):
-            raise ValueError(
-                f"Invalid imgsz format: '{imgsz}'. Use 640 (square) or 480x640 (HxW)."
-            )
-        if h <= 0 or w <= 0:
-            raise ValueError(
-                f"imgsz dimensions must be positive, got ({h}, {w})."
-            )
-        return h if h == w else (h, w)
-    try:
-        value = int(s)
-    except ValueError:
-        raise ValueError(
-            f"Invalid imgsz format: '{imgsz}'. Use 640 (square) or 480x640 (HxW)."
-        )
-    if value <= 0:
-        raise ValueError(f"imgsz must be positive, got {value}.")
-    return value
+    return normalize_imgsz(
+        imgsz,
+        name="imgsz",
+        allow_string=True,
+        allow_comma=True,
+    )
 
 
 def get_loaded_model_input_size(

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -10,6 +10,7 @@ from ..command_utils import (
     exit_with_error,
     help_json_callback,
     load_model_or_exit,
+    parse_imgsz_str,
     resolve_model_or_exit,
 )
 from ..output import OutputHandler
@@ -21,7 +22,7 @@ def export_cmd(
         "onnx",
         help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite (alias: litert), coreml",
     ),
-    imgsz: Optional[str] = typer.Option(None, help="Input image size (e.g. 640 or 640,480)"),
+    imgsz: Optional[str] = typer.Option(None, help="Input image size: 640 (square) or 480x640 (HxW)"),
     batch: int = typer.Option(1, help="Export batch size"),
     half: bool = typer.Option(False, help="FP16 precision"),
     int8: bool = typer.Option(False, help="INT8 quantization"),
@@ -119,19 +120,11 @@ def export_cmd(
         if fmt == "onnx":
             export_kwargs["max_det"] = max_det
     if imgsz is not None:
-        if "," in imgsz:
-            parts = imgsz.split(",")
-            if len(parts) != 2:
-                exit_with_error(out, "invalid_imgsz", f"Invalid imgsz format: {imgsz}. Use e.g. 640 or 640,480.")
-            try:
-                export_kwargs["imgsz"] = (int(parts[0]), int(parts[1]))
-            except ValueError:
-                exit_with_error(out, "invalid_imgsz", f"Invalid imgsz values: {imgsz}. Use integer dimensions.")
-        else:
-            try:
-                export_kwargs["imgsz"] = int(imgsz)
-            except ValueError:
-                exit_with_error(out, "invalid_imgsz", f"Invalid imgsz: {imgsz}. Use e.g. 640 or 640,480.")
+        try:
+            parsed = parse_imgsz_str(imgsz)
+        except ValueError as exc:
+            exit_with_error(out, "invalid_imgsz", str(exc))
+        export_kwargs["imgsz"] = parsed
     if data is not None:
         export_kwargs["data"] = data
     if data is not None or int8:
@@ -170,11 +163,12 @@ def export_cmd(
     else:
         size_mb = 0.0
 
-    if imgsz is not None and "," in imgsz:
-        parts = imgsz.split(",")
-        input_h, input_w = int(parts[0]), int(parts[1])
-    elif imgsz is not None:
-        input_h = input_w = int(imgsz)
+    if imgsz is not None:
+        parsed = parse_imgsz_str(imgsz)
+        if isinstance(parsed, int):
+            input_h = input_w = parsed
+        else:
+            input_h, input_w = parsed
     else:
         native = (
             loaded_model._get_input_size()

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -22,7 +22,10 @@ def export_cmd(
         "onnx",
         help="Export format: onnx, torchscript, tensorrt, openvino, ncnn, tflite (alias: litert), coreml",
     ),
-    imgsz: Optional[str] = typer.Option(None, help="Input image size: 640 (square) or 480x640 (HxW)"),
+    imgsz: Optional[str] = typer.Option(
+        None,
+        help="Input image size: 640 or 480x640 (HxW); 480,640 remains supported",
+    ),
     batch: int = typer.Option(1, help="Export batch size"),
     half: bool = typer.Option(False, help="FP16 precision"),
     int8: bool = typer.Option(False, help="INT8 quantization"),
@@ -119,12 +122,13 @@ def export_cmd(
         export_kwargs["iou"] = iou
         if fmt == "onnx":
             export_kwargs["max_det"] = max_det
+    parsed_imgsz = None
     if imgsz is not None:
         try:
-            parsed = parse_imgsz_str(imgsz)
+            parsed_imgsz = parse_imgsz_str(imgsz)
         except ValueError as exc:
             exit_with_error(out, "invalid_imgsz", str(exc))
-        export_kwargs["imgsz"] = parsed
+        export_kwargs["imgsz"] = parsed_imgsz
     if data is not None:
         export_kwargs["data"] = data
     if data is not None or int8:
@@ -163,12 +167,11 @@ def export_cmd(
     else:
         size_mb = 0.0
 
-    if imgsz is not None:
-        parsed = parse_imgsz_str(imgsz)
-        if isinstance(parsed, int):
-            input_h = input_w = parsed
+    if parsed_imgsz is not None:
+        if isinstance(parsed_imgsz, int):
+            input_h = input_w = parsed_imgsz
         else:
-            input_h, input_w = parsed
+            input_h, input_w = parsed_imgsz
     else:
         native = (
             loaded_model._get_input_size()

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -265,9 +265,22 @@ class YOLODataset(ImageCacheMixin, Dataset):
             label_files: List of label paths (optional, inferred if not provided).
             num_classes: Optional class-count bound used for OBB label validation.
         """
-        self.img_size = img_size
+        if isinstance(img_size, int):
+            self.img_size = (img_size, img_size)
+        elif isinstance(img_size, (list, tuple)):
+            if len(img_size) != 2:
+                raise ValueError(
+                    f"img_size must be a 2-element (height, width) tuple, "
+                    f"got {len(img_size)} elements: {img_size}."
+                )
+            self.img_size = (int(img_size[0]), int(img_size[1]))
+        else:
+            raise TypeError(
+                f"img_size must be int or (height, width) tuple, "
+                f"got {type(img_size).__name__}: {img_size!r}."
+            )
         self.preproc = preproc
-        self._input_dim = img_size
+        self._input_dim = self.img_size
         self.load_segments = load_segments
         self.load_obb = load_obb
         self.num_classes = num_classes
@@ -643,8 +656,21 @@ class COCODataset(ImageCacheMixin, Dataset):
         self.data_dir = Path(data_dir)
         self.json_file = json_file
         self.name = name
-        self.img_size = img_size
-        self._input_dim = img_size
+        if isinstance(img_size, int):
+            self.img_size = (img_size, img_size)
+        elif isinstance(img_size, (list, tuple)):
+            if len(img_size) != 2:
+                raise ValueError(
+                    f"img_size must be a 2-element (height, width) tuple, "
+                    f"got {len(img_size)} elements: {img_size}."
+                )
+            self.img_size = (int(img_size[0]), int(img_size[1]))
+        else:
+            raise TypeError(
+                f"img_size must be int or (height, width) tuple, "
+                f"got {type(img_size).__name__}: {img_size!r}."
+            )
+        self._input_dim = self.img_size
         self.preproc = preproc
         self.load_segments = load_segments
         self.load_obb = load_obb

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -30,6 +30,7 @@ from .obb import (
     xywhr_to_proxy_xyxy,
 )
 from libreyolo.training.distributed import is_main_process
+from libreyolo.utils.image_size import imgsz_to_hw
 
 logger = logging.getLogger(__name__)
 
@@ -245,7 +246,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
         self,
         data_dir: str | None = None,
         split: str = "train",
-        img_size: Tuple[int, int] = (640, 640),
+        img_size: int | Tuple[int, int] | List[int] = (640, 640),
         preproc=None,
         img_files: List[Path] | None = None,
         label_files: List[Path] | None = None,
@@ -265,20 +266,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
             label_files: List of label paths (optional, inferred if not provided).
             num_classes: Optional class-count bound used for OBB label validation.
         """
-        if isinstance(img_size, int):
-            self.img_size = (img_size, img_size)
-        elif isinstance(img_size, (list, tuple)):
-            if len(img_size) != 2:
-                raise ValueError(
-                    f"img_size must be a 2-element (height, width) tuple, "
-                    f"got {len(img_size)} elements: {img_size}."
-                )
-            self.img_size = (int(img_size[0]), int(img_size[1]))
-        else:
-            raise TypeError(
-                f"img_size must be int or (height, width) tuple, "
-                f"got {type(img_size).__name__}: {img_size!r}."
-            )
+        self.img_size = imgsz_to_hw(img_size, name="img_size")
         self.preproc = preproc
         self._input_dim = self.img_size
         self.load_segments = load_segments
@@ -626,7 +614,7 @@ class COCODataset(ImageCacheMixin, Dataset):
         data_dir: str,
         json_file: str = "instances_train2017.json",
         name: str = "train2017",
-        img_size: Tuple[int, int] = (640, 640),
+        img_size: int | Tuple[int, int] | List[int] = (640, 640),
         preproc=None,
         load_segments: bool = False,
         load_obb: bool = False,
@@ -656,20 +644,7 @@ class COCODataset(ImageCacheMixin, Dataset):
         self.data_dir = Path(data_dir)
         self.json_file = json_file
         self.name = name
-        if isinstance(img_size, int):
-            self.img_size = (img_size, img_size)
-        elif isinstance(img_size, (list, tuple)):
-            if len(img_size) != 2:
-                raise ValueError(
-                    f"img_size must be a 2-element (height, width) tuple, "
-                    f"got {len(img_size)} elements: {img_size}."
-                )
-            self.img_size = (int(img_size[0]), int(img_size[1]))
-        else:
-            raise TypeError(
-                f"img_size must be int or (height, width) tuple, "
-                f"got {type(img_size).__name__}: {img_size!r}."
-            )
+        self.img_size = imgsz_to_hw(img_size, name="img_size")
         self._input_dim = self.img_size
         self.preproc = preproc
         self.load_segments = load_segments

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 import yaml
 
+from libreyolo.utils.image_size import normalize_imgsz
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,7 +49,7 @@ class TrainConfig:
     # Data
     data: Optional[str] = None
     data_dir: Optional[str] = None
-    imgsz: Union[int, Tuple[int, int]] = 640
+    imgsz: Union[int, Tuple[int, int], List[int], str] = 640
 
     # Training
     epochs: int = 300
@@ -194,26 +196,11 @@ class TrainConfig:
     profile_open: bool = True
 
     def __post_init__(self):
-        if isinstance(self.imgsz, str):
-            raise TypeError(
-                f"imgsz must be an int (square) or tuple[int, int] (height, width), "
-                f"got str: {self.imgsz!r}. "
-                "Pass an int like 640 or a tuple like (480, 640). "
-                "From the CLI use the format 640 or 480x640 (parsed automatically)."
-            )
-        if isinstance(self.imgsz, (list, tuple)):
-            if len(self.imgsz) != 2:
-                raise ValueError(
-                    f"imgsz tuple must have exactly 2 elements (height, width), "
-                    f"got {len(self.imgsz)}."
-                )
-            h, w = self.imgsz
-            if not (isinstance(h, int) and isinstance(w, int)):
-                raise TypeError(f"imgsz tuple elements must be ints, got ({type(h).__name__}, {type(w).__name__}).")
-            if h <= 0 or w <= 0:
-                raise ValueError(f"imgsz tuple elements must be positive, got ({h}, {w}).")
-            if h == w:
-                self.imgsz = h
+        self.imgsz = normalize_imgsz(
+            self.imgsz,
+            name="imgsz",
+            allow_string=True,
+        )
 
     @classmethod
     def from_kwargs(cls, **kwargs):

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -194,6 +194,13 @@ class TrainConfig:
     profile_open: bool = True
 
     def __post_init__(self):
+        if isinstance(self.imgsz, str):
+            raise TypeError(
+                f"imgsz must be an int (square) or tuple[int, int] (height, width), "
+                f"got str: {self.imgsz!r}. "
+                "Pass an int like 640 or a tuple like (480, 640). "
+                "From the CLI use the format 640 or 480x640 (parsed automatically)."
+            )
         if isinstance(self.imgsz, (list, tuple)):
             if len(self.imgsz) != 2:
                 raise ValueError(
@@ -206,8 +213,6 @@ class TrainConfig:
             if h <= 0 or w <= 0:
                 raise ValueError(f"imgsz tuple elements must be positive, got ({h}, {w}).")
             if h == w:
-                # Square tuples are equivalent to the scalar form; normalize so
-                # downstream code paths that expect a scalar keep working.
                 self.imgsz = h
 
     @classmethod

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -224,9 +224,19 @@ class BaseTrainer(ABC):
     @property
     def input_size(self) -> Tuple[int, int]:
         imgsz = self.config.imgsz
+        if isinstance(imgsz, int):
+            return (imgsz, imgsz)
         if isinstance(imgsz, (list, tuple)):
+            if len(imgsz) != 2:
+                raise ValueError(
+                    f"imgsz tuple must have exactly 2 elements (height, width), "
+                    f"got {len(imgsz)}: {imgsz}."
+                )
             return (int(imgsz[0]), int(imgsz[1]))
-        return (int(imgsz), int(imgsz))
+        raise TypeError(
+            f"imgsz must be int or tuple[int, int], "
+            f"got {type(imgsz).__name__}: {imgsz!r}."
+        )
 
     # =========================================================================
     # Hook methods — subclasses override these

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -56,6 +56,7 @@ from ..data import (
     load_data_config,
     resolve_default_coco_image_dir,
 )
+from ..utils.image_size import imgsz_to_hw
 from ..utils.serialization import (
     SCHEMA_VERSION,
     build_class_names,
@@ -223,20 +224,7 @@ class BaseTrainer(ABC):
 
     @property
     def input_size(self) -> Tuple[int, int]:
-        imgsz = self.config.imgsz
-        if isinstance(imgsz, int):
-            return (imgsz, imgsz)
-        if isinstance(imgsz, (list, tuple)):
-            if len(imgsz) != 2:
-                raise ValueError(
-                    f"imgsz tuple must have exactly 2 elements (height, width), "
-                    f"got {len(imgsz)}: {imgsz}."
-                )
-            return (int(imgsz[0]), int(imgsz[1]))
-        raise TypeError(
-            f"imgsz must be int or tuple[int, int], "
-            f"got {type(imgsz).__name__}: {imgsz!r}."
-        )
+        return imgsz_to_hw(self.config.imgsz, name="imgsz")
 
     # =========================================================================
     # Hook methods — subclasses override these

--- a/libreyolo/utils/image_size.py
+++ b/libreyolo/utils/image_size.py
@@ -1,0 +1,107 @@
+"""Shared image-size normalization helpers."""
+
+from numbers import Integral
+from typing import Any
+
+
+ImageSize = int | tuple[int, int]
+
+
+def _positive_dimension(value: Any, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(
+            f"{name} dimensions must be integers, got {type(value).__name__}: "
+            f"{value!r}."
+        )
+    dimension = int(value)
+    if dimension <= 0:
+        raise ValueError(f"{name} dimensions must be positive, got {dimension}.")
+    return dimension
+
+
+def normalize_imgsz(
+    value: Any,
+    *,
+    name: str = "imgsz",
+    allow_string: bool = False,
+    allow_comma: bool = False,
+) -> ImageSize:
+    """Normalize a square or ``(height, width)`` image size.
+
+    Square pairs collapse to their scalar form. Strings may use ``HxW`` when
+    enabled; comma-separated pairs are an optional legacy CLI alias.
+    """
+    if isinstance(value, str):
+        if not allow_string:
+            raise TypeError(
+                f"{name} must be an int or (height, width) pair, got str: {value!r}."
+            )
+        text = value.strip()
+        if not text:
+            raise ValueError(f"{name} must not be empty.")
+
+        lowered = text.lower()
+        if "x" in lowered:
+            parts = lowered.split("x")
+        elif "," in text:
+            if not allow_comma:
+                raise ValueError(
+                    f"Invalid {name} format: {value!r}. Use 640 or 480x640 (HxW)."
+                )
+            parts = text.split(",")
+        else:
+            try:
+                return _positive_dimension(int(text), name=name)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid {name} format: {value!r}. Use 640 or 480x640 (HxW)."
+                ) from exc
+
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid {name} format: {value!r}. Use 640 or 480x640 (HxW)."
+            )
+        try:
+            height, width = (int(part.strip()) for part in parts)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid {name} format: {value!r}. Use 640 or 480x640 (HxW)."
+            ) from exc
+        height = _positive_dimension(height, name=name)
+        width = _positive_dimension(width, name=name)
+    elif isinstance(value, Integral) and not isinstance(value, bool):
+        return _positive_dimension(value, name=name)
+    elif isinstance(value, (list, tuple)):
+        if len(value) != 2:
+            raise ValueError(
+                f"{name} must have exactly 2 elements (height, width), "
+                f"got {len(value)}: {value!r}."
+            )
+        height = _positive_dimension(value[0], name=name)
+        width = _positive_dimension(value[1], name=name)
+    else:
+        raise TypeError(
+            f"{name} must be an int or (height, width) pair, got "
+            f"{type(value).__name__}: {value!r}."
+        )
+
+    return height if height == width else (height, width)
+
+
+def imgsz_to_hw(
+    value: Any,
+    *,
+    name: str = "imgsz",
+    allow_string: bool = False,
+    allow_comma: bool = False,
+) -> tuple[int, int]:
+    """Normalize an image size and return an explicit ``(height, width)`` pair."""
+    normalized = normalize_imgsz(
+        value,
+        name=name,
+        allow_string=allow_string,
+        allow_comma=allow_comma,
+    )
+    if isinstance(normalized, int):
+        return normalized, normalized
+    return normalized

--- a/tests/unit/cli/test_command_utils.py
+++ b/tests/unit/cli/test_command_utils.py
@@ -585,7 +585,8 @@ def test_export_cli_leaves_opset_auto_by_default(monkeypatch, tmp_path):
     assert captured["opset"] is None
 
 
-def test_export_cli_forwards_rectangular_imgsz(monkeypatch, tmp_path):
+@pytest.mark.parametrize("imgsz_arg", ["320,640", "320x640"])
+def test_export_cli_forwards_rectangular_imgsz(monkeypatch, tmp_path, imgsz_arg):
     captured = {}
 
     class _ExportModel:
@@ -615,7 +616,7 @@ def test_export_cli_forwards_rectangular_imgsz(monkeypatch, tmp_path):
             "export",
             "model=yolo9-t",
             "format=onnx",
-            "imgsz=320,640",
+            f"imgsz={imgsz_arg}",
             "batch=2",
             "--json",
         ],

--- a/tests/unit/test_dataset_loading.py
+++ b/tests/unit/test_dataset_loading.py
@@ -58,6 +58,96 @@ def test_yolo_annotation_loading_preserves_order_and_shape(tmp_path, monkeypatch
         assert file_name == f"sample_{index}.jpg"
 
 
+@pytest.mark.parametrize(
+    ("img_size", "expected"),
+    [
+        (64, (64, 64)),
+        ((32, 96), (32, 96)),
+        ([32, 96], (32, 96)),
+    ],
+)
+def test_yolo_dataset_normalizes_scalar_and_pair_img_size(
+    tmp_path, img_size, expected
+):
+    image_path = tmp_path / "sample.jpg"
+    label_path = tmp_path / "sample.txt"
+    Image.new("RGB", (100, 50), color="white").save(image_path)
+    label_path.write_text("0 0.5 0.5 0.25 0.5\n")
+
+    dataset = YOLODataset(
+        img_files=[image_path],
+        label_files=[label_path],
+        img_size=img_size,
+    )
+
+    assert dataset.img_size == expected
+    assert dataset.input_dim == expected
+    resized = dataset.load_resized_img(0)
+    assert resized.shape[0] <= expected[0]
+    assert resized.shape[1] <= expected[1]
+
+
+@pytest.mark.parametrize(
+    "img_size",
+    [0, -1, True, (32, 0), (32.5, 96), (32, 96, 128)],
+)
+def test_yolo_dataset_rejects_invalid_img_size_before_loading(tmp_path, img_size):
+    with pytest.raises((TypeError, ValueError)):
+        YOLODataset(
+            img_files=[tmp_path / "missing.jpg"],
+            label_files=[tmp_path / "missing.txt"],
+            img_size=img_size,
+        )
+
+
+def test_coco_dataset_normalizes_scalar_img_size(tmp_path):
+    pytest.importorskip("pycocotools")
+
+    image_dir = tmp_path / "train2017"
+    annotation_dir = tmp_path / "annotations"
+    image_dir.mkdir()
+    annotation_dir.mkdir()
+    Image.new("RGB", (100, 50), color="white").save(image_dir / "sample.jpg")
+    (annotation_dir / "instances_train2017.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {
+                        "id": 1,
+                        "file_name": "sample.jpg",
+                        "width": 100,
+                        "height": 50,
+                    }
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "bbox": [25, 10, 50, 30],
+                        "area": 1500,
+                        "iscrowd": 0,
+                    }
+                ],
+                "categories": [{"id": 1, "name": "target"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dataset = COCODataset(
+        data_dir=str(tmp_path),
+        json_file="instances_train2017.json",
+        name="train2017",
+        img_size=64,
+    )
+
+    assert dataset.img_size == (64, 64)
+    assert dataset.input_dim == (64, 64)
+    resized = dataset.load_resized_img(0)
+    assert resized.shape[:2] == (32, 64)
+
+
 def test_yolo_dataset_loads_obb_rows_as_proxy_box_and_angle(tmp_path):
     image_dir = tmp_path / "images"
     label_dir = tmp_path / "labels"

--- a/tests/unit/test_rectangular_imgsz.py
+++ b/tests/unit/test_rectangular_imgsz.py
@@ -33,8 +33,14 @@ class TestParseImgszStr:
     def test_rect_uppercase(self):
         assert parse_imgsz_str("480X640") == (480, 640)
 
+    def test_rect_legacy_comma(self):
+        assert parse_imgsz_str("480,640") == (480, 640)
+
     def test_square_tuple_collapses_to_int(self):
         assert parse_imgsz_str("640x640") == 640
+
+    def test_square_legacy_comma_collapses_to_int(self):
+        assert parse_imgsz_str("640,640") == 640
 
     def test_none_passthrough(self):
         assert parse_imgsz_str(None) is None
@@ -47,7 +53,10 @@ class TestParseImgszStr:
         with pytest.raises(ValueError):
             parse_imgsz_str(bad)
 
-    @pytest.mark.parametrize("bad", ["abc", "12ax640", "x640", "640x"])
+    @pytest.mark.parametrize(
+        "bad",
+        ["abc", "12ax640", "x640", "640x", "480,640,800"],
+    )
     def test_garbage_rejected(self, bad):
         with pytest.raises(ValueError):
             parse_imgsz_str(bad)
@@ -65,8 +74,21 @@ class TestTrainConfigImgsz:
     def test_rect_tuple_kept(self):
         assert TrainConfig(imgsz=(480, 640)).imgsz == (480, 640)
 
+    def test_rect_list_normalized_to_tuple(self):
+        assert TrainConfig(imgsz=[480, 640]).imgsz == (480, 640)
+
     def test_square_tuple_normalized_to_scalar(self):
         assert TrainConfig(imgsz=(640, 640)).imgsz == 640
+
+    def test_numeric_string_preserved_as_compatibility_input(self):
+        assert TrainConfig(imgsz="640").imgsz == 640
+
+    def test_hxw_string_accepted(self):
+        assert TrainConfig(imgsz="480x640").imgsz == (480, 640)
+
+    def test_python_comma_string_rejected(self):
+        with pytest.raises(ValueError):
+            TrainConfig(imgsz="480,640")
 
     def test_wrong_arity_rejected(self):
         with pytest.raises(ValueError):
@@ -79,6 +101,11 @@ class TestTrainConfigImgsz:
     def test_non_int_rejected(self):
         with pytest.raises(TypeError):
             TrainConfig(imgsz=(640.0, 480))
+
+    @pytest.mark.parametrize("bad", [640.0, True, "garbage", "0x640"])
+    def test_invalid_scalar_rejected_at_config_boundary(self, bad):
+        with pytest.raises((TypeError, ValueError)):
+            TrainConfig(imgsz=bad)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
It did not sanitized imgsz input at all for YOLO format dataset. And was not able to parse rectangular size input (tuple) and crashed.

This pull request is continuation of #649

Also, now there is stronger cli input parsing. There was overall inconsistency in that. cli trainer and predictor, validator and cmd has different input format. 'HxW' or `int` format are only allowed, nothing else.

And this is an suggestion, that you may want to add an example YOLO format dataset for unit test. This bug was not caught during automated test. I only discovered this during using dev branch internally.

It remains if you want to accept 'HxW' input on model.train() 


## Code provenance

written with opencode, conducted a manual review.
