### PR TITLE
Speed up RF100-VL epochs: post-resize cache, hoisted validator, graphed val

### DIFF
--- a/libreyolo/data/cache.py
+++ b/libreyolo/data/cache.py
@@ -1,16 +1,29 @@
-"""Optional decoded-image caching shared by dataset classes.
+"""Optional image caching shared by dataset classes.
 
-Every training epoch re-reads and re-decodes the same image files from disk.
-Enabling caching keeps the *decoded, pre-resize, pre-augmentation* image around
-so later reads skip that work. Because resize and augmentation always run
-downstream of the cache, the cached pixels are augmentation-agnostic and safe to
-reuse across every epoch.
+Every training epoch re-reads, re-decodes and re-resizes the same image files
+from disk. Enabling caching keeps the result of that deterministic work around
+so later epochs skip it. There are two cache points, and the dataset picks the
+right one per read:
+
+* **Post-resize** (``load_resized_img``): the decoded image after the
+  deterministic pre-augmentation resize to ``img_size``. This is the cache
+  point for every family whose transform consumes the dataset's resized frame
+  (it skips decode *and* resize), and it is the one that makes caching viable
+  at all on large-image datasets: a 4000x3000 source stores ~640px pixels,
+  roughly an order of magnitude smaller than the decoded original. Because
+  augmentation always runs downstream of this resize, the cached pixels are
+  augmentation-agnostic and safe to reuse across every epoch — later reads are
+  byte-identical to a fresh decode+resize by construction.
+* **Pre-resize** (``load_image``): the decoded full-resolution image. This is
+  the cache point for transforms that opt into ``wants_unresized_image`` and
+  own all resizing themselves (RT-DETR, DEIM, RF-DETR, PicoDet, ...). It skips
+  decode only, and stores original-resolution pixels.
 
 The ``cache`` flag accepts:
 
     False / None  -> disabled (default)
-    True / "ram"  -> keep decoded BGR images in RAM (per dataset instance)
-    "disk"        -> store decoded images as ``.npy`` beside each source image
+    True / "ram"  -> keep cached images in RAM (per dataset instance)
+    "disk"        -> store cached images as ``.npy`` beside each source image
 
 ``"disk"`` is process- and platform-safe (each DataLoader worker just reads the
 ``.npy`` file), so it is the recommended mode when training with workers. RAM
@@ -24,6 +37,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import cv2
 import numpy as np
 
 logger = logging.getLogger(__name__)
@@ -56,19 +70,24 @@ class ImageCacheMixin:
     * ``_image_path(index) -> Path`` — the source image path (used to locate the
       sibling ``.npy`` for disk caching).
 
-    and call :meth:`enable_image_cache` once ``self.num_imgs`` is known. When
-    caching is disabled (the default), :meth:`load_image` is exactly equivalent
-    to ``_decode_image``.
+    and expose ``self.img_size`` as an ``(h, w)`` tuple (used by
+    :meth:`load_resized_img`), then call :meth:`enable_image_cache` once
+    ``self.num_imgs`` is known. When caching is disabled (the default),
+    :meth:`load_image` is exactly equivalent to ``_decode_image`` and
+    :meth:`load_resized_img` to a fresh decode+resize.
     """
 
     cache: str | None = None
     _ram_cache: list | None = None
+    _resized_ram_cache: list | None = None
 
     def enable_image_cache(self, cache) -> None:
         """Configure caching from a user ``cache`` flag. Idempotent; safe with False."""
         self.cache = normalize_cache(cache)
-        self._ram_cache = [None] * self.num_imgs if self.cache == "ram" else None
-        if self.cache == "ram":
+        ram = self.cache == "ram"
+        self._ram_cache = [None] * self.num_imgs if ram else None
+        self._resized_ram_cache = [None] * self.num_imgs if ram else None
+        if ram:
             self._warn_if_ram_short()
         if self.cache:
             logger.info(
@@ -88,16 +107,60 @@ class ImageCacheMixin:
             return self._load_image_from_disk(index)
         return self._decode_image(index)
 
+    def load_resized_img(self, index: int) -> np.ndarray:
+        """Load the image after the deterministic pre-augmentation resize.
+
+        This is the post-resize cache point. It deliberately bypasses the
+        decoded-image cache (``load_image``) on cache hits and fills: storing
+        both the full-resolution decode and its resized product would roughly
+        double the footprint for no reuse, since families that consume the
+        resized frame never read the decoded one again.
+        """
+        cache = getattr(self, "cache", None)
+        if cache == "ram":
+            img = self._resized_ram_cache[index]
+            if img is None:
+                img = self._resize_decoded(self._decode_image(index))
+                self._resized_ram_cache[index] = img
+            # Copy so downstream in-place augmentation cannot corrupt the cache.
+            return img.copy()
+        if cache == "disk":
+            return self._load_resized_from_disk(index)
+        return self._resize_decoded(self._decode_image(index))
+
+    def _resize_decoded(self, img: np.ndarray) -> np.ndarray:
+        """Aspect-preserving resize so the longer side fits ``self.img_size``."""
+        r = min(self.img_size[0] / img.shape[0], self.img_size[1] / img.shape[1])
+        return cv2.resize(
+            img,
+            (int(img.shape[1] * r), int(img.shape[0] * r)),
+            interpolation=cv2.INTER_LINEAR,
+        ).astype(np.uint8)
+
     def _load_image_from_disk(self, index: int) -> np.ndarray:
         src = Path(self._image_path(index))
         # Append (not replace) the suffix so 'a.jpg' and 'a.png' never collide.
         npy = src.with_name(src.name + ".npy")
+        return self._disk_cached(npy, src, lambda: self._decode_image(index))
+
+    def _load_resized_from_disk(self, index: int) -> np.ndarray:
+        src = Path(self._image_path(index))
+        # The resized bytes depend on the target size, so key the sidecar on it:
+        # two runs at different imgsz must not read each other's pixels.
+        h, w = int(self.img_size[0]), int(self.img_size[1])
+        npy = src.with_name(f"{src.name}.r{h}x{w}.npy")
+        return self._disk_cached(
+            npy, src, lambda: self._resize_decoded(self._decode_image(index))
+        )
+
+    @staticmethod
+    def _disk_cached(npy: Path, src: Path, produce) -> np.ndarray:
         try:
             if npy.exists() and npy.stat().st_mtime >= src.stat().st_mtime:
                 return np.load(npy)
         except Exception:  # corrupt / unreadable cache -> rebuild from source
             pass
-        img = self._decode_image(index)
+        img = produce()
         try:
             np.save(str(npy), img)
         except OSError:  # read-only dataset dir -> skip persistence, still train
@@ -112,6 +175,15 @@ class ImageCacheMixin:
             return
         try:
             sample = self._decode_image(0)
+            # Families that consume the dataset's resized frame cache at the
+            # post-resize point, which is what actually occupies RAM; sizing
+            # the warning from the full-resolution decode would overstate the
+            # footprint by roughly (source pixels / resized pixels).
+            wants_unresized = getattr(
+                getattr(self, "preproc", None), "wants_unresized_image", False
+            )
+            if not wants_unresized:
+                sample = self._resize_decoded(sample)
         except Exception:
             return
         needed = sample.nbytes * self.num_imgs

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -530,16 +530,8 @@ class YOLODataset(ImageCacheMixin, Dataset):
             raise ValueError(f"Failed to load {img_file}")
         return img
 
-    def load_resized_img(self, index: int) -> np.ndarray:
-        """Load and resize image."""
-        img = self.load_image(index)
-        r = min(self.img_size[0] / img.shape[0], self.img_size[1] / img.shape[1])
-        resized_img = cv2.resize(
-            img,
-            (int(img.shape[1] * r), int(img.shape[0] * r)),
-            interpolation=cv2.INTER_LINEAR,
-        ).astype(np.uint8)
-        return resized_img
+    # load_resized_img comes from ImageCacheMixin: the deterministic resize is
+    # the post-resize cache point, so the mixin owns both the math and the cache.
 
     def _load_segments(self, index: int):
         if self.segments is None:
@@ -892,16 +884,8 @@ class COCODataset(ImageCacheMixin, Dataset):
             raise ValueError(f"Failed to load {img_file}")
         return img
 
-    def load_resized_img(self, index: int) -> np.ndarray:
-        """Load and resize image."""
-        img = self.load_image(index)
-        r = min(self.img_size[0] / img.shape[0], self.img_size[1] / img.shape[1])
-        resized_img = cv2.resize(
-            img,
-            (int(img.shape[1] * r), int(img.shape[0] * r)),
-            interpolation=cv2.INTER_LINEAR,
-        ).astype(np.uint8)
-        return resized_img
+    # load_resized_img comes from ImageCacheMixin: the deterministic resize is
+    # the post-resize cache point, so the mixin owns both the math and the cache.
 
     def _load_segments(self, index: int):
         if self.segments is None:

--- a/libreyolo/models/base/cuda_graph.py
+++ b/libreyolo/models/base/cuda_graph.py
@@ -127,10 +127,19 @@ class GraphRunner:
 
     auto_threshold: int = DEFAULT_AUTO_THRESHOLD
 
+    # When False, run() never captures on a shape miss and just runs eager;
+    # already-captured shapes still replay. Callers that iterate a DataLoader
+    # set this around their loop, because the loader's pin-memory threads call
+    # cudaHostAlloc while batches are in flight, and any synchronous CUDA
+    # allocation on the context invalidates a capture in progress. Such
+    # callers capture at a controlled point first (see capture()).
+    capture_on_miss: bool = True
+
     _graphs: Dict[GraphKey, _CapturedGraph] = field(default_factory=dict)
     _pool: Optional[Any] = None
     _misses: int = 0
     _fallback_reason: Optional[str] = None
+    _capture_failed: bool = False
     _warned_capacity: bool = False
     _warned_unused: bool = False
     _shape_counts: Dict[GraphKey, int] = field(default_factory=dict)
@@ -167,6 +176,17 @@ class GraphRunner:
                 return self.forward_fn(input_tensor)
 
         if captured is None:
+            if self._capture_failed or not self.capture_on_miss:
+                # No capture attempt. Either a previous capture already failed
+                # -- one cudaErrorStreamCaptureInvalidated poisons every later
+                # capture attempt on the context, and each retry pays warmup
+                # before failing the same way (measured: retry-per-batch made
+                # validation 2.4x slower than eager) -- or the caller forbade
+                # mid-loop capture because concurrent work (DataLoader
+                # pin-memory threads calling cudaHostAlloc) would invalidate
+                # it. Replays of already-captured shapes are unaffected.
+                self._misses += 1
+                return self.forward_fn(input_tensor)
             self._warn_if_precaptured_unused(key)
             if len(self._graphs) >= self.max_graphs:
                 if not self._warned_capacity:
@@ -183,6 +203,7 @@ class GraphRunner:
             try:
                 captured = self._capture(input_tensor)
             except Exception as exc:  # capture is best-effort by contract
+                self._capture_failed = True
                 self._note_fallback(f"capture failed: {type(exc).__name__}: {exc}")
                 return self.forward_fn(input_tensor)
             self._graphs[key] = captured
@@ -207,9 +228,18 @@ class GraphRunner:
         key = self._key(input_tensor)
         if key in self._graphs:
             return
+        if self._capture_failed:
+            # A failed capture poisons later capture attempts on this context;
+            # retrying costs a full warmup before failing identically. Callers
+            # that really want to retry can release() first.
+            raise CudaGraphUnavailable(
+                f"a previous capture failed for {self.family or 'model'}; "
+                "not retrying (call release() to reset)"
+            )
         try:
             self._graphs[key] = self._capture(input_tensor)
         except Exception as exc:
+            self._capture_failed = True
             raise CudaGraphUnavailable(
                 f"CUDA graph capture failed for {self.family or 'model'} at "
                 f"shape {tuple(input_tensor.shape)}: {exc}"
@@ -241,6 +271,7 @@ class GraphRunner:
         self._pool = None
         self._misses = 0
         self._fallback_reason = None
+        self._capture_failed = False
         self._warned_capacity = False
         self._warned_unused = False
 

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -187,9 +187,14 @@ class TrainConfig:
     # System
     workers: int = 4
     # Image caching to speed dataloading across epochs. Accepts False (off),
-    # True/'ram' (decoded images in RAM), or 'disk' (decoded images as .npy
-    # beside each source image). 'disk' is the safest choice with dataloader
-    # workers; default is off.
+    # True/'ram' (cached images in RAM), or 'disk' (cached images as .npy
+    # beside each source image). Families whose transform consumes the
+    # dataset's deterministic resize cache the *resized* image (skipping decode
+    # and resize, ~an order of magnitude smaller than caching the decode);
+    # families that opt into wants_unresized_image cache the full-resolution
+    # decode. Cached reads are byte-identical to fresh ones either way. The
+    # flag also enables caching in the per-epoch validation loop. 'disk' is
+    # the safest choice with dataloader workers; default is off.
     cache: Union[bool, str] = False
     patience: int = 50
     resume: bool = False

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -2610,6 +2610,9 @@ class BaseTrainer(ABC):
                 num_workers=self.config.workers,
                 save_plots=val_save_plots,
                 save_dir=val_save_dir,
+                # One knob for both loops: a run that opts into image caching
+                # for training gets the same for its (deterministic) validation.
+                cache=getattr(self.config, "cache", False),
             )
 
             if self.wrapper_model is None:

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -2637,7 +2637,20 @@ class BaseTrainer(ABC):
                     validator_cls = PointValidator
                 else:
                     validator_cls = DetectionValidator
-                validator = validator_cls(model=self.wrapper_model, config=val_config)
+                # One validator instance for the whole run, so the dataset,
+                # dataloader workers, pinned buffers and parsed ground truth
+                # survive between epochs instead of being rebuilt ~100 times.
+                # The per-epoch config is still honored: only save_plots and
+                # save_dir ever differ between the configs this loop builds,
+                # and neither is baked into the reused state.
+                validator = getattr(self, "_epoch_validator", None)
+                if validator is None or type(validator) is not validator_cls:
+                    validator = validator_cls(
+                        model=self.wrapper_model, config=val_config
+                    )
+                    self._epoch_validator = validator
+                else:
+                    validator.config = val_config
                 results = validator.run()
             finally:
                 self.wrapper_model.model = original_model

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -2613,6 +2613,18 @@ class BaseTrainer(ABC):
                 # One knob for both loops: a run that opts into image caching
                 # for training gets the same for its (deterministic) validation.
                 cache=getattr(self.config, "cache", False),
+                # Same principle for graph replay, gated on the inference-side
+                # capability: training capture (CudaGraphTrainSpec) and forward
+                # capture (SUPPORTS_CUDA_GRAPH) are separate opt-ins, and a
+                # family with only the former must validate eagerly rather
+                # than fail. Replay is bit-identical, so this is an execution
+                # detail, not a protocol change.
+                cuda_graph=(
+                    bool(getattr(self.config, "cuda_graph", False))
+                    and bool(
+                        getattr(self.wrapper_model, "SUPPORTS_CUDA_GRAPH", False)
+                    )
+                ),
             )
 
             if self.wrapper_model is None:

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -60,8 +60,21 @@ class BaseValidator(ABC):
 
     def run(self, **kwargs) -> Dict[str, float]:
         """Main validation entry point (template method)."""
+        # Local import: models.base imports validation.preprocessors, so a
+        # module-level import here would be circular.
+        from libreyolo.models.base.cuda_graph import normalize_cuda_graph_mode
+
         self._setup(**kwargs)
-        self._run_validation()
+        requested = getattr(self.config, "cuda_graph", False)
+        if normalize_cuda_graph_mode(requested) is None:
+            self._run_validation()
+        else:
+            # Same contract as predict(..., cuda_graph=...): unsupported
+            # families fail loudly up front, uncapturable situations (CPU
+            # device, odd input) fall back to eager inside the runner.
+            self.model._require_cuda_graph_support()
+            with self.model.cuda_graph_scope(requested):
+                self._run_validation()
         return self._finalize()
 
     def _setup_device(self) -> torch.device:
@@ -189,10 +202,15 @@ class BaseValidator(ABC):
 
     def _inference(self, images: torch.Tensor) -> Any:
         """Run model inference on a batch of images (B, C, H, W)."""
+        from libreyolo.models.base.cuda_graph import forward_maybe_graphed
+
         use_non_blocking = self.device.type == "cuda"
         images = images.to(self.device, non_blocking=use_non_blocking)
         with self._autocast_context():
-            return self.model._forward(images)
+            # Replays a captured CUDA graph when run() opened a graph scope;
+            # exactly model._forward(images) otherwise, including for the
+            # duck-typed model doubles in the test suite.
+            return forward_maybe_graphed(self.model, images)
 
     def _autocast_context(self):
         if self.config.half and self.device.type == "cuda":

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -70,10 +70,25 @@ class BaseValidator(ABC):
             self._run_validation()
         else:
             # Same contract as predict(..., cuda_graph=...): unsupported
-            # families fail loudly up front, uncapturable situations (CPU
-            # device, odd input) fall back to eager inside the runner.
+            # families fail loudly up front. Uncapturable situations (CPU
+            # device, capture failure) run the whole pass eagerly.
             self.model._require_cuda_graph_support()
-            with self.model.cuda_graph_scope(requested):
+            if self._capture_val_graph():
+                runner = self.model._get_graph_runner()
+                previous = runner.capture_on_miss
+                # Replay-only inside the loop. The loader's pin-memory threads
+                # call cudaHostAlloc while batches are in flight, and any
+                # synchronous CUDA allocation invalidates a capture in
+                # progress, so capture happens only at the controlled point in
+                # _capture_val_graph. A shape miss inside the loop (the final
+                # partial batch) runs eager.
+                runner.capture_on_miss = False
+                try:
+                    with self.model.cuda_graph_scope(requested):
+                        self._run_validation()
+                finally:
+                    runner.capture_on_miss = previous
+            else:
                 self._run_validation()
         return self._finalize()
 
@@ -218,6 +233,44 @@ class BaseValidator(ABC):
                 "cuda", dtype=torch_amp_dtype(self.config.amp_dtype)
             )
         return nullcontext()
+
+    def _capture_val_graph(self) -> bool:
+        """Capture the full-batch forward before the loop; True on success.
+
+        Capture must not happen inside the batch loop: the DataLoader's
+        pin-memory threads call cudaHostAlloc while batches are in flight, and
+        a synchronous CUDA allocation invalidates a capture in progress
+        (cudaErrorStreamCaptureInvalidated) -- observed to then poison every
+        later capture attempt in the process, while the epoch whose capture
+        failed lost its validation entirely. Here, before iteration starts,
+        the loader threads are quiet and warmup just synchronized the device.
+        No-op when the shape is already captured, so the validator the trainer
+        reuses across epochs pays this once per run.
+        """
+        from libreyolo.models.base.cuda_graph import CudaGraphUnavailable
+
+        imgsz = self.config.imgsz
+        if isinstance(imgsz, (list, tuple)):
+            imgsz_h, imgsz_w = int(imgsz[0]), int(imgsz[1])
+        else:
+            imgsz_h = imgsz_w = int(imgsz)
+        dummy = torch.zeros(
+            (self.config.batch_size, 3, imgsz_h, imgsz_w),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        model_module = getattr(self.model, "model", None)
+        if hasattr(model_module, "eval"):
+            model_module.eval()
+        try:
+            with torch.no_grad(), self._autocast_context():
+                self.model._get_graph_runner().capture(dummy)
+        except CudaGraphUnavailable as exc:
+            if not getattr(self, "_warned_eager_val", False):
+                self._warned_eager_val = True
+                logger.warning("cuda_graph: validation runs eager (%s)", exc)
+            return False
+        return True
 
     def _warmup_model(self, n_warmup: int = 3) -> None:
         """Run dummy inference passes to trigger JIT compilation and CUDA kernel caching."""

--- a/libreyolo/validation/base.py
+++ b/libreyolo/validation/base.py
@@ -89,7 +89,18 @@ class BaseValidator(ABC):
 
         self.save_dir.mkdir(parents=True, exist_ok=True)
 
-        self.dataloader = self._setup_dataloader()
+        # The dataset, the dataloader (worker spawn, pinned-buffer allocation)
+        # and the model warmup are per-instance costs, not per-run costs:
+        # nothing they depend on can change between two runs of one validator.
+        # Reusing them is what makes calling a single validator every training
+        # epoch cheap — a measured 4.6 s of cudaHostAlloc alone per rebuild.
+        # A fresh instance still builds everything, so standalone .val() calls
+        # behave exactly as before.
+        if self.dataloader is None:
+            self.dataloader = self._setup_dataloader()
+            warmup_needed = True
+        else:
+            warmup_needed = False
 
         self.seen = 0
         self.speed = {
@@ -100,7 +111,8 @@ class BaseValidator(ABC):
         }
 
         self._init_metrics()
-        self._warmup_model()
+        if warmup_needed:
+            self._warmup_model()
 
         if self.config.verbose:
             logger.info("Validating on %d images...", len(self.dataloader.dataset))

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -85,6 +85,12 @@ class ValidationConfig:
     # Workers
     num_workers: int = 4
 
+    # Image cache: False/None (off), True/'ram', or 'disk'. Same semantics as
+    # TrainConfig.cache. Validation preprocessing is deterministic, so cached
+    # reads are byte-identical to fresh ones; 'disk' pays immediately, 'ram'
+    # pays once the validator (and its workers) survive across epochs.
+    cache: Union[bool, str] = field(default=False, kw_only=True)
+
     # Precision
     half: bool = False
     amp_dtype: str = field(default="float16", kw_only=True)

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -91,6 +91,15 @@ class ValidationConfig:
     # pays once the validator (and its workers) survive across epochs.
     cache: Union[bool, str] = field(default=False, kw_only=True)
 
+    # Replay the model forward through captured CUDA graphs (True, False or
+    # 'auto'), using the same per-shape cache predict() uses. Validation is
+    # the ideal capture client: every batch has one shape (plus one partial
+    # final batch), and small detectors spend more host time launching the
+    # forward's kernels than the GPU spends running them. Replay is
+    # bit-identical to the eager forward (gated by tests/unit/test_cuda_graph
+    # .py); anything uncapturable falls back to eager with a warning.
+    cuda_graph: Union[bool, str] = field(default=False, kw_only=True)
+
     # Precision
     half: bool = False
     amp_dtype: str = field(default="float16", kw_only=True)

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -272,6 +272,10 @@ class DetectionValidator(BaseValidator):
             self._yolo_coco_img_files = list(dataset.img_files)
             self._yolo_coco_label_files = list(dataset.label_files)
 
+        # Both dataset classes are ImageCacheMixin; every construction branch
+        # above funnels through here, so this is the single cache switch.
+        dataset.enable_image_cache(getattr(self.config, "cache", False))
+
         use_cuda = torch.cuda.is_available() and self.device.type == "cuda"
         nw = self.config.num_workers
 

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -59,6 +59,10 @@ class DetectionValidator(BaseValidator):
         self._coco_label_to_category_id: Optional[Dict[int, int]] = None
         self._yolo_coco_img_files: Optional[List[Path]] = None
         self._yolo_coco_label_files: Optional[List[Path]] = None
+        # Parsed ground truth, cached across runs of this instance. The GT is
+        # immutable for the validator's lifetime; only the evaluator built on
+        # top of it accumulates state and must stay per-run.
+        self._gt_coco_api = None
 
     # =========================================================================
     # Setup
@@ -344,7 +348,10 @@ class DetectionValidator(BaseValidator):
                     "Install with: pip install pycocotools"
                 )
 
-            coco_api = COCO(str(self._coco_annotation_file))
+            coco_api = self._gt_coco_api
+            if coco_api is None:
+                coco_api = COCO(str(self._coco_annotation_file))
+                self._gt_coco_api = coco_api
             self.coco_evaluator = COCOEvaluator(
                 coco_api,
                 iou_type="bbox",
@@ -406,14 +413,17 @@ class DetectionValidator(BaseValidator):
             [Path(p) for p in label_files] if label_files else None
         )
 
-        coco_api = YOLOCocoAPI(
-            images_dir=images_dir,
-            labels_dir=labels_dir,
-            class_names=class_names,
-            image_files=image_files,
-            label_files=yolo_label_files,
-            **self._coco_api_kwargs(),
-        )
+        coco_api = self._gt_coco_api
+        if coco_api is None:
+            coco_api = YOLOCocoAPI(
+                images_dir=images_dir,
+                labels_dir=labels_dir,
+                class_names=class_names,
+                image_files=image_files,
+                label_files=yolo_label_files,
+                **self._coco_api_kwargs(),
+            )
+            self._gt_coco_api = coco_api
         self.coco_evaluator = COCOEvaluator(
             coco_api, iou_type="bbox", max_det=self._coco_max_det()
         )

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -42,6 +42,10 @@ class DetectionValidator(BaseValidator):
 
     task = "detect"
 
+    # Class-level default so instances built without __init__ (a pattern the
+    # test suite uses for narrow-scope validators) still resolve it.
+    _gt_coco_api = None
+
     def __init__(
         self,
         model: "BaseModel",

--- a/tests/unit/test_image_cache.py
+++ b/tests/unit/test_image_cache.py
@@ -107,3 +107,126 @@ def test_disk_cache_invalidates_on_source_change(tmp_path):
 
     expected = cv2.imread(str(tmp_path / "images" / "train" / "img0.png"))
     assert np.array_equal(fresh.load_image(0), expected)
+
+
+# ---------------------------------------------------------------------------
+# Post-resize cache point (load_resized_img)
+# ---------------------------------------------------------------------------
+
+
+class _WantsUnresized:
+    """Minimal stand-in for transforms that own all resizing (e.g. RT-DETR)."""
+
+    wants_unresized_image = True
+
+    def __call__(self, img, targets, input_dim):
+        return img, targets
+
+
+def test_resized_cache_bit_identical_across_modes(tmp_path):
+    """The cached resized image must be byte-equal to a fresh decode+resize."""
+    _write_files(tmp_path)
+    ref = _build(tmp_path)
+    ref.enable_image_cache(False)
+    expected = [ref.load_resized_img(i).copy() for i in range(len(ref))]
+
+    for mode in ("ram", "disk"):
+        ds = _build(tmp_path)
+        ds.enable_image_cache(mode)
+        for i in range(len(ds)):
+            first = ds.load_resized_img(i)   # fill
+            second = ds.load_resized_img(i)  # cached read
+            assert np.array_equal(first, expected[i]), mode
+            assert np.array_equal(second, expected[i]), mode
+
+
+def test_resized_ram_cache_returns_copies(tmp_path):
+    """In-place augmentation downstream must not corrupt the cache."""
+    ds = _make_dataset(tmp_path)
+    ds.enable_image_cache("ram")
+    clean = ds.load_resized_img(0).copy()
+    ds.load_resized_img(0)[:] = 0  # simulate an in-place augmentation
+    assert np.array_equal(ds.load_resized_img(0), clean)
+
+
+def test_resized_disk_sidecar_is_keyed_by_target_size(tmp_path):
+    """Two runs at different imgsz must not read each other's pixels."""
+    _write_files(tmp_path)
+
+    small = YOLODataset(data_dir=str(tmp_path), split="train", img_size=(64, 64))
+    small.enable_image_cache("disk")
+    small_img = small.load_resized_img(0)
+
+    big = YOLODataset(data_dir=str(tmp_path), split="train", img_size=(128, 128))
+    big.enable_image_cache("disk")
+    big_img = big.load_resized_img(0)
+
+    image_dir = tmp_path / "images" / "train"
+    assert (image_dir / "img0.png.r64x64.npy").exists()
+    assert (image_dir / "img0.png.r128x128.npy").exists()
+    assert small_img.shape != big_img.shape
+
+    # Cached re-reads still resolve to their own size.
+    assert np.array_equal(small.load_resized_img(0), small_img)
+    assert np.array_equal(big.load_resized_img(0), big_img)
+
+
+def test_resized_disk_cache_invalidates_on_source_change(tmp_path):
+    _write_files(tmp_path)
+    disk = _build(tmp_path)
+    disk.enable_image_cache("disk")
+    _ = disk.load_resized_img(0)  # populate cache
+
+    time.sleep(1.1)  # ensure a newer mtime than the .npy
+    new = np.full((40, 50, 3), 123, dtype=np.uint8)
+    Image.fromarray(new).save(tmp_path / "images" / "train" / "img0.png")
+
+    fresh_ref = _build(tmp_path)
+    fresh_ref.enable_image_cache(False)
+    expected = fresh_ref.load_resized_img(0)
+
+    fresh = _build(tmp_path)
+    fresh.enable_image_cache("disk")
+    assert np.array_equal(fresh.load_resized_img(0), expected)
+
+
+def test_pull_item_identical_across_cache_modes(tmp_path):
+    """End to end: the tensors entering augmentation are identical with and
+    without the cache, for both the resized path and the unresized opt-in."""
+    _write_files(tmp_path)
+
+    for preproc in (None, _WantsUnresized()):
+        ref = YOLODataset(
+            data_dir=str(tmp_path), split="train", img_size=(64, 64), preproc=preproc
+        )
+        ref.enable_image_cache(False)
+        expected = [ref.pull_item(i)[0].copy() for i in range(len(ref))]
+
+        for mode in ("ram", "disk"):
+            ds = YOLODataset(
+                data_dir=str(tmp_path), split="train", img_size=(64, 64), preproc=preproc
+            )
+            ds.enable_image_cache(mode)
+            for i in range(len(ds)):
+                _ = ds.pull_item(i)  # fill
+                assert np.array_equal(ds.pull_item(i)[0], expected[i]), (
+                    mode,
+                    type(preproc).__name__,
+                )
+
+
+def test_resized_path_does_not_fill_decode_cache(tmp_path):
+    """Caching both the decode and its resized product would double the
+    footprint for no reuse; the resized path must write only its own entry."""
+    ds = _make_dataset(tmp_path)
+    ds.enable_image_cache("ram")
+    _ = ds.load_resized_img(0)
+    assert ds._resized_ram_cache[0] is not None
+    assert ds._ram_cache[0] is None
+
+    disk = _build(tmp_path)
+    disk.enable_image_cache("disk")
+    _ = disk.load_resized_img(1)
+    image_dir = tmp_path / "images" / "train"
+    assert (image_dir / "img1.png.r64x64.npy").exists()
+    assert not (image_dir / "img1.png.npy").exists()

--- a/tests/unit/test_validator_cuda_graph.py
+++ b/tests/unit/test_validator_cuda_graph.py
@@ -23,6 +23,11 @@ class _Runner:
     def __init__(self, forward):
         self.forward = forward
         self.calls = 0
+        self.captures = []
+        self.capture_on_miss = True
+
+    def capture(self, x):
+        self.captures.append(tuple(x.shape))
 
     def run(self, x, auto=False):
         self.calls += 1
@@ -153,9 +158,34 @@ def test_enabled_opens_scope_and_routes_through_runner(tmp_path):
 
     assert model.support_checks == 1
     assert model.scope_modes == [True]
+    assert len(model.runner.captures) == 1, (
+        "capture must happen up front, before the batch loop"
+    )
     assert model.runner.calls == 1, "_inference must go through the graph runner"
     assert model.eager_calls == 1  # the runner double delegates to _forward
     assert model._cuda_graph_mode is None, "scope must close after the run"
+    assert model.runner.capture_on_miss is True, (
+        "the replay-only policy must be restored after the loop"
+    )
+    assert torch.equal(v.last_preds, torch.ones(2, 3, 8, 8) * 2)
+
+
+def test_capture_failure_runs_the_whole_pass_eager(tmp_path):
+    """A capture failure must degrade to a plain eager pass, not crash."""
+    from libreyolo.models.base.cuda_graph import CudaGraphUnavailable
+
+    model = _GraphAwareModel()
+
+    def failing_capture(x):
+        raise CudaGraphUnavailable("simulated capture failure")
+
+    model.runner.capture = failing_capture
+    v = _validator(model, tmp_path, cuda_graph=True)
+    v.run()
+
+    assert model.scope_modes == [], "no scope after a failed capture"
+    assert model.runner.calls == 0, "the loop must not touch the runner"
+    assert model.eager_calls == 1
     assert torch.equal(v.last_preds, torch.ones(2, 3, 8, 8) * 2)
 
 
@@ -221,6 +251,11 @@ def test_gpu_validation_forward_is_bit_identical(tmp_path):
             save_dir=str(tmp_path / "val"),
             verbose=False,
             cuda_graph=cuda_graph,
+            # Match the up-front capture (batch_size, 3, imgsz, imgsz) to the
+            # batch the stub loop feeds, so the loop replays rather than
+            # missing and running eager under the replay-only policy.
+            batch_size=2,
+            imgsz=64,
         )
         v = _FixedBatchValidator(model=model, config=config)
         with torch.no_grad():
@@ -229,5 +264,64 @@ def test_gpu_validation_forward_is_bit_identical(tmp_path):
 
     eager = run_once(False)
     graphed = run_once(True)
-    assert model.graph_info()["graph_count"] >= 1, "capture must have happened"
+    info = model.graph_info()
+    assert info["graph_count"] >= 1, "capture must have happened"
+    assert sum(c["replays"] for c in info["captured"]) >= 1, (
+        "the loop must replay the up-front capture, not run eager"
+    )
     _assert_outputs_equal(eager, graphed)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_runner_latches_eager_after_capture_failure():
+    """One failed capture must stop all further capture attempts: retrying
+    pays a full warmup per batch and fails identically on a poisoned context
+    (measured 2.4x slower than eager over a 25-epoch run)."""
+    from libreyolo.models.base.cuda_graph import CudaGraphUnavailable, GraphRunner
+
+    attempts = []
+    runner = GraphRunner(forward_fn=lambda x: x * 2, family="fake")
+
+    def failing_capture(x):
+        attempts.append(1)
+        raise RuntimeError("simulated cudaErrorStreamCaptureInvalidated")
+
+    runner._capture = failing_capture
+    x = torch.ones(2, 3, 8, 8, device="cuda")
+    with torch.no_grad():
+        first = runner.run(x)
+        second = runner.run(x)
+
+    assert len(attempts) == 1, "capture must not be retried after a failure"
+    assert torch.equal(first, x * 2) and torch.equal(second, x * 2)
+    assert runner.info()["eager_fallbacks"] == 2
+
+    # Explicit capture() short-circuits too, and release() resets the latch.
+    with pytest.raises(CudaGraphUnavailable, match="not retrying"), torch.no_grad():
+        runner.capture(x)
+    assert len(attempts) == 1
+    runner.release()
+    with torch.no_grad():
+        runner.run(x)
+    assert len(attempts) == 2, "release() must allow capture again"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_runner_capture_on_miss_false_never_captures():
+    from libreyolo.models.base.cuda_graph import GraphRunner
+
+    attempts = []
+    runner = GraphRunner(forward_fn=lambda x: x * 2, family="fake")
+
+    def counting_capture(x):
+        attempts.append(1)
+        raise AssertionError("must not be reached")
+
+    runner._capture = counting_capture
+    runner.capture_on_miss = False
+    x = torch.ones(2, 3, 8, 8, device="cuda")
+    with torch.no_grad():
+        out = runner.run(x)
+
+    assert attempts == [], "shape miss must run eager without capturing"
+    assert torch.equal(out, x * 2)

--- a/tests/unit/test_validator_cuda_graph.py
+++ b/tests/unit/test_validator_cuda_graph.py
@@ -1,0 +1,233 @@
+"""Validation forward through captured CUDA graphs (ValidationConfig.cuda_graph).
+
+The wiring under test: run() opens the model's graph scope when the config
+asks for it, _inference routes through forward_maybe_graphed, and everything
+degrades to the plain eager forward when graphs are off, unsupported, or
+uncapturable. Bit-identity of replay itself is gated by test_cuda_graph.py.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+from libreyolo.validation.base import BaseValidator
+from libreyolo.validation.config import ValidationConfig
+
+pytestmark = pytest.mark.unit
+
+
+class _Runner:
+    def __init__(self, forward):
+        self.forward = forward
+        self.calls = 0
+
+    def run(self, x, auto=False):
+        self.calls += 1
+        return self.forward(x)
+
+
+class _GraphAwareModel:
+    """Model double implementing the graph-scope contract."""
+
+    SUPPORTS_CUDA_GRAPH = True
+
+    def __init__(self):
+        self._cuda_graph_mode = None
+        self.eager_calls = 0
+        self.scope_modes = []
+        self.support_checks = 0
+        self.runner = _Runner(self._forward)
+
+    def _forward(self, x):
+        self.eager_calls += 1
+        return x * 2
+
+    def _get_graph_runner(self):
+        return self.runner
+
+    def _require_cuda_graph_support(self):
+        self.support_checks += 1
+        if not self.SUPPORTS_CUDA_GRAPH:
+            raise NotImplementedError
+
+    @contextmanager
+    def cuda_graph_scope(self, mode):
+        self.scope_modes.append(mode)
+        self._cuda_graph_mode = "auto" if mode == "auto" else "on"
+        try:
+            yield
+        finally:
+            self._cuda_graph_mode = None
+
+
+class _PlainModel:
+    """Model double that never opted into anything graph related."""
+
+    def __init__(self):
+        self.eager_calls = 0
+
+    def _forward(self, x):
+        self.eager_calls += 1
+        return x * 2
+
+
+class _OneBatchValidator(BaseValidator):
+    """Runs _inference on one fixed CPU batch; counts nothing else."""
+
+    imgsz = 8  # doubles accept anything; real models need >= their stride
+
+    def _setup_dataloader(self):
+        return object()
+
+    def _warmup_model(self, n_warmup: int = 3):
+        pass
+
+    def _init_metrics(self):
+        pass
+
+    def _run_validation(self):
+        # Mirror the real loop's execution context: eval mode, no autograd.
+        model = getattr(self.model, "model", None)
+        if hasattr(model, "eval"):
+            model.eval()
+        size = type(self).imgsz
+        with torch.no_grad():
+            self.last_preds = self._inference(torch.ones(2, 3, size, size))
+
+    def _preprocess_batch(self, batch):
+        raise AssertionError("not used")
+
+    def _postprocess_predictions(self, preds, batch):
+        raise AssertionError("not used")
+
+    def _update_metrics(self, preds, targets, img_info, img_ids=None):
+        raise AssertionError("not used")
+
+    def _compute_metrics(self):
+        return {}
+
+
+def _validator(model, tmp_path, **config_kwargs):
+    config = ValidationConfig(
+        data="x.yaml",
+        device="cpu",
+        save_dir=str(tmp_path / "val"),
+        verbose=False,
+        **config_kwargs,
+    )
+    return _OneBatchValidator(model=model, config=config)
+
+
+def _assert_outputs_equal(left, right):
+    """Structure-aware bit-equality for family forward outputs."""
+    from libreyolo.models.base.cuda_graph import _flatten
+
+    left_tensors, left_skeleton = _flatten(left)
+    right_tensors, right_skeleton = _flatten(right)
+    assert left_skeleton == right_skeleton
+    assert len(left_tensors) == len(right_tensors)
+    for index, (a, b) in enumerate(zip(left_tensors, right_tensors)):
+        assert torch.equal(a, b), f"tensor {index} differs"
+
+
+def test_config_defaults_off():
+    assert ValidationConfig(data="x.yaml").cuda_graph is False
+
+
+def test_disabled_takes_the_plain_eager_path(tmp_path):
+    """Duck-typed doubles without any graph surface must keep working."""
+    model = _PlainModel()
+    v = _validator(model, tmp_path)
+    v.run()
+    assert model.eager_calls == 1
+    assert torch.equal(v.last_preds, torch.ones(2, 3, 8, 8) * 2)
+
+
+def test_enabled_opens_scope_and_routes_through_runner(tmp_path):
+    model = _GraphAwareModel()
+    v = _validator(model, tmp_path, cuda_graph=True)
+    v.run()
+
+    assert model.support_checks == 1
+    assert model.scope_modes == [True]
+    assert model.runner.calls == 1, "_inference must go through the graph runner"
+    assert model.eager_calls == 1  # the runner double delegates to _forward
+    assert model._cuda_graph_mode is None, "scope must close after the run"
+    assert torch.equal(v.last_preds, torch.ones(2, 3, 8, 8) * 2)
+
+
+def test_auto_mode_is_passed_through(tmp_path):
+    model = _GraphAwareModel()
+    v = _validator(model, tmp_path, cuda_graph="auto")
+    v.run()
+    assert model.scope_modes == ["auto"]
+
+
+def test_unsupported_family_fails_loudly(tmp_path):
+    model = _GraphAwareModel()
+    model.SUPPORTS_CUDA_GRAPH = False
+    v = _validator(model, tmp_path, cuda_graph=True)
+    with pytest.raises(NotImplementedError):
+        v.run()
+
+
+def test_cpu_model_falls_back_to_eager_without_raising(tmp_path):
+    """Real yolo9 on CPU: scope opens, the runner rejects CPU input, output
+    must equal the eager forward."""
+    from libreyolo import LibreYOLO9
+
+    class _RealSizeValidator(_OneBatchValidator):
+        imgsz = 64
+
+    model = LibreYOLO9(model_path=None, size="t", device="cpu")
+    config = ValidationConfig(
+        data="x.yaml",
+        device="cpu",
+        save_dir=str(tmp_path / "val"),
+        verbose=False,
+        cuda_graph=True,
+    )
+    v = _RealSizeValidator(model=model, config=config)
+    v.run()
+
+    model.model.eval()
+    with torch.no_grad():
+        eager = model._forward(torch.ones(2, 3, 64, 64))
+    _assert_outputs_equal(v.last_preds, eager)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_gpu_validation_forward_is_bit_identical(tmp_path):
+    """Our wiring (autocast context + forward_maybe_graphed) must not change
+    a single bit of the forward output on the real capture path."""
+    from libreyolo import LibreYOLO9
+
+    model = LibreYOLO9(model_path=None, size="t", device="cuda")
+    model.model.eval()
+    torch.manual_seed(0)
+    batch = torch.rand(2, 3, 64, 64, device="cuda")
+
+    class _FixedBatchValidator(_OneBatchValidator):
+        def _run_validation(self):
+            self.last_preds = self._inference(batch)
+
+    def run_once(cuda_graph):
+        config = ValidationConfig(
+            data="x.yaml",
+            device="cuda",
+            save_dir=str(tmp_path / "val"),
+            verbose=False,
+            cuda_graph=cuda_graph,
+        )
+        v = _FixedBatchValidator(model=model, config=config)
+        with torch.no_grad():
+            v.run()
+        return v.last_preds
+
+    eager = run_once(False)
+    graphed = run_once(True)
+    assert model.graph_info()["graph_count"] >= 1, "capture must have happened"
+    _assert_outputs_equal(eager, graphed)

--- a/tests/unit/test_validator_reuse.py
+++ b/tests/unit/test_validator_reuse.py
@@ -1,0 +1,123 @@
+"""Reusing one validator instance across runs (per-epoch validation).
+
+The trainer calls a validator once per epoch. The dataset, dataloader
+(worker spawn, pinned buffers), model warmup and parsed ground truth are
+per-instance costs that must survive between runs; metrics and speed
+counters are per-run state that must reset. These tests pin that split.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from libreyolo.validation.base import BaseValidator
+from libreyolo.validation.config import ValidationConfig
+from libreyolo.validation.detection_validator import DetectionValidator
+
+pytestmark = pytest.mark.unit
+
+
+class _CountingValidator(BaseValidator):
+    """Stub that counts which template hooks each run() actually pays for."""
+
+    def __init__(self, model, config):
+        super().__init__(model, config)
+        self.dataloader_builds = 0
+        self.warmups = 0
+        self.metric_inits = 0
+        self.validations = 0
+
+    def _setup_dataloader(self):
+        self.dataloader_builds += 1
+        return object()  # anything non-None: our _run_validation ignores it
+
+    def _warmup_model(self, n_warmup: int = 3):
+        self.warmups += 1
+
+    def _init_metrics(self):
+        self.metric_inits += 1
+
+    def _run_validation(self):
+        self.validations += 1
+        self.seen += 4
+        self.speed["total"] += 1.0
+
+    def _preprocess_batch(self, batch):
+        raise AssertionError("not used by the stub")
+
+    def _postprocess_predictions(self, preds, batch):
+        raise AssertionError("not used by the stub")
+
+    def _update_metrics(self, preds, targets, img_info, img_ids=None):
+        raise AssertionError("not used by the stub")
+
+    def _compute_metrics(self):
+        return {}
+
+
+def _counting_validator(tmp_path):
+    config = ValidationConfig(
+        data="x.yaml",
+        device="cpu",
+        save_dir=str(tmp_path / "val"),
+        verbose=False,
+    )
+    return _CountingValidator(model=object(), config=config)
+
+
+def test_second_run_reuses_dataloader_and_warmup(tmp_path):
+    v = _counting_validator(tmp_path)
+    v.run()
+    v.run()
+
+    assert v.validations == 2
+    assert v.dataloader_builds == 1, "dataloader must be a per-instance cost"
+    assert v.warmups == 1, "warmup must be a per-instance cost"
+    assert v.metric_inits == 2, "metrics accumulate and must reset per run"
+
+
+def test_second_run_resets_per_run_counters(tmp_path):
+    v = _counting_validator(tmp_path)
+    v.run()
+    seen_after_first, total_after_first = v.seen, v.speed["total"]
+    v.run()
+
+    assert v.seen == seen_after_first, "seen must restart from zero each run"
+    assert v.speed["total"] == total_after_first, "speed must restart each run"
+
+
+def test_fresh_instance_still_builds_everything(tmp_path):
+    first = _counting_validator(tmp_path)
+    first.run()
+    second = _counting_validator(tmp_path)
+    second.run()
+
+    assert second.dataloader_builds == 1
+    assert second.warmups == 1
+
+
+def test_detection_gt_parse_is_cached_across_metric_inits(tmp_path):
+    """The COCO GT is immutable per instance; only the evaluator is per-run."""
+    annotation_file = tmp_path / "annotations.json"
+    annotation_file.write_text("{}")  # never actually parsed: COCO is mocked
+
+    v = object.__new__(DetectionValidator)
+    v.config = ValidationConfig(
+        data="x.yaml", device="cpu", verbose=False, save_plots=False
+    )
+    v._coco_annotation_file = annotation_file
+    v._coco_label_to_category_id = None
+    v._gt_coco_api = None
+    v.nc = 3
+
+    with (
+        patch("pycocotools.coco.COCO", return_value=MagicMock(imgs={})) as coco,
+        patch("libreyolo.validation.COCOEvaluator") as evaluator,
+    ):
+        v._init_metrics()
+        v._init_metrics()
+
+    assert coco.call_count == 1, "GT must be parsed once per instance"
+    assert evaluator.call_count == 2, "the evaluator accumulates: one per run"


### PR DESCRIPTION
## Summary
- Cache the deterministic pre-augmentation resize (not the full decode), so YOLO-family train/val epochs skip JPEG decode + resize after epoch 1 with bit-identical pixels; disk sidecars keyed by imgsz.
- Reuse one validator instance across the training epoch loop so dataloader workers, pinned buffers, and parsed GT survive between epochs instead of being rebuilt ~100 times.
- Replay validation forwards through the existing per-shape CUDA graph cache; capture once before the batch loop (avoids pin-memory `cudaHostAlloc` races), then replay-only inside the loop with a latch that never retries a failed capture.

## Test plan
- [x] Unit: `test_image_cache`, `test_validator_reuse`, `test_validator_cuda_graph`, `test_cuda_graph` (56+ related tests green)
- [x] Full unit suite: 4167 passed; only pre-existing unrelated `test_moge2_export_support_is_onnx_only` failure (reproduced on base `dev`)
- [x] Local 5070 Ti A/B/A on coco128 (25 epochs, `eval_interval=1`, mosaic on): warm baseline vs `cache=disk`+`cuda_graph` — losses and mAPs bit-identical; 1 graph, 200 replays, 0 fallbacks
- [x] Standalone pretrained LibreYOLO9s val on coco8: eager vs graphed+cached — every COCO metric identical to last float digit
- [ ] CI green on this PR
- [ ] Greptile review addressed if needed

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR accelerates repeated training validation by caching deterministic resized images, retaining validator resources across epochs, and replaying eligible validation forwards through CUDA graphs.
- Adds RAM and disk caches for post-resize image data, keyed by target image size.
- Reuses detection-family validators, persistent dataloaders, and parsed ground truth across training epochs.
- Captures validation CUDA graphs before dataloader iteration and falls back to eager execution for capture failures or unmatched shapes.
- Adds focused tests for cache equivalence, validator lifecycle reuse, and graph capture/replay behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code correctness or security failures identified.

Cache paths preserve the existing resize and coordinate contracts, validator reuse resets run-specific metric state, and CUDA graph replay observes in-place model updates while safely falling back to eager execution for unsupported conditions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/data/cache.py | Adds size-keyed post-resize RAM and disk caching while preserving native-image caching for preprocessors that own resizing. |
| libreyolo/data/dataset.py | Routes deterministic dataset resizing through the shared cache mixin without changing the image-label coordinate contract. |
| libreyolo/models/base/cuda_graph.py | Adds replay-only operation and a resettable failed-capture latch while retaining eager fallback behavior. |
| libreyolo/training/trainer.py | Reuses task-compatible validators across epochs and forwards training cache and supported CUDA-graph settings into validation. |
| libreyolo/validation/base.py | Retains dataloaders across runs, captures validation graphs before iteration, and resets per-run metrics and timing state. |
| libreyolo/validation/detection_validator.py | Enables validation image caching and retains immutable parsed ground truth while rebuilding evaluators each run. |
| libreyolo/validation/config.py | Adds explicit image-cache and CUDA-graph validation options with backward-compatible defaults. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Epoch[Training epoch] --> Swap[Select EMA or current model]
  Swap --> Validator[Reuse epoch validator]
  Validator --> Setup{Dataloader exists?}
  Setup -->|No| Build[Build persistent validation loader]
  Setup -->|Yes| Retain[Retain loader and parsed ground truth]
  Build --> Cache[Decode and resize image cache]
  Retain --> Cache
  Cache --> Capture{CUDA graph enabled and capturable?}
  Capture -->|Yes| Replay[Replay captured full-batch shape]
  Capture -->|No| Eager[Eager forward]
  Replay --> Partial{Shape mismatch?}
  Partial -->|Yes| Eager
  Partial -->|No| Metrics[Reset and compute epoch metrics]
  Eager --> Metrics
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Capture the validation graph before the ..."](https://github.com/libreyolo/libreyolo/commit/902b37115ca19fa5d23ca2e885126a57ac8d7130) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49369558)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Data Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-pipeline.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Validation Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/validation-pipeline.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
</details>

<!-- /greptile_comment -->