### PR TITLE
Add opt-in faster-coco-eval backend for COCO metrics (10-50x faster validation on dense datasets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- Opt-in `faster_coco_eval` flag (off by default) on `ValidationConfig`,
+  `TrainConfig`, `model.val()` / `model.train()` kwargs, and the CLI
+  (`--faster-coco-eval` on `libreyolo val` / `libreyolo train`). Routes
+  bbox/segm COCO metrics through the faster-coco-eval C++ backend
+  (10-50x faster on detection-dense datasets; validated bit-identical to
+  pycocotools within float64 summation order across the 100 RF100-VL
+  datasets). The `LIBREYOLO_FASTER_COCO_EVAL` env var overrides the flag
+  in either direction, the backend actually used (name + version) is
+  logged and exposed as `COCOEvaluator.last_backend` for provenance, and
+  the evaluator falls back to pycocotools with a warning if the package
+  is missing. Install via `pip install libreyolo[fast-eval]`.
+
 - LibreDETR, an inference-only museum port of the original DETR (ECCV 2020)
   in all four released COCO variants (`r50`, `r50dc5`, `r101`, `r101dc5`).
   Native outputs are bit-exact against the pinned facebookresearch/detr

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -329,6 +329,12 @@ def train_cmd(
         None,
         help="COCO evaluator cap (default: pycocotools AP@100)",
     ),
+    faster_coco_eval: bool = typer.Option(
+        False,
+        "--faster-coco-eval",
+        help="Use the faster-coco-eval C++ backend for validation COCO metrics "
+        "(requires the faster-coco-eval package; falls back to pycocotools)",
+    ),
     save_plots: bool = typer.Option(
         False, help="Save final validation plots during training"
     ),
@@ -534,6 +540,7 @@ def train_cmd(
         "eval_interval": eval_interval,
         "max_det": max_det,
         "eval_max_det": eval_max_det,
+        "faster_coco_eval": faster_coco_eval,
         "save_plots": save_plots,
         "patience": patience,
         "project": project,

--- a/libreyolo/cli/commands/val.py
+++ b/libreyolo/cli/commands/val.py
@@ -51,6 +51,12 @@ def val_cmd(
         None,
         help="COCO evaluator cap (default: pycocotools AP@100)",
     ),
+    faster_coco_eval: bool = typer.Option(
+        False,
+        "--faster-coco-eval",
+        help="Use the faster-coco-eval C++ backend for COCO metrics "
+        "(requires the faster-coco-eval package; falls back to pycocotools)",
+    ),
     half: bool = typer.Option(False, help="FP16 inference"),
     amp_dtype: str = typer.Option(
         "float16", help="CUDA autocast dtype when half=true: float16 or bfloat16"
@@ -138,6 +144,7 @@ def val_cmd(
             amp_dtype=amp_dtype,
             max_det=max_det,
             eval_max_det=eval_max_det,
+            faster_coco_eval=faster_coco_eval,
         )
     except FileNotFoundError as e:
         exit_with_error(out, "data_not_found", str(e))

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1712,6 +1712,8 @@ class BaseModel(ABC):
             save_json: Save predictions in COCO JSON format.
             plots: Alias for save_plots.
             verbose: Print detailed metrics.
+            faster_coco_eval: (kwarg) Use the faster-coco-eval C++ backend
+                for COCO metrics; falls back to pycocotools if unavailable.
 
         Returns:
             Dictionary with metrics/precision, metrics/recall,

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -182,6 +182,10 @@ class TrainConfig:
     # Optional COCO evaluator cap. None preserves pycocotools' historical
     # maxDets=[1, 10, 100] behavior independently of the prediction cap.
     eval_max_det: Optional[int] = None
+    # Use the faster-coco-eval C++ backend for in-training COCO validation
+    # metrics (bbox/segm). Off by default; falls back to pycocotools with a
+    # warning if the faster-coco-eval package is not installed.
+    faster_coco_eval: bool = False
     save_plots: bool = False
 
     # System

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -2615,6 +2615,7 @@ class BaseTrainer(ABC):
                 iou_thres=0.65,
                 max_det=getattr(self.config, "max_det", 300),
                 eval_max_det=getattr(self.config, "eval_max_det", None),
+                faster_coco_eval=getattr(self.config, "faster_coco_eval", False),
                 device=str(self.device),
                 half=self.config.amp and self.device.type == "cuda",
                 amp_dtype=getattr(self.config, "amp_dtype", "float16"),

--- a/libreyolo/validation/coco_evaluator.py
+++ b/libreyolo/validation/coco_evaluator.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Dict, Mapping, Optional
 
@@ -9,6 +10,45 @@ import numpy as np
 import torch
 
 logger = logging.getLogger(__name__)
+
+# Env override for the COCO eval backend: "1"/"true"/"yes" forces the
+# faster-coco-eval backend on, "0"/"false"/"no" forces it off, unset defers
+# to the faster_coco_eval config flag. Useful for benchmark harnesses that
+# cannot touch per-run configs.
+FASTER_COCO_EVAL_ENV_VAR = "LIBREYOLO_FASTER_COCO_EVAL"
+
+_warned_faster_unavailable = False
+
+
+def _faster_coco_eval_env_override() -> Optional[bool]:
+    value = os.environ.get(FASTER_COCO_EVAL_ENV_VAR)
+    if value is None:
+        return None
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def resolve_faster_coco_eval(requested: bool) -> bool:
+    """Decide whether to use the faster-coco-eval backend.
+
+    The LIBREYOLO_FASTER_COCO_EVAL env var, when set, overrides `requested`.
+    Returns False (stock pycocotools) if the package is not importable.
+    """
+    override = _faster_coco_eval_env_override()
+    enabled = requested if override is None else override
+    if not enabled:
+        return False
+    try:
+        import faster_coco_eval  # noqa: F401
+    except ImportError:
+        global _warned_faster_unavailable
+        if not _warned_faster_unavailable:
+            logger.warning(
+                "faster_coco_eval requested but not installed; falling back to "
+                "pycocotools. Install with: pip install faster-coco-eval"
+            )
+            _warned_faster_unavailable = True
+        return False
+    return True
 
 
 class COCOEvaluator:
@@ -25,12 +65,14 @@ class COCOEvaluator:
         iou_type: str = "bbox",
         label_to_category_id: Optional[Mapping[int, int]] = None,
         max_det: int = 100,
+        faster_coco_eval: bool = False,
     ):
         if max_det < 1:
             raise ValueError(f"max_det must be >= 1, got {max_det}")
         self.coco_gt = coco_gt
         self.iou_type = iou_type
         self.max_det = int(max_det)
+        self.faster_coco_eval = faster_coco_eval
         self.label_to_category_id = (
             {int(k): int(v) for k, v in label_to_category_id.items()}
             if label_to_category_id is not None
@@ -39,6 +81,8 @@ class COCOEvaluator:
         self.results = []
         self._img_ids = set()
         self._last_coco_eval = None
+        # Provenance: backend actually used by the last compute() call.
+        self.last_backend: Optional[str] = None
 
     def update(self, predictions: Dict, image_id: int):
         """
@@ -137,16 +181,7 @@ class COCOEvaluator:
             logger.warning("No predictions to evaluate")
             return self._empty_metrics()
 
-        try:
-            from pycocotools.coco import COCO  # noqa: F401
-            from pycocotools.cocoeval import COCOeval
-        except ImportError:
-            raise ImportError(
-                "pycocotools not installed. Install with: pip install pycocotools"
-            )
-
-        coco_dt = self.coco_gt.loadRes(self.results)
-        coco_eval = COCOeval(self.coco_gt, coco_dt, self.iou_type)
+        coco_eval = self._build_coco_eval()
         if self._img_ids:
             coco_eval.params.imgIds = sorted(self._img_ids)
         # Retain a real AR@100 compatibility slot while adding the requested
@@ -202,6 +237,56 @@ class COCOEvaluator:
             "AR_medium": float(coco_eval.stats[10]),
             "AR_large": float(coco_eval.stats[11]),
         }
+
+    def _build_coco_eval(self):
+        """Construct a COCOeval instance using the configured backend.
+
+        With faster_coco_eval=True (or the LIBREYOLO_FASTER_COCO_EVAL env
+        override) and the faster-coco-eval package installed, evaluation runs
+        through its C++ backend, which is 10-50x faster on detection-dense
+        datasets while producing metrics identical to pycocotools within
+        float64 summation order (<= 1 ULP).
+        """
+        if resolve_faster_coco_eval(self.faster_coco_eval):
+            import faster_coco_eval
+            from faster_coco_eval import COCO as FasterCOCO
+            from faster_coco_eval import COCOeval_faster
+
+            gt_dataset = getattr(self.coco_gt, "dataset", None)
+            if not gt_dataset or not gt_dataset.get("images"):
+                # COCO-like GT objects (e.g. YOLOCocoAPI) that don't carry a
+                # raw dataset dict: synthesize one from their index maps.
+                gt_dataset = {
+                    "images": list(self.coco_gt.imgs.values()),
+                    "annotations": list(self.coco_gt.anns.values()),
+                    "categories": list(self.coco_gt.cats.values()),
+                }
+            # use_deepcopy so backend-side mutations (e.g. segm polygon->RLE
+            # conversion) never leak back into self.coco_gt.
+            coco_gt = FasterCOCO(gt_dataset, use_deepcopy=True)
+            coco_dt = coco_gt.loadRes(self.results)
+            fce_version = getattr(
+                getattr(faster_coco_eval, "version", None), "__version__", "?"
+            )
+            self.last_backend = f"faster-coco-eval {fce_version}"
+            logger.info("COCO eval backend: %s", self.last_backend)
+            return COCOeval_faster(coco_gt, coco_dt, self.iou_type)
+
+        try:
+            import pycocotools
+            from pycocotools.coco import COCO  # noqa: F401
+            from pycocotools.cocoeval import COCOeval
+        except ImportError:
+            raise ImportError(
+                "pycocotools not installed. Install with: pip install pycocotools"
+            )
+
+        self.last_backend = (
+            f"pycocotools {getattr(pycocotools, '__version__', '?')}"
+        )
+        logger.debug("COCO eval backend: %s", self.last_backend)
+        coco_dt = self.coco_gt.loadRes(self.results)
+        return COCOeval(self.coco_gt, coco_dt, self.iou_type)
 
     def _empty_metrics(self) -> Dict[str, float]:
         """Return all-zero metrics dict."""

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -40,6 +40,9 @@ class ValidationConfig:
         num_workers: Number of dataloader workers.
         half: Whether to use FP16 inference.
         amp_dtype: Mixed-precision dtype used when half is enabled.
+        faster_coco_eval: Use the faster-coco-eval C++ backend for COCO
+            metrics (bbox/segm). Requires the faster-coco-eval package;
+            falls back to pycocotools with a warning if unavailable.
     """
 
     # Data
@@ -104,6 +107,9 @@ class ValidationConfig:
     half: bool = False
     amp_dtype: str = field(default="float16", kw_only=True)
     allow_download_scripts: bool = False
+
+    # COCO eval backend (off by default; opt-in C++ evaluator)
+    faster_coco_eval: bool = False
 
     # TTA
     augment: bool = False

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -399,6 +399,7 @@ class DetectionValidator(BaseValidator):
                 iou_type="bbox",
                 label_to_category_id=self._coco_label_to_category_id,
                 max_det=self._coco_max_det(),
+                faster_coco_eval=getattr(self.config, "faster_coco_eval", False),
             )
             if self.config.verbose:
                 logger.info(
@@ -467,7 +468,10 @@ class DetectionValidator(BaseValidator):
             )
             self._gt_coco_api = coco_api
         self.coco_evaluator = COCOEvaluator(
-            coco_api, iou_type="bbox", max_det=self._coco_max_det()
+            coco_api,
+            iou_type="bbox",
+            max_det=self._coco_max_det(),
+            faster_coco_eval=getattr(self.config, "faster_coco_eval", False),
         )
 
         if self.config.verbose:
@@ -1134,6 +1138,7 @@ class SegmentationValidator(DetectionValidator):
             iou_type="segm",
             label_to_category_id=self._coco_label_to_category_id,
             max_det=self._coco_max_det(),
+            faster_coco_eval=getattr(self.config, "faster_coco_eval", False),
         )
 
     def _update_metrics(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ lora = [
 plots = [
     "matplotlib>=3.7.0",
 ]
+fast-eval = [
+    # Opt-in C++ COCO eval backend (faster_coco_eval=True / --faster-coco-eval).
+    "faster-coco-eval>=1.7.0",
+]
 vlm = [
     # VLM-as-detector families load through transformers.
     # huggingface_hub (used for snapshot download) ships with transformers.

--- a/tests/unit/test_faster_coco_eval.py
+++ b/tests/unit/test_faster_coco_eval.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for the opt-in faster-coco-eval backend in COCOEvaluator.
+
+Covers:
+- Metric parity between pycocotools and faster-coco-eval on synthetic data.
+- Graceful fallback to pycocotools when faster-coco-eval is missing.
+- LIBREYOLO_FASTER_COCO_EVAL env var overriding the config flag both ways.
+- ValidationConfig / TrainConfig exposing the flag (off by default).
+"""
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from libreyolo.validation.coco_evaluator import (
+    COCOEvaluator,
+    FASTER_COCO_EVAL_ENV_VAR,
+    resolve_faster_coco_eval,
+)
+
+
+def _make_gt_dataset():
+    """Small synthetic COCO GT: 3 images, 2 categories, 6 annotations."""
+    images = [
+        {"id": i, "file_name": f"img{i}.jpg", "width": 100, "height": 100}
+        for i in range(3)
+    ]
+    categories = [
+        {"id": 0, "name": "cat", "supercategory": "object"},
+        {"id": 1, "name": "dog", "supercategory": "object"},
+    ]
+    annotations = []
+    ann_id = 1
+    boxes = [
+        (0, 0, [10, 10, 30, 30]),
+        (0, 1, [50, 50, 20, 40]),
+        (1, 0, [5, 5, 40, 20]),
+        (1, 1, [60, 10, 25, 25]),
+        (2, 0, [20, 20, 30, 50]),
+        (2, 1, [70, 70, 15, 15]),
+    ]
+    for img_id, cat_id, bbox in boxes:
+        annotations.append(
+            {
+                "id": ann_id,
+                "image_id": img_id,
+                "category_id": cat_id,
+                "bbox": bbox,
+                "area": bbox[2] * bbox[3],
+                "iscrowd": 0,
+            }
+        )
+        ann_id += 1
+    return {"images": images, "annotations": annotations, "categories": categories}
+
+
+def _make_coco_gt():
+    from pycocotools.coco import COCO
+
+    coco = COCO()
+    coco.dataset = _make_gt_dataset()
+    coco.createIndex()
+    return coco
+
+
+def _predictions():
+    """Predictions per image: one near-perfect match, one shifted, one miss."""
+    return [
+        # img 0: good matches
+        (0, {"boxes": [[10, 10, 41, 41], [51, 49, 69, 91]], "scores": [0.9, 0.8], "classes": [0, 1]}),
+        # img 1: one shifted box, one wrong class
+        (1, {"boxes": [[10, 8, 48, 27], [58, 12, 84, 33]], "scores": [0.7, 0.6], "classes": [0, 0]}),
+        # img 2: one match, one false positive
+        (2, {"boxes": [[21, 19, 49, 71], [1, 1, 9, 9]], "scores": [0.85, 0.3], "classes": [0, 1]}),
+    ]
+
+
+def _make_evaluator(faster: bool):
+    evaluator = COCOEvaluator(_make_coco_gt(), iou_type="bbox", faster_coco_eval=faster)
+    for img_id, preds in _predictions():
+        evaluator.update(preds, img_id)
+    return evaluator
+
+
+def _run_evaluator(faster: bool):
+    return _make_evaluator(faster).compute()
+
+
+class TestFasterCocoEvalParity:
+    def test_stock_backend_runs(self):
+        metrics = _run_evaluator(faster=False)
+        assert 0.0 < metrics["mAP"] <= 1.0
+        assert metrics["mAP50"] >= metrics["mAP"]
+
+    def test_metrics_match_pycocotools(self):
+        pytest.importorskip("faster_coco_eval")
+        stock = _run_evaluator(faster=False)
+        fast = _run_evaluator(faster=True)
+        assert set(stock) == set(fast)
+        for key in stock:
+            assert fast[key] == pytest.approx(stock[key], abs=1e-9), key
+
+    def test_yolo_coco_api_gt_without_dataset_dict(self, tmp_path):
+        """GT objects without a .dataset dict (YOLOCocoAPI-style) work too."""
+        pytest.importorskip("faster_coco_eval")
+
+        class MinimalGT:
+            def __init__(self, dataset):
+                self.imgs = {im["id"]: im for im in dataset["images"]}
+                self.anns = {a["id"]: a for a in dataset["annotations"]}
+                self.cats = {c["id"]: c for c in dataset["categories"]}
+
+        evaluator = COCOEvaluator(
+            MinimalGT(_make_gt_dataset()), iou_type="bbox", faster_coco_eval=True
+        )
+        for img_id, preds in _predictions():
+            evaluator.update(preds, img_id)
+        fast = evaluator.compute()
+        stock = _run_evaluator(faster=False)
+        for key in stock:
+            assert fast[key] == pytest.approx(stock[key], abs=1e-9), key
+
+
+class TestBackendResolution:
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv(FASTER_COCO_EVAL_ENV_VAR, raising=False)
+        assert resolve_faster_coco_eval(False) is False
+
+    def test_env_var_forces_on(self, monkeypatch):
+        pytest.importorskip("faster_coco_eval")
+        monkeypatch.setenv(FASTER_COCO_EVAL_ENV_VAR, "1")
+        assert resolve_faster_coco_eval(False) is True
+
+    def test_env_var_forces_off(self, monkeypatch):
+        monkeypatch.setenv(FASTER_COCO_EVAL_ENV_VAR, "0")
+        assert resolve_faster_coco_eval(True) is False
+
+    def test_fallback_when_package_missing(self, monkeypatch, caplog):
+        monkeypatch.delenv(FASTER_COCO_EVAL_ENV_VAR, raising=False)
+        # Simulate faster_coco_eval being uninstalled: a None entry in
+        # sys.modules makes `import faster_coco_eval` raise ImportError.
+        monkeypatch.setitem(sys.modules, "faster_coco_eval", None)
+        import libreyolo.validation.coco_evaluator as mod
+
+        monkeypatch.setattr(mod, "_warned_faster_unavailable", False)
+        with caplog.at_level("WARNING"):
+            assert resolve_faster_coco_eval(True) is False
+        assert any("falling back" in r.message for r in caplog.records)
+
+        # And the evaluator still produces stock metrics.
+        metrics = _run_evaluator(faster=True)
+        assert 0.0 < metrics["mAP"] <= 1.0
+
+
+class TestConfigFlag:
+    def test_validation_config_default_off(self):
+        from libreyolo.validation import ValidationConfig
+
+        cfg = ValidationConfig(data="dummy.yaml")
+        assert cfg.faster_coco_eval is False
+        assert cfg.update(faster_coco_eval=True).faster_coco_eval is True
+
+    def test_train_config_default_off(self):
+        from libreyolo.training.config import TrainConfig
+
+        assert TrainConfig().faster_coco_eval is False
+
+
+class TestBackendProvenance:
+    def test_stock_backend_recorded(self):
+        evaluator = _make_evaluator(faster=False)
+        evaluator.compute()
+        assert evaluator.last_backend is not None
+        assert evaluator.last_backend.startswith("pycocotools")
+
+    def test_faster_backend_recorded(self):
+        pytest.importorskip("faster_coco_eval")
+        evaluator = _make_evaluator(faster=True)
+        evaluator.compute()
+        assert evaluator.last_backend is not None
+        assert evaluator.last_backend.startswith("faster-coco-eval")


### PR DESCRIPTION
## Summary

Adds an opt-in `faster_coco_eval` flag that routes bbox/segm COCO metrics through the [faster-coco-eval](https://github.com/MiXaiLL76/faster_coco_eval) C++ backend instead of pycocotools' per-image Python loop. Off by default everywhere; pycocotools remains the default backend and a required dependency.

### Why

pycocotools `COCOeval.evaluate()` is O(dets × gts) per image in pure Python. On detection-dense datasets validation dominates wall time: during the RF100-VL benchmark campaign, `gwhd2021` (~44 boxes/image) spent ~4x more time in COCO eval than in training, making one dataset the makespan of a 100-dataset campaign. Swapping the backend cut its eval from ~500 s to ~10 s per epoch.

Parity was validated on real campaign prediction dumps across all 100 RF100-VL datasets: metrics are bit-identical to pycocotools within float64 summation order (≤ 1 ULP).

### API

- `COCOEvaluator(..., faster_coco_eval=False)` — backend construction centralized in `_build_coco_eval()`; `imgIds`, `maxDets`, `accumulate`/`summarize`, and `_standard_stats` are backend-agnostic and unchanged.
- `ValidationConfig.faster_coco_eval` / `TrainConfig.faster_coco_eval` (default `False`), wired through `DetectionValidator` (bbox + segm evaluators) and in-training validation.
- `model.val(faster_coco_eval=True)` / `model.train(faster_coco_eval=True)` kwargs.
- CLI: `--faster-coco-eval` on `libreyolo val` and `libreyolo train`.
- `LIBREYOLO_FASTER_COCO_EVAL=1|0` env var overrides the flag in either direction (for benchmark harnesses that can't touch per-run configs).
- Install: `pip install libreyolo[fast-eval]` (new optional extra, `faster-coco-eval>=1.7.0`).

### Design decisions

- **Off by default (G0).** The backend actually used is logged and recorded as `COCOEvaluator.last_backend` (e.g. `faster-coco-eval 1.7.2` / `pycocotools 2.0.10`), so any run's provenance is auditable. Flipping the default is a possible follow-up once `last_backend` is also plumbed into saved result JSONs — enabling it silently before that would make published numbers unattributable to a backend.
- **Graceful fallback.** If requested but not installed, evaluation falls back to pycocotools with a one-time warning rather than failing a long training run at its first validation epoch.
- **GT compatibility.** GT objects that don't carry a raw `dataset` dict (e.g. `YOLOCocoAPI` for YOLO text-label datasets) are supported by synthesizing one from their `imgs`/`anns`/`cats` index maps, loaded with `use_deepcopy=True` so backend-side mutations (segm polygon→RLE) never leak into the shared GT object.

### Tests

`tests/unit/test_faster_coco_eval.py` (11 tests): stock-vs-faster metric parity on synthetic data, `YOLOCocoAPI`-style GT objects, env-var override in both directions, graceful fallback when the package is missing, default-off on both configs, and `last_backend` provenance for both backends.

Full unit suite on this branch: 4453 passed, 169 skipped, 1 xfailed, 0 failed.

## Test plan

- [x] `pytest tests/unit/test_faster_coco_eval.py tests/unit/test_coco_validation.py` — 34 passed
- [x] Full `pytest tests/unit` — green
- [x] Real-data parity: 100/100 RF100-VL datasets bit-identical vs pycocotools (campaign verification)
- [ ] CI

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an opt-in faster-coco-eval backend while retaining pycocotools as the default and fallback.
- Propagates the backend option through validation, training, Python APIs, CLI commands, YAML configuration, and DDP validation.
- Reconstructs compatible ground-truth objects for the optional backend and records the backend used.
- Adds an optional dependency extra and focused parity, fallback, configuration, and provenance tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defects identified.

The optional backend remains disabled by default, falls back to the existing evaluator when unavailable, and the new configuration is consistently propagated through supported validation and training entry points.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/validation/coco_evaluator.py | Centralizes backend selection, fallback, ground-truth conversion, and backend provenance without changing the default evaluator. |
| libreyolo/validation/detection_validator.py | Propagates the new option to bbox and segmentation COCO evaluators across official-COCO and YOLO dataset paths. |
| libreyolo/training/trainer.py | Forwards the training configuration option into periodic detection and segmentation validation. |
| libreyolo/training/config.py | Adds an off-by-default training configuration field that participates in existing config serialization and reconstruction. |
| libreyolo/validation/config.py | Adds an off-by-default validation configuration field compatible with existing update and YAML flows. |
| libreyolo/cli/commands/train.py | Exposes and forwards the opt-in backend flag for training. |
| libreyolo/cli/commands/val.py | Exposes and forwards the opt-in backend flag for standalone validation. |
| pyproject.toml | Adds faster-coco-eval as an optional fast-eval dependency rather than changing required dependencies. |
| tests/unit/test_faster_coco_eval.py | Covers default behavior, fallback, environment overrides, bbox parity, synthesized ground truth, and backend provenance. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Input["CLI / model.train() / model.val() / environment"] --> Config["TrainConfig or ValidationConfig"]
    Config --> Validator["Detection or Segmentation Validator"]
    Validator --> Evaluator["COCOEvaluator"]
    Evaluator --> Resolve{"faster backend requested and installed?"}
    Resolve -->|Yes| Faster["faster-coco-eval"]
    Resolve -->|No| Stock["pycocotools"]
    Faster --> Metrics["COCO metrics"]
    Stock --> Metrics
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add opt-in faster-coco-eval backend for ..."](https://github.com/libreyolo/libreyolo/commit/9257facde87c1345c426e48a7ad581d86fb67232) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49551768)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Validation Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/validation-pipeline.md)
</details>

<!-- /greptile_comment -->