### PR TITLE
Add save_json option to validation

### DIFF
--- a/libreyolo/validation/coco_evaluator.py
+++ b/libreyolo/validation/coco_evaluator.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from pathlib import Path
 from typing import Dict, Mapping, Optional
 
 import numpy as np
@@ -122,15 +123,19 @@ class COCOEvaluator:
 
         Args:
             save_json: Optional path to save predictions in COCO JSON format.
+                Written even when no predictions were accumulated.
         """
+        if save_json:
+            # Written first: an opted-in run must produce the file even when
+            # there are no predictions or evaluation fails below, and loadRes
+            # mutates the result dicts in place (adds id/area/segmentation).
+            with open(save_json, "w") as f:
+                json.dump(self.results, f, indent=2)
+            logger.info("Saved predictions to %s", Path(save_json).resolve())
+
         if len(self.results) == 0:
             logger.warning("No predictions to evaluate")
             return self._empty_metrics()
-
-        if save_json:
-            with open(save_json, "w") as f:
-                json.dump(self.results, f, indent=2)
-            logger.info("Saved predictions to %s", save_json)
 
         try:
             from pycocotools.coco import COCO  # noqa: F401

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -28,7 +28,12 @@ class ValidationConfig:
         iou_thresholds: IoU thresholds for mAP calculation (default: 0.50 to 0.95).
         device: Device to use ("auto", "cuda", "mps", "cpu").
         save_dir: Directory to save results.
-        save_json: Whether to save predictions in COCO JSON format.
+        save_json: Whether to write the detections as a standard COCO
+            results JSON (list of image_id/category_id/bbox/score entries,
+            loadable by pycocotools loadRes) using the original dataset
+            image and category ids. Detection writes save_dir/predictions.json;
+            segmentation writes predictions_bbox.json and predictions_masks.json.
+            Tasks without COCO detections ignore the flag (OBB logs a warning).
         save_plots: Whether to save validation plots (metrics bar, per-class AP,
             confusion matrix, sample images). Default False.
         verbose: Whether to print detailed metrics.

--- a/tests/unit/cli/test_command_utils.py
+++ b/tests/unit/cli/test_command_utils.py
@@ -413,6 +413,61 @@ def test_val_forwards_protocol_cap_and_amp_dtype(monkeypatch):
     assert captured["eval_max_det"] == 500
 
 
+def test_val_forwards_save_json(monkeypatch):
+    app = _make_app([("val", val.val_cmd), ("info", special.info_cmd)])
+    captured = {}
+
+    class _DetectModel:
+        FAMILY = "yolo9"
+        task = "detect"
+        size = "t"
+        device = "cuda:0"
+
+        def val(self, **kwargs):
+            captured.update(kwargs)
+            return {
+                "metrics/mAP50": 0.5,
+                "metrics/mAP50-95": 0.25,
+                "metrics/precision": 0.4,
+                "metrics/recall": 0.3,
+            }
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.val.resolve_model_or_exit",
+        lambda out, model: model,
+    )
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.val.load_model_or_exit",
+        lambda out, model, model_path, device: _DetectModel(),
+    )
+    monkeypatch.setattr(
+        "libreyolo.utils.general.increment_path",
+        lambda path, exist_ok=False, mkdir=False: Path(path),
+    )
+
+    result = runner.invoke(
+        app,
+        ["val", "data=rf100vl.yaml", "model=LibreYOLO9t.pt", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["save_json"] is False
+
+    result = runner.invoke(
+        app,
+        [
+            "val",
+            "data=rf100vl.yaml",
+            "model=LibreYOLO9t.pt",
+            "save_json=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["save_json"] is True
+
+
 def test_val_rejects_invalid_max_det():
     app = _make_app([("val", val.val_cmd), ("info", special.info_cmd)])
     result = runner.invoke(

--- a/tests/unit/test_coco_validation.py
+++ b/tests/unit/test_coco_validation.py
@@ -327,6 +327,116 @@ def test_coco_evaluator_preserves_zero_legacy_aliases_without_valid_gt():
     assert metrics["mAP"] == -1.0
 
 
+def _imperfect_coco_fixture():
+    """Dense fixture with the top-scored box misplaced so mAP is non-trivial."""
+    coco, predictions = _dense_coco_fixture(8)
+    predictions["boxes"][0] = [50.0, 50.0, 52.0, 52.0]
+    return coco, predictions
+
+
+@pytest.mark.unit
+def test_detection_validator_save_json_disabled_writes_no_file(tmp_path):
+    from libreyolo.validation import COCOEvaluator
+    from libreyolo.validation.detection_validator import DetectionValidator
+
+    coco, predictions = _dense_coco_fixture(4)
+    evaluator = COCOEvaluator(coco, iou_type="bbox", label_to_category_id={0: 1})
+    evaluator.update(predictions, image_id=1)
+
+    validator = DetectionValidator.__new__(DetectionValidator)
+    validator.config = SimpleNamespace(verbose=False, save_json=False)
+    validator.save_dir = tmp_path
+    validator.coco_evaluator = evaluator
+
+    metrics = validator._compute_metrics()
+
+    assert metrics["metrics/mAP50-95"] == pytest.approx(1.0)
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.unit
+def test_detection_validator_save_json_round_trips_reported_map(tmp_path):
+    from pycocotools.cocoeval import COCOeval
+
+    from libreyolo.validation import COCOEvaluator
+    from libreyolo.validation.detection_validator import DetectionValidator
+
+    coco, predictions = _imperfect_coco_fixture()
+    evaluator = COCOEvaluator(coco, iou_type="bbox", label_to_category_id={0: 1})
+    evaluator.update(predictions, image_id=1)
+
+    validator = DetectionValidator.__new__(DetectionValidator)
+    validator.config = SimpleNamespace(verbose=False, save_json=True)
+    validator.save_dir = tmp_path
+    validator.coco_evaluator = evaluator
+
+    # Snapshot the entries fed to the evaluator; pycocotools loadRes mutates
+    # the originals in place during compute.
+    expected = [dict(entry) for entry in evaluator.results]
+    metrics = validator._compute_metrics()
+
+    json_path = tmp_path / "predictions.json"
+    assert json_path.exists()
+    saved = json.loads(json_path.read_text(encoding="utf-8"))
+    assert saved == expected
+    assert all(
+        set(entry) == {"image_id", "category_id", "bbox", "score"} for entry in saved
+    )
+    assert {entry["category_id"] for entry in saved} == {1}
+
+    reloaded = coco.loadRes(str(json_path))
+    reference = COCOeval(coco, reloaded, "bbox")
+    reference.params.imgIds = [1]
+    reference.evaluate()
+    reference.accumulate()
+    reference.summarize()
+
+    assert 0.0 < metrics["metrics/mAP50-95"] < 1.0
+    assert metrics["metrics/mAP50-95"] == float(reference.stats[0])
+    assert metrics["metrics/mAP50"] == float(reference.stats[1])
+
+
+@pytest.mark.unit
+def test_coco_evaluator_save_json_writes_empty_file_without_predictions(tmp_path):
+    pytest.importorskip("pycocotools")
+    from pycocotools.coco import COCO
+
+    from libreyolo.validation import COCOEvaluator
+
+    coco = COCO()
+    coco.dataset = {
+        "info": {},
+        "licenses": [],
+        "images": [
+            {"id": 1, "file_name": "empty.jpg", "width": 32, "height": 32}
+        ],
+        "annotations": [],
+        "categories": [{"id": 1, "name": "object"}],
+    }
+    coco.createIndex()
+    evaluator = COCOEvaluator(coco, label_to_category_id={0: 1})
+
+    json_path = tmp_path / "predictions.json"
+    metrics = evaluator.compute(save_json=str(json_path))
+
+    assert metrics["mAP"] == 0.0
+    assert json.loads(json_path.read_text(encoding="utf-8")) == []
+
+
+@pytest.mark.unit
+def test_save_json_stays_in_legacy_positional_config_layout():
+    from inspect import Parameter, signature
+
+    from libreyolo.validation.config import ValidationConfig
+
+    parameters = signature(ValidationConfig).parameters
+
+    # save_json predates the kw_only convention; converting it now would
+    # shift every later positional field, so its slot stays pinned.
+    assert parameters["save_json"].default is False
+    assert parameters["save_json"].kind is Parameter.POSITIONAL_OR_KEYWORD
+
+
 @pytest.mark.unit
 def test_detection_validator_uses_explicit_coco_json_paths(tmp_path):
     pytest.importorskip("pycocotools")


### PR DESCRIPTION
## What does this PR do?

Completes the `save_json` validation option. The flag was already wired end to end (`ValidationConfig.save_json`, `model.val(save_json=...)`, the validator writing into `save_dir`, and the CLI `--save-json` flag) but it had no test coverage and two gaps, which this PR closes:

- Always write the file when opted in: a run with zero detections previously returned empty metrics before the JSON dump, so `save_json=True` silently produced no file. The evaluator now writes the COCO results JSON before the empty-results return (matching the pose validator, which also writes its predictions file before its own empty check). The output is the standard COCO detections format: a list of `{"image_id", "category_id", "bbox": [x, y, w, h], "score"}` entries carrying the original dataset image and category ids, loadable by pycocotools `loadRes`.
- Log the absolute output path at INFO instead of the path as given (usually relative).
- Document the exact output contract on `ValidationConfig.save_json`: detection writes `save_dir/predictions.json`; segmentation writes `predictions_bbox.json` and `predictions_masks.json`; tasks without COCO detections ignore the flag (OBB logs a warning).
- Add test coverage: default off writes no file; opted in, the written file round-trips (`COCO.loadRes` on the file plus a fresh `COCOeval` reproduces the run's reported mAP exactly, on a fixture with non-trivial mAP); a run with no predictions still writes `[]`; the CLI forwards `save_json` to `model.val`; a signature test pins the config field's default and slot.

Scope: detection and segmentation COCO evaluation only; no other task gained JSON output.

Design note: `save_json` stays a positional config field rather than becoming keyword-only. It predates the kw_only convention and sits in the legacy positional layout; converting it would shift every later positional field, exactly what `test_new_validation_options_do_not_shift_legacy_positional_api` exists to prevent. The new signature test pins the current slot instead.

## Code provenance

Original implementation. The output format is the standard COCO detections JSON as consumed by pycocotools `loadRes`; no third-party code was read or copied.

## How was this tested?

CPU-only runs from a clean Python 3.12 venv (torch 2.13.0+cpu) on this branch:

- `tests/unit/test_coco_validation.py`: 23 passed (4 new)
- `tests/unit/cli/test_command_utils.py`: 40 passed (1 new)
- `tests/unit/test_amp_dtype.py`: 8 passed (holds the related signature-stability test)
- Combined run of the three files: 71 passed, 0 failed
- `ruff check` on the four changed files with the repo config at the dev-group floor version (0.14.10): all checks passed. Ruff 0.16.0's expanded defaults report only findings already present at the merge base; the diff introduces none.

https://claude.ai/code/session_01BqWFNpwxjHWJqCJT2Ccnv3

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds reliable opt-in COCO JSON export for validation.
- Writes detection and segmentation prediction files before empty-result handling.
- Logs the resolved output path.
- Documents the output-file contract and preserves the existing configuration signature.
- Adds coverage for CLI forwarding, disabled output, empty predictions, and pycocotools round-tripping.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable changed-code defects were identified.

The new write ordering produces the requested empty JSON artifact, preserves canonical prediction data before pycocotools mutation, and leaves the established detection and segmentation validation paths consistent with the documented filenames.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/validation/coco_evaluator.py | Moves the optional JSON write ahead of empty-result handling and logs the absolute output path without changing metric evaluation. |
| libreyolo/validation/config.py | Documents task-specific save_json behavior without changing the dataclass API. |
| tests/unit/cli/test_command_utils.py | Verifies that the CLI forwards both the default and enabled save_json values. |
| tests/unit/test_coco_validation.py | Covers disabled output, COCO round-tripping, empty-result output, and configuration-signature stability. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[ValidationConfig save_json] --> B{Task}
    B -->|Detection| C[predictions.json]
    B -->|Segmentation| D[predictions_bbox.json]
    B -->|Segmentation| E[predictions_masks.json]
    C --> F[COCOEvaluator.compute]
    D --> F
    E --> F
    F --> G[Write JSON before empty-result return]
    G --> H[Evaluate non-empty results]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Harden and test the validation save\_json..."](https://github.com/libreyolo/libreyolo/commit/5fa1da4080e1b54ec7dd9390e82eda64d7885823) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48737661)</sub>

<!-- /greptile_comment -->