### PR TITLE
Add RF-DETR Apple export coverage

### DIFF
--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -56,8 +56,8 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | rfdetr | detect | ✓ | ✓ | ✓ | ✓ |  | exp | exp | ✓ |
-| rfdetr | segment | ✓ | ✓ | exp | exp |  |  |  |  |
-| rfdetr | pose | ✓ | ✓ | exp | exp |  |  |  |  |
+| rfdetr | segment | ✓ | ✓ | exp | exp |  |  | exp | exp |
+| rfdetr | pose | ✓ | ✓ | exp | exp |  |  | exp | exp |
 | rfdetr | obb | ✓ | ✓ | exp | exp |  |  |  |  |
 | rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp | ✓ |
 | rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
@@ -427,12 +427,8 @@ A check mark applies only under any constraint listed here.
 - `rfdetr` / `detect` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `segment` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `segment` / `tflite`: onnx2tf 2.4.x assigns an invalid NHWC layout to the segmentation-head Einsum (78 channels versus the required 256), so conversion fails.
-- `rfdetr` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rfdetr` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
 - `rfdetr` / `pose` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `pose` / `tflite`: RF-DETR pose-x TFLite conversion exceeded the CPU timebox and 8 GB working memory without producing an artifact on this toolchain.
-- `rfdetr` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `rfdetr` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
 - `rfdetr` / `obb` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `rfdetr` / `obb` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.

--- a/libreyolo/backends/coreml.py
+++ b/libreyolo/backends/coreml.py
@@ -104,6 +104,20 @@ class CoreMLBackend(BaseBackend):
             str(path), compute_units=_to_compute_unit(compute_units)
         )
         spec = self.model.get_spec()
+        spec_inputs = list(getattr(spec.description, "input", ()))
+        if len(spec_inputs) > 1:
+            raise RuntimeError(
+                "CoreMLBackend supports exactly one model input; "
+                f"got {len(spec_inputs)}."
+            )
+        if spec_inputs:
+            self.input_name = spec_inputs[0].name
+            self._input_kind = spec_inputs[0].type.WhichOneof("Type")
+        else:
+            # Legacy unit fixtures and old LibreYOLO packages use the
+            # original image boundary without an explicit input contract.
+            self.input_name = "image"
+            self._input_kind = "imageType"
         self.output_names = [out.name for out in spec.description.output]
 
         meta = (
@@ -282,6 +296,27 @@ class CoreMLBackend(BaseBackend):
             padded = Image.new("RGB", (input_w, input_h), (114, 114, 114))
             padded.paste(resized, (0, 0))
             chw = np.array(padded).transpose(2, 0, 1).astype(np.float32)
+        elif family == "rfdetr" and self.task == "pose":
+            # GroupPose's native path resizes an RGB float tensor with
+            # antialiased bilinear interpolation. Preserve those fractional
+            # pixels for the exported TensorType boundary.
+            import torch.nn.functional as F
+
+            rgb = np.ascontiguousarray(np.asarray(img, dtype=np.float32))
+            tensor = (
+                torch.from_numpy(rgb)
+                .permute(2, 0, 1)
+                .unsqueeze(0)
+                .div(255.0)
+            )
+            resized = F.interpolate(
+                tensor,
+                size=(input_h, input_w),
+                mode="bilinear",
+                align_corners=False,
+                antialias=True,
+            )
+            return resized.mul(255.0), original_img, original_size, 1.0
         else:
             # yolo9, rtdetr, rfdetr: plain resize to the exported input.
             ratio = 1.0
@@ -366,9 +401,14 @@ class CoreMLBackend(BaseBackend):
                 f"CoreMLBackend expects (1, C, H, W) blob; got {blob.shape}"
             )
 
-        hwc = np.transpose(blob[0], (1, 2, 0))
-        uint8 = np.ascontiguousarray(np.clip(hwc, 0, 255).astype(np.uint8))
-        pil = Image.fromarray(uint8)
+        if self._input_kind == "multiArrayType":
+            runtime_input = np.ascontiguousarray(
+                blob.astype(np.float32) / 255.0
+            )
+        else:
+            hwc = np.transpose(blob[0], (1, 2, 0))
+            uint8 = np.ascontiguousarray(np.clip(hwc, 0, 255).astype(np.uint8))
+            runtime_input = Image.fromarray(uint8)
 
-        out = self.model.predict({"image": pil})
+        out = self.model.predict({self.input_name: runtime_input})
         return [np.asarray(out[name]) for name in self.output_names if name in out]

--- a/libreyolo/export/coreml.py
+++ b/libreyolo/export/coreml.py
@@ -14,6 +14,7 @@ Family conventions, mapped by the wrapper:
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from typing import Any
 
 import torch
@@ -39,6 +40,67 @@ _NMS_FREE_FAMILIES = {
     "deimv2": "DEIMv2",
     "ec": "EC",
 }
+
+
+@contextmanager
+def _prepare_rfdetr_coreml_graph(
+    nn_model: nn.Module,
+    dummy: torch.Tensor,
+    family: str,
+    task: str,
+):
+    """Apply RF-DETR's export-only Apple graph preparation transactionally."""
+    targets = []
+    if family == "rfdetr" and task == "segment":
+        targets = [
+            module
+            for module in nn_model.modules()
+            if hasattr(module, "_coreml_stable_proposal_order")
+        ]
+    previous = [
+        bool(module._coreml_stable_proposal_order)
+        for module in targets
+    ]
+    try:
+        for module in targets:
+            module._coreml_stable_proposal_order = True
+        if family == "rfdetr":
+            from .coreai import _prepare_coreai_graph
+
+            with _prepare_coreai_graph(nn_model, dummy, family):
+                yield nn_model
+        else:
+            yield nn_model
+    finally:
+        for module, value in zip(targets, previous):
+            module._coreml_stable_proposal_order = value
+
+
+def _rfdetr_output_names(task: str) -> list[str]:
+    names = ["pred_boxes", "pred_logits"]
+    task_output = {
+        "segment": "pred_masks",
+        "pose": "pred_keypoints",
+        "obb": "pred_angles",
+    }.get(task)
+    if task_output is not None:
+        names.append(task_output)
+    return names
+
+
+def _canonical_trace_probe(dummy: torch.Tensor) -> torch.Tensor:
+    """Build a deterministic, chromatic, non-constant RGB probe in [0, 1]."""
+    height, width = int(dummy.shape[-2]), int(dummy.shape[-1])
+    ys = torch.linspace(
+        0.05, 0.95, height, dtype=torch.float32, device=dummy.device
+    ).view(1, 1, height, 1)
+    xs = torch.linspace(
+        0.1, 0.9, width, dtype=torch.float32, device=dummy.device
+    ).view(1, 1, 1, width)
+    red = xs.expand(1, 1, height, width)
+    green = ys.expand(1, 1, height, width)
+    blue = (0.65 * red + 0.35 * green).clamp(0.0, 1.0)
+    return torch.cat((red, green, blue), dim=1).contiguous()
 
 
 class _YoloxPreprocess(nn.Module):
@@ -258,6 +320,7 @@ def export_coreml(
     conf: float = 0.25,
     metadata: dict | None = None,
     model_family: str | None = None,
+    model_task: str | None = None,
 ) -> str:
     """Export a PyTorch model to CoreML (.mlpackage / ML Program format).
 
@@ -279,6 +342,7 @@ def export_coreml(
         metadata: Dict of metadata to embed under user_defined_metadata.
         model_family: Family string (yolox | yolo9 | rtdetr | rfdetr) — selects
             the preprocess wrapper.
+        model_task: Task string. RF-DETR supports detect, segment, and pose.
 
     Returns:
         ``output_path`` on success.
@@ -286,12 +350,18 @@ def export_coreml(
     import coremltools as ct
 
     family = (model_family or "").lower()
+    task = str(model_task or (metadata or {}).get("task") or "detect").lower()
     if family not in _SUPPORTED_FAMILIES:
         raise NotImplementedError(
             f"CoreML export is not supported for model family {family!r}. "
             f"Supported: {sorted(_SUPPORTED_FAMILIES)}. "
             "Other families have not been validated end-to-end; "
             "use ONNX or TorchScript instead."
+        )
+    if family == "rfdetr" and task not in {"detect", "segment", "pose"}:
+        raise NotImplementedError(
+            "RF-DETR CoreML export supports detect, segment, and pose; "
+            f"got task={task!r}."
         )
     if nms and family in _NMS_FREE_FAMILIES:
         raise NotImplementedError(
@@ -315,31 +385,48 @@ def export_coreml(
         wrapped = _NMSOutputAdapter(wrapped, model_family).eval()
 
     # Always feed the wrapper canonical RGB float in [0, 1], on the model's device.
-    canonical_dummy = torch.zeros(
-        dummy.shape[0], 3, dummy.shape[2], dummy.shape[3],
-        dtype=torch.float32, device=dummy.device,
-    )
+    canonical_dummy = _canonical_trace_probe(dummy)
+    check_probe = 1.0 - canonical_dummy
     if nms and canonical_dummy.shape[0] != 1:
         raise RuntimeError("CoreML embedded NMS export currently requires batch=1")
     try:
-        traced = torch.jit.trace(wrapped, canonical_dummy)
+        with _prepare_rfdetr_coreml_graph(
+            wrapped,
+            canonical_dummy,
+            family,
+            task,
+        ):
+            traced = torch.jit.trace(
+                wrapped,
+                canonical_dummy,
+                check_trace=True,
+                check_inputs=[(check_probe,)],
+            )
     finally:
         if yolo9_restore is not None:
             yolo9_restore()
 
-    image_input = ct.ImageType(
-        name="image",
-        shape=tuple(canonical_dummy.shape),
-        scale=1.0 / 255.0,
-        bias=[0.0, 0.0, 0.0],
-        color_layout=ct.colorlayout.RGB,
-    )
+    if family == "rfdetr" and task == "pose":
+        coreml_input = ct.TensorType(
+            name="image",
+            shape=tuple(canonical_dummy.shape),
+        )
+        coreml_input_kind = "tensor"
+    else:
+        coreml_input = ct.ImageType(
+            name="image",
+            shape=tuple(canonical_dummy.shape),
+            scale=1.0 / 255.0,
+            bias=[0.0, 0.0, 0.0],
+            color_layout=ct.colorlayout.RGB,
+        )
+        coreml_input_kind = "image"
     compute_precision = (
         ct.precision.FLOAT16 if precision == "fp16" else ct.precision.FLOAT32
     )
 
     convert_kwargs = {
-        "inputs": [image_input],
+        "inputs": [coreml_input],
         "convert_to": "mlprogram",
         "compute_precision": compute_precision,
         "minimum_deployment_target": ct.target.iOS15,
@@ -349,6 +436,18 @@ def export_coreml(
             ct.TensorType(name="confidence"),
             ct.TensorType(name="coordinates"),
         ]
+    elif family == "rfdetr":
+        convert_kwargs["outputs"] = [
+            ct.TensorType(name=name)
+            for name in _rfdetr_output_names(task)
+        ]
+
+    if family == "rfdetr" and task == "pose":
+        # Preserving source divisions avoids measurable pose-box drift from
+        # Core ML Tools' divide-to-multiply rewrite on Apple CPU execution.
+        pass_pipeline = ct.PassPipeline()
+        pass_pipeline.remove_passes({"common::divide_to_multiply"})
+        convert_kwargs["pass_pipeline"] = pass_pipeline
 
     mlmodel = ct.convert(traced, **convert_kwargs)
 
@@ -359,6 +458,13 @@ def export_coreml(
         if metadata is None:
             metadata = {}
         metadata = {**metadata, "nms": True, "nms_iou": iou, "nms_conf": conf}
+
+    if family == "rfdetr":
+        metadata = {
+            **(metadata or {}),
+            "coreml_input_kind": coreml_input_kind,
+            "coreml_output_names": _rfdetr_output_names(task),
+        }
 
     if metadata:
         mlmodel.user_defined_metadata.update(_stringify_metadata(metadata))

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -1662,4 +1662,5 @@ class CoreMLExporter(BaseExporter):
             conf=conf,
             metadata=metadata,
             model_family=self.model._get_model_name(),
+            model_task=getattr(self.model, "task", "detect"),
         )

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -224,6 +224,16 @@ _add(
 )
 _add(
     "experimental",
+    ("rfdetr",),
+    ("segment", "pose"),
+    ("coreml",),
+    reason=(
+        "Fixed-canvas batch-one conversion and Apple runtime parity are "
+        "implemented; broader checkpoint and image-distribution coverage is pending."
+    ),
+)
+_add(
+    "experimental",
     ("dinov2", "eomt", "pidnet", "lingbotvision"),
     ("semantic",),
     ("tensorrt", "openvino"),
@@ -946,6 +956,16 @@ _add(
         "model checks torch.onnx.is_in_onnx_export). Which artifact is right "
         "is an ONNX question and is not settled here, but ONNX cannot be used "
         "as the reference for this family at a non-native canvas."
+    ),
+)
+_add(
+    "experimental",
+    ("rfdetr",),
+    ("segment", "pose"),
+    ("coreai",),
+    reason=(
+        "Fixed-canvas trained-checkpoint conversion and Apple runtime parity "
+        "are implemented; broader checkpoint coverage is pending."
     ),
 )
 _add(

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -57,7 +57,9 @@ def gen_sineembed_for_position(pos_tensor, dim=128):
     # sineembed_tensor = torch.zeros(n_query, bs, 256)
     scale = 2 * math.pi
     dim = int(dim)
-    dim_t = pos_tensor.new_ones((dim,), dtype=pos_tensor.dtype).cumsum(0) - 1
+    # Core ML Tools 9 does not lower aten::new_ones. Seed the fixed sequence
+    # from an existing tensor without changing its device, dtype, or values.
+    dim_t = torch.ones_like(pos_tensor[0, 0, :1]).expand(dim).cumsum(0) - 1
     dim_t = 10000 ** (2 * torch.div(dim_t, 2, rounding_mode="floor") / dim)
     x_embed = pos_tensor[:, :, 0] * scale
     y_embed = pos_tensor[:, :, 1] * scale
@@ -107,8 +109,14 @@ def gen_encoder_output_proposals(memory, memory_padding_mask=None, spatial_shape
             valid_height = torch.zeros_like(memory[:, 0, 0]).long() + height
             valid_width = torch.zeros_like(memory[:, 0, 0]).long() + width
 
-        grid_y = memory.new_ones((height, width), dtype=torch.float32).cumsum(0) - 1
-        grid_x = memory.new_ones((height, width), dtype=torch.float32).cumsum(1) - 1
+        # Core ML Tools 9 does not lower aten::new_ones. This seed is exactly
+        # the same all-ones grid but is expressed with supported operations.
+        grid_seed = torch.ones_like(
+            memory[0, _cur : (_cur + height * width), 0],
+            dtype=torch.float32,
+        ).reshape(height, width)
+        grid_y = grid_seed.cumsum(0) - 1
+        grid_x = grid_seed.cumsum(1) - 1
         grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)  # height, width, 2
 
         # reshape(-1, ...) and unsqueeze(0) broadcasting avoid hardcoding N_ in ONNX
@@ -152,11 +160,12 @@ def ms_deform_attn_core_pytorch(
     value_spatial_shapes: torch.Tensor,
     sampling_locations: torch.Tensor,
     attention_weights: torch.Tensor,
+    num_points: int,
     value_spatial_shapes_hw: list[tuple[int, int]] | None = None,
 ) -> torch.Tensor:
     """Pure-PyTorch fallback for the deformable-attention core."""
     batch_size, n_heads, head_dim, _ = value.shape
-    _, len_query, n_heads, num_levels, num_points, _ = sampling_locations.shape
+    _, len_query, n_heads, _, _ = sampling_locations.shape
     # Use Python int pairs when available (required for torch.export compatibility,
     # since iterating over a tensor and using scalar elements as split/view sizes
     # fails during FakeTensor tracing).
@@ -166,11 +175,16 @@ def ms_deform_attn_core_pytorch(
     sampling_value_list = []
     for level_index, (height, width) in enumerate(shapes):
         value_l_ = value_list[level_index].view(batch_size * n_heads, head_dim, height, width)
-        sampling_grid_l_ = sampling_grids[:, :, :, level_index].transpose(1, 2).flatten(0, 1)
+        point_start = level_index * num_points
+        sampling_grid_l_ = (
+            sampling_grids[:, :, :, point_start : point_start + num_points]
+            .transpose(1, 2)
+            .flatten(0, 1)
+        )
         sampling_value_l_ = _bilinear_grid_sample(value_l_, sampling_grid_l_, padding_mode="zeros", align_corners=False)
         sampling_value_list.append(sampling_value_l_)
     attention_weights = attention_weights.transpose(1, 2).reshape(
-        batch_size * n_heads, 1, len_query, num_levels * num_points
+        batch_size * n_heads, 1, len_query, attention_weights.shape[-1]
     )
     sampling_value_list = torch.stack(sampling_value_list, dim=-2).flatten(-2)
     output = (sampling_value_list * attention_weights).sum(-1).view(batch_size, n_heads * head_dim, len_query)
@@ -300,23 +314,44 @@ class MSDeformAttn(nn.Module):
         if input_padding_mask is not None:
             value = value.masked_fill(input_padding_mask[..., None], float(0))
 
+        # Level and point are bookkeeping axes. Flatten them so no Core ML
+        # intermediate exceeds the runtime's rank-five tensor limit.
+        num_locations = self.n_levels * self.n_points
         sampling_offsets = self.sampling_offsets(query).view(
-            batch_size, len_query, self.n_heads, self.n_levels, self.n_points, 2
+            batch_size, len_query, self.n_heads, num_locations, 2
         )
         attention_weights = self.attention_weights(query).view(
-            batch_size, len_query, self.n_heads, self.n_levels * self.n_points
+            batch_size, len_query, self.n_heads, num_locations
         )
 
+        reference_locations = (
+            reference_points[:, :, :, None, :]
+            .expand(-1, -1, -1, self.n_points, -1)
+            .reshape(
+                batch_size,
+                len_query,
+                num_locations,
+                reference_points.shape[-1],
+            )
+        )
         if reference_points.shape[-1] == 2:
             offset_normalizer = torch.stack([input_spatial_shapes[..., 1], input_spatial_shapes[..., 0]], -1)
+            offset_normalizer = (
+                offset_normalizer[:, None, :]
+                .expand(-1, self.n_points, -1)
+                .reshape(num_locations, 2)
+            )
             sampling_locations = (
-                reference_points[:, :, None, :, None, :]
-                + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+                reference_locations[:, :, None, :, :]
+                + sampling_offsets / offset_normalizer[None, None, None, :, :]
             )
         elif reference_points.shape[-1] == 4:
             sampling_locations = (
-                reference_points[:, :, None, :, None, :2]
-                + sampling_offsets / self.n_points * reference_points[:, :, None, :, None, 2:] * 0.5
+                reference_locations[:, :, None, :, :2]
+                + sampling_offsets
+                / self.n_points
+                * reference_locations[:, :, None, :, 2:]
+                * 0.5
             )
         else:
             raise ValueError(
@@ -332,6 +367,7 @@ class MSDeformAttn(nn.Module):
             input_spatial_shapes,
             sampling_locations,
             attention_weights,
+            self.n_points,
             value_spatial_shapes_hw=input_spatial_shapes_hw,
         )
         output = self.output_proj(output)
@@ -458,6 +494,7 @@ class Transformer(nn.Module):
         self.bbox_reparam = bbox_reparam
 
         self._export = False
+        self._coreml_stable_proposal_order = False
 
     def export(self):
         self._export = True
@@ -546,7 +583,48 @@ class Transformer(nn.Module):
                     )  # (bs, \sum{hw}, 4) unsigmoid
 
                 topk = min(self.num_queries, enc_outputs_class_unselected_gidx.shape[-2])
-                topk_proposals_gidx = torch.topk(enc_outputs_class_unselected_gidx.max(-1)[0], topk, dim=1)[1]  # bs, nq
+                proposal_scores = enc_outputs_class_unselected_gidx.max(-1)[0]
+                _, topk_proposals_gidx = torch.topk(
+                    proposal_scores,
+                    topk,
+                    dim=1,
+                    sorted=True,
+                )
+                if self._coreml_stable_proposal_order:
+                    # Core ML returns the correct top-k set but does not keep
+                    # its indices paired with PyTorch's score-ranked order.
+                    # Rebuild ranks without trusting sort/top-k permutation
+                    # outputs. The tiny index term resolves sub-1e-4 FP32 ties.
+                    selected_proposal_scores = torch.gather(
+                        proposal_scores,
+                        1,
+                        topk_proposals_gidx,
+                    )
+                    ranking_scores = selected_proposal_scores - (
+                        topk_proposals_gidx.to(
+                            selected_proposal_scores.dtype
+                        )
+                        * 1.0e-7
+                    )
+                    score_i = ranking_scores.unsqueeze(2)
+                    score_j = ranking_scores.unsqueeze(1)
+                    precedes = score_j > score_i
+                    proposal_ranks = precedes.sum(dim=2)
+                    rank_axis = (
+                        torch.ones_like(topk_proposals_gidx[0])
+                        .cumsum(0)
+                        .sub(1)
+                        .view(1, 1, topk)
+                    )
+                    rank_placement = (
+                        proposal_ranks.unsqueeze(2) == rank_axis
+                    ).to(proposal_scores.dtype)
+                    topk_proposals_gidx = (
+                        rank_placement
+                        * topk_proposals_gidx.to(
+                            proposal_scores.dtype
+                        ).unsqueeze(2)
+                    ).sum(dim=1).to(topk_proposals_gidx.dtype)
 
                 refpoint_embed_gidx_undetach = torch.gather(
                     enc_outputs_coord_unselected_gidx, 1, topk_proposals_gidx.unsqueeze(-1).repeat(1, 1, 4)

--- a/tests/e2e/test_coreai.py
+++ b/tests/e2e/test_coreai.py
@@ -45,6 +45,10 @@ CASES = [
     ("LibreYOLO9t.pt", "yolo9", 640),
     ("LibreDFINEn.pt", "dfine", 640),
     ("LibreRFDETRn.pt", "rfdetr", 384),
+    ("LibreRFDETRn-seg.pt", "rfdetr", 312),
+    # Pose currently has one published checkpoint; x is therefore the
+    # smallest trained variant available for a real runtime-parity probe.
+    ("LibreRFDETRx-pose.pt", "rfdetr", 576),
     ("LibreYOLOXn.pt", "yolox", 416),
     ("LibreDEIMn.pt", "deim", 640),
     ("LibreDEIMv2atto.pt", "deimv2", 320),
@@ -189,6 +193,10 @@ def _assert_parity(output_names, ref1, ref2, got1, got2):
         )
         sensitivity = float(np.abs(expected2 - expected1).max()) / scale
         margin = float("inf") if error == 0 else sensitivity / error
+        print(
+            f"out[{index}] ({output_names[index]}): error={error:.9e}, "
+            f"sensitivity={sensitivity:.9e}, margin={margin:.3f}x"
+        )
         assert error <= REL_TOL, (
             f"out[{index}] ({output_names[index]}) relative error "
             f"{error:.3e} exceeds {REL_TOL:.0e}"

--- a/tests/e2e/test_coreml_roundtrip.py
+++ b/tests/e2e/test_coreml_roundtrip.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
+import torch
+from PIL import Image
 
 pytestmark = [pytest.mark.coreml, pytest.mark.e2e]
 
@@ -151,3 +154,150 @@ def test_rfdetr_nms_true_raises(tmp_path):
             output_path=str(tmp_path / "rfdetr.mlpackage"),
             nms=True,
         )
+
+
+RFDETR_CASES = [
+    ("LibreRFDETRn.pt", "detect", 384),
+    ("LibreRFDETRn-seg.pt", "segment", 312),
+    # Pose currently has one published checkpoint; x is the smallest real case.
+    ("LibreRFDETRx-pose.pt", "pose", 576),
+]
+
+
+def _rfdetr_byte_probes(imgsz: int) -> tuple[np.ndarray, np.ndarray]:
+    yy, xx = np.mgrid[:imgsz, :imgsz]
+    first = np.stack(
+        (
+            (3 * xx + 5 * yy + 17) % 256,
+            (11 * xx + 7 * yy + 53) % 256,
+            (13 * xx + 19 * yy + 101) % 256,
+        ),
+        axis=-1,
+    ).astype(np.uint8)
+    second = np.stack(
+        (
+            (23 * xx + 2 * yy + 211) % 256,
+            (5 * xx + 29 * yy + 37) % 256,
+            (17 * xx + 31 * yy + 149) % 256,
+        ),
+        axis=-1,
+    ).astype(np.uint8)
+    return first, second
+
+
+def _rfdetr_tensor(image: np.ndarray) -> torch.Tensor:
+    value = torch.from_numpy(image.copy()).permute(2, 0, 1).unsqueeze(0)
+    return value.float().div_(255.0)
+
+
+def _rfdetr_flatten(value) -> list[torch.Tensor]:
+    if torch.is_tensor(value):
+        return [value]
+    if isinstance(value, (tuple, list)) and all(
+        torch.is_tensor(item) for item in value
+    ):
+        return list(value)
+    raise TypeError(f"Unexpected RF-DETR export output: {type(value).__name__}")
+
+
+def _rfdetr_prepared_reference(model, task: str, imgsz: int, probes):
+    from libreyolo.export.coreml import (
+        _prepare_rfdetr_coreml_graph,
+        _wrap_for_family,
+    )
+    from libreyolo.export.exporter import CoreMLExporter
+
+    tensors = tuple(_rfdetr_tensor(probe) for probe in probes)
+    exporter = CoreMLExporter(model)
+    with exporter._model_context(
+        torch.device("cpu"),
+        False,
+        False,
+        1,
+        (imgsz, imgsz),
+    ) as (nn_model, _):
+        wrapped = _wrap_for_family(nn_model, "rfdetr").eval()
+        with _prepare_rfdetr_coreml_graph(
+            wrapped,
+            tensors[0],
+            "rfdetr",
+            task,
+        ), torch.no_grad():
+            return [
+                [
+                    tensor.detach().cpu().numpy()
+                    for tensor in _rfdetr_flatten(wrapped(probe))
+                ]
+                for probe in tensors
+            ]
+
+
+def _rfdetr_artifact_outputs(artifact, probes):
+    import coremltools as ct
+
+    runtime = ct.models.MLModel(
+        str(artifact),
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+    )
+    spec = runtime.get_spec()
+    names = [feature.name for feature in spec.description.output]
+    input_feature = next(iter(spec.description.input))
+    input_kind = input_feature.type.WhichOneof("Type")
+    outputs = []
+    for probe in probes:
+        if input_kind == "imageType":
+            runtime_input = Image.fromarray(probe, mode="RGB")
+        else:
+            assert input_kind == "multiArrayType"
+            runtime_input = np.ascontiguousarray(
+                probe.astype(np.float32).transpose(2, 0, 1)[None] / 255.0
+            )
+        result = runtime.predict({input_feature.name: runtime_input})
+        outputs.append([np.asarray(result[name]) for name in names])
+    return names, outputs
+
+
+def _assert_rfdetr_raw_parity(names, reference, actual):
+    for index, (expected1, expected2, got1, got2) in enumerate(
+        zip(reference[0], reference[1], actual[0], actual[1])
+    ):
+        assert got1.shape == expected1.shape
+        assert got2.shape == expected2.shape
+        scale = max(
+            float(np.abs(expected1).max()),
+            float(np.abs(expected2).max()),
+            1e-12,
+        )
+        error = max(
+            float(np.abs(got1 - expected1).max()),
+            float(np.abs(got2 - expected2).max()),
+        ) / scale
+        sensitivity = float(np.abs(expected2 - expected1).max()) / scale
+        margin = float("inf") if error == 0 else sensitivity / error
+        print(
+            f"out[{index}] ({names[index]}): error={error:.9e}, "
+            f"sensitivity={sensitivity:.9e}, margin={margin:.3f}x"
+        )
+        assert error <= 3e-4
+        assert sensitivity >= 1e-6
+        assert margin >= 100.0
+
+
+@pytest.mark.parametrize("weights,task,imgsz", RFDETR_CASES)
+def test_rfdetr_coreml_raw_runtime_parity(weights, task, imgsz, tmp_path):
+    from libreyolo import LibreYOLO
+    from libreyolo.export.coreml import _rfdetr_output_names
+
+    model = LibreYOLO(weights, device="cpu")
+    assert model.task == task
+    artifact = model.export(
+        format="coreml",
+        imgsz=imgsz,
+        output_path=str(tmp_path / f"rfdetr-{task}.mlpackage"),
+        compute_units="cpu_only",
+    )
+    probes = _rfdetr_byte_probes(imgsz)
+    reference = _rfdetr_prepared_reference(model, task, imgsz, probes)
+    names, actual = _rfdetr_artifact_outputs(artifact, probes)
+    assert names == _rfdetr_output_names(task)
+    _assert_rfdetr_raw_parity(names, reference, actual)


### PR DESCRIPTION
Adds experimental RF-DETR Apple export coverage for detection, segmentation, and pose across Core ML and Core AI. The Core ML path now carries task metadata and semantic output names, selects the input boundary needed by pose, prepares the RF-DETR graph transactionally, and preserves task-specific preprocessing at runtime. Shared RF-DETR export rewrites avoid unsupported tensor construction and rank-six deformable-attention intermediates; segmentation uses an export-only stable proposal ordering. The support matrix and trained-checkpoint end-to-end tests now cover all six cells.

Tested on an Apple Silicon Mac mini with CPU-only runtime execution. Core ML detection, segmentation, and pose passed a 3e-4 relative-parity gate with at least 100x sensitivity margin; the largest observed relative error was 1.964e-4. Core AI detection, segmentation, and pose passed the same trained-checkpoint parity contract. Related Core ML and support unit tests passed (47 tests). Public inference checks were repeatable: segmentation produced 1.0 mask IoU and pose stayed within 0.000294 pixel maximum keypoint error.

This remains experimental fixed-canvas, batch-one support. Detection and segmentation use the smallest n checkpoints; pose uses x because it is the smallest published pose checkpoint.

## Code provenance

Original code written for this PR from LibreYOLO's first-party code and empirical Apple runtime experiments; no third-party code ported, adapted, or introduced, and no GPL/AGPL/LGPL/non-commercial/unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds experimental RF-DETR Apple export coverage.
- Adds Core ML task-aware inputs, semantic output names, metadata, runtime preprocessing, and transactional RF-DETR graph preparation.
- Rewrites RF-DETR deformable attention and segmentation proposal ordering for Apple conversion constraints.
- Enables RF-DETR segmentation and pose in the Core ML/Core AI support matrix and adds trained-checkpoint parity tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The batch-contract regression in Core ML export needs to be fixed before merging because multi-batch requests now silently produce batch-one artifacts and bypass the embedded-NMS rejection.

The new canonical trace probe discards the batch dimension supplied by the export pipeline before both validation and Core ML input-shape construction.

**Files Needing Attention:** libreyolo/export/coreml.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/export/coreml.py | Adds RF-DETR task-aware graph preparation and conversion, but the trace probe incorrectly forces every requested export to batch one. |
| libreyolo/backends/coreml.py | Adds spec-driven input handling and pose-specific antialiased tensor preprocessing consistent with the new RF-DETR pose boundary. |
| libreyolo/models/rfdetr/transformer.py | Rewrites unsupported tensor construction and flattens deformable-attention bookkeeping axes while preserving level-major ordering. |
| libreyolo/export/exporter.py | Propagates the model task into Core ML export. |
| libreyolo/export/support.py | Marks RF-DETR segmentation and pose as experimental for Core ML and Core AI. |
| tests/e2e/test_coreml_roundtrip.py | Adds runtime parity coverage for RF-DETR detection, segmentation, and pose, all using batch one. |
| tests/e2e/test_coreai.py | Adds trained segmentation and pose checkpoints to Core AI parity coverage. |
| docs/export_support.md | Documents experimental RF-DETR segmentation and pose support for Apple export formats. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Requested export batch] --> B[BaseExporter dummy tensor]
    B --> C[_canonical_trace_probe]
    C --> D[RF-DETR graph preparation and tracing]
    D --> E[Core ML conversion]
    E --> F[Metadata and mlpackage]
    F --> G[CoreMLBackend preprocessing]
    G --> H[Apple runtime inference]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fexport%2Fcoreml.py%3A91-103%0A**Trace%20probe%20discards%20export%20batch**%0A%0AWhen%20Core%20ML%20export%20requests%20a%20batch%20greater%20than%20one%2C%20%60_canonical_trace_probe%60%20replaces%20it%20with%20batch%20one%20before%20tracing%20and%20validation%2C%20causing%20non-NMS%20artifacts%20to%20expose%20the%20wrong%20fixed%20batch%20contract%20and%20preventing%20embedded%20NMS%20from%20rejecting%20unsupported%20multi-image%20exports.%0A%0A%60%60%60suggestion%0Adef%20_canonical_trace_probe%28dummy%3A%20torch.Tensor%29%20-%3E%20torch.Tensor%3A%0A%20%20%20%20%22%22%22Build%20a%20deterministic%2C%20chromatic%2C%20non-constant%20RGB%20probe%20in%20%5B0%2C%201%5D.%22%22%22%0A%20%20%20%20batch%20%3D%20int%28dummy.shape%5B0%5D%29%0A%20%20%20%20height%2C%20width%20%3D%20int%28dummy.shape%5B-2%5D%29%2C%20int%28dummy.shape%5B-1%5D%29%0A%20%20%20%20ys%20%3D%20torch.linspace%28%0A%20%20%20%20%20%20%20%200.05%2C%200.95%2C%20height%2C%20dtype%3Dtorch.float32%2C%20device%3Ddummy.device%0A%20%20%20%20%29.view%281%2C%201%2C%20height%2C%201%29%0A%20%20%20%20xs%20%3D%20torch.linspace%28%0A%20%20%20%20%20%20%20%200.1%2C%200.9%2C%20width%2C%20dtype%3Dtorch.float32%2C%20device%3Ddummy.device%0A%20%20%20%20%29.view%281%2C%201%2C%201%2C%20width%29%0A%20%20%20%20red%20%3D%20xs.expand%28batch%2C%201%2C%20height%2C%20width%29%0A%20%20%20%20green%20%3D%20ys.expand%28batch%2C%201%2C%20height%2C%20width%29%0A%20%20%20%20blue%20%3D%20%280.65%20*%20red%20%2B%200.35%20*%20green%29.clamp%280.0%2C%201.0%29%0A%20%20%20%20return%20torch.cat%28%28red%2C%20green%2C%20blue%29%2C%20dim%3D1%29.contiguous%28%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=665&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22experiment%2Frfdetr-apple-six-pr%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22experiment%2Frfdetr-apple-six-pr%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Fexport%2Fcoreml.py%3A91-103%0A**Trace%20probe%20discards%20export%20batch**%0A%0AWhen%20Core%20ML%20export%20requests%20a%20batch%20greater%20than%20one%2C%20%60_canonical_trace_probe%60%20replaces%20it%20with%20batch%20one%20before%20tracing%20and%20validation%2C%20causing%20non-NMS%20artifacts%20to%20expose%20the%20wrong%20fixed%20batch%20contract%20and%20preventing%20embedded%20NMS%20from%20rejecting%20unsupported%20multi-image%20exports.%0A%0A%60%60%60suggestion%0Adef%20_canonical_trace_probe%28dummy%3A%20torch.Tensor%29%20-%3E%20torch.Tensor%3A%0A%20%20%20%20%22%22%22Build%20a%20deterministic%2C%20chromatic%2C%20non-constant%20RGB%20probe%20in%20%5B0%2C%201%5D.%22%22%22%0A%20%20%20%20batch%20%3D%20int%28dummy.shape%5B0%5D%29%0A%20%20%20%20height%2C%20width%20%3D%20int%28dummy.shape%5B-2%5D%29%2C%20int%28dummy.shape%5B-1%5D%29%0A%20%20%20%20ys%20%3D%20torch.linspace%28%0A%20%20%20%20%20%20%20%200.05%2C%200.95%2C%20height%2C%20dtype%3Dtorch.float32%2C%20device%3Ddummy.device%0A%20%20%20%20%29.view%281%2C%201%2C%20height%2C%201%29%0A%20%20%20%20xs%20%3D%20torch.linspace%28%0A%20%20%20%20%20%20%20%200.1%2C%200.9%2C%20width%2C%20dtype%3Dtorch.float32%2C%20device%3Ddummy.device%0A%20%20%20%20%29.view%281%2C%201%2C%201%2C%20width%29%0A%20%20%20%20red%20%3D%20xs.expand%28batch%2C%201%2C%20height%2C%20width%29%0A%20%20%20%20green%20%3D%20ys.expand%28batch%2C%201%2C%20height%2C%20width%29%0A%20%20%20%20blue%20%3D%20%280.65%20*%20red%20%2B%200.35%20*%20green%29.clamp%280.0%2C%201.0%29%0A%20%20%20%20return%20torch.cat%28%28red%2C%20green%2C%20blue%29%2C%20dim%3D1%29.contiguous%28%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=665&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add RF-DETR Apple export coverage"](https://github.com/libreyolo/libreyolo/commit/fc26b86bcd95917db560f2084583d3958f3f7f29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48699298)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->