### PR TITLE
Feat/cuda graph training

### DIFF
--- a/docs/training_cuda_graphs.md
+++ b/docs/training_cuda_graphs.md
@@ -1,0 +1,94 @@
+# CUDA Graphs for Training
+
+Opt-in capture of the training network's forward and backward passes into
+CUDA graphs, cutting per-step kernel-launch overhead on launch-bound runs.
+
+```python
+from libreyolo import LIBREYOLO
+
+model = LIBREYOLO("libreyolo9t.pt")
+model.train(data="data.yaml", epochs=100, cuda_graph=True)
+```
+
+```bash
+libreyolo train --model libreyolo9t.pt --data data.yaml --cuda-graph
+```
+
+## When it helps
+
+Small and mid-size models are launch-bound during training: the host
+submits thousands of short kernels per step and the GPU idles between
+launches. Capturing the network into a graph replays the whole step as one
+launch. Measured on an RTX 5070 Ti (Windows, AMP, 640 px, synthetic data,
+no dataloader bottleneck):
+
+| Model | Batch | Eager | Graphed | Speedup |
+| --- | --- | --- | --- | --- |
+| yolo9-t | 16 | 105.1 ms/step | 67.5 ms/step | 1.56x |
+| yolo9-t | 8 | 92.6 ms/step | 41.2 ms/step | 2.25x |
+| yolo9-s | 16 | 115.5 ms/step | 94.0 ms/step | 1.23x |
+| yolo9-m | 8 | 93.0 ms/step | 84.2 ms/step | 1.10x |
+
+Two caveats. Launch overhead is highest on Windows; Linux gains are
+smaller (roughly a third to half of the numbers above). And graphs only
+speed up the GPU step: a dataloader-bound run sees no wall-clock change,
+so check `libreyolo profile` first if unsure where the time goes.
+
+## What is captured
+
+Only the network forward and backward. The loss (data-dependent mask
+selects, Hungarian matching), optimizer step, gradient clipping, EMA
+update and LR schedule stay eager. A graph is valid for exactly one input
+shape: the trainer counts batch shapes and captures once a shape has
+repeated a few times. Batches at any other shape, such as multi-scale
+batches or the last partial batch of an epoch, run eager unchanged.
+
+Enabling the flag never changes training numerics. YOLO9 trains
+bit-identically to eager; RF-DETR matches within its own eager
+run-to-run noise (its deformable-attention backward uses atomic
+accumulation, so even two identical seeded eager runs differ slightly).
+`tests/unit/test_cuda_graph_training.py` gates both.
+
+Multi-scale training composes with capture (one recurring shape gets the
+graph, other scales run eager), but most of the benefit comes from
+static-shape runs; pass `multi_scale=False` for RF-DETR when you want the
+full speedup.
+
+## Supported families
+
+| Family | Task | Support |
+| --- | --- | --- |
+| yolo9 (and yolo9_p2) | detect | yes |
+| rfdetr | detect | yes |
+| all others / other tasks | | eager fallback with a warning |
+
+Unsupported configurations downgrade to plain eager training with a
+single log message; `cuda_graph=True` is always safe to pass. Not
+supported in this version: distributed (DDP) runs, distillation runs, and
+non-detect tasks. Any capture failure at runtime also falls back to eager
+for the rest of the run.
+
+## Adding a family
+
+Implement `cuda_graph_train_spec` on the family trainer, returning a
+`CudaGraphTrainSpec` from `libreyolo.training.cuda_graph`:
+
+- `network`: a `GraphableNetwork` wrapping the model. Its forward must be
+  target-free and static-shaped for a fixed input shape (no host syncs,
+  no data-dependent shapes; constants created per call must be cached,
+  see `_cached_spatial_shapes` in the RF-DETR transformer for the
+  pattern).
+- `assemble(flat, imgs, targets, polygons)`: rebuild the network output
+  (`network.rebuild(flat)`) and run the family's loss exactly as
+  `on_forward` would, returning the same outputs dict.
+
+Gate the spec on task and model type so derived heads with different loss
+boundaries are excluded, and add a parity test comparing eager and
+graphed loss trajectories before enabling.
+
+## Memory
+
+A captured graph pins static input, output and workspace buffers for the
+forward and backward pass, so peak VRAM rises roughly by one extra set of
+activations for the captured shape. If that pushes a run over the limit,
+reduce batch size or leave the flag off.

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -258,6 +258,14 @@ def train_cmd(
     amp_dtype: str = typer.Option(
         "float16", help="CUDA AMP dtype: float16 or bfloat16"
     ),
+    cuda_graph: bool = typer.Option(
+        False,
+        "--cuda-graph",
+        help=(
+            "Capture the training forward/backward into CUDA graphs "
+            "(single-GPU, supported families only; others run eager)"
+        ),
+    ),
     pretrained: bool = typer.Option(True, help="Use pretrained weights"),
     lora: bool = typer.Option(
         False,
@@ -495,6 +503,7 @@ def train_cmd(
         "resume": resume_val,
         "amp": amp,
         "amp_dtype": amp_dtype,
+        "cuda_graph": cuda_graph,
         "lora": lora,
         "freeze": freeze_val,
         "optimizer": optimizer,

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -434,6 +434,7 @@ def _build_rfdetr_train_kwargs(
         "flip_prob": "flip_prob",
         "amp": "amp",
         "amp_dtype": "amp_dtype",
+        "cuda_graph": "cuda_graph",
         "max_det": "max_det",
         "eval_max_det": "eval_max_det",
         "lora": "lora",

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -896,6 +896,59 @@ class RFDETRTrainer(BaseTrainer):
         result.update(loss_dict)
         return result
 
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the DETR network, keep the criterion eager.
+
+        The detect-task LWDETR forward never reads targets (group-DETR
+        queries are a fixed ``num_queries * group_detr`` block in training
+        mode), so the whole network is static-shaped and capturable; the
+        Hungarian criterion is host-side by nature and stays eager,
+        mirroring ``on_forward``'s detect tail exactly. Seg/pose/obb/
+        classification/semantic variants route targets or masks through
+        the forward and run eager.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .nn import LibreRFDETRModel
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        model = self.model
+        if not isinstance(model, LibreRFDETRModel):
+            return None
+        if any(
+            getattr(model, attr, False)
+            for attr in ("segmentation", "pose", "obb", "classification", "semantic")
+        ):
+            return None
+        if getattr(self, "criterion", None) is None:
+            return None
+
+        network = GraphableNetwork(model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            outputs = network.rebuild(flat)
+            target_list = self._targets_to_rfdetr_list(
+                targets,
+                height=imgs.shape[-2],
+                width=imgs.shape[-1],
+            )
+            loss_dict = self.criterion(outputs, target_list)
+            weight_dict = self.criterion.weight_dict
+            total = sum(
+                loss_dict[key] * weight_dict[key]
+                for key in loss_dict
+                if key in weight_dict
+            )
+            result = {"total_loss": total}
+            result.update(loss_dict)
+            return result
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)
+
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
         loss_task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
         if loss_task == "classify":

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -286,8 +286,16 @@ class MSDeformAttn(nn.Module):
             # under strict torch.export capture.
             expected_len_in = sum(h * w for h, w in input_spatial_shapes_hw)
             assert expected_len_in == len_input, error_msg
-        elif not torch.jit.is_tracing() and not isinstance(
-            input_spatial_shapes, torch.fx.Proxy
+        # The int() readback below is a host sync, which CUDA graph capture
+        # forbids; the same values were already validated during the graph
+        # warm-up iterations, so the check is skipped only while capturing.
+        elif (
+            not torch.jit.is_tracing()
+            and not isinstance(input_spatial_shapes, torch.fx.Proxy)
+            and not (
+                input_spatial_shapes.is_cuda
+                and torch.cuda.is_current_stream_capturing()
+            )
         ):
             try:
                 expected_len_in = int(
@@ -481,21 +489,47 @@ class Transformer(nn.Module):
         valid_ratio = torch.stack([valid_ratio_w, valid_ratio_h], -1)
         return valid_ratio
 
+    def _cached_spatial_shapes(
+        self, spatial_shapes_hw: "list[tuple[int, int]]", device
+    ) -> torch.Tensor:
+        """Constant (n_levels, 2) level-shape tensor, cached per shape set.
+
+        Writing Python ints element-wise into a CUDA tensor issues one tiny
+        unpinned host-to-device copy per level on every forward, which is
+        wasted work eagerly and illegal inside CUDA graph capture. The
+        values only depend on the input resolution, so build the tensor
+        once per (shapes, device) and reuse it; the cached tensor is
+        read-only downstream.
+        """
+        key = (tuple(spatial_shapes_hw), str(device))
+        cached = getattr(self, "_spatial_shapes_cache", None)
+        if cached is None or cached[0] != key:
+            tensor = torch.tensor(
+                spatial_shapes_hw, device=device, dtype=torch.long
+            )
+            self._spatial_shapes_cache = (key, tensor)
+        return self._spatial_shapes_cache[1]
+
     def forward(self, srcs, masks, pos_embeds, refpoint_embed, query_feat, cross_attn_srcs=None):
         src_flatten = []
         mask_flatten = [] if masks is not None else None
         lvl_pos_embed_flatten = []
-        # Build spatial_shapes as a tensor directly so that the ONNX tracer
-        # can track h/w symbolically instead of baking them in as constants.
-        spatial_shapes = torch.empty((len(srcs), 2), device=srcs[0].device, dtype=torch.long)
+        # Under tracing, build spatial_shapes as a tensor directly so that
+        # the ONNX tracer can track h/w symbolically instead of baking them
+        # in as constants. Outside tracing the tensor is a per-resolution
+        # constant and comes from _cached_spatial_shapes after the loop.
+        tracing = torch.jit.is_tracing()
+        if tracing:
+            spatial_shapes = torch.empty((len(srcs), 2), device=srcs[0].device, dtype=torch.long)
         # Keep Python int pairs for gen_encoder_output_proposals — its loop uses h/w
         # as slice indices and linspace steps, which require Python ints, not tensors.
         spatial_shapes_hw: list[tuple[int, int]] = []
         valid_ratios = [] if masks is not None else None
         for lvl, (src, pos_embed) in enumerate(zip(srcs, pos_embeds)):
             _, c, h, w = src.shape
-            spatial_shapes[lvl, 0] = h
-            spatial_shapes[lvl, 1] = w
+            if tracing:
+                spatial_shapes[lvl, 0] = h
+                spatial_shapes[lvl, 1] = w
             spatial_shapes_hw.append((h, w))
 
             src = src.flatten(2).transpose(1, 2)  # bs, hw, c
@@ -505,6 +539,10 @@ class Transformer(nn.Module):
             if masks is not None:
                 mask = masks[lvl].flatten(1)  # bs, hw
                 mask_flatten.append(mask)
+        if not tracing:
+            spatial_shapes = self._cached_spatial_shapes(
+                spatial_shapes_hw, srcs[0].device
+            )
         memory = torch.cat(src_flatten, 1)  # bs, \sum{hxw}, c
         if masks is not None:
             mask_flatten = torch.cat(mask_flatten, 1)  # bs, \sum{hxw}

--- a/libreyolo/models/yolo9/trainer.py
+++ b/libreyolo/models/yolo9/trainer.py
@@ -118,3 +118,37 @@ class YOLO9Trainer(BaseTrainer):
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         return self.model(imgs, targets=targets)
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the network, keep the DFL/TAL loss eager.
+
+        The split reuses the model's own boundary: a train-mode forward
+        without targets returns the concatenated head maps, and
+        ``assemble`` replays exactly the loss path ``LibreYOLO9Model.
+        forward`` takes with targets (anchors tracking the input size,
+        then the head's loss over the raw maps). Restricted to the plain
+        detect head: subclasses with derived heads (e2e dual assignment)
+        or other tasks compute loss at a different boundary and run eager.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .nn import DDetect, LibreYOLO9Model
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        if not isinstance(self.model, LibreYOLO9Model):
+            return None
+        if type(self.model.head) is not DDetect:
+            return None
+
+        network = GraphableNetwork(self.model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            loss_fn = self.model.head._get_loss_fn(imgs.device)
+            loss_fn.update_anchors([imgs.shape[3], imgs.shape[2]])
+            return loss_fn(network.rebuild(flat), targets)
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -126,6 +126,13 @@ class TrainConfig:
     # CUDA autocast dtype when AMP is enabled. The explicit default preserves
     # historical amp=True behavior while allowing reproducible BF16 training.
     amp_dtype: str = "float16"
+    # Capture the network's training forward/backward into CUDA graphs to
+    # cut kernel-launch overhead on launch-bound (small-model) runs. Opt-in
+    # and single-GPU only; families without capture support, distributed
+    # runs and distillation runs fall back to eager training with a warning.
+    # Numerics are identical either way; batches whose shape differs from
+    # the captured shape (multi-scale, last partial batch) run eager.
+    cuda_graph: bool = False
     # Layer freezing. An int freezes the first N family-defined freeze groups;
     # a list freezes explicit group indices or module-name selectors; a string
     # freezes matching module/parameter names.

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -1,0 +1,314 @@
+"""CUDA graph capture for the training-step network forward and backward.
+
+Small and mid-size detectors are launch-bound during training: the host
+spends more time submitting kernel launches for the forward and backward
+passes than the GPU spends executing them, so the GPU idles between
+launches. Capturing the network's forward and backward into CUDA graphs
+(via ``torch.cuda.make_graphed_callables``) collapses thousands of per-step
+launches into two replays.
+
+Only the *network* is captured. The loss stays eager by design: detection
+losses are data-dependent (boolean-mask selects, Hungarian matching,
+host-side branching on assignment results), which is both illegal during
+graph capture and pointless to capture. The optimizer step, gradient
+clipping, EMA update and LR schedule also stay eager; they are a small
+fraction of step time and interact with GradScaler host-side logic.
+
+Enablement is opt-in per run (``train(..., cuda_graph=True)``). Each model
+family that supports capture provides a :class:`CudaGraphTrainSpec` through
+``BaseTrainer.cuda_graph_train_spec``; families without a spec silently run
+eager, so the flag is always safe to pass.
+
+Shape handling is dispatch-based, not constraint-based: a graph is valid
+for exactly the input shape it was captured with, so the manager counts
+shapes and captures one graph once a shape has repeated
+``warmup_threshold`` times. Batches at any other shape (multi-scale
+batches, the last partial batch of an epoch) run eager, unchanged. This
+keeps training numerics and behavior identical whether the flag is on or
+off, which the parity tests gate.
+
+Capture-time contracts (enforced by the trainer, documented here):
+
+- Capture happens lazily on a real training batch, after ``setup()`` has
+  finished every model mutation (weight loading, freezing, device moves).
+  Replacing a parameter tensor *after* capture would leave the graph
+  reading freed storage; in-place updates (optimizer steps, EMA source
+  reads, ``load_state_dict``) are safe because replay reads the same
+  addresses.
+- ``make_graphed_callables`` warm-up runs a few forward/backward passes on
+  the capture batch. Gradients produced by that warm-up are garbage and are
+  cleared by the train loop's own ``zero_grad`` before the first real
+  backward; BatchNorm running stats absorb a few extra updates from one
+  real batch, which is equivalent to a handful of extra steps on that
+  batch.
+- Under AMP, capture and replay must run with autocast caching disabled;
+  the trainer's autocast context handles this when a manager is active.
+- Distributed training, distillation and non-detect tasks are not captured
+  in this version; the trainer falls back to eager for those runs.
+
+Any failure to capture, at any point, permanently falls back to eager
+training for the rest of the run with a single warning. Capture never
+changes numerics; ``tests/unit/test_cuda_graph_training.py`` gates the loss
+trajectory as identical between eager and graphed runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+from torch import nn
+
+logger = logging.getLogger(__name__)
+
+# A shape must repeat this many times before capture pays off. One-shot
+# shapes (a lone odd-size batch) then never capture, while any steady-state
+# loop converges within the first few steps of epoch 0.
+DEFAULT_WARMUP_THRESHOLD = 3
+# Warm-up iterations make_graphed_callables runs before capture, so lazy
+# allocations, cuDNN benchmark picks and autotuning settle first.
+DEFAULT_NUM_WARMUP_ITERS = 3
+
+GraphKey = Tuple[Tuple[int, ...], torch.dtype, str]
+
+
+# =============================================================================
+# Output-tree flattening
+# =============================================================================
+#
+# ``make_graphed_callables`` requires the captured callable to return a
+# tensor or a tuple of tensors, while family networks return lists (YOLO
+# heads) or nested dicts (DETR-style ``{"pred_logits": ..., "aux_outputs":
+# [{...}, ...]}``). These helpers split any nesting of dict/list/tuple into
+# a flat tensor tuple plus a rebuildable skeleton. Autograd connectivity is
+# preserved because unflattening reinserts the *same* tensor objects the
+# graphed callable returned.
+
+
+@dataclass(frozen=True)
+class _Leaf:
+    """Placeholder for tensor index ``index`` in a flattened tree."""
+
+    index: int
+
+
+def flatten_tree(node: Any) -> Tuple[List[torch.Tensor], Any]:
+    """Split a nested container of tensors into (tensors, skeleton)."""
+    tensors: List[torch.Tensor] = []
+
+    def walk(item: Any) -> Any:
+        if isinstance(item, torch.Tensor):
+            tensors.append(item)
+            return _Leaf(len(tensors) - 1)
+        if isinstance(item, tuple):
+            return tuple(walk(v) for v in item)
+        if isinstance(item, list):
+            return [walk(v) for v in item]
+        if isinstance(item, dict):
+            return {k: walk(v) for k, v in item.items()}
+        # Non-tensor leaves (None, numbers) are baked into the skeleton.
+        return item
+
+    return tensors, walk(node)
+
+
+def unflatten_tree(skeleton: Any, tensors: List[torch.Tensor]) -> Any:
+    """Rebuild the original nesting from a skeleton and a flat tensor list."""
+    if isinstance(skeleton, _Leaf):
+        return tensors[skeleton.index]
+    if isinstance(skeleton, tuple):
+        return tuple(unflatten_tree(v, tensors) for v in skeleton)
+    if isinstance(skeleton, list):
+        return [unflatten_tree(v, tensors) for v in skeleton]
+    if isinstance(skeleton, dict):
+        return {k: unflatten_tree(v, tensors) for k, v in skeleton.items()}
+    return skeleton
+
+
+# =============================================================================
+# Family spec
+# =============================================================================
+
+
+class GraphableNetwork(nn.Module):
+    """Adapter giving any family network the captured-callable contract.
+
+    ``make_graphed_callables`` rebinds the forward of whatever callable it
+    is handed, and requires that forward to return a tensor tuple. Family
+    models return lists (YOLO heads) or nested dicts (DETR outputs) and
+    their forwards must stay eager for validation, EMA evaluation and
+    checkpointing, so capture always goes through this adapter instead:
+    it flattens the wrapped module's output to a tuple and remembers the
+    nesting, and ``rebuild`` restores it for the eager loss.
+
+    The output *structure* must be static across calls (tensor shapes are
+    already static by the capture contract); the skeleton recorded at
+    capture time is reused for every replay.
+    """
+
+    def __init__(self, module: nn.Module):
+        super().__init__()
+        self.module = module
+        self.skeleton: Any = None
+
+    def forward(self, imgs: torch.Tensor) -> Tuple[torch.Tensor, ...]:
+        flat, self.skeleton = flatten_tree(self.module(imgs))
+        return tuple(flat)
+
+    def rebuild(self, flat: Tuple[torch.Tensor, ...]) -> Any:
+        return unflatten_tree(self.skeleton, list(flat))
+
+
+@dataclass
+class CudaGraphTrainSpec:
+    """What a model family hands the trainer to enable training capture.
+
+    Attributes:
+        network: Module whose ``forward(imgs)`` runs the full trainable
+            network and returns a flat tuple of tensors. Use
+            :class:`GraphableNetwork` (or another dedicated adapter),
+            never the family model itself: ``make_graphed_callables``
+            rebinds the callable's forward, and the family model's forward
+            must stay eager for validation, EMA evaluation and
+            checkpointing.
+        assemble: Called eagerly as ``assemble(flat, imgs, targets,
+            polygons)`` with the network's output tuple; runs the loss and
+            returns the same outputs dict ``on_forward`` would produce
+            (must include ``"total_loss"``).
+    """
+
+    network: nn.Module
+    assemble: Callable[
+        [Tuple[torch.Tensor, ...], torch.Tensor, torch.Tensor, Any], Dict
+    ]
+
+
+# =============================================================================
+# Manager
+# =============================================================================
+
+
+class TrainGraphManager:
+    """Owns shape counting, capture and replay for one training run.
+
+    The manager captures at most one graph (the first shape to repeat
+    ``warmup_threshold`` times). Every graph pins its own static input,
+    output and workspace buffers for the forward *and* backward pass, so a
+    per-shape cache like inference uses would multiply peak training
+    memory; one graph covers the static-shape case completely and still
+    wins on the dominant shape of a multi-scale run.
+    """
+
+    def __init__(
+        self,
+        warmup_threshold: int = DEFAULT_WARMUP_THRESHOLD,
+        num_warmup_iters: int = DEFAULT_NUM_WARMUP_ITERS,
+    ):
+        self.warmup_threshold = max(1, int(warmup_threshold))
+        self.num_warmup_iters = max(1, int(num_warmup_iters))
+        self.disabled = False
+        self._graphed: Optional[Callable] = None
+        self._graph_key: Optional[GraphKey] = None
+        self._shape_counts: Dict[GraphKey, int] = {}
+        self._eager_after_capture = 0
+
+    @property
+    def captured(self) -> bool:
+        return self._graphed is not None
+
+    @staticmethod
+    def _key_for(imgs: torch.Tensor) -> GraphKey:
+        return (tuple(imgs.shape), imgs.dtype, str(imgs.device))
+
+    def _disable(self, reason: str) -> None:
+        self.disabled = True
+        self._graphed = None
+        logger.warning(
+            "cuda_graph training capture disabled, falling back to eager: %s",
+            reason,
+        )
+
+    def run(
+        self, spec: CudaGraphTrainSpec, imgs: torch.Tensor
+    ) -> Optional[Tuple[torch.Tensor, ...]]:
+        """Run the network under a graph if possible.
+
+        Returns the network's flat output tuple, or ``None`` when the
+        caller must run this batch eagerly (not captured yet, shape
+        mismatch, or capture permanently disabled).
+        """
+        if self.disabled:
+            return None
+        if not imgs.is_cuda:
+            self._disable("training batches are not on a CUDA device")
+            return None
+
+        key = self._key_for(imgs)
+
+        if self._graphed is not None:
+            if key != self._graph_key:
+                self._eager_after_capture += 1
+                return None
+            try:
+                return self._graphed(imgs)
+            except Exception as exc:  # replay must never kill a run
+                self._disable(f"graph replay failed: {exc!r}")
+                return None
+
+        seen = self._shape_counts.get(key, 0) + 1
+        self._shape_counts[key] = seen
+        if seen < self.warmup_threshold:
+            return None
+        return self._capture_and_run(spec, imgs)
+
+    def _capture_and_run(
+        self, spec: CudaGraphTrainSpec, imgs: torch.Tensor
+    ) -> Optional[Tuple[torch.Tensor, ...]]:
+        try:
+            # The sample clone becomes the graph's static input buffer; the
+            # live batch tensor must stay caller-owned. allow_unused_input
+            # mirrors eager autograd: parameters a family's training forward
+            # never touches (e.g. DETR heads exercised only at inference)
+            # get no gradient eagerly either, and the parity tests hold both
+            # modes to the same trajectory. The TypeError retry keeps older
+            # torch versions without the keyword working.
+            sample = (imgs.detach().clone(),)
+            try:
+                graphed = torch.cuda.make_graphed_callables(
+                    spec.network,
+                    sample,
+                    num_warmup_iters=self.num_warmup_iters,
+                    allow_unused_input=True,
+                )
+            except TypeError:
+                graphed = torch.cuda.make_graphed_callables(
+                    spec.network,
+                    sample,
+                    num_warmup_iters=self.num_warmup_iters,
+                )
+        except Exception as exc:
+            self._disable(f"graph capture failed: {exc!r}")
+            # A failed capture can leave asynchronous stream-capture errors
+            # queued; drain them here so they surface inside this handler
+            # instead of crashing an unrelated later launch, giving the
+            # eager fallback a clean stream to run on.
+            try:
+                torch.cuda.synchronize()
+            except Exception:
+                pass
+            return None
+
+        self._graphed = graphed
+        self._graph_key = self._key_for(imgs)
+        shape = tuple(imgs.shape)
+        logger.info(
+            "cuda_graph: captured training forward/backward at input shape %s",
+            (shape,),
+        )
+        try:
+            return self._graphed(imgs)
+        except Exception as exc:
+            self._disable(f"first graph replay failed: {exc!r}")
+            return None

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -38,9 +38,9 @@ Capture-time contracts (enforced by the trainer, documented here):
 - ``make_graphed_callables`` warm-up runs a few forward/backward passes on
   the capture batch. Gradients produced by that warm-up are garbage and are
   cleared by the train loop's own ``zero_grad`` before the first real
-  backward; BatchNorm running stats absorb a few extra updates from one
-  real batch, which is equivalent to a handful of extra steps on that
-  batch.
+  backward; stateful buffers (BatchNorm running stats) are snapshotted
+  before capture and restored in place afterwards, so the buffer
+  trajectory matches eager training exactly.
 - Under AMP, capture and replay must run with autocast caching disabled;
   the trainer's autocast context handles this when a manager is active.
 - Distributed training, distillation and non-detect tasks are not captured
@@ -263,9 +263,35 @@ class TrainGraphManager:
             return None
         return self._capture_and_run(spec, imgs)
 
+    @staticmethod
+    def _snapshot_buffers(
+        network: nn.Module,
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        """Clone every module buffer so warm-up side effects can be undone.
+
+        ``make_graphed_callables`` warm-up runs a few extra forward passes
+        on the live model, advancing stateful buffers (BatchNorm running
+        mean/var, ``num_batches_tracked``) beyond what one eager step
+        performs. Restoring the snapshot afterwards keeps the buffer
+        trajectory exactly eager-equivalent, so validation, EMA and
+        checkpoints see the same statistics either way. Restoration is
+        ``copy_`` in place: the captured kernels record buffer addresses,
+        and those must not change.
+        """
+        return [(buf, buf.detach().clone()) for buf in network.buffers()]
+
+    @staticmethod
+    def _restore_buffers(
+        snapshot: List[Tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        with torch.no_grad():
+            for buf, saved in snapshot:
+                buf.copy_(saved)
+
     def _capture_and_run(
         self, spec: CudaGraphTrainSpec, imgs: torch.Tensor
     ) -> Optional[Tuple[torch.Tensor, ...]]:
+        buffer_snapshot = self._snapshot_buffers(spec.network)
         try:
             # The sample clone becomes the graph's static input buffer; the
             # live batch tensor must stay caller-owned. allow_unused_input
@@ -298,7 +324,13 @@ class TrainGraphManager:
                 torch.cuda.synchronize()
             except Exception:
                 pass
+            self._restore_buffers(buffer_snapshot)
             return None
+
+        # Undo warm-up buffer drift before the first replay: the replay
+        # below then performs this batch's single BatchNorm update, exactly
+        # as the eager step would have.
+        self._restore_buffers(buffer_snapshot)
 
         self._graphed = graphed
         self._graph_key = self._key_for(imgs)

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -197,6 +197,14 @@ class BaseTrainer(ABC):
         self._profiler = None
         self._stop_training = False
 
+        # CUDA graph capture of the training network (opt-in via
+        # config.cuda_graph). None = disabled, zero overhead. The family
+        # spec is resolved lazily on the first training batch so capture
+        # sees the fully-constructed model and criterion.
+        self._cuda_graph_manager = None
+        self._cuda_graph_spec = None
+        self._cuda_graph_spec_resolved = False
+
     # =========================================================================
     # Config
     # =========================================================================
@@ -313,6 +321,62 @@ class BaseTrainer(ABC):
         instance. Detection-only trainers may ignore ``polygons``.
         """
         return self.model(imgs, targets)
+
+    def cuda_graph_train_spec(self):
+        """Family hook: describe how to capture this family's training step.
+
+        Return a :class:`~libreyolo.training.cuda_graph.CudaGraphTrainSpec`
+        splitting the step into a static-shaped network (captured) and an
+        eager loss (``assemble``), or ``None`` when the family, task or
+        current configuration does not support capture. Called once, on the
+        first training batch, only when ``config.cuda_graph`` is enabled.
+        """
+        return None
+
+    def _forward_train(
+        self,
+        imgs: torch.Tensor,
+        targets: torch.Tensor,
+        polygons: Optional[List] = None,
+    ) -> Dict:
+        """``on_forward`` with optional CUDA-graph capture of the network.
+
+        Routing keeps a hard equivalence contract: any batch that cannot go
+        through a captured graph (no family spec, shape mismatch, capture
+        disabled) takes the exact ``on_forward`` path instead, so enabling
+        ``cuda_graph`` never changes training numerics.
+        """
+        # getattr defaults keep partially-constructed trainers (test
+        # doubles, exotic subclasses skipping BaseTrainer.__init__) on the
+        # plain eager path.
+        manager = getattr(self, "_cuda_graph_manager", None)
+        if manager is not None and not manager.disabled:
+            if not getattr(self, "_cuda_graph_spec_resolved", False):
+                self._cuda_graph_spec_resolved = True
+                try:
+                    self._cuda_graph_spec = self.cuda_graph_train_spec()
+                except Exception as exc:
+                    self._cuda_graph_spec = None
+                    manager.disabled = True
+                    logger.warning(
+                        "cuda_graph=True ignored (family spec failed: %r); "
+                        "training runs eager.",
+                        exc,
+                    )
+                if self._cuda_graph_spec is None and not manager.disabled:
+                    manager.disabled = True
+                    logger.warning(
+                        "cuda_graph=True ignored (%s does not support "
+                        "training capture for this task); training runs "
+                        "eager.",
+                        type(self).__name__,
+                    )
+            spec = getattr(self, "_cuda_graph_spec", None)
+            if spec is not None:
+                flat = manager.run(spec, imgs)
+                if flat is not None:
+                    return spec.assemble(flat, imgs, targets, polygons)
+        return self.on_forward(imgs, targets, polygons=polygons)
 
     # =========================================================================
     # Shared infrastructure
@@ -1571,6 +1635,29 @@ class BaseTrainer(ABC):
                     },
                 )
 
+        # CUDA graph training capture (opt-in). Constructed last so capture
+        # can only ever see the fully-built model, optimizer and criterion.
+        # Unsupported run shapes downgrade to eager with one clear warning
+        # instead of failing the run.
+        if getattr(self.config, "cuda_graph", False):
+            reason = None
+            if self.device.type != "cuda":
+                reason = "device is not CUDA"
+            elif self.is_distributed:
+                reason = "distributed training is not supported yet"
+            elif self.distiller is not None:
+                reason = "distillation runs are not supported"
+            if reason is not None:
+                if is_main_process():
+                    logger.warning(
+                        "cuda_graph=True ignored (%s); training runs eager.",
+                        reason,
+                    )
+            else:
+                from libreyolo.training.cuda_graph import TrainGraphManager
+
+                self._cuda_graph_manager = TrainGraphManager()
+
         self._is_setup = True
 
     def _ddp_find_unused_parameters(self) -> bool:
@@ -1583,10 +1670,16 @@ class BaseTrainer(ABC):
         return False
 
     def _autocast_context(self):
-        """Create a CUDA autocast context using the configured dtype."""
+        """Create a CUDA autocast context using the configured dtype.
+
+        With CUDA graph training capture active, autocast's weight-cast
+        cache must be disabled: the capture recipe requires cache_enabled
+        =False so warm-up, capture and replay all see the same cast ops.
+        """
         return autocast(
             "cuda",
             dtype=torch_amp_dtype(getattr(self.config, "amp_dtype", "float16")),
+            cache_enabled=getattr(self, "_cuda_graph_manager", None) is None,
         )
 
     def _ddp_static_graph(self) -> bool:
@@ -2146,7 +2239,7 @@ class BaseTrainer(ABC):
             if self.scaler is not None:
                 with self._prof_phase("forward"):
                     with self._autocast_context():
-                        outputs = self.on_forward(imgs, targets, polygons=polygons)
+                        outputs = self._forward_train(imgs, targets, polygons)
                         total_loss_raw = outputs["total_loss"]
                         if distiller is not None:
                             distill_loss = distiller.compute_loss()
@@ -2165,7 +2258,7 @@ class BaseTrainer(ABC):
                     self.scaler.update()
             else:
                 with self._prof_phase("forward"):
-                    outputs = self.on_forward(imgs, targets, polygons=polygons)
+                    outputs = self._forward_train(imgs, targets, polygons)
                     total_loss_raw = outputs["total_loss"]
                     if distiller is not None:
                         distill_loss = distiller.compute_loss()
@@ -2198,7 +2291,12 @@ class BaseTrainer(ABC):
             for name, value in loss_components.items():
                 loss_component_sums[name] = loss_component_sums.get(name, 0.0) + value
 
-            del outputs, loss
+            # total_loss_raw is included so no reference to this step's
+            # autograd graph outlives the iteration: a live graph pins
+            # AccumulateGrad nodes to the default stream, which invalidates
+            # CUDA graph capture on a later batch (and idly retains memory
+            # otherwise).
+            del outputs, loss, total_loss_raw
 
             # LR update
             lr = self.lr_scheduler.update_lr(self.current_iter + 1)
@@ -2328,7 +2426,7 @@ class BaseTrainer(ABC):
             if self.scaler is not None:
                 with self._prof_phase("forward"):
                     with self._autocast_context():
-                        outputs = self.on_forward(imgs, targets, polygons=polygons)
+                        outputs = self._forward_train(imgs, targets, polygons)
                         total_loss_raw = outputs["total_loss"]
                         if distiller is not None:
                             distill_loss = distiller.compute_loss()
@@ -2348,7 +2446,7 @@ class BaseTrainer(ABC):
                         self.scaler.update()
             else:
                 with self._prof_phase("forward"):
-                    outputs = self.on_forward(imgs, targets, polygons=polygons)
+                    outputs = self._forward_train(imgs, targets, polygons)
                     total_loss_raw = outputs["total_loss"]
                     if distiller is not None:
                         distill_loss = distiller.compute_loss()
@@ -2385,7 +2483,9 @@ class BaseTrainer(ABC):
             for name, value in loss_components.items():
                 loss_component_sums[name] = loss_component_sums.get(name, 0.0) + value
 
-            del outputs, loss
+            # See the matching del in _train_epoch: total_loss_raw must not
+            # keep the autograd graph alive across iterations.
+            del outputs, loss, total_loss_raw
 
             # Progress bar
             postfix = {"loss": f"{loss_val:.4f}", "lr": f"{lr:.6f}"}

--- a/tests/unit/test_amp_dtype.py
+++ b/tests/unit/test_amp_dtype.py
@@ -64,14 +64,22 @@ def test_trainer_autocast_context_uses_configured_dtype(monkeypatch):
         def __exit__(self, *_):
             return False
 
-    def fake_autocast(device_type, *, dtype):
-        calls.append((device_type, dtype))
+    def fake_autocast(device_type, *, dtype, cache_enabled=True):
+        calls.append((device_type, dtype, cache_enabled))
         return _Context()
 
     monkeypatch.setattr("libreyolo.training.trainer.autocast", fake_autocast)
     trainer = SimpleNamespace(config=SimpleNamespace(amp_dtype="bfloat16"))
 
+    # Without a CUDA graph manager the autocast weight cache stays enabled.
     with BaseTrainer._autocast_context(trainer):
         pass
 
-    assert calls == [("cuda", torch.bfloat16)]
+    assert calls == [("cuda", torch.bfloat16, True)]
+
+    # With a manager active the capture recipe requires the cache disabled.
+    trainer._cuda_graph_manager = object()
+    with BaseTrainer._autocast_context(trainer):
+        pass
+
+    assert calls[-1] == ("cuda", torch.bfloat16, False)

--- a/tests/unit/test_cuda_graph_training.py
+++ b/tests/unit/test_cuda_graph_training.py
@@ -405,6 +405,16 @@ class TestCudaParityYolo9:
             model_e.named_parameters(), model_g.named_parameters()
         ):
             assert torch.equal(pe, pg), name
+        # Buffers too: capture warm-up must not leave extra BatchNorm
+        # running-stat updates behind (the manager snapshots and restores
+        # them), or validation, EMA and checkpoints would drift from eager.
+        buffer_names = 0
+        for (name, be), (_, bg) in zip(
+            model_e.named_buffers(), model_g.named_buffers()
+        ):
+            assert torch.equal(be, bg), name
+            buffer_names += 1
+        assert buffer_names > 0, "expected BatchNorm buffers to compare"
 
 
 @requires_cuda

--- a/tests/unit/test_cuda_graph_training.py
+++ b/tests/unit/test_cuda_graph_training.py
@@ -1,0 +1,490 @@
+"""Tests for CUDA graph capture of the training step.
+
+CPU tests cover the dispatch machinery (tree flattening, shape counting,
+fallback guarantees, trainer routing, family gating). CUDA tests gate the
+core promise: enabling ``cuda_graph`` must not change training numerics,
+so eager and graphed runs are compared step by step, loss and parameters
+both, for YOLO9 and RF-DETR.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch import nn
+
+from libreyolo.training.cuda_graph import (
+    CudaGraphTrainSpec,
+    GraphableNetwork,
+    TrainGraphManager,
+    flatten_tree,
+    unflatten_tree,
+)
+from libreyolo.training.trainer import BaseTrainer
+
+pytestmark = pytest.mark.unit
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required"
+)
+
+
+# =============================================================================
+# Tree flattening
+# =============================================================================
+
+
+class TestTreeFlatten:
+    def test_roundtrip_nested(self):
+        a, b, c = torch.zeros(1), torch.ones(2), torch.full((3,), 2.0)
+        tree = {
+            "pred": a,
+            "aux": [{"x": b}, {"x": c}],
+            "meta": (None, 7, "tag"),
+        }
+        flat, skeleton = flatten_tree(tree)
+        assert len(flat) == 3
+        rebuilt = unflatten_tree(skeleton, flat)
+        # Identity, not equality: autograd connectivity depends on the
+        # rebuilt tree containing the same tensor objects.
+        assert rebuilt["pred"] is a
+        assert rebuilt["aux"][0]["x"] is b
+        assert rebuilt["aux"][1]["x"] is c
+        assert rebuilt["meta"] == (None, 7, "tag")
+
+    def test_plain_list(self):
+        t = [torch.zeros(1), torch.zeros(2)]
+        flat, skeleton = flatten_tree(t)
+        rebuilt = unflatten_tree(skeleton, flat)
+        assert isinstance(rebuilt, list)
+        assert rebuilt[0] is t[0] and rebuilt[1] is t[1]
+
+    def test_graphable_network_adapter(self):
+        class Toy(nn.Module):
+            def forward(self, x):
+                return {"a": x * 2, "b": [x + 1, None]}
+
+        net = GraphableNetwork(Toy())
+        x = torch.arange(4.0)
+        flat = net(x)
+        assert isinstance(flat, tuple) and len(flat) == 2
+        rebuilt = net.rebuild(flat)
+        assert torch.equal(rebuilt["a"], x * 2)
+        assert rebuilt["b"][1] is None
+        # The wrapped module's parameters are visible through the adapter,
+        # which is what lets capture pass them as graph inputs.
+        assert isinstance(net.module, Toy)
+
+
+# =============================================================================
+# Manager dispatch
+# =============================================================================
+
+
+def _fake_cuda_batch(shape=(2, 3, 64, 64)):
+    """A stand-in for a CUDA batch tensor, usable on CPU-only machines."""
+    imgs = MagicMock(spec=torch.Tensor)
+    imgs.is_cuda = True
+    imgs.shape = torch.Size(shape)
+    imgs.dtype = torch.float32
+    imgs.device = "cuda:0"
+    return imgs
+
+
+def _spec():
+    return CudaGraphTrainSpec(network=MagicMock(), assemble=MagicMock())
+
+
+class TestTrainGraphManager:
+    def test_non_cuda_input_disables(self):
+        manager = TrainGraphManager()
+        out = manager.run(_spec(), torch.zeros(1, 3, 8, 8))
+        assert out is None
+        assert manager.disabled
+
+    def test_captures_after_threshold_and_replays(self):
+        manager = TrainGraphManager(warmup_threshold=3)
+        spec = _spec()
+        imgs = _fake_cuda_batch()
+        graphed = MagicMock(return_value=("flat",))
+        with patch(
+            "torch.cuda.make_graphed_callables", return_value=graphed
+        ) as make:
+            assert manager.run(spec, imgs) is None
+            assert manager.run(spec, imgs) is None
+            assert not manager.captured
+            out = manager.run(spec, imgs)
+        assert out == ("flat",)
+        assert manager.captured
+        make.assert_called_once()
+        # Subsequent same-shape batches replay without recapturing.
+        with patch("torch.cuda.make_graphed_callables") as make_again:
+            assert manager.run(spec, imgs) == ("flat",)
+        make_again.assert_not_called()
+
+    def test_shape_mismatch_falls_back_eager(self):
+        manager = TrainGraphManager(warmup_threshold=1)
+        spec = _spec()
+        with patch(
+            "torch.cuda.make_graphed_callables",
+            return_value=MagicMock(return_value=("flat",)),
+        ):
+            assert manager.run(spec, _fake_cuda_batch((2, 3, 64, 64))) == ("flat",)
+        # A different shape (multi-scale batch, last partial batch) must run
+        # eager without disabling the captured graph.
+        assert manager.run(spec, _fake_cuda_batch((1, 3, 64, 64))) is None
+        assert not manager.disabled
+        assert manager.run(spec, _fake_cuda_batch((2, 3, 64, 64))) == ("flat",)
+
+    def test_capture_failure_disables_permanently(self):
+        manager = TrainGraphManager(warmup_threshold=1)
+        spec = _spec()
+        imgs = _fake_cuda_batch()
+        with patch(
+            "torch.cuda.make_graphed_callables", side_effect=RuntimeError("boom")
+        ):
+            assert manager.run(spec, imgs) is None
+        assert manager.disabled
+        # Disabled means no further capture attempts at all.
+        with patch("torch.cuda.make_graphed_callables") as make:
+            assert manager.run(spec, imgs) is None
+        make.assert_not_called()
+
+    def test_replay_failure_disables(self):
+        manager = TrainGraphManager(warmup_threshold=1)
+        spec = _spec()
+        imgs = _fake_cuda_batch()
+        graphed = MagicMock(side_effect=[("flat",), RuntimeError("stale")])
+        with patch("torch.cuda.make_graphed_callables", return_value=graphed):
+            assert manager.run(spec, imgs) == ("flat",)
+        assert manager.run(spec, imgs) is None
+        assert manager.disabled
+
+
+# =============================================================================
+# Trainer routing
+# =============================================================================
+
+
+class _RoutingHost:
+    """Minimal stand-in exercising BaseTrainer._forward_train unbound."""
+
+    def __init__(self, manager, spec):
+        self._cuda_graph_manager = manager
+        self._cuda_graph_spec = None
+        self._cuda_graph_spec_resolved = False
+        self._spec_to_return = spec
+        self.on_forward_calls = 0
+
+    def cuda_graph_train_spec(self):
+        return self._spec_to_return
+
+    def on_forward(self, imgs, targets, polygons=None):
+        self.on_forward_calls += 1
+        return {"total_loss": torch.zeros(())}
+
+
+class TestForwardTrainRouting:
+    def test_no_manager_goes_eager(self):
+        host = _RoutingHost(manager=None, spec=None)
+        out = BaseTrainer._forward_train(host, torch.zeros(1), torch.zeros(1))
+        assert host.on_forward_calls == 1
+        assert "total_loss" in out
+
+    def test_family_without_spec_disables_and_goes_eager(self):
+        manager = TrainGraphManager()
+        host = _RoutingHost(manager=manager, spec=None)
+        BaseTrainer._forward_train(host, torch.zeros(1), torch.zeros(1))
+        assert host.on_forward_calls == 1
+        assert manager.disabled
+
+    def test_spec_used_when_graph_runs(self):
+        manager = TrainGraphManager()
+        flat = (torch.ones(2),)
+        assembled = {"total_loss": torch.ones(())}
+        spec = CudaGraphTrainSpec(
+            network=MagicMock(), assemble=MagicMock(return_value=assembled)
+        )
+        host = _RoutingHost(manager=manager, spec=spec)
+        with patch.object(TrainGraphManager, "run", return_value=flat):
+            out = BaseTrainer._forward_train(host, torch.zeros(1), torch.zeros(1))
+        assert out is assembled
+        assert host.on_forward_calls == 0
+        spec.assemble.assert_called_once()
+
+    def test_graph_miss_falls_back_to_on_forward(self):
+        manager = TrainGraphManager()
+        spec = CudaGraphTrainSpec(network=MagicMock(), assemble=MagicMock())
+        host = _RoutingHost(manager=manager, spec=spec)
+        with patch.object(TrainGraphManager, "run", return_value=None):
+            BaseTrainer._forward_train(host, torch.zeros(1), torch.zeros(1))
+        assert host.on_forward_calls == 1
+        spec.assemble.assert_not_called()
+
+    def test_spec_resolution_exception_disables(self):
+        manager = TrainGraphManager()
+        host = _RoutingHost(manager=manager, spec=None)
+        host.cuda_graph_train_spec = MagicMock(side_effect=RuntimeError("nope"))
+        BaseTrainer._forward_train(host, torch.zeros(1), torch.zeros(1))
+        assert manager.disabled
+        assert host.on_forward_calls == 1
+
+
+# =============================================================================
+# Family gating
+# =============================================================================
+
+
+class TestYolo9SpecGating:
+    def _host(self, task="detect"):
+        from libreyolo.models.yolo9.nn import LibreYOLO9Model
+        from libreyolo.models.yolo9.trainer import YOLO9Trainer
+
+        host = SimpleNamespace(
+            wrapper_model=SimpleNamespace(task=task),
+            model=LibreYOLO9Model(config="t", nb_classes=3),
+        )
+        return YOLO9Trainer.cuda_graph_train_spec, host
+
+    def test_detect_supported(self):
+        fn, host = self._host()
+        spec = fn(host)
+        assert spec is not None
+        assert spec.network.module is host.model
+
+    def test_non_detect_task_unsupported(self):
+        fn, host = self._host(task="pose")
+        assert fn(host) is None
+
+    def test_derived_head_unsupported(self):
+        fn, host = self._host()
+        # Subclassed heads (e2e dual assignment) compute loss at a
+        # different boundary; the exact-type gate must reject them.
+        class DerivedHead(type(host.model.head)):
+            pass
+
+        derived = DerivedHead.__new__(DerivedHead)
+        derived.__dict__.update(host.model.head.__dict__)
+        host.model.head = derived
+        assert fn(host) is None
+
+
+class TestRFDETRSpecGating:
+    def _host(self, task="detect", **model_flags):
+        from libreyolo.models.rfdetr.nn import LibreRFDETRModel
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        # __new__ dodges the heavy DINOv2 build; gating only reads flags.
+        model = object.__new__(LibreRFDETRModel)
+        flags = {
+            "segmentation": False,
+            "pose": False,
+            "obb": False,
+            "classification": False,
+            "semantic": False,
+        }
+        flags.update(model_flags)
+        for key, value in flags.items():
+            setattr(model, key, value)
+        host = SimpleNamespace(
+            wrapper_model=SimpleNamespace(task=task),
+            model=model,
+            criterion=MagicMock(weight_dict={}),
+            _targets_to_rfdetr_list=MagicMock(),
+        )
+        return RFDETRTrainer.cuda_graph_train_spec, host
+
+    def test_detect_supported(self):
+        fn, host = self._host()
+        spec = fn(host)
+        assert spec is not None
+        assert spec.network.module is host.model
+
+    def test_task_variants_unsupported(self):
+        for flag in ("segmentation", "pose", "obb", "classification"):
+            fn, host = self._host(**{flag: True})
+            assert fn(host) is None, flag
+        fn, host = self._host(task="segment")
+        assert fn(host) is None
+
+    def test_missing_criterion_unsupported(self):
+        fn, host = self._host()
+        host.criterion = None
+        assert fn(host) is None
+
+
+# =============================================================================
+# CUDA parity: enabling cuda_graph must not change training numerics
+# =============================================================================
+
+
+def _yolo9_targets(bsz, device, generator):
+    t = torch.zeros(bsz, 50, 5)
+    n = 10
+    cls = torch.randint(0, 3, (bsz, n), generator=generator).float()
+    cx = torch.rand(bsz, n, generator=generator) * 0.8 + 0.1
+    cy = torch.rand(bsz, n, generator=generator) * 0.8 + 0.1
+    w = torch.rand(bsz, n, generator=generator) * 0.2 + 0.05
+    h = torch.rand(bsz, n, generator=generator) * 0.2 + 0.05
+    t[:, :n, 0] = cls
+    t[:, :n, 1] = (cx - w / 2).clamp(0, 1)
+    t[:, :n, 2] = (cy - h / 2).clamp(0, 1)
+    t[:, :n, 3] = (cx + w / 2).clamp(0, 1)
+    t[:, :n, 4] = (cy + h / 2).clamp(0, 1)
+    return t.to(device)
+
+
+def _run_steps(model, forward_fn, imgs, targets, steps):
+    """Shared harness: SGD + AMP GradScaler loop, mirrors the trainer."""
+    from torch.amp import GradScaler, autocast
+
+    opt = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+    scaler = GradScaler("cuda")
+    losses = []
+    for _ in range(steps):
+        with autocast("cuda", cache_enabled=False):
+            outputs = forward_fn(imgs, targets)
+            loss = outputs["total_loss"]
+        opt.zero_grad()
+        scaler.scale(loss).backward()
+        scaler.step(opt)
+        scaler.update()
+        losses.append(float(loss.item()))
+    return losses
+
+
+@requires_cuda
+class TestCudaParityYolo9:
+    def test_loss_trajectory_identical(self):
+        from libreyolo.models.yolo9.nn import LibreYOLO9Model
+        from libreyolo.models.yolo9.trainer import YOLO9Trainer
+
+        bsz, size, steps = 2, 128, 6
+        gen = torch.Generator().manual_seed(3)
+        imgs = torch.randn(bsz, 3, size, size, generator=gen).cuda()
+        targets = _yolo9_targets(bsz, "cuda", gen)
+
+        def build():
+            torch.manual_seed(11)
+            model = LibreYOLO9Model(config="t", nb_classes=3).cuda().train()
+            return model
+
+        # Eager arm mirrors on_forward exactly.
+        model_e = build()
+        eager = _run_steps(
+            model_e,
+            lambda i, t: model_e(i, targets=t),
+            imgs,
+            targets,
+            steps,
+        )
+
+        # Graphed arm goes through the real spec + manager.
+        model_g = build()
+        host = SimpleNamespace(
+            wrapper_model=SimpleNamespace(task="detect"), model=model_g
+        )
+        spec = YOLO9Trainer.cuda_graph_train_spec(host)
+        assert spec is not None
+        manager = TrainGraphManager(warmup_threshold=1)
+
+        def graphed_forward(i, t):
+            flat = manager.run(spec, i)
+            assert flat is not None
+            return spec.assemble(flat, i, t)
+
+        graphed = _run_steps(model_g, graphed_forward, imgs, targets, steps)
+
+        assert manager.captured
+        assert eager == pytest.approx(graphed, rel=0, abs=0), (
+            f"eager {eager} != graphed {graphed}"
+        )
+        # Parameters must match exactly after the same number of steps.
+        for (name, pe), (_, pg) in zip(
+            model_e.named_parameters(), model_g.named_parameters()
+        ):
+            assert torch.equal(pe, pg), name
+
+
+@requires_cuda
+class TestCudaParityRFDETR:
+    """RF-DETR parity, with a tolerance matched to eager's own noise floor.
+
+    Unlike YOLO9, RF-DETR training is not bitwise reproducible even eager
+    to eager: the deformable-attention backward accumulates with atomics,
+    so two identical seeded eager runs diverge from step 1 (measured max
+    relative difference about 4e-4 over 4 steps on an RTX 5070 Ti). The
+    graph contract therefore is: the first step, whose forward and loss
+    run on identical weights, must match bit for bit, and the trajectory
+    must stay within the eager run-to-run noise band. A real gradient bug
+    (wrong boundary, stale buffers) diverges orders of magnitude faster.
+    """
+
+    # The DINOv2 backbone build fetches pretrained weights.
+    @pytest.mark.external_data
+    def test_loss_trajectory_identical(self):
+        from libreyolo.models.rfdetr.nn import LibreRFDETRModel
+        from libreyolo.models.rfdetr.trainer import RFDETRTrainer
+
+        steps = 4
+
+        def build():
+            torch.manual_seed(23)
+            model = LibreRFDETRModel(config="n", nb_classes=3, device="cuda")
+            model = model.cuda().train()
+            criterion, _ = model.build_criterion_and_postprocess()
+            criterion.to("cuda")
+            return model, criterion
+
+        model_e, criterion_e = build()
+        size = model_e.resolution
+        bsz = 2
+        gen = torch.Generator().manual_seed(5)
+        imgs = torch.randn(bsz, 3, size, size, generator=gen).cuda()
+        # The RF-DETR target converter expects pixel coordinates.
+        targets = _yolo9_targets(bsz, "cuda", gen)
+        targets[..., 1:5] *= size
+
+        def make_host(model, criterion):
+            host = SimpleNamespace(
+                wrapper_model=SimpleNamespace(task="detect"),
+                model=model,
+                criterion=criterion,
+                device=torch.device("cuda"),
+            )
+            host._targets_to_rfdetr_list = (
+                lambda *args, **kwargs: RFDETRTrainer._targets_to_rfdetr_list(
+                    host, *args, **kwargs
+                )
+            )
+            return host
+
+        host_e = make_host(model_e, criterion_e)
+
+        def eager_forward(i, t):
+            return RFDETRTrainer.on_forward(host_e, i, t)
+
+        eager = _run_steps(model_e, eager_forward, imgs, targets, steps)
+
+        model_g, criterion_g = build()
+        host_g = make_host(model_g, criterion_g)
+        spec = RFDETRTrainer.cuda_graph_train_spec(host_g)
+        assert spec is not None
+        manager = TrainGraphManager(warmup_threshold=1)
+
+        def graphed_forward(i, t):
+            flat = manager.run(spec, i)
+            assert flat is not None
+            return spec.assemble(flat, i, t)
+
+        graphed = _run_steps(model_g, graphed_forward, imgs, targets, steps)
+
+        assert manager.captured
+        assert eager[0] == graphed[0], (
+            f"step-0 loss must be bit-identical: {eager[0]} != {graphed[0]}"
+        )
+        assert eager == pytest.approx(graphed, rel=5e-3), (
+            f"trajectory outside eager noise band: eager {eager} != "
+            f"graphed {graphed}"
+        )


### PR DESCRIPTION
## Code provenance

Original implementation written for this PR. CUDA graph capture is built entirely on PyTorch public API (torch.cuda.make_graphed_callables, torch.cuda.is_current_stream_capturing) following PyTorch documented capture recipes. No third-party training framework code was consulted or referenced.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Implements opt-in, single-GPU CUDA graph training while retaining eager loss computation and fallback behavior.
- Adds graph capture, shape-based dispatch, buffer restoration, and eager fallback infrastructure.
- Integrates capture specifications for YOLO9 and RF-DETR.
- Exposes the feature through training configuration and the CLI.
- Adds CUDA parity, routing, fallback, and AMP tests plus usage documentation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported BatchNorm warm-up drift is addressed by snapshotting buffers before capture, restoring them in place before the first replay, and testing exact YOLO9 buffer parity.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/cuda_graph.py | Adds graph capture management, output-tree adaptation, shape dispatch, in-place buffer restoration, and permanent eager fallback after capture failures. |
| libreyolo/training/trainer.py | Integrates optional graph routing into both training loops while retaining eager execution for unsupported configurations and shape misses. |
| libreyolo/models/yolo9/trainer.py | Defines the captured-network/eager-loss boundary for the plain YOLO9 detection head. |
| libreyolo/models/rfdetr/trainer.py | Defines the captured RF-DETR network path while keeping target conversion and Hungarian criterion execution eager. |
| libreyolo/models/rfdetr/transformer.py | Avoids capture-time host synchronization and caches fixed spatial-shape tensors by shape and device. |
| tests/unit/test_cuda_graph_training.py | Covers dispatch and fallback behavior and verifies YOLO9 loss, parameter, and buffer parity between eager and graphed execution. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Batch[Training batch] --> Enabled{CUDA graph enabled and supported?}
  Enabled -- No --> Eager[Eager model forward]
  Enabled -- Yes --> Shape{Captured shape?}
  Shape -- No --> Warmup{Shape repeated enough?}
  Warmup -- No --> Eager
  Warmup -- Yes --> Snapshot[Snapshot model buffers]
  Snapshot --> Capture[Warm up and capture network]
  Capture --> Restore[Restore buffers in place]
  Restore --> Replay[Replay captured network]
  Shape -- Yes --> Replay
  Replay --> Loss[Eager family loss]
  Eager --> Loss
  Loss --> Backward[Backward and optimizer step]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Restore module buffers after capture war..."](https://github.com/libreyolo/libreyolo/commit/3ece9a044c12a15b0e95dc6a5fdd45afed1cae6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48866038)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
</details>

<!-- /greptile_comment -->