### PR TITLE
Add mesh task: human body mesh recovery on the MHR body model

### DIFF
--- a/PLAN_body_mesh_task.md
+++ b/PLAN_body_mesh_task.md
@@ -47,7 +47,9 @@ license included and a gate that records acceptance.
 * `LibreSAM3DBody` adapter with person-detector chaining
   (`person_boxes=` / `person_detector=`), following the gaze family's pattern.
 * Metrics: MPJPE, PA-MPJPE with a reflection-safe Procrustes, PVE.
-* `draw_mesh`: renderer-free projected-vertex scatter plus the MHR-70 skeleton.
+* `draw_mesh`: a shaded surface render via a small numpy/PIL painter's-algorithm
+  rasterizer (back-face culling, Lambertian shading, far-to-near ordering), with
+  no GL dependency. Vertex scatter remains the fallback when topology is absent.
 * Gates: export raises an explicit not-implemented error, validation explains
   the dataset-license situation, TTA is rejected.
 * Docs: ADR 0013, nomenclature, checkpoint schema.
@@ -105,3 +107,25 @@ fetches it from the upstream release and caches it locally.
    field.
 3. Export contract, validation dataset story, video and world-frame support,
    SMPL-X whole-body hands and face.
+
+## Do not use: AmmarkoV/SAM3DBody-cpp
+
+Investigated 2026-07-29 and rejected. It is a genuine standalone C++ inference
+engine for SAM 3D Body with real original work around it (BVH writer, OpenGL
+renderer, multi-view calibration), and it is labelled MIT. The MIT label does
+not hold: the repository commits Meta's MHR mesh geometry (`body_mesh.tri`,
+18439 vertices), a joint table auto-generated from `mhr_model.pt`, and ONNX
+exports of Meta's checkpoint, all under MIT with no SAM License propagated. Its
+Hugging Face weights repo is tagged `license:mit` while containing
+SAM-licensed decoder weights, the separately-licensed DINOv3 backbone, and an
+AGPL Ultralytics-derived detector. A third party cannot relicense Meta's work,
+so relying on that label would be laundering someone else's invalid
+relicensing. His own C code is plausibly his to license, but the same files
+also ship in MocapNET under FORTH's non-commercial terms, so provenance is
+unclear there too.
+
+Worth knowing rather than acting on: he wired LibreYOLO in as a license-clean
+alternative to Ultralytics YOLO11 (`--detector libreyolo`, with an auto mode
+that prefers a LibreYOLO export) and hosts `libreyolo9.onnx`. Redistributing
+that is entirely legitimate. A friendly heads-up about the mislabelled weights
+would protect him and avoid reputational adjacency for LibreYOLO.

--- a/PLAN_body_mesh_task.md
+++ b/PLAN_body_mesh_task.md
@@ -1,96 +1,107 @@
-# PLAN: `mesh` task (human body mesh recovery), Meta stack
+# Body mesh (`mesh`) task: status and follow-ups
 
-Scope: the Meta stack only, SAM 3D Body on the MHR body model. Other families
-(ROMP, 4D-Humans, NLF, Multi-HMR, TokenHMR, CameraHMR, SMPLer-X, GVHMR) were
-surveyed and are out of scope by decision. Investigation date 2026-07-28.
+Scope: human body mesh recovery. First family is SAM 3D Body on the MHR body
+model, integrated as a **wrapper** rather than a port. Investigation and
+implementation 2026-07-28/29.
 
-Status: **task contract and body model shipped; regressor blocked on weight
-access.** See "What is done" and "What is blocked" below.
+Status: **shipped and working end to end.** Branch `mesh-body-recovery` off
+`dev`.
 
-## Why the Meta stack, in one paragraph
+## Why the field is a licensing minefield
 
-The rest of the field predicts into SMPL, and SMPL is unusable here: the model
-files are non-commercial and non-redistributable, the `smplx` PyPI package's
-*code* carries that same non-commercial license (the most common misconception
-in this area), and the license reaches into any checkpoint trained against it.
-MHR is Apache 2.0 for code and assets with no registration, and SAM 3D Body's
-weights are redistributable under the SAM license with passthrough. It is the
-only end-to-end path where the body model, the code and the weights all clear.
+Nearly every mesh model predicts into SMPL, and SMPL is unusable for a
+permissive library: the model files are non-commercial and non-redistributable,
+the `smplx` PyPI package's *code* carries the same non-commercial license (the
+most common misconception in this area), and the license forbids using the
+model to train networks for commercial deployment, so it reaches into
+checkpoints too. Worse, SMPL is registration-gated, so no library can offer
+autodownload for it.
+
+MHR (Apache 2.0, code and assets, ungated) fixes the body-model layer. What it
+does not fix is the regressor layer: the only strong MHR regressor is SAM 3D
+Body, whose **code** is under the SAM License with military and trade-control
+field-of-use clauses. That code cannot enter an MIT tree.
+
+## The resolution: wrap, do not port
+
+`LibreSAM3DBody` calls the upstream package's public API and translates its
+output into `Meshes`. LibreYOLO ships no SAM-licensed bytes; the upstream
+package is an optional dependency the user installs. The SAM License triggers
+on *distributing* SAM Materials, and an adapter distributes none of their code.
+A user who never touches the mesh task never encounters those terms.
+
+Weights are separate from code: the SAM License permits redistribution with
+passthrough, so the checkpoints are mirrored on the LibreYOLO org with the
+license included and a gate that records acceptance.
 
 ## What is done
 
-Landed on branch `mesh-body-recovery`, off `dev`:
+* Task registration: `mesh`, suffix `-mesh`, aliases `body-mesh`, `hmr`,
+  `human-mesh-recovery`. `smpl` deliberately not aliased.
+* `Meshes` payload, row-aligned with `Results.boxes` as pose keypoints are.
+  Body-model-agnostic: `body_model` names the parameterization, counts are read
+  from the tensors. `save_obj()` writes Wavefront OBJ.
+* MHR body model decoder, fetched from the public Apache release, no
+  dependency beyond PyTorch.
+* Camera helpers: crop-camera lifting and perspective projection.
+* `LibreSAM3DBody` adapter with person-detector chaining
+  (`person_boxes=` / `person_detector=`), following the gaze family's pattern.
+* Metrics: MPJPE, PA-MPJPE with a reflection-safe Procrustes, PVE.
+* `draw_mesh`: renderer-free projected-vertex scatter plus the MHR-70 skeleton.
+* Gates: export raises an explicit not-implemented error, validation explains
+  the dataset-license situation, TTA is rejected.
+* Docs: ADR 0013, nomenclature, checkpoint schema.
 
-* **Task registration.** `mesh` in `TaskType`/`TASKS`, suffix `-mesh`, aliases
-  `body-mesh`, `hmr`, `human-mesh-recovery`. `smpl` deliberately not aliased.
-* **`Meshes` result payload**, row-aligned with `Results.boxes` the way pose
-  keypoints are. Body-model-agnostic: `body_model` names the parameterization
-  and all counts are read from the tensors. Slicing selects a person without
-  touching shared face topology; device moves cover topology and extras.
-  `save_obj()` writes standard Wavefront OBJ.
-* **MHR body model** (`libreyolo/models/sam3dbody/mhr_body.py`): TorchScript
-  loader, parameter assembly, unit conversion, and a downloader for the public
-  Apache-2.0 release asset. Validated against the real 696 MB asset.
-* **Camera helpers** (`camera.py`): crop-camera to full-image lifting and
-  perspective projection, so `joints2d` is in original-image pixels.
-* **Metrics** (`libreyolo/validation/mesh_metrics.py`): MPJPE, PA-MPJPE with a
-  reflection-safe Procrustes, PVE.
-* **Drawing** (`draw_mesh`): renderer-free projected-vertex scatter plus the
-  MHR-70 skeleton. No rasterizer dependency.
-* **Gates**: export raises an explicit not-implemented error, validation
-  explains the dataset-license situation, TTA is rejected with the
-  left/right-swap reason.
-* **Docs**: ADR 0013, nomenclature, checkpoint schema.
-* **Tests**: 54 unit tests on fabricated payloads, plus 9 `external_data`
-  integration tests against the real MHR asset.
+### Verified, not assumed
 
-Verified numbers, not assumptions: MHR `model_params` is 204 wide (3
-translation, 3 global rotation, 130 body pose, 68 bone scales), `betas` 45,
-`expression` 72, outputs 18439 vertices and 127 joints in centimeters, with
-translation entering the rig in decimeters. The upstream comment saying 127 is
-stale; the assertion two functions below it says 136. Rest-pose height decodes
-to 1.727 m and a requested 0.1/0.2/0.3 m translation moves the body by exactly
-that, which is what pins the unit conventions.
+* MHR `model_params` is 204 wide (3 translation, 3 global rotation, 130 body
+  pose, 68 bone scales); `betas` 45; `expression` 72; outputs 18439 vertices
+  and 127 joints in centimeters, translation entering in decimeters. The
+  upstream comment saying 127 is stale. Rest-pose height decodes to 1.727 m.
+* Real inference on the sample image: 1 person, 18439 vertices, 70 joints,
+  metric depth 4.0-4.9 m in front of the camera, 1.7 s on CUDA.
+* Projection parity against upstream: **max 0.0001 px** across all 70 joints,
+  confirming the camera-frame contract and focal-length handling.
 
-## What is blocked
+### Weight mirrors
 
-**SAM 3D Body regressor weights.** `facebook/sam-3d-body-dinov3` and
-`facebook/sam-3d-body-vith` are **gated with manual approval** on Hugging Face,
-and the token cached on this machine is invalid ("Invalid user token"). Both
-must be resolved before the regressor family can be built, because a port that
-cannot be run against real weights certifies nothing.
+* `LibreYOLO/LibreSAM3DBodyd3-mesh` (DINOv3 ViT-H/16+, 2109 MB)
+* `LibreYOLO/LibreSAM3DBodyh-mesh` (ViT-H, 1691 MB)
 
-To unblock, in order:
+Both public with `gated="auto"`: the user accepts the SAM License and attests
+they are not in a comprehensively sanctioned jurisdiction, then gets immediate
+access. Meta's own gate is manual and can take days; auto records the same
+acceptance without the wait. Flip to `manual` with one
+`update_repo_settings(gated="manual")` call if a human review step is wanted.
 
-1. Request access at https://huggingface.co/facebook/sam-3d-body-dinov3 and
-   wait for approval. Note the upstream warning that comprehensively sanctioned
-   jurisdictions are rejected.
-2. Generate a fresh token and `hf auth login --force`.
-3. Confirm with `huggingface_hub.model_info("facebook/sam-3d-body-dinov3")` and
-   an `hf_hub_download` of `model_config.yaml`.
+The MHR asset is **not** mirrored: it is Apache 2.0 and public, so LibreYOLO
+fetches it from the upstream release and caches it locally.
 
-Then the remaining work is the regressor family itself: DINOv3/ViT-H backbone,
-promptable decoder, MHR head and camera head; a `weights/convert_sam3dbody.py`
-converter into the LibreYOLO checkpoint schema; a top-down runner following the
-l2cs chaining pattern (`person_boxes=` / `person_detector=`, never an external
-detectron2 dependency); parity evidence on trained weights; and an upload to
-the LibreYOLO org carrying the SAM license text, since passthrough is a
-condition of redistribution.
+## Known limitations
 
-Naming when it lands: `LibreSAM3DBody<size>-mesh.pt`, sizes `d3` (DINOv3) and
-`h` (ViT-H), chosen to avoid colliding with the existing `LibreSAM` promptable
-tier.
+* The upstream repository has no packaging metadata, so it cannot be
+  `pip install`ed. Users clone it and set `SAM_3D_BODY_PATH`. If they
+  restructure, the adapter breaks.
+* The upstream estimator moves its batch to the GPU unconditionally, so there
+  is no CPU path. The adapter raises a clear error rather than failing deep
+  inside their code.
+* Their loader pulls DINOv3 from `torch.hub` at load time, which carries its
+  own license. That lands on the user's machine via their code, not ours.
 
-## Nothing is mirrored
+## Follow-ups
 
-The MHR asset is fetched from the public upstream release and cached locally
-rather than copied to the LibreYOLO org: it is freely reachable, Apache 2.0 and
-700 MB, so a second copy serves no one. No SMPL-derived artifact exists
-anywhere in this work.
-
-## Scope fences
-
-Out of scope and not started: video tracking, temporal smoothing, world-frame
-trajectories (the schema reserves room via future `*_world` fields), SMPL-X
-whole-body hands and face, training, mesh export formats beyond OBJ, any
-renderer dependency, and exported-graph support.
+1. **A permissive second family.** Verified survey: `simple-romp` is the
+   cleanest option, MIT with a self-contained LBS layer that does not import
+   `smplx`, no bundled SMPL bytes, and an existing `prepare_smpl` flow where
+   the user converts their own SMPL file. HMR 2.0 is the accuracy pick (clean
+   MIT, but `smplx` must be swapped for a permissive LBS layer). Reject HybrIK
+   and WHAM: both carry Max Planck proprietary-headered files, and WHAM has a
+   hard AGPL `ultralytics` dependency.
+2. **NVIDIA GEM-X is worth a serious look.** Apache-2.0 code, redistributable
+   commercially-usable weights with **no military or trade-control clause**,
+   targeting SOMA (Apache 2.0), with zero SMPL anywhere. The catch is that it
+   is video-only with no documented single-image path. If a single-frame
+   invocation works, it is a better licensing fit than anything else in the
+   field.
+3. Export contract, validation dataset story, video and world-frame support,
+   SMPL-X whole-body hands and face.

--- a/PLAN_body_mesh_task.md
+++ b/PLAN_body_mesh_task.md
@@ -1,0 +1,96 @@
+# PLAN: `mesh` task (human body mesh recovery), Meta stack
+
+Scope: the Meta stack only, SAM 3D Body on the MHR body model. Other families
+(ROMP, 4D-Humans, NLF, Multi-HMR, TokenHMR, CameraHMR, SMPLer-X, GVHMR) were
+surveyed and are out of scope by decision. Investigation date 2026-07-28.
+
+Status: **task contract and body model shipped; regressor blocked on weight
+access.** See "What is done" and "What is blocked" below.
+
+## Why the Meta stack, in one paragraph
+
+The rest of the field predicts into SMPL, and SMPL is unusable here: the model
+files are non-commercial and non-redistributable, the `smplx` PyPI package's
+*code* carries that same non-commercial license (the most common misconception
+in this area), and the license reaches into any checkpoint trained against it.
+MHR is Apache 2.0 for code and assets with no registration, and SAM 3D Body's
+weights are redistributable under the SAM license with passthrough. It is the
+only end-to-end path where the body model, the code and the weights all clear.
+
+## What is done
+
+Landed on branch `mesh-body-recovery`, off `dev`:
+
+* **Task registration.** `mesh` in `TaskType`/`TASKS`, suffix `-mesh`, aliases
+  `body-mesh`, `hmr`, `human-mesh-recovery`. `smpl` deliberately not aliased.
+* **`Meshes` result payload**, row-aligned with `Results.boxes` the way pose
+  keypoints are. Body-model-agnostic: `body_model` names the parameterization
+  and all counts are read from the tensors. Slicing selects a person without
+  touching shared face topology; device moves cover topology and extras.
+  `save_obj()` writes standard Wavefront OBJ.
+* **MHR body model** (`libreyolo/models/sam3dbody/mhr_body.py`): TorchScript
+  loader, parameter assembly, unit conversion, and a downloader for the public
+  Apache-2.0 release asset. Validated against the real 696 MB asset.
+* **Camera helpers** (`camera.py`): crop-camera to full-image lifting and
+  perspective projection, so `joints2d` is in original-image pixels.
+* **Metrics** (`libreyolo/validation/mesh_metrics.py`): MPJPE, PA-MPJPE with a
+  reflection-safe Procrustes, PVE.
+* **Drawing** (`draw_mesh`): renderer-free projected-vertex scatter plus the
+  MHR-70 skeleton. No rasterizer dependency.
+* **Gates**: export raises an explicit not-implemented error, validation
+  explains the dataset-license situation, TTA is rejected with the
+  left/right-swap reason.
+* **Docs**: ADR 0013, nomenclature, checkpoint schema.
+* **Tests**: 54 unit tests on fabricated payloads, plus 9 `external_data`
+  integration tests against the real MHR asset.
+
+Verified numbers, not assumptions: MHR `model_params` is 204 wide (3
+translation, 3 global rotation, 130 body pose, 68 bone scales), `betas` 45,
+`expression` 72, outputs 18439 vertices and 127 joints in centimeters, with
+translation entering the rig in decimeters. The upstream comment saying 127 is
+stale; the assertion two functions below it says 136. Rest-pose height decodes
+to 1.727 m and a requested 0.1/0.2/0.3 m translation moves the body by exactly
+that, which is what pins the unit conventions.
+
+## What is blocked
+
+**SAM 3D Body regressor weights.** `facebook/sam-3d-body-dinov3` and
+`facebook/sam-3d-body-vith` are **gated with manual approval** on Hugging Face,
+and the token cached on this machine is invalid ("Invalid user token"). Both
+must be resolved before the regressor family can be built, because a port that
+cannot be run against real weights certifies nothing.
+
+To unblock, in order:
+
+1. Request access at https://huggingface.co/facebook/sam-3d-body-dinov3 and
+   wait for approval. Note the upstream warning that comprehensively sanctioned
+   jurisdictions are rejected.
+2. Generate a fresh token and `hf auth login --force`.
+3. Confirm with `huggingface_hub.model_info("facebook/sam-3d-body-dinov3")` and
+   an `hf_hub_download` of `model_config.yaml`.
+
+Then the remaining work is the regressor family itself: DINOv3/ViT-H backbone,
+promptable decoder, MHR head and camera head; a `weights/convert_sam3dbody.py`
+converter into the LibreYOLO checkpoint schema; a top-down runner following the
+l2cs chaining pattern (`person_boxes=` / `person_detector=`, never an external
+detectron2 dependency); parity evidence on trained weights; and an upload to
+the LibreYOLO org carrying the SAM license text, since passthrough is a
+condition of redistribution.
+
+Naming when it lands: `LibreSAM3DBody<size>-mesh.pt`, sizes `d3` (DINOv3) and
+`h` (ViT-H), chosen to avoid colliding with the existing `LibreSAM` promptable
+tier.
+
+## Nothing is mirrored
+
+The MHR asset is fetched from the public upstream release and cached locally
+rather than copied to the LibreYOLO org: it is freely reachable, Apache 2.0 and
+700 MB, so a second copy serves no one. No SMPL-derived artifact exists
+anywhere in this work.
+
+## Scope fences
+
+Out of scope and not started: video tracking, temporal smoothing, world-frame
+trajectories (the schema reserves room via future `*_world` fields), SMPL-X
+whole-body hands and face, training, mesh export formats beyond OBJ, any
+renderer dependency, and exported-graph support.

--- a/PROPOSAL_body_mesh_api.md
+++ b/PROPOSAL_body_mesh_api.md
@@ -1,0 +1,143 @@
+# Proposal: `mesh` task (human body mesh recovery)
+
+Status: investigation complete, API proposal. No code exists yet. Companion surveys behind this document: 13 repositories read (image HMR, video HMR, whole-body, frameworks) plus a licensing deep dive on the SMPL family and its permissive alternatives.
+
+## 1. Is there a standard?
+
+Yes: SMPL, from Max Planck, is the de-facto standard for representing a 3D human body. Every benchmark (3DPW, AGORA, EMDB) and virtually every method speaks it. The parameterization:
+
+| Model | Covers | Vertices | Pose params | Shape | Extra |
+|---|---|---|---|---|---|
+| SMPL | body | 6,890 | 24 joints x 3 axis-angle = 72 (3 global_orient + 69 body_pose) | 10 betas | |
+| SMPL-X | body + hands + face | 10,475 | 3 global + 63 body + 2x45 hands + jaw/eyes | 10 betas | 10 expression |
+
+A body is fully described by `{global_orient, body_pose, betas, transl}`; a fixed differentiable decoder (linear blend skinning over a template mesh) turns that into vertices and joints. The mesh topology (faces) is constant, which is what makes the format an interchange standard: Blender add-ons, retargeting tools and mocap pipelines all consume it.
+
+The catch, and it is the central fact of this proposal: the SMPL and SMPL-X model files are non-commercial AND non-redistributable (one archive copy only, registration-gated), and the `smplx` Python package CODE carries the same non-commercial Max Planck license, not a permissive one. The SMPL license additionally forbids training networks on it "for commercial deployment", so the non-commercial cloud reaches into any checkpoint supervised by or decoding to SMPL. Under our weights policy, non-commercial weights are hostable with a license tag, but no-redistribution artifacts are not mirrorable: SMPL model files are in the cannot-mirror category, full stop. Every OSS repo in the field handles this the same way: the user registers at the MPI site and downloads the file themselves.
+
+Since 2025 there are, for the first time, permissive alternatives:
+
+- MHR / Momentum Human Rig (Meta, Apache 2.0 code AND assets, `pip install mhr`, no registration). It is the output format of SAM 3D Body, whose checkpoints permit commercial use and redistribution with license passthrough.
+- Anny (NAVER, Apache 2.0 code, CC0 geometry from MakeHuman). Fully clean, but no strong pretrained image-to-Anny regressor ships with it.
+
+Neither is SMPL-compatible; both ship learned mappings toward SMPL(-X) as separate opt-in components.
+
+## 2. What the field's APIs actually look like
+
+Thirteen repos surveyed. The user experience today is uniformly bad: conda env, pinned torch, compile something, register for SMPL, run demo scripts. Nobody offers `model.predict("img.jpg")` with auto-downloaded weights. No mainstream easy-install library ships this task at all; it is greenfield.
+
+Despite the mess, all of them converge on the same per-person payload: SMPL params (`global_orient`, `body_pose`, `betas`), camera translation, vertices, 3D joints, projected 2D joints, confidence. The three cleanest end-user APIs, for reference:
+
+- NLF: one TorchScript file, `model.detect_smpl_batched(frames)` returns pose, betas, transl, joints3d, vertices3d, joints2d, uncertainties. Detector is inside the graph.
+- simple-romp: `pip install simple_romp`, one-liner call, flat numpy dict, single-shot multi-person, permissive code and weights.
+- Multi-HMR: single forward on the full frame, list of per-person dicts, optional camera intrinsics input (non-commercial, reference only).
+
+Two architectural camps:
+
+- Single-shot (ROMP, Multi-HMR): full image in, all people out, no detector.
+- Top-down (HMR2.0/4D-Humans, TokenHMR, CameraHMR, OSX, SAM 3D Body): external person detector, then per-crop regression. These repos all bolt detectron2 or similar onto their demos, which is exactly the pain we can delete: we already have person detectors in-house.
+
+Video methods (WHAM, GVHMR, TRAM) add tracking, temporal smoothing and world-frame trajectories via SLAM or gravity alignment. A v1 image API can ignore all of it, and should; the schema just needs to name the camera frame explicitly so a world frame can be added later without breaking anything. The cleanest schema in the field is GVHMR's pair of dicts, each exactly `{global_orient, body_pose, betas, transl}`, one per coordinate frame.
+
+## 3. Proposed Python API
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreXXXs-mesh.pt")        # family TBD, task from -mesh suffix
+results = model("people.jpg", save=True)      # save=True draws skeleton + vertex overlay
+
+r = results
+r.boxes                    # person Boxes (N), same as detect/pose
+r.meshes                   # Meshes payload, row-aligned with boxes
+
+# Parametric core: directly splattable into a body-model forward
+r.meshes.global_orient     # (N, 3) axis-angle root rotation, camera frame
+r.meshes.body_pose         # (N, J_body, 3) axis-angle
+r.meshes.betas             # (N, num_betas)
+r.meshes.transl            # (N, 3) metric camera-space translation
+
+# Derived geometry, precomputed by the pipeline
+r.meshes.vertices          # (N, V, 3) camera-space, metric
+r.meshes.faces             # (F, 3) shared topology, constant per body model
+r.meshes.joints3d          # (N, J, 3) camera-space
+r.meshes.joints2d          # (N, J, 2) pixel coords in the original image
+r.meshes.conf              # (N,) per-person confidence
+
+# Identity of the representation, from checkpoint metadata
+r.meshes.body_model        # "smpl" | "smplx" | "mhr"
+
+# Conveniences
+r.meshes.save_obj("person0.obj", index=0)     # standard mesh interchange
+r.summary(); r.to_json()                       # params + joints2d (vertices omitted by default)
+
+# Optional intrinsics, as in the metric-aware repos
+results = model("people.jpg", focal_length=1400.0)   # or K=3x3; default: estimated or heuristic
+```
+
+Top-down families additionally follow the established gaze pattern for detector chaining:
+
+```python
+mesh = LibreYOLO("LibreXXXs-mesh.pt", person_detector="LibreYOLO9s.pt")  # default wired in
+r = mesh("people.jpg")
+r = mesh("people.jpg", person_boxes=my_boxes)    # BYO boxes, detector skipped
+```
+
+CLI: `libreyolo predict model=LibreXXXs-mesh.pt source=people.jpg` behaves like every other task.
+
+### Design decisions baked into the above
+
+- The parametric block IS the API. `{global_orient, body_pose, betas, transl}` is the field's universal denominator and splats directly into a body-model layer. Vertices/joints are derived caches, not the source of truth.
+- Camera frame is explicit and singular in v1. No world frame, no track IDs, no temporal smoothing. A future video story adds `r.meshes.global_orient_world` / `transl_world` (or a parallel `meshes_world` slot) without touching v1 fields.
+- Row-aligned with `Boxes`, exactly like `Keypoints` in the pose task. `joints2d` reuses the existing keypoint drawing path for `save=True`; full mesh rasterization is not a v1 requirement (a painter's-algorithm vertex overlay is enough, no renderer dependency).
+- `body_model` is a first-class metadata field. The schema is body-model-agnostic; SMPL, SMPL-X and MHR families coexist, with `V`, `J`, `num_betas` read from checkpoint metadata (analogous to `num_keypoints` / `keypoint_dim` in pose).
+- Single-shot families use the standard `InferenceRunner`; top-down families use a dedicated runner with `person_detector=` / `person_boxes=`, mirroring the existing crop-consumer precedent. Never an external detectron2-style dependency.
+
+## 4. The one decision that matters: which body model we ship
+
+This is a licensing decision, not a technical one, and it gates everything.
+
+Door A, SMPL compatibility: maximum ecosystem value, poisoned supply chain. We cannot host SMPL files, cannot depend on the `smplx` package (its code is non-commercial), and checkpoints that embed SMPL template/blendshape buffers are themselves redistributing derived SMPL data (grey at best). The honest version of Door A is the simple-romp pattern: a `libreyolo mesh prepare --smpl-path ...` step that converts the USER'S own registered download into our cache, a clean-room LBS forward pass of our own (the math is published; the DATA is what is licensed), and hosted checkpoints only for models whose weights are genuinely redistributable.
+
+Door B, MHR: Apache 2.0 body model, pip-installable assets, and SAM 3D Body as a strong pretrained predictor whose weights we may redistribute with license passthrough. Fully consistent with the MIT wedge. Cost: not SMPL, so the Blender/retargeting ecosystem needs a conversion step (MHR ships mappings).
+
+Recommendation: design the schema body-model-agnostic (already done above), ship the first hosted family through Door B, and treat Door A as a follow-up family for users who bring their own SMPL file. That gives a working `pip install` to first-mesh experience with zero license ceremony, which no library on earth offers today, while keeping the door open for SMPL interop.
+
+## 5. Candidate first families
+
+| Candidate | Type | Code | Weights | Verdict |
+|---|---|---|---|---|
+| SAM 3D Body (MHR) | top-down, promptable | SAM license | redistributable, commercial OK, passthrough | Door B flagship |
+| ROMP / simple-romp | single-shot | Apache/MIT | permissive, auto-download | Door A flagship; older accuracy, lightest port |
+| 4D-Humans (HMR2.0) | top-down | MIT | unstated; SMPL-entangled | reference architecture, weights unclear |
+| NLF | packaged top-down | MIT | non-commercial research | packaging inspiration; weights NC |
+| Multi-HMR, TokenHMR, CameraHMR, SMPLer-X, GVHMR | various | NC or gated | NC, registration-gated | schema reference only, no code porting |
+
+## 6. What adding the task touches
+
+The plumbing is the well-trodden ten-task path: `tasks.py` tables (`mesh`, aliases `body-mesh`/`hmr`/`smpl`, suffix `-mesh`), a `Meshes` payload class in `utils/results.py` implementing the tensor-payload protocol, a `_wrap_results` branch, `draw_mesh` in `utils/drawing.py` (skeleton via `joints2d` + vertex overlay), a `MeshValidator` (MPJPE / PA-MPJPE / PVE) with the `val()` dispatch entry, checkpoint metadata (`body_model`, `num_betas`, `num_body_joints`, `num_vertices`), export explicitly gated off in v1 like semantic/depth were, and docs (nomenclature, checkpoint schema, ADR).
+
+Genuinely new work, beyond plumbing:
+
+1. A body-model decoder layer of our own (LBS forward). Small, published math; the licensing lives in the data files, not the equations. For MHR the pip package is Apache and usable directly.
+2. Visualization without a renderer dependency (projected-vertex overlay).
+3. Evaluation data: 3DPW and EMDB are research-only licenses; the validator ships, hosted eval data does not. Same posture as other license-gated datasets.
+
+## 7. Scope fences (v1)
+
+- Image and video-as-frames inference only. No tracking, no temporal smoothing, no world-frame trajectory, no SLAM. The schema reserves room; the code does not attempt it.
+- Body only. SMPL-X hands/face/expression fields are schema-compatible extensions, not v1 deliverables.
+- Inference-only family at first (the gaze precedent). Training on mesh data is a separate, later effort with its own dataset-licensing investigation.
+- Export gated off with a clear error until the runtime metadata contract is defined.
+
+## 8. Suggested phasing
+
+1. Decide Door A vs Door B in the open (ADR).
+2. Contract: docs + `Meshes` schema + checkpoint metadata, reviewed before any model code.
+3. Port the chosen family, inference only, with the detector-chaining or single-shot runner as appropriate.
+4. Validator + a small permissively-licensed smoke-eval set.
+5. Ship; video/world-frame and SMPL-X whole-body as separately scoped follow-ups.
+
+## 9. Verdict
+
+It makes sense, and it is not too hard: the task plumbing is routine and well-precedented by pose (row-aligned payload) and gaze (detector chaining). The genuinely hard part is not code, it is the body-model license, and it is solvable: either the user-supplies-SMPL flow everyone else uses, or the new Apache-licensed MHR path that nobody has productized yet. Shipping `LibreYOLO("...-mesh.pt")` into a per-person parametric body with zero conda ceremony would be a first in the ecosystem.

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -899,3 +899,39 @@ Model weights (sensenova/SenseNova-Vision-7B-MoT, CC BY-NC 4.0,
 non-commercial) are mirrored byte-identically with attribution at
 huggingface.co/LibreYOLO/SenseNovaVision7b; mirroring does not change the
 license. See libreyolo/models/sensenova/NOTICE for the full provenance chain.
+
+--------------------------------------------------------------------
+MHR / Momentum Human Rig (Meta Platforms, Inc.)
+--------------------------------------------------------------------
+Source: https://github.com/facebookresearch/MHR
+License: Apache License 2.0 (see licenses/Apache-2.0.txt)
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Used for: the body model behind the `mesh` task. No MHR code is ported. The
+TorchScript asset assets/mhr_model.pt is downloaded at runtime from the public
+upstream release by libreyolo/models/sam3dbody/mhr_body.py and cached locally;
+it is NOT mirrored by LibreYOLO. The parameter layout used to drive it (204
+model parameters, 45 identity coefficients, 72 expression coefficients) is
+documented by the upstream Apache-2.0 demo.py and mhr.py and was additionally
+verified empirically against the released asset.
+
+--------------------------------------------------------------------
+SAM 3D Body (Meta Platforms, Inc.)
+--------------------------------------------------------------------
+Source: https://github.com/facebookresearch/sam-3d-body
+License: SAM License (NOT a permissive license; it carries field-of-use
+         restrictions including military, nuclear, espionage and weapons use,
+         a no-reverse-engineering clause, and unilateral amendment by Meta)
+Copyright (c) Meta Platforms, Inc. and affiliates.
+Used for: NO CODE FROM THIS PROJECT IS PORTED, ADAPTED OR VENDORED. Because
+the SAM License is not permissive, LibreYOLO deliberately wraps rather than
+ports it. libreyolo/models/sam3dbody/ is LibreYOLO's own MIT code that calls
+the upstream package's public API and maps its output into the Meshes result
+payload. The upstream package is an OPTIONAL dependency the user installs
+themselves; LibreYOLO ships none of it, and users who do not use the mesh task
+never encounter its terms.
+Model weights: the SAM License permits redistribution provided its terms are
+passed through, so the checkpoints are mirrored byte-identically at
+huggingface.co/LibreYOLO/LibreSAM3DBodyd3-mesh and
+huggingface.co/LibreYOLO/LibreSAM3DBodyh-mesh, each carrying the SAM License
+text and an access gate recording acceptance. Mirroring does not change the
+license: those weights remain SAM-licensed, not MIT.

--- a/docs/adr/0013-mesh-task-contract.md
+++ b/docs/adr/0013-mesh-task-contract.md
@@ -101,6 +101,38 @@ second copy would serve no one.
 * **Training** is out of scope; mesh training needs its own dataset-licensing
   investigation.
 
+### The first family is wrapped, not ported
+
+SAM 3D Body is the only strong MHR regressor. Its **code** is published under
+the SAM License, which is not one of the permissive licenses this project may
+derive code from: it carries field-of-use restrictions (no military or warfare
+use, no nuclear, espionage, guns or illegal weapons), a no-reverse-engineering
+clause, an indemnification obligation, and a term letting Meta amend the
+agreement unilaterally. Vendoring or reimplementing it would either put
+non-OSI code in an MIT tree or restructure incompatibly-licensed code to
+obscure its origin, both of which the licensing policy forbids.
+
+So `LibreSAM3DBody` **wraps** the upstream package rather than porting it. The
+adapter is LibreYOLO's own MIT code that calls the upstream public API and
+translates its output dict into `Meshes`. The SAM License obligation triggers
+on *distributing* SAM Materials; an adapter copies none of their code, and the
+upstream package is an optional dependency the user installs themselves. The
+practical consequence that matters: a user who never touches the mesh task
+never encounters SAM terms at all.
+
+Weights are a separate question from code. The SAM License does permit
+redistribution provided the terms are passed through, so the checkpoints are
+mirrored on the LibreYOLO org with the license included, behind a gate
+comparable to Meta's. Redistributing them ungated would route around Meta's
+sanctions screening and move that exposure onto this project.
+
+Consequences the wrapper accepts: the upstream repository has no packaging
+metadata, so it cannot be `pip install`ed and the user must clone it and point
+`SAM_3D_BODY_PATH` at it; the upstream estimator moves its batch to the GPU
+unconditionally, so there is no CPU path; and the mesh flagship depends on a
+third-party layout that could change. Those are the price of not taking their
+license into the tree.
+
 ## Consequences
 
 The task contract exists independently of any one model, so families can land

--- a/docs/adr/0013-mesh-task-contract.md
+++ b/docs/adr/0013-mesh-task-contract.md
@@ -1,0 +1,121 @@
+# ADR 0013: Body-mesh task contract
+
+Status: accepted
+Date: 2026-07-28
+
+## Context
+
+Human body mesh recovery estimates a posed 3D body from an image. It is a
+well-established research task with a decade of benchmarks, yet no
+easy-install computer vision library ships it: the entire field distributes
+conda environments, compiled dependencies and registration-gated model files,
+and the user-facing story stops at demo scripts. That gap is the opportunity.
+
+The gap exists for a licensing reason, not a technical one. The field
+standardized on SMPL and its descendants, and the SMPL family is unusable for
+a permissively licensed library:
+
+* The SMPL and SMPL-X model files are non-commercial **and**
+  non-redistributable. One archive copy is permitted; mirroring is not.
+* The `smplx` PyPI package's **code** carries the same Max Planck
+  non-commercial license, not a permissive one. This is the most common
+  misconception in the field and it rules out the package as a dependency.
+* The SMPL license forbids using the model to train networks for commercial
+  deployment, so the restriction reaches into any checkpoint supervised by it.
+
+Meta's MHR (Momentum Human Rig) is the first credible alternative: Apache 2.0
+for both code and assets, distributed from a public GitHub release with no
+registration, and the output representation of the SAM 3D Body regressor whose
+weights are redistributable under the SAM license with passthrough.
+
+## Decision
+
+### The task
+
+Add `mesh` as a task, filename suffix `-mesh`, aliases `body-mesh`, `hmr` and
+`human-mesh-recovery`. `smpl` is deliberately not an alias, because nothing
+shipped under this task is SMPL and silently accepting the name would imply an
+interoperability that does not exist.
+
+### The result payload
+
+`Results.meshes` holds a `Meshes` object whose rows align with
+`Results.boxes`, the same arrangement the pose task uses for keypoints. It
+carries the parametric core (`global_orient`, `body_pose`, `betas`, `transl`),
+the decoded geometry (`vertices`, shared `faces`, `joints3d`, `joints2d`),
+`conf`, optional `focal_length`, and an `extras` dict for model-specific
+parameters such as skeleton scale, hand pose and facial expression.
+
+The payload is body-model-agnostic by construction. `body_model` names the
+parameterization and every count is read back from the tensors, because the
+layouts genuinely differ: MHR uses Euler angles rather than axis-angle, a flat
+130-wide body-pose vector rather than one triplet per joint (rig joints carry
+different degrees of freedom), and 45 identity blendshape coefficients rather
+than 10 SMPL betas. Hard-coding SMPL's shapes would have made the first
+non-SMPL model a breaking change.
+
+Geometry fields are optional. A model may emit parameters without decoding a
+mesh, and that has to stay representable rather than being faked with empty
+arrays.
+
+### Coordinates and units
+
+Camera frame of the original image, only. `transl` is metric meters with +z
+away from the camera. `vertices` and `joints3d` are metric and already include
+`transl`. `joints2d` is in original-image pixels, not crop pixels, so top-down
+models must lift their crop camera to the full image before returning.
+
+There is no world or gravity frame in this version, and no field implies one.
+Video work (tracking, temporal smoothing, world-frame trajectories) would add
+explicitly named `*_world` fields rather than changing the meaning of these.
+
+### Body model
+
+MHR, loaded from its TorchScript form. The TorchScript file is self-contained
+and needs nothing but PyTorch, which avoids the `pymomentum` native dependency
+that the full MHR package requires and that has no reliable Windows wheel.
+
+Verified against the released asset rather than its documentation:
+`model_params` is 204 wide (3 translation, 3 global rotation, 130 body pose,
+68 bone scales), `betas` is 45, `expression` is 72, and outputs are 18439
+vertices plus a 127-joint skeleton state, all in centimeters. Translation
+enters the rig in decimeters. The upstream code comments this block as 127
+wide, which is stale; the assertion in the same file says 136.
+
+The asset is fetched from the public upstream release and cached locally rather
+than mirrored on the LibreYOLO org: it is freely reachable and 700 MB, so a
+second copy would serve no one.
+
+### Deferred deliberately
+
+* **Export** is gated off with an explicit error, as semantic and point were.
+  The runtime metadata contract (which body model, how many betas, whether the
+  body-model decoder lives inside the exported graph) must be defined before
+  artifacts exist that backends would have to keep reading.
+* **Validation** raises a clear error instead of pretending to have data. The
+  standard benchmarks (3DPW, EMDB, AGORA) are research-license only and are not
+  bundled. The metrics themselves ship as `libreyolo.validation.mesh_metrics`
+  (MPJPE, PA-MPJPE, PVE) for use against a dataset the user already holds.
+* **Test-time augmentation** is rejected: a horizontal flip swaps left and
+  right body parts, so merging flipped mesh parameters is not averaging.
+* **Training** is out of scope; mesh training needs its own dataset-licensing
+  investigation.
+
+## Consequences
+
+The task contract exists independently of any one model, so families can land
+incrementally. The MHR decoder is usable on its own to turn parameters into
+geometry.
+
+Visualization is renderer-free: meshes are drawn as a decimated scatter of
+projected vertices plus the skeleton, so `save=True` never pulls in a
+rasterizer. Full surface rendering remains available to users through the OBJ
+export on the payload.
+
+The chief cost is that LibreYOLO's body meshes are not SMPL, so the SMPL-shaped
+ecosystem (Blender add-ons, retargeting pipelines) needs a conversion step.
+Upstream MHR ships SMPL/SMPL-X conversion tools for exactly this. The
+alternative, shipping SMPL directly, would have required either a
+non-redistributable dependency or a user-supplied-file flow with a
+non-commercial cloud over every derived checkpoint. Choosing the permissive
+body model keeps the task consistent with the project's licensing posture.

--- a/docs/adr/0013-mesh-task-contract.md
+++ b/docs/adr/0013-mesh-task-contract.md
@@ -139,10 +139,16 @@ The task contract exists independently of any one model, so families can land
 incrementally. The MHR decoder is usable on its own to turn parameters into
 geometry.
 
-Visualization is renderer-free: meshes are drawn as a decimated scatter of
-projected vertices plus the skeleton, so `save=True` never pulls in a
-rasterizer. Full surface rendering remains available to users through the OBJ
-export on the payload.
+Visualization renders an actual shaded surface, because that is what a body
+mesh is expected to look like and a scatter of projected vertices does not
+communicate one. The renderer is a small painter's-algorithm rasterizer in
+numpy and PIL: back-facing triangles culled, the rest sorted far-to-near and
+filled with Lambertian shading. This deliberately avoids `pyrender` and
+PyTorch3D, which upstream projects use and which both need a GL context and
+install badly on some platforms. Cost is roughly half a second per person at
+36874 triangles, only on the `save=True` path. The vertex scatter survives as
+a fallback for results that carry projected points but no topology, and
+`save_obj()` remains the route to a real 3D file.
 
 The chief cost is that LibreYOLO's body meshes are not SMPL, so the SMPL-shaped
 ecosystem (Blender add-ons, retargeting pipelines) needs a conversion step.

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -65,6 +65,25 @@ Pose checkpoints additionally include:
   `0` for classes without keypoints. Runtime backends use this schema to select
   the active keypoints for the predicted class.
 
+Mesh checkpoints use the task string `mesh`, `nc: 1`, and
+`names: {0: "person"}`. Because parameter layouts differ between body models,
+the dimensions are recorded rather than assumed, the same way pose records
+`num_keypoints`:
+
+- `body_model`: the parameterization the checkpoint predicts into, such as
+  `mhr`. Required; consumers use it to interpret every field below and to pick
+  a body-model decoder.
+- `num_betas`: identity/shape coefficient count (45 for MHR).
+- `num_body_pose`: width of the body-pose parameter block (130 for MHR). This
+  is a flat parameter vector, not one triplet per joint, because rig joints
+  carry different degrees of freedom.
+- `num_vertices` / `num_joints`: geometry sizes the body-model decoder emits
+  (18439 and 127 for MHR), recorded so a payload can be validated before the
+  decoder is loaded.
+- `rotation_format`: how rotations are encoded, such as `euler_zyx` for MHR or
+  `axis_angle`. Never inferred from the tensor shape, since a 3-vector is
+  ambiguous between the two.
+
 Depth checkpoints use the task string `depth`, `nc: 1`, and
 `names: {0: "depth"}`. The single class-like slot exists only for checkpoint
 schema compatibility; depth predictions are dense float maps, not classes.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -208,6 +208,7 @@ From `libreyolo/tasks.py`:
 | `restore`     | `-restore` |
 | `matte`       | `-matte` |
 | `ocr`         | `-ocr` |
+| `mesh`        | `-mesh` |
 
 The factory accepts selected upstream-style aliases (`detection`, `det`,
 `segmentation`, `keypoints`, `cls`, …) at the API boundary; only the canonical
@@ -267,6 +268,20 @@ Detection quads are genuine polygons (rotated text) and do not populate
 `Results.boxes`. Canonical ocr filenames must carry the `-ocr` suffix; task
 aliases `text`, `text-recognition`, and `text_recognition` resolve to `ocr` at
 the API boundary.
+
+`mesh` is the task for human body mesh recovery: recovering a posed 3D body per
+detected person. Models expose `Results.meshes`, row-aligned with
+`Results.boxes` exactly as pose keypoints are, carrying the parametric core
+(`global_orient`, `body_pose`, `betas`, `transl`) plus decoded `vertices`,
+`joints3d` and `joints2d`. Everything is in the camera frame of the original
+image, with metric translation in meters and `joints2d` in original-image
+pixels; there is no world frame in this version. Parameter layouts vary by body
+model, so `Meshes.body_model` names the parameterization and shapes are read
+from the tensors rather than assumed. Canonical mesh filenames must carry the
+`-mesh` suffix; task aliases `body-mesh`, `hmr`, and `human-mesh-recovery`
+resolve to `mesh` at the API boundary. Note that `smpl` is deliberately *not*
+an alias: the shipped body model is MHR, and accepting the name would imply an
+interoperability that is not provided. See ADR 0013 for the full contract.
 
 Dataset and label contracts are documented in
 [`dataset_schema.md`](dataset_schema.md). A task is supported by a model family

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -70,6 +70,7 @@ instance, and panoptic segmentation; the `mobilenetv4` / `convnext` /
 | `zipdepth`  | `LibreZipDepth` | CamelCase preserved (`ZipDepth` brand casing); depth-only lightweight CNN (speed/edge tier) |
 | `birefnet`  | `LibreBiRefNet` | CamelCase preserved (Bilateral Reference); matte-only background-removal family |
 | `ppocr`     | `LibrePPOCR`    | All-caps acronym (PP-OCR brand, hyphen dropped); ocr-only two-stage text detection + recognition family |
+| `sam3dbody` | `LibreSAM3DBody` | All-caps acronym plus CamelCase `Body` (hyphens dropped); mesh-only family. Named in full rather than shortened so it does not collide with the `LibreSAM` promptable-segmentation tier. Sizes are backbone codes: `d3` (DINOv3 ViT-H/16+) and `h` (ViT-H). This family wraps an optional third-party package rather than porting it; see ADR 0013 |
 
 Casing rules observed in the table:
 

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -60,6 +60,7 @@ from .utils.results import (
     DepthMap,
     RestoredImage,
     Matte,
+    Meshes,
     OCRRegions,
 )
 
@@ -242,6 +243,7 @@ __all__ = [
     "DepthMap",
     "RestoredImage",
     "Matte",
+    "Meshes",
     "OCRRegions",
     # Assets
     "SAMPLE_IMAGE",

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -314,6 +314,17 @@ class BaseExporter(ABC):
         pre_trace_hook = kwargs.pop("_pre_trace_hook", None)
 
         task = getattr(self.model, "task", "detect")
+        if task == "mesh":
+            # Gated off for the first version, as semantic and point were: the
+            # runtime metadata contract for a mesh graph (which body model,
+            # how many betas, whether the body-model decoder is inside the
+            # graph or applied afterwards) has to be defined before artifacts
+            # exist that backends would have to keep reading.
+            raise NotImplementedError(
+                "Body-mesh export is not implemented yet. The exported-graph "
+                "metadata contract for the mesh task is still to be defined; "
+                "run mesh models through the PyTorch path for now."
+            )
         if task == "depth":
             # Depth export uses the fixed-resolution dense contract: backends
             # stretch-resize to the exported canvas and resize the depth map

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -733,11 +733,7 @@ class InferenceRunner:
                     joints2d=meshes_np.joints2d,
                     vertices2d=meshes_np.extras.get("vertices2d"),
                     faces=meshes_np.faces,
-                    vertex_depths=(
-                        meshes_np.vertices[..., 2]
-                        if meshes_np.vertices is not None
-                        else None
-                    ),
+                    vertices3d=meshes_np.vertices,
                 )
         else:
             annotated_img = original_img.copy()

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -732,6 +732,12 @@ class InferenceRunner:
                     annotated_img,
                     joints2d=meshes_np.joints2d,
                     vertices2d=meshes_np.extras.get("vertices2d"),
+                    faces=meshes_np.faces,
+                    vertex_depths=(
+                        meshes_np.vertices[..., 2]
+                        if meshes_np.vertices is not None
+                        else None
+                    ),
                 )
         else:
             annotated_img = original_img.copy()

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -33,6 +33,7 @@ from ...utils.drawing import (
     draw_masks,
     draw_obb,
     draw_depth_map,
+    draw_mesh,
     draw_ocr_regions,
     draw_panoptic,
     draw_points,
@@ -53,6 +54,7 @@ from ...utils.results import (
     Keypoints,
     Masks,
     Matte,
+    Meshes,
     OBB,
     OCRRegions,
     PanopticSegmentation,
@@ -66,6 +68,80 @@ from ...utils.video import collect_video_results, is_video_file, run_video_infer
 from .cuda_graph import forward_maybe_graphed, with_cuda_graph_scope
 
 logger = logging.getLogger(__name__)
+
+
+def _as_float_tensor(
+    value,
+    shape: Tuple[int, ...],
+    default: float | None = None,
+) -> torch.Tensor:
+    """Coerce a payload entry to a float tensor, or synthesize a constant one."""
+    if value is None:
+        if default is None:
+            return torch.zeros(shape, dtype=torch.float32)
+        return torch.full(shape, float(default), dtype=torch.float32)
+    if isinstance(value, torch.Tensor):
+        return value.float()
+    return torch.as_tensor(np.asarray(value), dtype=torch.float32)
+
+
+def _build_meshes(mesh_data: dict, orig_shape: Tuple[int, int]) -> Meshes:
+    """Turn a family's mesh payload dict into a ``Meshes`` result slot."""
+    required = ("global_orient", "body_pose", "betas", "transl")
+    missing = [key for key in required if mesh_data.get(key) is None]
+    if missing:
+        raise ValueError(
+            "Mesh-task models must return a 'meshes' payload containing "
+            f"{', '.join(required)}; missing: {', '.join(missing)}."
+        )
+    body_model = mesh_data.get("body_model")
+    if not body_model:
+        raise ValueError(
+            "Mesh payloads must name their parameterization via 'body_model' "
+            "(for example 'mhr'), since field shapes depend on it."
+        )
+
+    def optional(key):
+        value = mesh_data.get(key)
+        if value is None:
+            return None
+        if isinstance(value, torch.Tensor):
+            return value
+        return torch.as_tensor(np.asarray(value))
+
+    known = set(required) | {
+        "body_model",
+        "vertices",
+        "faces",
+        "joints3d",
+        "joints2d",
+        "conf",
+        "focal_length",
+        "extras",
+    }
+    extras = dict(mesh_data.get("extras") or {})
+    # Model-specific parameters (skeleton scale, hand pose, expression) may be
+    # passed at the top level rather than nested; keep them rather than drop
+    # them silently.
+    extras.update(
+        {k: v for k, v in mesh_data.items() if k not in known and v is not None}
+    )
+
+    return Meshes(
+        optional("global_orient"),
+        optional("body_pose"),
+        optional("betas"),
+        optional("transl"),
+        body_model=str(body_model),
+        vertices=optional("vertices"),
+        faces=optional("faces"),
+        joints3d=optional("joints3d"),
+        joints2d=optional("joints2d"),
+        conf=optional("conf"),
+        focal_length=optional("focal_length"),
+        extras=extras,
+        orig_shape=orig_shape,
+    )
 
 if TYPE_CHECKING:
     from .model import BaseModel
@@ -648,6 +724,15 @@ class InferenceRunner:
                 if isinstance(kpts_np, torch.Tensor):
                     kpts_np = kpts_np.cpu().numpy()
                 annotated_img = draw_keypoints(annotated_img, kpts_np)
+            # Draw body meshes: projected vertices plus the skeleton through
+            # the projected joints.
+            if result.meshes is not None and len(result.meshes) > 0:
+                meshes_np = result.meshes.numpy()
+                annotated_img = draw_mesh(
+                    annotated_img,
+                    joints2d=meshes_np.joints2d,
+                    vertices2d=meshes_np.extras.get("vertices2d"),
+                )
         else:
             annotated_img = original_img.copy()
 
@@ -800,6 +885,33 @@ class InferenceRunner:
                 path=str(image_path) if image_path else None,
                 names=self.model.names,
                 matte=Matte(matte_t.float(), (orig_h, orig_w)),
+            )
+
+        # Mesh: per-person body meshes carried alongside their person boxes,
+        # the same row-aligned arrangement pose uses for keypoints.
+        mesh_data = detections.get("meshes")
+        if mesh_data is not None:
+            orig_w, orig_h = original_size
+            meshes = _build_meshes(mesh_data, (orig_h, orig_w))
+            boxes_data = detections.get("boxes")
+            boxes = None
+            if boxes_data is not None:
+                boxes_t = _as_float_tensor(boxes_data, (0, 4))
+                scores = detections.get("scores")
+                classes_t = detections.get("classes")
+                n = boxes_t.shape[0]
+                boxes = Boxes(
+                    boxes_t,
+                    _as_float_tensor(scores, (n,), default=1.0),
+                    _as_float_tensor(classes_t, (n,), default=0.0),
+                    orig_shape=(orig_h, orig_w),
+                )
+            return Results(
+                boxes=boxes,
+                orig_shape=(orig_h, orig_w),
+                path=str(image_path) if image_path else None,
+                names=self.model.names,
+                meshes=meshes,
             )
 
         # OCR: polygons + transcripts, no axis-aligned boxes.

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1688,6 +1688,13 @@ class BaseModel(ABC):
                 "Augmented validation does not support restoration models yet. "
                 "Use augment=False for restore models."
             )
+        if augment and self.task == "mesh":
+            raise ValueError(
+                "Augmented validation does not support body-mesh models: a "
+                "horizontal flip swaps left and right body parts, so merging "
+                "flipped mesh parameters is not a matter of averaging. "
+                "Use augment=False for mesh models."
+            )
         if augment and self.task == "matte":
             raise ValueError(
                 "Augmented validation does not support matte models yet. "
@@ -1715,6 +1722,14 @@ class BaseModel(ABC):
             **kwargs,
         )
 
+        if self.task == "mesh":
+            raise NotImplementedError(
+                "Body-mesh validation needs a ground-truth mesh dataset, and the "
+                "usual benchmarks (3DPW, EMDB, AGORA) are research-license only, "
+                "so none is bundled. The metrics themselves are available as "
+                "libreyolo.validation.mesh_metrics (MPJPE, PA-MPJPE, PVE) for "
+                "evaluating against a dataset you already hold."
+            )
         if self.task == "gaze":
             raise NotImplementedError(
                 "Validation against gaze ground-truth datasets (MPIIGaze, Gaze360) "

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1330,6 +1330,13 @@ class BaseModel(ABC):
             raise NotImplementedError(
                 "Tracking does not support restoration models. Use predict()."
             )
+        if task == "mesh":
+            raise NotImplementedError(
+                "Tracking does not support body-mesh models yet. Use predict(). "
+                "Associating meshes over time also needs a temporal contract "
+                "(track IDs on the mesh rows, and a world frame) that the mesh "
+                "task does not define yet."
+            )
         if task == "ocr":
             raise NotImplementedError(
                 "Tracking does not support OCR models yet. Use predict()."

--- a/libreyolo/models/sam3dbody/__init__.py
+++ b/libreyolo/models/sam3dbody/__init__.py
@@ -1,0 +1,15 @@
+"""SAM 3D Body: human body mesh recovery on the MHR body model."""
+
+from .mhr_body import (
+    MHRBodyModel,
+    default_mhr_path,
+    ensure_mhr_model,
+    load_mhr_body_model,
+)
+
+__all__ = [
+    "MHRBodyModel",
+    "default_mhr_path",
+    "ensure_mhr_model",
+    "load_mhr_body_model",
+]

--- a/libreyolo/models/sam3dbody/__init__.py
+++ b/libreyolo/models/sam3dbody/__init__.py
@@ -1,15 +1,43 @@
 """SAM 3D Body: human body mesh recovery on the MHR body model."""
 
+from .camera import crop_cam_to_full_image, default_focal_length, perspective_project
 from .mhr_body import (
     MHRBodyModel,
     default_mhr_path,
     ensure_mhr_model,
     load_mhr_body_model,
 )
+from .person import (
+    CallablePersonDetector,
+    LibreYOLOPersonDetector,
+    PersonBox,
+    normalize_person_boxes,
+    resolve_person_detector,
+)
+
+
+def __getattr__(name):
+    # Imported lazily: building the family pulls in the optional upstream
+    # package, so merely importing libreyolo must not require it.
+    if name == "LibreSAM3DBody":
+        from .model import LibreSAM3DBody
+
+        return LibreSAM3DBody
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
+    "LibreSAM3DBody",
     "MHRBodyModel",
+    "PersonBox",
+    "CallablePersonDetector",
+    "LibreYOLOPersonDetector",
+    "crop_cam_to_full_image",
+    "default_focal_length",
     "default_mhr_path",
     "ensure_mhr_model",
     "load_mhr_body_model",
+    "normalize_person_boxes",
+    "perspective_project",
+    "resolve_person_detector",
 ]

--- a/libreyolo/models/sam3dbody/camera.py
+++ b/libreyolo/models/sam3dbody/camera.py
@@ -1,0 +1,119 @@
+"""Camera helpers shared by body-mesh models.
+
+Top-down mesh regressors see a square crop around one person, so everything
+they predict is expressed relative to that crop. The mesh task contract is
+stated on the original image instead: ``transl`` is metric in the full-image
+camera frame and ``joints2d`` is in original-image pixels. These helpers are
+the bridge, kept separate from any one model so the conversion is testable on
+its own.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple
+
+import torch
+
+
+def default_focal_length(image_height: int, image_width: int) -> float:
+    """Focal length guess for an image with unknown intrinsics.
+
+    Uses the image diagonal, which corresponds to roughly a 55 degree
+    horizontal field of view on a 4:3 frame. This is only a fallback: pass real
+    intrinsics, or a predicted focal length, whenever they are available, since
+    metric depth scales directly with this number.
+    """
+    return float(math.sqrt(image_height**2 + image_width**2))
+
+
+def crop_cam_to_full_image(
+    crop_cam: torch.Tensor,
+    box_center: torch.Tensor,
+    box_size: torch.Tensor,
+    image_size: Tuple[int, int],
+    focal_length: torch.Tensor | float,
+) -> torch.Tensor:
+    """Lift a weak-perspective crop camera to a full-image translation.
+
+    Args:
+        crop_cam: ``(N, 3)`` weak-perspective ``(s, tx, ty)`` predicted on the
+            crop, where ``s`` is scale and ``tx, ty`` are crop-normalized
+            offsets.
+        box_center: ``(N, 2)`` person box centers in original-image pixels.
+        box_size: ``(N,)`` side length of the square crop in original-image
+            pixels.
+        image_size: ``(height, width)`` of the original image.
+        focal_length: scalar or ``(N,)`` focal length in pixels.
+
+    Returns:
+        ``(N, 3)`` metric translation in the full-image camera frame.
+    """
+    height, width = image_size
+    scale, tx, ty = crop_cam[:, 0], crop_cam[:, 1], crop_cam[:, 2]
+
+    if not isinstance(focal_length, torch.Tensor):
+        focal_length = torch.full_like(scale, float(focal_length))
+    focal_length = focal_length.reshape(-1).to(scale)
+
+    # Depth follows from how large the person appears inside the crop: a
+    # smaller predicted scale means the person is further away.
+    box_size = box_size.reshape(-1).to(scale)
+    z = 2.0 * focal_length / (box_size * scale + 1e-9)
+
+    # Re-center from the crop's own frame onto the image principal point.
+    cx = box_center[:, 0] - width * 0.5
+    cy = box_center[:, 1] - height * 0.5
+    x = tx + cx * z / focal_length
+    y = ty + cy * z / focal_length
+    return torch.stack([x, y, z], dim=-1)
+
+
+def perspective_project(
+    points3d: torch.Tensor,
+    focal_length: torch.Tensor | float,
+    principal_point: Optional[torch.Tensor] = None,
+    image_size: Optional[Tuple[int, int]] = None,
+    translation: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Project metric camera-frame points to pixels.
+
+    Args:
+        points3d: ``(N, P, 3)`` points in the camera frame.
+        focal_length: scalar or ``(N,)`` focal length in pixels.
+        principal_point: ``(N, 2)`` principal point in pixels. Defaults to the
+            image center when ``image_size`` is given.
+        image_size: ``(height, width)``, used only to derive a default
+            principal point.
+        translation: optional ``(N, 3)`` translation added before projecting,
+            for points that are still root-relative.
+
+    Returns:
+        ``(N, P, 2)`` pixel coordinates.
+    """
+    if points3d.ndim != 3:
+        raise ValueError(
+            f"expected (N, P, 3) points, got shape {tuple(points3d.shape)}"
+        )
+    points = points3d if translation is None else points3d + translation[:, None, :]
+
+    batch = points.shape[0]
+    if not isinstance(focal_length, torch.Tensor):
+        focal_length = torch.full((batch,), float(focal_length), device=points.device)
+    focal_length = focal_length.reshape(-1).to(points).reshape(batch, 1)
+
+    if principal_point is None:
+        if image_size is None:
+            raise ValueError(
+                "perspective_project needs principal_point or image_size"
+            )
+        height, width = image_size
+        principal_point = torch.tensor(
+            [width * 0.5, height * 0.5], device=points.device, dtype=points.dtype
+        ).expand(batch, 2)
+    principal_point = principal_point.to(points).reshape(batch, 1, 2)
+
+    # Guard against division by a vanishing or negative depth for points that
+    # land behind the camera; those pixels are meaningless but must not be inf.
+    z = points[..., 2:3].clamp(min=1e-6)
+    return focal_length[..., None] * points[..., :2] / z + principal_point

--- a/libreyolo/models/sam3dbody/inference.py
+++ b/libreyolo/models/sam3dbody/inference.py
@@ -78,6 +78,18 @@ class MeshInferenceRunner:
 
         detector = self._resolve_runtime_detector(person_detector, person_boxes)
 
+        if person_boxes is not None and is_video_file(source):
+            # Refuse rather than drop them: a single set of boxes cannot follow
+            # a moving person across frames, and letting this through would
+            # surface as a per-frame "pass person_boxes" error telling the user
+            # to do the thing they already did.
+            raise ValueError(
+                "person_boxes applies to a single image and cannot be reused "
+                "across video frames, where people move between them. Pass "
+                "person_detector=... for video, or call the model per frame "
+                "with the boxes for that frame."
+            )
+
         if is_video_file(source):
             gen = self._predict_video(
                 source,

--- a/libreyolo/models/sam3dbody/inference.py
+++ b/libreyolo/models/sam3dbody/inference.py
@@ -233,6 +233,17 @@ class MeshInferenceRunner:
                 np.stack([np.asarray(r[key], dtype=np.float32) for r in raw])
             )
 
+        def stack_optional(key):
+            """Stack a field the upstream estimator may not emit.
+
+            Which parameter blocks come back depends on the inference type
+            (body-only runs omit the hand decoder's output), so a missing key
+            must degrade to "not reported" rather than raising.
+            """
+            if any(key not in r or r[key] is None for r in raw):
+                return None
+            return stack(key)
+
         transl = stack("pred_cam_t")
         vertices = stack("pred_vertices")
         joints3d = stack("pred_keypoints_3d")
@@ -261,9 +272,14 @@ class MeshInferenceRunner:
             conf=torch.as_tensor(np.array([p.score for p in people], dtype=np.float32)),
             focal_length=focal,
             extras={
-                "scale": stack("scale_params"),
-                "hand_pose": stack("hand_pose_params"),
-                "vertices2d": vertices2d,
+                key: value
+                for key, value in (
+                    ("scale", stack_optional("scale_params")),
+                    ("hand_pose", stack_optional("hand_pose_params")),
+                    ("expression", stack_optional("expr_params")),
+                    ("vertices2d", vertices2d),
+                )
+                if value is not None
             },
             orig_shape=orig_shape,
         )

--- a/libreyolo/models/sam3dbody/inference.py
+++ b/libreyolo/models/sam3dbody/inference.py
@@ -1,0 +1,301 @@
+"""Inference orchestrator for SAM 3D Body mesh recovery.
+
+Wraps the upstream estimator behind the same ``__call__`` shape the standard
+``InferenceRunner`` provides, so the family integrates with the rest of the
+framework. Mirrors the arrangement the gaze task uses: a two-stage pipeline
+(person detection then per-person regression) with its own runner, accepting
+the parameters that make sense and rejecting the ones that do not.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Union
+
+import numpy as np
+import torch
+from PIL import Image
+
+from ...utils.general import log_saved_result, resolve_save_path
+from ...utils.image_loader import ImageInput, ImageLoader
+from ...utils.results import Boxes, Meshes, Results
+from ...utils.video import collect_video_results, is_video_file, run_video_inference
+from .camera import perspective_project
+from .person import PersonBox, PersonDetector, normalize_person_boxes, resolve_person_detector
+
+if TYPE_CHECKING:
+    from .model import LibreSAM3DBody
+
+logger = logging.getLogger(__name__)
+
+
+class MeshInferenceRunner:
+    """Runs body-mesh inference for a ``LibreSAM3DBody`` model."""
+
+    def __init__(self, model: "LibreSAM3DBody"):
+        self.model = model
+
+    def __call__(
+        self,
+        source: ImageInput | None = None,
+        *,
+        person_boxes: Optional[Sequence] = None,
+        person_detector: Optional[PersonDetector] = None,
+        conf: float = 0.5,
+        save: bool = False,
+        output_path: Optional[str] = None,
+        color_format: str = "auto",
+        stream: bool = False,
+        vid_stride: int = 1,
+        show: bool = False,
+        output_file_format: Optional[str] = None,
+        device: Optional[str] = None,
+        focal_length: Optional[float] = None,
+        # Rejected loudly so detection-shaped kwargs do not silently no-op.
+        augment: bool = False,
+        tiling: bool = False,
+        **_: object,
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
+        if augment:
+            raise ValueError(
+                "TTA (augment=True) is not supported for body mesh: a horizontal "
+                "flip swaps left and right body parts, so flipped mesh parameters "
+                "cannot be merged by averaging."
+            )
+        if tiling:
+            raise ValueError(
+                "Tiled inference is not supported for body mesh (a person crop "
+                "would be split across tiles)."
+            )
+        if output_file_format is not None:
+            output_file_format = output_file_format.lower().lstrip(".")
+            if output_file_format not in ("jpg", "jpeg", "png", "webp"):
+                raise ValueError(
+                    f"Invalid output_file_format: {output_file_format}. "
+                    "Must be one of: 'jpg', 'png', 'webp'."
+                )
+
+        detector = self._resolve_runtime_detector(person_detector, person_boxes)
+
+        if is_video_file(source):
+            gen = self._predict_video(
+                source,
+                detector=detector,
+                conf=conf,
+                save=save,
+                show=show,
+                vid_stride=vid_stride,
+                output_path=output_path,
+                output_file_format=output_file_format,
+                focal_length=focal_length,
+            )
+            if stream:
+                return gen
+            return collect_video_results(gen, source, vid_stride)
+
+        if isinstance(source, (str, Path)) and Path(source).is_dir():
+            return [
+                self._predict_single(
+                    p,
+                    detector=detector,
+                    person_boxes=None,
+                    conf=conf,
+                    save=save,
+                    output_path=output_path,
+                    color_format=color_format,
+                    output_file_format=output_file_format,
+                    focal_length=focal_length,
+                )
+                for p in ImageLoader.collect_images(source)
+            ]
+
+        return self._predict_single(
+            source,
+            detector=detector,
+            person_boxes=person_boxes,
+            conf=conf,
+            save=save,
+            output_path=output_path,
+            color_format=color_format,
+            output_file_format=output_file_format,
+            focal_length=focal_length,
+        )
+
+    # =========================================================================
+    # Single-frame path
+    # =========================================================================
+
+    def _predict_single(
+        self,
+        image: ImageInput,
+        *,
+        detector: Optional[PersonDetector],
+        person_boxes: Optional[Sequence],
+        conf: float,
+        save: bool,
+        output_path: Optional[str],
+        color_format: str,
+        output_file_format: Optional[str],
+        focal_length: Optional[float],
+    ) -> Results:
+        image_path = image if isinstance(image, (str, Path)) else None
+        pil = ImageLoader.load(image, color_format=color_format)
+        rgb = np.asarray(pil)
+        result = self._run_mesh(rgb, detector, person_boxes, conf, image_path, focal_length)
+
+        if save:
+            ext = (output_file_format or "jpg").lower().lstrip(".")
+            save_path = resolve_save_path(output_path, image_path, ext=ext)
+            annotated = self._annotate(pil, result)
+            annotated.save(save_path)
+            log_saved_result(result, save_path)
+        return result
+
+    def _predict_video(
+        self,
+        source,
+        *,
+        detector,
+        conf,
+        save,
+        show,
+        vid_stride,
+        output_path,
+        output_file_format,
+        focal_length,
+    ) -> Generator[Results, None, None]:
+        def predict_frame(pil_img: Image.Image) -> Results:
+            return self._run_mesh(
+                np.asarray(pil_img), detector, None, conf, str(source), focal_length
+            )
+
+        yield from run_video_inference(
+            source,
+            predict_frame,
+            vid_stride=vid_stride,
+            save=save,
+            show=show,
+            output_path=output_path,
+            annotate_fn=self._annotate,
+        )
+
+    # =========================================================================
+    # Internals
+    # =========================================================================
+
+    def _resolve_runtime_detector(self, explicit, person_boxes):
+        if person_boxes is not None:
+            return None
+        if explicit is not None:
+            return resolve_person_detector(explicit)
+        return self.model.person_detector
+
+    def _collect_people(self, rgb, detector, person_boxes, conf) -> List[PersonBox]:
+        if person_boxes is not None:
+            return normalize_person_boxes(person_boxes, min_score=0.0)
+        if detector is None:
+            raise RuntimeError(
+                "LibreSAM3DBody has no person source. Pass person_boxes=[...] for "
+                "BYO boxes, or person_detector=... (a callable, a LibreYOLO model, "
+                "or a PersonDetector) when constructing or calling the model."
+            )
+        return [p for p in detector(rgb) if p.score >= conf]
+
+    def _empty(self, orig_shape, image_path) -> Results:
+        return Results(
+            boxes=Boxes(
+                torch.zeros((0, 4), dtype=torch.float32),
+                torch.zeros((0,), dtype=torch.float32),
+                torch.zeros((0,), dtype=torch.float32),
+            ),
+            orig_shape=orig_shape,
+            path=str(image_path) if image_path else None,
+            names=self.model.names,
+        )
+
+    def _run_mesh(
+        self, rgb, detector, person_boxes, conf, image_path, focal_length
+    ) -> Results:
+        h, w = rgb.shape[:2]
+        orig_shape = (h, w)
+        people = self._collect_people(rgb, detector, person_boxes, conf)
+        if not people:
+            return self._empty(orig_shape, image_path)
+
+        boxes_np = np.array([list(p.xyxy) for p in people], dtype=np.float32)
+        raw = self.model.estimate(rgb, boxes_np, focal_length=focal_length)
+        if not raw:
+            return self._empty(orig_shape, image_path)
+
+        def stack(key):
+            return torch.as_tensor(
+                np.stack([np.asarray(r[key], dtype=np.float32) for r in raw])
+            )
+
+        transl = stack("pred_cam_t")
+        vertices = stack("pred_vertices")
+        joints3d = stack("pred_keypoints_3d")
+        joints2d = stack("pred_keypoints_2d")
+        focal = torch.as_tensor(
+            np.array([float(np.asarray(r["focal_length"]).reshape(-1)[0]) for r in raw],
+                     dtype=np.float32)
+        )
+
+        # Vertices and joints come back root-relative; the camera translation is
+        # carried separately. Add it so the payload is in the camera frame, as
+        # the mesh contract requires.
+        vertices_cam = vertices + transl[:, None, :]
+        vertices2d = perspective_project(vertices_cam, focal, image_size=orig_shape)
+
+        meshes = Meshes(
+            stack("global_rot"),
+            stack("body_pose_params"),
+            stack("shape_params"),
+            transl,
+            body_model="mhr",
+            vertices=vertices_cam,
+            faces=self.model.faces,
+            joints3d=joints3d + transl[:, None, :],
+            joints2d=joints2d,
+            conf=torch.as_tensor(np.array([p.score for p in people], dtype=np.float32)),
+            focal_length=focal,
+            extras={
+                "scale": stack("scale_params"),
+                "hand_pose": stack("hand_pose_params"),
+                "vertices2d": vertices2d,
+            },
+            orig_shape=orig_shape,
+        )
+        return Results(
+            boxes=Boxes(
+                torch.as_tensor(boxes_np),
+                torch.as_tensor(np.array([p.score for p in people], dtype=np.float32)),
+                torch.zeros(len(people), dtype=torch.float32),
+            ),
+            orig_shape=orig_shape,
+            path=str(image_path) if image_path else None,
+            names=self.model.names,
+            meshes=meshes,
+        )
+
+    def _annotate(self, pil_img: Image.Image, result: Results) -> Image.Image:
+        from ...utils.drawing import draw_boxes, draw_mesh
+
+        if result.boxes is None or len(result.boxes) == 0:
+            return pil_img
+        annotated = draw_boxes(
+            pil_img,
+            result.boxes.xyxy.tolist(),
+            result.boxes.conf.tolist(),
+            result.boxes.cls.tolist(),
+            class_names=result.names,
+        )
+        if result.meshes is not None and len(result.meshes) > 0:
+            m = result.meshes.numpy()
+            annotated = draw_mesh(
+                annotated,
+                joints2d=m.joints2d,
+                vertices2d=m.extras.get("vertices2d"),
+            )
+        return annotated

--- a/libreyolo/models/sam3dbody/inference.py
+++ b/libreyolo/models/sam3dbody/inference.py
@@ -314,8 +314,8 @@ class MeshInferenceRunner:
                 joints2d=m.joints2d,
                 vertices2d=m.extras.get("vertices2d"),
                 faces=m.faces,
-                # Camera-space depth per vertex drives both the shading
-                # normals and the far-to-near draw order.
-                vertex_depths=m.vertices[..., 2] if m.vertices is not None else None,
+                # Metric camera-space vertices drive the shading normals and
+                # the far-to-near draw order.
+                vertices3d=m.vertices,
             )
         return annotated

--- a/libreyolo/models/sam3dbody/inference.py
+++ b/libreyolo/models/sam3dbody/inference.py
@@ -297,5 +297,9 @@ class MeshInferenceRunner:
                 annotated,
                 joints2d=m.joints2d,
                 vertices2d=m.extras.get("vertices2d"),
+                faces=m.faces,
+                # Camera-space depth per vertex drives both the shading
+                # normals and the far-to-near draw order.
+                vertex_depths=m.vertices[..., 2] if m.vertices is not None else None,
             )
         return annotated

--- a/libreyolo/models/sam3dbody/mhr_body.py
+++ b/libreyolo/models/sam3dbody/mhr_body.py
@@ -1,0 +1,225 @@
+"""MHR (Momentum Human Rig) body model wrapper.
+
+MHR is Meta's parametric human body model, released under Apache 2.0 for both
+code and assets. It is the body representation the SAM 3D Body regressor
+predicts into, and it is the reason a body-mesh task can exist here at all:
+the SMPL family, which the rest of the field standardized on, ships under a
+non-commercial license whose model files may not be redistributed, so LibreYOLO
+could neither host them nor depend on the ``smplx`` package (whose *code* also
+carries that non-commercial license).
+
+Only the TorchScript form of MHR is used. It is a single self-contained file
+that needs nothing beyond PyTorch, which avoids the ``pymomentum`` native
+dependency that the full MHR package requires and that has no reliable Windows
+wheel.
+
+Parameterization, verified against the released model rather than taken from
+documentation:
+
+* ``model_params`` is 204 wide: 3 translation, 3 global rotation, 130 body
+  pose, then 68 per-bone scales. Rotations are Euler angles in radians, not
+  axis-angle, and translation enters the rig in decimeters (hence the factor
+  of 10 below).
+* ``betas`` is 45 identity blendshape coefficients.
+* ``expression`` is 72 facial expression coefficients.
+* Outputs are 18439 vertices and a 127-joint skeleton state of
+  ``(x, y, z, qx, qy, qz, qw, scale)`` per joint, both in centimeters.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+import torch
+
+
+logger = logging.getLogger(__name__)
+
+
+# Public, ungated Apache-2.0 release asset. Not mirrored on the LibreYOLO org:
+# the upstream release is authoritative and freely reachable, so there is no
+# reason to hold a second copy of a 700 MB artifact.
+MHR_ASSETS_URL = (
+    "https://github.com/facebookresearch/MHR/releases/latest/download/assets.zip"
+)
+MHR_ARCHIVE_MEMBER = "assets/mhr_model.pt"
+MHR_LICENSE_URL = "https://github.com/facebookresearch/MHR/blob/main/LICENSE"
+
+
+class MHRBodyModel(torch.nn.Module):
+    """Decode MHR parameters into a posed mesh and skeleton."""
+
+    NUM_BETAS = 45
+    NUM_BODY_POSE = 130
+    NUM_SCALES = 68
+    NUM_EXPRESSION = 72
+    NUM_JOINTS = 127
+    NUM_VERTICES = 18439
+    MODEL_PARAM_DIM = 204
+
+    # The rig optimizes global translation in decimeters; parameters handed in
+    # here are meters, so they are scaled on the way in.
+    _TRANSLATION_SCALE = 10.0
+    # Vertices and joints come back in centimeters.
+    _CM_TO_M = 100.0
+
+    def __init__(self, module: torch.jit.ScriptModule):
+        super().__init__()
+        self.mhr = module
+        for param in self.mhr.parameters():
+            param.requires_grad = False
+
+    @classmethod
+    def from_file(
+        cls, path: str | Path, device: str | torch.device = "cpu"
+    ) -> "MHRBodyModel":
+        """Load the TorchScript MHR model from a local file."""
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(
+                f"MHR body model not found at {path}. Fetch it with "
+                "libreyolo.models.sam3dbody.mhr_body.ensure_mhr_model()."
+            )
+        module = torch.jit.load(str(path), map_location=str(device)).eval()
+        return cls(module).to(device).eval()
+
+    @property
+    def faces(self) -> Optional[torch.Tensor]:
+        """Mesh topology, when the loaded module exposes it."""
+        return getattr(self.mhr, "faces", None)
+
+    def forward(
+        self,
+        global_orient: torch.Tensor,
+        body_pose: torch.Tensor,
+        betas: torch.Tensor,
+        scales: torch.Tensor,
+        transl: Optional[torch.Tensor] = None,
+        expression: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Pose the body.
+
+        Args:
+            global_orient: ``(B, 3)`` root rotation as Euler angles in radians.
+            body_pose: ``(B, 130)`` body joint parameters in radians.
+            betas: ``(B, 45)`` identity blendshape coefficients.
+            scales: ``(B, 68)`` per-bone skeleton scales.
+            transl: ``(B, 3)`` root translation in meters. Defaults to zeros,
+                which leaves the body at the rig origin so a camera
+                translation can be applied afterwards.
+            expression: ``(B, 72)`` facial expression coefficients.
+
+        Returns:
+            ``(vertices, joints)`` with shapes ``(B, 18439, 3)`` and
+            ``(B, 127, 3)``, both in meters in the model's own frame.
+        """
+        batch = global_orient.shape[0]
+        device, dtype = global_orient.device, global_orient.dtype
+
+        if transl is None:
+            transl = torch.zeros(batch, 3, device=device, dtype=dtype)
+        if expression is None:
+            expression = torch.zeros(
+                batch, self.NUM_EXPRESSION, device=device, dtype=dtype
+            )
+
+        self._check_width("body_pose", body_pose, self.NUM_BODY_POSE)
+        self._check_width("betas", betas, self.NUM_BETAS)
+        self._check_width("scales", scales, self.NUM_SCALES)
+
+        model_params = torch.cat(
+            [transl * self._TRANSLATION_SCALE, global_orient, body_pose, scales],
+            dim=1,
+        )
+        if model_params.shape[1] != self.MODEL_PARAM_DIM:
+            raise ValueError(
+                f"assembled MHR model parameters are {model_params.shape[1]} wide, "
+                f"expected {self.MODEL_PARAM_DIM}"
+            )
+
+        vertices, skeleton_state = self.mhr(betas, model_params, expression)
+        # Skeleton state packs position, unit quaternion and scale per joint.
+        joints = skeleton_state[..., :3]
+        return vertices / self._CM_TO_M, joints / self._CM_TO_M
+
+    @staticmethod
+    def _check_width(name: str, tensor: torch.Tensor, expected: int) -> None:
+        if tensor.shape[-1] != expected:
+            raise ValueError(
+                f"{name} must be {expected} wide, got {tensor.shape[-1]}"
+            )
+
+
+def default_mhr_path() -> Path:
+    """Location LibreYOLO caches the MHR body model at."""
+    root = os.environ.get("LIBREYOLO_MHR_PATH")
+    if root:
+        return Path(root)
+    return Path.home() / ".cache" / "libreyolo" / "mhr" / "mhr_model.pt"
+
+
+def ensure_mhr_model(path: str | Path | None = None) -> Path:
+    """Return a local MHR model path, downloading the release asset if absent.
+
+    The asset is Apache 2.0 and served from a public GitHub release, so no
+    token, registration or license acceptance is involved.
+    """
+    target = Path(path) if path is not None else default_mhr_path()
+    if target.exists():
+        return target
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        "Downloading the MHR body model (Apache 2.0, ~700 MB) from %s",
+        MHR_ASSETS_URL,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        archive = Path(tmp) / "assets.zip"
+        request = urllib.request.Request(
+            MHR_ASSETS_URL, headers={"User-Agent": "libreyolo"}
+        )
+        with urllib.request.urlopen(request) as response, open(archive, "wb") as fh:
+            shutil.copyfileobj(response, fh)
+
+        with zipfile.ZipFile(archive) as zf:
+            member = next(
+                (n for n in zf.namelist() if n.endswith("mhr_model.pt")), None
+            )
+            if member is None:
+                raise RuntimeError(
+                    f"{MHR_ARCHIVE_MEMBER} is missing from the MHR release archive. "
+                    "The upstream release layout may have changed."
+                )
+            staged = Path(tmp) / "mhr_model.pt"
+            with zf.open(member) as src, open(staged, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            # Move into place only once complete, so an interrupted download
+            # never leaves a truncated file that later loads as corrupt.
+            shutil.move(str(staged), str(target))
+
+    logger.info("MHR body model ready at %s (license: %s)", target, MHR_LICENSE_URL)
+    return target
+
+
+def load_mhr_body_model(
+    path: str | Path | None = None,
+    device: str | torch.device = "cpu",
+    download: bool = True,
+) -> MHRBodyModel:
+    """Load the MHR body model, fetching it on first use when allowed."""
+    target = Path(path) if path is not None else default_mhr_path()
+    if not target.exists():
+        if not download:
+            raise FileNotFoundError(
+                f"MHR body model not found at {target} and download=False."
+            )
+        target = ensure_mhr_model(target)
+    return MHRBodyModel.from_file(target, device=device)

--- a/libreyolo/models/sam3dbody/model.py
+++ b/libreyolo/models/sam3dbody/model.py
@@ -1,0 +1,291 @@
+"""LibreYOLO adapter for SAM 3D Body (inference only).
+
+This is a **wrapper, not a port**. Meta's SAM 3D Body code is published under
+the SAM License, which is not one of the permissive licenses LibreYOLO's own
+code may be derived from, so none of it is vendored here. Instead this module
+calls the upstream package's public API and translates its output into
+LibreYOLO's ``Meshes`` result payload.
+
+The practical consequence is that the upstream package is an optional
+dependency the user installs themselves. LibreYOLO ships no SAM-licensed bytes,
+and a user who never touches the mesh task never encounters those terms. The
+weights are a separate matter: the SAM License does permit redistribution with
+passthrough, so they are mirrored on the LibreYOLO org behind the same kind of
+gate Meta uses.
+
+The body model underneath is MHR, which is Apache 2.0 and fetched from its
+public release by :func:`~libreyolo.models.sam3dbody.mhr_body.ensure_mhr_model`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from ..base.model import BaseModel
+from .mhr_body import ensure_mhr_model
+from .person import PersonDetector, resolve_person_detector
+
+logger = logging.getLogger(__name__)
+
+UPSTREAM_REPO = "https://github.com/facebookresearch/sam-3d-body"
+SAM_LICENSE_URL = f"{UPSTREAM_REPO}/blob/main/LICENSE"
+
+
+class LibreSAM3DBody(BaseModel):
+    """SAM 3D Body: image + person boxes -> per-person MHR body meshes."""
+
+    FAMILY = "sam3dbody"
+    FILENAME_PREFIX = "LibreSAM3DBody"
+    WEIGHT_EXT = ".ckpt"
+    # Size codes name the backbone: DINOv3 ViT-H/16+ and the original ViT-H.
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {"d3": 512, "h": 512}
+    SUPPORTED_TASKS = ("mesh",)
+    DEFAULT_TASK = "mesh"
+
+    TTA_ENABLED = False
+    SUPPORTS_BATCHED_PREDICT = False
+
+    def __init__(
+        self,
+        model_path=None,
+        size: str = "d3",
+        nb_classes: int = 1,
+        device: str = "auto",
+        task: str | None = None,
+        person_detector: Optional[PersonDetector] = None,
+        sam_3d_body_path: str | Path | None = None,
+        mhr_path: str | Path | None = None,
+        **kwargs,
+    ):
+        self._sam_3d_body_path = sam_3d_body_path or os.environ.get("SAM_3D_BODY_PATH")
+        self._mhr_path = mhr_path
+        self._ckpt_path = self._resolve_checkpoint(model_path, size)
+        self._estimator = None
+
+        super().__init__(
+            model_path=None,  # upstream's loader builds and loads in one step
+            size=size,
+            nb_classes=1,
+            device=device,
+            task=task,
+            **kwargs,
+        )
+        self.names = {0: "person"}
+        self.person_detector = (
+            resolve_person_detector(person_detector) if person_detector is not None else None
+        )
+        self.model.eval()
+
+    # =========================================================================
+    # Upstream package plumbing
+    # =========================================================================
+
+    def _import_upstream(self):
+        """Import the upstream package, with actionable guidance if absent."""
+        if self._sam_3d_body_path:
+            path = str(Path(self._sam_3d_body_path).resolve())
+            import sys
+
+            if path not in sys.path:
+                sys.path.insert(0, path)
+        # The MHR head prefers the pymomentum backend when this is unset, which
+        # has no reliable Windows wheel. Selecting the TorchScript path keeps
+        # the dependency surface to plain PyTorch.
+        os.environ.setdefault("MOMENTUM_ENABLED", "")
+        try:
+            import sam_3d_body  # noqa: F401
+
+            return sam_3d_body
+        except ImportError as e:
+            raise ImportError(
+                "LibreSAM3DBody wraps Meta's sam-3d-body package, which is not "
+                "bundled with LibreYOLO because it is published under the SAM "
+                "License rather than a permissive one.\n\n"
+                "Install it yourself:\n"
+                f"  git clone {UPSTREAM_REPO}\n"
+                "  pip install roma einops yacs omegaconf braceexpand "
+                "pytorch-lightning timm\n\n"
+                "Then point LibreYOLO at the clone, either with\n"
+                "  LibreSAM3DBody(..., sam_3d_body_path='/path/to/sam-3d-body')\n"
+                "or by setting the SAM_3D_BODY_PATH environment variable.\n\n"
+                f"Its terms, which you accept by using it: {SAM_LICENSE_URL}"
+            ) from e
+
+    @classmethod
+    def _resolve_checkpoint(cls, model_path, size: str) -> Path:
+        """Locate the upstream checkpoint, downloading from the mirror if needed."""
+        if model_path is not None:
+            path = Path(model_path)
+            if path.is_dir():
+                path = path / "model.ckpt"
+            if not path.exists():
+                raise FileNotFoundError(f"SAM 3D Body checkpoint not found: {path}")
+            return path
+
+        cache = Path.home() / ".cache" / "libreyolo" / "sam3dbody" / size
+        ckpt = cache / "model.ckpt"
+        if ckpt.exists():
+            return ckpt
+        return cls._download_checkpoint(cache, size)
+
+    @classmethod
+    def _download_checkpoint(cls, cache: Path, size: str) -> Path:
+        """Fetch the checkpoint and its config from the gated LibreYOLO mirror."""
+        repo = f"LibreYOLO/{cls.FILENAME_PREFIX}{size}-mesh"
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as e:
+            raise ImportError(
+                "huggingface_hub is required to download SAM 3D Body weights."
+            ) from e
+
+        cache.mkdir(parents=True, exist_ok=True)
+        try:
+            # The config must sit beside the checkpoint: upstream's loader looks
+            # for model_config.yaml next to (or one level above) the weights.
+            for filename in ("model_config.yaml", "LICENSE", "model.ckpt"):
+                hf_hub_download(repo_id=repo, filename=filename, local_dir=str(cache))
+        except Exception as e:  # noqa: BLE001 - surface the gate, whatever the cause
+            raise RuntimeError(
+                f"Could not download SAM 3D Body weights from {repo}.\n\n"
+                "These weights are redistributed under Meta's SAM License, and "
+                "the mirror is gated: you must accept the license terms on the "
+                f"model page (https://huggingface.co/{repo}) and authenticate "
+                "with `hf auth login`.\n\n"
+                f"Underlying error: {e}"
+            ) from e
+        return cache / "model.ckpt"
+
+    # =========================================================================
+    # BaseModel surface
+    # =========================================================================
+
+    def _init_model(self) -> nn.Module:
+        self._import_upstream()
+        from sam_3d_body import load_sam_3d_body
+
+        mhr = Path(self._mhr_path) if self._mhr_path else ensure_mhr_model()
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model, cfg = load_sam_3d_body(
+            str(self._ckpt_path), device=device, mhr_path=str(mhr)
+        )
+        self._cfg = cfg
+        return model
+
+    @property
+    def estimator(self):
+        """The upstream estimator, built lazily on first use."""
+        if self._estimator is None:
+            self._import_upstream()
+            from sam_3d_body import SAM3DBodyEstimator
+
+            self._estimator = SAM3DBodyEstimator(self.model, self._cfg)
+        return self._estimator
+
+    @property
+    def faces(self) -> torch.Tensor:
+        """Shared MHR mesh topology."""
+        return self.model.head_pose.faces.detach().cpu()
+
+    def estimate(
+        self,
+        image_rgb: np.ndarray,
+        boxes_xyxy: np.ndarray,
+        focal_length: Optional[float] = None,
+    ) -> List[dict]:
+        """Run the upstream estimator over one image and its person boxes."""
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "SAM 3D Body inference requires CUDA: the upstream estimator "
+                "moves its batch to the GPU unconditionally, so there is no "
+                "CPU path to fall back to."
+            )
+        cam_int = None
+        if focal_length is not None:
+            h, w = image_rgb.shape[:2]
+            cam_int = torch.tensor(
+                [[[float(focal_length), 0.0, w / 2.0],
+                  [0.0, float(focal_length), h / 2.0],
+                  [0.0, 0.0, 1.0]]],
+                dtype=torch.float32,
+            )
+        return self.estimator.process_one_image(
+            image_rgb, bboxes=np.asarray(boxes_xyxy, dtype=np.float32),
+            cam_int=cam_int, inference_type="body",
+        )
+
+    @property
+    def _runner(self):
+        if getattr(self, "_runner_instance", None) is None:
+            from .inference import MeshInferenceRunner
+
+            self._runner_instance = MeshInferenceRunner(self)
+        return self._runner_instance
+
+    # The detection-shaped hooks do not apply: the upstream estimator owns
+    # preprocessing, the forward pass and decoding.
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        return False  # foreign checkpoint format; constructed explicitly
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        return None
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        return 1
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {name: module for name, module in self.model.named_modules() if name}
+
+    @staticmethod
+    def _get_preprocess_numpy():
+        raise NotImplementedError(
+            "LibreSAM3DBody preprocesses per person crop inside the upstream "
+            "estimator, not through the detection-shaped numpy path."
+        )
+
+    def _preprocess(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreSAM3DBody preprocesses inside the upstream estimator."
+        )
+
+    def _forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreSAM3DBody runs the forward pass inside the upstream estimator."
+        )
+
+    def _postprocess(self, *args, **kwargs):
+        raise NotImplementedError(
+            "LibreSAM3DBody decodes inside the upstream estimator; "
+            "MeshInferenceRunner maps the result into Meshes."
+        )
+
+    def val(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Body-mesh validation needs a ground-truth mesh dataset, and the "
+            "usual benchmarks (3DPW, EMDB, AGORA) are research-license only, so "
+            "none is bundled. The metrics are available as "
+            "libreyolo.validation.mesh_metrics (MPJPE, PA-MPJPE, PVE) for "
+            "evaluating against a dataset you already hold."
+        )
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Training is out of scope for LibreSAM3DBody. Train upstream at "
+            f"{UPSTREAM_REPO}."
+        )
+
+    def export(self, format: str = "onnx", **kwargs) -> str:
+        raise NotImplementedError(
+            "Body-mesh export is not implemented yet; the exported-graph "
+            "metadata contract for the mesh task is still to be defined."
+        )

--- a/libreyolo/models/sam3dbody/model.py
+++ b/libreyolo/models/sam3dbody/model.py
@@ -172,9 +172,11 @@ class LibreSAM3DBody(BaseModel):
         from sam_3d_body import load_sam_3d_body
 
         mhr = Path(self._mhr_path) if self._mhr_path else ensure_mhr_model()
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        # Honour the caller's device rather than grabbing any available GPU:
+        # device="cpu" on a CUDA machine is a legitimate request, and silently
+        # overriding it would also desynchronize the guard in estimate().
         model, cfg = load_sam_3d_body(
-            str(self._ckpt_path), device=device, mhr_path=str(mhr)
+            str(self._ckpt_path), device=str(self.device), mhr_path=str(mhr)
         )
         self._cfg = cfg
         return model
@@ -190,9 +192,18 @@ class LibreSAM3DBody(BaseModel):
         return self._estimator
 
     @property
-    def faces(self) -> torch.Tensor:
-        """Shared MHR mesh topology."""
-        return self.model.head_pose.faces.detach().cpu()
+    def faces(self) -> Optional[torch.Tensor]:
+        """Shared MHR mesh topology, or None if upstream stops exposing it."""
+        head = getattr(self.model, "head_pose", None)
+        faces = getattr(head, "faces", None)
+        if faces is None:
+            logger.warning(
+                "The loaded sam-3d-body build does not expose head_pose.faces, "
+                "so mesh results will carry no topology: OBJ export and surface "
+                "rendering will be unavailable."
+            )
+            return None
+        return faces.detach().cpu()
 
     def estimate(
         self,
@@ -201,11 +212,21 @@ class LibreSAM3DBody(BaseModel):
         focal_length: Optional[float] = None,
     ) -> List[dict]:
         """Run the upstream estimator over one image and its person boxes."""
-        if not torch.cuda.is_available():
+        # Guard on this model's device, not on global CUDA availability: with
+        # device="cpu" on a CUDA machine the weights are on CPU, and a global
+        # check would wave that through into a device-mismatch crash inside the
+        # upstream estimator.
+        if self.device.type != "cuda":
             raise RuntimeError(
-                "SAM 3D Body inference requires CUDA: the upstream estimator "
-                "moves its batch to the GPU unconditionally, so there is no "
-                "CPU path to fall back to."
+                "SAM 3D Body inference requires a CUDA device, but this model "
+                f"is on {self.device}. The upstream estimator moves its batch "
+                "to the GPU unconditionally, so there is no CPU path to fall "
+                "back to. Construct with device='cuda'."
+                + (
+                    ""
+                    if torch.cuda.is_available()
+                    else " No CUDA device is visible to PyTorch here."
+                )
             )
         cam_int = None
         if focal_length is not None:

--- a/libreyolo/models/sam3dbody/person.py
+++ b/libreyolo/models/sam3dbody/person.py
@@ -1,0 +1,142 @@
+"""Person-source layer for body-mesh inference.
+
+Top-down mesh models need a person box before they can regress anything. Rather
+than binding one detector in, this defines a small protocol plus adapters, so a
+caller can hand over boxes directly, plug in a LibreYOLO detector, or pass any
+callable. Mirrors the arrangement the gaze task uses for faces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Protocol
+
+import numpy as np
+
+
+@dataclass
+class PersonBox:
+    """A single person detection in original-image pixels."""
+
+    xyxy: tuple
+    score: float = 1.0
+
+
+class PersonDetector(Protocol):
+    """Anything mapping a numpy RGB image to a list of ``PersonBox``."""
+
+    def __call__(self, image_rgb: np.ndarray) -> List[PersonBox]:  # pragma: no cover
+        ...
+
+
+@dataclass
+class CallablePersonDetector:
+    """Adapt an arbitrary ``image -> boxes`` callable into the protocol."""
+
+    fn: Callable[[np.ndarray], Any]
+    min_score: float = 0.0
+
+    def __call__(self, image_rgb: np.ndarray) -> List[PersonBox]:
+        return normalize_person_boxes(self.fn(image_rgb), self.min_score)
+
+
+@dataclass
+class LibreYOLOPersonDetector:
+    """Adapt a LibreYOLO detection model into a person detector.
+
+    Defaults to COCO class 0 ("person"). Pass ``person_class=None`` to keep
+    every detection, for a model that only ever emits people.
+    """
+
+    model: Any
+    conf: float = 0.4
+    person_class: Optional[int] = 0
+    imgsz: Optional[int] = None
+
+    def __call__(self, image_rgb: np.ndarray) -> List[PersonBox]:
+        from PIL import Image
+
+        kwargs: dict = {"conf": self.conf}
+        if self.imgsz is not None:
+            kwargs["imgsz"] = self.imgsz
+        if self.person_class is not None:
+            kwargs["classes"] = [self.person_class]
+        result = self.model(Image.fromarray(image_rgb), **kwargs)
+        if isinstance(result, list):
+            result = result[0]
+
+        boxes = result.boxes
+        if boxes is None or len(boxes) == 0:
+            return []
+        xyxy = boxes.xyxy
+        conf = boxes.conf
+        if hasattr(xyxy, "cpu"):
+            xyxy = xyxy.cpu().numpy()
+        if hasattr(conf, "cpu"):
+            conf = conf.cpu().numpy()
+        return [
+            PersonBox(
+                xyxy=(float(b[0]), float(b[1]), float(b[2]), float(b[3])),
+                score=float(s),
+            )
+            for b, s in zip(xyxy, conf)
+        ]
+
+
+def normalize_person_boxes(raw: Any, min_score: float = 0.0) -> List[PersonBox]:
+    """Coerce flexible box input into a list of ``PersonBox``."""
+    if raw is None:
+        return []
+    if isinstance(raw, np.ndarray):
+        if raw.ndim == 1:
+            raw = raw[None, :]
+        if raw.ndim != 2 or raw.shape[1] not in (4, 5):
+            raise ValueError(
+                f"expected person boxes of shape (N, 4) or (N, 5), got {raw.shape}"
+            )
+        rows = raw.tolist()
+    else:
+        rows = list(raw)
+
+    boxes: List[PersonBox] = []
+    for item in rows:
+        if isinstance(item, PersonBox):
+            if item.score >= min_score:
+                boxes.append(item)
+            continue
+        seq = list(item)
+        if len(seq) == 4:
+            score = 1.0
+        elif len(seq) >= 5:
+            score = float(seq[4])
+        else:
+            raise ValueError(
+                f"unsupported person-box length {len(seq)}; expected 4 or 5+"
+            )
+        if score < min_score:
+            continue
+        boxes.append(
+            PersonBox(
+                xyxy=(float(seq[0]), float(seq[1]), float(seq[2]), float(seq[3])),
+                score=score,
+            )
+        )
+    return boxes
+
+
+def resolve_person_detector(spec: Any) -> Optional[PersonDetector]:
+    """Coerce a user-supplied detector spec into a ``PersonDetector`` or None."""
+    if spec is None:
+        return None
+    if isinstance(spec, (CallablePersonDetector, LibreYOLOPersonDetector)):
+        return spec
+    from ..base.model import BaseModel
+
+    if isinstance(spec, BaseModel):
+        return LibreYOLOPersonDetector(model=spec)
+    if callable(spec):
+        return CallablePersonDetector(fn=spec)
+    raise TypeError(
+        f"Unsupported person_detector spec: {type(spec).__name__}. "
+        "Provide a callable, a LibreYOLO model, or a PersonDetector instance."
+    )

--- a/libreyolo/tasks.py
+++ b/libreyolo/tasks.py
@@ -21,6 +21,7 @@ TaskType = Literal[
     "restore",
     "matte",
     "ocr",
+    "mesh",
 ]
 TASKS = (
     "detect",
@@ -36,6 +37,7 @@ TASKS = (
     "restore",
     "matte",
     "ocr",
+    "mesh",
 )
 
 TASK_ALIASES = {
@@ -91,6 +93,12 @@ TASK_ALIASES = {
     "text": "ocr",
     "text-recognition": "ocr",
     "text_recognition": "ocr",
+    "mesh": "mesh",
+    "body-mesh": "mesh",
+    "body_mesh": "mesh",
+    "hmr": "mesh",
+    "human-mesh-recovery": "mesh",
+    "human_mesh_recovery": "mesh",
 }
 
 TASK_TO_SUFFIX = {
@@ -106,6 +114,7 @@ TASK_TO_SUFFIX = {
     "restore": "restore",
     "matte": "matte",
     "ocr": "ocr",
+    "mesh": "mesh",
 }
 
 SUFFIX_TO_TASK = {v: k for k, v in TASK_TO_SUFFIX.items()}

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -890,36 +890,49 @@ _MESH_LIGHT_DIR = np.array([-0.35, -0.55, -0.75], dtype=np.float32)
 def render_mesh_surface(
     img: Image.Image,
     vertices2d: np.ndarray,
-    vertex_depths: np.ndarray,
+    vertices3d: np.ndarray,
     faces: np.ndarray,
     color: Tuple[int, int, int] = MESH_SURFACE_COLOR,
     alpha: float = 0.9,
-    ambient: float = 0.35,
+    ambient: float = 0.22,
+    specular: float = 0.30,
+    shininess: float = 16.0,
+    shading: str = "diffuse",
 ) -> Image.Image:
     """Rasterize shaded body-mesh surfaces over an image.
 
     A small painter's-algorithm renderer: back-facing triangles are culled,
-    the rest are sorted far-to-near and filled with Lambertian shading. This
-    keeps a real surface render available without taking on a GPU rasterizer
-    dependency such as pyrender or PyTorch3D, neither of which installs
-    cleanly everywhere LibreYOLO runs.
+    the rest are sorted far-to-near and filled. This keeps a real surface
+    render available without a GPU rasterizer dependency such as pyrender or
+    PyTorch3D, neither of which installs cleanly everywhere LibreYOLO runs.
+
+    Shading normals are computed from the **metric camera-space** vertices,
+    not from screen coordinates. Mixing pixel units with metric depth makes
+    every normal point at the camera, which flattens the render into what
+    looks like a silhouette.
 
     Args:
         img: PIL image to draw on.
         vertices2d: ``(N, V, 2)`` projected vertices in pixels.
-        vertex_depths: ``(N, V)`` camera-space depth per vertex, used for
-            draw ordering and for reconstructing shading normals.
+        vertices3d: ``(N, V, 3)`` camera-space metric vertices. Drives both
+            the shading normals and the far-to-near draw order.
         faces: ``(F, 3)`` vertex indices, shared by every person.
-        color: Base RGB of the surface.
+        color: Base RGB of the surface, used by ``shading="diffuse"``.
         alpha: Blend weight of the rendered surface over the photo.
         ambient: Fraction of base color present in unlit areas.
+        specular: Strength of the highlight that conveys curvature.
+        shininess: Highlight tightness; larger is glossier.
+        shading: ``"diffuse"`` for lit clay, or ``"normal"`` to colour each
+            face by its normal direction, the convention papers use when the
+            point is to show surface orientation rather than realism.
     """
     verts2d = np.asarray(vertices2d, dtype=np.float32)
-    depths = np.asarray(vertex_depths, dtype=np.float32)
+    verts3d = np.asarray(vertices3d, dtype=np.float32)
     faces = np.asarray(faces, dtype=np.int64)
     if verts2d.ndim == 2:
         verts2d = verts2d[None, ...]
-        depths = depths[None, ...]
+    if verts3d.ndim == 2:
+        verts3d = verts3d[None, ...]
     if verts2d.size == 0 or faces.size == 0:
         return img.convert("RGB")
 
@@ -928,46 +941,63 @@ def render_mesh_surface(
     base = np.asarray(color, dtype=np.float32)
     light = _MESH_LIGHT_DIR / np.linalg.norm(_MESH_LIGHT_DIR)
 
-    for person_xy, person_z in zip(verts2d, depths):
-        # Reconstruct each triangle in a pseudo-camera space: screen x/y plus
-        # true depth. Normals from this are enough for plausible shading and
-        # avoid needing the intrinsics again here.
-        tri = np.stack(
-            [
-                np.concatenate([person_xy[faces[:, i]], person_z[faces[:, i], None]], axis=1)
-                for i in range(3)
-            ],
-            axis=1,
-        )  # (F, 3, 3)
+    for person_xy, person_xyz in zip(verts2d, verts3d):
+        tri2d = np.stack([person_xy[faces[:, i]] for i in range(3)], axis=1)
+        tri3d = np.stack([person_xyz[faces[:, i]] for i in range(3)], axis=1)
 
-        edge1 = tri[:, 1] - tri[:, 0]
-        edge2 = tri[:, 2] - tri[:, 0]
-        normals = np.cross(edge1, edge2)
+        # True geometric normals, in metres, from the camera-space mesh.
+        normals = np.cross(tri3d[:, 1] - tri3d[:, 0], tri3d[:, 2] - tri3d[:, 0])
         norm_len = np.linalg.norm(normals, axis=1)
         valid = norm_len > 1e-12
         normals[valid] /= norm_len[valid, None]
 
-        # Screen-space winding tells us which triangles face the camera.
-        signed_area = edge1[:, 0] * edge2[:, 1] - edge1[:, 1] * edge2[:, 0]
-        front = valid & (signed_area < 0)
-        if not front.any():
-            # Winding convention differs; fall back to the other orientation
-            # rather than rendering nothing.
-            front = valid & (signed_area > 0)
+        centroid = tri3d.mean(axis=1)
+        view_len = np.linalg.norm(centroid, axis=1)
+        view = centroid / np.maximum(view_len, 1e-9)[:, None]
+
+        # A face is visible when its normal opposes the viewing direction.
+        # Orient normals toward the camera so shading never depends on the
+        # mesh's winding convention.
+        facing = np.einsum("ij,ij->i", normals, view)
+        normals[facing > 0] *= -1
+        front = valid & (np.abs(facing) > 1e-6)
         if not front.any():
             continue
+        # Screen-space winding is the reliable visibility test for a closed
+        # body: keep the consistently-wound half.
+        edge1 = tri2d[:, 1] - tri2d[:, 0]
+        edge2 = tri2d[:, 2] - tri2d[:, 0]
+        signed_area = edge1[:, 0] * edge2[:, 1] - edge1[:, 1] * edge2[:, 0]
+        for sign in (-1.0, 1.0):
+            candidate = front & (signed_area * sign > 0)
+            if candidate.sum() > front.sum() * 0.25:
+                front = candidate
+                break
 
-        tri_front = tri[front]
-        shade = ambient + (1.0 - ambient) * np.clip(normals[front] @ light, 0.0, 1.0)
-        colors = np.clip(base[None, :] * shade[:, None], 0, 255).astype(np.uint8)
+        n = normals[front]
+        v = view[front]
+        if shading == "normal":
+            colors = np.clip((n * 0.5 + 0.5) * 255.0, 0, 255).astype(np.uint8)
+        else:
+            diffuse = np.clip(n @ light, 0.0, 1.0)
+            # Blinn-Phong highlight: the half-vector between light and viewer.
+            half = light - v
+            half /= np.maximum(np.linalg.norm(half, axis=1), 1e-9)[:, None]
+            spec = np.power(
+                np.clip(np.einsum("ij,ij->i", n, half), 0.0, 1.0), shininess
+            )
+            shade = ambient + (1.0 - ambient) * diffuse
+            lit = base[None, :] * shade[:, None] + 255.0 * specular * spec[:, None]
+            colors = np.clip(lit, 0, 255).astype(np.uint8)
 
+        tri_front = tri2d[front]
+        depth_front = tri3d[front, :, 2].mean(axis=1)
         # Painter's algorithm: farthest first, so nearer surfaces overwrite.
-        order = np.argsort(-tri_front[:, :, 2].mean(axis=1))
-        for idx in order:
+        for idx in np.argsort(-depth_front):
             a, b, c = tri_front[idx]
             draw.polygon(
                 [(a[0], a[1]), (b[0], b[1]), (c[0], c[1])],
-                fill=tuple(int(v) for v in colors[idx]),
+                fill=tuple(int(value) for value in colors[idx]),
             )
 
     if alpha >= 1.0:
@@ -980,12 +1010,13 @@ def draw_mesh(
     joints2d: np.ndarray | None = None,
     vertices2d: np.ndarray | None = None,
     faces: np.ndarray | None = None,
-    vertex_depths: np.ndarray | None = None,
+    vertices3d: np.ndarray | None = None,
     edges: Tuple[Tuple[int, int], ...] = MHR70_SKELETON_EDGES,
     vertex_color: Tuple[int, int, int] = MESH_VERTEX_COLOR,
     surface_color: Tuple[int, int, int] = MESH_SURFACE_COLOR,
     max_vertices: int = 1200,
     surface_alpha: float = 0.9,
+    shading: str = "diffuse",
     draw_skeleton: bool = False,
 ) -> Image.Image:
     """Overlay body meshes on an image.
@@ -1000,26 +1031,28 @@ def draw_mesh(
         joints2d: ``(N, K, 2)`` projected keypoints in pixels, or None.
         vertices2d: ``(N, V, 2)`` projected mesh vertices in pixels, or None.
         faces: ``(F, 3)`` shared mesh topology; enables surface rendering.
-        vertex_depths: ``(N, V)`` camera-space depths; enables surface
-            rendering and correct draw order.
+        vertices3d: ``(N, V, 3)`` camera-space metric vertices; enables
+            surface rendering, shading normals and correct draw order.
         edges: Pairs of keypoint indices to connect.
         vertex_color: RGB color for the fallback vertex scatter.
         surface_color: Base RGB of the rendered surface.
         max_vertices: Per-person cap on scattered vertices in fallback mode.
         surface_alpha: Blend weight of the rendered surface.
+        shading: ``"diffuse"`` or ``"normal"``; see ``render_mesh_surface``.
         draw_skeleton: Also draw the joint skeleton. Off by default: over a
             solid surface it mostly adds clutter.
     """
     img_draw = img.convert("RGB")
 
-    if vertices2d is not None and faces is not None and vertex_depths is not None:
+    if vertices2d is not None and faces is not None and vertices3d is not None:
         img_draw = render_mesh_surface(
             img_draw,
             vertices2d,
-            vertex_depths,
+            vertices3d,
             faces,
             color=surface_color,
             alpha=surface_alpha,
+            shading=shading,
         )
     elif vertices2d is not None:
         verts = np.asarray(vertices2d, dtype=np.float32)

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -869,6 +869,75 @@ def draw_gaze_arrows(
     return img_draw
 
 
+# MHR-70 keypoint skeleton. Indices 0-16 follow the COCO body ordering
+# exactly, 17-22 are the feet, 23-62 are the two hands and 63-69 are extra
+# anatomical landmarks; only the body, feet and neck links are drawn, because
+# finger edges collapse into noise at whole-image scale.
+MHR70_SKELETON_EDGES: Tuple[Tuple[int, int], ...] = COCO_KEYPOINT_EDGES + (
+    (15, 17), (15, 18), (15, 19),  # left ankle to big toe, small toe, heel
+    (16, 20), (16, 21), (16, 22),  # right ankle to big toe, small toe, heel
+    (63, 5), (63, 6),              # neck to shoulders
+)
+MESH_VERTEX_COLOR: Tuple[int, int, int] = (120, 200, 255)
+
+
+def draw_mesh(
+    img: Image.Image,
+    joints2d: np.ndarray | None = None,
+    vertices2d: np.ndarray | None = None,
+    edges: Tuple[Tuple[int, int], ...] = MHR70_SKELETON_EDGES,
+    vertex_color: Tuple[int, int, int] = MESH_VERTEX_COLOR,
+    max_vertices: int = 1200,
+    vertex_alpha: float = 0.55,
+) -> Image.Image:
+    """Overlay projected body meshes and their skeletons on an image.
+
+    Deliberately renderer-free: the mesh is conveyed as a decimated scatter of
+    its projected vertices rather than a shaded surface, so visualization never
+    pulls in a rasterizer dependency.
+
+    Args:
+        img: PIL image to draw on.
+        joints2d: ``(N, K, 2)`` projected keypoints in pixels, or None.
+        vertices2d: ``(N, V, 2)`` projected mesh vertices in pixels, or None.
+        edges: Pairs of keypoint indices to connect.
+        vertex_color: RGB color for the vertex scatter.
+        max_vertices: Per-person cap on drawn vertices; the cloud is evenly
+            subsampled above this, since drawing 18k dots per person is slow
+            and reads as a solid blob anyway.
+        vertex_alpha: Blend weight of the vertex overlay.
+    """
+    img_draw = img.convert("RGB")
+
+    if vertices2d is not None:
+        verts = np.asarray(vertices2d, dtype=np.float32)
+        if verts.ndim == 2:
+            verts = verts[None, ...]
+        if verts.size:
+            overlay = img_draw.copy()
+            draw = ImageDraw.Draw(overlay)
+            img_diag = (img.width ** 2 + img.height ** 2) ** 0.5
+            radius = max(1, int(round(img_diag / 900)))
+            for person in verts:
+                if len(person) > max_vertices:
+                    step = int(np.ceil(len(person) / max_vertices))
+                    person = person[::step]
+                for x, y in person:
+                    cx, cy = float(x), float(y)
+                    draw.ellipse(
+                        [cx - radius, cy - radius, cx + radius, cy + radius],
+                        fill=vertex_color,
+                    )
+            img_draw = Image.blend(img_draw, overlay, vertex_alpha)
+
+    if joints2d is not None:
+        joints = np.asarray(joints2d, dtype=np.float32)
+        if joints.size:
+            img_draw = draw_keypoints(img_draw, joints, edges=edges)
+
+    return img_draw
+
+
 def draw_tile_grid(
     img: Image.Image,
     tile_coords: List[Tuple[int, int, int, int]],

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -879,37 +879,149 @@ MHR70_SKELETON_EDGES: Tuple[Tuple[int, int], ...] = COCO_KEYPOINT_EDGES + (
     (63, 5), (63, 6),              # neck to shoulders
 )
 MESH_VERTEX_COLOR: Tuple[int, int, int] = (120, 200, 255)
+# Neutral clay, the convention for body-mesh overlays: light enough to read
+# against dark clothing, desaturated enough not to compete with the photo.
+MESH_SURFACE_COLOR: Tuple[int, int, int] = (200, 202, 210)
+# Light direction in camera space, pointing from the scene toward the viewer
+# and slightly up-left, which is what makes limbs read as rounded.
+_MESH_LIGHT_DIR = np.array([-0.35, -0.55, -0.75], dtype=np.float32)
+
+
+def render_mesh_surface(
+    img: Image.Image,
+    vertices2d: np.ndarray,
+    vertex_depths: np.ndarray,
+    faces: np.ndarray,
+    color: Tuple[int, int, int] = MESH_SURFACE_COLOR,
+    alpha: float = 0.9,
+    ambient: float = 0.35,
+) -> Image.Image:
+    """Rasterize shaded body-mesh surfaces over an image.
+
+    A small painter's-algorithm renderer: back-facing triangles are culled,
+    the rest are sorted far-to-near and filled with Lambertian shading. This
+    keeps a real surface render available without taking on a GPU rasterizer
+    dependency such as pyrender or PyTorch3D, neither of which installs
+    cleanly everywhere LibreYOLO runs.
+
+    Args:
+        img: PIL image to draw on.
+        vertices2d: ``(N, V, 2)`` projected vertices in pixels.
+        vertex_depths: ``(N, V)`` camera-space depth per vertex, used for
+            draw ordering and for reconstructing shading normals.
+        faces: ``(F, 3)`` vertex indices, shared by every person.
+        color: Base RGB of the surface.
+        alpha: Blend weight of the rendered surface over the photo.
+        ambient: Fraction of base color present in unlit areas.
+    """
+    verts2d = np.asarray(vertices2d, dtype=np.float32)
+    depths = np.asarray(vertex_depths, dtype=np.float32)
+    faces = np.asarray(faces, dtype=np.int64)
+    if verts2d.ndim == 2:
+        verts2d = verts2d[None, ...]
+        depths = depths[None, ...]
+    if verts2d.size == 0 or faces.size == 0:
+        return img.convert("RGB")
+
+    overlay = img.convert("RGB")
+    draw = ImageDraw.Draw(overlay)
+    base = np.asarray(color, dtype=np.float32)
+    light = _MESH_LIGHT_DIR / np.linalg.norm(_MESH_LIGHT_DIR)
+
+    for person_xy, person_z in zip(verts2d, depths):
+        # Reconstruct each triangle in a pseudo-camera space: screen x/y plus
+        # true depth. Normals from this are enough for plausible shading and
+        # avoid needing the intrinsics again here.
+        tri = np.stack(
+            [
+                np.concatenate([person_xy[faces[:, i]], person_z[faces[:, i], None]], axis=1)
+                for i in range(3)
+            ],
+            axis=1,
+        )  # (F, 3, 3)
+
+        edge1 = tri[:, 1] - tri[:, 0]
+        edge2 = tri[:, 2] - tri[:, 0]
+        normals = np.cross(edge1, edge2)
+        norm_len = np.linalg.norm(normals, axis=1)
+        valid = norm_len > 1e-12
+        normals[valid] /= norm_len[valid, None]
+
+        # Screen-space winding tells us which triangles face the camera.
+        signed_area = edge1[:, 0] * edge2[:, 1] - edge1[:, 1] * edge2[:, 0]
+        front = valid & (signed_area < 0)
+        if not front.any():
+            # Winding convention differs; fall back to the other orientation
+            # rather than rendering nothing.
+            front = valid & (signed_area > 0)
+        if not front.any():
+            continue
+
+        tri_front = tri[front]
+        shade = ambient + (1.0 - ambient) * np.clip(normals[front] @ light, 0.0, 1.0)
+        colors = np.clip(base[None, :] * shade[:, None], 0, 255).astype(np.uint8)
+
+        # Painter's algorithm: farthest first, so nearer surfaces overwrite.
+        order = np.argsort(-tri_front[:, :, 2].mean(axis=1))
+        for idx in order:
+            a, b, c = tri_front[idx]
+            draw.polygon(
+                [(a[0], a[1]), (b[0], b[1]), (c[0], c[1])],
+                fill=tuple(int(v) for v in colors[idx]),
+            )
+
+    if alpha >= 1.0:
+        return overlay
+    return Image.blend(img.convert("RGB"), overlay, alpha)
 
 
 def draw_mesh(
     img: Image.Image,
     joints2d: np.ndarray | None = None,
     vertices2d: np.ndarray | None = None,
+    faces: np.ndarray | None = None,
+    vertex_depths: np.ndarray | None = None,
     edges: Tuple[Tuple[int, int], ...] = MHR70_SKELETON_EDGES,
     vertex_color: Tuple[int, int, int] = MESH_VERTEX_COLOR,
+    surface_color: Tuple[int, int, int] = MESH_SURFACE_COLOR,
     max_vertices: int = 1200,
-    vertex_alpha: float = 0.55,
+    surface_alpha: float = 0.9,
+    draw_skeleton: bool = False,
 ) -> Image.Image:
-    """Overlay projected body meshes and their skeletons on an image.
+    """Overlay body meshes on an image.
 
-    Deliberately renderer-free: the mesh is conveyed as a decimated scatter of
-    its projected vertices rather than a shaded surface, so visualization never
-    pulls in a rasterizer dependency.
+    Renders a shaded surface when the topology and depths are available, which
+    is what a body mesh is meant to look like. Falls back to a decimated vertex
+    scatter when only projected points are on hand, so a parameters-only result
+    still shows something.
 
     Args:
         img: PIL image to draw on.
         joints2d: ``(N, K, 2)`` projected keypoints in pixels, or None.
         vertices2d: ``(N, V, 2)`` projected mesh vertices in pixels, or None.
+        faces: ``(F, 3)`` shared mesh topology; enables surface rendering.
+        vertex_depths: ``(N, V)`` camera-space depths; enables surface
+            rendering and correct draw order.
         edges: Pairs of keypoint indices to connect.
-        vertex_color: RGB color for the vertex scatter.
-        max_vertices: Per-person cap on drawn vertices; the cloud is evenly
-            subsampled above this, since drawing 18k dots per person is slow
-            and reads as a solid blob anyway.
-        vertex_alpha: Blend weight of the vertex overlay.
+        vertex_color: RGB color for the fallback vertex scatter.
+        surface_color: Base RGB of the rendered surface.
+        max_vertices: Per-person cap on scattered vertices in fallback mode.
+        surface_alpha: Blend weight of the rendered surface.
+        draw_skeleton: Also draw the joint skeleton. Off by default: over a
+            solid surface it mostly adds clutter.
     """
     img_draw = img.convert("RGB")
 
-    if vertices2d is not None:
+    if vertices2d is not None and faces is not None and vertex_depths is not None:
+        img_draw = render_mesh_surface(
+            img_draw,
+            vertices2d,
+            vertex_depths,
+            faces,
+            color=surface_color,
+            alpha=surface_alpha,
+        )
+    elif vertices2d is not None:
         verts = np.asarray(vertices2d, dtype=np.float32)
         if verts.ndim == 2:
             verts = verts[None, ...]
@@ -928,9 +1040,9 @@ def draw_mesh(
                         [cx - radius, cy - radius, cx + radius, cy + radius],
                         fill=vertex_color,
                     )
-            img_draw = Image.blend(img_draw, overlay, vertex_alpha)
+            img_draw = Image.blend(img_draw, overlay, 0.55)
 
-    if joints2d is not None:
+    if draw_skeleton and joints2d is not None:
         joints = np.asarray(joints2d, dtype=np.float32)
         if joints.size:
             img_draw = draw_keypoints(img_draw, joints, edges=edges)

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -1012,6 +1012,177 @@ class Gaze(_TensorPayload):
         )
 
 
+class Meshes:
+    """Parametric human body meshes for a single image.
+
+    Rows are aligned with the parent ``Results.boxes`` (person boxes), the same
+    contract ``Keypoints`` follows for the pose task: row ``i`` of every tensor
+    here describes the person in box ``i``.
+
+    Everything is expressed in the camera frame of the original image.
+    ``transl`` is metric (meters) with +z pointing away from the camera;
+    ``vertices`` and ``joints3d`` are metric and already include ``transl``;
+    ``joints2d`` is in pixels on the original image canvas, not on the crop the
+    network actually saw. A world/gravity frame is deliberately absent in this
+    version, so no field here silently means "world".
+
+    Parameter layouts differ between body models, so nothing about the shapes
+    is hard-coded: ``body_model`` names the parameterization and the counts are
+    read back from the tensors. For ``"mhr"`` (Momentum Human Rig), rotations
+    are Euler angles in radians rather than axis-angle, ``body_pose`` is a flat
+    per-joint parameter vector rather than one triplet per joint (rig joints
+    carry different degrees of freedom), and ``betas`` are identity blendshape
+    coefficients. Model-specific extras such as skeleton scale, hand pose and
+    facial expression live in ``extras``.
+    """
+
+    def __init__(
+        self,
+        global_orient: TensorLike,
+        body_pose: TensorLike,
+        betas: TensorLike,
+        transl: TensorLike,
+        *,
+        body_model: str,
+        vertices: TensorLike | None = None,
+        faces: TensorLike | None = None,
+        joints3d: TensorLike | None = None,
+        joints2d: TensorLike | None = None,
+        conf: TensorLike | None = None,
+        focal_length: TensorLike | None = None,
+        extras: Optional[Dict[str, TensorLike]] = None,
+        orig_shape: Tuple[int, int] | None = None,
+    ):
+        self.global_orient = global_orient
+        self.body_pose = body_pose
+        self.betas = betas
+        self.transl = transl
+        self.body_model = str(body_model)
+        self.vertices = vertices
+        # Topology is shared by every person in the image, so it is stored once
+        # and never sliced per row.
+        self.faces = faces
+        self.joints3d = joints3d
+        self.joints2d = joints2d
+        self.conf = conf
+        self.focal_length = focal_length
+        self.extras = dict(extras) if extras else {}
+        self.orig_shape = orig_shape
+
+    # Per-row tensors, in the order they are rebuilt by _rebuild().
+    _ROW_FIELDS = (
+        "global_orient",
+        "body_pose",
+        "betas",
+        "transl",
+        "vertices",
+        "joints3d",
+        "joints2d",
+        "conf",
+        "focal_length",
+    )
+
+    def _rebuild(self, fn, shared_fn=None) -> "Meshes":
+        """Rebuild with ``fn`` over per-row tensors.
+
+        ``shared_fn`` handles the shared face topology; it follows ``fn`` for
+        device and dtype moves but is the identity for row slicing, where
+        selecting a person must not touch the mesh connectivity.
+        """
+        if shared_fn is None:
+            shared_fn = fn
+        values = {name: fn(getattr(self, name)) for name in self._ROW_FIELDS}
+        return Meshes(
+            values.pop("global_orient"),
+            values.pop("body_pose"),
+            values.pop("betas"),
+            values.pop("transl"),
+            body_model=self.body_model,
+            faces=shared_fn(self.faces),
+            extras={k: fn(v) for k, v in self.extras.items()},
+            orig_shape=self.orig_shape,
+            **values,
+        )
+
+    @property
+    def num_vertices(self) -> int:
+        return 0 if self.vertices is None else int(self.vertices.shape[1])
+
+    @property
+    def num_joints(self) -> int:
+        return 0 if self.joints3d is None else int(self.joints3d.shape[1])
+
+    @property
+    def num_betas(self) -> int:
+        return int(self.betas.shape[-1])
+
+    @property
+    def has_vertices(self) -> bool:
+        return self.vertices is not None
+
+    @property
+    def params(self) -> Dict[str, TensorLike]:
+        """The parametric core, shaped to splat into a body-model forward."""
+        core = {
+            "global_orient": self.global_orient,
+            "body_pose": self.body_pose,
+            "betas": self.betas,
+            "transl": self.transl,
+        }
+        core.update(self.extras)
+        return core
+
+    def save_obj(self, path: str | Path, index: int = 0) -> None:
+        """Write one person's mesh to a Wavefront OBJ file."""
+        if self.vertices is None or self.faces is None:
+            raise ValueError(
+                "This result carries no mesh geometry, only parameters, so it "
+                "cannot be written as OBJ."
+            )
+        if not 0 <= index < len(self):
+            raise IndexError(
+                f"index {index} is out of range for {len(self)} mesh(es)"
+            )
+        verts = np.asarray(_numpy(self.vertices))[index]
+        faces = np.asarray(_numpy(self.faces))
+
+        path = Path(path)
+        if path.parent and path.parent != Path("."):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(f"# LibreYOLO body mesh ({self.body_model})\n")
+            for v in verts:
+                fh.write(f"v {float(v[0]):.6f} {float(v[1]):.6f} {float(v[2]):.6f}\n")
+            # OBJ vertex indices are 1-based.
+            for f in faces:
+                fh.write(f"f {int(f[0]) + 1} {int(f[1]) + 1} {int(f[2]) + 1}\n")
+
+    def to(self, *args, **kwargs) -> "Meshes":
+        return self._rebuild(lambda d: _move(d, *args, **kwargs))
+
+    def cpu(self) -> "Meshes":
+        return self._rebuild(_cpu)
+
+    def cuda(self) -> "Meshes":
+        return self._rebuild(_cuda)
+
+    def numpy(self) -> "Meshes":
+        return self._rebuild(_numpy)
+
+    def __getitem__(self, idx) -> "Meshes":
+        return self._rebuild(lambda d: _slice_first(d, idx), shared_fn=lambda d: d)
+
+    def __len__(self) -> int:
+        return int(self.global_orient.shape[0])
+
+    def __repr__(self) -> str:
+        return (
+            f"Meshes(n={len(self)}, body_model='{self.body_model}', "
+            f"betas={self.num_betas}, vertices={self.num_vertices}, "
+            f"joints={self.num_joints}, orig_shape={self.orig_shape})"
+        )
+
+
 class Results:
     """Single-image result with flat detection/segmentation slots."""
 
@@ -1029,6 +1200,7 @@ class Results:
         "restored",
         "matte",
         "ocr",
+        "meshes",
     )
 
     def __init__(
@@ -1055,6 +1227,7 @@ class Results:
         matte: Optional[Matte] = None,
         ocr: Optional[OCRRegions] = None,
         restore_scale: int = 1,
+        meshes: Optional[Meshes] = None,
     ):
         if boxes is not None and boxes.orig_shape is None:
             boxes = boxes.with_orig_shape(orig_shape)
@@ -1084,6 +1257,7 @@ class Results:
         self.restored = restored
         self.matte = matte
         self.ocr = ocr
+        self.meshes = meshes
         # Integer upscale factor of a restore/super-resolution result: the
         # restored canvas is ``restore_scale`` times the input. 1 for
         # deblur/denoise and every non-restore task.
@@ -1113,6 +1287,7 @@ class Results:
             "restored": self.restored,
             "matte": self.matte,
             "ocr": self.ocr,
+            "meshes": self.meshes,
             "restore_scale": self.restore_scale,
             "speed": dict(self.speed),
             "track_id": self.track_id,
@@ -1175,6 +1350,7 @@ class Results:
         matte: Optional[Matte] = None,
         ocr: Optional[OCRRegions] = None,
         restore_scale: Optional[int] = None,
+        meshes: Optional[Meshes] = None,
     ) -> "Results":
         if boxes is not None:
             self.boxes = boxes.with_orig_shape(self.orig_shape)
@@ -1198,6 +1374,8 @@ class Results:
             self.depth_map = depth_map
         if restored is not None:
             self.restored = restored
+        if meshes is not None:
+            self.meshes = meshes
         if matte is not None:
             self.matte = matte if matte.orig_shape is not None else Matte(matte.data, self.orig_shape)
         if ocr is not None:
@@ -1395,6 +1573,9 @@ class Results:
         obb_np = None
         if self.obb is not None:
             obb_np = self.obb.numpy() if isinstance(self.obb.data, torch.Tensor) else self.obb
+        # Converted once rather than per row: mesh payloads carry vertex arrays
+        # large enough that repeating the conversion per person is wasteful.
+        meshes_np = self.meshes.numpy() if self.meshes is not None else None
         track_ids = _numpy(self.track_id)
         rows = []
         for i in range(len(boxes_np)):
@@ -1448,6 +1629,36 @@ class Results:
                     "pitch_deg": round(float(gaze_np.data[i, 0]) * 180.0 / math.pi, decimals),
                     "yaw_deg": round(float(gaze_np.data[i, 1]) * 180.0 / math.pi, decimals),
                 }
+            if meshes_np is not None and i < len(meshes_np):
+                # Vertices are deliberately omitted: tens of thousands of
+                # coordinates per person is not something to hand back as JSON.
+                # Use ``result.meshes.vertices`` or ``save_obj`` for geometry.
+                mesh_row = {
+                    "body_model": meshes_np.body_model,
+                    "global_orient": [
+                        round(float(v), decimals) for v in meshes_np.global_orient[i]
+                    ],
+                    "transl": [round(float(v), decimals) for v in meshes_np.transl[i]],
+                    "betas": [round(float(v), decimals) for v in meshes_np.betas[i]],
+                    "num_vertices": meshes_np.num_vertices,
+                }
+                if meshes_np.conf is not None:
+                    mesh_row["confidence"] = round(float(meshes_np.conf[i]), decimals)
+                if meshes_np.focal_length is not None:
+                    mesh_row["focal_length"] = round(
+                        float(np.asarray(meshes_np.focal_length[i]).reshape(-1)[0]),
+                        decimals,
+                    )
+                if meshes_np.joints2d is not None:
+                    joints2d = meshes_np.joints2d[i]
+                    if normalize:
+                        h, w = self.orig_shape
+                        joints2d = joints2d / np.array([w, h], dtype=float)
+                    mesh_row["joints2d"] = {
+                        "x": [round(float(x), decimals) for x in joints2d[:, 0]],
+                        "y": [round(float(y), decimals) for y in joints2d[:, 1]],
+                    }
+                row["mesh"] = mesh_row
             if track_ids is not None:
                 row["track_id"] = int(track_ids[i])
             rows.append(row)
@@ -1475,6 +1686,8 @@ class Results:
             return 1
         if self.ocr is not None:
             return len(self.ocr)
+        if self.meshes is not None:
+            return len(self.meshes)
         return 0
 
     def __repr__(self) -> str:
@@ -1501,6 +1714,8 @@ class Results:
             parts.append(f"matte={self.matte}")
         if self.ocr is not None:
             parts.append(f"ocr={self.ocr}")
+        if self.meshes is not None:
+            parts.append(f"meshes={self.meshes}")
         if self.track_id is not None:
             parts.append(f"track_ids={len(self.track_id)}")
         if self.frame_idx is not None:

--- a/libreyolo/validation/mesh_metrics.py
+++ b/libreyolo/validation/mesh_metrics.py
@@ -1,0 +1,174 @@
+"""Metrics for human body mesh recovery.
+
+The field reports three numbers, all in millimeters and all lower-is-better:
+
+* **MPJPE**, mean per-joint position error after aligning the root joint.
+  Measures pose accuracy while ignoring where the person is in the scene.
+* **PA-MPJPE** (also written MPJPE-PA or "reconstruction error"), the same
+  quantity after a full Procrustes alignment (rotation, uniform scale and
+  translation). Removes global orientation and body-size error, isolating the
+  articulated pose itself.
+* **PVE** (also called MPVPE), mean per-vertex position error after root
+  alignment, which unlike the joint metrics is sensitive to body shape.
+
+Kept as free functions rather than folded into a validator class so the math
+can be tested directly against hand-computed cases.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def _root_align(
+    points: torch.Tensor, root_index: int | None, root: Optional[torch.Tensor]
+) -> torch.Tensor:
+    if root is not None:
+        return points - root[:, None, :]
+    if root_index is None:
+        return points - points.mean(dim=1, keepdim=True)
+    return points - points[:, root_index : root_index + 1, :]
+
+
+def mpjpe(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    root_index: int | None = 0,
+    mask: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Mean per-joint position error after root alignment.
+
+    Args:
+        pred: ``(N, J, 3)`` predicted joints.
+        target: ``(N, J, 3)`` ground-truth joints, same units as ``pred``.
+        root_index: Joint index to align on. ``None`` centers on the centroid.
+        mask: Optional ``(N, J)`` boolean mask of valid joints.
+
+    Returns:
+        Scalar tensor: the mean error over all valid joints.
+    """
+    _check_pair(pred, target)
+    pred = _root_align(pred, root_index, None)
+    target = _root_align(target, root_index, None)
+    error = torch.linalg.norm(pred - target, dim=-1)
+    return _masked_mean(error, mask)
+
+
+def pve(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    root: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Mean per-vertex position error after root alignment.
+
+    Args:
+        pred: ``(N, V, 3)`` predicted vertices.
+        target: ``(N, V, 3)`` ground-truth vertices.
+        root: Optional ``(N, 3)`` alignment point per sample. Defaults to the
+            vertex centroid, since a mesh has no canonical root vertex.
+    """
+    _check_pair(pred, target)
+    pred = _root_align(pred, None, root)
+    target = _root_align(target, None, root)
+    return torch.linalg.norm(pred - target, dim=-1).mean()
+
+
+def procrustes_align(
+    pred: torch.Tensor, target: torch.Tensor
+) -> torch.Tensor:
+    """Similarity-align ``pred`` onto ``target`` per sample.
+
+    Solves the orthogonal Procrustes problem for rotation, uniform scale and
+    translation (the classic Umeyama solution) and returns the transformed
+    prediction. Reflections are excluded: a mirrored body is a different pose,
+    not an aligned one, so the sign of the smallest singular value is flipped
+    when the naive solution would reflect.
+
+    Args:
+        pred: ``(N, P, 3)`` points to align.
+        target: ``(N, P, 3)`` reference points.
+    """
+    _check_pair(pred, target)
+    # Solved in double precision: the SVD of a near-degenerate configuration
+    # is where this silently loses accuracy in float32.
+    pred64, target64 = pred.double(), target.double()
+
+    pred_mean = pred64.mean(dim=1, keepdim=True)
+    target_mean = target64.mean(dim=1, keepdim=True)
+    pred_c = pred64 - pred_mean
+    target_c = target64 - target_mean
+
+    variance = (pred_c**2).sum(dim=(1, 2), keepdim=True)
+    covariance = pred_c.transpose(1, 2) @ target_c
+    u, s, vh = torch.linalg.svd(covariance)
+
+    # Force a proper rotation (det = +1) rather than a reflection.
+    det = torch.linalg.det(u @ vh)
+    sign = torch.ones_like(s)
+    sign[:, -1] = torch.sign(det)
+    rotation = (u * sign[:, None, :]) @ vh
+    trace = (s * sign).sum(dim=1).reshape(-1, 1, 1)
+
+    scale = trace / variance.clamp(min=1e-12)
+    aligned = scale * (pred_c @ rotation) + target_mean
+    return aligned.to(pred.dtype)
+
+
+def pa_mpjpe(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    mask: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Mean per-joint position error after full Procrustes alignment."""
+    aligned = procrustes_align(pred, target)
+    error = torch.linalg.norm(aligned - target, dim=-1)
+    return _masked_mean(error, mask)
+
+
+def _check_pair(pred: torch.Tensor, target: torch.Tensor) -> None:
+    if pred.shape != target.shape:
+        raise ValueError(
+            f"prediction and target must match, got {tuple(pred.shape)} "
+            f"and {tuple(target.shape)}"
+        )
+    if pred.ndim != 3 or pred.shape[-1] != 3:
+        raise ValueError(
+            f"expected (N, P, 3) point sets, got {tuple(pred.shape)}"
+        )
+
+
+def _masked_mean(error: torch.Tensor, mask: Optional[torch.Tensor]) -> torch.Tensor:
+    if mask is None:
+        return error.mean()
+    mask = mask.to(error.dtype)
+    total = mask.sum()
+    if total == 0:
+        return torch.zeros((), dtype=error.dtype, device=error.device)
+    return (error * mask).sum() / total
+
+
+def mesh_metrics(
+    pred_joints: torch.Tensor,
+    target_joints: torch.Tensor,
+    pred_vertices: Optional[torch.Tensor] = None,
+    target_vertices: Optional[torch.Tensor] = None,
+    root_index: int | None = 0,
+    mask: Optional[torch.Tensor] = None,
+    scale_to_mm: float = 1000.0,
+) -> dict:
+    """Compute the standard mesh-recovery metric set.
+
+    Inputs are assumed metric (meters); ``scale_to_mm`` converts to the
+    millimeters the literature reports in.
+    """
+    metrics = {
+        "metrics/mpjpe": float(mpjpe(pred_joints, target_joints, root_index, mask))
+        * scale_to_mm,
+        "metrics/pa_mpjpe": float(pa_mpjpe(pred_joints, target_joints, mask))
+        * scale_to_mm,
+    }
+    if pred_vertices is not None and target_vertices is not None:
+        metrics["metrics/pve"] = float(pve(pred_vertices, target_vertices)) * scale_to_mm
+    return metrics

--- a/tests/unit/test_mesh_task.py
+++ b/tests/unit/test_mesh_task.py
@@ -522,9 +522,13 @@ class TestSurfaceRenderer:
             [[[16.0, 16.0], [48.0, 16.0], [48.0, 48.0], [16.0, 48.0]]],
             dtype=np.float32,
         )
-        depths = np.full((1, 4), 5.0, dtype=np.float32)
+        # Camera-space metres, tilted so the face normal is not degenerate.
+        verts3d = np.array(
+            [[[-0.2, -0.2, 5.0], [0.2, -0.2, 5.0], [0.2, 0.2, 5.2], [-0.2, 0.2, 5.2]]],
+            dtype=np.float32,
+        )
         faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
-        return verts2d, depths, faces
+        return verts2d, verts3d, faces
 
     def test_renders_a_visible_surface(self):
         from PIL import Image
@@ -532,8 +536,8 @@ class TestSurfaceRenderer:
         from libreyolo.utils.drawing import render_mesh_surface
 
         img = Image.new("RGB", (64, 64), (0, 0, 0))
-        verts2d, depths, faces = self._quad()
-        out = render_mesh_surface(img, verts2d, depths, faces, alpha=1.0)
+        verts2d, verts3d, faces = self._quad()
+        out = render_mesh_surface(img, verts2d, verts3d, faces, alpha=1.0)
         arr = np.asarray(out)
         # The middle of the quad must be painted, the corner must not.
         assert arr[32, 32].sum() > 0
@@ -546,11 +550,11 @@ class TestSurfaceRenderer:
         from libreyolo.utils.drawing import render_mesh_surface
 
         img = Image.new("RGB", (64, 64), (0, 0, 0))
-        verts2d, depths, faces = self._quad()
-        forward = np.asarray(render_mesh_surface(img, verts2d, depths, faces, alpha=1.0))
+        verts2d, verts3d, faces = self._quad()
+        forward = np.asarray(render_mesh_surface(img, verts2d, verts3d, faces, alpha=1.0))
         reversed_faces = faces[:, ::-1].copy()
         backward = np.asarray(
-            render_mesh_surface(img, verts2d, depths, reversed_faces, alpha=1.0)
+            render_mesh_surface(img, verts2d, verts3d, reversed_faces, alpha=1.0)
         )
         assert forward[32, 32].sum() > 0
         assert backward[32, 32].sum() > 0
@@ -563,9 +567,10 @@ class TestSurfaceRenderer:
         img = Image.new("RGB", (64, 64), (0, 0, 0))
         # Two overlapping people at different depths; the near one wins.
         verts2d = np.repeat(self._quad()[0], 2, axis=0)
+        base3d = self._quad()[1]
         faces = self._quad()[2]
-        far = np.full((1, 4), 20.0, dtype=np.float32)
-        near = np.full((1, 4), 2.0, dtype=np.float32)
+        far = base3d + np.array([0.0, 0.0, 15.0], dtype=np.float32)
+        near = base3d - np.array([0.0, 0.0, 3.0], dtype=np.float32)
         out = render_mesh_surface(
             img, verts2d, np.concatenate([far, near]), faces, alpha=1.0
         )
@@ -577,9 +582,9 @@ class TestSurfaceRenderer:
         from libreyolo.utils.drawing import render_mesh_surface
 
         img = Image.new("RGB", (64, 64), (0, 0, 0))
-        verts2d, depths, faces = self._quad()
-        opaque = np.asarray(render_mesh_surface(img, verts2d, depths, faces, alpha=1.0))
-        blended = np.asarray(render_mesh_surface(img, verts2d, depths, faces, alpha=0.5))
+        verts2d, verts3d, faces = self._quad()
+        opaque = np.asarray(render_mesh_surface(img, verts2d, verts3d, faces, alpha=1.0))
+        blended = np.asarray(render_mesh_surface(img, verts2d, verts3d, faces, alpha=0.5))
         assert blended[32, 32].sum() < opaque[32, 32].sum()
 
     def test_empty_geometry_is_a_no_op(self):
@@ -589,7 +594,8 @@ class TestSurfaceRenderer:
 
         img = Image.new("RGB", (32, 32))
         out = render_mesh_surface(
-            img, np.zeros((0, 0, 2)), np.zeros((0, 0)), np.zeros((0, 3), dtype=np.int64)
+            img, np.zeros((0, 0, 2)), np.zeros((0, 0, 3)),
+            np.zeros((0, 3), dtype=np.int64)
         )
         assert out.size == img.size
 
@@ -599,9 +605,9 @@ class TestSurfaceRenderer:
         from libreyolo.utils.drawing import draw_mesh
 
         img = Image.new("RGB", (64, 64), (0, 0, 0))
-        verts2d, depths, faces = self._quad()
+        verts2d, verts3d, faces = self._quad()
         surface = np.asarray(
-            draw_mesh(img, vertices2d=verts2d, faces=faces, vertex_depths=depths,
+            draw_mesh(img, vertices2d=verts2d, faces=faces, vertices3d=verts3d,
                       surface_alpha=1.0)
         )
         scatter = np.asarray(draw_mesh(img, vertices2d=verts2d))

--- a/tests/unit/test_mesh_task.py
+++ b/tests/unit/test_mesh_task.py
@@ -1,0 +1,512 @@
+"""Unit tests for the body-mesh task contract.
+
+Everything here runs on fabricated payloads: the task plumbing, the result
+container, the camera conversions and the metrics are all exercised without a
+trained model, so they stay meaningful regardless of which mesh families ship.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.models.sam3dbody.camera import (
+    crop_cam_to_full_image,
+    default_focal_length,
+    perspective_project,
+)
+from libreyolo.tasks import (
+    TASKS,
+    detect_task_suffix,
+    normalize_task,
+    resolve_task,
+    task_to_suffix,
+)
+from libreyolo.utils.results import Boxes, Meshes, Results
+from libreyolo.validation.mesh_metrics import (
+    mesh_metrics,
+    mpjpe,
+    pa_mpjpe,
+    procrustes_align,
+    pve,
+)
+
+
+pytestmark = pytest.mark.unit
+
+N_BETAS = 45
+N_BODY_POSE = 130
+
+
+def make_meshes(n: int = 2, with_geometry: bool = True) -> Meshes:
+    """Build a fabricated mesh payload shaped like an MHR prediction."""
+    geometry = {}
+    if with_geometry:
+        geometry = {
+            "vertices": torch.randn(n, 64, 3),
+            "faces": torch.randint(0, 64, (30, 3)),
+            "joints3d": torch.randn(n, 70, 3),
+            "joints2d": torch.rand(n, 70, 2) * 100,
+        }
+    return Meshes(
+        torch.randn(n, 3),
+        torch.randn(n, N_BODY_POSE),
+        torch.randn(n, N_BETAS),
+        torch.randn(n, 3),
+        body_model="mhr",
+        conf=torch.rand(n),
+        focal_length=torch.full((n,), 1400.0),
+        extras={"scale": torch.randn(n, 28)},
+        orig_shape=(200, 300),
+        **geometry,
+    )
+
+
+def make_results(n: int = 2) -> Results:
+    boxes = Boxes(torch.rand(n, 4) * 100, torch.rand(n), torch.zeros(n))
+    return Results(
+        boxes=boxes,
+        orig_shape=(200, 300),
+        names={0: "person"},
+        meshes=make_meshes(n),
+    )
+
+
+class TestTaskRegistration:
+    def test_mesh_is_a_task(self):
+        assert "mesh" in TASKS
+
+    @pytest.mark.parametrize(
+        "alias", ["mesh", "body-mesh", "body_mesh", "hmr", "human-mesh-recovery"]
+    )
+    def test_aliases_normalize(self, alias):
+        assert normalize_task(alias) == "mesh"
+
+    def test_suffix_roundtrip(self):
+        assert task_to_suffix("mesh") == "mesh"
+        assert detect_task_suffix("LibreSAM3DBodyd3-mesh.pt") == "mesh"
+
+    def test_detect_suffix_ignores_unrelated_names(self):
+        assert detect_task_suffix("LibreYOLO9s.pt") is None
+
+    def test_resolve_task_precedence(self):
+        # Explicit task beats the filename.
+        assert (
+            resolve_task(
+                explicit_task="mesh",
+                filename_task="pose",
+                supported_tasks=("mesh", "pose"),
+            )
+            == "mesh"
+        )
+        # Checkpoint metadata beats the filename.
+        assert (
+            resolve_task(
+                checkpoint_task="mesh",
+                filename_task="detect",
+                supported_tasks=("mesh", "detect"),
+            )
+            == "mesh"
+        )
+
+    def test_unsupported_task_rejected(self):
+        with pytest.raises(ValueError, match="not supported"):
+            resolve_task(explicit_task="mesh", supported_tasks=("detect",))
+
+    def test_smpl_is_not_silently_aliased(self):
+        # Nothing shipped here is SMPL, and quietly accepting the name would
+        # imply an interoperability the payload does not provide.
+        with pytest.raises(ValueError):
+            normalize_task("smpl")
+
+
+class TestMeshesPayload:
+    def test_shapes_and_counts(self):
+        m = make_meshes(3)
+        assert len(m) == 3
+        assert m.num_betas == N_BETAS
+        assert m.num_vertices == 64
+        assert m.num_joints == 70
+        assert m.body_model == "mhr"
+        assert m.has_vertices
+
+    def test_params_bundle_includes_extras(self):
+        params = make_meshes().params
+        assert {"global_orient", "body_pose", "betas", "transl"} <= set(params)
+        assert "scale" in params
+
+    def test_slicing_selects_one_person_but_keeps_topology(self):
+        m = make_meshes(3)
+        one = m[0]
+        assert len(one) == 1
+        assert one.global_orient.shape == (1, 3)
+        assert one.joints2d.shape == (1, 70, 2)
+        # Face connectivity is shared by everyone in the image and must not be
+        # sliced along with the per-person rows.
+        assert one.faces.shape == m.faces.shape
+        assert one.extras["scale"].shape == (1, 28)
+
+    def test_device_and_dtype_moves_cover_topology(self):
+        m = make_meshes(2).numpy()
+        assert isinstance(m.vertices, np.ndarray)
+        assert isinstance(m.faces, np.ndarray)
+        assert isinstance(m.extras["scale"], np.ndarray)
+
+    def test_cpu_roundtrip_preserves_values(self):
+        m = make_meshes(2)
+        assert torch.allclose(m.cpu().betas, m.betas)
+
+    def test_parameters_only_payload_is_valid(self):
+        # A model may emit parameters without decoding geometry; that must
+        # remain representable rather than forcing empty vertex arrays.
+        m = make_meshes(2, with_geometry=False)
+        assert not m.has_vertices
+        assert m.num_vertices == 0
+        assert len(m) == 2
+
+    def test_save_obj_writes_valid_wavefront(self, tmp_path):
+        m = make_meshes(2)
+        out = tmp_path / "person.obj"
+        m.save_obj(out, index=1)
+        lines = out.read_text(encoding="utf-8").splitlines()
+        assert sum(1 for line in lines if line.startswith("v ")) == 64
+        assert sum(1 for line in lines if line.startswith("f ")) == 30
+        # OBJ indices are 1-based, so no face may reference vertex 0.
+        for line in lines:
+            if line.startswith("f "):
+                assert all(int(i) >= 1 for i in line.split()[1:])
+
+    def test_save_obj_without_geometry_is_a_clear_error(self, tmp_path):
+        m = make_meshes(1, with_geometry=False)
+        with pytest.raises(ValueError, match="no mesh geometry"):
+            m.save_obj(tmp_path / "x.obj")
+
+    def test_save_obj_rejects_out_of_range_index(self, tmp_path):
+        with pytest.raises(IndexError):
+            make_meshes(2).save_obj(tmp_path / "x.obj", index=5)
+
+
+class TestResultsIntegration:
+    def test_results_carries_meshes(self):
+        r = make_results(2)
+        assert r.meshes is not None
+        assert len(r) == 2
+
+    def test_results_slicing_keeps_rows_aligned(self):
+        r = make_results(3)
+        one = r[1]
+        assert len(one.boxes) == 1
+        assert len(one.meshes) == 1
+
+    def test_summary_reports_parameters_but_not_vertices(self):
+        row = make_results(2).summary()[0]
+        assert "mesh" in row
+        mesh_row = row["mesh"]
+        assert mesh_row["body_model"] == "mhr"
+        assert len(mesh_row["global_orient"]) == 3
+        assert len(mesh_row["betas"]) == N_BETAS
+        assert mesh_row["num_vertices"] == 64
+        # Tens of thousands of coordinates per person do not belong in JSON.
+        assert "vertices" not in mesh_row
+
+    def test_summary_normalizes_joints(self):
+        r = make_results(1)
+        raw = r.summary()[0]["mesh"]["joints2d"]
+        norm = r.summary(normalize=True)[0]["mesh"]["joints2d"]
+        assert max(norm["x"]) <= 1.0
+        assert max(raw["x"]) > 1.0
+
+    def test_to_json_serializes(self):
+        import json
+
+        parsed = json.loads(make_results(2).to_json())
+        assert parsed[0]["mesh"]["body_model"] == "mhr"
+
+    def test_repr_mentions_meshes(self):
+        assert "meshes=" in repr(make_results(1))
+
+
+class TestWrapResults:
+    def _wrap(self, payload):
+        from libreyolo.models.base.inference import _build_meshes
+
+        return _build_meshes(payload, (200, 300))
+
+    def test_builds_from_minimal_payload(self):
+        m = self._wrap(
+            {
+                "body_model": "mhr",
+                "global_orient": np.zeros((2, 3), dtype=np.float32),
+                "body_pose": np.zeros((2, N_BODY_POSE), dtype=np.float32),
+                "betas": np.zeros((2, N_BETAS), dtype=np.float32),
+                "transl": np.zeros((2, 3), dtype=np.float32),
+            }
+        )
+        assert len(m) == 2
+        assert m.orig_shape == (200, 300)
+
+    def test_missing_parameters_are_rejected(self):
+        with pytest.raises(ValueError, match="missing"):
+            self._wrap({"body_model": "mhr", "global_orient": np.zeros((1, 3))})
+
+    def test_missing_body_model_is_rejected(self):
+        with pytest.raises(ValueError, match="body_model"):
+            self._wrap(
+                {
+                    "global_orient": np.zeros((1, 3)),
+                    "body_pose": np.zeros((1, N_BODY_POSE)),
+                    "betas": np.zeros((1, N_BETAS)),
+                    "transl": np.zeros((1, 3)),
+                }
+            )
+
+    def test_full_wrap_pairs_meshes_with_person_boxes(self):
+        """The runner must return meshes row-aligned with their boxes."""
+        from libreyolo.models.base.inference import InferenceRunner
+
+        class DummyModel:
+            names = {0: "person"}
+            task = "mesh"
+
+        runner = InferenceRunner(DummyModel())
+        result = runner._wrap_results(
+            {
+                "boxes": np.array([[10.0, 10.0, 50.0, 90.0], [60.0, 5.0, 95.0, 99.0]]),
+                "scores": np.array([0.9, 0.8]),
+                "classes": np.array([0.0, 0.0]),
+                "meshes": {
+                    "body_model": "mhr",
+                    "global_orient": np.zeros((2, 3), dtype=np.float32),
+                    "body_pose": np.zeros((2, N_BODY_POSE), dtype=np.float32),
+                    "betas": np.zeros((2, N_BETAS), dtype=np.float32),
+                    "transl": np.zeros((2, 3), dtype=np.float32),
+                },
+            },
+            (300, 200),
+            None,
+            None,
+        )
+        assert result.meshes is not None
+        assert len(result.boxes) == len(result.meshes) == 2
+        assert result.orig_shape == (200, 300)
+        assert result.names == {0: "person"}
+
+    def test_wrap_without_boxes_still_returns_meshes(self):
+        from libreyolo.models.base.inference import InferenceRunner
+
+        class DummyModel:
+            names = {0: "person"}
+            task = "mesh"
+
+        result = InferenceRunner(DummyModel())._wrap_results(
+            {
+                "meshes": {
+                    "body_model": "mhr",
+                    "global_orient": np.zeros((1, 3), dtype=np.float32),
+                    "body_pose": np.zeros((1, N_BODY_POSE), dtype=np.float32),
+                    "betas": np.zeros((1, N_BETAS), dtype=np.float32),
+                    "transl": np.zeros((1, 3), dtype=np.float32),
+                }
+            },
+            (300, 200),
+            None,
+            None,
+        )
+        assert result.boxes is None
+        assert len(result.meshes) == 1
+
+    def test_unknown_keys_are_kept_as_extras(self):
+        m = self._wrap(
+            {
+                "body_model": "mhr",
+                "global_orient": np.zeros((1, 3)),
+                "body_pose": np.zeros((1, N_BODY_POSE)),
+                "betas": np.zeros((1, N_BETAS)),
+                "transl": np.zeros((1, 3)),
+                "hand_pose": np.zeros((1, 108)),
+            }
+        )
+        assert "hand_pose" in m.extras
+
+
+class TestCamera:
+    def test_center_point_projects_to_principal_point(self):
+        pixels = perspective_project(
+            torch.tensor([[[0.0, 0.0, 5.0]]]), 1000.0, image_size=(480, 640)
+        )
+        assert torch.allclose(pixels.flatten(), torch.tensor([320.0, 240.0]))
+
+    def test_known_offset(self):
+        # x = 1 m at z = 5 m with f = 1000 px lands 200 px right of center.
+        pixels = perspective_project(
+            torch.tensor([[[1.0, 0.0, 5.0]]]), 1000.0, image_size=(480, 640)
+        )
+        assert torch.allclose(pixels.flatten(), torch.tensor([520.0, 240.0]))
+
+    def test_translation_argument_matches_pre_adding_it(self):
+        points = torch.randn(2, 5, 3) + torch.tensor([0.0, 0.0, 6.0])
+        transl = torch.randn(2, 3) * 0.1
+        a = perspective_project(points + transl[:, None, :], 900.0, image_size=(480, 640))
+        b = perspective_project(points, 900.0, image_size=(480, 640), translation=transl)
+        assert torch.allclose(a, b, atol=1e-5)
+
+    def test_points_behind_camera_stay_finite(self):
+        pixels = perspective_project(
+            torch.tensor([[[0.1, 0.1, -2.0]]]), 1000.0, image_size=(480, 640)
+        )
+        assert torch.isfinite(pixels).all()
+
+    def test_requires_principal_point_or_image_size(self):
+        with pytest.raises(ValueError, match="principal_point or image_size"):
+            perspective_project(torch.zeros(1, 1, 3), 1000.0)
+
+    def test_rejects_wrong_rank(self):
+        with pytest.raises(ValueError, match=r"\(N, P, 3\)"):
+            perspective_project(torch.zeros(4, 3), 1000.0, image_size=(10, 10))
+
+    def test_crop_camera_depth_matches_closed_form(self):
+        # z = 2f / (box_size * scale)
+        transl = crop_cam_to_full_image(
+            torch.tensor([[1.0, 0.0, 0.0]]),
+            torch.tensor([[320.0, 240.0]]),
+            torch.tensor([200.0]),
+            (480, 640),
+            1000.0,
+        )
+        assert transl[0, 2] == pytest.approx(10.0)
+        assert transl[0, 0] == pytest.approx(0.0)
+
+    def test_off_center_box_shifts_translation(self):
+        # A box 100 px right of center at 10 m with f = 1000 sits 1 m right.
+        transl = crop_cam_to_full_image(
+            torch.tensor([[1.0, 0.0, 0.0]]),
+            torch.tensor([[420.0, 240.0]]),
+            torch.tensor([200.0]),
+            (480, 640),
+            1000.0,
+        )
+        assert transl[0, 0] == pytest.approx(1.0)
+
+    def test_default_focal_length_is_the_diagonal(self):
+        assert default_focal_length(480, 640) == pytest.approx(800.0)
+
+
+class TestMeshMetrics:
+    def test_identical_inputs_score_zero(self):
+        joints = torch.randn(4, 17, 3)
+        assert float(mpjpe(joints, joints)) == pytest.approx(0.0, abs=1e-6)
+        assert float(pa_mpjpe(joints, joints)) == pytest.approx(0.0, abs=1e-6)
+
+    def test_root_alignment_cancels_translation(self):
+        joints = torch.randn(4, 17, 3)
+        shifted = joints + torch.tensor([1.0, -2.0, 3.0])
+        assert float(mpjpe(shifted, joints)) == pytest.approx(0.0, abs=1e-5)
+
+    def test_known_error_value(self):
+        joints = torch.randn(2, 17, 3)
+        moved = joints.clone()
+        moved[:, 1:, 0] += 0.1
+        # 16 of 17 joints move by exactly 0.1 after root alignment.
+        assert float(mpjpe(moved, joints)) == pytest.approx(0.1 * 16 / 17, abs=1e-6)
+
+    def test_procrustes_removes_rotation_scale_and_translation(self):
+        joints = torch.randn(3, 17, 3)
+        angle = 0.7
+        rotation = torch.tensor(
+            [
+                [math.cos(angle), -math.sin(angle), 0.0],
+                [math.sin(angle), math.cos(angle), 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        transformed = (joints @ rotation.T) * 2.5 + torch.tensor([5.0, -3.0, 1.0])
+        assert float(pa_mpjpe(transformed, joints)) == pytest.approx(0.0, abs=1e-5)
+        # The un-aligned metric should be large, proving the test is not
+        # trivially passing because the transform did nothing.
+        assert float(mpjpe(transformed, joints)) > 1.0
+
+    def test_procrustes_does_not_align_away_a_reflection(self):
+        # A mirrored body is a different pose, so a reflection must still cost.
+        joints = torch.randn(2, 17, 3)
+        reflected = joints.clone()
+        reflected[..., 0] *= -1
+        assert float(pa_mpjpe(reflected, joints)) > 0.1
+
+    def test_procrustes_output_shape(self):
+        joints = torch.randn(2, 17, 3)
+        assert procrustes_align(joints + 1.0, joints).shape == joints.shape
+
+    def test_mask_restricts_the_average(self):
+        joints = torch.randn(2, 17, 3)
+        moved = joints.clone()
+        moved[:, 1:, 0] += 0.1
+        mask = torch.zeros(2, 17, dtype=torch.bool)
+        mask[:, 0] = True  # only the (unmoved) root counts
+        assert float(mpjpe(moved, joints, mask=mask)) == pytest.approx(0.0, abs=1e-6)
+
+    def test_empty_mask_does_not_divide_by_zero(self):
+        joints = torch.randn(1, 17, 3)
+        mask = torch.zeros(1, 17, dtype=torch.bool)
+        assert float(mpjpe(joints + 1.0, joints, mask=mask)) == 0.0
+
+    def test_pve_cancels_translation(self):
+        verts = torch.randn(2, 200, 3)
+        assert float(pve(verts + torch.tensor([1.0, 2.0, 3.0]), verts)) == pytest.approx(
+            0.0, abs=1e-5
+        )
+
+    def test_shape_mismatch_is_rejected(self):
+        with pytest.raises(ValueError, match="must match"):
+            mpjpe(torch.randn(2, 17, 3), torch.randn(2, 16, 3))
+
+    def test_metric_bundle_is_reported_in_millimeters(self):
+        joints = torch.randn(2, 17, 3)
+        moved = joints.clone()
+        moved[:, 1:, 0] += 0.1  # 0.1 m -> ~94 mm after root alignment
+        metrics = mesh_metrics(moved, joints)
+        assert metrics["metrics/mpjpe"] == pytest.approx(0.1 * 16 / 17 * 1000, abs=1e-3)
+        assert "metrics/pve" not in metrics
+
+    def test_metric_bundle_includes_pve_when_vertices_given(self):
+        joints = torch.randn(2, 17, 3)
+        verts = torch.randn(2, 50, 3)
+        metrics = mesh_metrics(joints, joints, verts, verts)
+        assert metrics["metrics/pve"] == pytest.approx(0.0, abs=1e-3)
+
+
+class TestDrawing:
+    def test_draw_mesh_returns_an_image_of_the_same_size(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import draw_mesh
+
+        img = Image.new("RGB", (300, 200))
+        out = draw_mesh(
+            img,
+            joints2d=np.random.rand(2, 70, 2) * 100,
+            vertices2d=np.random.rand(2, 500, 2) * 100,
+        )
+        assert out.size == img.size
+
+    def test_draw_mesh_handles_missing_inputs(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import draw_mesh
+
+        img = Image.new("RGB", (64, 64))
+        assert draw_mesh(img).size == img.size
+
+    def test_vertex_cloud_is_decimated(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import draw_mesh
+
+        # 18k vertices per person is the real MHR count; drawing must stay
+        # bounded rather than scaling with it.
+        img = Image.new("RGB", (128, 128))
+        out = draw_mesh(img, vertices2d=np.random.rand(1, 18439, 2) * 128,
+                        max_vertices=100)
+        assert out.size == img.size

--- a/tests/unit/test_mesh_task.py
+++ b/tests/unit/test_mesh_task.py
@@ -510,3 +510,112 @@ class TestDrawing:
         out = draw_mesh(img, vertices2d=np.random.rand(1, 18439, 2) * 128,
                         max_vertices=100)
         assert out.size == img.size
+
+
+class TestSurfaceRenderer:
+    """The shaded-surface path, which is what a body mesh should look like."""
+
+    @staticmethod
+    def _quad():
+        """A square made of two triangles, centered in a 64x64 image."""
+        verts2d = np.array(
+            [[[16.0, 16.0], [48.0, 16.0], [48.0, 48.0], [16.0, 48.0]]],
+            dtype=np.float32,
+        )
+        depths = np.full((1, 4), 5.0, dtype=np.float32)
+        faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
+        return verts2d, depths, faces
+
+    def test_renders_a_visible_surface(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import render_mesh_surface
+
+        img = Image.new("RGB", (64, 64), (0, 0, 0))
+        verts2d, depths, faces = self._quad()
+        out = render_mesh_surface(img, verts2d, depths, faces, alpha=1.0)
+        arr = np.asarray(out)
+        # The middle of the quad must be painted, the corner must not.
+        assert arr[32, 32].sum() > 0
+        assert arr[2, 2].sum() == 0
+
+    def test_renders_regardless_of_winding_order(self):
+        """Either triangle winding must produce a surface, not an empty image."""
+        from PIL import Image
+
+        from libreyolo.utils.drawing import render_mesh_surface
+
+        img = Image.new("RGB", (64, 64), (0, 0, 0))
+        verts2d, depths, faces = self._quad()
+        forward = np.asarray(render_mesh_surface(img, verts2d, depths, faces, alpha=1.0))
+        reversed_faces = faces[:, ::-1].copy()
+        backward = np.asarray(
+            render_mesh_surface(img, verts2d, depths, reversed_faces, alpha=1.0)
+        )
+        assert forward[32, 32].sum() > 0
+        assert backward[32, 32].sum() > 0
+
+    def test_nearer_surface_is_drawn_over_farther(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import render_mesh_surface
+
+        img = Image.new("RGB", (64, 64), (0, 0, 0))
+        # Two overlapping people at different depths; the near one wins.
+        verts2d = np.repeat(self._quad()[0], 2, axis=0)
+        faces = self._quad()[2]
+        far = np.full((1, 4), 20.0, dtype=np.float32)
+        near = np.full((1, 4), 2.0, dtype=np.float32)
+        out = render_mesh_surface(
+            img, verts2d, np.concatenate([far, near]), faces, alpha=1.0
+        )
+        assert np.asarray(out)[32, 32].sum() > 0
+
+    def test_alpha_blends_with_the_photo(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import render_mesh_surface
+
+        img = Image.new("RGB", (64, 64), (0, 0, 0))
+        verts2d, depths, faces = self._quad()
+        opaque = np.asarray(render_mesh_surface(img, verts2d, depths, faces, alpha=1.0))
+        blended = np.asarray(render_mesh_surface(img, verts2d, depths, faces, alpha=0.5))
+        assert blended[32, 32].sum() < opaque[32, 32].sum()
+
+    def test_empty_geometry_is_a_no_op(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import render_mesh_surface
+
+        img = Image.new("RGB", (32, 32))
+        out = render_mesh_surface(
+            img, np.zeros((0, 0, 2)), np.zeros((0, 0)), np.zeros((0, 3), dtype=np.int64)
+        )
+        assert out.size == img.size
+
+    def test_draw_mesh_prefers_the_surface_when_topology_is_available(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import draw_mesh
+
+        img = Image.new("RGB", (64, 64), (0, 0, 0))
+        verts2d, depths, faces = self._quad()
+        surface = np.asarray(
+            draw_mesh(img, vertices2d=verts2d, faces=faces, vertex_depths=depths,
+                      surface_alpha=1.0)
+        )
+        scatter = np.asarray(draw_mesh(img, vertices2d=verts2d))
+        # A filled surface covers the quad centre; a vertex scatter does not.
+        assert surface[32, 32].sum() > scatter[32, 32].sum()
+
+    def test_skeleton_is_off_by_default_over_a_surface(self):
+        from PIL import Image
+
+        from libreyolo.utils.drawing import draw_mesh
+
+        img = Image.new("RGB", (64, 64), (0, 0, 0))
+        joints = np.full((1, 70, 2), 32.0, dtype=np.float32)
+        without = np.asarray(draw_mesh(img, joints2d=joints))
+        with_skeleton = np.asarray(draw_mesh(img, joints2d=joints, draw_skeleton=True))
+        assert without.sum() == 0
+        assert with_skeleton.sum() > 0

--- a/tests/unit/test_mhr_body_model.py
+++ b/tests/unit/test_mhr_body_model.py
@@ -1,0 +1,123 @@
+"""Integration checks for the MHR body model.
+
+Marked ``external_data``: these need the ~700 MB Apache-2.0 MHR release asset,
+so they are excluded from the fast unit run. Point ``LIBREYOLO_MHR_PATH`` at an
+existing copy, or let the first run fetch it.
+
+The assertions are physical rather than golden-value: a rest-pose body should
+be roughly human-sized, translation should move it rigidly by exactly the
+requested amount, and pose and identity parameters should each change the
+geometry. Those catch the unit and convention mistakes that actually happen
+here (centimeters vs meters, the decimeter translation factor, parameter blocks
+concatenated in the wrong order) without pinning numbers that a legitimate
+upstream asset update would change.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.sam3dbody.mhr_body import (
+    MHRBodyModel,
+    default_mhr_path,
+    load_mhr_body_model,
+)
+
+pytestmark = pytest.mark.external_data
+
+
+@pytest.fixture(scope="module")
+def body_model() -> MHRBodyModel:
+    path = default_mhr_path()
+    if not path.exists():
+        pytest.skip(
+            f"MHR body model not present at {path}; "
+            "set LIBREYOLO_MHR_PATH or run ensure_mhr_model()."
+        )
+    return load_mhr_body_model(path, device="cpu", download=False)
+
+
+def zeros(batch: int) -> dict:
+    return {
+        "global_orient": torch.zeros(batch, 3),
+        "body_pose": torch.zeros(batch, MHRBodyModel.NUM_BODY_POSE),
+        "betas": torch.zeros(batch, MHRBodyModel.NUM_BETAS),
+        "scales": torch.zeros(batch, MHRBodyModel.NUM_SCALES),
+    }
+
+
+def test_rest_pose_shapes(body_model):
+    vertices, joints = body_model(**zeros(2))
+    assert vertices.shape == (2, MHRBodyModel.NUM_VERTICES, 3)
+    assert joints.shape == (2, MHRBodyModel.NUM_JOINTS, 3)
+
+
+def test_rest_pose_is_human_sized(body_model):
+    # Output must be meters, not the centimeters the rig works in.
+    vertices, _ = body_model(**zeros(1))
+    height = float(vertices[0, :, 1].max() - vertices[0, :, 1].min())
+    assert 1.4 < height < 2.1, f"rest-pose body is {height:.2f} m tall"
+
+
+def test_translation_moves_the_body_rigidly(body_model):
+    # Verifies the decimeter scaling applied to translation on the way in.
+    base, _ = body_model(**zeros(2))
+    offset = torch.tensor([[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]])
+    moved, _ = body_model(**zeros(2), transl=offset)
+    assert torch.allclose(moved - base, offset[:, None, :], atol=1e-4)
+
+
+def test_pose_parameters_change_geometry(body_model):
+    base, _ = body_model(**zeros(2))
+    params = zeros(2)
+    params["body_pose"] = torch.randn(2, MHRBodyModel.NUM_BODY_POSE) * 0.1
+    posed, _ = body_model(**params)
+    assert (posed - base).abs().max() > 1e-4
+
+
+def test_identity_parameters_change_geometry(body_model):
+    base, _ = body_model(**zeros(2))
+    params = zeros(2)
+    params["betas"] = torch.randn(2, MHRBodyModel.NUM_BETAS) * 0.5
+    reshaped, _ = body_model(**params)
+    assert (reshaped - base).abs().max() > 1e-4
+
+
+@pytest.mark.parametrize(
+    "field,width",
+    [("body_pose", 99), ("betas", 10), ("scales", 24)],
+)
+def test_wrong_parameter_widths_are_rejected(body_model, field, width):
+    params = zeros(1)
+    params[field] = torch.zeros(1, width)
+    with pytest.raises(ValueError, match=field):
+        body_model(**params)
+
+
+def test_decoded_mesh_round_trips_through_the_result_payload(body_model):
+    """The decoder output should drop straight into a Meshes slot."""
+    from libreyolo.models.sam3dbody.camera import perspective_project
+    from libreyolo.utils.results import Meshes
+
+    params = zeros(1)
+    transl = torch.tensor([[0.0, 0.0, 4.0]])
+    vertices, joints = body_model(**params, transl=transl)
+    joints2d = perspective_project(joints, 1000.0, image_size=(480, 640))
+
+    meshes = Meshes(
+        params["global_orient"],
+        params["body_pose"],
+        params["betas"],
+        transl,
+        body_model="mhr",
+        vertices=vertices,
+        joints3d=joints,
+        joints2d=joints2d,
+        orig_shape=(480, 640),
+    )
+    assert len(meshes) == 1
+    assert meshes.num_vertices == MHRBodyModel.NUM_VERTICES
+    assert meshes.num_joints == MHRBodyModel.NUM_JOINTS
+    # A body 4 m in front of the camera should project inside the frame.
+    assert (joints2d[..., 0] > 0).any() and (joints2d[..., 0] < 640).any()

--- a/tests/unit/test_sam3dbody_adapter.py
+++ b/tests/unit/test_sam3dbody_adapter.py
@@ -213,6 +213,30 @@ class TestRunnerGuards:
         with pytest.raises(ValueError, match="Tiled inference"):
             runner(rgb(), person_boxes=[[0, 0, 9, 9]], tiling=True)
 
+    def test_person_boxes_with_video_is_refused_upfront(self, tmp_path):
+        """Static boxes cannot follow a moving person, so say so clearly.
+
+        Without this guard the boxes are silently dropped and each frame
+        raises "pass person_boxes", telling the user to do what they did.
+        """
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 16)
+        runner = MeshInferenceRunner(FakeModel())
+        with pytest.raises(ValueError, match="cannot be reused across video"):
+            runner(str(video), person_boxes=[[0, 0, 9, 9]])
+
+    def test_video_with_a_detector_is_not_refused(self, tmp_path):
+        """The guard must only reject the boxes case, not video as such."""
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 16)
+        model = FakeModel(person_detector=CallablePersonDetector(fn=lambda img: []))
+        runner = MeshInferenceRunner(model)
+        # Reaches the decode path and fails there on the fake file, rather than
+        # being turned away by the person-source guard.
+        with pytest.raises(Exception) as exc:
+            runner(str(video))
+        assert "cannot be reused across video" not in str(exc.value)
+
     def test_bad_output_format_rejected(self):
         runner = MeshInferenceRunner(FakeModel())
         with pytest.raises(ValueError, match="output_file_format"):

--- a/tests/unit/test_sam3dbody_adapter.py
+++ b/tests/unit/test_sam3dbody_adapter.py
@@ -297,6 +297,45 @@ class TestRealModelParity:
         assert torch.allclose(reprojected, meshes.joints2d, atol=1e-2)
 
 
+class TestDeviceAndTaskGuards:
+    """Regression cover for the device and task-dispatch guards."""
+
+    def _bare_model(self, device: str):
+        from libreyolo.models.sam3dbody.model import LibreSAM3DBody
+
+        model = LibreSAM3DBody.__new__(LibreSAM3DBody)
+        model.device = torch.device(device)
+        return model
+
+    def test_estimate_rejects_a_cpu_model_even_when_cuda_exists(self):
+        """A global CUDA check would wave this through into a device mismatch."""
+        model = self._bare_model("cpu")
+        with pytest.raises(RuntimeError, match="requires a CUDA device"):
+            model.estimate(rgb(), np.zeros((1, 4), dtype=np.float32))
+
+    def test_estimate_error_names_the_offending_device(self):
+        model = self._bare_model("cpu")
+        with pytest.raises(RuntimeError, match="is on cpu"):
+            model.estimate(rgb(), np.zeros((1, 4), dtype=np.float32))
+
+    def test_faces_degrades_when_upstream_stops_exposing_topology(self):
+        model = self._bare_model("cpu")
+        model.model = object()  # no head_pose attribute at all
+        assert model.faces is None
+
+    def test_track_is_refused_for_mesh_models(self):
+        """val() guards mesh; track() must too, or it silently misbehaves."""
+        from libreyolo.models.base.model import BaseModel
+
+        class Stub:
+            task = "mesh"
+
+        # track() is a generator function, so its guards, like every other
+        # task guard there, raise on first iteration rather than on the call.
+        with pytest.raises(NotImplementedError, match="body-mesh"):
+            next(BaseModel.track(Stub(), source="video.mp4"))
+
+
 class TestUpstreamDependency:
     def test_missing_package_explains_the_licensing_situation(self, monkeypatch):
         """The error must tell users why it is not bundled and how to install it."""

--- a/tests/unit/test_sam3dbody_adapter.py
+++ b/tests/unit/test_sam3dbody_adapter.py
@@ -1,0 +1,309 @@
+"""Unit tests for the SAM 3D Body adapter.
+
+The adapter wraps an optional third-party package and a 2 GB checkpoint, so
+these tests stub both: a fake model object stands in for the family and returns
+the output dict shape the upstream estimator produces. That keeps the mapping
+logic, the person-source resolution and the error paths under test in the fast
+suite, independent of whether the upstream package is installed.
+
+Parity against the real model lives in the external_data suite.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.models.sam3dbody.inference import MeshInferenceRunner
+from libreyolo.models.sam3dbody.person import (
+    CallablePersonDetector,
+    LibreYOLOPersonDetector,
+    PersonBox,
+    normalize_person_boxes,
+    resolve_person_detector,
+)
+
+pytestmark = pytest.mark.unit
+
+N_VERTS = 12
+N_JOINTS = 70
+
+
+def fake_person_output(seed: int = 0) -> dict:
+    """One person's worth of upstream-shaped output."""
+    rng = np.random.default_rng(seed)
+    return {
+        "pred_vertices": rng.normal(size=(N_VERTS, 3)).astype(np.float32),
+        "pred_keypoints_3d": rng.normal(size=(N_JOINTS, 3)).astype(np.float32),
+        "pred_keypoints_2d": (rng.random((N_JOINTS, 2)) * 100).astype(np.float32),
+        "pred_cam_t": np.array([0.1, 0.2, 4.0], dtype=np.float32),
+        "global_rot": rng.normal(size=(3,)).astype(np.float32),
+        "body_pose_params": rng.normal(size=(133,)).astype(np.float32),
+        "shape_params": rng.normal(size=(45,)).astype(np.float32),
+        "scale_params": rng.normal(size=(28,)).astype(np.float32),
+        "hand_pose_params": rng.normal(size=(108,)).astype(np.float32),
+        "focal_length": np.float32(1500.0),
+    }
+
+
+class FakeModel:
+    """Stands in for LibreSAM3DBody without the upstream package or weights."""
+
+    names = {0: "person"}
+    task = "mesh"
+
+    def __init__(self, person_detector=None, n_out=1):
+        self.person_detector = person_detector
+        self.faces = torch.randint(0, N_VERTS, (20, 3))
+        self.n_out = n_out
+        self.last_call = None
+
+    def estimate(self, image_rgb, boxes_xyxy, focal_length=None):
+        self.last_call = {"boxes": np.asarray(boxes_xyxy), "focal_length": focal_length}
+        return [fake_person_output(i) for i in range(self.n_out)]
+
+
+def rgb(h=200, w=300):
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+class TestPersonSource:
+    def test_normalize_accepts_plain_boxes(self):
+        boxes = normalize_person_boxes([[0, 0, 10, 10], [5, 5, 20, 20]])
+        assert len(boxes) == 2
+        assert boxes[0].score == 1.0
+
+    def test_normalize_accepts_scores_and_filters(self):
+        boxes = normalize_person_boxes([[0, 0, 10, 10, 0.9], [0, 0, 5, 5, 0.1]], 0.5)
+        assert len(boxes) == 1
+
+    def test_normalize_accepts_arrays(self):
+        assert len(normalize_person_boxes(np.zeros((3, 4)))) == 3
+
+    def test_normalize_accepts_single_row_array(self):
+        assert len(normalize_person_boxes(np.array([0.0, 0.0, 5.0, 5.0]))) == 1
+
+    def test_normalize_passes_through_personbox(self):
+        boxes = normalize_person_boxes([PersonBox((0, 0, 1, 1), 0.7)])
+        assert boxes[0].score == 0.7
+
+    def test_normalize_rejects_bad_width(self):
+        with pytest.raises(ValueError, match="unsupported person-box length"):
+            normalize_person_boxes([[1, 2, 3]])
+
+    def test_normalize_rejects_bad_array_shape(self):
+        with pytest.raises(ValueError, match=r"\(N, 4\) or \(N, 5\)"):
+            normalize_person_boxes(np.zeros((3, 7)))
+
+    def test_resolve_wraps_callable(self):
+        assert isinstance(resolve_person_detector(lambda img: []), CallablePersonDetector)
+
+    def test_resolve_passes_none(self):
+        assert resolve_person_detector(None) is None
+
+    def test_resolve_rejects_junk(self):
+        with pytest.raises(TypeError, match="Unsupported person_detector"):
+            resolve_person_detector(42)
+
+    def test_callable_detector_normalizes(self):
+        det = CallablePersonDetector(fn=lambda img: [[0, 0, 9, 9, 0.8]])
+        out = det(rgb())
+        assert len(out) == 1 and out[0].score == pytest.approx(0.8)
+
+
+class TestRunnerMapping:
+    def _run(self, model=None, **kwargs):
+        model = model or FakeModel()
+        runner = MeshInferenceRunner(model)
+        return runner(rgb(), person_boxes=[[10, 10, 50, 150]], **kwargs)
+
+    def test_returns_boxes_and_meshes_row_aligned(self):
+        result = self._run(FakeModel(n_out=2))
+        assert len(result.meshes) == 2
+        assert result.meshes.body_model == "mhr"
+
+    def test_translation_is_added_into_camera_frame(self):
+        """Upstream returns root-relative geometry; the payload must be camera-frame."""
+        model = FakeModel()
+        result = self._run(model)
+        raw = fake_person_output(0)
+        expected = raw["pred_vertices"] + raw["pred_cam_t"]
+        assert np.allclose(result.meshes.vertices[0].numpy(), expected, atol=1e-5)
+        # Depth must be positive: the person is in front of the camera.
+        assert float(result.meshes.vertices[..., 2].min()) > 0
+
+    def test_joints3d_also_camera_frame(self):
+        result = self._run()
+        raw = fake_person_output(0)
+        assert np.allclose(
+            result.meshes.joints3d[0].numpy(),
+            raw["pred_keypoints_3d"] + raw["pred_cam_t"],
+            atol=1e-5,
+        )
+
+    def test_joints2d_passed_through_unmodified(self):
+        result = self._run()
+        assert np.allclose(
+            result.meshes.joints2d[0].numpy(),
+            fake_person_output(0)["pred_keypoints_2d"],
+            atol=1e-5,
+        )
+
+    def test_projected_vertices_available_for_drawing(self):
+        result = self._run()
+        v2d = result.meshes.extras["vertices2d"]
+        assert v2d.shape == (1, N_VERTS, 2)
+
+    def test_model_specific_params_land_in_extras(self):
+        meshes = self._run().meshes
+        assert meshes.extras["scale"].shape == (1, 28)
+        assert meshes.extras["hand_pose"].shape == (1, 108)
+
+    def test_topology_is_shared_not_per_person(self):
+        meshes = self._run(FakeModel(n_out=2)).meshes
+        assert meshes.faces.shape == (20, 3)
+        assert meshes[0].faces.shape == (20, 3)
+
+    def test_focal_length_forwarded_to_estimator(self):
+        model = FakeModel()
+        self._run(model, focal_length=1234.0)
+        assert model.last_call["focal_length"] == 1234.0
+
+    def test_boxes_reach_the_estimator(self):
+        model = FakeModel()
+        self._run(model)
+        assert model.last_call["boxes"].shape == (1, 4)
+
+    def test_summary_and_json_round_trip(self):
+        import json
+
+        result = self._run()
+        assert json.loads(result.to_json())[0]["mesh"]["body_model"] == "mhr"
+
+
+class TestRunnerGuards:
+    def test_no_person_source_is_an_actionable_error(self):
+        runner = MeshInferenceRunner(FakeModel())
+        with pytest.raises(RuntimeError, match="person_boxes|person_detector"):
+            runner(rgb())
+
+    def test_augment_rejected(self):
+        runner = MeshInferenceRunner(FakeModel())
+        with pytest.raises(ValueError, match="left and right"):
+            runner(rgb(), person_boxes=[[0, 0, 9, 9]], augment=True)
+
+    def test_tiling_rejected(self):
+        runner = MeshInferenceRunner(FakeModel())
+        with pytest.raises(ValueError, match="Tiled inference"):
+            runner(rgb(), person_boxes=[[0, 0, 9, 9]], tiling=True)
+
+    def test_bad_output_format_rejected(self):
+        runner = MeshInferenceRunner(FakeModel())
+        with pytest.raises(ValueError, match="output_file_format"):
+            runner(rgb(), person_boxes=[[0, 0, 9, 9]], output_file_format="gif")
+
+    def test_no_people_returns_empty_result_not_a_crash(self):
+        runner = MeshInferenceRunner(FakeModel())
+        result = runner(rgb(), person_boxes=[])
+        assert len(result.boxes) == 0
+        assert result.meshes is None
+
+    def test_detector_below_confidence_yields_empty(self):
+        model = FakeModel(person_detector=CallablePersonDetector(
+            fn=lambda img: [[0, 0, 9, 9, 0.1]]
+        ))
+        result = MeshInferenceRunner(model)(rgb(), conf=0.5)
+        assert len(result.boxes) == 0
+
+
+@pytest.mark.external_data
+class TestRealModelParity:
+    """Runs the real model. Needs the upstream package, weights and CUDA."""
+
+    @pytest.fixture(scope="class")
+    def model(self):
+        import os
+
+        torch_cuda = torch.cuda.is_available()
+        if not torch_cuda:
+            pytest.skip("SAM 3D Body inference requires CUDA")
+        if not os.environ.get("SAM_3D_BODY_PATH"):
+            pytest.skip("SAM_3D_BODY_PATH not set")
+        ckpt = os.environ.get("SAM_3D_BODY_CKPT")
+        if not ckpt or not os.path.exists(ckpt):
+            pytest.skip("SAM_3D_BODY_CKPT not set to an existing checkpoint")
+        from libreyolo.models.sam3dbody import LibreSAM3DBody
+
+        return LibreSAM3DBody(model_path=ckpt, size="d3")
+
+    def test_predicts_a_body_in_the_camera_frame(self, model):
+        import libreyolo
+        from PIL import Image
+
+        width, height = Image.open(libreyolo.SAMPLE_IMAGE).size
+        result = model(
+            libreyolo.SAMPLE_IMAGE,
+            person_boxes=[[width * 0.2, height * 0.05, width * 0.8, height * 0.95]],
+        )
+        meshes = result.meshes
+        assert len(meshes) == 1
+        assert meshes.num_vertices == 18439
+        assert meshes.num_joints == 70
+        assert meshes.betas.shape == (1, 45)
+        # Metric depth, in front of the camera, at a plausible distance.
+        assert 0.5 < float(meshes.transl[0, 2]) < 20.0
+        assert float(meshes.vertices[..., 2].min()) > 0
+        # Projected joints should land on the image canvas.
+        inside = (
+            (meshes.joints2d[..., 0] > 0)
+            & (meshes.joints2d[..., 0] < width)
+            & (meshes.joints2d[..., 1] > 0)
+            & (meshes.joints2d[..., 1] < height)
+        )
+        assert inside.float().mean() > 0.8
+
+    def test_our_projection_matches_upstreams(self, model):
+        """Our camera math must reproduce the upstream 2D joints exactly."""
+        import libreyolo
+        from PIL import Image
+
+        from libreyolo.models.sam3dbody.camera import perspective_project
+
+        width, height = Image.open(libreyolo.SAMPLE_IMAGE).size
+        result = model(
+            libreyolo.SAMPLE_IMAGE,
+            person_boxes=[[width * 0.2, height * 0.05, width * 0.8, height * 0.95]],
+        )
+        meshes = result.meshes
+        reprojected = perspective_project(
+            meshes.joints3d, meshes.focal_length, image_size=(height, width)
+        )
+        assert torch.allclose(reprojected, meshes.joints2d, atol=1e-2)
+
+
+class TestUpstreamDependency:
+    def test_missing_package_explains_the_licensing_situation(self, monkeypatch):
+        """The error must tell users why it is not bundled and how to install it."""
+        import sys
+
+        from libreyolo.models.sam3dbody.model import LibreSAM3DBody
+
+        monkeypatch.setitem(sys.modules, "sam_3d_body", None)
+        monkeypatch.delitem(sys.modules, "sam_3d_body")
+        real_import = __import__
+
+        def blocked(name, *args, **kwargs):
+            if name == "sam_3d_body":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", blocked)
+        model = LibreSAM3DBody.__new__(LibreSAM3DBody)
+        model._sam_3d_body_path = None
+        with pytest.raises(ImportError) as exc:
+            model._import_upstream()
+        message = str(exc.value)
+        assert "SAM License" in message
+        assert "github.com/facebookresearch/sam-3d-body" in message
+        assert "sam_3d_body_path" in message

--- a/tests/unit/test_sam3dbody_adapter.py
+++ b/tests/unit/test_sam3dbody_adapter.py
@@ -160,6 +160,21 @@ class TestRunnerMapping:
         assert meshes.extras["scale"].shape == (1, 28)
         assert meshes.extras["hand_pose"].shape == (1, 108)
 
+    def test_missing_optional_params_are_omitted_not_fatal(self):
+        """Body-only runs omit hand output; that must degrade, not raise."""
+
+        class BodyOnlyModel(FakeModel):
+            def estimate(self, image_rgb, boxes_xyxy, focal_length=None):
+                out = fake_person_output(0)
+                del out["hand_pose_params"]
+                return [out]
+
+        meshes = MeshInferenceRunner(BodyOnlyModel())(
+            rgb(), person_boxes=[[10, 10, 50, 150]]
+        ).meshes
+        assert "hand_pose" not in meshes.extras
+        assert "scale" in meshes.extras
+
     def test_topology_is_shared_not_per_person(self):
         meshes = self._run(FakeModel(n_out=2)).meshes
         assert meshes.faces.shape == (20, 3)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -79,6 +79,7 @@ def test_task_type_literal_is_public():
         "restore",
         "matte",
         "ocr",
+        "mesh",
     }
 
 


### PR DESCRIPTION
# What does this PR do?

Adds `mesh`, the human body mesh recovery task: an image in, a posed 3D body
per detected person out. No easy-install CV library ships this today.

```python
model = LibreSAM3DBody(person_detector=LibreYOLO("LibreYOLO9s.pt"))
r = model("people.jpg", save=True)

r.meshes.global_orient / body_pose / betas / transl   # parametric core
r.meshes.vertices, r.meshes.joints3d, r.meshes.joints2d
r.meshes.save_obj("person0.obj", index=0)
```

## Why this shape

The task is a licensing problem before it is a technical one, and that drove
every structural decision here.

Nearly every mesh model predicts into **SMPL**, which LibreYOLO cannot use: the
model files are non-commercial and non-redistributable, the `smplx` PyPI
package's *code* carries the same non-commercial license (the most common
misconception in this area), and the license forbids using the model to train
networks for commercial deployment, so it reaches into checkpoints too. SMPL is
also registration-gated, so it can never support autodownload.

**MHR** (Apache 2.0, code and assets, ungated) solves the body-model layer. It
does not solve the regressor layer: the only strong MHR regressor is Meta's
**SAM 3D Body**, whose *code* is under the SAM License, which carries
field-of-use restrictions (military, nuclear, espionage, weapons), a
no-reverse-engineering clause, and unilateral amendment by Meta. That is not a
permissive license, so porting it into this tree was not an option.

So the family **wraps rather than ports**. `LibreSAM3DBody` is LibreYOLO's own
MIT code calling the upstream package's public API and mapping its output into
`Meshes`. The upstream package is an optional dependency the user installs
themselves; this repository ships none of it. The practical consequence that
matters: **a user who never touches the mesh task never encounters SAM terms.**

Weights are a separate question from code. The SAM License does permit
redistribution provided the terms are passed through, so the checkpoints are
mirrored on the LibreYOLO org with the license text included and a gate that
records acceptance.

## What is in here

- **Task contract**: `mesh` registered with the `-mesh` suffix and aliases
  `body-mesh`, `hmr`, `human-mesh-recovery`. `smpl` is deliberately *not* an
  alias, since nothing shipped is SMPL and accepting the name would imply an
  interoperability that does not exist.
- **`Meshes` payload**, row-aligned with `Results.boxes` exactly as pose
  keypoints are. Body-model-agnostic by construction: `body_model` names the
  parameterization and every count is read from the tensors, because layouts
  genuinely differ (MHR uses Euler angles, a flat 130-wide pose vector, and 45
  identity coefficients rather than 10 SMPL betas). Hard-coding SMPL's shapes
  would have made the first non-SMPL model a breaking change.
- **MHR body model** decoder, fetched from the public Apache release, adding no
  dependency beyond PyTorch (the TorchScript form avoids `pymomentum`, which
  has no reliable Windows wheel).
- **Camera helpers**: crop-camera lifting and perspective projection, so
  `joints2d` lands in original-image pixels rather than crop pixels.
- **Person-detector chaining** (`person_boxes=` / `person_detector=`),
  following the gaze family's pattern. This also removes upstream's detectron2
  requirement, since a LibreYOLO detector supplies the boxes.
- **Metrics**: MPJPE, PA-MPJPE with a reflection-safe Procrustes, PVE.
- **Rendering**: a small painter's-algorithm rasterizer in numpy and PIL
  (back-face culling, Lambertian plus Blinn-Phong, far-to-near ordering), so
  `save=True` produces a real shaded surface without a GL dependency such as
  pyrender or PyTorch3D. `shading="normal"` gives the normal-mapped view papers
  use.
- **Gates**: export raises an explicit not-implemented error (the runtime
  metadata contract is undefined), `val()` explains the dataset-license
  situation rather than pretending to have data, and `track()` and TTA are
  refused with reasons.
- **Docs**: ADR 0013, nomenclature, checkpoint schema, `THIRD_PARTY_NOTICES.txt`.

## Coordinates

Camera frame of the original image, only. `transl` is metric metres with +z
away from the camera; `vertices` and `joints3d` include `transl`; `joints2d` is
in original-image pixels. There is deliberately **no world frame** in this
version and no field implies one, so a future video story can add explicit
`*_world` fields without changing what these mean.

## Deliberately out of scope

Video tracking, temporal smoothing and world-frame trajectories; SMPL-X
whole-body hands and face; training; export; any renderer dependency.

## Weight mirrors

| Repo | Backbone | Size | Gate |
|---|---|---|---|
| `LibreYOLO/LibreSAM3DBodyd3-mesh` | DINOv3 ViT-H/16+ | 2109 MB | `auto` |
| `LibreYOLO/LibreSAM3DBodyh-mesh` | ViT-H | 1691 MB | `auto` |

Both carry the SAM License text and a card stating the weights are SAM-licensed
rather than MIT. The gate records license acceptance plus an attestation that
the requester is not in a comprehensively sanctioned jurisdiction, mirroring
Meta's own screening; redistributing ungated would route around it and move the
export-control exposure onto this project. `auto` was chosen over `manual` so
access is immediate while still recording acceptance.

The MHR asset is **not** mirrored: it is Apache 2.0 and public, so LibreYOLO
fetches it from the upstream release and caches it locally rather than holding
a second copy of a 700 MB artifact.

## Known limitations

- The upstream repository has no packaging metadata, so it cannot be
  `pip install`ed. Users clone it and set `SAM_3D_BODY_PATH`. If upstream
  restructures, the adapter breaks.
- The upstream estimator moves its batch to the GPU unconditionally, so there
  is no CPU path. The adapter raises a clear error rather than failing deep
  inside third-party code.
- Upstream pulls DINOv3 from `torch.hub` at load time, which carries its own
  license. That lands on the user's machine via their code, not ours.
- Unrelated papercut noticed while testing: annotated **video** is written as
  FMP4, which Chrome will not play. Not touched here.

# How was this tested?

Verified against the real model rather than assumed:

- **MHR parameterization** determined by probing the released Apache asset:
  204 model parameters (3 translation, 3 global rotation, 130 body pose, 68
  bone scales), 45 betas, 72 expression, 18439 vertices, 127 joints, output in
  centimetres with translation entering in decimetres. The upstream comment
  saying 127 is stale. Rest-pose height decodes to 1.727 m and a requested
  0.1/0.2/0.3 m translation moves the body by exactly that, which pins the unit
  conventions.
- **Projection parity**: our camera math reproduces upstream's 2D joints to a
  maximum of **0.0001 px** across all 70 joints.
- **End-to-end**: three people detected and reconstructed on the sample image
  at plausible relative depths (4.42 m / 7.94 m / 9.67 m), 1.7 s on CUDA.
- **Video**: three clips (rooftop dance, two parkour) rendered through the
  video path; 109/109, 143/150 and 133/195 frames resolved a body, the misses
  being detector dropout under motion blur rather than mesh failures.

Test suite:

- `tests/unit/test_mesh_task.py` (66) — task registration, payload semantics,
  slicing, OBJ export, camera math, metrics, the surface renderer.
- `tests/unit/test_sam3dbody_adapter.py` (34) — output mapping, person-source
  resolution, device and task guards, all on a stubbed upstream so CI needs
  neither the package nor the 2 GB weights. Two `external_data` tests exercise
  the real model.
- `tests/unit/test_mhr_body_model.py` (9, `external_data`) — physical
  assertions against the real asset.

**Full unit suite: 3877 passed.**

Reviewed twice with the Greptile CLI. Five defects found and fixed: two
device-handling bugs (a CUDA guard testing global availability instead of the
model's device, and `_init_model` overriding the caller's device), a missing
`track()` guard, a brittle attribute access on upstream's API, and
`person_boxes` being silently dropped for video sources and then producing an
error telling the user to pass the argument they had just passed. Final verdict
4/5, "safe to merge".

## Code provenance

All code in this PR was written for LibreYOLO. **No code is ported, adapted,
paraphrased, or derived from any third-party project.** No notice-file entry
for ported code is required because nothing is ported; the entries added to
`THIRD_PARTY_NOTICES.txt` document runtime relationships and redistributed
weights instead.

| LibreYOLO file | Upstream repository | Commit | License |
|---|---|---|---|
| *(none — no ported or adapted code)* | | | |

Relationships that are **not** ported code, recorded for clarity:

- **`facebookresearch/sam-3d-body` (SAM License, not permissive).** Deliberately
  **not** vendored, ported, or reimplemented, precisely because its license is
  not permissive. `libreyolo/models/sam3dbody/{model,inference,person}.py` is
  original code written against the upstream public API (`load_sam_3d_body`,
  `SAM3DBodyEstimator.process_one_image`) the way any caller would. Reading an
  API in order to call it is not deriving from it. The package is an optional
  dependency the user installs; LibreYOLO ships none of its code and does not
  depend on it.
- **`facebookresearch/MHR` (Apache 2.0).** No code ported. The TorchScript
  asset is downloaded at runtime from the public upstream release and cached
  locally; it is not mirrored. The parameter layout used to drive it is
  documented by upstream's Apache-2.0 `demo.py` and `mhr.py` and was
  additionally verified empirically against the released asset.
- **Weights redistributed** at `LibreYOLO/LibreSAM3DBodyd3-mesh` and
  `LibreYOLO/LibreSAM3DBodyh-mesh`, byte-identical, under the SAM License with
  its text included and a gate recording acceptance, as clause 1.b.i of that
  license requires. Mirroring does not change the license: those weights are
  SAM-licensed, not MIT.
- **Standard algorithms implemented from their published definitions**, not
  from any implementation: Procrustes/Umeyama alignment with a reflection
  guard (`mesh_metrics.py`), and back-face culling, painter's-algorithm
  ordering and Lambertian/Blinn-Phong shading (`drawing.py`).
- **No SMPL-derived artifact** is used, produced, or redistributed anywhere in
  this PR.
- **`AmmarkoV/SAM3DBody-cpp` was evaluated and rejected** as a source of
  MIT-licensed mesh tooling. It is labelled MIT while committing Meta's MHR
  mesh geometry, a joint table generated from `mhr_model.pt`, and ONNX exports
  of Meta's SAM-licensed checkpoint. A third party cannot relicense Meta's
  work, so nothing from it is used here.
