### PR TITLE
Lift kernel registry to libreyolo/kernels; opt-in hub MSDA kernel for DETR families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ before 1.4.0 are documented in the
   instead of the portable `grid_sample` path. Installing the extra is the
   opt-in; `LIBREYOLO_HUB_KERNELS=0` disables it. Eager CUDA fp32 only;
   exports always keep the portable path; load or runtime failures fall back
-  with one warning.
+  with one warning. The Hub artifact is pinned to an audited commit
+  revision, and a CUDA-only parity test
+  (`test_hub_matches_portable_on_cuda`) gates revision bumps.
 
 - `val_loss=True` extended from the `g0` flagships to **every trainable
   family** (`g0`, `g1` and `g2`), across four tasks rather than detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ before 1.4.0 are documented in the
   and `libreyolo.quant.kernels` remains a working alias. See
   `docs/kernels.md`.
 - Optional accelerated multi-scale deformable attention (`ms_deform_attn`
-  slot): with `pip install libreyolo[hub-kernels]` and
-  `LIBREYOLO_HUB_KERNELS=1`, RF-DETR, LibreDeformableDETR, and
-  LibreDINO-DETR run the compiled Apache-2.0 CUDA kernel from
-  `kernels-community/deformable-detr` (forward and backward) instead of the
-  portable `grid_sample` path. Off by default; eager CUDA fp32 only; exports
-  always keep the portable path.
+  slot): with `pip install libreyolo[hub-kernels]`, RF-DETR,
+  LibreDeformableDETR, and LibreDINO-DETR run the compiled Apache-2.0 CUDA
+  kernel from `kernels-community/deformable-detr` (forward and backward)
+  instead of the portable `grid_sample` path. Installing the extra is the
+  opt-in; `LIBREYOLO_HUB_KERNELS=0` disables it. Eager CUDA fp32 only;
+  exports always keep the portable path; load or runtime failures fall back
+  with one warning.
 
 - `val_loss=True` extended from the `g0` flagships to **every trainable
   family** (`g0`, `g1` and `g2`), across four tasks rather than detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- Library-wide kernel registry at `libreyolo/kernels/` (lifted from
+  `libreyolo/quant/kernels/`), organized by purpose: `quant/simulate/`
+  (fake-quant Triton, any device, STE backward), `quant/execute/`
+  (finalized-only fp8 GEMM path and unpack kernels), and `attention/`.
+  `LIBREYOLO_KERNELS` replaces `LIBREYOLO_QUANT_KERNELS` (still honored),
+  and `libreyolo.quant.kernels` remains a working alias. See
+  `docs/kernels.md`.
+- Optional accelerated multi-scale deformable attention (`ms_deform_attn`
+  slot): with `pip install libreyolo[hub-kernels]` and
+  `LIBREYOLO_HUB_KERNELS=1`, RF-DETR, LibreDeformableDETR, and
+  LibreDINO-DETR run the compiled Apache-2.0 CUDA kernel from
+  `kernels-community/deformable-detr` (forward and backward) instead of the
+  portable `grid_sample` path. Off by default; eager CUDA fp32 only; exports
+  always keep the portable path.
+
 - `val_loss=True` extended from the `g0` flagships to **every trainable
   family** (`g0`, `g1` and `g2`), across four tasks rather than detection
   alone:

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -541,6 +541,12 @@ Used for: the standalone inference-only LibreDeformableDETR family
           converted from the Apache-2.0 SenseTime Hugging Face mirrors and
           rehosted at LibreYOLO/LibreDeformableDETR{r50ss,r50ssdc5,r50,
           r50refine,r50twostage}; see docs/provenance/deformable_detr.md.
+          The autograd bridge in
+          libreyolo/kernels/attention/ms_deform_attn.py follows the upstream
+          MSDeformAttnFunction interface; the compiled CUDA kernel itself is
+          NOT vendored. It is fetched at runtime, opt-in only
+          (LIBREYOLO_HUB_KERNELS=1), from the Apache-2.0 Hub repository
+          kernels-community/deformable-detr via the `kernels` package.
 
 --------------------------------------------------------------------
 Swin Transformer (Microsoft)

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -544,9 +544,10 @@ Used for: the standalone inference-only LibreDeformableDETR family
           The autograd bridge in
           libreyolo/kernels/attention/ms_deform_attn.py follows the upstream
           MSDeformAttnFunction interface; the compiled CUDA kernel itself is
-          NOT vendored. It is fetched at runtime, opt-in only
-          (LIBREYOLO_HUB_KERNELS=1), from the Apache-2.0 Hub repository
-          kernels-community/deformable-detr via the `kernels` package.
+          NOT vendored. It is fetched at runtime from the Apache-2.0 Hub
+          repository kernels-community/deformable-detr, only when the
+          optional `kernels` package (the libreyolo[hub-kernels] extra) is
+          installed; LIBREYOLO_HUB_KERNELS=0 disables it.
 
 --------------------------------------------------------------------
 Swin Transformer (Microsoft)

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -45,7 +45,10 @@ nothing changes (no network access, portable paths everywhere). Set
 `LIBREYOLO_HUB_KERNELS=0` to disable them without uninstalling. Nothing is
 vendored; artifacts are fetched and cached by the `kernels` package, and a
 kernel that fails to load or run disables itself for the process and falls
-back to the portable path with one warning.
+back to the portable path with one warning. Every hub kernel is pinned to an
+audited commit revision in its provider module — a moved branch on the Hub
+can never change the binary that runs in-process. Bumping a pin requires a
+GPU parity run of the provider's `*_matches_portable_on_cuda` test.
 
 Current hub-backed slot:
 

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -1,0 +1,72 @@
+# Kernel registry
+
+`libreyolo/kernels/` hosts the library-wide registry of pluggable accelerated
+implementations. Every op has a portable default; accelerated variants
+register on top and are selected per-op by predicate. A missing optional
+dependency is never an error, only a fallback.
+
+## Layout (purpose first, backend second)
+
+- `kernels/quant/simulate/`: fake-quantization Triton kernels. Numerics-true
+  simulation with STE backward, any device. They serve QAT/QAD **and**
+  simulated PTQ/`val()` inference; the enforced boundary is
+  `is_finalized`, not train-vs-deploy.
+- `kernels/quant/execute/`: finalized-only real-precision paths. No backward,
+  real hardware: the `fp8_gemm` tensor-core GEMM (`torch._scaled_mm`), its
+  fused Triton prologue/epilogue, and the packed-weight unpack kernels.
+- `kernels/attention/`: attention ops shared across model families. Currently
+  the `ms_deform_attn` slot (multi-scale deformable attention) consumed by
+  the Deformable-DETR-lineage families.
+- The reference implementations stay in `libreyolo/quant/fake_quant.py` and
+  `libreyolo/quant/packing.py`: `quant/` defines what the numbers mean,
+  `kernels/` makes them fast. `packing.py` never has variants because it is
+  the checkpoint contract.
+
+## Selection
+
+Implementations are tried newest-first; the first one whose predicate passes
+wins, falling back to the reference. `libreyolo.kernels.active()` reports the
+current selection.
+
+- `LIBREYOLO_KERNELS=off|reference` forces the reference implementations;
+  any other value selects only implementations registered under that name.
+  `LIBREYOLO_QUANT_KERNELS` is honored as a legacy alias.
+- GEMM and attention slots (`fp8_gemm`, `ms_deform_attn`, `nvfp4_gemm`, ...)
+  have no reference implementation. Callers must check `resolve()` returns
+  non-None and keep their portable path as the fallback; exported graphs
+  (ONNX, TensorRT, torch.export) always use the portable path.
+
+## Hub kernels (opt-in)
+
+Compiled kernels published on the Hugging Face Hub load at runtime through
+the optional `kernels` package (`pip install libreyolo[hub-kernels]`) and are
+**off by default**. Set `LIBREYOLO_HUB_KERNELS=1` to enable them. Nothing is
+vendored; artifacts are fetched and cached by the `kernels` package.
+
+Current hub-backed slot:
+
+- `ms_deform_attn` <- [`kernels-community/deformable-detr`](https://huggingface.co/kernels-community/deformable-detr)
+  (Apache-2.0): the compiled CUDA multi-scale deformable attention
+  forward/backward from Deformable DETR. Wired into the RF-DETR,
+  LibreDeformableDETR, and LibreDINO-DETR attention cores; eligible inputs
+  are CUDA fp32 in eager mode. Training is accelerated too (the compiled
+  backward registers through an autograd bridge).
+
+Out-of-tree compiled kernels can also ship as a `libreyolo_kernels` package,
+which self-registers on import (e.g. a future CUTLASS NVFP4 GEMM for the
+documented `nvfp4_gemm` slot).
+
+## Adding an implementation
+
+Register a callable with the slot's reference signature and a cheap
+predicate:
+
+```python
+from libreyolo import kernels
+
+kernels.register("fake_quant_fp8", my_impl, name="mybackend", predicate=my_check)
+```
+
+Parity is gated by `tests/unit/kernels/` against shapes harvested from real
+models into `tools/shapes.json`; any accelerated implementation must match
+the reference exactly (forward) and to 1e-6 (STE gradients).

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -36,12 +36,16 @@ current selection.
   non-None and keep their portable path as the fallback; exported graphs
   (ONNX, TensorRT, torch.export) always use the portable path.
 
-## Hub kernels (opt-in)
+## Hub kernels
 
 Compiled kernels published on the Hugging Face Hub load at runtime through
-the optional `kernels` package (`pip install libreyolo[hub-kernels]`) and are
-**off by default**. Set `LIBREYOLO_HUB_KERNELS=1` to enable them. Nothing is
-vendored; artifacts are fetched and cached by the `kernels` package.
+the optional `kernels` package. Installing the extra is the opt-in:
+`pip install libreyolo[hub-kernels]` enables them, and without the package
+nothing changes (no network access, portable paths everywhere). Set
+`LIBREYOLO_HUB_KERNELS=0` to disable them without uninstalling. Nothing is
+vendored; artifacts are fetched and cached by the `kernels` package, and a
+kernel that fails to load or run disables itself for the process and falls
+back to the portable path with one warning.
 
 Current hub-backed slot:
 
@@ -50,11 +54,25 @@ Current hub-backed slot:
   forward/backward from Deformable DETR. Wired into the RF-DETR,
   LibreDeformableDETR, and LibreDINO-DETR attention cores; eligible inputs
   are CUDA fp32 in eager mode. Training is accelerated too (the compiled
-  backward registers through an autograd bridge).
+  backward registers through an autograd bridge). Active whenever the
+  `kernels` package is installed, unless `LIBREYOLO_HUB_KERNELS=0`.
 
 Out-of-tree compiled kernels can also ship as a `libreyolo_kernels` package,
 which self-registers on import (e.g. a future CUTLASS NVFP4 GEMM for the
 documented `nvfp4_gemm` slot).
+
+## Hardware behavior
+
+Accelerated implementations engage only where their predicate passes; every
+op always has a portable path, so no platform needs configuration:
+
+- CPU-only and Apple Silicon (MPS): all CUDA/Triton predicates fail;
+  reference implementations run as plain torch ops.
+- NVIDIA CUDA: Triton kernels and eligible hub/GEMM kernels engage.
+- AMD ROCm: torch reports CUDA and ROCm wheels ship Triton's AMD backend,
+  so Triton kernels can engage; parity is currently only exercised on
+  NVIDIA in CI. Hub kernels resolve per-variant; a missing variant simply
+  falls back.
 
 ## Adding an implementation
 

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -118,15 +118,16 @@ convention; the E4M3 activation snap on conv inputs is simulation-only).
 Finalize with `remainder="fp16"` so the non-quantized interior runs in half
 precision (the loader installs the same float32 I/O root hooks the cast
 recipes use). Residual drift vs the simulated tier is half-precision
-rounding plus GEMM summation order; `LIBREYOLO_QUANT_KERNELS=off` restores
-the exact simulated path everywhere. Measured on LibreFeyNobg (263M Swin-L
+rounding plus GEMM summation order; `LIBREYOLO_KERNELS=off` (legacy alias
+`LIBREYOLO_QUANT_KERNELS`) restores the exact simulated path everywhere. Measured on LibreFeyNobg (263M Swin-L
 matte, RTX 5070 Ti, 1024px, controlled ABBA runs): fp8 vs fp16 is
 85.7 vs 95.0 ms for a batch-1 graphed forward and 123.1 vs 129.3 ms through
 the full graphed `predict` path. At batch 4 the full path is 515.4 vs
 535.3 ms. The finalized fp8 file is 275 MB vs 531 MB for fp16.
 
 `model.quant_info()` reports the recipe and module state;
-`libreyolo.quant.kernels.active()` reports the selected implementations.
+`libreyolo.kernels.active()` reports the selected implementations (the
+registry lives in `libreyolo/kernels/`; see `docs/kernels.md`).
 Linux CUDA PyTorch environments commonly already include Triton. On Windows,
 install a PyTorch-compatible `triton-windows` build to enable the fused cast
 and epilogue; inference remains functional without it.

--- a/libreyolo/kernels/__init__.py
+++ b/libreyolo/kernels/__init__.py
@@ -18,8 +18,9 @@ Architecture (vLLM-shaped, scaled down to a library that rents its runtime):
 - Compiled kernels ship out-of-tree in the optional ``libreyolo-kernels``
   package. If installed, it is imported here and self-registers via
   :func:`register`; the core package never grows a build dependency.
-- Hugging Face Hub kernels (the ``kernels`` package) are opt-in via
-  ``LIBREYOLO_HUB_KERNELS=1``; absence of the package or the env var is the
+- Hugging Face Hub kernels load through the optional ``kernels`` package
+  (the ``libreyolo[hub-kernels]`` extra); installing it is the opt-in, and
+  ``LIBREYOLO_HUB_KERNELS=0`` disables it. Absence of the package is the
   normal fallback case.
 - Selection is per-op: implementations are tried newest-first and the first
   one whose predicate passes wins, falling back to the reference. The

--- a/libreyolo/kernels/__init__.py
+++ b/libreyolo/kernels/__init__.py
@@ -1,37 +1,51 @@
-"""Kernel registry: pluggable accelerated implementations for quant ops.
+"""Kernel registry: pluggable accelerated implementations for library ops.
 
 Architecture (vLLM-shaped, scaled down to a library that rents its runtime):
 
-- The reference implementations in ``fake_quant.py`` are always registered
-  and always available. They are the numerical oracle: any accelerated
-  implementation must match them (parity tests gate in-tree kernels, and
-  ``packing.py`` never has variants because it is the checkpoint contract).
-- Triton kernels live under ``kernels/triton/`` as plain Python (JIT
-  compiled at runtime, no build step, no wheels).
+- Op slots are organized by purpose, not backend:
+  ``kernels/quant/simulate/`` holds fake-quantization kernels (any device,
+  STE backward, run during QAT *and* simulated PTQ/val inference),
+  ``kernels/quant/execute/`` holds finalized-only real-precision paths
+  (no backward, real hardware), and ``kernels/attention/`` holds attention
+  ops shared across model families.
+- The reference implementations in ``quant/fake_quant.py`` are always
+  registered and always available. They are the numerical oracle: any
+  accelerated implementation must match them (parity tests gate in-tree
+  kernels, and ``quant/packing.py`` never has variants because it is the
+  checkpoint contract).
+- Triton kernels are plain Python (JIT compiled at runtime, no build step,
+  no wheels) and are imported lazily on first resolution.
 - Compiled kernels ship out-of-tree in the optional ``libreyolo-kernels``
   package. If installed, it is imported here and self-registers via
   :func:`register`; the core package never grows a build dependency.
+- Hugging Face Hub kernels (the ``kernels`` package) are opt-in via
+  ``LIBREYOLO_HUB_KERNELS=1``; absence of the package or the env var is the
+  normal fallback case.
 - Selection is per-op: implementations are tried newest-first and the first
   one whose predicate passes wins, falling back to the reference. The
-  ``LIBREYOLO_QUANT_KERNELS`` environment variable overrides selection:
+  ``LIBREYOLO_KERNELS`` environment variable overrides selection:
   ``off``/``reference`` forces the reference implementations; any other
   value selects only implementations registered under that name.
+  ``LIBREYOLO_QUANT_KERNELS`` is honored as a legacy alias.
 
 Registered op slots (callables with the reference signatures):
 ``fake_quant_int8_per_channel``, ``fake_quant_int8_affine``,
 ``fake_quant_fp8``, ``fake_quant_int_grouped``, ``fake_quant_nvfp4_weight``,
 ``fake_quant_nvfp4_dynamic``, ``fake_quant_mxfp4_weight``,
-``fake_quant_mxfp4_dynamic``. GEMM slots (``nvfp4_gemm``, ...) may be
-registered by external packages; they have no reference implementation and
-callers must check :func:`resolve` returns non-None before use.
+``fake_quant_mxfp4_dynamic``, plus the unpack slots ``unpack_int_grouped``
+and ``unpack_nvfp4``. GEMM and attention slots (``fp8_gemm``,
+``ms_deform_attn``, ``nvfp4_gemm``, ...) have no reference implementation:
+callers must check :func:`resolve` returns non-None before use and keep
+their portable path as the fallback.
 """
 
+import importlib
 import importlib.util
 import logging
 import os
 from typing import Callable, Dict, List, Optional
 
-from .. import fake_quant as _reference
+from ..quant import fake_quant as _reference
 
 logger = logging.getLogger(__name__)
 
@@ -74,14 +88,32 @@ def clear_cache():
 
 
 def _forced() -> str:
+    forced = os.environ.get("LIBREYOLO_KERNELS", "").strip().lower()
+    if forced:
+        return forced
+    # Legacy alias from when the registry lived under libreyolo/quant/.
     return os.environ.get("LIBREYOLO_QUANT_KERNELS", "").strip().lower()
 
 
 _INTREE_ATTEMPTED = False
 
+# In-tree providers imported lazily on first resolution. Triton modules and
+# the attention provider self-register on import; each group fails
+# independently so a missing optional dependency never hides the others.
+_LAZY_PROVIDERS = (
+    # Triton fake-quant kernels (need triton; absent on Windows).
+    ".quant.simulate",
+    # Triton finalized-path kernels.
+    ".quant.execute.fp8_fusion",
+    ".quant.execute.unpack_int_grouped",
+    ".quant.execute.unpack_nvfp4",
+    # Hub-backed attention kernels (need the `kernels` package, opt-in).
+    ".attention.ms_deform_attn",
+)
+
 
 def _ensure_intree_loaded():
-    """Lazily import the in-tree Triton kernels on first resolution.
+    """Lazily import the in-tree accelerated providers on first resolution.
 
     Lazy so `import libreyolo` never pays the triton import cost, and
     skipped entirely when the env forces the reference implementations.
@@ -91,10 +123,11 @@ def _ensure_intree_loaded():
     if _INTREE_ATTEMPTED or _forced() in ("off", "reference"):
         return
     _INTREE_ATTEMPTED = True
-    try:
-        from . import triton  # noqa: F401  (self-registers on import)
-    except Exception as exc:
-        logger.debug("In-tree Triton kernels unavailable: %s", exc)
+    for module_name in _LAZY_PROVIDERS:
+        try:
+            importlib.import_module(module_name, __name__)
+        except Exception as exc:
+            logger.debug("In-tree kernel provider %s unavailable: %s", module_name, exc)
 
 
 def resolve(op: str) -> Optional[Callable]:
@@ -145,7 +178,7 @@ def _make_proxy(op: str) -> Callable:
     def proxy(*args, **kwargs):
         impl = resolve(op)
         if impl is None:
-            raise RuntimeError(f"No implementation available for quant op '{op}'.")
+            raise RuntimeError(f"No implementation available for op '{op}'.")
         return impl(*args, **kwargs)
 
     proxy.__name__ = op
@@ -161,7 +194,7 @@ for _op in REFERENCE_OPS:
 # Unpack slots (finalized-checkpoint dequantization): the packing module is
 # the contract and provides the reference implementations; accelerated
 # variants register on top exactly like the fake-quant slots.
-from .. import packing as _packing  # noqa: E402
+from ..quant import packing as _packing  # noqa: E402
 
 UNPACK_OPS = ("unpack_int_grouped", "unpack_nvfp4")
 register("unpack_int_grouped", _packing.unpack_int_grouped_weight, name="reference")
@@ -173,7 +206,7 @@ for _op in UNPACK_OPS:
 # In-tree GEMM kernels built on stock torch (no triton, no build step).
 # fp8_gemm: finalized fp8 QuantLinear on the fp8 tensor cores via
 # torch._scaled_mm (Ada/Hopper/Blackwell); resolves to None elsewhere.
-from . import scaled_mm_fp8  # noqa: E402,F401  (self-registers)
+from .quant.execute import scaled_mm_fp8  # noqa: E402,F401  (self-registers)
 
 # Optional out-of-tree compiled kernels (e.g. the CUTLASS NVFP4 GEMM).
 # The package self-registers on import; absence is the normal case.

--- a/libreyolo/kernels/attention/__init__.py
+++ b/libreyolo/kernels/attention/__init__.py
@@ -1,0 +1,1 @@
+"""Attention kernels shared across model families."""

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -1,0 +1,231 @@
+"""Multi-scale deformable attention op slot (``ms_deform_attn``).
+
+Slot signature (the classic Deformable-DETR layout):
+
+- ``value``: ``(bs, Len_in, n_heads, c)``
+- ``spatial_shapes``: ``(n_levels, 2)`` int64 tensor of ``(H, W)`` per level
+- ``sampling_locations``: ``(bs, Len_q, n_heads, n_levels, n_points, 2)``
+- ``attention_weights``: ``(bs, Len_q, n_heads, n_levels, n_points)``
+- returns ``(bs, Len_q, n_heads * c)``, or None when the input is not
+  eligible so the caller falls back to its portable path.
+
+Like the GEMM slots, no reference implementation is registered: every model
+family keeps its own upstream-parity ``grid_sample`` port as the default and
+only consults this slot through :func:`maybe_ms_deform_attn`.
+
+The in-tree provider loads the compiled CUDA kernel published at
+``kernels-community/deformable-detr`` on the Hugging Face Hub (Apache-2.0)
+via the optional ``kernels`` package. Nothing is vendored: the artifact is
+fetched at runtime, and only when the user opts in with
+``LIBREYOLO_HUB_KERNELS=1``. The autograd bridge below follows the
+``MSDeformAttnFunction`` interface of Deformable-DETR
+(https://github.com/fundamentalvision/Deformable-DETR, Apache-2.0,
+Copyright (c) 2020 SenseTime).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+from typing import Optional
+
+import torch
+
+from .. import register, resolve
+
+logger = logging.getLogger(__name__)
+
+_HUB_REPO = "kernels-community/deformable-detr"
+_MAX_IM2COL_STEP = 64
+
+_hub_kernel = None
+_hub_failed = False
+
+
+def _hub_enabled() -> bool:
+    return os.environ.get("LIBREYOLO_HUB_KERNELS", "").strip().lower() in (
+        "1",
+        "true",
+        "on",
+        "yes",
+    )
+
+
+def _eligible() -> bool:
+    """Cheap predicate: the expensive Hub fetch is deferred to the first call."""
+    return (
+        _hub_enabled()
+        and not _hub_failed
+        and importlib.util.find_spec("kernels") is not None
+        and torch.cuda.is_available()
+    )
+
+
+def _load_hub_kernel():
+    """Fetch and cache the Hub kernel; a failure disables the provider."""
+    global _hub_kernel, _hub_failed
+    if _hub_kernel is not None or _hub_failed:
+        return _hub_kernel
+    try:
+        from kernels import get_kernel
+
+        _hub_kernel = get_kernel(_HUB_REPO)
+    except Exception as exc:
+        _hub_failed = True
+        logger.warning("Hub kernel %s unavailable: %s", _HUB_REPO, exc)
+    return _hub_kernel
+
+
+class _MSDeformAttnFunction(torch.autograd.Function):
+    """Autograd bridge over the compiled forward/backward pair."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        value,
+        spatial_shapes,
+        level_start_index,
+        sampling_locations,
+        attention_weights,
+        im2col_step,
+    ):
+        ctx.im2col_step = im2col_step
+        output = _hub_kernel.ms_deform_attn_forward(
+            value,
+            spatial_shapes,
+            level_start_index,
+            sampling_locations,
+            attention_weights,
+            im2col_step,
+        )
+        ctx.save_for_backward(
+            value,
+            spatial_shapes,
+            level_start_index,
+            sampling_locations,
+            attention_weights,
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (
+            value,
+            spatial_shapes,
+            level_start_index,
+            sampling_locations,
+            attention_weights,
+        ) = ctx.saved_tensors
+        grad_value, grad_sampling_loc, grad_attn_weight = (
+            _hub_kernel.ms_deform_attn_backward(
+                value,
+                spatial_shapes,
+                level_start_index,
+                sampling_locations,
+                attention_weights,
+                grad_output.contiguous(),
+                ctx.im2col_step,
+            )
+        )
+        return grad_value, None, None, grad_sampling_loc, grad_attn_weight, None
+
+
+def level_start_index(spatial_shapes: torch.Tensor) -> torch.Tensor:
+    """Per-level start offsets into the flattened value, from (H, W) pairs."""
+    areas = spatial_shapes[:, 0] * spatial_shapes[:, 1]
+    return torch.cat([areas.new_zeros(1), areas.cumsum(0)[:-1]])
+
+
+def _supported_inputs(
+    value: torch.Tensor,
+    spatial_shapes,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+) -> bool:
+    if not isinstance(spatial_shapes, torch.Tensor):
+        return False
+    if not (
+        value.is_cuda
+        and sampling_locations.is_cuda
+        and attention_weights.is_cuda
+        and spatial_shapes.is_cuda
+    ):
+        return False
+    # The compiled kernel dispatches on fp32; half inputs (e.g. autocast)
+    # take the portable path.
+    if not (
+        value.dtype == torch.float32
+        and sampling_locations.dtype == torch.float32
+        and attention_weights.dtype == torch.float32
+    ):
+        return False
+    if value.dim() != 4 or sampling_locations.dim() != 6 or attention_weights.dim() != 5:
+        return False
+    batch = value.shape[0]
+    step = batch if batch < _MAX_IM2COL_STEP else _MAX_IM2COL_STEP
+    return batch % step == 0
+
+
+def hub_ms_deform_attn(
+    value: torch.Tensor,
+    spatial_shapes: torch.Tensor,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    """Run MSDA on the compiled Hub kernel, or return None to fall back."""
+    global _hub_failed
+    if not _supported_inputs(
+        value, spatial_shapes, sampling_locations, attention_weights
+    ):
+        return None
+    if _load_hub_kernel() is None:
+        return None
+    batch = value.shape[0]
+    step = batch if batch < _MAX_IM2COL_STEP else _MAX_IM2COL_STEP
+    shapes = spatial_shapes.to(dtype=torch.int64)
+    try:
+        return _MSDeformAttnFunction.apply(
+            value.contiguous(),
+            shapes,
+            level_start_index(shapes),
+            sampling_locations.contiguous(),
+            attention_weights.contiguous(),
+            step,
+        )
+    except Exception as exc:
+        # A kernel that loads but rejects this torch/GPU combination must
+        # never break inference: disable the provider and fall back.
+        _hub_failed = True
+        logger.warning("Hub kernel %s failed, falling back: %s", _HUB_REPO, exc)
+        return None
+
+
+def maybe_ms_deform_attn(
+    value: torch.Tensor,
+    spatial_shapes,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    """Resolve the ``ms_deform_attn`` slot and run it, or return None.
+
+    Callers keep their portable grid_sample port as the fallback. Tracing
+    and export always take the portable path: exported graphs must not
+    capture a runtime-fetched kernel.
+    """
+    if (
+        torch.jit.is_tracing()
+        or torch.compiler.is_compiling()
+        or torch.onnx.is_in_onnx_export()
+    ):
+        return None
+    impl = resolve("ms_deform_attn")
+    if impl is None:
+        return None
+    return impl(value, spatial_shapes, sampling_locations, attention_weights)
+
+
+register("ms_deform_attn", hub_ms_deform_attn, name="hub", predicate=_eligible)
+
+
+__all__ = ["hub_ms_deform_attn", "level_start_index", "maybe_ms_deform_attn"]

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -16,9 +16,11 @@ only consults this slot through :func:`maybe_ms_deform_attn`.
 The in-tree provider loads the compiled CUDA kernel published at
 ``kernels-community/deformable-detr`` on the Hugging Face Hub (Apache-2.0)
 via the optional ``kernels`` package. Nothing is vendored: the artifact is
-fetched at runtime. Installing the ``libreyolo[hub-kernels]`` extra is the
-opt-in; once the ``kernels`` package is present the provider is on by
-default and ``LIBREYOLO_HUB_KERNELS=0`` disables it. The autograd bridge
+fetched at runtime, pinned to the audited revision in ``_HUB_REVISION`` so
+a moved branch can never swap the binary that runs in-process. Installing
+the ``libreyolo[hub-kernels]`` extra is the opt-in; once the ``kernels``
+package is present the provider is on by default and
+``LIBREYOLO_HUB_KERNELS=0`` disables it. The autograd bridge
 below follows the ``MSDeformAttnFunction`` interface of Deformable-DETR
 (https://github.com/fundamentalvision/Deformable-DETR, Apache-2.0,
 Copyright (c) 2020 SenseTime).
@@ -38,6 +40,11 @@ from .. import register, resolve
 logger = logging.getLogger(__name__)
 
 _HUB_REPO = "kernels-community/deformable-detr"
+# Commit pin: native code fetched from the Hub executes in-process (forward
+# and backward), so selection by repo name alone would let a moved branch
+# change the binary under users. Bump deliberately, with a GPU parity run
+# (tests/unit/kernels/test_ms_deform_attn.py::test_hub_matches_portable_on_cuda).
+_HUB_REVISION = "4d2393e5d7879f7cf68db04cc7c9c7342272bc05"
 _MAX_IM2COL_STEP = 64
 
 _hub_kernel = None
@@ -78,7 +85,7 @@ def _load_hub_kernel():
     try:
         from kernels import get_kernel
 
-        _hub_kernel = get_kernel(_HUB_REPO)
+        _hub_kernel = get_kernel(_HUB_REPO, revision=_HUB_REVISION)
     except Exception as exc:
         _hub_failed = True
         logger.warning("Hub kernel %s unavailable: %s", _HUB_REPO, exc)
@@ -171,6 +178,8 @@ def _supported_inputs(
     if value.dim() != 4 or sampling_locations.dim() != 6 or attention_weights.dim() != 5:
         return False
     batch = value.shape[0]
+    if batch == 0:
+        return False
     step = batch if batch < _MAX_IM2COL_STEP else _MAX_IM2COL_STEP
     return batch % step == 0
 
@@ -186,6 +195,12 @@ def hub_ms_deform_attn(
     if not _supported_inputs(
         value, spatial_shapes, sampling_locations, attention_weights
     ):
+        return None
+    if _hub_kernel is None and torch.cuda.is_current_stream_capturing():
+        # Never fetch/load the kernel module inside CUDA graph capture; the
+        # load performs I/O and module initialization that would poison the
+        # capture. Graph warmup iterations load it, after which captures
+        # record the compiled op like any other.
         return None
     if _load_hub_kernel() is None:
         return None
@@ -209,6 +224,11 @@ def hub_ms_deform_attn(
         return None
 
 
+def _not_exporting() -> bool:
+    """Fallback for ``torch.compiler.is_exporting`` on torch versions without it."""
+    return False
+
+
 def maybe_ms_deform_attn(
     value: torch.Tensor,
     spatial_shapes,
@@ -219,11 +239,14 @@ def maybe_ms_deform_attn(
 
     Callers keep their portable grid_sample port as the fallback. Tracing
     and export always take the portable path: exported graphs must not
-    capture a runtime-fetched kernel.
+    capture a runtime-fetched kernel. ``is_exporting`` covers non-strict
+    ``torch.export``, which traces with FakeTensors without setting
+    ``is_compiling``.
     """
     if (
         torch.jit.is_tracing()
         or torch.compiler.is_compiling()
+        or getattr(torch.compiler, "is_exporting", _not_exporting)()
         or torch.onnx.is_in_onnx_export()
     ):
         return None

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -16,9 +16,10 @@ only consults this slot through :func:`maybe_ms_deform_attn`.
 The in-tree provider loads the compiled CUDA kernel published at
 ``kernels-community/deformable-detr`` on the Hugging Face Hub (Apache-2.0)
 via the optional ``kernels`` package. Nothing is vendored: the artifact is
-fetched at runtime, and only when the user opts in with
-``LIBREYOLO_HUB_KERNELS=1``. The autograd bridge below follows the
-``MSDeformAttnFunction`` interface of Deformable-DETR
+fetched at runtime. Installing the ``libreyolo[hub-kernels]`` extra is the
+opt-in; once the ``kernels`` package is present the provider is on by
+default and ``LIBREYOLO_HUB_KERNELS=0`` disables it. The autograd bridge
+below follows the ``MSDeformAttnFunction`` interface of Deformable-DETR
 (https://github.com/fundamentalvision/Deformable-DETR, Apache-2.0,
 Copyright (c) 2020 SenseTime).
 """
@@ -44,11 +45,18 @@ _hub_failed = False
 
 
 def _hub_enabled() -> bool:
-    return os.environ.get("LIBREYOLO_HUB_KERNELS", "").strip().lower() in (
-        "1",
-        "true",
-        "on",
-        "yes",
+    """Hub kernels are on by default; installing the extra is the opt-in.
+
+    The runtime fetch only ever happens when the optional ``kernels``
+    package is installed (see :func:`_eligible`), so users who never
+    installed ``libreyolo[hub-kernels]`` are unaffected.
+    ``LIBREYOLO_HUB_KERNELS=0`` is the opt-out.
+    """
+    return os.environ.get("LIBREYOLO_HUB_KERNELS", "").strip().lower() not in (
+        "0",
+        "false",
+        "off",
+        "no",
     )
 
 

--- a/libreyolo/kernels/quant/__init__.py
+++ b/libreyolo/kernels/quant/__init__.py
@@ -1,0 +1,12 @@
+"""Quantization kernels, split by purpose.
+
+``simulate/`` holds fake-quantization kernels: numerics-true simulation with
+STE backward, runnable on any device. They serve QAT/QAD *and* simulated
+PTQ/val inference; the enforced boundary is ``is_finalized``, not
+train-vs-deploy.
+
+``execute/`` holds finalized-only real-precision paths: no backward, real
+hardware (fp8 tensor cores, packed-weight unpack). ``quant/packing.py`` stays
+in ``libreyolo/quant/`` because it is the checkpoint contract, never a
+swappable kernel.
+"""

--- a/libreyolo/kernels/quant/execute/__init__.py
+++ b/libreyolo/kernels/quant/execute/__init__.py
@@ -1,0 +1,6 @@
+"""Finalized-only real-precision kernels (no backward, real hardware).
+
+``scaled_mm_fp8`` is stock torch and is imported eagerly by the registry.
+The triton modules (``fp8_fusion``, ``unpack_*``) are imported lazily by the
+registry on first resolution, so this package must not import them here.
+"""

--- a/libreyolo/kernels/quant/execute/fp8_fusion.py
+++ b/libreyolo/kernels/quant/execute/fp8_fusion.py
@@ -1,0 +1,131 @@
+"""Fused Triton prologue/epilogue around the native FP8 GEMM.
+
+These are finalized-only execution kernels: they wrap the ``fp8_gemm``
+tensor-core path from ``scaled_mm_fp8.py`` with a fused activation cast and
+a fused per-channel epilogue. They have no backward; the simulated tier
+covers training.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import torch
+import triton
+import triton.language as tl
+
+from libreyolo import kernels
+
+
+@triton.jit
+def _static_fp8_cast_kernel(
+    input_ptr,
+    inverse_scale_ptr,
+    output_ptr,
+    n_elements: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Fused static-scale activation quantization for native FP8 GEMMs."""
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid = offsets < n_elements
+    # Scaling follows the prepared FP8 oracle in fp32. Fusing it into this
+    # memory pass avoids materializing the fp32 activation tensor.
+    values = tl.load(input_ptr + offsets, mask=valid).to(tl.float32)
+    inverse_scale = tl.load(inverse_scale_ptr).to(tl.float32)
+    values *= inverse_scale
+    values = tl.maximum(tl.minimum(values, 448.0), -448.0)
+    tl.store(output_ptr + offsets, values.to(tl.float8e4nv), mask=valid)
+
+
+def static_fp8_cast(inputs: torch.Tensor, inverse_scale: torch.Tensor) -> torch.Tensor:
+    """Multiply, saturate, and cast a contiguous CUDA tensor to E4M3."""
+    if not (
+        inputs.is_cuda
+        and inputs.is_contiguous()
+        and inverse_scale.is_cuda
+        and inverse_scale.numel() == 1
+    ):
+        raise ValueError("static FP8 cast expects contiguous CUDA inputs and scale")
+    output = torch.empty_like(inputs, dtype=torch.float8_e4m3fn)
+    _static_fp8_cast_kernel[(triton.cdiv(inputs.numel(), 256),)](
+        inputs,
+        inverse_scale,
+        output,
+        n_elements=inputs.numel(),
+        BLOCK_SIZE=256,
+    )
+    return output
+
+
+@triton.jit
+def _perchannel_epilogue_kernel(
+    input_ptr,
+    scale_ptr,
+    bias_ptr,
+    output_ptr,
+    n_elements: tl.constexpr,
+    n_columns: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid = offsets < n_elements
+    columns = offsets % n_columns
+    values = tl.load(input_ptr + offsets, mask=valid).to(tl.float32)
+    scale = tl.load(scale_ptr + columns, mask=valid).to(tl.float32)
+    values *= scale
+    if HAS_BIAS:
+        values += tl.load(bias_ptr + columns, mask=valid).to(tl.float32)
+    tl.store(output_ptr + offsets, values, mask=valid)
+
+
+def perchannel_fp8_epilogue(
+    inputs: torch.Tensor,
+    scale: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    """Fuse row-scale restoration, bias, and FP16 storage in one pass."""
+    if not (
+        inputs.is_cuda
+        and inputs.is_contiguous()
+        and scale.is_cuda
+        and scale.numel() == inputs.shape[-1]
+        and (bias is None or (bias.is_cuda and bias.numel() == inputs.shape[-1]))
+    ):
+        raise ValueError("FP8 epilogue expects contiguous CUDA tensors")
+    output = torch.empty_like(inputs, dtype=torch.float16)
+    _perchannel_epilogue_kernel[(triton.cdiv(inputs.numel(), 256),)](
+        inputs,
+        scale,
+        bias if bias is not None else scale,
+        output,
+        n_elements=inputs.numel(),
+        n_columns=inputs.shape[-1],
+        HAS_BIAS=bias is not None,
+        BLOCK_SIZE=256,
+    )
+    return output
+
+
+def _eligible() -> bool:
+    return importlib.util.find_spec("triton") is not None and torch.cuda.is_available()
+
+
+kernels.register(
+    "fp8_cast_static",
+    static_fp8_cast,
+    name="triton",
+    predicate=_eligible,
+)
+kernels.register(
+    "fp8_perchannel_epilogue",
+    perchannel_fp8_epilogue,
+    name="triton",
+    predicate=_eligible,
+)
+
+
+__all__ = [
+    "perchannel_fp8_epilogue",
+    "static_fp8_cast",
+]

--- a/libreyolo/kernels/quant/execute/scaled_mm_fp8.py
+++ b/libreyolo/kernels/quant/execute/scaled_mm_fp8.py
@@ -30,7 +30,7 @@ from typing import Optional
 
 import torch
 
-from . import register
+from libreyolo.kernels import register
 
 _E4M3_MAX = 448.0
 
@@ -90,7 +90,7 @@ def make_aux(act_scale, w_scale, bias, device, *, tensorwise: bool = False):
 def _cast_static_fp8(x: torch.Tensor, inv: torch.Tensor) -> torch.Tensor:
     # The optional Triton implementation fuses multiply, saturation, and cast
     # into one memory pass. Stock torch remains the portable fallback.
-    from . import resolve
+    from libreyolo.kernels import resolve
 
     impl = resolve("fp8_cast_static")
     if impl is not None:
@@ -129,7 +129,7 @@ def fp8_linear_scaled_mm(
         x2 = x2.to(torch.float16)
 
     x8 = _cast_static_fp8(x2, inv)
-    from . import resolve
+    from libreyolo.kernels import resolve
 
     epilogue = resolve("fp8_perchannel_epilogue")
     try:

--- a/libreyolo/kernels/quant/execute/unpack_int_grouped.py
+++ b/libreyolo/kernels/quant/execute/unpack_int_grouped.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from libreyolo.quant import kernels
+from libreyolo import kernels
 from libreyolo.quant import packing as _reference
 
 

--- a/libreyolo/kernels/quant/execute/unpack_nvfp4.py
+++ b/libreyolo/kernels/quant/execute/unpack_nvfp4.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from libreyolo.quant import kernels
+from libreyolo import kernels
 from libreyolo.quant import packing as _reference
 
 

--- a/libreyolo/kernels/quant/simulate/__init__.py
+++ b/libreyolo/kernels/quant/simulate/__init__.py
@@ -1,25 +1,23 @@
-"""Triton quantization kernels (JIT, no build step)."""
+"""Triton fake-quantization kernels (JIT, no build step).
 
-from .fp8 import fake_quant_fp8, perchannel_fp8_epilogue, static_fp8_cast
+Importing this package self-registers every simulate kernel; the registry
+imports it lazily so ``import libreyolo`` never pays the triton import cost.
+"""
+
+from .fp8 import fake_quant_fp8
 from .int_grouped import fake_quant_int_grouped
 from .int8_per_channel import fake_quant_int8_per_channel
 from .mxfp4 import fake_quant_mxfp4_dynamic, fake_quant_mxfp4_weight
 from .nvfp4_dynamic import fake_quant_nvfp4_dynamic
 from .nvfp4_weight import fake_quant_nvfp4_weight
-from .unpack_int_grouped import unpack_int_grouped
-from .unpack_nvfp4 import unpack_nvfp4
 
 
 __all__ = [
     "fake_quant_fp8",
-    "perchannel_fp8_epilogue",
-    "static_fp8_cast",
     "fake_quant_int_grouped",
     "fake_quant_int8_per_channel",
     "fake_quant_mxfp4_dynamic",
     "fake_quant_mxfp4_weight",
     "fake_quant_nvfp4_dynamic",
     "fake_quant_nvfp4_weight",
-    "unpack_int_grouped",
-    "unpack_nvfp4",
 ]

--- a/libreyolo/kernels/quant/simulate/fp8.py
+++ b/libreyolo/kernels/quant/simulate/fp8.py
@@ -10,8 +10,8 @@ import triton
 import triton.language as tl
 from triton.language.extra import libdevice
 
+from libreyolo import kernels
 from libreyolo.quant import fake_quant as _reference
-from libreyolo.quant import kernels
 
 
 _FP8_CONFIGS = (
@@ -21,96 +21,6 @@ _FP8_CONFIGS = (
     triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=1),
     triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
 )
-
-
-@triton.jit
-def _static_fp8_cast_kernel(
-    input_ptr,
-    inverse_scale_ptr,
-    output_ptr,
-    n_elements: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-):
-    """Fused static-scale activation quantization for native FP8 GEMMs."""
-    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    valid = offsets < n_elements
-    # Scaling follows the prepared FP8 oracle in fp32. Fusing it into this
-    # memory pass avoids materializing the fp32 activation tensor.
-    values = tl.load(input_ptr + offsets, mask=valid).to(tl.float32)
-    inverse_scale = tl.load(inverse_scale_ptr).to(tl.float32)
-    values *= inverse_scale
-    values = tl.maximum(tl.minimum(values, 448.0), -448.0)
-    tl.store(output_ptr + offsets, values.to(tl.float8e4nv), mask=valid)
-
-
-def static_fp8_cast(inputs: torch.Tensor, inverse_scale: torch.Tensor) -> torch.Tensor:
-    """Multiply, saturate, and cast a contiguous CUDA tensor to E4M3."""
-    if not (
-        inputs.is_cuda
-        and inputs.is_contiguous()
-        and inverse_scale.is_cuda
-        and inverse_scale.numel() == 1
-    ):
-        raise ValueError("static FP8 cast expects contiguous CUDA inputs and scale")
-    output = torch.empty_like(inputs, dtype=torch.float8_e4m3fn)
-    _static_fp8_cast_kernel[(triton.cdiv(inputs.numel(), 256),)](
-        inputs,
-        inverse_scale,
-        output,
-        n_elements=inputs.numel(),
-        BLOCK_SIZE=256,
-    )
-    return output
-
-
-@triton.jit
-def _perchannel_epilogue_kernel(
-    input_ptr,
-    scale_ptr,
-    bias_ptr,
-    output_ptr,
-    n_elements: tl.constexpr,
-    n_columns: tl.constexpr,
-    HAS_BIAS: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-):
-    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    valid = offsets < n_elements
-    columns = offsets % n_columns
-    values = tl.load(input_ptr + offsets, mask=valid).to(tl.float32)
-    scale = tl.load(scale_ptr + columns, mask=valid).to(tl.float32)
-    values *= scale
-    if HAS_BIAS:
-        values += tl.load(bias_ptr + columns, mask=valid).to(tl.float32)
-    tl.store(output_ptr + offsets, values, mask=valid)
-
-
-def perchannel_fp8_epilogue(
-    inputs: torch.Tensor,
-    scale: torch.Tensor,
-    bias: torch.Tensor | None,
-) -> torch.Tensor:
-    """Fuse row-scale restoration, bias, and FP16 storage in one pass."""
-    if not (
-        inputs.is_cuda
-        and inputs.is_contiguous()
-        and scale.is_cuda
-        and scale.numel() == inputs.shape[-1]
-        and (bias is None or (bias.is_cuda and bias.numel() == inputs.shape[-1]))
-    ):
-        raise ValueError("FP8 epilogue expects contiguous CUDA tensors")
-    output = torch.empty_like(inputs, dtype=torch.float16)
-    _perchannel_epilogue_kernel[(triton.cdiv(inputs.numel(), 256),)](
-        inputs,
-        scale,
-        bias if bias is not None else scale,
-        output,
-        n_elements=inputs.numel(),
-        n_columns=inputs.shape[-1],
-        HAS_BIAS=bias is not None,
-        BLOCK_SIZE=256,
-    )
-    return output
 
 
 @triton.autotune(
@@ -229,23 +139,9 @@ kernels.register(
     name="triton",
     predicate=_eligible,
 )
-kernels.register(
-    "fp8_cast_static",
-    static_fp8_cast,
-    name="triton",
-    predicate=_eligible,
-)
-kernels.register(
-    "fp8_perchannel_epilogue",
-    perchannel_fp8_epilogue,
-    name="triton",
-    predicate=_eligible,
-)
 
 
 __all__ = [
     "autotune_cache",
     "fake_quant_fp8",
-    "perchannel_fp8_epilogue",
-    "static_fp8_cast",
 ]

--- a/libreyolo/kernels/quant/simulate/int8_per_channel.py
+++ b/libreyolo/kernels/quant/simulate/int8_per_channel.py
@@ -10,8 +10,8 @@ import triton
 import triton.language as tl
 from triton.language.extra import libdevice
 
+from libreyolo import kernels
 from libreyolo.quant import fake_quant as _reference
-from libreyolo.quant import kernels
 
 
 _DYNAMIC_CONFIGS = (

--- a/libreyolo/kernels/quant/simulate/int_grouped.py
+++ b/libreyolo/kernels/quant/simulate/int_grouped.py
@@ -10,8 +10,8 @@ import triton
 import triton.language as tl
 from triton.language.extra import libdevice
 
+from libreyolo import kernels
 from libreyolo.quant import fake_quant as _reference
-from libreyolo.quant import kernels
 
 
 _GROUPED_CONFIGS = (

--- a/libreyolo/kernels/quant/simulate/mxfp4.py
+++ b/libreyolo/kernels/quant/simulate/mxfp4.py
@@ -10,8 +10,8 @@ import triton
 import triton.language as tl
 from triton.language.extra import libdevice
 
+from libreyolo import kernels
 from libreyolo.quant import fake_quant as _reference
-from libreyolo.quant import kernels
 
 
 _MXFP4_CONFIGS = (

--- a/libreyolo/kernels/quant/simulate/nvfp4_dynamic.py
+++ b/libreyolo/kernels/quant/simulate/nvfp4_dynamic.py
@@ -9,8 +9,8 @@ import torch
 import triton
 import triton.language as tl
 
+from libreyolo import kernels
 from libreyolo.quant import fake_quant as _reference
-from libreyolo.quant import kernels
 
 from .nvfp4_weight import _launch as _quantize_with_amax
 from .nvfp4_weight import autotune_cache as _quantize_autotune_cache

--- a/libreyolo/kernels/quant/simulate/nvfp4_weight.py
+++ b/libreyolo/kernels/quant/simulate/nvfp4_weight.py
@@ -15,8 +15,8 @@ import triton
 import triton.language as tl
 from triton.language.extra import libdevice
 
+from libreyolo import kernels
 from libreyolo.quant import fake_quant as _reference
-from libreyolo.quant import kernels
 
 
 _NVFP4_CONFIGS = (

--- a/libreyolo/models/deformable_detr/ms_deform_attn.py
+++ b/libreyolo/models/deformable_detr/ms_deform_attn.py
@@ -15,6 +15,8 @@ import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 from torch.nn.init import constant_, xavier_uniform_
 
+from ...kernels.attention.ms_deform_attn import maybe_ms_deform_attn
+
 
 def _is_power_of_2(value: int) -> bool:
     if not isinstance(value, int) or value < 0:
@@ -28,7 +30,17 @@ def ms_deform_attn_core_pytorch(
     sampling_locations: Tensor,
     attention_weights: Tensor,
 ) -> Tensor:
-    """Pure-PyTorch deformable attention core used on every device/backend."""
+    """Portable deformable attention core used on every device/backend.
+
+    When the optional accelerated ``ms_deform_attn`` kernel slot resolves
+    (see ``libreyolo/kernels/attention/ms_deform_attn.py``) it takes over;
+    the grid_sample path below stays the default and the export path.
+    """
+    accelerated = maybe_ms_deform_attn(
+        value, value_spatial_shapes, sampling_locations, attention_weights
+    )
+    if accelerated is not None:
+        return accelerated
     batch, _, heads, channels = value.shape
     _, queries, _, levels, points, _ = sampling_locations.shape
     split_sizes = [height * width for height, width in value_spatial_shapes]

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -23,6 +23,7 @@ import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 from torch.nn.init import constant_, xavier_uniform_
 
+from ...kernels.attention.ms_deform_attn import maybe_ms_deform_attn
 from .keypoints import KEYPOINT_PRED_DIM, ConditionalQueryInitializer
 from .tensors import _bilinear_grid_sample
 
@@ -154,7 +155,26 @@ def ms_deform_attn_core_pytorch(
     attention_weights: torch.Tensor,
     value_spatial_shapes_hw: list[tuple[int, int]] | None = None,
 ) -> torch.Tensor:
-    """Pure-PyTorch fallback for the deformable-attention core."""
+    """Portable deformable-attention core (upstream-parity fallback).
+
+    When the optional accelerated ``ms_deform_attn`` kernel slot resolves it
+    takes over; export callers pass ``value_spatial_shapes_hw`` and always
+    keep the portable path below.
+    """
+    if value_spatial_shapes_hw is None:
+        weights = attention_weights
+        if weights.dim() == 4:
+            # The caller flattens (levels, points); the slot takes them split.
+            weights = weights.unflatten(-1, sampling_locations.shape[-3:-1])
+        accelerated = maybe_ms_deform_attn(
+            # (bs, heads, c, Len_in) -> the slot's (bs, Len_in, heads, c).
+            value.permute(0, 3, 1, 2),
+            value_spatial_shapes,
+            sampling_locations,
+            weights,
+        )
+        if accelerated is not None:
+            return accelerated
     batch_size, n_heads, head_dim, _ = value.shape
     _, len_query, n_heads, num_levels, num_points, _ = sampling_locations.shape
     # Use Python int pairs when available (required for torch.export compatibility,

--- a/libreyolo/models/rfdetr/transformer.py
+++ b/libreyolo/models/rfdetr/transformer.py
@@ -155,26 +155,14 @@ def ms_deform_attn_core_pytorch(
     attention_weights: torch.Tensor,
     value_spatial_shapes_hw: list[tuple[int, int]] | None = None,
 ) -> torch.Tensor:
-    """Portable deformable-attention core (upstream-parity fallback).
+    """Portable deformable-attention core, used on every device/backend.
 
-    When the optional accelerated ``ms_deform_attn`` kernel slot resolves it
-    takes over; export callers pass ``value_spatial_shapes_hw`` and always
-    keep the portable path below.
+    This is the upstream-parity ``grid_sample`` port and the only path
+    exports ever see. The accelerated ``ms_deform_attn`` kernel slot is
+    consulted in :meth:`MSDeformAttn.forward` *before* the layout transpose
+    that produces this function's ``(bs, heads, c, Len_in)`` value tensor,
+    so the fast path pays no extra copies.
     """
-    if value_spatial_shapes_hw is None:
-        weights = attention_weights
-        if weights.dim() == 4:
-            # The caller flattens (levels, points); the slot takes them split.
-            weights = weights.unflatten(-1, sampling_locations.shape[-3:-1])
-        accelerated = maybe_ms_deform_attn(
-            # (bs, heads, c, Len_in) -> the slot's (bs, Len_in, heads, c).
-            value.permute(0, 3, 1, 2),
-            value_spatial_shapes,
-            sampling_locations,
-            weights,
-        )
-        if accelerated is not None:
-            return accelerated
     batch_size, n_heads, head_dim, _ = value.shape
     _, len_query, n_heads, num_levels, num_points, _ = sampling_locations.shape
     # Use Python int pairs when available (required for torch.export compatibility,
@@ -353,6 +341,23 @@ class MSDeformAttn(nn.Module):
                 "Last dim of reference_points must be 2 or 4, but get {} instead.".format(reference_points.shape[-1])
             )
         attention_weights = F.softmax(attention_weights, -1)
+
+        if not self._export:
+            # Consult the accelerated slot with the classic Deformable-DETR
+            # layout while ``value`` is still (bs, Len_in, d_model): one
+            # zero-copy view away from the slot's (bs, Len_in, heads, c).
+            # Export mode always takes the portable core below, whose
+            # ``value_spatial_shapes_hw`` int pairs keep it traceable.
+            accelerated = maybe_ms_deform_attn(
+                value.view(
+                    batch_size, len_input, self.n_heads, self.d_model // self.n_heads
+                ),
+                input_spatial_shapes,
+                sampling_locations,
+                attention_weights.unflatten(-1, (self.n_levels, self.n_points)),
+            )
+            if accelerated is not None:
+                return self.output_proj(accelerated)
 
         value = (
             value.transpose(1, 2).contiguous().view(batch_size, self.n_heads, self.d_model // self.n_heads, len_input)

--- a/libreyolo/quant/__init__.py
+++ b/libreyolo/quant/__init__.py
@@ -31,6 +31,10 @@ from .modules import (
     QuantLinear,
 )
 
+# Back-compat alias: the kernel registry moved to libreyolo/kernels/, but
+# `libreyolo.quant.kernels.active()` stays a documented entry point.
+from . import kernels  # noqa: E402,F401
+
 __all__ = [
     "DEFAULT_CALIB_DATA",
     "QUANT_SCHEMA_VERSION",

--- a/libreyolo/quant/kernels.py
+++ b/libreyolo/quant/kernels.py
@@ -1,0 +1,19 @@
+"""Back-compat shim: the kernel registry moved to :mod:`libreyolo.kernels`.
+
+Kept so ``from libreyolo.quant import kernels`` and
+``libreyolo.quant.kernels.active()`` keep working. Attribute access is
+forwarded lazily (PEP 562) because this module participates in the
+``libreyolo.kernels`` <-> ``libreyolo.quant`` import cycle: at shim import
+time the registry module may be mid-initialization, so names must not be
+bound eagerly.
+"""
+
+import libreyolo.kernels as _registry
+
+
+def __getattr__(name):
+    return getattr(_registry, name)
+
+
+def __dir__():
+    return dir(_registry)

--- a/libreyolo/quant/modules.py
+++ b/libreyolo/quant/modules.py
@@ -16,7 +16,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from . import kernels as K
+from .. import kernels as K
 from .fake_quant import (
     E4M3_MAX,
     autocast_off,
@@ -344,7 +344,7 @@ class QuantLinear(nn.Linear, _ActObserverMixin):
             return None
         aux = self.__dict__.get("_q_native_aux")
         if aux is None or aux[0].device != x.device:
-            from .kernels.scaled_mm_fp8 import make_aux
+            from ..kernels.quant.execute.scaled_mm_fp8 import make_aux
 
             aux = make_aux(
                 self._native_act_scale(x.device),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,8 @@ sam = [
 ]
 hub-kernels = [
     # Optional runtime loader for compiled Hub kernels (e.g. the
-    # ms_deform_attn slot). Off by default; enabled with
-    # LIBREYOLO_HUB_KERNELS=1. See docs/kernels.md.
+    # ms_deform_attn slot). Installing this extra is the opt-in; disable
+    # with LIBREYOLO_HUB_KERNELS=0. See docs/kernels.md.
     "kernels>=0.6.0",
 ]
 openvocab = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,12 @@ sam = [
     "transformers>=5.3.0",
     "timm>=1.0.23",
 ]
+hub-kernels = [
+    # Optional runtime loader for compiled Hub kernels (e.g. the
+    # ms_deform_attn slot). Off by default; enabled with
+    # LIBREYOLO_HUB_KERNELS=1. See docs/kernels.md.
+    "kernels>=0.6.0",
+]
 openvocab = [
     # Discriminative open-vocabulary detectors load through transformers
     # (GroundingDinoForObjectDetection / Owlv2ForObjectDetection /

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -30,7 +30,9 @@ LEN_IN = sum(h * w for h, w in SHAPES)
 def _clean_registry_env(monkeypatch):
     monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
     monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
-    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    # Hub kernels are on by default when the `kernels` package is installed;
+    # pin them off so these tests behave the same on any machine.
+    monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
     kernels.clear_cache()
     yield
     kernels.unregister("ms_deform_attn", "mock")
@@ -53,10 +55,20 @@ def _classic_inputs():
     return value, spatial_shapes, sampling_locations, attention_weights
 
 
-def test_slot_resolves_to_none_by_default():
+def test_slot_resolves_to_none_when_disabled():
     assert kernels.resolve("ms_deform_attn") is None
     value, shapes, locations, weights = _classic_inputs()
     assert maybe_ms_deform_attn(value, shapes, locations, weights) is None
+
+
+def test_hub_default_on_and_env_opt_out(monkeypatch):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    assert module._hub_enabled()
+    for value in ("0", "false", "off", "no"):
+        monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", value)
+        assert not module._hub_enabled()
 
 
 def test_hub_impl_rejects_cpu_inputs():

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib.util
+
 import pytest
 import torch
 
@@ -13,6 +15,9 @@ from libreyolo.kernels.attention.ms_deform_attn import (
 )
 from libreyolo.models.deformable_detr.ms_deform_attn import (
     ms_deform_attn_core_pytorch as classic_core,
+)
+from libreyolo.models.rfdetr.transformer import (
+    MSDeformAttn as RFDETRMSDeformAttn,
 )
 from libreyolo.models.rfdetr.transformer import (
     ms_deform_attn_core_pytorch as rfdetr_core,
@@ -120,29 +125,8 @@ def test_classic_call_site_routes_through_slot(monkeypatch):
     ]
 
 
-def test_rfdetr_call_site_adapts_layout(monkeypatch):
-    recorded = []
-    _register_mock(monkeypatch, recorded)
-    value, shapes, locations, weights = _classic_inputs()
-    rfdetr_value = value.permute(0, 2, 3, 1).contiguous()
-    rfdetr_weights = weights.flatten(-2)
-    out = rfdetr_core(rfdetr_value, shapes, locations, rfdetr_weights)
-    assert torch.equal(
-        out, torch.full((BATCH, LEN_Q, HEADS * CHANNELS), 7.0)
-    )
-    # The adapter must hand the slot the classic layout.
-    assert recorded == [
-        (
-            (BATCH, LEN_IN, HEADS, CHANNELS),
-            (LEVELS, 2),
-            (BATCH, LEN_Q, HEADS, LEVELS, POINTS, 2),
-            (BATCH, LEN_Q, HEADS, LEVELS, POINTS),
-        )
-    ]
-
-
-def test_rfdetr_adapter_is_numerically_equivalent():
-    """The rfdetr layout adaptation must express the same attention problem."""
+def test_rfdetr_layout_is_numerically_equivalent():
+    """The rfdetr core's layout must express the same attention problem."""
     value, shapes, locations, weights = _classic_inputs()
     classic_out = classic_core(value, shapes, locations, weights)
     rfdetr_out = rfdetr_core(
@@ -154,15 +138,146 @@ def test_rfdetr_adapter_is_numerically_equivalent():
     torch.testing.assert_close(rfdetr_out, classic_out, rtol=1e-5, atol=1e-5)
 
 
-def test_export_hw_path_skips_slot(monkeypatch):
+D_MODEL = HEADS * CHANNELS
+
+
+def _rfdetr_attention_module():
+    torch.manual_seed(0)
+    return RFDETRMSDeformAttn(
+        d_model=D_MODEL, n_levels=LEVELS, n_heads=HEADS, n_points=POINTS
+    )
+
+
+def _rfdetr_attention_inputs():
+    generator = torch.Generator().manual_seed(1)
+    query = torch.randn(BATCH, LEN_Q, D_MODEL, generator=generator)
+    reference_points = torch.rand(BATCH, LEN_Q, LEVELS, 2, generator=generator)
+    input_flatten = torch.randn(BATCH, LEN_IN, D_MODEL, generator=generator)
+    spatial_shapes = torch.tensor(SHAPES, dtype=torch.int64)
+    return query, reference_points, input_flatten, spatial_shapes
+
+
+def test_rfdetr_attention_forward_routes_through_slot(monkeypatch):
+    """The real RF-DETR attention module must consult the slot in eager mode.
+
+    This is the regression test for the slot being wired at a call site the
+    model actually reaches: RF-DETR always threads ``input_spatial_shapes_hw``
+    through its decoder, so gating the slot on that argument being None
+    (an earlier revision of this PR) made the kernel unreachable.
+    """
     recorded = []
     _register_mock(monkeypatch, recorded)
-    value, shapes, locations, weights = _classic_inputs()
-    rfdetr_core(
-        value.permute(0, 2, 3, 1).contiguous(),
-        shapes,
-        locations,
-        weights.flatten(-2),
-        value_spatial_shapes_hw=SHAPES,
+    module = _rfdetr_attention_module()
+    query, reference_points, input_flatten, spatial_shapes = (
+        _rfdetr_attention_inputs()
+    )
+    out = module(
+        query,
+        reference_points,
+        input_flatten,
+        spatial_shapes,
+        level_start_index(spatial_shapes),
+        input_spatial_shapes_hw=SHAPES,
+    )
+    # The slot receives the classic Deformable-DETR layout...
+    assert recorded == [
+        (
+            (BATCH, LEN_IN, HEADS, CHANNELS),
+            (LEVELS, 2),
+            (BATCH, LEN_Q, HEADS, LEVELS, POINTS, 2),
+            (BATCH, LEN_Q, HEADS, LEVELS, POINTS),
+        )
+    ]
+    # ...and its output feeds output_proj: mock returns all-7s, so the
+    # module output equals output_proj of an all-7s tensor.
+    expected = module.output_proj(
+        torch.full((BATCH, LEN_Q, D_MODEL), 7.0)
+    )
+    torch.testing.assert_close(out, expected)
+
+
+def test_rfdetr_attention_export_mode_skips_slot(monkeypatch):
+    recorded = []
+    _register_mock(monkeypatch, recorded)
+    module = _rfdetr_attention_module()
+    module.export()
+    query, reference_points, input_flatten, spatial_shapes = (
+        _rfdetr_attention_inputs()
+    )
+    module(
+        query,
+        reference_points,
+        input_flatten,
+        spatial_shapes,
+        level_start_index(spatial_shapes),
+        input_spatial_shapes_hw=SHAPES,
     )
     assert recorded == []
+
+
+def test_rfdetr_attention_slot_matches_portable(monkeypatch):
+    """A slot impl wrapping the portable core must reproduce module output."""
+
+    def portable_impl(value, spatial_shapes, sampling_locations, attention_weights):
+        # Wrap the rfdetr portable core (slot-free) rather than classic_core,
+        # which consults the slot itself and would recurse into this impl.
+        return rfdetr_core(
+            value.permute(0, 2, 3, 1).contiguous(),
+            spatial_shapes,
+            sampling_locations,
+            attention_weights.flatten(-2),
+        )
+
+    module = _rfdetr_attention_module()
+    query, reference_points, input_flatten, spatial_shapes = (
+        _rfdetr_attention_inputs()
+    )
+    args = (
+        query,
+        reference_points,
+        input_flatten,
+        spatial_shapes,
+        level_start_index(spatial_shapes),
+    )
+    baseline = module(*args, input_spatial_shapes_hw=SHAPES)
+
+    kernels.register("ms_deform_attn", portable_impl, name="mock")
+    monkeypatch.setenv("LIBREYOLO_KERNELS", "mock")
+    kernels.clear_cache()
+    routed = module(*args, input_spatial_shapes_hw=SHAPES)
+    torch.testing.assert_close(routed, baseline, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or importlib.util.find_spec("kernels") is None,
+    reason="needs CUDA and the `kernels` package (libreyolo[hub-kernels])",
+)
+def test_hub_matches_portable_on_cuda():
+    """Forward/backward parity of the pinned Hub kernel vs the portable core.
+
+    This is the GPU smoke for the provider: run it on any CUDA box with the
+    ``hub-kernels`` extra installed before bumping ``_HUB_REVISION``.
+    """
+    value, shapes, locations, weights = _classic_inputs()
+    value = value.cuda().requires_grad_(True)
+    shapes = shapes.cuda()
+    locations = locations.cuda().requires_grad_(True)
+    weights = weights.cuda().requires_grad_(True)
+
+    hub_out = hub_ms_deform_attn(value, shapes, locations, weights)
+    if hub_out is None:
+        pytest.skip("hub kernel unavailable on this box (load failed)")
+    hub_out.sum().backward()
+    hub_grads = (value.grad.clone(), locations.grad.clone(), weights.grad.clone())
+
+    value.grad = locations.grad = weights.grad = None
+    # classic_core consults the slot itself; the autouse fixture pins
+    # LIBREYOLO_HUB_KERNELS=0 for this file, so it runs the portable path.
+    ref_out = classic_core(value, shapes, locations, weights)
+    ref_out.sum().backward()
+    ref_grads = (value.grad, locations.grad, weights.grad)
+
+    torch.testing.assert_close(hub_out, ref_out, rtol=1e-4, atol=1e-5)
+    for hub_grad, ref_grad in zip(hub_grads, ref_grads):
+        torch.testing.assert_close(hub_grad, ref_grad, rtol=1e-3, atol=1e-4)

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -1,0 +1,156 @@
+"""CPU tests for the ``ms_deform_attn`` op slot and its call-site adapters."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo import kernels
+from libreyolo.kernels.attention.ms_deform_attn import (
+    hub_ms_deform_attn,
+    level_start_index,
+    maybe_ms_deform_attn,
+)
+from libreyolo.models.deformable_detr.ms_deform_attn import (
+    ms_deform_attn_core_pytorch as classic_core,
+)
+from libreyolo.models.rfdetr.transformer import (
+    ms_deform_attn_core_pytorch as rfdetr_core,
+)
+
+pytestmark = pytest.mark.unit
+
+BATCH, LEN_Q, HEADS, CHANNELS = 2, 3, 2, 4
+SHAPES = [(4, 6), (2, 3)]
+LEVELS, POINTS = len(SHAPES), 2
+LEN_IN = sum(h * w for h, w in SHAPES)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_env(monkeypatch):
+    monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
+    monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
+    monkeypatch.delenv("LIBREYOLO_HUB_KERNELS", raising=False)
+    kernels.clear_cache()
+    yield
+    kernels.unregister("ms_deform_attn", "mock")
+    kernels.clear_cache()
+
+
+def _classic_inputs():
+    generator = torch.Generator().manual_seed(0)
+    value = torch.randn(BATCH, LEN_IN, HEADS, CHANNELS, generator=generator)
+    spatial_shapes = torch.tensor(SHAPES, dtype=torch.int64)
+    sampling_locations = torch.rand(
+        BATCH, LEN_Q, HEADS, LEVELS, POINTS, 2, generator=generator
+    )
+    attention_weights = torch.rand(
+        BATCH, LEN_Q, HEADS, LEVELS, POINTS, generator=generator
+    )
+    attention_weights = attention_weights / attention_weights.sum(
+        dim=(-2, -1), keepdim=True
+    )
+    return value, spatial_shapes, sampling_locations, attention_weights
+
+
+def test_slot_resolves_to_none_by_default():
+    assert kernels.resolve("ms_deform_attn") is None
+    value, shapes, locations, weights = _classic_inputs()
+    assert maybe_ms_deform_attn(value, shapes, locations, weights) is None
+
+
+def test_hub_impl_rejects_cpu_inputs():
+    value, shapes, locations, weights = _classic_inputs()
+    assert hub_ms_deform_attn(value, shapes, locations, weights) is None
+
+
+def test_level_start_index():
+    shapes = torch.tensor(SHAPES, dtype=torch.int64)
+    expected = torch.tensor([0, SHAPES[0][0] * SHAPES[0][1]], dtype=torch.int64)
+    assert torch.equal(level_start_index(shapes), expected)
+
+
+def _register_mock(monkeypatch, recorded):
+    def mock_impl(value, spatial_shapes, sampling_locations, attention_weights):
+        recorded.append(
+            (
+                tuple(value.shape),
+                tuple(spatial_shapes.shape),
+                tuple(sampling_locations.shape),
+                tuple(attention_weights.shape),
+            )
+        )
+        heads_times_c = value.shape[2] * value.shape[3]
+        return torch.full(
+            (value.shape[0], sampling_locations.shape[1], heads_times_c), 7.0
+        )
+
+    kernels.register("ms_deform_attn", mock_impl, name="mock")
+    monkeypatch.setenv("LIBREYOLO_KERNELS", "mock")
+    kernels.clear_cache()
+
+
+def test_classic_call_site_routes_through_slot(monkeypatch):
+    recorded = []
+    _register_mock(monkeypatch, recorded)
+    value, shapes, locations, weights = _classic_inputs()
+    out = classic_core(value, shapes, locations, weights)
+    assert torch.equal(
+        out, torch.full((BATCH, LEN_Q, HEADS * CHANNELS), 7.0)
+    )
+    assert recorded == [
+        (
+            (BATCH, LEN_IN, HEADS, CHANNELS),
+            (LEVELS, 2),
+            (BATCH, LEN_Q, HEADS, LEVELS, POINTS, 2),
+            (BATCH, LEN_Q, HEADS, LEVELS, POINTS),
+        )
+    ]
+
+
+def test_rfdetr_call_site_adapts_layout(monkeypatch):
+    recorded = []
+    _register_mock(monkeypatch, recorded)
+    value, shapes, locations, weights = _classic_inputs()
+    rfdetr_value = value.permute(0, 2, 3, 1).contiguous()
+    rfdetr_weights = weights.flatten(-2)
+    out = rfdetr_core(rfdetr_value, shapes, locations, rfdetr_weights)
+    assert torch.equal(
+        out, torch.full((BATCH, LEN_Q, HEADS * CHANNELS), 7.0)
+    )
+    # The adapter must hand the slot the classic layout.
+    assert recorded == [
+        (
+            (BATCH, LEN_IN, HEADS, CHANNELS),
+            (LEVELS, 2),
+            (BATCH, LEN_Q, HEADS, LEVELS, POINTS, 2),
+            (BATCH, LEN_Q, HEADS, LEVELS, POINTS),
+        )
+    ]
+
+
+def test_rfdetr_adapter_is_numerically_equivalent():
+    """The rfdetr layout adaptation must express the same attention problem."""
+    value, shapes, locations, weights = _classic_inputs()
+    classic_out = classic_core(value, shapes, locations, weights)
+    rfdetr_out = rfdetr_core(
+        value.permute(0, 2, 3, 1).contiguous(),
+        shapes,
+        locations,
+        weights.flatten(-2),
+    )
+    torch.testing.assert_close(rfdetr_out, classic_out, rtol=1e-5, atol=1e-5)
+
+
+def test_export_hw_path_skips_slot(monkeypatch):
+    recorded = []
+    _register_mock(monkeypatch, recorded)
+    value, shapes, locations, weights = _classic_inputs()
+    rfdetr_core(
+        value.permute(0, 2, 3, 1).contiguous(),
+        shapes,
+        locations,
+        weights.flatten(-2),
+        value_spatial_shapes_hw=SHAPES,
+    )
+    assert recorded == []

--- a/tests/unit/kernels/test_registry.py
+++ b/tests/unit/kernels/test_registry.py
@@ -1,0 +1,69 @@
+"""CPU tests for the library-wide kernel registry and its quant shim."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from libreyolo import kernels
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_env(monkeypatch):
+    monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
+    monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
+    kernels.clear_cache()
+    yield
+    kernels.clear_cache()
+
+
+def test_quant_shim_forwards_to_registry():
+    from libreyolo.quant import kernels as shim
+
+    assert shim.resolve is kernels.resolve
+    assert shim.register is kernels.register
+    assert shim.active is kernels.active
+    assert shim.clear_cache is kernels.clear_cache
+    assert shim.REFERENCE_OPS == kernels.REFERENCE_OPS
+
+
+def test_reference_ops_resolve_on_cpu():
+    for op in kernels.REFERENCE_OPS + kernels.UNPACK_OPS:
+        assert kernels.resolve(op) is not None, op
+
+
+def test_env_force_reference(monkeypatch):
+    reference = [
+        e["impl"]
+        for e in kernels._REGISTRY["fake_quant_fp8"]
+        if e["name"] == "reference"
+    ][0]
+    monkeypatch.setenv("LIBREYOLO_KERNELS", "off")
+    kernels.clear_cache()
+    assert kernels.resolve("fake_quant_fp8") is reference
+
+    monkeypatch.delenv("LIBREYOLO_KERNELS")
+    monkeypatch.setenv("LIBREYOLO_QUANT_KERNELS", "reference")
+    kernels.clear_cache()
+    assert kernels.resolve("fake_quant_fp8") is reference
+
+
+def test_active_lists_attention_slot():
+    # The attention provider needs no triton, so the slot registers on any
+    # platform; without the opt-in env it must resolve to nothing.
+    assert kernels.active().get("ms_deform_attn") == "unavailable"
+
+
+def test_registry_importable_before_quant():
+    """Importing libreyolo.kernels first must survive the quant cycle."""
+    code = (
+        "import libreyolo.kernels as k; "
+        "import libreyolo.quant; "
+        "assert k.resolve('fake_quant_fp8') is not None; "
+        "assert libreyolo.quant.kernels.resolve is k.resolve"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, timeout=300)

--- a/tests/unit/kernels/test_registry.py
+++ b/tests/unit/kernels/test_registry.py
@@ -52,9 +52,11 @@ def test_env_force_reference(monkeypatch):
     assert kernels.resolve("fake_quant_fp8") is reference
 
 
-def test_active_lists_attention_slot():
+def test_active_lists_attention_slot(monkeypatch):
     # The attention provider needs no triton, so the slot registers on any
-    # platform; without the opt-in env it must resolve to nothing.
+    # platform; with hub kernels pinned off it must resolve to nothing.
+    monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
+    kernels.clear_cache()
     assert kernels.active().get("ms_deform_attn") == "unavailable"
 
 

--- a/tests/unit/kernels/test_triton_kernels.py
+++ b/tests/unit/kernels/test_triton_kernels.py
@@ -12,7 +12,7 @@ import importlib.util
 import pytest
 import torch
 
-from libreyolo.quant import kernels
+from libreyolo import kernels
 
 from .harness import check_parity, load_shapes
 
@@ -27,47 +27,47 @@ HAS_TRITON_CUDA = (
 LANDED_KERNELS: tuple[tuple[str, str, str], ...] = (
     (
         "fake_quant_nvfp4_weight",
-        "libreyolo.quant.kernels.triton.nvfp4_weight",
+        "libreyolo.kernels.quant.simulate.nvfp4_weight",
         "fake_quant_nvfp4_weight",
     ),
     (
         "fake_quant_nvfp4_dynamic",
-        "libreyolo.quant.kernels.triton.nvfp4_dynamic",
+        "libreyolo.kernels.quant.simulate.nvfp4_dynamic",
         "fake_quant_nvfp4_dynamic",
     ),
     (
         "fake_quant_int8_per_channel",
-        "libreyolo.quant.kernels.triton.int8_per_channel",
+        "libreyolo.kernels.quant.simulate.int8_per_channel",
         "fake_quant_int8_per_channel",
     ),
     (
         "fake_quant_int_grouped",
-        "libreyolo.quant.kernels.triton.int_grouped",
+        "libreyolo.kernels.quant.simulate.int_grouped",
         "fake_quant_int_grouped",
     ),
     (
         "fake_quant_fp8",
-        "libreyolo.quant.kernels.triton.fp8",
+        "libreyolo.kernels.quant.simulate.fp8",
         "fake_quant_fp8",
     ),
     (
         "fake_quant_mxfp4_weight",
-        "libreyolo.quant.kernels.triton.mxfp4",
+        "libreyolo.kernels.quant.simulate.mxfp4",
         "fake_quant_mxfp4_weight",
     ),
     (
         "fake_quant_mxfp4_dynamic",
-        "libreyolo.quant.kernels.triton.mxfp4",
+        "libreyolo.kernels.quant.simulate.mxfp4",
         "fake_quant_mxfp4_dynamic",
     ),
     (
         "unpack_int_grouped",
-        "libreyolo.quant.kernels.triton.unpack_int_grouped",
+        "libreyolo.kernels.quant.execute.unpack_int_grouped",
         "unpack_int_grouped",
     ),
     (
         "unpack_nvfp4",
-        "libreyolo.quant.kernels.triton.unpack_nvfp4",
+        "libreyolo.kernels.quant.execute.unpack_nvfp4",
         "unpack_nvfp4",
     ),
 )
@@ -99,10 +99,17 @@ def test_triton_kernel_registration_and_escape_hatch(
 ) -> None:
     module = importlib.import_module(module_name)
     implementation = getattr(module, implementation_name)
+    monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
     monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
     kernels.clear_cache()
     assert kernels.resolve(op) is implementation
 
+    monkeypatch.setenv("LIBREYOLO_KERNELS", "off")
+    kernels.clear_cache()
+    assert kernels.resolve(op) is not implementation
+    monkeypatch.delenv("LIBREYOLO_KERNELS")
+
+    # Legacy alias from the registry's previous home under libreyolo/quant/.
     monkeypatch.setenv("LIBREYOLO_QUANT_KERNELS", "off")
     kernels.clear_cache()
     assert kernels.resolve(op) is not implementation

--- a/tests/unit/test_quantize.py
+++ b/tests/unit/test_quantize.py
@@ -311,7 +311,10 @@ def test_kernel_registry_reference_forced_by_env(monkeypatch):
 
 
 def test_kernel_registry_active_allows_lazy_registration(monkeypatch):
-    from libreyolo.quant import kernels
+    # Patch the real registry module: the libreyolo.quant.kernels shim
+    # forwards attribute reads but is a distinct module object, so setattr
+    # on it would not reach the registry internals.
+    from libreyolo import kernels
 
     loaded = False
 


### PR DESCRIPTION
Opened by an agent. Verified: full CPU unit runs listed below. Not verified: the CUDA hub-kernel path (this machine has CPU-only torch).

## What changed

- Kernel registry lifted from `libreyolo/quant/kernels/` to library-wide `libreyolo/kernels/`, organized by purpose:
  - `kernels/quant/simulate/`: fake-quant Triton kernels (any device, STE backward; serve QAT and simulated PTQ/val).
  - `kernels/quant/execute/`: finalized-only real-precision paths (`scaled_mm_fp8`, fused fp8 cast/epilogue split out of `fp8.py` into `fp8_fusion.py`, `unpack_*`).
  - `kernels/attention/`: new `ms_deform_attn` op slot.
- New accelerated multi-scale deformable attention: with `pip install libreyolo[hub-kernels]`, the compiled CUDA MSDA kernel from Hub repo `kernels-community/deformable-detr` (Apache-2.0) serves RF-DETR, LibreDeformableDETR, and LibreDINO-DETR, forward and backward. Installing the extra is the opt-in (no package, no change, no network access); `LIBREYOLO_HUB_KERNELS=0` disables it. Eligible inputs are eager CUDA fp32; tracing/ONNX/torch.export always use the portable grid_sample path, so exports are untouched; load or runtime failures disable the provider for the process and fall back with one warning.
- `LIBREYOLO_KERNELS` supersedes `LIBREYOLO_QUANT_KERNELS` (legacy alias still honored). `libreyolo.quant.kernels` stays a working alias via a lazy shim.
- Docs: new `docs/kernels.md` (incl. per-platform behavior: CPU/MPS fall back to reference ops, ROCm can engage Triton); `docs/quantization.md` pointers updated. CHANGELOG and THIRD_PARTY_NOTICES updated.
- Why shared-code change: the slot is consumed by three families; the registry mechanism already existed and only moved.

## Reviewer notes

- The per-family MSDA ports stay byte-equivalent fallbacks; call sites only gained a guarded slot lookup that resolves to None by default.
- Import cycle `libreyolo.kernels` <-> `libreyolo.quant` is handled by a PEP 562 shim; `tests/unit/kernels/test_registry.py` covers the kernels-first import order in a subprocess.
- Not verified: actual Hub kernel execution on CUDA (needs a CUDA box with the `kernels` package; predicate-gated, worst case falls back with a warning). Suggested check: install the extra, RF-DETR predict + short train step on GPU, compare against `LIBREYOLO_HUB_KERNELS=0`.

## Tests

- `tests/unit/kernels` + `tests/unit/test_quantize.py`: 66 passed, 22 CUDA-only skipped (CPU box). New tests cover the registry move, env aliases, the import cycle, the MSDA slot default/opt-out, and the call-site layout adapters (numeric equivalence on CPU).
- Deformable-DETR / DINO-DETR / RF-DETR suites (inference, parity, export, registry, postprocess, pose/obb/preprocess, trainer smokes): all passed.
- Full unit tier collection: 5017 tests collect with no import errors.

## Code provenance

- Moved files are pre-existing LibreYOLO code (git renames; MIT).
- New code (registry generalization, `kernels/attention/ms_deform_attn.py`, shim, tests, docs) was written for this PR.
- The autograd bridge in `kernels/attention/ms_deform_attn.py` follows the `MSDeformAttnFunction` interface of Deformable-DETR (https://github.com/fundamentalvision/Deformable-DETR, commit 11169a60c33333af00a4849f1808023eba96a931, Apache-2.0, Copyright (c) 2020 SenseTime). The compiled kernel itself is NOT vendored: it is fetched at runtime, only when the optional `kernels` package is installed, from the Apache-2.0 Hub repository kernels-community/deformable-detr. THIRD_PARTY_NOTICES.txt updated accordingly.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves the quantization kernel registry into a library-wide hierarchy and adds opt-in accelerated multi-scale deformable attention for DETR-family models. The follow-up pins the fetched native Hub kernel to an immutable revision, addressing the prior supply-chain concern.
- Reorganizes simulation and execution kernels under `libreyolo/kernels/`.
- Preserves the former quantization-kernel import path through a lazy compatibility shim.
- Adds a guarded Hub-backed CUDA attention implementation with portable fallbacks for unsupported inputs and exports.
- Pins the Hub artifact to a full commit revision and adds CUDA parity coverage for future revision changes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the native Hub artifact is now requested with a full commit revision at the only `get_kernel` call site, fixing the previously reported mutable-artifact path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/kernels/attention/ms_deform_attn.py | Adds the guarded Hub-backed CUDA attention provider and now loads its native artifact using a full immutable commit revision. |
| libreyolo/kernels/__init__.py | Generalizes the kernel registry and lazily imports a closed list of in-tree providers. |
| libreyolo/models/deformable_detr/ms_deform_attn.py | Consults the accelerated attention slot before retaining the existing portable implementation as fallback. |
| libreyolo/models/rfdetr/transformer.py | Adds the accelerated slot before RF-DETR's layout conversion while preserving the export-compatible portable path. |
| libreyolo/quant/kernels.py | Provides a lazy compatibility shim for the registry's former public import path. |
| pyproject.toml | Adds the optional Hub-kernel runtime loader extra. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Caller[DETR-family attention caller] --> Guard{Exporting or unsupported input?}
    Guard -->|Yes| Portable[Portable grid_sample implementation]
    Guard -->|No| Registry[Resolve ms_deform_attn slot]
    Registry --> Available{Pinned Hub provider available?}
    Available -->|No| Portable
    Available -->|Yes| Native[Execute pinned CUDA forward/backward]
    Native --> Success{Execution succeeds?}
    Success -->|Yes| Output[Return accelerated result]
    Success -->|No| Disable[Disable provider and warn once]
    Disable --> Portable
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix RF-DETR slot wiring, pin the Hub ker..."](https://github.com/libreyolo/libreyolo/commit/e7ceee9c3d1022536d653ba35027af2c1f236699) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49808431)</sub>

<!-- /greptile_comment -->