### PR TITLE
Graphed validation for the DETR-line campaign families

### DIFF
--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -43,6 +43,11 @@ class LibreDEIMv2(BaseModel):
     val_preprocessor_class = DEIMv2ValPreprocessor
     TTA_FIXED_SIZE = True  # resizes to a fixed square; multi-scale TTA is a no-op
     IMGSZ_DIVISOR = 32
+    # Same graph-safety argument as D-FINE (DEIMv2 shares the DEIM/D-FINE
+    # decoder line): fixed eval_spatial_size, lazily built anchors settle in
+    # capture warmup, static top-k. Captures and replays bit-identically
+    # (tests/unit/test_cuda_graph_detr_families.py).
+    SUPPORTS_CUDA_GRAPH = True
 
     @classmethod
     def _validate_imgsz(cls, imgsz: int, *, context: str = "DEIMv2 imgsz") -> int:

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -49,6 +49,12 @@ class LibreDFINE(BaseModel):
     }
     val_preprocessor_class = DFINEValPreprocessor
     TTA_FIXED_SIZE = True  # resizes to a fixed square; multi-scale TTA is a no-op
+    # The eval forward (HGNetv2 backbone + hybrid encoder + FDR decoder) is
+    # pure tensor work at a fixed eval_spatial_size: anchors are regenerated
+    # lazily but settle during capture warmup, and top-k selection has a
+    # static output shape. Captures and replays bit-identically
+    # (tests/unit/test_cuda_graph_detr_families.py).
+    SUPPORTS_CUDA_GRAPH = True
 
     @classmethod
     def can_load(cls, weights_dict: dict) -> bool:

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -41,6 +41,11 @@ class LibreEC(BaseModel):
     POSE_NUM_KEYPOINTS = 17
     KEYPOINT_DIM = 3
     val_preprocessor_class = ECValPreprocessor
+    # EC shares the D-FINE decoder line (ECTrainer subclasses DFINETrainer)
+    # with an ECViT backbone; the eval forward is pure tensor work at a fixed
+    # eval_spatial_size. Captures and replays bit-identically
+    # (tests/unit/test_cuda_graph_detr_families.py).
+    SUPPORTS_CUDA_GRAPH = True
 
     _GH_RELEASE_BASE = (
         "https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1"

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -126,6 +126,12 @@ class LibreRFDETR(BaseModel):
     TRAIN_CONFIG: ClassVar[type[RFDETRConfig]] = RFDETRConfig
     val_preprocessor_class: ClassVar[type[RFDETRValPreprocessor]] = RFDETRValPreprocessor
     TTA_FIXED_SIZE: ClassVar[bool] = True  # fixed square; multi-scale TTA is a no-op
+    # The eval forward (DINOv2 backbone + deformable-attention decoder) is
+    # pure tensor work with a static output structure; deformable attention
+    # uses atomics only in its backward, so the inference forward captures
+    # and replays bit-identically
+    # (tests/unit/test_cuda_graph_detr_families.py).
+    SUPPORTS_CUDA_GRAPH: ClassVar[bool] = True
 
     # CLI parameters intentionally ignored by native RF-DETR training.
     UNSUPPORTED_TRAIN_PARAMS: ClassVar[set[str]] = {

--- a/tests/unit/test_cuda_graph_detr_families.py
+++ b/tests/unit/test_cuda_graph_detr_families.py
@@ -1,0 +1,225 @@
+"""Per-family CUDA-graph parity gates for the DETR-line eval forwards.
+
+``SUPPORTS_CUDA_GRAPH`` is an opt-in that every family must re-earn with its
+own parity evidence (models/base/model.py). This module is that evidence for
+the RF100-VL campaign families whose validation is launch-bound: RF-DETR,
+D-FINE, DEIMv2 and EC, plus YOLOv9-E2E, which inherits the flag from
+LibreYOLO9 and therefore needs its own proof that the inherited capture path
+is safe for the dual-assignment head's eval forward.
+
+The CPU tests pin the opt-in surface and run everywhere. The CUDA tests gate
+the load-bearing claim -- capture and replay change nothing, bit for bit --
+at both the model level (capture_graph + _forward_graphed) and the validator
+level (the exact wiring training-time validation uses: up-front capture,
+replay-only loop policy, graph scope).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.deimv2.model import LibreDEIMv2
+from libreyolo.models.dfine.model import LibreDFINE
+from libreyolo.models.ec.model import LibreEC
+from libreyolo.models.rfdetr.model import LibreRFDETR
+from libreyolo.models.yolo9_e2e.model import LibreYOLO9E2E
+from libreyolo.validation.base import BaseValidator
+from libreyolo.validation.config import ValidationConfig
+
+pytestmark = pytest.mark.unit
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA graph capture requires a CUDA device"
+)
+
+# (family, constructor, capture imgsz). Sizes are each family's smallest
+# variant at its native eval resolution, so the captured shape is the one a
+# real campaign validation would replay. RF-DETR takes ``model_path={}`` (the
+# random-init convention its other unit tests use) because ``None`` means
+# "download pretrained" for that family.
+FAMILY_CASES = [
+    (
+        "rfdetr",
+        lambda device: LibreRFDETR(model_path={}, size="n", nb_classes=2, device=device),
+        384,
+    ),
+    (
+        "dfine",
+        lambda device: LibreDFINE(None, size="n", nb_classes=2, device=device),
+        640,
+    ),
+    (
+        "deimv2",
+        lambda device: LibreDEIMv2(None, size="atto", nb_classes=2, device=device),
+        320,
+    ),
+    (
+        "ec",
+        lambda device: LibreEC(None, size="s", nb_classes=2, device=device),
+        640,
+    ),
+    (
+        "yolo9_e2e",
+        lambda device: LibreYOLO9E2E(None, size="t", device=device),
+        320,
+    ),
+]
+
+CASE_IDS = [case[0] for case in FAMILY_CASES]
+
+
+def _tensors(obj):
+    """Flatten a forward output to its tensors, whatever container it uses."""
+    if isinstance(obj, torch.Tensor):
+        return [obj]
+    if isinstance(obj, (list, tuple)):
+        return [t for item in obj for t in _tensors(item)]
+    if isinstance(obj, dict):
+        return [t for item in obj.values() for t in _tensors(item)]
+    return []
+
+
+def _assert_bit_identical(eager, graphed, family):
+    eager_tensors, graph_tensors = _tensors(eager), _tensors(graphed)
+    assert eager_tensors, f"{family} forward produced no tensors"
+    assert len(eager_tensors) == len(graph_tensors)
+    for index, (lhs, rhs) in enumerate(zip(eager_tensors, graph_tensors)):
+        assert lhs.shape == rhs.shape
+        assert torch.equal(lhs, rhs), (
+            f"{family} graph replay diverged from eager at tensor {index}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Opt-in surface (CPU)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("family,build,imgsz", FAMILY_CASES, ids=CASE_IDS)
+def test_family_opts_in(family, build, imgsz):
+    model = build("cpu")
+    assert type(model).SUPPORTS_CUDA_GRAPH is True
+    assert model.graph_info()["supported"] is True
+
+
+@pytest.mark.parametrize("family,build,imgsz", FAMILY_CASES, ids=CASE_IDS)
+def test_cpu_forward_falls_back_without_raising(family, build, imgsz):
+    """On CPU the runner must reject capture and return the eager result."""
+    model = build("cpu")
+    model.model.eval()
+    torch.manual_seed(0)
+    x = torch.rand(1, 3, imgsz, imgsz)
+    with torch.no_grad():
+        eager = model._forward(x)
+        with model.cuda_graph_scope(True):
+            fallback = model._forward_graphed(x)
+    assert model.graph_info()["graph_count"] == 0
+    _assert_bit_identical(eager, fallback, family)
+
+
+# ---------------------------------------------------------------------------
+# Capture/replay parity (CUDA)
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+@pytest.mark.parametrize("family,build,imgsz", FAMILY_CASES, ids=CASE_IDS)
+def test_capture_replay_is_bit_identical(family, build, imgsz):
+    """The load-bearing claim, per family: a replayed graph equals eager."""
+    model = build("cuda")
+    model.model.eval()
+    torch.manual_seed(0)
+    x = torch.rand(2, 3, imgsz, imgsz, device="cuda")
+
+    with torch.no_grad():
+        eager = model._forward(x)
+        model.capture_graph(imgsz=imgsz, batch=2)
+        with model.cuda_graph_scope(True):
+            graphed = model._forward_graphed(x)
+
+    info = model.graph_info()
+    assert info["graph_count"] == 1, f"{family} capture did not happen"
+    assert sum(c["replays"] for c in info["captured"]) >= 1, (
+        f"{family} ran eager instead of replaying"
+    )
+    _assert_bit_identical(eager, graphed, family)
+    model.release_graphs()
+
+
+# ---------------------------------------------------------------------------
+# Validator wiring parity (CUDA): the path training-time validation takes.
+# ---------------------------------------------------------------------------
+
+
+class _FixedBatchValidator(BaseValidator):
+    """Feeds one fixed CUDA batch through _inference; nothing else."""
+
+    def __init__(self, model, config, batch):
+        super().__init__(model=model, config=config)
+        self._batch = batch
+        self.last_preds = None
+
+    def _setup_dataloader(self):
+        return object()
+
+    def _warmup_model(self, n_warmup: int = 3):
+        pass
+
+    def _init_metrics(self):
+        pass
+
+    def _run_validation(self):
+        model = getattr(self.model, "model", None)
+        if hasattr(model, "eval"):
+            model.eval()
+        with torch.no_grad():
+            self.last_preds = self._inference(self._batch)
+
+    def _preprocess_batch(self, batch):
+        raise AssertionError("not used")
+
+    def _postprocess_predictions(self, preds, batch):
+        raise AssertionError("not used")
+
+    def _update_metrics(self, preds, targets, img_info, img_ids=None):
+        raise AssertionError("not used")
+
+    def _compute_metrics(self):
+        return {}
+
+
+@requires_cuda
+@pytest.mark.parametrize("family,build,imgsz", FAMILY_CASES, ids=CASE_IDS)
+def test_validator_wiring_is_bit_identical(family, build, imgsz, tmp_path):
+    """run() with cuda_graph=True (up-front capture, replay-only loop) must
+    produce the exact eager forward output for every campaign family."""
+    model = build("cuda")
+    model.model.eval()
+    torch.manual_seed(0)
+    batch = torch.rand(2, 3, imgsz, imgsz, device="cuda")
+
+    def run_once(cuda_graph):
+        config = ValidationConfig(
+            data="x.yaml",
+            device="cuda",
+            save_dir=str(tmp_path / "val"),
+            verbose=False,
+            cuda_graph=cuda_graph,
+            batch_size=2,
+            imgsz=imgsz,
+        )
+        validator = _FixedBatchValidator(model=model, config=config, batch=batch)
+        with torch.no_grad():
+            validator.run()
+        return validator.last_preds
+
+    eager = run_once(False)
+    graphed = run_once(True)
+    info = model.graph_info()
+    assert info["graph_count"] >= 1, f"{family} capture must have happened"
+    assert sum(c["replays"] for c in info["captured"]) >= 1, (
+        f"{family} loop must replay the up-front capture, not run eager"
+    )
+    _assert_bit_identical(eager, graphed, family)
+    model.release_graphs()

--- a/tests/unit/test_cuda_graph_detr_families.py
+++ b/tests/unit/test_cuda_graph_detr_families.py
@@ -19,11 +19,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from libreyolo.models.deimv2.model import LibreDEIMv2
-from libreyolo.models.dfine.model import LibreDFINE
-from libreyolo.models.ec.model import LibreEC
-from libreyolo.models.rfdetr.model import LibreRFDETR
-from libreyolo.models.yolo9_e2e.model import LibreYOLO9E2E
 from libreyolo.validation.base import BaseValidator
 from libreyolo.validation.config import ValidationConfig
 
@@ -33,37 +28,57 @@ requires_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA graph capture requires a CUDA device"
 )
 
+
+# Model classes are imported inside the builders, not at module scope: RF-DETR's
+# DINOv2 backbone imports ``transformers``, which ships only with the ``rfdetr``
+# extra, and a module-scope import would fail collection for every family in an
+# environment without it.
+def _build_rfdetr(device):
+    pytest.importorskip(
+        "transformers",
+        reason="RF-DETR needs the rfdetr extra",
+        exc_type=ImportError,
+    )
+    from libreyolo.models.rfdetr.model import LibreRFDETR
+
+    # ``model_path={}`` is the random-init convention RF-DETR's other unit tests
+    # use; ``None`` means "download pretrained" for this family.
+    return LibreRFDETR(model_path={}, size="n", nb_classes=2, device=device)
+
+
+def _build_dfine(device):
+    from libreyolo.models.dfine.model import LibreDFINE
+
+    return LibreDFINE(None, size="n", nb_classes=2, device=device)
+
+
+def _build_deimv2(device):
+    from libreyolo.models.deimv2.model import LibreDEIMv2
+
+    return LibreDEIMv2(None, size="atto", nb_classes=2, device=device)
+
+
+def _build_ec(device):
+    from libreyolo.models.ec.model import LibreEC
+
+    return LibreEC(None, size="s", nb_classes=2, device=device)
+
+
+def _build_yolo9_e2e(device):
+    from libreyolo.models.yolo9_e2e.model import LibreYOLO9E2E
+
+    return LibreYOLO9E2E(None, size="t", device=device)
+
+
 # (family, constructor, capture imgsz). Sizes are each family's smallest
 # variant at its native eval resolution, so the captured shape is the one a
-# real campaign validation would replay. RF-DETR takes ``model_path={}`` (the
-# random-init convention its other unit tests use) because ``None`` means
-# "download pretrained" for that family.
+# real campaign validation would replay.
 FAMILY_CASES = [
-    (
-        "rfdetr",
-        lambda device: LibreRFDETR(model_path={}, size="n", nb_classes=2, device=device),
-        384,
-    ),
-    (
-        "dfine",
-        lambda device: LibreDFINE(None, size="n", nb_classes=2, device=device),
-        640,
-    ),
-    (
-        "deimv2",
-        lambda device: LibreDEIMv2(None, size="atto", nb_classes=2, device=device),
-        320,
-    ),
-    (
-        "ec",
-        lambda device: LibreEC(None, size="s", nb_classes=2, device=device),
-        640,
-    ),
-    (
-        "yolo9_e2e",
-        lambda device: LibreYOLO9E2E(None, size="t", device=device),
-        320,
-    ),
+    ("rfdetr", _build_rfdetr, 384),
+    ("dfine", _build_dfine, 640),
+    ("deimv2", _build_deimv2, 320),
+    ("ec", _build_ec, 640),
+    ("yolo9_e2e", _build_yolo9_e2e, 320),
 ]
 
 CASE_IDS = [case[0] for case in FAMILY_CASES]


### PR DESCRIPTION
## Summary

- Opt `rfdetr`, `dfine`, `deimv2` and `ec` into `SUPPORTS_CUDA_GRAPH` so training-time validation can capture their eval forwards (RF100-VL perf-coverage PRD, item P1.2). Validation is launch-bound for the small variants those campaigns run, so this is the biggest remaining epoch-time lever for the DETR MUST families.
- Add per-family parity gates in `tests/unit/test_cuda_graph_detr_families.py` (the `test_validator_cuda_graph.py` mould): opt-in surface + clean CPU fallback, CUDA capture/replay bit-parity vs eager at the model level, and at the validator level — the exact wiring training-time validation uses (up-front capture, replay-only loop policy, graph scope).
- Verify YOLOv9-E2E's inherited flag (PRD item P0.3): the e2e dual-assignment head's eval forward is included in every gate as its own case and captures/replays bit-identically, so the inheritance from `LibreYOLO9` is proven safe and no `SUPPORTS_CUDA_GRAPH = False` override is needed.

Why these forwards are graph-safe: D-FINE/DEIMv2/EC share the FDR decoder line — pure tensor work at a fixed `eval_spatial_size`, lazily built anchors settle during capture warmup, top-k has a static output shape. RF-DETR's deformable attention uses atomics only in its backward, never in the inference forward.

Not included, deliberately: training capture specs for dfine/deimv2/ec (PRD P1.3). Their training forward passes `targets` into the network to build contrastive-denoising query groups whose count varies with per-image GT, which violates the capture contract (target-free forward, static shapes). Documented as infeasible without restructuring denoising.

## Test plan

- [x] `pytest tests/unit/test_cuda_graph_detr_families.py` — 20/20 pass on CUDA hardware (RTX 5070 Ti, fp32): 10 CPU (opt-in + fallback), 5 model-level capture/replay bit-parity, 5 validator-level wiring bit-parity.
- [ ] CI (CPU-only) runs the 10 CPU tests; CUDA gates are skipped there by design.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR opts four DETR-line model families into CUDA-graph validation and adds CPU fallback, model replay, and validator-wiring parity coverage. The RF-DETR test isolation is improved, but its constructor still introduces an external weight-download dependency into the unit suite.
- Enables `SUPPORTS_CUDA_GRAPH` for RF-DETR, D-FINE, DEIMv2, and EC.
- Adds shared parity gates for those families and YOLOv9-E2E.
- Defers RF-DETR imports until its parameterized cases are built.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the new RF-DETR unit cases can fail in offline environments despite the optional-package guard.

The package-level skip fixes collection when Transformers is absent, but when it is installed the size-n RF-DETR constructor still reaches `AutoModel.from_pretrained`, making the unit suite depend on remote Hugging Face availability.

**Files Needing Attention:** tests/unit/test_cuda_graph_detr_families.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/deimv2/model.py | Enables CUDA-graph validation for DEIMv2 with parity coverage in the new tests. |
| libreyolo/models/dfine/model.py | Enables CUDA-graph validation for D-FINE with parity coverage in the new tests. |
| libreyolo/models/ec/model.py | Enables CUDA-graph validation for EC with parity coverage in the new tests. |
| libreyolo/models/rfdetr/model.py | Enables CUDA-graph validation for RF-DETR. |
| tests/unit/test_cuda_graph_detr_families.py | Adds comprehensive parity coverage, but RF-DETR construction can download DINOv2 weights and fail in offline unit-test environments. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atests%2Funit%2Ftest_cuda_graph_detr_families.py%3A46%0A**RF-DETR%20unit%20tests%20require%20network%20access**%0A%0AIf%20%60transformers%60%20is%20installed%20but%20the%20DINOv2%20weights%20are%20not%20cached%20and%20Hugging%20Face%20is%20unavailable%2C%20this%20random-init%20construction%20still%20reaches%20%60AutoModel.from_pretrained%60%2C%20causing%20every%20RF-DETR%20parameterization%20to%20fail%20instead%20of%20running%20or%20skipping.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=682&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22perf%2Fdetr-graphed-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Fdetr-graphed-validation%22.%0A%0A%23%23%23%20Issue%201%0Atests%2Funit%2Ftest_cuda_graph_detr_families.py%3A46%0A**RF-DETR%20unit%20tests%20require%20network%20access**%0A%0AIf%20%60transformers%60%20is%20installed%20but%20the%20DINOv2%20weights%20are%20not%20cached%20and%20Hugging%20Face%20is%20unavailable%2C%20this%20random-init%20construction%20still%20reaches%20%60AutoModel.from_pretrained%60%2C%20causing%20every%20RF-DETR%20parameterization%20to%20fail%20instead%20of%20running%20or%20skipping.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=682&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Defer the RF-DETR import so the gates co..."](https://github.com/libreyolo/libreyolo/commit/5a0581a9d7d3a07e79ca426a221c8519f2fcce33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49403975)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->