### PR TITLE
Give D-FINE training upstream's per-size multi-scale repeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ before 1.4.0 are documented in the
 - Native fp8 execution tier: finalized fp8 QuantLinear runs on the fp8 tensor cores via torch._scaled_mm (Ada/Hopper/Blackwell); optional Triton kernels fuse activation conversion and the per-channel scale/bias epilogue, while validation-selected FeyNobg Swin stage-0 Linears use manifest-recorded tensorwise weight scales for a fully fused cuBLASLt epilogue. Finalized fp8 QuantConv2d convolves in fp16 on cached dequantized weights, and fp16-remainder checkpoints get float32 I/O root hooks. On LibreFeyNobg/RTX 5070 Ti, fp8 is 123.1 vs 129.3 ms for batch-1 graphed predict and 515.4 vs 535.3 ms at batch 4, with a 275 vs 531 MB file.
 - CUDA graph capture for the birefnet and feynobg families via encoder-only capture (the deformable decoder replays wrong under capture and stays eager; graphed output is bit-identical to eager); GraphRunner warms up on the capture stream so lazily-allocated cuBLASLt/cuDNN workspaces stop invalidating capture, and quant modules cache the calibration flag as a host bool (the per-forward .item() sync also invalidated capture)
 
+### Fixed
+
+- D-FINE training now applies upstream's per-size multi-scale recipe instead
+  of a hardcoded `base_size_repeat=3`: n trains at fixed size, s uses 20,
+  m 6, l 4, x 3 (Peterande/D-FINE custom fine-tune configs; only X matched
+  before). New `DFINEConfig.base_size_repeat` field overrides the per-size
+  default when set (#675)
+
 ## [1.4.0] - 2026-07-24
 
 LibreYOLO v1.4.0: 15 new model families, 3 new tasks (panoptic, matte, OCR), a quantization stack, two new trackers, and a multi-GPU training correctness overhaul.

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -46,7 +46,11 @@ from ...data import (
     load_data_config,
 )
 from ...data.dataset import COCODataset, YOLODataset
-from ...training.config import DFINEConfig, TrainConfig
+from ...training.config import (
+    DFINEConfig,
+    TrainConfig,
+    resolve_dfine_base_size_repeat,
+)
 from ...training.scheduler import FlatCosineScheduler
 from ...training.trainer import BaseTrainer
 from .loss import DFINECriterion
@@ -360,6 +364,13 @@ class DFINETrainer(BaseTrainer):
     # _setup_data override — wire DFINEMultiScaleCollate (when enabled)
     # =========================================================================
 
+    def _train_base_size_repeat(self) -> Optional[int]:
+        """Multi-scale repeat for this run: config override or per-size default."""
+        return resolve_dfine_base_size_repeat(
+            getattr(self.config, "size", ""),
+            getattr(self.config, "base_size_repeat", None),
+        )
+
     def _setup_data(self):
         """Mirror of ``BaseTrainer._setup_data`` but uses ``DFINEMultiScaleCollate``.
 
@@ -485,9 +496,13 @@ class DFINETrainer(BaseTrainer):
 
         # Multi-scale collate (or default yolox_collate_fn).
         if getattr(self.config, "multi_scale", False) and not load_segments:
+            # Upstream pins base_size_repeat per size (n disables multi-scale,
+            # s 20, m 6, l 4, x 3); this used to be hardcoded to 3, which only
+            # X actually wants. None makes the collate keep batches at
+            # base_size, which is exactly upstream's `~` for the N size.
             collate_fn = DFINEMultiScaleCollate(
                 base_size=self.config.imgsz,
-                base_size_repeat=3,
+                base_size_repeat=self._train_base_size_repeat(),
                 stop_epoch=stop_epoch,
             )
         else:

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -367,6 +367,26 @@ class YOLO9PoseConfig(YOLO9Config):
     name: str = "yolo9_pose_exp"
 
 
+# Upstream's custom fine-tune configs pin the multi-scale collate's
+# base_size_repeat per size (Peterande/D-FINE, configs/dfine/custom/*.yml):
+# N disables multi-scale outright (`base_size_repeat: ~`) and smaller models
+# get more scale variety. Verified against upstream 2026-08; see issue #675.
+DFINE_BASE_SIZE_REPEAT: dict = {"n": None, "s": 20, "m": 6, "l": 4, "x": 3}
+
+
+def resolve_dfine_base_size_repeat(size, override=None):
+    """The multi-scale repeat the D-FINE trainer should hand its collate.
+
+    An explicit ``override`` (``DFINEConfig.base_size_repeat``) wins; otherwise
+    the upstream per-size default applies. ``None`` means the collate keeps
+    every batch at ``base_size`` (upstream's ``~`` for the N size). Unknown
+    sizes fall back to 3, the value that used to be hardcoded for everyone.
+    """
+    if override is not None:
+        return int(override)
+    return DFINE_BASE_SIZE_REPEAT.get(str(size).lower(), 3)
+
+
 @dataclass(kw_only=True)
 class DFINEConfig(TrainConfig):
     """D-FINE-specific training defaults.
@@ -404,6 +424,11 @@ class DFINEConfig(TrainConfig):
     backbone_lr_mult: float = 0.5  # upstream's fine-tune recipe uses 0.5×
     clip_max_norm: float = 0.1  # upstream default; 0 disables clipping
     multi_scale: bool = True  # per-batch random resize via DFINEMultiScaleCollate
+    # How often the base size appears among the multi-scale collate's choices.
+    # Unset (None) resolves to the upstream per-size default via
+    # resolve_dfine_base_size_repeat: n disables multi-scale, s 20, m 6, l 4,
+    # x 3. Set an int to override for every size.
+    base_size_repeat: Optional[int] = None
     aug_stop_epoch_ratio: float = 0.85  # disable strong augs at epoch * ratio
     crop_resize_prob: float = 0.0
 

--- a/tests/unit/test_dfine_base_size_repeat.py
+++ b/tests/unit/test_dfine_base_size_repeat.py
@@ -1,0 +1,125 @@
+"""D-FINE multi-scale ``base_size_repeat``: per-size upstream defaults.
+
+The D-FINE trainer used to hardcode ``base_size_repeat=3`` for every size,
+while upstream's custom fine-tune configs pin it per size (n disables
+multi-scale, s 20, m 6, l 4, x 3) — only X coincidentally matched. These
+tests pin the mapping to the upstream values, the resolution order
+(explicit config override > per-size default > legacy 3), and the wiring
+from trainer kwargs down to the collate. See issue #675.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from libreyolo.data.augment.detr import DetrMultiScaleCollate
+from libreyolo.training.config import (
+    DFINE_BASE_SIZE_REPEAT,
+    DFINEConfig,
+    resolve_dfine_base_size_repeat,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Config surface
+# ---------------------------------------------------------------------------
+
+
+def test_config_default_is_unset():
+    """None means "use the per-size upstream default", decided at trainer time."""
+    assert DFINEConfig().base_size_repeat is None
+
+
+def test_mapping_matches_upstream_custom_configs():
+    """Peterande/D-FINE configs/dfine/custom/*.yml, verified 2026-08."""
+    assert DFINE_BASE_SIZE_REPEAT == {"n": None, "s": 20, "m": 6, "l": 4, "x": 3}
+
+
+# ---------------------------------------------------------------------------
+# Resolution order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [("n", None), ("s", 20), ("m", 6), ("l", 4), ("x", 3)],
+)
+def test_per_size_defaults(size, expected):
+    assert resolve_dfine_base_size_repeat(size) == expected
+
+
+def test_size_lookup_is_case_insensitive():
+    assert resolve_dfine_base_size_repeat("S") == 20
+
+
+def test_explicit_override_wins_even_on_n():
+    """A user's config value beats the per-size default, including n's None."""
+    assert resolve_dfine_base_size_repeat("n", override=7) == 7
+    assert resolve_dfine_base_size_repeat("s", override=3) == 3
+
+
+def test_unknown_size_falls_back_to_legacy_constant():
+    """Sizes without an upstream recipe keep the previously hardcoded 3."""
+    assert resolve_dfine_base_size_repeat("b") == 3
+    assert resolve_dfine_base_size_repeat("") == 3
+
+
+# ---------------------------------------------------------------------------
+# Collate behavior at the two interesting values
+# ---------------------------------------------------------------------------
+
+
+def test_collate_with_none_repeat_keeps_batches_at_base_size():
+    """None must mean fixed-size batches (upstream's ``~`` for the N size)."""
+    collate = DetrMultiScaleCollate(base_size=640, base_size_repeat=None)
+    assert collate.scales is None
+
+
+def test_collate_with_s_repeat_weights_base_size_twenty_times():
+    collate = DetrMultiScaleCollate(base_size=640, base_size_repeat=20)
+    assert collate.scales.count(640) == 20
+    # ±25% envelope in multiples of 32 must still be present around the base.
+    assert min(collate.scales) == 480
+    assert max(collate.scales) == 800
+
+
+# ---------------------------------------------------------------------------
+# Trainer wiring (kwargs -> config -> resolver)
+# ---------------------------------------------------------------------------
+
+
+def _make_trainer(**overrides):
+    from libreyolo import LibreDFINE
+    from libreyolo.models.dfine.trainer import DFINETrainer
+
+    wrapper = LibreDFINE(None, size="n", device="cpu")
+    kwargs = dict(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="n",
+        num_classes=80,
+        data=None,
+        epochs=1,
+        batch=2,
+        imgsz=640,
+        device="cpu",
+        amp=False,
+        ema=False,
+        eval_interval=-1,
+    )
+    kwargs.update(overrides)
+    return DFINETrainer(**kwargs)
+
+
+def test_trainer_resolves_per_size_default_for_n():
+    """n trains at fixed size out of the box, exactly like upstream."""
+    trainer = _make_trainer()
+    assert trainer._train_base_size_repeat() is None
+
+
+def test_trainer_honors_explicit_config_override():
+    """base_size_repeat passed as a train kwarg flows through to the collate."""
+    trainer = _make_trainer(base_size_repeat=7)
+    assert trainer._train_base_size_repeat() == 7


### PR DESCRIPTION
## Summary

Fixes the D-FINE finding from #675: the trainer hardcoded `base_size_repeat=3` into `DFINEMultiScaleCollate` for every size, while upstream's custom fine-tune configs (Peterande/D-FINE, `configs/dfine/custom/*.yml`, re-verified against upstream today) pin it per size:

| size | upstream | LibreYOLO before |
|---|---|---|
| n | disabled (`~`) | 3 |
| s | 20 | 3 |
| m | 6 | 3 |
| l | 4 | 3 |
| x | 3 | 3 |

Only X coincidentally matched, so every other size trained under a different scale distribution than the recipe it claims to follow.

Changes:
- `DFINEConfig.base_size_repeat: Optional[int] = None` — `None` resolves the upstream per-size default via a new `resolve_dfine_base_size_repeat()` (next to the mapping in `training/config.py`, same precedent as `DEIMV2_SIZE_DEFAULTS`); an int overrides for every size. This mirrors how the DEIM trainer already reads the same knob from its config.
- The D-FINE trainer resolves the value through a small `_train_base_size_repeat()` hook instead of the constant. No collate changes: `DetrMultiScaleCollate` already treats `None` as "keep every batch at `base_size`", which is exactly upstream's `~` for the N size.
- Unknown sizes fall back to the legacy 3.

The DEIMv2/EC Dense O2O gap from #675 is a feature-sized change (new augmentation capability in the pass-through path) and is intentionally not part of this PR; the issue stays open for it.

## Proof

New unit tests pin the mapping to the upstream values, the resolution order (config override > per-size default > legacy 3), the collate behavior at `None` and `20`, and the kwarg-to-collate wiring through a real `DFINETrainer`.

End-to-end over coco128 (real trainers + dataloaders, epoch 0):

```
dfine-n default:     scales=None            batches seen: [(640, 640)]
dfine-n override=20: scales=[480..800]      batches seen: [(512,512), (640,640), (704,704), (736,736)]
dfine-s default:     scales=[480..800, 640x20]  batches seen: [(640,640), (672,672), (768,768), (800,800)]
```

## Test plan

- [x] `tests/unit/test_dfine_base_size_repeat.py` (new, 12 tests)
- [x] `pytest tests/unit -k "dfine or config"` — 297 passed, 8 skipped
- [x] End-to-end collate inspection over coco128 (above)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces D-FINE’s hardcoded multi-scale base-size repeat with upstream-compatible defaults selected by model size, while preserving an explicit configuration override and the legacy fallback for unknown sizes.
- Adds the n/s/m/l/x repeat mapping and resolver to the training configuration.
- Wires the resolved repeat into D-FINE’s multi-scale collate setup.
- Adds focused tests for defaults, overrides, fallback behavior, fixed-size semantics, and trainer wiring.
- Documents the corrected training recipe in the changelog.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new per-size defaults correctly propagated to the D-FINE collate path.

Valid D-FINE sizes resolve to the intended repeat values, explicit integer overrides take precedence, unknown sizes retain the prior value, and the collate safely treats the N-size None value as fixed-size batching.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/config.py | Adds the optional D-FINE override, upstream per-size defaults, and deterministic resolution order without disrupting existing configuration construction. |
| libreyolo/models/dfine/trainer.py | Replaces the hardcoded collate repeat with the resolved value; the inherited collate correctly interprets the N-size None default as fixed-size batching. |
| tests/unit/test_dfine_base_size_repeat.py | Covers every mapped size, override precedence, unknown-size fallback, collate semantics, and trainer configuration wiring. |
| CHANGELOG.md | Accurately describes the corrected per-size D-FINE training behavior and override surface. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Give D-FINE training upstream&#39;s per-size..."](https://github.com/libreyolo/libreyolo/commit/0280cdfb89f02c2ceb473f9ddbce6e7c833dab8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49380990)</sub>

<!-- /greptile_comment -->