### PR TITLE
Fix CUDA-graph capture race with DataLoader pin-memory threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- CUDA graph capture no longer races with DataLoader pin-memory threads:
+  training capture (`train(..., cuda_graph=True)`) and inference/validation
+  capture now run with `capture_error_mode="thread_local"`, so a
+  `cudaHostAlloc` from a pin-memory thread staging the next batch can no
+  longer invalidate the capture and poison that thread (previously the run
+  died with "AcceleratorError ... in pin memory thread" /
+  `cudaErrorStreamCaptureUnsupported`; observed twice on an RF100-VL
+  campaign with `pin_memory` dataloaders)
 - D-FINE training now applies upstream's per-size multi-scale recipe instead
   of a hardcoded `base_size_repeat=3`: n trains at fixed size, s uses 20,
   m 6, l 4, x 3 (Peterande/D-FINE custom fine-tune configs; only X matched

--- a/libreyolo/models/base/cuda_graph.py
+++ b/libreyolo/models/base/cuda_graph.py
@@ -331,7 +331,19 @@ class GraphRunner:
             torch.cuda.synchronize()
 
             graph = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(graph, pool=self._pool, stream=stream):
+            # thread_local: only this thread is restricted during capture.
+            # Under the default "global" mode, a DataLoader pin-memory
+            # thread staging the next batch (cudaHostAlloc) would both
+            # invalidate the capture and be poisoned by it, killing the
+            # run on its next batch fetch. The pin thread never touches
+            # the capturing stream, so nothing it does belongs in the
+            # graph.
+            with torch.cuda.graph(
+                graph,
+                pool=self._pool,
+                stream=stream,
+                capture_error_mode="thread_local",
+            ):
                 output = self.forward_fn(static_input)
 
         static_outputs, skeleton = _flatten(output)

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -55,13 +55,53 @@ trajectory as identical between eager and graphed runs.
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 import torch
 from torch import nn
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _thread_local_capture_errors() -> Iterator[None]:
+    """Make ``make_graphed_callables`` capture with ``thread_local`` errors.
+
+    Capture defaults to ``capture_error_mode="global"``, under which a CUDA
+    call from *any* host thread invalidates the capture. A DataLoader with
+    ``pin_memory=True`` keeps a pin-memory thread alive that calls
+    ``cudaHostAlloc`` whenever it stages the next prefetched batch, so a
+    lazy capture taken on a live training batch races with it: the capture
+    dies with ``cudaErrorStreamCaptureUnsupported`` and, worse, the error
+    poisons the pin-memory thread, which re-raises on the next batch fetch
+    and kills the whole run (observed twice on the first RF100-VL Vast
+    campaign, as "AcceleratorError ... in pin memory thread").
+
+    ``thread_local`` is PyTorch's documented mode for exactly this
+    situation: only the capturing thread is restricted during capture, and
+    other threads' CUDA calls proceed normally without being captured. The
+    pin-memory thread touches only its own pinned host buffers, never the
+    capturing stream, so nothing it does belongs in the graph.
+
+    ``make_graphed_callables`` constructs its own ``CUDAGraph`` objects and
+    exposes no way to choose the mode, so for the duration of the call the
+    ``torch.cuda.CUDAGraph`` symbol it instantiates is swapped for a
+    subclass that forces the mode at ``capture_begin``.
+    """
+    original = torch.cuda.CUDAGraph
+
+    class _ThreadLocalCaptureGraph(original):  # type: ignore[misc, valid-type]
+        def capture_begin(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["capture_error_mode"] = "thread_local"
+            super().capture_begin(*args, **kwargs)
+
+    torch.cuda.CUDAGraph = _ThreadLocalCaptureGraph
+    try:
+        yield
+    finally:
+        torch.cuda.CUDAGraph = original
 
 # A shape must repeat this many times before capture pays off. One-shot
 # shapes (a lone odd-size batch) then never capture, while any steady-state
@@ -301,19 +341,20 @@ class TrainGraphManager:
             # modes to the same trajectory. The TypeError retry keeps older
             # torch versions without the keyword working.
             sample = (imgs.detach().clone(),)
-            try:
-                graphed = torch.cuda.make_graphed_callables(
-                    spec.network,
-                    sample,
-                    num_warmup_iters=self.num_warmup_iters,
-                    allow_unused_input=True,
-                )
-            except TypeError:
-                graphed = torch.cuda.make_graphed_callables(
-                    spec.network,
-                    sample,
-                    num_warmup_iters=self.num_warmup_iters,
-                )
+            with _thread_local_capture_errors():
+                try:
+                    graphed = torch.cuda.make_graphed_callables(
+                        spec.network,
+                        sample,
+                        num_warmup_iters=self.num_warmup_iters,
+                        allow_unused_input=True,
+                    )
+                except TypeError:
+                    graphed = torch.cuda.make_graphed_callables(
+                        spec.network,
+                        sample,
+                        num_warmup_iters=self.num_warmup_iters,
+                    )
         except Exception as exc:
             self._disable(f"graph capture failed: {exc!r}")
             # A failed capture can leave asynchronous stream-capture errors

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -55,6 +55,7 @@ trajectory as identical between eager and graphed runs.
 from __future__ import annotations
 
 import logging
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
@@ -63,6 +64,14 @@ import torch
 from torch import nn
 
 logger = logging.getLogger(__name__)
+
+# Serializes the torch.cuda.CUDAGraph swap below. Without it, two host
+# threads capturing concurrently would each save a different "original"
+# (the second thread saves the first thread's subclass) and the interleaved
+# restores could leave a temporary subclass installed for the rest of the
+# process. Capture is rare and takes seconds, so holding the lock across
+# the whole capture is fine.
+_capture_patch_lock = threading.Lock()
 
 
 @contextmanager
@@ -90,18 +99,19 @@ def _thread_local_capture_errors() -> Iterator[None]:
     ``torch.cuda.CUDAGraph`` symbol it instantiates is swapped for a
     subclass that forces the mode at ``capture_begin``.
     """
-    original = torch.cuda.CUDAGraph
+    with _capture_patch_lock:
+        original = torch.cuda.CUDAGraph
 
-    class _ThreadLocalCaptureGraph(original):  # type: ignore[misc, valid-type]
-        def capture_begin(self, *args: Any, **kwargs: Any) -> None:
-            kwargs["capture_error_mode"] = "thread_local"
-            super().capture_begin(*args, **kwargs)
+        class _ThreadLocalCaptureGraph(original):  # type: ignore[misc, valid-type]
+            def capture_begin(self, *args: Any, **kwargs: Any) -> None:
+                kwargs["capture_error_mode"] = "thread_local"
+                super().capture_begin(*args, **kwargs)
 
-    torch.cuda.CUDAGraph = _ThreadLocalCaptureGraph
-    try:
-        yield
-    finally:
-        torch.cuda.CUDAGraph = original
+        torch.cuda.CUDAGraph = _ThreadLocalCaptureGraph
+        try:
+            yield
+        finally:
+            torch.cuda.CUDAGraph = original
 
 # A shape must repeat this many times before capture pays off. One-shot
 # shapes (a lone odd-size batch) then never capture, while any steady-state

--- a/tests/unit/test_cuda_graph.py
+++ b/tests/unit/test_cuda_graph.py
@@ -463,3 +463,52 @@ def test_capture_raises_rather_than_falling_back():
     with torch.no_grad():
         with pytest.raises(CudaGraphUnavailable, match="capture failed"):
             runner.capture(torch.randn(1, 3, 32, 32, device="cuda"))
+
+
+@requires_cuda
+def test_capture_survives_concurrent_pinned_allocations():
+    """Capture must use capture_error_mode="thread_local".
+
+    Under the default "global" mode a cudaHostAlloc from any other host
+    thread — which is exactly what a DataLoader pin-memory thread does while
+    staging the next batch — invalidates the capture and poisons that
+    thread. Seen in the wild during training-time validation on the first
+    RF100-VL Vast campaign.
+    """
+    import threading
+
+    net = torch.nn.Conv2d(3, 8, 3, padding=1).cuda().eval()
+    runner = GraphRunner(forward_fn=net, family="fake")
+    x = torch.randn(1, 3, 32, 32, device="cuda")
+
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    def hammer():
+        held = []
+        size = 0
+        while not stop.is_set():
+            try:
+                # Strictly growing sizes defeat the caching host allocator,
+                # so every iteration is a real cudaHostAlloc.
+                held.append(
+                    torch.empty(4096 + size * 640, dtype=torch.uint8).pin_memory()
+                )
+                size += 1
+            except BaseException as exc:  # must never happen
+                errors.append(exc)
+                return
+
+    thread = threading.Thread(target=hammer, daemon=True)
+    thread.start()
+    try:
+        with torch.no_grad():
+            out = runner.run(x)
+    finally:
+        stop.set()
+        thread.join(timeout=30)
+
+    assert not errors, f"pin-memory stand-in thread was poisoned: {errors[0]!r}"
+    assert runner.info()["graph_count"] == 1
+    assert runner.info()["fallback_reason"] is None
+    torch.testing.assert_close(out, net(x))

--- a/tests/unit/test_cuda_graph_training.py
+++ b/tests/unit/test_cuda_graph_training.py
@@ -190,6 +190,33 @@ class TestThreadLocalCaptureErrors:
                 raise RuntimeError("boom")
         assert torch.cuda.CUDAGraph is original
 
+    def test_concurrent_contexts_serialize_and_restore_the_original(self):
+        """Unsynchronized, two overlapping contexts would each save a
+        different "original" (the second saves the first's subclass) and
+        the interleaved restores could leave a temporary subclass installed
+        for the rest of the process. The patch lock must serialize them:
+        every context sees the true original as its base class, and the
+        true original is what remains at the end."""
+        import threading
+        import time
+
+        original = torch.cuda.CUDAGraph
+        bases = []
+
+        def use_context():
+            with _thread_local_capture_errors():
+                bases.append(torch.cuda.CUDAGraph.__mro__[1])
+                time.sleep(0.02)
+
+        threads = [threading.Thread(target=use_context) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert torch.cuda.CUDAGraph is original
+        assert bases == [original] * 4
+
     def test_forces_thread_local_at_capture_begin(self):
         class FakeGraph:
             def capture_begin(self, *args, **kwargs):

--- a/tests/unit/test_cuda_graph_training.py
+++ b/tests/unit/test_cuda_graph_training.py
@@ -18,6 +18,7 @@ from libreyolo.training.cuda_graph import (
     CudaGraphTrainSpec,
     GraphableNetwork,
     TrainGraphManager,
+    _thread_local_capture_errors,
     flatten_tree,
     unflatten_tree,
 )
@@ -160,6 +161,110 @@ class TestTrainGraphManager:
             assert manager.run(spec, imgs) == ("flat",)
         assert manager.run(spec, imgs) is None
         assert manager.disabled
+
+
+# =============================================================================
+# Capture error mode (pin-memory thread race)
+# =============================================================================
+#
+# Capture defaults to capture_error_mode="global", under which a cudaHostAlloc
+# from a DataLoader pin-memory thread invalidates the capture AND poisons the
+# pin thread, killing the run on the next batch fetch (seen twice on the first
+# RF100-VL Vast campaign as "AcceleratorError ... in pin memory thread").
+# Capture must therefore run in "thread_local" mode, where other threads'
+# CUDA calls proceed normally.
+
+
+class TestThreadLocalCaptureErrors:
+    def test_swaps_and_restores_cudagraph_symbol(self):
+        original = torch.cuda.CUDAGraph
+        with _thread_local_capture_errors():
+            assert torch.cuda.CUDAGraph is not original
+            assert issubclass(torch.cuda.CUDAGraph, original)
+        assert torch.cuda.CUDAGraph is original
+
+    def test_restores_on_exception(self):
+        original = torch.cuda.CUDAGraph
+        with pytest.raises(RuntimeError, match="boom"):
+            with _thread_local_capture_errors():
+                raise RuntimeError("boom")
+        assert torch.cuda.CUDAGraph is original
+
+    def test_forces_thread_local_at_capture_begin(self):
+        class FakeGraph:
+            def capture_begin(self, *args, **kwargs):
+                self.begin_kwargs = kwargs
+
+        with patch("torch.cuda.CUDAGraph", FakeGraph):
+            with _thread_local_capture_errors():
+                graph = torch.cuda.CUDAGraph()
+                # torch.cuda.graph.__enter__ passes the default explicitly;
+                # the subclass must override it.
+                graph.capture_begin(capture_error_mode="global")
+        assert graph.begin_kwargs["capture_error_mode"] == "thread_local"
+
+    def test_manager_captures_under_the_patch(self):
+        """The capture path must instantiate the patched graph class."""
+        manager = TrainGraphManager(warmup_threshold=1)
+        original = torch.cuda.CUDAGraph
+        seen = {}
+
+        def record_class(*args, **kwargs):
+            seen["cls"] = torch.cuda.CUDAGraph
+            return MagicMock(return_value=("flat",))
+
+        with patch("torch.cuda.make_graphed_callables", side_effect=record_class):
+            assert manager.run(_spec(), _fake_cuda_batch()) == ("flat",)
+        assert seen["cls"] is not original
+        assert issubclass(seen["cls"], original)
+        assert torch.cuda.CUDAGraph is original
+
+    @requires_cuda
+    def test_capture_survives_concurrent_pinned_allocations(self):
+        """Regression for the campaign killer: capture while a stand-in for
+        the DataLoader pin-memory thread keeps calling cudaHostAlloc."""
+        import threading
+
+        net = GraphableNetwork(nn.Conv2d(3, 8, 3, padding=1).cuda())
+        spec = CudaGraphTrainSpec(
+            network=net,
+            assemble=lambda flat, *args: {"total_loss": flat[0].sum()},
+        )
+        manager = TrainGraphManager(warmup_threshold=1)
+        imgs = torch.randn(2, 3, 32, 32, device="cuda")
+
+        stop = threading.Event()
+        errors: list[BaseException] = []
+
+        def hammer():
+            held = []
+            size = 0
+            while not stop.is_set():
+                try:
+                    # Strictly growing sizes defeat the caching host
+                    # allocator, so every iteration is a real cudaHostAlloc,
+                    # exactly what the pin-memory thread issues per batch.
+                    held.append(
+                        torch.empty(4096 + size * 640, dtype=torch.uint8).pin_memory()
+                    )
+                    size += 1
+                except BaseException as exc:  # must never happen
+                    errors.append(exc)
+                    return
+
+        thread = threading.Thread(target=hammer, daemon=True)
+        thread.start()
+        try:
+            out = manager.run(spec, imgs)
+        finally:
+            stop.set()
+            thread.join(timeout=30)
+
+        assert not errors, f"pin-memory stand-in thread was poisoned: {errors[0]!r}"
+        assert out is not None
+        assert manager.captured and not manager.disabled
+        # And the graph still replays.
+        assert manager.run(spec, imgs) is not None
 
 
 # =============================================================================

--- a/tests/unit/test_moge2.py
+++ b/tests/unit/test_moge2.py
@@ -179,11 +179,16 @@ def test_backend_normal_decode_accepts_bchw_and_repairs_invalid_vectors():
     assert normal[-1, -1].tolist() == pytest.approx([0.0, 0.0, -1.0])
 
 
-def test_moge2_export_support_is_onnx_only():
+def test_moge2_export_support_matrix():
+    """onnx and executorch are validated (each backed by its own parity
+    evidence: same-canvas angular parity for onnx, the XNNPACK flagship
+    e2e test for executorch); every other format stays blocked."""
     from libreyolo.export.support import EXPORT_FORMATS, get_support
 
-    assert get_support("moge2", "normal", "onnx").tier == "validated"
-    for format_name in set(EXPORT_FORMATS) - {"onnx"}:
+    validated = {"onnx", "executorch"}
+    for format_name in validated:
+        assert get_support("moge2", "normal", format_name).tier == "validated"
+    for format_name in set(EXPORT_FORMATS) - validated:
         assert get_support("moge2", "normal", format_name).tier == "blocked"
 
 


### PR DESCRIPTION
﻿## Summary

Fixes the CUDA-graph capture race that killed 2 of 100 datasets on the first RF100-VL Vast campaign ("AcceleratorError ... in pin memory thread").

Graph capture ran in the default `capture_error_mode="global"`, under which a CUDA call from **any** host thread invalidates the capture. A DataLoader with `pin_memory=True` keeps a pin-memory thread alive that calls `cudaHostAlloc` whenever it stages the next prefetched batch, so a lazy capture taken mid-epoch races with it: the capture dies with `cudaErrorStreamCaptureUnsupported` and, worse, the error poisons the pin-memory thread, which re-raises on the next batch fetch and kills the whole run.

`thread_local` is PyTorch's documented mode for exactly this situation: only the capturing thread is restricted during capture; other threads' CUDA calls proceed normally without being captured. The pin-memory thread touches only its own pinned host buffers, never the capturing stream, so nothing it does belongs in the graph.

- **Inference/validation (`GraphRunner._capture`)**: pass `capture_error_mode="thread_local"` to `torch.cuda.graph` directly.
- **Training (`TrainGraphManager._capture_and_run`)**: `torch.cuda.make_graphed_callables` constructs its own `CUDAGraph` objects and exposes no way to choose the mode, so the `torch.cuda.CUDAGraph` symbol is swapped for a mode-forcing subclass for the duration of the call (restored in a `finally`).

No behavior change otherwise: capture points, fallback ladders, and numerics are untouched (the existing eager/graphed parity suites still gate bit-identical loss trajectories).

## Test plan

- [x] New CPU tests: the patch context swaps/restores `torch.cuda.CUDAGraph` (including on exception), forces `thread_local` at `capture_begin`, and the manager's capture path instantiates the patched class.
- [x] New GPU regression tests on both paths: capture succeeds while a stand-in pin-memory thread hammers real `cudaHostAlloc` (strictly growing sizes to defeat the caching host allocator), and the thread is never poisoned.
- [x] Negative control on a local RTX GPU: the same hammer against `capture_error_mode="global"` reproduces the exact campaign failure ÔÇö hammer thread dies with `AcceleratorError` / `cudaErrorStreamCaptureUnsupported` and the capture is invalidated.
- [x] `test_cuda_graph_training.py` + `test_cuda_graph.py`: 68 passed, 1 skipped (needs 2 GPUs), 1 deselected (external_data).
- [x] `test_validator_cuda_graph.py`, `test_validator_reuse.py`, `test_image_cache.py`: 25 passed.

## Code provenance

All code in this PR is original, written for this PR. It uses only PyTorch's public, documented API (`capture_error_mode="thread_local"` on `torch.cuda.graph` / `CUDAGraph.capture_begin`); no third-party code was ported, adapted, or derived.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents DataLoader pin-memory activity from invalidating CUDA graph capture and completes the earlier concurrency fix by serializing the temporary training-time CUDAGraph replacement.
- Uses thread-local capture error handling for inference and validation graphs.
- Temporarily substitutes a mode-forcing CUDAGraph subclass during training capture, with locking and unconditional restoration.
- Adds CPU concurrency/restoration tests and GPU regression coverage for concurrent pinned-memory allocation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported unsynchronized global class replacement is now serialized and restored in a finally block.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/cuda_graph.py | Adds a serialized, exception-safe temporary CUDAGraph subclass that forces thread-local capture errors during training graph construction. |
| libreyolo/models/base/cuda_graph.py | Configures inference and validation graph capture to use thread-local error handling directly. |
| tests/unit/test_cuda_graph_training.py | Covers symbol replacement, restoration, concurrent serialization, forced capture mode, manager integration, and pinned-allocation regression behavior. |
| tests/unit/test_cuda_graph.py | Adds GPU regression coverage proving inference capture survives concurrent pinned-memory allocations. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Training graph capture requested] --> B[Acquire capture patch lock]
    B --> C[Save original CUDAGraph class]
    C --> D[Install thread-local forcing subclass]
    D --> E[make_graphed_callables captures graph]
    E --> F[Restore original class in finally]
    F --> G[Release capture patch lock]
    H[DataLoader pin-memory thread] --> I[cudaHostAlloc proceeds independently]
    I -. does not invalidate .-> E
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Unbreak dev CI: moge2 export support is ..."](https://github.com/libreyolo/libreyolo/commit/59ce05137aa003376f6b92321dbb4f89239af737) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49387033)</sub>

<!-- /greptile_comment -->
