### PR TITLE
Remove per-pair device syncs from the GO-LSD match union

### DIFF
--- a/libreyolo/models/deim/loss.py
+++ b/libreyolo/models/deim/loss.py
@@ -336,8 +336,9 @@ class DEIMCriterion(nn.Module):
             count_sort_indices = torch.argsort(counts, descending=True)
             unique_sorted = unique[count_sort_indices]
             column_to_row = {}
-            for idx in unique_sorted:
-                row_idx, col_idx = idx[0].item(), idx[1].item()
+            # One batched GPU->CPU transfer; upstream's per-element .item()
+            # loop costs two device syncs per unique pair (~1,200/step).
+            for row_idx, col_idx in unique_sorted.tolist():
                 if row_idx not in column_to_row:
                     column_to_row[row_idx] = col_idx
             final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)

--- a/libreyolo/models/dfine/loss.py
+++ b/libreyolo/models/dfine/loss.py
@@ -10,6 +10,9 @@ Differences from upstream:
   matcher + weight_dict + losses as plain kwargs.
 - ``misc.dist_utils.{is_dist_available_and_initialized, get_world_size}``
   inlined as small helpers (LibreYOLO is single-GPU from this module's POV).
+- ``_get_go_indices`` batches its GPU->CPU transfer (one ``tolist`` per image
+  instead of upstream's two ``.item()`` device syncs per unique pair); the
+  output is identical.
 """
 
 from __future__ import annotations
@@ -406,8 +409,9 @@ class DFINECriterion(nn.Module):
             count_sort_indices = torch.argsort(counts, descending=True)
             unique_sorted = unique[count_sort_indices]
             column_to_row = {}
-            for idx in unique_sorted:
-                row_idx, col_idx = idx[0].item(), idx[1].item()
+            # One batched GPU->CPU transfer; upstream's per-element .item()
+            # loop costs two device syncs per unique pair (~1,200/step).
+            for row_idx, col_idx in unique_sorted.tolist():
                 if row_idx not in column_to_row:
                     column_to_row[row_idx] = col_idx
             final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)

--- a/libreyolo/models/ec/pose_loss.py
+++ b/libreyolo/models/ec/pose_loss.py
@@ -292,8 +292,9 @@ class ECPoseCriterion(nn.Module):
             unique, counts = torch.unique(ind, return_counts=True, dim=0)
             unique_sorted = unique[torch.argsort(counts, descending=True)]
             col_to_row = {}
-            for u in unique_sorted:
-                r, c = u[0].item(), u[1].item()
+            # One batched GPU->CPU transfer; upstream's per-element .item()
+            # loop costs two device syncs per unique pair.
+            for r, c in unique_sorted.tolist():
                 if r not in col_to_row:
                     col_to_row[r] = c
             rows = torch.tensor(list(col_to_row.keys()), device=ind.device).long()

--- a/tests/unit/test_detr_go_indices.py
+++ b/tests/unit/test_detr_go_indices.py
@@ -1,0 +1,120 @@
+"""Equivalence tests for the vectorized GO-LSD match-union (`_get_go_indices`).
+
+The upstream implementation walked the unique (query, gt) pairs with two
+`.item()` calls per pair — about 1,200 device syncs per training step for the
+DETR families. The vectorized form batches that into one `.tolist()` transfer.
+These tests pin the output to a reference re-implementation of the original
+per-element loop, over randomized inputs, for every class that carries the
+method (DFINECriterion, DEIMCriterion, ECPoseCriterion — ECCriterion inherits
+D-FINE's).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from libreyolo.models.deim.loss import DEIMCriterion
+from libreyolo.models.dfine.loss import DFINECriterion
+from libreyolo.models.ec.pose_loss import ECPoseCriterion
+
+pytestmark = pytest.mark.unit
+
+
+def _reference_go_indices(indices, indices_aux_list):
+    """Upstream D-FINE loop, verbatim semantics: first col per row wins,
+    iterating unique pairs in count-descending order."""
+    results = []
+    for indices_aux in indices_aux_list:
+        indices = [
+            (torch.cat([idx1[0], idx2[0]]), torch.cat([idx1[1], idx2[1]]))
+            for idx1, idx2 in zip(indices.copy(), indices_aux.copy())
+        ]
+    for ind in [torch.cat([idx[0][:, None], idx[1][:, None]], 1) for idx in indices]:
+        unique, counts = torch.unique(ind, return_counts=True, dim=0)
+        unique_sorted = unique[torch.argsort(counts, descending=True)]
+        column_to_row = {}
+        for idx in unique_sorted:
+            row_idx, col_idx = idx[0].item(), idx[1].item()
+            if row_idx not in column_to_row:
+                column_to_row[row_idx] = col_idx
+        results.append(
+            (
+                torch.tensor(list(column_to_row.keys()), device=ind.device).long(),
+                torch.tensor(list(column_to_row.values()), device=ind.device).long(),
+            )
+        )
+    return results
+
+
+def _random_match(generator, num_queries=30, max_gt=6):
+    n = int(torch.randint(0, max_gt + 1, (1,), generator=generator))
+    rows = torch.randperm(num_queries, generator=generator)[:n]
+    cols = torch.randperm(max(n, 1), generator=generator)[:n]
+    return rows.long(), cols.long()
+
+
+def _go_indices_fn(criterion_cls):
+    # _get_go_indices does not touch self, so bind-free invocation keeps the
+    # test independent of each criterion's constructor plumbing.
+    return lambda indices, aux: criterion_cls._get_go_indices(None, indices, aux)
+
+
+@pytest.mark.parametrize(
+    "criterion_cls",
+    [DFINECriterion, DEIMCriterion, ECPoseCriterion],
+    ids=["dfine", "deim", "ecpose"],
+)
+def test_go_indices_matches_upstream_loop(criterion_cls):
+    generator = torch.Generator().manual_seed(0)
+    fn = _go_indices_fn(criterion_cls)
+    for _ in range(25):
+        batch = int(torch.randint(1, 5, (1,), generator=generator))
+        num_layers = int(torch.randint(1, 8, (1,), generator=generator))
+        indices = [_random_match(generator) for _ in range(batch)]
+        aux_list = [
+            [_random_match(generator) for _ in range(batch)]
+            for _ in range(num_layers)
+        ]
+        got = fn(indices, aux_list)
+        expected = _reference_go_indices(indices, aux_list)
+        assert len(got) == len(expected) == batch
+        for (g_rows, g_cols), (e_rows, e_cols) in zip(got, expected):
+            assert torch.equal(g_rows, e_rows)
+            assert torch.equal(g_cols, e_cols)
+            assert g_rows.dtype == torch.int64
+            assert g_cols.dtype == torch.int64
+
+
+@pytest.mark.parametrize(
+    "criterion_cls",
+    [DFINECriterion, DEIMCriterion, ECPoseCriterion],
+    ids=["dfine", "deim", "ecpose"],
+)
+def test_go_indices_empty_matches(criterion_cls):
+    empty = (torch.zeros(0).long(), torch.zeros(0).long())
+    got = _go_indices_fn(criterion_cls)([empty], [[empty]])
+    assert len(got) == 1
+    assert got[0][0].numel() == 0
+    assert got[0][1].numel() == 0
+
+
+def test_go_indices_does_not_sync_per_element(monkeypatch):
+    """Guard the fix: a per-element `.item()` regression re-introduces ~1,200
+    device syncs per step. The batched form calls `.item()` zero times."""
+    calls = {"n": 0}
+    original = torch.Tensor.item
+
+    def counting_item(self):
+        calls["n"] += 1
+        return original(self)
+
+    monkeypatch.setattr(torch.Tensor, "item", counting_item)
+    generator = torch.Generator().manual_seed(1)
+    indices = [_random_match(generator) for _ in range(4)]
+    aux_list = [[_random_match(generator) for _ in range(4)] for _ in range(6)]
+    DFINECriterion._get_go_indices(None, indices, aux_list)
+    assert calls["n"] == 0, (
+        f"_get_go_indices called .item() {calls['n']} times; the transfer "
+        "must stay batched (.tolist once per image)"
+    )


### PR DESCRIPTION
What: batch the GPU->CPU transfer in the GO-LSD match union (`_get_go_indices`), removing ~270 device syncs per training step for the D-FINE line (dfine, deim, deimv2, rtdetrv4, ec) and ECPose.
Why: the loop called `.item()` twice per unique (query, gt) pair on a CUDA tensor — the single largest source of true device syncs in DETR-family training steps. Upstream D-FINE and EdgeCrafter both carry the same loop, so there is nothing to port; this is an original micro-fix with identical output.

- `dfine/loss.py`, `deim/loss.py`, `ec/pose_loss.py`: one `tolist()` per image instead of two `.item()` per pair. Iteration order and first-col-per-row semantics unchanged.
- `tests/unit/test_detr_go_indices.py`: output equivalence vs the upstream loop over randomized inputs for all three classes, empty-match edge case, and a regression guard asserting `_get_go_indices` performs zero `.item()` calls.

Measured (ec-s, 640px, batch 8, RTX 5070 Ti, profiler A/B, alternating runs): `aten::item` 1,377 -> 1,107 per step; end-to-end step time unchanged (405 vs 408-413 ms) because on this bare-metal box each sync costs ~10 us. The benefit is bounded to environments with expensive host-device round trips (containerized/virtualized GPU boxes, busy pipelines); this PR does not claim a throughput win.

Check: the equivalence test covers the semantics; remaining per-step syncs (loss-component logging, box assert `__bool__`s, `nonzero` in denoising) are intentionally out of scope.
Verified: new tests plus dfine/deim trainer smoke suites pass locally (29 passed); ec-s trains and profiles normally with the change.
Opened by an agent.

## Code provenance

Original code written for this PR, modifying LibreYOLO's existing D-FINE-lineage ports (already attributed in-file to Peterande/D-FINE and lyuwenyu/RT-DETR, both Apache-2.0). The change was verified against upstream (D-FINE and Intellindust-AI-Lab/EdgeCrafter, Apache-2.0) to confirm both carry the original per-element loop; no third-party code was copied. No GPL/AGPL/LGPL/non-commercial/unknown-license material involved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR preserves GO-LSD match-union selection while replacing per-pair scalar extraction with one batched tensor-to-list conversion per image.
- Updates D-FINE, DEIM, and ECPose loss implementations.
- Adds randomized reference-equivalence and empty-match coverage.
- Adds a regression guard against reintroducing per-element `.item()` calls.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security regressions identified.

The changed loops preserve the existing pair order and Python integer key semantics, and the added tests compare all affected implementations against the prior algorithm across randomized and empty inputs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/dfine/loss.py | Replaces scalar extraction in `_get_go_indices` with an equivalent batched conversion and documents the optimization. |
| libreyolo/models/deim/loss.py | Applies the same semantics-preserving batched conversion to DEIM match union. |
| libreyolo/models/ec/pose_loss.py | Applies the batched conversion to ECPose while preserving row-to-column selection behavior. |
| tests/unit/test_detr_go_indices.py | Adds cross-implementation equivalence, empty-input, dtype, and per-element synchronization regression coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Batch the GO-LSD match-union device tran..."](https://github.com/libreyolo/libreyolo/commit/e08aed8852f83aad97feebe00109157d70310511) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50251413)</sub>

<!-- /greptile_comment -->