### PR TITLE
Add a model-PRD skill, and let agents open PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,14 +113,15 @@
 - Keep PRs to the least code needed to solve the stated problem.
 - Do not mention other computer vision libraries in PR titles or descriptions
   unless the comparison is necessary to explain compatibility or API behavior.
-- Whether the agent opens the PR or hands over a pre-filled link, the title and
-  description are written to be read by a human reviewer, not as a transcript of
-  what the agent did. The required `## Code provenance` section must be accurate
-  for the actual diff, never a placeholder, or the `provenance-check` CI gate
-  fails.
-- An agent that opens a PR says so plainly in the description and states what it
-  verified and what it did not. It never implies review or approval it does not
-  have.
+- **Agent-written PR descriptions are short and factual.** Bullets, not prose.
+  What changed, why, what the reviewer should check, what was not verified.
+  No narration of the agent's process, no restating of its own reasoning, no
+  adjectives, no selling. Ten lines beats fifty. A human who wants the longer
+  story will ask for it or write it themselves.
+- The required `## Code provenance` section must be accurate for the actual
+  diff, never a placeholder, or the `provenance-check` CI gate fails.
+- An agent that opens a PR says so in one line, and states what it verified and
+  what it did not. It never implies review or approval it does not have.
 
 ## General library constraints
 - Generally every user facing API (Python, yamls, etc) has to follow the de-facto YOLO CLI/API conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@
   Opening a PR is where an agent's authority stops: it does not approve, does
   not merge, and does not dismiss review findings.
 - Agents must not post issue comments or PR comments unless a human explicitly
-  asks for it. Replying to review findings on the agent's own PR is part of the
-  work and is allowed.
+  asks for it. This holds on the agent's own PR too: address review findings by
+  pushing a commit, and put anything else in the summary to the human.
 - Humans handle issue creation, review submission, and final merge decisions.
 - Handing over a one-click pre-filled GitHub URL instead of opening the PR
   remains a valid option, and is the better one when the work is exploratory or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,17 +27,20 @@
 ## Agent conduct
 
 - Agents must not open GitHub issues.
-- Agents must not open pull requests.
+- Agents may open pull requests. The PR must target `dev`, and its description
+  must include a `## Code provenance` section that is accurate for the actual
+  diff (see `.github/pull_request_template.md` and the `merge-to-dev` skill).
+  Opening a PR is where an agent's authority stops: it does not approve, does
+  not merge, and does not dismiss review findings.
 - Agents must not post issue comments or PR comments unless a human explicitly
-  asks for it.
-- Humans handle issue creation, PR creation, review submission, and final merge
-  decisions.
-- Agents may reply with a one-click GitHub URL so the human can open the PR or
-  issue themselves, and should pre-fill it. For a PR, pre-fill the title and a
-  description that includes the required `## Code provenance` section (see
-  `.github/pull_request_template.md` and the `merge-to-dev` skill); for an
-  issue, the `libreyolo-report-issue` skill already does this. Pre-filling the
-  handoff URL is expected; opening the PR itself (e.g. `gh pr create`) is not.
+  asks for it. Replying to review findings on the agent's own PR is part of the
+  work and is allowed.
+- Humans handle issue creation, review submission, and final merge decisions.
+- Handing over a one-click pre-filled GitHub URL instead of opening the PR
+  remains a valid option, and is the better one when the work is exploratory or
+  the human wants the description in their own words. For an issue, which an
+  agent still may not open, the `libreyolo-report-issue` skill produces that
+  pre-filled link.
 - When possible, work in git worktrees
 - `release` is the default branch that visitors land on and clone; `dev` is the
   integration branch where all development lands before it is promoted to a release.
@@ -110,11 +113,14 @@
 - Keep PRs to the least code needed to solve the stated problem.
 - Do not mention other computer vision libraries in PR titles or descriptions
   unless the comparison is necessary to explain compatibility or API behavior.
-- The agent pre-fills a draft PR title and description (including the required
-  `## Code provenance` section); the human edits it into their own words before
-  submitting, so the history stays easy for reviewers and future readers to
-  follow. The provenance section must be accurate for the actual diff, never a
-  placeholder, or the `provenance-check` CI gate fails.
+- Whether the agent opens the PR or hands over a pre-filled link, the title and
+  description are written to be read by a human reviewer, not as a transcript of
+  what the agent did. The required `## Code provenance` section must be accurate
+  for the actual diff, never a placeholder, or the `provenance-check` CI gate
+  fails.
+- An agent that opens a PR says so plainly in the description and states what it
+  verified and what it did not. It never implies review or approval it does not
+  have.
 
 ## General library constraints
 - Generally every user facing API (Python, yamls, etc) has to follow the de-facto YOLO CLI/API conventions

--- a/skills/libreyolo-write-model-prd/SKILL.md
+++ b/skills/libreyolo-write-model-prd/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: libreyolo-write-model-prd
+description: >-
+  Write the PRD (port handoff) for adding a new model to LibreYOLO: the
+  single markdown document an implementing agent executes end to end. Use when
+  someone proposes a model ("should we add X?", "can we port X?", "write a PRD
+  for X", "what would it take to add X"), when triaging a model-request issue,
+  or when building a batch of candidates for the museum tier. Covers the
+  already-in-the-tree check, the license gate, choosing the port source and
+  scaffold, the fixed PRD section template, and publishing the result to a
+  gist registered in issue #637. This is the planning half; the execution half
+  is `libreyolo-port-model`.
+---
+
+# Write a PRD for adding a model to LibreYOLO
+
+The deliverable is **one markdown file** that an implementing agent can follow
+without further research: what the model is, whether we may legally ship it,
+where to port it from, what to clone, what gates to pass, and what will silently
+break. If the reader has to go re-derive the license or hunt for a scaffold, the
+PRD failed.
+
+This skill does not port anything. When the PRD is approved, the implementer
+follows `libreyolo-port-model` (and `libreyolo-upload-hf-model` at the weights
+step). Keep the PRD free of process the skills already own: cite the skill
+section instead of restating it.
+
+## 1. First question: is it already in the tree?
+
+Do this before any research. It is the cheapest step and the most expensive one
+to skip.
+
+```bash
+git fetch upstream dev
+git ls-tree --name-only upstream/dev:libreyolo/models/
+```
+
+**Always inventory `dev`, never a feature branch.** `dev` carries far more
+families than any working branch. A campaign that inventoried a feature branch
+wrote a complete PRD for YOLOv1, which had already shipped as
+`libreyolo/models/yolo1/`, and nearly instructed an agent to create
+`libreyolo/models/swin/`, which already exists and holds a shared backbone that
+Grounding DINO imports.
+
+Check four things, not one:
+
+1. The family directory (`libreyolo/models/<family>/`).
+2. The `FAMILY` id and `FILENAME_PREFIX` you intend to claim, against every
+   existing family.
+3. The architecture as a **component**. A model can already be in the tree as a
+   shared backbone or neck without being a family of its own
+   (`git grep -l "<ArchName>" upstream/dev -- libreyolo`).
+4. `docs/nomenclature.md` and `weights/LICENSE_NOTICE.txt`, which sometimes
+   record a family before or after the code moves.
+
+If it already exists, **stop and write a short note instead of a PRD**: what is
+shipped, what is genuinely missing, and the one or two residual tasks worth
+doing. Register that note the same way (section 6). A PRD for a shipped model
+wastes an entire implementation cycle.
+
+## 2. License gate
+
+Run `libreyolo-license-audit` for the verdict. Do not improvise licensing
+judgement here. What this skill adds is what the PRD must *record*.
+
+Two different bars, and collapsing them is the most common error:
+
+- **Code** vendored into core must be MIT, Apache-2.0 or BSD. No GPL, AGPL,
+  LGPL, non-commercial or unknown-license code, ever, including rewrites.
+- **Weights** only need to be **redistributable**. Non-commercial weights are
+  shippable when tagged accordingly. Weights that forbid redistribution are not
+  a blocker either: link upstream instead of rehosting (the YOLO-NAS precedent).
+
+Consequences the PRD must state explicitly:
+
+- **A permissive reimplementation rescues a tainted original.** Both original
+  FCOS repos open with a non-commercial clause, so neither may be read or
+  ported, but torchvision ships a BSD-3 FCOS and that is a clean path. Name the
+  source to use *and* the source to stay out of.
+- **Never launder.** Rewriting non-permissive code to disguise its origin is
+  prohibited regardless of how the result looks.
+- **Primary sources only, with evidence URLs in the PRD.** The GitHub license
+  API (`https://api.github.com/repos/<org>/<repo>/license`), the raw `LICENSE`
+  file, and the HF model card YAML. Never a recollection, never a badge.
+- **Say "implied" when it is implied.** Most weights carry no per-artifact
+  license and inherit it from the releasing repository. torchvision publishes
+  none at all and explicitly disclaims that pretrained models "may have their
+  own licenses or terms and conditions derived from the dataset used for
+  training". Write that distinction on the model card rather than upgrading an
+  inference into a stated grant.
+- **Check per-variant, not per-model.** Licenses differ across sizes and
+  generations. MiDaS is MIT, but its v2 and v2.1 checkpoints were fine-tuned
+  from CC-BY-NC pretraining, so only some variants are clean.
+- **Watch the backbone init.** A "trained by us" checkpoint often starts from a
+  third-party backbone whose license still applies.
+- **Beware the popular decoy.** The most-starred implementation is often the
+  unusable one. Name it in the PRD so nobody finds it later and assumes it is
+  fine.
+
+## 3. Port source and scaffold
+
+Pick the source that combines permissive code with loadable weights, preferring
+the one whose module names match the checkpoints so conversion stays a
+metadata-wrap. State the runner-up and why it lost, because the implementer will
+otherwise rediscover it.
+
+For the scaffold, read the per-family ledger in `libreyolo-port-model`
+(its section 4) and name a concrete directory to clone. Then check the
+identifiers you are claiming do not collide, and list the families whose
+`can_load` could steal your checkpoints, so the PRD can require bidirectional
+rejection tests.
+
+## 4. Scope and maturity
+
+Say which tasks are in scope and declare `SUPPORTED_TASKS` explicitly. Then pick
+a maturity target from `libreyolo-port-model` section 2, and remember that
+**inference-only is a legitimate ship state**. A PRD that gates delivery on a
+working trainer will usually stall. Make the trainer a follow-up unless training
+is the point of the port.
+
+## 5. The PRD document
+
+Use these sections, in this order. It is the shape that has survived adversarial
+review, and a consistent shape is what lets an implementing agent trust it.
+
+```
+# Handoff: add <MODEL> as a LibreYOLO <task> family
+
+**For:** an implementing agent starting fresh.
+**Process authority:** skills/libreyolo-port-model/SKILL.md.
+
+## 0. Mandatory gates          (the non-negotiables, see below)
+## 1. The model                (architecture, variants/sizes, historic significance)
+## 2. License                  (verdict + evidence URLs + rehost-or-link decision)
+## 3. Why we did not add it before
+## 4. Why we are adding it now
+## 5. Head start already in-tree (closest scaffold, and its traps)
+## 6. Scope and maturity
+## 7. Implementation pointers  (family id, can_load, converter, export contract)
+## 8. Definition of done       (checklist mirroring section 0)
+```
+
+Section 0 always carries these gates:
+
+1. **Upstream parity**: `max_abs_diff == 0.0` in eval mode against the
+   recommended source, for every shipped size, before any postprocess, export or
+   trainer code exists. If the port vendors the same implementation it compares
+   against, that check is tautological: say so and give a meaningful alternative
+   (published metric reproduction, or parity against the reference the weights
+   came from).
+2. **Export parity**, separately: the exported graph must match our PyTorch
+   output on the same image. "The export runs" is not the bar (see section 7).
+3. **Weights**: rehost per `libreyolo-upload-hf-model` when redistributable, or
+   link upstream when not. Verify auto-download on a cleared cache.
+4. **Tests**: the right registration for the task (see section 7).
+5. **UI smoke check**: load one converted checkpoint through the UI and confirm
+   predict renders.
+
+Close with the branch rule: branch off `dev` and land the work through
+`merge-to-dev`. An agent may open the PR but never approves or merges it. The PR
+body must contain a filled `## Code provenance` section, which
+`provenance-check.yml` enforces by matching a `^#{1,6}\s*code provenance$`
+heading and failing when it is missing or empty.
+
+Style: no em dashes or en dashes, no personal names, no machine-specific paths.
+State only what you verified, and tell the implementer to verify at port time
+where you could not.
+
+## 6. Publish and register
+
+A PRD nobody can find is lost work.
+
+1. Publish it as a **public gist** (`gh gist create <file> --public --desc "..."`).
+   Per-file anchors are the filename lowercased with dots turned into hyphens,
+   for example `#file-handoff_detr_detect-md`.
+2. Register it in **issue #637, "Model candidates to be added to the library"**:
+   https://github.com/LibreYOLO/libreyolo/issues/637
+   Edit the issue body, put the model under its task category (Detection,
+   Instance segmentation, Classification, Semantic segmentation, Keypoint/pose,
+   Depth), and follow the existing line format:
+
+   ```
+   - <Model>: <paper or repo url> (<license summary>). Handoff: <gist anchor url>
+   ```
+
+   Models already shipped go in the `ADDED` section at the bottom with their
+   family name, not in the candidate list.
+3. Before publishing anything, scan for leakage: no real names, usernames,
+   emails, absolute machine paths, or credentials. Repo-relative paths only.
+
+Keep the issue and the gist in sync. The issue is the index; the gist is the
+content.
+
+## 7. Facts PRD authors get wrong
+
+Verified against `dev`. Each of these has already shipped in a PRD and had to be
+corrected.
+
+- **`from_pretrained` does not exist.** `LibreYOLO` is a factory *function*
+  (`libreyolo/models/__init__.py`) that takes a path. The auto-download check is
+  `LibreYOLO("Libre<Family><size>.pt")` on a cleared cache with no staged copy
+  under `weights/`. Note that `libreyolo-port-model` and
+  `libreyolo-upload-hf-model` both still show a stale `from_pretrained` form;
+  do not copy it into a PRD.
+- **A non-YOLO-grid export needs two backend edits, not one.**
+  `_is_nms_free_family()` is a module-level function in
+  `libreyolo/backends/base.py` (not a `BaseBackend` method) and only decides
+  whether NMS is re-applied *after* parsing. The parse itself is family
+  dispatched in `_parse_outputs`, whose final `else` falls through to
+  `_parse_yolo9` and reads the graph as a `(4+nc, N)` YOLO tensor. A DETR-shaped
+  graph parsed that way returns garbage while appearing to export fine. Route to
+  `_parse_dfine` like the shipped DETR families. Never cite line numbers for
+  either: they move between branches.
+- **`MODEL_CATALOG` is detect-only.** It drives `test_val_coco128.py` and its
+  mAP50-95 gate, so a classify, depth or semantic-segmentation row fails by
+  construction. Point those families at a per-family unit suite instead, and
+  check what the closest merged family actually registers before writing the
+  gate.
+- **Historic model, modern artifact.** For older models the cleanly licensed
+  implementation is often not the historic one: torchvision's AlexNet is the
+  "one weird trick" variant, its VGG weights were trained from scratch rather
+  than converted from the original release, and its FCN has no skip fusion. Ship
+  the modern rebuild if you like, but require the PRD to say so plainly on the
+  model card rather than exhibiting a replica under a historic name.
+- **Weight hosting rots.** Checkpoints living only on Google Drive or a personal
+  academic host need rehosting early in the port, not at the end.

--- a/skills/merge-to-dev/SKILL.md
+++ b/skills/merge-to-dev/SKILL.md
@@ -119,12 +119,32 @@ required provenance section comes up blank. GitHub honours `title` and `body`
 query params on the compare page, so pre-fill them yourself and the human
 lands on a PR form already filled in.
 
-Write the body the way `.github/pull_request_template.md` asks: a normal
-description in whatever shape fits the change, plus, **required, a
-`## Code provenance` section**. The `provenance-check` CI gate fails the PR
-if that section is missing or empty, so it is the one part you must always
-include. Keep it short, factual prose, matching the repo's house style, no
-checkboxes and no tables:
+Write the body the way `.github/pull_request_template.md` asks: a description
+plus, **required, a `## Code provenance` section**. The `provenance-check` CI
+gate fails the PR if that section is missing or empty, so it is the one part you
+must always include.
+
+**Keep it short and factual. Bullets, not prose.** Per `AGENTS.md`: what
+changed, why, what to check, what was not verified. No process narration, no
+adjectives, no selling. Ten lines beats fifty. Shape:
+
+```markdown
+What: <one line>
+Why: <one line>
+
+- <change 1>
+- <change 2>
+
+Check: <what the reviewer should look at>
+Not verified: <what you did not test, or "nothing outstanding">
+Opened by an agent.
+
+## Code provenance
+<one accurate line, see below>
+```
+
+For the provenance section itself, short factual prose, no checkboxes and no
+tables:
 
 - First-party only: a `## Code provenance` heading followed by one line, e.g.
   "Original code written for this PR; bug fixes to LibreYOLO's own first-party

--- a/skills/merge-to-dev/SKILL.md
+++ b/skills/merge-to-dev/SKILL.md
@@ -2,11 +2,11 @@
 name: merge-to-dev
 description: >-
   The whole dance for landing code on LibreYOLO's dev branch: branch, commit,
-  push to upstream, then hand the user a one-click compare URL that pre-fills
-  the PR title and description (including the required Code provenance section)
-  for them to review and submit (agents must not open the PR themselves),
-  and once they have opened it, babysit the Greptile bot review until it is
-  happy. Use whenever the user says "put this on dev", "push this to dev",
+  push to upstream, then either open the PR against dev or hand the user a
+  one-click compare URL that pre-fills the PR title and description (including
+  the required Code provenance section), and once the PR exists, babysit the
+  Greptile bot review until it is happy. Agents may open the PR but never
+  approve or merge it. Use whenever the user says "put this on dev", "push this to dev",
   "merge this to dev", "ship this", "open a PR for this", or hands over
   finished work on LibreYOLO/libreyolo. The user should never have to ask for
   the PR link; producing it is the task.
@@ -15,14 +15,22 @@ description: >-
 # Merge code to dev
 
 There is exactly one way code lands on `dev` in `LibreYOLO/libreyolo`:
-**branch -> commit -> push to upstream -> the human opens a PR with base
-`dev`**. Never push to `dev` directly, even though the account has admin.
-And per `AGENTS.md`, the **agent never opens the PR**: it pushes the branch
-and hands over a one-click compare URL that pre-fills the PR title and
-description (with the required Code provenance section), and the human reviews
-and submits it. When the user says "put this on dev", run the dance below
-and end your turn with that link, not with a question and not with a PR you
-opened yourself.
+**branch -> commit -> push to upstream -> a PR with base `dev`**. Never push to
+`dev` directly, even though the account has admin.
+
+Per `AGENTS.md`, an agent **may open that PR**, but opening it is where the
+agent's authority stops: never approve, never merge, never dismiss a review
+finding. Two valid endings, and the choice is the user's:
+
+- **Open the PR** (`gh pr create --base dev`) when the user asked for a PR or
+  the work is finished and self-contained. Say in the description that an agent
+  opened it, and what was verified.
+- **Hand over a one-click compare URL** that pre-fills the title and description
+  (with the required Code provenance section) when the work is exploratory, or
+  the user wants the description in their own words.
+
+Either way the description carries an accurate `## Code provenance` section, and
+you end your turn with the PR or compare link, not with a question.
 
 ## Environment gotchas (read first, they bite every session)
 
@@ -136,22 +144,22 @@ python -c "import urllib.parse,sys; print('https://github.com/LibreYOLO/libreyol
 
 Hand the user that single pre-filled link and stop.
 
-**Pre-filling the URL is allowed; opening the PR is not.** `AGENTS.md`:
-"Agents must not open pull requests"; "Humans handle ... PR creation." So
-never run `gh pr create`; hand the pre-filled compare URL and let the human
-review, edit the prose into their own words, and submit. The `## Code
-provenance` section is the accurate part you own; never leave it blank or the
-CI gate fails.
+**Or open it yourself.** `AGENTS.md` allows an agent to open the PR
+(`gh pr create --base dev --title ... --body ...`), but never to approve, merge,
+or dismiss a review finding. Prefer opening it when the user asked for a PR;
+prefer the pre-filled link when the work is exploratory or the user wants the
+prose in their own words. Either way the `## Code provenance` section is the
+part you own: never leave it blank or the CI gate fails, and never let the
+description imply a review that has not happened.
 
 **Deliver the link without being asked.** "Pushed the branch" is not a
-finished turn; the link is the deliverable. CI (`unit-tests.yml`,
-`install-smoke.yml`) runs once the human opens the PR to `dev`, so their
-click is also what starts the CI signal.
+finished turn; the PR or the compare link is the deliverable. CI
+(`unit-tests.yml`, `install-smoke.yml`) runs once the PR to `dev` exists.
 
-### 5. Babysit Greptile (after the human opens the PR)
+### 5. Babysit Greptile (after the PR is open)
 
-This step needs a PR to exist, so it starts once the human has opened it
-from your link (or tells you "it's open" / "ship it"). Do not sit polling
+This step needs a PR to exist, so it starts once you have opened it or the
+human has (or tells you "it's open" / "ship it"). Do not sit polling
 for a PR number before then. When the PR author is one of the repo admins,
 the Greptile bot reviews the PR automatically a few minutes after it opens
 (and again after each push).
@@ -223,8 +231,8 @@ merging to dev is their click.
 ## Anti-patterns
 
 - Pushing to `dev` or `release` directly. Never, admin or not.
-- Opening the PR yourself with `gh pr create`. `AGENTS.md` forbids it; hand
-  the one-click compare URL and let the human submit.
+- Approving or merging your own PR, or dismissing a Greptile finding to make a
+  check go green. Opening the PR is allowed; deciding it is good is not.
 - Handing a bare `?expand=1` link with no `&body=`. It leaves the required
   `## Code provenance` section blank, so the `provenance-check` CI gate fails.
 - Padding the description with checkbox lists or a provenance table. The


### PR DESCRIPTION
What: new skill for writing model-port PRDs, plus agents may now open PRs.
Why: the "how do we add this model" doc had no owner, so each one repeated the same mistakes.

- `skills/libreyolo-write-model-prd/` (new). Planning half of a port. Licensing delegates to `libreyolo-license-audit`, execution to `libreyolo-port-model`.
- Encodes three tree-verified facts PRDs keep getting wrong: `from_pretrained` does not exist (`LibreYOLO` is a factory function); non-YOLO-grid exports need a `_parse_outputs` branch, not just `_is_nms_free_family()`; `MODEL_CATALOG` is detect-only.
- Makes "is it already shipped?" step one, inventoried against `dev`. A PRD was written for YOLOv1, already shipped; another nearly told an agent to overwrite `libreyolo/models/swin/`, which Grounding DINO imports.
- `AGENTS.md` + `merge-to-dev`: agents may open PRs against `dev`. No approving, no merging, no dismissing findings. Agents still may not open issues.
- `AGENTS.md` + `merge-to-dev`: agent PR descriptions must be short and factual.

Check: the policy wording in `AGENTS.md` "Agent conduct" and "Pull Request (PR) policy".
Not verified: docs only, no library code touched. Commit 2 is independently revertable.
Follow-up, not in this PR: `libreyolo-port-model` and `libreyolo-upload-hf-model` still carry the stale `from_pretrained` form.
Opened by an agent.

## Code provenance

Original prose written for this PR. No third-party code or text ported, adapted, or derived; no GPL/AGPL/LGPL/non-commercial/unknown-license material involved. The new skill quotes only LibreYOLO's own files and links public upstream URLs for reference.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates repository policy to let agents open pull requests against `dev` and adds a planning skill for model-port PRDs.
- Aligns agent conduct and `merge-to-dev` guidance around PR creation, provenance, concise descriptions, and human-only review decisions.
- Adds checks for existing model implementations, licensing, port scaffolds, export behavior, test registration, and PRD publication.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Allows agents to open PRs while consistently reserving comments, review decisions, and merges for explicitly authorized human workflows. |
| skills/libreyolo-write-model-prd/SKILL.md | Adds a structured model-port planning workflow covering inventory, licensing, implementation scope, validation gates, and publication. |
| skills/merge-to-dev/SKILL.md | Updates the development PR workflow to support either agent-opened PRs or human handoff links while preserving review and merge boundaries. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Drop the agent PR-comment permission"](https://github.com/libreyolo/libreyolo/commit/956f32cd7001c005f8f7a5cd0714de58d218c5e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49382721)</sub>

<!-- /greptile_comment -->