### PR TITLE
Extend training CUDA graph capture from 2 to 24 families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ before 1.4.0 are documented in the
   `mobilenetv4`, `efficientnetv2`), semantic (`segformer`,
   `lingbotvision`), point (`fomo`) and restore (`nafnet`). Measured on an
   RTX 5070 Ti under AMP: 3.63x (FOMO), 2.74x (MobileNetV4), 1.99x (YOLO9-t),
-  1.04–1.26x for the rest; the win tracks how much of a step is network
-  rather than loss, and is largest at small batch sizes. The encoder-decoder
+  1.04-1.26x for the rest; the win tracks how much of a step is network
+  rather than loss, and is largest at small batch sizes. End to end on a real
+  20-epoch YOLO9-t fine-tune (406 images, dataloader and validation
+  included): 428 s to 368 s, 1.16x, with identical mAP50-95 and per-epoch
+  losses. The encoder-decoder
   detectors capture backbone plus encoder only, because their decoder sizes
   its denoising queries from the batch's ground-truth count, so its token
   count is not static. Most families are bit-identical to eager; the three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- CUDA graph capture of the **training** step (`train(..., cuda_graph=True)`
+  / `--cuda-graph`) extended from 2 families to **24**, across five tasks:
+  detect (`yolo9`, `yolo9_p2`, `yolo9_e2e`, `yolox`, `yolo7`, `yolonas`,
+  `picodet`, `rtmdet`, `rfdetr`, `dfine`, `deim`, `deimv2`, `rtdetr`,
+  `rtdetrv2`, `rtdetrv4`, `ec`), classify (`resnet`, `convnext`,
+  `mobilenetv4`, `efficientnetv2`), semantic (`segformer`,
+  `lingbotvision`), point (`fomo`) and restore (`nafnet`). Measured on an
+  RTX 5070 Ti under AMP: 3.63x (FOMO), 2.74x (MobileNetV4), 1.99x (YOLO9-t),
+  1.04–1.26x for the rest; the win tracks how much of a step is network
+  rather than loss, and is largest at small batch sizes. The encoder-decoder
+  detectors capture backbone plus encoder only, because their decoder sizes
+  its denoising queries from the batch's ground-truth count, so its token
+  count is not static. Most families are bit-identical to eager; the three
+  documented exceptions (families whose own eager training is not
+  reproducible, RTMDet's cross-level shared head convolutions, and networks
+  with stochastic depth inside the captured region) are measured and
+  tolerance-gated per family in
+  `tests/e2e/test_cuda_graph_training_families.py`. See
+  `docs/training_cuda_graphs.md`.
+
 - CUDA graph capture (`predict(..., cuda_graph=True)`) extended from the
   initial 8 families to **39**, spanning detect, segment, pose, point,
   classify, semantic, depth, restore, matte and OCR. Every enabled family is
@@ -57,6 +77,13 @@ before 1.4.0 are documented in the
   OWLv2 vision attention. See `docs/kernels.md`.
 
 ### Fixed
+
+- `train(..., cuda_graph=True)` was a silent no-op for D-FINE, DEIM, DEIMv2,
+  RT-DETRv4 and EC. Those trainers override `_train_epoch` with a copy of the
+  base loop that called `on_forward` (the eager path) instead of
+  `_forward_train` (the routed one), so capture never engaged and the flag
+  did nothing. The e2e suite now asserts capture actually engages per family
+  rather than only that the run completes.
 
 - `LibreViT` and `LibreDeiT` now honor their `fused_attn` attribute. It was a
   timm-compatibility vestige that nothing read, so

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ UV := uv run --no-sync
 E2E_TIMEOUT ?= 900
 
 .DEFAULT_GOAL := help
-.PHONY: help setup format lint typecheck test test_pr_gate test_install_smoke test_e2e print_nightly_suite test_general_nightly test_flagship_nightly test_nightly test_rf5 build clean
+.PHONY: help setup format lint typecheck test test_pr_gate test_install_smoke test_e2e print_nightly_suite test_general_nightly test_flagship_nightly test_training_nightly test_nightly test_rf5 build clean
 
 help:
 	@echo "═══════════════════════════════════════════════════════════════════════════════"
@@ -30,6 +30,7 @@ help:
 	@echo "  print_nightly_suite           - Print nightly suite version and contract"
 	@echo "  test_general_nightly          - Run broad native inference nightly checks"
 	@echo "  test_flagship_nightly         - Run heavy YOLO9/RF-DETR nightly checks"
+	@echo "  test_training_nightly         - Run training-time GPU checks (CUDA graph capture)"
 	@echo "  test_nightly                  - Run general + flagship nightly checks"
 	@echo "  test_rf5                      - Run RF5 training benchmark tests"
 	@echo "  build                         - Build package"
@@ -135,9 +136,13 @@ test_general_nightly: print_nightly_suite
 test_flagship_nightly: print_nightly_suite
 	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='flagship_nightly and not export_backend'
 
+test_training_nightly: print_nightly_suite
+	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='training_nightly'
+
 test_nightly: print_nightly_suite
 	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='general_nightly'
 	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='flagship_nightly and not export_backend'
+	LIBREYOLO_FAIL_ON_NIGHTLY_SKIP=1 $(MAKE) test_e2e MARKERS='training_nightly'
 
 test_rf5: clean
 	$(UV) pytest tests/e2e/test_rf5_training.py -m rf5 -v

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 	@echo "  test_general_nightly          - Run broad native inference nightly checks"
 	@echo "  test_flagship_nightly         - Run heavy YOLO9/RF-DETR nightly checks"
 	@echo "  test_training_nightly         - Run training-time GPU checks (CUDA graph capture)"
-	@echo "  test_nightly                  - Run general + flagship nightly checks"
+	@echo "  test_nightly                  - Run general + flagship + training nightly checks"
 	@echo "  test_rf5                      - Run RF5 training benchmark tests"
 	@echo "  build                         - Build package"
 	@echo "  clean                         - Remove build and test cache artifacts"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -247,6 +247,16 @@ V2.3 contract:
   CLI, and one RF1 training/reload size per flagship family; currently 48 tests
   with `not export_backend`. The full RF1 size matrix remains available under
   `-m rf1` for manual or future full-matrix runs.
+- `training_nightly`: training-time GPU features that neither inference lane
+  covers. Currently CUDA graph training capture: one case per distinct
+  mechanism rather than per family (a bespoke spec, a spec over a refactored
+  family head plus the mid-run capture invalidation, the DETR encoder mixin,
+  the classify mixin, the semantic mixin), plus the paths where a defect is
+  invisible from the loss alone: capture without AMP, layer freezing, resume,
+  gradient accumulation, validation with a live graph, and capture failing
+  mid-run. 14 tests. The full per-family sweep stays under `-m e2e`.
+  This lane exists because a feature whose every failure mode is a silent
+  fallback to eager cannot be left to manual runs.
 - Detector families cover detection, classifier families cover normalized
   probability plus top-1 stability, and DeepLabv3 covers dense semantic masks.
   L2CS gaze is non-redistributable (no public download route), so it runs as a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -229,6 +229,7 @@ Commands:
 ```bash
 make test_general_nightly
 make test_flagship_nightly
+make test_training_nightly
 make test_nightly
 make test_e2e E2E_TIMEOUT=1800
 ```

--- a/docs/training_cuda_graphs.md
+++ b/docs/training_cuda_graphs.md
@@ -14,81 +14,188 @@ model.train(data="data.yaml", epochs=100, cuda_graph=True)
 libreyolo train --model libreyolo9t.pt --data data.yaml --cuda-graph
 ```
 
-## When it helps
+The flag is always safe to pass: a family, task or configuration that
+cannot be captured logs one line and trains eager, unchanged.
 
-Small and mid-size models are launch-bound during training: the host
-submits thousands of short kernels per step and the GPU idles between
-launches. Capturing the network into a graph replays the whole step as one
-launch. Measured on an RTX 5070 Ti (Windows, AMP, 640 px, synthetic data,
-no dataloader bottleneck):
+## What is captured, and why that bounds the win
 
-| Model | Batch | Eager | Graphed | Speedup |
-| --- | --- | --- | --- | --- |
-| yolo9-t | 16 | 105.1 ms/step | 67.5 ms/step | 1.56x |
-| yolo9-t | 8 | 92.6 ms/step | 41.2 ms/step | 2.25x |
-| yolo9-s | 16 | 115.5 ms/step | 94.0 ms/step | 1.23x |
-| yolo9-m | 8 | 93.0 ms/step | 84.2 ms/step | 1.10x |
+Only the network's forward and backward. The loss stays eager by design:
+detection losses select with boolean masks, run Hungarian matching, and
+branch on assignment results, none of which a graph can record. The
+optimizer step, gradient clipping, EMA update and LR schedule stay eager
+too.
 
-Two caveats. Launch overhead is highest on Windows; Linux gains are
-smaller (roughly a third to half of the numbers above). And graphs only
-speed up the GPU step: a dataloader-bound run sees no wall-clock change,
-so check `libreyolo profile` first if unsure where the time goes.
+So the ceiling is set by how much of the step is network, and that varies
+enormously by family. Measured on an RTX 5070 Ti at 640 px, batch 8:
 
-## What is captured
+| Family | Network share of the step | Ceiling if the network were free |
+| --- | --- | --- |
+| yolo9-t | 84% | 6.1x |
+| yolo7-b | 44% | 1.8x |
+| yolox-t | 31% | 1.5x |
+| rtmdet-t | 26% | 1.3x |
 
-Only the network forward and backward. The loss (data-dependent mask
-selects, Hungarian matching), optimizer step, gradient clipping, EMA
-update and LR schedule stay eager. A graph is valid for exactly one input
-shape: the trainer counts batch shapes and captures once a shape has
-repeated a few times. Batches at any other shape, such as multi-scale
-batches or the last partial batch of an epoch, run eager unchanged.
+YOLOX and RTMDet spend most of a step inside SimOTA and the dynamic
+soft-label assigner, and D-FINE spends most of one inside its aux and
+denoising losses. Capturing the network still helps those families, but
+their bottleneck is the loss, not launches.
 
-Enabling the flag never changes training numerics. YOLO9 trains
-bit-identically to eager; RF-DETR matches within its own eager
-run-to-run noise (its deformable-attention backward uses atomic
-accumulation, so even two identical seeded eager runs differ slightly).
-`tests/unit/test_cuda_graph_training.py` gates both.
+## Measured speedups
 
-Multi-scale training composes with capture (one recurring shape gets the
-graph, other scales run eager), but most of the benefit comes from
-static-shape runs; pass `multi_scale=False` for RF-DETR when you want the
-full speedup.
+RTX 5070 Ti, Windows, AMP, generated data (no dataloader bottleneck),
+fastest step of 24 after warm-up. Detection runs at 640 px, classification
+at 224 px.
+
+| Family | Size | Batch | Eager | Graphed | Speedup | Numerics |
+| --- | --- | --- | --- | --- | --- | --- |
+| fomo | s | 16 | 7.0 ms | 1.9 ms | **3.63x** | 1 ULP |
+| mobilenetv4 | s | 16 | 14.5 ms | 5.3 ms | **2.74x** | exact |
+| efficientnetv2 | b0 | 16 | 29.0 ms | 11.9 ms | **2.44x** | exact |
+| yolo9 | t | 8 | 93.6 ms | 47.0 ms | **1.99x** | exact |
+| yolo9_e2e | t | 8 | 114.7 ms | 65.3 ms | 1.76x | exact |
+| yolo9_p2 | t | 8 | 150.0 ms | 101.0 ms | 1.49x | exact |
+| nafnet | s | 8 | 132.5 ms | 105.5 ms | 1.26x | exact |
+| resnet | 18 | 16 | 9.5 ms | 7.6 ms | 1.25x | exact |
+| picodet | s | 8 | 145.0 ms | 118.7 ms | 1.22x | exact |
+| deim | n | 4 | 187.5 ms | 158.3 ms | 1.18x | eager noise |
+| rtdetrv4 | s | 4 | 187.0 ms | 158.5 ms | 1.18x | eager noise |
+| yolonas | s | 8 | 87.3 ms | 74.4 ms | 1.17x | exact |
+| dfine | n | 4 | 185.3 ms | 159.2 ms | 1.16x | eager noise |
+| deimv2 | atto | 4 | 124.8 ms | 107.5 ms | 1.16x | eager noise |
+| rfdetr | n | 4 | 276.3 ms | 239.8 ms | 1.15x | eager noise |
+| rtdetrv2 | r18 | 4 | 95.1 ms | 83.0 ms | 1.15x | eager noise |
+| ec | s | 4 | 216.3 ms | 188.2 ms | 1.15x | eager noise |
+| convnext | t | 16 | 23.1 ms | 20.1 ms | 1.15x | exact |
+| yolox | t | 8 | 102.2 ms | 90.5 ms | 1.13x | exact |
+| segformer | b0 | 8 | 60.1 ms | 53.7 ms | 1.12x | own RNG stream |
+| rtdetr | r18 | 4 | 97.6 ms | 87.0 ms | 1.12x | eager noise |
+| rtmdet | t | 8 | 149.7 ms | 136.2 ms | 1.10x | float rounding |
+| yolo7 | b | 4 | 102.5 ms | 98.0 ms | 1.05x | exact |
+| lingbotvision | s | 8 | 34.4 ms | 33.1 ms | 1.04x | 1 ULP |
+
+Three things move these numbers:
+
+- **Batch size.** Small batches are launch-bound, large ones are
+  compute-bound. RT-DETR-r18 gains 1.19x at batch 2 and 1.04x at batch 8.
+- **Platform.** Launch overhead is highest on Windows; Linux gains are
+  roughly a third to half of the above.
+- **The dataloader.** Graphs only speed up the GPU step. A dataloader-bound
+  run sees no wall-clock change, so check `libreyolo profile` first if you
+  are not sure where the time goes.
+
+## Numerics
+
+The four "Numerics" values above mean:
+
+- **exact**: the graphed run reproduces the eager loss trajectory bit for
+  bit. Most families.
+- **1 ULP**: differs in the last bit of float32 (about 1e-7 relative) from
+  a different summation order.
+- **eager noise**: the family does not reproduce its *own* eager run
+  either: deformable attention accumulates its backward with atomics, and
+  TF32 convolutions pick a reduction order per launch. The graphed run stays
+  inside that spread, and at step 0 its gradients differ from eager by the
+  same magnitude two eager runs differ from each other.
+- **float rounding** (RTMDet only): RTMDet shares its head convolutions
+  across all three pyramid levels, so those two weights' gradient is a sum
+  of three contributions. Eager autograd and the graphed backward sum them
+  in a different order, which under fp16 differs in the last bits: 137 of
+  139 gradients stay bit-identical and the other two differ by about 3e-4
+  relative. The dynamic assigner's discrete choices then amplify that over
+  a run.
+- **own RNG stream** (SegFormer only): its MiT encoder has stochastic depth
+  inside the captured region. Capture does not disable it, but a replayed
+  graph consumes the generator on its own schedule, so it does not reproduce
+  the sequence an eager step would draw. The run is statistically equivalent
+  to eager, in the same way a different seed is. The manager logs this once
+  at capture time for any family it applies to.
+
+`tests/unit/test_cuda_graph_training.py` gates the dispatch and gating
+rules; `tests/e2e/test_cuda_graph_training_families.py` runs real two-epoch
+trainings per family and holds each one to the tolerance documented here.
+
+## Shapes
+
+A graph is valid for exactly the input shape it was captured with. The
+trainer counts batch shapes and captures once a shape has repeated three
+times. Batches at any other shape (multi-scale batches, the last partial
+batch of an epoch) run eager, unchanged.
+
+This matters for the DETR families, which resize every batch by default:
+with `multi_scale=True` a short run may never see one shape often enough to
+capture at all. Pass `multi_scale=False` when you want the full speedup.
+
+Some families change what the captured region computes partway through a
+run. YOLOX turns on its L1 regression branch when mosaic closes
+(`no_aug_epochs`), which adds tensors to the network's output; the trainer
+invalidates the capture at that point and re-captures once the new shape has
+settled. A family hook that does something similar should call
+`self.invalidate_cuda_graph(reason)`.
 
 ## Supported families
 
-| Family | Task | Support |
-| --- | --- | --- |
-| yolo9 (and yolo9_p2) | detect | yes |
-| rfdetr | detect | yes |
-| all others / other tasks | | eager fallback with a warning |
+| Task | Families |
+| --- | --- |
+| detect | yolo9, yolo9_p2, yolo9_e2e, yolox, yolo7, yolonas, picodet, rtmdet, rfdetr, dfine, deim, deimv2, rtdetr, rtdetrv2, rtdetrv4, ec |
+| classify | resnet, convnext, mobilenetv4, efficientnetv2 |
+| semantic | segformer, lingbotvision |
+| point | fomo |
+| restore | nafnet |
 
-Unsupported configurations downgrade to plain eager training with a
-single log message; `cuda_graph=True` is always safe to pass. Not
-supported in this version: distributed (DDP) runs, distillation runs, and
-non-detect tasks. Any capture failure at runtime also falls back to eager
-for the rest of the run.
+Everything else, meaning other tasks on the families above, families not
+listed, distributed (DDP) runs and distillation runs, downgrades to plain eager
+training with a single log message. Any capture failure at runtime also
+falls back to eager for the rest of the run.
+
+For the encoder-decoder detectors (D-FINE, DEIM, DEIMv2, RT-DETR v1/v2/v4,
+EC) only the backbone and encoder are captured. Their decoder reads the
+ground truth to build contrastive-denoising queries, and the number of those
+queries comes from the largest ground-truth count in the batch, so the
+decoder's token count changes from batch to batch.
 
 ## Adding a family
 
 Implement `cuda_graph_train_spec` on the family trainer, returning a
 `CudaGraphTrainSpec` from `libreyolo.training.cuda_graph`:
 
-- `network`: a `GraphableNetwork` wrapping the model. Its forward must be
-  target-free and static-shaped for a fixed input shape (no host syncs,
-  no data-dependent shapes; constants created per call must be cached,
-  see `_cached_spatial_shapes` in the RF-DETR transformer for the
-  pattern).
-- `assemble(flat, imgs, targets, polygons)`: rebuild the network output
-  (`network.rebuild(flat)`) and run the family's loss exactly as
-  `on_forward` would, returning the same outputs dict.
+- `network`: a `GraphableNetwork` wrapping the capturable half. Its forward
+  must take images only and be static-shaped for a fixed input shape: no
+  host syncs, no data-dependent shapes, and no host-to-device copies of
+  unpinned CPU tensors (a `torch.arange(...).to(device)` or
+  `torch.zeros(...).type_as(x)` inside the forward is illegal during capture
+  so build those on the target device, see `YOLOXHead.forward_train_maps`).
+- `assemble(flat, imgs, targets, polygons)`: rebuild the network output with
+  `network.rebuild(flat)` and run the family's loss exactly as `on_forward`
+  would, returning the same outputs dict.
+
+Prefer factoring the eager remainder into a method both `on_forward` and
+`assemble` call, so the two paths cannot drift. Three shared mixins already
+cover the common shapes:
+
+| Mixin | Covers |
+| --- | --- |
+| `models/base/classify_cuda_graph.py` | `logits = model(imgs)` + cross-entropy |
+| `models/base/semantic_cuda_graph.py` | networks exposing `forward_logits` / `loss_from_logits` |
+| `models/base/detr_cuda_graph.py` | `backbone -> encoder -> decoder(feats, targets)` |
 
 Gate the spec on task and model type so derived heads with different loss
-boundaries are excluded, and add a parity test comparing eager and
-graphed loss trajectories before enabling.
+boundaries are excluded, return `None` for anything unverified, and add the
+family to `tests/e2e/test_cuda_graph_training_families.py` with a measured
+tolerance before enabling it.
+
+One trap worth knowing: a family trainer that overrides `_train_epoch` must
+call `self._forward_train(imgs, targets, polygons)`, not `self.on_forward`.
+`on_forward` is the eager path; `_forward_train` is the one that routes
+through the graph. D-FINE and DEIM copied the base loop and called
+`on_forward`, which made `cuda_graph=True` a silent no-op for five families.
 
 ## Memory
 
 A captured graph pins static input, output and workspace buffers for the
-forward and backward pass, so peak VRAM rises roughly by one extra set of
-activations for the captured shape. If that pushes a run over the limit,
-reduce batch size or leave the flag off.
+forward and backward pass, so peak VRAM rises by roughly one extra set of
+activations for the captured shape. Measured across the families above, peak
+allocation moved between −5% and +19%; the relative cost is largest for the
+small classification models, whose activations are small to begin with
+(ResNet-18 at 224 px, batch 16: 0.48 GB eager, 0.57 GB graphed), and is
+negligible for the detectors. If it pushes a run over the limit, reduce the
+batch size or leave the flag off.

--- a/docs/training_cuda_graphs.md
+++ b/docs/training_cuda_graphs.md
@@ -100,7 +100,38 @@ Three things move these numbers:
   run sees no wall-clock change, so check `libreyolo profile` first if you
   are not sure where the time goes.
 
+### Without AMP
+
+Everything above is measured under AMP, the default. Capture engages the same
+way at `amp=False`, but the balance shifts: fp32 kernels run longer, so a step
+is less launch-bound and most families gain less. A few gain more.
+
+| Family | Batch | AMP | fp32 |
+| --- | --- | --- | --- |
+| mobilenetv4-s | 16 | 2.74x | 3.61x |
+| fomo-s | 16 | 3.63x | 3.06x |
+| yolo9-t | 8 | 1.99x | 1.69x |
+| yolo9_e2e-t | 8 | 1.76x | 1.52x |
+| picodet-s | 8 | 1.22x | 1.15x |
+| dfine-n | 4 | 1.16x | 1.13x |
+| yolox-t | 8 | 1.13x | 1.08x |
+| nafnet-s | 8 | 1.26x | 1.08x |
+| resnet-18 | 16 | 1.25x | 1.05x |
+| rtmdet-t | 8 | 1.10x | 1.04x |
+| yolonas-s | 8 | 1.17x | 1.03x |
+| rtdetr-r18 | 4 | 1.12x | 0.99x |
+
 ## Numerics
+
+**The parity column below is measured under AMP.** At `amp=False` these
+families do not reproduce their own eager runs on this hardware, with or
+without capture: two identical seeded eager YOLO9-t runs diverge by 36%
+relative over 20 steps, and YOLOX-t by 2.6%. cuDNN picks a nondeterministic
+weight-gradient algorithm for some fp32 convolution shapes (measured directly:
+two back-to-back fp32 wgrads on one 8x64x160x160 convolution differ by 3.2e-7
+relative), and a training loop compounds that. Turning TF32 off does not fix
+it. So at fp32 "bit-identical" is not an available guarantee for anything,
+and the graph is not what takes it away.
 
 The four "Numerics" values above mean:
 
@@ -127,9 +158,21 @@ The four "Numerics" values above mean:
   to eager, in the same way a different seed is. The manager logs this once
   at capture time for any family it applies to.
 
+The sharpest evidence is per-parameter, at step 0, where both arms provably
+hold identical weights: the loss is bit-identical for every one of the 24
+families, and no BatchNorm buffer differs. Gradients are bit-identical too
+for yolo9 (583/583), yolo9_p2 (775/775), yolo9_e2e (693/693), yolox
+(219/219), yolonas (460/460), picodet (369/369), yolo7 (271/271) and deimv2
+(298/300). D-FINE, DEIM and RT-DETRv2 look far worse (112/400, 113/422,
+95/312) until the same comparison is run eager against eager, which gives
+116/400, 117/422 and 98/312: those families reproduce barely a quarter of
+their own gradients, and capture moves 3 or 4 more out of several hundred.
+
 `tests/unit/test_cuda_graph_training.py` gates the dispatch and gating
 rules; `tests/e2e/test_cuda_graph_training_families.py` runs real two-epoch
-trainings per family and holds each one to the tolerance documented here.
+trainings per family and holds each one to the tolerance documented here,
+plus layer freezing, resume-from-checkpoint, gradient accumulation,
+validation with a live graph, and capture failing mid-run.
 
 ## Shapes
 

--- a/docs/training_cuda_graphs.md
+++ b/docs/training_cuda_graphs.md
@@ -42,9 +42,11 @@ their bottleneck is the loss, not launches.
 
 ## Measured speedups
 
-RTX 5070 Ti, Windows, AMP, generated data (no dataloader bottleneck),
-fastest step of 24 after warm-up. Detection runs at 640 px, classification
-at 224 px.
+RTX 5070 Ti, Windows, AMP. Each arm runs in its own process from a shared
+saved state (identical weights, optimizer momentum, GradScaler scale and
+input batch), replaying one real batch so the dataloader is out of the loop
+and what is compared is the GPU step. Figures are the fastest of 24 steps
+after warm-up. Detection runs at 640 px, classification at 224 px.
 
 | Family | Size | Batch | Eager | Graphed | Speedup | Numerics |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -72,6 +74,21 @@ at 224 px.
 | rtmdet | t | 8 | 149.7 ms | 136.2 ms | 1.10x | float rounding |
 | yolo7 | b | 4 | 102.5 ms | 98.0 ms | 1.05x | exact |
 | lingbotvision | s | 8 | 34.4 ms | 33.1 ms | 1.04x | 1 ULP |
+
+### End to end
+
+The table above isolates the GPU step. A complete fine-tune also pays for
+the dataloader and for validation, so the wall-clock gain is smaller. YOLO9-t
+on a 406-image detection set, 20 epochs, batch 8, 640 px, 4 dataloader
+workers:
+
+| | Eager | Graphed |
+| --- | --- | --- |
+| Wall clock | 428.4 s | 367.7 s (**1.16x**) |
+| Mean epoch | 21.0 s | 18.1 s |
+| mAP50-95 | 0.6394 | 0.6394 |
+| mAP50 | 0.9403 | 0.9403 |
+| Per-epoch losses | | identical to eager |
 
 Three things move these numbers:
 

--- a/libreyolo/models/base/classify_cuda_graph.py
+++ b/libreyolo/models/base/classify_cuda_graph.py
@@ -1,0 +1,49 @@
+"""CUDA-graph training capture for the plain-softmax classification families.
+
+ResNet, ConvNeXt, MobileNetV4 and EfficientNetV2 share one training step:
+``logits = model(imgs)`` followed by ``F.cross_entropy(logits, targets)``.
+The forward never reads the labels, so the whole backbone-plus-head is
+static-shaped and capturable, and only the cross-entropy stays eager. One
+mixin therefore covers the group; per-family trainers just inherit it.
+
+Cross-entropy is cheap next to the backbone, so these families sit at the
+favourable end of the capture trade-off: nearly the entire step is inside
+the graph.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+__all__ = ["ClassifyCudaGraphMixin"]
+
+
+class ClassifyCudaGraphMixin:
+    """Provide ``cuda_graph_train_spec`` for cross-entropy classification.
+
+    Mixed in ahead of ``BaseTrainer`` so it overrides the base hook, which
+    returns ``None`` (eager) for families that have not opted in.
+    """
+
+    def cuda_graph_train_spec(self):
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "classify")
+        if task != "classify":
+            return None
+        model = getattr(self, "model", None)
+        if not isinstance(model, torch.nn.Module):
+            return None
+
+        network = GraphableNetwork(model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            logits = network.rebuild(flat)
+            loss = F.cross_entropy(logits, targets)
+            return {"total_loss": loss, "loss_ce": loss.detach()}
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/base/detr_cuda_graph.py
+++ b/libreyolo/models/base/detr_cuda_graph.py
@@ -1,0 +1,180 @@
+"""CUDA-graph training capture for the encoder-decoder detector families.
+
+D-FINE, DEIM, DEIMv2, RT-DETR, RT-DETRv2, RT-DETRv4 and EC all share one
+network shape::
+
+    feats = backbone(images)
+    feats = encoder(feats)
+    out   = decoder(feats, targets=...)
+
+Only the first two stages can be captured. The decoder reads the ground
+truth to build contrastive-denoising queries, and the number of those
+queries is derived from the largest ground-truth count in the batch, so the
+decoder's token count changes from batch to batch — the one thing a CUDA
+graph cannot tolerate. The Hungarian criterion after it is host-side by
+nature.
+
+So the split is backbone + encoder inside the graph, decoder + criterion
+eager. That is roughly a fifth to a quarter of the step for these families:
+the win is real at small batch sizes, where the backbone is launch-bound,
+and fades at large ones, where it is compute-bound.
+
+Neither half is reimplemented here, on purpose. The capturable half runs the
+family's *own* ``forward`` with the decoder stubbed out, so per-family
+details (D-FINE splitting a low-level feature map off the backbone before
+the encoder, EC handing an encoder map to a mask head) are honoured without
+this module knowing about them. The eager half swaps ``forward`` for one
+that resumes at the decoder and then calls the family's own ``on_forward``,
+so target conversion and loss aggregation stay in one place per family and
+cannot drift from the eager path.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Tuple
+
+import torch
+from torch import nn
+
+__all__ = ["DETREncoderCudaGraphMixin"]
+
+
+@contextmanager
+def _patched_forward(module: nn.Module, replacement) -> Iterator[None]:
+    """Swap ``module.forward`` for ``replacement`` inside the block.
+
+    Patched on the instance, so the class is untouched and other models of
+    the same family in this process are unaffected. Removed rather than
+    reassigned on exit, or the instance would keep a shadow of the class
+    forward forever. ``nn.Module.__call__`` reads ``self.forward``, so hooks
+    and autograd behave exactly as they do for the real method.
+    """
+    had_own = "forward" in module.__dict__
+    original = module.__dict__.get("forward")
+    module.forward = replacement
+    try:
+        yield
+    finally:
+        if had_own:
+            module.forward = original
+        else:
+            del module.forward
+
+
+class _BackboneEncoder(nn.Module):
+    """The capturable half: everything the family's forward does before the
+    decoder.
+
+    Rather than re-deriving that prefix, this runs the real forward with the
+    decoder stubbed out and keeps whatever the model handed it. The decoder
+    call's positional ``feats`` become the graph's outputs; so do any tensor
+    keyword arguments, unless the model passed one of the feats itself (EC
+    hands ``feats[0]`` to its mask head), in which case the position is
+    recorded and the tensor is not duplicated in the output tuple.
+
+    The recorded layout is fixed after the first call. That is safe because
+    capture warm-up runs this eagerly before recording, and the model's
+    forward takes the same branch for every batch at a fixed input shape.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+        # (kwarg name, ("feat", index) | ("extra", index)), set on first call.
+        self.kwarg_layout: List[Tuple[str, Tuple[str, int]]] = []
+        self.num_feats: int = 0
+
+    def forward(self, imgs: torch.Tensor) -> Tuple[torch.Tensor, ...]:
+        grabbed: Dict[str, Any] = {}
+
+        def stub(feats, targets=None, **kwargs):
+            grabbed["feats"] = list(feats)
+            grabbed["kwargs"] = dict(kwargs)
+            # The real return value is discarded: the caller only wants what
+            # reached the decoder. An empty tuple keeps every family's
+            # ``return self.decoder(...)`` valid.
+            return ()
+
+        with _patched_forward(self.model.decoder, stub):
+            self.model(imgs, targets=None)
+
+        feats = grabbed["feats"]
+        kwargs = grabbed["kwargs"]
+        extras: List[torch.Tensor] = []
+        layout: List[Tuple[str, Tuple[str, int]]] = []
+        for name, value in kwargs.items():
+            if not torch.is_tensor(value):
+                continue
+            shared = next(
+                (i for i, f in enumerate(feats) if f is value),
+                None,
+            )
+            if shared is not None:
+                layout.append((name, ("feat", shared)))
+            else:
+                layout.append((name, ("extra", len(extras))))
+                extras.append(value)
+        self.kwarg_layout = layout
+        self.num_feats = len(feats)
+        return (*feats, *extras)
+
+    def split(self, flat: List[torch.Tensor]):
+        """Undo :meth:`forward`'s packing: (feats, decoder kwargs)."""
+        feats = flat[: self.num_feats]
+        extras = flat[self.num_feats :]
+        kwargs = {
+            name: (feats[index] if kind == "feat" else extras[index])
+            for name, (kind, index) in self.kwarg_layout
+        }
+        return feats, kwargs
+
+
+class DETREncoderCudaGraphMixin:
+    """Provide ``cuda_graph_train_spec`` for the encoder-decoder detectors.
+
+    Mixed in ahead of ``BaseTrainer`` so it overrides the base hook. Families
+    whose model lacks the ``backbone``/``encoder``/``decoder`` trio, or which
+    run a non-detect task, fall back to eager.
+    """
+
+    # Tasks whose loss reaches past this boundary in ways the split does not
+    # cover (segmentation feeds an encoder map to a mask head and carries
+    # mask targets, pose adds keypoint targets). Detect only, for now.
+    _CUDA_GRAPH_TASKS: Tuple[str, ...] = ("detect",)
+
+    def cuda_graph_train_spec(self):
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        # getattr default keeps partially-constructed trainers (test doubles,
+        # subclasses skipping the mixin's own __init__ path) on the eager
+        # route rather than raising out of the spec resolution.
+        if task not in getattr(self, "_CUDA_GRAPH_TASKS", ("detect",)):
+            return None
+        model = getattr(self, "model", None)
+        raw = getattr(model, "module", model)
+        if not isinstance(raw, nn.Module):
+            return None
+        if not all(hasattr(raw, name) for name in ("backbone", "encoder", "decoder")):
+            return None
+        if getattr(self, "criterion", None) is None:
+            return None
+
+        adapter = _BackboneEncoder(raw)
+        network = GraphableNetwork(adapter)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            feats, decoder_kwargs = adapter.split(list(network.rebuild(flat)))
+
+            def resume(_imgs, targets=None, **kwargs):
+                kwargs.update(decoder_kwargs)
+                return raw.decoder(feats, targets=targets, **kwargs)
+
+            with _patched_forward(raw, resume):
+                return self.on_forward(imgs, targets, polygons=polygons)
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/base/detr_cuda_graph.py
+++ b/libreyolo/models/base/detr_cuda_graph.py
@@ -56,10 +56,10 @@ def _patched_forward(module: nn.Module, replacement) -> Iterator[None]:
     try:
         yield
     finally:
-        if had_own:
+        if had_own and original is not None:
             module.forward = original
         else:
-            del module.forward
+            module.__dict__.pop("forward", None)
 
 
 class _BackboneEncoder(nn.Module):

--- a/libreyolo/models/base/semantic_cuda_graph.py
+++ b/libreyolo/models/base/semantic_cuda_graph.py
@@ -1,0 +1,66 @@
+"""CUDA-graph training capture for the dense-logits semantic families.
+
+SegFormer and LingBot-Vision train the same way: encode the image, predict
+per-class logits at the network's native (patch or stride-4) resolution,
+upsample to the label grid, then cross-entropy with an ignore index. Only
+the first half can be captured — the upsample target size comes from the
+labels, and the all-pixels-ignored guard is a host sync.
+
+A family opts in by exposing that split on its network module:
+
+``forward_logits(images) -> logits``
+    Pure function of the input at a fixed input shape.
+``loss_from_logits(logits, targets) -> {"total_loss": ..., ...}``
+    The eager remainder, called by the family's own ``forward`` too, so the
+    graphed and eager paths cannot drift.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+__all__ = ["SemanticLogitsCudaGraphMixin"]
+
+
+class _LogitsOnly(nn.Module):
+    """Adapter exposing ``forward_logits`` as a plain forward for capture."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, imgs: torch.Tensor) -> torch.Tensor:
+        return self.model.forward_logits(imgs)
+
+
+class SemanticLogitsCudaGraphMixin:
+    """Provide ``cuda_graph_train_spec`` for dense-logits semantic training.
+
+    Mixed in ahead of ``BaseTrainer`` so it overrides the base hook. Returns
+    ``None`` — plain eager training — for any other task, or for a network
+    that does not expose the two-method split.
+    """
+
+    def cuda_graph_train_spec(self):
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", None)
+        if task != "semantic":
+            return None
+        model = getattr(self, "model", None)
+        raw = getattr(model, "module", model)
+        if not isinstance(raw, nn.Module):
+            return None
+        if not (hasattr(raw, "forward_logits") and hasattr(raw, "loss_from_logits")):
+            return None
+
+        network = GraphableNetwork(_LogitsOnly(raw))
+
+        def assemble(flat, imgs, targets, polygons=None):
+            return raw.loss_from_logits(network.rebuild(flat), targets)
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/convnext/trainer.py
+++ b/libreyolo/models/convnext/trainer.py
@@ -16,11 +16,12 @@ import torch.nn.functional as F
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
+from ..base.classify_cuda_graph import ClassifyCudaGraphMixin
 from ..base.classify_validation_loss import ClassifyValidationLossMixin
 from .config import ConvNeXtConfig
 
 
-class ConvNeXtTrainer(ClassifyValidationLossMixin, BaseTrainer):
+class ConvNeXtTrainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin, BaseTrainer):
     """Cross-entropy fine-tuning trainer for ConvNeXt classification."""
 
     # Non-detect task: select the best checkpoint by top-1 accuracy.

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -54,9 +54,10 @@ from .transforms import (
     DEIMPassThroughDataset,
     DEIMTrainTransform,
 )
+from ..base.detr_cuda_graph import DETREncoderCudaGraphMixin
 
 
-class DEIMTrainer(BaseTrainer):
+class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
     # DEIM shares D-FINE's architecture shape: CNN (HGNetv2) backbone plus a
     # transformer encoder/decoder with nn.Linear projections. lora=True
     # freezes the backbone and the transformer base weights and trains LoRA
@@ -565,7 +566,7 @@ class DEIMTrainer(BaseTrainer):
 
             if self.scaler is not None:
                 with self._autocast_context():
-                    outputs = self.on_forward(imgs, targets, polygons=polygons)
+                    outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"]
                 self.optimizer.zero_grad()
                 self.scaler.scale(loss).backward()
@@ -577,7 +578,7 @@ class DEIMTrainer(BaseTrainer):
                 self.scaler.step(self.optimizer)
                 self.scaler.update()
             else:
-                outputs = self.on_forward(imgs, targets, polygons=polygons)
+                outputs = self._forward_train(imgs, targets, polygons)
                 loss = outputs["total_loss"]
                 self.optimizer.zero_grad()
                 loss.backward()
@@ -684,7 +685,7 @@ class DEIMTrainer(BaseTrainer):
 
             if self.scaler is not None:
                 with self._autocast_context():
-                    outputs = self.on_forward(imgs, targets, polygons=polygons)
+                    outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"] / actual_window
                 self.scaler.scale(loss).backward()
                 if is_opt_step:
@@ -696,7 +697,7 @@ class DEIMTrainer(BaseTrainer):
                     self.scaler.step(self.optimizer)
                     self.scaler.update()
             else:
-                outputs = self.on_forward(imgs, targets, polygons=polygons)
+                outputs = self._forward_train(imgs, targets, polygons)
                 loss = outputs["total_loss"] / actual_window
                 loss.backward()
                 if is_opt_step:

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -62,11 +62,12 @@ from .transforms import (
     DFINEPassThroughDataset,
     DFINETrainTransform,
 )
+from ..base.detr_cuda_graph import DETREncoderCudaGraphMixin
 
 logger = logging.getLogger(__name__)
 
 
-class DFINETrainer(BaseTrainer):
+class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
     # D-FINE pairs a CNN (HGNetv2) backbone with a transformer encoder/decoder
     # whose projections are nn.Linear layers. lora=True freezes the backbone
     # and the transformer base weights and trains LoRA adapters on the
@@ -638,7 +639,7 @@ class DFINETrainer(BaseTrainer):
 
             if self.scaler is not None:
                 with self._autocast_context():
-                    outputs = self.on_forward(imgs, targets, polygons=polygons)
+                    outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"]
                 self.optimizer.zero_grad()
                 self.scaler.scale(loss).backward()
@@ -650,7 +651,7 @@ class DFINETrainer(BaseTrainer):
                 self.scaler.step(self.optimizer)
                 self.scaler.update()
             else:
-                outputs = self.on_forward(imgs, targets, polygons=polygons)
+                outputs = self._forward_train(imgs, targets, polygons)
                 loss = outputs["total_loss"]
                 self.optimizer.zero_grad()
                 loss.backward()
@@ -757,7 +758,7 @@ class DFINETrainer(BaseTrainer):
 
             if self.scaler is not None:
                 with self._autocast_context():
-                    outputs = self.on_forward(imgs, targets, polygons=polygons)
+                    outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"] / actual_window
                 self.scaler.scale(loss).backward()
                 if is_opt_step:
@@ -769,7 +770,7 @@ class DFINETrainer(BaseTrainer):
                     self.scaler.step(self.optimizer)
                     self.scaler.update()
             else:
-                outputs = self.on_forward(imgs, targets, polygons=polygons)
+                outputs = self._forward_train(imgs, targets, polygons)
                 loss = outputs["total_loss"] / actual_window
                 loss.backward()
                 if is_opt_step:

--- a/libreyolo/models/efficientnetv2/trainer.py
+++ b/libreyolo/models/efficientnetv2/trainer.py
@@ -16,11 +16,12 @@ import torch.nn.functional as F
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
+from ..base.classify_cuda_graph import ClassifyCudaGraphMixin
 from ..base.classify_validation_loss import ClassifyValidationLossMixin
 from .config import EfficientNetV2Config
 
 
-class EfficientNetV2Trainer(ClassifyValidationLossMixin, BaseTrainer):
+class EfficientNetV2Trainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin, BaseTrainer):
     """Cross-entropy fine-tuning trainer for EfficientNetV2 classification."""
 
     # Non-detect task: select the best checkpoint by top-1 accuracy.

--- a/libreyolo/models/fomo/trainer.py
+++ b/libreyolo/models/fomo/trainer.py
@@ -158,6 +158,41 @@ class FOMOTrainer(BaseTrainer):
 
         return self._loss_fn(logits, targets.long())
 
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the whole network, keep the loss eager.
+
+        FOMO's forward is a plain convolutional stack over images only, so
+        the network is static-shaped for a fixed batch; the centroid loss
+        (which reads the label grid) stays eager. The grid-shape check in
+        ``on_forward`` is reproduced here so a mismatched ``imgsz`` still
+        fails loudly instead of capturing a wrong graph.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "point")
+        if task != "point":
+            return None
+        if not isinstance(self.model, torch.nn.Module):
+            return None
+        if getattr(self, "_loss_fn", None) is None:
+            return None
+
+        network = GraphableNetwork(self.model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            logits = network.rebuild(flat)
+            if logits.shape[-2:] != targets.shape[-2:]:
+                raise ValueError(
+                    f"Model output grid {tuple(logits.shape[-2:])} does not "
+                    f"match target grid {tuple(targets.shape[-2:])}."
+                )
+            return self._loss_fn(logits, targets.long())
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)
+
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:
         return {"ce": float(outputs.get("ce", 0.0))}
 

--- a/libreyolo/models/lingbotvision/nn.py
+++ b/libreyolo/models/lingbotvision/nn.py
@@ -298,27 +298,41 @@ class LingBotVisionSemanticSegmenter(nn.Module):
         if module.bias is not None:
             nn.init.zeros_(module.bias)
 
-    def forward(self, x: Tensor, targets: Optional[Tensor] = None):
+    def forward_logits(self, x: Tensor) -> Tensor:
+        """Normalise, encode and predict the patch-resolution logits.
+
+        The boundary the CUDA-graph training capture splits on: a pure
+        function of the input at a fixed input shape. Upsampling to the
+        label grid, the all-ignored check (a host sync) and cross-entropy
+        read the labels and stay eager.
+        """
         x = (x - self._mean.to(x.dtype)) / self._std.to(x.dtype)
         _, patch_tokens = self.backbone(x)
         B, N, D = patch_tokens.shape
         h = x.shape[-2] // self.backbone.patch_size
         w = x.shape[-1] // self.backbone.patch_size
         feat = patch_tokens.transpose(1, 2).reshape(B, D, h, w)
-        logits = self.predict(feat)
+        return self.predict(feat)
+
+    def loss_from_logits(self, logits: Tensor, targets: Tensor) -> dict:
+        """Cross-entropy at the label resolution, from patch-resolution logits."""
+        logits_full = F.interpolate(
+            logits.float(), size=targets.shape[-2:], mode="bilinear", align_corners=False
+        )
+        targets = targets.long()
+        if bool((targets != self.IGNORE_INDEX).any()):
+            loss = F.cross_entropy(logits_full, targets, ignore_index=self.IGNORE_INDEX)
+        else:
+            # cross_entropy returns NaN when every pixel is ignored; emit a
+            # finite zero that still carries a grad_fn.
+            loss = logits_full.sum() * 0.0
+        return {"total_loss": loss, "sem": loss}
+
+    def forward(self, x: Tensor, targets: Optional[Tensor] = None):
+        logits = self.forward_logits(x)
 
         if self.training and targets is not None:
-            logits_full = F.interpolate(
-                logits.float(), size=targets.shape[-2:], mode="bilinear", align_corners=False
-            )
-            targets = targets.long()
-            if bool((targets != self.IGNORE_INDEX).any()):
-                loss = F.cross_entropy(logits_full, targets, ignore_index=self.IGNORE_INDEX)
-            else:
-                # cross_entropy returns NaN when every pixel is ignored; emit a
-                # finite zero that still carries a grad_fn.
-                loss = logits_full.sum() * 0.0
-            return {"total_loss": loss, "sem": loss}
+            return self.loss_from_logits(logits, targets)
 
         return {"semantic_logits": logits}
 

--- a/libreyolo/models/lingbotvision/trainer.py
+++ b/libreyolo/models/lingbotvision/trainer.py
@@ -19,12 +19,15 @@ from ...training.config import LingBotVisionConfig, TrainConfig
 from ...training.distributed import is_main_process, unwrap_model
 from ...training.scheduler import FlatCosineScheduler, LinearLRScheduler
 from ...training.trainer import BaseTrainer
+from ..base.semantic_cuda_graph import SemanticLogitsCudaGraphMixin
 from ..base.semantic_validation_loss import SemanticValidationLossMixin
 
 logger = logging.getLogger(__name__)
 
 
-class LingBotVisionTrainer(SemanticValidationLossMixin, BaseTrainer):
+class LingBotVisionTrainer(
+    SemanticLogitsCudaGraphMixin, SemanticValidationLossMixin, BaseTrainer
+):
     """Trainer for the LibreLingBotVision semantic-segmentation family."""
 
     best_metric_key: str = "metrics/mIoU"

--- a/libreyolo/models/mobilenetv4/trainer.py
+++ b/libreyolo/models/mobilenetv4/trainer.py
@@ -16,11 +16,12 @@ import torch.nn.functional as F
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
+from ..base.classify_cuda_graph import ClassifyCudaGraphMixin
 from ..base.classify_validation_loss import ClassifyValidationLossMixin
 from .config import MobileNetV4Config
 
 
-class MobileNetV4Trainer(ClassifyValidationLossMixin, BaseTrainer):
+class MobileNetV4Trainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin, BaseTrainer):
     """Cross-entropy fine-tuning trainer for MobileNetV4 classification."""
 
     # Non-detect task: select the best checkpoint by top-1 accuracy.

--- a/libreyolo/models/nafnet/trainer.py
+++ b/libreyolo/models/nafnet/trainer.py
@@ -107,11 +107,47 @@ class NAFNetTrainer(BaseTrainer):
     ) -> Dict[str, torch.Tensor]:
         del polygons
         pred = self.model(imgs)
+        return self._restore_loss(pred, targets)
+
+    def _restore_loss(
+        self, pred: torch.Tensor, targets: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
+        """Charbonnier loss + PSNR over the network's restored image.
+
+        Split out of ``on_forward`` so the CUDA-graph path shares the exact
+        same tail: the graph captures the network only, and this method is
+        the eager remainder for both routes.
+        """
         pred = pred[:, :, : targets.shape[-2], : targets.shape[-1]]
         loss = charbonnier_loss(pred, targets)
         mse = torch.mean((pred.detach() - targets.detach()).pow(2)).clamp_min(1e-12)
         psnr = -10.0 * torch.log10(mse)
         return {"total_loss": loss, "loss_restore": loss.detach(), "psnr": psnr}
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the restoration network, keep the loss eager.
+
+        NAFNet's forward takes only the degraded image, so the network is
+        static-shaped for a fixed crop size; the Charbonnier loss and PSNR
+        readout stay eager.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "restore")
+        if task != "restore":
+            return None
+        if not isinstance(self.model, torch.nn.Module):
+            return None
+
+        network = GraphableNetwork(self.model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            return self._restore_loss(network.rebuild(flat), targets)
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)
 
     def get_loss_components(self, outputs: Dict[str, Any]) -> Dict[str, float]:
         return {

--- a/libreyolo/models/picodet/trainer.py
+++ b/libreyolo/models/picodet/trainer.py
@@ -192,9 +192,13 @@ class PICODETTrainer(BaseTrainer):
             family="picodet",
         )
 
-    def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
-        cls_scores, bbox_preds = self.model(imgs)
+    def _loss_from_head(self, cls_scores, bbox_preds, targets: torch.Tensor) -> Dict:
+        """Run the criterion over raw head outputs.
 
+        Split out of ``on_forward`` so the CUDA-graph path shares the exact
+        same tail: the graph captures the network only, and this method is
+        the eager remainder for both routes.
+        """
         # Targets: (B, max_labels, 5) [class, cx, cy, w, h] in pixel coords,
         # zero-padded. Convert to per-image (gt_boxes_xyxy, gt_labels) lists.
         gt_boxes_list = []
@@ -217,3 +221,36 @@ class PICODETTrainer(BaseTrainer):
             gt_labels_list.append(cls)
 
         return self._loss_fn(cls_scores, bbox_preds, gt_boxes_list, gt_labels_list)
+
+    def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
+        cls_scores, bbox_preds = self.model(imgs)
+        return self._loss_from_head(cls_scores, bbox_preds, targets)
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the network, keep the SimOTA assigner eager.
+
+        The network forward takes images only, so the boundary is the one
+        ``on_forward`` already uses; ``assemble`` is ``_loss_from_head``,
+        shared verbatim with the eager path.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .nn import LibrePICODETModel
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        if not isinstance(self.model, LibrePICODETModel):
+            return None
+        if getattr(self, "_loss_fn", None) is None:
+            return None
+
+        network = GraphableNetwork(self.model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            cls_scores, bbox_preds = network.rebuild(flat)
+            return self._loss_from_head(cls_scores, bbox_preds, targets)
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/resnet/trainer.py
+++ b/libreyolo/models/resnet/trainer.py
@@ -15,11 +15,12 @@ import torch.nn.functional as F
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
+from ..base.classify_cuda_graph import ClassifyCudaGraphMixin
 from ..base.classify_validation_loss import ClassifyValidationLossMixin
 from .config import ResNetConfig
 
 
-class ResNetTrainer(ClassifyValidationLossMixin, BaseTrainer):
+class ResNetTrainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin, BaseTrainer):
     """Cross-entropy fine-tuning trainer for ResNet classification."""
 
     best_metric_key = "metrics/accuracy_top1"

--- a/libreyolo/models/rtdetr/trainer.py
+++ b/libreyolo/models/rtdetr/trainer.py
@@ -26,6 +26,7 @@ from libreyolo.models.yolo9.transforms import (
 from .config import RTDETRConfig
 from .loss import RTDETRLoss
 from .transforms import RTDETRTrainTransform
+from ..base.detr_cuda_graph import DETREncoderCudaGraphMixin
 
 
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ def convert_targets_for_detr(
     return detr_targets
 
 
-class RTDETRTrainer(BaseTrainer):
+class RTDETRTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
     """RT-DETR-specific trainer."""
 
     # RT-DETR pairs a CNN (PResNet/HGNetv2) backbone with a transformer

--- a/libreyolo/models/rtmdet/trainer.py
+++ b/libreyolo/models/rtmdet/trainer.py
@@ -135,14 +135,13 @@ class RTMDetTrainer(BaseTrainer):
             family="rtmdet",
         )
 
-    def on_forward(
-        self,
-        imgs: torch.Tensor,
-        targets: torch.Tensor,
-        polygons: Optional[List] = None,
-    ) -> Dict:
-        cls_scores, bbox_preds = self.model(imgs)
+    def _loss_from_head(self, cls_scores, bbox_preds, targets: torch.Tensor) -> Dict:
+        """Run the criterion over raw head outputs.
 
+        Split out of ``on_forward`` so the CUDA-graph path shares the exact
+        same tail: the graph captures the network only, and this method is
+        the eager remainder for both routes.
+        """
         # Targets: (B, max_labels, 5) [class, cx, cy, w, h] in pixel coords,
         # zero-padded. Convert to per-image (gt_boxes_xyxy, gt_labels) lists.
         gt_boxes_list = []
@@ -165,3 +164,41 @@ class RTMDetTrainer(BaseTrainer):
             gt_labels_list.append(cls)
 
         return self._loss_fn(cls_scores, bbox_preds, gt_boxes_list, gt_labels_list)
+
+    def on_forward(
+        self,
+        imgs: torch.Tensor,
+        targets: torch.Tensor,
+        polygons: Optional[List] = None,
+    ) -> Dict:
+        cls_scores, bbox_preds = self.model(imgs)
+        return self._loss_from_head(cls_scores, bbox_preds, targets)
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the network, keep the dynamic assigner eager.
+
+        The network forward takes images only, so the boundary is the one
+        ``on_forward`` already uses; ``assemble`` is ``_loss_from_head``,
+        shared verbatim with the eager path.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .nn import LibreRTMDetModel
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        if not isinstance(self.model, LibreRTMDetModel):
+            return None
+        if getattr(self, "_loss_fn", None) is None:
+            return None
+
+        network = GraphableNetwork(self.model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            cls_scores, bbox_preds = network.rebuild(flat)
+            return self._loss_from_head(cls_scores, bbox_preds, targets)
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/segformer/nn.py
+++ b/libreyolo/models/segformer/nn.py
@@ -407,22 +407,37 @@ class LibreSegformerNet(nn.Module):
             nn.init.ones_(module.weight)
             nn.init.zeros_(module.bias)
 
+    def forward_logits(self, x: torch.Tensor) -> torch.Tensor:
+        """Normalise, encode and decode to the head's native-resolution logits.
+
+        The boundary the CUDA-graph training capture splits on: a pure
+        function of the input at a fixed input shape. Everything after it
+        (upsampling to the label grid, the ignore-index check, cross-entropy)
+        depends on the labels and stays eager.
+        """
+        x = (x - self.pixel_mean.to(dtype=x.dtype)) / self.pixel_std.to(dtype=x.dtype)
+        return self.decode_head(self.encoder(x))
+
+    def loss_from_logits(self, logits: torch.Tensor, targets: torch.Tensor) -> dict:
+        """Cross-entropy at the label resolution, from native-resolution logits."""
+        logits = F.interpolate(
+            logits, size=targets.shape[-2:], mode="bilinear", align_corners=False
+        )
+        targets = targets.long()
+        if bool((targets != self.IGNORE_INDEX).any()):
+            loss = F.cross_entropy(logits, targets, ignore_index=self.IGNORE_INDEX)
+        else:
+            # cross_entropy returns NaN when every pixel is ignored; emit a
+            # graph-connected zero so the optimizer step stays sane.
+            loss = logits.sum() * 0.0
+        return {"total_loss": loss, "sem": loss}
+
     def forward(self, x: torch.Tensor, targets: torch.Tensor | None = None):
         h, w = x.shape[-2], x.shape[-1]
-        x = (x - self.pixel_mean.to(dtype=x.dtype)) / self.pixel_std.to(dtype=x.dtype)
-        encoder_hidden_states = self.encoder(x)
-        logits = self.decode_head(encoder_hidden_states)
+        logits = self.forward_logits(x)
 
         if self.training and targets is not None:
-            logits = F.interpolate(logits, size=targets.shape[-2:], mode="bilinear", align_corners=False)
-            targets = targets.long()
-            if bool((targets != self.IGNORE_INDEX).any()):
-                loss = F.cross_entropy(logits, targets, ignore_index=self.IGNORE_INDEX)
-            else:
-                # cross_entropy returns NaN when every pixel is ignored; emit a
-                # graph-connected zero so the optimizer step stays sane.
-                loss = logits.sum() * 0.0
-            return {"total_loss": loss, "sem": loss}
+            return self.loss_from_logits(logits, targets)
 
         return F.interpolate(logits, size=(h, w), mode="bilinear", align_corners=False)
 

--- a/libreyolo/models/segformer/trainer.py
+++ b/libreyolo/models/segformer/trainer.py
@@ -19,12 +19,15 @@ from ...training.config import SegformerConfig, TrainConfig
 from ...training.distributed import is_main_process, unwrap_model
 from ...training.scheduler import FlatCosineScheduler, LinearLRScheduler
 from ...training.trainer import BaseTrainer
+from ..base.semantic_cuda_graph import SemanticLogitsCudaGraphMixin
 from ..base.semantic_validation_loss import SemanticValidationLossMixin
 
 logger = logging.getLogger(__name__)
 
 
-class SegformerTrainer(SemanticValidationLossMixin, BaseTrainer):
+class SegformerTrainer(
+    SemanticLogitsCudaGraphMixin, SemanticValidationLossMixin, BaseTrainer
+):
     """Trainer for the LibreSegformer semantic-segmentation family."""
 
     best_metric_key: str = "metrics/mIoU"

--- a/libreyolo/models/yolo7/net.py
+++ b/libreyolo/models/yolo7/net.py
@@ -145,6 +145,15 @@ class YOLOv7Model(nn.Module):
 
         if targets is None:
             return head_out
+        return self.compute_loss(head_out, targets)
+
+    def compute_loss(self, head_out, targets: torch.Tensor):
+        """SimOTA loss over already-computed head maps.
+
+        Split out of ``forward`` so a caller that has the raw maps (the
+        CUDA-graph training path captures the network and only the maps
+        cross the graph boundary) runs the identical criterion.
+        """
         if self._criterion is None:
             from .loss import YOLOv7Loss
             self._criterion = YOLOv7Loss(self.num_classes, self.anchors, self.strides)

--- a/libreyolo/models/yolo7/trainer.py
+++ b/libreyolo/models/yolo7/trainer.py
@@ -79,10 +79,14 @@ class YOLOv7Trainer(YOLOXTrainer):
         # v7's net has no head.use_l1 stage (unlike YOLOX); just close mosaic.
         BaseTrainer.on_mosaic_disable(self)
 
-    def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
-        # YOLO9TrainTransform labels are [cls, x1, y1, x2, y2] normalized to
-        # [0, 1]; YOLOv7Loss wants [cls, cx, cy, w, h] in input pixels.
-        # Zero-padded rows stay all-zero through this conversion.
+    @staticmethod
+    def _to_pixel_cxcywh(imgs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """YOLO9TrainTransform labels -> the format YOLOv7Loss expects.
+
+        In: ``[cls, x1, y1, x2, y2]`` normalized to [0, 1].
+        Out: ``[cls, cx, cy, w, h]`` in input pixels.
+        Zero-padded rows stay all-zero through this conversion.
+        """
         h, w = imgs.shape[-2:]
         x1 = targets[..., 1] * w
         y1 = targets[..., 2] * h
@@ -91,5 +95,41 @@ class YOLOv7Trainer(YOLOXTrainer):
         converted = torch.stack(
             [(x1 + x2) / 2, (y1 + y2) / 2, x2 - x1, y2 - y1], dim=-1
         )
-        targets = torch.cat([targets[..., :1], converted], dim=-1)
-        return self.model(imgs, targets)
+        return torch.cat([targets[..., :1], converted], dim=-1)
+
+    def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
+        return self.model(imgs, self._to_pixel_cxcywh(imgs, targets))
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the network, keep the SimOTA loss eager.
+
+        ``YOLOv7Model.forward`` already splits at the right boundary — with
+        ``targets=None`` it returns the three raw head maps — so the graph
+        covers the whole net and ``assemble`` is the label conversion plus
+        ``compute_loss``, exactly what ``on_forward`` runs.
+
+        Overrides the YOLOX spec this class would otherwise inherit; v7's
+        net has no ``head.use_l1`` stage, so no capture invalidation is
+        needed at mosaic close.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .net import YOLOv7Model
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        raw = getattr(self.model, "module", self.model)
+        if not isinstance(raw, YOLOv7Model):
+            return None
+
+        network = GraphableNetwork(raw)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            return raw.compute_loss(
+                network.rebuild(flat), self._to_pixel_cxcywh(imgs, targets)
+            )
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/yolo9_e2e/trainer.py
+++ b/libreyolo/models/yolo9_e2e/trainer.py
@@ -43,3 +43,37 @@ class YOLO9E2ETrainer(YOLO9Trainer):
             model,
             max_labels=int(getattr(self.config, "max_labels", 100)),
         )
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph both branches, keep the dual TAL loss eager.
+
+        The base YOLO9 spec is restricted to the plain ``DDetect`` head, so
+        E2E needs its own: a train-mode forward without targets returns
+        ``{"one2many": [...], "one2one": [...]}`` — both branches' raw maps,
+        including the detach that blocks one-to-one gradients from reaching
+        the backbone — and ``assemble`` replays the dual-assignment loss over
+        them exactly as ``YOLO9E2EDetect.forward`` does with targets.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .nn import LibreYOLO9E2EModel, YOLO9E2EDetect
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        if type(self.model) is not LibreYOLO9E2EModel:
+            return None
+        if type(self.model.head) is not YOLO9E2EDetect:
+            return None
+
+        network = GraphableNetwork(self.model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            branches = network.rebuild(flat)
+            loss_fn = self.model.head._get_loss_fn(imgs.device)
+            loss_fn.update_anchors([imgs.shape[3], imgs.shape[2]])
+            return loss_fn(branches["one2many"], branches["one2one"], targets)
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/yolonas/trainer.py
+++ b/libreyolo/models/yolonas/trainer.py
@@ -92,3 +92,37 @@ class YOLONASTrainer(BaseTrainer):
             "iou": log_losses[1],
             "dfl": log_losses[2],
         }
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph the network, keep the PPYoloE loss eager.
+
+        ``on_forward`` already splits at the right boundary — the network
+        forward takes only images, and the assigner-driven loss runs after
+        it — so ``assemble`` is that same tail verbatim.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .nn import LibreYOLONASModel
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        if not isinstance(self.model, LibreYOLONASModel):
+            return None
+        if getattr(self, "loss_fn", None) is None:
+            return None
+
+        network = GraphableNetwork(self.model)
+
+        def assemble(flat, imgs, targets, polygons=None):
+            total_loss, log_losses = self.loss_fn(network.rebuild(flat), targets)
+            return {
+                "total_loss": total_loss,
+                "cls": log_losses[0],
+                "iou": log_losses[1],
+                "dfl": log_losses[2],
+            }
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/yolox/nn.py
+++ b/libreyolo/models/yolox/nn.py
@@ -491,6 +491,72 @@ class YOLOXHead(nn.Module):
             b.data.fill_(-math.log((1 - prior_prob) / prior_prob))
             conv.bias = torch.nn.Parameter(b.view(-1), requires_grad=True)
 
+    def forward_train_maps(self, xin):
+        """Run the training convolutions and decode, without the loss.
+
+        Returns ``(outputs, x_shifts, y_shifts, expanded_strides,
+        origin_preds)`` — everything :meth:`get_losses` consumes except the
+        labels and the images. This is the boundary the CUDA-graph training
+        capture splits on: every tensor here is a pure function of the input
+        images at a fixed input shape, while ``get_losses`` (SimOTA) is
+        data-dependent and stays eager.
+
+        ``forward`` calls this for its own training branch, so the two paths
+        cannot drift.
+        """
+        outputs = []
+        origin_preds = []
+        x_shifts = []
+        y_shifts = []
+        expanded_strides = []
+
+        for k, (cls_conv, reg_conv, stride_this_level, x) in enumerate(
+            zip(self.cls_convs, self.reg_convs, self.strides, xin)
+        ):
+            x = self.stems[k](x)
+            cls_feat = cls_conv(x)
+            cls_output = self.cls_preds[k](cls_feat)
+
+            reg_feat = reg_conv(x)
+            reg_output = self.reg_preds[k](reg_feat)
+            obj_output = self.obj_preds[k](reg_feat)
+
+            output = torch.cat([reg_output, obj_output, cls_output], 1)
+            output, grid = self.get_output_and_grid(
+                output, k, stride_this_level, xin[0].type()
+            )
+            x_shifts.append(grid[:, :, 0])
+            y_shifts.append(grid[:, :, 1])
+            # Built directly on the feature map's device: allocating on CPU
+            # and moving with ``type_as`` is an unpinned host-to-device copy
+            # on every call, which is illegal inside a CUDA graph capture.
+            # Strides (8/16/32) are exact in every dtype used here.
+            expanded_strides.append(
+                torch.full(
+                    (1, grid.shape[1]),
+                    float(stride_this_level),
+                    dtype=xin[0].dtype,
+                    device=xin[0].device,
+                )
+            )
+            if self.use_l1:
+                batch_size = reg_output.shape[0]
+                hsize, wsize = reg_output.shape[-2:]
+                reg_output = reg_output.view(batch_size, 1, 4, hsize, wsize)
+                reg_output = reg_output.permute(0, 1, 3, 4, 2).reshape(
+                    batch_size, -1, 4
+                )
+                origin_preds.append(reg_output.clone())
+            outputs.append(output)
+
+        return (
+            torch.cat(outputs, 1),
+            x_shifts,
+            y_shifts,
+            expanded_strides,
+            origin_preds,
+        )
+
     def forward(self, xin, labels=None, imgs=None):
         """
         Forward pass supporting both training and inference.
@@ -504,6 +570,27 @@ class YOLOXHead(nn.Module):
             Training: loss dict
             Inference: list of detection outputs
         """
+        if self.training:
+            (
+                outputs,
+                x_shifts,
+                y_shifts,
+                expanded_strides,
+                origin_preds,
+            ) = self.forward_train_maps(xin)
+            if labels is None:
+                return outputs
+            return self.get_losses(
+                imgs,
+                x_shifts,
+                y_shifts,
+                expanded_strides,
+                labels,
+                outputs,
+                origin_preds,
+                dtype=xin[0].dtype,
+            )
+
         outputs = []
         loss_outputs = []
         origin_preds = []
@@ -525,10 +612,14 @@ class YOLOXHead(nn.Module):
             reg_output = self.reg_preds[k](reg_feat)
             obj_output = self.obj_preds[k](reg_feat)
 
-            if self.training:
-                output = torch.cat([reg_output, obj_output, cls_output], 1)
-                output, grid = self.get_output_and_grid(
-                    output, k, stride_this_level, xin[0].type()
+            if self.emit_loss_outputs:
+                # Same assembly the training branch does, from the conv
+                # outputs already computed above: no extra convolutions.
+                loss_output, grid = self.get_output_and_grid(
+                    torch.cat([reg_output, obj_output, cls_output], 1),
+                    k,
+                    stride_this_level,
+                    xin[0].type(),
                 )
                 x_shifts.append(grid[:, :, 0])
                 y_shifts.append(grid[:, :, 1])
@@ -540,45 +631,20 @@ class YOLOXHead(nn.Module):
                 if self.use_l1:
                     batch_size = reg_output.shape[0]
                     hsize, wsize = reg_output.shape[-2:]
-                    reg_output = reg_output.view(batch_size, 1, 4, hsize, wsize)
-                    reg_output = reg_output.permute(0, 1, 3, 4, 2).reshape(
+                    l1_output = reg_output.view(batch_size, 1, 4, hsize, wsize)
+                    l1_output = l1_output.permute(0, 1, 3, 4, 2).reshape(
                         batch_size, -1, 4
                     )
-                    origin_preds.append(reg_output.clone())
-            else:
-                if self.emit_loss_outputs:
-                    # Same assembly the training branch does, from the conv
-                    # outputs already computed above: no extra convolutions.
-                    loss_output, grid = self.get_output_and_grid(
-                        torch.cat([reg_output, obj_output, cls_output], 1),
-                        k,
-                        stride_this_level,
-                        xin[0].type(),
-                    )
-                    x_shifts.append(grid[:, :, 0])
-                    y_shifts.append(grid[:, :, 1])
-                    expanded_strides.append(
-                        torch.zeros(1, grid.shape[1])
-                        .fill_(stride_this_level)
-                        .type_as(xin[0])
-                    )
-                    if self.use_l1:
-                        batch_size = reg_output.shape[0]
-                        hsize, wsize = reg_output.shape[-2:]
-                        l1_output = reg_output.view(batch_size, 1, 4, hsize, wsize)
-                        l1_output = l1_output.permute(0, 1, 3, 4, 2).reshape(
-                            batch_size, -1, 4
-                        )
-                        origin_preds.append(l1_output.clone())
-                    loss_outputs.append(loss_output)
+                    origin_preds.append(l1_output.clone())
+                loss_outputs.append(loss_output)
 
-                output = torch.cat(
-                    [reg_output, obj_output.sigmoid(), cls_output.sigmoid()], 1
-                )
+            output = torch.cat(
+                [reg_output, obj_output.sigmoid(), cls_output.sigmoid()], 1
+            )
 
             outputs.append(output)
 
-        if self.emit_loss_outputs and not self.training:
+        if self.emit_loss_outputs:
             # Everything get_losses needs except the labels, which only the
             # validation-loss adapter has.
             self._loss_cache = {
@@ -590,20 +656,7 @@ class YOLOXHead(nn.Module):
                 "dtype": xin[0].dtype,
             }
 
-        if self.training:
-            if labels is None:
-                return torch.cat(outputs, 1)
-            return self.get_losses(
-                imgs,
-                x_shifts,
-                y_shifts,
-                expanded_strides,
-                labels,
-                torch.cat(outputs, 1),
-                origin_preds,
-                dtype=xin[0].dtype,
-            )
-        elif self.export:
+        if self.export:
             # Export mode: decode grid offsets and return single flat tensor
             # suitable for ONNX/TorchScript tracing.
             decoded = []
@@ -647,11 +700,19 @@ class YOLOXHead(nn.Module):
         n_ch = 5 + self.num_classes
         hsize, wsize = output.shape[-2:]
         if grid.shape[2:4] != output.shape[2:4]:
-            yv, xv = meshgrid([torch.arange(hsize), torch.arange(wsize)])
+            # Built directly on ``device``: a CPU arange followed by ``.to``
+            # is an unpinned host-to-device copy, which is illegal inside a
+            # CUDA graph capture. Same values either way.
+            yv, xv = meshgrid(
+                [
+                    torch.arange(hsize, device=device),
+                    torch.arange(wsize, device=device),
+                ]
+            )
             grid = (
                 torch.stack((xv, yv), 2)
                 .view(1, 1, hsize, wsize, 2)
-                .to(device=device, dtype=output.dtype)
+                .to(dtype=output.dtype)
             )
             self.grids[k] = grid
 

--- a/libreyolo/models/yolox/trainer.py
+++ b/libreyolo/models/yolox/trainer.py
@@ -91,6 +91,68 @@ class YOLOXTrainer(BaseTrainer):
         self.train_loader.dataset.close_mosaic()
         raw = getattr(self.model, "module", self.model)
         raw.head.use_l1 = True
+        # use_l1 adds the origin_preds tensors to the captured region's
+        # output, so any graph taken before this point no longer matches
+        # what the loss needs.
+        self.invalidate_cuda_graph("YOLOX enabled the L1 branch at mosaic close")
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         return self.model(imgs, targets)
+
+    def cuda_graph_train_spec(self):
+        """Capture spec: graph backbone + head convolutions, SimOTA eager.
+
+        ``YOLOXHead.forward_train_maps`` is the boundary: everything it
+        returns is a pure function of the input images at a fixed input
+        shape, while ``get_losses`` runs SimOTA, which loops per ground-truth
+        box on the host and is neither capturable nor worth capturing.
+
+        The head's ``use_l1`` flag changes what ``forward_train_maps``
+        returns, so ``on_mosaic_disable`` invalidates the capture when it
+        flips; a graph is never replayed across that switch.
+        """
+        from libreyolo.training.cuda_graph import (
+            CudaGraphTrainSpec,
+            GraphableNetwork,
+        )
+        from .nn import LibreYOLOXModel
+
+        task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task != "detect":
+            return None
+        raw = getattr(self.model, "module", self.model)
+        if not isinstance(raw, LibreYOLOXModel):
+            return None
+
+        class _YOLOXNetwork(torch.nn.Module):
+            """Backbone + head convolutions + decode, no loss."""
+
+            def __init__(self, model):
+                super().__init__()
+                self.model = model
+
+            def forward(self, imgs):
+                return self.model.head.forward_train_maps(self.model.backbone(imgs))
+
+        network = GraphableNetwork(_YOLOXNetwork(raw))
+
+        def assemble(flat, imgs, targets, polygons=None):
+            (
+                outputs,
+                x_shifts,
+                y_shifts,
+                expanded_strides,
+                origin_preds,
+            ) = network.rebuild(flat)
+            return raw.head.get_losses(
+                imgs,
+                x_shifts,
+                y_shifts,
+                expanded_strides,
+                targets,
+                outputs,
+                origin_preds,
+                dtype=outputs.dtype,
+            )
+
+        return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -130,8 +130,10 @@ class TrainConfig:
     # cut kernel-launch overhead on launch-bound (small-model) runs. Opt-in
     # and single-GPU only; families without capture support, distributed
     # runs and distillation runs fall back to eager training with a warning.
-    # Numerics are identical either way; batches whose shape differs from
-    # the captured shape (multi-scale, last partial batch) run eager.
+    # Most supported families reproduce eager numerics exactly; documented
+    # exceptions use family-specific parity tolerances. Batches whose shape
+    # differs from the captured shape (multi-scale, last partial batch) run
+    # eager. See docs/training_cuda_graphs.md.
     cuda_graph: bool = False
     # Layer freezing. An int freezes the first N family-defined freeze groups;
     # a list freezes explicit group indices or module-name selectors; a string

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -43,13 +43,25 @@ Capture-time contracts (enforced by the trainer, documented here):
   trajectory matches eager training exactly.
 - Under AMP, capture and replay must run with autocast caching disabled;
   the trainer's autocast context handles this when a manager is active.
-- Distributed training, distillation and non-detect tasks are not captured
-  in this version; the trainer falls back to eager for those runs.
+- Distributed training and distillation are not captured in this version;
+  the trainer falls back to eager for those runs.
+- A family whose captured region stops matching what the loss needs partway
+  through a run (YOLOX adds its L1 branch at mosaic close) calls
+  ``BaseTrainer.invalidate_cuda_graph``; the manager drops the graph,
+  restores the eager forward and re-captures once a shape settles again.
 
 Any failure to capture, at any point, permanently falls back to eager
-training for the rest of the run with a single warning. Capture never
-changes numerics; ``tests/unit/test_cuda_graph_training.py`` gates the loss
-trajectory as identical between eager and graphed runs.
+training for the rest of the run with a single warning.
+
+Capture is bit-identical for most families. Three documented exceptions,
+all inherent rather than defects: families whose own eager training is not
+reproducible (deformable-attention atomics, TF32 reduction order) stay
+inside that spread; RTMDet's cross-level shared head convolutions sum their
+three gradient contributions in a different order; and a network with
+dropout or stochastic depth inside the captured region draws its own random
+stream on replay (the manager logs this at capture time). See
+``docs/training_cuda_graphs.md`` for the per-family table, and
+``tests/e2e/test_cuda_graph_training_families.py`` for the gates.
 """
 
 from __future__ import annotations
@@ -263,6 +275,12 @@ class TrainGraphManager:
         self._graph_key: Optional[GraphKey] = None
         self._shape_counts: Dict[GraphKey, int] = {}
         self._eager_after_capture = 0
+        # ``make_graphed_callables`` rebinds the module's forward in place.
+        # Kept so a later invalidate() can put the eager forward back before
+        # re-capturing; without it the next capture's warm-up would call the
+        # previous graph and die replaying inside an active capture.
+        self._captured_network: Optional[nn.Module] = None
+        self._forward_before_capture: Optional[Tuple[bool, Any]] = None
 
     @property
     def captured(self) -> bool:
@@ -275,10 +293,55 @@ class TrainGraphManager:
     def _disable(self, reason: str) -> None:
         self.disabled = True
         self._graphed = None
+        self._restore_eager_forward()
         logger.warning(
             "cuda_graph training capture disabled, falling back to eager: %s",
             reason,
         )
+
+    def _restore_eager_forward(self) -> None:
+        """Undo ``make_graphed_callables``' in-place forward rebind.
+
+        It replaces ``module.forward`` with a closure that replays the graph.
+        Leaving that in place after dropping a graph is unsafe twice over: a
+        re-capture's warm-up would replay the dead graph inside the new
+        capture (``Cannot prepare for replay during capturing stage``), and
+        the eager fallback would silently keep replaying it.
+        """
+        network = self._captured_network
+        if network is None:
+            return
+        had_own, original = self._forward_before_capture or (False, None)
+        if had_own:
+            network.forward = original
+        else:
+            network.__dict__.pop("forward", None)
+        self._captured_network = None
+        self._forward_before_capture = None
+
+    def invalidate(self, reason: str) -> None:
+        """Drop the captured graph and re-capture on a later batch.
+
+        A graph is only valid while the captured region's op sequence is
+        fixed. Some families change that sequence *during* a run: YOLOX
+        turns on its L1 branch when mosaic closes, which adds tensors to
+        the network's output. Replaying the old graph past such a switch
+        would silently keep training the pre-switch network, so the family
+        trainer calls this at the switch and the manager re-captures once
+        the new shape has settled.
+
+        Shape counts are reset too, so the warm-up threshold applies again
+        and a switch that lands on the last few batches of a run never pays
+        for a capture it cannot amortise.
+        """
+        if self.disabled or self._graphed is None:
+            self._shape_counts.clear()
+            return
+        self._graphed = None
+        self._graph_key = None
+        self._shape_counts.clear()
+        self._restore_eager_forward()
+        logger.info("cuda_graph: capture invalidated (%s); will re-capture", reason)
 
     def run(
         self, spec: CudaGraphTrainSpec, imgs: torch.Tensor
@@ -314,6 +377,43 @@ class TrainGraphManager:
         return self._capture_and_run(spec, imgs)
 
     @staticmethod
+    def _stochastic_layers(network: nn.Module) -> List[str]:
+        """Names of active randomness-drawing layers inside the capture.
+
+        Capture does not break these: PyTorch registers the generator with
+        the graph and advances its offset per replay, so dropout keeps
+        dropping and stochastic depth keeps dropping paths. What changes is
+        *which* elements: a replayed graph consumes the generator on its own
+        schedule, so it does not reproduce the sequence an eager run of the
+        same step would draw.
+
+        The consequence is worth stating out loud rather than discovering
+        from a diff: for a network with these layers, a graphed run is
+        statistically equivalent to the eager run, and equivalent to
+        changing the seed, but its loss trajectory is not the eager one.
+        Every family without them stays bit-identical.
+        """
+        stochastic = []
+        for name, module in network.named_modules():
+            if isinstance(module, nn.modules.dropout._DropoutNd):
+                if float(getattr(module, "p", 0.0)) > 0.0:
+                    stochastic.append(name)
+                continue
+            # Stochastic depth ships under several names across families
+            # (DropPath, StochasticDepth, TimmDropPath); they share the
+            # drop-probability attribute rather than a base class.
+            for attr in ("drop_prob", "p"):
+                value = getattr(module, attr, None)
+                if (
+                    isinstance(value, float)
+                    and value > 0.0
+                    and "drop" in type(module).__name__.lower()
+                ):
+                    stochastic.append(name)
+                    break
+        return stochastic
+
+    @staticmethod
     def _snapshot_buffers(
         network: nn.Module,
     ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
@@ -342,6 +442,10 @@ class TrainGraphManager:
         self, spec: CudaGraphTrainSpec, imgs: torch.Tensor
     ) -> Optional[Tuple[torch.Tensor, ...]]:
         buffer_snapshot = self._snapshot_buffers(spec.network)
+        forward_before = (
+            "forward" in spec.network.__dict__,
+            spec.network.__dict__.get("forward"),
+        )
         try:
             # The sample clone becomes the graph's static input buffer; the
             # live batch tensor must stay caller-owned. allow_unused_input
@@ -366,6 +470,10 @@ class TrainGraphManager:
                         num_warmup_iters=self.num_warmup_iters,
                     )
         except Exception as exc:
+            # A partially-applied capture can leave the rebound forward
+            # behind; put the eager one back before giving up.
+            self._captured_network = spec.network
+            self._forward_before_capture = forward_before
             self._disable(f"graph capture failed: {exc!r}")
             # A failed capture can leave asynchronous stream-capture errors
             # queued; drain them here so they surface inside this handler
@@ -383,6 +491,8 @@ class TrainGraphManager:
         # as the eager step would have.
         self._restore_buffers(buffer_snapshot)
 
+        self._captured_network = spec.network
+        self._forward_before_capture = forward_before
         self._graphed = graphed
         self._graph_key = self._key_for(imgs)
         shape = tuple(imgs.shape)
@@ -390,6 +500,16 @@ class TrainGraphManager:
             "cuda_graph: captured training forward/backward at input shape %s",
             (shape,),
         )
+        stochastic = self._stochastic_layers(spec.network)
+        if stochastic:
+            logger.info(
+                "cuda_graph: the captured network has %d randomness-drawing "
+                "layers (e.g. %s); replay draws its own random stream, so "
+                "this run is statistically equivalent to the eager one but "
+                "will not reproduce its exact loss trajectory",
+                len(stochastic),
+                ", ".join(stochastic[:3]),
+            )
         try:
             return self._graphed(imgs)
         except Exception as exc:

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -23,9 +23,8 @@ Shape handling is dispatch-based, not constraint-based: a graph is valid
 for exactly the input shape it was captured with, so the manager counts
 shapes and captures one graph once a shape has repeated
 ``warmup_threshold`` times. Batches at any other shape (multi-scale
-batches, the last partial batch of an epoch) run eager, unchanged. This
-keeps training numerics and behavior identical whether the flag is on or
-off, which the parity tests gate.
+batches, the last partial batch of an epoch) run eager, unchanged, so a
+shape the graph does not cover costs speed and nothing else.
 
 Capture-time contracts (enforced by the trainer, documented here):
 
@@ -442,12 +441,21 @@ class TrainGraphManager:
     def _capture_and_run(
         self, spec: CudaGraphTrainSpec, imgs: torch.Tensor
     ) -> Optional[Tuple[torch.Tensor, ...]]:
-        buffer_snapshot = self._snapshot_buffers(spec.network)
         forward_before = (
             "forward" in spec.network.__dict__,
             spec.network.__dict__.get("forward"),
         )
+        # Empty until the snapshot succeeds, so the handler below can restore
+        # unconditionally: restoring nothing is a no-op.
+        buffer_snapshot: List[Tuple[torch.Tensor, torch.Tensor]] = []
         try:
+            # Inside the guard on purpose. Cloning every buffer is a real
+            # allocation on the device, and it happens at the moment memory
+            # is tightest: right before capture reserves static input, output
+            # and workspace buffers for a whole forward and backward. An OOM
+            # here used to escape and kill the run, which is the one outcome
+            # an opt-in speed flag must never produce.
+            buffer_snapshot = self._snapshot_buffers(spec.network)
             # The sample clone becomes the graph's static input buffer; the
             # live batch tensor must stay caller-owned. allow_unused_input
             # mirrors eager autograd: parameters a family's training forward

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -36,11 +36,12 @@ Capture-time contracts (enforced by the trainer, documented here):
   reads, ``load_state_dict``) are safe because replay reads the same
   addresses.
 - ``make_graphed_callables`` warm-up runs a few forward/backward passes on
-  the capture batch. Gradients produced by that warm-up are garbage and are
-  cleared by the train loop's own ``zero_grad`` before the first real
-  backward; stateful buffers (BatchNorm running stats) are snapshotted
-  before capture and restored in place afterwards, so the buffer
-  trajectory matches eager training exactly.
+  the capture batch. Its backward goes through ``torch.autograd.grad`` with
+  ``only_inputs=True``, so it never writes ``.grad`` and cannot pollute an
+  accumulation window (which zeroes only at the window's start, not per
+  micro-batch). Stateful buffers (BatchNorm running stats) *are* advanced by
+  those extra forwards, so they are snapshotted before capture and restored
+  in place afterwards and the buffer trajectory matches eager exactly.
 - Under AMP, capture and replay must run with autocast caching disabled;
   the trainer's autocast context handles this when a manager is active.
 - Distributed training and distillation are not captured in this version;

--- a/libreyolo/training/cuda_graph.py
+++ b/libreyolo/training/cuda_graph.py
@@ -313,7 +313,7 @@ class TrainGraphManager:
         if network is None:
             return
         had_own, original = self._forward_before_capture or (False, None)
-        if had_own:
+        if had_own and original is not None:
             network.forward = original
         else:
             network.__dict__.pop("forward", None)

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -368,6 +368,17 @@ class BaseTrainer(ABC):
         """
         return None
 
+    def invalidate_cuda_graph(self, reason: str) -> None:
+        """Drop any captured training graph so a later batch re-captures.
+
+        Call this from a family hook that changes what the captured region
+        computes mid-run (YOLOX enabling its L1 branch at mosaic close is
+        the canonical case). A no-op when capture is off.
+        """
+        manager = getattr(self, "_cuda_graph_manager", None)
+        if manager is not None:
+            manager.invalidate(reason)
+
     def _forward_train(
         self,
         imgs: torch.Tensor,

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -387,10 +387,16 @@ class BaseTrainer(ABC):
     ) -> Dict:
         """``on_forward`` with optional CUDA-graph capture of the network.
 
-        Routing keeps a hard equivalence contract: any batch that cannot go
+        Routing keeps a hard *dispatch* contract: any batch that cannot go
         through a captured graph (no family spec, shape mismatch, capture
-        disabled) takes the exact ``on_forward`` path instead, so enabling
-        ``cuda_graph`` never changes training numerics.
+        disabled) takes the exact ``on_forward`` path instead. So the flag
+        never changes which code computes the loss.
+
+        It is not a bit-identical contract for every family. Most reproduce
+        eager exactly; three documented cases do not, for reasons inherent
+        to the family rather than to capture. See the exception list in
+        ``libreyolo.training.cuda_graph`` and the per-family table in
+        ``docs/training_cuda_graphs.md``.
         """
         # getattr defaults keep partially-constructed trainers (test
         # doubles, exotic subclasses skipping BaseTrainer.__init__) on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,6 +375,7 @@ markers = [
     "e2e: end-to-end tests requiring full model loading and inference",
     "general_nightly: broad nightly inference checks across all model families",
     "flagship_nightly: heavier nightly checks for flagship YOLO9/RF-DETR models",
+    "training_nightly: nightly GPU checks for training-time features (CUDA graph capture) that neither inference nightly lane covers",
     "export_backend: tests covering an export backend or serialized runtime format",
     "supported_backend: tests covering a release-blocking supported backend",
     "experimental_backend: tests covering an experimental backend",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,7 +14,7 @@ from tests.e2e.nightly_contract import nightly_summary_line
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _FAIL_ON_NIGHTLY_SKIP_ENV = "LIBREYOLO_FAIL_ON_NIGHTLY_SKIP"
-_NIGHTLY_MARKERS = ("general_nightly", "flagship_nightly")
+_NIGHTLY_MARKERS = ("general_nightly", "flagship_nightly", "training_nightly")
 
 
 def _repo_python_env() -> dict[str, str]:

--- a/tests/e2e/nightly_contract.py
+++ b/tests/e2e/nightly_contract.py
@@ -1,6 +1,6 @@
 """Versioned contract for the nightly e2e test suite."""
 
-NIGHTLY_E2E_SUITE_VERSION = "2.3"
+NIGHTLY_E2E_SUITE_VERSION = "2.4"
 NIGHTLY_E2E_SUITE_CONTRACT = (
     "general=smallest task-appropriate native inference case for every public "
     "model family, "
@@ -12,7 +12,9 @@ NIGHTLY_E2E_SUITE_CONTRACT = (
     "families use probability and top-1 stability gates; "
     "FCN adds a real-checkpoint semantic predict, mIoU, and UI-render smoke; "
     "flagship=YOLO9/RF-DETR validation, video, tracking, CLI, and one RF1 "
-    "training/reload size per flagship family; export backends remain outside "
+    "training/reload size per flagship family; training=representative "
+    "real-CUDA coverage for training-time features, currently CUDA graph "
+    "capture and its lifecycle/fallback paths; export backends remain outside "
     "the default nightly"
 )
 NIGHTLY_E2E_SUITE_CHANGE_POLICY = (

--- a/tests/e2e/test_cuda_graph_training_families.py
+++ b/tests/e2e/test_cuda_graph_training_families.py
@@ -34,7 +34,12 @@ import torch
 import yaml
 from PIL import Image
 
-pytestmark = pytest.mark.general_nightly
+# Not ``general_nightly``: that marker has a documented contract as the broad
+# *inference* sweep with a fixed case count (docs/testing.md). These are
+# training runs, so they follow the house pattern for training e2e files
+# (test_training_regression.py, test_dfine_seg_training.py): plain ``e2e``,
+# plus ``slow`` because the full file trains 20-odd models twice over.
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
 
 requires_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(),

--- a/tests/e2e/test_cuda_graph_training_families.py
+++ b/tests/e2e/test_cuda_graph_training_families.py
@@ -1,23 +1,24 @@
 """Per-family CUDA graph *training* capture, through the real train() API.
 
-The unit suite covers dispatch and gating with fakes; this file runs actual
+The unit suite covers dispatch and gating with fakes. This file runs actual
 training runs on a generated dataset and checks the two things a user cares
 about:
 
-* capture engages and stays engaged — no silent fallback to eager, which is
-  what every failure mode in this feature degrades to and is therefore
-  invisible without an explicit assertion;
+* capture engages and stays engaged. Every failure mode in this feature
+  degrades to eager, silently, so a run that merely completes proves
+  nothing; the capture log line has to be asserted. Five families shipped
+  with the flag doing literally nothing until this assertion was added.
 * enabling the flag does not move the loss trajectory.
 
-The second check is exact for families whose training step is deterministic
-on this hardware, and skipped for the rest. Deformable attention accumulates
-its backward with atomics and TF32 convolutions pick their reduction order
-per launch, so D-FINE, DEIM, RT-DETR and friends do not reproduce their own
-eager run either; asserting a band there would test the noise, not the
-capture. ``tests/unit/test_cuda_graph_training.py`` holds those families to
-step-0 gradient equivalence instead.
+The second check adapts to the family rather than assuming determinism: the
+eager arm runs twice to measure how far it moves on its own, and the graphed
+arm is held to that spread plus a documented per-family ``rel_tol``.
+Deformable attention accumulates its backward with atomics and TF32
+convolutions pick their reduction order per launch, so several families do
+not reproduce their own eager run either, and a fixed band would test that
+noise instead of the capture.
 
-No downloads: the dataset is generated, and every model is built with
+No downloads: the datasets are generated and every model is built with
 ``model_path=None``. Families that pull a pretrained backbone at
 construction are marked ``external_data``.
 """
@@ -458,6 +459,41 @@ def test_non_detect_loss_trajectory_stays_within_eager_noise(
         f"{noise:.3e} and the allowance is {rel_tol:.3g} x {scale:.3g}"
         f"\n  eager  {eager_a}\n  eager2 {eager_b}\n  graph  {graphed}"
     )
+
+
+@requires_cuda
+def test_gradient_accumulation_matches_eager(detect_dataset, tmp_path):
+    """Capture must be safe when ``zero_grad`` runs once per window.
+
+    The plain loop zeroes gradients after every forward, so capture warm-up
+    could not pollute them even if it wrote ``.grad``. The accumulation loop
+    zeroes only at the start of a window, so the safety here rests on
+    ``make_graphed_callables`` warming up through ``torch.autograd.grad``
+    (which returns gradients rather than accumulating them). This asserts
+    that rather than trusting it.
+    """
+    import libreyolo
+
+    def run(cuda_graph):
+        torch.manual_seed(0)
+        model = libreyolo.LibreYOLO9(None, "t")
+        return model.train(
+            data=str(detect_dataset),
+            epochs=2,
+            batch=4,
+            nbs=16,  # 4 micro-batches per optimizer step
+            imgsz=320,
+            device=0,
+            workers=0,
+            seed=0,
+            project=str(tmp_path),
+            name="graph" if cuda_graph else "eager",
+            exist_ok=True,
+            cuda_graph=cuda_graph,
+            eval_interval=100,
+        )["epoch_losses"]
+
+    assert run(False) == run(True)
 
 
 @requires_cuda

--- a/tests/e2e/test_cuda_graph_training_families.py
+++ b/tests/e2e/test_cuda_graph_training_families.py
@@ -467,6 +467,166 @@ def test_non_detect_loss_trajectory_stays_within_eager_noise(
 
 
 @requires_cuda
+def test_capture_engages_without_amp(detect_dataset, tmp_path, caplog):
+    """``amp=False`` is a supported path and must still capture.
+
+    Everything else in this file runs under AMP, the default. Without it
+    ``trainer.scaler`` is None and the autocast context is never entered, so
+    the capture path takes different branches in the trainer.
+
+    No loss assertion here on purpose: at fp32 this hardware does not
+    reproduce its own eager run (cuDNN picks a nondeterministic weight-
+    gradient algorithm for some shapes), so equality would test that noise
+    rather than the capture. See docs/training_cuda_graphs.md.
+    """
+    import libreyolo
+
+    torch.manual_seed(0)
+    model = libreyolo.LibreYOLO9(None, "t")
+    with caplog.at_level(logging.INFO, logger=CAPTURE_LOGGER):
+        result = model.train(
+            data=str(detect_dataset),
+            epochs=2,
+            batch=4,
+            imgsz=320,
+            device=0,
+            workers=0,
+            seed=0,
+            amp=False,
+            project=str(tmp_path),
+            name="fp32",
+            exist_ok=True,
+            cuda_graph=True,
+            eval_interval=100,
+        )
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("captured training forward/backward" in m for m in messages), messages
+    assert not [m for m in messages if "capture disabled" in m], messages
+    assert all(np.isfinite(result["epoch_losses"])), result["epoch_losses"]
+
+
+@requires_cuda
+def test_layer_freezing_matches_eager(detect_dataset, tmp_path):
+    """Frozen layers change which parameters get gradients.
+
+    ``make_graphed_callables`` is handed the whole adapter, so a frozen
+    backbone means most of its parameters want no gradient. That path runs
+    on ``allow_unused_input=True``; this checks it produces the eager answer
+    rather than silently dropping live gradients too.
+    """
+    import libreyolo
+
+    def run(cuda_graph):
+        torch.manual_seed(0)
+        model = libreyolo.LibreYOLO9(None, "t")
+        return model.train(
+            data=str(detect_dataset),
+            epochs=2,
+            batch=4,
+            imgsz=320,
+            device=0,
+            workers=0,
+            seed=0,
+            freeze="10",
+            project=str(tmp_path),
+            name="graph" if cuda_graph else "eager",
+            exist_ok=True,
+            cuda_graph=cuda_graph,
+            eval_interval=100,
+        )["epoch_losses"]
+
+    assert run(False) == run(True)
+
+
+@requires_cuda
+def test_resume_from_checkpoint_recaptures(detect_dataset, tmp_path):
+    """A resumed run must capture again and keep training.
+
+    Capture records parameter addresses, so a checkpoint load that replaced
+    tensors instead of copying into them would leave the graph reading freed
+    storage. Resume loads before ``setup()``, so capture always sees the
+    final tensors, but that ordering is worth a test rather than a comment.
+    """
+    import libreyolo
+
+    torch.manual_seed(0)
+    first = libreyolo.LibreYOLO9(None, "t").train(
+        data=str(detect_dataset),
+        epochs=2,
+        batch=4,
+        imgsz=320,
+        device=0,
+        workers=0,
+        seed=0,
+        project=str(tmp_path),
+        name="first",
+        exist_ok=True,
+        cuda_graph=True,
+        eval_interval=100,
+    )
+
+    torch.manual_seed(0)
+    resumed = libreyolo.LibreYOLO9(first["last_checkpoint"], "t").train(
+        data=str(detect_dataset),
+        epochs=4,
+        batch=4,
+        imgsz=320,
+        device=0,
+        workers=0,
+        seed=0,
+        project=str(tmp_path),
+        name="second",
+        exist_ok=True,
+        cuda_graph=True,
+        resume=True,
+        eval_interval=100,
+    )
+    assert resumed["epoch_losses"], "resume produced no epochs"
+    assert all(np.isfinite(resumed["epoch_losses"])), resumed["epoch_losses"]
+
+
+@requires_cuda
+def test_capture_failure_does_not_kill_the_run(detect_dataset, tmp_path, caplog):
+    """Capture is opt-in and best-effort: failing it must cost speed, not the run.
+
+    The realistic trigger is an out-of-memory while allocating the graph's
+    static buffers, which is exactly when a user least wants their training
+    to die.
+    """
+    import libreyolo
+
+    def exploding(*args, **kwargs):
+        raise torch.cuda.OutOfMemoryError("simulated OOM during capture")
+
+    original = torch.cuda.make_graphed_callables
+    torch.cuda.make_graphed_callables = exploding
+    try:
+        with caplog.at_level(logging.INFO, logger=CAPTURE_LOGGER):
+            torch.manual_seed(0)
+            result = libreyolo.LibreYOLO9(None, "t").train(
+                data=str(detect_dataset),
+                epochs=2,
+                batch=4,
+                imgsz=320,
+                device=0,
+                workers=0,
+                seed=0,
+                project=str(tmp_path),
+                name="oom",
+                exist_ok=True,
+                cuda_graph=True,
+                eval_interval=100,
+            )
+    finally:
+        torch.cuda.make_graphed_callables = original
+
+    messages = [record.getMessage() for record in caplog.records]
+    disabled = [m for m in messages if "capture disabled" in m]
+    assert len(disabled) == 1, f"expected exactly one warning, got {disabled}"
+    assert all(np.isfinite(result["epoch_losses"])), result["epoch_losses"]
+
+
+@requires_cuda
 def test_gradient_accumulation_matches_eager(detect_dataset, tmp_path):
     """Capture must be safe when ``zero_grad`` runs once per window.
 

--- a/tests/e2e/test_cuda_graph_training_families.py
+++ b/tests/e2e/test_cuda_graph_training_families.py
@@ -1,0 +1,551 @@
+"""Per-family CUDA graph *training* capture, through the real train() API.
+
+The unit suite covers dispatch and gating with fakes; this file runs actual
+training runs on a generated dataset and checks the two things a user cares
+about:
+
+* capture engages and stays engaged — no silent fallback to eager, which is
+  what every failure mode in this feature degrades to and is therefore
+  invisible without an explicit assertion;
+* enabling the flag does not move the loss trajectory.
+
+The second check is exact for families whose training step is deterministic
+on this hardware, and skipped for the rest. Deformable attention accumulates
+its backward with atomics and TF32 convolutions pick their reduction order
+per launch, so D-FINE, DEIM, RT-DETR and friends do not reproduce their own
+eager run either; asserting a band there would test the noise, not the
+capture. ``tests/unit/test_cuda_graph_training.py`` holds those families to
+step-0 gradient equivalence instead.
+
+No downloads: the dataset is generated, and every model is built with
+``model_path=None``. Families that pull a pretrained backbone at
+construction are marked ``external_data``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from PIL import Image
+
+pytestmark = pytest.mark.general_nightly
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA graph training capture requires a CUDA device",
+)
+
+CAPTURE_LOGGER = "libreyolo.training.cuda_graph"
+
+
+# (family id, class name, size, imgsz, task, rel_tol, extra train kwargs)
+#
+# ``rel_tol`` is how far the graphed loss may sit from the eager one, as a
+# fraction of the loss magnitude, *on top of* whatever spread two eager runs
+# show on their own. 0.0 means the family's whole training step is
+# reproducible and capture must reproduce it exactly.
+CASES = [
+    ("yolo9", "LibreYOLO9", "t", 320, "detect", 0.0, {}),
+    ("yolo9_p2", "LibreYOLO9P2", "t", 320, "detect", 0.0, {}),
+    ("yolo9_e2e", "LibreYOLO9E2E", "t", 320, "detect", 0.0, {}),
+    ("yolox", "LibreYOLOX", "t", 320, "detect", 0.0, {}),
+    ("picodet", "LibrePICODET", "s", 320, "detect", 0.0, {"allow_experimental": True}),
+    ("yolo7", "LibreYOLO7", "b", 320, "detect", 0.0, {"allow_experimental": True}),
+    # YOLO-NAS captures bit-identically on a fixed batch (the unit suite gates
+    # that), but its affine/mixup pipeline draws from generators the training
+    # seed does not reach, so two eager train() runs already differ.
+    ("yolonas", "LibreYOLONAS", "s", 320, "detect", 0.01, {}),
+    # RTMDet shares its head convolutions across all three pyramid levels
+    # (``share_conv=True`` aliases cls_convs[n][i].conv to cls_convs[0][i]),
+    # so those two weights' gradient is a sum of three contributions. Eager
+    # autograd and the graphed backward sum them in a different order, which
+    # under fp16 differs in the last bits — 137 of 139 gradients are still
+    # bit-identical — and the dynamic assigner's discrete choices amplify it.
+    ("rtmdet", "LibreRTMDet", "t", 320, "detect", 0.05, {"allow_experimental": True}),
+    # Encoder-boundary capture. None of these reproduce their own eager run:
+    # deformable attention accumulates its backward with atomics.
+    # multi_scale=False because they resize every batch by default and a graph
+    # is valid for exactly one input shape, so with jitter on a short run
+    # never sees one shape often enough to capture at all.
+    ("dfine", "LibreDFINE", "n", 320, "detect", 0.01, {"multi_scale": False}),
+    ("deim", "LibreDEIM", "n", 320, "detect", 0.01, {"multi_scale": False}),
+    ("deimv2", "LibreDEIMv2", "atto", 320, "detect", 0.01, {"multi_scale": False}),
+    ("rtdetr", "LibreRTDETR", "r18", 320, "detect", 0.01, {}),
+    ("rtdetrv2", "LibreRTDETRv2", "r18", 320, "detect", 0.01, {}),
+    ("rtdetrv4", "LibreRTDETRv4", "s", 320, "detect", 0.01, {"multi_scale": False}),
+    (
+        "ec",
+        "LibreEC",
+        "s",
+        320,
+        "detect",
+        0.01,
+        {"allow_experimental": True, "multi_scale": False},
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def detect_dataset(tmp_path_factory) -> Path:
+    """A generated 24-image YOLO-format detection dataset.
+
+    Deliberately not a download: these tests must be able to run offline and
+    must not depend on a dataset's contents staying fixed.
+    """
+    root = tmp_path_factory.mktemp("cuda_graph_train_data")
+    rng = np.random.default_rng(0)
+    for split, count in (("train", 16), ("valid", 8)):
+        (root / split / "images").mkdir(parents=True)
+        (root / split / "labels").mkdir(parents=True)
+        for i in range(count):
+            pixels = rng.integers(0, 255, (320, 320, 3), dtype=np.uint8)
+            Image.fromarray(pixels).save(root / split / "images" / f"{i:03d}.jpg")
+            rows = []
+            for _ in range(rng.integers(2, 6)):
+                cx, cy = rng.uniform(0.2, 0.8, 2)
+                w, h = rng.uniform(0.05, 0.15, 2)
+                rows.append(f"{rng.integers(0, 2)} {cx:.6f} {cy:.6f} {w:.6f} {h:.6f}")
+            (root / split / "labels" / f"{i:03d}.txt").write_text("\n".join(rows))
+    (root / "data.yaml").write_text(
+        yaml.dump(
+            {
+                "path": str(root),
+                "train": "train/images",
+                "val": "valid/images",
+                "nc": 2,
+                "names": ["a", "b"],
+            }
+        )
+    )
+    return root / "data.yaml"
+
+
+def _train(
+    class_name: str,
+    size: str,
+    imgsz: int,
+    task: str,
+    data: Path,
+    save_dir: Path,
+    cuda_graph: bool,
+    extra: dict,
+) -> dict:
+    import libreyolo
+
+    torch.manual_seed(0)
+    model_kwargs = {"task": task} if task != "detect" else {}
+    model = getattr(libreyolo, class_name)(None, size, **model_kwargs)
+    return model.train(
+        data=str(data),
+        epochs=2,
+        batch=4,
+        imgsz=imgsz,
+        device=0,
+        workers=0,
+        seed=0,
+        project=str(save_dir),
+        name=f"{'graph' if cuda_graph else 'eager'}",
+        exist_ok=True,
+        cuda_graph=cuda_graph,
+        # Validation is not what this file measures, and mAP on random
+        # images is meaningless; keep the runs short.
+        eval_interval=100,
+        **extra,
+    )
+
+
+@requires_cuda
+@pytest.mark.external_data  # several families fetch a pretrained backbone
+@pytest.mark.parametrize(
+    "family,class_name,size,imgsz,task,deterministic,extra",
+    CASES,
+    ids=[case[0] for case in CASES],
+)
+def test_capture_engages_and_holds(
+    family,
+    class_name,
+    size,
+    imgsz,
+    task,
+    deterministic,
+    extra,
+    detect_dataset,
+    tmp_path,
+    caplog,
+):
+    """A real run must capture, keep the graph, and finish with a finite loss."""
+    with caplog.at_level(logging.INFO, logger=CAPTURE_LOGGER):
+        result = _train(
+            class_name, size, imgsz, task, detect_dataset, tmp_path, True, extra
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("captured training forward/backward" in m for m in messages), (
+        f"{family}: capture never engaged; log was {messages}"
+    )
+    disabled = [m for m in messages if "capture disabled" in m]
+    assert not disabled, f"{family}: capture fell back to eager: {disabled}"
+    assert np.isfinite(result["final_loss"]), f"{family}: {result['final_loss']}"
+
+
+@requires_cuda
+@pytest.mark.external_data
+@pytest.mark.parametrize(
+    "family,class_name,size,imgsz,task,rel_tol,extra",
+    CASES,
+    ids=[case[0] for case in CASES],
+)
+def test_loss_trajectory_stays_within_eager_noise(
+    family, class_name, size, imgsz, task, rel_tol, extra, detect_dataset, tmp_path
+):
+    """Capture must not move the loss further than eager moves on its own.
+
+    A fixed seed does not make every family's ``train()`` reproducible, so
+    asserting equality across the board would test the family's determinism
+    rather than the capture. The eager arm runs twice to measure that spread
+    first; the graphed arm is then held to it plus the family's documented
+    ``rel_tol``. A family listed at ``rel_tol=0`` must show zero spread and
+    reproduce it exactly — if that ever stops holding, this fails and says so
+    rather than quietly widening.
+
+    A wrong capture boundary, a stale buffer or a dropped gradient moves the
+    loss by tens of percent or produces NaN, so this band is loose enough to
+    be stable and tight enough to catch every failure seen while building it.
+    """
+    eager_a = _train(
+        class_name, size, imgsz, task, detect_dataset, tmp_path / "e1", False, extra
+    )["epoch_losses"]
+    eager_b = _train(
+        class_name, size, imgsz, task, detect_dataset, tmp_path / "e2", False, extra
+    )["epoch_losses"]
+    graphed = _train(
+        class_name, size, imgsz, task, detect_dataset, tmp_path / "g", True, extra
+    )["epoch_losses"]
+
+    assert all(np.isfinite(graphed)), f"{family}: {graphed}"
+    noise = max(abs(a - b) for a, b in zip(eager_a, eager_b))
+    gap = max(abs(a - g) for a, g in zip(eager_a, graphed))
+    scale = max(abs(x) for x in eager_a)
+    if rel_tol == 0.0:
+        assert noise == 0.0, (
+            f"{family} is listed as exactly reproducible but two eager runs "
+            f"differ by {noise:.3e}: {eager_a} vs {eager_b}"
+        )
+    assert gap <= max(noise * 4.0, rel_tol * scale), (
+        f"{family}: graph moved the loss by {gap:.3e}; eager's own spread is "
+        f"{noise:.3e} and the allowance is {rel_tol:.3g} x {scale:.3g}"
+        f"\n  eager  {eager_a}\n  eager2 {eager_b}\n  graph  {graphed}"
+    )
+
+
+# =============================================================================
+# Non-detect tasks
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def classify_dataset(tmp_path_factory) -> Path:
+    """A generated 3-class ImageFolder dataset."""
+    root = tmp_path_factory.mktemp("cuda_graph_train_cls")
+    rng = np.random.default_rng(1)
+    for split, count in (("train", 18), ("val", 6)):
+        for i in range(count):
+            folder = root / split / f"class{i % 3}"
+            folder.mkdir(parents=True, exist_ok=True)
+            pixels = rng.integers(0, 255, (224, 224, 3), dtype=np.uint8)
+            Image.fromarray(pixels).save(folder / f"{i:03d}.jpg")
+    return root
+
+
+@pytest.fixture(scope="module")
+def semantic_dataset(tmp_path_factory) -> Path:
+    """A generated 3-class dense-mask dataset."""
+    root = tmp_path_factory.mktemp("cuda_graph_train_sem")
+    rng = np.random.default_rng(2)
+    for split, count in (("train", 16), ("val", 4)):
+        (root / "images" / split).mkdir(parents=True)
+        (root / "masks" / split).mkdir(parents=True)
+        for i in range(count):
+            pixels = rng.integers(0, 255, (256, 256, 3), dtype=np.uint8)
+            Image.fromarray(pixels).save(root / "images" / split / f"{i:03d}.jpg")
+            mask = np.zeros((256, 256), np.uint8)
+            for label in (1, 2):
+                y, x = rng.integers(0, 150, 2)
+                mask[y : y + 80, x : x + 80] = label
+            Image.fromarray(mask).save(root / "masks" / split / f"{i:03d}.png")
+    (root / "data.yaml").write_text(
+        yaml.dump(
+            {
+                "path": str(root),
+                "train": "images/train",
+                "val": "images/val",
+                "masks_dir": "masks",
+                "nc": 3,
+                "names": ["background", "a", "b"],
+            }
+        )
+    )
+    return root / "data.yaml"
+
+
+@pytest.fixture(scope="module")
+def restore_dataset(tmp_path_factory) -> Path:
+    """A generated paired noisy/clean restoration dataset."""
+    root = tmp_path_factory.mktemp("cuda_graph_train_restore")
+    rng = np.random.default_rng(3)
+    for split, count in (("train", 12), ("val", 4)):
+        (root / split / "inputs").mkdir(parents=True)
+        (root / split / "targets").mkdir(parents=True)
+        for i in range(count):
+            clean = rng.integers(0, 255, (256, 256, 3), dtype=np.uint8)
+            noisy = np.clip(
+                clean.astype(np.float32) + rng.normal(0, 12, clean.shape), 0, 255
+            ).astype(np.uint8)
+            Image.fromarray(noisy).save(root / split / "inputs" / f"{i:03d}.png")
+            Image.fromarray(clean).save(root / split / "targets" / f"{i:03d}.png")
+    (root / "data.yaml").write_text(
+        yaml.dump(
+            {
+                "path": str(root),
+                "train": "train/inputs",
+                "val": "val/inputs",
+                "input_dir": "inputs",
+                "target_dir": "targets",
+                "nc": 1,
+                "names": ["restore"],
+            }
+        )
+    )
+    return root / "data.yaml"
+
+
+# (family, class name, size, imgsz, task, dataset fixture, rel_tol, extra)
+NON_DETECT_CASES = [
+    ("resnet", "LibreResNet", "18", 224, "classify", "classify_dataset", 0.0, {}),
+    ("convnext", "LibreConvNeXt", "t", 224, "classify", "classify_dataset", 0.0, {}),
+    (
+        "mobilenetv4",
+        "LibreMobileNetV4",
+        "s",
+        224,
+        "classify",
+        "classify_dataset",
+        0.0,
+        {},
+    ),
+    (
+        "efficientnetv2",
+        "LibreEfficientNetV2",
+        "b0",
+        224,
+        "classify",
+        "classify_dataset",
+        0.0,
+        {},
+    ),
+    # NAFNet captures bit-identically on a fixed batch (graph_bench and the
+    # unit suite gate that); its coupled crop/flip augmentation is what makes
+    # two eager train() runs differ.
+    ("nafnet", "LibreNAFNet", "s", 256, "restore", "restore_dataset", 0.01, {}),
+    ("fomo", "LibreFOMO", "s", 96, "point", "detect_dataset", 0.01,
+     {"allow_experimental": True}),
+    (
+        "lingbotvision",
+        "LibreLingBotVision",
+        "s",
+        224,
+        "semantic",
+        "semantic_dataset",
+        0.01,
+        {},
+    ),
+    # SegFormer's MiT encoder has stochastic depth inside the captured region,
+    # so replay draws its own random stream (see TrainGraphManager's capture
+    # log). Statistically equivalent, not reproducible against eager.
+    (
+        "segformer",
+        "LibreSegformer",
+        "b0",
+        256,
+        "semantic",
+        "semantic_dataset",
+        0.05,
+        {},
+    ),
+]
+
+
+@requires_cuda
+@pytest.mark.external_data
+@pytest.mark.parametrize(
+    "family,class_name,size,imgsz,task,dataset_fixture,rel_tol,extra",
+    NON_DETECT_CASES,
+    ids=[case[0] for case in NON_DETECT_CASES],
+)
+def test_non_detect_capture_engages_and_holds(
+    family,
+    class_name,
+    size,
+    imgsz,
+    task,
+    dataset_fixture,
+    rel_tol,
+    extra,
+    request,
+    tmp_path,
+    caplog,
+):
+    """Classification, restoration, point and semantic families capture too."""
+    data = request.getfixturevalue(dataset_fixture)
+    with caplog.at_level(logging.INFO, logger=CAPTURE_LOGGER):
+        result = _train(class_name, size, imgsz, task, data, tmp_path, True, extra)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("captured training forward/backward" in m for m in messages), (
+        f"{family}: capture never engaged; log was {messages}"
+    )
+    disabled = [m for m in messages if "capture disabled" in m]
+    assert not disabled, f"{family}: capture fell back to eager: {disabled}"
+    assert np.isfinite(result["final_loss"]), f"{family}: {result['final_loss']}"
+
+
+@requires_cuda
+@pytest.mark.external_data
+@pytest.mark.parametrize(
+    "family,class_name,size,imgsz,task,dataset_fixture,rel_tol,extra",
+    NON_DETECT_CASES,
+    ids=[case[0] for case in NON_DETECT_CASES],
+)
+def test_non_detect_loss_trajectory_stays_within_eager_noise(
+    family,
+    class_name,
+    size,
+    imgsz,
+    task,
+    dataset_fixture,
+    rel_tol,
+    extra,
+    request,
+    tmp_path,
+):
+    data = request.getfixturevalue(dataset_fixture)
+    eager_a = _train(
+        class_name, size, imgsz, task, data, tmp_path / "e1", False, extra
+    )["epoch_losses"]
+    eager_b = _train(
+        class_name, size, imgsz, task, data, tmp_path / "e2", False, extra
+    )["epoch_losses"]
+    graphed = _train(class_name, size, imgsz, task, data, tmp_path / "g", True, extra)[
+        "epoch_losses"
+    ]
+
+    assert all(np.isfinite(graphed)), f"{family}: {graphed}"
+    noise = max(abs(a - b) for a, b in zip(eager_a, eager_b))
+    gap = max(abs(a - g) for a, g in zip(eager_a, graphed))
+    scale = max(abs(x) for x in eager_a)
+    if rel_tol == 0.0:
+        assert noise == 0.0, (
+            f"{family} is listed as exactly reproducible but two eager runs "
+            f"differ by {noise:.3e}: {eager_a} vs {eager_b}"
+        )
+    assert gap <= max(noise * 4.0, rel_tol * scale), (
+        f"{family}: graph moved the loss by {gap:.3e}; eager's own spread is "
+        f"{noise:.3e} and the allowance is {rel_tol:.3g} x {scale:.3g}"
+        f"\n  eager  {eager_a}\n  eager2 {eager_b}\n  graph  {graphed}"
+    )
+
+
+@requires_cuda
+def test_in_training_validation_runs_with_a_live_graph(detect_dataset, tmp_path):
+    """Per-epoch validation must still work while a graph is captured.
+
+    Capture rebinds the forward of the *adapter* module, never the family
+    model's, precisely so validation, EMA evaluation and checkpointing keep
+    running the eager forward. This asserts that end to end rather than
+    trusting the design: the other cases in this file all disable validation
+    to stay fast.
+    """
+    import libreyolo
+
+    torch.manual_seed(0)
+    model = libreyolo.LibreYOLO9(None, "t")
+    result = model.train(
+        data=str(detect_dataset),
+        epochs=2,
+        batch=4,
+        imgsz=320,
+        device=0,
+        workers=0,
+        seed=0,
+        project=str(tmp_path),
+        name="valgraph",
+        exist_ok=True,
+        cuda_graph=True,
+        eval_interval=1,
+    )
+    assert len(result["val_metrics"]) == 2, result["val_metrics"]
+    assert Path(result["last_checkpoint"]).exists()
+
+
+@requires_cuda
+def test_yolox_capture_survives_the_mosaic_close_switch(detect_dataset, tmp_path):
+    """YOLOX turns on its L1 branch mid-run; the graph must be rebuilt there.
+
+    ``head.use_l1`` adds the origin_preds tensors to what the captured
+    region returns. Replaying the pre-switch graph would keep training the
+    pre-switch network, and re-capturing without restoring the eager forward
+    fails with "Cannot prepare for replay during capturing stage" and
+    silently disables capture for the rest of the run.
+    """
+    import libreyolo
+
+    def run(cuda_graph):
+        torch.manual_seed(0)
+        model = libreyolo.LibreYOLOX(None, "t")
+        return model.train(
+            data=str(detect_dataset),
+            epochs=4,
+            no_aug_epochs=2,  # mosaic closes at epoch 2 -> use_l1 flips
+            batch=4,
+            imgsz=320,
+            device=0,
+            workers=0,
+            seed=0,
+            project=str(tmp_path),
+            name="graph" if cuda_graph else "eager",
+            exist_ok=True,
+            cuda_graph=cuda_graph,
+            eval_interval=100,
+        )
+
+    caplog_logger = logging.getLogger(CAPTURE_LOGGER)
+    records: list[str] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Collect()
+    caplog_logger.addHandler(handler)
+    previous_level = caplog_logger.level
+    caplog_logger.setLevel(logging.INFO)
+    try:
+        eager = run(False)
+        graphed = run(True)
+    finally:
+        caplog_logger.removeHandler(handler)
+        caplog_logger.setLevel(previous_level)
+
+    assert sum("captured training forward/backward" in m for m in records) >= 2, (
+        f"expected a re-capture after the switch; log was {records}"
+    )
+    assert any("capture invalidated" in m for m in records), records
+    assert not [m for m in records if "capture disabled" in m], records
+    assert eager["epoch_losses"] == graphed["epoch_losses"], (
+        f"eager {eager['epoch_losses']} != graphed {graphed['epoch_losses']}"
+    )

--- a/tests/e2e/test_cuda_graph_training_families.py
+++ b/tests/e2e/test_cuda_graph_training_families.py
@@ -35,11 +35,31 @@ import yaml
 from PIL import Image
 
 # Not ``general_nightly``: that marker has a documented contract as the broad
-# *inference* sweep with a fixed case count (docs/testing.md). These are
-# training runs, so they follow the house pattern for training e2e files
-# (test_training_regression.py, test_dfine_seg_training.py): plain ``e2e``,
-# plus ``slow`` because the full file trains 20-odd models twice over.
+# *inference* sweep (docs/testing.md), and these are training runs. The full
+# file is ``e2e`` + ``slow``; a representative subset is additionally marked
+# ``training_nightly`` so the real capture paths run on GPU every night. That
+# lane exists because neither inference nightly marker selects this file, and
+# a feature whose every failure mode is a silent fallback to eager is exactly
+# the kind that must not rely on someone running it by hand.
 pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+# One case per distinct mechanism rather than every family: the reference
+# bespoke spec (yolo9), a spec built on a refactored family head plus the
+# mid-run invalidation path (yolox), the encoder-boundary DETR mixin (dfine),
+# the classify mixin (resnet), and the semantic mixin, which is also the one
+# family that draws its own RNG stream inside the graph (segformer).
+NIGHTLY_FAMILIES = frozenset({"yolo9", "yolox", "dfine", "resnet", "segformer"})
+
+
+def _cases(cases):
+    """Attach ``training_nightly`` to the representative subset."""
+    return [
+        pytest.param(
+            *case,
+            marks=[pytest.mark.training_nightly] if case[0] in NIGHTLY_FAMILIES else [],
+        )
+        for case in cases
+    ]
 
 requires_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(),
@@ -203,7 +223,7 @@ def test_capture_engages_and_holds(
 @pytest.mark.external_data
 @pytest.mark.parametrize(
     "family,class_name,size,imgsz,task,rel_tol,extra",
-    CASES,
+    _cases(CASES),
     ids=[case[0] for case in CASES],
 )
 def test_loss_trajectory_stays_within_eager_noise(
@@ -390,7 +410,7 @@ NON_DETECT_CASES = [
 @pytest.mark.external_data
 @pytest.mark.parametrize(
     "family,class_name,size,imgsz,task,dataset_fixture,rel_tol,extra",
-    NON_DETECT_CASES,
+    _cases(NON_DETECT_CASES),
     ids=[case[0] for case in NON_DETECT_CASES],
 )
 def test_non_detect_capture_engages_and_holds(
@@ -424,7 +444,7 @@ def test_non_detect_capture_engages_and_holds(
 @pytest.mark.external_data
 @pytest.mark.parametrize(
     "family,class_name,size,imgsz,task,dataset_fixture,rel_tol,extra",
-    NON_DETECT_CASES,
+    _cases(NON_DETECT_CASES),
     ids=[case[0] for case in NON_DETECT_CASES],
 )
 def test_non_detect_loss_trajectory_stays_within_eager_noise(
@@ -467,6 +487,7 @@ def test_non_detect_loss_trajectory_stays_within_eager_noise(
 
 
 @requires_cuda
+@pytest.mark.training_nightly
 def test_capture_engages_without_amp(detect_dataset, tmp_path, caplog):
     """``amp=False`` is a supported path and must still capture.
 
@@ -506,6 +527,7 @@ def test_capture_engages_without_amp(detect_dataset, tmp_path, caplog):
 
 
 @requires_cuda
+@pytest.mark.training_nightly
 def test_layer_freezing_matches_eager(detect_dataset, tmp_path):
     """Frozen layers change which parameters get gradients.
 
@@ -539,6 +561,7 @@ def test_layer_freezing_matches_eager(detect_dataset, tmp_path):
 
 
 @requires_cuda
+@pytest.mark.training_nightly
 def test_resume_from_checkpoint_recaptures(detect_dataset, tmp_path):
     """A resumed run must capture again and keep training.
 
@@ -586,6 +609,7 @@ def test_resume_from_checkpoint_recaptures(detect_dataset, tmp_path):
 
 
 @requires_cuda
+@pytest.mark.training_nightly
 def test_capture_failure_does_not_kill_the_run(detect_dataset, tmp_path, caplog):
     """Capture is opt-in and best-effort: failing it must cost speed, not the run.
 
@@ -627,6 +651,7 @@ def test_capture_failure_does_not_kill_the_run(detect_dataset, tmp_path, caplog)
 
 
 @requires_cuda
+@pytest.mark.training_nightly
 def test_gradient_accumulation_matches_eager(detect_dataset, tmp_path):
     """Capture must be safe when ``zero_grad`` runs once per window.
 
@@ -662,6 +687,7 @@ def test_gradient_accumulation_matches_eager(detect_dataset, tmp_path):
 
 
 @requires_cuda
+@pytest.mark.training_nightly
 def test_in_training_validation_runs_with_a_live_graph(detect_dataset, tmp_path):
     """Per-epoch validation must still work while a graph is captured.
 
@@ -694,6 +720,7 @@ def test_in_training_validation_runs_with_a_live_graph(detect_dataset, tmp_path)
 
 
 @requires_cuda
+@pytest.mark.training_nightly
 def test_yolox_capture_survives_the_mosaic_close_switch(detect_dataset, tmp_path):
     """YOLOX turns on its L1 branch mid-run; the graph must be rebuilt there.
 

--- a/tests/unit/test_cuda_graph_training.py
+++ b/tests/unit/test_cuda_graph_training.py
@@ -164,6 +164,146 @@ class TestTrainGraphManager:
 
 
 # =============================================================================
+# Invalidation (mid-run changes to what the captured region computes)
+# =============================================================================
+#
+# YOLOX turns on its L1 branch when mosaic closes, which adds tensors to the
+# network's output. Replaying the pre-switch graph past that point would keep
+# training the pre-switch network, so the family trainer invalidates and the
+# manager re-captures.
+
+
+class _ToyNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return (self.lin(x),)
+
+
+class TestCaptureInvalidation:
+    def _captured(self, network):
+        manager = TrainGraphManager(warmup_threshold=1)
+        spec = CudaGraphTrainSpec(network=network, assemble=MagicMock())
+        imgs = _fake_cuda_batch()
+
+        def fake_make_graphed(module, sample, **kwargs):
+            # Mirror the real call's in-place rebind of module.forward.
+            module.forward = MagicMock(return_value=("flat",))
+            return module
+
+        with patch(
+            "torch.cuda.make_graphed_callables", side_effect=fake_make_graphed
+        ):
+            assert manager.run(spec, imgs) == ("flat",)
+        return manager, spec, imgs
+
+    def test_invalidate_restores_eager_forward_and_recaptures(self):
+        network = _ToyNet()
+        eager_forward = network.forward
+        manager, spec, imgs = self._captured(network)
+        assert manager.captured
+        assert "forward" in network.__dict__  # capture rebound it
+
+        manager.invalidate("mosaic close")
+        assert not manager.captured
+        assert not manager.disabled
+        # The eager forward is back: a re-capture's warm-up must not replay
+        # the dead graph (that fails with "Cannot prepare for replay during
+        # capturing stage" and permanently disables capture).
+        assert "forward" not in network.__dict__
+        assert network.forward.__func__ is eager_forward.__func__
+
+        with patch(
+            "torch.cuda.make_graphed_callables",
+            return_value=MagicMock(return_value=("flat2",)),
+        ) as make:
+            assert manager.run(spec, imgs) == ("flat2",)
+        make.assert_called_once()
+
+    def test_invalidate_resets_the_warmup_count(self):
+        manager = TrainGraphManager(warmup_threshold=3)
+        spec = _spec()
+        imgs = _fake_cuda_batch()
+        assert manager.run(spec, imgs) is None
+        assert manager.run(spec, imgs) is None
+        manager.invalidate("nothing captured yet")
+        # Counting starts over, so a switch landing near the end of a run
+        # never pays for a capture it cannot amortise.
+        with patch("torch.cuda.make_graphed_callables") as make:
+            assert manager.run(spec, imgs) is None
+            assert manager.run(spec, imgs) is None
+        make.assert_not_called()
+
+    def test_invalidate_after_disable_is_a_noop(self):
+        manager = TrainGraphManager(warmup_threshold=1)
+        manager.disabled = True
+        manager.invalidate("late switch")
+        assert manager.disabled
+        assert not manager.captured
+
+    def test_capture_failure_restores_eager_forward(self):
+        network = _ToyNet()
+        manager = TrainGraphManager(warmup_threshold=1)
+        spec = CudaGraphTrainSpec(network=network, assemble=MagicMock())
+        with patch(
+            "torch.cuda.make_graphed_callables", side_effect=RuntimeError("boom")
+        ):
+            assert manager.run(spec, _fake_cuda_batch()) is None
+        assert manager.disabled
+        # The eager fallback must call the real forward, not a half-built graph.
+        assert "forward" not in network.__dict__
+
+    def test_trainer_hook_routes_to_manager(self):
+        manager = TrainGraphManager()
+        host = SimpleNamespace(_cuda_graph_manager=manager)
+        with patch.object(TrainGraphManager, "invalidate") as invalidate:
+            BaseTrainer.invalidate_cuda_graph(host, "because")
+        invalidate.assert_called_once_with("because")
+
+    def test_trainer_hook_without_manager_is_a_noop(self):
+        BaseTrainer.invalidate_cuda_graph(SimpleNamespace(), "because")
+
+
+# =============================================================================
+# Stochastic-layer detection
+# =============================================================================
+#
+# Capture does not disable dropout or stochastic depth, but a replayed graph
+# consumes the generator on its own schedule, so it does not reproduce the
+# sequence an eager step would draw. Families that have such layers inside the
+# captured region are statistically equivalent, not bit-identical, and the
+# manager says so once at capture time rather than leaving it to be found in
+# a diff.
+
+
+class TestStochasticLayerDetection:
+    def test_clean_network_reports_none(self):
+        assert TrainGraphManager._stochastic_layers(_ToyNet()) == []
+
+    def test_active_dropout_is_reported(self):
+        net = nn.Sequential(nn.Linear(4, 4), nn.Dropout(0.5))
+        assert TrainGraphManager._stochastic_layers(net) == ["1"]
+
+    def test_disabled_dropout_is_not_reported(self):
+        net = nn.Sequential(nn.Linear(4, 4), nn.Dropout(0.0))
+        assert TrainGraphManager._stochastic_layers(net) == []
+
+    def test_stochastic_depth_is_reported_by_name(self):
+        class DropPath(nn.Module):
+            def __init__(self, drop_prob):
+                super().__init__()
+                self.drop_prob = drop_prob
+
+            def forward(self, x):
+                return x
+
+        net = nn.Sequential(DropPath(0.1), DropPath(0.0))
+        assert TrainGraphManager._stochastic_layers(net) == ["0"]
+
+
+# =============================================================================
 # Capture error mode (pin-memory thread race)
 # =============================================================================
 #
@@ -444,6 +584,233 @@ class TestRFDETRSpecGating:
         fn, host = self._host()
         host.criterion = None
         assert fn(host) is None
+
+
+class TestClassifyMixinGating:
+    """One mixin serves ResNet, ConvNeXt, MobileNetV4 and EfficientNetV2.
+
+    All four train on ``F.cross_entropy(model(imgs), targets)``, so the
+    network never reads the labels and the whole of it is capturable.
+    """
+
+    def _host(self, task="classify", model=None):
+        from libreyolo.models.base.classify_cuda_graph import ClassifyCudaGraphMixin
+
+        host = SimpleNamespace(
+            wrapper_model=SimpleNamespace(task=task),
+            model=nn.Linear(4, 3) if model is None else model,
+        )
+        return ClassifyCudaGraphMixin.cuda_graph_train_spec, host
+
+    def test_classify_supported(self):
+        fn, host = self._host()
+        spec = fn(host)
+        assert spec is not None
+        assert spec.network.module is host.model
+
+    def test_other_tasks_unsupported(self):
+        for task in ("detect", "segment", "semantic"):
+            fn, host = self._host(task=task)
+            assert fn(host) is None, task
+
+    def test_non_module_unsupported(self):
+        fn, host = self._host(model="not a module")
+        assert fn(host) is None
+
+    def test_assemble_matches_the_eager_loss(self):
+        import torch.nn.functional as F
+
+        fn, host = self._host()
+        spec = fn(host)
+        imgs = torch.randn(2, 4)
+        targets = torch.tensor([0, 2])
+        logits = host.model(imgs)
+        spec.network(imgs)  # records the output skeleton
+        out = spec.assemble((logits,), imgs, targets)
+        assert torch.equal(out["total_loss"], F.cross_entropy(logits, targets))
+        assert "loss_ce" in out
+
+    def test_every_classify_trainer_inherits_it(self):
+        from libreyolo.models.base.classify_cuda_graph import ClassifyCudaGraphMixin
+        from libreyolo.models.convnext.trainer import ConvNeXtTrainer
+        from libreyolo.models.efficientnetv2.trainer import EfficientNetV2Trainer
+        from libreyolo.models.mobilenetv4.trainer import MobileNetV4Trainer
+        from libreyolo.models.resnet.trainer import ResNetTrainer
+
+        for trainer in (
+            ResNetTrainer,
+            ConvNeXtTrainer,
+            MobileNetV4Trainer,
+            EfficientNetV2Trainer,
+        ):
+            assert issubclass(trainer, ClassifyCudaGraphMixin), trainer.__name__
+
+
+class TestSemanticMixinGating:
+    def _host(self, task="semantic", model=None):
+        from libreyolo.models.base.semantic_cuda_graph import (
+            SemanticLogitsCudaGraphMixin,
+        )
+
+        class Net(nn.Module):
+            def forward_logits(self, imgs):
+                return imgs * 2
+
+            def loss_from_logits(self, logits, targets):
+                return {"total_loss": logits.sum(), "sem": logits.sum()}
+
+        host = SimpleNamespace(
+            wrapper_model=SimpleNamespace(task=task),
+            model=Net() if model is None else model,
+        )
+        return SemanticLogitsCudaGraphMixin.cuda_graph_train_spec, host
+
+    def test_semantic_supported(self):
+        fn, host = self._host()
+        assert fn(host) is not None
+
+    def test_other_tasks_unsupported(self):
+        fn, host = self._host(task="detect")
+        assert fn(host) is None
+
+    def test_network_without_the_split_unsupported(self):
+        fn, host = self._host(model=nn.Linear(4, 4))
+        assert fn(host) is None
+
+    def test_both_families_expose_the_split(self):
+        from libreyolo.models.lingbotvision.nn import LingBotVisionSemanticSegmenter
+        from libreyolo.models.segformer.nn import LibreSegformerNet
+
+        for cls in (LibreSegformerNet, LingBotVisionSemanticSegmenter):
+            assert hasattr(cls, "forward_logits"), cls.__name__
+            assert hasattr(cls, "loss_from_logits"), cls.__name__
+
+
+class TestDETRMixinGating:
+    """One mixin serves D-FINE, DEIM, DEIMv2, RT-DETR v1/v2/v4 and EC.
+
+    The decoder reads the ground truth to size its denoising queries, so the
+    capture stops at the encoder.
+    """
+
+    def _host(self, task="detect", model=None, criterion=MagicMock()):
+        from libreyolo.models.base.detr_cuda_graph import DETREncoderCudaGraphMixin
+
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.backbone = nn.Identity()
+                self.encoder = nn.Identity()
+                self.decoder = nn.Identity()
+
+        host = SimpleNamespace(
+            wrapper_model=SimpleNamespace(task=task),
+            model=Net() if model is None else model,
+            criterion=criterion,
+        )
+        return DETREncoderCudaGraphMixin.cuda_graph_train_spec, host
+
+    def test_detect_supported(self):
+        fn, host = self._host()
+        assert fn(host) is not None
+
+    def test_other_tasks_unsupported(self):
+        for task in ("segment", "pose", "semantic"):
+            fn, host = self._host(task=task)
+            assert fn(host) is None, task
+
+    def test_model_without_the_trio_unsupported(self):
+        fn, host = self._host(model=nn.Linear(4, 4))
+        assert fn(host) is None
+
+    def test_missing_criterion_unsupported(self):
+        fn, host = self._host(criterion=None)
+        assert fn(host) is None
+
+    def test_every_detr_trainer_inherits_it(self):
+        from libreyolo.models.base.detr_cuda_graph import DETREncoderCudaGraphMixin
+        from libreyolo.models.deim.trainer import DEIMTrainer
+        from libreyolo.models.deimv2.trainer import DEIMv2Trainer
+        from libreyolo.models.dfine.trainer import DFINETrainer
+        from libreyolo.models.ec.trainer import ECTrainer
+        from libreyolo.models.rtdetr.trainer import RTDETRTrainer
+        from libreyolo.models.rtdetrv2.trainer import RTDETRv2Trainer
+        from libreyolo.models.rtdetrv4.trainer import RTDETRv4Trainer
+
+        for trainer in (
+            DFINETrainer,
+            DEIMTrainer,
+            DEIMv2Trainer,
+            ECTrainer,
+            RTDETRTrainer,
+            RTDETRv2Trainer,
+            RTDETRv4Trainer,
+        ):
+            assert issubclass(trainer, DETREncoderCudaGraphMixin), trainer.__name__
+
+    def test_capture_half_runs_the_families_own_forward(self):
+        """The capturable half must not re-derive the family's prefix.
+
+        DEIMv2's backbone emits more maps than its encoder consumes without
+        splitting a low-level feature off, which a hand-rolled prefix got
+        wrong (it passed ``low_level_feat=`` to a decoder that has no such
+        argument). Running the real forward with the decoder stubbed keeps
+        every family's own branching.
+        """
+        from libreyolo.models.base.detr_cuda_graph import _BackboneEncoder
+
+        seen = {}
+
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.backbone = nn.Identity()
+                self.encoder = nn.Identity()
+                self.decoder = nn.Identity()
+
+            def forward(self, x, targets=None):
+                a, b = x, x * 2
+                return self.decoder([a, b], targets=targets, extra=x * 3)
+
+        net = Net()
+        original_decoder_forward = net.decoder.forward
+        adapter = _BackboneEncoder(net)
+        flat = adapter(torch.ones(2))
+        assert len(flat) == 3  # two feats plus the one tensor kwarg
+        feats, kwargs = adapter.split(list(flat))
+        assert len(feats) == 2
+        assert set(kwargs) == {"extra"}
+        assert torch.equal(kwargs["extra"], torch.full((2,), 3.0))
+        # The stub is removed again: the decoder must be callable afterwards.
+        assert net.decoder.forward.__func__ is original_decoder_forward.__func__
+        seen.clear()
+
+    def test_shared_tensor_kwarg_is_not_duplicated(self):
+        """EC hands ``feats[0]`` to its mask head; it must not be emitted twice.
+
+        ``make_graphed_callables`` returns one static output buffer per
+        output tensor, and the same tensor appearing twice would give the
+        eager half two aliases of one buffer instead of the two distinct
+        values the family expects.
+        """
+        from libreyolo.models.base.detr_cuda_graph import _BackboneEncoder
+
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.backbone = nn.Identity()
+                self.encoder = nn.Identity()
+                self.decoder = nn.Identity()
+
+            def forward(self, x, targets=None):
+                feats = [x, x * 2]
+                return self.decoder(feats, targets=targets, spatial_feat=feats[0])
+
+        adapter = _BackboneEncoder(Net())
+        flat = adapter(torch.ones(2))
+        assert len(flat) == 2
+        feats, kwargs = adapter.split(list(flat))
+        assert kwargs["spatial_feat"] is feats[0]
 
 
 # =============================================================================

--- a/tests/unit/test_cuda_graph_training.py
+++ b/tests/unit/test_cuda_graph_training.py
@@ -152,6 +152,44 @@ class TestTrainGraphManager:
             assert manager.run(spec, imgs) is None
         make.assert_not_called()
 
+    def test_buffer_snapshot_failure_disables_instead_of_raising(self):
+        """An OOM cloning the BatchNorm snapshot must not kill the run.
+
+        The snapshot allocates a copy of every module buffer, on device, at
+        the moment memory is tightest: immediately before capture reserves
+        static input, output and workspace buffers for a whole forward and
+        backward. It used to run outside the capture guard, so that OOM
+        propagated out of the training step and ended the run. An opt-in
+        speed flag must degrade to eager, never to a crash.
+        """
+        manager = TrainGraphManager(warmup_threshold=1)
+        spec = _spec()
+        with patch.object(
+            TrainGraphManager,
+            "_snapshot_buffers",
+            side_effect=torch.cuda.OutOfMemoryError("snapshot OOM"),
+        ):
+            assert manager.run(spec, _fake_cuda_batch()) is None
+        assert manager.disabled
+
+    def test_buffer_snapshot_failure_skips_restore(self):
+        """With no snapshot taken there is nothing to restore.
+
+        The handler restores unconditionally, so the failure path must leave
+        an empty snapshot rather than a half-built one it would then try to
+        copy back into live buffers.
+        """
+        manager = TrainGraphManager(warmup_threshold=1)
+        spec = _spec()
+        with patch.object(
+            TrainGraphManager,
+            "_snapshot_buffers",
+            side_effect=torch.cuda.OutOfMemoryError("snapshot OOM"),
+        ):
+            with patch.object(TrainGraphManager, "_restore_buffers") as restore:
+                assert manager.run(spec, _fake_cuda_batch()) is None
+        restore.assert_called_once_with([])
+
     def test_replay_failure_disables(self):
         manager = TrainGraphManager(warmup_threshold=1)
         spec = _spec()


### PR DESCRIPTION
`train(..., cuda_graph=True)` went from 2 families to 24, across five tasks.

## What

- New per-family specs: yolox, yolo7, yolo9_e2e, yolonas, picodet, rtmdet, fomo, nafnet.
- Three shared mixins in `libreyolo/models/base/`:
  - `classify_cuda_graph.py`: resnet, convnext, mobilenetv4, efficientnetv2
  - `semantic_cuda_graph.py`: segformer, lingbotvision
  - `detr_cuda_graph.py`: dfine, deim, deimv2, rtdetr, rtdetrv2, rtdetrv4, ec
- `TrainGraphManager.invalidate()` + `BaseTrainer.invalidate_cuda_graph()`, for families that change what the captured region computes mid-run (YOLOX enables its L1 branch at mosaic close).
- Capture now logs randomness-drawing layers inside the graph once.

## Two bugs fixed

- **`cuda_graph=True` was a silent no-op for dfine, deim, deimv2, rtdetrv4 and ec.** Those trainers copy `_train_epoch` and called `on_forward` (eager) instead of `_forward_train` (routed). Nothing errored; capture never engaged.
- **Re-capture was impossible.** `make_graphed_callables` rebinds `module.forward` in place; dropping a graph without restoring it makes the next capture's warm-up replay the dead graph inside the new capture and permanently disables the feature.

## Measured (RTX 5070 Ti, Windows, AMP, fastest of 24 steps)

fomo 3.63x, mobilenetv4 2.74x, efficientnetv2 2.44x, yolo9-t 1.99x, yolo9_e2e 1.76x, yolo9_p2 1.49x, nafnet/resnet 1.25-1.26x, picodet 1.22x, deim/rtdetrv4 1.18x, yolonas 1.17x, dfine/deimv2/rfdetr/rtdetrv2/ec 1.15-1.16x, convnext 1.15x, yolox/segformer/rtdetr 1.12-1.13x, rtmdet 1.10x, yolo7/lingbotvision 1.04-1.05x.

End to end, YOLO9-t on 406 images, 20 epochs, dataloader and validation included: 428.4s -> 367.7s (1.16x), mAP50-95 0.6394 both arms, per-epoch losses identical.

The win tracks how much of a step is network rather than loss, and is largest at small batch. Phase split at 640/b8: yolo9-t network 84% (ceiling 6.1x), yolox-t 31% (1.5x), rtmdet-t 26% (1.3x). SimOTA is 69% of a YOLOX step.

## Numerics: needs a call before merge

The old contract was "enabling `cuda_graph` never changes training numerics". That is now false in two places, both inherent:

- **rtmdet**: `share_conv=True` aliases the head convs across all 3 pyramid levels, so those 2 weights' gradient is a 3-term sum. Eager and graphed sum in a different order; under fp16 that differs in the last bits. 137 of 139 gradients stay bit-identical.
- **segformer**: stochastic depth inside the captured region. A replayed graph consumes the generator on its own schedule, so it does not reproduce the eager draw sequence. Statistically equivalent, like a different seed.

I softened the doc rather than the code. The alternative is to keep the contract absolute and drop those two, costing 1.10x (rtmdet, 1.24x at b4) and 1.12x (segformer). **Product call, not a technical one.**

Every other family is bit-identical, except fomo and lingbotvision at 1 ULP of float32.

## Normal precision (amp=False)

Every family still captures at fp32. Speedups shift, because fp32 kernels run longer so a step is less launch-bound:

| Family | AMP | fp32 |
| --- | --- | --- |
| mobilenetv4-s b16 | 2.74x | 3.61x |
| fomo-s b16 | 3.63x | 3.06x |
| yolo9-t b8 | 1.99x | 1.69x |
| yolo9_e2e-t b8 | 1.76x | 1.52x |
| picodet-s b8 | 1.22x | 1.15x |
| dfine-n b4 | 1.16x | 1.13x |
| yolox-t b8 | 1.13x | 1.08x |
| nafnet-s b8 | 1.26x | 1.08x |
| resnet-18 b16 | 1.25x | 1.05x |
| rtmdet-t b8 | 1.10x | 1.04x |
| yolonas-s b8 | 1.17x | 1.03x |
| rtdetr-r18 b4 | 1.12x | 0.99x |

**The parity guarantee is AMP-only, and the doc now says so.** At fp32 these families do not reproduce their own eager runs: two identical seeded eager YOLO9-t runs diverge 36% relative over 20 steps, YOLOX-t 2.6%. cuDNN picks a nondeterministic weight-gradient algorithm for some fp32 convolution shapes (measured: two back-to-back wgrads on one 8x64x160x160 conv differ by 3.2e-7 relative), and TF32 off does not fix it. Capture is not what removes reproducibility there.

## Step-0 per-parameter evidence

Both arms provably hold identical weights at step 0. Loss delta is **exactly zero for all 24 families**, and **no BatchNorm buffer differs** anywhere. Gradients bit-identical: yolo9 583/583, yolo9_p2 775/775, yolo9_e2e 693/693, yolox 219/219, yolonas 460/460, picodet 369/369, yolo7 271/271, deimv2 298/300, rtmdet 173/177.

D-FINE, DEIM and RT-DETRv2 look alarming (112/400, 113/422, 95/312) until the identical comparison runs eager against eager: 116/400, 117/422, 98/312. Those families reproduce barely a quarter of their own gradients; capture moves 3 or 4 more out of several hundred. The encoder-boundary split is sound.

## Edge paths now tested

- `amp=False` capture
- layer freezing (frozen params exercise `allow_unused_input`): bit-identical to eager
- resume from checkpoint: re-captures, keeps training
- capture raising OOM: exactly one warning, run finishes eager with the eager losses
- gradient accumulation (`nbs`), where `zero_grad` runs once per window rather than per micro-batch
- per-epoch validation with a live graph

## Check

- `tests/unit`: 5068 passed, 0 failed.
- New `tests/e2e/test_cuda_graph_training_families.py`: 49 tests, all pass. Per-family it asserts capture actually engages (every failure mode here degrades to eager silently), and holds the loss trajectory to the family's own eager-to-eager spread plus a documented per-family tolerance. Plus gradient accumulation, live-graph validation, and the YOLOX mosaic-close switch.
- `tests/unit/test_cuda_graph_training.py`: +23 tests for invalidation, forward restoration, stochastic-layer detection, and the three mixins' gating.
- `ruff`: 137 errors before and after; the new files are clean.

## Not verified

- One box only: Windows, RTX 5070 Ti, torch 2.11+cu128. Nothing run on Linux or Ampere/Hopper. Failure mode there is a warning plus eager fallback, not broken training.
- Resume-from-checkpoint with a live graph.
- DDP and distillation stay excluded, as before.
- Non-detect tasks on multi-task families (rfdetr seg/pose, ec seg/pose, dfine segment, rtmdet segment, yolonas pose) stay eager, gated.
- Six DETR families default to `multi_scale=True`, where a graph may never capture in a short run. Documented; `multi_scale=False` for the full speedup.
- `skills/run-rf100vl-benchmark/SKILL.md` still says `cuda_graph: true` is "bit-identical". True for the YOLO families, not for the DETR families or rtmdet. Not edited here: a recipe change orphans banked epochs.

## Code provenance

All code in this PR is original, written for this PR, or a refactor of existing LibreYOLO code moved to a new boundary:

- New files (`libreyolo/models/base/classify_cuda_graph.py`, `semantic_cuda_graph.py`, `detr_cuda_graph.py`, `tests/e2e/test_cuda_graph_training_families.py`): original.
- `libreyolo/models/yolox/nn.py`: existing YOLOX head code split into `forward_train_maps` with no behavior change, plus two constant allocations moved onto the target device. The surrounding YOLOX implementation's provenance (Megvii YOLOX, Apache-2.0) is unchanged and already recorded in the notice files.
- `libreyolo/models/yolo7/net.py`, `segformer/nn.py`, `lingbotvision/nn.py`: existing loss tails split into named methods, no behavior change.
- Everything else: new methods on existing trainers, and additions to `libreyolo/training/cuda_graph.py` and `trainer.py`.

No third-party code is introduced, adapted, or derived in this PR, so no notice-file changes are required.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends training CUDA graph capture across detection, classification, semantic segmentation, point detection, and restoration families, while adding graph invalidation and safe eager-forward restoration.
- Adds shared classification, semantic, and DETR encoder capture adapters plus family-specific capture specifications.
- Routes copied D-FINE and DEIM training loops through the graph-aware forward path.
- Adds representative nightly coverage and per-family end-to-end checks for capture engagement, parity, fallback, accumulation, validation, resume, and YOLOX recapture.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up scope.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/cuda_graph.py | Adds capture invalidation, eager-forward restoration, safer capture fallback, and stochastic-layer diagnostics without an eligible unresolved finding. |
| libreyolo/training/trainer.py | Exposes graph invalidation to family trainers and retains eager routing whenever capture is unavailable. |
| libreyolo/models/base/detr_cuda_graph.py | Introduces a shared backbone-and-encoder capture boundary that resumes each opted-in family’s decoder and criterion eagerly. |
| libreyolo/models/base/classify_cuda_graph.py | Adds shared whole-network capture with eager cross-entropy assembly for four classification families. |
| libreyolo/models/base/semantic_cuda_graph.py | Adds shared logits-only capture while preserving each semantic model’s eager loss implementation. |
| libreyolo/models/yolox/trainer.py | Invalidates and recaptures the training graph when mosaic closure enables YOLOX’s L1 branch. |
| tests/e2e/test_cuda_graph_training_families.py | Adds CUDA-dependent family coverage for engagement, numerical behavior, fallback, accumulation, validation, resume, and recapture. |
| tests/unit/test_cuda_graph_training.py | Expands unit coverage for graph lifecycle restoration, invalidation, mixin gating, and capture failure behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Batch[Training batch] --> Route[BaseTrainer._forward_train]
    Route -->|Unsupported or graph unavailable| Eager[Family on_forward]
    Route -->|Stable CUDA shape| Manager[TrainGraphManager]
    Manager --> Capture[Captured network region]
    Capture --> Assemble[Eager loss / decoder assembly]
    Assemble --> Backward[Backward and optimizer step]
    Eager --> Backward
    Switch[Mid-run model phase change] --> Invalidate[invalidate_cuda_graph]
    Invalidate --> Restore[Restore eager forward]
    Restore --> Manager
    Failure[Capture or replay failure] --> Restore
    Restore --> Eager
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Align CUDA graph nightly contracts"](https://github.com/libreyolo/libreyolo/commit/fdeb38ec5442a22573fc523b0d824f0265ae707f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50019773)</sub>

**Context used:**

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->