### PR TITLE
Align weight-hosting policy and integration checklist across skills and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,10 @@
 - Never add new sections, restructure, or grow the README without an
   explicit user request. It balances being a landing page against being
   documentation; depth belongs in `/docs` or on the website.
+- One sanctioned exception: when a new model family lands, adding its single
+  row to the existing family support table is expected. One row, in the
+  existing table, and nothing else; only tick export columns that were
+  actually run.
 - Style: no em dashes, no decorative or AI-flavored characters, no fluff.
 - The detailed editing contract lives in `skills/libreyolo-update-readme/`.
 

--- a/skills/libreyolo-license-audit/SKILL.md
+++ b/skills/libreyolo-license-audit/SKILL.md
@@ -51,9 +51,13 @@ They routinely differ and each can independently block:
 - **Weights**: learned parameters. Carry their own license, often inherited
   from *training data terms* (Gaze360 makes L2CS weights non-redistributable;
   some upstream checkpoints are CC-BY-NC even where the code is Apache-2.0;
-  VisDrone training data makes a fine-tune CC-BY-NC-SA). Apache code +
-  NC weights means: ship the code, do not host the weights, or host behind
-  an explicit variant notice (the `-visdrone` preview pattern).
+  VisDrone training data makes a fine-tune CC-BY-NC-SA). **Redistributable is
+  the only bar for hosting weights**: Apache code + NC weights means ship the
+  code and host the weights with the NC license shipped verbatim, the card
+  tagged correctly, and a non-commercial banner leading the card (SegFormer
+  and `-visdrone` precedents); downstream users are responsible for complying
+  with the weight license. Weights whose terms forbid redistribution (L2CS /
+  Gaze360) are never hosted.
 - **Datasets**: gate before hosting or wiring auto-download; that gate lives
   in `skills/libreyolo-upload-hf-dataset`.
 
@@ -63,9 +67,10 @@ Quick decision table (source license, what it means here):
 |---|---|---|
 | MIT / Apache-2.0 / BSD / public domain | yes, with attribution | yes, with LICENSE+NOTICE |
 | CC-BY (weights/data) | n/a | yes, attribute |
-| CC-BY-NC / research-only | **no** | **no**; surface to maintainer |
+| CC-BY-NC (redistributable, non-commercial) | **no** | yes — license verbatim + non-commercial banner on the card; users responsible for compliance |
+| Research-only / redistribution forbidden | **no** | **no** (link upstream when a CDN exists) |
 | GPL / AGPL / LGPL | **no** | **no** (weights from AGPL *code* are a maintainer call; ask) |
-| Custom (DINOv3-style, Deci, model-specific) | maintainer call | maintainer call; document verbatim |
+| Custom (DINOv3-style, Deci, model-specific) | maintainer call | if the terms clearly permit redistribution, host with the license verbatim + banner (NVIDIA SCL / SegFormer precedent); ambiguous terms are a maintainer call — document verbatim |
 | Unknown / no license | treat as all-rights-reserved: **no** | **no** |
 
 ## The four notice surfaces (what changes when)

--- a/skills/libreyolo-port-model/SKILL.md
+++ b/skills/libreyolo-port-model/SKILL.md
@@ -78,7 +78,11 @@ For weights, check the HF model card YAML at the top:
 ```yaml
 license: apache-2.0    # ← permissive
 license: gpl-3.0       # ← copyleft
-license: cc-by-nc-4.0  # ← non-commercial: usually a hard "no"
+license: cc-by-nc-4.0  # ← non-commercial: still hostable — redistributable is
+                       #   the only bar for weights. Ship the license verbatim
+                       #   and lead the card with a non-commercial banner
+                       #   (SegFormer precedent); users are responsible for
+                       #   complying with the weight license.
 ```
 
 **Already-shipped reference cases**:
@@ -1164,7 +1168,13 @@ Always edited:
 | `libreyolo/training/config.py` | append `<Family>Config(TrainConfig)` if shared route. Family-local `models/<family>/config.py` is also fine — RF-DETR, RT-DETR, YOLOv9-E2E |
 | `libreyolo/validation/preprocessors.py` | append `<Family>ValPreprocessor` |
 | `tests/unit/test_<family>_*.py` | parity / shape / loss / smoke / sibling-rejection |
-| `tests/e2e/conftest.py` | append rows to `MODEL_CATALOG` |
+| `tests/e2e/conftest.py` | task-appropriate registration: for detect, append rows to `MODEL_CATALOG` and `GENERAL_NIGHTLY_INFERENCE_MODELS` (plus `_EXPERIMENTAL_TRAINING_SKIP` when training is out of scope). `MODEL_CATALOG` is detect-only — its mAP gate fails classify / semantic / depth rows by construction; mirror the closest merged non-detect family instead |
+| `CHANGELOG.md` | `Unreleased / Added` entry for the new family |
+| `README.md` | one row in the family support table — nothing else (README policy in `AGENTS.md`; tick only export columns you actually ran) |
+| `reports/export_inventory.json` | regenerate — `tests/unit` checks the committed snapshot matches the runtime inventory (including the family's `group`) |
+| `docs/testing.md` | bump the general-nightly test count when nightly models were added |
+| `pyproject.toml` | add the `<family>` pytest marker |
+| `docs/nomenclature.md` | family / filename rows |
 
 Conditional:
 

--- a/skills/libreyolo-port-model/SKILL.md
+++ b/skills/libreyolo-port-model/SKILL.md
@@ -123,6 +123,11 @@ Pick one and document scope explicitly:
 
 **Inference-only is a legitimate ship state.** Don't gate the port on a working trainer.
 
+Which target to pick belongs to the PRD: `libreyolo-write-model-prd` section 4
+carries the three-gate trainer rule (task shape, upstream fine-tune recipe,
+audience/rollout tier). If the PRD is silent on maturity, apply the same gates
+and record the answer in the PR description.
+
 ## 3. Pick your scaffold
 
 Use this decision tree to pick the family you'll clone as your starting point.

--- a/skills/libreyolo-port-model/SKILL.md
+++ b/skills/libreyolo-port-model/SKILL.md
@@ -1168,7 +1168,7 @@ Always edited:
 | `libreyolo/training/config.py` | append `<Family>Config(TrainConfig)` if shared route. Family-local `models/<family>/config.py` is also fine — RF-DETR, RT-DETR, YOLOv9-E2E |
 | `libreyolo/validation/preprocessors.py` | append `<Family>ValPreprocessor` |
 | `tests/unit/test_<family>_*.py` | parity / shape / loss / smoke / sibling-rejection |
-| `tests/e2e/conftest.py` | task-appropriate registration: for detect, append rows to `MODEL_CATALOG` and `GENERAL_NIGHTLY_INFERENCE_MODELS` (plus `_EXPERIMENTAL_TRAINING_SKIP` when training is out of scope). `MODEL_CATALOG` is detect-only — its mAP gate fails classify / semantic / depth rows by construction; mirror the closest merged non-detect family instead |
+| `tests/e2e/conftest.py` | task-appropriate registration: for detect, append rows to `MODEL_CATALOG` and `GENERAL_NIGHTLY_INFERENCE_MODELS` (and add the family to `_EXPERIMENTAL_TRAINING_SKIP` in `tests/e2e/test_rf1_training.py` when training is out of scope). `MODEL_CATALOG` is detect-only — its mAP gate fails classify / semantic / depth rows by construction; mirror the closest merged non-detect family instead |
 | `CHANGELOG.md` | `Unreleased / Added` entry for the new family |
 | `README.md` | one row in the family support table — nothing else (README policy in `AGENTS.md`; tick only export columns you actually ran) |
 | `reports/export_inventory.json` | regenerate — `tests/unit` checks the committed snapshot matches the runtime inventory (including the family's `group`) |

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -83,8 +83,13 @@ file = name + ".pt"
 
 Never-upload families: **L2CS** (Gaze360 terms forbid redistribution) and any
 weight whose upstream/training-data license fails the gate in
-`skills/libreyolo-license-audit`. DepthAnythingV2 `b`/`l`/`g` weights are
-CC-BY-NC; hosting them is a maintainer decision, not a default. The
+`skills/libreyolo-license-audit`. **Redistributable is the only bar for
+hosting weights**: non-commercial but redistributable weights (CC-BY-NC, the
+NVIDIA Source Code License) are hosted — ship the upstream license verbatim,
+tag the card correctly, and lead with a non-commercial banner (SegFormer
+precedent); downstream users are responsible for complying with the weight
+license. Only weights whose terms forbid redistribution (L2CS) or whose
+license is unknown stay unhosted. The
 open-vocabulary and SAM/VLM tiers ship HF *snapshot directories*
 (`LibreGroundingDINOt`, `LibreOWLv2b16`, ...), not single `.pt` files; their
 repos mirror upstream snapshot layout plus card, so the 5-file contract below
@@ -242,7 +247,8 @@ and hosted; BiRefNet `t` (lite) weights have no explicit license tag on the
 upstream HF repo (MIT badge in the card body only), so hosting the lite weights
 is a maintainer decision, not a default (`weights/upload_birefnet_hf.py` guards
 it behind `--confirm-lite-license`). DepthAnythingV2 `b`/`l`/`g` are CC-BY-NC
-(maintainer decision to host); `-visdrone` variants are a research preview
+(redistributable, therefore hostable — license verbatim + non-commercial
+banner on the card); `-visdrone` variants are a research preview
 under VisDrone's CC BY-NC-SA (repo `LibreYOLO/LibreYOLO9P2s-visdrone`, with
 the license stated loudly on the card); FOMO weights have no cleared hosting
 license yet. **LibreSegformer b0-b5 are NON-COMMERCIAL**: they derive from

--- a/skills/libreyolo-write-model-prd/SKILL.md
+++ b/skills/libreyolo-write-model-prd/SKILL.md
@@ -206,9 +206,8 @@ corrected.
 - **`from_pretrained` does not exist.** `LibreYOLO` is a factory *function*
   (`libreyolo/models/__init__.py`) that takes a path. The auto-download check is
   `LibreYOLO("Libre<Family><size>.pt")` on a cleared cache with no staged copy
-  under `weights/`. Note that `libreyolo-port-model` and
-  `libreyolo-upload-hf-model` both still show a stale `from_pretrained` form;
-  do not copy it into a PRD.
+  under `weights/`. Do not write a `from_pretrained` call into a PRD; the bare
+  canonical filename is the download trigger.
 - **A non-YOLO-grid export needs two backend edits, not one.**
   `_is_nms_free_family()` is a module-level function in
   `libreyolo/backends/base.py` (not a `BaseBackend` method) and only decides

--- a/skills/libreyolo-write-model-prd/SKILL.md
+++ b/skills/libreyolo-write-model-prd/SKILL.md
@@ -118,6 +118,35 @@ a maturity target from `libreyolo-port-model` section 2, and remember that
 working trainer will usually stall. Make the trainer a follow-up unless training
 is the point of the port.
 
+Whether the PRD requires a trainer is a three-gate test, not taste:
+
+1. **Task shape.** The task is closed-set and label-supervised: the user's
+   dataset is images plus plain labels the existing pipeline already carries
+   (boxes, masks, keypoints, class ids). Prompt-driven, text-conditioned,
+   zero-shot and multimodal models (SAM, VLMs, CLIP, open-vocab detectors,
+   foundation backbones) fail this gate and never ship training code: their
+   "training" is web-scale pretraining, not user fine-tuning.
+2. **Upstream recipe.** Upstream ships a permissively licensed *fine-tuning*
+   implementation (loss, assignment, recipe) that converges on a small dataset
+   on a single GPU. A pretraining pipeline needing multi-node or web-scale
+   data does not count (Depth Anything V2's teacher-student distillation is
+   the precedent: supervised task, no user-facing recipe, inference-only).
+3. **Audience.** The port is meant for practitioners to fine-tune (headed for
+   `g2` or better). Museum/historic ports and inference-only specialists
+   (`g3`/`g4` candidates: original DETR, Faster R-CNN) ship inference-only
+   even for classical detection; the trainer is an optional follow-up.
+
+All three pass: the PRD requires a trainer (production-grade when e2e
+convergence is validated, otherwise gated experimental behind
+`allow_experimental=True`). Any gate fails: inference-only, and the PRD names
+the failed gate. Genuinely unsure: write "maturity: maintainer call" in the
+PRD and ask, instead of guessing.
+
+The one-line intuition: ship a trainer when a real user could run
+`model.train(data="their_small_dataset.yaml")` on one GPU and expect a better
+model; ship inference-only when "training" really means "pretraining nobody
+can reproduce".
+
 Also name the **rollout group** the family enters (`MODEL_GROUPS` in
 `libreyolo/models/registry.py`; semantics in `docs/nomenclature.md`, "Model
 groups"). New ports normally enter `g2` (trainable) or `g3` (inference-only);


### PR DESCRIPTION
What: align the weight-hosting policy and the port integration checklist across the porting skills and AGENTS.md.
Why: a congruence review found the three skills and AGENTS.md giving conflicting instructions on non-commercial weights, README edits, and post-port integration steps.

- Weight-hosting policy unified on one bar: redistributable. Non-commercial but redistributable weights (CC-BY-NC, NVIDIA SCL) are hosted with the license shipped verbatim plus a non-commercial banner; users are responsible for compliance. Updated the stale "usually a hard no" comment in `libreyolo-port-model` and the "maintainer decision" wording in `libreyolo-upload-hf-model`.
- `libreyolo-port-model` files-touched matrix now carries the CI-relevant integration items that were previously undocumented: CHANGELOG entry, README family row, `reports/export_inventory.json` regeneration, `docs/testing.md` nightly count, pytest family marker, nomenclature rows, and a task-appropriate `tests/e2e/conftest.py` note (`MODEL_CATALOG` is detect-only).
- AGENTS.md README policy gains its one sanctioned exception: a single family-support-table row when a new family lands.
- `libreyolo-write-model-prd` no longer claims the port/upload skills show a stale `from_pretrained` form (they were already fixed).

Check: policy wording matches maintainer intent on non-commercial weights.
Not verified: nothing outstanding (docs/skills only, no code paths).
Opened by an agent.

## Code provenance
Original documentation written for this PR; no third-party code ported, adapted, or introduced; no GPL/AGPL/LGPL/non-commercial/unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns model-porting guidance around a redistribution-based weight-hosting policy and expands the documented integration checklist.
- Permits hosting redistributable non-commercial weights with verbatim licensing and a prominent non-commercial notice.
- Corrects the training-skip checklist to reference the collection in `tests/e2e/test_rf1_training.py`.
- Documents required changelog, README, inventory, testing, marker, and nomenclature updates.
- Clarifies trainer maturity criteria and canonical weight-loading guidance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

No blocking failure remains; both previously reported inconsistencies are corrected at the current head.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds the narrowly scoped README family-table exception used by new model integrations. |
| skills/libreyolo-license-audit/SKILL.md | Defines redistribution, rather than commercial-use permission, as the weight-hosting threshold while retaining escalation for ambiguous terms. |
| skills/libreyolo-port-model/SKILL.md | Aligns non-commercial weight guidance and expands the model-port integration checklist, including the corrected experimental-training skip location. |
| skills/libreyolo-upload-hf-model/SKILL.md | Aligns upload instructions with the audit policy and required notices for redistributable non-commercial weights. |
| skills/libreyolo-write-model-prd/SKILL.md | Adds trainer maturity gates and removes stale guidance about a nonexistent weight-loading API. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Add three-gate trainer rule to PRD skill..."](https://github.com/libreyolo/libreyolo/commit/afc52d82c3dc21bdee04db7ddaecd6d8b9daf504) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49516438)</sub>

<!-- /greptile_comment -->