### PR TITLE
Make faster-coco-eval the default COCO metrics backend, with backend provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,20 @@ before 1.4.0 are documented in the
 - Native fp8 execution tier: finalized fp8 QuantLinear runs on the fp8 tensor cores via torch._scaled_mm (Ada/Hopper/Blackwell); optional Triton kernels fuse activation conversion and the per-channel scale/bias epilogue, while validation-selected FeyNobg Swin stage-0 Linears use manifest-recorded tensorwise weight scales for a fully fused cuBLASLt epilogue. Finalized fp8 QuantConv2d convolves in fp16 on cached dequantized weights, and fp16-remainder checkpoints get float32 I/O root hooks. On LibreFeyNobg/RTX 5070 Ti, fp8 is 123.1 vs 129.3 ms for batch-1 graphed predict and 515.4 vs 535.3 ms at batch 4, with a 275 vs 531 MB file.
 - CUDA graph capture for the birefnet and feynobg families via encoder-only capture (the deformable decoder replays wrong under capture and stays eager; graphed output is bit-identical to eager); GraphRunner warms up on the capture stream so lazily-allocated cuBLASLt/cuDNN workspaces stop invalidating capture, and quant modules cache the calibration flag as a host bool (the per-forward .item() sync also invalidated capture)
 
+### Changed
+
+- The faster-coco-eval COCO metrics backend is now the default
+  (`faster_coco_eval=True` on `ValidationConfig` / `TrainConfig`; CLI gains
+  `--no-faster-coco-eval` to opt out, and `LIBREYOLO_FASTER_COCO_EVAL=0`
+  still forces pycocotools). Decision based on measured parity across all
+  100 RF100-VL test splits: 1381/1400 metric values bit-identical to
+  pycocotools, max deviation 2.22e-16, headline deltas exactly 0, with
+  15.6x faster evaluation overall (56x on detection-dense datasets).
+  pycocotools remains the automatic fallback when faster-coco-eval is not
+  installed. For provenance, the backend actually used is now always
+  logged at INFO, surfaced as `model.last_eval_backend` after `val()`,
+  and included as `eval_backend` in the CLI JSON payload
+
 ### Fixed
 
 - YOLOX BatchNorm eps=1e-3 / momentum=0.03 (official YOLOX values) is now

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -330,10 +330,10 @@ def train_cmd(
         help="COCO evaluator cap (default: pycocotools AP@100)",
     ),
     faster_coco_eval: bool = typer.Option(
-        False,
-        "--faster-coco-eval",
+        True,
+        "--faster-coco-eval/--no-faster-coco-eval",
         help="Use the faster-coco-eval C++ backend for validation COCO metrics "
-        "(requires the faster-coco-eval package; falls back to pycocotools)",
+        "(default: on when installed; falls back to pycocotools)",
     ),
     save_plots: bool = typer.Option(
         False, help="Save final validation plots during training"

--- a/libreyolo/cli/commands/val.py
+++ b/libreyolo/cli/commands/val.py
@@ -52,10 +52,10 @@ def val_cmd(
         help="COCO evaluator cap (default: pycocotools AP@100)",
     ),
     faster_coco_eval: bool = typer.Option(
-        False,
-        "--faster-coco-eval",
+        True,
+        "--faster-coco-eval/--no-faster-coco-eval",
         help="Use the faster-coco-eval C++ backend for COCO metrics "
-        "(requires the faster-coco-eval package; falls back to pycocotools)",
+        "(default: on when installed; falls back to pycocotools)",
     ),
     half: bool = typer.Option(False, help="FP16 inference"),
     amp_dtype: str = typer.Option(
@@ -307,6 +307,8 @@ def val_cmd(
         "data": data,
         "split": split,
         "device": str(loaded_model.device),
+        # COCO eval backend provenance, e.g. "faster-coco-eval 1.7.2".
+        "eval_backend": getattr(loaded_model, "last_eval_backend", None),
         "metrics": {
             "mAP50": round(mAP50, 4),
             "mAP50_95": round(mAP50_95, 4),

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1713,7 +1713,10 @@ class BaseModel(ABC):
             plots: Alias for save_plots.
             verbose: Print detailed metrics.
             faster_coco_eval: (kwarg) Use the faster-coco-eval C++ backend
-                for COCO metrics; falls back to pycocotools if unavailable.
+                for COCO metrics. Default True; falls back to pycocotools
+                if the package is unavailable. Pass False (or set
+                LIBREYOLO_FASTER_COCO_EVAL=0) to force pycocotools. The
+                backend used is surfaced as ``model.last_eval_backend``.
 
         Returns:
             Dictionary with metrics/precision, metrics/recall,
@@ -1855,4 +1858,9 @@ class BaseModel(ABC):
         else:
             validator_cls = DetectionValidator
         validator = validator_cls(model=self, config=config)
-        return validator()
+        metrics = validator()
+        # Provenance: which COCO eval backend produced these metrics
+        # (e.g. "faster-coco-eval 1.7.2" / "pycocotools 2.0.10"; None for
+        # validators that don't run COCO evaluation).
+        self.last_eval_backend = getattr(validator, "eval_backend", None)
+        return metrics

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -183,9 +183,9 @@ class TrainConfig:
     # maxDets=[1, 10, 100] behavior independently of the prediction cap.
     eval_max_det: Optional[int] = None
     # Use the faster-coco-eval C++ backend for in-training COCO validation
-    # metrics (bbox/segm). Off by default; falls back to pycocotools with a
+    # metrics (bbox/segm). On by default; falls back to pycocotools with a
     # warning if the faster-coco-eval package is not installed.
-    faster_coco_eval: bool = False
+    faster_coco_eval: bool = True
     save_plots: bool = False
 
     # System

--- a/libreyolo/validation/coco_evaluator.py
+++ b/libreyolo/validation/coco_evaluator.py
@@ -284,7 +284,7 @@ class COCOEvaluator:
         self.last_backend = (
             f"pycocotools {getattr(pycocotools, '__version__', '?')}"
         )
-        logger.debug("COCO eval backend: %s", self.last_backend)
+        logger.info("COCO eval backend: %s", self.last_backend)
         coco_dt = self.coco_gt.loadRes(self.results)
         return COCOeval(self.coco_gt, coco_dt, self.iou_type)
 

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -41,8 +41,9 @@ class ValidationConfig:
         half: Whether to use FP16 inference.
         amp_dtype: Mixed-precision dtype used when half is enabled.
         faster_coco_eval: Use the faster-coco-eval C++ backend for COCO
-            metrics (bbox/segm). Requires the faster-coco-eval package;
-            falls back to pycocotools with a warning if unavailable.
+            metrics (bbox/segm). On by default; falls back to pycocotools
+            with a warning if the faster-coco-eval package is unavailable.
+            Set False (or LIBREYOLO_FASTER_COCO_EVAL=0) to force pycocotools.
     """
 
     # Data
@@ -108,8 +109,12 @@ class ValidationConfig:
     amp_dtype: str = field(default="float16", kw_only=True)
     allow_download_scripts: bool = False
 
-    # COCO eval backend (off by default; opt-in C++ evaluator)
-    faster_coco_eval: bool = False
+    # COCO eval backend. On by default: uses the faster-coco-eval C++
+    # evaluator when installed (metrics identical to pycocotools within
+    # float64 summation order), silently-audited fallback to pycocotools
+    # otherwise. The backend actually used is logged and surfaced as
+    # model.last_eval_backend.
+    faster_coco_eval: bool = True
 
     # TTA
     augment: bool = False

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -1050,6 +1050,9 @@ class DetectionValidator(BaseValidator):
             save_json = str(self.save_dir / "predictions.json")
 
         coco_metrics = self.coco_evaluator.compute(save_json=save_json)
+        # Provenance for callers (surfaced as model.last_eval_backend).
+        # getattr: tests substitute lightweight evaluator stubs.
+        self.eval_backend = getattr(self.coco_evaluator, "last_backend", None)
 
         metrics = {
             "metrics/precision": coco_metrics["precision"],
@@ -1233,6 +1236,9 @@ class SegmentationValidator(DetectionValidator):
 
         bbox = self.bbox_evaluator.compute(save_json=bbox_json)
         mask = self.mask_evaluator.compute(save_json=mask_json)
+        # Provenance for callers (surfaced as model.last_eval_backend).
+        # getattr: tests substitute lightweight evaluator stubs.
+        self.eval_backend = getattr(self.bbox_evaluator, "last_backend", None)
 
         return {
             "metrics/mAP50-95": mask["mAP"],

--- a/tests/unit/test_faster_coco_eval.py
+++ b/tests/unit/test_faster_coco_eval.py
@@ -124,7 +124,7 @@ class TestFasterCocoEvalParity:
 
 
 class TestBackendResolution:
-    def test_off_by_default(self, monkeypatch):
+    def test_disabled_request_stays_disabled(self, monkeypatch):
         monkeypatch.delenv(FASTER_COCO_EVAL_ENV_VAR, raising=False)
         assert resolve_faster_coco_eval(False) is False
 
@@ -155,17 +155,17 @@ class TestBackendResolution:
 
 
 class TestConfigFlag:
-    def test_validation_config_default_off(self):
+    def test_validation_config_default_on(self):
         from libreyolo.validation import ValidationConfig
 
         cfg = ValidationConfig(data="dummy.yaml")
-        assert cfg.faster_coco_eval is False
-        assert cfg.update(faster_coco_eval=True).faster_coco_eval is True
+        assert cfg.faster_coco_eval is True
+        assert cfg.update(faster_coco_eval=False).faster_coco_eval is False
 
-    def test_train_config_default_off(self):
+    def test_train_config_default_on(self):
         from libreyolo.training.config import TrainConfig
 
-        assert TrainConfig().faster_coco_eval is False
+        assert TrainConfig().faster_coco_eval is True
 
 
 class TestBackendProvenance:


### PR DESCRIPTION
## Summary

Makes the faster-coco-eval C++ backend (introduced opt-in by #695) the **default** for bbox/segm COCO metrics, and hardens backend provenance so any run can be audited for which evaluator produced its numbers.

### Why flip now

#695 shipped off-by-default pending parity evidence at scale and provenance plumbing. Both exist now:

- **Parity, measured across all 100 RF100-VL test splits** (real prediction dumps, not synthetic): 1381/1400 metric values bit-identical to pycocotools, maximum deviation 2.22e-16 (float64 summation order), headline mAP deltas exactly 0.
- **Speed**: 15.6× faster evaluation overall, 56× on detection-dense datasets (gwhd2021, 43.6 boxes/image: ~500 s → ~10 s per eval). On dense datasets COCO eval was dominating validation wall time — 4× the training time per epoch.

### What changes

- `ValidationConfig.faster_coco_eval` / `TrainConfig.faster_coco_eval` default `True`.
- CLI: `--faster-coco-eval/--no-faster-coco-eval` (default on) for `val` and `train`.
- `LIBREYOLO_FASTER_COCO_EVAL=0` still force-disables globally (unchanged).
- pycocotools remains the automatic fallback with a one-time warning when faster-coco-eval isn't installed; it also remains a required dependency (`faster-coco-eval` stays an optional `[fast-eval]` extra).

### Provenance (so a backend swap can never be invisible)

- The backend actually used is now always logged at INFO for both backends (was DEBUG for pycocotools).
- `DetectionValidator`/`SegmentationValidator` expose `eval_backend`; `model.val()` surfaces it as `model.last_eval_backend`.
- `libreyolo val` includes `"eval_backend"` (e.g. `"faster-coco-eval 1.7.2"`) in its JSON payload.

Deliberately **not** added to the returned metrics dict: consumers iterate it generically as floats (`base.py` logs every value with `%.4f`, `val_plotter.py` calls `float(v)` on every entry), so a string key would break them. Provenance travels on the model object and CLI payload instead.

### Tests

Updated `test_faster_coco_eval.py` defaults (`TestConfigFlag` now pins default-on); parity, env-override, fallback, and `last_backend` provenance tests unchanged and passing.

## Test plan

- [x] `pytest tests/unit/test_faster_coco_eval.py tests/unit/test_coco_validation.py` — 34 passed
- [x] Full `pytest tests/unit`: 4458 passed, 169 skipped, 1 xfailed, 0 failed
- [x] Parity at scale: 100/100 RF100-VL datasets (campaign verification, see #695 history)
- [ ] CI

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes faster-coco-eval the default COCO metrics implementation while retaining pycocotools fallback and explicit opt-out controls.
- Adds negatable faster-evaluation flags to validation and training commands.
- Propagates the backend used through validators, `model.last_eval_backend`, logging, and validation JSON output.
- Updates configuration defaults, documentation, changelog entries, and unit-test expectations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The default change, explicit opt-out, fallback path, and provenance propagation remain internally consistent across configuration, validators, the model API, and CLI output.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/validation/coco_evaluator.py | Preserves backend resolution behavior while promoting pycocotools backend provenance logging to INFO. |
| libreyolo/validation/detection_validator.py | Captures the evaluator backend after detection and segmentation metric computation. |
| libreyolo/models/base/model.py | Exposes the completed validator's backend provenance as model.last_eval_backend. |
| libreyolo/cli/commands/val.py | Enables faster-coco-eval by default, adds an explicit negative flag, and includes backend provenance in JSON results. |
| libreyolo/cli/commands/train.py | Enables faster-coco-eval by default while preserving an explicit CLI opt-out. |
| libreyolo/validation/config.py | Changes standalone validation's faster-coco-eval configuration default to enabled. |
| libreyolo/training/config.py | Changes in-training COCO evaluation's faster-coco-eval configuration default to enabled. |
| tests/unit/test_faster_coco_eval.py | Updates configuration-default assertions while retaining backend-resolution and provenance coverage. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Config["Validation or training config<br/>faster_coco_eval=True"] --> Resolve["Resolve environment override<br/>and package availability"]
    Resolve -->|Available and enabled| Fast["faster-coco-eval"]
    Resolve -->|Disabled or unavailable| PyCOCO["pycocotools"]
    Fast --> Metrics["COCO metrics"]
    PyCOCO --> Metrics
    Metrics --> Validator["validator.eval_backend"]
    Validator --> Model["model.last_eval_backend"]
    Model --> CLI["val JSON eval_backend"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Make faster-coco-eval the default COCO m..."](https://github.com/libreyolo/libreyolo/commit/9db32b3776e06c757c4bc066996049655686b8fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49688762)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Validation Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/validation-pipeline.md)
</details>

<!-- /greptile_comment -->