### PR TITLE
Add run-rf100vl-benchmark skill

### DIFF
--- a/skills/run-rf100vl-benchmark/SKILL.md
+++ b/skills/run-rf100vl-benchmark/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: run-rf100vl-benchmark
+description: >-
+  Run the RF100-VL (Roboflow 100-VL) detection benchmark on LibreYOLO models
+  end to end: dataset download with version locking, per-dataset fine-tuning,
+  protocol-conformant pycocotools evaluation at maxDets 500, artifact
+  publishing, and multi-GPU execution on vast.ai (the default compute). Use
+  when someone wants to "run RF100-VL", "benchmark on Roboflow 100",
+  reproduce or extend published RF100-VL numbers, or add a model family to
+  the campaign. Training and eval run in the vision-analysis-benchmark
+  harness; this skill holds the protocol, the locked decisions, and the
+  compute playbook.
+---
+
+# Run the RF100-VL benchmark
+
+RF100-VL: 100 real-world detection datasets from Roboflow Universe (164,149
+images, 564 classes, 7 domains), paper arXiv 2505.20612 (NeurIPS 2025
+Datasets and Benchmarks). Each dataset ships fixed `train`/`valid`/`test`
+splits in COCO JSON. There is no official runner; the harness referenced
+below is the runner.
+
+## Protocol (locked decisions)
+
+| Decision | Value | Authority |
+|---|---|---|
+| Scoring | pycocotools, `maxDets=500`, per-dataset `test` split | paper |
+| Headline metric | AP 0.50:0.95, unweighted mean over the 100 datasets | paper |
+| Per-domain means | published alongside (7 domains) | our addition |
+| Split discipline | train on `train`, select on `valid`, report on `test` | Roboflow reference code |
+| Selection | validate every epoch, EMA weights, keep best AP50:95 | Roboflow reference code |
+| Epoch budget | cap 100, early stopping patience 20 | LibreYOLO policy (reference runs a fixed 100; disclosed deviation) |
+| Effective batch | 16 (physical batch x gradient accumulation) | Roboflow reference code |
+| Precision | fp32; bf16 only via explicit `amp_dtype`; never fp16 autocast | LibreYOLO policy |
+| Eval thresholds | conf 0.001; NMS IoU 0.65 for NMS families, identical at selection and final eval; DETR families are NMS-free top-k | LibreYOLO policy |
+| Seed | 0 | LibreYOLO policy |
+| Recipes | one pinned JSON per family in the harness (`va_bench/recipes/rf100vl/`), sha recorded in every run, same recipe for all 100 datasets | LibreYOLO policy |
+
+Never report toolkit-native trapezoidal mAP; it inflates up to 2.7 AP on
+RF100-VL versus pycocotools (paper, App B). LibreYOLO validation is
+pycocotools-based already; the 500 cap is the opt-in `eval_max_det` kwarg
+(`model.val(data=..., split="test", eval_max_det=500)`). Defaults for normal
+users are unchanged (AP at maxDets 100) and test-locked.
+
+## Where the work happens
+
+Repo `LibreYOLO/vision-analysis-benchmark` (the harness). Two verbs:
+
+```bash
+# per-dataset fine-tuning: one worker per GPU, subprocess children,
+# atomic status files, resume, timeouts, dense-dataset OOM fallback
+va-bench rf100vl-train --data-dir ./rf100-vl --weights-root ./rf100vl-weights --gpus 0,1,2,3,4,5,6,7
+
+# per-dataset test-split eval: cached and resumable, emits one
+# va.submission.v1 JSON with a per-dataset rf100vl block
+va-bench rf100vl --all --data-dir ./rf100-vl --weights-root ./rf100vl-weights
+```
+
+- Dataset download: add `--download` (wraps the `rf100vl` pip package; needs
+  a free `ROBOFLOW_API_KEY` in the env; about 40 GB). The harness writes a
+  version lock and replays recorded versions; it never re-resolves latest.
+- Weights contract: training places `best.pt` at
+  `<weights_root>/<dataset>/<weight_file>`; eval resolves exactly that path.
+- A capability guard aborts training on any libreyolo build without
+  `eval_max_det`/`amp_dtype` support, so a wrong install cannot silently
+  produce off-protocol numbers.
+- Exact flags and current behavior: the harness README (RF100-VL section)
+  and `--help` are authoritative; do not trust this skill for flag lists.
+
+## Decisions to take per campaign
+
+1. Model list and sizes. Flagships deep (yolo9 and rfdetr, all or most
+   sizes); every other family starts with its one or two smallest variants.
+2. Pilot first: run the `rf20vl` subset end to end. A family graduates to
+   the full 100 only if all 20 datasets complete, a kill-and-resume drill
+   reproduces the uninterrupted result within noise, and its AP ordering is
+   sane.
+3. Budget and waves: price the run from current marketplace offers (below),
+   publish after the flagships land, append families as they finish.
+4. Recipe deviations: any change lives in the recipe JSON, is hash-recorded
+   in every run, and is disclosed with the results. No silent knobs.
+
+## Artifacts and publishing
+
+Keep, per model: per-dataset eval JSONs, per-dataset raw predictions (COCO
+detections), per-run `stats.json` (recipe sha, best epoch, seed, dataset
+version, wall time), the recipe JSON, the dataset version lock, and the
+final submission JSON.
+
+- Upload the per-model artifact folder to a Hugging Face dataset repo under
+  the LibreYOLO org (one folder per model). Anyone can then rescore from the
+  JSONs with pycocotools, no GPU needed; that is the reproducibility story.
+- The leaderboard submission goes to the `vision-analysis` repo through its
+  `submit-benchmark-results` flow (validate, rebuild, PR, deploy). See the
+  `benchmark-on-visionanalysis` skill for the handoff.
+- Never hand-edit result JSONs. Regenerate them.
+
+## Compute: vast.ai (default)
+
+Account setup, 2FA, launch, exec, tail, pull, guard, and destroy discipline:
+follow `skills/launch-serverless-gpu-job` (Vast section). This section adds
+only the RF100-VL specifics.
+
+- Workload shape: independent single-GPU jobs, batch 16 at 640 px, under 12
+  GB VRAM for most families. No interconnect requirement, so interruptible
+  consumer boxes dominate datacenter cards on price per GPU-hour.
+- Primary target: one 8x RTX 5090 interruptible box. Fallback: several 1-4x
+  RTX 5090 or RTX 4090 boxes; the orchestrator takes any GPU count and
+  multi-box runs split the dataset list.
+- Offer filter: verified host, reliability above 0.99, at least 8 vCPU per
+  GPU, at least 300 GB disk, at least 500 Mbps down, download cost under
+  0.01 USD per GB, host driver CUDA capability 12.8 or newer. Bid 20 to 30
+  percent above the current minimum to reduce outbid churn.
+- Prices move within hours: re-check offers immediately before every wave
+  and archive the query plus results with the run records.
+- Interruptible semantics: being outbid pauses the box; its disk persists
+  (and bills) while the instance exists; destroy deletes it. The harness
+  resumes at dataset level (status files) and epoch level (`last.pt`). Sync
+  `weights_root` and results off-box at milestones (HF), and always `pull`
+  before `destroy`.
+- Local-first rule: the whole flow must pass on a local GPU (one dataset,
+  then the rf20vl pilot) before renting anything. Credits are for the
+  campaign, not for debugging.
+- Rough sizing: 0.5 to 1 consumer-GPU-hour per dataset for YOLO-family
+  models, 1 to 2.5 for DETR-family; a full 100-dataset pass per family lands
+  roughly between 30 and 200 GPU-hours depending on family.
+
+## Traps
+
+- Stock pycocotools `summarize()` breaks with a non-default maxDets list
+  (headline AP becomes -1). LibreYOLO and the harness compute the stats
+  directly; never call stock summarize with a modified list.
+- Only use the `rf100vl` package download. Raw website exports carry a dummy
+  class 0 with shifted category ids; mixing cleaned ground truth with
+  uncleaned predictions scores near zero.
+- One dataset is literally named `-grccs`: write `--datasets=-grccs` (the
+  space form is eaten by argparse).
+- Never resume a checkpoint after changing physical batch or accumulation.
+  The harness refuses via run signatures; do not override it.
+- Dense datasets can OOM rfdetr; the harness picks a grad-accum fallback at
+  dataset start and restarts from epoch 0 on a mid-run OOM. Expected.
+- The ec family trains with its AdamW no-mosaic recipe (mosaic triggers a
+  degenerate-box assertion).
+- The largest datasets take hours per run. Per-dataset timeouts plus the
+  rerun list handle the tail; raise the timeout for slow families, never
+  remove it.
+- Differences under 0.5 mAP on the 100-dataset mean are noise. Replicate
+  before claiming a win.
+- `ROBOFLOW_API_KEY` and vast credentials live in env or local config only.
+  Never commit keys; upstream reference repos did, and it cost them.
+
+## Published numbers to beat (fully supervised, AP 0.50:0.95)
+
+RF-DETR N/S/M/L/XL/2XL: 57.7 / 60.2 / 61.2 / 62.2 / 62.9 / 63.2. LW-DETR
+T to X: 57.1 to 62.1. D-FINE N to X: 58.2 to 62.2. YOLO11 N to X: 55.3 to
+56.5. YOLO26 N to X: 52.0 to 60.0. Sources: the rf-detr repo README
+(develop) and paper v4 tables. No YOLO9-lineage numbers exist anywhere yet.


### PR DESCRIPTION
## What does this PR do?

Adds `skills/run-rf100vl-benchmark/SKILL.md`: the authoritative in-repo guide for running the RF100-VL benchmark on LibreYOLO models.

- Locked protocol table with three-tier attribution (paper-mandated, reference-observed, LibreYOLO policy), including pycocotools maxDets 500 via the new opt-in `eval_max_det`, per-epoch best-on-valid selection, test-split reporting, and early stopping (patience 20) as the one disclosed deviation.
- Harness entry points (`va-bench rf100vl-train` / `va-bench rf100vl`), the weights-root contract, dataset download with version locking, and the capability guard. Flag lists deliberately defer to the harness README to avoid drift.
- Per-campaign decision checklist (model tiers, rf20vl pilot gate, waves, recipe-deviation rule).
- Artifact publishing conventions: per-model HF folders (per-dataset eval JSONs, raw predictions, recipe, version lock, stats) plus the vision-analysis submission flow.
- vast.ai compute playbook: interruptible consumer GPUs as default, offer filter, bidding, interruption semantics, local-first rule, rough sizing.
- Trap index distilled from the reference-repo investigation (stock summarize breakage, dummy-class ids, `-grccs`, resume signatures, OOM fallback, noise floor, key hygiene).

## Code provenance

Original documentation written for this repository. Protocol facts derive from the RF100-VL paper (arXiv 2505.20612) and public roboflow/rf100-vl repositories; published comparison numbers from the public rf-detr README and paper tables. No code copied.

## How was this tested?

Docs-only change. Commands and kwarg names cross-checked against current dev (`eval_max_det`, `amp_dtype`) and the vision-analysis-benchmark harness PR #6 head. Scanned clean for em/en dashes, third-party library names, personal names, and machine paths.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an operational skill for running and publishing RF100-VL benchmark campaigns.
- Defines the locked training, validation, selection, and reporting protocol.
- Documents harness entry points, dataset and artifact contracts, campaign decisions, and recovery behavior.
- Adds a Vast.ai compute playbook, known traps, and published comparison numbers.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation is safe to merge after clarifying the non-blocking bf16 activation instructions.

The benchmark workflow and evaluation API match the repository implementation, but setting `amp_dtype` alone does not activate bf16 because autocast also requires `half=True`.

**Files Needing Attention:** skills/run-rf100vl-benchmark/SKILL.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| skills/run-rf100vl-benchmark/SKILL.md | Adds comprehensive RF100-VL campaign guidance, but the bf16 instruction omits the `half=True` switch required to activate autocast. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Pilot[Run one-dataset check and RF20-VL pilot] --> Train[Fine-tune each dataset]
    Train --> Select[Select best EMA checkpoint on valid]
    Select --> Eval[Evaluate test split with maxDets 500]
    Eval --> Artifacts[Publish predictions, metrics, recipes, and locks]
    Artifacts --> Submit[Submit results to vision-analysis]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A34%0A**Bf16%20activation%20omits%20half%20flag**%0A%0ASetting%20%60amp_dtype%3D%22bfloat16%22%60%20alone%20does%20not%20enable%20autocast%3B%20%60half%3DTrue%60%20is%20also%20required%2C%20so%20following%20this%20instruction%20leaves%20the%20run%20in%20fp32%20while%20its%20recipe%20appears%20to%20request%20bf16.%0A%0A%60%60%60suggestion%0A%7C%20Precision%20%7C%20fp32%3B%20bf16%20only%20via%20explicit%20%60half%3DTrue%2C%20amp_dtype%3D%22bfloat16%22%60%3B%20never%20fp16%20autocast%20%7C%20LibreYOLO%20policy%20%7C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22add-rf100vl-benchmark-skill%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-rf100vl-benchmark-skill%22.%0A%0A%23%23%23%20Issue%201%0Askills%2Frun-rf100vl-benchmark%2FSKILL.md%3A34%0A**Bf16%20activation%20omits%20half%20flag**%0A%0ASetting%20%60amp_dtype%3D%22bfloat16%22%60%20alone%20does%20not%20enable%20autocast%3B%20%60half%3DTrue%60%20is%20also%20required%2C%20so%20following%20this%20instruction%20leaves%20the%20run%20in%20fp32%20while%20its%20recipe%20appears%20to%20request%20bf16.%0A%0A%60%60%60suggestion%0A%7C%20Precision%20%7C%20fp32%3B%20bf16%20only%20via%20explicit%20%60half%3DTrue%2C%20amp_dtype%3D%22bfloat16%22%60%3B%20never%20fp16%20autocast%20%7C%20LibreYOLO%20policy%20%7C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add run-rf100vl-benchmark skill"](https://github.com/libreyolo/libreyolo/commit/f5e9af40d3bece6d2f100e474e6d4de277a50dcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48699491)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->