### PR TITLE
Log missing/unexpected keys on non-strict checkpoint loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- Non-strict checkpoint loads (families with `_strict_loading() == False`,
+  e.g. YOLOX) now log a warning with the counts and first names of missing
+  and unexpected state-dict keys instead of silently discarding them. Shape
+  mismatches always raised, but name mismatches let a partially matching
+  checkpoint "load" and predict with fresh-initialized tensors for the
+  dropped keys with no trace. Healthy loads stay silent; full key lists are
+  available at DEBUG level
 - YOLOX BatchNorm eps=1e-3 / momentum=0.03 (official YOLOX values) is now
   applied by `LibreYOLOXModel` at construction instead of as a post-hoc fixup
   in the `LibreYOLOX` wrapper, so it survives the class-count rebuild

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -833,6 +833,13 @@ class BaseModel(ABC):
         tensors wherever keys were absent. Shape mismatches raise regardless of
         strictness, but name mismatches do not, so this logs them. A healthy
         load stays silent.
+
+        Families with custom ``_load_weights`` overrides must either route
+        their final ``load_state_dict`` through this helper (YOLO-NAS) or
+        police the returned missing/unexpected keys themselves with
+        family-specific rules (D-FINE/DEIM/EC tolerate regenerated anchor
+        buffers but raise on other unexpected keys; DINOv2/RF-DETR/PIDNet
+        validate the key sets against the expected architecture).
         """
         result = self.model.load_state_dict(
             state_dict, strict=self._strict_loading()

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -250,7 +250,7 @@ class BaseModel(ABC):
             self.model_path = None
             state_dict = self._prepare_state_dict(self._strip_ddp_prefix(model_path))
             self._validate_loaded_state_dict_for_task(state_dict, model_path)
-            self.model.load_state_dict(state_dict, strict=self._strict_loading())
+            self._load_state_dict_logged(state_dict, source="state dict")
         else:
             self.model_path = model_path
 
@@ -817,12 +817,42 @@ class BaseModel(ABC):
                 apply_quant_structure(self, quant_manifest)
 
             self._prepare_model_for_state_dict(state_dict)
-            self.model.load_state_dict(state_dict, strict=self._strict_loading())
+            self._load_state_dict_logged(state_dict, source=str(model_path))
             self.model.to(self.device).eval()
         except Exception as e:
             raise RuntimeError(
                 f"Failed to load model weights from {model_path}: {e}"
             ) from e
+
+    def _load_state_dict_logged(self, state_dict: dict, source: str) -> None:
+        """Load with the family's strictness, making silent key drops visible.
+
+        Families that load with strict=False (e.g. YOLOX) previously discarded
+        missing/unexpected keys without a trace: a partially matching
+        checkpoint would "load" and then quietly predict with fresh-initialized
+        tensors wherever keys were absent. Shape mismatches raise regardless of
+        strictness, but name mismatches do not, so this logs them. A healthy
+        load stays silent.
+        """
+        result = self.model.load_state_dict(
+            state_dict, strict=self._strict_loading()
+        )
+        missing = list(getattr(result, "missing_keys", []) or [])
+        unexpected = list(getattr(result, "unexpected_keys", []) or [])
+        if missing or unexpected:
+            logger.warning(
+                "Non-strict load from %s: %d missing key(s) (model keeps "
+                "initialized weights for these) and %d unexpected key(s) "
+                "(ignored). First missing: %s. First unexpected: %s. "
+                "This usually indicates a size/task/architecture mismatch.",
+                source,
+                len(missing),
+                len(unexpected),
+                missing[:5],
+                unexpected[:5],
+            )
+            logger.debug("All missing keys: %s", missing)
+            logger.debug("All unexpected keys: %s", unexpected)
 
     def _allow_checkpoint_task_mismatch(self, checkpoint_task: str) -> bool:
         """Return whether a family permits loading a checkpoint from another task."""

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -471,7 +471,7 @@ class LibreYOLONAS(BaseModel):
                 if ckpt_names is not None:
                     self.names = self._sanitize_names(ckpt_names, effective_nc)
 
-            self.model.load_state_dict(state_dict, strict=self._strict_loading())
+            self._load_state_dict_logged(state_dict, source=str(model_path))
         except Exception as e:
             raise RuntimeError(
                 f"Failed to load YOLO-NAS weights from {model_path}: {e}"

--- a/tests/unit/test_nonstrict_load_logging.py
+++ b/tests/unit/test_nonstrict_load_logging.py
@@ -1,0 +1,48 @@
+"""Non-strict checkpoint loads must log dropped keys instead of hiding them.
+
+YOLOX loads with strict=False. Shape mismatches raise regardless of
+strictness, but *named* key mismatches (missing/unexpected) were silently
+discarded: a partially matching checkpoint would "load" and then predict with
+fresh-initialized tensors wherever keys were absent. `_load_state_dict_logged`
+makes that visible with a warning while keeping healthy loads silent.
+"""
+
+import logging
+
+import pytest
+
+from libreyolo.models.yolox.model import LibreYOLOX
+
+pytestmark = pytest.mark.unit
+
+LOGGER_NAME = "libreyolo.models.base.model"
+
+
+def _clean_state(size="s", nb_classes=3):
+    return LibreYOLOX(size=size, nb_classes=nb_classes).model.state_dict()
+
+
+class TestNonStrictLoadLogging:
+    def test_healthy_load_is_silent(self, caplog):
+        state = _clean_state()
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            LibreYOLOX(model_path=state, size="s", nb_classes=3)
+        assert not [r for r in caplog.records if "Non-strict load" in r.message]
+
+    def test_missing_and_unexpected_keys_warn(self, caplog):
+        state = _clean_state()
+        dropped = [k for k in state if k.startswith("head.")][:3]
+        for key in dropped:
+            del state[key]
+        state["totally.bogus.weight"] = next(iter(state.values())).clone()
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            LibreYOLOX(model_path=state, size="s", nb_classes=3)
+
+        warnings = [r for r in caplog.records if "Non-strict load" in r.message]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "3 missing key(s)" in msg
+        assert "1 unexpected key(s)" in msg
+        assert dropped[0] in msg
+        assert "totally.bogus.weight" in msg


### PR DESCRIPTION
## Summary

Makes non-strict checkpoint loading loud. Families with `_strict_loading() == False` (YOLOX) previously discarded missing/unexpected state-dict keys without any trace: a partially matching checkpoint would "load" and then quietly predict with fresh-initialized tensors wherever keys were absent.

Shape mismatches always raise (PyTorch raises them regardless of `strict`), so the silent failure mode is specifically *named* key mismatches. During the RF100-VL yolox-nano investigation this cost hours: the load path had to be manually instrumented before it could be ruled out as the cause of a 0.57→0.16 metric collapse (the actual cause was the BN eps bug fixed in #700 — but a loud loader would have excluded this hypothesis in seconds).

### Behavior

- Both non-strict load sites (`BaseModel.__init__` dict path and `_load_weights`) route through a new `_load_state_dict_logged` helper.
- On any missing/unexpected keys: one WARNING with counts and the first five names of each class, plus full key lists at DEBUG.
- Healthy loads stay completely silent; strict families are unaffected (they raise before the helper's check matters).

Note: legitimate partial loads (e.g. permitted cross-task loads where the head is intentionally re-initialized) now emit this warning too — that is by design, since "your head weights are fresh-initialized" is exactly what a user should see.

### Tests

`tests/unit/test_nonstrict_load_logging.py`: healthy load is silent; a state dict with 3 deleted head keys and 1 bogus key produces exactly one warning naming both counts and example keys.

## Test plan

- [x] New unit tests
- [x] Full `pytest tests/unit`: 4460 passed, 169 skipped, 1 xfailed, 0 failed
- [ ] CI

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds centralized warning and debug logging for state-dict key mismatches and routes the base and YOLO-NAS loading paths through it.
- Adds `_load_state_dict_logged` to report missing and unexpected keys.
- Adds unit coverage for healthy and mismatched YOLOX state dictionaries.
- Documents the behavior in the changelog.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because several custom non-strict checkpoint loaders still silently accept key mismatches.

The shared and YOLO-NAS paths now report mismatches, but the previously reported bypass remains in custom loaders such as D-FINE, DEIM, EC, RF-DETR, PIDNet, and DINOv2, where one or both returned mismatch lists are not surfaced.

**Files Needing Attention:** libreyolo/models/base/model.py and the affected custom model loaders under libreyolo/models/
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/base/model.py | Adds the shared state-dict loading helper and uses it for dictionary and standard file-loading paths. |
| libreyolo/models/yolonas/model.py | Routes YOLO-NAS checkpoint loading through the shared mismatch logger. |
| tests/unit/test_nonstrict_load_logging.py | Tests silent healthy loading and warning details for missing and unexpected YOLOX keys. |
| CHANGELOG.md | Documents the new non-strict checkpoint mismatch diagnostics. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Route YOLO-NAS custom loader through log..."](https://github.com/libreyolo/libreyolo/commit/dc4c696cb27567e8e417021dc32985eb7e224666) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49686489)</sub>

<!-- /greptile_comment -->