### PR TITLE
Add screen sources and streaming inference

### DIFF
--- a/docs/adr/0004-model-ensembling.md
+++ b/docs/adr/0004-model-ensembling.md
@@ -104,9 +104,9 @@ expressible.
 - The source image is decoded once and handed to members as PIL.
 - Members may live on different devices; fusion runs on the first member's
   output device (post-suppression row counts are small).
-- v1 task scope is detect only; any non-detect member raises at
-  construction. Sources: image path / PIL / numpy / bytes / directory.
-  Video and stream raise in v1 (Phase 2).
+- Task scope is detect only; any non-detect member raises at construction.
+  Sources: image path / PIL / numpy / bytes / list / directory / video / screen.
+  `stream=True` yields fused `Results` lazily for every source type.
 - `Results.speed` reports per-member inference times plus fusion
   (`member_0`, `member_1`, …, `fusion`), so the N× cost is visible.
 - WBF's `min(W_T, W_N) / W_N` rescale means fused scores can drop below the
@@ -151,9 +151,10 @@ both are documented and tested.
 - **Phase 1 (this ADR, implemented):** `libreyolo/ops/fusion.py`,
   `libreyolo/ensemble/`, stub-member unit tests, lazy exports. Zero changes
   to model families, no new dependencies, nothing imported unless used.
-- **Phase 2 (fast follows):** `ensemble.val()` (the measured-mAP number that
-  justifies the N× latency), video/stream, CLI comma-list models, a
-  `class_map` hook for name aliases ("person" vs "pedestrian").
+- **Phase 2 (partial):** video/stream is implemented. Remaining work is
+  `ensemble.val()` (the measured-mAP number that justifies the N× latency),
+  CLI comma-list models, and a `class_map` hook for name aliases
+  ("person" vs "pedestrian").
 - **Phase 3:** baked single-file ONNX ensemble — one input, one
   `(1, max_det, 6)` output in union label ids, indistinguishable from a
   single exported detector with embedded suppression. The graph compiles

--- a/docs/adr/0004-model-ensembling.md
+++ b/docs/adr/0004-model-ensembling.md
@@ -105,7 +105,8 @@ expressible.
 - Members may live on different devices; fusion runs on the first member's
   output device (post-suppression row counts are small).
 - Task scope is detect only; any non-detect member raises at construction.
-  Sources: image path / PIL / numpy / bytes / list / directory / video / screen.
+  Sources: image path / PIL / numpy / bytes / list / directory / video / screen
+  / webcam / network stream / YouTube / multi-stream file.
   `stream=True` yields fused `Results` lazily for every source type.
 - `Results.speed` reports per-member inference times plus fusion
   (`member_0`, `member_1`, …, `fusion`), so the N× cost is visible.

--- a/docs/predict_sources.md
+++ b/docs/predict_sources.md
@@ -1,0 +1,106 @@
+# Prediction sources
+
+LibreYOLO classifies prediction inputs before loading them. Webcam indices and
+network stream URLs therefore enter the video path directly instead of being
+interpreted as image filenames.
+
+| Source | Python value | Behavior |
+| --- | --- | --- |
+| Image or image URL | `"image.jpg"`, `PIL.Image`, NumPy, tensor | One result |
+| Image directory or list | `"images/"`, `[image1, image2]` | List, or a lazy generator with `stream=True` |
+| Video file or URL | `"clip.mp4"` | List by default; generator with `stream=True` |
+| Screen | `"screen"`, `"screen 1"` | One capture; continuous with `stream=True` |
+| Webcam | `0`, `1`, or a numeric CLI source | Continuous; requires `stream=True` in Python |
+| Network stream | `rtsp://`, `rtmp://`, `tcp://`, `udp://`, or an HLS `.m3u8` URL | Continuous; requires `stream=True` in Python |
+| YouTube | A `youtube.com` or `youtu.be` page URL | Resolved through `yt-dlp`, then read as a live stream |
+| Multiple cameras | A list of stream sources or a `.streams` text file | One capture thread per source; results are yielded with the source in `result.path` |
+
+## Python
+
+Live sources are unbounded, so the Python API requires lazy consumption:
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreYOLO9t.pt")
+
+for result in model(0, stream=True):
+    print(result.path, result.frame_idx, result.boxes)
+```
+
+RTSP and YouTube use the same call:
+
+```python
+for result in model("rtsp://127.0.0.1:8554/camera", stream=True):
+    ...
+
+for result in model("https://youtu.be/VIDEO_ID", stream=True):
+    ...
+```
+
+Install the YouTube resolver only when needed:
+
+```bash
+pip install "libreyolo[stream]"
+```
+
+By default each capture thread keeps only its newest frame. This bounds memory
+and latency when inference is slower than capture. Set `stream_buffer=True` to
+preserve every captured frame at the cost of a growing queue and increasing
+latency.
+
+## Multiple cameras
+
+Pass a Python list:
+
+```python
+sources = [0, "rtsp://127.0.0.1:8554/loading-dock"]
+for result in model(sources, stream=True):
+    print(result.path, result.frame_idx)
+```
+
+Or put one source per line in `cameras.streams`; blank lines and lines beginning
+with `#` are ignored:
+
+```text
+# Local webcam
+0
+
+# Docker-published camera
+rtsp://127.0.0.1:8554/loading-dock
+```
+
+```python
+for result in model("cameras.streams", stream=True):
+    ...
+```
+
+Capture is concurrent, while inference and result delivery remain ordered by
+availability. Each result carries a per-source `frame_idx`. Credentials in a
+stream URL are redacted from `result.path`.
+
+## CLI
+
+The CLI enables lazy streaming automatically for live inputs. It emits one JSON
+object per frame in JSON mode.
+
+```bash
+libreyolo predict source=0 model=LibreYOLO9t.pt show=true
+libreyolo predict source=rtsp://127.0.0.1:8554/camera model=LibreRFDETRn.pt
+libreyolo predict source=cameras.streams model=LibreYOLO9t.pt --json
+```
+
+Use `q` to stop a displayed stream or `Ctrl+C` otherwise.
+
+## Local RTSP loop
+
+One reproducible local setup uses MediaMTX as the RTSP server and FFmpeg as the
+publisher:
+
+```bash
+docker run --rm --name libreyolo-mediamtx -p 8554:8554 bluenviron/mediamtx:latest
+ffmpeg -re -stream_loop -1 -i clip.mp4 -c copy -rtsp_transport tcp -f rtsp rtsp://127.0.0.1:8554/camera
+```
+
+Then consume `rtsp://127.0.0.1:8554/camera`. OpenCV must have the corresponding
+video backend enabled; the standard `opencv-python` wheels include FFmpeg.

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -61,7 +61,13 @@ from ..utils.results import (
     RestoredImage,
     SemanticMask,
 )
-from ..utils.video import collect_video_results, is_video_file, run_video_inference
+from ..utils.screen import ScreenSource, grab_screen, is_screen_source
+from ..utils.video import (
+    FrameSource,
+    collect_video_results,
+    is_video_file,
+    run_video_inference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -513,9 +519,7 @@ class BaseBackend(ABC):
             )
             return tensor, img, size, 1.0
         elif self.model_family in {"faster_rcnn", "mask_rcnn"}:
-            return self._preprocess_faster_rcnn(
-                image, effective_imgsz, color_format
-            )
+            return self._preprocess_faster_rcnn(image, effective_imgsz, color_format)
         elif self.model_family == "retinanet":
             from ..models.retinanet.utils import (
                 preprocess_image as retinanet_preprocess_image,
@@ -547,9 +551,7 @@ class BaseBackend(ABC):
             )
             return tensor, img, size, 1.0
         elif self.model_family == "centernet":
-            return self._preprocess_centernet(
-                image, effective_imgsz, color_format
-            )
+            return self._preprocess_centernet(image, effective_imgsz, color_format)
         elif self.model_family in ("dfine", "rtdetrv4"):
             tensor, img, size = self._preprocess_dfine(
                 image, effective_imgsz, color_format
@@ -993,9 +995,7 @@ class BaseBackend(ABC):
             raise NotImplementedError(
                 "CenterNet exported inference requires a square input canvas."
             )
-        return preprocess_image(
-            image, input_size=input_h, color_format=color_format
-        )
+        return preprocess_image(image, input_size=input_h, color_format=color_format)
 
     @staticmethod
     def _preprocess_detr(image, input_size, color_format):
@@ -1696,12 +1696,8 @@ class BaseBackend(ABC):
                 class_ids = class_ids[keep]
             order = np.argsort(-level_scores, kind="stable")
             level_boxes = boxes[anchor_ids[order]].copy()
-            level_boxes[:, [0, 2]] = np.clip(
-                level_boxes[:, [0, 2]], 0, resized_w
-            )
-            level_boxes[:, [1, 3]] = np.clip(
-                level_boxes[:, [1, 3]], 0, resized_h
-            )
+            level_boxes[:, [0, 2]] = np.clip(level_boxes[:, [0, 2]], 0, resized_w)
+            level_boxes[:, [1, 3]] = np.clip(level_boxes[:, [1, 3]], 0, resized_h)
             selected_boxes.append(level_boxes)
             selected_scores.append(level_scores[order])
             selected_classes.append(class_ids[order].astype(np.int64, copy=False))
@@ -1753,8 +1749,7 @@ class BaseBackend(ABC):
             packed = packed.T
         if packed.shape[0] != 8732 or packed.shape[1] != 4 + self.nb_classes:
             raise ValueError(
-                "SSD backend output must have shape "
-                f"(1, {4 + self.nb_classes}, 8732)"
+                f"SSD backend output must have shape (1, {4 + self.nb_classes}, 8732)"
             )
 
         boxes_all = packed[:, :4]
@@ -2211,7 +2206,9 @@ class BaseBackend(ABC):
         pred_logits = np.asarray(all_outputs[0][0], dtype=np.float32)
         pred_boxes = np.asarray(all_outputs[1][0], dtype=np.float32)
         if pred_logits.ndim != 2 or pred_boxes.ndim != 2:
-            raise ValueError("DETR backend expects (Q, classes) logits and (Q, 4) boxes")
+            raise ValueError(
+                "DETR backend expects (Q, classes) logits and (Q, 4) boxes"
+            )
         if pred_logits.shape[0] != pred_boxes.shape[0] or pred_boxes.shape[1] != 4:
             raise ValueError("DETR backend logits and boxes have incompatible shapes")
 
@@ -2316,7 +2313,9 @@ class BaseBackend(ABC):
         """Parse the export graph's baked top-100 CenterNet detections."""
         from ..postprocess.centernet import postprocess
 
-        decoded = all_outputs[0] if isinstance(all_outputs, (tuple, list)) else all_outputs
+        decoded = (
+            all_outputs[0] if isinstance(all_outputs, (tuple, list)) else all_outputs
+        )
         result = postprocess(
             decoded,
             conf_thres=conf,
@@ -3046,14 +3045,10 @@ class BaseBackend(ABC):
             far_depth = torch.quantile(non_sky_depth, 0.99)
             if corrected is depth:
                 corrected = depth.clone()
-            corrected[index] = torch.where(
-                non_sky, depth[index], far_depth
-            )
+            corrected[index] = torch.where(non_sky, depth[index], far_depth)
 
         inverse_depth = torch.reciprocal(corrected.clamp_min(1e-6))
-        return BaseBackend._parse_depth_output(
-            [inverse_depth.numpy()], original_size
-        )
+        return BaseBackend._parse_depth_output([inverse_depth.numpy()], original_size)
 
     def _parse_depth_outputs(
         self, all_outputs, original_size: Tuple[int, int]
@@ -4192,12 +4187,18 @@ class BaseBackend(ABC):
         classes: Optional[List[int]] = None,
         max_det: int = 300,
         color_format: str = "auto",
+        start_idx: int = 0,
     ) -> List[Results]:
         """Process multiple images (file paths or in-memory).
 
         When ``batch > 1`` and the runtime accepts stacked blobs, each chunk
         of ``batch`` images runs as a single forward pass; otherwise images
         run sequentially.
+
+        ``start_idx`` is the position of ``images[0]`` within the caller's full
+        source. It only affects the indexed filename stems given to in-memory
+        images, so streaming can hand over one chunk at a time without two
+        chunks both saving an ``image0``.
         """
         use_batched = (
             batch > 1
@@ -4212,7 +4213,7 @@ class BaseBackend(ABC):
                 results.extend(
                     self._predict_batch(
                         images[start : start + batch],
-                        start_idx=start,
+                        start_idx=start_idx + start,
                         save=save,
                         output_path=output_path,
                         conf=conf,
@@ -4239,11 +4240,34 @@ class BaseBackend(ABC):
                     max_det=max_det,
                     color_format=color_format,
                     save_stem=(
-                        None if isinstance(image, (str, Path)) else f"image{idx}"
+                        None
+                        if isinstance(image, (str, Path))
+                        else f"image{start_idx + idx}"
                     ),
                 )
             )
         return results
+
+    def _stream_in_batches(
+        self,
+        images: List,
+        batch: int = 1,
+        **kwargs,
+    ) -> Generator[Results, None, None]:
+        """Yield Results for *images* one at a time, ``batch`` images per step.
+
+        Peak memory holds one chunk of Results rather than the whole source.
+        Each chunk still goes through ``_process_in_batches``, so runtime
+        overrides (such as the TensorRT batching path) keep applying.
+        """
+        step = max(1, int(batch))
+        for start in range(0, len(images), step):
+            yield from self._process_in_batches(
+                images[start : start + step],
+                batch=batch,
+                start_idx=start,
+                **kwargs,
+            )
 
     def _predict_batch(
         self,
@@ -4467,7 +4491,7 @@ class BaseBackend(ABC):
         color_format: str = "auto",
         **kwargs,
     ) -> Union[Results, List[Results], Generator[Results, None, None]]:
-        """Run inference on an image, list of images, directory, or video."""
+        """Run inference on images, directories, videos, or screen captures."""
         normalize_predict_kwargs(kwargs)
         if device not in (None, "", "auto", self.device):
             logger.warning(
@@ -4496,27 +4520,36 @@ class BaseBackend(ABC):
                 return gen
             return collect_video_results(gen, source, vid_stride)
 
-        # Handle in-memory batch input (list/tuple of images)
-        if isinstance(source, (list, tuple)):
-            return self._process_in_batches(
-                list(source),
-                batch=batch,
-                save=save,
-                output_path=output_path,
+        # Handle screen-capture input ("screen", "screen 1", "screen 1 x y w h")
+        if is_screen_source(source):
+            return self._predict_screen(
+                source,
                 conf=conf,
                 iou=iou,
                 imgsz=imgsz,
                 classes=classes,
                 max_det=max_det,
-                color_format=color_format,
+                save=save,
+                show=show,
+                stream=stream,
+                vid_stride=vid_stride,
+                output_path=output_path,
             )
 
-        if isinstance(source, (str, Path)) and Path(source).is_dir():
-            image_paths = ImageLoader.collect_images(source)
-            if not image_paths:
-                return []
-            return self._process_in_batches(
-                image_paths,
+        # Handle in-memory batch input (list/tuple of images) and directories.
+        # Both collapse to a list of images run in batches.
+        images = None
+        if isinstance(source, (list, tuple)):
+            images = list(source)
+        elif isinstance(source, (str, Path)) and Path(source).is_dir():
+            images = ImageLoader.collect_images(source)
+            if not images:
+                return iter(()) if stream else []
+
+        if images is not None or stream:
+            if images is None:
+                images = [source]
+            batch_kwargs = dict(
                 batch=batch,
                 save=save,
                 output_path=output_path,
@@ -4527,6 +4560,9 @@ class BaseBackend(ABC):
                 max_det=max_det,
                 color_format=color_format,
             )
+            if stream:
+                return self._stream_in_batches(images, **batch_kwargs)
+            return self._process_in_batches(images, **batch_kwargs)
 
         return self._predict_single(
             source,
@@ -4548,7 +4584,7 @@ class BaseBackend(ABC):
 
     def _predict_video(
         self,
-        source: Union[str, Path],
+        source: Union[str, Path, FrameSource],
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -4559,8 +4595,10 @@ class BaseBackend(ABC):
         show: bool = False,
         vid_stride: int = 1,
         output_path: Optional[str] = None,
+        source_label: Optional[str] = None,
     ) -> Generator[Results, None, None]:
         """Run inference on a video file, yielding per-frame Results."""
+        source_label = str(source) if source_label is None else source_label
         effective_imgsz = self._resolve_predict_imgsz(imgsz)
 
         def predict_frame(pil_img):
@@ -4575,54 +4613,54 @@ class BaseBackend(ABC):
                 return self._build_classify_result(
                     all_outputs,
                     orig_shape=orig_shape,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "embed":
                 return self._build_embedding_result(
                     all_outputs,
                     orig_shape=orig_shape,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "restore":
                 return self._build_restore_result(
                     all_outputs,
                     orig_shape=orig_shape,
                     original_size=original_size,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "depth":
                 return self._build_depth_result(
                     all_outputs,
                     orig_shape=orig_shape,
                     original_size=original_size,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "normal":
                 return self._build_normal_result(
                     all_outputs,
                     orig_shape=orig_shape,
                     original_size=original_size,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "edge":
                 return self._build_edge_result(
                     all_outputs,
                     orig_shape=orig_shape,
                     original_size=original_size,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "matte":
                 return self._build_matte_result(
                     all_outputs,
                     orig_shape=orig_shape,
                     original_size=original_size,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "gaze":
                 return self._build_gaze_result(
                     all_outputs,
                     orig_shape=orig_shape,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "semantic":
                 return self._build_semantic_result(
@@ -4631,7 +4669,7 @@ class BaseBackend(ABC):
                     original_size=original_size,
                     effective_imgsz=effective_imgsz,
                     ratio=float(ratio or 1.0),
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             if self.task == "point":
                 return self._build_point_result(
@@ -4641,7 +4679,7 @@ class BaseBackend(ABC):
                     effective_imgsz=effective_imgsz,
                     conf=conf,
                     max_det=max_det,
-                    image_path=str(source),
+                    image_path=source_label,
                 )
             parsed = self._parse_outputs(
                 all_outputs,
@@ -4663,7 +4701,7 @@ class BaseBackend(ABC):
                 obb=obb,
                 keypoints=keypoints,
                 orig_shape=orig_shape,
-                image_path=str(source),
+                image_path=source_label,
                 iou=iou,
                 classes=classes,
                 max_det=max_det,
@@ -4677,3 +4715,52 @@ class BaseBackend(ABC):
             show=show,
             output_path=output_path,
         )
+
+    def _predict_screen(
+        self,
+        source: Union[str, Path],
+        *,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[ImageSize] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        save: bool = False,
+        show: bool = False,
+        stream: bool = False,
+        vid_stride: int = 1,
+        output_path: Optional[str] = None,
+    ) -> Union[Results, Generator[Results, None, None]]:
+        """Capture one screenshot, or continuously capture when streaming."""
+        if stream:
+
+            def stream_results():
+                yield from self._predict_video(
+                    ScreenSource(source, vid_stride=vid_stride),
+                    conf=conf,
+                    iou=iou,
+                    imgsz=imgsz,
+                    classes=classes,
+                    max_det=max_det,
+                    save=save,
+                    show=show,
+                    output_path=output_path,
+                    source_label=str(source),
+                )
+
+            return stream_results()
+
+        result = self._predict_single(
+            grab_screen(source),
+            save=save,
+            output_path=output_path,
+            conf=conf,
+            iou=iou,
+            imgsz=imgsz,
+            classes=classes,
+            max_det=max_det,
+            color_format="rgb",
+            save_stem="screen",
+        )
+        result.path = str(source)
+        return result

--- a/libreyolo/backends/base.py
+++ b/libreyolo/backends/base.py
@@ -61,11 +61,11 @@ from ..utils.results import (
     RestoredImage,
     SemanticMask,
 )
-from ..utils.screen import ScreenSource, grab_screen, is_screen_source
+from ..utils.screen import ScreenSource, grab_screen
+from ..utils.source import SourceKind, build_stream_source, classify_source
 from ..utils.video import (
     FrameSource,
     collect_video_results,
-    is_video_file,
     run_video_inference,
 )
 
@@ -4473,7 +4473,9 @@ class BaseBackend(ABC):
 
     def __call__(
         self,
-        source: Union[str, Path, Image.Image, np.ndarray, list, tuple, None] = None,
+        source: Union[
+            str, Path, int, Image.Image, np.ndarray, list, tuple, None
+        ] = None,
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -4485,6 +4487,7 @@ class BaseBackend(ABC):
         batch: int = 1,
         # video parameters
         stream: bool = False,
+        stream_buffer: bool = False,
         vid_stride: int = 1,
         show: bool = False,
         output_path: str | None = None,
@@ -4502,10 +4505,12 @@ class BaseBackend(ABC):
                 device,
             )
 
-        # Handle video input
-        if is_video_file(source):
+        source_spec = classify_source(source)
+
+        # Handle finite video input.
+        if source_spec.kind == SourceKind.VIDEO:
             gen = self._predict_video(
-                source,
+                source_spec.source,
                 conf=conf,
                 iou=iou,
                 imgsz=imgsz,
@@ -4518,12 +4523,36 @@ class BaseBackend(ABC):
             )
             if stream:
                 return gen
-            return collect_video_results(gen, source, vid_stride)
+            return collect_video_results(gen, source_spec.source, vid_stride)
+
+        if source_spec.live:
+            if not stream:
+                raise ValueError(
+                    "Live stream sources require stream=True so results are "
+                    "consumed incrementally."
+                )
+            frame_source = build_stream_source(
+                source_spec,
+                vid_stride=vid_stride,
+                stream_buffer=stream_buffer,
+            )
+            return self._predict_video(
+                frame_source,
+                source_label="stream",
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                save=save,
+                show=show,
+                output_path=output_path,
+            )
 
         # Handle screen-capture input ("screen", "screen 1", "screen 1 x y w h")
-        if is_screen_source(source):
+        if source_spec.kind == SourceKind.SCREEN:
             return self._predict_screen(
-                source,
+                source_spec.source,
                 conf=conf,
                 iou=iou,
                 imgsz=imgsz,
@@ -4539,10 +4568,10 @@ class BaseBackend(ABC):
         # Handle in-memory batch input (list/tuple of images) and directories.
         # Both collapse to a list of images run in batches.
         images = None
-        if isinstance(source, (list, tuple)):
-            images = list(source)
-        elif isinstance(source, (str, Path)) and Path(source).is_dir():
-            images = ImageLoader.collect_images(source)
+        if source_spec.kind == SourceKind.IMAGE_BATCH:
+            images = list(source_spec.items)
+        elif source_spec.kind == SourceKind.DIRECTORY:
+            images = ImageLoader.collect_images(source_spec.source)
             if not images:
                 return iter(()) if stream else []
 

--- a/libreyolo/backends/tensorrt.py
+++ b/libreyolo/backends/tensorrt.py
@@ -358,6 +358,7 @@ class TensorRTBackend(BaseBackend):
         classes: Optional[List[int]] = None,
         max_det: int = 300,
         color_format: str = "auto",
+        start_idx: int = 0,
     ) -> list:
         """Process multiple images with GPU batching when possible.
 
@@ -386,6 +387,7 @@ class TensorRTBackend(BaseBackend):
                 classes=classes,
                 max_det=max_det,
                 color_format=color_format,
+                start_idx=start_idx,
             )
 
         effective_imgsz = self._resolve_predict_imgsz(imgsz)
@@ -408,7 +410,9 @@ class TensorRTBackend(BaseBackend):
                 # use an indexed stem so save=True does not overwrite files.
                 image_path = image if isinstance(image, (str, Path)) else None
                 save_name = (
-                    image_path if image_path is not None else f"image{i + offset}"
+                    image_path
+                    if image_path is not None
+                    else f"image{start_idx + i + offset}"
                 )
                 preprocess_info.append(
                     (orig_img, orig_size, ratio, image_path, save_name)

--- a/libreyolo/cli/commands/predict.py
+++ b/libreyolo/cli/commands/predict.py
@@ -2,6 +2,7 @@
 
 import inspect
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Optional
 
@@ -49,6 +50,10 @@ def _build_predict_kwargs(
     max_det: int,
     save: bool,
     batch: int,
+    stream: bool,
+    stream_buffer: bool,
+    vid_stride: int,
+    show: bool,
     output_path: Optional[str],
     color_format: str,
     tiling: bool,
@@ -64,6 +69,10 @@ def _build_predict_kwargs(
         "max_det": max_det,
         "save": save,
         "batch": batch,
+        "stream": stream,
+        "stream_buffer": stream_buffer,
+        "vid_stride": vid_stride,
+        "show": show,
         "output_path": output_path,
         "color_format": color_format,
         "tiling": tiling,
@@ -121,6 +130,16 @@ def predict_cmd(
         help="Images per forward pass for directory sources "
         "(batch > 1 runs true batched inference on supported models)",
     ),
+    stream: bool = typer.Option(
+        False,
+        help="Yield results incrementally (automatic for webcams/live streams)",
+    ),
+    stream_buffer: bool = typer.Option(
+        False,
+        help="Buffer every live frame instead of keeping only the newest",
+    ),
+    vid_stride: int = typer.Option(1, help="Process every N-th video/live frame"),
+    show: bool = typer.Option(False, help="Display video/live results; q stops"),
     tiling: bool = typer.Option(False, help="Tiled inference for large images"),
     overlap_ratio: float = typer.Option(0.2, help="Tile overlap ratio"),
     output_path: Optional[str] = typer.Option(None, help="Explicit output path"),
@@ -168,10 +187,29 @@ def predict_cmd(
     except ValueError as exc:
         exit_with_error(out, "invalid_imgsz", str(exc))
 
-    # Validate source exists
-    source_path = Path(source)
-    if not source_path.exists() and not source.startswith(("http://", "https://")):
-        exit_with_error(out, "source_not_found", f"Source not found: {source}")
+    # Classify before path validation so webcam indices and RTSP-style URLs do
+    # not fall through as nonexistent image files.
+    from libreyolo.utils.source import SourceKind, classify_source
+
+    try:
+        source_spec = classify_source(source)
+    except FileNotFoundError as exc:
+        exit_with_error(out, "source_not_found", str(exc))
+    except (TypeError, ValueError) as exc:
+        exit_with_error(out, "config_type_error", str(exc))
+
+    remote_prefixes = ("http://", "https://", "s3://", "gs://")
+    if source_spec.kind in {SourceKind.IMAGE, SourceKind.VIDEO}:
+        source_path = Path(source)
+        if not source_path.exists() and not source.startswith(remote_prefixes):
+            exit_with_error(out, "source_not_found", f"Source not found: {source}")
+
+    runtime_source = (
+        source_spec.items[0]
+        if source_spec.kind == SourceKind.STREAM
+        else source_spec.source
+    )
+    effective_stream = stream or source_spec.live
 
     # Resolve CLI model name (yolox-s → LibreYOLOXs.pt)
     model_path = resolve_model_or_exit(out, model)
@@ -288,6 +326,10 @@ def predict_cmd(
         max_det=max_det,
         save=save,
         batch=batch,
+        stream=effective_stream,
+        stream_buffer=stream_buffer,
+        vid_stride=vid_stride,
+        show=show,
         output_path=output_path,
         color_format=color_format,
         tiling=tiling,
@@ -299,8 +341,54 @@ def predict_cmd(
     if gallery_obj is not None:
         predict_kwargs["gallery"] = gallery_obj
         predict_kwargs["threshold"] = gallery_threshold
-    results = loaded_model(source, **predict_kwargs)
+    results = loaded_model(runtime_source, **predict_kwargs)
     elapsed = time.time() - t0
+
+    if effective_stream and isinstance(results, Iterator):
+        image_size = get_loaded_model_input_size(loaded_model, imgsz=imgsz)
+        image_shape = (
+            [image_size[0], image_size[1]]
+            if isinstance(image_size, tuple)
+            else [image_size, image_size]
+        )
+        frame_number = 0
+        try:
+            for result in results:
+                frame_number += 1
+                predictions = result.summary()
+                path = result.path or str(source)
+                frame_idx = getattr(result, "frame_idx", None)
+                human = (
+                    f"frame {frame_number} {path}: {result.orig_shape[1]}x"
+                    f"{result.orig_shape[0]} {len(predictions)} result"
+                    f"{'s' if len(predictions) != 1 else ''}"
+                )
+                data = {
+                    "source": str(source),
+                    "model": model,
+                    "model_family": get_loaded_model_family(loaded_model) or "unknown",
+                    "image_size": image_shape,
+                    "device": str(loaded_model.device),
+                    "frame_index": frame_idx,
+                    "results": [
+                        {
+                            "path": path,
+                            "original_shape": list(result.orig_shape),
+                            "predictions": predictions,
+                        }
+                    ],
+                    "_human_text": human,
+                }
+                if save and output_path:
+                    data["output_path"] = output_path
+                out.result(data)
+        except KeyboardInterrupt:
+            out.progress("Inference stopped.")
+        finally:
+            close = getattr(results, "close", None)
+            if close is not None:
+                close()
+        return
 
     # Normalize to list
     if not isinstance(results, list):

--- a/libreyolo/ensemble/model.py
+++ b/libreyolo/ensemble/model.py
@@ -34,8 +34,9 @@ from ..utils.image_loader import ImageInput, ImageLoader
 from ..utils.logging import ensure_default_logging
 from ..utils.predict_args import normalize_predict_kwargs
 from ..utils.results import Boxes, Results
-from ..utils.screen import ScreenSource, grab_screen, is_screen_source
-from ..utils.video import collect_video_results, is_video_file, run_video_inference
+from ..utils.screen import ScreenSource, grab_screen
+from ..utils.source import SourceKind, build_stream_source, classify_source
+from ..utils.video import collect_video_results, run_video_inference
 
 logger = logging.getLogger(__name__)
 
@@ -293,6 +294,7 @@ class LibreEnsemble:
         color_format: str = "auto",
         batch: int = 1,
         stream: bool = False,
+        stream_buffer: bool = False,
         vid_stride: int = 1,
         show: bool = False,
         **kwargs,
@@ -330,10 +332,12 @@ class LibreEnsemble:
             "color_format": color_format,
         }
 
-        if is_video_file(source):
+        source_spec = classify_source(source)
+
+        if source_spec.kind == SourceKind.VIDEO:
             gen = self._predict_frames(
-                source,
-                str(source),
+                source_spec.source,
+                str(source_spec.source),
                 conf_l,
                 iou_l,
                 imgsz_l,
@@ -344,14 +348,36 @@ class LibreEnsemble:
             )
             if stream:
                 return gen
-            return collect_video_results(gen, source, vid_stride)
+            return collect_video_results(gen, source_spec.source, vid_stride)
 
-        if is_screen_source(source):
+        if source_spec.live:
+            if not stream:
+                raise ValueError(
+                    "Live stream sources require stream=True so results are "
+                    "consumed incrementally."
+                )
+            frame_source = build_stream_source(
+                source_spec,
+                vid_stride=vid_stride,
+                stream_buffer=stream_buffer,
+            )
+            return self._predict_frames(
+                frame_source,
+                "stream",
+                conf_l,
+                iou_l,
+                imgsz_l,
+                device_l,
+                show=show,
+                **predict_kwargs,
+            )
+
+        if source_spec.kind == SourceKind.SCREEN:
             if stream:
 
                 def stream_results():
                     yield from self._predict_frames(
-                        ScreenSource(source, vid_stride=vid_stride),
+                        ScreenSource(source_spec.source, vid_stride=vid_stride),
                         str(source),
                         conf_l,
                         iou_l,
@@ -363,7 +389,7 @@ class LibreEnsemble:
 
                 return stream_results()
             return self._predict_one(
-                grab_screen(source),
+                grab_screen(source_spec.source),
                 conf_l,
                 iou_l,
                 imgsz_l,
@@ -373,10 +399,10 @@ class LibreEnsemble:
             )
 
         sources = None
-        if isinstance(source, (list, tuple)):
-            sources = list(source)
-        elif isinstance(source, (str, Path)) and Path(source).is_dir():
-            sources = ImageLoader.collect_images(source)
+        if source_spec.kind == SourceKind.IMAGE_BATCH:
+            sources = list(source_spec.items)
+        elif source_spec.kind == SourceKind.DIRECTORY:
+            sources = ImageLoader.collect_images(source_spec.source)
 
         if sources is not None:
             if stream:

--- a/libreyolo/ensemble/model.py
+++ b/libreyolo/ensemble/model.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, Generator, List, Optional, Sequence, Tuple, Union
 
 import torch
 
@@ -34,7 +34,8 @@ from ..utils.image_loader import ImageInput, ImageLoader
 from ..utils.logging import ensure_default_logging
 from ..utils.predict_args import normalize_predict_kwargs
 from ..utils.results import Boxes, Results
-from ..utils.video import is_video_file
+from ..utils.screen import ScreenSource, grab_screen, is_screen_source
+from ..utils.video import collect_video_results, is_video_file, run_video_inference
 
 logger = logging.getLogger(__name__)
 
@@ -165,9 +166,7 @@ class LibreEnsemble:
         n = len(self.members)
         if weights is not None:
             if len(weights) != n:
-                raise ValueError(
-                    f"weights has {len(weights)} entries for {n} members"
-                )
+                raise ValueError(f"weights has {len(weights)} entries for {n} members")
             # Positivity (not non-negativity) so NaN weights also fail loudly.
             if not all(w > 0 for w in weights):
                 raise ValueError("weights must all be positive")
@@ -187,12 +186,14 @@ class LibreEnsemble:
                 f"{', '.join(sorted(FUSIONS))}, or a callable"
             )
 
-        if isinstance(min_votes, bool) or not isinstance(min_votes, int) or min_votes < 1:
+        if (
+            isinstance(min_votes, bool)
+            or not isinstance(min_votes, int)
+            or min_votes < 1
+        ):
             raise ValueError(f"min_votes must be a positive int, got {min_votes!r}")
         if min_votes > n:
-            raise ValueError(
-                f"min_votes={min_votes} can never be met by {n} members"
-            )
+            raise ValueError(f"min_votes={min_votes} can never be met by {n} members")
         if self.fusion == "nms" and min_votes > 1:
             raise ValueError(
                 "fusion='nms' cannot count votes; use fusion='wbf' or "
@@ -265,7 +266,10 @@ class LibreEnsemble:
                 "Ensemble label spaces differ: %d classes in the union, %d not "
                 "shared by every member (%s%s). Boxes only fuse within the same "
                 "class name — check member names dicts if these should match.",
-                len(union), len(partial), shown, more,
+                len(union),
+                len(partial),
+                shown,
+                more,
             )
         return union, luts, models_per_label, label_weights
 
@@ -275,7 +279,7 @@ class LibreEnsemble:
 
     def __call__(
         self,
-        source: ImageInput | None = None,
+        source: ImageInput | Sequence[ImageInput] | None = None,
         *,
         conf: Union[float, Sequence[float]] = 0.25,
         iou: Union[float, Sequence[float]] = 0.45,
@@ -289,8 +293,10 @@ class LibreEnsemble:
         color_format: str = "auto",
         batch: int = 1,
         stream: bool = False,
+        vid_stride: int = 1,
+        show: bool = False,
         **kwargs,
-    ) -> Union[Results, List[Results]]:
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """Run every member on *source* and return fused Results.
 
         ``conf``, ``iou``, ``imgsz``, and ``device`` keep their standard
@@ -304,41 +310,179 @@ class LibreEnsemble:
         backends ignore it. ``classes`` (union class ids) and ``max_det`` apply
         to the fused result — members run generously and the ensemble trims
         once. ``batch`` is accepted for API parity; images are processed
-        sequentially.
+        sequentially. With ``stream=True``, images, directories, videos, and
+        screen captures yield fused Results one at a time.
         """
         normalize_predict_kwargs(kwargs)
         del batch
-        if stream or is_video_file(source):
-            raise NotImplementedError(
-                "video and stream ensembling are not available yet; run the "
-                "members individually for video sources"
-            )
 
         n = len(self.members)
         conf_l = self._per_member(conf, n, "conf")
         iou_l = self._per_member(iou, n, "iou")
         imgsz_l = self._per_member(imgsz, n, "imgsz", list_only=True)
         device_l = self._per_member(device, n, "device")
+        predict_kwargs = {
+            "classes": classes,
+            "max_det": max_det,
+            "augment": augment,
+            "save": save,
+            "output_path": output_path,
+            "color_format": color_format,
+        }
 
-        if isinstance(source, (str, Path)) and Path(source).is_dir():
+        if is_video_file(source):
+            gen = self._predict_frames(
+                source,
+                str(source),
+                conf_l,
+                iou_l,
+                imgsz_l,
+                device_l,
+                vid_stride=vid_stride,
+                show=show,
+                **predict_kwargs,
+            )
+            if stream:
+                return gen
+            return collect_video_results(gen, source, vid_stride)
+
+        if is_screen_source(source):
+            if stream:
+
+                def stream_results():
+                    yield from self._predict_frames(
+                        ScreenSource(source, vid_stride=vid_stride),
+                        str(source),
+                        conf_l,
+                        iou_l,
+                        imgsz_l,
+                        device_l,
+                        show=show,
+                        **predict_kwargs,
+                    )
+
+                return stream_results()
+            return self._predict_one(
+                grab_screen(source),
+                conf_l,
+                iou_l,
+                imgsz_l,
+                device_l,
+                source_label=str(source),
+                **{**predict_kwargs, "color_format": "rgb"},
+            )
+
+        sources = None
+        if isinstance(source, (list, tuple)):
+            sources = list(source)
+        elif isinstance(source, (str, Path)) and Path(source).is_dir():
+            sources = ImageLoader.collect_images(source)
+
+        if sources is not None:
+            if stream:
+                return self._stream_images(
+                    sources,
+                    conf_l,
+                    iou_l,
+                    imgsz_l,
+                    device_l,
+                    **predict_kwargs,
+                )
             return [
                 self._predict_one(
-                    p, conf_l, iou_l, imgsz_l, device_l,
-                    classes=classes, max_det=max_det, augment=augment,
-                    save=save, output_path=output_path, color_format=color_format,
+                    item,
+                    conf_l,
+                    iou_l,
+                    imgsz_l,
+                    device_l,
+                    **predict_kwargs,
                 )
-                for p in ImageLoader.collect_images(source)
+                for item in sources
             ]
 
+        if stream:
+            return self._stream_images(
+                [source],
+                conf_l,
+                iou_l,
+                imgsz_l,
+                device_l,
+                **predict_kwargs,
+            )
+
         return self._predict_one(
-            source, conf_l, iou_l, imgsz_l, device_l,
-            classes=classes, max_det=max_det, augment=augment,
-            save=save, output_path=output_path, color_format=color_format,
+            source,
+            conf_l,
+            iou_l,
+            imgsz_l,
+            device_l,
+            **predict_kwargs,
         )
 
-    def predict(self, *args, **kwargs) -> Union[Results, List[Results]]:
+    def predict(
+        self, *args, **kwargs
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
         """Alias for ``__call__``."""
         return self(*args, **kwargs)
+
+    def _stream_images(
+        self,
+        sources: Sequence[ImageInput],
+        conf_l: List,
+        iou_l: List,
+        imgsz_l: List,
+        device_l: List,
+        **kwargs,
+    ) -> Generator[Results, None, None]:
+        """Lazily fuse a finite image sequence."""
+        for source in sources:
+            yield self._predict_one(source, conf_l, iou_l, imgsz_l, device_l, **kwargs)
+
+    def _predict_frames(
+        self,
+        source,
+        source_label: str,
+        conf_l: List,
+        iou_l: List,
+        imgsz_l: List,
+        device_l: List,
+        *,
+        vid_stride: int = 1,
+        show: bool = False,
+        classes: Optional[List[int]],
+        max_det: int,
+        augment: bool,
+        save: bool,
+        output_path: Optional[str],
+        color_format: str,
+    ) -> Generator[Results, None, None]:
+        """Fuse frames from a video-like source."""
+        del color_format
+
+        def predict_frame(image):
+            return self._predict_one(
+                image,
+                conf_l,
+                iou_l,
+                imgsz_l,
+                device_l,
+                classes=classes,
+                max_det=max_det,
+                augment=augment,
+                save=False,
+                output_path=None,
+                color_format="rgb",
+                source_label=source_label,
+            )
+
+        return run_video_inference(
+            source,
+            predict_frame,
+            vid_stride=vid_stride,
+            save=save,
+            show=show,
+            output_path=output_path,
+        )
 
     @staticmethod
     def _per_member(value, n: int, name: str, *, list_only: bool = False):
@@ -346,9 +490,7 @@ class LibreEnsemble:
         seq_types = (list,) if list_only else (list, tuple)
         if isinstance(value, seq_types):
             if len(value) != n:
-                raise ValueError(
-                    f"{name} has {len(value)} entries for {n} members"
-                )
+                raise ValueError(f"{name} has {len(value)} entries for {n} members")
             return list(value)
         return [value] * n
 
@@ -366,11 +508,12 @@ class LibreEnsemble:
         save: bool,
         output_path: Optional[str],
         color_format: str,
+        source_label: Optional[Union[str, Path]] = None,
     ) -> Results:
         # Decode once; members receive the same PIL image.
         img = ImageLoader.load(source, color_format=color_format)
         w, h = img.size
-        image_path = source if isinstance(source, (str, Path)) else None
+        image_path = source if isinstance(source, (str, Path)) else source_label
 
         speed: Dict[str, float] = {}
         member_results: List[Results] = []
@@ -398,7 +541,9 @@ class LibreEnsemble:
             scores,
             labels,
             model_ids,
-            weights=torch.tensor(self.weights, dtype=torch.float32, device=boxes.device),
+            weights=torch.tensor(
+                self.weights, dtype=torch.float32, device=boxes.device
+            ),
             num_models=len(self.members),
             iou_thr=self.fusion_iou,
             min_votes=self.min_votes,

--- a/libreyolo/ensemble/model.py
+++ b/libreyolo/ensemble/model.py
@@ -395,9 +395,12 @@ class LibreEnsemble:
                     iou_l,
                     imgsz_l,
                     device_l,
+                    source_label=(
+                        None if isinstance(item, (str, Path)) else f"image{idx}"
+                    ),
                     **predict_kwargs,
                 )
-                for item in sources
+                for idx, item in enumerate(sources)
             ]
 
         if stream:
@@ -435,8 +438,17 @@ class LibreEnsemble:
         **kwargs,
     ) -> Generator[Results, None, None]:
         """Lazily fuse a finite image sequence."""
-        for source in sources:
-            yield self._predict_one(source, conf_l, iou_l, imgsz_l, device_l, **kwargs)
+        for idx, source in enumerate(sources):
+            source_label = None if isinstance(source, (str, Path)) else f"image{idx}"
+            yield self._predict_one(
+                source,
+                conf_l,
+                iou_l,
+                imgsz_l,
+                device_l,
+                source_label=source_label,
+                **kwargs,
+            )
 
     def _predict_frames(
         self,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -69,8 +69,13 @@ from ...utils.results import (
     RestoredImage,
     SemanticMask,
 )
-from ...utils.screen import ScreenSource, grab_screen, is_screen_source
-from ...utils.video import collect_video_results, is_video_file, run_video_inference
+from ...utils.screen import ScreenSource, grab_screen
+from ...utils.source import SourceKind, build_stream_source, classify_source
+from ...utils.video import (
+    FrameSource,
+    collect_video_results,
+    run_video_inference,
+)
 from .cuda_graph import forward_maybe_graphed, with_cuda_graph_scope
 
 logger = logging.getLogger(__name__)
@@ -163,7 +168,11 @@ class InferenceRunner:
     @with_cuda_graph_scope
     def __call__(
         self,
-        source: ImageInput | list[ImageInput] | tuple[ImageInput, ...] | None = None,
+        source: ImageInput
+        | int
+        | list[ImageInput | int]
+        | tuple[ImageInput | int, ...]
+        | None = None,
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -176,6 +185,7 @@ class InferenceRunner:
         batch: int = 1,
         # video parameters
         stream: bool = False,
+        stream_buffer: bool = False,
         vid_stride: int = 1,
         show: bool = False,
         # libreyolo-specific
@@ -209,6 +219,9 @@ class InferenceRunner:
                 instead of a materialized list. Recommended for video, screen
                 capture, and large directories to avoid high memory usage. A
                 single-image source yields exactly one Results.
+            stream_buffer: Keep every captured live frame instead of retaining
+                only the newest frame per camera. Buffering preserves frames but
+                can increase latency when inference is slower than capture.
             vid_stride: Process every N-th video or screen frame (default: 1).
             show: If True, display annotated frames in a window (video and
                 screen sources only).
@@ -281,10 +294,12 @@ class InferenceRunner:
                 "Use augment=False for edge models."
             )
 
-        # Handle video input
-        if is_video_file(source):
+        source_spec = classify_source(source)
+
+        # Handle finite video input.
+        if source_spec.kind == SourceKind.VIDEO:
             gen = self._predict_video(
-                source,
+                source_spec.source,
                 conf=conf,
                 iou=iou,
                 imgsz=imgsz,
@@ -298,12 +313,38 @@ class InferenceRunner:
             )
             if stream:
                 return gen
-            return collect_video_results(gen, source, vid_stride)
+            return collect_video_results(gen, source_spec.source, vid_stride)
+
+        # Webcams and network streams are unbounded and always stay lazy.
+        if source_spec.live:
+            if not stream:
+                raise ValueError(
+                    "Live stream sources require stream=True so results are "
+                    "consumed incrementally."
+                )
+            frame_source = build_stream_source(
+                source_spec,
+                vid_stride=vid_stride,
+                stream_buffer=stream_buffer,
+            )
+            return self._predict_video(
+                frame_source,
+                source_label="stream",
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                save=save,
+                show=show,
+                output_path=output_path,
+                **kwargs,
+            )
 
         # Handle screen-capture input ("screen", "screen 1", "screen 1 x y w h")
-        if is_screen_source(source):
+        if source_spec.kind == SourceKind.SCREEN:
             return self._predict_screen(
-                source,
+                source_spec.source,
                 conf=conf,
                 iou=iou,
                 imgsz=imgsz,
@@ -321,10 +362,10 @@ class InferenceRunner:
         # Handle in-memory batch input (list/tuple of images) and directories.
         # Both collapse to a list of images run in batches.
         images: Optional[List[ImageInput]] = None
-        if isinstance(source, (list, tuple)):
-            images = list(source)
-        elif isinstance(source, (str, Path)) and Path(source).is_dir():
-            images = ImageLoader.collect_images(source)
+        if source_spec.kind == SourceKind.IMAGE_BATCH:
+            images = list(source_spec.items)
+        elif source_spec.kind == SourceKind.DIRECTORY:
+            images = ImageLoader.collect_images(source_spec.source)
             if not images:
                 return iter(()) if stream else []
 
@@ -1283,7 +1324,7 @@ class InferenceRunner:
 
     def _predict_video(
         self,
-        source: Union[str, Path],
+        source: Union[str, Path, FrameSource],
         *,
         conf: float = 0.25,
         iou: float = 0.45,
@@ -1294,13 +1335,15 @@ class InferenceRunner:
         show: bool = False,
         vid_stride: int = 1,
         output_path: Optional[str] = None,
+        source_label: Optional[str] = None,
         **kwargs,
     ) -> Generator[Results, None, None]:
         """Run inference on a video file, yielding per-frame Results."""
+        source_label = str(source) if source_label is None else source_label
         yield from run_video_inference(
             source,
             self._frame_predictor(
-                str(source),
+                source_label,
                 conf=conf,
                 iou=iou,
                 imgsz=imgsz,

--- a/libreyolo/models/base/inference.py
+++ b/libreyolo/models/base/inference.py
@@ -69,6 +69,7 @@ from ...utils.results import (
     RestoredImage,
     SemanticMask,
 )
+from ...utils.screen import ScreenSource, grab_screen, is_screen_source
 from ...utils.video import collect_video_results, is_video_file, run_video_inference
 from .cuda_graph import forward_maybe_graphed, with_cuda_graph_scope
 
@@ -191,7 +192,9 @@ class InferenceRunner:
 
         Args:
             source: Input image, list/tuple of in-memory images, directory
-                path, or video file path.
+                path, video file path, or a screen-capture source such as
+                ``"screen"``, ``"screen 1"``, or ``"screen 1 100 200 512 256"``
+                (monitor index, then ``left top width height``).
             conf: Confidence threshold.
             iou: IoU threshold for NMS.
             imgsz: Input size override (None = model default).
@@ -202,12 +205,13 @@ class InferenceRunner:
                 With batch > 1, supported families run a single stacked
                 forward per chunk (true batched inference); batch=1 keeps
                 the sequential one-forward-per-image behavior.
-            stream: If True, return a generator yielding per-frame Results.
-                Recommended for video to avoid high memory usage. Applies to
-                video sources only; list and directory sources always return
-                a fully materialized list.
-            vid_stride: Process every N-th video frame (default: 1).
-            show: If True, display annotated frames in a window (video only).
+            stream: If True, return a generator yielding Results one at a time
+                instead of a materialized list. Recommended for video, screen
+                capture, and large directories to avoid high memory usage. A
+                single-image source yields exactly one Results.
+            vid_stride: Process every N-th video or screen frame (default: 1).
+            show: If True, display annotated frames in a window (video and
+                screen sources only).
             output_path: Optional output path.
             color_format: Color format hint.
             tiling: Enable tiled inference for large images.
@@ -225,7 +229,7 @@ class InferenceRunner:
             **kwargs: Additional arguments for postprocessing.
 
         Returns:
-            Results, list of Results, or generator of Results (video + stream).
+            Results, list of Results, or generator of Results (stream=True).
         """
         kwargs = normalize_predict_kwargs(
             kwargs, passthrough={"num_select", "gallery", "threshold"}
@@ -296,33 +300,38 @@ class InferenceRunner:
                 return gen
             return collect_video_results(gen, source, vid_stride)
 
-        # Handle in-memory batch input (list/tuple of images)
-        if isinstance(source, (list, tuple)):
-            return self._process_in_batches(
-                list(source),
-                batch=batch,
-                save=save,
-                output_path=output_path,
+        # Handle screen-capture input ("screen", "screen 1", "screen 1 x y w h")
+        if is_screen_source(source):
+            return self._predict_screen(
+                source,
                 conf=conf,
                 iou=iou,
                 imgsz=imgsz,
                 classes=classes,
                 max_det=max_det,
-                color_format=color_format,
-                tiling=tiling,
-                overlap_ratio=overlap_ratio,
+                save=save,
+                show=show,
+                stream=stream,
+                vid_stride=vid_stride,
+                output_path=output_path,
                 output_file_format=output_file_format,
-                augment=augment,
                 **kwargs,
             )
 
-        # Handle directory input
-        if isinstance(source, (str, Path)) and Path(source).is_dir():
-            image_paths = ImageLoader.collect_images(source)
-            if not image_paths:
-                return []
-            return self._process_in_batches(
-                image_paths,
+        # Handle in-memory batch input (list/tuple of images) and directories.
+        # Both collapse to a list of images run in batches.
+        images: Optional[List[ImageInput]] = None
+        if isinstance(source, (list, tuple)):
+            images = list(source)
+        elif isinstance(source, (str, Path)) and Path(source).is_dir():
+            images = ImageLoader.collect_images(source)
+            if not images:
+                return iter(()) if stream else []
+
+        if images is not None or stream:
+            if images is None:
+                images = [source]
+            batch_kwargs = dict(
                 batch=batch,
                 save=save,
                 output_path=output_path,
@@ -338,6 +347,9 @@ class InferenceRunner:
                 augment=augment,
                 **kwargs,
             )
+            if stream:
+                return self._stream_in_batches(images, **batch_kwargs)
+            return self._process_in_batches(images, **batch_kwargs)
 
         # Use tiled inference if enabled
         if tiling:
@@ -416,6 +428,28 @@ class InferenceRunner:
                 else:
                     self.model.model.to(target)
 
+    def _stream_in_batches(
+        self,
+        images: Sequence[ImageInput],
+        batch: int = 1,
+        **kwargs,
+    ) -> Generator[Results, None, None]:
+        """Yield Results for *images* one at a time, ``batch`` images per step.
+
+        Peak memory holds one chunk of Results rather than the whole source.
+        Each chunk still goes through ``_process_in_batches``, so family
+        overrides (batched forward passes, backend-specific batching) keep
+        applying.
+        """
+        step = max(1, int(batch))
+        for start in range(0, len(images), step):
+            yield from self._process_in_batches(
+                images[start : start + step],
+                batch=batch,
+                start_idx=start,
+                **kwargs,
+            )
+
     def _process_in_batches(
         self,
         images: Sequence[ImageInput],
@@ -432,6 +466,7 @@ class InferenceRunner:
         overlap_ratio: float = 0.2,
         output_file_format: Optional[str] = None,
         augment: bool = False,
+        start_idx: int = 0,
         **kwargs,
     ) -> List[Results]:
         """Process multiple images (file paths or in-memory).
@@ -440,6 +475,11 @@ class InferenceRunner:
         images runs as one stacked forward pass; the batched output is
         sliced back per image and fed to the family's existing batch-1
         postprocess. Otherwise images run sequentially, one forward each.
+
+        ``start_idx`` is the position of ``images[0]`` within the caller's full
+        source. It only affects the indexed filename stems given to in-memory
+        images, so streaming can hand over one chunk at a time without two
+        chunks both saving an ``image0``.
         """
         use_batched = (
             batch > 1
@@ -458,7 +498,7 @@ class InferenceRunner:
                 results.extend(
                     self._predict_batch(
                         images[start : start + batch],
-                        start_idx=start,
+                        start_idx=start_idx + start,
                         save=save,
                         output_path=output_path,
                         conf=conf,
@@ -477,7 +517,9 @@ class InferenceRunner:
         for idx, image in enumerate(images):
             # In-memory images have no filename to derive a save name from;
             # index them so save=True does not overwrite a single file.
-            save_stem = None if isinstance(image, (str, Path)) else f"image{idx}"
+            save_stem = (
+                None if isinstance(image, (str, Path)) else f"image{start_idx + idx}"
+            )
             if tiling:
                 results.append(
                     self._predict_tiled(
@@ -1255,6 +1297,35 @@ class InferenceRunner:
         **kwargs,
     ) -> Generator[Results, None, None]:
         """Run inference on a video file, yielding per-frame Results."""
+        yield from run_video_inference(
+            source,
+            self._frame_predictor(
+                str(source),
+                conf=conf,
+                iou=iou,
+                imgsz=imgsz,
+                classes=classes,
+                max_det=max_det,
+                **kwargs,
+            ),
+            vid_stride=vid_stride,
+            save=save,
+            show=show,
+            output_path=output_path,
+        )
+
+    def _frame_predictor(
+        self,
+        source_label: str,
+        *,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[int] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        **kwargs,
+    ):
+        """Build the per-frame ``PIL image -> Results`` callable for a stream."""
         effective_imgsz = imgsz if imgsz is not None else self.model._get_input_size()
 
         # Pass "effective_imgsz" immediately to kwargs
@@ -1278,16 +1349,72 @@ class InferenceRunner:
                 classes=classes,
                 **kwargs,
             )
-            return self._wrap_results(detections, original_size, str(source), classes)
+            return self._wrap_results(detections, original_size, source_label, classes)
 
-        yield from run_video_inference(
-            source,
-            predict_frame,
-            vid_stride=vid_stride,
+        return predict_frame
+
+    def _predict_screen(
+        self,
+        source: Union[str, Path],
+        *,
+        conf: float = 0.25,
+        iou: float = 0.45,
+        imgsz: Optional[int] = None,
+        classes: Optional[List[int]] = None,
+        max_det: int = 300,
+        save: bool = False,
+        show: bool = False,
+        stream: bool = False,
+        vid_stride: int = 1,
+        output_path: Optional[str] = None,
+        output_file_format: Optional[str] = None,
+        **kwargs,
+    ) -> Union[Results, Generator[Results, None, None]]:
+        """Run inference on the screen.
+
+        Without ``stream=True`` this grabs one frame and returns a single
+        Results, the screenshot equivalent of predicting on an image file. With
+        ``stream=True`` it captures continuously and yields Results per frame,
+        which for a live screen never ends on its own: bound it with
+        ``itertools.islice`` or break out of the loop.
+        """
+        if stream:
+
+            def stream_results():
+                yield from run_video_inference(
+                    ScreenSource(source, vid_stride=vid_stride),
+                    self._frame_predictor(
+                        str(source),
+                        conf=conf,
+                        iou=iou,
+                        imgsz=imgsz,
+                        classes=classes,
+                        max_det=max_det,
+                        **kwargs,
+                    ),
+                    save=save,
+                    show=show,
+                    output_path=output_path,
+                )
+
+            return stream_results()
+
+        result = self._predict_single(
+            grab_screen(source),
             save=save,
-            show=show,
             output_path=output_path,
+            conf=conf,
+            iou=iou,
+            imgsz=imgsz,
+            classes=classes,
+            max_det=max_det,
+            color_format="rgb",
+            output_file_format=output_file_format,
+            save_stem="screen",
+            **kwargs,
         )
+        result.path = str(source)
+        return result
 
     def _merge_tile_detections(
         self,

--- a/libreyolo/utils/predict_args.py
+++ b/libreyolo/utils/predict_args.py
@@ -14,7 +14,6 @@ NOOP_PREDICT_KWARGS = {
     "retina_masks",
     "show_conf",
     "show_labels",
-    "stream_buffer",
     "verbose",
 }
 REJECTED_PREDICT_KWARGS = {"visualize", "embed"}
@@ -28,6 +27,7 @@ ACCEPTED_PREDICT_KWARGS = {
     "augment",
     "save",
     "stream",
+    "stream_buffer",
     "vid_stride",
 }
 
@@ -40,8 +40,7 @@ def normalize_predict_kwargs(kwargs: dict, passthrough: set[str] | None = None) 
     rejected = sorted(k for k in remaining if k in REJECTED_PREDICT_KWARGS)
     if rejected:
         raise NotImplementedError(
-            "LibreYOLO does not support these predict options: "
-            f"{', '.join(rejected)}."
+            f"LibreYOLO does not support these predict options: {', '.join(rejected)}."
         )
 
     noops = sorted(k for k in remaining if k in NOOP_PREDICT_KWARGS)

--- a/libreyolo/utils/screen.py
+++ b/libreyolo/utils/screen.py
@@ -1,0 +1,262 @@
+"""Screen-capture source utilities for LibreYOLO.
+
+A screen source is a string of the form ``"screen"``, optionally followed by a
+monitor index and an optional capture box::
+
+    "screen"                    # every monitor, merged
+    "screen 1"                  # monitor 1 (the primary display)
+    "screen 100 200 512 256"    # box on the merged desktop
+    "screen 1 100 200 512 256"  # box on monitor 1
+
+Box coordinates are ``left top width height`` and are relative to the chosen
+monitor's top-left corner.
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional, Tuple, Union
+
+import numpy as np
+
+# "screen" plus zero or more whitespace-separated integers.
+_SCREEN_RE = re.compile(r"^screen(?P<nums>(?:\s+-?\d+)*)\s*$", re.IGNORECASE)
+
+DEFAULT_SCREEN_FPS = 30.0
+
+
+@dataclass(frozen=True)
+class ScreenRegion:
+    """A monitor index plus an optional capture box within that monitor."""
+
+    monitor: int = 0
+    left: Optional[int] = None
+    top: Optional[int] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+    @property
+    def has_box(self) -> bool:
+        return all(
+            value is not None
+            for value in (self.left, self.top, self.width, self.height)
+        )
+
+    def __str__(self) -> str:
+        if self.has_box:
+            return (
+                f"screen {self.monitor} {self.left} {self.top} "
+                f"{self.width} {self.height}"
+            )
+        return f"screen {self.monitor}"
+
+
+def is_screen_source(source) -> bool:
+    """Check whether *source* is a screen-capture source string."""
+    if not isinstance(source, (str, Path)):
+        return False
+    return _SCREEN_RE.match(str(source)) is not None
+
+
+def parse_screen_source(source: Union[str, Path]) -> ScreenRegion:
+    """Parse a screen source string into a :class:`ScreenRegion`.
+
+    Raises:
+        ValueError: If *source* is not a screen source, or carries a number of
+            integers other than 0 (whole monitor), 1 (monitor index), 4 (box on
+            the merged desktop), or 5 (monitor index plus box).
+    """
+    match = _SCREEN_RE.match(str(source))
+    if match is None:
+        raise ValueError(f"Not a screen source: {source!r}")
+
+    nums = [int(tok) for tok in match.group("nums").split()]
+
+    if len(nums) == 0:
+        return ScreenRegion()
+    if len(nums) == 1:
+        return ScreenRegion(monitor=nums[0])
+    if len(nums) == 4:
+        left, top, width, height = nums
+        return ScreenRegion(monitor=0, left=left, top=top, width=width, height=height)
+    if len(nums) == 5:
+        monitor, left, top, width, height = nums
+        return ScreenRegion(
+            monitor=monitor, left=left, top=top, width=width, height=height
+        )
+
+    raise ValueError(
+        f"Invalid screen source: {source!r}. Expected 'screen', "
+        "'screen <monitor>', 'screen <left> <top> <width> <height>', or "
+        "'screen <monitor> <left> <top> <width> <height>'."
+    )
+
+
+def _import_mss():
+    try:
+        import mss
+    except ImportError:
+        raise ImportError(
+            "Screen capture requires the 'mss' package. "
+            "Install it with: pip install mss"
+        ) from None
+    return mss
+
+
+def _resolve_box(sct, region: ScreenRegion) -> dict:
+    """Turn a :class:`ScreenRegion` into an absolute mss capture box."""
+    monitors = sct.monitors
+    if not 0 <= region.monitor < len(monitors):
+        raise ValueError(
+            f"Monitor {region.monitor} does not exist. "
+            f"{len(monitors) - 1} monitor(s) detected; valid indices are "
+            f"0 (all monitors merged) to {len(monitors) - 1}."
+        )
+
+    monitor = monitors[region.monitor]
+    coordinates = (region.left, region.top, region.width, region.height)
+    if all(value is None for value in coordinates):
+        return dict(monitor)
+    if any(value is None for value in coordinates):
+        raise ValueError("Screen capture box requires left, top, width, and height")
+
+    left = region.left
+    top = region.top
+    width = region.width
+    height = region.height
+    assert left is not None and top is not None
+    assert width is not None and height is not None
+
+    if width <= 0 or height <= 0:
+        raise ValueError(
+            f"Screen capture box must have positive size, got "
+            f"width={width}, height={height}."
+        )
+
+    # Box coordinates are relative to the monitor's own origin.
+    return {
+        "left": monitor["left"] + left,
+        "top": monitor["top"] + top,
+        "width": width,
+        "height": height,
+    }
+
+
+def grab_screen(source: Union[str, Path, ScreenRegion] = "screen") -> np.ndarray:
+    """Capture the screen once and return an RGB ``uint8`` array (HWC).
+
+    Args:
+        source: A screen source string or a :class:`ScreenRegion`.
+
+    Returns:
+        RGB image array of shape ``(height, width, 3)``.
+    """
+    region = source if isinstance(source, ScreenRegion) else parse_screen_source(source)
+    mss = _import_mss()
+
+    with mss.mss() as sct:
+        box = _resolve_box(sct, region)
+        shot = sct.grab(box)
+        # mss returns BGRA; drop alpha and flip to RGB.
+        return np.asarray(shot, dtype=np.uint8)[:, :, :3][:, :, ::-1].copy()
+
+
+class ScreenSource:
+    """Iterate over screen captures, mirroring :class:`~.video.VideoSource`.
+
+    Supports use as a context manager::
+
+        with ScreenSource("screen 1", max_frames=100) as src:
+            for frame_bgr, frame_idx in src:
+                ...
+
+    Args:
+        source: Screen source string or :class:`ScreenRegion`.
+        vid_stride: Emit every N-th capture (default ``1`` = every capture).
+        max_frames: Stop after this many emitted frames. ``None`` (default)
+            captures until the consumer stops asking, which for a live screen
+            means forever.
+
+    Note:
+        Frames are yielded as BGR arrays so the shared frame-inference loop can
+        treat a screen and a video file identically.
+    """
+
+    def __init__(
+        self,
+        source: Union[str, Path, ScreenRegion] = "screen",
+        vid_stride: int = 1,
+        max_frames: Optional[int] = None,
+    ):
+        self.region = (
+            source if isinstance(source, ScreenRegion) else parse_screen_source(source)
+        )
+        self._vid_stride = max(1, int(vid_stride))
+        if max_frames is not None and max_frames < 0:
+            raise ValueError("max_frames must be non-negative or None")
+        self._max_frames = max_frames
+        self._iterated = False
+
+        mss = _import_mss()
+        self._sct = mss.mss()
+        try:
+            self._box = _resolve_box(self._sct, self.region)
+        except Exception:
+            self.release()
+            raise
+
+        self.fps: float = DEFAULT_SCREEN_FPS / self._vid_stride
+        # A live screen has no frame count; max_frames bounds it when given.
+        self.total_frames: int = int(max_frames or 0)
+        self.width: int = int(self._box["width"])
+        self.height: int = int(self._box["height"])
+        # Stem used when an annotated capture is written to disk.
+        self.save_name: str = "screen"
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "ScreenSource":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.release()
+
+    # ------------------------------------------------------------------
+    # Iteration
+    # ------------------------------------------------------------------
+
+    def __iter__(self) -> Iterator[Tuple[np.ndarray, int]]:
+        if self._sct is None or self._iterated:
+            raise RuntimeError(
+                "ScreenSource has been consumed or released. "
+                "Create a new instance to iterate again."
+            )
+        self._iterated = True
+
+        emitted = 0
+        frame_idx = 0
+        while self._max_frames is None or emitted < self._max_frames:
+            shot = self._sct.grab(self._box)
+            if frame_idx % self._vid_stride == 0:
+                frame_bgra = np.asarray(shot, dtype=np.uint8)
+                yield frame_bgra[:, :, :3].copy(), frame_idx
+                emitted += 1
+            frame_idx += 1
+
+    def release(self):
+        """Close the underlying mss handle. Safe to call multiple times."""
+        sct = getattr(self, "_sct", None)
+        if sct is not None:
+            try:
+                sct.close()
+            finally:
+                self._sct = None
+
+    def __repr__(self) -> str:
+        return (
+            f"ScreenSource(region='{self.region}', "
+            f"size={self.width}x{self.height}, "
+            f"vid_stride={self._vid_stride})"
+        )

--- a/libreyolo/utils/source.py
+++ b/libreyolo/utils/source.py
@@ -1,0 +1,570 @@
+"""Prediction-source dispatch and threaded live-stream capture.
+
+This module owns the distinction between images, finite video, screen capture,
+and live inputs. Keeping that decision in one place prevents stream locators
+from falling through to :class:`ImageLoader` as if they were file paths.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import threading
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Deque, Iterator, Sequence
+from urllib.parse import urlsplit, urlunsplit
+
+import numpy as np
+
+from .screen import is_screen_source
+from .video import is_video_file
+
+
+NETWORK_STREAM_SCHEMES = frozenset({"rtsp", "rtmp", "tcp", "udp"})
+YOUTUBE_HOSTS = frozenset(
+    {
+        "youtu.be",
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "music.youtube.com",
+    }
+)
+STREAM_LIST_EXTENSION = ".streams"
+_HLS_EXTENSIONS = frozenset({".m3u8"})
+_SAFE_STEM_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class SourceKind(str, Enum):
+    """Kinds understood by the public prediction entry points."""
+
+    IMAGE = "image"
+    IMAGE_BATCH = "image_batch"
+    DIRECTORY = "directory"
+    VIDEO = "video"
+    SCREEN = "screen"
+    STREAM = "stream"
+    STREAMS = "streams"
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """A classified prediction source."""
+
+    kind: SourceKind
+    source: Any
+    items: tuple[Any, ...] = ()
+
+    @property
+    def live(self) -> bool:
+        return self.kind in {SourceKind.STREAM, SourceKind.STREAMS}
+
+
+@dataclass(frozen=True)
+class StreamFrame:
+    """One frame from a live source, including per-camera identity."""
+
+    frame_bgr: np.ndarray
+    frame_idx: int
+    source_index: int
+    source_label: str
+    fps: float
+
+
+def _url_parts(value: Any):
+    if not isinstance(value, (str, Path)):
+        return None
+    try:
+        return urlsplit(str(value))
+    except ValueError:
+        return None
+
+
+def is_youtube_url(source: Any) -> bool:
+    """Return whether *source* is a YouTube page URL."""
+    parts = _url_parts(source)
+    if parts is None or parts.scheme.lower() not in {"http", "https"}:
+        return False
+    host = (parts.hostname or "").lower().rstrip(".")
+    return host in YOUTUBE_HOSTS or host.endswith(".youtube.com")
+
+
+def is_network_stream(source: Any) -> bool:
+    """Return whether *source* is a direct network-video locator."""
+    parts = _url_parts(source)
+    if parts is None:
+        return False
+    if parts.scheme.lower() in NETWORK_STREAM_SCHEMES:
+        return True
+    return (
+        parts.scheme.lower() in {"http", "https"}
+        and Path(parts.path).suffix.lower() in _HLS_EXTENSIONS
+    )
+
+
+def _existing_path(source: Any) -> Path | None:
+    if not isinstance(source, (str, Path)):
+        return None
+    try:
+        path = Path(source)
+        return path if path.exists() else None
+    except (OSError, ValueError):
+        return None
+
+
+def _webcam_index(source: Any) -> int | None:
+    if isinstance(source, bool):
+        return None
+    if isinstance(source, int):
+        if source < 0:
+            raise ValueError(f"Webcam index must be non-negative, got {source}")
+        return source
+    if isinstance(source, str) and source.strip().isdigit():
+        # An existing file named "0" remains an ordinary file source.
+        if _existing_path(source) is None:
+            return int(source.strip())
+    return None
+
+
+def normalize_stream_locator(source: Any) -> int | str:
+    """Normalize one webcam/video-stream locator for OpenCV."""
+    webcam = _webcam_index(source)
+    if webcam is not None:
+        return webcam
+    if isinstance(source, (str, Path)):
+        return str(source)
+    raise TypeError(
+        "Live stream sources must be webcam indices or video stream URLs, "
+        f"got {type(source).__name__}"
+    )
+
+
+def _is_stream_item(source: Any) -> bool:
+    return (
+        _webcam_index(source) is not None
+        or is_network_stream(source)
+        or is_youtube_url(source)
+        or is_video_file(source)
+    )
+
+
+def _read_stream_list(path: Path) -> tuple[int | str, ...]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Stream list not found: {path}")
+    sources = []
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        value = raw_line.strip()
+        if not value or value.startswith("#"):
+            continue
+        if not _is_stream_item(value):
+            raise ValueError(
+                f"Invalid stream source on line {line_number} of {path}: {value!r}"
+            )
+        sources.append(normalize_stream_locator(value))
+    if not sources:
+        raise ValueError(f"Stream list is empty: {path}")
+    return tuple(sources)
+
+
+def classify_source(source: Any) -> SourceSpec:
+    """Classify one public prediction source without opening it."""
+    if is_screen_source(source):
+        return SourceSpec(SourceKind.SCREEN, source)
+
+    webcam = _webcam_index(source)
+    if webcam is not None:
+        return SourceSpec(SourceKind.STREAM, webcam, (webcam,))
+
+    if is_network_stream(source) or is_youtube_url(source):
+        normalized = normalize_stream_locator(source)
+        return SourceSpec(SourceKind.STREAM, normalized, (normalized,))
+
+    if isinstance(source, (list, tuple)):
+        items = tuple(source)
+        stream_flags = tuple(_is_stream_item(item) for item in items)
+        if items and all(stream_flags):
+            normalized = tuple(normalize_stream_locator(item) for item in items)
+            return SourceSpec(SourceKind.STREAMS, source, normalized)
+        if any(stream_flags):
+            raise TypeError(
+                "A source list cannot mix live/video streams with image inputs"
+            )
+        return SourceSpec(SourceKind.IMAGE_BATCH, source, items)
+
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        if path.suffix.lower() == STREAM_LIST_EXTENSION:
+            items = _read_stream_list(path)
+            return SourceSpec(SourceKind.STREAMS, source, items)
+        if is_video_file(source):
+            return SourceSpec(SourceKind.VIDEO, source)
+        existing = _existing_path(source)
+        if existing is not None and existing.is_dir():
+            return SourceSpec(SourceKind.DIRECTORY, source)
+
+    return SourceSpec(SourceKind.IMAGE, source)
+
+
+def redact_source(source: int | str) -> str:
+    """Create a user-facing label without exposing URL credentials."""
+    if isinstance(source, int):
+        return str(source)
+    parts = _url_parts(source)
+    if parts is None or not parts.scheme or not parts.netloc:
+        return str(source)
+    host = parts.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if parts.port is not None:
+        host = f"{host}:{parts.port}"
+    if parts.username is not None:
+        host = f"{parts.username}:***@{host}"
+    # Direct stream query strings commonly contain bearer tokens or signed
+    # URLs. A YouTube page's public video id is useful and not a credential;
+    # retain that one query while dropping direct-stream queries from labels.
+    query = parts.query if is_youtube_url(source) else ""
+    return urlunsplit((parts.scheme, host, parts.path, query, ""))
+
+
+def source_save_stem(source: int | str, source_index: int = 0) -> str:
+    """Return a filesystem-safe name for a live source."""
+    if isinstance(source, int):
+        return f"webcam{source}"
+    if is_youtube_url(source):
+        return f"youtube{source_index}"
+    parts = _url_parts(source)
+    candidate = ""
+    if parts is not None and parts.scheme:
+        candidate = Path(parts.path).stem or parts.hostname or "stream"
+    else:
+        candidate = Path(str(source)).stem
+    safe = _SAFE_STEM_RE.sub("_", candidate).strip("._")
+    return safe or f"stream{source_index}"
+
+
+def _import_yt_dlp():
+    try:
+        import yt_dlp
+    except ImportError as exc:
+        raise ImportError(
+            "YouTube sources require yt-dlp. Install it with "
+            '`pip install "libreyolo[stream]"`.'
+        ) from exc
+    return yt_dlp
+
+
+def resolve_youtube_stream(source: str) -> str:
+    """Resolve a YouTube page to a direct media URL without downloading it."""
+    yt_dlp = _import_yt_dlp()
+    options = {
+        "format": "best[ext=mp4]/best",
+        "noplaylist": True,
+        "quiet": True,
+        "no_warnings": True,
+    }
+    try:
+        with yt_dlp.YoutubeDL(options) as downloader:
+            info = downloader.extract_info(source, download=False)
+    except Exception as exc:
+        raise ConnectionError(f"Could not resolve YouTube source: {source}") from exc
+
+    if isinstance(info, dict) and info.get("entries"):
+        info = next((entry for entry in info["entries"] if entry), None)
+    direct_url = info.get("url") if isinstance(info, dict) else None
+    if not direct_url:
+        raise ConnectionError(f"YouTube source has no playable media URL: {source}")
+    return str(direct_url)
+
+
+class StreamSource:
+    """Read the latest frames from one webcam or network stream on a thread."""
+
+    total_frames = 0
+
+    def __init__(
+        self,
+        source: int | str | Path,
+        *,
+        vid_stride: int = 1,
+        buffer: bool = False,
+        source_index: int = 0,
+        ready_event: threading.Event | None = None,
+    ):
+        self.source = normalize_stream_locator(source)
+        self.source_index = int(source_index)
+        self.source_label = redact_source(self.source)
+        self.save_name = source_save_stem(self.source, self.source_index)
+        self._vid_stride = max(1, int(vid_stride))
+        self._buffer = bool(buffer)
+        self._queue: Deque[StreamFrame] = deque(maxlen=None if buffer else 1)
+        self._condition = threading.Condition()
+        self._ready_event = ready_event
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._cap = None
+        self._terminal = False
+        self._error: BaseException | None = None
+        self._iterated = False
+        self._next_frame_idx = 0
+        self.fps = 30.0
+        self.width = 0
+        self.height = 0
+
+    @property
+    def num_streams(self) -> int:
+        return 1
+
+    def _open_capture(self):
+        import cv2
+
+        capture_source: int | str = self.source
+        if isinstance(capture_source, str) and is_youtube_url(capture_source):
+            capture_source = resolve_youtube_stream(capture_source)
+
+        if isinstance(capture_source, int) and sys.platform.startswith("win"):
+            backend = getattr(cv2, "CAP_DSHOW", None)
+            cap = (
+                cv2.VideoCapture(capture_source, backend)
+                if backend is not None
+                else cv2.VideoCapture(capture_source)
+            )
+            if not cap.isOpened() and backend is not None:
+                cap.release()
+                cap = cv2.VideoCapture(capture_source)
+        else:
+            cap = cv2.VideoCapture(capture_source)
+        return cap
+
+    def _open(self) -> None:
+        if self._cap is not None:
+            return
+        import cv2
+
+        cap = self._open_capture()
+        if not cap.isOpened():
+            cap.release()
+            raise ConnectionError(f"Cannot open live stream: {self.source_label}")
+
+        fps = float(cap.get(cv2.CAP_PROP_FPS) or 0.0)
+        self.fps = fps if fps > 0 else 30.0
+        self.width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+        self.height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+        ok, frame = cap.read()
+        if not ok or frame is None:
+            cap.release()
+            raise ConnectionError(
+                f"Live stream opened but returned no frames: {self.source_label}"
+            )
+
+        self._cap = cap
+        self._next_frame_idx = 1
+        self._enqueue(frame, 0)
+
+    def _enqueue(self, frame: np.ndarray, frame_idx: int) -> None:
+        if frame_idx % self._vid_stride:
+            return
+        packet = StreamFrame(
+            frame_bgr=frame,
+            frame_idx=frame_idx,
+            source_index=self.source_index,
+            source_label=self.source_label,
+            fps=self.fps,
+        )
+        with self._condition:
+            self._queue.append(packet)
+            self._condition.notify_all()
+        if self._ready_event is not None:
+            self._ready_event.set()
+
+    def _mark_terminal(self, error: BaseException | None = None) -> None:
+        with self._condition:
+            self._terminal = True
+            self._error = error
+            self._condition.notify_all()
+        if self._ready_event is not None:
+            self._ready_event.set()
+
+    def _reader(self) -> None:
+        cap = self._cap
+        assert cap is not None
+        error = None
+        try:
+            while not self._stop.is_set():
+                ok, frame = cap.read()
+                if not ok or frame is None:
+                    break
+                frame_idx = self._next_frame_idx
+                self._next_frame_idx += 1
+                self._enqueue(frame, frame_idx)
+        except BaseException as exc:
+            error = RuntimeError(f"Live stream failed: {self.source_label}")
+            error.__cause__ = exc
+        finally:
+            # The reader thread owns release after it starts. In particular,
+            # this prevents VideoCapture.release() from racing FFmpeg read().
+            cap.release()
+            if self._cap is cap:
+                self._cap = None
+            self._mark_terminal(error)
+
+    def _start_reader(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._reader,
+            name=f"libreyolo-stream-{self.source_index}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def __enter__(self) -> "StreamSource":
+        self._open()
+        self._start_reader()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.release()
+
+    def _take_nowait(self) -> tuple[StreamFrame | None, bool, BaseException | None]:
+        with self._condition:
+            packet = self._queue.popleft() if self._queue else None
+            return packet, self._terminal and not self._queue, self._error
+
+    def __iter__(self) -> Iterator[StreamFrame]:
+        if self._iterated:
+            raise RuntimeError("StreamSource has already been consumed")
+        self._iterated = True
+        while True:
+            with self._condition:
+                self._condition.wait_for(lambda: self._queue or self._terminal)
+                if self._queue:
+                    packet = self._queue.popleft()
+                elif self._error is not None:
+                    raise self._error
+                else:
+                    break
+            yield packet
+
+    def release(self) -> None:
+        self._stop.set()
+        with self._condition:
+            self._condition.notify_all()
+        if self._ready_event is not None:
+            self._ready_event.set()
+        thread = self._thread
+        if (
+            thread is not None
+            and thread is not threading.current_thread()
+            and thread.is_alive()
+        ):
+            # OpenCV/FFmpeg can crash if VideoCapture.release() races a read()
+            # on another thread. A live reader normally returns once per frame,
+            # observes _stop, and joins before the capture is closed.
+            thread.join(timeout=2.0)
+        if thread is not None and thread.is_alive():
+            # A backend read can remain blocked while a network endpoint is
+            # disappearing. The daemon reader retains ownership of its capture
+            # and releases it when read() returns; closing it concurrently is
+            # unsafe in FFmpeg.
+            return
+        cap, self._cap = self._cap, None
+        if cap is not None:
+            cap.release()
+
+
+class MultiStreamSource:
+    """Multiplex multiple independently threaded video captures."""
+
+    total_frames = 0
+    fps = 30.0
+    width = 0
+    height = 0
+    save_name = "streams"
+
+    def __init__(
+        self,
+        sources: Sequence[int | str | Path],
+        *,
+        vid_stride: int = 1,
+        buffer: bool = False,
+    ):
+        if not sources:
+            raise ValueError("At least one live stream source is required")
+        self._ready = threading.Event()
+        self.streams = [
+            StreamSource(
+                source,
+                vid_stride=vid_stride,
+                buffer=buffer,
+                source_index=index,
+                ready_event=self._ready,
+            )
+            for index, source in enumerate(sources)
+        ]
+        self._iterated = False
+
+    @property
+    def num_streams(self) -> int:
+        return len(self.streams)
+
+    def __enter__(self) -> "MultiStreamSource":
+        try:
+            with ThreadPoolExecutor(max_workers=len(self.streams)) as executor:
+                futures = [executor.submit(stream._open) for stream in self.streams]
+                for future in futures:
+                    future.result()
+            for stream in self.streams:
+                stream._start_reader()
+        except BaseException:
+            self.release()
+            raise
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.release()
+
+    def __iter__(self) -> Iterator[StreamFrame]:
+        if self._iterated:
+            raise RuntimeError("MultiStreamSource has already been consumed")
+        self._iterated = True
+        active = set(range(len(self.streams)))
+        while active:
+            self._ready.clear()
+            emitted = False
+            for index in tuple(active):
+                packet, terminal, error = self.streams[index]._take_nowait()
+                if packet is not None:
+                    emitted = True
+                    yield packet
+                if error is not None:
+                    raise error
+                if terminal:
+                    active.remove(index)
+            if not emitted and active:
+                self._ready.wait(timeout=0.1)
+
+    def release(self) -> None:
+        for stream in self.streams:
+            stream.release()
+
+
+def build_stream_source(
+    spec: SourceSpec,
+    *,
+    vid_stride: int = 1,
+    stream_buffer: bool = False,
+) -> StreamSource | MultiStreamSource:
+    """Build a lazy threaded capture from a classified live source."""
+    if spec.kind == SourceKind.STREAM:
+        return StreamSource(spec.items[0], vid_stride=vid_stride, buffer=stream_buffer)
+    if spec.kind == SourceKind.STREAMS:
+        return MultiStreamSource(
+            spec.items, vid_stride=vid_stride, buffer=stream_buffer
+        )
+    raise TypeError(f"Source kind {spec.kind.value!r} is not a live stream")

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -3,7 +3,7 @@
 import logging
 import warnings
 from pathlib import Path
-from typing import Callable, Generator, Iterator, Tuple, Union
+from typing import Callable, Generator, Iterator, Protocol, Tuple, Union
 
 import numpy as np
 
@@ -28,6 +28,27 @@ VIDEO_EXTENSIONS = {
     ".wmv",
     ".webm",
 }
+
+
+class FrameSource(Protocol):
+    """What ``run_video_inference`` needs from a frame source.
+
+    :class:`VideoSource` and :class:`~libreyolo.utils.screen.ScreenSource` both
+    satisfy it: a context manager that iterates ``(BGR frame, frame index)``
+    and reports the geometry needed to write an output video.
+    """
+
+    fps: float
+    total_frames: int
+    width: int
+    height: int
+    save_name: str
+
+    def __enter__(self) -> "FrameSource": ...
+
+    def __exit__(self, *exc) -> None: ...
+
+    def __iter__(self) -> Iterator[Tuple[np.ndarray, int]]: ...
 
 
 def is_video_file(source) -> bool:
@@ -91,6 +112,7 @@ class VideoSource:
             )
 
         self._path = str(path)
+        self.save_name = self._path
         self._vid_stride = max(1, int(vid_stride))
 
         self._cap = cv2.VideoCapture(self._path)
@@ -272,7 +294,7 @@ def collect_video_results(
 
 
 def run_video_inference(
-    source: Union[str, Path],
+    source: Union[str, Path, "FrameSource"],
     predict_frame_fn: Callable,
     *,
     vid_stride: int = 1,
@@ -282,13 +304,17 @@ def run_video_inference(
     annotate_fn: Union[Callable, None] = None,
     progress: bool = True,
 ) -> Generator:
-    """Generic video inference loop shared by all backends.
+    """Generic frame-by-frame inference loop shared by all backends.
 
     Args:
-        source: Path to video file.
+        source: Path to a video file, or an already-built frame source such as
+            :class:`VideoSource` or
+            :class:`~libreyolo.utils.screen.ScreenSource`. A frame source
+            yields ``(BGR frame, frame index)`` and has already applied its own
+            ``vid_stride``, so *vid_stride* is ignored for that form.
         predict_frame_fn: Callable that takes a PIL RGB image and returns
             a ``Results`` object.
-        vid_stride: Process every N-th frame.
+        vid_stride: Process every N-th frame (file sources only).
         save: Write annotated output video.
         show: Display frames in a cv2 window.
         output_path: Output path for saved video.
@@ -317,20 +343,34 @@ def run_video_inference(
         draw_points,
     )
 
-    with VideoSource(source, vid_stride=vid_stride) as video_src:
+    if isinstance(source, (str, Path)):
+        frame_source = VideoSource(source, vid_stride=vid_stride)
+        # VideoSource decodes every frame and this loop sees only the kept ones,
+        # so the frame count and output fps both scale down by the stride.
+        stride_divisor = max(1, vid_stride)
+        save_name = source
+        desc = Path(source).name
+    else:
+        # A pre-built frame source has already applied its own stride.
+        frame_source = source
+        stride_divisor = 1
+        save_name = getattr(source, "save_name", "stream")
+        desc = str(save_name)
+
+    with frame_source as video_src:
         writer = None
         out_path = None
         effective_fps = None
         if save:
-            out_path = resolve_video_save_path(source, output_path)
-            effective_fps = video_src.fps / max(1, vid_stride)
+            out_path = resolve_video_save_path(save_name, output_path)
+            effective_fps = video_src.fps / stride_divisor
             # The writer is created lazily from the first output frame instead
             # of the source dimensions: restore/super-resolution results render
             # on a canvas ``restore_scale`` times the source frame.
 
-        total = video_src.total_frames // max(1, vid_stride) or None
+        total = video_src.total_frames // stride_divisor or None
         pbar = (
-            tqdm(total=total, desc=Path(source).name, unit="frame", dynamic_ncols=True)
+            tqdm(total=total, desc=desc, unit="frame", dynamic_ncols=True)
             if progress
             else None
         )

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -3,7 +3,7 @@
 import logging
 import warnings
 from pathlib import Path
-from typing import Callable, Generator, Iterator, Protocol, Tuple, Union
+from typing import Any, Callable, Generator, Iterator, Protocol, Tuple, Union
 
 import numpy as np
 
@@ -48,7 +48,7 @@ class FrameSource(Protocol):
 
     def __exit__(self, *exc) -> None: ...
 
-    def __iter__(self) -> Iterator[Tuple[np.ndarray, int]]: ...
+    def __iter__(self) -> Iterator[Any]: ...
 
 
 def is_video_file(source) -> bool:
@@ -74,8 +74,11 @@ def resolve_video_save_path(
     """
     if output_path is not None:
         out = Path(output_path)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        return str(out)
+        if out.suffix:
+            out.parent.mkdir(parents=True, exist_ok=True)
+            return str(out)
+        out.mkdir(parents=True, exist_ok=True)
+        return str(out / f"{Path(source).stem}.mp4")
 
     save_dir = Path("runs/detect") / "predict"
     save_dir = increment_path(save_dir, exist_ok=False, mkdir=True)
@@ -358,11 +361,32 @@ def run_video_inference(
         desc = str(save_name)
 
     with frame_source as video_src:
-        writer = None
+        writers = {}
+        out_paths = {}
         out_path = None
         effective_fps = None
+        is_multi = int(getattr(video_src, "num_streams", 1)) > 1
+        multi_output_dir = None
+        multi_output_template = None
         if save:
-            out_path = resolve_video_save_path(save_name, output_path)
+            if is_multi:
+                if output_path is None:
+                    multi_output_dir = increment_path(
+                        Path("runs/detect") / "predict",
+                        exist_ok=False,
+                        mkdir=True,
+                    )
+                else:
+                    requested = Path(output_path)
+                    if requested.suffix:
+                        requested.parent.mkdir(parents=True, exist_ok=True)
+                        multi_output_dir = requested.parent
+                        multi_output_template = requested
+                    else:
+                        requested.mkdir(parents=True, exist_ok=True)
+                        multi_output_dir = requested
+            else:
+                out_path = resolve_video_save_path(save_name, output_path)
             effective_fps = video_src.fps / stride_divisor
             # The writer is created lazily from the first output frame instead
             # of the source dimensions: restore/super-resolution results render
@@ -376,7 +400,19 @@ def run_video_inference(
         )
 
         try:
-            for frame_bgr, frame_idx in video_src:
+            for frame_item in video_src:
+                if hasattr(frame_item, "frame_bgr"):
+                    frame_bgr = frame_item.frame_bgr
+                    frame_idx = int(frame_item.frame_idx)
+                    source_index = int(frame_item.source_index)
+                    source_label = str(frame_item.source_label)
+                    frame_fps = float(frame_item.fps or effective_fps or 30.0)
+                else:
+                    frame_bgr, frame_idx = frame_item
+                    source_index = 0
+                    source_label = None
+                    frame_fps = float(effective_fps or 30.0)
+
                 # Convert BGR frame to PIL RGB for the model pipeline
                 frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
                 pil_img = Image.fromarray(frame_rgb)
@@ -384,6 +420,8 @@ def run_video_inference(
                 # Run model-specific inference
                 result = predict_frame_fn(pil_img)
                 result.frame_idx = frame_idx
+                if source_label is not None:
+                    result.path = source_label
 
                 # Annotate frame for save/show
                 if save or show:
@@ -492,15 +530,41 @@ def run_video_inference(
                     )
 
                     if save:
+                        writer = writers.get(source_index)
                         if writer is None:
                             frame_h, frame_w = annotated_bgr.shape[:2]
+                            if is_multi:
+                                from .source import source_save_stem
+
+                                assert source_label is not None
+                                assert multi_output_dir is not None
+                                if multi_output_template is not None:
+                                    suffix = multi_output_template.suffix or ".mp4"
+                                    filename = (
+                                        f"{multi_output_template.stem}_{source_index}"
+                                        f"{suffix}"
+                                    )
+                                else:
+                                    stem = source_save_stem(source_label, source_index)
+                                    filename = f"{stem}_{source_index}.mp4"
+                                current_out_path = str(multi_output_dir / filename)
+                            else:
+                                current_out_path = out_path
+                            assert current_out_path is not None
                             writer = VideoWriter(
-                                out_path, effective_fps, frame_w, frame_h
+                                current_out_path, frame_fps, frame_w, frame_h
                             )
+                            writers[source_index] = writer
+                            out_paths[source_index] = current_out_path
                         writer.write_frame(annotated_bgr)
 
                     if show:
-                        cv2.imshow("LibreYOLO", annotated_bgr)
+                        window_name = (
+                            f"LibreYOLO: {source_label}"
+                            if is_multi and source_label is not None
+                            else "LibreYOLO"
+                        )
+                        cv2.imshow(window_name, annotated_bgr)
                         if cv2.waitKey(1) & 0xFF == ord("q"):
                             break
 
@@ -514,8 +578,8 @@ def run_video_inference(
         finally:
             if pbar is not None:
                 pbar.close()
-            if writer is not None:
+            for source_index, writer in writers.items():
                 writer.release()
-                logger.info("Video saved to %s", out_path)
+                logger.info("Video saved to %s", out_paths[source_index])
             if show:
                 cv2.destroyAllWindows()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ dev = [
 ]
 
 [project.optional-dependencies]
+stream = [
+    # YouTube page URLs are resolved lazily to direct media URLs. Webcam,
+    # RTSP/RTMP/TCP/UDP, HLS, and local multi-stream inputs need no extra.
+    "yt-dlp",
+]
 onnx = [
     "onnx>=1.14.0",
     "onnxsim>=0.4.0",
@@ -220,6 +225,7 @@ wandb = [
     "wandb>=0.16.0",
 ]
 all = [
+    "libreyolo[stream]",
     "libreyolo[onnx]",
     "libreyolo[rfdetr]",
     "libreyolo[eomt]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "PyYAML>=6.0",
     "requests>=2.25.0",
     "opencv-python>=4.11.0.86",
+    "mss>=9.0.1",
     "tqdm>=4.65.0",
     "pycocotools>=2.0.0",
     "typer>=0.9.0",

--- a/tests/unit/cli/commands/test_predict.py
+++ b/tests/unit/cli/commands/test_predict.py
@@ -82,6 +82,35 @@ class _FakeRestoreModel:
         )
 
 
+class _FakeStreamModel:
+    FAMILY = "yolo9"
+    task = "classify"
+    size = "t"
+    device = "cpu"
+
+    def __init__(self):
+        self.calls = []
+
+    def _get_input_size(self) -> int:
+        return 224
+
+    def __call__(self, source, **kwargs):
+        self.calls.append((source, kwargs))
+
+        def generate():
+            for frame_idx in range(2):
+                yield Results(
+                    boxes=None,
+                    orig_shape=(10, 12),
+                    path=str(source),
+                    names={0: "cat", 1: "dog"},
+                    probs=Probs(torch.tensor([0.2, 0.8])),
+                    frame_idx=frame_idx,
+                )
+
+        return generate()
+
+
 def test_predict_formats_classification_probs(monkeypatch, tmp_path):
     source = tmp_path / "image.jpg"
     Image.new("RGB", (12, 10)).save(source)
@@ -191,3 +220,61 @@ def test_predict_formats_restore_results(monkeypatch, tmp_path):
 
     assert human_result.exit_code == 0
     assert "restored" in human_result.stdout
+
+
+def test_predict_webcam_source_auto_streams_as_ndjson(monkeypatch):
+    fake_model = _FakeStreamModel()
+    monkeypatch.setattr(
+        predict_module,
+        "resolve_model_or_exit",
+        lambda out, model: model,
+    )
+    monkeypatch.setattr(
+        predict_module,
+        "load_model_or_exit",
+        lambda *args, **kwargs: fake_model,
+    )
+
+    result = runner.invoke(
+        _make_app(),
+        [
+            "source=0",
+            "model=fake-stream.pt",
+            "stream_buffer=true",
+            "vid_stride=2",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [row["frame_index"] for row in rows] == [0, 1]
+    assert all(row["results"][0]["predictions"][0]["name"] == "dog" for row in rows)
+    source, kwargs = fake_model.calls[0]
+    assert source == 0
+    assert kwargs["stream"] is True
+    assert kwargs["stream_buffer"] is True
+    assert kwargs["vid_stride"] == 2
+
+
+def test_predict_rtsp_source_bypasses_local_path_validation(monkeypatch):
+    fake_model = _FakeStreamModel()
+    monkeypatch.setattr(
+        predict_module,
+        "resolve_model_or_exit",
+        lambda out, model: model,
+    )
+    monkeypatch.setattr(
+        predict_module,
+        "load_model_or_exit",
+        lambda *args, **kwargs: fake_model,
+    )
+
+    source = "rtsp://127.0.0.1:8554/camera"
+    result = runner.invoke(
+        _make_app(),
+        [f"source={source}", "model=fake-stream.pt", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert fake_model.calls[0][0] == source

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -415,6 +415,26 @@ class TestPredict:
 
         assert Path(result.saved_path).exists()
 
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_in_memory_sequence_save_uses_indexed_names(self, tmp_path, image, stream):
+        from pathlib import Path
+
+        out_dir = tmp_path / "out"
+        results = LibreEnsemble(list(_pair_members()))(
+            [image, image],
+            save=True,
+            stream=stream,
+            output_path=str(out_dir),
+        )
+        if stream:
+            results = list(results)
+
+        assert [Path(result.saved_path).name for result in results] == [
+            "image0.jpg",
+            "image1.jpg",
+        ]
+        assert all(Path(result.saved_path).exists() for result in results)
+
     def test_val_and_export_raise(self):
         ens = LibreEnsemble(list(_pair_members()))
         with pytest.raises(NotImplementedError):

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -3,11 +3,13 @@
 import subprocess
 import sys
 
+import numpy as np
 import pytest
 import torch
 from PIL import Image
 
 from libreyolo.ensemble import ExternalDetector, LibreEnsemble
+from libreyolo.ensemble import model as ensemble_model
 from libreyolo.utils.results import Boxes, Results
 
 pytestmark = pytest.mark.unit
@@ -214,8 +216,10 @@ class TestPredict:
 
     def test_classes_filter_uses_union_ids(self, image):
         a = StubMember(
-            COCOISH, boxes=[[0, 0, 10, 10], [50, 50, 60, 60]],
-            scores=[0.9, 0.8], cls=[0, 1],
+            COCOISH,
+            boxes=[[0, 0, 10, 10], [50, 50, 60, 60]],
+            scores=[0.9, 0.8],
+            cls=[0, 1],
         )
         b = StubMember(COCOISH)
         result = LibreEnsemble([a, b])(image, classes=[1])
@@ -223,15 +227,15 @@ class TestPredict:
 
     def test_min_votes_consensus(self, image):
         a = StubMember(
-            COCOISH, boxes=[[0, 0, 10, 10], [50, 50, 60, 60]],
-            scores=[0.9, 0.95], cls=[0, 0],
+            COCOISH,
+            boxes=[[0, 0, 10, 10], [50, 50, 60, 60]],
+            scores=[0.9, 0.95],
+            cls=[0, 0],
         )
         b = StubMember(COCOISH, boxes=[[0, 0, 10, 12]], scores=[0.7], cls=[0])
         result = LibreEnsemble([a, b], min_votes=2)(image)
         assert len(result) == 1
-        assert torch.allclose(
-            result.boxes.xyxy[0, 3], torch.tensor(10.875), atol=1e-4
-        )
+        assert torch.allclose(result.boxes.xyxy[0, 3], torch.tensor(10.875), atol=1e-4)
 
     def test_speed_keys(self, image):
         result = LibreEnsemble(list(_pair_members()))(image)
@@ -251,8 +255,10 @@ class TestPredict:
 
     def test_nonfinite_member_rows_dropped(self, image):
         a = StubMember(
-            COCOISH, boxes=[[0, 0, 10, 10], [0, 0, float("nan"), 10]],
-            scores=[0.9, 0.8], cls=[0, 0],
+            COCOISH,
+            boxes=[[0, 0, 10, 10], [0, 0, float("nan"), 10]],
+            scores=[0.9, 0.8],
+            cls=[0, 0],
         )
         result = LibreEnsemble([a, StubMember(COCOISH)])(image)
         assert len(result) == 1
@@ -300,15 +306,90 @@ class TestPredict:
         with pytest.raises(ValueError, match="inconsistent shapes"):
             ens(image)
 
-    def test_video_raises(self):
-        ens = LibreEnsemble(list(_pair_members()))
-        with pytest.raises(NotImplementedError, match="video"):
-            ens("clip.mp4")
+    def test_single_image_stream_is_lazy(self, image):
+        a, b = _pair_members()
+        results = LibreEnsemble([a, b])(image, stream=True)
 
-    def test_stream_raises(self, image):
-        ens = LibreEnsemble(list(_pair_members()))
-        with pytest.raises(NotImplementedError):
-            ens(image, stream=True)
+        assert a.calls == [] and b.calls == []
+        result = next(results)
+        assert isinstance(result, Results)
+        assert len(a.calls) == 1 and len(b.calls) == 1
+        with pytest.raises(StopIteration):
+            next(results)
+
+    def test_list_stream_yields_fused_results(self, image):
+        a, b = _pair_members()
+        results = LibreEnsemble([a, b])([image, image], stream=True)
+
+        assert a.calls == [] and b.calls == []
+        assert len(list(results)) == 2
+        assert len(a.calls) == 2 and len(b.calls) == 2
+
+    def test_video_stream_uses_frame_loop(self, image, monkeypatch):
+        a, b = _pair_members()
+
+        def fake_run_video(source, predict_frame, **kwargs):
+            assert source == "clip.mp4"
+            yield predict_frame(image)
+            yield predict_frame(image)
+
+        monkeypatch.setattr(ensemble_model, "run_video_inference", fake_run_video)
+        results = LibreEnsemble([a, b])("clip.mp4", stream=True, vid_stride=2)
+
+        assert a.calls == [] and b.calls == []
+        streamed = list(results)
+        assert len(streamed) == 2
+        assert all(r.path == "clip.mp4" for r in streamed)
+
+    def test_video_without_stream_collects_results(self, image, monkeypatch):
+        def fake_run_video(source, predict_frame, **kwargs):
+            yield predict_frame(image)
+
+        monkeypatch.setattr(ensemble_model, "run_video_inference", fake_run_video)
+        monkeypatch.setattr(
+            ensemble_model,
+            "collect_video_results",
+            lambda gen, source, vid_stride: list(gen),
+        )
+
+        results = LibreEnsemble(list(_pair_members()))("clip.mp4")
+
+        assert isinstance(results, list) and len(results) == 1
+
+    def test_screen_source_grabs_rgb_frame(self, monkeypatch):
+        monkeypatch.setattr(
+            ensemble_model,
+            "grab_screen",
+            lambda source: np.zeros((8, 10, 3), dtype=np.uint8),
+        )
+
+        result = LibreEnsemble(list(_pair_members()))("screen 1")
+
+        assert result.orig_shape == (8, 10)
+        assert result.path == "screen 1"
+
+    def test_screen_stream_opens_capture_lazily(self, image, monkeypatch):
+        opened = []
+        marker = object()
+
+        def fake_screen_source(source, vid_stride):
+            opened.append((source, vid_stride))
+            return marker
+
+        def fake_run_video(source, predict_frame, **kwargs):
+            assert source is marker
+            yield predict_frame(image)
+
+        monkeypatch.setattr(ensemble_model, "ScreenSource", fake_screen_source)
+        monkeypatch.setattr(ensemble_model, "run_video_inference", fake_run_video)
+
+        results = LibreEnsemble(list(_pair_members()))(
+            "screen", stream=True, vid_stride=4
+        )
+
+        assert opened == []
+        assert len(list(results)) == 1
+        assert opened == [("screen", 4)]
 
     def test_unknown_predict_kwarg_raises(self, image):
         ens = LibreEnsemble(list(_pair_members()))

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -219,6 +219,46 @@ def test_runner_stream_screen_opens_capture_lazily(monkeypatch):
     assert opened == [("screen", 3)]
 
 
+@pytest.mark.parametrize("source", [0, "rtsp://127.0.0.1:8554/camera"])
+def test_runner_live_sources_require_lazy_streaming(source):
+    runner = InferenceRunner(_StubModel())
+
+    with pytest.raises(ValueError, match="stream=True"):
+        runner(source)
+
+
+def test_runner_routes_multi_camera_sources_to_threaded_capture(monkeypatch):
+    runner = InferenceRunner(_StubModel())
+    sentinel = object()
+    calls = {}
+
+    def fake_build(spec, *, vid_stride, stream_buffer):
+        calls["build"] = (spec.items, vid_stride, stream_buffer)
+        return sentinel
+
+    def fake_predict(source, **kwargs):
+        calls["predict"] = (source, kwargs)
+        yield "frame"
+
+    monkeypatch.setattr(inference_base, "build_stream_source", fake_build)
+    runner._predict_video = fake_predict
+
+    results = runner(
+        [0, "rtsp://127.0.0.1:8554/camera"],
+        stream=True,
+        stream_buffer=True,
+        vid_stride=2,
+    )
+
+    assert list(results) == ["frame"]
+    assert calls["build"] == (
+        (0, "rtsp://127.0.0.1:8554/camera"),
+        2,
+        True,
+    )
+    assert calls["predict"][0] is sentinel
+
+
 # =============================================================================
 # Exported-backend pipeline (BaseBackend and TensorRT batching)
 # =============================================================================
@@ -309,6 +349,37 @@ def test_backend_screen_source_grabs_one_rgb_image(monkeypatch):
     assert captured["image"].shape == (9, 11, 3)
     assert captured["kwargs"]["color_format"] == "rgb"
     assert result.path == "screen 1"
+
+
+@pytest.mark.parametrize("source", [0, "rtsp://127.0.0.1:8554/camera"])
+def test_backend_live_sources_require_lazy_streaming(source):
+    backend = _bare_backend()
+
+    with pytest.raises(ValueError, match="stream=True"):
+        backend(source)
+
+
+def test_backend_routes_webcam_to_threaded_capture(monkeypatch):
+    backend = _bare_backend()
+    sentinel = object()
+    calls = {}
+
+    def fake_build(spec, *, vid_stride, stream_buffer):
+        calls["build"] = (spec.items, vid_stride, stream_buffer)
+        return sentinel
+
+    def fake_predict(source, **kwargs):
+        calls["predict"] = (source, kwargs)
+        yield "frame"
+
+    monkeypatch.setattr(backend_base, "build_stream_source", fake_build)
+    backend._predict_video = fake_predict
+
+    results = backend(0, stream=True, stream_buffer=True, vid_stride=3)
+
+    assert list(results) == ["frame"]
+    assert calls["build"] == ((0,), 3, True)
+    assert calls["predict"][0] is sentinel
 
 
 def test_backend_sequential_batches_pass_indexed_save_stems():

--- a/tests/unit/test_list_batch_predict.py
+++ b/tests/unit/test_list_batch_predict.py
@@ -7,8 +7,10 @@ import pytest
 import torch
 from PIL import Image
 
+from libreyolo.backends import base as backend_base
 from libreyolo.backends.base import BaseBackend
 from libreyolo.backends.tensorrt import TensorRTBackend
+from libreyolo.models.base import inference as inference_base
 from libreyolo.models.base.inference import InferenceRunner
 from libreyolo.utils.image_loader import ImageLoader
 
@@ -144,6 +146,79 @@ def test_runner_tiling_list_save_indexes_large_image_dirs(tmp_path):
     assert stems == ["image0", "image1"]
 
 
+def test_runner_streams_list_lazily_in_batch_sized_chunks():
+    runner = InferenceRunner(_StubModel())
+    images = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(3)]
+    calls = []
+
+    def fake_process(chunk, *, batch, start_idx, **kwargs):
+        calls.append((len(chunk), batch, start_idx))
+        return [f"result-{start_idx + i}" for i in range(len(chunk))]
+
+    runner._process_in_batches = fake_process
+    results = runner(images, batch=2, stream=True)
+
+    assert calls == []
+    assert next(results) == "result-0"
+    assert calls == [(2, 2, 0)]
+    assert list(results) == ["result-1", "result-2"]
+    assert calls == [(2, 2, 0), (1, 2, 2)]
+
+
+def test_runner_streams_single_image_as_one_result():
+    runner = InferenceRunner(_StubModel())
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    results = runner(image, stream=True)
+
+    assert not isinstance(results, list)
+    streamed = list(results)
+    assert len(streamed) == 1
+    assert streamed[0].orig_shape == (8, 8)
+
+
+def test_runner_empty_stream_yields_nothing():
+    runner = InferenceRunner(_StubModel())
+
+    assert list(runner([], stream=True)) == []
+
+
+def test_runner_screen_source_grabs_one_rgb_image(monkeypatch):
+    runner = InferenceRunner(_StubModel())
+    monkeypatch.setattr(
+        inference_base,
+        "grab_screen",
+        lambda source: np.zeros((9, 11, 3), dtype=np.uint8),
+    )
+
+    result = runner("screen 1")
+
+    assert result.orig_shape == (9, 11)
+    assert result.path == "screen 1"
+
+
+def test_runner_stream_screen_opens_capture_lazily(monkeypatch):
+    runner = InferenceRunner(_StubModel())
+    opened = []
+
+    def fake_screen_source(source, vid_stride):
+        opened.append((source, vid_stride))
+        return object()
+
+    def fake_run_video(source, predict_frame, **kwargs):
+        if False:
+            yield source, predict_frame, kwargs
+
+    monkeypatch.setattr(inference_base, "ScreenSource", fake_screen_source)
+    monkeypatch.setattr(inference_base, "run_video_inference", fake_run_video)
+
+    results = runner("screen", stream=True, vid_stride=3)
+
+    assert opened == []
+    assert list(results) == []
+    assert opened == [("screen", 3)]
+
+
 # =============================================================================
 # Exported-backend pipeline (BaseBackend and TensorRT batching)
 # =============================================================================
@@ -174,6 +249,66 @@ def test_backend_call_routes_list_to_process_in_batches():
     assert out == ["r", "r", "r"]
     assert seen["batch"] == 2
     assert len(seen["images"]) == 3
+
+
+def test_backend_streams_list_lazily_in_batch_sized_chunks():
+    backend = _bare_backend()
+    images = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(3)]
+    calls = []
+
+    def fake_process(chunk, *, batch, start_idx, **kwargs):
+        calls.append((len(chunk), batch, start_idx))
+        return [f"result-{start_idx + i}" for i in range(len(chunk))]
+
+    backend._process_in_batches = fake_process
+    results = backend(images, batch=2, stream=True)
+
+    assert calls == []
+    assert next(results) == "result-0"
+    assert calls == [(2, 2, 0)]
+    assert list(results) == ["result-1", "result-2"]
+    assert calls == [(2, 2, 0), (1, 2, 2)]
+
+
+def test_backend_streams_single_image_as_one_result():
+    backend = _bare_backend()
+    seen = []
+
+    def fake_process(chunk, **kwargs):
+        seen.extend(chunk)
+        return ["result"]
+
+    backend._process_in_batches = fake_process
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    results = backend(image, stream=True)
+
+    assert seen == []
+    assert list(results) == ["result"]
+    assert len(seen) == 1 and seen[0] is image
+
+
+def test_backend_screen_source_grabs_one_rgb_image(monkeypatch):
+    backend = _bare_backend()
+    captured = {}
+
+    def fake_single(image, **kwargs):
+        captured["image"] = image
+        captured["kwargs"] = kwargs
+        return type("Result", (), {"path": None})()
+
+    backend._predict_single = fake_single
+    monkeypatch.setattr(
+        backend_base,
+        "grab_screen",
+        lambda source: np.zeros((9, 11, 3), dtype=np.uint8),
+    )
+
+    result = backend("screen 1")
+
+    assert captured["image"].shape == (9, 11, 3)
+    assert captured["kwargs"]["color_format"] == "rgb"
+    assert result.path == "screen 1"
 
 
 def test_backend_sequential_batches_pass_indexed_save_stems():
@@ -217,7 +352,9 @@ def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
 
     seen_parse_kwargs = []
 
-    def parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300):
+    def parse_outputs(
+        per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300
+    ):
         seen_parse_kwargs.append({"iou": iou, "max_det": max_det})
         return (
             np.zeros((0, 4), dtype=np.float32),
@@ -258,12 +395,12 @@ def test_tensorrt_batched_in_memory_images_keep_path_none_and_indexed_saves():
 
     images = [np.zeros((8, 8, 3), dtype=np.uint8)] * 3
     results = backend._process_in_batches(
-        images, batch=2, save=True, iou=0.6, max_det=50
+        images, batch=2, save=True, iou=0.6, max_det=50, start_idx=4
     )
 
     assert len(results) == 3
     assert built_paths == [None, None, None]
-    assert saved_names == ["image0", "image1", "image2"]
+    assert saved_names == ["image4", "image5", "image6"]
     # iou/max_det must reach the parser, mirroring _predict_single.
     assert seen_parse_kwargs == [{"iou": 0.6, "max_det": 50}] * 3
 
@@ -602,9 +739,7 @@ def test_deimv2_batched_routing_with_marker_outputs():
                 (0.5 + 0.2) * orig_h,
             ]
         )
-        torch.testing.assert_close(
-            result.boxes.xyxy[0], expected, rtol=1e-5, atol=1e-4
-        )
+        torch.testing.assert_close(result.boxes.xyxy[0], expected, rtol=1e-5, atol=1e-4)
 
 
 def test_picodet_batched_predict_smoke_matches_sequential():
@@ -653,7 +788,9 @@ def _marker_preprocess(image, imgsz, color_format):
     )
 
 
-def _marker_parse_outputs(per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300):
+def _marker_parse_outputs(
+    per_image, imgsz, orig_size, conf, ratio=1.0, iou=0.45, max_det=300
+):
     marker = float(np.asarray(per_image[0]).ravel()[0])
     return (
         np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32),
@@ -722,7 +859,12 @@ def test_backend_predict_batch_falls_back_when_runtime_rejects_batch():
 
     # Chunk of 2 fails batched, re-runs per image; final chunk of 1 runs
     # sequentially because the failure latched batching off.
-    assert blob_shapes == [(2, 3, 32, 32), (1, 3, 32, 32), (1, 3, 32, 32), (1, 3, 32, 32)]
+    assert blob_shapes == [
+        (2, 3, 32, 32),
+        (1, 3, 32, 32),
+        (1, 3, 32, 32),
+        (1, 3, 32, 32),
+    ]
     assert [marker for _, marker in results] == [10.0, 60.0, 200.0]
     assert backend._batched_inference_failed is True
 

--- a/tests/unit/test_live_sources.py
+++ b/tests/unit/test_live_sources.py
@@ -1,0 +1,264 @@
+"""Local-only coverage for live prediction-source dispatch and capture."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from libreyolo.utils import source as source_module
+from libreyolo.utils.source import (
+    MultiStreamSource,
+    SourceKind,
+    StreamFrame,
+    StreamSource,
+    classify_source,
+    redact_source,
+    resolve_youtube_stream,
+)
+from libreyolo.utils.results import Probs, Results
+from libreyolo.utils.video import run_video_inference
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("value", [0, 2, "0", "3"])
+def test_webcam_indices_dispatch_as_streams(value):
+    spec = classify_source(value)
+    assert spec.kind == SourceKind.STREAM
+    assert spec.items == (int(value),)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "rtsp://127.0.0.1:8554/camera",
+        "rtmp://127.0.0.1/live/camera",
+        "tcp://127.0.0.1:9000",
+        "udp://127.0.0.1:9000",
+        "https://example.test/live/camera.m3u8",
+    ],
+)
+def test_network_urls_dispatch_before_image_paths(value):
+    spec = classify_source(value)
+    assert spec.kind == SourceKind.STREAM
+    assert spec.items == (value,)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://www.youtube.com/watch?v=abc123",
+        "https://youtu.be/abc123",
+    ],
+)
+def test_youtube_pages_dispatch_as_streams(value):
+    assert classify_source(value).kind == SourceKind.STREAM
+
+
+def test_image_url_remains_an_image():
+    assert classify_source("https://example.test/camera.jpg").kind == SourceKind.IMAGE
+
+
+def test_stream_list_file_supports_comments_webcams_and_rtsp(tmp_path):
+    path = tmp_path / "cameras.streams"
+    path.write_text(
+        "# loading dock\n0\n\nrtsp://127.0.0.1:8554/warehouse\n",
+        encoding="utf-8",
+    )
+    spec = classify_source(path)
+    assert spec.kind == SourceKind.STREAMS
+    assert spec.items == (0, "rtsp://127.0.0.1:8554/warehouse")
+
+
+def test_multi_source_list_cannot_mix_images_and_streams():
+    with pytest.raises(TypeError, match="cannot mix"):
+        classify_source([0, np.zeros((4, 4, 3), dtype=np.uint8)])
+
+
+def test_rtsp_credentials_are_redacted_from_result_label():
+    label = redact_source("rtsp://alice:secret@camera.test:8554/live")
+    assert "secret" not in label
+    assert label == "rtsp://alice:***@camera.test:8554/live"
+
+
+def test_youtube_resolution_uses_yt_dlp_without_downloading(monkeypatch):
+    calls = {}
+
+    class FakeYDL:
+        def __init__(self, options):
+            calls["options"] = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def extract_info(self, url, download):
+            calls["url"] = url
+            calls["download"] = download
+            return {"url": "https://media.test/direct.mp4"}
+
+    monkeypatch.setattr(
+        source_module,
+        "_import_yt_dlp",
+        lambda: SimpleNamespace(YoutubeDL=FakeYDL),
+    )
+    resolved = resolve_youtube_stream("https://youtu.be/example")
+    assert resolved == "https://media.test/direct.mp4"
+    assert calls["download"] is False
+    assert calls["options"]["noplaylist"] is True
+
+
+class _FakeCapture:
+    def __init__(self, source, frames, *, first_read_barrier=None):
+        self.source = source
+        self.frames = list(frames)
+        self.first_read_barrier = first_read_barrier
+        self.read_count = 0
+        self.released = False
+
+    def isOpened(self):
+        return True
+
+    def get(self, prop):
+        import cv2
+
+        values = {
+            cv2.CAP_PROP_FPS: 25.0,
+            cv2.CAP_PROP_FRAME_WIDTH: 8,
+            cv2.CAP_PROP_FRAME_HEIGHT: 6,
+        }
+        return values.get(prop, 0)
+
+    def read(self):
+        if self.read_count == 0 and self.first_read_barrier is not None:
+            self.first_read_barrier.wait(timeout=2)
+        self.read_count += 1
+        if not self.frames:
+            return False, None
+        return True, self.frames.pop(0)
+
+    def release(self):
+        self.released = True
+
+
+def _frames(source_index, count=3):
+    return [
+        np.full((6, 8, 3), source_index * 10 + i, dtype=np.uint8) for i in range(count)
+    ]
+
+
+def test_single_webcam_capture_runs_on_reader_thread(monkeypatch):
+    import cv2
+
+    captures = []
+
+    def fake_video_capture(source, *args):
+        capture = _FakeCapture(source, _frames(0))
+        captures.append(capture)
+        return capture
+
+    monkeypatch.setattr(cv2, "VideoCapture", fake_video_capture)
+    with StreamSource(0, buffer=True) as stream:
+        packets = list(stream)
+
+    assert [packet.frame_idx for packet in packets] == [0, 1, 2]
+    assert [int(packet.frame_bgr[0, 0, 0]) for packet in packets] == [0, 1, 2]
+    assert captures[0].released is True
+    assert stream._thread is not None
+    assert stream._thread.name == "libreyolo-stream-0"
+
+
+def test_multiple_cameras_open_and_read_independently(monkeypatch):
+    import cv2
+
+    barrier = threading.Barrier(2)
+    captures = {}
+
+    def fake_video_capture(source, *args):
+        capture = _FakeCapture(
+            source,
+            _frames(int(source), count=2),
+            first_read_barrier=barrier,
+        )
+        captures[source] = capture
+        return capture
+
+    monkeypatch.setattr(cv2, "VideoCapture", fake_video_capture)
+    with MultiStreamSource([0, 1], buffer=True) as streams:
+        packets = list(streams)
+
+    assert {(packet.source_index, packet.frame_idx) for packet in packets} == {
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+    }
+    assert {packet.source_label for packet in packets} == {"0", "1"}
+    assert all(capture.released for capture in captures.values())
+
+
+def test_existing_numeric_filename_is_not_claimed_as_webcam(tmp_path, monkeypatch):
+    numeric_file = tmp_path / "0"
+    numeric_file.write_bytes(b"not an image")
+    monkeypatch.chdir(tmp_path)
+    assert classify_source("0").kind == SourceKind.IMAGE
+
+
+def test_missing_stream_list_fails_at_dispatch(tmp_path):
+    path = Path(tmp_path) / "missing.streams"
+    with pytest.raises(FileNotFoundError, match="Stream list not found"):
+        classify_source(path)
+
+
+def test_shared_video_loop_preserves_per_camera_path_and_frame_index():
+    class FakeMultiSource:
+        total_frames = 0
+        fps = 25.0
+        width = 8
+        height = 6
+        save_name = "streams"
+        num_streams = 2
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def __iter__(self):
+            for source_index, label in enumerate(("camera-a", "camera-b")):
+                yield StreamFrame(
+                    frame_bgr=np.zeros((6, 8, 3), dtype=np.uint8),
+                    frame_idx=4 + source_index,
+                    source_index=source_index,
+                    source_label=label,
+                    fps=25.0,
+                )
+
+    def predict_frame(_image):
+        return Results(
+            boxes=None,
+            orig_shape=(6, 8),
+            probs=Probs(torch.tensor([1.0])),
+            names={0: "frame"},
+        )
+
+    results = list(
+        run_video_inference(
+            FakeMultiSource(),
+            predict_frame,
+            progress=False,
+        )
+    )
+
+    assert [(result.path, result.frame_idx) for result in results] == [
+        ("camera-a", 4),
+        ("camera-b", 5),
+    ]

--- a/tests/unit/test_predict_kwargs.py
+++ b/tests/unit/test_predict_kwargs.py
@@ -24,7 +24,6 @@ def test_noop_predict_kwargs_warn_and_are_removed():
         "retina_masks",
         "show_conf",
         "show_labels",
-        "stream_buffer",
         "verbose",
     ],
 )
@@ -50,6 +49,7 @@ def test_rejected_predict_kwargs_fail_clearly():
         ("max_det", 300),
         ("save", False),
         ("stream", False),
+        ("stream_buffer", False),
         ("vid_stride", 1),
     ],
 )
@@ -58,9 +58,9 @@ def test_supported_predict_kwargs_are_accepted(key, value):
 
 
 def test_native_passthrough_kwargs_are_forwarded_explicitly():
-    assert normalize_predict_kwargs({"num_select": 100}, passthrough={"num_select"}) == {
-        "num_select": 100
-    }
+    assert normalize_predict_kwargs(
+        {"num_select": 100}, passthrough={"num_select"}
+    ) == {"num_select": 100}
 
 
 def test_passthrough_kwargs_are_not_silently_accepted_by_default():

--- a/tests/unit/test_screen.py
+++ b/tests/unit/test_screen.py
@@ -1,0 +1,138 @@
+"""Unit tests for screen-capture source parsing and frame iteration."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from libreyolo.utils import screen
+from libreyolo.utils.screen import (
+    ScreenRegion,
+    ScreenSource,
+    _resolve_box,
+    grab_screen,
+    is_screen_source,
+    parse_screen_source,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeCapture:
+    def __init__(self):
+        self.monitors = [
+            {"left": -4, "top": 0, "width": 8, "height": 3},
+            {"left": 0, "top": 0, "width": 4, "height": 3},
+        ]
+        self.grabs = []
+        self.closed = False
+
+    def grab(self, box):
+        self.grabs.append(dict(box))
+        frame = np.empty((box["height"], box["width"], 4), dtype=np.uint8)
+        frame[...] = (10, 20, 30, 255)  # BGRA
+        return frame
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+@pytest.fixture
+def fake_mss(monkeypatch):
+    captures = []
+
+    def make_capture():
+        capture = _FakeCapture()
+        captures.append(capture)
+        return capture
+
+    monkeypatch.setattr(
+        screen, "_import_mss", lambda: SimpleNamespace(mss=make_capture)
+    )
+    return captures
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["screen", "SCREEN", "screen 1", "screen -2 3 4 5", "screen 1 2 3 4 5"],
+)
+def test_is_screen_source_accepts_documented_forms(value):
+    assert is_screen_source(value)
+
+
+@pytest.mark.parametrize("value", [None, 0, "screenshot", "screen one", "screen 1.5"])
+def test_is_screen_source_rejects_other_inputs(value):
+    assert not is_screen_source(value)
+
+
+def test_parse_screen_source_forms():
+    assert parse_screen_source("screen") == ScreenRegion()
+    assert parse_screen_source("screen 2") == ScreenRegion(monitor=2)
+    assert parse_screen_source("screen 10 20 30 40") == ScreenRegion(
+        monitor=0, left=10, top=20, width=30, height=40
+    )
+    assert parse_screen_source("screen 2 10 20 30 40") == ScreenRegion(
+        monitor=2, left=10, top=20, width=30, height=40
+    )
+
+
+def test_parse_screen_source_rejects_bad_arity():
+    with pytest.raises(ValueError, match="Invalid screen source"):
+        parse_screen_source("screen 1 2")
+    with pytest.raises(ValueError, match="Not a screen source"):
+        parse_screen_source("camera")
+
+
+def test_resolve_box_uses_monitor_relative_coordinates():
+    capture = _FakeCapture()
+
+    box = _resolve_box(
+        capture, ScreenRegion(monitor=1, left=1, top=2, width=2, height=1)
+    )
+
+    assert box == {"left": 1, "top": 2, "width": 2, "height": 1}
+
+
+def test_resolve_box_rejects_invalid_monitor_and_size():
+    capture = _FakeCapture()
+    with pytest.raises(ValueError, match="Monitor -1"):
+        _resolve_box(capture, ScreenRegion(monitor=-1))
+    with pytest.raises(ValueError, match="positive size"):
+        _resolve_box(capture, ScreenRegion(left=0, top=0, width=0, height=2))
+    with pytest.raises(ValueError, match="requires left, top, width, and height"):
+        _resolve_box(capture, ScreenRegion(width=2, height=2))
+
+
+def test_grab_screen_returns_rgb(fake_mss):
+    image = grab_screen("screen 1")
+
+    assert image.shape == (3, 4, 3)
+    assert image.dtype == np.uint8
+    assert image[0, 0].tolist() == [30, 20, 10]
+    assert fake_mss[0].closed is True
+
+
+def test_screen_source_yields_bgr_with_stride_and_closes(fake_mss):
+    source = ScreenSource("screen 1", vid_stride=2, max_frames=2)
+
+    with source:
+        frames = list(source)
+
+    assert [index for _, index in frames] == [0, 2]
+    assert all(frame[0, 0].tolist() == [10, 20, 30] for frame, _ in frames)
+    assert len(fake_mss[0].grabs) == 3
+    assert source.fps == 15.0
+    assert source.total_frames == 2
+    assert source.save_name == "screen"
+    assert fake_mss[0].closed is True
+
+
+def test_screen_source_rejects_negative_max_frames():
+    with pytest.raises(ValueError, match="max_frames"):
+        ScreenSource("screen", max_frames=-1)


### PR DESCRIPTION
What: Add screenshot sources and lazy streaming inference.
Why: Support desktop capture and bounded result memory across inference sources.

- Adds screen, monitor, and region capture through the optional `mss` runtime.
- Makes `stream=True` lazy for images, directories, videos, screens, exported backends, and ensembles.
- Preserves result/save indices across streamed batches and documents the expanded ensemble source contract.

Check: source parsing, generator cleanup, and result naming across streamed batches.
Verified: Ruff; 137 focused tests; Windows PR unit gate (5,050 passed, 130 skipped, 159 deselected, 1 xfailed); live dual-monitor capture.
Not verified: live screen capture on Linux or macOS.
Opened by an agent.

## Code provenance
Original code written for this PR; no third-party code copied, ported, adapted, or derived. Adds `mss>=9.0.1` as an external runtime dependency; mss is MIT-licensed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds screen capture and lazy streaming inference across native models, exported backends, ensembles, and the CLI.
- Classifies finite images, videos, screens, webcams, network streams, and multi-stream inputs through a shared source contract.
- Adds incremental result delivery, bounded live-frame buffering, stream cleanup, and persistent indices across streamed batches.
- Extends ensemble inference and documentation to cover video, screen, and live-stream sources.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported in-memory sequence overwrite is fixed by assigning indexed labels to both materialized and streamed sequence items.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/utils/source.py | Introduces shared source classification and live/multi-stream frame-source handling. |
| libreyolo/utils/screen.py | Adds optional MSS-backed monitor and region capture with finite and continuous source adapters. |
| libreyolo/utils/video.py | Generalizes video inference around frame sources, per-source metadata, cleanup, and streamed saving. |
| libreyolo/models/base/inference.py | Extends native model inference to lazily process images, videos, screens, and live sources. |
| libreyolo/backends/base.py | Adds matching source classification and lazy streaming behavior for exported backends. |
| libreyolo/ensemble/model.py | Adds lazy image and frame ensembling while indexing in-memory sequence save names. |
| libreyolo/cli/commands/predict.py | Adds live-source-aware CLI options, incremental output, and generator cleanup. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Input[Prediction source] --> Classify[classify_source]
    Classify --> Images[Image or directory]
    Classify --> Video[Finite video]
    Classify --> Screen[Screen capture]
    Classify --> Live[Webcam or network stream]
    Images --> Batch[Batch or lazy image iterator]
    Video --> Frames[FrameSource]
    Screen --> Frames
    Live --> Buffered[Buffered live FrameSource]
    Buffered --> Frames
    Batch --> Infer[Model backend or ensemble]
    Frames --> Infer
    Infer --> Results[Results iterator]
    Results --> CLI[CLI output]
    Results --> Save[Image or video saving]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Add live prediction sources"](https://github.com/libreyolo/libreyolo/commit/020863b148e442aacb50a176e03e362fb67d6581) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50048439)</sub>

<!-- /greptile_comment -->