### PR TITLE
Add ExecuTorch export and runtime support

### DIFF
--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -199,6 +199,19 @@ bit-identical:
 - `interpolation`: resize filter, `"bilinear"` or `"bicubic"`. Readers default
   to `"bilinear"` when the key is absent.
 
+ExecuTorch exports write the flat metadata to a required
+`<program>.pte.json` sidecar. The v1 contract is CPU, FP32, batch 1, and a
+fixed input canvas. It additionally requires:
+
+- `executorch_version`: installed ExecuTorch package version used to export.
+- `executorch_delegate`: `"xnnpack"`.
+- `executorch_delegate_partitions`: positive number of XNNPACK delegate calls
+  retained in the lowered edge program.
+
+The loader rejects a sidecar that claims another delegate, dynamic shapes, or
+non-FP32 precision. A `.pte` is backend-specific and is not a native PyTorch
+checkpoint.
+
 For ONNX YOLO9 detection exports with `nms=true`, output `0` / `output` is the
 standalone post-NMS tensor using the export-time `nms_conf`, `nms_iou`, and
 `max_det` values. When `nms_raw_output=true`, output `1` / `raw` is reserved for

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -13,20 +13,20 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | clip | embed |  |  |  |  |  |  |  |  |  |
 | convnext | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
 | deim | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
-| deimv2 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
+| deimv2 | detect | exp | ✓ |  | exp | exp |  |  |  | ✓ |
 | depth_anything | depth | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
 | depth_anything3 | depth |  |  |  |  |  |  |  |  |  |
-| dexined | edge | ✓ |  |  |  |  |  |  |  |  |
+| dexined | edge | ✓ |  | exp |  |  |  |  |  |  |
 | dfine | detect | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
 | dfine | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | dinov2 | semantic | ✓ | ✓ |  | exp | exp |  |  |  |  |
 | dinov2 | classify | ✓ |  |  |  |  |  |  |  | exp |
 | dinov2 | embed |  |  |  |  |  |  |  |  |  |
-| ec | detect | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
+| ec | detect | ✓ | ✓ | ✓ | exp | exp |  |  |  | ✓ |
 | ec | pose | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | ec | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | edgetam | segment |  |  |  |  |  |  |  |  |  |
-| efficientnetv2 | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| efficientnetv2 | classify | ✓ | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | eomt | semantic | ✓ | ✓ |  | exp | exp |  |  |  |  |
 | eomt | segment |  |  |  |  |  |  |  |  |  |
 | eomt | panoptic |  |  |  |  |  |  |  |  |  |
@@ -41,28 +41,28 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | lingbotvision | semantic | ✓ | ✓ |  | exp | exp |  |  |  | ✓ |
 | locateanything | detect |  |  |  |  |  |  |  |  |  |
 | locateanything | point |  |  |  |  |  |  |  |  |  |
-| mobilenetv4 | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| mobilenetv4 | classify | ✓ | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | mobilesam | segment |  |  |  |  |  |  |  |  |  |
 | moge2 | normal | ✓ |  |  |  |  |  |  |  |  |
 | nafnet | restore | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | omdet_turbo | detect |  |  |  |  |  |  |  |  |  |
 | ov_deim | detect |  |  |  |  |  |  |  |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |  |  |
-| picodet | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| picodet | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | picosam3 | segment | ✓ |  |  |  |  |  |  |  |  |
-| pidnet | semantic | ✓ | ✓ |  | exp | exp | ✓ | ✓ |  | ✓ |
+| pidnet | semantic | ✓ | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | ppocr | ocr |  |  |  |  |  |  |  |  |  |
 | qwen3vl | detect |  |  |  |  |  |  |  |  |  |
 | realesrgan | restore | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
-| resnet | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| resnet | classify | ✓ | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
 | rfdetr | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  | exp | exp | ✓ |
 | rfdetr | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | rfdetr | pose | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | rfdetr | obb | ✓ | ✓ | exp | exp | exp |  |  |  |  |
-| rtdetr | detect | ✓ | ✓ | exp | exp | exp |  |  | exp | ✓ |
+| rtdetr | detect | ✓ | ✓ | ✓ | exp | exp |  |  | exp | ✓ |
 | rtdetrv2 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
 | rtdetrv4 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
-| rtmdet | detect | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
+| rtmdet | detect | ✓ | ✓ |  | exp | exp |  |  |  | ✓ |
 | rtmdet | segment |  |  |  |  |  |  |  |  |  |
 | sam | segment |  |  |  |  |  |  |  |  |  |
 | sam2 | segment |  |  |  |  |  |  |  |  |  |
@@ -73,18 +73,18 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | siglip2 | embed |  |  |  |  |  |  |  |  |  |
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |  |
 | swinir | restore | exp | exp | exp | exp | exp | exp |  |  |  |
-| teed | edge | ✓ |  |  |  |  |  |  |  |  |
+| teed | edge | ✓ |  | exp |  |  |  |  |  |  |
 | yolo1 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo2 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo3 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo4 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo7 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
-| yolo9_e2e | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo9_e2e | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolonas | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolonas | pose | ✓ | ✓ | exp | exp | exp | ✓ |  |  |  |
-| yolox | detect | ✓ | ✓ | exp | exp | exp | ✓ | ✓ | exp | ✓ |
+| yolox | detect | ✓ | ✓ | ✓ | exp | exp | ✓ | ✓ | exp | ✓ |
 | zipdepth | depth | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 
 ## Parity thresholds
@@ -113,11 +113,13 @@ A check mark applies only under any constraint listed here.
 - `dinov2` / `semantic` / `onnx`: fixed 518x518 input
 - `dinov2` / `semantic` / `torchscript`: fixed 518x518 input
 - `dinov2` / `classify` / `onnx`: fixed 224x224 input
+- `ec` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `ec` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `ec` / `pose` / `onnx`: fixed 640x640 input
 - `ec` / `pose` / `torchscript`: fixed 640x640 input
 - `ec` / `segment` / `onnx`: fixed 640x640 input
 - `ec` / `segment` / `torchscript`: fixed 640x640 input
+- `efficientnetv2` / `classify` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `efficientnetv2` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 - `eomt` / `semantic` / `onnx`: fixed 512x512 input
 - `eomt` / `semantic` / `torchscript`: fixed 512x512 input
@@ -127,20 +129,24 @@ A check mark applies only under any constraint listed here.
 - `lingbotvision` / `semantic` / `onnx`: fixed 512x512 input
 - `lingbotvision` / `semantic` / `torchscript`: fixed 512x512 input
 - `lingbotvision` / `semantic` / `coreai`: fixed family-native canvases (PIDNet 1024, LingBotVision 512); trained LibrePIDNets-sem and LibreLingBotVisions-sem checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; exported backends already implement the shared dense-logit resize and argmax contract
+- `mobilenetv4` / `classify` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `mobilenetv4` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 - `moge2` / `normal` / `onnx`: fixed square batch-1 export canvas divisible by 14; exported inference rejects non-square sources rather than stretching image-plane geometry; the official MIT ViT-S/B/L normal checkpoints are covered by FP32 same-canvas native-versus-ONNX angular parity below 0.1 degree
 - `nafnet` / `restore` / `onnx`: fixed-resolution export canvas
 - `nafnet` / `restore` / `torchscript`: fixed-resolution export canvas
 - `nafnet` / `restore` / `ncnn`: fixed-resolution export canvas
 - `nafnet` / `restore` / `coreai`: fixed export canvas; permissively licensed trained restoration checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `picodet` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `picodet` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `picosam3` / `segment` / `onnx`: raw fixed-96 ROI contract: roi_image -> mask_logits
+- `pidnet` / `semantic` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `pidnet` / `semantic` / `coreai`: fixed family-native canvases (PIDNet 1024, LingBotVision 512); trained LibrePIDNets-sem and LibreLingBotVisions-sem checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; exported backends already implement the shared dense-logit resize and argmax contract
 - `realesrgan` / `restore` / `onnx`: ONNX supports dynamic spatial input; TorchScript and NCNN are fixed-canvas
 - `realesrgan` / `restore` / `torchscript`: ONNX supports dynamic spatial input; TorchScript and NCNN are fixed-canvas
 - `realesrgan` / `restore` / `ncnn`: ONNX supports dynamic spatial input; TorchScript and NCNN are fixed-canvas
 - `realesrgan` / `restore` / `tflite`: fixed-resolution export canvas
 - `realesrgan` / `restore` / `coreai`: fixed export canvas; permissively licensed trained restoration checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `resnet` / `classify` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `resnet` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 - `rfdetr` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `rfdetr` / `detect` / `coreai`: fixed export canvas; trained LibreRFDETRn weights are covered on macOS 27 against the graph the exporter itself prepares, using direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin. Conversion needed _rebake_rfdetr_pos_embed in export/coreai.py: the backbone bakes its position embedding for its configured 384 canvas, so exporting at any other size left an antialiased bicubic in the graph and the converter has no lowering for aten._upsample_bicubic2d_aa. The rebake re-runs the model's OWN baking path for the actual canvas, so the interpolation happens eagerly, outside the graph, computing exactly what it computed before. NOTE the reference. This family is verified against the exporter's prepared graph, not against ONNX, and the difference is not a detail: at a 640 canvas the rfdetr ONNX artifact disagrees with that same prepared graph by 9.3e-01. Core AI's rebake preserves the antialiased resize the eager model performs, whereas the ONNX path disables antialiasing (the model checks torch.onnx.is_in_onnx_export). Which artifact is right is an ONNX question and is not settled here, but ONNX cannot be used as the reference for this family at a non-native canvas.
@@ -150,6 +156,7 @@ A check mark applies only under any constraint listed here.
 - `rfdetr` / `pose` / `torchscript`: fixed task-native input resolution
 - `rfdetr` / `obb` / `onnx`: fixed task-native input resolution
 - `rfdetr` / `obb` / `torchscript`: fixed task-native input resolution
+- `rtdetr` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `rtdetr` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `rtdetrv2` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `rtdetrv4` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
@@ -165,9 +172,11 @@ A check mark applies only under any constraint listed here.
 - `yolo7` / `detect` / `coreai`: fixed 640x640 export canvas; trained LibreYOLO7b weights are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; the export decoder uses direct arange grids because Core AI 0.4.1 mislowers the equivalent cumulative-sum expression
 - `yolo9` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo9` / `detect` / `coreai`: fixed export canvas; trained LibreYOLO9t weights are covered on macOS 27 by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `yolo9_e2e` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo9_e2e` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `yolo9_p2` / `detect` / `coreai`: fixed 640x640 export canvas; a deterministic YOLO9-P2-T model initialized from the SHA-256-pinned, permissively licensed trained LibreYOLO9t checkpoint is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; this validates conversion, not P2 task accuracy, and does not depend on the restricted VisDrone research-preview checkpoint
 - `yolonas` / `detect` / `coreai`: fixed 96x96 export canvas with pre-shaped canonical RGB tensors; a deterministic, license-clean synthetic YOLO-NAS-S state is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; the state receives 12 native training steps and a 20x regression-head scale to make both exported outputs non-degenerate; this validates conversion, not detection accuracy, raw-image preprocessing, or native-640 behavior, and does not convert restricted official weights
+- `yolox` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolox` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `zipdepth` / `depth` / `onnx`: fixed-resolution export canvas
 - `zipdepth` / `depth` / `torchscript`: fixed-resolution export canvas
@@ -200,6 +209,7 @@ A check mark applies only under any constraint listed here.
 - `deim` / `detect` / `ncnn`: NCNN export is not supported for DEIM: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `deim` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `deim` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `deimv2` / `detect` / `executorch`: The trained atto model captures, lowers, and serializes, but the ExecuTorch 1.2 runtime process terminates while executing forward.
 - `deimv2` / `detect` / `ncnn`: NCNN export is not supported for DEIMv2: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `deimv2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `deimv2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
@@ -216,7 +226,6 @@ A check mark applies only under any constraint listed here.
 - `depth_anything3` / `depth` / `coreml`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `coreai`: The model raises NotImplementedError for every format: depth export is out of scope per ADR 0006, the depth task contract. Depth Anything V2 exports and validates at 5.2e-06, so this is specific to the V3 family and not a Core AI limitation.
 - `dexined` / `edge` / `torchscript`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
-- `dexined` / `edge` / `executorch`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `tensorrt`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `openvino`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `ncnn`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
@@ -434,7 +443,6 @@ A check mark applies only under any constraint listed here.
 - `picosam3` / `segment` / `tflite`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `coreml`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `coreai`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
-- `pidnet` / `semantic` / `executorch`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `pidnet` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `ppocr` / `ocr` / `onnx`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `torchscript`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
@@ -477,6 +485,7 @@ A check mark applies only under any constraint listed here.
 - `rtdetrv4` / `detect` / `ncnn`: NCNN export is not supported for RT-DETRv4: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rtdetrv4` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `rtdetrv4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `rtmdet` / `detect` / `executorch`: ExecuTorch 1.2 XNNPACK lowering fails in FuseBatchNormPass because the generated graph has a duplicate fused parameter name.
 - `rtmdet` / `detect` / `ncnn`: PNNX 20260526 reports an unregistered nn.Conv2d layer and leaves the RTMDet NCNN graph without usable input blobs.
 - `rtmdet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `rtmdet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
@@ -563,7 +572,6 @@ A check mark applies only under any constraint listed here.
 - `swinir` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `swinir` / `restore` / `coreai`: The export process DIES rather than hangs, and the kill point moves between runs, which is the signature of memory exhaustion rather than a stuck loop. One run reached 'Step 3/3: Optimizing and writing the asset' before stopping; a later run of the same graph at the same 128 canvas died inside to_coreai() before returning, in both cases with a leaked-semaphore warning and no traceback. Window attention unrolls into a very large number of small ops, so the converter's peak memory is the prime suspect on a 16 GB machine. Next steps: watch RSS during conversion, try the smallest available size at a 64 canvas, and check the system log for a memory kill. Do NOT assume optimize() is at fault; an earlier note said so on the strength of a single run and the second run contradicted it.
 - `teed` / `edge` / `torchscript`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
-- `teed` / `edge` / `executorch`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `teed` / `edge` / `tensorrt`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `teed` / `edge` / `openvino`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `teed` / `edge` / `ncnn`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -32,7 +32,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | eomt | panoptic |  |  |  |  |  |  |  |  |  |
 | feynobg | matte | exp | ✓ | exp | exp | exp |  |  |  |  |
 | florence2 | detect |  |  |  |  |  |  |  |  |  |
-| fomo | point | ✓ | ✓ |  | exp | exp | ✓ |  |  | ✓ |
+| fomo | point | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | grounding_dino | detect |  |  |  |  |  |  |  |  |  |
 | internvl3 | detect |  |  |  |  |  |  |  |  |  |
 | kosmos2 | detect |  |  |  |  |  |  |  |  |  |
@@ -326,7 +326,6 @@ A check mark applies only under any constraint listed here.
 - `florence2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
-- `fomo` / `point` / `executorch`: This family is not wired to the shared point heatmap and backend peak-decoding export contract.
 - `fomo` / `point` / `tflite`: onnx2tf 2.4.x produces an invalid depthwise-convolution graph for the static SAME-padded FOMO backbone on this toolchain.
 - `fomo` / `point` / `coreml`: The CoreML wrapper does not implement the raw point-heatmap contract.
 - `grounding_dino` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -6,86 +6,86 @@ Do not edit the matrix by hand.
 `✓` means parity-validated, `exp` means conversion is available without a
 numeric parity guarantee, and an empty cell is blocked in preflight.
 
-| Family | Task | onnx | torchscript | tensorrt | openvino | ncnn | tflite | coreml | coreai |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| birefnet | matte | exp | ✓ | exp | exp |  |  |  |  |
-| clip | classify | ✓ |  |  |  |  |  |  | ✓ |
-| clip | embed |  |  |  |  |  |  |  |  |
-| convnext | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
-| deim | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
-| deimv2 | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
-| depth_anything | depth | ✓ | ✓ | exp | exp |  |  |  | ✓ |
-| depth_anything3 | depth |  |  |  |  |  |  |  |  |
-| dexined | edge | ✓ |  |  |  |  |  |  |  |
-| dfine | detect | ✓ | ✓ | exp | exp |  |  |  | ✓ |
-| dfine | segment | ✓ | ✓ | exp | exp |  |  |  |  |
-| dinov2 | semantic | ✓ | ✓ | exp | exp |  |  |  |  |
-| dinov2 | classify | ✓ |  |  |  |  |  |  | exp |
-| dinov2 | embed |  |  |  |  |  |  |  |  |
-| ec | detect | ✓ | ✓ | exp | exp |  |  |  | ✓ |
-| ec | pose | ✓ | ✓ | exp | exp |  |  |  |  |
-| ec | segment | ✓ | ✓ | exp | exp |  |  |  |  |
-| edgetam | segment |  |  |  |  |  |  |  |  |
-| efficientnetv2 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
-| eomt | semantic | ✓ | ✓ | exp | exp |  |  |  |  |
-| eomt | segment |  |  |  |  |  |  |  |  |
-| eomt | panoptic |  |  |  |  |  |  |  |  |
-| feynobg | matte | exp | ✓ | exp | exp |  |  |  |  |
-| florence2 | detect |  |  |  |  |  |  |  |  |
-| fomo | point | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| grounding_dino | detect |  |  |  |  |  |  |  |  |
-| internvl3 | detect |  |  |  |  |  |  |  |  |
-| kosmos2 | detect |  |  |  |  |  |  |  |  |
-| l2cs | gaze | ✓ |  |  |  |  |  |  |  |
-| lfm2vl | detect |  |  |  |  |  |  |  |  |
-| lingbotvision | semantic | ✓ | ✓ | exp | exp |  |  |  | ✓ |
-| locateanything | detect |  |  |  |  |  |  |  |  |
-| locateanything | point |  |  |  |  |  |  |  |  |
-| mobilenetv4 | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
-| mobilesam | segment |  |  |  |  |  |  |  |  |
-| moge2 | normal | ✓ |  |  |  |  |  |  |  |
-| nafnet | restore | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| omdet_turbo | detect |  |  |  |  |  |  |  |  |
-| ov_deim | detect |  |  |  |  |  |  |  |  |
-| owlv2 | detect |  |  |  |  |  |  |  |  |
-| picodet | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| picosam3 | segment | ✓ |  |  |  |  |  |  |  |
-| pidnet | semantic | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
-| ppocr | ocr |  |  |  |  |  |  |  |  |
-| qwen3vl | detect |  |  |  |  |  |  |  |  |
-| realesrgan | restore | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
-| resnet | classify | ✓ | ✓ | exp | exp | ✓ | ✓ |  | ✓ |
-| rfdetr | detect | ✓ | ✓ | ✓ | ✓ |  | exp | exp | ✓ |
-| rfdetr | segment | ✓ | ✓ | exp | exp |  |  |  |  |
-| rfdetr | pose | ✓ | ✓ | exp | exp |  |  |  |  |
-| rfdetr | obb | ✓ | ✓ | exp | exp |  |  |  |  |
-| rtdetr | detect | ✓ | ✓ | exp | exp |  |  | exp | ✓ |
-| rtdetrv2 | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
-| rtdetrv4 | detect | exp | ✓ | exp | exp |  |  |  | ✓ |
-| rtmdet | detect | ✓ | ✓ | exp | exp |  |  |  | ✓ |
-| rtmdet | segment |  |  |  |  |  |  |  |  |
-| sam | segment |  |  |  |  |  |  |  |  |
-| sam2 | segment |  |  |  |  |  |  |  |  |
-| sam3 | segment |  |  |  |  |  |  |  |  |
-| sam3dbody | mesh |  |  |  |  |  |  |  |  |
-| segformer | semantic |  |  |  |  |  |  |  |  |
-| siglip2 | classify | ✓ |  |  |  |  |  |  | ✓ |
-| siglip2 | embed |  |  |  |  |  |  |  |  |
-| smolvlm2 | detect |  |  |  |  |  |  |  |  |
-| swinir | restore | exp | exp | exp | exp | exp |  |  |  |
-| teed | edge | ✓ |  |  |  |  |  |  |  |
-| yolo1 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolo2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolo3 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolo4 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolo7 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
-| yolo9_e2e | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolo9_p2 | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolonas | detect | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
-| yolonas | pose | ✓ | ✓ | exp | exp | ✓ |  |  |  |
-| yolox | detect | ✓ | ✓ | exp | exp | ✓ | ✓ | exp | ✓ |
-| zipdepth | depth | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| Family | Task | onnx | torchscript | executorch | tensorrt | openvino | ncnn | tflite | coreml | coreai |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| birefnet | matte | exp | ✓ | exp | exp | exp |  |  |  |  |
+| clip | classify | ✓ |  |  |  |  |  |  |  | ✓ |
+| clip | embed |  |  |  |  |  |  |  |  |  |
+| convnext | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| deim | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
+| deimv2 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
+| depth_anything | depth | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
+| depth_anything3 | depth |  |  |  |  |  |  |  |  |  |
+| dexined | edge | ✓ |  |  |  |  |  |  |  |  |
+| dfine | detect | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
+| dfine | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
+| dinov2 | semantic | ✓ | ✓ |  | exp | exp |  |  |  |  |
+| dinov2 | classify | ✓ |  |  |  |  |  |  |  | exp |
+| dinov2 | embed |  |  |  |  |  |  |  |  |  |
+| ec | detect | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
+| ec | pose | ✓ | ✓ | exp | exp | exp |  |  |  |  |
+| ec | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
+| edgetam | segment |  |  |  |  |  |  |  |  |  |
+| efficientnetv2 | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| eomt | semantic | ✓ | ✓ |  | exp | exp |  |  |  |  |
+| eomt | segment |  |  |  |  |  |  |  |  |  |
+| eomt | panoptic |  |  |  |  |  |  |  |  |  |
+| feynobg | matte | exp | ✓ | exp | exp | exp |  |  |  |  |
+| florence2 | detect |  |  |  |  |  |  |  |  |  |
+| fomo | point | ✓ | ✓ |  | exp | exp | ✓ |  |  | ✓ |
+| grounding_dino | detect |  |  |  |  |  |  |  |  |  |
+| internvl3 | detect |  |  |  |  |  |  |  |  |  |
+| kosmos2 | detect |  |  |  |  |  |  |  |  |  |
+| l2cs | gaze | ✓ |  |  |  |  |  |  |  |  |
+| lfm2vl | detect |  |  |  |  |  |  |  |  |  |
+| lingbotvision | semantic | ✓ | ✓ |  | exp | exp |  |  |  | ✓ |
+| locateanything | detect |  |  |  |  |  |  |  |  |  |
+| locateanything | point |  |  |  |  |  |  |  |  |  |
+| mobilenetv4 | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| mobilesam | segment |  |  |  |  |  |  |  |  |  |
+| moge2 | normal | ✓ |  |  |  |  |  |  |  |  |
+| nafnet | restore | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| omdet_turbo | detect |  |  |  |  |  |  |  |  |  |
+| ov_deim | detect |  |  |  |  |  |  |  |  |  |
+| owlv2 | detect |  |  |  |  |  |  |  |  |  |
+| picodet | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| picosam3 | segment | ✓ |  |  |  |  |  |  |  |  |
+| pidnet | semantic | ✓ | ✓ |  | exp | exp | ✓ | ✓ |  | ✓ |
+| ppocr | ocr |  |  |  |  |  |  |  |  |  |
+| qwen3vl | detect |  |  |  |  |  |  |  |  |  |
+| realesrgan | restore | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| resnet | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
+| rfdetr | detect | ✓ | ✓ | exp | ✓ | ✓ |  | exp | exp | ✓ |
+| rfdetr | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
+| rfdetr | pose | ✓ | ✓ | exp | exp | exp |  |  |  |  |
+| rfdetr | obb | ✓ | ✓ | exp | exp | exp |  |  |  |  |
+| rtdetr | detect | ✓ | ✓ | exp | exp | exp |  |  | exp | ✓ |
+| rtdetrv2 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
+| rtdetrv4 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
+| rtmdet | detect | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
+| rtmdet | segment |  |  |  |  |  |  |  |  |  |
+| sam | segment |  |  |  |  |  |  |  |  |  |
+| sam2 | segment |  |  |  |  |  |  |  |  |  |
+| sam3 | segment |  |  |  |  |  |  |  |  |  |
+| sam3dbody | mesh |  |  |  |  |  |  |  |  |  |
+| segformer | semantic |  |  |  |  |  |  |  |  |  |
+| siglip2 | classify | ✓ |  |  |  |  |  |  |  | ✓ |
+| siglip2 | embed |  |  |  |  |  |  |  |  |  |
+| smolvlm2 | detect |  |  |  |  |  |  |  |  |  |
+| swinir | restore | exp | exp | exp | exp | exp | exp |  |  |  |
+| teed | edge | ✓ |  |  |  |  |  |  |  |  |
+| yolo1 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo2 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo3 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo4 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo7 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo9 | detect | ✓ | ✓ | exp | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
+| yolo9_e2e | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo9_p2 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolonas | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolonas | pose | ✓ | ✓ | exp | exp | exp | ✓ |  |  |  |
+| yolox | detect | ✓ | ✓ | exp | exp | exp | ✓ | ✓ | exp | ✓ |
+| zipdepth | depth | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 
 ## Parity thresholds
 
@@ -179,6 +179,7 @@ A check mark applies only under any constraint listed here.
 - `birefnet` / `matte` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `birefnet` / `matte` / `coreai`: The decoder needs torchvision deform_conv2d, which the Core AI converter cannot lower ('unable to handle call function op: deform_conv2d.default'). The same operator already blocks the NCNN path. An encoder-only contract is the realistic route, matching the seam the CUDA graph work used.
 - `clip` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `clip` / `classify` / `executorch`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `clip` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `clip` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `clip` / `classify` / `ncnn`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
@@ -186,6 +187,7 @@ A check mark applies only under any constraint listed here.
 - `clip` / `classify` / `coreml`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `clip` / `embed` / `onnx`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `clip` / `embed` / `torchscript`: Embedding export is not implemented in v1; use the native predict()/embed() API.
+- `clip` / `embed` / `executorch`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `clip` / `embed` / `tensorrt`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `clip` / `embed` / `openvino`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `clip` / `embed` / `ncnn`: Embedding export is not implemented in v1; use the native predict()/embed() API.
@@ -204,6 +206,7 @@ A check mark applies only under any constraint listed here.
 - `depth_anything` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `depth_anything3` / `depth` / `onnx`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `torchscript`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
+- `depth_anything3` / `depth` / `executorch`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `tensorrt`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `openvino`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `ncnn`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
@@ -211,6 +214,7 @@ A check mark applies only under any constraint listed here.
 - `depth_anything3` / `depth` / `coreml`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `coreai`: The model raises NotImplementedError for every format: depth export is out of scope per ADR 0006, the depth task contract. Depth Anything V2 exports and validates at 5.2e-06, so this is specific to the V3 family and not a Core AI limitation.
 - `dexined` / `edge` / `torchscript`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
+- `dexined` / `edge` / `executorch`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `tensorrt`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `openvino`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `ncnn`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
@@ -224,11 +228,13 @@ A check mark applies only under any constraint listed here.
 - `dfine` / `segment` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `dfine` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `dfine` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
+- `dinov2` / `semantic` / `executorch`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `dinov2` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `dinov2` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `dinov2` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `dinov2` / `semantic` / `coreai`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `dinov2` / `classify` / `torchscript`: LibreDINOv2 classify export currently supports ONNX only.
+- `dinov2` / `classify` / `executorch`: LibreDINOv2 classify export currently supports ONNX only.
 - `dinov2` / `classify` / `tensorrt`: LibreDINOv2 classify export currently supports ONNX only.
 - `dinov2` / `classify` / `openvino`: LibreDINOv2 classify export currently supports ONNX only.
 - `dinov2` / `classify` / `ncnn`: LibreDINOv2 classify export currently supports ONNX only.
@@ -236,6 +242,7 @@ A check mark applies only under any constraint listed here.
 - `dinov2` / `classify` / `coreml`: LibreDINOv2 classify export currently supports ONNX only.
 - `dinov2` / `embed` / `onnx`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `dinov2` / `embed` / `torchscript`: Embedding export is not implemented in v1; use the native predict()/embed() API.
+- `dinov2` / `embed` / `executorch`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `dinov2` / `embed` / `tensorrt`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `dinov2` / `embed` / `openvino`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `dinov2` / `embed` / `ncnn`: Embedding export is not implemented in v1; use the native predict()/embed() API.
@@ -255,6 +262,7 @@ A check mark applies only under any constraint listed here.
 - `ec` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
 - `edgetam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
+- `edgetam` / `segment` / `executorch`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
@@ -262,12 +270,14 @@ A check mark applies only under any constraint listed here.
 - `edgetam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `efficientnetv2` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `eomt` / `semantic` / `executorch`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `eomt` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `eomt` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `eomt` / `semantic` / `coreai`: torch.export refuses the graph: GuardOnDataDependentSymNode, 'Could not guard on data-dependent expression Eq(u0, 1)'. Something in the mask path reads a value off a tensor and branches on it, which becomes an unbacked symbol with no hint the tracer can resolve. This is a real capture failure, not a missing operator and not the task gate: it was measured with the gate open. Fixing it means finding the host read and making the shape static for a fixed export canvas, the same shape of fix as the rfdetr torch._assert.
 - `eomt` / `segment` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `segment` / `executorch`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `openvino`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `segment` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
@@ -276,6 +286,7 @@ A check mark applies only under any constraint listed here.
 - `eomt` / `segment` / `coreai`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `onnx`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `torchscript`: EoMT instance and panoptic export do not yet have runtime parsing.
+- `eomt` / `panoptic` / `executorch`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `tensorrt`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `openvino`: EoMT instance and panoptic export do not yet have runtime parsing.
 - `eomt` / `panoptic` / `ncnn`: EoMT instance and panoptic export do not yet have runtime parsing.
@@ -288,16 +299,19 @@ A check mark applies only under any constraint listed here.
 - `feynobg` / `matte` / `coreai`: This family and task have not been validated for Core AI export.
 - `florence2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `florence2` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
 - `florence2` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
+- `fomo` / `point` / `executorch`: This family is not wired to the shared point heatmap and backend peak-decoding export contract.
 - `fomo` / `point` / `tflite`: onnx2tf 2.4.x produces an invalid depthwise-convolution graph for the static SAME-padded FOMO backbone on this toolchain.
 - `fomo` / `point` / `coreml`: The CoreML wrapper does not implement the raw point-heatmap contract.
 - `grounding_dino` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
+- `grounding_dino` / `detect` / `executorch`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `openvino`: Open-vocabulary runtime export is out of scope for v1.
 - `grounding_dino` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
@@ -306,6 +320,7 @@ A check mark applies only under any constraint listed here.
 - `grounding_dino` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `internvl3` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `internvl3` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
 - `internvl3` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
@@ -314,6 +329,7 @@ A check mark applies only under any constraint listed here.
 - `internvl3` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `kosmos2` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
@@ -321,6 +337,7 @@ A check mark applies only under any constraint listed here.
 - `kosmos2` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
 - `kosmos2` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `l2cs` / `gaze` / `torchscript`: The v1 L2CS gaze export contract supports ONNX only.
+- `l2cs` / `gaze` / `executorch`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `tensorrt`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `openvino`: The v1 L2CS gaze export contract supports ONNX only.
 - `l2cs` / `gaze` / `ncnn`: The v1 L2CS gaze export contract supports ONNX only.
@@ -329,17 +346,20 @@ A check mark applies only under any constraint listed here.
 - `l2cs` / `gaze` / `coreai`: The model itself refuses: 'LibreL2CS export to coreai is not implemented. The v1 gaze export contract supports ONNX only.' That is a model-side decision, unchanged by opening the support gate, so nothing about Core AI is being tested here. Wiring the gaze contract beyond ONNX comes first.
 - `lfm2vl` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `lfm2vl` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `tflite`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
 - `lfm2vl` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
+- `lingbotvision` / `semantic` / `executorch`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `lingbotvision` / `semantic` / `ncnn`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `lingbotvision` / `semantic` / `tflite`: The dense-logits runtime contract is implemented, but this transformer graph has not produced a parity-valid edge-runtime artifact.
 - `lingbotvision` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `locateanything` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `locateanything` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `locateanything` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
 - `locateanything` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `locateanything` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
 - `locateanything` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
@@ -348,6 +368,7 @@ A check mark applies only under any constraint listed here.
 - `locateanything` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `onnx`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `torchscript`: Generative VLM export is out of scope for v1.
+- `locateanything` / `point` / `executorch`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `openvino`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `ncnn`: Generative VLM export is out of scope for v1.
@@ -357,6 +378,7 @@ A check mark applies only under any constraint listed here.
 - `mobilenetv4` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `mobilesam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
+- `mobilesam` / `segment` / `executorch`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
@@ -364,6 +386,7 @@ A check mark applies only under any constraint listed here.
 - `mobilesam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
 - `mobilesam` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `moge2` / `normal` / `torchscript`: This family is not wired to the fixed-canvas dense unit-normal export and backend renormalization contract.
+- `moge2` / `normal` / `executorch`: This family is not wired to the fixed-canvas dense unit-normal export and backend renormalization contract.
 - `moge2` / `normal` / `tensorrt`: This family is not wired to the fixed-canvas dense unit-normal export and backend renormalization contract.
 - `moge2` / `normal` / `openvino`: This family is not wired to the fixed-canvas dense unit-normal export and backend renormalization contract.
 - `moge2` / `normal` / `ncnn`: This family is not wired to the fixed-canvas dense unit-normal export and backend renormalization contract.
@@ -374,6 +397,7 @@ A check mark applies only under any constraint listed here.
 - `nafnet` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `omdet_turbo` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
+- `omdet_turbo` / `detect` / `executorch`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `openvino`: Open-vocabulary runtime export is out of scope for v1.
 - `omdet_turbo` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
@@ -382,6 +406,7 @@ A check mark applies only under any constraint listed here.
 - `omdet_turbo` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
+- `ov_deim` / `detect` / `executorch`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `openvino`: Open-vocabulary runtime export is out of scope for v1.
 - `ov_deim` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
@@ -390,6 +415,7 @@ A check mark applies only under any constraint listed here.
 - `ov_deim` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `onnx`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `torchscript`: Open-vocabulary runtime export is out of scope for v1.
+- `owlv2` / `detect` / `executorch`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `tensorrt`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `openvino`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `ncnn`: Open-vocabulary runtime export is out of scope for v1.
@@ -399,15 +425,18 @@ A check mark applies only under any constraint listed here.
 - `picodet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `picodet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `picosam3` / `segment` / `torchscript`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `picosam3` / `segment` / `executorch`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `tensorrt`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `openvino`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `ncnn`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `tflite`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `coreml`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
 - `picosam3` / `segment` / `coreai`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
+- `pidnet` / `semantic` / `executorch`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `pidnet` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `ppocr` / `ocr` / `onnx`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `torchscript`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
+- `ppocr` / `ocr` / `executorch`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `tensorrt`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `openvino`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `ppocr` / `ocr` / `ncnn`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
@@ -416,6 +445,7 @@ A check mark applies only under any constraint listed here.
 - `ppocr` / `ocr` / `coreai`: OCR uses two networks for detection and recognition with dynamic per-region cropping, so it does not fit the single-graph export contract.
 - `qwen3vl` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `qwen3vl` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
@@ -450,6 +480,7 @@ A check mark applies only under any constraint listed here.
 - `rtmdet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `rtmdet` / `segment` / `onnx`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `rtmdet` / `segment` / `torchscript`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
+- `rtmdet` / `segment` / `executorch`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `rtmdet` / `segment` / `tensorrt`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `rtmdet` / `segment` / `openvino`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `rtmdet` / `segment` / `ncnn`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
@@ -458,6 +489,7 @@ A check mark applies only under any constraint listed here.
 - `rtmdet` / `segment` / `coreai`: RTMDet-Ins export is not supported yet; the dynamic-kernel mask decode has no exported-runtime contract. Use native PyTorch inference for task='segment'.
 - `sam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
+- `sam` / `segment` / `executorch`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
@@ -466,6 +498,7 @@ A check mark applies only under any constraint listed here.
 - `sam` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
+- `sam2` / `segment` / `executorch`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam2` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
@@ -474,6 +507,7 @@ A check mark applies only under any constraint listed here.
 - `sam2` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `torchscript`: Promptable model export is out of scope for the v1 runtime contract.
+- `sam3` / `segment` / `executorch`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `tensorrt`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `openvino`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3` / `segment` / `ncnn`: Promptable model export is out of scope for the v1 runtime contract.
@@ -482,6 +516,7 @@ A check mark applies only under any constraint listed here.
 - `sam3` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `sam3dbody` / `mesh` / `onnx`: Body-mesh export is blocked until its graph outputs, metadata, and backend runtime contract are defined.
 - `sam3dbody` / `mesh` / `torchscript`: Body-mesh export is blocked until its graph outputs, metadata, and backend runtime contract are defined.
+- `sam3dbody` / `mesh` / `executorch`: Body-mesh export is blocked until its graph outputs, metadata, and backend runtime contract are defined.
 - `sam3dbody` / `mesh` / `tensorrt`: Body-mesh export is blocked until its graph outputs, metadata, and backend runtime contract are defined.
 - `sam3dbody` / `mesh` / `openvino`: Body-mesh export is blocked until its graph outputs, metadata, and backend runtime contract are defined.
 - `sam3dbody` / `mesh` / `ncnn`: Body-mesh export is blocked until its graph outputs, metadata, and backend runtime contract are defined.
@@ -490,6 +525,7 @@ A check mark applies only under any constraint listed here.
 - `sam3dbody` / `mesh` / `coreai`: Body-mesh export is blocked until its graph outputs, metadata, and backend runtime contract are defined.
 - `segformer` / `semantic` / `onnx`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `torchscript`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
+- `segformer` / `semantic` / `executorch`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `tensorrt`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `openvino`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `ncnn`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
@@ -497,6 +533,7 @@ A check mark applies only under any constraint listed here.
 - `segformer` / `semantic` / `coreml`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `coreai`: LibreSegformer implements no export path at all ('Export is not implemented for LibreSegformer yet'), so this is not a Core AI limitation. Note its weights are non-commercial regardless.
 - `siglip2` / `classify` / `torchscript`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
+- `siglip2` / `classify` / `executorch`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `siglip2` / `classify` / `tensorrt`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `siglip2` / `classify` / `openvino`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `siglip2` / `classify` / `ncnn`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
@@ -504,6 +541,7 @@ A check mark applies only under any constraint listed here.
 - `siglip2` / `classify` / `coreml`: Frozen-class vision-language export is ONNX-only in v1; re-export the frozen ONNX graph for a different deployment runtime.
 - `siglip2` / `embed` / `onnx`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `siglip2` / `embed` / `torchscript`: Embedding export is not implemented in v1; use the native predict()/embed() API.
+- `siglip2` / `embed` / `executorch`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `siglip2` / `embed` / `tensorrt`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `siglip2` / `embed` / `openvino`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `siglip2` / `embed` / `ncnn`: Embedding export is not implemented in v1; use the native predict()/embed() API.
@@ -512,6 +550,7 @@ A check mark applies only under any constraint listed here.
 - `siglip2` / `embed` / `coreai`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `smolvlm2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
+- `smolvlm2` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `tensorrt`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `openvino`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `ncnn`: Generative VLM export is out of scope for v1.
@@ -522,6 +561,7 @@ A check mark applies only under any constraint listed here.
 - `swinir` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `swinir` / `restore` / `coreai`: The export process DIES rather than hangs, and the kill point moves between runs, which is the signature of memory exhaustion rather than a stuck loop. One run reached 'Step 3/3: Optimizing and writing the asset' before stopping; a later run of the same graph at the same 128 canvas died inside to_coreai() before returning, in both cases with a leaked-semaphore warning and no traceback. Window attention unrolls into a very large number of small ops, so the converter's peak memory is the prime suspect on a 16 GB machine. Next steps: watch RSS during conversion, try the smallest available size at a 64 canvas, and check the system log for a memory kill. Do NOT assume optimize() is at fault; an earlier note said so on the strength of a single run and the second run contradicted it.
 - `teed` / `edge` / `torchscript`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
+- `teed` / `edge` / `executorch`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `teed` / `edge` / `tensorrt`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `teed` / `edge` / `openvino`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `teed` / `edge` / `ncnn`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -55,7 +55,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | qwen3vl | detect |  |  |  |  |  |  |  |  |  |
 | realesrgan | restore | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
 | resnet | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
-| rfdetr | detect | ✓ | ✓ | exp | ✓ | ✓ |  | exp | exp | ✓ |
+| rfdetr | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  | exp | exp | ✓ |
 | rfdetr | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | rfdetr | pose | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | rfdetr | obb | ✓ | ✓ | exp | exp | exp |  |  |  |  |
@@ -79,7 +79,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | yolo3 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo4 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo7 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
-| yolo9 | detect | ✓ | ✓ | exp | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
+| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
 | yolo9_e2e | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
 | yolonas | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
@@ -142,6 +142,7 @@ A check mark applies only under any constraint listed here.
 - `realesrgan` / `restore` / `tflite`: fixed-resolution export canvas
 - `realesrgan` / `restore` / `coreai`: fixed export canvas; permissively licensed trained restoration checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 - `resnet` / `classify` / `coreai`: fixed export canvas; a representative published trained ImageNet checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
+- `rfdetr` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `rfdetr` / `detect` / `coreai`: fixed export canvas; trained LibreRFDETRn weights are covered on macOS 27 against the graph the exporter itself prepares, using direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin. Conversion needed _rebake_rfdetr_pos_embed in export/coreai.py: the backbone bakes its position embedding for its configured 384 canvas, so exporting at any other size left an antialiased bicubic in the graph and the converter has no lowering for aten._upsample_bicubic2d_aa. The rebake re-runs the model's OWN baking path for the actual canvas, so the interpolation happens eagerly, outside the graph, computing exactly what it computed before. NOTE the reference. This family is verified against the exporter's prepared graph, not against ONNX, and the difference is not a detail: at a 640 canvas the rfdetr ONNX artifact disagrees with that same prepared graph by 9.3e-01. Core AI's rebake preserves the antialiased resize the eager model performs, whereas the ONNX path disables antialiasing (the model checks torch.onnx.is_in_onnx_export). Which artifact is right is an ONNX question and is not settled here, but ONNX cannot be used as the reference for this family at a non-native canvas.
 - `rfdetr` / `segment` / `onnx`: fixed task-native input resolution
 - `rfdetr` / `segment` / `torchscript`: fixed task-native input resolution
@@ -162,6 +163,7 @@ A check mark applies only under any constraint listed here.
 - `yolo3` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
 - `yolo4` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
 - `yolo7` / `detect` / `coreai`: fixed 640x640 export canvas; trained LibreYOLO7b weights are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; the export decoder uses direct arange grids because Core AI 0.4.1 mislowers the equivalent cumulative-sum expression
+- `yolo9` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo9` / `detect` / `coreai`: fixed export canvas; trained LibreYOLO9t weights are covered on macOS 27 by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 - `yolo9_e2e` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `yolo9_p2` / `detect` / `coreai`: fixed 640x640 export canvas; a deterministic YOLO9-P2-T model initialized from the SHA-256-pinned, permissively licensed trained LibreYOLO9t checkpoint is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; this validates conversion, not P2 task accuracy, and does not depend on the restricted VisDrone research-preview checkpoint

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -12,12 +12,12 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | clip | classify | ✓ |  |  |  |  |  |  |  | ✓ |
 | clip | embed |  |  |  |  |  |  |  |  |  |
 | convnext | classify | ✓ | ✓ | exp | exp | exp | ✓ | ✓ |  | ✓ |
-| deim | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
+| deim | detect | exp | ✓ |  | exp | exp |  |  |  | ✓ |
 | deimv2 | detect | exp | ✓ |  | exp | exp |  |  |  | ✓ |
 | depth_anything | depth | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
 | depth_anything3 | depth |  |  |  |  |  |  |  |  |  |
 | dexined | edge | ✓ |  | exp |  |  |  |  |  |  |
-| dfine | detect | ✓ | ✓ | exp | exp | exp |  |  |  | ✓ |
+| dfine | detect | ✓ | ✓ |  | exp | exp |  |  |  | ✓ |
 | dfine | segment | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | dinov2 | semantic | ✓ | ✓ |  | exp | exp |  |  |  |  |
 | dinov2 | classify | ✓ |  |  |  |  |  |  |  | exp |
@@ -60,8 +60,8 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | rfdetr | pose | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | rfdetr | obb | ✓ | ✓ | exp | exp | exp |  |  |  |  |
 | rtdetr | detect | ✓ | ✓ | ✓ | exp | exp |  |  | exp | ✓ |
-| rtdetrv2 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
-| rtdetrv4 | detect | exp | ✓ | exp | exp | exp |  |  |  | ✓ |
+| rtdetrv2 | detect | exp | ✓ | ✓ | exp | exp |  |  |  | ✓ |
+| rtdetrv4 | detect | exp | ✓ | ✓ | exp | exp |  |  |  | ✓ |
 | rtmdet | detect | ✓ | ✓ |  | exp | exp |  |  |  | ✓ |
 | rtmdet | segment |  |  |  |  |  |  |  |  |  |
 | sam | segment |  |  |  |  |  |  |  |  |  |
@@ -74,11 +74,11 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |  |
 | swinir | restore | exp | exp | exp | exp | exp | exp |  |  |  |
 | teed | edge | ✓ |  | exp |  |  |  |  |  |  |
-| yolo1 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
-| yolo2 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
-| yolo3 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
-| yolo4 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
-| yolo7 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
+| yolo1 | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo2 | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo3 | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo4 | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
+| yolo7 | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ |
 | yolo9_e2e | detect | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  | ✓ |
 | yolo9_p2 | detect | ✓ | ✓ | exp | exp | exp | ✓ |  |  | ✓ |
@@ -158,17 +158,24 @@ A check mark applies only under any constraint listed here.
 - `rfdetr` / `obb` / `torchscript`: fixed task-native input resolution
 - `rtdetr` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `rtdetr` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `rtdetrv2` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `rtdetrv2` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
+- `rtdetrv4` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `rtdetrv4` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `rtmdet` / `detect` / `coreai`: fixed export canvas; a representative published trained checkpoint for each family is covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; RT-DETRv2 permits one shared whole-query permutation across its box and logit outputs because DETR query rows are an unordered set
 - `siglip2` / `classify` / `onnx`: frozen-class labels and fixed input resolution
 - `siglip2` / `classify` / `coreai`: frozen class set and fixed export canvas; permissively licensed trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 - `teed` / `edge` / `onnx`: fixed-resolution batch-1 edge-probability canvas
+- `yolo1` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo1` / `detect` / `ncnn`: fixed 448x448 input
 - `yolo1` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo2` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo2` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo3` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo3` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo4` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo4` / `detect` / `coreai`: fixed family-native canvases (YOLO1 448, YOLO2 608, YOLO3 416, YOLO4 608); representative published trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; Core AI graph preparation exactly folds Darknet inference batch normalization into the preceding convolutions because Core AI 0.4.1 does not preserve Darknet's epsilon-after-square-root formula
+- `yolo7` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo7` / `detect` / `coreai`: fixed 640x640 export canvas; trained LibreYOLO7b weights are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin; the export decoder uses direct arange grids because Core AI 0.4.1 mislowers the equivalent cumulative-sum expression
 - `yolo9` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo9` / `detect` / `coreai`: fixed export canvas; trained LibreYOLO9t weights are covered on macOS 27 by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
@@ -206,6 +213,7 @@ A check mark applies only under any constraint listed here.
 - `clip` / `embed` / `coreml`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `clip` / `embed` / `coreai`: Embedding export is not implemented in v1; use the native predict()/embed() API.
 - `convnext` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `deim` / `detect` / `executorch`: The trained nano model captures, lowers, and serializes, but ExecuTorch 1.2 runtime execution fails with an invalid delegated tensor dimension order.
 - `deim` / `detect` / `ncnn`: NCNN export is not supported for DEIM: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `deim` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `deim` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
@@ -232,6 +240,7 @@ A check mark applies only under any constraint listed here.
 - `dexined` / `edge` / `tflite`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `coreml`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
 - `dexined` / `edge` / `coreai`: The edge exported-runtime contract is ONNX-only in v1; add runtime parity before enabling another format.
+- `dfine` / `detect` / `executorch`: Strict capture reaches an unsupported ContextVar read in deformable attention. Forcing the manual exported grid-sample path permits serialization, but ExecuTorch 1.2 runtime execution still fails with an invalid delegated tensor dimension order.
 - `dfine` / `detect` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `dfine` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `dfine` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -488,6 +488,17 @@ class BaseBackend(ABC):
                 image, effective_imgsz, color_format
             )
             return tensor, img, size, ratio
+        elif self.model_family == "yolo1":
+            from ..models.darknet.preprocess import (
+                preprocess_image_stretch as _v1_pre,
+            )
+
+            sz = (
+                effective_imgsz
+                if isinstance(effective_imgsz, int)
+                else max(effective_imgsz)
+            )
+            return _v1_pre(image, input_size=sz, color_format=color_format)
         elif self.model_family in ("yolo2", "yolo3", "yolo4"):
             from ..models.darknet.preprocess import preprocess_image as _dk_pre
 
@@ -1296,10 +1307,14 @@ class BaseBackend(ABC):
             return boxes, max_scores, class_ids
 
         input_h, input_w = _imgsz_hw(effective_imgsz)
-        ratio = min(input_h / orig_h, input_w / orig_w)
-        boxes[:, :4] /= ratio
-        if keypoints is not None:
-            keypoints[..., :2] /= ratio
+        if self.model_family == "yolo1":
+            boxes[:, [0, 2]] *= orig_w / input_w
+            boxes[:, [1, 3]] *= orig_h / input_h
+        else:
+            ratio = min(input_h / orig_h, input_w / orig_w)
+            boxes[:, :4] /= ratio
+            if keypoints is not None:
+                keypoints[..., :2] /= ratio
         boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, orig_w)
         boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, orig_h)
         if keypoints is not None:

--- a/libreyolo/backends/executorch.py
+++ b/libreyolo/backends/executorch.py
@@ -1,0 +1,176 @@
+"""ExecuTorch inference backend for LibreYOLO."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from ..tasks import normalize_supported_tasks, normalize_task, resolve_task
+from ..utils.general import COCO_CLASSES
+from ..utils.serialization import warn_on_metadata_schema_version
+from .base import BaseBackend, _read_metadata_imgsz, _read_pose_metadata
+
+logger = logging.getLogger(__name__)
+
+
+class ExecuTorchBackend(BaseBackend):
+    """Run a fixed-shape ``.pte`` program through the ExecuTorch Python runtime."""
+
+    def __init__(
+        self,
+        model_path: str,
+        nb_classes: int | None = None,
+        device: str = "auto",
+        task: str | None = None,
+    ):
+        program_path = Path(model_path)
+        if not program_path.exists():
+            raise FileNotFoundError(f"ExecuTorch program not found: {model_path}")
+
+        try:
+            from executorch.runtime import Runtime
+        except (ImportError, OSError) as exc:
+            raise ImportError(
+                "ExecuTorch inference requires the optional runtime. "
+                "Install it with: pip install libreyolo[executorch]"
+            ) from exc
+
+        if str(device).lower() not in {"auto", "cpu"}:
+            logger.warning(
+                "ExecuTorch XNNPACK programs run on CPU; ignoring device=%r.", device
+            )
+
+        sidecar_path = Path(f"{program_path}.json")
+        if not sidecar_path.exists():
+            raise FileNotFoundError(
+                f"ExecuTorch metadata sidecar not found: {sidecar_path}"
+            )
+        try:
+            metadata = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                f"Invalid ExecuTorch metadata sidecar: {sidecar_path}"
+            ) from exc
+        if not isinstance(metadata, dict):
+            raise TypeError(
+                f"ExecuTorch metadata sidecar must contain a JSON object: {sidecar_path}"
+            )
+        warn_on_metadata_schema_version(
+            metadata,
+            artifact=f"ExecuTorch metadata for {model_path}",
+            logger=logger,
+        )
+
+        delegate = str(metadata.get("executorch_delegate", "")).lower()
+        if delegate != "xnnpack":
+            raise ValueError(
+                "This LibreYOLO version only supports ExecuTorch programs "
+                f"exported for XNNPACK, got {delegate or 'missing delegate metadata'!r}."
+            )
+        dynamic = metadata.get("dynamic")
+        if dynamic not in {False, "false", "False"}:
+            raise ValueError(
+                "ExecuTorch v1 requires metadata dynamic=false, "
+                f"got {dynamic!r}."
+            )
+        precision = str(metadata.get("precision", "")).lower()
+        if precision != "fp32":
+            raise ValueError(
+                "ExecuTorch v1 requires metadata precision='fp32', "
+                f"got {precision or 'missing precision metadata'!r}."
+            )
+
+        runtime = Runtime.get()
+        if not runtime.backend_registry.is_available("XnnpackBackend"):
+            raise RuntimeError(
+                "The installed ExecuTorch runtime does not provide "
+                "XnnpackBackend, but this program requires it."
+            )
+        # Loading from bytes avoids keeping the .pte file memory-mapped and
+        # locked for the backend lifetime on Windows.
+        self.program = runtime.load_program(program_path.read_bytes())
+        if "forward" not in self.program.method_names:
+            raise ValueError("ExecuTorch program does not contain a 'forward' method.")
+        self.method = self.program.load_method("forward")
+
+        model_family = metadata.get("model_family")
+        model_size = metadata.get("model_size") or metadata.get("size")
+        default_task = normalize_task(metadata.get("default_task"), default="detect")
+        metadata_task = normalize_task(metadata.get("task"), default=default_task)
+        supported_tasks = normalize_supported_tasks(
+            metadata.get("supported_tasks", (metadata_task,))
+        )
+        resolved_task = resolve_task(
+            explicit_task=task,
+            checkpoint_task=metadata_task,
+            default_task=default_task,
+            supported_tasks=supported_tasks,
+        )
+        imgsz = _read_metadata_imgsz(
+            metadata,
+            model_family,
+            artifact=f"ExecuTorch metadata for {model_path}",
+        )
+        if imgsz is None:
+            raise ValueError("ExecuTorch metadata must declare a fixed input size.")
+
+        if nb_classes is not None:
+            resolved_nb_classes = int(nb_classes)
+        elif "nc" in metadata or "nb_classes" in metadata:
+            resolved_nb_classes = int(metadata.get("nc", metadata.get("nb_classes")))
+        else:
+            resolved_nb_classes = 80
+
+        names_raw = metadata.get("names")
+        if isinstance(names_raw, str):
+            names_raw = json.loads(names_raw)
+        if isinstance(names_raw, dict):
+            names = {int(key): str(value) for key, value in names_raw.items()}
+        elif resolved_nb_classes == 80:
+            names = {i: name for i, name in enumerate(COCO_CLASSES)}
+        else:
+            names = self.build_names(resolved_nb_classes)
+
+        super().__init__(
+            model_path=str(program_path),
+            nb_classes=resolved_nb_classes,
+            device="cpu",
+            imgsz=imgsz,
+            model_family=model_family,
+            names=names,
+            model_size=model_size,
+            task=resolved_task,
+            supported_tasks=supported_tasks,
+            default_task=default_task,
+            crop_pct=(
+                float(metadata["crop_pct"]) if metadata.get("crop_pct") else None
+            ),
+            interpolation=metadata.get("interpolation"),
+            **_read_pose_metadata(metadata),
+        )
+
+    def _run_inference(self, blob: np.ndarray) -> list[np.ndarray]:
+        if blob.dtype != np.float32:
+            blob = blob.astype(np.float32, copy=False)
+        tensor = torch.from_numpy(np.ascontiguousarray(blob)).cpu()
+        with torch.no_grad():
+            outputs = self.method.execute((tensor,))
+        if not isinstance(outputs, (list, tuple)):
+            raise TypeError(
+                "ExecuTorch forward must return a sequence of tensors, "
+                f"got {type(outputs)!r}."
+            )
+
+        result = []
+        for output in outputs:
+            if not isinstance(output, torch.Tensor):
+                raise TypeError(
+                    "ExecuTorch forward returned a non-tensor output: "
+                    f"{type(output)!r}."
+                )
+            result.append(np.ascontiguousarray(output.detach().cpu().numpy()))
+        return result

--- a/libreyolo/cli/commands/export.py
+++ b/libreyolo/cli/commands/export.py
@@ -21,8 +21,8 @@ def export_cmd(
     format: str = typer.Option(
         "onnx",
         help=(
-            "Export format: onnx, torchscript, tensorrt, openvino, ncnn, "
-            "tflite (alias: litert), coreml, coreai (Apple, macOS only)"
+            "Export format: onnx, torchscript, executorch, tensorrt, openvino, "
+            "ncnn, tflite (alias: litert), coreml, coreai (Apple, macOS only)"
         ),
     ),
     imgsz: Optional[str] = typer.Option(

--- a/libreyolo/export/executorch.py
+++ b/libreyolo/export/executorch.py
@@ -1,0 +1,169 @@
+"""ExecuTorch export helpers.
+
+This integration is an original implementation against ExecuTorch's documented
+public Python API. No ExecuTorch source code is vendored or adapted here.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import torch
+
+
+def check_executorch_available() -> None:
+    """Raise an actionable error when the optional ExecuTorch stack is absent."""
+    try:
+        from executorch.backends.xnnpack.partition.xnnpack_partitioner import (  # noqa: F401
+            XnnpackPartitioner,
+        )
+        from executorch.exir import to_edge_transform_and_lower  # noqa: F401
+    except (ImportError, OSError) as exc:
+        raise ImportError(
+            "ExecuTorch export requires the optional ExecuTorch toolchain. "
+            "Install it with: pip install libreyolo[executorch]"
+        ) from exc
+
+
+def _delegate_partition_count(edge_program) -> int:
+    """Count delegate calls in the public exported edge program."""
+    graph = edge_program.exported_program("forward").graph_module.graph
+    return sum(
+        "executorch_call_delegate" in str(node.target)
+        for node in graph.nodes
+        if node.op == "call_function"
+    )
+
+
+def _commit_artifact_pair(
+    program_bytes: bytes,
+    metadata: dict,
+    program_path: Path,
+) -> None:
+    """Commit a program and JSON sidecar together, restoring prior files on error."""
+    sidecar_path = Path(f"{program_path}.json")
+    program_path.parent.mkdir(parents=True, exist_ok=True)
+
+    staged: dict[Path, Path] = {}
+    backups: dict[Path, Path] = {}
+    committed: list[Path] = []
+    success = False
+    try:
+        for final_path, payload in (
+            (program_path, program_bytes),
+            (
+                sidecar_path,
+                json.dumps(metadata, indent=2, sort_keys=True).encode("utf-8"),
+            ),
+        ):
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                prefix=f".{final_path.name}.",
+                suffix=".tmp",
+                dir=final_path.parent,
+                delete=False,
+            ) as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+                staged[final_path] = Path(handle.name)
+
+        for final_path in (program_path, sidecar_path):
+            if final_path.exists():
+                with tempfile.NamedTemporaryFile(
+                    prefix=f".{final_path.name}.",
+                    suffix=".backup",
+                    dir=final_path.parent,
+                    delete=False,
+                ) as backup_handle:
+                    backup_path = Path(backup_handle.name)
+                backup_path.unlink()
+                os.replace(final_path, backup_path)
+                backups[final_path] = backup_path
+
+            os.replace(staged[final_path], final_path)
+            committed.append(final_path)
+        success = True
+    except Exception as commit_error:
+        rollback_errors = []
+        for final_path in reversed(committed):
+            try:
+                if final_path.exists():
+                    final_path.unlink()
+            except OSError as exc:
+                rollback_errors.append(exc)
+        for final_path, backup_path in backups.items():
+            try:
+                if backup_path.exists():
+                    os.replace(backup_path, final_path)
+            except OSError as exc:
+                rollback_errors.append(exc)
+        if rollback_errors:
+            retained = ", ".join(
+                str(path) for path in backups.values() if path.exists()
+            )
+            raise RuntimeError(
+                "ExecuTorch artifact commit failed and rollback was incomplete. "
+                f"Recovery backups were retained at: {retained}"
+            ) from commit_error
+        raise
+    finally:
+        for staged_path in staged.values():
+            if staged_path.exists():
+                staged_path.unlink()
+        if success:
+            for backup_path in backups.values():
+                if backup_path.exists():
+                    backup_path.unlink()
+
+
+def export_executorch(
+    model: torch.nn.Module,
+    example_input: torch.Tensor,
+    *,
+    output_path: str,
+    metadata: dict,
+) -> str:
+    """Capture, lower to XNNPACK, and serialize a fixed-shape FP32 program."""
+    check_executorch_available()
+
+    from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+        XnnpackPartitioner,
+    )
+    from executorch.exir import to_edge_transform_and_lower
+
+    exported = torch.export.export(model, (example_input,), strict=True)
+    try:
+        edge_program = to_edge_transform_and_lower(
+            exported,
+            partitioner=[XnnpackPartitioner()],
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "ExecuTorch XNNPACK lowering could not start a required host tool. "
+            "Ensure the ExecuTorch-bundled 'flatc' executable is on PATH; on "
+            "Windows, run from a Visual Studio 2022 Developer PowerShell."
+        ) from exc
+    partition_count = _delegate_partition_count(edge_program)
+    if partition_count == 0:
+        raise RuntimeError(
+            "ExecuTorch produced no XNNPACK delegate partitions. Refusing to "
+            "label a portable-kernel-only program as XNNPACK."
+        )
+
+    program = edge_program.to_executorch()
+    output = Path(output_path)
+    sidecar = dict(metadata)
+    sidecar.update(
+        {
+            "executorch_version": importlib.metadata.version("executorch"),
+            "executorch_delegate": "xnnpack",
+            "executorch_delegate_partitions": partition_count,
+        }
+    )
+    _commit_artifact_pair(program.buffer, sidecar, output)
+    return str(output)

--- a/libreyolo/export/executorch.py
+++ b/libreyolo/export/executorch.py
@@ -10,9 +10,28 @@ import importlib.metadata
 import json
 import os
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 
 import torch
+
+
+@contextmanager
+def _capture_compatibility(metadata: dict):
+    """Temporarily select family-local decompositions for strict capture."""
+    module = None
+    previous = None
+    if metadata.get("model_family") == "rtdetrv4":
+        from ..models.dfine import ms_deform
+
+        module = ms_deform
+        previous = module._FORCE_MANUAL_GRID_SAMPLE_EXPORT
+        module._FORCE_MANUAL_GRID_SAMPLE_EXPORT = True
+    try:
+        yield
+    finally:
+        if module is not None:
+            module._FORCE_MANUAL_GRID_SAMPLE_EXPORT = previous
 
 
 def check_executorch_available() -> None:
@@ -136,7 +155,8 @@ def export_executorch(
     )
     from executorch.exir import to_edge_transform_and_lower
 
-    exported = torch.export.export(model, (example_input,), strict=True)
+    with _capture_compatibility(metadata):
+        exported = torch.export.export(model, (example_input,), strict=True)
     try:
         edge_program = to_edge_transform_and_lower(
             exported,

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -1311,6 +1311,74 @@ class TorchScriptExporter(BaseExporter):
         )
 
 
+class ExecuTorchExporter(BaseExporter):
+    """Fixed-shape, batch-1, FP32 ExecuTorch export with XNNPACK delegation."""
+
+    format_name = "executorch"
+    suffix = ".pte"
+    requires_onnx = False
+    supports_int8 = False
+    supports_fp16 = False
+    apply_model_half = False
+
+    def _resolve_params(self, output_path, imgsz, device, half, int8):
+        if device is not None and str(device).lower() not in {"auto", "cpu"}:
+            raise ValueError("ExecuTorch XNNPACK export requires device='cpu'.")
+        return super()._resolve_params(
+            output_path, imgsz, torch.device("cpu"), half, int8
+        )
+
+    def _preflight(self, *, half: bool, int8: bool, data: Optional[str], **kwargs):
+        delegate = str(kwargs.get("delegate", "xnnpack")).lower()
+        if delegate != "xnnpack":
+            raise ValueError(
+                "ExecuTorch v1 supports delegate='xnnpack' only, "
+                f"got {delegate!r}."
+            )
+        super()._preflight(half=half, int8=int8, data=data, **kwargs)
+        from .executorch import check_executorch_available
+
+        check_executorch_available()
+
+    def _build_metadata(self, precision, dynamic, onnx_path, imgsz=None):
+        meta = super()._build_metadata(
+            precision, False, onnx_path, imgsz=imgsz
+        )
+        crop_pct = getattr(self.model, "crop_pct", None)
+        interpolation = getattr(self.model, "interpolation", None)
+        if crop_pct is not None:
+            meta["crop_pct"] = float(crop_pct)
+        if interpolation is not None:
+            meta["interpolation"] = str(interpolation)
+        return meta
+
+    def _export(
+        self,
+        nn_model,
+        dummy,
+        *,
+        output_path,
+        metadata,
+        dynamic,
+        delegate="xnnpack",
+        **kwargs,
+    ):
+        if dummy.shape[0] != 1:
+            raise ValueError(
+                f"ExecuTorch v1 requires batch=1, got batch={dummy.shape[0]}."
+            )
+        if dynamic:
+            raise ValueError("ExecuTorch v1 requires dynamic=False.")
+        from .executorch import export_executorch
+
+        return export_executorch(
+            nn_model,
+            dummy,
+            output_path=output_path,
+            metadata=metadata,
+        )
+
+
 class TensorRTExporter(BaseExporter):
     format_name = "tensorrt"
     suffix = ".engine"

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -202,6 +202,26 @@ class _SemanticExportWrapper(torch.nn.Module):
         return output
 
 
+class _YOLONASExportWrapper(torch.nn.Module):
+    """Expose decoded YOLO-NAS tensors without training-only auxiliaries."""
+
+    def __init__(self, model: torch.nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x):
+        output = self.model(x)
+        # Eager and torch.export capture return ``(decoded, raw)``. ONNX
+        # tracing already returns ``decoded`` directly, so accept both forms.
+        if (
+            isinstance(output, tuple)
+            and len(output) == 2
+            and isinstance(output[0], tuple)
+        ):
+            return output[0]
+        return output
+
+
 # =============================================================================
 # BaseExporter ABC
 # =============================================================================
@@ -804,6 +824,10 @@ class BaseExporter(ABC):
             from ..models.yolo7.export import YOLO7ExportWrapper
 
             nn_model = YOLO7ExportWrapper(nn_model).to(device)
+            nn_model.eval()
+            dfine_wrapped = True
+        elif family == "yolonas":
+            nn_model = _YOLONASExportWrapper(nn_model).to(device)
             nn_model.eval()
             dfine_wrapped = True
         elif family in {"rtdetr", "rtdetrv2", "rtdetrv4"}:

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -1345,6 +1345,18 @@ class ExecuTorchExporter(BaseExporter):
     supports_fp16 = False
     apply_model_half = False
 
+    def __call__(
+        self, *, dynamic: bool = False, batch: int = 1, **kwargs
+    ) -> str:
+        """Reject unsupported shapes before the destructive LoRA merge."""
+        if batch != 1:
+            raise ValueError(
+                f"ExecuTorch v1 requires batch=1, got batch={batch}."
+            )
+        if dynamic:
+            raise ValueError("ExecuTorch v1 requires dynamic=False.")
+        return super().__call__(dynamic=False, batch=1, **kwargs)
+
     def _resolve_params(self, output_path, imgsz, device, half, int8):
         if device is not None and str(device).lower() not in {"auto", "cpu"}:
             raise ValueError("ExecuTorch XNNPACK export requires device='cpu'.")

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -11,6 +11,7 @@ Tier = Literal["validated", "experimental", "blocked"]
 EXPORT_FORMATS = (
     "onnx",
     "torchscript",
+    "executorch",
     "tensorrt",
     "openvino",
     "ncnn",
@@ -67,6 +68,18 @@ _add(
     ("detect",),
     ("onnx", "torchscript", "ncnn", "tflite"),
     since="1.3",
+)
+_add(
+    "experimental",
+    ("yolo9", "rfdetr"),
+    ("detect",),
+    ("executorch",),
+    reason=(
+        "Fixed-shape batch-1 FP32 export, XNNPACK runtime execution, random-weight "
+        "raw parity, and predict plumbing are covered. A trained-checkpoint "
+        "matched-detection parity record is still required for validated status."
+    ),
+    constraint="ExecuTorch 1.3, XNNPACK, CPU, FP32, batch 1, fixed input shape",
 )
 _add(
     "validated",

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -171,6 +171,78 @@ _add(
     ),
 )
 _add(
+    "experimental",
+    ("ec",),
+    ("pose", "segment"),
+    ("executorch",),
+    reason=(
+        "Full XNNPACK conversion, runtime execution, two-input sensitivity, "
+        "deterministic random-weight raw parity, and task result parsing are "
+        "covered. Trained-checkpoint task parity is not yet available."
+    ),
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape; "
+        "EC segmentation requires a canvas large enough for its top-300 query selection"
+    ),
+)
+_add(
+    "experimental",
+    ("yolonas",),
+    ("pose",),
+    ("executorch",),
+    reason=(
+        "Full XNNPACK conversion, runtime execution, two-input sensitivity, "
+        "deterministic random-weight raw parity, and keypoint result parsing "
+        "are covered. Trained-checkpoint pose parity is not yet available."
+    ),
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
+    "experimental",
+    ("convnext",),
+    ("classify",),
+    ("executorch",),
+    reason=(
+        "Full XNNPACK conversion, runtime execution, two-input sensitivity, "
+        "and deterministic random-weight logits parity are covered. "
+        "Trained-checkpoint classification parity is not yet available."
+    ),
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
+    "experimental",
+    ("nafnet", "realesrgan"),
+    ("restore",),
+    ("executorch",),
+    reason=(
+        "Full XNNPACK conversion, runtime execution, two-input sensitivity, "
+        "deterministic random-weight image parity, and restored-image result "
+        "parsing are covered. Trained-checkpoint restoration parity is not "
+        "yet available."
+    ),
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
+    "experimental",
+    ("fomo",),
+    ("point",),
+    ("executorch",),
+    reason=(
+        "Full XNNPACK conversion, runtime execution, two-input sensitivity, "
+        "deterministic random-weight heatmap parity, and point result parsing "
+        "are covered. Trained-checkpoint localization parity is not yet available."
+    ),
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed square input shape"
+    ),
+)
+_add(
     "validated",
     ("efficientnetv2", "mobilenetv4", "resnet"),
     ("classify",),

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Iterator, Literal
+from typing import Literal
 
 from ..tasks import TASKS
 
@@ -70,16 +71,19 @@ _add(
     since="1.3",
 )
 _add(
-    "experimental",
+    "validated",
     ("yolo9", "rfdetr"),
     ("detect",),
     ("executorch",),
     reason=(
-        "Fixed-shape batch-1 FP32 export, XNNPACK runtime execution, random-weight "
-        "raw parity, and predict plumbing are covered. A trained-checkpoint "
-        "matched-detection parity record is still required for validated status."
+        "Runtime and raw-output parity are covered in "
+        "tests/e2e/test_executorch.py; trained-checkpoint detection parity is "
+        "covered by its external-data flagship test."
     ),
-    constraint="ExecuTorch 1.3, XNNPACK, CPU, FP32, batch 1, fixed input shape",
+    since="1.3",
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
 )
 _add(
     "validated",

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -87,6 +87,69 @@ _add(
 )
 _add(
     "validated",
+    ("ec", "picodet", "rtdetr", "yolo9_e2e", "yolox"),
+    ("detect",),
+    ("executorch",),
+    reason=(
+        "Trained-checkpoint XNNPACK export, runtime execution, and matched "
+        "post-NMS detection parity are covered by the external-data flagship "
+        "test in tests/e2e/test_executorch.py."
+    ),
+    since="1.3",
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
+    "blocked",
+    ("rtmdet",),
+    ("detect",),
+    ("executorch",),
+    reason=(
+        "ExecuTorch 1.2 XNNPACK lowering fails in FuseBatchNormPass because "
+        "the generated graph has a duplicate fused parameter name."
+    ),
+)
+_add(
+    "blocked",
+    ("deimv2",),
+    ("detect",),
+    ("executorch",),
+    reason=(
+        "The trained atto model captures, lowers, and serializes, but the "
+        "ExecuTorch 1.2 runtime process terminates while executing forward."
+    ),
+)
+_add(
+    "validated",
+    ("efficientnetv2", "mobilenetv4", "resnet"),
+    ("classify",),
+    ("executorch",),
+    reason=(
+        "Trained-checkpoint XNNPACK logits cosine and top-1 parity are covered "
+        "by the external-data flagship test in tests/e2e/test_executorch.py."
+    ),
+    since="1.3",
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
+    "validated",
+    ("pidnet",),
+    ("semantic",),
+    ("executorch",),
+    reason=(
+        "Trained-checkpoint XNNPACK semantic-mask parity is covered by the "
+        "external-data flagship test in tests/e2e/test_executorch.py."
+    ),
+    since="1.3",
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
+    "validated",
     ("yolo9",),
     ("detect",),
     ("tensorrt", "openvino"),
@@ -371,10 +434,25 @@ _add(
     constraint="fixed-resolution batch-1 edge-probability canvas",
 )
 _add(
+    "experimental",
+    ("teed", "dexined"),
+    ("edge",),
+    ("executorch",),
+    reason=(
+        "Full XNNPACK conversion, runtime execution, two-input sensitivity, "
+        "and deterministic random-weight parity are covered. Redistributable "
+        "trained checkpoints are unavailable, so task-accuracy parity has not "
+        "been established."
+    ),
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
     "blocked",
     ("teed", "dexined"),
     ("edge",),
-    tuple(fmt for fmt in EXPORT_FORMATS if fmt != "onnx"),
+    tuple(fmt for fmt in EXPORT_FORMATS if fmt not in {"onnx", "executorch"}),
     reason=(
         "The edge exported-runtime contract is ONNX-only in v1; add runtime "
         "parity before enabling another format."

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -87,7 +87,20 @@ _add(
 )
 _add(
     "validated",
-    ("ec", "picodet", "rtdetr", "yolo9_e2e", "yolox"),
+    (
+        "ec",
+        "picodet",
+        "rtdetr",
+        "rtdetrv2",
+        "rtdetrv4",
+        "yolo1",
+        "yolo2",
+        "yolo3",
+        "yolo4",
+        "yolo7",
+        "yolo9_e2e",
+        "yolox",
+    ),
     ("detect",),
     ("executorch",),
     reason=(
@@ -98,6 +111,29 @@ _add(
     since="1.3",
     constraint=(
         "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
+    ),
+)
+_add(
+    "blocked",
+    ("dfine",),
+    ("detect",),
+    ("executorch",),
+    reason=(
+        "Strict capture reaches an unsupported ContextVar read in deformable "
+        "attention. Forcing the manual exported grid-sample path permits "
+        "serialization, but ExecuTorch 1.2 runtime execution still fails with "
+        "an invalid delegated tensor dimension order."
+    ),
+)
+_add(
+    "blocked",
+    ("deim",),
+    ("detect",),
+    ("executorch",),
+    reason=(
+        "The trained nano model captures, lowers, and serializes, but "
+        "ExecuTorch 1.2 runtime execution fails with an invalid delegated "
+        "tensor dimension order."
     ),
 )
 _add(
@@ -118,6 +154,20 @@ _add(
     reason=(
         "The trained atto model captures, lowers, and serializes, but the "
         "ExecuTorch 1.2 runtime process terminates while executing forward."
+    ),
+)
+_add(
+    "experimental",
+    ("yolo9_p2", "yolonas"),
+    ("detect",),
+    ("executorch",),
+    reason=(
+        "Full XNNPACK conversion, runtime execution, two-input sensitivity, "
+        "and deterministic random-weight raw parity are covered. A permissive "
+        "trained-checkpoint detection parity record is not available."
+    ),
+    constraint=(
+        "ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape"
     ),
 )
 _add(

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -244,8 +244,8 @@ def LibreYOLO(
     the appropriate model instance.
 
     Args:
-        model_path: Path to weights (.pt), ONNX (.onnx), TensorRT (.engine),
-                    or OpenVINO/ncnn directory.
+        model_path: Path to weights (.pt), ONNX (.onnx), ExecuTorch (.pte),
+                    TensorRT (.engine), or OpenVINO/ncnn directory.
         size: Model size variant (auto-detected from weights if omitted).
         reg_max: Regression max for DFL (YOLOv9 only, default: 16).
         nb_classes: Number of classes (auto-detected if omitted).
@@ -298,6 +298,13 @@ def LibreYOLO(
         from ..backends.torchscript import TorchScriptBackend
 
         return TorchScriptBackend(
+            model_path, nb_classes=nb_classes, device=device, task=task
+        )
+
+    if model_path.endswith(".pte"):
+        from ..backends.executorch import ExecuTorchBackend
+
+        return ExecuTorchBackend(
             model_path, nb_classes=nb_classes, device=device, task=task
         )
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1655,9 +1655,10 @@ class BaseModel(ABC):
         """Export model to deployment format.
 
         Args:
-            format: Target format ("onnx", "torchscript", "tensorrt",
-                "openvino", "ncnn", "tflite"). "litert" is accepted as an
-                alias for "tflite" (LiteRT is TensorFlow Lite's new name).
+            format: Target format ("onnx", "torchscript", "executorch",
+                "tensorrt", "openvino", "ncnn", "tflite"). "litert" is
+                accepted as an alias for "tflite" (LiteRT is TensorFlow
+                Lite's new name).
             **kwargs: Format-specific parameters forwarded to the exporter.
 
         Returns:

--- a/libreyolo/models/dfine/ms_deform.py
+++ b/libreyolo/models/dfine/ms_deform.py
@@ -61,6 +61,10 @@ def get_activation(act, inpace: bool = True):
 _FORCE_MANUAL_GRID_SAMPLE: ContextVar[bool] = ContextVar(
     "_FORCE_MANUAL_GRID_SAMPLE", default=False
 )
+# Strict torch.export capture cannot trace ContextVar.get(). Exporters that
+# require this decomposition temporarily set this plain module flag before
+# capture and restore it afterwards.
+_FORCE_MANUAL_GRID_SAMPLE_EXPORT = False
 
 
 def _grid_sample_bilinear_manual(feat, grid, padding_mode="zeros", align_corners=False):
@@ -159,7 +163,11 @@ def deformable_attention_core_func_v2(
         sampling_grid_l = sampling_locations_list[level]
 
         if method == "default":
-            if torch.onnx.is_in_onnx_export() or _FORCE_MANUAL_GRID_SAMPLE.get():
+            if (
+                torch.onnx.is_in_onnx_export()
+                or _FORCE_MANUAL_GRID_SAMPLE_EXPORT
+                or _FORCE_MANUAL_GRID_SAMPLE.get()
+            ):
                 sampling_value_l = _grid_sample_bilinear_manual(
                     value_l, sampling_grid_l, padding_mode="zeros", align_corners=False
                 )

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -279,7 +279,14 @@ class MSDeformAttn(nn.Module):
         # Eq(u0, 1)"). The check is a developer sanity check over spatial
         # shapes that are constant for a fixed export canvas, so evaluate it
         # in Python when the shapes are concrete and skip the tensor path.
-        if not torch.jit.is_tracing() and not isinstance(
+        if self._export and input_spatial_shapes_hw is not None:
+            # Export callers already carry the fixed canvas geometry as Python
+            # integer pairs. Validate against those values instead of reading
+            # back from input_spatial_shapes, which creates an unbacked symbol
+            # under strict torch.export capture.
+            expected_len_in = sum(h * w for h, w in input_spatial_shapes_hw)
+            assert expected_len_in == len_input, error_msg
+        elif not torch.jit.is_tracing() and not isinstance(
             input_spatial_shapes, torch.fx.Proxy
         ):
             try:
@@ -290,11 +297,6 @@ class MSDeformAttn(nn.Module):
                 expected_len_in = None
             if expected_len_in is not None and not isinstance(len_input, torch.Tensor):
                 assert expected_len_in == len_input, error_msg
-        elif self._export:
-            expected_len_in = (
-                input_spatial_shapes[:, 0] * input_spatial_shapes[:, 1]
-            ).sum()
-            torch._assert(expected_len_in == len_input, error_msg)
 
         value = self.value_proj(input_flatten)
         if input_padding_mask is not None:

--- a/libreyolo/models/yolo9/nn.py
+++ b/libreyolo/models/yolo9/nn.py
@@ -559,6 +559,10 @@ class DDetect(nn.Module):
             torch.tensor(stride) if stride else torch.zeros(self.nl)
         )
         self.register_buffer("stride", stride_tensor, persistent=False)
+        # Preserve the architecture's fixed stride values as Python scalars for
+        # graph export. Iterating over the tensor buffer and calling float()
+        # introduces aten.item/sym_float nodes that edge runtimes cannot lower.
+        self._stride_values = tuple(float(value) for value in stride_tensor.tolist())
 
         self._loss_fn = None
 
@@ -652,7 +656,7 @@ class DDetect(nn.Module):
         anchor_points = []
         stride_scale = []
         dtype, device = feats[0].dtype, feats[0].device
-        for feat, stride in zip(feats, self.stride):
+        for feat, stride in zip(feats, self._stride_values):
             _, _, h, w = feat.shape
             shift_x = torch.arange(end=w, device=device, dtype=dtype) + 0.5
             shift_y = torch.arange(end=h, device=device, dtype=dtype) + 0.5
@@ -661,7 +665,7 @@ class DDetect(nn.Module):
                 torch.stack([shift_x, shift_y], dim=-1).reshape(-1, 2)
             )
             stride_scale.append(
-                torch.full((h * w, 1), float(stride), dtype=dtype, device=device)
+                torch.full((h * w, 1), stride, dtype=dtype, device=device)
             )
         return torch.cat(anchor_points), torch.cat(stride_scale)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ onnx = [
     "onnxsim>=0.4.0",
     "onnxruntime>=1.16.0",
 ]
+executorch = [
+    # Fixed-shape FP32 .pte export and Python runtime validation. Kept out of
+    # aggregate extras because ExecuTorch constrains the compatible Torch pair.
+    "executorch",
+]
 coreai = [
     # Core AI (.aimodel) export, macOS only: the toolchain neither converts
     # nor runs elsewhere. Kept out of every aggregate extra on purpose,
@@ -352,6 +357,7 @@ markers = [
     "experimental_backend: tests covering an experimental backend",
     "onnx: tests covering ONNX export or inference",
     "torchscript: tests covering TorchScript export or inference",
+    "executorch: tests requiring the optional ExecuTorch exporter/runtime",
     "smoke: fast end-to-end pipeline checks on tiny synthetic data (CPU, <60s)",
     "tensorrt: tests requiring TensorRT",
     "trt: alias for TensorRT tests requiring TensorRT",

--- a/tests/e2e/test_executorch.py
+++ b/tests/e2e/test_executorch.py
@@ -53,6 +53,28 @@ def _box_iou(first: np.ndarray, second: np.ndarray) -> float:
     return float(intersection / union) if union else 0.0
 
 
+def _align_unordered_queries(reference, candidate):
+    """Apply one logits-and-box assignment to every query-indexed output."""
+    from scipy.optimize import linear_sum_assignment
+
+    reference_parts = []
+    candidate_parts = []
+    for expected, actual in zip(reference[:2], candidate[:2]):
+        assert expected.ndim >= 3 and actual.ndim >= 3
+        scale = max(float(np.abs(expected).max()), 1e-12)
+        reference_parts.append(expected[0].reshape(expected.shape[1], -1) / scale)
+        candidate_parts.append(actual[0].reshape(actual.shape[1], -1) / scale)
+    reference_key = np.concatenate(reference_parts, axis=1)
+    candidate_key = np.concatenate(candidate_parts, axis=1)
+    cost = np.max(
+        np.abs(reference_key[:, None, :] - candidate_key[None, :, :]),
+        axis=2,
+    )
+    rows, columns = linear_sum_assignment(cost)
+    order = columns[np.argsort(rows)]
+    return [output[:, order, ...] for output in candidate]
+
+
 @pytest.mark.parametrize(
     ("family", "imgsz"),
     [("yolo9", 64), ("rfdetr", 384)],
@@ -258,6 +280,116 @@ def test_additional_detection_raw_parity(tmp_path, monkeypatch, family):
     )
     result = runtime.predict(image, conf=0.0, max_det=20)
     assert result.boxes is not None
+
+
+@pytest.mark.experimental_backend
+@pytest.mark.parametrize(
+    ("case", "imgsz"),
+    [
+        ("convnext_classify", 64),
+        ("nafnet_restore", 64),
+        ("ec_pose", 64),
+        ("ec_segment", 128),
+        ("fomo_point", 64),
+        ("realesrgan_restore", 32),
+        ("yolonas_pose", 64),
+    ],
+)
+def test_additional_task_raw_parity(tmp_path, monkeypatch, case, imgsz):
+    """Cover fixed-shape task graphs without redistributable trained parity data."""
+    _require_executorch(monkeypatch)
+
+    from libreyolo import (
+        LibreConvNeXt,
+        LibreEC,
+        LibreFOMO,
+        LibreNAFNet,
+        LibreRealESRGAN,
+        LibreYOLO,
+        LibreYOLONAS,
+    )
+    from libreyolo.export.exporter import ExecuTorchExporter
+
+    constructors = {
+        "convnext_classify": lambda: LibreConvNeXt(
+            None, size="t", nb_classes=3, device="cpu"
+        ),
+        "nafnet_restore": lambda: LibreNAFNet(None, size="s", device="cpu"),
+        "ec_pose": lambda: LibreEC(None, size="s", task="pose", device="cpu"),
+        "ec_segment": lambda: LibreEC(
+            None, size="s", task="segment", nb_classes=2, device="cpu"
+        ),
+        "fomo_point": lambda: LibreFOMO(
+            None, size="s", nb_classes=2, device="cpu"
+        ),
+        "realesrgan_restore": lambda: LibreRealESRGAN(
+            None, size="x4t", device="cpu"
+        ),
+        "yolonas_pose": lambda: LibreYOLONAS(
+            None, size="n", task="pose", device="cpu"
+        ),
+    }
+    torch.manual_seed(21)
+    model = constructors[case]()
+    first = torch.from_numpy(
+        np.random.default_rng(21).standard_normal(
+            (1, 3, imgsz, imgsz), dtype=np.float32
+        )
+    )
+    second = torch.full_like(first, 100.0)
+
+    exporter = ExecuTorchExporter(model)
+    with exporter._model_context(
+        torch.device("cpu"), False, False, 1, (imgsz, imgsz)
+    ) as (prepared, _), torch.no_grad():
+        expected = prepared(first)
+    if isinstance(expected, torch.Tensor):
+        expected = (expected,)
+
+    artifact = model.export(
+        "executorch",
+        output_path=str(tmp_path / f"{case}.pte"),
+        imgsz=imgsz,
+        batch=1,
+        dynamic=False,
+    )
+    runtime = LibreYOLO(artifact)
+    actual = runtime._run_inference(first.numpy())
+    changed = runtime._run_inference(second.numpy())
+
+    assert len(expected) == len(actual)
+    expected_arrays = [output.detach().cpu().numpy() for output in expected]
+    if case == "ec_segment":
+        actual = _align_unordered_queries(expected_arrays, actual)
+    parity_error = 0.0
+    for expected_array, actual_output in zip(expected_arrays, actual):
+        np.testing.assert_allclose(
+            actual_output, expected_array, rtol=1e-3, atol=2e-4
+        )
+        parity_error = max(
+            parity_error,
+            float(np.max(np.abs(actual_output - expected_array))),
+        )
+    sensitivity = max(
+        float(np.max(np.abs(first_output - second_output)))
+        for first_output, second_output in zip(actual, changed)
+    )
+    assert sensitivity > max(parity_error * 100, 1e-4)
+
+    image = np.random.default_rng(22).integers(
+        0, 256, (imgsz, imgsz, 3), dtype=np.uint8
+    )
+    result = runtime.predict(image, conf=0.0, max_det=10)
+    expected_attribute = {
+        "convnext_classify": "probs",
+        "nafnet_restore": "restored",
+        "ec_pose": "keypoints",
+        "ec_segment": "masks",
+        "fomo_point": "points",
+        "realesrgan_restore": "restored",
+        "yolonas_pose": "keypoints",
+    }[case]
+    assert getattr(result, expected_attribute) is not None
 
 
 @pytest.mark.external_data

--- a/tests/e2e/test_executorch.py
+++ b/tests/e2e/test_executorch.py
@@ -30,6 +30,29 @@ def _require_executorch(monkeypatch):
     monkeypatch.setenv("PATH", f"{bundled.parent}{os.pathsep}{os.environ['PATH']}")
 
 
+def _detections(result) -> np.ndarray:
+    """Return postprocessed detection rows for list and scalar Results APIs."""
+    if isinstance(result, list):
+        result = result[0]
+    return result.boxes.data.detach().cpu().numpy()
+
+
+def _box_iou(first: np.ndarray, second: np.ndarray) -> float:
+    x1 = max(first[0], second[0])
+    y1 = max(first[1], second[1])
+    x2 = min(first[2], second[2])
+    y2 = min(first[3], second[3])
+    intersection = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    first_area = max(0.0, first[2] - first[0]) * max(
+        0.0, first[3] - first[1]
+    )
+    second_area = max(0.0, second[2] - second[0]) * max(
+        0.0, second[3] - second[1]
+    )
+    union = first_area + second_area - intersection
+    return float(intersection / union) if union else 0.0
+
+
 @pytest.mark.parametrize(
     ("family", "imgsz"),
     [("yolo9", 64), ("rfdetr", 384)],
@@ -118,6 +141,73 @@ def test_detection_flagship_raw_parity_and_predict(
     result = backend.predict(image)
     assert isinstance(result, Results)
     assert result.boxes is not None
+
+
+@pytest.mark.external_data
+@pytest.mark.flagship_nightly
+@pytest.mark.parametrize(
+    ("family", "weights_env", "imgsz"),
+    [
+        ("yolo9", "LIBREYOLO_EXECUTORCH_YOLO9_WEIGHTS", 640),
+        ("rfdetr", "LIBREYOLO_EXECUTORCH_RFDETR_WEIGHTS", 384),
+    ],
+)
+def test_trained_detection_parity(
+    tmp_path, monkeypatch, family, weights_env, imgsz
+):
+    """Match trained native and ExecuTorch post-NMS detections on real images."""
+    _require_executorch(monkeypatch)
+
+    from libreyolo import LibreYOLO
+
+    weights_value = os.environ.get(weights_env)
+    image_values = os.environ.get("LIBREYOLO_EXECUTORCH_IMAGES", "").splitlines()
+    if not weights_value or len(image_values) < 2:
+        pytest.skip(
+            f"set {weights_env} and LIBREYOLO_EXECUTORCH_IMAGES "
+            "to a newline-separated list of at least two images"
+        )
+
+    weights = Path(weights_value)
+    images = [Path(value) for value in image_values if value.strip()]
+    if not weights.is_file() or any(not image.is_file() for image in images):
+        pytest.skip("staged trained-checkpoint parity inputs are unavailable")
+
+    native = LibreYOLO(str(weights), device="cpu")
+    artifact = native.export(
+        "executorch",
+        output_path=str(tmp_path / f"{family}.pte"),
+        imgsz=imgsz,
+        batch=1,
+        dynamic=False,
+    )
+    runtime = LibreYOLO(artifact)
+
+    for image in images:
+        expected = _detections(
+            native.predict(str(image), conf=0.25, iou=0.6)
+        )
+        actual = _detections(
+            runtime.predict(str(image), conf=0.25, iou=0.6)
+        )
+        assert len(expected) > 0
+        assert len(actual) == len(expected)
+
+        remaining = set(range(len(actual)))
+        for expected_row in expected:
+            same_class = [
+                index
+                for index in remaining
+                if int(actual[index, 5]) == int(expected_row[5])
+            ]
+            assert same_class
+            match = max(
+                same_class,
+                key=lambda index: _box_iou(expected_row, actual[index]),
+            )
+            remaining.remove(match)
+            assert _box_iou(expected_row, actual[match]) >= 0.95
+            assert abs(float(expected_row[4] - actual[match, 4])) <= 0.01
 
 
 def test_failed_export_restores_yolo9_state(tmp_path, monkeypatch):

--- a/tests/e2e/test_executorch.py
+++ b/tests/e2e/test_executorch.py
@@ -143,6 +143,49 @@ def test_detection_flagship_raw_parity_and_predict(
     assert result.boxes is not None
 
 
+@pytest.mark.experimental_backend
+@pytest.mark.parametrize(
+    ("family", "class_name", "size"),
+    [
+        ("teed", "LibreTEED", "t"),
+        ("dexined", "LibreDexiNed", "b"),
+    ],
+)
+def test_edge_map_runtime_parity(
+    tmp_path, monkeypatch, family, class_name, size
+):
+    """Prove edge-map conversion and parity without restricted checkpoints."""
+    _require_executorch(monkeypatch)
+
+    import libreyolo
+    from libreyolo import LibreYOLO
+
+    torch.manual_seed(7)
+    model_class = getattr(libreyolo, class_name)
+    model = model_class(None, size=size, device="cpu")
+    first = np.random.default_rng(7).integers(
+        0, 256, (40, 64, 3), dtype=np.uint8
+    )
+    second = np.random.default_rng(8).integers(
+        0, 256, (40, 64, 3), dtype=np.uint8
+    )
+    expected = model.predict(first, imgsz=64).edges.data.numpy()
+
+    artifact = model.export(
+        "executorch",
+        output_path=str(tmp_path / f"{family}.pte"),
+        imgsz=64,
+        batch=1,
+        dynamic=False,
+    )
+    runtime = LibreYOLO(artifact)
+    actual = runtime.predict(first).edges.data.numpy()
+    changed = runtime.predict(second).edges.data.numpy()
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=2e-4)
+    assert float(np.max(np.abs(actual - changed))) > 1e-4
+
+
 @pytest.mark.external_data
 @pytest.mark.flagship_nightly
 @pytest.mark.parametrize(
@@ -150,6 +193,11 @@ def test_detection_flagship_raw_parity_and_predict(
     [
         ("yolo9", "LIBREYOLO_EXECUTORCH_YOLO9_WEIGHTS", 640),
         ("rfdetr", "LIBREYOLO_EXECUTORCH_RFDETR_WEIGHTS", 384),
+        ("yolox", "LIBREYOLO_EXECUTORCH_YOLOX_WEIGHTS", 416),
+        ("picodet", "LIBREYOLO_EXECUTORCH_PICODET_WEIGHTS", 320),
+        ("yolo9_e2e", "LIBREYOLO_EXECUTORCH_YOLO9_E2E_WEIGHTS", 640),
+        ("ec", "LIBREYOLO_EXECUTORCH_EC_WEIGHTS", 640),
+        ("rtdetr", "LIBREYOLO_EXECUTORCH_RTDETR_WEIGHTS", 640),
     ],
 )
 def test_trained_detection_parity(
@@ -208,6 +256,102 @@ def test_trained_detection_parity(
             remaining.remove(match)
             assert _box_iou(expected_row, actual[match]) >= 0.95
             assert abs(float(expected_row[4] - actual[match, 4])) <= 0.01
+
+
+@pytest.mark.external_data
+@pytest.mark.flagship_nightly
+@pytest.mark.parametrize(
+    ("family", "weights_env"),
+    [
+        ("mobilenetv4", "LIBREYOLO_EXECUTORCH_MOBILENETV4_WEIGHTS"),
+        ("efficientnetv2", "LIBREYOLO_EXECUTORCH_EFFICIENTNETV2_WEIGHTS"),
+        ("resnet", "LIBREYOLO_EXECUTORCH_RESNET_WEIGHTS"),
+    ],
+)
+def test_trained_classification_parity(
+    tmp_path, monkeypatch, family, weights_env
+):
+    """Match trained native and ExecuTorch logits and top-1 predictions."""
+    _require_executorch(monkeypatch)
+
+    from libreyolo import LibreYOLO
+
+    weights_value = os.environ.get(weights_env)
+    image_values = os.environ.get("LIBREYOLO_EXECUTORCH_IMAGES", "").splitlines()
+    if not weights_value or len(image_values) < 2:
+        pytest.skip(
+            f"set {weights_env} and LIBREYOLO_EXECUTORCH_IMAGES "
+            "to a newline-separated list of at least two images"
+        )
+
+    weights = Path(weights_value)
+    images = [Path(value) for value in image_values if value.strip()]
+    if not weights.is_file() or any(not image.is_file() for image in images):
+        pytest.skip("staged trained-checkpoint parity inputs are unavailable")
+
+    native = LibreYOLO(str(weights), device="cpu")
+    artifact = native.export(
+        "executorch",
+        output_path=str(tmp_path / f"{family}.pte"),
+        imgsz=224,
+        batch=1,
+        dynamic=False,
+    )
+    runtime = LibreYOLO(artifact)
+
+    for image in images:
+        native_result = native.predict(str(image))
+        runtime_result = runtime.predict(str(image))
+        expected = native_result.probs.data.detach().cpu().numpy()
+        actual = runtime_result.probs.data.detach().cpu().numpy()
+        cosine = float(
+            np.dot(expected, actual)
+            / (np.linalg.norm(expected) * np.linalg.norm(actual))
+        )
+        assert cosine >= 0.999
+        assert int(np.argmax(actual)) == int(np.argmax(expected))
+
+
+@pytest.mark.external_data
+@pytest.mark.flagship_nightly
+def test_trained_pidnet_semantic_parity(tmp_path, monkeypatch):
+    """Match trained PIDNet semantic maps after public postprocessing."""
+    _require_executorch(monkeypatch)
+
+    from libreyolo import LibreYOLO
+
+    weights_value = os.environ.get("LIBREYOLO_EXECUTORCH_PIDNET_WEIGHTS")
+    image_values = os.environ.get("LIBREYOLO_EXECUTORCH_IMAGES", "").splitlines()
+    if not weights_value or len(image_values) < 2:
+        pytest.skip(
+            "set LIBREYOLO_EXECUTORCH_PIDNET_WEIGHTS and "
+            "LIBREYOLO_EXECUTORCH_IMAGES to at least two images"
+        )
+
+    weights = Path(weights_value)
+    images = [Path(value) for value in image_values if value.strip()]
+    if not weights.is_file() or any(not image.is_file() for image in images):
+        pytest.skip("staged trained-checkpoint parity inputs are unavailable")
+
+    native = LibreYOLO(str(weights), device="cpu")
+    artifact = native.export(
+        "executorch",
+        output_path=str(tmp_path / "pidnet.pte"),
+        imgsz=1024,
+        batch=1,
+        dynamic=False,
+    )
+    runtime = LibreYOLO(artifact)
+
+    for image in images:
+        expected = (
+            native.predict(str(image)).semantic_mask.data.detach().cpu().numpy()
+        )
+        actual = (
+            runtime.predict(str(image)).semantic_mask.data.detach().cpu().numpy()
+        )
+        assert expected.shape == actual.shape
+        assert float(np.mean(expected == actual)) >= 0.95
 
 
 def test_failed_export_restores_yolo9_state(tmp_path, monkeypatch):

--- a/tests/e2e/test_executorch.py
+++ b/tests/e2e/test_executorch.py
@@ -186,6 +186,80 @@ def test_edge_map_runtime_parity(
     assert float(np.max(np.abs(actual - changed))) > 1e-4
 
 
+@pytest.mark.experimental_backend
+@pytest.mark.parametrize("family", ["yolonas", "yolo9_p2"])
+def test_additional_detection_raw_parity(tmp_path, monkeypatch, family):
+    """Cover detector families lacking redistributable trained parity data."""
+    _require_executorch(monkeypatch)
+
+    from libreyolo import LibreYOLO, LibreYOLO9P2, LibreYOLONAS
+    from libreyolo.export.exporter import ExecuTorchExporter
+
+    torch.manual_seed(11)
+    if family == "yolonas":
+        model = LibreYOLONAS(None, size="s", nb_classes=2, device="cpu")
+    else:
+        model = LibreYOLO9P2(
+            None, size="t", nb_classes=2, device="cpu"
+        )
+
+    first = torch.from_numpy(
+        np.random.default_rng(11).standard_normal(
+            (1, 3, 64, 64), dtype=np.float32
+        )
+    )
+    second = (
+        torch.full_like(first, 100.0)
+        if family == "yolo9_p2"
+        else torch.from_numpy(
+            np.random.default_rng(12).standard_normal(
+                (1, 3, 64, 64), dtype=np.float32
+            )
+        )
+    )
+    exporter = ExecuTorchExporter(model)
+    with exporter._model_context(
+        torch.device("cpu"), False, False, 1, (64, 64)
+    ) as (prepared, _), torch.no_grad():
+        expected = prepared(first)
+    if isinstance(expected, torch.Tensor):
+        expected = (expected,)
+
+    artifact = model.export(
+        "executorch",
+        output_path=str(tmp_path / f"{family}.pte"),
+        imgsz=64,
+        batch=1,
+        dynamic=False,
+    )
+    runtime = LibreYOLO(artifact)
+    actual = runtime._run_inference(first.numpy())
+    changed = runtime._run_inference(second.numpy())
+
+    assert len(expected) == len(actual)
+    parity_error = 0.0
+    for expected_output, actual_output in zip(expected, actual):
+        expected_array = expected_output.detach().cpu().numpy()
+        np.testing.assert_allclose(
+            actual_output, expected_array, rtol=1e-3, atol=2e-4
+        )
+        parity_error = max(
+            parity_error,
+            float(np.max(np.abs(actual_output - expected_array))),
+        )
+    sensitivity = max(
+        float(np.max(np.abs(first_output - second_output)))
+        for first_output, second_output in zip(actual, changed)
+    )
+    assert sensitivity > max(parity_error * 100, 1e-4)
+
+    image = np.random.default_rng(13).integers(
+        0, 256, (64, 64, 3), dtype=np.uint8
+    )
+    result = runtime.predict(image, conf=0.0, max_det=20)
+    assert result.boxes is not None
+
+
 @pytest.mark.external_data
 @pytest.mark.flagship_nightly
 @pytest.mark.parametrize(
@@ -198,6 +272,13 @@ def test_edge_map_runtime_parity(
         ("yolo9_e2e", "LIBREYOLO_EXECUTORCH_YOLO9_E2E_WEIGHTS", 640),
         ("ec", "LIBREYOLO_EXECUTORCH_EC_WEIGHTS", 640),
         ("rtdetr", "LIBREYOLO_EXECUTORCH_RTDETR_WEIGHTS", 640),
+        ("rtdetrv2", "LIBREYOLO_EXECUTORCH_RTDETRV2_WEIGHTS", 640),
+        ("rtdetrv4", "LIBREYOLO_EXECUTORCH_RTDETRV4_WEIGHTS", 640),
+        ("yolo1", "LIBREYOLO_EXECUTORCH_YOLO1_WEIGHTS", 448),
+        ("yolo2", "LIBREYOLO_EXECUTORCH_YOLO2_WEIGHTS", 416),
+        ("yolo3", "LIBREYOLO_EXECUTORCH_YOLO3_WEIGHTS", 416),
+        ("yolo4", "LIBREYOLO_EXECUTORCH_YOLO4_WEIGHTS", 416),
+        ("yolo7", "LIBREYOLO_EXECUTORCH_YOLO7_WEIGHTS", 640),
     ],
 )
 def test_trained_detection_parity(

--- a/tests/e2e/test_executorch.py
+++ b/tests/e2e/test_executorch.py
@@ -1,0 +1,152 @@
+"""Real ExecuTorch XNNPACK export/runtime checks for detection flagships."""
+
+from __future__ import annotations
+
+import importlib.resources
+import os
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = [pytest.mark.e2e, pytest.mark.executorch]
+
+
+def _require_executorch(monkeypatch):
+    pytest.importorskip("executorch")
+    pytest.importorskip("executorch.runtime")
+    if shutil.which("flatc") is not None:
+        return
+
+    # ExecuTorch Windows wheels bundle flatc but 1.2 does not add its
+    # directory to PATH. Keep this host-tool workaround local to the real
+    # toolchain test; production emits an actionable error.
+    package_root = importlib.resources.files("executorch")
+    bundled = Path(str(package_root.joinpath("data", "bin", "flatc.exe")))
+    if not bundled.exists():
+        pytest.skip("ExecuTorch lowering requires flatc on PATH")
+    monkeypatch.setenv("PATH", f"{bundled.parent}{os.pathsep}{os.environ['PATH']}")
+
+
+@pytest.mark.parametrize(
+    ("family", "imgsz"),
+    [("yolo9", 64), ("rfdetr", 384)],
+)
+def test_detection_flagship_raw_parity_and_predict(
+    tmp_path, monkeypatch, family, imgsz
+):
+    _require_executorch(monkeypatch)
+
+    from libreyolo import LibreRFDETR, LibreYOLO, LibreYOLO9
+    from libreyolo.export.exporter import ExecuTorchExporter
+    from libreyolo.utils.results import Results
+
+    torch.manual_seed(0)
+    if family == "yolo9":
+        model = LibreYOLO9(None, size="t", nb_classes=2, device="cpu")
+    else:
+        pytest.importorskip("transformers")
+        model = LibreRFDETR(
+            {}, size="n", nb_classes=2, device="cpu", task="detect"
+        )
+    model.model.eval()
+    original_training = model.model.training
+    original_export = getattr(
+        getattr(model.model, "head", None), "export", None
+    )
+
+    rng = np.random.default_rng(0)
+    first = torch.from_numpy(
+        rng.standard_normal((1, 3, imgsz, imgsz), dtype=np.float32)
+    )
+    second = (
+        torch.full_like(first, 100.0)
+        if family == "yolo9"
+        else torch.from_numpy(
+            np.random.default_rng(1).standard_normal(
+                (1, 3, imgsz, imgsz), dtype=np.float32
+            )
+        )
+    )
+
+    exporter = ExecuTorchExporter(model)
+    with exporter._model_context(
+        torch.device("cpu"), False, False, 1, (imgsz, imgsz)
+    ) as (prepared, _), torch.no_grad():
+        expected = prepared(first)
+    if isinstance(expected, torch.Tensor):
+        expected = (expected,)
+
+    artifact = model.export(
+        "executorch",
+        output_path=str(tmp_path / f"{family}.pte"),
+        imgsz=imgsz,
+        batch=1,
+        dynamic=False,
+    )
+    assert model.model.training is original_training
+    if original_export is not None:
+        assert model.model.head.export is original_export
+
+    backend = LibreYOLO(artifact)
+    actual = backend._run_inference(first.numpy())
+    changed = backend._run_inference(second.numpy())
+    assert len(actual) == len(expected)
+
+    parity_error = 0.0
+    for actual_output, expected_output in zip(actual, expected):
+        expected_array = expected_output.detach().cpu().numpy()
+        np.testing.assert_allclose(
+            actual_output, expected_array, rtol=1e-3, atol=2e-4
+        )
+        parity_error = max(
+            parity_error,
+            float(np.max(np.abs(actual_output - expected_array))),
+        )
+
+    sensitivity = max(
+        float(np.max(np.abs(first_output - second_output)))
+        for first_output, second_output in zip(actual, changed)
+    )
+    assert sensitivity > max(parity_error * 100, 1e-4)
+
+    image = np.random.default_rng(2).integers(
+        0, 256, (imgsz, imgsz, 3), dtype=np.uint8
+    )
+    result = backend.predict(image)
+    assert isinstance(result, Results)
+    assert result.boxes is not None
+
+
+def test_failed_export_restores_yolo9_state(tmp_path, monkeypatch):
+    _require_executorch(monkeypatch)
+
+    from libreyolo import LibreYOLO9
+
+    model = LibreYOLO9(None, size="t", nb_classes=2, device="cpu")
+    model.model.train()
+    original_training = model.model.training
+    original_export = model.model.head.export
+
+    def fail_export(*args, **kwargs):
+        raise RuntimeError("simulated lowering failure")
+
+    monkeypatch.setattr(
+        "libreyolo.export.executorch.export_executorch", fail_export
+    )
+    output = tmp_path / "failed.pte"
+    with pytest.raises(RuntimeError, match="simulated"):
+        model.export(
+            "executorch",
+            output_path=str(output),
+            imgsz=64,
+            batch=1,
+            dynamic=False,
+        )
+
+    assert model.model.training is original_training
+    assert model.model.head.export is original_export
+    assert not output.exists()
+    assert not Path(f"{output}.json").exists()

--- a/tests/unit/test_executorch_backend.py
+++ b/tests/unit/test_executorch_backend.py
@@ -1,0 +1,122 @@
+"""Unit tests for ExecuTorch sidecar loading and runtime execution."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from typing import ClassVar
+
+import numpy as np
+import pytest
+
+from libreyolo.backends.executorch import ExecuTorchBackend
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeRegistry:
+    def __init__(self, available: bool = True):
+        self.available = available
+
+    def is_available(self, name):
+        return self.available and name == "XnnpackBackend"
+
+
+class _FakeMethod:
+    def execute(self, inputs):
+        return [inputs[0] + 1, inputs[0].mean(dim=(2, 3))]
+
+
+class _FakeProgram:
+    method_names: ClassVar = {"forward"}
+
+    def load_method(self, name):
+        assert name == "forward"
+        return _FakeMethod()
+
+
+def _install_fake_runtime(monkeypatch, *, backend_available=True):
+    runtime = types.ModuleType("executorch.runtime")
+
+    class Runtime:
+        backend_registry = _FakeRegistry(backend_available)
+
+        @classmethod
+        def get(cls):
+            return cls
+
+        @classmethod
+        def load_program(cls, data):
+            assert isinstance(data, bytes)
+            return _FakeProgram()
+
+    runtime.Runtime = Runtime
+    package = types.ModuleType("executorch")
+    package.__path__ = []
+    monkeypatch.setitem(sys.modules, "executorch", package)
+    monkeypatch.setitem(sys.modules, "executorch.runtime", runtime)
+
+
+def _write_artifact(tmp_path):
+    path = tmp_path / "model.pte"
+    path.write_bytes(b"fake-pte")
+    metadata = {
+        "schema_version": "1.0",
+        "model_family": "yolo9",
+        "size": "t",
+        "task": "detect",
+        "supported_tasks": ["detect"],
+        "default_task": "detect",
+        "nc": 2,
+        "names": {"0": "a", "1": "b"},
+        "imgsz": 64,
+        "imgsz_h": 64,
+        "imgsz_w": 64,
+        "precision": "fp32",
+        "dynamic": False,
+        "executorch_version": "1.3.0",
+        "executorch_delegate": "xnnpack",
+    }
+    (tmp_path / "model.pte.json").write_text(
+        json.dumps(metadata), encoding="utf-8"
+    )
+    return path
+
+
+def test_backend_loads_sidecar_and_returns_contiguous_numpy(tmp_path, monkeypatch):
+    _install_fake_runtime(monkeypatch)
+    path = _write_artifact(tmp_path)
+
+    backend = ExecuTorchBackend(str(path))
+    outputs = backend._run_inference(np.zeros((1, 3, 64, 64), dtype=np.float64))
+
+    assert backend.model_family == "yolo9"
+    assert backend.task == "detect"
+    assert backend.names == {0: "a", 1: "b"}
+    assert [output.shape for output in outputs] == [(1, 3, 64, 64), (1, 3)]
+    assert all(output.flags.c_contiguous for output in outputs)
+    assert all(output.dtype == np.float32 for output in outputs)
+
+
+def test_backend_requires_xnnpack_runtime(tmp_path, monkeypatch):
+    _install_fake_runtime(monkeypatch, backend_available=False)
+    path = _write_artifact(tmp_path)
+
+    with pytest.raises(RuntimeError, match="XnnpackBackend"):
+        ExecuTorchBackend(str(path))
+
+
+def test_backend_rejects_missing_or_wrong_sidecar(tmp_path, monkeypatch):
+    _install_fake_runtime(monkeypatch)
+    path = tmp_path / "model.pte"
+    path.write_bytes(b"fake-pte")
+
+    with pytest.raises(FileNotFoundError, match="sidecar"):
+        ExecuTorchBackend(str(path))
+
+    (tmp_path / "model.pte.json").write_text(
+        json.dumps({"executorch_delegate": "vulkan"}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="XNNPACK"):
+        ExecuTorchBackend(str(path))

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -14,6 +14,7 @@ import libreyolo.export.onnx as onnx_module
 from libreyolo.export.exporter import (
     BaseExporter,
     CoreMLExporter,
+    ExecuTorchExporter,
     NcnnExporter,
     OnnxExporter,
     OpenVINOExporter,
@@ -127,6 +128,7 @@ class TestExporterFormats:
     def test_expected_keys(self):
         assert "onnx" in BaseExporter._registry
         assert "torchscript" in BaseExporter._registry
+        assert "executorch" in BaseExporter._registry
         assert "tensorrt" in BaseExporter._registry
         assert "openvino" in BaseExporter._registry
         assert "ncnn" in BaseExporter._registry
@@ -144,6 +146,9 @@ class TestExporterFormats:
         assert TensorRTExporter.requires_onnx is True
         assert TorchScriptExporter.apply_model_half is True
         assert TorchScriptExporter.supports_embedded_nms is False
+        assert ExecuTorchExporter.suffix == ".pte"
+        assert ExecuTorchExporter.supports_fp16 is False
+        assert ExecuTorchExporter.supports_int8 is False
         assert NcnnExporter.supports_int8 is False
         assert TFLiteExporter.requires_onnx is True
         assert TFLiteExporter.supports_fp16 is False

--- a/tests/unit/test_export_executorch.py
+++ b/tests/unit/test_export_executorch.py
@@ -14,7 +14,7 @@ from libreyolo.export.executorch import (
     _capture_compatibility,
     _commit_artifact_pair,
 )
-from libreyolo.export.exporter import ExecuTorchExporter
+from libreyolo.export.exporter import BaseExporter, ExecuTorchExporter
 
 pytestmark = pytest.mark.unit
 
@@ -59,6 +59,26 @@ def test_executorch_constraints_reject_unsupported_requests(monkeypatch):
             metadata={},
             dynamic=True,
         )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"batch": 2, "dynamic": False}, "batch=1"),
+        ({"batch": 1, "dynamic": True}, "dynamic=False"),
+    ],
+)
+def test_executorch_shape_constraints_reject_before_base_export(
+    monkeypatch, kwargs, message
+):
+    """Invalid requests must not reach BaseExporter's destructive LoRA merge."""
+    base_call = MagicMock(side_effect=AssertionError("base export entered"))
+    monkeypatch.setattr(BaseExporter, "__call__", base_call)
+
+    with pytest.raises(ValueError, match=message):
+        ExecuTorchExporter(_wrapper())(**kwargs)
+
+    base_call.assert_not_called()
 
 
 def test_executorch_metadata_is_fixed_fp32_contract():

--- a/tests/unit/test_export_executorch.py
+++ b/tests/unit/test_export_executorch.py
@@ -1,0 +1,108 @@
+"""Unit tests for the ExecuTorch exporter and artifact transaction."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from libreyolo.export.executorch import _commit_artifact_pair
+from libreyolo.export.exporter import ExecuTorchExporter
+
+pytestmark = pytest.mark.unit
+
+
+def _wrapper() -> MagicMock:
+    wrapper = MagicMock()
+    wrapper._get_model_name.return_value = "yolo9"
+    wrapper._get_input_size.return_value = 64
+    wrapper.task = "detect"
+    wrapper.SUPPORTED_TASKS = ("detect",)
+    wrapper.DEFAULT_TASK = "detect"
+    wrapper.size = "t"
+    wrapper.nb_classes = 2
+    wrapper.names = {0: "a", 1: "b"}
+    wrapper.device = torch.device("cpu")
+    return wrapper
+
+
+def test_executorch_constraints_reject_unsupported_requests(monkeypatch):
+    exporter = ExecuTorchExporter(_wrapper())
+    monkeypatch.setattr(
+        "libreyolo.export.executorch.check_executorch_available", lambda: None
+    )
+
+    with pytest.raises(ValueError, match="xnnpack"):
+        exporter._preflight(
+            half=False, int8=False, data=None, delegate="vulkan"
+        )
+    with pytest.raises(ValueError, match="batch=1"):
+        exporter._export(
+            torch.nn.Identity(),
+            torch.zeros(2, 3, 8, 8),
+            output_path="unused.pte",
+            metadata={},
+            dynamic=False,
+        )
+    with pytest.raises(ValueError, match="dynamic=False"):
+        exporter._export(
+            torch.nn.Identity(),
+            torch.zeros(1, 3, 8, 8),
+            output_path="unused.pte",
+            metadata={},
+            dynamic=True,
+        )
+
+
+def test_executorch_metadata_is_fixed_fp32_contract():
+    exporter = ExecuTorchExporter(_wrapper())
+    metadata = exporter._build_metadata(
+        "fp32", True, None, imgsz=(64, 64)
+    )
+    assert metadata["precision"] == "fp32"
+    assert metadata["dynamic"] is False
+    assert metadata["task"] == "detect"
+    assert metadata["imgsz_h"] == metadata["imgsz_w"] == 64
+
+
+def test_artifact_pair_writes_program_and_sidecar(tmp_path):
+    path = tmp_path / "model.pte"
+    _commit_artifact_pair(b"program", {"task": "detect"}, path)
+
+    assert path.read_bytes() == b"program"
+    assert json.loads(Path(f"{path}.json").read_text(encoding="utf-8")) == {
+        "task": "detect"
+    }
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob(".*.backup"))
+
+
+def test_artifact_pair_restores_preexisting_files_on_commit_failure(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "model.pte"
+    sidecar = Path(f"{path}.json")
+    path.write_bytes(b"old-program")
+    sidecar.write_text('{"old": true}', encoding="utf-8")
+
+    real_replace = os.replace
+
+    def fail_sidecar_commit(source, destination):
+        source_path = Path(source)
+        destination_path = Path(destination)
+        if source_path.suffix == ".tmp" and destination_path == sidecar:
+            raise OSError("simulated sidecar commit failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", fail_sidecar_commit)
+    with pytest.raises(OSError, match="simulated"):
+        _commit_artifact_pair(b"new-program", {"old": False}, path)
+
+    assert path.read_bytes() == b"old-program"
+    assert sidecar.read_text(encoding="utf-8") == '{"old": true}'
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob(".*.backup"))

--- a/tests/unit/test_export_executorch.py
+++ b/tests/unit/test_export_executorch.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from libreyolo.export.executorch import _commit_artifact_pair
+from libreyolo.export.executorch import (
+    _capture_compatibility,
+    _commit_artifact_pair,
+)
 from libreyolo.export.exporter import ExecuTorchExporter
 
 pytestmark = pytest.mark.unit
@@ -67,6 +70,15 @@ def test_executorch_metadata_is_fixed_fp32_contract():
     assert metadata["dynamic"] is False
     assert metadata["task"] == "detect"
     assert metadata["imgsz_h"] == metadata["imgsz_w"] == 64
+
+
+def test_rtdetrv4_capture_compatibility_restores_module_flag():
+    from libreyolo.models.dfine import ms_deform
+
+    assert ms_deform._FORCE_MANUAL_GRID_SAMPLE_EXPORT is False
+    with _capture_compatibility({"model_family": "rtdetrv4"}):
+        assert ms_deform._FORCE_MANUAL_GRID_SAMPLE_EXPORT is True
+    assert ms_deform._FORCE_MANUAL_GRID_SAMPLE_EXPORT is False
 
 
 def test_artifact_pair_writes_program_and_sidecar(tmp_path):

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -74,7 +74,14 @@ def test_executorch_realtime_support_is_evidence_backed():
         ("pidnet", "semantic"),
         ("resnet", "classify"),
         ("rtdetr", "detect"),
+        ("rtdetrv2", "detect"),
+        ("rtdetrv4", "detect"),
         ("rfdetr", "detect"),
+        ("yolo1", "detect"),
+        ("yolo2", "detect"),
+        ("yolo3", "detect"),
+        ("yolo4", "detect"),
+        ("yolo7", "detect"),
         ("yolo9", "detect"),
         ("yolo9_e2e", "detect"),
         ("yolox", "detect"),
@@ -83,9 +90,13 @@ def test_executorch_realtime_support_is_evidence_backed():
         assert get_support(family, task, "executorch").tier == "validated"
 
     assert get_support("rtmdet", "detect", "executorch").tier == "blocked"
+    assert get_support("dfine", "detect", "executorch").tier == "blocked"
+    assert get_support("deim", "detect", "executorch").tier == "blocked"
     assert get_support("deimv2", "detect", "executorch").tier == "blocked"
     assert get_support("teed", "edge", "executorch").tier == "experimental"
     assert get_support("dexined", "edge", "executorch").tier == "experimental"
+    assert get_support("yolonas", "detect", "executorch").tier == "experimental"
+    assert get_support("yolo9_p2", "detect", "executorch").tier == "experimental"
 
 
 def test_tflite_support_keys_use_canonical_tasks():

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -97,6 +97,13 @@ def test_executorch_realtime_support_is_evidence_backed():
     assert get_support("dexined", "edge", "executorch").tier == "experimental"
     assert get_support("yolonas", "detect", "executorch").tier == "experimental"
     assert get_support("yolo9_p2", "detect", "executorch").tier == "experimental"
+    assert get_support("ec", "pose", "executorch").tier == "experimental"
+    assert get_support("ec", "segment", "executorch").tier == "experimental"
+    assert get_support("yolonas", "pose", "executorch").tier == "experimental"
+    assert get_support("convnext", "classify", "executorch").tier == "experimental"
+    assert get_support("nafnet", "restore", "executorch").tier == "experimental"
+    assert get_support("realesrgan", "restore", "executorch").tier == "experimental"
+    assert get_support("fomo", "point", "executorch").tier == "experimental"
 
 
 def test_tflite_support_keys_use_canonical_tasks():

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -65,6 +65,29 @@ def test_experimental_export_warns_in_preflight():
         exporter._preflight(half=False, int8=False, data=None)
 
 
+def test_executorch_realtime_support_is_evidence_backed():
+    validated = {
+        ("ec", "detect"),
+        ("efficientnetv2", "classify"),
+        ("mobilenetv4", "classify"),
+        ("picodet", "detect"),
+        ("pidnet", "semantic"),
+        ("resnet", "classify"),
+        ("rtdetr", "detect"),
+        ("rfdetr", "detect"),
+        ("yolo9", "detect"),
+        ("yolo9_e2e", "detect"),
+        ("yolox", "detect"),
+    }
+    for family, task in validated:
+        assert get_support(family, task, "executorch").tier == "validated"
+
+    assert get_support("rtmdet", "detect", "executorch").tier == "blocked"
+    assert get_support("deimv2", "detect", "executorch").tier == "blocked"
+    assert get_support("teed", "edge", "executorch").tier == "experimental"
+    assert get_support("dexined", "edge", "executorch").tier == "experimental"
+
+
 def test_tflite_support_keys_use_canonical_tasks():
     from libreyolo.export.tflite import supported_tflite_exports
 
@@ -267,6 +290,7 @@ def test_generated_export_docs_are_current():
         capture_output=True,
         text=True,
         env=env,
+        check=False,
     )
     assert result.returncode == 0, result.stdout + result.stderr
 


### PR DESCRIPTION
## What does this PR do?

Adds ExecuTorch `.pte` export and runtime loading through the public `model.export(format=executorch)` and `LibreYOLO(path).predict(...)` APIs.

The initial contract is deliberately fixed: ExecuTorch 1.2, XNNPACK, CPU FP32, batch 1, fixed input shape, and one image tensor input. Program metadata is stored in an atomic `.pte.json` sidecar, dependencies remain optional, and failed exports do not leave partial artifacts.

The evidence-backed support matrix covers trained detection parity for YOLO1/2/3/4/7/9, YOLO9-E2E, YOLOX, PicoDet, EC, RT-DETR/v2/v4, and RF-DETR; trained classification parity for ResNet, MobileNetV4, and EfficientNetV2; and trained semantic parity for PIDNet. Additional conversion/runtime/raw-parity coverage is recorded as experimental for YOLO9-P2, YOLO-NAS detection and pose, EC pose and segmentation, ConvNeXt classification, FOMO point detection, NAFNet and Real-ESRGAN restoration, and TEED/DexiNed edge detection.

Reproducible ExecuTorch 1.2 failures remain explicitly blocked for D-FINE, DEIM, DEIMv2, and RTMDet rather than being advertised as supported.

## Code provenance

Original code written for this PR using ExecuTorch's documented public APIs. No third-party code was copied, adapted, paraphrased, or introduced. ExecuTorch is a BSD-licensed optional dependency and is not vendored. No GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license material is involved.

## How was this tested?

Tested on Windows x86-64 with Python 3.12, PyTorch 2.11.0, ExecuTorch 1.2.0, XNNPACK, CPU FP32, batch 1, and fixed input shapes.

Trained native-versus-ExecuTorch post-NMS parity used two staged COCO images across the validated detector families. Trained logits/top-1 parity covered three classification families, and trained output parity covered PIDNet semantic segmentation. Deterministic full-architecture tests also verify raw tensor parity, two-input sensitivity, runtime result parsing, artifact/metadata behavior, failure cleanup, and support-tier enforcement.

Focused regression results include 30 passing ExecuTorch support/export unit tests, 30 passing classic-model unit tests with 12 dependency-gated skips, and passing focused runtime tests for every support cell added by this branch. The generated export compatibility table is current.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds fixed-shape CPU ExecuTorch export and inference support.
- Introduces XNNPACK-backed `.pte` generation with JSON sidecar metadata and failure cleanup.
- Adds runtime loading, preprocessing, output parsing, CLI/public API integration, and model-family support gates.
- Documents the compatibility matrix and adds focused unit and end-to-end coverage.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not yet appear safe to merge because interrupted artifact installation can leave a new ExecuTorch program paired with stale or missing metadata.

The early ExecuTorch shape validation fixes the previously reported LoRA mutation path, but the program and sidecar are still committed through separate replacements and the loader has no generation check linking them, so termination during commit can produce an unusable or incorrectly interpreted export.

**Files Needing Attention:** libreyolo/export/executorch.py and libreyolo/backends/executorch.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/export/executorch.py | Implements ExecuTorch graph capture, XNNPACK lowering, metadata generation, and paired-artifact commit handling. |
| libreyolo/backends/executorch.py | Adds `.pte` loading, sidecar validation, fixed-shape preprocessing, runtime execution, and result parsing. |
| libreyolo/export/exporter.py | Integrates ExecuTorch into the shared exporter and now rejects unsupported shape options before LoRA mutation. |
| libreyolo/export/support.py | Defines validated and experimental ExecuTorch support tiers across model families and tasks. |
| tests/unit/test_export_executorch.py | Covers shape preflight, export metadata, commit rollback, cleanup, and support constraints. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Model export API or CLI] --> B[ExecuTorch preflight]
  B --> C[Prepare fixed batch-1 FP32 graph]
  C --> D[Lower with XNNPACK]
  D --> E[Write .pte program]
  D --> F[Write .pte.json metadata]
  E --> G[ExecuTorch backend]
  F --> G
  G --> H[Preprocess fixed-shape image]
  H --> I[Execute forward]
  I --> J[Parse task-specific results]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Validate ExecuTorch shapes early"](https://github.com/libreyolo/libreyolo/commit/62676eabc8dad0845754198cfda161379f0304d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48701325)</sub>

**Context used:**

- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)

<!-- /greptile_comment -->