### PR TITLE
Port classic ViT classifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- LibreViT, an inference-only classic Vision Transformer classifier in
+  patch-16 tiny/small/base/large sizes at 224px. Native pretrained logits are
+  bit-exact against the pinned Apache-2.0 timm AugReg checkpoints for all four
+  sizes, with top-1/top-5 validation and ONNX Runtime prediction parity
 - LibreDETR, an inference-only museum port of the original DETR (ECCV 2020)
   in all four released COCO variants (`r50`, `r50dc5`, `r101`, `r101dc5`).
   Native outputs are bit-exact against the pinned facebookresearch/detr

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ selects the task. These families are extras on top of the core library.
 - **Semantic segmentation:** SegFormer, PIDNet, EoMT, DINOv2
 - **Panoptic segmentation:** EoMT
 - **Oriented boxes (OBB):** RF-DETR
-- **Classification:** ResNet, ConvNeXt, MobileNetV4, EfficientNetV2, DINOv2, CLIP, SigLIP2
+- **Classification:** ResNet, ConvNeXt, MobileNetV4, EfficientNetV2, ViT, DINOv2, CLIP, SigLIP2
 - **Point detection:** FOMO, LocateAnything
 - **Depth estimation:** Depth Anything 3, Depth Anything V2, ZipDepth
 - **Surface-normal estimation:** MoGe-2 (ViT-S/B/L)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,6 +95,7 @@ LibreYOLO 推荐以下模型系列，因为它们在性能上达到最佳平衡�
     <tr><td>PicoDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td><td></td><td></td></tr>
     <tr><td>RTMDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>EC</td><td>✓</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>ViT</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>L2CS</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
   </tbody>
 </table>

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -779,15 +779,22 @@ License: Apache License 2.0
 Copyright (c) Ross Wightman and the timm contributors.
 Used for: the native image-classification model families ported from
           timm architectures — libreyolo/models/{mobilenetv4,convnext,
-          efficientnetv2,resnet}/ — and the shared Swin backbone at
+          efficientnetv2,resnet,vit}/ — and the shared Swin backbone at
           libreyolo/models/swin/. Module/attribute names mirror timm so
           its Apache-2.0 ImageNet-1k pretrained weights load unchanged and
           inference is bit-identical. Architecture lineage: ConvNeXt also
           derives from facebookresearch/ConvNeXt (MIT); EfficientNetV2 from
           google/automl (Apache-2.0); ResNet from He et al. 2015. Weights
-          (timm *.in1k / *.fb_in1k / a1_in1k, Apache-2.0) are mirrored on
+          (timm *.in1k / *.fb_in1k / *.augreg*_in21k_ft_in1k / a1_in1k,
+          Apache-2.0) are mirrored on
           the LibreYOLO Hugging Face org. ConvNeXt-V2 fcmae weights
           (CC-BY-NC) are NOT used.
+
+          LibreViT specifically derives its native fixed-224 patch-16 graph
+          from timm v1.0.28, commit
+          8ef73809f622e0031bd7f4940265734aef8b9978. Its AugReg checkpoint
+          revisions and source/converted SHA-256 hashes are recorded in
+          docs/provenance/vit.md.
 
 --------------------------------------------------------------------
 Apache License 2.0 (full text)

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -78,6 +78,7 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |  |
 | swinir | restore | ✓ | ✓ |  | ✓ | ✓ |  | ✓ |  |  |
 | teed | edge | ✓ | ✓ | ✓ | ✓ | ✓ |  | ✓ |  |  |
+| vit | classify | ✓ | exp | exp | exp | exp | exp |  |  |  |
 | yolo1 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |  |  | ✓ |
 | yolo2 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | exp |  |  | ✓ |
 | yolo3 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |  |  | ✓ |
@@ -287,6 +288,7 @@ A check mark applies only under any constraint listed here.
 - `teed` / `edge` / `tensorrt`: TensorRT 10.16 FP32, batch 1, fixed input shape
 - `teed` / `edge` / `openvino`: OpenVINO 2026.2 CPU FP32, batch 1, fixed input shape
 - `teed` / `edge` / `tflite`: LiteRT 2.1.2 CPU FP32, batch 1, fixed input shape
+- `vit` / `classify` / `onnx`: FP32, fixed 224x224 input
 - `yolo1` / `detect` / `executorch`: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
 - `yolo1` / `detect` / `tensorrt`: TensorRT 10.16 FP32 with a fixed canvas; YOLO1 requires 448x448
 - `yolo1` / `detect` / `openvino`: fixed export canvas; YOLO1 requires 448x448
@@ -703,6 +705,9 @@ A check mark applies only under any constraint listed here.
 - `teed` / `edge` / `ncnn`: PNNX 20260526 leaves an unsupported Tensor.index channel-reversal node, so the generated NCNN network has no runnable input.
 - `teed` / `edge` / `coreml`: This edge runtime has no parity-valid artifact for the requested format.
 - `teed` / `edge` / `coreai`: This edge runtime has no parity-valid artifact for the requested format.
+- `vit` / `classify` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
+- `vit` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `vit` / `classify` / `coreai`: This family and task have not been validated for Core AI export.
 - `yolo1` / `detect` / `tflite`: onnx2tf 2.6.7 emits an ONNX_EINSUM custom operation that LiteRT 2.1.2 cannot prepare at the native 448x448 canvas.
 - `yolo1` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo2` / `detect` / `tflite`: LiteRT 2.1.2 cannot prepare the onnx2tf 2.6.7 artifact because a RESHAPE maps 4,225 input elements to one output element.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -50,7 +50,7 @@ Libre<FAMILY><size>[-<task>].pt
 The model families registered into the model factory (the VLM tier is a
 separate category, covered in the note below). Most are detectors; `pidnet`, `segformer`, and `lingbotvision` are semantic-only; `eomt` supports semantic,
 instance, and panoptic segmentation; the `mobilenetv4` / `convnext` /
-`efficientnetv2` / `resnet` families are classify-only:
+`efficientnetv2` / `resnet` / `vit` families are classify-only:
 
 | Family id (`FAMILY`) | Filename prefix | Casing rule applied |
 |---|---|---|
@@ -89,6 +89,7 @@ instance, and panoptic segmentation; the `mobilenetv4` / `convnext` /
 | `convnext`  | `LibreConvNeXt`  | CamelCase preserved (upstream brand casing `ConvNeXt`) — classify-only family |
 | `efficientnetv2` | `LibreEfficientNetV2` | CamelCase preserved (EfficientNet is not an acronym) — classify-only accuracy tier |
 | `resnet`    | `LibreResNet`    | CamelCase preserved (`ResNet` brand casing) — classify-only baseline |
+| `vit`       | `LibreViT`       | All-caps acronym (`ViT` classic Vision Transformer) — inference-only classifier |
 | `clip`      | `LibreCLIP`     | All-caps acronym (`CLIP` zero-shot classify + image/text embed) — inference-only |
 | `siglip2`   | `LibreSigLIP2`  | Upstream brand casing preserved (`SigLIP`) + version (`SigLIP 2` zero-shot classify + image/text embed); inference-only |
 | `nafnet`    | `LibreNAFNet`   | All-caps acronym + CamelCase `Net`; restore-only image-restoration family |
@@ -189,6 +190,7 @@ ships:
 | `convnext`  | `t`, `s`, `b` (V1 Tiny/Small/Base) |
 | `efficientnetv2` | `b0`, `b1`, `b2`, `b3` (EfficientNetV2-base scaling tiers) |
 | `resnet`    | `18`, `34`, `50`, `101` (ResNet depth) |
+| `vit`       | `ti`, `s`, `b`, `l` (classic patch-16 Tiny/Small/Base/Large; all at 224) |
 | `nafnet`    | `s`, `l` (small width-32 / large width-64 restoration models). Weight variants select the degradation: `LibreNAFNetl-restore.pt` (GoPro deblur) and `LibreNAFNetl-restore-sidd.pt` (SIDD denoise, the model behind the `denoise` alias) |
 | `realesrgan` | `x4`, `x2`, `x4t` (size code encodes scale + tier: `x4` = RealESRGAN_x4plus RRDBNet 4x quality default, `x2` = RealESRGAN_x2plus RRDBNet 2x, `x4t` = realesr-general-x4v3 SRVGG compact 4x fast/video tier) |
 | `swinir`    | `s`, `m`, `l` (all 4x: lightweight SwinIR-S, real-world SwinIR-M, and real-world SwinIR-L) |
@@ -443,6 +445,7 @@ Detector-factory family support follows:
 | `convnext`  | `("classify",)`                | classify | ConvNeXt V1 image classifier; t/s/b at 224; predict + top-1/top-5 `val` + CE fine-tune train + ONNX |
 | `efficientnetv2` | `("classify",)`             | classify | EfficientNetV2-base image classifier; b0/b1/b2/b3 at 224/240/260/300; predict + top-1/top-5 `val` + CE fine-tune train + ONNX |
 | `resnet`    | `("classify",)`             | classify | vanilla ResNet image classifier (v1.5); 18/34/50/101 at 224; predict + top-1/top-5 `val` + CE fine-tune train + ONNX |
+| `vit`       | `("classify",)`             | classify | classic patch-16 Vision Transformer; ti/s/b/l at 224 with AugReg ImageNet-1k weights; predict + top-1/top-5 `val` + ONNX; inference-only |
 | `clip`      | `("classify", "embed")`     | classify | shared two-tower `-cls` weights; zero-shot classify or whole-image/text embeddings in one space |
 | `siglip2`   | `("classify", "embed")`     | classify | shared two-tower `-cls` weights; zero-shot classify or multilingual whole-image/text embeddings in one space |
 | `facerec`   | `("embed",)`                | embed | two-stage face-region embeddings; rows align with face boxes; inference-only |
@@ -680,13 +683,19 @@ LibreResNet18-cls.pt       # ResNet-18  (224, ImageNet-1k, a1 recipe)
 LibreResNet34-cls.pt       # ResNet-34  (224, ImageNet-1k, a1 recipe)
 LibreResNet50-cls.pt       # ResNet-50  (224, ImageNet-1k, a1 recipe)
 LibreResNet101-cls.pt      # ResNet-101 (224, ImageNet-1k, a1 recipe)
+
+LibreViTti-cls.pt          # ViT-Tiny/16  (224, AugReg ImageNet-1k)
+LibreViTs-cls.pt           # ViT-Small/16 (224, AugReg ImageNet-1k)
+LibreViTb-cls.pt           # ViT-Base/16  (224, AugReg2 ImageNet-1k)
+LibreViTl-cls.pt           # ViT-Large/16 (224, AugReg ImageNet-1k)
 ```
 
 Unlike `gaze`/`point` (which carry their suffix despite being single-task),
 `classify` keeps its `-cls` suffix to match the ecosystem-wide convention. The
 `mobilenetv4` family is a native port of MobileNetV4 (the speed tier); the
 `convnext` family is a native port of ConvNeXt V1; the `efficientnetv2` family
-is a native port of EfficientNetV2-base (the accuracy tier). All are derived
+is a native port of EfficientNetV2-base (the accuracy tier); and `vit` is the
+inference-only classic patch-16 Vision Transformer family. All are derived
 from timm (Apache-2.0); weights are Apache-2.0 ImageNet-1k and load
 bit-identically (see each family's `NOTICE`, e.g.
 `libreyolo/models/efficientnetv2/NOTICE`, `libreyolo/models/convnext/NOTICE`).
@@ -695,7 +704,7 @@ are excluded; EfficientNetV2 ships only the ImageNet-1k checkpoints, as the
 `.in21k`/JFT variants carry extra-data terms.
 
 **Eval resolution is a deliberate choice.** The classify families evaluate at a
-real-time-friendly default (224 for MobileNetV4 s/m, ConvNeXt, ResNet; 256 for
+real-time-friendly default (224 for MobileNetV4 s/m, ConvNeXt, ResNet, ViT; 256 for
 MobileNetV4-l; 224/240/260/300 for EfficientNetV2 b0–b3) rather than timm's
 larger *test* resolutions (e.g. 256/288/320), which trade ~1.6–2× compute for a
 few tenths of a percent top-1. This does **not** affect parity — given the same

--- a/docs/provenance/vit.md
+++ b/docs/provenance/vit.md
@@ -1,0 +1,37 @@
+# LibreViT provenance
+
+LibreViT is a native PyTorch port of the fixed 224px, patch-16 classic Vision
+Transformer graph. No incompatible source was consulted or used.
+
+## Code sources
+
+- `huggingface/pytorch-image-models`, tag `v1.0.28`, commit
+  `8ef73809f622e0031bd7f4940265734aef8b9978`, Apache-2.0:
+  <https://github.com/huggingface/pytorch-image-models/tree/8ef73809f622e0031bd7f4940265734aef8b9978>
+- `google-research/vision_transformer`, commit
+  `64801f1b3b367b3611cc27a3d45cc22870a36fb3`, Apache-2.0:
+  <https://github.com/google-research/vision_transformer/tree/64801f1b3b367b3611cc27a3d45cc22870a36fb3>
+
+The implementation retains only the learned class token, absolute position
+embedding, pre-normalized attention/MLP blocks, final normalization, and linear
+classifier needed by the four shipped checkpoints. State-dict names remain
+aligned with timm; conversion adds LibreYOLO metadata without changing learned
+tensors.
+
+## Weight sources
+
+All source model cards declare `apache-2.0`. The source artifact in each row is
+`model.safetensors`; revisions and SHA-256 hashes pin the exact downloaded
+bytes. Converted hashes pin the corresponding published LibreYOLO checkpoint.
+
+| Size | Upstream model and revision | Source SHA-256 | LibreYOLO file | Converted SHA-256 |
+|---|---|---|---|---|
+| `ti` | [`timm/vit_tiny_patch16_224.augreg_in21k_ft_in1k`](https://huggingface.co/timm/vit_tiny_patch16_224.augreg_in21k_ft_in1k/tree/7d3afdd0cf93ad84d986eb2d6bcc5812ebd0b106) at `7d3afdd0cf93ad84d986eb2d6bcc5812ebd0b106` | `fecf81b492bd13ee7a5297cb74d1d417aac8bf7e1b7d96aed89c4691984587ed` | `LibreViTti-cls.pt` | `faa3cbe82da7c5a94677b3235c743b47562c4da26ede5d563ebdb89f4fec3394` |
+| `s` | [`timm/vit_small_patch16_224.augreg_in21k_ft_in1k`](https://huggingface.co/timm/vit_small_patch16_224.augreg_in21k_ft_in1k/tree/7e2c55630205e1266030f18370f4c6ed1a514b52) at `7e2c55630205e1266030f18370f4c6ed1a514b52` | `79c03c635cdfd798a364a9d8c4e5c0b7255b975ea2c9616046d4f77ab01435aa` | `LibreViTs-cls.pt` | `070717a28e61f8759ae0017c191bf4c80c59228cc863001f128467c08a0d95e0` |
+| `b` | [`timm/vit_base_patch16_224.augreg2_in21k_ft_in1k`](https://huggingface.co/timm/vit_base_patch16_224.augreg2_in21k_ft_in1k/tree/063c6c38a5d8510b2e57df480445e94b231dad2c) at `063c6c38a5d8510b2e57df480445e94b231dad2c` | `32aa17d6e17b43500f531d5f6dc9bc93e56ed8841b8a75682e1bb295d722405b` | `LibreViTb-cls.pt` | `f084ee6c8a94dff5a59d34907da82c51a9c71d2cbc6b8ba540820a784bd54ca6` |
+| `l` | [`timm/vit_large_patch16_224.augreg_in21k_ft_in1k`](https://huggingface.co/timm/vit_large_patch16_224.augreg_in21k_ft_in1k/tree/0930ab3308b84cb2ae091a4a80703c459412a4c7) at `0930ab3308b84cb2ae091a4a80703c459412a4c7` | `109390825a5bada2864f1b74445a63d29c51ef079c349644bc98996c452f6cf1` | `LibreViTl-cls.pt` | `8881263620f2e19362ccbcce929ca6cf07725f3ce4c24bd81479e16492d262be` |
+
+Conversion is reproducible with `weights/convert_vit_weights.py`. Each output
+passes the strict checkpoint metadata validator and strict native state-dict
+loading. Pretrained logits match timm exactly (`max_abs_diff == 0`) for all
+four sizes.

--- a/docs/provenance/vit.md
+++ b/docs/provenance/vit.md
@@ -35,3 +35,15 @@ Conversion is reproducible with `weights/convert_vit_weights.py`. Each output
 passes the strict checkpoint metadata validator and strict native state-dict
 loading. Pretrained logits match timm exactly (`max_abs_diff == 0`) for all
 four sizes.
+
+## Published artifacts
+
+Each public repository contains exactly `.gitattributes`, `README.md`,
+`LICENSE`, `NOTICE`, and its one canonical checkpoint:
+
+| Size | LibreYOLO repository | Initial verified revision |
+|---|---|---|
+| `ti` | [`LibreYOLO/LibreViTti-cls`](https://huggingface.co/LibreYOLO/LibreViTti-cls/tree/b5275cde8067f04681f8b1536538544cc311d95f) | `b5275cde8067f04681f8b1536538544cc311d95f` |
+| `s` | [`LibreYOLO/LibreViTs-cls`](https://huggingface.co/LibreYOLO/LibreViTs-cls/tree/c68ab6f37c533bf32580f400fb10b00d0c2aed3a) | `c68ab6f37c533bf32580f400fb10b00d0c2aed3a` |
+| `b` | [`LibreYOLO/LibreViTb-cls`](https://huggingface.co/LibreYOLO/LibreViTb-cls/tree/003b0fede7e890fc994478c8dac3dfc48bcbab86) | `003b0fede7e890fc994478c8dac3dfc48bcbab86` |
+| `l` | [`LibreYOLO/LibreViTl-cls`](https://huggingface.co/LibreYOLO/LibreViTl-cls/tree/4aa51c2ee7149c97b277154ec8b09e160b26fce8) | `4aa51c2ee7149c97b277154ec8b09e160b26fce8` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -234,11 +234,11 @@ make test_e2e E2E_TIMEOUT=1800
 
 V2.2 contract:
 
-- `general_nightly`: one smallest native inference case for every public
-  detector family, including inference-only museum families, that has a public
+- `general_nightly`: one smallest native inference case for every public model
+  family, including inference-only museum families, that has a public
   auto-download route (LibreYOLO HF, or Deci's CDN for YOLO-NAS), plus
   batched/sequential parity and selected open-vocabulary smoke cases; currently
-  36 tests.
+  38 tests.
 - `flagship_nightly`: heavier YOLO9/RF-DETR native validation, video, tracking,
   CLI, and one RF1 training/reload size per flagship family; currently 48 tests
   with `not export_backend`. The full RF1 size matrix remains available under

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -227,6 +227,7 @@ __all__ = [
     "LibrePIDNet",
     "LibreSegformer",
     "LibreLingBotVision",
+    "LibreViT",
     "LibreMobileNetV4",
     "LibreConvNeXt",
     "LibreEfficientNetV2",

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -46,6 +46,7 @@ from .models import (
     LibrePIDNet,
     LibreSegformer,
     LibreLingBotVision,
+    LibreViT,
     LibreMobileNetV4,
     LibreConvNeXt,
     LibreEfficientNetV2,

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -618,6 +618,15 @@ class BaseBackend(ABC):
                 interpolation="bilinear",
                 square_resize=True,
             )
+        elif self.model_family == "vit":
+            from ..models.vit.utils import VIT_MEAN, VIT_STD
+
+            transform_kwargs.update(
+                mean=VIT_MEAN,
+                std=VIT_STD,
+                crop_pct=0.9,
+                interpolation="bicubic",
+            )
         transform = build_classify_transforms(
             h,
             augment=False,

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -607,6 +607,18 @@ _add(
 )
 _add(
     "validated",
+    ("vit",),
+    ("classify",),
+    ("onnx",),
+    reason=(
+        "A real AugReg ImageNet-1k checkpoint is covered by raw-logit and "
+        "public probability parity in tests/unit/test_vit_export.py."
+    ),
+    since="1.5",
+    constraint="FP32, fixed 224x224 input",
+)
+_add(
+    "validated",
     ("mobilenetv4", "convnext", "efficientnetv2", "resnet"),
     ("classify",),
     ("openvino",),

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -766,6 +766,7 @@ __all__ = [
     "LibrePIDNet",
     "LibreSegformer",
     "LibreLingBotVision",
+    "LibreViT",
     "LibreMobileNetV4",
     "LibreConvNeXt",
     "LibreEfficientNetV2",

--- a/libreyolo/models/__init__.py
+++ b/libreyolo/models/__init__.py
@@ -103,6 +103,7 @@ from .eomt.model import LibreEoMT  # noqa: E402,F401  (semantic-only; EoMT query
 from .pidnet.model import LibrePIDNet  # noqa: E402,F401  (semantic-only; can_load uses PIDNet fusion keys)
 from .segformer.model import LibreSegformer  # noqa: E402,F401  (semantic-only; can_load uses decode_head/encoder.stages keys, unique to this family)
 from .lingbotvision.model import LibreLingBotVision  # noqa: E402,F401  (semantic-only; can_load keyed on backbone.rope_embed.periods + storage_tokens + predict head)
+from .vit.model import LibreViT  # noqa: E402  (classify-only; top-level classic-ViT signature)
 from .mobilenetv4.model import LibreMobileNetV4  # noqa: E402  (classify-only; can_load is highly specific)
 from .convnext.model import LibreConvNeXt  # noqa: E402  (classify-only; can_load is highly specific)
 from .efficientnetv2.model import LibreEfficientNetV2  # noqa: E402  (classify-only; can_load is highly specific)

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -53,6 +53,7 @@ MODEL_GROUPS: dict[str, str] = {
     "detr": "g3",
     "deformable_detr": "g3",
     "faster_rcnn": "g3",
+    "vit": "g3",
     "eomt": "g3",
     "pidnet": "g3",
     "depth_anything": "g3",

--- a/libreyolo/models/vit/NOTICE
+++ b/libreyolo/models/vit/NOTICE
@@ -1,0 +1,32 @@
+LibreViT - third-party attribution
+==================================
+
+The native Vision Transformer architecture in ``nn.py`` is derived from:
+
+    Source:  https://github.com/huggingface/pytorch-image-models
+    File:    timm/models/vision_transformer.py and supporting timm/layers modules
+    Version: v1.0.28
+    Commit:  8ef73809f622e0031bd7f4940265734aef8b9978
+    Author:  Ross Wightman and the timm contributors
+    License: Apache License 2.0
+
+LibreYOLO retains only the classic fixed-224 patch-16 classifier graph used by
+the shipped AugReg ImageNet-1k checkpoints. Dynamic image sizes, alternate
+pooling, register tokens, patch dropout, layer scale, stochastic depth, and
+other later extensions are omitted. Module and parameter names remain aligned
+with timm so all learned tensors load unchanged and exact inference parity can
+be tested.
+
+The architecture and AugReg checkpoint lineage originate from:
+
+    Source:  https://github.com/google-research/vision_transformer
+    Commit:  64801f1b3b367b3611cc27a3d45cc22870a36fb3
+    Authors: Alexey Dosovitskiy et al., Google Research
+    License: Apache License 2.0
+
+The released checkpoints are the Apache-2.0 timm conversions of Google's
+AugReg ImageNet-21k pretraining followed by ImageNet-1k fine-tuning. Each
+published LibreYOLO weight repository carries the upstream Apache-2.0 license
+and its own attribution notice.
+
+Apache License 2.0: https://www.apache.org/licenses/LICENSE-2.0

--- a/libreyolo/models/vit/__init__.py
+++ b/libreyolo/models/vit/__init__.py
@@ -1,0 +1,5 @@
+"""LibreViT family: classic patch-16 Vision Transformer classifiers."""
+
+from .model import LibreViT
+
+__all__ = ["LibreViT"]

--- a/libreyolo/models/vit/model.py
+++ b/libreyolo/models/vit/model.py
@@ -170,8 +170,8 @@ class LibreViT(BaseModel):
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         return self.model(input_tensor)
 
-    def _postprocess(self, output: Any, **kwargs) -> Dict:
-        return _vit_postprocess(output, **kwargs)
+    def _postprocess(self, output: Any, *args, **kwargs) -> Dict:
+        return _vit_postprocess(output, *args, **kwargs)
 
     def train(self, *args, **kwargs):
         del args, kwargs

--- a/libreyolo/models/vit/model.py
+++ b/libreyolo/models/vit/model.py
@@ -1,0 +1,161 @@
+"""LibreViT: standalone classic Vision Transformer classification family."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from PIL import Image
+
+from ...utils.image_loader import ImageInput
+from ..base import BaseModel
+from .nn import VisionTransformer
+from .utils import preprocess_image as _vit_preprocess
+
+
+class LibreViT(BaseModel):
+    """Classic ViT image classifiers in tiny, small, base, and large sizes.
+
+    ViT established the pure transformer over fixed image patches as a
+    competitive vision backbone. Its learned class token and position
+    embeddings became the architectural starting point for later CLIP, DINO,
+    SAM, and transformer-based detection families.
+
+    This first museum release is inference-only. It supports prediction,
+    ImageNet-style top-1/top-5 validation, and export, while the AugReg
+    fine-tuning recipe remains out of scope.
+    """
+
+    FAMILY = "vit"
+    FILENAME_PREFIX = "LibreViT"
+    INPUT_SIZES = {"ti": 224, "s": 224, "b": 224, "l": 224}
+    SUPPORTED_TASKS = ("classify",)
+    DEFAULT_TASK = "classify"
+    REQUIRE_TASK_SUFFIX = True
+    TRAIN_CONFIG = None
+
+    # All four AugReg ImageNet-1k checkpoints use the same timm eval config.
+    CROP_PCT = {"ti": 0.9, "s": 0.9, "b": 0.9, "l": 0.9}
+
+    @classmethod
+    def can_load(cls, weights_dict: dict) -> bool:
+        """Claim only shipped 224px patch-16 classic-ViT checkpoints."""
+        return (
+            "cls_token" in weights_dict
+            and "pos_embed" in weights_dict
+            and "patch_embed.proj.weight" in weights_dict
+            and "head.weight" in weights_dict
+            and cls.detect_size(weights_dict) is not None
+        )
+
+    @classmethod
+    def detect_size(cls, weights_dict: dict) -> Optional[str]:
+        """Infer the exact shipped tier from embedding width and block depth."""
+        patch_key = "patch_embed.proj.weight"
+        pos_key = "pos_embed"
+        head_key = "head.weight"
+        if patch_key not in weights_dict or pos_key not in weights_dict or head_key not in weights_dict:
+            return None
+
+        patch = weights_dict[patch_key]
+        pos = weights_dict[pos_key]
+        if patch.ndim != 4 or tuple(patch.shape[1:]) != (3, 16, 16):
+            return None
+        # 224 / 16 = 14, plus one class token. Reject patch32, 384px, hybrid,
+        # and in21k-only head layouts instead of silently resizing them.
+        if pos.ndim != 3 or int(pos.shape[1]) != 197:
+            return None
+
+        highest_block = -1
+        for key in weights_dict:
+            match = re.match(r"^blocks\.(\d+)\.norm1\.weight$", key)
+            if match:
+                highest_block = max(highest_block, int(match.group(1)))
+        signature = (int(patch.shape[0]), highest_block + 1)
+        return {
+            (192, 12): "ti",
+            (384, 12): "s",
+            (768, 12): "b",
+            (1024, 24): "l",
+        }.get(signature)
+
+    @classmethod
+    def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
+        head = weights_dict.get("head.weight")
+        return int(head.shape[0]) if head is not None and head.ndim == 2 else None
+
+    def __init__(
+        self,
+        model_path=None,
+        size: str = "ti",
+        nb_classes: int = 1000,
+        device: str = "auto",
+        task: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            model_path=model_path,
+            size=size,
+            nb_classes=nb_classes,
+            device=device,
+            task=task,
+            **kwargs,
+        )
+        self.crop_pct = self.CROP_PCT[self.size]
+        self.interpolation = "bicubic"
+        if isinstance(model_path, str):
+            self._load_weights(model_path)
+
+    def _init_model(self) -> nn.Module:
+        return VisionTransformer(size=self.size, num_classes=self.nb_classes)
+
+    def _get_available_layers(self) -> Dict[str, nn.Module]:
+        return {
+            "patch_embed": self.model.patch_embed,
+            "blocks": self.model.blocks,
+            "norm": self.model.norm,
+            "classifier": self.model.head,
+        }
+
+    def _rebuild_for_new_classes(self, new_nb_classes: int) -> None:
+        self.nb_classes = new_nb_classes
+        self.names = {i: f"class_{i}" for i in range(new_nb_classes)}
+        self.model.reset_classifier(new_nb_classes)
+        self.model.to(self.device)
+
+    def _get_preprocess_numpy(self):
+        from functools import partial
+
+        from .utils import preprocess_numpy
+
+        return partial(preprocess_numpy, crop_pct=self.crop_pct)
+
+    def _preprocess(
+        self,
+        image: ImageInput,
+        color_format: str = "auto",
+        input_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
+        effective_size = input_size if input_size is not None else self.input_size
+        return _vit_preprocess(
+            image,
+            input_size=effective_size,
+            crop_pct=self.crop_pct,
+            color_format=color_format,
+        )
+
+    def _forward(self, input_tensor: torch.Tensor) -> Any:
+        return self.model(input_tensor)
+
+    def _postprocess(self, *args, **kwargs) -> Dict:
+        del args, kwargs
+        raise NotImplementedError("ViT postprocessing lands after the upstream parity gate.")
+
+    def train(self, *args, **kwargs):
+        del args, kwargs
+        raise NotImplementedError(
+            "ViT is shipped inference-only in this museum release. The AugReg "
+            "fine-tuning recipe is not implemented in LibreYOLO yet."
+        )

--- a/libreyolo/models/vit/model.py
+++ b/libreyolo/models/vit/model.py
@@ -9,7 +9,9 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
+from ...postprocess.vit import postprocess as _vit_postprocess
 from ...utils.image_loader import ImageInput
+from ...validation.vit_validator import ViTClassifyValidator
 from ..base import BaseModel
 from .nn import VisionTransformer
 from .utils import preprocess_image as _vit_preprocess
@@ -35,6 +37,7 @@ class LibreViT(BaseModel):
     DEFAULT_TASK = "classify"
     REQUIRE_TASK_SUFFIX = True
     TRAIN_CONFIG = None
+    validator_class = ViTClassifyValidator
 
     # All four AugReg ImageNet-1k checkpoints use the same timm eval config.
     CROP_PCT = {"ti": 0.9, "s": 0.9, "b": 0.9, "l": 0.9}
@@ -56,30 +59,44 @@ class LibreViT(BaseModel):
         patch_key = "patch_embed.proj.weight"
         pos_key = "pos_embed"
         head_key = "head.weight"
-        if patch_key not in weights_dict or pos_key not in weights_dict or head_key not in weights_dict:
+        cls_key = "cls_token"
+        if any(
+            key not in weights_dict
+            for key in (patch_key, pos_key, head_key, cls_key)
+        ):
             return None
 
         patch = weights_dict[patch_key]
         pos = weights_dict[pos_key]
+        cls_token = weights_dict[cls_key]
+        head = weights_dict[head_key]
         if patch.ndim != 4 or tuple(patch.shape[1:]) != (3, 16, 16):
             return None
+        embed_dim = int(patch.shape[0])
         # 224 / 16 = 14, plus one class token. Reject patch32, 384px, hybrid,
         # and in21k-only head layouts instead of silently resizing them.
-        if pos.ndim != 3 or int(pos.shape[1]) != 197:
+        if tuple(pos.shape) != (1, 197, embed_dim):
+            return None
+        if tuple(cls_token.shape) != (1, 1, embed_dim):
+            return None
+        if head.ndim != 2 or int(head.shape[1]) != embed_dim:
             return None
 
-        highest_block = -1
+        block_indices = set()
         for key in weights_dict:
             match = re.match(r"^blocks\.(\d+)\.norm1\.weight$", key)
             if match:
-                highest_block = max(highest_block, int(match.group(1)))
-        signature = (int(patch.shape[0]), highest_block + 1)
-        return {
+                block_indices.add(int(match.group(1)))
+        signature = (embed_dim, len(block_indices))
+        size = {
             (192, 12): "ti",
             (384, 12): "s",
             (768, 12): "b",
             (1024, 24): "l",
         }.get(signature)
+        if size is None or block_indices != set(range(len(block_indices))):
+            return None
+        return size
 
     @classmethod
     def detect_nb_classes(cls, weights_dict: dict) -> Optional[int]:
@@ -153,9 +170,8 @@ class LibreViT(BaseModel):
     def _forward(self, input_tensor: torch.Tensor) -> Any:
         return self.model(input_tensor)
 
-    def _postprocess(self, *args, **kwargs) -> Dict:
-        del args, kwargs
-        raise NotImplementedError("ViT postprocessing lands after the upstream parity gate.")
+    def _postprocess(self, output: Any, **kwargs) -> Dict:
+        return _vit_postprocess(output, **kwargs)
 
     def train(self, *args, **kwargs):
         del args, kwargs

--- a/libreyolo/models/vit/model.py
+++ b/libreyolo/models/vit/model.py
@@ -109,7 +109,11 @@ class LibreViT(BaseModel):
             self._load_weights(model_path)
 
     def _init_model(self) -> nn.Module:
-        return VisionTransformer(size=self.size, num_classes=self.nb_classes)
+        return VisionTransformer(
+            size=self.size,
+            num_classes=self.nb_classes,
+            init_weights=not self._loading_from_weights,
+        )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:
         return {

--- a/libreyolo/models/vit/model.py
+++ b/libreyolo/models/vit/model.py
@@ -61,8 +61,7 @@ class LibreViT(BaseModel):
         head_key = "head.weight"
         cls_key = "cls_token"
         if any(
-            key not in weights_dict
-            for key in (patch_key, pos_key, head_key, cls_key)
+            key not in weights_dict for key in (patch_key, pos_key, head_key, cls_key)
         ):
             return None
 

--- a/libreyolo/models/vit/nn.py
+++ b/libreyolo/models/vit/nn.py
@@ -54,9 +54,7 @@ class LayerNorm(nn.LayerNorm):
         super().__init__(dim, eps=NORM_EPS, elementwise_affine=True)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return F.layer_norm(
-            x, self.normalized_shape, self.weight, self.bias, self.eps
-        )
+        return F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
 
 
 class PatchEmbed(nn.Module):
@@ -252,9 +250,7 @@ class VisionTransformer(nn.Module):
         x = self.blocks(x)
         return self.norm(x)
 
-    def forward_head(
-        self, x: torch.Tensor, pre_logits: bool = False
-    ) -> torch.Tensor:
+    def forward_head(self, x: torch.Tensor, pre_logits: bool = False) -> torch.Tensor:
         x = x[:, 0]
         x = self.fc_norm(x)
         x = self.head_drop(x)

--- a/libreyolo/models/vit/nn.py
+++ b/libreyolo/models/vit/nn.py
@@ -122,14 +122,23 @@ class Attention(nn.Module):
         )
         q, k, v = qkv.unbind(0)
         q, k = self.q_norm(q), self.k_norm(k)
-        x = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            attn_mask=None,
-            dropout_p=self.attn_drop.p if self.training else 0.0,
-            is_causal=False,
-        )
+        if torch.onnx.is_in_onnx_export():
+            # LibreYOLO defaults to ONNX opset 13, where PyTorch has no
+            # symbolic for fused SDPA. Keep eager inference on the exact timm
+            # path and lower the same equation to primitive MatMul/Softmax
+            # operators only while tracing an ONNX graph.
+            attention = (q * self.scale) @ k.transpose(-2, -1)
+            attention = self.attn_drop(attention.softmax(dim=-1))
+            x = attention @ v
+        else:
+            x = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=None,
+                dropout_p=self.attn_drop.p if self.training else 0.0,
+                is_causal=False,
+            )
         x = x.transpose(1, 2).reshape(batch, tokens, channels)
         x = self.norm(x)
         x = self.proj(x)

--- a/libreyolo/models/vit/nn.py
+++ b/libreyolo/models/vit/nn.py
@@ -1,0 +1,30 @@
+"""Native ViT architecture placeholder for the family-skeleton commit."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class VisionTransformer(nn.Module):
+    """Construction-only placeholder replaced by the native graph next commit."""
+
+    def __init__(self, size: str = "ti", num_classes: int = 1000):
+        super().__init__()
+        if size not in {"ti", "s", "b", "l"}:
+            raise ValueError("Unknown ViT size. Choose from: ti, s, b, l.")
+        self.size = size
+        self.num_classes = num_classes
+        self.patch_embed = nn.Identity()
+        self.blocks = nn.Identity()
+        self.norm = nn.Identity()
+        self.head = nn.Linear(1, num_classes)
+
+    def reset_classifier(self, num_classes: int) -> None:
+        self.num_classes = num_classes
+        weight = self.head.weight
+        self.head = nn.Linear(1, num_classes).to(device=weight.device, dtype=weight.dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        del x
+        raise NotImplementedError("The native ViT graph lands in the architecture commit.")

--- a/libreyolo/models/vit/nn.py
+++ b/libreyolo/models/vit/nn.py
@@ -1,30 +1,255 @@
-"""Native ViT architecture placeholder for the family-skeleton commit."""
+"""Classic Vision Transformer (ViT) for LibreYOLO.
+
+Derived from the Apache-2.0 timm Vision Transformer implementation at
+``huggingface/pytorch-image-models`` v1.0.28. This file is modified for
+LibreYOLO: it keeps only the fixed-224, patch-16, learned-class-token graph
+used by the four shipped AugReg checkpoints and removes timm's dynamic-image,
+alternate-pooling, register-token, and feature-extraction extensions. Module
+names intentionally remain checkpoint-compatible. See ``NOTICE`` for the
+exact upstream pin and attribution.
+
+The architecture originates with "An Image Is Worth 16x16 Words" (ICLR 2021)
+and uses a learned class token, learned absolute position embeddings, pre-norm
+self-attention/MLP blocks, a final LayerNorm, and a linear classifier.
+
+Copyright 2020 Ross Wightman
+Licensed under the Apache License, Version 2.0.
+"""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Dict
+
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+
+IMG_SIZE = 224
+PATCH_SIZE = 16
+NORM_EPS = 1e-6
+
+
+@dataclass(frozen=True)
+class ViTSpec:
+    """One fixed patch-16 ViT capacity tier."""
+
+    embed_dim: int
+    depth: int
+    num_heads: int
+
+
+ARCH_DEFS: Dict[str, ViTSpec] = {
+    "ti": ViTSpec(embed_dim=192, depth=12, num_heads=3),
+    "s": ViTSpec(embed_dim=384, depth=12, num_heads=6),
+    "b": ViTSpec(embed_dim=768, depth=12, num_heads=12),
+    "l": ViTSpec(embed_dim=1024, depth=24, num_heads=16),
+}
+
+
+class LayerNorm(nn.LayerNorm):
+    """LayerNorm matching timm's default non-fast path and epsilon."""
+
+    def __init__(self, dim: int):
+        super().__init__(dim, eps=NORM_EPS, elementwise_affine=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.layer_norm(
+            x, self.normalized_shape, self.weight, self.bias, self.eps
+        )
+
+
+class PatchEmbed(nn.Module):
+    """Patchify a fixed 224px image with a stride-16 convolution."""
+
+    def __init__(self, embed_dim: int):
+        super().__init__()
+        self.img_size = (IMG_SIZE, IMG_SIZE)
+        self.patch_size = (PATCH_SIZE, PATCH_SIZE)
+        self.grid_size = (IMG_SIZE // PATCH_SIZE, IMG_SIZE // PATCH_SIZE)
+        self.num_patches = self.grid_size[0] * self.grid_size[1]
+        self.proj = nn.Conv2d(
+            3,
+            embed_dim,
+            kernel_size=PATCH_SIZE,
+            stride=PATCH_SIZE,
+            bias=True,
+        )
+        self.norm = nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        torch._assert(
+            x.shape[-2] == IMG_SIZE,
+            f"Input height must be {IMG_SIZE} for the fixed ViT graph.",
+        )
+        torch._assert(
+            x.shape[-1] == IMG_SIZE,
+            f"Input width must be {IMG_SIZE} for the fixed ViT graph.",
+        )
+        x = self.proj(x)
+        x = x.flatten(2).transpose(1, 2)
+        return self.norm(x)
+
+
+class Attention(nn.Module):
+    """Multi-head self-attention with one fused QKV projection."""
+
+    def __init__(self, dim: int, num_heads: int):
+        super().__init__()
+        if dim % num_heads:
+            raise ValueError("ViT embedding width must be divisible by num_heads.")
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.attn_dim = dim
+        self.scale = self.head_dim**-0.5
+        self.fused_attn = True
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=True)
+        self.q_norm = nn.Identity()
+        self.k_norm = nn.Identity()
+        self.attn_drop = nn.Dropout(0.0)
+        self.norm = nn.Identity()
+        self.gate = None
+        self.proj = nn.Linear(dim, dim, bias=True)
+        self.proj_drop = nn.Dropout(0.0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch, tokens, channels = x.shape
+        qkv = (
+            self.qkv(x)
+            .reshape(batch, tokens, 3, self.num_heads, self.head_dim)
+            .permute(2, 0, 3, 1, 4)
+        )
+        q, k, v = qkv.unbind(0)
+        q, k = self.q_norm(q), self.k_norm(k)
+        x = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=self.attn_drop.p if self.training else 0.0,
+            is_causal=False,
+        )
+        x = x.transpose(1, 2).reshape(batch, tokens, channels)
+        x = self.norm(x)
+        x = self.proj(x)
+        return self.proj_drop(x)
+
+
+class Mlp(nn.Module):
+    """ViT MLP: Linear, GELU, dropout, Linear, dropout."""
+
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(dim, hidden_dim, bias=True)
+        self.act = nn.GELU()
+        self.drop1 = nn.Dropout(0.0)
+        self.norm = nn.Identity()
+        self.fc2 = nn.Linear(hidden_dim, dim, bias=True)
+        self.drop2 = nn.Dropout(0.0)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop1(x)
+        x = self.norm(x)
+        x = self.fc2(x)
+        return self.drop2(x)
+
+
+class Block(nn.Module):
+    """Pre-normalized self-attention and MLP residual block."""
+
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float = 4.0):
+        super().__init__()
+        self.norm1 = LayerNorm(dim)
+        self.attn = Attention(dim, num_heads)
+        self.ls1 = nn.Identity()
+        self.drop_path1 = nn.Identity()
+        self.norm2 = LayerNorm(dim)
+        self.mlp = Mlp(dim, int(dim * mlp_ratio))
+        self.ls2 = nn.Identity()
+        self.drop_path2 = nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.drop_path1(self.ls1(self.attn(self.norm1(x))))
+        x = x + self.drop_path2(self.ls2(self.mlp(self.norm2(x))))
+        return x
 
 
 class VisionTransformer(nn.Module):
-    """Construction-only placeholder replaced by the native graph next commit."""
+    """Fixed patch-16 classic ViT with timm-compatible state-dict names."""
 
-    def __init__(self, size: str = "ti", num_classes: int = 1000):
+    def __init__(
+        self,
+        size: str = "ti",
+        num_classes: int = 1000,
+        init_weights: bool = True,
+    ):
         super().__init__()
-        if size not in {"ti", "s", "b", "l"}:
-            raise ValueError("Unknown ViT size. Choose from: ti, s, b, l.")
+        if size not in ARCH_DEFS:
+            raise ValueError(
+                f"Unknown ViT size {size!r}; choose from {list(ARCH_DEFS)}."
+            )
+        spec = ARCH_DEFS[size]
         self.size = size
         self.num_classes = num_classes
-        self.patch_embed = nn.Identity()
-        self.blocks = nn.Identity()
-        self.norm = nn.Identity()
-        self.head = nn.Linear(1, num_classes)
+        self.num_features = self.embed_dim = spec.embed_dim
+        self.num_prefix_tokens = 1
+
+        self.patch_embed = PatchEmbed(spec.embed_dim)
+        self.cls_token = nn.Parameter(torch.empty(1, 1, spec.embed_dim))
+        self.pos_embed = nn.Parameter(
+            torch.empty(1, self.patch_embed.num_patches + 1, spec.embed_dim)
+        )
+        self.pos_drop = nn.Dropout(0.0)
+        self.patch_drop = nn.Identity()
+        self.norm_pre = nn.Identity()
+        self.blocks = nn.Sequential(
+            *[Block(spec.embed_dim, spec.num_heads) for _ in range(spec.depth)]
+        )
+        self.norm = LayerNorm(spec.embed_dim)
+        self.fc_norm = nn.Identity()
+        self.head_drop = nn.Dropout(0.0)
+        self.head = nn.Linear(spec.embed_dim, num_classes)
+
+        if init_weights:
+            nn.init.trunc_normal_(self.pos_embed, std=0.02)
+            nn.init.normal_(self.cls_token, std=1e-6)
+            self.apply(self._init_linear)
+
+    @staticmethod
+    def _init_linear(module: nn.Module) -> None:
+        if isinstance(module, nn.Linear):
+            nn.init.trunc_normal_(module.weight, std=0.02)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
 
     def reset_classifier(self, num_classes: int) -> None:
+        """Replace the classifier while preserving the current device/dtype."""
         self.num_classes = num_classes
         weight = self.head.weight
-        self.head = nn.Linear(1, num_classes).to(device=weight.device, dtype=weight.dtype)
+        self.head = nn.Linear(self.embed_dim, num_classes).to(
+            device=weight.device, dtype=weight.dtype
+        )
+
+    def forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)
+        cls_token = self.cls_token.expand(x.shape[0], -1, -1)
+        x = torch.cat((cls_token, x), dim=1)
+        x = self.pos_drop(x + self.pos_embed)
+        x = self.patch_drop(x)
+        x = self.norm_pre(x)
+        x = self.blocks(x)
+        return self.norm(x)
+
+    def forward_head(
+        self, x: torch.Tensor, pre_logits: bool = False
+    ) -> torch.Tensor:
+        x = x[:, 0]
+        x = self.fc_norm(x)
+        x = self.head_drop(x)
+        return x if pre_logits else self.head(x)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        del x
-        raise NotImplementedError("The native ViT graph lands in the architecture commit.")
+        return self.forward_head(self.forward_features(x))

--- a/libreyolo/models/vit/utils.py
+++ b/libreyolo/models/vit/utils.py
@@ -1,13 +1,52 @@
-"""ViT preprocessing placeholders, implemented after the parity gate."""
+"""Preprocessing for LibreViT AugReg image classifiers."""
 
 from __future__ import annotations
 
+from typing import Tuple
 
-def preprocess_image(*args, **kwargs):
-    del args, kwargs
-    raise NotImplementedError("ViT preprocessing lands after the upstream parity gate.")
+import numpy as np
+import torch
+from PIL import Image
+
+from ...data.classify_dataset import build_classify_transforms
+from ...utils.image_loader import ImageInput, ImageLoader
+
+VIT_MEAN = (0.5, 0.5, 0.5)
+VIT_STD = (0.5, 0.5, 0.5)
 
 
-def preprocess_numpy(*args, **kwargs):
-    del args, kwargs
-    raise NotImplementedError("ViT preprocessing lands after the upstream parity gate.")
+def build_eval_transform(input_size: int, crop_pct: float = 0.9):
+    """Return the exact timm AugReg evaluation transform."""
+    return build_classify_transforms(
+        imgsz=input_size,
+        augment=False,
+        mean=VIT_MEAN,
+        std=VIT_STD,
+        crop_pct=crop_pct,
+        interpolation="bicubic",
+    )
+
+
+def preprocess_image(
+    image: ImageInput,
+    input_size: int,
+    crop_pct: float = 0.9,
+    color_format: str = "auto",
+) -> Tuple[torch.Tensor, Image.Image, Tuple[int, int], float]:
+    """Load one image and return the shared classification predict tuple."""
+    pil = ImageLoader.load(image, color_format=color_format)
+    orig_w, orig_h = pil.size
+    tensor = build_eval_transform(input_size, crop_pct)(pil).unsqueeze(0)
+    return tensor, pil, (orig_w, orig_h), 1.0
+
+
+def preprocess_numpy(
+    img_rgb_hwc, input_size: int, crop_pct: float = 0.9
+) -> torch.Tensor:
+    """Convert an RGB HWC array (or PIL image) to normalized CHW input."""
+    pil = (
+        img_rgb_hwc
+        if isinstance(img_rgb_hwc, Image.Image)
+        else Image.fromarray(np.asarray(img_rgb_hwc).astype("uint8"))
+    )
+    return build_eval_transform(input_size, crop_pct)(pil)

--- a/libreyolo/models/vit/utils.py
+++ b/libreyolo/models/vit/utils.py
@@ -1,0 +1,13 @@
+"""ViT preprocessing placeholders, implemented after the parity gate."""
+
+from __future__ import annotations
+
+
+def preprocess_image(*args, **kwargs):
+    del args, kwargs
+    raise NotImplementedError("ViT preprocessing lands after the upstream parity gate.")
+
+
+def preprocess_numpy(*args, **kwargs):
+    del args, kwargs
+    raise NotImplementedError("ViT preprocessing lands after the upstream parity gate.")

--- a/libreyolo/postprocess/vit.py
+++ b/libreyolo/postprocess/vit.py
@@ -1,0 +1,22 @@
+"""Postprocessing for classic ViT classification logits."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import torch
+import torch.nn.functional as F
+
+
+def postprocess(output: Any, **kwargs) -> Dict[str, torch.Tensor]:
+    """Convert one classifier output into a probability vector."""
+    del kwargs
+    logits = output
+    if isinstance(logits, (list, tuple)):
+        logits = logits[0]
+    if isinstance(logits, dict):
+        logits = logits.get("logits", logits.get("predictions"))
+    logits = torch.as_tensor(logits).float()
+    if logits.ndim > 1:
+        logits = logits.reshape(-1) if logits.shape[0] == 1 else logits[0]
+    return {"probs": F.softmax(logits, dim=-1)}

--- a/libreyolo/postprocess/vit.py
+++ b/libreyolo/postprocess/vit.py
@@ -8,9 +8,9 @@ import torch
 import torch.nn.functional as F
 
 
-def postprocess(output: Any, **kwargs) -> Dict[str, torch.Tensor]:
+def postprocess(output: Any, *args, **kwargs) -> Dict[str, torch.Tensor]:
     """Convert one classifier output into a probability vector."""
-    del kwargs
+    del args, kwargs
     logits = output
     if isinstance(logits, (list, tuple)):
         logits = logits[0]

--- a/libreyolo/validation/__init__.py
+++ b/libreyolo/validation/__init__.py
@@ -4,6 +4,7 @@ from .config import ValidationConfig
 from .detection_validator import DetectionValidator, SegmentationValidator
 from .classify_validator import ClassifyValidator
 from .clip_validator import CLIPClassifyValidator
+from .vit_validator import ViTClassifyValidator
 from .obb_validator import OBBValidator
 from .coco_evaluator import COCOEvaluator
 from .pose_validator import PoseValidator
@@ -26,6 +27,7 @@ __all__ = [
     "SegmentationValidator",
     "ClassifyValidator",
     "CLIPClassifyValidator",
+    "ViTClassifyValidator",
     "OBBValidator",
     "PoseValidator",
     "PointValidator",

--- a/libreyolo/validation/vit_validator.py
+++ b/libreyolo/validation/vit_validator.py
@@ -1,0 +1,17 @@
+"""Image-classification validator with ViT AugReg preprocessing."""
+
+from __future__ import annotations
+
+from .classify_validator import ClassifyValidator
+
+
+class ViTClassifyValidator(ClassifyValidator):
+    """Top-1/top-5 validator using the published AugReg eval transform."""
+
+    def _dataset_transform_kwargs(self) -> dict:
+        return {
+            "mean": (0.5, 0.5, 0.5),
+            "std": (0.5, 0.5, 0.5),
+            "interpolation": "bicubic",
+            "crop_pct": 0.9,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,6 +347,7 @@ testpaths = ["tests"]
 timeout_method = "thread"
 markers = [
     "unit: fast tests that avoid external weights or large files",
+    "vit: tests covering the ViT classification family",
     "external_data: tests that require external datasets, weights, or staged large files",
     "network: tests that intentionally use non-local network access",
     "e2e: end-to-end tests requiring full model loading and inference",

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1359,6 +1359,30 @@
     "available": true,
     "group": "g3"
   },
+  "vit": {
+    "class": "libreyolo.models.vit.model.LibreViT",
+    "tasks": [
+      "classify"
+    ],
+    "default_task": "classify",
+    "sizes": {
+      "ti": 224,
+      "s": 224,
+      "b": 224,
+      "l": 224
+    },
+    "default_imgsz": {
+      "ti": 224,
+      "s": 224,
+      "b": 224,
+      "l": 224
+    },
+    "task_sizes": {},
+    "export_override": "none",
+    "optional_extra": null,
+    "available": true,
+    "group": "g3"
+  },
   "yolo1": {
     "class": "libreyolo.models.yolo1.model.LibreYOLO1",
     "tasks": [

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -63,6 +63,7 @@ file = name + ".pt"
 | ConvNeXt | `LibreConvNeXt` | `LibreConvNeXtt-cls.pt` |
 | EfficientNetV2 | `LibreEfficientNetV2` | `LibreEfficientNetV2b0-cls.pt` |
 | ResNet | `LibreResNet` | `LibreResNet50-cls.pt` |
+| ViT | `LibreViT` | `LibreViTti-cls.pt` (classic patch-16 AugReg classifier; Apache-2.0 code + weights; inference-only) |
 | CLIP | `LibreCLIP` | `LibreCLIPb32-cls.pt` (zero-shot, open-vocab classify) |
 | SigLIP2 | `LibreSigLIP2` | `LibreSigLIP2b16-cls.pt` (zero-shot, open-vocab classify) |
 | NAFNet | `LibreNAFNet` | `LibreNAFNets-restore.pt` (restore-only; `-sidd` variant = SIDD denoise) |
@@ -192,6 +193,9 @@ LibreEfficientNetV2b2-cls.pt, LibreEfficientNetV2b3-cls.pt,
 
 LibreResNet18-cls.pt, LibreResNet34-cls.pt,
 LibreResNet50-cls.pt, LibreResNet101-cls.pt,
+
+LibreViTti-cls.pt, LibreViTs-cls.pt,
+LibreViTb-cls.pt, LibreViTl-cls.pt,
 
 LibreCLIPb32-cls.pt, LibreCLIPb16-cls.pt, LibreCLIPl14-cls.pt,
 

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -420,6 +420,7 @@ After the repo is uploaded, add it to a collection:
 | Repo type | Collection |
 |---|---|
 | Detection weights | `LibreYOLO/libreyolo-models-698875bf2b5f695708415169` |
+| Classification weights | `LibreYOLO/libreyolo-classification-6a4164414d64a10aa8576885` |
 | RF-DETR segmentation | `LibreYOLO/rf-detr-instance-segmentation-69bde2744d6c285366a69603` |
 | New seg family (e.g. YOLOX-seg) | **Ask the user** — create a new collection or extend existing |
 | New detection family with no siblings yet | Add to `LibreYOLO Models` |

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -509,6 +509,10 @@ MODEL_CATALOG = [
     ("picodet", "s", "LibrePICODETs.pt"),
     ("picodet", "m", "LibrePICODETm.pt"),
     ("picodet", "l", "LibrePICODETl.pt"),
+    ("vit", "ti", "LibreViTti-cls.pt"),
+    ("vit", "s", "LibreViTs-cls.pt"),
+    ("vit", "b", "LibreViTb-cls.pt"),
+    ("vit", "l", "LibreViTl-cls.pt"),
 ]
 
 FLAGSHIP_FAMILIES = {"yolo9", "rfdetr"}
@@ -540,6 +544,7 @@ GENERAL_NIGHTLY_INFERENCE_MODELS = [
     ("rtdetrv4", "s", "weights/LibreRTDETRv4s.pt"),
     ("picodet", "s", "LibrePICODETs.pt"),
     ("rtmdet", "t", "LibreRTMDett.pt"),
+    ("vit", "ti", "LibreViTti-cls.pt"),
 ]
 
 # Derived lists (no manual maintenance)
@@ -573,7 +578,7 @@ QUICK_TEST_MODELS = [("yolox", "n"), ("yolo9", "t"), ("rtdetr", "r18")]
 FULL_TEST_MODELS = [
     (family, size)
     for family, size in NON_RFDETR_MODELS
-    if family != "faster_rcnn"
+    if family not in {"faster_rcnn", "vit"}
 ]
 
 # RF-DETR test set (separate due to dependency)
@@ -604,6 +609,7 @@ FAMILY_MARKERS = {
     "rtmdet": pytest.mark.rtmdet,
     "l2cs": pytest.mark.l2cs,
     "fomo": pytest.mark.fomo,
+    "vit": pytest.mark.vit,
 }
 
 

--- a/tests/e2e/test_deterministic_inference.py
+++ b/tests/e2e/test_deterministic_inference.py
@@ -1,7 +1,7 @@
 """Nightly native inference checks for every public model family.
 
 This is the broad tier: one smallest pretrained case per family, native model
-load, two inference passes, and stable detection/gaze outputs. Keep exports and
+load, two inference passes, and stable task-native outputs. Keep exports and
 training out of this file; those belong to flagship or backend-specific suites.
 """
 
@@ -95,6 +95,20 @@ def _assert_batched_detection_output_matches_sequential(family, sequential, batc
     torch.testing.assert_close(sequential_cls, batched_cls, rtol=0, atol=0)
 
 
+def _assert_classification_output_is_stable(family, first, second):
+    assert first.probs is not None, f"{family} did not return probabilities"
+    assert second.probs is not None, f"{family} did not return probabilities"
+    assert first.orig_shape == second.orig_shape
+    assert first.names, f"{family} result has no class names"
+
+    first_probs = _tensor(first.probs.data)
+    second_probs = _tensor(second.probs.data)
+    assert torch.isfinite(first_probs).all(), f"{family} produced non-finite probabilities"
+    assert torch.isclose(first_probs.sum(), torch.tensor(1.0), atol=1e-5)
+    torch.testing.assert_close(first_probs, second_probs, rtol=1e-5, atol=1e-6)
+    assert first.probs.top1 == second.probs.top1
+
+
 def _run_l2cs(weights, size):
     from libreyolo import LibreL2CS
 
@@ -136,7 +150,10 @@ def test_native_inference_is_stable(family, size, weights, sample_image):
     try:
         first = model(sample_image, conf=0.25)
         second = model(sample_image, conf=0.25)
-        _assert_detection_output_is_stable(family, first, second)
+        if family == "vit":
+            _assert_classification_output_is_stable(family, first, second)
+        else:
+            _assert_detection_output_is_stable(family, first, second)
     finally:
         del model
         cuda_cleanup()
@@ -173,6 +190,10 @@ def test_batched_list_predict_matches_sequential(family, size, weights, sample_i
         batched = model(images, conf=conf, batch=2)
 
         assert len(sequential) == len(batched) == 2
+        if family == "vit":
+            for r_seq, r_bat in zip(sequential, batched):
+                _assert_classification_output_is_stable(family, r_seq, r_bat)
+            return
         assert len(sequential[0]) > 0, f"{family} returned no detections"
         for r_seq, r_bat in zip(sequential, batched):
             # Full box/score/class parity for every image with detections

--- a/tests/e2e/test_rf1_training.py
+++ b/tests/e2e/test_rf1_training.py
@@ -91,6 +91,11 @@ DETR_RF1_FAMILIES = {"dfine", "deim", "deimv2", "rtdetr"}
 # convergence has not been validated against the RF1 mAP floor. Every RF1
 # training test skips them — keep the two tests consistent via this map.
 _EXPERIMENTAL_TRAINING_SKIP = {
+    "vit": (
+        "ViT ships inference-only: the AugReg fine-tuning recipe is outside "
+        "this museum port, and train() raises. Pretrained and export parity "
+        "are verified separately."
+    ),
     "detr": (
         "Original DETR ships inference-only: its 500-epoch Hungarian-matching "
         "training recipe is not implemented, and train() raises. Inference "

--- a/tests/e2e/test_val_coco128.py
+++ b/tests/e2e/test_val_coco128.py
@@ -31,6 +31,11 @@ MIN_MAP = 0.18  # Uniform threshold for all models
 )
 def test_val_coco128(family, size, weights):
     """Validate a pretrained model on coco128 and check mAP >= 0.18."""
+    if family == "vit":
+        pytest.skip(
+            "ViT is a classifier; ImageNet-style top-1/top-5 validation uses "
+            "ClassifyValidator rather than the COCO detection mAP contract."
+        )
     weights = require_test_weights(weights)
     model = LibreYOLO(weights, size=size)
 

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -57,6 +57,7 @@ class TestResolveModelName:
             ),
             ("fomo-s", "fomo-s-point", "LibreFOMOs-point.pt"),
             ("siglip2-b16", "siglip2-b16-cls", "LibreSigLIP2b16-cls.pt"),
+            ("vit-ti", "vit-ti-cls", "LibreViTti-cls.pt"),
             ("zipdepth-b", "zipdepth-b-depth", "LibreZipDepthb-depth.pt"),
         ],
     )

--- a/tests/unit/test_classify_discriminators.py
+++ b/tests/unit/test_classify_discriminators.py
@@ -79,6 +79,7 @@ def test_classify_filenames_require_cls_suffix():
         LibreEfficientNetV2,
         LibreMobileNetV4,
         LibreResNet,
+        LibreViT,
     )
 
     for cls, size in [
@@ -86,6 +87,7 @@ def test_classify_filenames_require_cls_suffix():
         (LibreConvNeXt, "t"),
         (LibreEfficientNetV2, "b0"),
         (LibreMobileNetV4, "s"),
+        (LibreViT, "ti"),
     ]:
         stem = f"{cls.FILENAME_PREFIX}{size}"
         assert cls.detect_size_from_filename(f"{stem}-cls.pt") == size, (

--- a/tests/unit/test_ddp_loader_sharding.py
+++ b/tests/unit/test_ddp_loader_sharding.py
@@ -549,6 +549,7 @@ def _pose_val_gate_worker(rank, world_size, port, out_dir):
             dist.destroy_process_group()
 
 
+@pytest.mark.distributed
 @pytest.mark.skipif(
     sys.platform == "win32" and sys.version_info < (3, 8),
     reason="mp.spawn on Windows needs Python 3.8+",

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -65,6 +65,13 @@ def test_experimental_export_warns_in_preflight():
         exporter._preflight(half=False, int8=False, data=None)
 
 
+def test_vit_onnx_is_parity_validated():
+    entry = get_support("vit", "classify", "onnx")
+    assert entry.tier == "validated"
+    assert entry.constraint == "FP32, fixed 224x224 input"
+    assert "test_vit_export.py" in entry.reason
+
+
 def test_executorch_realtime_support_is_evidence_backed():
     validated = {
         ("clip", "embed"),

--- a/tests/unit/test_vit.py
+++ b/tests/unit/test_vit.py
@@ -1,0 +1,171 @@
+"""LibreViT unit coverage for registry, inference, and preprocessing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.vit.model import LibreViT
+from libreyolo.models.vit.nn import VisionTransformer
+from libreyolo.models.vit.utils import build_eval_transform
+from libreyolo.postprocess.vit import postprocess
+
+pytestmark = [pytest.mark.unit, pytest.mark.vit]
+
+
+def _signature_state(size: str, num_classes: int = 1000) -> dict:
+    specs = {
+        "ti": (192, 12),
+        "s": (384, 12),
+        "b": (768, 12),
+        "l": (1024, 24),
+    }
+    embed_dim, depth = specs[size]
+    state = {
+        "cls_token": torch.empty(1, 1, embed_dim),
+        "pos_embed": torch.empty(1, 197, embed_dim),
+        "patch_embed.proj.weight": torch.empty(embed_dim, 3, 16, 16),
+        "head.weight": torch.empty(num_classes, embed_dim),
+    }
+    state.update(
+        {f"blocks.{index}.norm1.weight": torch.empty(embed_dim) for index in range(depth)}
+    )
+    return state
+
+
+def test_registered_and_classify_only_contract():
+    from libreyolo.models.base import BaseModel
+    from libreyolo.validation.vit_validator import ViTClassifyValidator
+
+    assert LibreViT in BaseModel._registry
+    model = LibreViT(size="ti", nb_classes=7, device="cpu")
+    assert model.family == "vit"
+    assert model.task == "classify"
+    assert model.input_size == 224
+    assert model.crop_pct == 0.9
+    assert model.interpolation == "bicubic"
+    assert model.validator_class is ViTClassifyValidator
+
+
+def test_canonical_multichar_filename_and_required_suffix():
+    assert LibreViT.detect_size_from_filename("LibreViTti-cls.pt") == "ti"
+    assert LibreViT.detect_size_from_filename("LibreViTs-cls.pt") == "s"
+    assert LibreViT.detect_size_from_filename("LibreViTb-cls.pt") == "b"
+    assert LibreViT.detect_size_from_filename("LibreViTl-cls.pt") == "l"
+    assert LibreViT.detect_task_from_filename("LibreViTti-cls.pt") == "classify"
+    assert LibreViT.detect_size_from_filename("LibreViTti.pt") is None
+    assert LibreViT.detect_size_from_filename("LibreVitt-cls.pt") is None
+
+
+@pytest.mark.parametrize("size", ["ti", "s", "b", "l"])
+def test_exact_shipped_signatures_detect_size_and_classes(size):
+    state = _signature_state(size, num_classes=37)
+    assert LibreViT.can_load(state)
+    assert LibreViT.detect_size(state) == size
+    assert LibreViT.detect_nb_classes(state) == 37
+
+
+def test_unsupported_patch_resolution_and_incomplete_depth_are_rejected():
+    patch32 = _signature_state("b")
+    patch32["patch_embed.proj.weight"] = torch.empty(768, 3, 32, 32)
+    resolution384 = _signature_state("b")
+    resolution384["pos_embed"] = torch.empty(1, 577, 768)
+    missing_block = _signature_state("ti")
+    missing_block.pop("blocks.4.norm1.weight")
+
+    for state in (patch32, resolution384, missing_block):
+        assert LibreViT.detect_size(state) is None
+        assert not LibreViT.can_load(state)
+
+
+def test_sibling_discriminators_reject_vit_bidirectionally():
+    from libreyolo import (
+        LibreCLIP,
+        LibreConvNeXt,
+        LibreDEIMv2,
+        LibreDINOv2,
+        LibreEfficientNetV2,
+        LibreEoMT,
+        LibreMobileNetV4,
+        LibreRFDETR,
+        LibreResNet,
+    )
+
+    vit_state = _signature_state("ti")
+    siblings = (
+        LibreDINOv2,
+        LibreCLIP,
+        LibreResNet,
+        LibreConvNeXt,
+        LibreMobileNetV4,
+        LibreEfficientNetV2,
+        LibreRFDETR,
+        LibreDEIMv2,
+        LibreEoMT,
+    )
+    for sibling in siblings:
+        assert not sibling.can_load(vit_state), sibling.__name__
+
+    sibling_signatures = (
+        {"backbone.patch_embed.proj.weight": torch.empty(1), "linear.weight": torch.empty(1)},
+        {"logit_scale": torch.empty(1), "text_projection": torch.empty(1), "visual.conv1.weight": torch.empty(1)},
+        {"conv1.weight": torch.empty(1), "fc.weight": torch.empty(1), "layer1.0.conv1.weight": torch.empty(1)},
+        {"stem.0.weight": torch.empty(1), "head.fc.weight": torch.empty(1), "stages.0.blocks.0.gamma": torch.empty(1)},
+        {"conv_stem.weight": torch.empty(1), "conv_head.weight": torch.empty(1), "blocks.0.pw_exp.conv.weight": torch.empty(1)},
+        {"conv_stem.weight": torch.empty(1), "conv_head.weight": torch.empty(1), "blocks.0.se.conv_reduce.weight": torch.empty(1)},
+        {"transformer.decoder.weight": torch.empty(1)},
+        {"decoder.swish_ffn.weight": torch.empty(1)},
+        {
+            "query.weight": torch.empty(1),
+            "mask_head.fc1.weight": torch.empty(1),
+            "mask_head.fc2.weight": torch.empty(1),
+            "mask_head.fc3.weight": torch.empty(1),
+            "class_predictor.weight": torch.empty(1),
+            "embeddings.patch_embeddings.projection.weight": torch.empty(1),
+        },
+    )
+    for state in sibling_signatures:
+        assert not LibreViT.can_load(state)
+
+
+def test_forward_reset_classifier_and_postprocess():
+    model = VisionTransformer(size="ti", num_classes=7).eval()
+    with torch.inference_mode():
+        logits = model(torch.zeros(1, 3, 224, 224))
+    assert logits.shape == (1, 7)
+
+    model.reset_classifier(3)
+    with torch.inference_mode():
+        logits = model(torch.zeros(1, 3, 224, 224))
+    assert logits.shape == (1, 3)
+    probs = postprocess(logits)["probs"]
+    assert probs.shape == (3,)
+    assert torch.isclose(probs.sum(), torch.tensor(1.0), atol=1e-6)
+    assert int(probs.argmax()) == int(logits.argmax())
+
+
+def test_eval_preprocessing_exactly_matches_timm_augreg():
+    timm = pytest.importorskip("timm")
+    from timm.data import create_transform, resolve_model_data_config
+
+    reference = timm.create_model(
+        "vit_tiny_patch16_224.augreg_in21k_ft_in1k", pretrained=False
+    )
+    config = resolve_model_data_config(reference)
+    pixels = np.arange(277 * 301 * 3, dtype=np.uint32).reshape(277, 301, 3)
+    image = Image.fromarray(pixels.astype(np.uint8))
+
+    expected = create_transform(**config, is_training=False)(image)
+    actual = build_eval_transform(224, crop_pct=0.9)(image)
+    assert config["mean"] == (0.5, 0.5, 0.5)
+    assert config["std"] == (0.5, 0.5, 0.5)
+    assert config["crop_pct"] == 0.9
+    assert torch.equal(actual, expected)
+
+
+def test_training_is_explicitly_unsupported():
+    model = LibreViT(size="ti", nb_classes=2, device="cpu")
+    with pytest.raises(NotImplementedError, match="inference-only"):
+        model.train(data="smoke10")

--- a/tests/unit/test_vit.py
+++ b/tests/unit/test_vit.py
@@ -30,7 +30,10 @@ def _signature_state(size: str, num_classes: int = 1000) -> dict:
         "head.weight": torch.empty(num_classes, embed_dim),
     }
     state.update(
-        {f"blocks.{index}.norm1.weight": torch.empty(embed_dim) for index in range(depth)}
+        {
+            f"blocks.{index}.norm1.weight": torch.empty(embed_dim)
+            for index in range(depth)
+        }
     )
     return state
 
@@ -115,12 +118,35 @@ def test_sibling_discriminators_reject_vit_bidirectionally():
         assert not sibling.can_load(vit_state), sibling.__name__
 
     sibling_signatures = (
-        {"backbone.patch_embed.proj.weight": torch.empty(1), "linear.weight": torch.empty(1)},
-        {"logit_scale": torch.empty(1), "text_projection": torch.empty(1), "visual.conv1.weight": torch.empty(1)},
-        {"conv1.weight": torch.empty(1), "fc.weight": torch.empty(1), "layer1.0.conv1.weight": torch.empty(1)},
-        {"stem.0.weight": torch.empty(1), "head.fc.weight": torch.empty(1), "stages.0.blocks.0.gamma": torch.empty(1)},
-        {"conv_stem.weight": torch.empty(1), "conv_head.weight": torch.empty(1), "blocks.0.pw_exp.conv.weight": torch.empty(1)},
-        {"conv_stem.weight": torch.empty(1), "conv_head.weight": torch.empty(1), "blocks.0.se.conv_reduce.weight": torch.empty(1)},
+        {
+            "backbone.patch_embed.proj.weight": torch.empty(1),
+            "linear.weight": torch.empty(1),
+        },
+        {
+            "logit_scale": torch.empty(1),
+            "text_projection": torch.empty(1),
+            "visual.conv1.weight": torch.empty(1),
+        },
+        {
+            "conv1.weight": torch.empty(1),
+            "fc.weight": torch.empty(1),
+            "layer1.0.conv1.weight": torch.empty(1),
+        },
+        {
+            "stem.0.weight": torch.empty(1),
+            "head.fc.weight": torch.empty(1),
+            "stages.0.blocks.0.gamma": torch.empty(1),
+        },
+        {
+            "conv_stem.weight": torch.empty(1),
+            "conv_head.weight": torch.empty(1),
+            "blocks.0.pw_exp.conv.weight": torch.empty(1),
+        },
+        {
+            "conv_stem.weight": torch.empty(1),
+            "conv_head.weight": torch.empty(1),
+            "blocks.0.se.conv_reduce.weight": torch.empty(1),
+        },
         {"transformer.decoder.weight": torch.empty(1)},
         {"decoder.swish_ffn.weight": torch.empty(1)},
         {

--- a/tests/unit/test_vit.py
+++ b/tests/unit/test_vit.py
@@ -47,6 +47,12 @@ def test_registered_and_classify_only_contract():
     assert model.crop_pct == 0.9
     assert model.interpolation == "bicubic"
     assert model.validator_class is ViTClassifyValidator
+    assert ViTClassifyValidator._dataset_transform_kwargs(None) == {
+        "mean": (0.5, 0.5, 0.5),
+        "std": (0.5, 0.5, 0.5),
+        "interpolation": "bicubic",
+        "crop_pct": 0.9,
+    }
 
 
 def test_canonical_multichar_filename_and_required_suffix():

--- a/tests/unit/test_vit_export.py
+++ b/tests/unit/test_vit_export.py
@@ -1,0 +1,79 @@
+"""LibreViT ONNX export and runtime parity coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+pytestmark = [pytest.mark.unit, pytest.mark.vit, pytest.mark.onnx]
+
+
+def test_random_tiny_onnx_round_trip_matches_eager(tmp_path):
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxruntime")
+    import onnxruntime as ort
+
+    from libreyolo import LibreViT
+
+    eager = LibreViT(size="ti", nb_classes=11, device="cpu")
+    eager.model.eval()
+    image = np.random.default_rng(2020).standard_normal(
+        (1, 3, 224, 224), dtype=np.float32
+    )
+    with torch.inference_mode():
+        expected = eager.model(torch.from_numpy(image)).numpy()
+
+    output_path = tmp_path / "LibreViTti-cls.onnx"
+    exported = eager.export(
+        format="onnx", imgsz=224, half=False, output_path=str(output_path)
+    )
+    session = ort.InferenceSession(exported, providers=["CPUExecutionProvider"])
+    assert [output.name for output in session.get_outputs()] == ["output"]
+    actual = session.run(None, {session.get_inputs()[0].name: image})[0]
+
+    assert actual.shape == expected.shape == (1, 11)
+    np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.external_data
+@pytest.mark.network
+def test_pretrained_tiny_onnx_backend_matches_native_predict(tmp_path):
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxruntime")
+
+    from libreyolo import LibreYOLO
+    from libreyolo.backends.onnx import OnnxBackend
+
+    local = Path("weights/LibreViTti-cls.pt")
+    weights = str(local) if local.exists() else "LibreViTti-cls.pt"
+    native = LibreYOLO(weights, device="cpu")
+    pixels = np.arange(277 * 301 * 3, dtype=np.uint32).reshape(277, 301, 3)
+    image = Image.fromarray(pixels.astype(np.uint8))
+
+    input_tensor, _, _, _ = native._preprocess(image)
+    with torch.inference_mode():
+        expected_logits = native.model(input_tensor).numpy()
+
+    output_path = tmp_path / "LibreViTti-cls.onnx"
+    exported = native.export(
+        format="onnx", imgsz=224, half=False, output_path=str(output_path)
+    )
+    backend = OnnxBackend(exported, device="cpu")
+    actual_logits = backend.session.run(
+        None, {backend.input_name: input_tensor.numpy()}
+    )[0]
+    np.testing.assert_allclose(actual_logits, expected_logits, rtol=1e-4, atol=1e-4)
+
+    native_result = native.predict(image)
+    exported_result = backend.predict(image)
+    torch.testing.assert_close(
+        exported_result.probs.data,
+        native_result.probs.data,
+        rtol=1e-4,
+        atol=1e-5,
+    )
+    assert exported_result.probs.top1 == native_result.probs.top1

--- a/tests/unit/test_vit_parity.py
+++ b/tests/unit/test_vit_parity.py
@@ -1,0 +1,49 @@
+"""LibreViT exact pretrained-logit parity against the pinned timm reference."""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.external_data, pytest.mark.network]
+
+TAGS = {
+    "ti": "vit_tiny_patch16_224.augreg_in21k_ft_in1k",
+    "s": "vit_small_patch16_224.augreg_in21k_ft_in1k",
+    "b": "vit_base_patch16_224.augreg2_in21k_ft_in1k",
+    "l": "vit_large_patch16_224.augreg_in21k_ft_in1k",
+}
+
+
+@pytest.mark.parametrize("size", list(TAGS))
+def test_timm_pretrained_parity(size):
+    """Every shipped checkpoint loads strictly and produces identical logits."""
+    timm = pytest.importorskip("timm")
+    from libreyolo.models.vit.nn import VisionTransformer
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    reference = timm.create_model(TAGS[size], pretrained=True).eval()
+    native = VisionTransformer(
+        size=size, num_classes=1000, init_weights=False
+    ).eval()
+    result = native.load_state_dict(reference.state_dict(), strict=True)
+    assert not result.missing_keys and not result.unexpected_keys
+
+    reference = reference.to(device)
+    native = native.to(device)
+    generator = torch.Generator(device=device).manual_seed(2020)
+    image = torch.randn(1, 3, 224, 224, generator=generator, device=device)
+    with torch.inference_mode():
+        expected = reference(image)
+        actual = native(image)
+
+    max_abs_diff = (expected - actual).abs().max().item()
+    print(f"size={size} device={device} max_abs_diff={max_abs_diff}")
+    assert max_abs_diff == 0.0
+
+    del reference, native, image, expected, actual
+    gc.collect()
+    if device.type == "cuda":
+        torch.cuda.empty_cache()

--- a/tests/unit/test_vit_parity.py
+++ b/tests/unit/test_vit_parity.py
@@ -25,9 +25,7 @@ def test_timm_pretrained_parity(size):
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     reference = timm.create_model(TAGS[size], pretrained=True).eval()
-    native = VisionTransformer(
-        size=size, num_classes=1000, init_weights=False
-    ).eval()
+    native = VisionTransformer(size=size, num_classes=1000, init_weights=False).eval()
     result = native.load_state_dict(reference.state_dict(), strict=True)
     assert not result.missing_keys and not result.unexpected_keys
 

--- a/tests/unit/ui/test_ui_summary.py
+++ b/tests/unit/ui/test_ui_summary.py
@@ -79,6 +79,19 @@ def test_openvocab_model_names_flags_set_classes_families():
     assert not any(n.startswith("yolo9-") for n in flagged)
 
 
+def test_vit_cli_alias_is_ui_downloadable():
+    from libreyolo.cli.config import get_all_cli_names
+    from libreyolo.ui.server import _resolve_download_url
+
+    names = get_all_cli_names()
+    assert "vit-ti" in names
+    assert "vit-ti-cls" in names
+    assert _resolve_download_url("vit-ti") == (
+        "https://huggingface.co/LibreYOLO/LibreViTti-cls/resolve/main/"
+        "LibreViTti-cls.pt"
+    )
+
+
 def test_factory_openvocab_names_resolve_in_the_factory():
     """Every UI-listed factory name must stay a valid LibreOpenVocab alias."""
     from libreyolo.models.openvocab import _ALIASES

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -94,6 +94,10 @@ project the weights were derived from. Per-family summary:
     ResNet   (LibreResNet{18,34,50,101}-cls)           Apache-2.0
              upstream: timm (a1_in1k "ResNet Strikes Back" recipe), ImageNet-1k
 
+    ViT      (LibreViT{ti,s,b,l}-cls)                  Apache-2.0
+             upstream: timm AugReg ImageNet-21k pretraining + ImageNet-1k
+             fine-tuning; metadata wrap only, learned tensors unchanged
+
     CLIP     (LibreCLIP{b32,b16}-cls)                  MIT (weights)
              upstream: mlfoundations/open_clip LAION-2B checkpoints;
              see libreyolo/models/clip/NOTICE.md for the LAION

--- a/weights/convert_vit_weights.py
+++ b/weights/convert_vit_weights.py
@@ -1,0 +1,84 @@
+"""Convert Apache-2.0 timm AugReg ViT weights to LibreYOLO checkpoints.
+
+The native ``libreyolo.models.vit.nn.VisionTransformer`` mirrors the classic
+ViT module names in timm v1.0.28, pinned to commit
+``8ef73809f622e0031bd7f4940265734aef8b9978``. Conversion therefore preserves
+every learned tensor unchanged and adds only LibreYOLO checkpoint metadata.
+
+All four source model cards explicitly declare ``license: apache-2.0``. The
+checkpoints are redistributable and are rehosted with their upstream license
+and attribution notice. See ``libreyolo/models/vit/NOTICE``.
+
+Usage::
+
+    python weights/convert_vit_weights.py
+    python weights/convert_vit_weights.py --size ti
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _conversion_utils import (
+    add_repo_root_to_path,
+    imagenet1k_names,
+    save_checkpoint,
+    wrap_libreyolo_checkpoint,
+)
+
+TAGS = {
+    "ti": "vit_tiny_patch16_224.augreg_in21k_ft_in1k",
+    "s": "vit_small_patch16_224.augreg_in21k_ft_in1k",
+    "b": "vit_base_patch16_224.augreg2_in21k_ft_in1k",
+    "l": "vit_large_patch16_224.augreg_in21k_ft_in1k",
+}
+
+
+def convert(size: str) -> Path:
+    """Download, strictly validate, and metadata-wrap one ViT tier."""
+    import timm
+
+    add_repo_root_to_path()
+    from libreyolo.models.vit.nn import VisionTransformer
+
+    tag = TAGS[size]
+    reference = timm.create_model(tag, pretrained=True)
+    state_dict = reference.state_dict()
+
+    native = VisionTransformer(size=size, num_classes=1000, init_weights=False)
+    result = native.load_state_dict(state_dict, strict=True)
+    assert not result.missing_keys and not result.unexpected_keys, (
+        result.missing_keys[:5],
+        result.unexpected_keys[:5],
+    )
+
+    checkpoint = wrap_libreyolo_checkpoint(
+        state_dict,
+        model_family="vit",
+        size=size,
+        nc=1000,
+        names=imagenet1k_names(),
+        task="classify",
+        imgsz=224,
+    )
+
+    output = Path("weights") / f"LibreViT{size}-cls.pt"
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    save_checkpoint(checkpoint, temporary)
+    temporary.replace(output)
+    print(f"Wrote {output} (timm {tag}, nc=1000, task=classify, imgsz=224)")
+    return output
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--size",
+        choices=list(TAGS),
+        default=None,
+        help="Variant to convert (default: all).",
+    )
+    args = parser.parse_args()
+    for selected_size in [args.size] if args.size else list(TAGS):
+        convert(selected_size)


### PR DESCRIPTION
Closes #637.

## Summary

- Add inference-only `LibreViT` classification for patch-16 `ti`, `s`, `b`, and `l` models at 224 pixels.
- Integrate model discovery, CLI/UI aliases, validation, conversion, auto-download, ONNX support, documentation, and tests.
- Publish the four canonical Apache-2.0 checkpoints under the LibreYOLO Hugging Face organization.
- Limit the shared backend change to ViT metadata so other families keep their existing preprocessing.
- Route an existing two-rank Gloo regression test through the serial Linux distributed job instead of OS-wide xdist. Production code is unaffected.

## Verification

- Pinned upstream eager parity: all four sizes produce `max_abs_diff == 0.0`.
- Focused integration gate: 156 passed. ViT and ONNX gate after final formatting: 13 passed, plus 4 external parity tests.
- GitHub PR gate: unit matrices passed on Ubuntu, macOS, and Windows; the serial Linux distributed job passed with the corrected Gloo marker.
- Checkpoint schema and clean-cache auto-download verified for all four published artifacts.
- Not verified: ImageNet accuracy evaluation or export runtimes other than ONNX.

## Code provenance

- `libreyolo/models/vit/nn.py` is derived from `rwightman/timm` v1.0.28 commit `8ef73809f622e0031bd7f4940265734aef8b9978` under Apache-2.0. Architecture lineage was checked against `google-research/vision_transformer` commit `64801f1b3b367b3611cc27a3d45cc22870a36fb3`, also Apache-2.0.
- Conversion, integration, export-path, test code, and the Gloo marker correction were written for LibreYOLO. The converter adds LibreYOLO metadata without changing learned parameters.
- Exact checkpoint source revisions, source and converted hashes, license evidence, and notice locations are recorded in `docs/provenance/vit.md`.