### PR TITLE
Add profiler support for all g0/g1/g2 families

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -47,7 +47,11 @@ nothing changes (no network access, portable paths everywhere). Set
 `LIBREYOLO_HUB_KERNELS=0` to disable them without uninstalling. Nothing is
 vendored; artifacts are fetched and cached by the `kernels` package, and a
 kernel that fails to load or run disables itself for the process and falls
-back to the portable path with one warning. Every hub kernel is pinned to an
+back to the portable path with one warning. When the installed `kernels`
+release cannot resolve the pinned commit (newer releases reject SHA
+revisions and validate a metadata schema older kernel repos predate), the
+provider fetches the pinned snapshot directly via `huggingface_hub` and
+imports the matching build variant itself — same binary, same pin. Every hub kernel is pinned to an
 audited commit revision in its provider module — a moved branch on the Hub
 can never change the binary that runs in-process. Bumping a pin requires a
 GPU parity run of the provider's `*_matches_portable_on_cuda` test.

--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -34,6 +34,30 @@ the log says so instead of reporting a completed training.
 It is **zero overhead when off** (the default); the hot loop's hooks short
 -circuit to a no-op. Profiling is ignored under distributed (DDP) training.
 
+### Family coverage
+
+**Training** profiling is supported across every trainable family — all of
+**g0, g1 and g2** in `libreyolo/models/registry.py`, every task (detect,
+point, classify, semantic, restore). That includes the DFINE/DEIM-family
+trainers, whose copied training loops carry the same hooks as the base loop.
+`tests/e2e/test_profile_training_families.py` runs a real profiled training
+per family and is kept in lockstep with the registry, so a family cannot join
+a trainable group without profiler coverage. Families whose training is gated
+behind `allow_experimental=True` (ec, yolo7, rtmdet, picodet, fomo) need that
+flag alongside `profile=True` — or `--allow-experimental` on the CLI.
+
+**Inference** profiling (`libreyolo profile infer`) drives the shared
+predict-stage contract, verified per family for every g0/g1 family plus the
+g2 detect/point families (`tests/e2e/test_profile_inference_families.py`);
+g3 inference-only families use the same stage contract and work through the
+same path. Classify/semantic/restore predict paths are best-effort: the
+stage split still measures, but the "postprocess = NMS" verdict semantics
+are detection-specific.
+
+Out of scope: g4 (museum, frozen) and the s tier (SAM / open-vocab / VLM
+siblings), whose predict surfaces differ from the staged contract this tool
+measures.
+
 ### What it prints
 
 ```
@@ -111,7 +135,10 @@ libreyolo profile compare <before.json> <after.json>   # did it help? img/s + ms
 Every command takes either the **self-contained `profile.json`** (recommended — copy
 it freely) or a raw `profile_trace.json`. `get <file>` with no field lists every
 metric. `run` follows normal training defaults, including AMP on supported CUDA
-devices; pass `--no-amp` to force fp32. Use **`run --repeat N`** for mean±stdev
+devices; pass `--no-amp` to force fp32. For families whose training is gated as
+experimental (e.g. ec), pass **`--allow-experimental`**: a profile run trains a
+few steps and writes no checkpoint, so the unvalidated-convergence caveat
+behind the gate does not apply. Use **`run --repeat N`** for mean±stdev
 img/s — a single run *lies* when the step is launch-bound (the bottleneck itself
 makes the step time noisy). Repeated runs emit an aggregate `profile_repeat.json`
 for `compare`, plus per-trial `prof_*/profile.json` files for drill-down.

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -90,6 +90,12 @@ def run_cmd(
     warmup: int = typer.Option(5, "--warmup", help="Warmup steps before measuring"),
     repeat: int = typer.Option(1, "--repeat", help="Repeat N times for mean +/- stdev (a single run lies when launch-bound)"),
     device: str = typer.Option("0", "--device"),
+    allow_experimental: bool = typer.Option(
+        False, "--allow-experimental",
+        help="Acknowledge an experimental training path (e.g. ec) so gated "
+             "families can be profiled. A profile run trains for a few steps "
+             "and writes no checkpoint, so the unvalidated-convergence caveat "
+             "behind the gate does not apply."),
     project: str = typer.Option("runs/profile", "--project"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
@@ -107,12 +113,14 @@ def run_cmd(
     for i in range(max(1, repeat)):
         name = f"prof_{i}" if repeat > 1 else "prof"
         model = LibreYOLO(model_path=weights, size=size, device=device)
+        # Only forwarded when set: non-gated families don't accept the kwarg.
+        extra = {"allow_experimental": True} if allow_experimental else {}
         model.train(
             data=data, epochs=epochs, batch=batch, imgsz=imgsz, workers=workers,
             amp=amp, device=device, profile=True, profile_then_stop=True,
             profile_steps=steps,
             profile_warmup=warmup, profile_open=False, no_aug_epochs=0,
-            project=project, name=name, exist_ok=True,
+            project=project, name=name, exist_ok=True, **extra,
         )
         last_dir = Path(project) / name
         pj = last_dir / "profile.json"

--- a/libreyolo/kernels/attention/ms_deform_attn.py
+++ b/libreyolo/kernels/attention/ms_deform_attn.py
@@ -17,7 +17,11 @@ The in-tree provider loads the compiled CUDA kernel published at
 ``kernels-community/deformable-detr`` on the Hugging Face Hub (Apache-2.0)
 via the optional ``kernels`` package. Nothing is vendored: the artifact is
 fetched at runtime, pinned to the audited revision in ``_HUB_REVISION`` so
-a moved branch can never swap the binary that runs in-process. Installing
+a moved branch can never swap the binary that runs in-process. When the
+installed ``kernels`` release cannot resolve the pin (its resolver rejects
+commit SHAs and validates a newer metadata schema), the provider fetches
+the pinned snapshot directly and imports the matching build variant itself
+— same binary, same pin, no resolver in between. Installing
 the ``libreyolo[hub-kernels]`` extra is the opt-in; once the ``kernels``
 package is present the provider is on by default and
 ``LIBREYOLO_HUB_KERNELS=0`` disables it. The autograd bridge
@@ -32,6 +36,9 @@ import functools
 import importlib.util
 import logging
 import os
+import platform as _platform
+import sys
+from pathlib import Path
 from typing import Optional
 
 import torch
@@ -78,6 +85,73 @@ def _eligible() -> bool:
     )
 
 
+def _pinned_variant_name() -> Optional[str]:
+    """The build-variant directory the running torch/CUDA/OS maps to.
+
+    Mirrors the ``kernels`` package's naming (``torch<maj><min>-[cxx11-]
+    cu<ver>-<arch>-<os>``) strictly: an exact match or nothing, because a
+    compiled extension is only ABI-safe against the torch minor and CUDA
+    build it was compiled for.
+    """
+    cuda = torch.version.cuda
+    if not cuda:
+        return None
+    torch_tag = "".join(torch.__version__.split(".")[:2])
+    cuda_tag = cuda.replace(".", "")
+    os_name = _platform.system().lower()
+    machine = _platform.machine().lower()
+    machine = {"amd64": "x86_64", "arm64": "aarch64"}.get(machine, machine)
+    if os_name == "windows":
+        return f"torch{torch_tag}-cu{cuda_tag}-{machine}-windows"
+    if os_name == "linux":
+        return f"torch{torch_tag}-cxx11-cu{cuda_tag}-{machine}-linux"
+    return None
+
+
+def _load_pinned_snapshot():
+    """Load the pinned revision without the ``kernels`` resolver.
+
+    Current ``kernels`` releases resolve revisions through the Hub's kernels
+    API, which rejects commit SHAs, and validate a metadata schema this
+    repo's artifacts predate — either one silently kills the provider even
+    though the pinned binaries themselves load and pass parity. The pin is
+    the contract, so fetch it directly (``huggingface_hub`` resolves SHA
+    revisions fine) and import the matching build variant ourselves.
+    """
+    variant = _pinned_variant_name()
+    if variant is None:
+        return None
+    from huggingface_hub import snapshot_download
+
+    root = Path(
+        snapshot_download(
+            _HUB_REPO,
+            revision=_HUB_REVISION,
+            allow_patterns=[f"build/{variant}/*"],
+        )
+    )
+    package = root / "build" / variant
+    if not (package / "__init__.py").exists():
+        logger.warning(
+            "Hub kernel %s has no build variant %s; using the portable path",
+            _HUB_REPO,
+            variant,
+        )
+        return None
+    module_name = f"_libreyolo_hub_{variant.replace('-', '_')}"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        package / "__init__.py",
+        submodule_search_locations=[str(package)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _load_hub_kernel():
     """Fetch and cache the Hub kernel; a failure disables the provider."""
     global _hub_kernel, _hub_failed
@@ -88,8 +162,16 @@ def _load_hub_kernel():
 
         _hub_kernel = get_kernel(_HUB_REPO, revision=_HUB_REVISION)
     except Exception as exc:
+        # ``get_kernel`` is version-sensitive (SHA pins and this repo's
+        # metadata schema stopped resolving in newer releases); the direct
+        # snapshot loader below is the compatibility path.
+        logger.debug("kernels.get_kernel could not load %s: %s", _HUB_REPO, exc)
+        try:
+            _hub_kernel = _load_pinned_snapshot()
+        except Exception as exc2:
+            logger.warning("Hub kernel %s unavailable: %s", _HUB_REPO, exc2)
+    if _hub_kernel is None:
         _hub_failed = True
-        logger.warning("Hub kernel %s unavailable: %s", _HUB_REPO, exc)
     return _hub_kernel
 
 

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -28,6 +28,7 @@ The integration tricks in this file:
 
 from __future__ import annotations
 
+import logging
 import math
 import sys
 from pathlib import Path
@@ -55,6 +56,8 @@ from .transforms import (
     DEIMTrainTransform,
 )
 from ..base.detr_cuda_graph import DETREncoderCudaGraphMixin
+
+logger = logging.getLogger(__name__)
 
 
 class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
@@ -521,6 +524,9 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
            optimizer step.
         3. Apply per-group LR multipliers (the scheduler returns one base LR;
            each param group's ``lr_mult`` scales it).
+
+        The profiler hooks (``wrap_loader`` / ``_prof_phase`` / ``prof.step``)
+        mirror the parent loop exactly so ``profile=True`` works here too.
         """
         # Gradient accumulation is opt-in; delegate when enabled.
         if self._accum_steps > 1:
@@ -553,7 +559,10 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
 
-        for batch_idx, batch in enumerate(pbar):
+        # getattr: test doubles may bypass BaseTrainer.__init__, same as _profiler.
+        prof = getattr(self, "_profiler", None)
+        loader = prof.wrap_loader(pbar) if prof is not None else pbar
+        for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
             else:
@@ -561,32 +570,39 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                 polygons = None
             self.current_iter = epoch * len(self.train_loader) + batch_idx
 
-            imgs = imgs.to(self.device, non_blocking=True)
-            targets = targets.to(self.device, non_blocking=True)
+            with self._prof_phase("to_device"):
+                imgs = imgs.to(self.device, non_blocking=True)
+                targets = targets.to(self.device, non_blocking=True)
 
             if self.scaler is not None:
-                with self._autocast_context():
+                with self._prof_phase("forward"):
+                    with self._autocast_context():
+                        outputs = self._forward_train(imgs, targets, polygons)
+                        loss = outputs["total_loss"]
+                self.optimizer.zero_grad()
+                with self._prof_phase("backward"):
+                    self.scaler.scale(loss).backward()
+                    if clip_max_norm > 0:
+                        self.scaler.unscale_(self.optimizer)
+                        torch.nn.utils.clip_grad_norm_(
+                            self.model.parameters(), clip_max_norm
+                        )
+                with self._prof_phase("optimizer"):
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+            else:
+                with self._prof_phase("forward"):
                     outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"]
                 self.optimizer.zero_grad()
-                self.scaler.scale(loss).backward()
-                if clip_max_norm > 0:
-                    self.scaler.unscale_(self.optimizer)
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
-            else:
-                outputs = self._forward_train(imgs, targets, polygons)
-                loss = outputs["total_loss"]
-                self.optimizer.zero_grad()
-                loss.backward()
-                if clip_max_norm > 0:
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.optimizer.step()
+                with self._prof_phase("backward"):
+                    loss.backward()
+                    if clip_max_norm > 0:
+                        torch.nn.utils.clip_grad_norm_(
+                            self.model.parameters(), clip_max_norm
+                        )
+                with self._prof_phase("optimizer"):
+                    self.optimizer.step()
 
             if self.ema_model is not None:
                 self.ema_model.update(self.model)
@@ -609,15 +625,34 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
 
+            if prof is not None:
+                prof.step()
+                if prof.finished:
+                    if getattr(self.config, "profile_then_stop", False):
+                        self._stop_training = True
+                        break
+                    # Window closed: drop the hooks so the rest of the run
+                    # pays nothing, and keep training.
+                    logger.info(
+                        "Profile window complete; training continues "
+                        "(profile_then_stop=True stops here instead)"
+                    )
+                    self._profiler = None
+                    prof = None
+
         num_batches = max(num_batches, 1)
         avg_loss = total_loss / num_batches
         avg_loss_components = {
             name: value / num_batches for name, value in loss_component_sums.items()
         }
 
+        # Validation. A profile-only run (profile_then_stop) truncated the
+        # epoch, so validating the barely-trained weights would waste time and
+        # could poison the best-metric state.
         val_metrics = None
         if (
-            self.config.eval_interval > 0
+            not getattr(self, "_stop_training", False)
+            and self.config.eval_interval > 0
             and (epoch + 1) % self.config.eval_interval == 0
         ):
             val_metrics = self._validate_epoch(epoch)
@@ -665,7 +700,10 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
         actual_window = accum
         base_lr = self.optimizer.param_groups[0]["lr"]
 
-        for batch_idx, batch in enumerate(pbar):
+        # getattr: test doubles may bypass BaseTrainer.__init__, same as _profiler.
+        prof = getattr(self, "_profiler", None)
+        loader = prof.wrap_loader(pbar) if prof is not None else pbar
+        for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
             else:
@@ -676,36 +714,43 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             opt_step = epoch * steps_per_epoch + batch_idx // accum
             self.current_iter = opt_step
 
-            imgs = imgs.to(self.device, non_blocking=True)
-            targets = targets.to(self.device, non_blocking=True)
+            with self._prof_phase("to_device"):
+                imgs = imgs.to(self.device, non_blocking=True)
+                targets = targets.to(self.device, non_blocking=True)
 
             if batch_idx % accum == 0:
                 self.optimizer.zero_grad(set_to_none=True)
                 actual_window = min(accum, len(self.train_loader) - batch_idx)
 
             if self.scaler is not None:
-                with self._autocast_context():
+                with self._prof_phase("forward"):
+                    with self._autocast_context():
+                        outputs = self._forward_train(imgs, targets, polygons)
+                        loss = outputs["total_loss"] / actual_window
+                with self._prof_phase("backward"):
+                    self.scaler.scale(loss).backward()
+                if is_opt_step:
+                    with self._prof_phase("optimizer"):
+                        if clip_max_norm > 0:
+                            self.scaler.unscale_(self.optimizer)
+                            torch.nn.utils.clip_grad_norm_(
+                                self.model.parameters(), clip_max_norm
+                            )
+                        self.scaler.step(self.optimizer)
+                        self.scaler.update()
+            else:
+                with self._prof_phase("forward"):
                     outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"] / actual_window
-                self.scaler.scale(loss).backward()
+                with self._prof_phase("backward"):
+                    loss.backward()
                 if is_opt_step:
-                    if clip_max_norm > 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-            else:
-                outputs = self._forward_train(imgs, targets, polygons)
-                loss = outputs["total_loss"] / actual_window
-                loss.backward()
-                if is_opt_step:
-                    if clip_max_norm > 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.optimizer.step()
+                    with self._prof_phase("optimizer"):
+                        if clip_max_norm > 0:
+                            torch.nn.utils.clip_grad_norm_(
+                                self.model.parameters(), clip_max_norm
+                            )
+                        self.optimizer.step()
 
             if is_opt_step:
                 if self.ema_model is not None:
@@ -728,15 +773,34 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
 
+            if prof is not None:
+                prof.step()
+                if prof.finished:
+                    if getattr(self.config, "profile_then_stop", False):
+                        self._stop_training = True
+                        break
+                    # Window closed: drop the hooks so the rest of the run
+                    # pays nothing, and keep training.
+                    logger.info(
+                        "Profile window complete; training continues "
+                        "(profile_then_stop=True stops here instead)"
+                    )
+                    self._profiler = None
+                    prof = None
+
         num_batches = max(num_batches, 1)
         avg_loss = total_loss / num_batches
         avg_loss_components = {
             name: value / num_batches for name, value in loss_component_sums.items()
         }
 
+        # Validation. A profile-only run (profile_then_stop) truncated the
+        # epoch, so validating the barely-trained weights would waste time and
+        # could poison the best-metric state.
         val_metrics = None
         if (
-            self.config.eval_interval > 0
+            not getattr(self, "_stop_training", False)
+            and self.config.eval_interval > 0
             and (epoch + 1) % self.config.eval_interval == 0
         ):
             val_metrics = self._validate_epoch(epoch)

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -594,6 +594,9 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
            optimizer step.
         3. Apply per-group LR multipliers (the scheduler returns one base LR;
            each param group's ``lr_mult`` scales it).
+
+        The profiler hooks (``wrap_loader`` / ``_prof_phase`` / ``prof.step``)
+        mirror the parent loop exactly so ``profile=True`` works here too.
         """
         # Gradient accumulation is opt-in; delegate when enabled.
         if self._accum_steps > 1:
@@ -626,7 +629,10 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
         num_batches = 0
         loss_component_sums: Dict[str, float] = {}
 
-        for batch_idx, batch in enumerate(pbar):
+        # getattr: test doubles may bypass BaseTrainer.__init__, same as _profiler.
+        prof = getattr(self, "_profiler", None)
+        loader = prof.wrap_loader(pbar) if prof is not None else pbar
+        for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
             else:
@@ -634,32 +640,39 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                 polygons = None
             self.current_iter = epoch * len(self.train_loader) + batch_idx
 
-            imgs = imgs.to(self.device, non_blocking=True)
-            targets = targets.to(self.device, non_blocking=True)
+            with self._prof_phase("to_device"):
+                imgs = imgs.to(self.device, non_blocking=True)
+                targets = targets.to(self.device, non_blocking=True)
 
             if self.scaler is not None:
-                with self._autocast_context():
+                with self._prof_phase("forward"):
+                    with self._autocast_context():
+                        outputs = self._forward_train(imgs, targets, polygons)
+                        loss = outputs["total_loss"]
+                self.optimizer.zero_grad()
+                with self._prof_phase("backward"):
+                    self.scaler.scale(loss).backward()
+                    if clip_max_norm > 0:
+                        self.scaler.unscale_(self.optimizer)
+                        torch.nn.utils.clip_grad_norm_(
+                            self.model.parameters(), clip_max_norm
+                        )
+                with self._prof_phase("optimizer"):
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+            else:
+                with self._prof_phase("forward"):
                     outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"]
                 self.optimizer.zero_grad()
-                self.scaler.scale(loss).backward()
-                if clip_max_norm > 0:
-                    self.scaler.unscale_(self.optimizer)
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
-            else:
-                outputs = self._forward_train(imgs, targets, polygons)
-                loss = outputs["total_loss"]
-                self.optimizer.zero_grad()
-                loss.backward()
-                if clip_max_norm > 0:
-                    torch.nn.utils.clip_grad_norm_(
-                        self.model.parameters(), clip_max_norm
-                    )
-                self.optimizer.step()
+                with self._prof_phase("backward"):
+                    loss.backward()
+                    if clip_max_norm > 0:
+                        torch.nn.utils.clip_grad_norm_(
+                            self.model.parameters(), clip_max_norm
+                        )
+                with self._prof_phase("optimizer"):
+                    self.optimizer.step()
 
             if self.ema_model is not None:
                 self.ema_model.update(self.model)
@@ -682,15 +695,34 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
 
+            if prof is not None:
+                prof.step()
+                if prof.finished:
+                    if getattr(self.config, "profile_then_stop", False):
+                        self._stop_training = True
+                        break
+                    # Window closed: drop the hooks so the rest of the run
+                    # pays nothing, and keep training.
+                    logger.info(
+                        "Profile window complete; training continues "
+                        "(profile_then_stop=True stops here instead)"
+                    )
+                    self._profiler = None
+                    prof = None
+
         num_batches = max(num_batches, 1)
         avg_loss = total_loss / num_batches
         avg_loss_components = {
             name: value / num_batches for name, value in loss_component_sums.items()
         }
 
+        # Validation. A profile-only run (profile_then_stop) truncated the
+        # epoch, so validating the barely-trained weights would waste time and
+        # could poison the best-metric state.
         val_metrics = None
         if (
-            self.config.eval_interval > 0
+            not getattr(self, "_stop_training", False)
+            and self.config.eval_interval > 0
             and (epoch + 1) % self.config.eval_interval == 0
         ):
             val_metrics = self._validate_epoch(epoch)
@@ -738,7 +770,10 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
         actual_window = accum
         base_lr = self.optimizer.param_groups[0]["lr"]
 
-        for batch_idx, batch in enumerate(pbar):
+        # getattr: test doubles may bypass BaseTrainer.__init__, same as _profiler.
+        prof = getattr(self, "_profiler", None)
+        loader = prof.wrap_loader(pbar) if prof is not None else pbar
+        for batch_idx, batch in enumerate(loader):
             if len(batch) == 5:
                 imgs, targets, img_infos, img_ids, polygons = batch
             else:
@@ -749,36 +784,43 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             opt_step = epoch * steps_per_epoch + batch_idx // accum
             self.current_iter = opt_step
 
-            imgs = imgs.to(self.device, non_blocking=True)
-            targets = targets.to(self.device, non_blocking=True)
+            with self._prof_phase("to_device"):
+                imgs = imgs.to(self.device, non_blocking=True)
+                targets = targets.to(self.device, non_blocking=True)
 
             if batch_idx % accum == 0:
                 self.optimizer.zero_grad(set_to_none=True)
                 actual_window = min(accum, len(self.train_loader) - batch_idx)
 
             if self.scaler is not None:
-                with self._autocast_context():
+                with self._prof_phase("forward"):
+                    with self._autocast_context():
+                        outputs = self._forward_train(imgs, targets, polygons)
+                        loss = outputs["total_loss"] / actual_window
+                with self._prof_phase("backward"):
+                    self.scaler.scale(loss).backward()
+                if is_opt_step:
+                    with self._prof_phase("optimizer"):
+                        if clip_max_norm > 0:
+                            self.scaler.unscale_(self.optimizer)
+                            torch.nn.utils.clip_grad_norm_(
+                                self.model.parameters(), clip_max_norm
+                            )
+                        self.scaler.step(self.optimizer)
+                        self.scaler.update()
+            else:
+                with self._prof_phase("forward"):
                     outputs = self._forward_train(imgs, targets, polygons)
                     loss = outputs["total_loss"] / actual_window
-                self.scaler.scale(loss).backward()
+                with self._prof_phase("backward"):
+                    loss.backward()
                 if is_opt_step:
-                    if clip_max_norm > 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-            else:
-                outputs = self._forward_train(imgs, targets, polygons)
-                loss = outputs["total_loss"] / actual_window
-                loss.backward()
-                if is_opt_step:
-                    if clip_max_norm > 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.model.parameters(), clip_max_norm
-                        )
-                    self.optimizer.step()
+                    with self._prof_phase("optimizer"):
+                        if clip_max_norm > 0:
+                            torch.nn.utils.clip_grad_norm_(
+                                self.model.parameters(), clip_max_norm
+                            )
+                        self.optimizer.step()
 
             if is_opt_step:
                 if self.ema_model is not None:
@@ -801,15 +843,34 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             postfix.update({k: f"{v:.4f}" for k, v in loss_components.items()})
             pbar.set_postfix(postfix)
 
+            if prof is not None:
+                prof.step()
+                if prof.finished:
+                    if getattr(self.config, "profile_then_stop", False):
+                        self._stop_training = True
+                        break
+                    # Window closed: drop the hooks so the rest of the run
+                    # pays nothing, and keep training.
+                    logger.info(
+                        "Profile window complete; training continues "
+                        "(profile_then_stop=True stops here instead)"
+                    )
+                    self._profiler = None
+                    prof = None
+
         num_batches = max(num_batches, 1)
         avg_loss = total_loss / num_batches
         avg_loss_components = {
             name: value / num_batches for name, value in loss_component_sums.items()
         }
 
+        # Validation. A profile-only run (profile_then_stop) truncated the
+        # epoch, so validating the barely-trained weights would waste time and
+        # could poison the best-metric state.
         val_metrics = None
         if (
-            self.config.eval_interval > 0
+            not getattr(self, "_stop_training", False)
+            and self.config.eval_interval > 0
             and (epoch + 1) % self.config.eval_interval == 0
         ):
             val_metrics = self._validate_epoch(epoch)

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -780,6 +780,12 @@ class LibreDINOv2(BaseModel):
         if resolved_lr0 is None:
             resolved_lr0 = 1e-4
 
+        # A caller-supplied device must win over the wrapper's; passing both
+        # through to the trainer raised "multiple values for 'device'".
+        resolved_device = train_kwargs.pop("device", None)
+        if resolved_device is None:
+            resolved_device = str(self.device)
+
         trainer = DINOv2Trainer(
             model=self.model,
             wrapper_model=self,
@@ -794,7 +800,7 @@ class LibreDINOv2(BaseModel):
             name=str(name),
             exist_ok=exist_ok,
             resume=resume,
-            device=str(self.device),
+            device=resolved_device,
             callbacks=callbacks,
             **train_kwargs,
         )

--- a/tests/e2e/test_profile_inference_families.py
+++ b/tests/e2e/test_profile_inference_families.py
@@ -1,0 +1,123 @@
+"""Per-family inference profiler support (``libreyolo profile infer``).
+
+``InferenceProfiler`` duck-types on the shared predict-stage contract
+(``_preprocess`` / ``_forward`` / ``_postprocess``), so in principle any
+detection wrapper works. This file proves it per family instead of assuming
+it: every g0/g1 family plus the g2 detect/point families runs a short
+profiled inference window and must emit a valid ``profile.json`` with the
+stage split and latency percentiles.
+
+Classification / semantic / restoration predict paths are documented as
+best-effort for ``profile infer`` (their postprocess semantics differ from
+the detect contract this tool measures), so they are not enrolled here.
+Training-side profiler coverage for those lives in
+``test_profile_training_families.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+# The g2 detect/point families (the rest of g2 is classify/semantic/restore).
+G2_DETECT = {
+    "yolox": ("LibreYOLOX", "t", None, {}),
+    "yolo7": ("LibreYOLO7", "b", None, {}),
+    "rtmdet": ("LibreRTMDet", "t", None, {}),
+    "picodet": ("LibrePICODET", "s", None, {}),
+    "fomo": ("LibreFOMO", "s", None, {"task": "point"}),
+}
+
+# (family id, class name, size, ctor model_path, ctor kwargs)
+CASES = [
+    # g0
+    ("yolo9", "LibreYOLO9", "t", None, {}),
+    ("rfdetr", "LibreRFDETR", "n", {}, {}),
+    # g1
+    ("yolo9_e2e", "LibreYOLO9E2E", "t", None, {}),
+    ("yolo9_p2", "LibreYOLO9P2", "t", None, {}),
+    ("ec", "LibreEC", "s", None, {}),
+    ("rtdetr", "LibreRTDETR", "r18", None, {}),
+    ("rtdetrv2", "LibreRTDETRv2", "r18", None, {}),
+    ("rtdetrv4", "LibreRTDETRv4", "s", None, {}),
+    ("dfine", "LibreDFINE", "n", None, {}),
+    ("deim", "LibreDEIM", "n", None, {}),
+    ("deimv2", "LibreDEIMv2", "atto", None, {}),
+    ("yolonas", "LibreYOLONAS", "s", None, {}),
+    # g2 detect/point
+    *[(fam, *spec) for fam, spec in G2_DETECT.items()],
+]
+
+
+@pytest.fixture(scope="module")
+def sample_image(tmp_path_factory) -> str:
+    root = tmp_path_factory.mktemp("profile_infer_data")
+    rng = np.random.default_rng(0)
+    path = root / "img.jpg"
+    Image.fromarray(
+        rng.integers(0, 255, (320, 320, 3), dtype=np.uint8)
+    ).save(path)
+    return str(path)
+
+
+@pytest.mark.external_data  # several families fetch a pretrained backbone
+@pytest.mark.parametrize(
+    "family,class_name,size,ctor,ctor_kwargs",
+    CASES,
+    ids=[case[0] for case in CASES],
+)
+def test_infer_profile_emits_report(
+    family, class_name, size, ctor, ctor_kwargs, sample_image, tmp_path
+):
+    import libreyolo
+    from libreyolo.profiling import InferenceProfiler
+
+    torch.manual_seed(0)
+    model = getattr(libreyolo, class_name)(ctor, size, **ctor_kwargs)
+    prof = InferenceProfiler(
+        model,
+        warmup=2,
+        runs=6,
+        batch=1,
+        trace=True,
+        save_dir=tmp_path,
+        meta={"model": family},
+    )
+    analysis = prof.run([sample_image])
+
+    profile_json = tmp_path / "profile.json"
+    assert profile_json.exists(), f"{family}: profile.json was not emitted"
+    out = json.loads(profile_json.read_text(encoding="utf-8"))
+    assert out.get("schema") == "libreyolo.profile.analysis/v1", f"{family}"
+    assert out.get("mode") == "inference", f"{family}"
+
+    stages = analysis.get("stages_ms") or {}
+    assert stages.get("forward", 0) > 0, f"{family}: no forward time: {stages}"
+    lat = analysis.get("latency") or {}
+    assert lat.get("p50_ms") and lat["p50_ms"] > 0, f"{family}: no latency"
+    assert analysis.get("img_per_s") and analysis["img_per_s"] > 0, f"{family}"
+    assert analysis.get("bound"), f"{family}: no verdict"
+
+
+def test_enrollment_tracks_the_registry():
+    """g0/g1 entirely, plus the g2 detect/point subset, must stay enrolled."""
+    from libreyolo.models.registry import families_in
+
+    enrolled = {case[0] for case in CASES}
+    expected = (
+        set(families_in("g0")) | set(families_in("g1")) | set(G2_DETECT)
+    )
+    assert enrolled == expected, (
+        f"inference-profiler e2e coverage drifted: "
+        f"missing={sorted(expected - enrolled)} extra={sorted(enrolled - expected)}"
+    )
+    # If a G2_DETECT family is renamed/regrouped, fail here rather than
+    # silently testing a ghost.
+    assert set(G2_DETECT) <= set(families_in("g2"))

--- a/tests/e2e/test_profile_training_families.py
+++ b/tests/e2e/test_profile_training_families.py
@@ -1,0 +1,405 @@
+"""Per-family training profiler support, through the real train() API.
+
+The unit suite proves the profiler hooks exist in every G0/G1 training loop
+(``test_training_profiler.py`` drives the loop methods directly). This file
+proves the whole pipeline per family: ``profile=True`` must travel from the
+public ``train()`` kwargs into the trainer config, build the profiler in
+``setup()``, drive the hooked loop, and emit the analysis artifacts.
+
+The assertion is on the artifacts, not on run completion: the failure mode
+this feature ships against is the *silent no-op* (a run that trains happily
+and writes nothing), so a test that only checks train() returned would prove
+nothing. Every trainable family from ``libreyolo.models.registry`` (groups
+g0, g1 and g2 — all tasks: detect, point, classify, semantic, restore) is
+enrolled; adding a family to those groups without profiler support fails the
+registry-coverage test at the bottom. g3 is inference-only and g4 is frozen,
+so training profiling does not apply there; the s tier is excluded from group
+rollouts by definition.
+
+No downloads: the dataset is generated and every model is built with random
+init. Families that pull a pretrained backbone at construction are covered by
+the ``external_data`` marker, mirroring ``test_cuda_graph_training_families``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from PIL import Image
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+DEVICE = "0" if torch.cuda.is_available() else "cpu"
+
+# (family id, class name, size, ctor model_path, ctor kwargs, dataset fixture,
+#  extra train kwargs)
+#
+# imgsz 320 everywhere except rfdetr, which validates imgsz against its
+# DINOv2 windowing and defaults to its native input size when omitted.
+# multi_scale=False for the families that resize every batch by default:
+# profiling wants a steady per-step shape so the window measures one
+# configuration instead of a mix. Sizes/tasks mirror
+# ``test_cuda_graph_training_families`` — the previous cross-family rollout.
+CASES = [
+    # g0
+    ("yolo9", "LibreYOLO9", "t", None, {}, "detect_dataset", {"imgsz": 320}),
+    ("rfdetr", "LibreRFDETR", "n", {}, {}, "detect_dataset", {}),
+    # g1
+    ("yolo9_e2e", "LibreYOLO9E2E", "t", None, {}, "detect_dataset", {"imgsz": 320}),
+    ("yolo9_p2", "LibreYOLO9P2", "t", None, {}, "detect_dataset", {"imgsz": 320}),
+    (
+        "ec",
+        "LibreEC",
+        "s",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "allow_experimental": True, "multi_scale": False},
+    ),
+    ("rtdetr", "LibreRTDETR", "r18", None, {}, "detect_dataset", {"imgsz": 320}),
+    ("rtdetrv2", "LibreRTDETRv2", "r18", None, {}, "detect_dataset", {"imgsz": 320}),
+    (
+        "rtdetrv4",
+        "LibreRTDETRv4",
+        "s",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "multi_scale": False},
+    ),
+    (
+        "dfine",
+        "LibreDFINE",
+        "n",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "multi_scale": False},
+    ),
+    (
+        "deim",
+        "LibreDEIM",
+        "n",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "multi_scale": False},
+    ),
+    (
+        "deimv2",
+        "LibreDEIMv2",
+        "atto",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "multi_scale": False},
+    ),
+    ("yolonas", "LibreYOLONAS", "s", None, {}, "detect_dataset", {"imgsz": 320}),
+    # g2 — supporting trainables (all through the BaseTrainer loop)
+    ("yolox", "LibreYOLOX", "t", None, {}, "detect_dataset", {"imgsz": 320}),
+    (
+        "yolo7",
+        "LibreYOLO7",
+        "b",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "allow_experimental": True},
+    ),
+    (
+        "rtmdet",
+        "LibreRTMDet",
+        "t",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "allow_experimental": True},
+    ),
+    (
+        "picodet",
+        "LibrePICODET",
+        "s",
+        None,
+        {},
+        "detect_dataset",
+        {"imgsz": 320, "allow_experimental": True},
+    ),
+    (
+        "fomo",
+        "LibreFOMO",
+        "s",
+        None,
+        {"task": "point"},
+        "detect_dataset",
+        {"imgsz": 96, "allow_experimental": True},
+    ),
+    (
+        "segformer",
+        "LibreSegformer",
+        "b0",
+        None,
+        {"task": "semantic"},
+        "semantic_dataset",
+        {"imgsz": 256},
+    ),
+    (
+        "lingbotvision",
+        "LibreLingBotVision",
+        "s",
+        None,
+        {"task": "semantic"},
+        "semantic_dataset",
+        {"imgsz": 224},
+    ),
+    (
+        "dinov2",
+        "LibreDINOv2",
+        "s",
+        None,
+        {"task": "semantic"},
+        "semantic_dataset",
+        {"imgsz": 224},
+    ),
+    (
+        "nafnet",
+        "LibreNAFNet",
+        "s",
+        None,
+        {"task": "restore"},
+        "restore_dataset",
+        {"imgsz": 256},
+    ),
+    (
+        "resnet",
+        "LibreResNet",
+        "18",
+        None,
+        {"task": "classify"},
+        "classify_dataset",
+        {"imgsz": 224},
+    ),
+    (
+        "convnext",
+        "LibreConvNeXt",
+        "t",
+        None,
+        {"task": "classify"},
+        "classify_dataset",
+        {"imgsz": 224},
+    ),
+    (
+        "mobilenetv4",
+        "LibreMobileNetV4",
+        "s",
+        None,
+        {"task": "classify"},
+        "classify_dataset",
+        {"imgsz": 224},
+    ),
+    (
+        "efficientnetv2",
+        "LibreEfficientNetV2",
+        "b0",
+        None,
+        {"task": "classify"},
+        "classify_dataset",
+        {"imgsz": 224},
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def detect_dataset(tmp_path_factory) -> Path:
+    """A generated 24-image YOLO-format detection dataset (offline)."""
+    root = tmp_path_factory.mktemp("profile_train_data")
+    rng = np.random.default_rng(0)
+    for split, count in (("train", 16), ("valid", 8)):
+        (root / split / "images").mkdir(parents=True)
+        (root / split / "labels").mkdir(parents=True)
+        for i in range(count):
+            pixels = rng.integers(0, 255, (320, 320, 3), dtype=np.uint8)
+            Image.fromarray(pixels).save(root / split / "images" / f"{i:03d}.jpg")
+            rows = []
+            for _ in range(rng.integers(2, 6)):
+                cx, cy = rng.uniform(0.2, 0.8, 2)
+                w, h = rng.uniform(0.05, 0.15, 2)
+                rows.append(f"{rng.integers(0, 2)} {cx:.6f} {cy:.6f} {w:.6f} {h:.6f}")
+            (root / split / "labels" / f"{i:03d}.txt").write_text("\n".join(rows))
+    (root / "data.yaml").write_text(
+        yaml.dump(
+            {
+                "path": str(root),
+                "train": "train/images",
+                "val": "valid/images",
+                "nc": 2,
+                "names": ["a", "b"],
+            }
+        )
+    )
+    return root / "data.yaml"
+
+
+@pytest.fixture(scope="module")
+def classify_dataset(tmp_path_factory) -> Path:
+    """A generated 3-class ImageFolder dataset."""
+    root = tmp_path_factory.mktemp("profile_train_cls")
+    rng = np.random.default_rng(1)
+    for split, count in (("train", 18), ("val", 6)):
+        for i in range(count):
+            folder = root / split / f"class{i % 3}"
+            folder.mkdir(parents=True, exist_ok=True)
+            pixels = rng.integers(0, 255, (224, 224, 3), dtype=np.uint8)
+            Image.fromarray(pixels).save(folder / f"{i:03d}.jpg")
+    return root
+
+
+@pytest.fixture(scope="module")
+def semantic_dataset(tmp_path_factory) -> Path:
+    """A generated 3-class dense-mask dataset."""
+    root = tmp_path_factory.mktemp("profile_train_sem")
+    rng = np.random.default_rng(2)
+    for split, count in (("train", 16), ("val", 4)):
+        (root / "images" / split).mkdir(parents=True)
+        (root / "masks" / split).mkdir(parents=True)
+        for i in range(count):
+            pixels = rng.integers(0, 255, (256, 256, 3), dtype=np.uint8)
+            Image.fromarray(pixels).save(root / "images" / split / f"{i:03d}.jpg")
+            mask = np.zeros((256, 256), np.uint8)
+            for label in (1, 2):
+                y, x = rng.integers(0, 150, 2)
+                mask[y : y + 80, x : x + 80] = label
+            Image.fromarray(mask).save(root / "masks" / split / f"{i:03d}.png")
+    (root / "data.yaml").write_text(
+        yaml.dump(
+            {
+                "path": str(root),
+                "train": "images/train",
+                "val": "images/val",
+                "masks_dir": "masks",
+                "nc": 3,
+                "names": ["background", "a", "b"],
+            }
+        )
+    )
+    return root / "data.yaml"
+
+
+@pytest.fixture(scope="module")
+def restore_dataset(tmp_path_factory) -> Path:
+    """A generated paired noisy/clean restoration dataset."""
+    root = tmp_path_factory.mktemp("profile_train_restore")
+    rng = np.random.default_rng(3)
+    for split, count in (("train", 12), ("val", 4)):
+        (root / split / "inputs").mkdir(parents=True)
+        (root / split / "targets").mkdir(parents=True)
+        for i in range(count):
+            clean = rng.integers(0, 255, (256, 256, 3), dtype=np.uint8)
+            noisy = np.clip(
+                clean.astype(np.float32) + rng.normal(0, 12, clean.shape), 0, 255
+            ).astype(np.uint8)
+            Image.fromarray(noisy).save(root / split / "inputs" / f"{i:03d}.png")
+            Image.fromarray(clean).save(root / split / "targets" / f"{i:03d}.png")
+    (root / "data.yaml").write_text(
+        yaml.dump(
+            {
+                "path": str(root),
+                "train": "train/inputs",
+                "val": "val/inputs",
+                "input_dir": "inputs",
+                "target_dir": "targets",
+                "nc": 1,
+                "names": ["restore"],
+            }
+        )
+    )
+    return root / "data.yaml"
+
+
+@pytest.mark.external_data  # several families fetch a pretrained backbone
+@pytest.mark.parametrize(
+    "family,class_name,size,ctor,ctor_kwargs,dataset_fixture,extra",
+    CASES,
+    ids=[case[0] for case in CASES],
+)
+def test_profile_emits_report(
+    family, class_name, size, ctor, ctor_kwargs, dataset_fixture, extra,
+    request, tmp_path,
+):
+    """profile=True + profile_then_stop=True must emit the analysis artifacts
+    and truncate the run — for every trainable family, through the public API."""
+    import libreyolo
+
+    dataset = request.getfixturevalue(dataset_fixture)
+    torch.manual_seed(0)
+    model = getattr(libreyolo, class_name)(ctor, size, **ctor_kwargs)
+    result = model.train(
+        data=str(dataset),
+        epochs=3,
+        batch=4,
+        workers=0,
+        device=DEVICE,
+        project=str(tmp_path),
+        name="prof",
+        exist_ok=True,
+        profile=True,
+        profile_then_stop=True,
+        profile_warmup=1,
+        profile_steps=2,
+        profile_open=False,
+        eval_interval=100,
+        **extra,
+    )
+
+    save_dir = tmp_path / "prof"
+    profile_json = save_dir / "profile.json"
+    assert profile_json.exists(), (
+        f"{family}: profile.json was not emitted — profile=True was a no-op"
+    )
+    assert (save_dir / "profile_trace.json").exists(), f"{family}: no trace"
+    assert (save_dir / "profile_summary.json").exists(), f"{family}: no summary"
+
+    prof = json.loads(profile_json.read_text(encoding="utf-8"))
+    assert prof.get("schema") == "libreyolo.profile.analysis/v1", f"{family}"
+    assert prof.get("img_per_s") and prof["img_per_s"] > 0, (
+        f"{family}: no throughput measured: {prof.get('img_per_s')}"
+    )
+    # The phase brackets must have landed: forward/backward attribution is
+    # what distinguishes a real profile from a bare wall-clock number.
+    phase_names = {p["phase"] for p in prof.get("phases", [])}
+    assert {"forward", "backward"} <= phase_names, (
+        f"{family}: phases missing from trace: {sorted(phase_names)}"
+    )
+
+    # profile_then_stop: the run must truncate once the window fills, not
+    # train for the requested 3 epochs. Families with a default effective
+    # batch (rfdetr: nbs=16 -> 4-step accumulation) get their window rounded
+    # up to accumulation boundaries, which can push the close past epoch 1 on
+    # a tiny dataset — so the bound is "fewer than requested", not "one".
+    assert len(result["epoch_losses"]) < 3, (
+        f"{family}: expected a truncated run, got all "
+        f"{len(result['epoch_losses'])} epochs"
+    )
+
+
+def test_all_trainable_families_are_enrolled():
+    """Adding a family to g0/g1/g2 without enrolling it here must fail loudly.
+
+    Profiler support is a rollout-group feature: the trainable groups promise
+    it (see ``libreyolo/models/registry.py``). This keeps CASES in lockstep
+    with the registry so the promise is enforced by CI rather than by review.
+    """
+    from libreyolo.models.registry import families_in
+
+    enrolled = {case[0] for case in CASES}
+    expected = (
+        set(families_in("g0")) | set(families_in("g1")) | set(families_in("g2"))
+    )
+    assert enrolled == expected, (
+        f"profiler e2e coverage drifted from the registry: "
+        f"missing={sorted(expected - enrolled)} extra={sorted(enrolled - expected)}"
+    )

--- a/tests/unit/cli/commands/test_profile.py
+++ b/tests/unit/cli/commands/test_profile.py
@@ -145,3 +145,36 @@ def test_compare_significance_note(tmp_path):
     assert r.exit_code == 0
     assert "single run" in r.stdout
     assert "ms/image" in r.stdout
+
+
+def test_run_forwards_allow_experimental(tmp_path, monkeypatch):
+    """--allow-experimental reaches model.train(); without the flag the kwarg
+    is absent entirely (non-gated families don't accept it)."""
+    import libreyolo
+
+    calls: list[dict] = []
+
+    class _StubModel:
+        def __init__(self, **kw):
+            pass
+
+        def train(self, **kw):
+            calls.append(kw)
+
+    monkeypatch.setattr(libreyolo, "LibreYOLO", _StubModel)
+
+    r = runner.invoke(_app(), ["profile", "run", "coco128",
+                               "--project", str(tmp_path),
+                               "--allow-experimental"])
+    assert r.exit_code == 3  # stub trains but produces no profile.json
+    assert calls
+    assert calls[0]["allow_experimental"] is True
+    assert calls[0]["profile"] is True
+    assert calls[0]["profile_then_stop"] is True
+
+    calls.clear()
+    r = runner.invoke(_app(), ["profile", "run", "coco128",
+                               "--project", str(tmp_path)])
+    assert r.exit_code == 3
+    assert calls
+    assert "allow_experimental" not in calls[0]

--- a/tests/unit/kernels/test_ms_deform_attn.py
+++ b/tests/unit/kernels/test_ms_deform_attn.py
@@ -281,3 +281,80 @@ def test_hub_matches_portable_on_cuda():
     torch.testing.assert_close(hub_out, ref_out, rtol=1e-4, atol=1e-5)
     for hub_grad, ref_grad in zip(hub_grads, ref_grads):
         torch.testing.assert_close(hub_grad, ref_grad, rtol=1e-3, atol=1e-4)
+
+
+# =============================================================================
+# Pinned-snapshot fallback loader (the ``kernels``-resolver compatibility path)
+# =============================================================================
+
+
+def test_pinned_variant_name_maps_platform(monkeypatch):
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.setattr(torch, "__version__", "2.11.0+cu128")
+    monkeypatch.setattr(torch.version, "cuda", "12.8")
+    monkeypatch.setattr(module._platform, "system", lambda: "Linux")
+    monkeypatch.setattr(module._platform, "machine", lambda: "x86_64")
+    assert module._pinned_variant_name() == "torch211-cxx11-cu128-x86_64-linux"
+
+    monkeypatch.setattr(module._platform, "system", lambda: "Windows")
+    monkeypatch.setattr(module._platform, "machine", lambda: "AMD64")
+    assert module._pinned_variant_name() == "torch211-cu128-x86_64-windows"
+
+    monkeypatch.setattr(module._platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(module._platform, "system", lambda: "Linux")
+    assert module._pinned_variant_name() == "torch211-cxx11-cu128-aarch64-linux"
+
+    # CPU-only torch has no CUDA build to match.
+    monkeypatch.setattr(torch.version, "cuda", None)
+    assert module._pinned_variant_name() is None
+
+
+def test_load_hub_kernel_falls_back_when_resolver_rejects_pin(monkeypatch):
+    """A ``kernels`` release that cannot resolve the SHA pin must not kill the
+    provider: the direct snapshot loader is tried before giving up."""
+    import sys
+    import types
+
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.setattr(module, "_hub_kernel", None)
+    monkeypatch.setattr(module, "_hub_failed", False)
+
+    fake_kernels = types.ModuleType("kernels")
+
+    def rejects_sha(*args, **kwargs):
+        raise ValueError("Invalid rev id")
+
+    fake_kernels.get_kernel = rejects_sha
+    monkeypatch.setitem(sys.modules, "kernels", fake_kernels)
+
+    sentinel = object()
+    monkeypatch.setattr(module, "_load_pinned_snapshot", lambda: sentinel)
+    assert module._load_hub_kernel() is sentinel
+    assert module._hub_failed is False
+
+
+def test_load_hub_kernel_disables_when_both_paths_fail(monkeypatch):
+    import sys
+    import types
+
+    from libreyolo.kernels.attention import ms_deform_attn as module
+
+    monkeypatch.setattr(module, "_hub_kernel", None)
+    monkeypatch.setattr(module, "_hub_failed", False)
+
+    fake_kernels = types.ModuleType("kernels")
+
+    def rejects_sha(*args, **kwargs):
+        raise ValueError("Invalid rev id")
+
+    fake_kernels.get_kernel = rejects_sha
+    monkeypatch.setitem(sys.modules, "kernels", fake_kernels)
+
+    def no_snapshot():
+        raise OSError("offline")
+
+    monkeypatch.setattr(module, "_load_pinned_snapshot", no_snapshot)
+    assert module._load_hub_kernel() is None
+    assert module._hub_failed is True

--- a/tests/unit/test_training_profiler.py
+++ b/tests/unit/test_training_profiler.py
@@ -324,6 +324,100 @@ def test_profile_then_stop_truncates_without_validation(tmp_path):
     assert val_metrics is None
 
 
+# --- DETR-family trainers: the copied loops must keep the profiler hooks ----
+#
+# DFINETrainer/DEIMTrainer override _train_epoch/_train_epoch_accum with a
+# structural copy of the BaseTrainer loop. These tests pin the profiler hooks
+# into those copies: without them profile=True is a silent no-op for the whole
+# family (dfine, deim, deimv2, rtdetrv4, ec) — no report, no early stop.
+
+
+def _bare_detr_trainer(trainer_cls, tmp_path, *, num_batches, **config_overrides):
+    """Bare-bones DFINE/DEIM trainer (bypasses ``__init__``, mirroring
+    ``_build_profiled_trainer``) with a live CPU profiler whose window closes
+    after 3 steps (warmup 1 + measured 2, since active is clamped to >= 2)."""
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.model = nn.Linear(1, 1, bias=False)
+    param = next(trainer.model.parameters())
+    trainer.train_loader = _Loader(num_batches)
+    trainer.config = SimpleNamespace(
+        epochs=1,
+        batch=1,
+        log_interval=999,
+        eval_interval=-1,
+        clip_max_norm=0.0,
+        **config_overrides,
+    )
+    trainer.device = torch.device("cpu")
+    trainer.optimizer = torch.optim.SGD([param], lr=0.1)
+    trainer.scaler = None
+    trainer.ema_model = None
+    trainer.lr_scheduler = SimpleNamespace(update_lr=lambda _: 0.1)
+    trainer.wrapper_model = SimpleNamespace(task="detect")
+    trainer._stop_training = False
+
+    forwards = []
+
+    def on_forward(imgs, targets, polygons=None):
+        forwards.append(1)
+        return {"total_loss": (param * 0).sum() + 1.0}
+
+    trainer.on_forward = on_forward
+    trainer.get_loss_components = lambda outputs: {}
+    trainer._profiler = TrainStepProfiler(
+        device=torch.device("cpu"), warmup=1, active=1, trace=False,
+        open_report=False, save_dir=tmp_path, meta={"model": "t", "batch": 1},
+    )
+    return trainer, forwards
+
+
+def _detr_trainer_classes():
+    from libreyolo.models.deim.trainer import DEIMTrainer
+    from libreyolo.models.dfine.trainer import DFINETrainer
+
+    return [DFINETrainer, DEIMTrainer]
+
+
+@pytest.mark.parametrize("trainer_idx", [0, 1], ids=["dfine", "deim"])
+@pytest.mark.parametrize("nbs", [None, 2], ids=["plain", "accum"])
+def test_detr_profile_window_close_keeps_training(trainer_idx, nbs, tmp_path):
+    """Default profile=True: the window closes and the epoch keeps training."""
+    trainer_cls = _detr_trainer_classes()[trainer_idx]
+    trainer, forwards = _bare_detr_trainer(
+        trainer_cls, tmp_path, num_batches=6, nbs=nbs
+    )
+
+    trainer_cls._train_epoch(trainer, 0)
+
+    assert trainer._profiler is None  # hooks dropped after the window
+    assert trainer._stop_training is False
+    assert len(forwards) == 6  # every batch still trained
+
+
+@pytest.mark.parametrize("trainer_idx", [0, 1], ids=["dfine", "deim"])
+@pytest.mark.parametrize("nbs", [None, 2], ids=["plain", "accum"])
+def test_detr_profile_then_stop_truncates_without_validation(
+    trainer_idx, nbs, tmp_path
+):
+    """profile_then_stop=True: stop right after the window; the partial epoch
+    must not be validated."""
+    trainer_cls = _detr_trainer_classes()[trainer_idx]
+    trainer, forwards = _bare_detr_trainer(
+        trainer_cls, tmp_path, num_batches=6, nbs=nbs, profile_then_stop=True
+    )
+    validated = []
+    trainer._validate_epoch = lambda epoch, **kw: validated.append(epoch)
+    trainer.config.eval_interval = 1  # would validate every epoch otherwise
+
+    _, val_metrics, _, _ = trainer_cls._train_epoch(trainer, 0)
+
+    assert trainer._stop_training is True
+    # Window only: warmup 1 + measured 2 (active is clamped to >= 2).
+    assert len(forwards) == 3
+    assert validated == []
+    assert val_metrics is None
+
+
 def test_memory_pressure_detected(tmp_path):
     ev = _trace_events()
     for i in range(20):


### PR DESCRIPTION
What: training and inference profiler support for every g0/g1/g2 family, plus two fixes found along the way.
Why: `profile=True` was silently ignored for the DETR line (dfine/deim/deimv2/ec/rtdetrv4), and the hub MSDeformAttn kernel never loaded under current `kernels` releases.

- Add profiler hooks (loader wrap, phase marks, step accounting, `profile_then_stop`) to the `DFINETrainer` and `DEIMTrainer` loops; ec, deimv2 and rtdetrv4 inherit them.
- Add `--allow-experimental` to `libreyolo profile run` so gated families can be profiled.
- Fix `LibreDINOv2.train()` raising "multiple values for 'device'" when a device kwarg is passed.
- Fix the `ms_deform_attn` hub provider: `kernels>=0.16` rejects the pinned SHA and this repo's metadata schema, so the provider now falls back to a direct `huggingface_hub` snapshot of the same pinned revision.
- Tests: per-family e2e profile runs for training (25 families) and inference (17 families) with registry lockstep guards; unit tests for the CLI flag, DETR profile windows, and the kernel fallback.
- Docs: family coverage in `docs/profiler.md`, fallback behavior in `docs/kernels.md`.

Check: profiler hook placement in the dfine/deim trainers mirrors `BaseTrainer`; the snapshot fallback keeps the same pinned revision and provider ordering.
Verified: touched unit suites pass post-rebase (249 passed); both e2e sweeps pass locally on CUDA (Windows, torch 2.11). Not verified: hub kernel load on macOS.
Opened by an agent.

## Code provenance

Original code written for this PR: first-party profiler hooks mirroring LibreYOLO's own `BaseTrainer` loop, first-party bug fixes, and tests. No third-party code was ported, adapted, or introduced. The `ms_deform_attn` change only alters how the already-integrated hub kernel (kernels-community/deformable-detr, Apache-2.0, unchanged pinned revision) is fetched; no code from that repository was copied. No GPL/AGPL/LGPL/non-commercial/unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends training profiler support to the copied D-FINE and DEIM loops, exposes experimental-family profiling through the CLI, and fixes DINOv2 device forwarding and pinned MSDeformAttn kernel loading.
- Adds profiler phases, loader timing, step accounting, early stopping, and validation suppression to D-FINE/DEIM trainer loops.
- Adds registry-locked training and inference profiling coverage across supported model families.
- Adds a direct Hugging Face snapshot fallback for the pinned hub kernel revision.
- Preserves explicit DINOv2 training-device overrides without passing duplicate arguments.
- Documents profiler family coverage and kernel fallback behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code regression identified.

The copied trainer hooks match the established BaseTrainer lifecycle, device overrides are reconciled during trainer setup, and kernel loading retains a guarded portable fallback when the pinned binary cannot be imported.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/dfine/trainer.py | Mirrors BaseTrainer profiler behavior in both plain and gradient-accumulation loops, including early-stop validation suppression. |
| libreyolo/models/deim/trainer.py | Adds the same profiler lifecycle and phase instrumentation as the D-FINE and base trainer loops. |
| libreyolo/kernels/attention/ms_deform_attn.py | Adds an exact torch/CUDA/platform variant loader for the pinned snapshot while retaining process-wide portable fallback on failure. |
| libreyolo/cli/commands/profile.py | Adds an opt-in CLI flag and forwards the experimental acknowledgment only when requested. |
| libreyolo/models/dinov2/model.py | Resolves an explicit training-device override once before constructing the trainer, whose setup moves the model accordingly. |
| tests/e2e/test_profile_training_families.py | Adds artifact-based profiled-training coverage with a registry lockstep assertion for all g0/g1/g2 trainable families. |
| tests/e2e/test_profile_inference_families.py | Adds per-family inference profiling coverage for the staged prediction contract and guards enrollment against registry drift. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  CLI[profile run] --> Model[LibreYOLO model]
  Model --> Trainer[Family trainer]
  Trainer --> Hooks[Profiler loader and phase hooks]
  Hooks --> Report[profile.json and trace]
  Kernel[kernels.get_kernel] -->|success| CUDA[MSDeformAttn CUDA kernel]
  Kernel -->|resolver failure| Snapshot[Pinned Hugging Face snapshot]
  Snapshot -->|matching build| CUDA
  Snapshot -->|unavailable or incompatible| Portable[Portable attention path]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix hub MSDA kernel loading under curren..."](https://github.com/libreyolo/libreyolo/commit/68d65b9a82de8c4bd4dddcef7f8ea33635a85289) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50212042)</sub>

**Context used:**

- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)

<!-- /greptile_comment -->