### PR TITLE
Kernel campaign: MSDA wire-ups for 8 more families, SDPA across 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,15 +30,23 @@ before 1.4.0 are documented in the
 
 - Fused scaled-dot-product attention across the transformer families, using
   stock torch (no optional dependency). SegFormer, Depth Anything (and
-  MoGe-2), BERT, Grounding DINO, SwinIR and PP-OCR use it by default; ONNX
-  export still traces the primitive-op equation, so exported graphs are
-  unchanged. Families pinned to a byte-exact parity bar (Swin,
+  MoGe-2), BERT, Grounding DINO, SwinIR and PP-OCR use it by default; graph
+  capture (ONNX, plus the `torch.jit.trace`-based TorchScript, CoreML and
+  NCNN exporters) still records the primitive-op equation, so exported graphs
+  are unchanged. Families pinned to a byte-exact parity bar (Swin,
   LibreDINO-DETR's Swin backbone, BiRefNet, FeyNoBG, OWLv2, LW-DETR,
   SigLIP 2, ZipDepth, MobileSAM) keep manual attention by default and opt in
   with `libreyolo.kernels.attention.set_fused_attention(model)`, which trades
   byte-exact agreement with upstream for the fused kernels. Measured on an
-  RTX 5070 Ti under fp16 autocast: 1.77x on Swin window attention, 3.74x on
+  RTX 5070 Ti under fp16 autocast: ~2x on Swin window attention, ~3.8x on
   OWLv2 vision attention. See `docs/kernels.md`.
+
+### Fixed
+
+- `LibreViT` and `LibreDeiT` now honor their `fused_attn` attribute. It was a
+  timm-compatibility vestige that nothing read, so
+  `libreyolo.kernels.attention.set_fused_attention` reported switching it
+  while fused attention kept running. Default behavior is unchanged for both.
 
 - `val_loss=True` extended from the `g0` flagships to **every trainable
   family** (`g0`, `g1` and `g2`), across four tasks rather than detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,28 @@ before 1.4.0 are documented in the
   and `libreyolo.quant.kernels` remains a working alias. See
   `docs/kernels.md`.
 - Optional accelerated multi-scale deformable attention (`ms_deform_attn`
-  slot): with `pip install libreyolo[hub-kernels]`, RF-DETR,
-  LibreDeformableDETR, and LibreDINO-DETR run the compiled Apache-2.0 CUDA
-  kernel from `kernels-community/deformable-detr` (forward and backward)
-  instead of the portable `grid_sample` path. Installing the extra is the
+  slot): with `pip install libreyolo[hub-kernels]`, every
+  Deformable-DETR-lineage family runs the compiled Apache-2.0 CUDA kernel
+  from `kernels-community/deformable-detr` (forward and backward) instead of
+  the portable `grid_sample` path: RF-DETR, LibreDeformableDETR,
+  LibreDINO-DETR, LW-DETR, Grounding DINO, RT-DETR, RT-DETRv2, D-FINE,
+  RT-DETRv4, DEIM, DEIMv2, EC and OV-DEIM. Installing the extra is the
   opt-in; `LIBREYOLO_HUB_KERNELS=0` disables it. Eager CUDA fp32 only;
   exports always keep the portable path; load or runtime failures fall back
-  with one warning.
+  with one warning. Shapes the slot cannot express (a per-level sampling
+  point count, or `method='discrete'`) also fall back.
+
+- Fused scaled-dot-product attention across the transformer families, using
+  stock torch (no optional dependency). SegFormer, Depth Anything (and
+  MoGe-2), BERT, Grounding DINO, SwinIR and PP-OCR use it by default; ONNX
+  export still traces the primitive-op equation, so exported graphs are
+  unchanged. Families pinned to a byte-exact parity bar (Swin,
+  LibreDINO-DETR's Swin backbone, BiRefNet, FeyNoBG, OWLv2, LW-DETR,
+  SigLIP 2, ZipDepth, MobileSAM) keep manual attention by default and opt in
+  with `libreyolo.kernels.attention.set_fused_attention(model)`, which trades
+  byte-exact agreement with upstream for the fused kernels. Measured on an
+  RTX 5070 Ti under fp16 autocast: 1.77x on Swin window attention, 3.74x on
+  OWLv2 vision attention. See `docs/kernels.md`.
 
 - `val_loss=True` extended from the `g0` flagships to **every trainable
   family** (`g0`, `g1` and `g2`), across four tasks rather than detection

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -14,9 +14,11 @@ dependency is never an error, only a fallback.
 - `kernels/quant/execute/`: finalized-only real-precision paths. No backward,
   real hardware: the `fp8_gemm` tensor-core GEMM (`torch._scaled_mm`), its
   fused Triton prologue/epilogue, and the packed-weight unpack kernels.
-- `kernels/attention/`: attention ops shared across model families. Currently
-  the `ms_deform_attn` slot (multi-scale deformable attention) consumed by
-  the Deformable-DETR-lineage families.
+- `kernels/attention/`: attention ops shared across model families. The
+  `ms_deform_attn` slot (multi-scale deformable attention) consumed by the
+  Deformable-DETR-lineage families, plus `sdpa.py`, which is policy rather
+  than a kernel: it records when a family may hand its attention to torch's
+  fused `scaled_dot_product_attention` and provides the opt-in switch.
 - The reference implementations stay in `libreyolo/quant/fake_quant.py` and
   `libreyolo/quant/packing.py`: `quant/` defines what the numbers mean,
   `kernels/` makes them fast. `packing.py` never has variants because it is
@@ -51,15 +53,59 @@ Current hub-backed slot:
 
 - `ms_deform_attn` <- [`kernels-community/deformable-detr`](https://huggingface.co/kernels-community/deformable-detr)
   (Apache-2.0): the compiled CUDA multi-scale deformable attention
-  forward/backward from Deformable DETR. Wired into the RF-DETR,
-  LibreDeformableDETR, and LibreDINO-DETR attention cores; eligible inputs
-  are CUDA fp32 in eager mode. Training is accelerated too (the compiled
-  backward registers through an autograd bridge). Active whenever the
-  `kernels` package is installed, unless `LIBREYOLO_HUB_KERNELS=0`.
+  forward/backward from Deformable DETR. Eligible inputs are CUDA fp32 in
+  eager mode. Training is accelerated too (the compiled backward registers
+  through an autograd bridge). Active whenever the `kernels` package is
+  installed, unless `LIBREYOLO_HUB_KERNELS=0`.
+
+  Wired into every Deformable-DETR-lineage family: RF-DETR,
+  LibreDeformableDETR, LibreDINO-DETR, LW-DETR, Grounding DINO, RT-DETR,
+  RT-DETRv2, D-FINE (and RT-DETRv4), DEIM (and DEIMv2), EC, and OV-DEIM.
+  Families whose core carries a different layout adapt to the slot's before
+  calling it; a shape that cannot be expressed in the slot's layout falls
+  through to the portable path instead. Two cases do that today: a
+  `num_points_list` with a different point count per level, and the
+  `method='discrete'` integer-index sampling, which is a different equation.
+  The EC pose variant keeps its own contract and is not wired.
 
 Out-of-tree compiled kernels can also ship as a `libreyolo_kernels` package,
 which self-registers on import (e.g. a future CUTLASS NVFP4 GEMM for the
 documented `nvfp4_gemm` slot).
+
+## Fused attention (SDPA)
+
+Model families written as `q @ k.T -> softmax -> @ v` can hand their attention
+to `torch.nn.functional.scaled_dot_product_attention`, which dispatches to the
+flash / memory-efficient / cuDNN kernels instead of materialising the score
+matrix. This needs no optional dependency: it is stock torch.
+
+Two rules decide when a family uses it.
+
+**ONNX export never does.** LibreYOLO defaults to opset 13, which has no
+symbolic for fused SDPA, so every swapped call site keeps the primitive-op
+equation under `torch.onnx.is_in_onnx_export()`. Exported graphs are unchanged.
+
+**A byte-exact parity bar keeps manual math by default.** Several ports are
+pinned to `max_abs_diff == 0` against a reference that itself runs manual
+attention (the Swin and OWLv2 harnesses explicitly switch the reference's fused
+path *off* to get there). Fused kernels accumulate in a different order, so
+those families keep manual attention and expose a `fused_attn` flag:
+
+```python
+from libreyolo.kernels.attention import set_fused_attention
+
+set_fused_attention(model)  # returns how many attention modules switched
+```
+
+That trades byte-exact agreement with the family's upstream reference for the
+fused kernels. On an RTX 5070 Ti under fp16 autocast, Swin window attention
+(512 windows x 49 tokens x 384) goes from 1.278 ms to 0.721 ms (1.77x) and
+OWLv2 vision attention (3600 tokens x 1024) from 6.483 ms to 1.735 ms (3.74x).
+
+| Route | Families |
+| --- | --- |
+| SDPA by default (bar is a tolerance) | SegFormer, Depth Anything (and MoGe-2), BERT, Grounding DINO, SwinIR, PP-OCR |
+| Opt-in via `set_fused_attention` (bar is byte-exact) | Swin, LibreDINO-DETR's Swin backbone, BiRefNet (and FeyNoBG), OWLv2, LW-DETR, SigLIP 2, ZipDepth, MobileSAM |
 
 ## Hardware behavior
 

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -81,9 +81,25 @@ matrix. This needs no optional dependency: it is stock torch.
 
 Two rules decide when a family uses it.
 
-**ONNX export never does.** LibreYOLO defaults to opset 13, which has no
-symbolic for fused SDPA, so every swapped call site keeps the primitive-op
-equation under `torch.onnx.is_in_onnx_export()`. Exported graphs are unchanged.
+**Graph capture never does.** Every swapped call site keeps the primitive-op
+equation behind `manual_attention_required()`, which covers ONNX export
+(LibreYOLO defaults to opset 13, which has no symbolic for fused SDPA) *and*
+`torch.jit.trace`, the capture used by the TorchScript, CoreML and NCNN
+exporters. Exported graphs are unchanged.
+
+Two capture kinds are deliberately excluded. `torch.compile` lowers SDPA
+better than the manual equation, so forcing primitives there would deoptimize
+compiled inference; `torch.compiler.is_compiling()` cannot tell it apart from
+`torch.export`, so neither is gated. That is safe for the `torch.export`
+backends because both decompose SDPA to core ATen before their converter runs
+(Core AI through `run_decompositions()`, ExecuTorch through
+`to_edge_transform_and_lower`).
+
+Note this is a *looser* rule than the `ms_deform_attn` slot's, which also
+refuses under `torch.compiler.is_compiling()`. That slot dispatches to a
+runtime-fetched compiled kernel that must never be captured at all; SDPA is
+stock torch either way, so only the capture formats that care about the op
+spelling are gated.
 
 **A byte-exact parity bar keeps manual math by default.** Several ports are
 pinned to `max_abs_diff == 0` against a reference that itself runs manual
@@ -96,6 +112,10 @@ from libreyolo.kernels.attention import set_fused_attention
 
 set_fused_attention(model)  # returns how many attention modules switched
 ```
+
+The count is the number of `fused_attn` flags that moved, and every module
+carrying one honors it. `LibreViT` and `LibreDeiT` also carry the flag (they
+default to SDPA, following timm) so the switch turns them off too.
 
 That trades byte-exact agreement with the family's upstream reference for the
 fused kernels. On an RTX 5070 Ti under fp16 autocast, Swin window attention

--- a/libreyolo/kernels/attention/__init__.py
+++ b/libreyolo/kernels/attention/__init__.py
@@ -1,1 +1,5 @@
 """Attention kernels shared across model families."""
+
+from .sdpa import fused_attention_modules, set_fused_attention
+
+__all__ = ["fused_attention_modules", "set_fused_attention"]

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -26,6 +26,7 @@ Copyright (c) 2020 SenseTime).
 
 from __future__ import annotations
 
+import functools
 import importlib.util
 import logging
 import os
@@ -209,6 +210,48 @@ def hub_ms_deform_attn(
         return None
 
 
+def ms_deform_attn_available() -> bool:
+    """Whether the slot could run here, checked before adapting layouts.
+
+    Families whose native layout differs from the slot's ask this first so
+    the adaptation work (and any ``tolist()`` that would bake constants into
+    a trace) never happens on the portable path. Tracing and export always
+    report unavailable: exported graphs must not capture a runtime-fetched
+    kernel.
+    """
+    if (
+        torch.jit.is_tracing()
+        or torch.compiler.is_compiling()
+        or torch.onnx.is_in_onnx_export()
+    ):
+        return False
+    return resolve("ms_deform_attn") is not None
+
+
+@functools.lru_cache(maxsize=32)
+def _cached_shapes(pairs: tuple, device: torch.device) -> torch.Tensor:
+    return torch.tensor(pairs, dtype=torch.int64, device=device)
+
+
+def spatial_shapes_tensor(value_spatial_shapes, device) -> torch.Tensor:
+    """Normalize per-level ``(H, W)`` pairs to the int64 tensor the slot wants.
+
+    Several families carry their spatial shapes as Python pairs; the compiled
+    kernel reads them from device memory. The small results are cached so the
+    host-to-device copy happens once per shape set rather than per call. Only
+    valid under :func:`ms_deform_attn_available`, which rules out tracing.
+    """
+    if isinstance(value_spatial_shapes, torch.Tensor):
+        if (
+            value_spatial_shapes.dtype == torch.int64
+            and value_spatial_shapes.device == device
+        ):
+            return value_spatial_shapes
+        value_spatial_shapes = value_spatial_shapes.tolist()
+    pairs = tuple((int(height), int(width)) for height, width in value_spatial_shapes)
+    return _cached_shapes(pairs, device)
+
+
 def maybe_ms_deform_attn(
     value: torch.Tensor,
     spatial_shapes,
@@ -221,11 +264,7 @@ def maybe_ms_deform_attn(
     and export always take the portable path: exported graphs must not
     capture a runtime-fetched kernel.
     """
-    if (
-        torch.jit.is_tracing()
-        or torch.compiler.is_compiling()
-        or torch.onnx.is_in_onnx_export()
-    ):
+    if not ms_deform_attn_available():
         return None
     impl = resolve("ms_deform_attn")
     if impl is None:
@@ -233,7 +272,46 @@ def maybe_ms_deform_attn(
     return impl(value, spatial_shapes, sampling_locations, attention_weights)
 
 
+def maybe_ms_deform_attn_v2(
+    value: torch.Tensor,
+    spatial_shapes,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+    num_points_list,
+) -> Optional[torch.Tensor]:
+    """Slot adapter for the RT-DETRv2-style flat-points layout.
+
+    v2 cores carry ``sum(num_points_list)`` sampling points flattened across
+    levels and support a different point count per level, while the slot's
+    layout is ``(n_levels, n_points)``. Only a uniform count reshapes onto
+    it, so a ragged ``num_points_list`` returns None and the caller keeps its
+    portable path. ``value`` must already be in the slot's
+    ``(bs, Len_in, n_heads, c)`` layout.
+    """
+    if not ms_deform_attn_available():
+        return None
+    levels = len(num_points_list)
+    if levels == 0 or len(spatial_shapes) != levels:
+        return None
+    points = int(num_points_list[0])
+    if any(int(count) != points for count in num_points_list):
+        return None
+    return maybe_ms_deform_attn(
+        value,
+        spatial_shapes,
+        sampling_locations.unflatten(3, (levels, points)),
+        attention_weights.unflatten(3, (levels, points)),
+    )
+
+
 register("ms_deform_attn", hub_ms_deform_attn, name="hub", predicate=_eligible)
 
 
-__all__ = ["hub_ms_deform_attn", "level_start_index", "maybe_ms_deform_attn"]
+__all__ = [
+    "hub_ms_deform_attn",
+    "level_start_index",
+    "maybe_ms_deform_attn",
+    "maybe_ms_deform_attn_v2",
+    "ms_deform_attn_available",
+    "spatial_shapes_tensor",
+]

--- a/libreyolo/kernels/attention/sdpa.py
+++ b/libreyolo/kernels/attention/sdpa.py
@@ -23,9 +23,44 @@ attention class, next to the parity bar it has to meet.
 
 from __future__ import annotations
 
+import torch
 from torch import nn
 
-__all__ = ["fused_attention_modules", "set_fused_attention"]
+__all__ = [
+    "fused_attention_modules",
+    "manual_attention_required",
+    "set_fused_attention",
+]
+
+
+def manual_attention_required() -> bool:
+    """Whether a graph capture in progress must see the primitive-op equation.
+
+    Two capture kinds need it:
+
+    - **ONNX export.** LibreYOLO defaults to opset 13, which has no symbolic
+      for fused SDPA.
+    - **``torch.jit.trace``**, which is how the TorchScript, CoreML and NCNN
+      exporters capture. Their artifacts were validated on primitive-op
+      graphs, and a traced ``aten::scaled_dot_product_attention`` is a
+      different graph for every downstream converter to handle.
+
+    Two capture kinds are deliberately *excluded*:
+
+    - **``torch.compile``** lowers SDPA better than the manual equation, so
+      forcing primitives there would deoptimize compiled inference.
+      ``torch.compiler.is_compiling()`` cannot distinguish it from
+      ``torch.export``, so neither is gated here.
+    - **``torch.export``** (ExecuTorch, Core AI) decomposes SDPA to core ATen
+      in ``run_decompositions()`` before the converter sees it.
+
+    The ``ms_deform_attn`` slot uses a stricter rule (it also refuses under
+    ``torch.compiler.is_compiling()``) because it dispatches to a
+    runtime-fetched compiled kernel that must never be captured at all. This
+    one is stock torch either way, so only the capture formats that care
+    about the op spelling are covered.
+    """
+    return torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()
 
 
 def _as_module(model) -> nn.Module:

--- a/libreyolo/kernels/attention/sdpa.py
+++ b/libreyolo/kernels/attention/sdpa.py
@@ -1,0 +1,50 @@
+"""Fused scaled-dot-product attention: the shared policy, not a new kernel.
+
+``torch.nn.functional.scaled_dot_product_attention`` dispatches to the flash,
+memory-efficient or cuDNN attention kernels instead of materialising the
+``(heads, q, k)`` score matrix. Model families written as
+``q @ k.T -> softmax -> @ v`` can hand their attention to it, but two rules
+decide *when*:
+
+- **Export never does.** LibreYOLO defaults to ONNX opset 13, which has no
+  symbolic for fused SDPA, so every swapped call site keeps the primitive-op
+  equation under ``torch.onnx.is_in_onnx_export()``.
+- **Byte-exact parity bars keep manual math by default.** Several ports are
+  pinned to ``max_abs_diff == 0`` against a reference that itself runs manual
+  attention (the Swin and OWLv2 parity harnesses explicitly switch the
+  reference's fused path *off* to get that). Fused kernels accumulate in a
+  different order, so those families carry ``fused_attn = False`` and only
+  switch when a caller opts in with :func:`set_fused_attention`. Families
+  whose bar is a tolerance use SDPA by default and carry no flag.
+
+Which family is which is recorded in the module docstring of each rewired
+attention class, next to the parity bar it has to meet.
+"""
+
+from __future__ import annotations
+
+from torch import nn
+
+__all__ = ["fused_attention_modules", "set_fused_attention"]
+
+
+def fused_attention_modules(module: nn.Module):
+    """Yield every submodule carrying an opt-in ``fused_attn`` flag."""
+    for candidate in module.modules():
+        if isinstance(getattr(candidate, "fused_attn", None), bool):
+            yield candidate
+
+
+def set_fused_attention(module: nn.Module, enabled: bool = True) -> int:
+    """Switch fused SDPA on or off across a model; returns how many flags moved.
+
+    Trades byte-exact agreement with the family's upstream reference for the
+    fused attention kernels. Returning zero means the model has no opt-in
+    attention: either it already uses SDPA unconditionally, or it has no
+    scaled-dot-product attention at all.
+    """
+    count = 0
+    for attention in fused_attention_modules(module):
+        attention.fused_attn = enabled
+        count += 1
+    return count

--- a/libreyolo/kernels/attention/sdpa.py
+++ b/libreyolo/kernels/attention/sdpa.py
@@ -28,14 +28,26 @@ from torch import nn
 __all__ = ["fused_attention_modules", "set_fused_attention"]
 
 
-def fused_attention_modules(module: nn.Module):
+def _as_module(model) -> nn.Module:
+    """Accept a task wrapper (which holds ``.model``) or a bare nn.Module."""
+    if isinstance(model, nn.Module):
+        return model
+    inner = getattr(model, "model", None)
+    if isinstance(inner, nn.Module):
+        return inner
+    raise TypeError(
+        f"expected an nn.Module or a LibreYOLO model wrapping one, got {type(model).__name__}"
+    )
+
+
+def fused_attention_modules(model):
     """Yield every submodule carrying an opt-in ``fused_attn`` flag."""
-    for candidate in module.modules():
+    for candidate in _as_module(model).modules():
         if isinstance(getattr(candidate, "fused_attn", None), bool):
             yield candidate
 
 
-def set_fused_attention(module: nn.Module, enabled: bool = True) -> int:
+def set_fused_attention(model, enabled: bool = True) -> int:
     """Switch fused SDPA on or off across a model; returns how many flags moved.
 
     Trades byte-exact agreement with the family's upstream reference for the
@@ -44,7 +56,7 @@ def set_fused_attention(module: nn.Module, enabled: bool = True) -> int:
     scaled-dot-product attention at all.
     """
     count = 0
-    for attention in fused_attention_modules(module):
+    for attention in fused_attention_modules(model):
         attention.fused_attn = enabled
         count += 1
     return count

--- a/libreyolo/models/bert/nn.py
+++ b/libreyolo/models/bert/nn.py
@@ -12,6 +12,7 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 class BertEmbeddings(nn.Module):
@@ -52,9 +53,10 @@ class BertSelfAttention(nn.Module):
 
     def forward(self, x, attn_mask):
         q, k, v = self._shape(self.query(x)), self._shape(self.key(x)), self._shape(self.value(x))
-        if torch.onnx.is_in_onnx_export():
-            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
-            # fused SDPA: keep the exact primitive-op equation while tracing.
+        if manual_attention_required():
+            # Graph capture (ONNX, and the jit.trace-based TorchScript /
+            # CoreML / NCNN exporters) must see the primitive-op equation;
+            # eager inference keeps the fused kernels below.
             scores = (q @ k.transpose(-1, -2)) / math.sqrt(self.head_dim)
             if attn_mask is not None:
                 scores = scores + attn_mask

--- a/libreyolo/models/bert/nn.py
+++ b/libreyolo/models/bert/nn.py
@@ -52,11 +52,32 @@ class BertSelfAttention(nn.Module):
 
     def forward(self, x, attn_mask):
         q, k, v = self._shape(self.query(x)), self._shape(self.key(x)), self._shape(self.value(x))
-        scores = (q @ k.transpose(-1, -2)) / math.sqrt(self.head_dim)
-        if attn_mask is not None:
-            scores = scores + attn_mask
-        probs = scores.softmax(-1)
-        ctx = (probs @ v).permute(0, 2, 1, 3).contiguous()
+        if torch.onnx.is_in_onnx_export():
+            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
+            # fused SDPA: keep the exact primitive-op equation while tracing.
+            scores = (q @ k.transpose(-1, -2)) / math.sqrt(self.head_dim)
+            if attn_mask is not None:
+                scores = scores + attn_mask
+            probs = scores.softmax(-1)
+            ctx = probs @ v
+        else:
+            mask = attn_mask
+            if mask is not None and mask.dtype == torch.bool:
+                # Grounding DINO's block-diagonal mask arrives boolean and the
+                # eager path above ADDS it (True -> +1, False -> +0), a weak
+                # bias rather than a hard -inf mask. SDPA reads a bool mask as
+                # "allowed", so cast to keep the additive semantics.
+                mask = mask.to(q.dtype)
+            ctx = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=1.0 / math.sqrt(self.head_dim),
+            )
+        ctx = ctx.permute(0, 2, 1, 3).contiguous()
         b, n = x.shape[0], x.shape[1]
         return ctx.view(b, n, -1)
 

--- a/libreyolo/models/birefnet/nn.py
+++ b/libreyolo/models/birefnet/nn.py
@@ -68,8 +68,9 @@ class Mlp(nn.Module):
 class WindowAttention(nn.Module):
     """Window multi-head self-attention with a relative-position-bias table.
 
-    Uses the manual (non-SDPA) computation ``(q * scale) @ k^T + bias`` so the
+    Defaults to the manual computation ``(q * scale) @ k^T + bias`` so the
     forward is bit-identical to the upstream reference run with SDPA disabled.
+    ``fused_attn`` opts into the fused kernels and gives that up.
     """
 
     def __init__(self, dim: int, window_size: Tuple[int, int], num_heads: int, qkv_bias: bool = True):
@@ -101,6 +102,11 @@ class WindowAttention(nn.Module):
         self.proj = nn.Linear(dim, dim)
         self.proj_drop = nn.Dropout(0.0)
         self.softmax = nn.Softmax(dim=-1)
+        # Opt-in fused SDPA. Default off: weights/parity_birefnet.py pins
+        # max_abs_diff == 0.0 against upstream BiRefNet and fused kernels
+        # accumulate in a different order. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
     def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         B_, N, C = x.shape
@@ -113,6 +119,21 @@ class WindowAttention(nn.Module):
             .unsqueeze(0)
             .to(dtype=q.dtype, device=q.device)
         )
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            # SDPA takes one additive float mask, so the relative position bias
+            # and the shifted-window mask are summed into it. The window mask is
+            # (nW, N, N) and the batch is laid out as (batch, nW) flattened, so
+            # repeat tiles it per window.
+            attn_mask = relative_position_bias
+            if mask is not None:
+                attn_mask = attn_mask + mask.to(dtype=q.dtype).unsqueeze(1).repeat(
+                    B_ // mask.shape[0], 1, 1, 1
+                )
+            fused = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False,
+                scale=self.scale,
+            )
+            return self.proj_drop(self.proj(fused.transpose(1, 2).reshape(B_, N, C)))
         q = q * self.scale
         attn = q @ k.transpose(-2, -1)
         attn = attn + relative_position_bias

--- a/libreyolo/models/birefnet/nn.py
+++ b/libreyolo/models/birefnet/nn.py
@@ -30,6 +30,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torchvision.ops import deform_conv2d
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 # ======================================================================
@@ -119,7 +120,7 @@ class WindowAttention(nn.Module):
             .unsqueeze(0)
             .to(dtype=q.dtype, device=q.device)
         )
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             # SDPA takes one additive float mask, so the relative position bias
             # and the shifted-window mask are summed into it. The window mask is
             # (nW, N, N) and the batch is laid out as (batch, nW) flattened, so

--- a/libreyolo/models/deim/ms_deform.py
+++ b/libreyolo/models/deim/ms_deform.py
@@ -16,6 +16,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn_v2,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
+
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
     x = x.clip(min=0.0, max=1.0)
@@ -128,7 +134,25 @@ def deformable_attention_core_func_v2(
         method: ``"default"`` (bilinear) or ``"discrete"`` (nearest integer).
 
     Returns: ``(bs, Len_q, n_head * c)``.
+
+    The loop below is the default and the export path. When the optional
+    accelerated ``ms_deform_attn`` slot resolves and the flat point layout
+    reshapes onto the slot's ``(n_levels, n_points)`` one, it takes over
+    (see ``libreyolo/kernels/attention/ms_deform_attn.py``);
+    ``method='discrete'`` never does, its integer-index sampling is a
+    different equation.
     """
+    if method == "default" and ms_deform_attn_available():
+        accelerated = maybe_ms_deform_attn_v2(
+            # Per-level (bs, n_head, c, H*W) -> the slot's (bs, Len_in, n_head, c).
+            torch.cat(list(value), dim=-1).permute(0, 3, 1, 2),
+            spatial_shapes_tensor(value_spatial_shapes, value[0].device),
+            sampling_locations,
+            attention_weights,
+            num_points_list,
+        )
+        if accelerated is not None:
+            return accelerated
     bs, n_head, c, _ = value[0].shape
     _, Len_q, _, _, _ = sampling_locations.shape
 

--- a/libreyolo/models/deit/nn.py
+++ b/libreyolo/models/deit/nn.py
@@ -98,12 +98,24 @@ class Attention(nn.Module):
         )
         query, key, value = qkv.unbind(0)
         query, key = self.q_norm(query), self.k_norm(key)
-        x = F.scaled_dot_product_attention(
-            query,
-            key,
-            value,
-            dropout_p=self.attn_drop.p if self.training else 0.0,
-        )
+        # ``fused_attn`` was a timm-compat attribute that nothing read, so
+        # libreyolo.kernels.attention.set_fused_attention() reported switching
+        # it while SDPA kept running. Honoring it here makes that count true.
+        # Unlike every other family the gate carries no export condition, so
+        # the default (True) keeps today's behavior exactly: DeiT is the one
+        # family that traces SDPA into its ONNX graph on purpose, which is why
+        # ``export/onnx.py:47`` bumps it to opset 17.
+        if self.fused_attn:
+            x = F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                dropout_p=self.attn_drop.p if self.training else 0.0,
+            )
+        else:
+            attention = (query * self.scale) @ key.transpose(-2, -1)
+            attention = self.attn_drop(attention.softmax(dim=-1))
+            x = attention @ value
         x = x.transpose(1, 2).reshape(batch, tokens, channels)
         x = self.norm(x)
         x = self.proj(x)

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/attention.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/attention.py
@@ -10,6 +10,8 @@
 
 import logging
 
+import torch
+import torch.nn.functional as F  # noqa: N812
 from torch import Tensor
 from torch import nn
 
@@ -50,13 +52,25 @@ class Attention(nn.Module):
         B, N, C = x.shape
         qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
 
-        q, k, v = qkv[0] * self.scale, qkv[1], qkv[2]
-        attn = q @ k.transpose(-2, -1)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+        if torch.onnx.is_in_onnx_export():
+            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
+            # fused SDPA: keep the exact primitive-op equation while tracing.
+            attn = (q * self.scale) @ k.transpose(-2, -1)
+            attn = self.attn_drop(attn.softmax(dim=-1))
+            x = attn @ v
+        else:
+            x = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=None,
+                dropout_p=self.attn_drop.p if self.training else 0.0,
+                is_causal=False,
+                scale=self.scale,
+            )
 
-        attn = attn.softmax(dim=-1)
-        attn = self.attn_drop(attn)
-
-        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        x = x.transpose(1, 2).reshape(B, N, C)
         x = self.proj(x)
         x = self.proj_drop(x)
         return x

--- a/libreyolo/models/depth_anything/_vendor/dinov2_layers/attention.py
+++ b/libreyolo/models/depth_anything/_vendor/dinov2_layers/attention.py
@@ -10,10 +10,10 @@
 
 import logging
 
-import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import Tensor
 from torch import nn
+from libreyolo.kernels.attention.sdpa import manual_attention_required
 
 
 logger = logging.getLogger("dinov2")
@@ -53,9 +53,10 @@ class Attention(nn.Module):
         qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
 
         q, k, v = qkv[0], qkv[1], qkv[2]
-        if torch.onnx.is_in_onnx_export():
-            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
-            # fused SDPA: keep the exact primitive-op equation while tracing.
+        if manual_attention_required():
+            # Graph capture (ONNX, and the jit.trace-based TorchScript /
+            # CoreML / NCNN exporters) must see the primitive-op equation;
+            # eager inference keeps the fused kernels below.
             attn = (q * self.scale) @ k.transpose(-2, -1)
             attn = self.attn_drop(attn.softmax(dim=-1))
             x = attn @ v

--- a/libreyolo/models/dfine/ms_deform.py
+++ b/libreyolo/models/dfine/ms_deform.py
@@ -17,6 +17,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn_v2,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
+
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
     x = x.clip(min=0.0, max=1.0)
@@ -143,7 +149,30 @@ def deformable_attention_core_func_v2(
         method: ``"default"`` (bilinear) or ``"discrete"`` (nearest integer).
 
     Returns: ``(bs, Len_q, n_head * c)``.
+
+    The loop below is the default and the export path. When the optional
+    accelerated ``ms_deform_attn`` slot resolves and the flat point layout
+    reshapes onto the slot's ``(n_levels, n_points)`` one, it takes over
+    (see ``libreyolo/kernels/attention/ms_deform_attn.py``). Neither
+    ``method='discrete'`` nor the forced-manual grid_sample used by the
+    ONNX/Core AI exporters ever does.
     """
+    if (
+        method == "default"
+        and not _FORCE_MANUAL_GRID_SAMPLE_EXPORT
+        and not _FORCE_MANUAL_GRID_SAMPLE.get()
+        and ms_deform_attn_available()
+    ):
+        accelerated = maybe_ms_deform_attn_v2(
+            # Per-level (bs, n_head, c, H*W) -> the slot's (bs, Len_in, n_head, c).
+            torch.cat(list(value), dim=-1).permute(0, 3, 1, 2),
+            spatial_shapes_tensor(value_spatial_shapes, value[0].device),
+            sampling_locations,
+            attention_weights,
+            num_points_list,
+        )
+        if accelerated is not None:
+            return accelerated
     bs, n_head, c, _ = value[0].shape
     _, Len_q, _, _, _ = sampling_locations.shape
 

--- a/libreyolo/models/dinodetr/swin.py
+++ b/libreyolo/models/dinodetr/swin.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 
 from ..deformable_detr.common import NestedTensor
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 def _to_2tuple(value: int) -> tuple[int, int]:
@@ -142,7 +143,7 @@ class WindowAttention(nn.Module):
             -1,
         )
         relative_bias = relative_bias.permute(2, 0, 1).contiguous()
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             # SDPA takes one additive float mask, so the relative position bias
             # and the shifted-window mask are summed into it. The window mask is
             # (num_windows, tokens, tokens) and the batch is laid out as

--- a/libreyolo/models/dinodetr/swin.py
+++ b/libreyolo/models/dinodetr/swin.py
@@ -114,6 +114,11 @@ class WindowAttention(nn.Module):
         self.proj_drop = nn.Dropout(0.0)
         nn.init.trunc_normal_(self.relative_position_bias_table, std=0.02)
         self.softmax = nn.Softmax(dim=-1)
+        # Opt-in fused SDPA. Default off: tests/unit/test_dinodetr_parity.py
+        # pins max_abs_diff == 0.0 against the upstream checkpoint and fused
+        # kernels accumulate in a different order. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
     def forward(self, x: Tensor, mask: Tensor | None = None) -> Tensor:
         batch_windows, tokens, channels = x.shape
@@ -129,7 +134,6 @@ class WindowAttention(nn.Module):
             .permute(2, 0, 3, 1, 4)
         )
         query, key, value = qkv[0], qkv[1], qkv[2]
-        attention = (query * self.scale) @ key.transpose(-2, -1)
         relative_bias = self.relative_position_bias_table[
             self.relative_position_index.view(-1)
         ].view(
@@ -138,6 +142,28 @@ class WindowAttention(nn.Module):
             -1,
         )
         relative_bias = relative_bias.permute(2, 0, 1).contiguous()
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            # SDPA takes one additive float mask, so the relative position bias
+            # and the shifted-window mask are summed into it. The window mask is
+            # (num_windows, tokens, tokens) and the batch is laid out as
+            # (batch, num_windows) flattened, so repeat tiles it per window.
+            attn_mask = relative_bias.unsqueeze(0)
+            if mask is not None:
+                attn_mask = attn_mask + mask.unsqueeze(1).repeat(
+                    batch_windows // mask.shape[0], 1, 1, 1
+                )
+            fused = F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                dropout_p=self.attn_drop.p if self.training else 0.0,
+                is_causal=False,
+                scale=self.scale,
+            )
+            fused = fused.transpose(1, 2).reshape(batch_windows, tokens, channels)
+            return self.proj_drop(self.proj(fused))
+        attention = (query * self.scale) @ key.transpose(-2, -1)
         attention = attention + relative_bias.unsqueeze(0)
         if mask is not None:
             num_windows = mask.shape[0]

--- a/libreyolo/models/ec/utils.py
+++ b/libreyolo/models/ec/utils.py
@@ -15,6 +15,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn_v2,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
 from ..dfine.box_ops import box_xyxy_to_cxcywh
 
 
@@ -93,6 +98,30 @@ def deformable_attention_core_func_v2(
     method: str = "default",
     value_shape: str = "default",
 ):
+    """Multi-scale deformable attention aggregator (grid_sample variant).
+
+    The loop below is the default and the export path. When the optional
+    accelerated ``ms_deform_attn`` slot resolves and the flat point layout
+    reshapes onto the slot's ``(n_levels, n_points)`` one, it takes over
+    (see ``libreyolo/kernels/attention/ms_deform_attn.py``);
+    ``method='discrete'`` never does, its integer-index sampling is a
+    different equation.
+    """
+    if method == "default" and ms_deform_attn_available():
+        if value_shape == "default":
+            # Per-level (bs, n_head, c, H*W) -> the slot's (bs, Len_in, n_head, c).
+            flat_value = torch.cat(list(value), dim=-1).permute(0, 3, 1, 2)
+        else:
+            flat_value = value
+        accelerated = maybe_ms_deform_attn_v2(
+            flat_value,
+            spatial_shapes_tensor(value_spatial_shapes, flat_value.device),
+            sampling_locations,
+            attention_weights,
+            num_points_list,
+        )
+        if accelerated is not None:
+            return accelerated
     if value_shape == "default":
         bs, n_head, c, _ = value[0].shape
     elif value_shape == "reshape":

--- a/libreyolo/models/grounding_dino/nn.py
+++ b/libreyolo/models/grounding_dino/nn.py
@@ -18,6 +18,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
 from ..bert.nn import BertModel
 from ..swin.nn import SwinBackbone, SwinDims
 
@@ -59,6 +64,21 @@ def generate_masks_with_special_tokens_and_transfer_map(input_ids):
 
 
 def _msda(value, shapes_list, sampling_locations, attention_weights):
+    """Portable multi-scale deformable attention (classic Deformable-DETR layout).
+
+    The per-level loop below is the default and the export path; when the
+    optional accelerated ``ms_deform_attn`` slot resolves it takes over
+    (see ``libreyolo/kernels/attention/ms_deform_attn.py``).
+    """
+    if ms_deform_attn_available():
+        accelerated = maybe_ms_deform_attn(
+            value,
+            spatial_shapes_tensor(shapes_list, value.device),
+            sampling_locations,
+            attention_weights,
+        )
+        if accelerated is not None:
+            return accelerated
     b, _, nh, hd = value.shape
     _, nq, _, nl, npnt, _ = sampling_locations.shape
     value_list = value.split([h * w for h, w in shapes_list], dim=1)
@@ -101,11 +121,29 @@ class GDMultiheadAttention(nn.Module):
         def shape(t, lin):
             return lin(t).view(b, -1, self.num_heads, self.head_size).transpose(1, 2)
         ql, kl, vl = shape(q, self.query), shape(k, self.key), shape(v, self.value)
-        scores = (ql @ kl.transpose(-1, -2)) / math.sqrt(self.head_size)
-        if attention_mask is not None:
-            scores = scores + attention_mask
-        probs = scores.softmax(-1)
-        ctx = (probs @ vl).permute(0, 2, 1, 3).contiguous().view(b, -1, self.num_heads * self.head_size)
+        if torch.onnx.is_in_onnx_export():
+            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
+            # fused SDPA: keep the exact primitive-op equation while tracing.
+            scores = (ql @ kl.transpose(-1, -2)) / math.sqrt(self.head_size)
+            if attention_mask is not None:
+                scores = scores + attention_mask
+            ctx = scores.softmax(-1) @ vl
+        else:
+            mask = attention_mask
+            if mask is not None and mask.dtype == torch.bool:
+                # The eager path ADDS the mask (True -> +1, False -> +0); SDPA
+                # reads a bool mask as "allowed", so cast to stay additive.
+                mask = mask.to(ql.dtype)
+            ctx = F.scaled_dot_product_attention(
+                ql,
+                kl,
+                vl,
+                attn_mask=mask,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=1.0 / math.sqrt(self.head_size),
+            )
+        ctx = ctx.permute(0, 2, 1, 3).contiguous().view(b, -1, self.num_heads * self.head_size)
         return self.out_proj(ctx)
 
 

--- a/libreyolo/models/grounding_dino/nn.py
+++ b/libreyolo/models/grounding_dino/nn.py
@@ -25,6 +25,7 @@ from ...kernels.attention.ms_deform_attn import (
 )
 from ..bert.nn import BertModel
 from ..swin.nn import SwinBackbone, SwinDims
+from ...kernels.attention.sdpa import manual_attention_required
 
 SPECIAL_TOKENS = [101, 102, 1012, 1029]  # BERT [CLS], [SEP], '.', '?'
 
@@ -121,9 +122,10 @@ class GDMultiheadAttention(nn.Module):
         def shape(t, lin):
             return lin(t).view(b, -1, self.num_heads, self.head_size).transpose(1, 2)
         ql, kl, vl = shape(q, self.query), shape(k, self.key), shape(v, self.value)
-        if torch.onnx.is_in_onnx_export():
-            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
-            # fused SDPA: keep the exact primitive-op equation while tracing.
+        if manual_attention_required():
+            # Graph capture (ONNX, and the jit.trace-based TorchScript /
+            # CoreML / NCNN exporters) must see the primitive-op equation;
+            # eager inference keeps the fused kernels below.
             scores = (ql @ kl.transpose(-1, -2)) / math.sqrt(self.head_size)
             if attention_mask is not None:
                 scores = scores + attention_mask

--- a/libreyolo/models/lwdetr/nn.py
+++ b/libreyolo/models/lwdetr/nn.py
@@ -37,6 +37,7 @@ from ...kernels.attention.ms_deform_attn import (
     ms_deform_attn_available,
     spatial_shapes_tensor,
 )
+from ...kernels.attention.sdpa import manual_attention_required
 
 __all__ = ["LWDETR_CONFIGS", "LWDETRExportWrapper", "LibreLWDETRModel"]
 
@@ -289,7 +290,7 @@ class Attention(nn.Module):
             batch, num_tokens, 3, self.num_heads, self.head_dim
         ).permute(2, 0, 3, 1, 4)
         query, key, value = qkv.unbind(0)
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             x = F.scaled_dot_product_attention(
                 query, key, value, attn_mask=None, dropout_p=0.0,
                 is_causal=False, scale=self.scale,
@@ -1032,7 +1033,7 @@ class MultiheadAttention(nn.Module):
 
         q, k, v = _split_heads(q), _split_heads(k), _split_heads(v)
 
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             attn_output = F.scaled_dot_product_attention(
                 q, k, v, attn_mask=None, dropout_p=0.0, is_causal=False,
                 scale=1.0 / math.sqrt(self.head_dim),

--- a/libreyolo/models/lwdetr/nn.py
+++ b/libreyolo/models/lwdetr/nn.py
@@ -32,6 +32,12 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
+
 __all__ = ["LWDETR_CONFIGS", "LWDETRExportWrapper", "LibreLWDETRModel"]
 
 
@@ -265,6 +271,11 @@ class Attention(nn.Module):
         else:
             self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.proj = nn.Linear(dim, dim)
+        # Opt-in fused SDPA. Default off: weights/parity_lwdetr.py pins
+        # max_abs_diff == 0.0 against the official model and fused kernels
+        # accumulate in a different order. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
     def forward(self, x: Tensor) -> Tensor:
         batch, num_tokens, channels = x.shape
@@ -278,9 +289,16 @@ class Attention(nn.Module):
             batch, num_tokens, 3, self.num_heads, self.head_dim
         ).permute(2, 0, 3, 1, 4)
         query, key, value = qkv.unbind(0)
-        attn = (query * self.scale) @ key.transpose(-2, -1)
-        attn = attn.softmax(dim=-1)
-        x = (attn @ value).transpose(1, 2).reshape(batch, num_tokens, channels)
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            x = F.scaled_dot_product_attention(
+                query, key, value, attn_mask=None, dropout_p=0.0,
+                is_causal=False, scale=self.scale,
+            )
+        else:
+            attn = (query * self.scale) @ key.transpose(-2, -1)
+            attn = attn.softmax(dim=-1)
+            x = attn @ value
+        x = x.transpose(1, 2).reshape(batch, num_tokens, channels)
         return self.proj(x)
 
 
@@ -803,7 +821,25 @@ def ms_deform_attn_core_pytorch(
     reference path whenever exporting or running fp16. LibreYOLO always takes
     it: no build step, runs on every device, and exports to ONNX opset >= 16
     (``grid_sample`` -> ``GridSample``).
+
+    When the optional accelerated ``ms_deform_attn`` kernel slot resolves
+    (see ``libreyolo/kernels/attention/ms_deform_attn.py``) it takes over;
+    the grid_sample path below stays the default and the export path.
     """
+    if ms_deform_attn_available():
+        weights = attention_weights
+        if weights.dim() == 4:
+            # The caller flattens (levels, points); the slot takes them split.
+            weights = weights.unflatten(-1, sampling_locations.shape[-3:-1])
+        accelerated = maybe_ms_deform_attn(
+            # (bs, heads, c, Len_in) -> the slot's (bs, Len_in, heads, c).
+            value.permute(0, 3, 1, 2),
+            spatial_shapes_tensor(value_spatial_shapes, value.device),
+            sampling_locations,
+            weights,
+        )
+        if accelerated is not None:
+            return accelerated
     batch, n_heads, head_dim, _ = value.shape
     _, len_query, _, num_levels, num_points, _ = sampling_locations.shape
     value_list = value.split([h * w for h, w in value_spatial_shapes], dim=3)
@@ -962,6 +998,11 @@ class MultiheadAttention(nn.Module):
         self.in_proj_weight = nn.Parameter(torch.empty(3 * embed_dim, embed_dim))
         self.in_proj_bias = nn.Parameter(torch.empty(3 * embed_dim)) if bias else None
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        # Opt-in fused SDPA: exactly the accumulation-order gap the class
+        # docstring above describes, which weights/parity_lwdetr.py's
+        # max_abs_diff == 0.0 bar would catch. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
         nn.init.xavier_uniform_(self.in_proj_weight)
         if self.in_proj_bias is not None:
@@ -991,10 +1032,16 @@ class MultiheadAttention(nn.Module):
 
         q, k, v = _split_heads(q), _split_heads(k), _split_heads(v)
 
-        q = q / math.sqrt(self.head_dim)
-        attn = torch.bmm(q, k.transpose(-2, -1))
-        attn = F.softmax(attn, dim=-1)
-        attn_output = torch.bmm(attn, v)
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            attn_output = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=False,
+                scale=1.0 / math.sqrt(self.head_dim),
+            )
+        else:
+            q = q / math.sqrt(self.head_dim)
+            attn = torch.bmm(q, k.transpose(-2, -1))
+            attn = F.softmax(attn, dim=-1)
+            attn_output = torch.bmm(attn, v)
 
         attn_output = (
             attn_output.permute(1, 0, 2)

--- a/libreyolo/models/mobilesam/nn.py
+++ b/libreyolo/models/mobilesam/nn.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 from typing import Tuple
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 def to_2tuple(x):
@@ -336,7 +337,7 @@ class Attention(torch.nn.Module):
             if self.training
             else self.ab
         )
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             # The learned attention bias is already an additive (heads, N, N)
             # term and broadcasts over the batch.
             x = F.scaled_dot_product_attention(

--- a/libreyolo/models/mobilesam/nn.py
+++ b/libreyolo/models/mobilesam/nn.py
@@ -280,6 +280,11 @@ class Attention(torch.nn.Module):
         self.norm = nn.LayerNorm(dim)
         self.qkv = nn.Linear(dim, h)
         self.proj = nn.Linear(self.dh, dim)
+        # Opt-in fused SDPA. Default off: tests/unit/test_mobilesam_parity.py
+        # pins max_abs_diff == 0 against upstream MobileSAM and fused kernels
+        # accumulate in a different order. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
         points = list(itertools.product(range(resolution[0]), range(resolution[1])))
         N = len(points)
@@ -326,13 +331,23 @@ class Attention(torch.nn.Module):
         k = k.permute(0, 2, 1, 3)
         v = v.permute(0, 2, 1, 3)
 
-        attn = (q @ k.transpose(-2, -1)) * self.scale + (
+        bias = (
             self.attention_biases[:, self.attention_bias_idxs]
             if self.training
             else self.ab
         )
-        attn = attn.softmax(dim=-1)
-        x = (attn @ v).transpose(1, 2).reshape(B, N, self.dh)
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            # The learned attention bias is already an additive (heads, N, N)
+            # term and broadcasts over the batch.
+            x = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=bias, dropout_p=0.0, is_causal=False,
+                scale=self.scale,
+            )
+        else:
+            attn = (q @ k.transpose(-2, -1)) * self.scale + bias
+            attn = attn.softmax(dim=-1)
+            x = attn @ v
+        x = x.transpose(1, 2).reshape(B, N, self.dh)
         x = self.proj(x)
         return x
 

--- a/libreyolo/models/mobilesam/transformer.py
+++ b/libreyolo/models/mobilesam/transformer.py
@@ -206,6 +206,11 @@ class Attention(nn.Module):
         self.k_proj = nn.Linear(embedding_dim, self.internal_dim)
         self.v_proj = nn.Linear(embedding_dim, self.internal_dim)
         self.out_proj = nn.Linear(self.internal_dim, embedding_dim)
+        # Opt-in fused SDPA. Default off: tests/unit/test_mobilesam_parity.py
+        # pins max_abs_diff == 0 against upstream MobileSAM and fused kernels
+        # accumulate in a different order. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
     def _separate_heads(self, x: Tensor, num_heads: int) -> Tensor:
         b, n, c = x.shape
@@ -230,12 +235,16 @@ class Attention(nn.Module):
 
         # Attention
         _, _, _, c_per_head = q.shape
-        attn = q @ k.permute(0, 1, 3, 2)  # B x N_heads x N_tokens x N_tokens
-        attn = attn / math.sqrt(c_per_head)
-        attn = torch.softmax(attn, dim=-1)
-
-        # Get output
-        out = attn @ v
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=False,
+                scale=1.0 / math.sqrt(c_per_head),
+            )
+        else:
+            attn = q @ k.permute(0, 1, 3, 2)  # B x N_heads x N_tokens x N_tokens
+            attn = attn / math.sqrt(c_per_head)
+            attn = torch.softmax(attn, dim=-1)
+            out = attn @ v
         out = self._recombine_heads(out)
         out = self.out_proj(out)
 

--- a/libreyolo/models/mobilesam/transformer.py
+++ b/libreyolo/models/mobilesam/transformer.py
@@ -11,6 +11,7 @@ import math
 from typing import Tuple, Type
 
 from ._common import MLPBlock
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 class TwoWayTransformer(nn.Module):
@@ -235,7 +236,7 @@ class Attention(nn.Module):
 
         # Attention
         _, _, _, c_per_head = q.shape
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             out = torch.nn.functional.scaled_dot_product_attention(
                 q, k, v, attn_mask=None, dropout_p=0.0, is_causal=False,
                 scale=1.0 / math.sqrt(c_per_head),

--- a/libreyolo/models/openvocab/ovdeim/decoder.py
+++ b/libreyolo/models/openvocab/ovdeim/decoder.py
@@ -20,6 +20,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.init as init
 
+from ....kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn_v2,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
+
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
     x = x.clip(min=0.0, max=1.0)
@@ -48,7 +54,24 @@ def deformable_attention_core_func_v2(
 
     Returns:
         output (Tensor): [bs, Length_{query}, C]
+
+    The loop below is the default and the export path. When the optional
+    accelerated ``ms_deform_attn`` slot resolves and the flat point layout
+    reshapes onto the slot's ``(n_levels, n_points)`` one, it takes over
+    (see ``libreyolo/kernels/attention/ms_deform_attn.py``);
+    ``method='discrete'`` never does, its integer-index sampling is a
+    different equation.
     """
+    if method == "default" and ms_deform_attn_available():
+        accelerated = maybe_ms_deform_attn_v2(
+            value,
+            spatial_shapes_tensor(value_spatial_shapes, value.device),
+            sampling_locations,
+            attention_weights,
+            num_points_list,
+        )
+        if accelerated is not None:
+            return accelerated
     bs, _, n_head, c = value.shape
     _, Len_q, _, _, _ = sampling_locations.shape
 

--- a/libreyolo/models/owlv2/nn.py
+++ b/libreyolo/models/owlv2/nn.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 @dataclass
@@ -104,7 +105,7 @@ class Owlv2Attention(nn.Module):
         q = self.q_proj(x).view(*shape).transpose(1, 2)
         k = self.k_proj(x).view(*shape).transpose(1, 2)
         v = self.v_proj(x).view(*shape).transpose(1, 2)
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             # attn_mask is already the additive float causal+padding mask.
             out = F.scaled_dot_product_attention(
                 q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False,

--- a/libreyolo/models/owlv2/nn.py
+++ b/libreyolo/models/owlv2/nn.py
@@ -91,6 +91,12 @@ class Owlv2Attention(nn.Module):
         self.v_proj = nn.Linear(hidden, hidden)
         self.q_proj = nn.Linear(hidden, hidden)
         self.out_proj = nn.Linear(hidden, hidden)
+        # Opt-in fused SDPA. Default off: weights/parity_owlv2.py pins
+        # objectness_logits to max_abs_diff == 0 and switches the transformers
+        # reference's own SDPA off to get it (its comment measures ~1e-4 on
+        # long vision sequences). Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         b, n, _ = x.shape
@@ -98,6 +104,13 @@ class Owlv2Attention(nn.Module):
         q = self.q_proj(x).view(*shape).transpose(1, 2)
         k = self.k_proj(x).view(*shape).transpose(1, 2)
         v = self.v_proj(x).view(*shape).transpose(1, 2)
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            # attn_mask is already the additive float causal+padding mask.
+            out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False,
+                scale=self.scale,
+            )
+            return self.out_proj(out.transpose(1, 2).reshape(b, n, -1))
         attn = torch.matmul(q, k.transpose(2, 3)) * self.scale
         if attn_mask is not None:
             attn = attn + attn_mask

--- a/libreyolo/models/ppocr/rec.py
+++ b/libreyolo/models/ppocr/rec.py
@@ -82,9 +82,18 @@ class Attention(nn.Module):
             .reshape(b, n, 3, self.num_heads, self.head_dim)
             .permute(2, 0, 3, 1, 4)
         )
-        q, k, v = qkv[0] * self.scale, qkv[1], qkv[2]
-        attn = q.matmul(k.transpose(-2, -1)).softmax(dim=-1)
-        x = attn.matmul(v).transpose(1, 2).reshape(b, n, self.dim)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+        if torch.onnx.is_in_onnx_export():
+            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
+            # fused SDPA: keep the exact primitive-op equation while tracing.
+            attn = (q * self.scale).matmul(k.transpose(-2, -1)).softmax(dim=-1)
+            x = attn.matmul(v)
+        else:
+            x = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=False,
+                scale=self.scale,
+            )
+        x = x.transpose(1, 2).reshape(b, n, self.dim)
         return self.proj(x)
 
 

--- a/libreyolo/models/ppocr/rec.py
+++ b/libreyolo/models/ppocr/rec.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .backbones import PPHGNetV2B4, PPLCNetV3
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 class ConvBNLayer(nn.Module):
@@ -83,9 +84,10 @@ class Attention(nn.Module):
             .permute(2, 0, 3, 1, 4)
         )
         q, k, v = qkv[0], qkv[1], qkv[2]
-        if torch.onnx.is_in_onnx_export():
-            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
-            # fused SDPA: keep the exact primitive-op equation while tracing.
+        if manual_attention_required():
+            # Graph capture (ONNX, and the jit.trace-based TorchScript /
+            # CoreML / NCNN exporters) must see the primitive-op equation;
+            # eager inference keeps the fused kernels below.
             attn = (q * self.scale).matmul(k.transpose(-2, -1)).softmax(dim=-1)
             x = attn.matmul(v)
         else:

--- a/libreyolo/models/rtdetr/utils.py
+++ b/libreyolo/models/rtdetr/utils.py
@@ -12,6 +12,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
+
 
 # =============================================================================
 # Core Utilities (used by nn.py, denoising.py, loss.py)
@@ -68,6 +74,19 @@ def deformable_attention_core_func(
     Returns:
         output: [bs, query_length, C]
     """
+    # The grid_sample path below is the default and the export path; when the
+    # optional accelerated ``ms_deform_attn`` slot resolves it takes over
+    # (see ``libreyolo/kernels/attention/ms_deform_attn.py``). The layout here
+    # is already the slot's, so only the spatial shapes need normalizing.
+    if ms_deform_attn_available():
+        accelerated = maybe_ms_deform_attn(
+            value,
+            spatial_shapes_tensor(value_spatial_shapes, value.device),
+            sampling_locations,
+            attention_weights,
+        )
+        if accelerated is not None:
+            return accelerated
     bs, _, n_head, c = value.shape
     _, Len_q, _, n_levels, n_points, _ = sampling_locations.shape
 

--- a/libreyolo/models/rtdetrv2/utils.py
+++ b/libreyolo/models/rtdetrv2/utils.py
@@ -9,6 +9,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ...kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn_v2,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
+
 
 def inverse_sigmoid(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
     x = x.clip(min=0.0, max=1.0)
@@ -55,7 +61,23 @@ def deformable_attention_core_func_v2(
     Differs from v1 in: (a) flat ``sum(num_points_list)`` layout instead of
     ``[L, P]``; (b) per-level split via ``num_points_list``; (c) optional
     ``method='discrete'`` integer-index sampling for TensorRT <8.5.
+
+    The loop below is the default and the export path. When the optional
+    accelerated ``ms_deform_attn`` slot resolves and the flat point layout
+    reshapes onto the slot's ``(n_levels, n_points)`` one, it takes over;
+    ``method='discrete'`` never does, its integer-index sampling is a
+    different equation.
     """
+    if method == "default" and ms_deform_attn_available():
+        accelerated = maybe_ms_deform_attn_v2(
+            value,
+            spatial_shapes_tensor(value_spatial_shapes, value.device),
+            sampling_locations,
+            attention_weights,
+            num_points_list,
+        )
+        if accelerated is not None:
+            return accelerated
     bs, _, n_head, c = value.shape
     _, Len_q, _, _, _ = sampling_locations.shape
 

--- a/libreyolo/models/segformer/nn.py
+++ b/libreyolo/models/segformer/nn.py
@@ -132,9 +132,23 @@ class EfficientSelfAttention(nn.Module):
         key_states = self.k_proj(kv_hidden_states).view(kv_hidden_shape).transpose(1, 2)
         value_states = self.v_proj(kv_hidden_states).view(kv_hidden_shape).transpose(1, 2)
 
-        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
-        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
-        attn_output = torch.matmul(attn_weights, value_states)
+        if torch.onnx.is_in_onnx_export():
+            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
+            # fused SDPA. Lower the same equation to primitive ops while
+            # tracing; eager inference keeps the fused kernels below.
+            attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
+            attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+            attn_output = torch.matmul(attn_weights, value_states)
+        else:
+            attn_output = F.scaled_dot_product_attention(
+                query_states,
+                key_states,
+                value_states,
+                attn_mask=None,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=self.scaling,
+            )
         attn_output = attn_output.transpose(1, 2).contiguous()
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()

--- a/libreyolo/models/segformer/nn.py
+++ b/libreyolo/models/segformer/nn.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from ...kernels.attention.sdpa import manual_attention_required
 
 IGNORE_INDEX = 255
 # Every LayerNorm in the Apache-2.0 reference implementation is built as
@@ -132,10 +133,10 @@ class EfficientSelfAttention(nn.Module):
         key_states = self.k_proj(kv_hidden_states).view(kv_hidden_shape).transpose(1, 2)
         value_states = self.v_proj(kv_hidden_states).view(kv_hidden_shape).transpose(1, 2)
 
-        if torch.onnx.is_in_onnx_export():
-            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
-            # fused SDPA. Lower the same equation to primitive ops while
-            # tracing; eager inference keeps the fused kernels below.
+        if manual_attention_required():
+            # Graph capture (ONNX, and the jit.trace-based TorchScript /
+            # CoreML / NCNN exporters) must see the primitive-op equation;
+            # eager inference keeps the fused kernels below.
             attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
             attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
             attn_output = torch.matmul(attn_weights, value_states)

--- a/libreyolo/models/siglip2/nn.py
+++ b/libreyolo/models/siglip2/nn.py
@@ -115,6 +115,12 @@ class SiglipAttention(nn.Module):
         self.v_proj = nn.Linear(dim, dim)
         self.q_proj = nn.Linear(dim, dim)
         self.out_proj = nn.Linear(dim, dim)
+        # Opt-in fused SDPA. Default off by design: the manual matmul above is
+        # what makes the text tower and vision encoder bit-identical to the
+        # reference (tests/unit/test_siglip2_parity.py, _EXACT_TOL = 0.0), and
+        # the reference is forced to attn_implementation="eager" to get there.
+        # Flip with libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
     def forward(self, x: torch.Tensor, attn_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
         input_shape = x.shape[:-1]  # (B, T)
@@ -123,11 +129,18 @@ class SiglipAttention(nn.Module):
         k = self.k_proj(x).view(hidden_shape).transpose(1, 2)
         v = self.v_proj(x).view(hidden_shape).transpose(1, 2)
 
-        attn_weights = torch.matmul(q, k.transpose(-1, -2)) * self.scale
-        if attn_mask is not None:
-            attn_weights = attn_weights + attn_mask
-        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
-        attn_output = torch.matmul(attn_weights, v)
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            # attn_mask is already additive float when present.
+            attn_output = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False,
+                scale=self.scale,
+            )
+        else:
+            attn_weights = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+            if attn_mask is not None:
+                attn_weights = attn_weights + attn_mask
+            attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_output = torch.matmul(attn_weights, v)
         attn_output = attn_output.transpose(1, 2).contiguous()
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         return self.out_proj(attn_output)

--- a/libreyolo/models/siglip2/nn.py
+++ b/libreyolo/models/siglip2/nn.py
@@ -36,6 +36,7 @@ from typing import Dict, Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +130,7 @@ class SiglipAttention(nn.Module):
         k = self.k_proj(x).view(hidden_shape).transpose(1, 2)
         v = self.v_proj(x).view(hidden_shape).transpose(1, 2)
 
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             # attn_mask is already additive float when present.
             attn_output = F.scaled_dot_product_attention(
                 q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False,

--- a/libreyolo/models/swin/nn.py
+++ b/libreyolo/models/swin/nn.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 def window_partition(x: torch.Tensor, ws: int) -> torch.Tensor:
@@ -80,7 +81,7 @@ class WindowAttention(nn.Module):
         b_, n, c = x.shape
         qkv = self.qkv(x).reshape(b_, n, 3, self.num_heads, -1).permute(2, 0, 3, 1, 4)
         q, k, v = qkv.unbind(0)
-        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+        if self.fused_attn and not manual_attention_required():
             # SDPA takes one additive float mask, so the relative position bias
             # and the shifted-window mask are summed into it. The window mask is
             # (num_win, n, n) and the batch is laid out as (batch, num_win)

--- a/libreyolo/models/swin/nn.py
+++ b/libreyolo/models/swin/nn.py
@@ -54,6 +54,11 @@ class WindowAttention(nn.Module):
         # timm scales q pre-matmul; transformers scales the q@k product. Same math,
         # different fp rounding — must match the source model to stay bit-exact.
         self.tf_order = tf_order
+        # Opt-in fused SDPA. Default off: tests/unit/test_swin_parity.py pins
+        # max_abs_diff == 0.0 against timm with its own fused_attn switched off,
+        # and fused kernels accumulate in a different order. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
         self.relative_position_bias_table = nn.Parameter(
             torch.zeros((2 * window_size - 1) * (2 * window_size - 1), num_heads)
         )
@@ -75,6 +80,21 @@ class WindowAttention(nn.Module):
         b_, n, c = x.shape
         qkv = self.qkv(x).reshape(b_, n, 3, self.num_heads, -1).permute(2, 0, 3, 1, 4)
         q, k, v = qkv.unbind(0)
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
+            # SDPA takes one additive float mask, so the relative position bias
+            # and the shifted-window mask are summed into it. The window mask is
+            # (num_win, n, n) and the batch is laid out as (batch, num_win)
+            # flattened, so repeat tiles it per window.
+            attn_mask = self._rel_pos_bias()
+            if mask is not None:
+                attn_mask = attn_mask + mask.unsqueeze(1).repeat(
+                    b_ // mask.shape[0], 1, 1, 1
+                )
+            x = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False,
+                scale=self.scale,
+            )
+            return self.proj(x.transpose(1, 2).reshape(b_, n, -1))
         if self.tf_order:
             attn = (q @ k.transpose(-2, -1)) * self.scale
         else:

--- a/libreyolo/models/swinir/nn.py
+++ b/libreyolo/models/swinir/nn.py
@@ -16,6 +16,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils import checkpoint
+from ...kernels.attention.sdpa import manual_attention_required
 
 
 def _to_2tuple(value: int | Sequence[int]) -> tuple[int, int]:
@@ -149,9 +150,10 @@ class WindowAttention(nn.Module):
             -1,
         )
         bias = relative_bias.permute(2, 0, 1).unsqueeze(0)
-        if torch.onnx.is_in_onnx_export():
-            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
-            # fused SDPA: keep the exact primitive-op equation while tracing.
+        if manual_attention_required():
+            # Graph capture (ONNX, and the jit.trace-based TorchScript /
+            # CoreML / NCNN exporters) must see the primitive-op equation;
+            # eager inference keeps the fused kernels below.
             attention = (q * self.scale) @ k.transpose(-2, -1)
             attention = attention + bias
             if mask is not None:

--- a/libreyolo/models/swinir/nn.py
+++ b/libreyolo/models/swinir/nn.py
@@ -140,7 +140,6 @@ class WindowAttention(nn.Module):
         )
         qkv = qkv.permute(2, 0, 3, 1, 4)
         q, k, v = qkv[0], qkv[1], qkv[2]
-        attention = (q * self.scale) @ k.transpose(-2, -1)
 
         relative_bias = self.relative_position_bias_table[
             self.relative_position_index.view(-1)
@@ -149,20 +148,46 @@ class WindowAttention(nn.Module):
             self.window_size[0] * self.window_size[1],
             -1,
         )
-        attention = attention + relative_bias.permute(2, 0, 1).unsqueeze(0)
-        if mask is not None:
-            num_windows = mask.shape[0]
-            attention = attention.view(
-                batch_windows // num_windows,
-                num_windows,
-                self.num_heads,
-                tokens,
-                tokens,
+        bias = relative_bias.permute(2, 0, 1).unsqueeze(0)
+        if torch.onnx.is_in_onnx_export():
+            # LibreYOLO defaults to ONNX opset 13, which has no symbolic for
+            # fused SDPA: keep the exact primitive-op equation while tracing.
+            attention = (q * self.scale) @ k.transpose(-2, -1)
+            attention = attention + bias
+            if mask is not None:
+                num_windows = mask.shape[0]
+                attention = attention.view(
+                    batch_windows // num_windows,
+                    num_windows,
+                    self.num_heads,
+                    tokens,
+                    tokens,
+                )
+                attention = attention + mask.unsqueeze(1).unsqueeze(0)
+                attention = attention.view(-1, self.num_heads, tokens, tokens)
+            attention = self.attn_drop(self.softmax(attention))
+            x = attention @ v
+        else:
+            # SDPA takes one additive float mask, so the relative position bias
+            # and the shifted-window mask are summed into it. The window mask
+            # is (num_windows, tokens, tokens) and the batch is laid out as
+            # (batch, num_windows) flattened, so repeat tiles it per window.
+            attn_mask = bias
+            if mask is not None:
+                num_windows = mask.shape[0]
+                attn_mask = bias + mask.unsqueeze(1).repeat(
+                    batch_windows // num_windows, 1, 1, 1
+                )
+            x = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_mask,
+                dropout_p=self.attn_drop.p if self.training else 0.0,
+                is_causal=False,
+                scale=self.scale,
             )
-            attention = attention + mask.unsqueeze(1).unsqueeze(0)
-            attention = attention.view(-1, self.num_heads, tokens, tokens)
-        attention = self.attn_drop(self.softmax(attention))
-        x = (attention @ v).transpose(1, 2).reshape(batch_windows, tokens, channels)
+        x = x.transpose(1, 2).reshape(batch_windows, tokens, channels)
         return self.proj_drop(self.proj(x))
 
 

--- a/libreyolo/models/vit/nn.py
+++ b/libreyolo/models/vit/nn.py
@@ -120,15 +120,14 @@ class Attention(nn.Module):
         )
         q, k, v = qkv.unbind(0)
         q, k = self.q_norm(q), self.k_norm(k)
-        if torch.onnx.is_in_onnx_export():
-            # LibreYOLO defaults to ONNX opset 13, where PyTorch has no
-            # symbolic for fused SDPA. Keep eager inference on the exact timm
-            # path and lower the same equation to primitive MatMul/Softmax
-            # operators only while tracing an ONNX graph.
-            attention = (q * self.scale) @ k.transpose(-2, -1)
-            attention = self.attn_drop(attention.softmax(dim=-1))
-            x = attention @ v
-        else:
+        # ``fused_attn`` was a timm-compat attribute that nothing read, so
+        # libreyolo.kernels.attention.set_fused_attention() reported switching
+        # it while SDPA kept running. Honoring it here makes that count true.
+        # The gate stays ONNX-only rather than the shared
+        # ``manual_attention_required()``: this family is outside the kernel
+        # campaign and its jit.trace-based artifacts (TorchScript, CoreML,
+        # NCNN) were validated with SDPA in the graph.
+        if self.fused_attn and not torch.onnx.is_in_onnx_export():
             x = F.scaled_dot_product_attention(
                 q,
                 k,
@@ -137,6 +136,14 @@ class Attention(nn.Module):
                 dropout_p=self.attn_drop.p if self.training else 0.0,
                 is_causal=False,
             )
+        else:
+            # LibreYOLO defaults to ONNX opset 13, where PyTorch has no
+            # symbolic for fused SDPA. Keep eager inference on the exact timm
+            # path and lower the same equation to primitive MatMul/Softmax
+            # operators only while tracing an ONNX graph.
+            attention = (q * self.scale) @ k.transpose(-2, -1)
+            attention = self.attn_drop(attention.softmax(dim=-1))
+            x = attention @ v
         x = x.transpose(1, 2).reshape(batch, tokens, channels)
         x = self.norm(x)
         x = self.proj(x)

--- a/libreyolo/models/zipdepth/nn.py
+++ b/libreyolo/models/zipdepth/nn.py
@@ -30,6 +30,7 @@ from typing import List, Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from ...kernels.attention.sdpa import manual_attention_required
 
 # Upstream MODEL_CONFIGS. Only 'base' has released checkpoints today; the other
 # entries are kept so future upstream releases map onto new size codes without
@@ -231,7 +232,7 @@ class EfficientGlobalAttention(nn.Module):
             .expand(B, -1, -1, -1)
         )
 
-        fused = self.fused_attn and not torch.onnx.is_in_onnx_export()
+        fused = self.fused_attn and not manual_attention_required()
         if fused:
             tokens_updated = F.scaled_dot_product_attention(
                 q_tok, k_sp, v_sp, attn_mask=None, dropout_p=0.0,

--- a/libreyolo/models/zipdepth/nn.py
+++ b/libreyolo/models/zipdepth/nn.py
@@ -208,6 +208,11 @@ class EfficientGlobalAttention(nn.Module):
 
         self.proj_out = nn.Conv2d(dim, dim, 1)
         self.norm = nn.BatchNorm2d(dim)
+        # Opt-in fused SDPA. Default off: tests/unit/test_zipdepth_parity.py
+        # pins max_abs_diff == 0.0 against the official implementation and
+        # fused kernels accumulate in a different order. Flip with
+        # libreyolo.kernels.attention.set_fused_attention(model).
+        self.fused_attn = False
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         B, C, H, W = x.shape
@@ -226,8 +231,15 @@ class EfficientGlobalAttention(nn.Module):
             .expand(B, -1, -1, -1)
         )
 
-        attn_t2s = (q_tok @ k_sp.transpose(-2, -1)) * self.scale
-        tokens_updated = F.softmax(attn_t2s, dim=-1) @ v_sp
+        fused = self.fused_attn and not torch.onnx.is_in_onnx_export()
+        if fused:
+            tokens_updated = F.scaled_dot_product_attention(
+                q_tok, k_sp, v_sp, attn_mask=None, dropout_p=0.0,
+                is_causal=False, scale=self.scale,
+            )
+        else:
+            attn_t2s = (q_tok @ k_sp.transpose(-2, -1)) * self.scale
+            tokens_updated = F.softmax(attn_t2s, dim=-1) @ v_sp
 
         q_sp = (
             self.q_spatial(x)
@@ -244,8 +256,14 @@ class EfficientGlobalAttention(nn.Module):
         )
         v_tok = tokens_updated
 
-        attn_s2t = F.softmax((q_sp @ k_tok.transpose(-2, -1)) * self.scale, dim=-1)
-        out = attn_s2t @ v_tok
+        if fused:
+            out = F.scaled_dot_product_attention(
+                q_sp, k_tok, v_tok, attn_mask=None, dropout_p=0.0,
+                is_causal=False, scale=self.scale,
+            )
+        else:
+            attn_s2t = F.softmax((q_sp @ k_tok.transpose(-2, -1)) * self.scale, dim=-1)
+            out = attn_s2t @ v_tok
 
         out = out.transpose(1, 2).reshape(B, N, C).transpose(1, 2).reshape(B, C, H, W)
         return x + self.norm(self.proj_out(out))

--- a/tests/unit/kernels/test_ms_deform_attn_families.py
+++ b/tests/unit/kernels/test_ms_deform_attn_families.py
@@ -1,0 +1,420 @@
+"""Per-family adapters onto the ``ms_deform_attn`` op slot.
+
+Two things are checked for every family that was rewired:
+
+1. With the slot active, the family core hands it the classic Deformable-DETR
+   layout (a mock implementation records what it received).
+2. With the slot inactive - the CPU / no-kernel-installed case, which is the
+   default everywhere these tests run - the family core takes its own
+   untouched grid_sample path and produces the same attention output as the
+   reference classic core.
+
+Together those pin the accelerated path's input contract and prove the
+portable path is still the one that runs by default.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo import kernels
+from libreyolo.kernels.attention.ms_deform_attn import (
+    maybe_ms_deform_attn_v2,
+    ms_deform_attn_available,
+    spatial_shapes_tensor,
+)
+from libreyolo.models.deformable_detr.ms_deform_attn import (
+    ms_deform_attn_core_pytorch as classic_core,
+)
+from libreyolo.models.deim.ms_deform import (
+    deformable_attention_core_func_v2 as deim_core,
+)
+from libreyolo.models.dfine.ms_deform import (
+    deformable_attention_core_func_v2 as dfine_core,
+)
+from libreyolo.models.ec.utils import deformable_attention_core_func_v2 as ec_core
+from libreyolo.models.grounding_dino.nn import _msda as gdino_core
+from libreyolo.models.lwdetr.nn import ms_deform_attn_core_pytorch as lwdetr_core
+from libreyolo.models.openvocab.ovdeim.decoder import (
+    deformable_attention_core_func_v2 as ovdeim_core,
+)
+from libreyolo.models.rtdetr.utils import (
+    deformable_attention_core_func as rtdetr_core,
+)
+from libreyolo.models.rtdetrv2.utils import (
+    deformable_attention_core_func_v2 as rtdetrv2_core,
+)
+
+pytestmark = pytest.mark.unit
+
+BATCH, LEN_Q, HEADS, CHANNELS = 2, 3, 2, 4
+SHAPES = [(4, 6), (2, 3)]
+LEVELS, POINTS = len(SHAPES), 2
+LEN_IN = sum(h * w for h, w in SHAPES)
+NUM_POINTS_LIST = [POINTS] * LEVELS
+
+CLASSIC_CALL = (
+    (BATCH, LEN_IN, HEADS, CHANNELS),
+    (LEVELS, 2),
+    (BATCH, LEN_Q, HEADS, LEVELS, POINTS, 2),
+    (BATCH, LEN_Q, HEADS, LEVELS, POINTS),
+)
+MOCK_OUTPUT = torch.full((BATCH, LEN_Q, HEADS * CHANNELS), 7.0)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_env(monkeypatch):
+    monkeypatch.delenv("LIBREYOLO_KERNELS", raising=False)
+    monkeypatch.delenv("LIBREYOLO_QUANT_KERNELS", raising=False)
+    # Hub kernels are on by default when the `kernels` package is installed;
+    # pin them off so these tests behave the same on any machine.
+    monkeypatch.setenv("LIBREYOLO_HUB_KERNELS", "0")
+    kernels.clear_cache()
+    yield
+    kernels.unregister("ms_deform_attn", "mock")
+    kernels.clear_cache()
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    """Register a mock slot implementation and collect the shapes it sees."""
+    calls: list[tuple] = []
+
+    def mock_impl(value, spatial_shapes, sampling_locations, attention_weights):
+        calls.append(
+            (
+                tuple(value.shape),
+                tuple(spatial_shapes.shape),
+                tuple(sampling_locations.shape),
+                tuple(attention_weights.shape),
+            )
+        )
+        return MOCK_OUTPUT.clone()
+
+    kernels.register("ms_deform_attn", mock_impl, name="mock")
+    monkeypatch.setenv("LIBREYOLO_KERNELS", "mock")
+    kernels.clear_cache()
+    return calls
+
+
+def _classic_inputs():
+    generator = torch.Generator().manual_seed(0)
+    value = torch.randn(BATCH, LEN_IN, HEADS, CHANNELS, generator=generator)
+    sampling_locations = torch.rand(
+        BATCH, LEN_Q, HEADS, LEVELS, POINTS, 2, generator=generator
+    )
+    weights = torch.rand(BATCH, LEN_Q, HEADS, LEVELS, POINTS, generator=generator)
+    weights = weights / weights.sum(dim=(-2, -1), keepdim=True)
+    return value, sampling_locations, weights
+
+
+def _split_value(value):
+    """Classic layout -> the per-level ``(bs, n_head, c, H*W)`` list D-FINE uses."""
+    permuted = value.permute(0, 2, 3, 1)
+    return permuted.split([h * w for h, w in SHAPES], dim=-1)
+
+
+def _reference_msda(value, spatial_shapes, sampling_locations, attention_weights):
+    """Standalone MSDA oracle in the slot's signature.
+
+    Written out here rather than delegating to a family core, both so it is
+    independent of the code under test and because a family core would route
+    straight back into the slot.
+    """
+    batch, _, heads, channels = value.shape
+    _, queries, _, levels, points, _ = sampling_locations.shape
+    shapes = [(int(h), int(w)) for h, w in spatial_shapes.tolist()]
+    values = value.split([h * w for h, w in shapes], dim=1)
+    grids = 2 * sampling_locations - 1
+    sampled = [
+        torch.nn.functional.grid_sample(
+            values[level]
+            .flatten(2)
+            .transpose(1, 2)
+            .reshape(batch * heads, channels, height, width),
+            grids[:, :, :, level].transpose(1, 2).flatten(0, 1),
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        for level, (height, width) in enumerate(shapes)
+    ]
+    weights = attention_weights.transpose(1, 2).reshape(
+        batch * heads, 1, queries, levels * points
+    )
+    out = (torch.stack(sampled, dim=-2).flatten(-2) * weights).sum(-1)
+    return out.view(batch, heads * channels, queries).transpose(1, 2).contiguous()
+
+
+# --- one callable per family, in that family's native argument layout -------
+
+
+def _call_lwdetr(value, locations, weights):
+    # (bs, Len_in, heads, c) -> lwdetr's (bs, heads, c, Len_in); flat weights.
+    return lwdetr_core(
+        value.permute(0, 2, 3, 1).contiguous(),
+        SHAPES,
+        locations,
+        weights.flatten(-2),
+    )
+
+
+def _call_gdino(value, locations, weights):
+    return gdino_core(value, SHAPES, locations, weights)
+
+
+def _call_rtdetr(value, locations, weights):
+    return rtdetr_core(value, SHAPES, locations, weights)
+
+
+def _call_rtdetrv2(value, locations, weights):
+    return rtdetrv2_core(
+        value, SHAPES, locations.flatten(3, 4), weights.flatten(3, 4), NUM_POINTS_LIST
+    )
+
+
+def _call_dfine(value, locations, weights):
+    return dfine_core(
+        _split_value(value),
+        SHAPES,
+        locations.flatten(3, 4),
+        weights.flatten(3, 4),
+        NUM_POINTS_LIST,
+    )
+
+
+def _call_deim(value, locations, weights):
+    return deim_core(
+        _split_value(value),
+        SHAPES,
+        locations.flatten(3, 4),
+        weights.flatten(3, 4),
+        NUM_POINTS_LIST,
+    )
+
+
+def _call_ec(value, locations, weights):
+    return ec_core(
+        _split_value(value),
+        SHAPES,
+        locations.flatten(3, 4),
+        weights.flatten(3, 4),
+        NUM_POINTS_LIST,
+    )
+
+
+def _call_ec_reshape(value, locations, weights):
+    return ec_core(
+        value,
+        SHAPES,
+        locations.flatten(3, 4),
+        weights.flatten(3, 4),
+        NUM_POINTS_LIST,
+        value_shape="reshape",
+    )
+
+
+def _call_ovdeim(value, locations, weights):
+    return ovdeim_core(
+        value, SHAPES, locations.flatten(3, 4), weights.flatten(3, 4), NUM_POINTS_LIST
+    )
+
+
+FAMILY_CORES = {
+    "lwdetr": _call_lwdetr,
+    "grounding_dino": _call_gdino,
+    "rtdetr": _call_rtdetr,
+    "rtdetrv2": _call_rtdetrv2,
+    "dfine": _call_dfine,
+    "deim": _call_deim,
+    "ec": _call_ec,
+    "ec_reshape": _call_ec_reshape,
+    "ovdeim": _call_ovdeim,
+}
+
+
+@pytest.mark.parametrize("family", sorted(FAMILY_CORES))
+def test_family_routes_through_slot_in_classic_layout(family, recorded):
+    """Whatever the family's native layout, the slot must see the classic one."""
+    value, locations, weights = _classic_inputs()
+    out = FAMILY_CORES[family](value, locations, weights)
+    assert torch.equal(out, MOCK_OUTPUT)
+    assert recorded == [CLASSIC_CALL]
+
+
+@pytest.mark.parametrize("family", sorted(FAMILY_CORES))
+def test_family_falls_back_to_portable_path(family, recorded):
+    """The wire-up must be inert when the slot has no eligible implementation."""
+    kernels.unregister("ms_deform_attn", "mock")
+    kernels.clear_cache()
+    value, locations, weights = _classic_inputs()
+    out = FAMILY_CORES[family](value, locations, weights)
+    assert recorded == []
+    torch.testing.assert_close(
+        out, classic_core(value, SHAPES, locations, weights), rtol=0, atol=0
+    )
+
+
+@pytest.mark.parametrize("family", sorted(FAMILY_CORES))
+def test_family_portable_path_matches_classic_reference(family):
+    """The layout adaptation expresses the same attention problem as classic."""
+    value, locations, weights = _classic_inputs()
+    torch.testing.assert_close(
+        FAMILY_CORES[family](value, locations, weights),
+        classic_core(value, SHAPES, locations, weights),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+@pytest.mark.parametrize("family", sorted(FAMILY_CORES))
+def test_family_accelerated_result_matches_portable(family, monkeypatch):
+    """Numerical closure: a correct slot implementation gives the right answer.
+
+    The shape test above pins what the slot receives; this one pins that those
+    arguments, run through a reference multi-scale deformable attention,
+    reproduce what the family computes itself. Registering the classic core as
+    the implementation stands in for the compiled Hub kernel, which is
+    Linux-only and cannot be exercised here.
+    """
+    kernels.register("ms_deform_attn", _reference_msda, name="mock")
+    monkeypatch.setenv("LIBREYOLO_KERNELS", "mock")
+    kernels.clear_cache()
+
+    value, locations, weights = _classic_inputs()
+    accelerated = FAMILY_CORES[family](value, locations, weights)
+
+    kernels.unregister("ms_deform_attn", "mock")
+    kernels.clear_cache()
+    monkeypatch.delenv("LIBREYOLO_KERNELS")
+    portable = FAMILY_CORES[family](value, locations, weights)
+
+    torch.testing.assert_close(accelerated, portable, rtol=1e-5, atol=1e-6)
+
+
+# --- guards that must keep the slot out of the way -------------------------
+
+V2_CORES = {
+    "rtdetrv2": rtdetrv2_core,
+    "ovdeim": ovdeim_core,
+}
+
+
+@pytest.mark.parametrize("family", sorted(V2_CORES))
+def test_v2_discrete_method_never_reaches_slot(family, recorded):
+    """``method='discrete'`` is a different equation: it must stay portable."""
+    value, locations, weights = _classic_inputs()
+    V2_CORES[family](
+        value,
+        SHAPES,
+        locations.flatten(3, 4),
+        weights.flatten(3, 4),
+        NUM_POINTS_LIST,
+        method="discrete",
+    )
+    assert recorded == []
+
+
+def test_dfine_discrete_method_never_reaches_slot(recorded):
+    value, locations, weights = _classic_inputs()
+    dfine_core(
+        _split_value(value),
+        SHAPES,
+        locations.flatten(3, 4),
+        weights.flatten(3, 4),
+        NUM_POINTS_LIST,
+        method="discrete",
+    )
+    assert recorded == []
+
+
+def test_dfine_forced_manual_grid_sample_never_reaches_slot(recorded, monkeypatch):
+    """The exporters' manual-grid_sample escape hatch outranks the slot."""
+    from libreyolo.models.dfine import ms_deform
+
+    value, locations, weights = _classic_inputs()
+    args = (
+        _split_value(value),
+        SHAPES,
+        locations.flatten(3, 4),
+        weights.flatten(3, 4),
+        NUM_POINTS_LIST,
+    )
+
+    monkeypatch.setattr(ms_deform, "_FORCE_MANUAL_GRID_SAMPLE_EXPORT", True)
+    dfine_core(*args)
+    assert recorded == []
+    monkeypatch.setattr(ms_deform, "_FORCE_MANUAL_GRID_SAMPLE_EXPORT", False)
+
+    token = ms_deform._FORCE_MANUAL_GRID_SAMPLE.set(True)
+    try:
+        dfine_core(*args)
+    finally:
+        ms_deform._FORCE_MANUAL_GRID_SAMPLE.reset(token)
+    assert recorded == []
+
+
+def test_ragged_num_points_never_reaches_slot(recorded):
+    """A per-level point count does not reshape onto the slot's (L, P) layout."""
+    generator = torch.Generator().manual_seed(0)
+    ragged = [1, 3]
+    total = sum(ragged)
+    value = torch.randn(BATCH, LEN_IN, HEADS, CHANNELS, generator=generator)
+    locations = torch.rand(BATCH, LEN_Q, HEADS, total, 2, generator=generator)
+    weights = torch.rand(BATCH, LEN_Q, HEADS, total, generator=generator)
+    out = rtdetrv2_core(value, SHAPES, locations, weights, ragged)
+    assert recorded == []
+    assert out.shape == (BATCH, LEN_Q, HEADS * CHANNELS)
+
+
+def test_v2_adapter_rejects_ragged_and_mismatched_levels(recorded):
+    value, locations, weights = _classic_inputs()
+    shapes = spatial_shapes_tensor(SHAPES, value.device)
+    flat_locations, flat_weights = locations.flatten(3, 4), weights.flatten(3, 4)
+    assert (
+        maybe_ms_deform_attn_v2(value, shapes, flat_locations, flat_weights, [1, 3])
+        is None
+    )
+    assert (
+        maybe_ms_deform_attn_v2(value, shapes, flat_locations, flat_weights, []) is None
+    )
+    # More point groups than levels: the split cannot be a per-level one.
+    assert (
+        maybe_ms_deform_attn_v2(
+            value, shapes, flat_locations, flat_weights, [1, 1, 1, 1]
+        )
+        is None
+    )
+    assert recorded == []
+
+
+def test_export_never_reaches_slot(recorded, monkeypatch):
+    """ONNX export must not capture a runtime-fetched kernel."""
+    monkeypatch.setattr(torch.onnx, "is_in_onnx_export", lambda: True)
+    assert not ms_deform_attn_available()
+    value, locations, weights = _classic_inputs()
+    for call in FAMILY_CORES.values():
+        call(value, locations, weights)
+    assert recorded == []
+
+
+# --- spatial_shapes_tensor -------------------------------------------------
+
+
+def test_spatial_shapes_tensor_from_pairs():
+    shapes = spatial_shapes_tensor(SHAPES, torch.device("cpu"))
+    assert shapes.dtype == torch.int64
+    assert torch.equal(shapes, torch.tensor(SHAPES, dtype=torch.int64))
+    # Repeated lookups reuse the cached tensor rather than re-copying.
+    assert spatial_shapes_tensor(tuple(SHAPES), torch.device("cpu")) is shapes
+
+
+def test_spatial_shapes_tensor_passes_through_matching_tensor():
+    existing = torch.tensor(SHAPES, dtype=torch.int64)
+    assert spatial_shapes_tensor(existing, existing.device) is existing
+    converted = spatial_shapes_tensor(
+        torch.tensor(SHAPES, dtype=torch.int32), torch.device("cpu")
+    )
+    assert converted.dtype == torch.int64
+    assert torch.equal(converted, existing)

--- a/tests/unit/kernels/test_sdpa_attention.py
+++ b/tests/unit/kernels/test_sdpa_attention.py
@@ -297,3 +297,13 @@ def test_bool_mask_keeps_the_additive_bert_semantics():
 
 def test_set_fused_attention_reports_zero_on_a_model_without_the_flag():
     assert set_fused_attention(torch.nn.Linear(4, 4)) == 0
+
+
+def test_set_fused_attention_accepts_a_task_wrapper():
+    """Users hold the task object, whose nn.Module lives on `.model`."""
+    module, _ = OPT_IN["swin"]()
+    wrapper = SimpleNamespace(model=module)
+    assert set_fused_attention(wrapper) >= 1
+    assert all(m.fused_attn for m in fused_attention_modules(wrapper))
+    with pytest.raises(TypeError, match="expected an nn.Module"):
+        set_fused_attention(SimpleNamespace())

--- a/tests/unit/kernels/test_sdpa_attention.py
+++ b/tests/unit/kernels/test_sdpa_attention.py
@@ -1,0 +1,299 @@
+"""Per-family SDPA swaps: same equation, same state_dict, untouched export path.
+
+Every family below had ``q @ k.T -> softmax -> @ v`` replaced by
+``F.scaled_dot_product_attention``. Which of the two paths runs by default is
+decided by the family's parity bar (see ``libreyolo/kernels/attention/sdpa.py``):
+
+* **default-on** - the bar is a tolerance, so SDPA runs unless ONNX export is
+  tracing;
+* **opt-in** - the bar is ``max_abs_diff == 0`` against a reference that itself
+  runs manual attention, so manual math stays the default and
+  ``set_fused_attention`` is the switch.
+
+The checks are the same either way: the two paths agree numerically (including
+under every mask shape the family passes), no parameter appears or disappears,
+and ONNX export always takes the manual path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from libreyolo.kernels.attention import fused_attention_modules, set_fused_attention
+
+pytestmark = pytest.mark.unit
+
+DIM, HEADS, BATCH, TOKENS = 32, 4, 2, 16
+WINDOW = (4, 4)
+NUM_WINDOWS = 4
+ATOL = 1e-5
+
+
+def _seeded(*shape, device="cpu"):
+    generator = torch.Generator().manual_seed(0)
+    return torch.randn(*shape, generator=generator, device=device)
+
+
+def _window_mask():
+    """A shifted-window mask in the (num_windows, tokens, tokens) layout."""
+    mask = torch.zeros(NUM_WINDOWS, TOKENS, TOKENS)
+    mask[1, :, TOKENS // 2 :] = -100.0
+    mask[3, : TOKENS // 2, :] = -100.0
+    return mask
+
+
+def _additive_mask(rows=TOKENS, cols=TOKENS):
+    mask = torch.zeros(BATCH, 1, rows, cols)
+    mask[0, :, :, cols // 2 :] = torch.finfo(torch.float32).min
+    return mask
+
+
+# --- one (build, call) pair per rewired attention module -------------------
+
+
+def _segformer(sr_ratio):
+    from libreyolo.models.segformer.nn import EfficientSelfAttention
+
+    module = EfficientSelfAttention(DIM, HEADS, sr_ratio).eval()
+    return module, lambda m: m(_seeded(BATCH, TOKENS, DIM), 4, 4)
+
+
+def _depth_anything():
+    from libreyolo.models.depth_anything._vendor.dinov2_layers.attention import Attention
+
+    return Attention(DIM, HEADS).eval(), lambda m: m(_seeded(BATCH, TOKENS, DIM))
+
+
+def _bert(mask):
+    from libreyolo.models.bert.nn import BertSelfAttention
+
+    cfg = SimpleNamespace(num_attention_heads=HEADS, hidden_size=DIM)
+    return BertSelfAttention(cfg).eval(), lambda m: m(_seeded(BATCH, TOKENS, DIM), mask)
+
+
+def _gdino(mask):
+    from libreyolo.models.grounding_dino.nn import GDMultiheadAttention
+
+    def call(module):
+        x = _seeded(BATCH, TOKENS, DIM)
+        return module(x, x, x, attention_mask=mask)
+
+    return GDMultiheadAttention(DIM, HEADS).eval(), call
+
+
+def _swinir(mask):
+    from libreyolo.models.swinir.nn import WindowAttention
+
+    module = WindowAttention(DIM, WINDOW, HEADS).eval()
+    torch.nn.init.normal_(module.relative_position_bias_table, std=0.5)
+    windows = BATCH * NUM_WINDOWS
+    return module, lambda m: m(_seeded(windows, TOKENS, DIM), mask)
+
+
+def _ppocr():
+    from libreyolo.models.ppocr.rec import Attention
+
+    return Attention(DIM, HEADS).eval(), lambda m: m(_seeded(BATCH, TOKENS, DIM))
+
+
+def _swin(mask, tf_order):
+    from libreyolo.models.swin.nn import WindowAttention
+
+    module = WindowAttention(DIM, HEADS, WINDOW[0], tf_order=tf_order).eval()
+    torch.nn.init.normal_(module.relative_position_bias_table, std=0.5)
+    windows = BATCH * NUM_WINDOWS
+    return module, lambda m: m(_seeded(windows, TOKENS, DIM), mask)
+
+
+def _dinodetr_swin(mask):
+    from libreyolo.models.dinodetr.swin import WindowAttention
+
+    module = WindowAttention(DIM, WINDOW, HEADS).eval()
+    torch.nn.init.normal_(module.relative_position_bias_table, std=0.5)
+    windows = BATCH * NUM_WINDOWS
+    return module, lambda m: m(_seeded(windows, TOKENS, DIM), mask)
+
+
+def _birefnet(mask):
+    from libreyolo.models.birefnet.nn import WindowAttention
+
+    module = WindowAttention(DIM, WINDOW, HEADS).eval()
+    torch.nn.init.normal_(module.relative_position_bias_table, std=0.5)
+    windows = BATCH * NUM_WINDOWS
+    return module, lambda m: m(_seeded(windows, TOKENS, DIM), mask)
+
+
+def _owlv2(mask):
+    from libreyolo.models.owlv2.nn import Owlv2Attention
+
+    return Owlv2Attention(DIM, HEADS).eval(), lambda m: m(_seeded(BATCH, TOKENS, DIM), mask)
+
+
+def _lwdetr_vit(use_cae):
+    from libreyolo.models.lwdetr.nn import Attention
+
+    module = Attention(DIM, HEADS, use_cae=use_cae).eval()
+    return module, lambda m: m(_seeded(BATCH, TOKENS, DIM))
+
+
+def _lwdetr_mha():
+    from libreyolo.models.lwdetr.nn import MultiheadAttention
+
+    def call(module):
+        x = _seeded(BATCH, TOKENS, DIM)
+        return module(x, x, x)
+
+    return MultiheadAttention(DIM, HEADS).eval(), call
+
+
+def _siglip2(mask):
+    from libreyolo.models.siglip2.nn import SiglipAttention
+
+    return SiglipAttention(DIM, HEADS).eval(), lambda m: m(_seeded(BATCH, TOKENS, DIM), mask)
+
+
+def _zipdepth():
+    from libreyolo.models.zipdepth.nn import EfficientGlobalAttention
+
+    module = EfficientGlobalAttention(DIM, num_tokens=4, num_heads=HEADS).eval()
+    return module, lambda m: m(_seeded(BATCH, DIM, 4, 4))
+
+
+def _mobilesam_tinyvit():
+    from libreyolo.models.mobilesam.nn import Attention
+
+    # This class overrides train() with an @torch.no_grad() wrapper that
+    # returns None, so .eval() cannot be chained.
+    module = Attention(DIM, key_dim=8, num_heads=HEADS, resolution=WINDOW)
+    torch.nn.init.normal_(module.attention_biases, std=0.5)
+    module.eval()  # caches `ab` from the perturbed biases
+    return module, lambda m: m(_seeded(BATCH, TOKENS, DIM))
+
+
+def _mobilesam_transformer():
+    from libreyolo.models.mobilesam.transformer import Attention
+
+    def call(module):
+        x = _seeded(BATCH, TOKENS, DIM)
+        return module(x, x, x)
+
+    return Attention(DIM, HEADS).eval(), call
+
+
+DEFAULT_ON = {
+    "segformer": lambda: _segformer(1),
+    "segformer_reduced": lambda: _segformer(2),
+    "depth_anything": _depth_anything,
+    "bert": lambda: _bert(None),
+    "bert_float_mask": lambda: _bert(_additive_mask()),
+    "bert_bool_mask": lambda: _bert(torch.eye(TOKENS, dtype=torch.bool)[None, None]),
+    "grounding_dino": lambda: _gdino(None),
+    "grounding_dino_mask": lambda: _gdino(_additive_mask()),
+    "swinir": lambda: _swinir(None),
+    "swinir_masked": lambda: _swinir(_window_mask()),
+    "ppocr": _ppocr,
+}
+
+OPT_IN = {
+    "swin": lambda: _swin(None, False),
+    "swin_masked": lambda: _swin(_window_mask(), False),
+    "swin_tf_order": lambda: _swin(_window_mask(), True),
+    "dinodetr_swin": lambda: _dinodetr_swin(None),
+    "dinodetr_swin_masked": lambda: _dinodetr_swin(_window_mask()),
+    "birefnet": lambda: _birefnet(None),
+    "birefnet_masked": lambda: _birefnet(_window_mask()),
+    "owlv2": lambda: _owlv2(None),
+    "owlv2_masked": lambda: _owlv2(_additive_mask()),
+    "lwdetr_vit": lambda: _lwdetr_vit(False),
+    "lwdetr_vit_cae": lambda: _lwdetr_vit(True),
+    "lwdetr_mha": _lwdetr_mha,
+    "siglip2": lambda: _siglip2(None),
+    "siglip2_masked": lambda: _siglip2(_additive_mask()),
+    "zipdepth": _zipdepth,
+    "mobilesam_tinyvit": _mobilesam_tinyvit,
+    "mobilesam_transformer": _mobilesam_transformer,
+}
+
+
+@pytest.mark.parametrize("case", sorted(OPT_IN))
+def test_opt_in_default_is_manual_and_fused_agrees(case):
+    """Manual math is what runs by default; opting in changes only rounding."""
+    module, call = OPT_IN[case]()
+    assert getattr(module, "fused_attn") is False
+    with torch.no_grad():
+        manual = call(module)
+        assert set_fused_attention(module) >= 1
+        fused = call(module)
+    torch.testing.assert_close(fused, manual, rtol=1e-5, atol=ATOL)
+
+
+@pytest.mark.parametrize("case", sorted(OPT_IN))
+def test_opt_in_export_ignores_the_flag(case, monkeypatch):
+    """Even opted in, ONNX export must trace the primitive-op equation."""
+    module, call = OPT_IN[case]()
+    with torch.no_grad():
+        manual = call(module)
+        set_fused_attention(module)
+        monkeypatch.setattr(torch.onnx, "is_in_onnx_export", lambda: True)
+        exported = call(module)
+    torch.testing.assert_close(exported, manual, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("case", sorted(OPT_IN))
+def test_opt_in_round_trips_back_to_manual(case):
+    module, _ = OPT_IN[case]()
+    assert set_fused_attention(module, True) >= 1
+    assert all(m.fused_attn for m in fused_attention_modules(module))
+    assert set_fused_attention(module, False) >= 1
+    assert not any(m.fused_attn for m in fused_attention_modules(module))
+
+
+@pytest.mark.parametrize("case", sorted(DEFAULT_ON))
+def test_default_on_matches_its_export_path(case, monkeypatch):
+    """SDPA runs by default and agrees with the primitive-op export path."""
+    module, call = DEFAULT_ON[case]()
+    with torch.no_grad():
+        fused = call(module)
+        monkeypatch.setattr(torch.onnx, "is_in_onnx_export", lambda: True)
+        exported = call(module)
+    torch.testing.assert_close(fused, exported, rtol=1e-5, atol=ATOL)
+
+
+@pytest.mark.parametrize("case", sorted({**DEFAULT_ON, **OPT_IN}))
+def test_state_dict_keys_are_untouched(case):
+    """A forward-math swap must not add, drop or rename a single parameter."""
+    module, _ = {**DEFAULT_ON, **OPT_IN}[case]()
+    before = sorted(module.state_dict())
+    set_fused_attention(module, True)
+    assert sorted(module.state_dict()) == before
+    # `fused_attn` is a plain bool attribute, never a buffer or parameter.
+    assert not any(key.endswith("fused_attn") for key in before)
+
+
+def test_bool_mask_keeps_the_additive_bert_semantics():
+    """transformers' eager path ADDS the bool mask; SDPA would read it as a gate.
+
+    Without the cast in BertSelfAttention a False entry would become -inf
+    instead of +0, which is a different model, not a rounding difference.
+    """
+    from libreyolo.models.bert.nn import BertSelfAttention
+
+    cfg = SimpleNamespace(num_attention_heads=HEADS, hidden_size=DIM)
+    module = BertSelfAttention(cfg).eval()
+    x = _seeded(BATCH, TOKENS, DIM)
+    mask = torch.zeros(BATCH, 1, TOKENS, TOKENS, dtype=torch.bool)
+    mask[:, :, :, : TOKENS // 2] = True
+
+    with torch.no_grad():
+        fused = module(x, mask)
+        as_gate = module(x, torch.where(mask, 0.0, float("-inf")))
+        as_bias = module(x, mask.to(x.dtype))
+    torch.testing.assert_close(fused, as_bias, rtol=1e-5, atol=ATOL)
+    assert (fused - as_gate).abs().max().item() > 1e-3
+
+
+def test_set_fused_attention_reports_zero_on_a_model_without_the_flag():
+    assert set_fused_attention(torch.nn.Linear(4, 4)) == 0

--- a/tests/unit/kernels/test_sdpa_attention.py
+++ b/tests/unit/kernels/test_sdpa_attention.py
@@ -23,6 +23,7 @@ import pytest
 import torch
 
 from libreyolo.kernels.attention import fused_attention_modules, set_fused_attention
+from libreyolo.kernels.attention.sdpa import manual_attention_required
 
 pytestmark = pytest.mark.unit
 
@@ -297,6 +298,82 @@ def test_bool_mask_keeps_the_additive_bert_semantics():
 
 def test_set_fused_attention_reports_zero_on_a_model_without_the_flag():
     assert set_fused_attention(torch.nn.Linear(4, 4)) == 0
+
+
+# --- capture gating -------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", sorted({**DEFAULT_ON, **OPT_IN}))
+def test_jit_trace_captures_the_primitive_op_equation(case):
+    """TorchScript / CoreML / NCNN capture with jit.trace, which sets no ONNX flag.
+
+    Their artifacts were validated on primitive-op graphs, so a traced graph
+    must not contain aten::scaled_dot_product_attention even when the family
+    runs SDPA eagerly.
+    """
+    module, call = {**DEFAULT_ON, **OPT_IN}[case]()
+    set_fused_attention(module, True)
+
+    class Traceable(torch.nn.Module):
+        """Wrapper so masks and None arguments stay inside the traced region.
+
+        jit.trace only accepts tensors as example inputs; several of these
+        modules take an optional mask. The inputs are built inside forward and
+        become trace constants, which is fine - the assertion is about which
+        ops the graph contains, not about re-running it.
+        """
+
+        def __init__(self):
+            super().__init__()
+            self.inner = module
+
+        def forward(self, unused):
+            return call(self.inner)
+
+    with torch.no_grad():
+        traced = torch.jit.trace(Traceable(), torch.zeros(1), check_trace=False)
+    assert "scaled_dot_product_attention" not in str(traced.inlined_graph), case
+
+
+def test_manual_attention_required_covers_onnx_and_trace(monkeypatch):
+    assert not manual_attention_required()
+    monkeypatch.setattr(torch.onnx, "is_in_onnx_export", lambda: True)
+    assert manual_attention_required()
+    monkeypatch.undo()
+    monkeypatch.setattr(torch.jit, "is_tracing", lambda: True)
+    assert manual_attention_required()
+
+
+def test_manual_attention_required_leaves_torch_compile_alone(monkeypatch):
+    """torch.compile lowers SDPA better than the manual equation."""
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    assert not manual_attention_required()
+
+
+# --- the timm-compat flags that used to be vestigial ----------------------
+
+
+@pytest.mark.parametrize("family", ["vit", "deit"])
+def test_timm_compat_fused_attn_flag_is_honored(family):
+    """set_fused_attention must not report switching a flag nothing reads."""
+    if family == "vit":
+        from libreyolo.models.vit.nn import Attention
+    else:
+        from libreyolo.models.deit.nn import Attention
+
+    module = Attention(DIM, HEADS).eval()
+    assert module.fused_attn is True, "these two default to SDPA, unlike the campaign families"
+    x = _seeded(BATCH, TOKENS, DIM)
+    with torch.no_grad():
+        fused = module(x)
+        assert set_fused_attention(module, False) == 1
+        manual = module(x)
+    # Same equation, so the outputs still agree - but the flag must actually
+    # have selected a different code path.
+    torch.testing.assert_close(fused, manual, rtol=1e-5, atol=ATOL)
+    assert not torch.equal(fused, manual), (
+        f"{family}: set_fused_attention reported a switch that changed nothing"
+    )
 
 
 def test_set_fused_attention_accepts_a_task_wrapper():


### PR DESCRIPTION
Executes the kernel campaign: Phase 1 (MSDA wire-ups) and Phase 2 (SDPA swaps). Phase 3 untouched.

Targets `dev`. #712 has since merged, and `dev` is merged in here (bd590b49) — the `ms_deform_attn.py` conflict was #712's new `is_exporting` guard landing on the same block this PR refactored into `ms_deform_attn_available()`; both are kept.

One family per commit. Happy to split into per-family PRs if preferred.

## What

**Phase 1 — 8 more families on the `ms_deform_attn` slot.** `lwdetr`, `grounding_dino`, `rtdetr`, `rtdetrv2`, `dfine` (+`rtdetrv4`), `deim` (+`deimv2`), `ec`, `openvocab/ovdeim`. Every one keeps its own grid_sample port as the default and the export path; the slot only takes over when a compiled implementation is eligible.

**Phase 2 — SDPA across 15 families.** Default-on where the parity bar is a tolerance, opt-in where it is byte-exact.

## The main finding: most Phase-2 families had to be opt-in

The plan expected "default-on likely fine" for most of Phase 2. Reading the actual bars, **8 of 14 attention modules are pinned byte-exact**, several against a reference whose *own* fused path is explicitly switched off to get there (`test_swin_parity.py:30` loops over the timm reference setting `fused_attn = False`; `parity_owlv2.py:32` says the same about transformers). Fused kernels accumulate in a different order, so per the plan's decision rule those keep manual math by default.

| Family | Bar | Where | Route |
| --- | --- | --- | --- |
| segformer | none found (searched `tests/`, `weights/`) | — | default-on |
| depth_anything (+moge2) | PSNR > 40 vs export | `tests/unit/test_depth_anything.py:216` | default-on |
| bert | `< 1e-4` | `weights/parity_bert.py:40` | default-on |
| grounding_dino | `< 1e-3` | `weights/parity_grounding_dino.py:108` | default-on |
| swinir | `rtol/atol 1e-3` vs export | `tests/unit/test_swinir.py:212-217` | default-on |
| ppocr | `< 1e-3` | `weights/parity_ppocr.py:104` | default-on |
| swin | **`== 0.0`** | `tests/unit/test_swin_parity.py:44` | opt-in |
| dinodetr swin | **`== 0.0`** | `tests/unit/test_dinodetr_parity.py:265` | opt-in |
| birefnet (+feynobg) | **`== 0.0`** | `weights/parity_birefnet.py:93` | opt-in |
| owlv2 | **`objectness_logits: 0.0`** | `weights/parity_owlv2.py:65` | opt-in |
| lwdetr (ViT + decoder MHA) | **`== 0.0`** | `weights/parity_lwdetr.py:150` | opt-in |
| siglip2 towers | **`_EXACT_TOL = 0.0`** | `tests/unit/test_siglip2_parity.py:46` | opt-in |
| zipdepth | **`== 0.0`** | `tests/unit/test_zipdepth_parity.py:84` | opt-in |
| mobilesam | **`== 0`** | `tests/unit/test_mobilesam_parity.py:73` | opt-in |

No tolerance was relaxed, no parity test edited or xfailed. Opt-in modules carry `fused_attn = False` (timm's convention, mirroring `vit/nn.py`); the switch is `libreyolo.kernels.attention.set_fused_attention(model)`. No new env vars.

siglip2's MAP pooling head is left entirely alone, as instructed.

## Measured diffs

**Default-on families, fixed-seed CPU forward, this branch vs #712 head** (random weights, whole-model output):

| family | max_abs_diff | output range | relative |
| --- | --- | --- | --- |
| segformer b0 | 5.96e-08 | 0.2485 | 2.4e-07 |
| swinir x2 | 7.15e-07 | 4.0125 | 1.8e-07 |
| ppocr rec t | 1.86e-09 | 0.0021 | 8.9e-07 |
| depth_anything vits | 2.61e-08 | 0.0349 | 7.5e-07 |
| bert encoder | 8.35e-07 | 6.7538 | 1.2e-07 |

fp32 rounding only. grounding_dino is not in this table (needs a full config to build); its text backbone is the bert row and both its changes are covered by the unit tests.

**Whole-model outputs that must not move at all** — same A/B, CUDA: `dfine_s`, `rtdetr_r18`, `deim_s`, `swin_t_cls` are **byte-identical** to #712 head. That is the Phase-1 wire-ups being inert without a compiled kernel, and swin's SDPA being off by default.

**GPU verification, RTX 5070 Ti.** CPU tests only exercise SDPA's math backend; on CUDA torch picks flash/mem-efficient/cuDNN, which is where mask handling actually differs. All 28 module/mask combinations agree in fp32 (worst 2.97e-06 relative, on a masked window-attention case) and under fp16 autocast (worst 1.3e-02 relative, fp16 noise). Speedups, fp16 autocast:

- Swin window attention, 512 windows x 49 tokens x 384: 1.278 ms -> 0.721 ms (**1.77x**)
- OWLv2 vision attention, 3600 tokens x 1024: 6.483 ms -> 1.735 ms (**3.74x**)

## Ambiguities, and what was done

- **BERT's boolean mask is a bias, not a gate.** `bert/nn.py` passes Grounding DINO a 4-D *bool* mask that the eager path ADDS (True -> +1, False -> +0), deliberately replicating a transformers quirk. SDPA reads a bool mask as "allowed" and would turn False into -inf — a different model, not a rounding difference. The mask is cast to the query dtype before SDPA sees it, with a regression test that fails if it is ever read as a gate.
- **Window masks.** Swin/SwinIR/BiRefNet/DINO-DETR add a relative position bias *and* a shifted-window mask; SDPA takes one additive mask, so they are summed and the window mask is tiled to match the (batch, num_windows) flattened batch. Every masked variant is covered by an equivalence test on CPU and GPU.
- **v2 ragged `num_points_list`** does not reshape onto the slot's `(n_levels, n_points)` layout: guarded with an explicit uniformity check, falls through. Tested.
- **`method='discrete'`** is integer-index sampling, a different equation: never reaches the slot. Tested.
- **dfine's forced-manual grid_sample** (`_FORCE_MANUAL_GRID_SAMPLE` / `_EXPORT`, the ONNX and Core AI escape hatch) outranks the slot. Tested. `_grid_sample_bilinear_manual` untouched.
- **dfine/deim/ec hand their core a per-level value list**, not the single tensor the slot wants, so the accelerated path pays one concat to rebuild it. Only on the accelerated path; unmeasurable here (see below).
- **ec's pose MSDA variant** left untouched, per the plan.
- 4 small helpers were added to `libreyolo/kernels/attention/ms_deform_attn.py` (availability pre-check, spatial-shape normalisation, the v2 layout adapter) rather than duplicating the same subtle uniformity check across 7 families.

## Tests

- `pytest tests/unit -m "not network and not external_data"` — **5033 passed, 1 failed** on the merge commit; the failure is the pidnet/ncnn flake below. (Earlier run on the pre-merge branch: 4989 passed, 2 failed. `dev` at the time, same command: 4863 passed, 0 failed.)

  The 2 failures are pre-existing flakes, not regressions. Evidence for each, rather than an assertion:

  - `test_pidnet.py::...test_exported_semantic_parity[ncnn]` — **fails 1 run in 6 on #712 head, running completely alone.** The mechanism is in the test and the exporter already: the test's own comment (`test_pidnet.py:219-222`) says untrained logits are near-tied so a rounding difference flips many argmax pixels, and the failing runs carry `ncnn.py:123`'s warning that the Windows PNNX wheel choked on an unescaped `C:\...` path in its generated loader and the artifacts were accepted anyway. Neither depends on this PR.
  - `test_cuda_graph_training.py::TestCudaParityYolo9::test_loss_trajectory_identical` — order-dependent: running `test_cuda_graph_training.py + test_pidnet.py` together, **#712 head fails it and this branch passes it**. It also passed on #712 head in the full suite and failed here, i.e. it moves in both directions independently of the change.

  Neither `yolo9` nor `pidnet` imports any module this PR touches.

- `tests/unit/kernels/` — 150 passed, 18 skipped (Triton kernels; no Triton on Windows). Two new files: per-family MSDA adapter tests (layout the slot receives, portable-path fallback, and a numerical-closure test running the adapted arguments through a reference MSDA) and per-module SDPA tests (both paths agree under every mask shape, export takes the primitive-op path even when opted in, `state_dict()` keys unchanged).
- `ruff` on every changed file: no new findings (5 pre-existing ones left alone).

Not verified:
- **The compiled Hub kernel itself.** `kernels-community/deformable-detr` builds are Linux-only and this box is Windows, so `ms_deform_attn_available()` is False here and the accelerated path never executed. What is verified is the contract: the shapes each family hands the slot, and that those arguments reproduce the family's own output when run through a reference MSDA. Someone should run one DETR family on Linux with `libreyolo[hub-kernels]` before this is trusted in anger.
- Weight-backed parity harnesses (`weights/parity_*.py`, `network`/`external_data` tests) were not run — they need checkpoints and network. They are the reason the byte-exact families are opt-in, so their defaults are unchanged by construction, but they have not been executed.

## Code provenance

All changes are original code written for this PR, plus rewiring of existing in-tree LibreYOLO code. No code was copied, ported, adapted, or derived from any third-party source. No new dependencies; the SDPA swaps use stock `torch.nn.functional.scaled_dot_product_attention`.

Existing upstream attribution headers in the touched files (Deformable-DETR, RT-DETR, D-FINE, DEIM, LW-DETR, DINOv2, MobileSAM and the rest, all Apache-2.0/MIT/BSD) are unchanged and still accurate: the ported math is preserved as the default path in every file, with the accelerated branch added alongside it.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends the shared deformable-attention slot to additional DETR-lineage families and introduces default-on or opt-in SDPA according to each family’s parity requirements.
- Adds shared MSDA layout and availability adapters with portable fallbacks.
- Adds graph-capture-aware SDPA policy and a model-wide fused-attention switch.
- Rewires attention implementations across transformer families and adds adapter, mask, parity, capture, and state-dict tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/kernels/attention/ms_deform_attn.py | Adds reusable availability, shape-normalization, and uniform-v2-layout adapters while preserving export and unsupported-layout fallbacks. |
| libreyolo/kernels/attention/sdpa.py | Centralizes graph-capture policy and provides fused-attention discovery and switching for bare modules and public model wrappers. |
| libreyolo/models/bert/nn.py | Routes eager self-attention through SDPA while preserving BERT’s unusual additive boolean-mask semantics and primitive export path. |
| libreyolo/models/grounding_dino/nn.py | Adds SDPA and compiled deformable-attention routing with portable fallbacks. |
| libreyolo/models/vit/nn.py | Makes the existing fused-attention flag functional without changing the default eager or ONNX behavior. |
| libreyolo/models/deit/nn.py | Makes the existing fused-attention flag functional while preserving the default SDPA and opset-17 export path. |
| tests/unit/kernels/test_ms_deform_attn_families.py | Exercises family-specific MSDA layouts, unsupported cases, fallback behavior, and numerical closure. |
| tests/unit/kernels/test_sdpa_attention.py | Covers default and opt-in attention routes, mask semantics, capture gates, wrapper switching, and unchanged state dictionaries. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Call[Model attention call] --> Kind{Attention type}
    Kind -->|MSDA| Eligible{Compiled slot eligible?}
    Eligible -->|No or export| Portable[Family portable grid_sample path]
    Eligible -->|Yes| Adapter[Normalize family layout]
    Adapter --> Kernel[Compiled MSDA kernel]
    Kernel -->|Load or runtime failure| Portable
    Kind -->|Scaled dot-product| Capture{ONNX or jit.trace capture?}
    Capture -->|Yes| Manual[Primitive MatMul Softmax path]
    Capture -->|No| Policy{Family parity policy}
    Policy -->|Default-on| SDPA[PyTorch fused SDPA]
    Policy -->|Byte-exact default| Flag{fused_attn enabled?}
    Flag -->|No| Manual
    Flag -->|Yes| SDPA
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;upstream/d..."](https://github.com/libreyolo/libreyolo/commit/bd590b49b4f357596465f7cf3df397052cafb250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49871691)</sub>

<!-- /greptile_comment -->