### PR TITLE
Audit RF100-VL skill against the first real Vast campaign

### DIFF
--- a/skills/run-rf100vl-benchmark/SKILL.md
+++ b/skills/run-rf100vl-benchmark/SKILL.md
@@ -6,10 +6,12 @@ description: >-
   protocol-conformant pycocotools evaluation at maxDets 500, artifact
   publishing, and multi-GPU execution on vast.ai (the default compute). Use
   when someone wants to "run RF100-VL", "benchmark on Roboflow 100",
-  reproduce or extend published RF100-VL numbers, or add a model family to
-  the campaign. Training and eval run in the vision-analysis-benchmark
-  harness; this skill holds the protocol, the locked decisions, and the
-  compute playbook.
+  reproduce or extend published RF100-VL numbers, add a model family to the
+  campaign, asks why campaign GPUs look underutilized or the ETA looks wrong,
+  or needs to decide stop-vs-destroy / packing depth. Training and eval run
+  in the vision-analysis-benchmark harness; this skill holds the protocol,
+  locked decisions, compute playbook, and the operational lessons that
+  change money and wall-clock.
 ---
 
 # Run the RF100-VL benchmark
@@ -19,6 +21,12 @@ images, 564 classes, 7 domains), paper arXiv 2505.20612 (NeurIPS 2025
 Datasets and Benchmarks). Each dataset ships fixed `train`/`valid`/`test`
 splits in COCO JSON. There is no official runner; the harness referenced
 below is the runner.
+
+Exact install/launch commands: harness
+`docs/rf100vl-operator-runbook.md`. Vast rental mechanics (2FA/TOTP, launch,
+destroy): `skills/launch-serverless-gpu-job` (Vast section) or the personal
+`vast-launch` skill. This skill is the protocol plus the operational
+knowledge those two do not cover.
 
 ## Protocol (locked decisions)
 
@@ -35,6 +43,7 @@ below is the runner.
 | Eval thresholds | conf 0.001; NMS IoU 0.65 for NMS families, identical at selection and final eval; DETR families are NMS-free top-k | LibreYOLO policy |
 | Seed | 0 | LibreYOLO policy |
 | Recipes | one pinned JSON per family in the harness (`va_bench/recipes/rf100vl/`), sha recorded in every run, same recipe for all 100 datasets | LibreYOLO policy |
+| Execution (YOLO) | `cuda_graph: true` and `cache: "disk"` in the recipe protocol when the installed LibreYOLO supports them (bit-identical; covered by recipe hash) | measured 2026-08 |
 
 Never report toolkit-native trapezoidal mAP; it inflates up to 2.7 AP on
 RF100-VL versus pycocotools (paper, App B). LibreYOLO validation is
@@ -42,197 +51,215 @@ pycocotools-based already; the 500 cap is the opt-in `eval_max_det` kwarg
 (`model.val(data=..., split="test", eval_max_det=500)`). Defaults for normal
 users are unchanged (AP at maxDets 100) and test-locked.
 
+Validation frequency is protocol-mandated every epoch (gdino
+`val_interval=1`; rt-detr / d-fine / lw-detr call `evaluate()` unconditionally,
+lw-detr twice). The knob that exists is validation COST (image cache, hoisted
+validator, graphed val forward), not frequency. LibreYOLO's own
+`TrainConfig.eval_interval` defaults to 10 — a short smoke never validates
+unless you pass `eval_interval=1`.
+
 ## Where the work happens
 
-Repo `LibreYOLO/vision-analysis-benchmark` (the harness). Two verbs:
+Repo `LibreYOLO/vision-analysis-benchmark` (harness branch `rf100vl-harness`).
 
 ```bash
-# per-dataset fine-tuning: one worker per GPU, subprocess children,
+# per-dataset fine-tuning: one worker per lane, subprocess children,
 # atomic status files, resume, timeouts, dense-dataset OOM fallback
-va-bench rf100vl-train --data-dir ./rf100-vl --weights-root ./rf100vl-weights --gpus 0,1,2,3,4,5,6,7
+va-bench rf100vl-train --data-dir ./rf100-vl --weights-root ./rf100vl-weights \
+  --gpus 0,1,2,3,4,5,6,7 --jobs-per-gpu 3
 
-# per-dataset test-split eval: cached and resumable, emits one
-# va.submission.v1 JSON with a per-dataset rf100vl block
+# per-dataset test-split eval
 va-bench rf100vl --all --data-dir ./rf100-vl --weights-root ./rf100vl-weights
 
-# or both plus checks and rendering as ONE resumable command:
-# preflight -> train -> eval -> markdown report beside the submission
+# both plus checks and rendering as ONE resumable command
 va-bench rf100vl-campaign --model yolov9t --data-dir ./rf100-vl \
-  --weights-root ./rf100vl-weights --gpus 0,1,2,3,4,5,6,7
+  --weights-root ./rf100vl-weights --gpus 0,1,2,3,4,5,6,7 --jobs-per-gpu 3
 ```
 
-Supporting verbs: `rf100vl-preflight` (validate the box BEFORE spending
-GPU-hours: capabilities, data-vs-lock, splits, recipe, torch-vs-GPU sm
-support, disk), `rf100vl-dash` (live localhost dashboard: per-GPU lanes,
-dataset grid, loss/mAP curves, log tails; SSH-tunnel it from rented boxes),
-`rf100vl-report` (submission JSON to markdown report or leaderboard).
+`--jobs-per-gpu` is the single biggest throughput lever. It is set by VRAM
+per lane and CPU headroom, not by GPU compute. Measured (yolov9t ≈ 6.2
+GB/lane, yolov9s ≈ 10.8 GB/lane before val-graph static buffers; re-measure
+after stack changes). CUDA graphs improve packing because they remove host
+launch contention between lanes sharing a GPU.
 
-- **Dataset, fast path (use this on rented boxes).** Pull the pre-built copy at
-  [`LibreYOLO/rf100-vl`](https://huggingface.co/datasets/LibreYOLO/rf100-vl):
-  100 per-dataset tars, already cleaned, plus `versions.json`, `NOTICE`, and
-  `licenses.json`. No `ROBOFLOW_API_KEY`, and version-pinned so two boxes
-  cannot silently score different data.
+Supporting verbs: `rf100vl-preflight`, `rf100vl-dash` (pass `--data-dir` or
+queued datasets show no image counts and the ETA is size-blind),
+`rf100vl-report`.
 
-  ```bash
-  pip install huggingface_hub
-  python -c "from huggingface_hub import snapshot_download; \
-    snapshot_download('LibreYOLO/rf100-vl', repo_type='dataset', \
-                      local_dir='rf100-vl', max_workers=8)"
-  cd rf100-vl && for f in *.tar; do tar xf "$f" && rm "$f"; done
-  ```
+- **Dataset, fast path.** Pull [`LibreYOLO/rf100-vl`](https://huggingface.co/datasets/LibreYOLO/rf100-vl):
+  100 per-dataset tars + lock files. Prefer `max_workers=32` and stay logged
+  in (`HF_TOKEN`) for the authenticated rate limit. Do not cargo-cult
+  `huggingface_hub[hf_transfer]` / `HF_HUB_ENABLE_HF_TRANSFER=1` on hub 1.x.
+- **Dataset, canonical path.** `--download` wraps the `rf100vl` pip package
+  (`ROBOFLOW_API_KEY`); use it to rebuild/verify the HF copy. Licensing is in
+  `va_bench/data/rf100vl_licenses.json`.
+- Weights: `best.pt` at `<weights_root>/<dataset>/<weight_file>`.
+- A capability guard aborts on builds without `eval_max_det`/`amp_dtype`.
+  `cuda_graph` / `cache` are reported, not required — missing them runs the
+  protocol correctly, just slower.
+- Flag lists: harness README / `--help` win over this skill.
 
-  What makes it fast is few large files instead of 164k small ones, served by
-  the hub's default (Xet-backed) transfer. Do not cargo-cult the old
-  `huggingface_hub[hf_transfer]` extra or `HF_HUB_ENABLE_HF_TRANSFER=1`: on
-  huggingface_hub 1.x the extra installs nothing and the env var is ignored
-  (both only mattered on hub 0.x). An HF token is NOT required for a public
-  dataset and does not raise throughput, but staying logged in
-  (`huggingface-cli login`, or `HF_TOKEN` in the env) gets the higher
-  authenticated rate limit, which is worth having when several boxes pull at
-  once. Measured: Roboflow serves ~2.2 MB/s from a home line and ~16 MB/s from
-  a datacenter, so the canonical path costs 45 min to 5.6 h; the tars are minutes.
+## Decisions BEFORE dataset one (one-way doors)
 
-- **Dataset, canonical path.** `--download` wraps the `rf100vl` pip package and
-  needs a free `ROBOFLOW_API_KEY`; about 40 GB. Use it to REBUILD the HF copy,
-  to verify it, or if the HF copy is unavailable. The harness writes a version
-  lock and replays recorded versions; it never re-resolves latest.
-  We host the HF copy; it is not a hedge or a stopgap. Licensing is recorded in
-  `va_bench/data/rf100vl_licenses.json`, which deliberately keeps BOTH upstream
-  statements rather than resolving them silently: the benchmark repository
-  claims Apache-2.0 as a blanket licence over the datasets, while all 100
-  Universe projects individually report MIT (checked per project and
-  cross-validated against the `License:` line inside downloaded exports). Both
-  permit redistribution and derivatives with notice retention, so the
-  disagreement changes nothing operationally; we rely on the per-project field
-  and preserve every dataset's own README.dataset.txt inside its archive.
-- Weights contract: training places `best.pt` at
-  `<weights_root>/<dataset>/<weight_file>`; eval resolves exactly that path.
-- A capability guard aborts training on any libreyolo build without
-  `eval_max_det`/`amp_dtype` support, so a wrong install cannot silently
-  produce off-protocol numbers.
-- Exact flags and current behavior: the harness README (RF100-VL section)
-  and `--help` are authoritative; do not trust this skill for flag lists.
+The run signature hashes the recipe. **Any recipe change
+(`cuda_graph`, `cache`, epochs, imgsz, …) means a fresh campaign** — banked
+checkpoints under the old recipe cannot be resumed. Enabling `cuda_graph`
+mid-campaign once orphaned 973 banked epochs.
 
-## Decisions to take per campaign
-
-1. Model list and sizes. Flagships deep (yolo9 and rfdetr, all or most
-   sizes); every other family starts with its one or two smallest variants.
-2. Pilot first: run the `rf20vl` subset end to end. A family graduates to
-   the full 100 only if all 20 datasets complete, a kill-and-resume drill
-   reproduces the uninterrupted result within noise, and its AP ordering is
-   sane.
-3. Budget and waves: price the run from current marketplace offers (below),
-   publish after the flagships land, append families as they finish.
-4. Recipe deviations: any change lives in the recipe JSON, is hash-recorded
-   in every run, and is disclosed with the results. No silent knobs.
-
-## Artifacts and publishing
-
-Keep, per model: per-dataset eval JSONs, per-dataset raw predictions (COCO
-detections), per-run `stats.json` (recipe sha, best epoch, seed, dataset
-version, wall time), the recipe JSON, the dataset version lock, and the
-final submission JSON.
-
-The eval verb writes predictions itself (`<fingerprint>.predictions.json.gz`
-beside each per-dataset result, path recorded in the submission). It is on by
-default; do not turn it off for a run you intend to publish, because it is the
-only thing that makes the claim below true.
-
-- Upload the per-model artifact folder to a Hugging Face dataset repo under
-  the LibreYOLO org (one folder per model) with `va-bench sync-artifacts`.
-  Create the results repo by hand first, then use a **fine-grained token
-  scoped to that one repo with write access only**; the uploader treats
-  `create_repo` as best-effort precisely so such a token works. Pass
-  `--eval-dir` or the per-dataset predictions are not collected, and those are
-  what make the claim below true. Anyone can then rescore from the
-  JSONs with pycocotools, no GPU needed; that is the reproducibility story.
-  Verified end to end: a stock-pycocotools rescore of a saved dump, importing
-  no harness code, reproduced the harness AP to four decimals.
-- The leaderboard submission goes to the `vision-analysis` repo through its
-  `submit-benchmark-results` flow (validate, rebuild, PR, deploy). See the
-  `benchmark-on-visionanalysis` skill for the handoff.
-- Never hand-edit result JSONs. Regenerate them.
+1. Recipe final? (`va_bench/recipes/rf100vl/*.json`)
+2. LibreYOLO commit pinned and *actually* installed?
+   `pip install --upgrade` on a git URL **silently no-ops when the version
+   string is unchanged** and reports success. Use
+   `pip install -q --force-reinstall --no-deps "git+..."`, then prove the
+   installed `TrainConfig` has the fields the recipe sets.
+3. Vast TOTP seed saved (`~/.config/vastai/vast_totp_seed`)? A 2FA session
+   expiring mid-campaign once forced stopping a billing box through an
+   unverifiable path.
+4. Shakedown done on the current stack? (below)
 
 ## Compute: vast.ai (default)
 
-Account setup, 2FA, launch, exec, tail, pull, guard, and destroy discipline:
-follow `skills/launch-serverless-gpu-job` (Vast section). This section adds
-only the RF100-VL specifics.
+Account setup, 2FA, launch, exec, pull, destroy: follow
+`skills/launch-serverless-gpu-job` (Vast section). RF100-VL specifics:
 
 - **Image, tested end to end:**
-  `vastai/pytorch:2.11.0-cu128-cuda-12.9-mini-py312-2026-06-15`. A Vast image
-  takes their well-travelled key-injection path; a plain `pytorch/pytorch`
-  works on many hosts but on others sshd refuses your key with `bad ownership
-  or modes for file /root/.ssh/authorized_keys` and there is no way in to fix
-  it. The cu128 build matters just as much: their default tag cannot run a
-  5090 (`no kernel image is available for execution on the device`). The
-  interpreter is `/venv/main/bin/python`, not `python`.
-- **Accept or reject the host in 60 seconds, before installing anything.**
-  `deploy/vast/accept-box.sh` in the harness repo checks GPUs, torch kernels
-  for those GPUs, a real matmul, huggingface.co, PyPI, and disk. Six rented
-  hosts in one evening produced five distinct infrastructure failures, none of
-  them visible on the offer card, including two whose networks could not reach
-  huggingface.co. That failure is the nastiest: `snapshot_download` does not
-  error, it hangs silently while the meter runs. Budget about a dollar for the
-  host search and destroy duds immediately.
-- Workload shape: independent single-GPU jobs, batch 16 at 640 px, under 12
-  GB VRAM for most families. No interconnect requirement, so interruptible
-  consumer boxes dominate datacenter cards on price per GPU-hour.
-- Primary target: one 8x RTX 5090 interruptible box. Fallback: several 1-4x
-  RTX 5090 or RTX 4090 boxes; the orchestrator takes any GPU count and
-  multi-box runs split the dataset list.
-- Offer filter: verified host, reliability above 0.99, at least 8 vCPU per
-  GPU, at least 300 GB disk, at least 500 Mbps down, download cost under
-  0.01 USD per GB, host driver CUDA capability 12.8 or newer. Bid 20 to 30
-  percent above the current minimum to reduce outbid churn.
-- Prices move within hours: re-check offers immediately before every wave
-  and archive the query plus results with the run records.
-- Interruptible semantics: being outbid pauses the box; its disk persists
-  (and bills) while the instance exists; destroy deletes it. The harness
-  resumes at dataset level (status files) and epoch level (`last.pt`). Sync
-  `weights_root` and results off-box at milestones (HF), and always `pull`
-  before `destroy`.
-- Local-first rule: the whole flow must pass on a local GPU (one dataset,
-  then the rf20vl pilot) before renting anything. Credits are for the
-  campaign, not for debugging. Corollary proven in practice: when a variable
-  changes (a new image, a new provider), test it on ONE cheap GPU first. A
-  single-GPU box settled an image question for about 15 cents that had
-  already cost several dollars of guessing on 8-GPU boxes.
-- Human-flown first: `docs/rf100vl-operator-runbook.md` in the harness repo is
-  every command from rent to destroy, for a person, with what healthy output
-  looks like and where the money goes. Automation is for flows someone has
-  already flown by hand.
-- Rough sizing: 0.5 to 1 consumer-GPU-hour per dataset for YOLO-family
-  models, 1 to 2.5 for DETR-family; a full 100-dataset pass per family lands
-  roughly between 30 and 200 GPU-hours depending on family.
+  `vastai/pytorch:2.11.0-cu128-cuda-12.9-mini-py312-2026-06-15`. Vast's own
+  image takes their key-injection path; plain `pytorch/pytorch` sometimes
+  leaves sshd rejecting keys. cu128 is required for 5090 (`sm_120`).
+  Interpreter: `/venv/main/bin/python`, not bare `python`.
+- **Accept or reject in 60 seconds** with harness
+  `deploy/vast/accept-box.sh` (GPUs, kernels, matmul, HF, PyPI, disk ≥ 120
+  GB free). Destroy duds immediately. **`loading` is essentially unbilled**
+  (meter starts at `running`); a wedged 15-minute pull destroyed after
+  measured ~$0.02. An older estimate of "~$1 for the host search" overstated
+  this by ~10x — the real cost is operator attention. Never nurse a doubtful
+  host because destroying it "feels wasteful."
+- **Disk allocate ~120 GB without image cache, ~250 GB with
+  `cache: "disk"`.** The offer filter "machine has ≥ 300 GB free" and the
+  `--disk` you rent are different; disk bills on allocated GB. One campaign
+  needs roughly 70 GB (image + pip + 49 GB dataset + weights); disk-cache
+  `.npy` sidecars add ~105 GB across 100 datasets.
+- Workload is **CPU / host-bound**, priced GPU-centric. Measured
+  [pre-cache]: 46 ms GPU vs 507 ms CPU per step; 8 cores/lane still ~94%
+  CPU-saturated. `pick_box.py`'s old `MIN_CORES_PER_LANE = 3.0` was far too
+  low. Weight core count and single-core clock heavily (a 2.6 GHz EPYC 7K62
+  lost to a consumer Ryzen). Size cores for epoch 1 (cache fill + all lanes
+  cold), not the steady-state average. Prefer high-clock CPUs even if the
+  GPU $/hr is slightly higher.
+- Primary target: one 8× RTX 5090 interruptible box with strong CPU; pack
+  with `--jobs-per-gpu` after a VRAM/lane re-measure. Fallback: several
+  1–4× 5090/4090 boxes.
+- Offer filter: verified, reliability > 0.99, **≥ 8 vCPU per lane after
+  packing**, machine disk ≥ 300 GB free (so 120–250 allocated fits), ≥ 500
+  Mbps down, download < 0.01 USD/GB, host driver CUDA 12.8+, distinct
+  egress IP from known-bad NATs. Bid 20–30% above minimum.
+- Interruptible: outbid pauses the box; disk persists and bills; destroy
+  deletes. Harness resumes at dataset (status files) and epoch (`last.pt`)
+  level. Sync weights/results off-box at milestones; always pull before
+  destroy.
+- Local-first: one dataset, then rf20vl pilot, then rent. When the stack
+  changes (new LibreYOLO commit, recipe, packing, image), shake out on ONE
+  cheap GPU first (~$1).
+
+### What healthy looks like (do not "fix" this)
+
+- Launch/host-bound: [pre-cache] healthy meant GPUs at **9–35% util and
+  ~170 W of 575 W** with everything fine. Low GPU numbers are the signature
+  of this workload, not a fault. (Graphed train+val + image cache should
+  raise this — re-baseline in the shakedown.) The runbook once claimed
+  60–100% util as healthy; that reading burned an expensive detour.
+- `nvidia-smi` util is time-with-a-kernel-resident on the CARD, not die
+  occupancy per job. With 3 lanes sharing a GPU the row describes the card.
+- Datasets are heterogeneous: **92 to 8,791** train images, **0.31 to 12+
+  MP**. Epoch times span ~40×. Longest-first scheduling; one dataset sets
+  the makespan.
+- Epoch 1 costs 1.3–2.1× a steady epoch [pre-cache]; with post-resize cache
+  the ratio **widens** (epoch 1 fills the cache). **Every ETA in the first
+  hour is garbage** — do not make money decisions off it. A "16.4 h" ETA
+  was once an artifact of averaging epoch 1 into a two-epoch mean.
+
+### When something looks slow: profile, do not theorize
+
+`libreyolo profile` answers "where is the time going" in under a minute.
+An hour of py-spy (blocked by container caps), `ps` aggregation, and
+log-timestamp forensics produced a confidently wrong answer that
+`libreyolo profile run` corrected in 52 seconds. The campaign should print
+a Profile hint next to the Monitor hint; if it does not, still run:
+
+```bash
+libreyolo profile run ...      # one profiled training epoch
+libreyolo profile phases ...   # train / validation / save split
+libreyolo profile what-if ...  # projected gain from a fix
+```
+
+High self-CPU on an op like `aten::max` with near-zero self-CUDA usually
+marks a GPU→CPU sync absorbing device wait, not a CPU bottleneck in that
+op. Total self-CUDA ≪ total self-CPU ⇒ launch-bound (CUDA graphs).
+
+### Shakedown (before any full campaign)
+
+1. Rent one cheap high-clock-CPU GPU.
+2. Install exactly as the campaign would (`--force-reinstall --no-deps`);
+   prove recipe fields exist on the installed `TrainConfig`.
+3. Run 2–3 representative datasets (tiny ~100 imgs, huge ~8k, large-image
+   12 MP class), 10–15 epochs, `eval_interval=1`, plus one full completion.
+4. Kill-and-resume between checkpoints (not mid-write).
+5. Record VRAM/lane, cores/lane at epoch 1 and steady state, epoch-1 ratio,
+   validation share, healthy util band. Size the real box from those numbers.
+
+### Stopping and resuming
+
+- **Ctrl-C mid-checkpoint can corrupt `last.pt`** and poison resume for that
+  dataset. Stop gracefully: `tmux send-keys -t bench C-c`, wait for the
+  orchestrator to exit, then `vastai stop instance` if keeping the box.
+- A **stopped** box bills disk only; restart needs those exact GPUs still
+  free. Decide stop-vs-destroy from disk $/day, re-stage cost (~35 min,
+  nearly free bandwidth), and whether banked checkpoints are usable
+  (recipe change ⇒ they are not).
+- Destroy ends spend. Always pull/sync first.
+
+## Decisions to take per campaign
+
+1. Model list and sizes. Flagships deep (yolo9 and rfdetr); other families
+   start with their one or two smallest variants.
+2. Pilot first: `rf20vl` end to end. Graduate to 100 only if all 20 complete,
+   kill-and-resume reproduces within noise, and AP ordering is sane.
+3. Budget and waves: price from live offers (`deploy/vast/pick_box.py`),
+   publish after flagships land, append families as they finish.
+4. Recipe deviations: live in the recipe JSON, hash-recorded, disclosed.
+   No silent knobs. Finalize before dataset one.
+
+## Artifacts and publishing
+
+Keep, per model: per-dataset eval JSONs, raw predictions (COCO detections),
+per-run `stats.json` (recipe sha, best epoch, seed, dataset version, wall
+time), the recipe JSON, the dataset version lock, and the final submission
+JSON. Predictions are on by default for publishable runs.
+
+- Upload with `va-bench sync-artifacts` to a LibreYOLO HF dataset repo
+  (create the repo by hand; fine-grained write token scoped to that repo).
+  Pass `--eval-dir` so predictions are collected. Stock-pycocotools rescore
+  of a saved dump reproduced harness AP to four decimals with no harness
+  code imported.
+- Leaderboard submission: `vision-analysis` via `submit-benchmark-results`
+  (see `benchmark-on-visionanalysis`).
+- Never hand-edit result JSONs. Regenerate them.
 
 ## Traps
 
 - Stock pycocotools `summarize()` breaks with a non-default maxDets list
-  (headline AP becomes -1). LibreYOLO and the harness compute the stats
-  directly; never call stock summarize with a modified list.
-- Use package-cleaned data only, from either source above. The `rf100vl` package
-  rewrites category numbering on download (dummy class 0 removed, ids shifted to
-  0-based contiguous, annotation ids from 1), and the HF copy was produced by
-  running exactly that code, so both are equivalent and version-pinned. **Never
-  a raw export from the Universe website**: those keep the dummy class and the
-  original numbering, and scoring them against the benchmark ground truth gives
-  close to zero mAP.
-- One dataset is literally named `-grccs`: write `--datasets=-grccs` (the
-  space form is eaten by argparse).
-- Never resume a checkpoint after changing physical batch or accumulation.
-  The harness refuses via run signatures; do not override it.
-- Dense datasets can OOM rfdetr; the harness picks a grad-accum fallback at
-  dataset start and restarts from epoch 0 on a mid-run OOM. Expected.
-- The ec family trains with its AdamW no-mosaic recipe (mosaic triggers a
-  degenerate-box assertion).
-- The largest datasets take hours per run. Per-dataset timeouts plus the
-  rerun list handle the tail; raise the timeout for slow families, never
-  remove it.
-- Differences under 0.5 mAP on the 100-dataset mean are noise. Replicate
-  before claiming a win.
-- `ROBOFLOW_API_KEY` and vast credentials live in env or local config only.
-  Never commit keys; upstream reference repos did, and it cost them.
+  (headline AP becomes -1). Never call it with a modified list.
+- Package-cleaned data only. Raw Universe exports keep the dummy class and
+  score near zero.
+- Dataset named `-grccs`: `--datasets=-grccs` (space form is eaten by argparse).
+- Never resume after changing physical batch, accumulation, **or recipe
+  fields covered by the run signature** (including `cuda_graph` / `cache`).
+- Dense datasets can OOM rfdetr; harness falls back to grad-accum and
+  restarts that dataset from epoch 0. Expected.
+- ec family: AdamW, no mosaic (mosaic triggers a degenerate-box assertion).
+- Largest datasets take hours; raise timeouts for slow families, never remove.
+- Differences under 0.5 mAP on the 100-dataset mean are noise. Replicate.
+- `ROBOFLOW_API_KEY` and vast credentials: env/local config only. Never commit.
 
 ## Published numbers to beat (fully supervised, AP 0.50:0.95)
 


### PR DESCRIPTION
## Summary
- Rewrite `skills/run-rf100vl-benchmark` with the operational lessons that actually cost time/money on the first yolov9t Vast campaign: profiler-first debugging, what healthy (low) GPU util looks like, `--jobs-per-gpu` + packing VRAM, dataset heterogeneity / epoch-1 ETA garbage, recipe-hash as a one-way door, `pip --force-reinstall --no-deps`, graceful stop vs corrupt `last.pt`, TOTP pre-step, loading essentially unbilled, 120/250 GB disk not 300.
- Keep the locked protocol table; correct the compute/traps sections that actively misled agents (60–100% util, ~$1 host search, missing packing knobs).
- Pair with harness commit on `rf100vl-harness` (`e30295e`) that implements the same lessons in code/runbook (profile hint, `cache` recipe plumbing, pick_box cores floor).

## Test plan
- [ ] Read the skill as an agent about to launch a campaign: confirm one-way doors and shakedown are impossible to miss
- [ ] Cross-check numbers against harness `docs/rf100vl-operator-runbook.md` on `rf100vl-harness` (already updated in lockstep)
- [ ] Greptile / human skim for anything that still points at the old stack as current truth without a re-measure note

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR substantially refreshes the RF100-VL benchmark skill with lessons from the first Vast campaign.
- Adds profiler-first diagnosis, GPU packing, CPU and disk sizing, and realistic utilization and ETA guidance.
- Documents recipe-hash boundaries, installation verification, shakedown procedures, and safe stop/resume behavior.
- Retains the locked evaluation protocol while delegating exact commands to the benchmark harness runbook.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge, with no concrete changed-code defect identified.

The updated commands and configuration fields checked against this repository are supported, and the external harness paths are clearly delegated rather than presented as local LibreYOLO paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| skills/run-rf100vl-benchmark/SKILL.md | Rewrites benchmark operations guidance without an established incorrect or unreachable workflow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Audit the RF100-VL skill against the fir..."](https://github.com/libreyolo/libreyolo/commit/74c745210c488fd6433a1873e9d35979a53335a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49372543)</sub>

<!-- /greptile_comment -->