### PR TITLE
Fix MNN unit tests failing on POSIX CI runners

### DIFF
--- a/tests/unit/test_export_mnn.py
+++ b/tests/unit/test_export_mnn.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -238,7 +239,17 @@ def test_windows_teardown_failure_requires_independent_artifact_validation(
         "version",
         lambda package: "3.6.1",
     )
-    monkeypatch.setattr(mnn_export.os, "name", "nt")
+
+    class _WindowsOS:
+        # Patching os.name globally would make pathlib pick WindowsPath on
+        # POSIX and crash; swap a delegating fake into the module namespace
+        # so only mnn_export sees the Windows platform.
+        name = "nt"
+
+        def __getattr__(self, attribute):
+            return getattr(os, attribute)
+
+    monkeypatch.setattr(mnn_export, "os", _WindowsOS())
 
     def fake_run(command, **kwargs):
         output = Path(command[command.index("--MNNModel") + 1])

--- a/tests/unit/test_mnn_backend.py
+++ b/tests/unit/test_mnn_backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -134,7 +135,12 @@ def test_backend_loads_cpu_module_and_preserves_output_order(tmp_path, monkeypat
     assert backend.names == {0: "a", 1: "b"}
     assert backend.input_names == ["images"]
     assert backend.output_names == ["boxes", "logits"]
-    assert calls["config"] == ({"backend": 0, "precision": 1, "numThread": 4},)
+    # The backend clamps threads to min(cpu_count, 4); CI runners can have
+    # fewer than 4 cores, so mirror the clamp instead of hardcoding 4.
+    expected_threads = min(max(os.cpu_count() or 1, 1), 4)
+    assert calls["config"] == (
+        {"backend": 0, "precision": 1, "numThread": expected_threads},
+    )
     assert calls["load"]["dynamic"] is False
     assert calls["load"]["shape_mutable"] is False
     assert fake_module.inputs[0].shape == (2, 3, 8, 8)


### PR DESCRIPTION
What: fix the two MNN unit tests that have kept `dev` CI red on Linux and macOS since #722.
Why: `dev` unit tests fail on POSIX runners; both failures are environment assumptions in tests, not library bugs.

- `test_export_mnn.py::test_windows_teardown_failure_requires_independent_artifact_validation`: `monkeypatch.setattr(mnn_export.os, "name", "nt")` patched the global `os.name`, so `pathlib.Path()` resolved to `WindowsPath` on POSIX and raised `NotImplementedError`; the exception recurred while pytest formatted the failure report, killing the xdist worker (INTERNALERROR aborts the whole job). Replaced with a delegating fake `os` object swapped into the `mnn_export` module namespace, so only the module under test sees `name == "nt"`.
- `test_mnn_backend.py::test_backend_loads_cpu_module_and_preserves_output_order`: hardcoded `numThread: 4`, but the backend clamps to `min(cpu_count, 4)` and macOS runners have 3 cores. The test now mirrors the clamp.
- Test-only; no library code changed.

Check: the fake `os` still exercises the real `os.name == "nt"` branch in `_can_recover_windows_converter_teardown`.
Verified: both files pass locally on Windows (41 passed); Ubuntu unit job went red-to-green on this branch after the first fix. Not verified locally: macOS; this PR's CI run is the proof.
Opened by an agent.

## Code provenance

Original code written for this PR; test-only fixes to LibreYOLO's own first-party tests. No third-party code ported, adapted, or introduced; no GPL/AGPL/LGPL/non-commercial/unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This test-only PR prevents Windows teardown simulation from mutating process-global platform state and makes the MNN backend assertion portable across lower-core CI runners.
- Replaces the global `os.name` patch with a module-local delegating OS fake.
- Computes the expected MNN thread count using the backend’s CPU clamp.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/unit/test_export_mnn.py | Safely scopes Windows platform simulation to the MNN export module while preserving the real OS operations used by the test. |
| tests/unit/test_mnn_backend.py | Updates the expected runtime thread configuration to account for CI hosts exposing fewer than four CPUs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix MNN backend thread-count assertion o..."](https://github.com/libreyolo/libreyolo/commit/4ef00ea5afa97b601b17240c4dde2e6d61ec12a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50215963)</sub>

<!-- /greptile_comment -->