### PR TITLE
Fix YOLOX BN eps/momentum lost on class-count rebuild (silently corrupted reload metrics, catastrophic for nano)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,20 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- YOLOX BatchNorm eps=1e-3 / momentum=0.03 (official YOLOX values) is now
+  applied by `LibreYOLOXModel` at construction instead of as a post-hoc fixup
+  in the `LibreYOLOX` wrapper, so it survives the class-count rebuild
+  (`_rebuild_for_new_classes`) that `train()` performs when the dataset `nc`
+  differs from the checkpoint. Previously any such fine-tune trained and
+  reported in-training validation at torch's default eps=1e-5 but was
+  reloaded for inference at 1e-3 — same tensors, different normalization.
+  Regular-conv sizes barely move, but depthwise `n` has per-channel
+  running_var small enough for eps to dominate: on RF100-VL `ball` the same
+  nano checkpoint scores 0.566 mAP50-95 evaluated at its trained eps and
+  0.151 after a stock reload. Checkpoints trained before this fix carry
+  eps=1e-5 semantics and must be evaluated with BN eps overridden to 1e-5
+  (or have `sqrt((var+1e-3)/(var+1e-5))` folded into BN weights) to report
+  faithful numbers
 - CUDA graph capture no longer races with DataLoader pin-memory threads:
   training capture (`train(..., cuda_graph=True)`) and inference/validation
   capture now run with `capture_error_mode="thread_local"`, so a

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -90,14 +90,9 @@ class LibreYOLOX(BaseModel):
         if isinstance(model_path, str):
             self._load_weights(model_path)
 
-        # Official YOLOX sets BatchNorm eps=1e-3, momentum=0.03 on EVERY size
-        # (Exp.get_model() in yolox_base.py), not just nano. eps is load-bearing
-        # at inference: gating it to "n" left t/s/m/l/x on torch's default 1e-5,
-        # costing ~1-1.5 mAP that grows with depth.
-        for m in self.model.modules():
-            if isinstance(m, nn.BatchNorm2d):
-                m.eps = 1e-3
-                m.momentum = 0.03
+        # BatchNorm eps=1e-3 / momentum=0.03 (official YOLOX) is applied by
+        # LibreYOLOXModel.__init__ itself so it survives class-count rebuilds
+        # during training; no wrapper-level fixup is needed here.
 
     # =========================================================================
     # Model lifecycle

--- a/libreyolo/models/yolox/nn.py
+++ b/libreyolo/models/yolox/nn.py
@@ -1016,6 +1016,27 @@ class LibreYOLOXModel(nn.Module):
             act=act,
         )
 
+        # Official YOLOX sets BatchNorm eps=1e-3, momentum=0.03 on every size
+        # (Exp.get_model() in yolox_base.py). It must be applied HERE, at
+        # construction, not as a post-hoc fixup in the LibreYOLOX wrapper:
+        # training calls _rebuild_for_new_classes() when the dataset class
+        # count differs from the checkpoint, which constructs a fresh
+        # LibreYOLOXModel — a wrapper-level fixup does not survive that
+        # rebuild. The result was a model trained (and in-training validated)
+        # at torch's default eps=1e-5 but reloaded for inference at 1e-3.
+        # Harmless for the regular-conv sizes, catastrophic for depthwise
+        # "n", whose per-channel running_var is small enough that eps
+        # dominates: on RF100-VL "ball", the same nano checkpoint scores
+        # 0.566 mAP at eps=1e-5 and 0.151 at eps=1e-3.
+        self._apply_official_bn_hyperparams()
+
+    def _apply_official_bn_hyperparams(self) -> None:
+        """Set BatchNorm eps/momentum to the values official YOLOX uses."""
+        for module in self.modules():
+            if isinstance(module, nn.BatchNorm2d):
+                module.eps = 1e-3
+                module.momentum = 0.03
+
     def forward(self, x, targets=None):
         """
         Forward pass supporting both training and inference.

--- a/tests/unit/test_yolox_bn_hyperparams.py
+++ b/tests/unit/test_yolox_bn_hyperparams.py
@@ -1,0 +1,54 @@
+"""YOLOX BatchNorm hyperparameters must match official YOLOX and survive rebuilds.
+
+Official YOLOX (Exp.get_model() in yolox_base.py) sets BN eps=1e-3 and
+momentum=0.03 on every size. A wrapper-level post-construction fixup was lost
+whenever training rebuilt the model for a new dataset class count
+(_rebuild_for_new_classes), so models trained (and in-training validated) at
+torch's default eps=1e-5 were later reloaded and evaluated at 1e-3. For the
+depthwise "n" size, whose per-channel running_var is small enough for eps to
+dominate, that silently corrupted reload-time metrics (RF100-VL "ball": 0.566
+mAP at the trained eps vs 0.151 after reload).
+
+These tests pin the invariant at every construction path.
+"""
+
+import pytest
+import torch.nn as nn
+
+from libreyolo.models.yolox.model import LibreYOLOX
+from libreyolo.models.yolox.nn import LibreYOLOXModel
+
+pytestmark = pytest.mark.unit
+
+OFFICIAL_EPS = 1e-3
+OFFICIAL_MOMENTUM = 0.03
+
+
+def _bn_modules(module: nn.Module):
+    bns = [m for m in module.modules() if isinstance(m, nn.BatchNorm2d)]
+    assert bns, "expected BatchNorm2d modules in a YOLOX model"
+    return bns
+
+
+def _assert_official_bn(module: nn.Module):
+    for bn in _bn_modules(module):
+        assert bn.eps == OFFICIAL_EPS
+        assert bn.momentum == OFFICIAL_MOMENTUM
+
+
+class TestYOLOXBNHyperparams:
+    @pytest.mark.parametrize("size", ["n", "t", "s"])
+    def test_bare_model_construction(self, size):
+        """LibreYOLOXModel itself must apply official BN settings."""
+        _assert_official_bn(LibreYOLOXModel(config=size, nb_classes=3))
+
+    def test_wrapper_construction(self):
+        _assert_official_bn(LibreYOLOX(size="n", nb_classes=80).model)
+
+    def test_survives_class_count_rebuild(self):
+        """The regression: _rebuild_for_new_classes constructs a fresh
+        LibreYOLOXModel; official BN settings must survive it."""
+        wrapper = LibreYOLOX(size="n", nb_classes=80)
+        wrapper._rebuild_for_new_classes(18)
+        assert wrapper.nb_classes == 18
+        _assert_official_bn(wrapper.model)


### PR DESCRIPTION
## Summary

Fixes a silent train/inference inconsistency in YOLOX BatchNorm hyperparameters that corrupted reload-time metrics for fine-tuned models — catastrophically for the depthwise `n` size (discovered when yolox-nano published 0.3601 on the RF100-VL campaign while its training-time validation said ~0.55).

### The bug

`LibreYOLOX.__init__` applied official YOLOX BN settings (`eps=1e-3`, `momentum=0.03`, per `Exp.get_model()` in upstream `yolox_base.py`) as a post-construction fixup on the wrapper. But `train()` calls `_rebuild_for_new_classes()` whenever the dataset class count differs from the checkpoint, which constructs a **fresh** `LibreYOLOXModel` — with plain `nn.BatchNorm2d` at torch's default `eps=1e-5`. The fixup never re-ran.

Consequence: every YOLOX fine-tune on a non-COCO class count trained and reported in-training validation at `eps=1e-5`, then was reloaded for inference at `1e-3`. Identical tensors, different normalization — and since eps is not a tensor, checkpoints carry no trace of it.

### Impact by size

Regular-conv sizes barely move (~1e-3 mAP on RF100-VL `ball`: 0.6196 vs 0.6210 for tiny). Depthwise `n` is the casualty: its per-channel `running_var` distribution is small enough that eps dominates (measured p1 ≈ 4e-4, 21% of channels < 1e-2). Same nano checkpoint, same data, same eval settings:

| BN eps at eval | val mAP50-95 |
|---|---|
| 1e-3 (stock reload) | 0.1500 |
| 1e-5 (as trained) | **0.5663** — matches the trainer's reported 0.5663 to 4 decimals |

### The fix

Apply the official BN hyperparameters in `LibreYOLOXModel.__init__` itself (`_apply_official_bn_hyperparams()`), so every construction path — including the class-count rebuild — gets them. The now-redundant wrapper-level loop is removed. This is a numeric no-op for all wrapper-constructed models (they already had 1e-3); the change is that rebuilt models now keep it.

Acceptance test on a controlled fine-tune: trainer-reported metric and recomputation from its own `best.pt` now agree exactly.

### Note on previously fine-tuned checkpoints

Checkpoints fine-tuned before this fix were trained under `eps=1e-5` semantics and cannot be detected or auto-corrected at load (eps isn't persisted). Faithful evaluation requires either overriding BN eps to `1e-5` after load, or folding `sqrt((var+1e-3)/(var+1e-5))` into the BN weights (verified equivalent to ~2e-4 mAP). Documented in the CHANGELOG entry. Persisting BN eps in checkpoint metadata could make this detectable in the future; left as a possible follow-up.

### Tests

`tests/unit/test_yolox_bn_hyperparams.py`: pins `eps=1e-3` / `momentum=0.03` on bare `LibreYOLOXModel` construction (n/t/s), wrapper construction, and — the regression — across `_rebuild_for_new_classes()`.

## Test plan

- [x] New regression tests pass (fail on pre-fix code)
- [x] Neighboring YOLOX unit tests pass
- [x] Full `pytest tests/unit` on this branch
- [x] Empirical verification on real RF100-VL nano/tiny checkpoints (eps flip reproduces trainer-reported metrics to 4 decimals)
- [ ] CI

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves official YOLOX BatchNorm configuration into the underlying model constructor so every construction and class-count rebuild path receives consistent normalization semantics.

- Applies `eps=1e-3` and `momentum=0.03` to all YOLOX BatchNorm2d modules during `LibreYOLOXModel` construction.
- Removes the now-redundant wrapper-level adjustment.
- Adds regression coverage for direct, wrapper, and class-count rebuild construction paths.
- Documents the behavior change and compatibility implications for previously fine-tuned checkpoints.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the BatchNorm settings consistently applied across all current YOLOX construction and rebuild paths.

The model constructor now establishes the normalization invariant before any weight-loading or training path uses the model, class-count rebuilds invoke that constructor, and subsequent SyncBatchNorm conversion preserves the configured values.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/yolox/nn.py | Centralizes official BatchNorm hyperparameters in the concrete model constructor, covering all current YOLOX construction paths. |
| libreyolo/models/yolox/model.py | Removes the redundant wrapper-level BatchNorm mutation now that initialization is handled by LibreYOLOXModel. |
| tests/unit/test_yolox_bn_hyperparams.py | Verifies official BatchNorm values for direct and wrapped construction and after class-count rebuilding. |
| CHANGELOG.md | Documents the fixed training/reload inconsistency and the handling required for older affected checkpoints. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[LibreYOLOX wrapper] --> B[LibreYOLOXModel constructor]
    C[Class-count rebuild] --> B
    D[Direct model construction] --> B
    B --> E[Build backbone and head]
    E --> F[Apply official BN eps and momentum]
    F --> G[Consistent training and reload semantics]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix YOLOX BN eps/momentum lost on class-..."](https://github.com/libreyolo/libreyolo/commit/7df7b5bb26e593b4bbda18d6d6850721b324a87b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49637260)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->