### PR TITLE
Make the ms_deform_attn Hub kernel actually load (it never has)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -132,8 +132,10 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.10
 
+      # Installs the extra so the canary exercises the real client under the
+      # version cap, rather than skipping past the check it exists to make.
       - name: Install dependencies
-        run: uv pip install --no-sources --torch-backend cpu --group dev -e "."
+        run: uv pip install --no-sources --torch-backend cpu --group dev -e ".[hub-kernels]"
 
       - name: Resolve pinned Hub kernel revisions
         run: uv run --no-sync pytest tests/unit/kernels -m network --durations=10

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -107,3 +107,33 @@ jobs:
         env:
           LIBREYOLO_PR_GATE: "1"
         run: uv run --no-sync pytest tests/unit -m "${{ env.PR_GATE_MARKERS }} and distributed" --durations=25
+
+  # The compiled Hub kernels are pinned to audited commits. A pin the loader
+  # cannot fetch costs every user the accelerated path on every platform, and
+  # says so only in one log line inside a fallback that is meant to be quiet.
+  # This job resolves the live pins so that failure mode is visible instead.
+  #
+  # Deliberately separate and not part of the PR gate: it needs network, it
+  # reports on the Hub's state rather than on the pull request's changes, and
+  # a red pin should not block unrelated work. Keep it out of the required
+  # checks; treat a failure here as "open a PR bumping the pin".
+  hub-kernel-pins:
+    name: Hub kernel pins resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Create virtual environment
+        run: uv venv --python 3.10
+
+      - name: Install dependencies
+        run: uv pip install --no-sources --torch-backend cpu --group dev -e "."
+
+      - name: Resolve pinned Hub kernel revisions
+        run: uv run --no-sync pytest tests/unit/kernels -m network --durations=10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,15 +58,33 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
-- A Hub kernel whose pinned revision cannot be fetched is now reported as the
-  packaging bug it is (ERROR, naming the pin) instead of blending into the
-  routine "no build for this platform" fallback, which is now INFO. A new
-  non-blocking `hub-kernel-pins` CI job resolves the live pins so an unusable
-  pin cannot ship unnoticed. **The current `ms_deform_attn` pin is unusable**:
-  it is a raw commit SHA and the `kernels` client rejects commit SHAs on its
-  `/api/kernels/` endpoint, so the accelerated path never engages on any
-  platform. Results are unaffected (every family falls back to its portable
-  path); the speedup is simply not there until the pin is re-expressed.
+- The `ms_deform_attn` Hub kernel never actually loaded. The `hub-kernels`
+  extra allowed any `kernels>=0.6.0`, but 0.14 moved revision resolution to an
+  endpoint that rejects the commit SHAs the providers pin to, so a fresh
+  install silently lost the accelerated path on every platform (results were
+  unaffected — every family fell back to its portable `grid_sample` path).
+  The extra now caps the client at `<0.14`, bisected against the real kernel:
+  0.11.7/0.12.3/0.13.0 load and run it, 0.14.1/0.15.2/0.16.0 cannot resolve
+  the pin.
+
+  With the kernel actually running, forward output matches the portable path
+  to 1.1e-06 relative and the autograd bridge's gradients to 4.8e-07; speedups
+  at 640px DETR decoder shapes on an RTX 5070 Ti range from 1.06x (DEIM) to
+  2.42x (Grounding DINO). See `docs/kernels.md`.
+
+  A pin that cannot be fetched is now logged at ERROR naming the revision,
+  instead of blending into the routine "no compiled build for this platform"
+  fallback, which is now INFO. A new non-blocking `hub-kernel-pins` CI job
+  resolves the live pins so this cannot ship unnoticed again.
+
+- `tests/unit/__init__.py` was missing while `tests/` and `tests/unit/kernels/`
+  both had one, so pytest put `tests/unit` on `sys.path` and imported the test
+  directory `tests/unit/kernels` as the top-level `kernels` package. That
+  shadowed the Hub client inside the test suite: `from kernels import
+  get_kernel` raised `ImportError`, and the provider's GPU parity test
+  (`test_hub_matches_portable_on_cuda`) skipped itself as "hub kernel
+  unavailable" on every machine, including ones where the kernel works. It
+  now runs, and passes on an RTX 5070 Ti.
 
 - `LibreViT` and `LibreDeiT` now honor their `fused_attn` attribute. It was a
   timm-compatibility vestige that nothing read, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ before 1.4.0 are documented in the
   RT-DETRv4, DEIM, DEIMv2, EC and OV-DEIM. Installing the extra is the
   opt-in; `LIBREYOLO_HUB_KERNELS=0` disables it. Eager CUDA fp32 only;
   exports always keep the portable path; load or runtime failures fall back
-  with one warning. The Hub artifact is pinned to an audited commit
+  (see the pin note under Fixed). The Hub artifact is pinned to an audited commit
   revision, and a CUDA-only parity test
   (`test_hub_matches_portable_on_cuda`) gates revision bumps. Shapes the slot
   cannot express (a per-level sampling point count, or `method='discrete'`)
@@ -57,6 +57,16 @@ before 1.4.0 are documented in the
   OWLv2 vision attention. See `docs/kernels.md`.
 
 ### Fixed
+
+- A Hub kernel whose pinned revision cannot be fetched is now reported as the
+  packaging bug it is (ERROR, naming the pin) instead of blending into the
+  routine "no build for this platform" fallback, which is now INFO. A new
+  non-blocking `hub-kernel-pins` CI job resolves the live pins so an unusable
+  pin cannot ship unnoticed. **The current `ms_deform_attn` pin is unusable**:
+  it is a raw commit SHA and the `kernels` client rejects commit SHAs on its
+  `/api/kernels/` endpoint, so the accelerated path never engages on any
+  platform. Results are unaffected (every family falls back to its portable
+  path); the speedup is simply not there until the pin is re-expressed.
 
 - `LibreViT` and `LibreDeiT` now honor their `fused_attn` attribute. It was a
   timm-compatibility vestige that nothing read, so

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -47,10 +47,30 @@ nothing changes (no network access, portable paths everywhere). Set
 `LIBREYOLO_HUB_KERNELS=0` to disable them without uninstalling. Nothing is
 vendored; artifacts are fetched and cached by the `kernels` package, and a
 kernel that fails to load or run disables itself for the process and falls
-back to the portable path with one warning. Every hub kernel is pinned to an
-audited commit revision in its provider module — a moved branch on the Hub
-can never change the binary that runs in-process. Bumping a pin requires a
-GPU parity run of the provider's `*_matches_portable_on_cuda` test.
+back to the portable path. Every hub kernel is pinned to an audited commit
+revision in its provider module — a moved branch on the Hub can never change
+the binary that runs in-process. Bumping a pin requires a GPU parity run of
+the provider's `*_matches_portable_on_cuda` test.
+
+A load failure is one of two things, and they are logged differently because
+only one of them is your machine's business:
+
+- **No compiled build for this platform** (OS, torch or CUDA combination the
+  kernel authors did not build). Logged at INFO; the portable path is the
+  right answer and nothing is wrong.
+- **The pinned revision cannot be fetched at all.** Logged at ERROR, because
+  it is a packaging bug on our side that costs *every* user the accelerated
+  path regardless of platform. The `hub-kernel-pins` CI job resolves the live
+  pins so this cannot pass unnoticed; it needs network, is not part of the PR
+  gate, and a failure there means "open a PR bumping the pin", not "this pull
+  request is broken".
+
+> **Known issue.** The current `ms_deform_attn` pin is a raw commit SHA, and
+> the `kernels` client rejects commit SHAs on its `/api/kernels/` endpoint
+> (`RevisionNotFoundError: Invalid rev id`) — verified against `kernels`
+> 0.16.0, which `kernels>=0.6.0` allows. Until the pin is expressed in a form
+> that client accepts, the accelerated path never engages on any platform.
+> Results are unaffected: every family falls back to its portable path.
 
 Current hub-backed slot:
 

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -65,12 +65,14 @@ only one of them is your machine's business:
   gate, and a failure there means "open a PR bumping the pin", not "this pull
   request is broken".
 
-> **Known issue.** The current `ms_deform_attn` pin is a raw commit SHA, and
-> the `kernels` client rejects commit SHAs on its `/api/kernels/` endpoint
-> (`RevisionNotFoundError: Invalid rev id`) — verified against `kernels`
-> 0.16.0, which `kernels>=0.6.0` allows. Until the pin is expressed in a form
-> that client accepts, the accelerated path never engages on any platform.
-> Results are unaffected: every family falls back to its portable path.
+The pins are commit SHAs, and `kernels` 0.14 moved revision resolution to an
+endpoint that only accepts branch and tag names — a SHA-pinned load fails
+there with `RevisionNotFoundError` and the acceleration silently disappears.
+The `hub-kernels` extra therefore caps the client at `<0.14`. Bisected against
+the real kernel: 0.11.7, 0.12.3 and 0.13.0 load and run it; 0.14.1, 0.15.2 and
+0.16.0 cannot resolve the pin. Lift the cap only when the pins can be
+expressed in a form the newer client accepts without giving up the
+immutability a SHA buys.
 
 Current hub-backed slot:
 
@@ -80,6 +82,28 @@ Current hub-backed slot:
   eager mode. Training is accelerated too (the compiled backward registers
   through an autograd bridge). Active whenever the `kernels` package is
   installed, unless `LIBREYOLO_HUB_KERNELS=0`.
+
+  Measured on an RTX 5070 Ti against the portable path, at D-FINE/RT-DETR
+  640px decoder shapes (levels 80/40/20/10, batch 2, 300 queries, 8 heads x
+  32ch, 4 points), forward only:
+
+  | Family | Speedup |
+  | --- | --- |
+  | Grounding DINO | 2.42x |
+  | RT-DETR | 2.14x |
+  | RT-DETRv2 | 1.47x |
+  | LW-DETR | 1.31x |
+  | OV-DEIM | 1.20x |
+  | EC | 1.11x |
+  | D-FINE | 1.07x |
+  | DEIM | 1.06x |
+
+  Outputs match the portable path to 1.1e-06 relative, and the autograd
+  bridge's gradients match to 4.8e-07 (`d/dvalue`; `d/dsampling_locations` and
+  `d/dattention_weights` are bit-identical). D-FINE, DEIM and EC sit at the
+  bottom because their decoders hand the core a *per-level* value list, so the
+  accelerated path pays one concat to rebuild the slot's layout; the families
+  that already hold a single value tensor keep the full win.
 
   Wired into every Deformable-DETR-lineage family: RF-DETR,
   LibreDeformableDETR, LibreDINO-DETR, LW-DETR, Grounding DINO, RT-DETR,

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -92,13 +92,18 @@ def _classify_load_failure(exc: BaseException) -> str:
     silently costs every user the accelerated path -- so it must not look
     like routine fallback in the logs.
     """
-    if isinstance(exc, ImportError):
+    # FileNotFoundError is what the client raises for "no build variant for
+    # this system", and it quotes the revision it looked under -- so classify
+    # on the exception type before going anywhere near the message text.
+    if isinstance(exc, (ImportError, FileNotFoundError)):
         return "unsupported"
     name = type(exc).__name__
     if name in ("RevisionNotFoundError", "RepositoryNotFoundError", "EntryNotFoundError"):
         return "unresolvable"
+    # Narrow phrases only. A bare "revision" substring also appears in the
+    # perfectly normal "Cannot find a build variant ... (revision: <sha>)".
     text = str(exc).lower()
-    if "revision" in text or "rev id" in text:
+    if "invalid rev id" in text or "revision not found" in text:
         return "unresolvable"
     return "unsupported"
 

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -50,6 +50,11 @@ _MAX_IM2COL_STEP = 64
 
 _hub_kernel = None
 _hub_failed = False
+# Why the load failed, for tests and for choosing the log level. "unsupported"
+# is a normal outcome (no compiled build for this OS/torch/CUDA combination);
+# "unresolvable" means the pin above cannot be fetched at all, which is a
+# packaging bug on our side and is wrong on every platform.
+_hub_failure_kind: Optional[str] = None
 
 
 def _hub_enabled() -> bool:
@@ -78,9 +83,29 @@ def _eligible() -> bool:
     )
 
 
+def _classify_load_failure(exc: BaseException) -> str:
+    """Split "no build for this machine" from "the pin cannot be fetched".
+
+    The first is the normal outcome on any platform the kernel authors did
+    not build for, and the portable path is the right answer. The second
+    means :data:`_HUB_REVISION` is unusable, which is wrong *everywhere* and
+    silently costs every user the accelerated path -- so it must not look
+    like routine fallback in the logs.
+    """
+    if isinstance(exc, ImportError):
+        return "unsupported"
+    name = type(exc).__name__
+    if name in ("RevisionNotFoundError", "RepositoryNotFoundError", "EntryNotFoundError"):
+        return "unresolvable"
+    text = str(exc).lower()
+    if "revision" in text or "rev id" in text:
+        return "unresolvable"
+    return "unsupported"
+
+
 def _load_hub_kernel():
     """Fetch and cache the Hub kernel; a failure disables the provider."""
-    global _hub_kernel, _hub_failed
+    global _hub_kernel, _hub_failed, _hub_failure_kind
     if _hub_kernel is not None or _hub_failed:
         return _hub_kernel
     try:
@@ -89,7 +114,24 @@ def _load_hub_kernel():
         _hub_kernel = get_kernel(_HUB_REPO, revision=_HUB_REVISION)
     except Exception as exc:
         _hub_failed = True
-        logger.warning("Hub kernel %s unavailable: %s", _HUB_REPO, exc)
+        _hub_failure_kind = _classify_load_failure(exc)
+        if _hub_failure_kind == "unresolvable":
+            logger.error(
+                "Hub kernel %s cannot be resolved at the pinned revision %s, so "
+                "the accelerated path is unavailable on every platform. This is "
+                "a LibreYOLO packaging bug, not a problem with your machine: "
+                "%s. Falling back to the portable implementation.",
+                _HUB_REPO,
+                _HUB_REVISION,
+                exc,
+            )
+        else:
+            logger.info(
+                "No compiled %s build for this platform; using the portable "
+                "implementation: %s",
+                _HUB_REPO,
+                exc,
+            )
     return _hub_kernel
 
 

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -119,8 +119,11 @@ def _load_hub_kernel():
             logger.error(
                 "Hub kernel %s cannot be resolved at the pinned revision %s, so "
                 "the accelerated path is unavailable on every platform. This is "
-                "a LibreYOLO packaging bug, not a problem with your machine: "
-                "%s. Falling back to the portable implementation.",
+                "a LibreYOLO packaging problem, not a problem with your machine; "
+                "the usual cause is a `kernels` client outside the range pinned "
+                "by the libreyolo[hub-kernels] extra, since newer clients reject "
+                "commit-SHA revisions. Falling back to the portable "
+                "implementation. Underlying error: %s",
                 _HUB_REPO,
                 _HUB_REVISION,
                 exc,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,16 @@ hub-kernels = [
     # Optional runtime loader for compiled Hub kernels (e.g. the
     # ms_deform_attn slot). Installing this extra is the opt-in; disable
     # with LIBREYOLO_HUB_KERNELS=0. See docs/kernels.md.
-    "kernels>=0.6.0",
+    #
+    # Capped below 0.14: providers pin their artifact to an audited commit
+    # SHA, and 0.14 moved resolution to an /api/kernels/ endpoint that only
+    # accepts branch and tag names, so every SHA-pinned load fails with
+    # RevisionNotFoundError and the accelerated path silently disappears.
+    # Bisected against the real kernel on an RTX 5070 Ti: 0.11.7, 0.12.3 and
+    # 0.13.0 load and run it; 0.14.1, 0.15.2 and 0.16.0 cannot resolve the
+    # pin at all. Lift the cap once the pins can be expressed in a form the
+    # newer client accepts without giving up the immutability a SHA buys.
+    "kernels>=0.6.0,<0.14",
 ]
 openvocab = [
     # Discriminative open-vocabulary detectors load through transformers

--- a/tests/unit/kernels/test_ms_deform_attn_hub_pin.py
+++ b/tests/unit/kernels/test_ms_deform_attn_hub_pin.py
@@ -52,6 +52,18 @@ class _RevisionNotFoundError(Exception):
         (FileNotFoundError("Cannot find a build variant for this system"), "unsupported"),
         (ImportError("No module named 'kernels'"), "unsupported"),
         (RuntimeError("CUDA driver version is insufficient"), "unsupported"),
+        # Verbatim from a CPU-only CI runner. It names the revision it looked
+        # under, which a loose substring match reads as a dead pin and then
+        # shouts about a packaging bug that does not exist.
+        (
+            FileNotFoundError(
+                "Cannot find a build variant for this system in "
+                "kernels-community/deformable-detr (revision: "
+                "4d2393e5d7879f7cf68db04cc7c9c7342272bc05). Available variants: "
+                "torch212-cxx11-cu130-x86_64-linux, torch211-cu128-x86_64-windows"
+            ),
+            "unsupported",
+        ),
     ],
 )
 def test_load_failures_are_classified(exc, expected):

--- a/tests/unit/kernels/test_ms_deform_attn_hub_pin.py
+++ b/tests/unit/kernels/test_ms_deform_attn_hub_pin.py
@@ -1,0 +1,145 @@
+"""The Hub kernel pin must stay fetchable, and must fail loudly when it isn't.
+
+``_HUB_REVISION`` pins the compiled multi-scale deformable attention kernel to
+an audited commit so a moved Hub branch cannot swap the native binary that
+runs in-process. A pin the loader cannot fetch costs every user the
+accelerated path, on every platform, behind a single log line inside a
+fallback that is *supposed* to be quiet -- which is exactly how an unusable
+pin reached ``dev`` unnoticed.
+
+Two layers here:
+
+* the classification and log level, testable offline everywhere;
+* a network canary that resolves the live pin, which is the check that would
+  have caught it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+
+import pytest
+
+from libreyolo.kernels.attention import ms_deform_attn as module
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider_state():
+    """The loader caches its verdict in module globals; restore them."""
+    saved = (module._hub_kernel, module._hub_failed, module._hub_failure_kind)
+    module._hub_kernel, module._hub_failed, module._hub_failure_kind = None, False, None
+    yield
+    module._hub_kernel, module._hub_failed, module._hub_failure_kind = saved
+
+
+# --- classification -------------------------------------------------------
+
+
+class _RevisionNotFoundError(Exception):
+    """Stands in for huggingface_hub's error without importing it."""
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (_RevisionNotFoundError("404 Client Error. Invalid rev id: abc123"), "unresolvable"),
+        (Exception("Revision Not Found for url: .../tree/abc123/build"), "unresolvable"),
+        (FileNotFoundError("Cannot find a build variant for this system"), "unsupported"),
+        (ImportError("No module named 'kernels'"), "unsupported"),
+        (RuntimeError("CUDA driver version is insufficient"), "unsupported"),
+    ],
+)
+def test_load_failures_are_classified(exc, expected):
+    assert module._classify_load_failure(exc) == expected
+
+
+def _force_load_failure(monkeypatch, exc):
+    """Make ``from kernels import get_kernel`` succeed but the call raise."""
+
+    def boom(*args, **kwargs):
+        raise exc
+
+    fake = type("FakeKernels", (), {"get_kernel": staticmethod(boom)})
+    monkeypatch.setitem(__import__("sys").modules, "kernels", fake)
+    return module._load_hub_kernel()
+
+
+def test_dead_pin_is_logged_as_an_error(monkeypatch, caplog):
+    """A pin nobody can fetch is our bug, and must not read as routine fallback."""
+    with caplog.at_level(logging.DEBUG, logger=module.logger.name):
+        assert _force_load_failure(monkeypatch, _RevisionNotFoundError("Invalid rev id")) is None
+    assert module._hub_failure_kind == "unresolvable"
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "an unusable revision pin must be logged at ERROR"
+    assert module._HUB_REVISION in errors[0].getMessage()
+    assert "packaging bug" in errors[0].getMessage()
+
+
+def test_missing_build_variant_is_not_an_error(monkeypatch, caplog):
+    """No build for this OS/torch/CUDA is normal; the portable path is correct."""
+    with caplog.at_level(logging.DEBUG, logger=module.logger.name):
+        assert (
+            _force_load_failure(
+                monkeypatch, FileNotFoundError("Cannot find a build variant for this system")
+            )
+            is None
+        )
+    assert module._hub_failure_kind == "unsupported"
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_a_failed_load_never_raises_into_inference(monkeypatch):
+    """Whatever goes wrong, callers get None and fall back."""
+    assert _force_load_failure(monkeypatch, RuntimeError("anything at all")) is None
+    assert module._hub_failed is True
+
+
+# --- the live canary ------------------------------------------------------
+
+
+@pytest.mark.network
+def test_pinned_revision_is_fetchable():
+    """The pin must resolve on the endpoint the ``kernels`` client actually uses.
+
+    Deliberately plain HTTP against ``/api/kernels/...`` rather than going
+    through the ``kernels`` package: this has to run wherever there is a
+    network, with no optional dependency, no GPU and no compiled build for
+    the runner's platform. Resolution happens before variant matching, so a
+    runner with no build for its own OS still catches a dead pin.
+    """
+    url = (
+        f"https://huggingface.co/api/kernels/{module._HUB_REPO}"
+        f"/tree/{module._HUB_REVISION}/build"
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            payload = json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        pytest.fail(
+            f"Pinned revision {module._HUB_REVISION} of {module._HUB_REPO} is not "
+            f"fetchable ({exc.code} {exc.reason}) from {url}. The accelerated "
+            "ms_deform_attn path is dead on every platform until the pin is fixed."
+        )
+    except urllib.error.URLError as exc:  # offline runner, not a pin problem
+        pytest.skip(f"no network: {exc}")
+    assert payload, "the pinned revision resolved but exposes no build variants"
+
+
+@pytest.mark.network
+def test_hub_load_failure_is_never_a_dead_pin():
+    """End-to-end canary through the real loader, where the package is present.
+
+    Skips when ``kernels`` is not installed. A machine with no compiled build
+    is fine and expected; an unresolvable pin is not.
+    """
+    pytest.importorskip("kernels")
+    module._load_hub_kernel()
+    assert module._hub_failure_kind != "unresolvable", (
+        f"{module._HUB_REPO} pinned at {module._HUB_REVISION} could not be "
+        "resolved by the kernels client"
+    )

--- a/tests/unit/kernels/test_ms_deform_attn_hub_pin.py
+++ b/tests/unit/kernels/test_ms_deform_attn_hub_pin.py
@@ -76,8 +76,9 @@ def test_dead_pin_is_logged_as_an_error(monkeypatch, caplog):
     assert module._hub_failure_kind == "unresolvable"
     errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
     assert errors, "an unusable revision pin must be logged at ERROR"
-    assert module._HUB_REVISION in errors[0].getMessage()
-    assert "packaging bug" in errors[0].getMessage()
+    message = errors[0].getMessage()
+    assert module._HUB_REVISION in message, "the error must name the unusable pin"
+    assert "hub-kernels" in message, "the error must point at the version cap to check"
 
 
 def test_missing_build_variant_is_not_an_error(monkeypatch, caplog):
@@ -103,17 +104,17 @@ def test_a_failed_load_never_raises_into_inference(monkeypatch):
 
 
 @pytest.mark.network
-def test_pinned_revision_is_fetchable():
-    """The pin must resolve on the endpoint the ``kernels`` client actually uses.
+def test_pinned_revision_exists_in_the_repo():
+    """The pinned commit must still exist upstream, with build variants on it.
 
-    Deliberately plain HTTP against ``/api/kernels/...`` rather than going
-    through the ``kernels`` package: this has to run wherever there is a
-    network, with no optional dependency, no GPU and no compiled build for
-    the runner's platform. Resolution happens before variant matching, so a
-    runner with no build for its own OS still catches a dead pin.
+    Plain HTTP against the models API, which does accept commit SHAs, so this
+    runs with no optional dependency, no GPU and no compiled build for the
+    runner's platform. It catches a pin that was rewritten or force-pushed
+    away; it deliberately does *not* go through ``/api/kernels/``, which
+    rejects SHAs outright and would fail even when the pin is perfectly good.
     """
     url = (
-        f"https://huggingface.co/api/kernels/{module._HUB_REPO}"
+        f"https://huggingface.co/api/models/{module._HUB_REPO}"
         f"/tree/{module._HUB_REVISION}/build"
     )
     try:
@@ -121,25 +122,38 @@ def test_pinned_revision_is_fetchable():
             payload = json.loads(response.read())
     except urllib.error.HTTPError as exc:
         pytest.fail(
-            f"Pinned revision {module._HUB_REVISION} of {module._HUB_REPO} is not "
-            f"fetchable ({exc.code} {exc.reason}) from {url}. The accelerated "
-            "ms_deform_attn path is dead on every platform until the pin is fixed."
+            f"Pinned revision {module._HUB_REVISION} of {module._HUB_REPO} no "
+            f"longer exists upstream ({exc.code} {exc.reason}) at {url}."
         )
     except urllib.error.URLError as exc:  # offline runner, not a pin problem
         pytest.skip(f"no network: {exc}")
-    assert payload, "the pinned revision resolved but exposes no build variants"
+    assert payload, "the pinned revision exists but exposes no build variants"
 
 
 @pytest.mark.network
-def test_hub_load_failure_is_never_a_dead_pin():
-    """End-to-end canary through the real loader, where the package is present.
+def test_installed_kernels_client_can_resolve_the_pin():
+    """The canary that matters: the *installed* client must accept the pin.
 
-    Skips when ``kernels`` is not installed. A machine with no compiled build
-    is fine and expected; an unresolvable pin is not.
+    ``kernels`` 0.14 moved revision resolution to an endpoint that rejects
+    commit SHAs, which silently removed the accelerated path everywhere. The
+    ``hub-kernels`` extra caps the client below that, and this asserts the cap
+    is still doing its job. A runner with no compiled build for its platform
+    is fine and expected -- that is a different failure kind.
     """
-    pytest.importorskip("kernels")
+    client = pytest.importorskip("kernels")
+    # This directory is itself named `kernels`. If the test tree ever ends up
+    # on sys.path as a top-level package again it shadows the real client, and
+    # every hub test degrades to a silent skip -- which is exactly how the
+    # provider's GPU parity test sat dead for its whole life.
+    assert hasattr(client, "get_kernel"), (
+        f"`import kernels` resolved to {getattr(client, '__file__', client)!r} "
+        "instead of the Hub client. Something (a missing __init__.py in a "
+        "parent test package) is shadowing it, and the hub tests below are "
+        "not testing what they claim to."
+    )
     module._load_hub_kernel()
     assert module._hub_failure_kind != "unresolvable", (
-        f"{module._HUB_REPO} pinned at {module._HUB_REVISION} could not be "
-        "resolved by the kernels client"
+        f"the installed kernels client cannot resolve {module._HUB_REPO} at "
+        f"{module._HUB_REVISION}. Check the version cap on the hub-kernels "
+        "extra in pyproject.toml."
     )


### PR DESCRIPTION
The `ms_deform_attn` compiled kernel **had never executed, anywhere** — not in CI, not on any dev machine, not once since it was added. Two independent causes, both fixed here, both now verified against the real kernel running on an RTX 5070 Ti.

**Nothing was broken for users**: every family fell back to its portable `grid_sample` path and produced correct results. What was missing was the entire point of the feature. `release` is unaffected — `libreyolo/kernels/` does not exist there.

## Cause 1: the dependency range let in a client that rejects our pins

The `hub-kernels` extra allowed any `kernels>=0.6.0`. Version **0.14** moved revision resolution to an `/api/kernels/` endpoint that only accepts branch and tag names, so the commit-SHA pins providers use fail with `RevisionNotFoundError: Invalid rev id`. A fresh install got 0.16 and silently lost the accelerated path.

Bisected against the real kernel rather than guessed:

| kernels | result |
| --- | --- |
| 0.6.0, 0.9.0, 0.10.5 | pin resolves (no build variant for this OS) |
| **0.11.7, 0.12.3, 0.13.0** | **kernel loads and runs** |
| 0.14.1, 0.15.2, 0.16.0 | cannot resolve the pin |

Capped at `<0.14`. This **keeps the SHA pin** and the immutability #712 wanted — no supply-chain tradeoff.

## Cause 2: the test tree shadowed the Hub client, so the one test that checks this could never run

`tests/unit/__init__.py` was missing while `tests/` and `tests/unit/kernels/` both had one. pytest therefore put `tests/unit` on `sys.path` and imported the *test directory* `tests/unit/kernels` as the top-level `kernels` package.

Inside the suite, `from kernels import get_kernel` raised `ImportError: cannot import name 'get_kernel' from 'kernels' (tests/unit/kernels/__init__.py)`. The provider's own GPU parity test, `test_hub_matches_portable_on_cuda`, caught that and skipped itself as *"hub kernel unavailable on this box (load failed)"* — on **every machine it has ever run on**, including ones where the kernel works perfectly.

One empty `__init__.py` fixes it. That test now runs and passes.

This is the more interesting bug: a green suite was reporting success while the only check that mattered had disqualified itself.

## What the kernel is actually worth

Now measurable. RTX 5070 Ti, D-FINE/RT-DETR 640px decoder shapes (levels 80/40/20/10, batch 2, 300 queries, 8 heads x 32ch, 4 points), forward only:

| Family | Speedup |
| --- | --- |
| Grounding DINO | 2.42x |
| RT-DETR | 2.14x |
| RT-DETRv2 | 1.47x |
| LW-DETR | 1.31x |
| OV-DEIM | 1.20x |
| EC | 1.11x |
| D-FINE | 1.07x |
| DEIM | 1.06x |

Correctness: forward matches the portable path to **1.1e-06** relative; autograd-bridge gradients match to **4.8e-07** (`d/dvalue`; `d/dsampling_locations` and `d/dattention_weights` are bit-identical).

D-FINE, DEIM and EC sit lowest because their decoders hand the core a *per-level* value list, so the accelerated path pays one concat to rebuild the slot layout. I flagged that cost as unmeasurable in #713; it is now measured, and it is the difference between ~1.06x and ~2x.

## Not shipping silently again

- A pin that cannot be resolved is logged at **ERROR** naming the revision, instead of blending into the routine "no compiled build for this platform" fallback, which is now **INFO**. Those two were sharing one warning, which is how this hid.
- A non-blocking **`hub-kernel-pins` CI job** installs the extra and resolves the live pins. It is deliberately outside the PR gate — it reports on the Hub's state, not on a pull request's changes. Please keep it out of required checks.
- The canary asserts `import kernels` actually yields the Hub client, so the shadowing cannot silently return.

## Tests

- Full suite **5043 passed, 0 failed** with the kernel live — the first time it has ever run in that state. (`tests/unit/kernels`: 195 passed, one more than before, the resurrected GPU parity test.)
- `ruff` clean on all changed files.
- Adding `tests/unit/__init__.py` changes how those modules are imported; the full green suite is the check on that, and no test imports a sibling test module by top-level name.

## Code provenance

All changes are original code written for this PR. No third-party code copied, ported, or adapted. No new dependencies; the added canary uses stdlib `urllib`. The only dependency change is tightening an existing optional bound.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores loading of the optional SHA-pinned deformable-attention Hub kernel and adds monitoring intended to distinguish unavailable platform builds from unresolvable revisions.
- Caps the optional `kernels` client below the incompatible 0.14 release.
- Prevents the test package from shadowing the installed Hub client.
- Adds failure classification, focused tests, and a non-blocking live-pin CI canary.
- Documents fallback behavior, compatibility constraints, correctness, and measured performance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Constrains the optional Hub client to versions below 0.14 so commit-SHA revisions remain supported. |
| libreyolo/kernels/attention/ms_deform_attn.py | Classifies kernel-loading failures and assigns distinct logging behavior to platform and revision failures. |
| tests/unit/kernels/test_ms_deform_attn_hub_pin.py | Adds offline classification coverage and network checks for the pinned revision and installed client. |
| tests/unit/__init__.py | Makes the unit-test tree a package so its kernels directory no longer shadows the external client. |
| .github/workflows/unit-tests.yml | Adds a separate non-blocking job that installs the optional client and runs network-marked pin checks. |
| docs/kernels.md | Documents client compatibility, fallback diagnostics, correctness results, and measured acceleration. |
| CHANGELOG.md | Records the previously inactive acceleration path, its causes, and the added safeguards. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Install[Install libreyolo hub-kernels extra] --> Constraint[kernels 0.6 to below 0.14]
    Constraint --> Load[Load SHA-pinned ms_deform_attn kernel]
    Load -->|Success| Accelerated[Use compiled CUDA path]
    Load -->|No platform build| Info[Log INFO and use portable path]
    Load -->|Revision cannot resolve| Error[Log ERROR and use portable path]
    Canary[Non-blocking network CI canary] --> Constraint
    Canary --> Load
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Do not misread &quot;no build variant&quot; as a d..."](https://github.com/libreyolo/libreyolo/commit/cf381b25835969917c29f27ae54a7156880c5c2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49909013)</sub>

<!-- /greptile_comment -->