### PR TITLE
Add Comet, ClearML, Neptune, and DVCLive loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- Built-in Comet, ClearML, Neptune (`neptune-scale`) and DVC/DVCLive training
+  loggers, with the same canonical metrics and failure-isolation contract as
+  the existing TensorBoard, MLflow and Weights & Biases integrations.
+
 - CUDA graph capture (`predict(..., cuda_graph=True)`) extended from the
   initial 8 families to **39**, spanning detect, segment, pose, point,
   classify, semantic, depth, restore, matte and OCR. Every enabled family is

--- a/docs/training_loggers.md
+++ b/docs/training_loggers.md
@@ -43,8 +43,8 @@ module-level class, not a closure or lambda.
 ## Built-in loggers
 
 Built-in loggers are callback objects layered on the same universal hooks.
-Enable TensorBoard, MLflow, or Weights & Biases by name, or pass configured
-instances:
+Enable TensorBoard, MLflow, Weights & Biases, Comet, ClearML, Neptune or
+DVCLive by name, or pass configured instances:
 
 ```python
 model.train(data="coco8.yaml", loggers="tensorboard")
@@ -57,7 +57,7 @@ model.train(
 )
 ```
 
-All three log the same canonical metric names per epoch: `train/loss`,
+All seven log the same canonical metric names per epoch: `train/loss`,
 `train/loss/<component>`, `lr/<group>`, `val/<metric>`,
 `time/epoch_seconds`. They also log the resolved training config at
 start. A backend failure mid-run (server down, auth expired) disables
@@ -180,6 +180,76 @@ log_checkpoints=False)` — project falls back to `WANDB_PROJECT`, then
 `log_checkpoints=True` uploads `weights/best.pt` as a model artifact.
 
 Run names default to `<family><size>-<task>` (e.g. `yolo9s-detect`).
+
+### Comet
+
+```
+pip install libreyolo[comet]
+```
+
+`CometLogger(project_name=None, workspace=None, name=None, api_key=None,
+online=None, log_artifacts=True, log_checkpoints=False)` uses the current
+`comet_ml.start()` API. The project falls back to `COMET_PROJECT_NAME`, then
+`"libreyolo"`; credentials fall back to Comet's normal `COMET_API_KEY` or
+`comet login` configuration. Set `online=False` for an offline experiment.
+
+### ClearML
+
+```
+pip install libreyolo[clearml]
+```
+
+`ClearMLLogger(project_name="LibreYOLO", task_name=None, tags=None,
+output_uri=None, log_artifacts=True, log_checkpoints=False)` creates a fresh
+ClearML training task, reports the resolved config under `TrainConfig`, and
+marks the task failed when training raises. Automatic framework connection is
+disabled to prevent duplicate metric reporting; ClearML's configured server
+and credentials are otherwise used normally.
+
+### Neptune
+
+```
+pip install libreyolo[neptune]
+```
+
+`NeptuneLogger(project=None, api_token=None, name=None, run_id=None,
+tags=None, mode=None, capture_console=False, log_artifacts=True,
+log_checkpoints=False)` uses Neptune's current `neptune-scale` client, not the
+legacy `neptune` package. Project and credentials fall back to
+`NEPTUNE_PROJECT` and `NEPTUNE_API_TOKEN`. Use `mode="offline"` for local
+logging or `run_id=` to attach to an existing run.
+
+The stable Neptune client currently requires `protobuf<7`, while the TFLite
+extra requires protobuf 7 through `onnx2tf`. For that reason Neptune is not
+included in `libreyolo[all]`; install `libreyolo[neptune]` in an environment
+without the TFLite extra.
+
+### DVCLive / DVC
+
+```
+pip install libreyolo[dvclive]  # or libreyolo[dvc]
+```
+
+`DVCLiveLogger(log_dir=None, resume=None, report=None, save_dvc_exp=False,
+dvcyaml=None, monitor_system=False, log_checkpoints=False)` writes to
+`<save_dir>/dvclive`; both `loggers="dvclive"` and `loggers="dvc"` activate
+it. On resumed LibreYOLO training it resumes the DVCLive history and uses the
+trainer's 1-based epoch as the DVCLive step.
+
+DVCLive uses `/` to build its summary tree and cannot store a float at a path
+that is also a parent (for example, both `train/loss` and
+`train/loss/box`). LibreYOLO keeps the parent name and dot-encodes only the
+conflicting child separator: `train/loss.box`. This preserves every metric
+without disabling the logger; non-conflicting names stay unchanged.
+
+DVCLive itself normally defaults to saving a DVC experiment and writing a
+root `dvc.yaml`. LibreYOLO deliberately defaults both behaviours off so an
+opt-in logger does not create Git/DVC state outside the training run. Pass
+`save_dvc_exp=True` and/or an explicit `dvcyaml=".../dvc.yaml"` when that is
+the desired workflow. When `log_checkpoints=True` is explicitly enabled,
+checkpoint registration uses `cache=False`, so it never silently adds the
+checkpoint to the DVC cache. As with DVCLive directly, artifact registration
+requires a DVC repository.
 
 ## Always-on run status (`status.json`, `metrics.jsonl`, `train.log`)
 

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -225,9 +225,8 @@ class LibreDEIM(BaseModel):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -257,9 +257,8 @@ class LibreDEIMv2(BaseModel):
                 family default).
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -315,9 +315,8 @@ class LibreDFINE(BaseModel):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -318,9 +318,8 @@ class LibreEC(BaseModel):
 
         Args:
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         if self.task == "pose":
             return self._train_pose(

--- a/libreyolo/models/fomo/model.py
+++ b/libreyolo/models/fomo/model.py
@@ -196,9 +196,8 @@ class LibreFOMO(BaseModel):
 
         Args:
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         if not allow_experimental:
             raise NotImplementedError(

--- a/libreyolo/models/picodet/model.py
+++ b/libreyolo/models/picodet/model.py
@@ -207,9 +207,8 @@ class LibrePICODET(BaseModel):
 
         Args:
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         if not allow_experimental:
             raise RuntimeError(

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -1200,9 +1200,8 @@ class LibreRFDETR(BaseModel):
             output_dir: Directory for training runs and checkpoints.
             resume: Checkpoint path, or True to resume the loaded checkpoint.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         output_path = Path(output_dir)
         train_kwargs = dict(kwargs)

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -535,9 +535,8 @@ class LibreRTDETR(BaseModel):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
 
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -114,9 +114,8 @@ class LibreRTDETRv4(LibreDFINE):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -284,9 +284,8 @@ class LibreRTMDet(BaseModel):
 
         Args:
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         if self.task == "segment":
             raise NotImplementedError(

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -526,9 +526,8 @@ class LibreYOLO9(BaseModel):
                 load the matching LibreYOLO9 detect checkpoint for transfer
                 learning, or pass a checkpoint path/name.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
 
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.

--- a/libreyolo/models/yolo9_e2e/model.py
+++ b/libreyolo/models/yolo9_e2e/model.py
@@ -211,9 +211,8 @@ class LibreYOLO9E2E(LibreYOLO9):
             patience: Early stopping patience.
             allow_download_scripts: Allow embedded Python in dataset YAML downloads.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
 
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -523,9 +523,8 @@ class LibreYOLONAS(BaseModel):
                 task default).
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
         """
         # Task-specific defaults for arguments left unset by the caller.
         if lr0 is None:

--- a/libreyolo/models/yolox/model.py
+++ b/libreyolo/models/yolox/model.py
@@ -231,9 +231,8 @@ class LibreYOLOX(BaseModel):
             amp: Enable automatic mixed precision training.
             patience: Early stopping patience.
             callbacks: Optional training callback or iterable of callbacks.
-            loggers: Optional built-in experiment loggers: a name
-                ('tensorboard', 'mlflow', 'wandb'), a configured logger
-                instance, or an iterable mixing both.
+            loggers: Optional built-in experiment loggers: a registered name,
+                a configured logger instance, or an iterable mixing both.
 
         Returns:
             Training results dict with final_loss, best_mAP50, best_mAP50_95, etc.

--- a/libreyolo/training/__init__.py
+++ b/libreyolo/training/__init__.py
@@ -20,7 +20,11 @@ from .config import (
     YOLOv7Config as YOLOv7Config,
 )
 from .loggers import (
+    ClearMLLogger as ClearMLLogger,
+    CometLogger as CometLogger,
+    DVCLiveLogger as DVCLiveLogger,
     MLflowLogger as MLflowLogger,
+    NeptuneLogger as NeptuneLogger,
     TensorBoardLogger as TensorBoardLogger,
     WandbLogger as WandbLogger,
     resolve_loggers as resolve_loggers,

--- a/libreyolo/training/loggers/__init__.py
+++ b/libreyolo/training/loggers/__init__.py
@@ -1,4 +1,4 @@
-"""Built-in experiment loggers (TensorBoard, MLflow, Weights & Biases).
+"""Built-in experiment loggers layered on the public training hooks.
 
 Loggers are ordinary training callbacks consuming the public hook system
 (:mod:`libreyolo.training.callbacks`). Enable them by name::
@@ -13,39 +13,48 @@ or pass configured instances (mixing with names is fine)::
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List
+from collections.abc import Iterable
+from typing import Any
 
 from .base import BaseLogger as BaseLogger
+from .clearml_logger import ClearMLLogger as ClearMLLogger
+from .comet_logger import CometLogger as CometLogger
+from .dvclive_logger import DVCLiveLogger as DVCLiveLogger
 from .mlflow_logger import MLflowLogger as MLflowLogger
+from .neptune_logger import NeptuneLogger as NeptuneLogger
 from .tensorboard_logger import TensorBoardLogger as TensorBoardLogger
 from .wandb_logger import WandbLogger as WandbLogger
 
 _LOGGER_FACTORIES = {
+    "clearml": ClearMLLogger,
+    "comet": CometLogger,
+    "dvc": DVCLiveLogger,
+    "dvclive": DVCLiveLogger,
+    "neptune": NeptuneLogger,
     "tensorboard": TensorBoardLogger,
     "mlflow": MLflowLogger,
     "wandb": WandbLogger,
 }
 
 
-def resolve_loggers(loggers: Any) -> List[Any]:
+def resolve_loggers(loggers: Any) -> list[Any]:
     """Resolve the ``loggers=`` train argument into callback instances.
 
-    Accepts ``None``, a logger name (``"tensorboard"``, ``"mlflow"``,
-    ``"wandb"``), a callback object, or an iterable mixing both.
+    Accepts ``None``, a registered logger name, a callback object, or an
+    iterable mixing both. ``"dvc"`` is an alias for ``"dvclive"``.
     """
     if loggers is None:
         return []
     if isinstance(loggers, str) or not isinstance(loggers, Iterable):
         loggers = [loggers]
 
-    resolved: List[Any] = []
+    resolved: list[Any] = []
     for item in loggers:
         if isinstance(item, str):
             key = item.strip().lower()
             if key not in _LOGGER_FACTORIES:
                 raise ValueError(
-                    f"Unknown logger {item!r}. "
-                    f"Valid names: {sorted(_LOGGER_FACTORIES)}"
+                    f"Unknown logger {item!r}. Valid names: {sorted(_LOGGER_FACTORIES)}"
                 )
             resolved.append(_LOGGER_FACTORIES[key]())
         else:

--- a/libreyolo/training/loggers/base.py
+++ b/libreyolo/training/loggers/base.py
@@ -13,7 +13,8 @@ them:
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 from ..callbacks import (
     TrainEndEvent,
@@ -25,14 +26,14 @@ from ..callbacks import (
 logger = logging.getLogger("libreyolo")
 
 
-def epoch_metrics(event: TrainEpochEvent) -> Dict[str, float]:
+def epoch_metrics(event: TrainEpochEvent) -> dict[str, float]:
     """Flatten a :class:`TrainEpochEvent` into the canonical metric schema.
 
     The same names are used by every built-in logger so dashboards look
     identical across backends: ``train/loss``, ``train/loss/<component>``,
     ``lr/<group>``, ``val/<metric>`` and ``time/epoch_seconds``.
     """
-    metrics: Dict[str, float] = {"train/loss": event.train_loss}
+    metrics: dict[str, float] = {"train/loss": event.train_loss}
     for name, value in event.train_loss_items.items():
         metrics[f"train/loss/{name}"] = value
     for name, value in event.lr.items():
@@ -51,6 +52,21 @@ def run_name_for(event: Any) -> str:
     family = event.model_family or "model"
     size = event.model_size or ""
     return f"{family}{size}-{event.task}"
+
+
+def artifact_paths(
+    event: TrainEndEvent, *, log_checkpoints: bool = False
+) -> list[Path]:
+    """Return the standard, existing artifacts for a completed training run."""
+    save_dir = Path(event.save_dir)
+    candidates = [
+        save_dir / "results.csv",
+        save_dir / "train_config.yaml",
+        save_dir / "summary.json",
+    ]
+    if log_checkpoints:
+        candidates.append(save_dir / "weights" / "best.pt")
+    return [path for path in candidates if path.is_file()]
 
 
 class BaseLogger:
@@ -85,8 +101,7 @@ class BaseLogger:
         except Exception:
             self._disabled = True
             logger.exception(
-                "%s failed; disabling it for the rest of this run "
-                "(training continues)",
+                "%s failed; disabling it for the rest of this run (training continues)",
                 type(self).__name__,
             )
             # Best-effort teardown so an already-opened backend run/writer

--- a/libreyolo/training/loggers/clearml_logger.py
+++ b/libreyolo/training/loggers/clearml_logger.py
@@ -1,0 +1,131 @@
+"""ClearML logger built on the public training hooks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ..callbacks import (
+    TrainEndEvent,
+    TrainEpochEvent,
+    TrainExceptionEvent,
+    TrainStartEvent,
+)
+from .base import BaseLogger, artifact_paths, epoch_metrics, run_name_for
+
+
+def _import_clearml_task():
+    try:
+        from clearml import Task
+    except ImportError as exc:
+        raise ImportError(
+            "ClearMLLogger requires the 'clearml' package. "
+            "Install it with: pip install libreyolo[clearml]"
+        ) from exc
+    return Task
+
+
+def _metric_parts(name: str) -> tuple[str, str]:
+    title, separator, series = name.partition("/")
+    return (title, series) if separator else ("metrics", title)
+
+
+class ClearMLLogger(BaseLogger):
+    """Log training to ClearML.
+
+    Args:
+        project_name: ClearML project name. Defaults to ``"LibreYOLO"``.
+        task_name: ClearML task name. Defaults to ``<family><size>-<task>``.
+        tags: Optional ClearML task tags.
+        output_uri: Optional ClearML output storage URI.
+        log_artifacts: Upload the standard training result files at train end.
+        log_checkpoints: Also upload ``weights/best.pt``.
+    """
+
+    def __init__(
+        self,
+        project_name: str = "LibreYOLO",
+        task_name: str | None = None,
+        tags: Sequence[str] | None = None,
+        output_uri: str | None = None,
+        log_artifacts: bool = True,
+        log_checkpoints: bool = False,
+    ):
+        super().__init__()
+        _import_clearml_task()
+        self.project_name = project_name
+        self.task_name = task_name
+        self.tags = tuple(tags or ())
+        self.output_uri = output_uri
+        self.log_artifacts = log_artifacts
+        self.log_checkpoints = log_checkpoints
+        self._task = None
+        self._clearml_logger = None
+
+    def _handle_start(self, event: TrainStartEvent) -> None:
+        task_cls = _import_clearml_task()
+        self._task = task_cls.init(
+            project_name=self.project_name,
+            task_name=self.task_name or run_name_for(event),
+            tags=list(self.tags) or None,
+            reuse_last_task_id=False,
+            output_uri=self.output_uri,
+            auto_connect_arg_parser=False,
+            auto_connect_frameworks=False,
+        )
+        self._clearml_logger = self._task.get_logger()
+        if event.config:
+            self._task.connect_configuration(
+                dict(event.config),
+                name="TrainConfig",
+                ignore_remote_overrides=True,
+            )
+
+    def _handle_epoch_end(self, event: TrainEpochEvent) -> None:
+        if self._clearml_logger is None:
+            return
+        for name, value in epoch_metrics(event).items():
+            title, series = _metric_parts(name)
+            self._clearml_logger.report_scalar(
+                title=title,
+                series=series,
+                value=value,
+                iteration=event.epoch,
+            )
+
+    def _handle_end(self, event: TrainEndEvent) -> None:
+        if self._task is None:
+            return
+        if event.best_metric is not None and self._clearml_logger is not None:
+            self._clearml_logger.report_single_value("best_metric", event.best_metric)
+            if event.best_epoch is not None:
+                self._clearml_logger.report_single_value("best_epoch", event.best_epoch)
+        if self.log_artifacts:
+            for path in artifact_paths(event, log_checkpoints=self.log_checkpoints):
+                self._task.upload_artifact(
+                    name=path.name,
+                    artifact_object=str(path),
+                    wait_on_upload=True,
+                )
+        self._task.close()
+        self._task = None
+        self._clearml_logger = None
+
+    def _handle_exception(self, event: TrainExceptionEvent) -> None:
+        self._fail(event.exception_type, event.exception_message)
+
+    def _teardown(self) -> None:
+        self._fail(
+            "logger backend failure",
+            "LibreYOLO disabled ClearML after a logging error",
+        )
+
+    def _fail(self, reason: str, message: str) -> None:
+        if self._task is None:
+            return
+        self._task.mark_failed(
+            ignore_errors=False,
+            status_reason=reason,
+            status_message=message,
+        )
+        self._task = None
+        self._clearml_logger = None

--- a/libreyolo/training/loggers/comet_logger.py
+++ b/libreyolo/training/loggers/comet_logger.py
@@ -1,0 +1,121 @@
+"""Comet logger built on the public training hooks."""
+
+from __future__ import annotations
+
+import os
+
+from ..callbacks import (
+    TrainEndEvent,
+    TrainEpochEvent,
+    TrainExceptionEvent,
+    TrainStartEvent,
+)
+from .base import BaseLogger, artifact_paths, epoch_metrics, run_name_for
+
+
+def _import_comet():
+    try:
+        import comet_ml
+    except ImportError as exc:
+        raise ImportError(
+            "CometLogger requires the 'comet-ml' package. "
+            "Install it with: pip install libreyolo[comet]"
+        ) from exc
+    return comet_ml
+
+
+class CometLogger(BaseLogger):
+    """Log training to Comet.
+
+    Args:
+        project_name: Comet project. Defaults to ``COMET_PROJECT_NAME``, then
+            ``"libreyolo"``.
+        workspace: Comet workspace. Defaults to Comet's configured workspace.
+        name: Experiment name. Defaults to ``<family><size>-<task>``.
+        api_key: Comet API key. Prefer ``COMET_API_KEY`` or ``comet login``.
+        online: Set ``False`` for Comet's offline experiment mode.
+        log_artifacts: Upload the standard training result files at train end.
+        log_checkpoints: Also upload ``weights/best.pt``.
+    """
+
+    def __init__(
+        self,
+        project_name: str | None = None,
+        workspace: str | None = None,
+        name: str | None = None,
+        api_key: str | None = None,
+        online: bool | None = None,
+        log_artifacts: bool = True,
+        log_checkpoints: bool = False,
+    ):
+        super().__init__()
+        _import_comet()
+        self.project_name = project_name
+        self.workspace = workspace
+        self.name = name
+        self.api_key = api_key
+        self.online = online
+        self.log_artifacts = log_artifacts
+        self.log_checkpoints = log_checkpoints
+        self._experiment = None
+
+    def _handle_start(self, event: TrainStartEvent) -> None:
+        comet = _import_comet()
+        kwargs = {
+            "project_name": self.project_name
+            or os.environ.get("COMET_PROJECT_NAME", "libreyolo"),
+            "mode": "create",
+        }
+        for key, value in (
+            ("workspace", self.workspace),
+            ("api_key", self.api_key),
+            ("online", self.online),
+        ):
+            if value is not None:
+                kwargs[key] = value
+        self._experiment = comet.start(**kwargs)
+        self._experiment.set_name(self.name or run_name_for(event))
+        if event.config:
+            self._experiment.log_parameters(dict(event.config))
+
+    def _handle_epoch_end(self, event: TrainEpochEvent) -> None:
+        if self._experiment is None:
+            return
+        self._experiment.log_metrics(
+            epoch_metrics(event), step=event.epoch, epoch=event.epoch
+        )
+
+    def _handle_end(self, event: TrainEndEvent) -> None:
+        if self._experiment is None:
+            return
+        summary = {"status": "finished"}
+        if event.best_metric is not None:
+            summary.update(
+                best_metric=event.best_metric,
+                best_epoch=event.best_epoch,
+            )
+        self._experiment.log_others(summary)
+        if self.log_artifacts:
+            for path in artifact_paths(event, log_checkpoints=self.log_checkpoints):
+                self._experiment.log_asset(str(path), file_name=path.name)
+        self._finish()
+
+    def _handle_exception(self, event: TrainExceptionEvent) -> None:
+        if self._experiment is not None:
+            self._experiment.log_others(
+                {
+                    "status": "failed",
+                    "exception_type": event.exception_type,
+                    "exception_message": event.exception_message,
+                }
+            )
+        self._finish()
+
+    def _teardown(self) -> None:
+        self._finish()
+
+    def _finish(self) -> None:
+        if self._experiment is None:
+            return
+        self._experiment.end()
+        self._experiment = None

--- a/libreyolo/training/loggers/dvclive_logger.py
+++ b/libreyolo/training/loggers/dvclive_logger.py
@@ -1,0 +1,151 @@
+"""DVCLive logger built on the public training hooks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ..callbacks import (
+    TrainEndEvent,
+    TrainEpochEvent,
+    TrainExceptionEvent,
+    TrainStartEvent,
+)
+from .base import BaseLogger, epoch_metrics, run_name_for
+
+
+def _import_dvclive():
+    try:
+        from dvclive import Live
+    except ImportError as exc:
+        raise ImportError(
+            "DVCLiveLogger requires the 'dvclive' package. "
+            "Install it with: pip install libreyolo[dvclive]"
+        ) from exc
+    return Live
+
+
+def _safe_param(value: Any) -> Any:
+    """Convert resolved config values to DVCLive's supported param types."""
+    if value is None:
+        return "None"
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _safe_param(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_safe_param(item) for item in value]
+    return str(value)
+
+
+def _metric_name(name: str, all_names: set[str]) -> str:
+    """Avoid DVCLive's scalar-versus-subtree summary collision.
+
+    DVCLive treats ``/`` as nesting, so it cannot hold both ``train/loss``
+    as a float and ``train/loss/box`` as a child. Keep the parent canonical
+    and encode the conflicting child separator as a dot: ``train/loss.box``.
+    """
+    parts = name.split("/")
+    for index in range(len(parts) - 1):
+        parent = "/".join(parts[: index + 1])
+        if parent in all_names:
+            suffix = ".".join(parts[index + 1 :])
+            return f"{parent}.{suffix}"
+    return name
+
+
+class DVCLiveLogger(BaseLogger):
+    """Write training metrics and parameters with DVCLive.
+
+    The safe defaults do not save a DVC experiment, write ``dvc.yaml`` or
+    cache files. Enable those DVCLive behaviours explicitly if desired.
+
+    Args:
+        log_dir: Output directory. Defaults to ``<save_dir>/dvclive``.
+        resume: Resume existing DVCLive history. Defaults to whether the
+            LibreYOLO training run itself is resumed.
+        report: Optional DVCLive report format (``"html"``, ``"md"`` or
+            ``"notebook"``).
+        save_dvc_exp: Save a DVC experiment when the run ends. Default false.
+        dvcyaml: Optional path to a ``dvc.yaml`` file, or a boolean accepted
+            by DVCLive. Default ``None`` disables pipeline-file updates.
+        monitor_system: Ask DVCLive to record system metrics.
+        log_checkpoints: Register ``weights/best.pt`` as a model artifact.
+    """
+
+    def __init__(
+        self,
+        log_dir: str | None = None,
+        resume: bool | None = None,
+        report: str | None = None,
+        save_dvc_exp: bool = False,
+        dvcyaml: str | Path | bool | None = None,
+        monitor_system: bool = False,
+        log_checkpoints: bool = False,
+    ):
+        super().__init__()
+        _import_dvclive()
+        self.log_dir = log_dir
+        self.resume = resume
+        self.report = report
+        self.save_dvc_exp = save_dvc_exp
+        self.dvcyaml = dvcyaml
+        self.monitor_system = monitor_system
+        self.log_checkpoints = log_checkpoints
+        self._live = None
+
+    def _handle_start(self, event: TrainStartEvent) -> None:
+        live_cls = _import_dvclive()
+        self._live = live_cls(
+            dir=self.log_dir or str(Path(event.save_dir) / "dvclive"),
+            resume=(event.start_epoch > 1 if self.resume is None else self.resume),
+            report=self.report,
+            save_dvc_exp=self.save_dvc_exp,
+            dvcyaml=self.dvcyaml,
+            exp_name=run_name_for(event),
+            monitor_system=self.monitor_system,
+        )
+        if event.config:
+            self._live.log_params(_safe_param(dict(event.config)))
+
+    def _handle_epoch_end(self, event: TrainEpochEvent) -> None:
+        if self._live is None:
+            return
+        # LibreYOLO events are 1-based. Setting the step explicitly also keeps
+        # resumed runs aligned with the trainer rather than a local counter.
+        self._live.step = event.epoch
+        metrics = epoch_metrics(event)
+        names = set(metrics)
+        for name, value in metrics.items():
+            self._live.log_metric(_metric_name(name, names), value)
+        self._live.make_summary()
+
+    def _handle_end(self, event: TrainEndEvent) -> None:
+        if self._live is None:
+            return
+        if event.best_metric is not None:
+            self._live.summary["best_metric"] = event.best_metric
+            self._live.summary["best_epoch"] = event.best_epoch
+        if self.log_checkpoints:
+            best = Path(event.save_dir) / "weights" / "best.pt"
+            if best.is_file():
+                self._live.log_artifact(
+                    best,
+                    type="model",
+                    name=f"{run_name_for(event)}-best",
+                    cache=False,
+                )
+        self._finish()
+
+    def _handle_exception(self, event: TrainExceptionEvent) -> None:
+        self._finish()
+
+    def _teardown(self) -> None:
+        self._finish()
+
+    def _finish(self) -> None:
+        if self._live is None:
+            return
+        self._live.end()
+        self._live = None

--- a/libreyolo/training/loggers/neptune_logger.py
+++ b/libreyolo/training/loggers/neptune_logger.py
@@ -1,0 +1,133 @@
+"""Neptune logger built on the public training hooks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ..callbacks import (
+    TrainEndEvent,
+    TrainEpochEvent,
+    TrainExceptionEvent,
+    TrainStartEvent,
+)
+from .base import BaseLogger, artifact_paths, epoch_metrics, run_name_for
+
+
+def _import_neptune_run():
+    try:
+        from neptune_scale import Run
+    except ImportError as exc:
+        raise ImportError(
+            "NeptuneLogger requires the 'neptune-scale' package. "
+            "Install it with: pip install libreyolo[neptune]"
+        ) from exc
+    return Run
+
+
+class NeptuneLogger(BaseLogger):
+    """Log training with Neptune's current ``neptune-scale`` client.
+
+    Args:
+        project: Neptune project path. Defaults to ``NEPTUNE_PROJECT``.
+        api_token: Neptune API token. Prefer ``NEPTUNE_API_TOKEN``.
+        name: Experiment name. Defaults to ``<family><size>-<task>``.
+        run_id: Optional custom ID, also used by Neptune to resume a run.
+        tags: Optional Neptune run tags.
+        mode: Neptune mode: ``"async"``, ``"offline"`` or ``"disabled"``.
+        capture_console: Capture stdout/stderr into Neptune.
+        log_artifacts: Upload the standard training result files at train end.
+        log_checkpoints: Also upload ``weights/best.pt``.
+    """
+
+    def __init__(
+        self,
+        project: str | None = None,
+        api_token: str | None = None,
+        name: str | None = None,
+        run_id: str | None = None,
+        tags: Sequence[str] | None = None,
+        mode: str | None = None,
+        capture_console: bool = False,
+        log_artifacts: bool = True,
+        log_checkpoints: bool = False,
+    ):
+        super().__init__()
+        _import_neptune_run()
+        self.project = project
+        self.api_token = api_token
+        self.name = name
+        self.run_id = run_id
+        self.tags = tuple(tags or ())
+        self.mode = mode
+        self.capture_console = capture_console
+        self.log_artifacts = log_artifacts
+        self.log_checkpoints = log_checkpoints
+        self._run = None
+
+    def _handle_start(self, event: TrainStartEvent) -> None:
+        run_cls = _import_neptune_run()
+        self._run = run_cls(
+            project=self.project,
+            api_token=self.api_token,
+            experiment_name=self.name or run_name_for(event),
+            run_id=self.run_id,
+            mode=self.mode,
+            enable_console_log_capture=self.capture_console,
+        )
+        if event.config:
+            self._run.log_configs(
+                data={"config": dict(event.config)},
+                flatten=True,
+                cast_unsupported=True,
+            )
+        if self.tags:
+            self._run.add_tags(tags=self.tags)
+
+    def _handle_epoch_end(self, event: TrainEpochEvent) -> None:
+        if self._run is None:
+            return
+        self._run.log_metrics(data=epoch_metrics(event), step=event.epoch)
+
+    def _handle_end(self, event: TrainEndEvent) -> None:
+        if self._run is None:
+            return
+        summary = {"run/status": "finished"}
+        if event.best_metric is not None:
+            summary.update(
+                {
+                    "run/best_metric": event.best_metric,
+                    "run/best_epoch": event.best_epoch,
+                }
+            )
+        self._run.log_configs(data=summary, cast_unsupported=True)
+        if self.log_artifacts:
+            files = {
+                f"artifacts/{path.name}": path
+                for path in artifact_paths(event, log_checkpoints=self.log_checkpoints)
+            }
+            if files:
+                self._run.assign_files(files=files)
+        self._close()
+
+    def _handle_exception(self, event: TrainExceptionEvent) -> None:
+        if self._run is not None:
+            self._run.log_configs(
+                data={
+                    "run/status": "failed",
+                    "run/exception_type": event.exception_type,
+                    "run/exception_message": event.exception_message,
+                }
+            )
+        self._close()
+
+    def _teardown(self) -> None:
+        if self._run is None:
+            return
+        self._run.terminate()
+        self._run = None
+
+    def _close(self) -> None:
+        if self._run is None:
+            return
+        self._run.close()
+        self._run = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,21 @@ mlflow = [
 wandb = [
     "wandb>=0.16.0",
 ]
+comet = [
+    "comet-ml>=3.47.1",
+]
+clearml = [
+    "clearml>=1.17.0",
+]
+neptune = [
+    "neptune-scale>=0.30.0",
+]
+dvclive = [
+    "dvclive>=3.49.0",
+]
+dvc = [
+    "libreyolo[dvclive]",
+]
 all = [
     "libreyolo[onnx]",
     "libreyolo[rfdetr]",
@@ -244,6 +259,11 @@ all = [
     "libreyolo[tensorboard]",
     "libreyolo[mlflow]",
     "libreyolo[wandb]",
+    "libreyolo[comet]",
+    "libreyolo[clearml]",
+    "libreyolo[dvclive]",
+    # Keep Neptune separate: stable neptune-scale requires protobuf<7 while
+    # the TFLite/onnx2tf extra included above requires protobuf 7.
 ]
 
 [project.scripts]
@@ -289,6 +309,13 @@ build-backend = "setuptools.build_meta"
 # `uv sync` produces a GPU-enabled environment by default. macOS keeps the
 # PyPI default (CPU/MPS wheel) since download.pytorch.org has no darwin builds.
 # Requires NVIDIA driver >= 555 (CUDA 12.8 runtime) on the host.
+[tool.uv]
+conflicts = [
+    [{ extra = "neptune" }, { extra = "tflite" }],
+    [{ extra = "neptune" }, { extra = "litert" }],
+    [{ extra = "neptune" }, { extra = "all" }],
+]
+
 [tool.uv.sources]
 torch = [
     { index = "pytorch-cu128", marker = "sys_platform != 'darwin'" },

--- a/tests/unit/test_training_loggers.py
+++ b/tests/unit/test_training_loggers.py
@@ -302,7 +302,7 @@ def test_trainer_start_event_carries_resolved_config(tmp_path):
 def test_resolve_loggers_none_and_unknown():
     assert resolve_loggers(None) == []
     with pytest.raises(ValueError, match="Unknown logger"):
-        resolve_loggers("clearml")
+        resolve_loggers("not-a-logger")
 
 
 def test_resolve_loggers_strings_and_instances(fake_mlflow, fake_tensorboard):

--- a/tests/unit/test_training_loggers_extended.py
+++ b/tests/unit/test_training_loggers_extended.py
@@ -1,0 +1,415 @@
+"""Unit tests for Comet, ClearML, Neptune and DVCLive loggers."""
+
+from __future__ import annotations
+
+import builtins
+import pickle
+from typing import ClassVar
+
+import pytest
+
+from libreyolo.training.callbacks import (
+    TrainEndEvent,
+    TrainEpochEvent,
+    TrainExceptionEvent,
+    TrainStartEvent,
+)
+from libreyolo.training.loggers import (
+    ClearMLLogger,
+    CometLogger,
+    DVCLiveLogger,
+    NeptuneLogger,
+    resolve_loggers,
+)
+from libreyolo.training.loggers import (
+    clearml_logger as clearml_module,
+)
+from libreyolo.training.loggers import (
+    comet_logger as comet_module,
+)
+from libreyolo.training.loggers import (
+    dvclive_logger as dvclive_module,
+)
+from libreyolo.training.loggers import (
+    neptune_logger as neptune_module,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _start_event(save_dir: str, *, start_epoch: int = 1) -> TrainStartEvent:
+    return TrainStartEvent(
+        start_epoch=start_epoch,
+        total_epochs=2,
+        model_family="yolo9",
+        model_size="s",
+        task="detect",
+        save_dir=save_dir,
+        config={"epochs": 2, "lr0": 0.01, "data": None},
+    )
+
+
+def _epoch_event(save_dir: str, *, epoch: int = 1) -> TrainEpochEvent:
+    return TrainEpochEvent(
+        epoch=epoch,
+        total_epochs=2,
+        model_family="yolo9",
+        model_size="s",
+        task="detect",
+        save_dir=save_dir,
+        train_loss=1.5,
+        train_loss_items={"box": 0.2},
+        lr={"group0": 0.01},
+        val_metrics={"metrics/mAP50": 0.6},
+        validated=True,
+        is_best=True,
+        current_metric=0.6,
+        current_metric_name="metrics/mAP50",
+        best_metric=0.6,
+        best_metric_name="metrics/mAP50",
+        best_epoch=1,
+        epoch_seconds=2.5,
+    )
+
+
+def _end_event(save_dir: str) -> TrainEndEvent:
+    return TrainEndEvent(
+        total_epochs=2,
+        completed_epochs=2,
+        model_family="yolo9",
+        model_size="s",
+        task="detect",
+        save_dir=save_dir,
+        final_loss=1.0,
+        best_metric=0.6,
+        best_epoch=1,
+        total_seconds=5.0,
+        results={"final_loss": 1.0},
+    )
+
+
+def _exception_event(save_dir: str) -> TrainExceptionEvent:
+    exc = RuntimeError("boom")
+    return TrainExceptionEvent(
+        epoch=1,
+        total_epochs=2,
+        model_family="yolo9",
+        model_size="s",
+        task="detect",
+        save_dir=save_dir,
+        exception=exc,
+        exception_type="RuntimeError",
+        exception_message="boom",
+        elapsed_seconds=1.0,
+    )
+
+
+class FakeCometExperiment:
+    def __init__(self):
+        self.calls = []
+
+    def set_name(self, name):
+        self.calls.append(("set_name", name))
+
+    def log_parameters(self, params):
+        self.calls.append(("log_parameters", params))
+
+    def log_metrics(self, metrics, step=None, epoch=None):
+        self.calls.append(("log_metrics", metrics, step, epoch))
+
+    def log_others(self, values):
+        self.calls.append(("log_others", values))
+
+    def log_asset(self, path, file_name=None):
+        self.calls.append(("log_asset", path, file_name))
+
+    def end(self):
+        self.calls.append(("end",))
+
+
+class FakeComet:
+    def __init__(self):
+        self.start_kwargs = None
+        self.experiment = FakeCometExperiment()
+
+    def start(self, **kwargs):
+        self.start_kwargs = kwargs
+        return self.experiment
+
+
+class FakeClearMLLogger:
+    def __init__(self):
+        self.scalars = []
+        self.single_values = []
+
+    def report_scalar(self, **kwargs):
+        self.scalars.append(kwargs)
+
+    def report_single_value(self, name, value):
+        self.single_values.append((name, value))
+
+
+class FakeClearMLTask:
+    instances: ClassVar[list] = []
+
+    def __init__(self, init_kwargs):
+        self.init_kwargs = init_kwargs
+        self.logger = FakeClearMLLogger()
+        self.configurations = []
+        self.artifacts = []
+        self.closed = False
+        self.failed = None
+        self.__class__.instances.append(self)
+
+    @classmethod
+    def init(cls, **kwargs):
+        return cls(kwargs)
+
+    def get_logger(self):
+        return self.logger
+
+    def connect_configuration(self, config, **kwargs):
+        self.configurations.append((config, kwargs))
+
+    def upload_artifact(self, **kwargs):
+        self.artifacts.append(kwargs)
+
+    def close(self):
+        self.closed = True
+
+    def mark_failed(self, **kwargs):
+        self.failed = kwargs
+
+
+class FakeNeptuneRun:
+    instances: ClassVar[list] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.configs = []
+        self.metrics = []
+        self.tags = []
+        self.files = []
+        self.closed = False
+        self.terminated = False
+        self.__class__.instances.append(self)
+
+    def log_configs(self, **kwargs):
+        self.configs.append(kwargs)
+
+    def log_metrics(self, **kwargs):
+        self.metrics.append(kwargs)
+
+    def add_tags(self, **kwargs):
+        self.tags.append(kwargs)
+
+    def assign_files(self, **kwargs):
+        self.files.append(kwargs)
+
+    def close(self):
+        self.closed = True
+
+    def terminate(self):
+        self.terminated = True
+
+
+class FakeDVCLive:
+    instances: ClassVar[list] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.params = []
+        self.metrics = []
+        self.summary = {}
+        self.step = 0
+        self.artifacts = []
+        self.summary_calls = 0
+        self.ended = False
+        self.__class__.instances.append(self)
+
+    def log_params(self, params):
+        self.params.append(params)
+
+    def log_metric(self, name, value):
+        self.metrics.append((name, value, self.step))
+
+    def make_summary(self):
+        self.summary_calls += 1
+
+    def log_artifact(self, path, **kwargs):
+        self.artifacts.append((path, kwargs))
+
+    def end(self):
+        self.ended = True
+
+
+@pytest.fixture
+def fake_backends(monkeypatch):
+    comet = FakeComet()
+    FakeClearMLTask.instances = []
+    FakeNeptuneRun.instances = []
+    FakeDVCLive.instances = []
+    monkeypatch.setattr(comet_module, "_import_comet", lambda: comet)
+    monkeypatch.setattr(clearml_module, "_import_clearml_task", lambda: FakeClearMLTask)
+    monkeypatch.setattr(neptune_module, "_import_neptune_run", lambda: FakeNeptuneRun)
+    monkeypatch.setattr(dvclive_module, "_import_dvclive", lambda: FakeDVCLive)
+    return comet
+
+
+def _write_artifacts(tmp_path):
+    (tmp_path / "results.csv").write_text("epoch\n1\n")
+    (tmp_path / "summary.json").write_text("{}")
+    (tmp_path / "weights").mkdir()
+    (tmp_path / "weights" / "best.pt").write_bytes(b"00")
+
+
+def test_resolve_all_extended_logger_names_and_dvc_alias(fake_backends):
+    resolved = resolve_loggers(["comet", "clearml", "neptune", "dvc", "dvclive"])
+    assert [type(item) for item in resolved] == [
+        CometLogger,
+        ClearMLLogger,
+        NeptuneLogger,
+        DVCLiveLogger,
+        DVCLiveLogger,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("module", "helper_name", "package_name", "extra_name"),
+    [
+        (comet_module, "_import_comet", "comet_ml", "comet"),
+        (clearml_module, "_import_clearml_task", "clearml", "clearml"),
+        (neptune_module, "_import_neptune_run", "neptune_scale", "neptune"),
+        (dvclive_module, "_import_dvclive", "dvclive", "dvclive"),
+    ],
+)
+def test_extended_logger_import_errors_name_install_extra(
+    monkeypatch, module, helper_name, package_name, extra_name
+):
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == package_name:
+            raise ImportError(f"blocked {package_name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    with pytest.raises(ImportError, match=rf"libreyolo\[{extra_name}\]"):
+        getattr(module, helper_name)()
+
+
+def test_comet_logger_full_lifecycle(fake_backends, tmp_path):
+    _write_artifacts(tmp_path)
+    logger = CometLogger(project_name="project", workspace="team", log_checkpoints=True)
+    logger.on_train_start(_start_event(str(tmp_path)))
+    logger.on_train_epoch_end(_epoch_event(str(tmp_path)))
+    logger.on_train_end(_end_event(str(tmp_path)))
+
+    assert fake_backends.start_kwargs == {
+        "project_name": "project",
+        "mode": "create",
+        "workspace": "team",
+    }
+    calls = fake_backends.experiment.calls
+    assert ("set_name", "yolo9s-detect") in calls
+    metrics = next(call for call in calls if call[0] == "log_metrics")
+    assert metrics[1]["val/mAP50"] == 0.6
+    assert metrics[2:] == (1, 1)
+    assert any(call[0] == "log_asset" and call[2] == "best.pt" for call in calls)
+    assert calls[-1] == ("end",)
+
+
+def test_clearml_logger_full_lifecycle(fake_backends, tmp_path):
+    _write_artifacts(tmp_path)
+    logger = ClearMLLogger(tags=["nightly"], log_checkpoints=True)
+    logger.on_train_start(_start_event(str(tmp_path)))
+    logger.on_train_epoch_end(_epoch_event(str(tmp_path)))
+    logger.on_train_end(_end_event(str(tmp_path)))
+
+    task = FakeClearMLTask.instances[0]
+    assert task.init_kwargs["task_name"] == "yolo9s-detect"
+    assert task.init_kwargs["reuse_last_task_id"] is False
+    assert task.configurations[0][1]["ignore_remote_overrides"] is True
+    val_metric = next(
+        item
+        for item in task.logger.scalars
+        if item["title"] == "val" and item["series"] == "mAP50"
+    )
+    assert val_metric["value"] == 0.6
+    assert any(item["name"] == "best.pt" for item in task.artifacts)
+    assert task.closed is True
+
+
+def test_clearml_marks_training_exception_failed(fake_backends, tmp_path):
+    logger = ClearMLLogger()
+    logger.on_train_start(_start_event(str(tmp_path)))
+    logger.on_train_exception(_exception_event(str(tmp_path)))
+
+    task = FakeClearMLTask.instances[0]
+    assert task.failed["status_reason"] == "RuntimeError"
+    assert task.failed["status_message"] == "boom"
+
+
+def test_neptune_logger_uses_current_scale_api(fake_backends, tmp_path):
+    _write_artifacts(tmp_path)
+    logger = NeptuneLogger(
+        project="team/project", tags=["nightly"], log_checkpoints=True
+    )
+    logger.on_train_start(_start_event(str(tmp_path)))
+    logger.on_train_epoch_end(_epoch_event(str(tmp_path)))
+    logger.on_train_end(_end_event(str(tmp_path)))
+
+    run = FakeNeptuneRun.instances[0]
+    assert run.kwargs["project"] == "team/project"
+    assert run.kwargs["enable_console_log_capture"] is False
+    assert run.configs[0]["flatten"] is True
+    assert run.metrics[0]["data"]["train/loss"] == 1.5
+    assert run.metrics[0]["step"] == 1
+    assert run.tags == [{"tags": ("nightly",)}]
+    assert any("artifacts/best.pt" in item["files"] for item in run.files)
+    assert run.closed is True
+
+
+def test_neptune_backend_failure_terminates_run(fake_backends, tmp_path):
+    logger = NeptuneLogger()
+    logger.on_train_start(_start_event(str(tmp_path)))
+    run = FakeNeptuneRun.instances[0]
+
+    def explode(**kwargs):
+        raise ConnectionError("server down")
+
+    run.log_metrics = explode
+    logger.on_train_epoch_end(_epoch_event(str(tmp_path)))
+    assert run.terminated is True
+
+
+def test_dvclive_safe_defaults_resume_and_lifecycle(fake_backends, tmp_path):
+    _write_artifacts(tmp_path)
+    logger = DVCLiveLogger(log_checkpoints=True)
+    logger.on_train_start(_start_event(str(tmp_path), start_epoch=2))
+    logger.on_train_epoch_end(_epoch_event(str(tmp_path), epoch=2))
+    logger.on_train_end(_end_event(str(tmp_path)))
+
+    live = FakeDVCLive.instances[0]
+    assert live.kwargs["dir"] == str(tmp_path / "dvclive")
+    assert live.kwargs["resume"] is True
+    assert live.kwargs["save_dvc_exp"] is False
+    assert live.kwargs["dvcyaml"] is None
+    assert live.params[0]["data"] == "None"
+    assert ("train/loss", 1.5, 2) in live.metrics
+    assert ("train/loss.box", 0.2, 2) in live.metrics
+    assert live.summary_calls == 1
+    assert live.summary == {"best_metric": 0.6, "best_epoch": 1}
+    assert live.artifacts[0][1]["cache"] is False
+    assert live.ended is True
+
+
+def test_extended_logger_instances_are_picklable(fake_backends):
+    instances = (
+        CometLogger(),
+        ClearMLLogger(),
+        NeptuneLogger(),
+        DVCLiveLogger(),
+    )
+    for instance in instances:
+        assert pickle.loads(pickle.dumps(instance)) is not None


### PR DESCRIPTION
What: Add Comet, ClearML, Neptune, and DVC/DVCLive experiment loggers.
Why: Extend built-in training logger coverage through the existing public callback system.
Related: #166

- Preserves rank-zero dispatch, canonical metrics, DDP-picklable configuration, artifact logging, and runtime failure isolation.
- Adds optional extras, public exports, backend documentation, safe DVCLive defaults, and focused tests.
- Keeps Neptune separate from the aggregate extra because its stable protobuf constraint conflicts with the TFLite stack.

Check: DVCLive parent/child metric encoding and the Neptune/TFLite dependency conflict.
Verified: 86 focused tests and a real one-epoch YOLO9-t CPU training with all four SDKs in offline, disabled, or local modes.
Not verified: authenticated uploads to hosted Comet, ClearML, or Neptune services.
Opened by an agent.

## Code provenance
Original code written for this PR against published SDK APIs; no third-party source code was ported, adapted, or copied, and no GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license material is involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds Comet, ClearML, Neptune, and DVCLive integrations to the existing callback-based training logger system.
- Adds backend-specific lifecycle, metric, configuration, and artifact handling.
- Registers public logger names and exports, including the `dvc` alias.
- Adds optional dependency extras, documentation, and focused lifecycle and serialization tests.
- Extends logger documentation across trainable model APIs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/training/loggers/base.py | Adds shared artifact discovery while preserving guarded backend-failure isolation. |
| libreyolo/training/loggers/comet_logger.py | Implements Comet run creation, canonical metrics, artifacts, completion, and failure handling. |
| libreyolo/training/loggers/clearml_logger.py | Implements ClearML task lifecycle, scalar reporting, configuration, artifacts, and failed-task status. |
| libreyolo/training/loggers/neptune_logger.py | Implements the neptune-scale lifecycle, configuration, metrics, tags, and artifact assignment. |
| libreyolo/training/loggers/dvclive_logger.py | Implements local DVCLive logging with resume-aware steps, collision-safe metric names, and conservative DVC defaults. |
| libreyolo/training/loggers/__init__.py | Registers the four new logger backends and the DVC alias without eagerly importing optional SDK packages. |
| pyproject.toml | Adds optional backend extras while intentionally excluding Neptune from the aggregate extra. |
| tests/unit/test_training_loggers_extended.py | Covers backend lifecycle calls, failure isolation, DVCLive encoding and defaults, name resolution, and picklability. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Trainer
    participant Resolver as Logger resolver
    participant Logger as Built-in logger
    participant SDK as Backend SDK
    Trainer->>Resolver: resolve loggers configuration
    Resolver-->>Trainer: callback instances
    Trainer->>Logger: on_train_start(event)
    Logger->>SDK: create run and log config
    loop Each completed epoch
        Trainer->>Logger: on_train_epoch_end(event)
        Logger->>SDK: log canonical metrics
    end
    alt Training completes
        Trainer->>Logger: on_train_end(event)
        Logger->>SDK: upload artifacts and close
    else Training raises
        Trainer->>Logger: on_train_exception(event)
        Logger->>SDK: mark failed and close
    end
    alt Backend operation fails
        Logger->>Logger: disable logger and teardown
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge dev into logger branch"](https://github.com/libreyolo/libreyolo/commit/3055b43fb4236a3cd5a78879143831a89a034e2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50049662)</sub>

**Context used:**

- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)

<!-- /greptile_comment -->