### PR TITLE
Add deepstream=True ONNX export (nvinfer contract + generated configs)

### DIFF
--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -22,7 +22,9 @@ with class labels also get a labels file. For the detection example above:
 - `libreyolo9s_labels.txt`: one class name per line.
 
 DeepStream builds the TensorRT engine from the ONNX on first run and caches
-it next to the model.
+it next to the model. Detection configs use the parser builder's required
+`model_b{batch}_gpu0_{precision}.engine` cache name; other tasks keep a
+model-specific engine filename.
 
 ## The parser library
 
@@ -93,7 +95,7 @@ your own fine-tuned weights.
 parser library): DeepStream has no post-processor for these, so the graph's
 native outputs pass through untouched and the application decodes them from
 the tensor metadata. Multi-output graphs are fine; every output layer
-reaches the metadata with the same output names and dynamic batch axes as a
+reaches the metadata with the same output names and dynamic axes as a
 regular ONNX export. No labels file is written.
 
 | Task | Families |
@@ -135,6 +137,11 @@ benchmark accounting:
   accurate.
 - pidnet emits a class map at 1/8 of the input resolution and
   lingbotvision at 1/16; DeepStream upsamples the class map for display.
+
+The ONNX parity gate feeds already-preprocessed tensors, so it validates graph
+outputs but cannot detect a wrong `nvinfer` color order or padding policy.
+Config-level tests cover the declared settings; end-to-end DeepStream
+validation is still required.
 
 For exact-parity workloads, validate on your data before deploying; all
 other math is parity-tested against each family's native postprocess.

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -42,17 +42,37 @@ Adjust `custom-lib-path` in the generated config to the built
 the parser applies the confidence threshold and DeepStream's clustering
 stage (`cluster-mode=2`) suppresses using `nms-iou-threshold`.
 
-## Supported families
+## Supported tasks and families
 
-Detection task only. CNN families: yolo9, yolox, yolonas, rtmdet, picodet,
-yolo1, yolo2, yolo3, yolo4, yolo7. DETR families: rfdetr, dfine, deim,
-deimv2, ec, rtdetr, rtdetrv2, rtdetrv4.
+**Detection** (`network-type=0`, needs the parser library above):
+yolo9, yolo9_p2, yolo9_e2e, yolo1, yolo2, yolo3, yolo4, yolo7, yolox,
+yolonas, rtmdet, picodet, rfdetr, dfine, deim, deimv2, ec, rtdetr,
+rtdetrv2, rtdetrv4.
+
+DETR heads and yolo9_e2e's one-to-one head emit at most one prediction per
+object, so their configs set `cluster-mode=4`: DeepStream must not run NMS
+over them or it merges distinct detections. Anchor and grid heads get
+`cluster-mode=2` with `nms-iou-threshold`.
+
+**Classification** (`network-type=1`, no parser library needed):
+mobilenetv4, convnext, efficientnetv2, resnet, dinov2. The graph emits
+softmax probabilities, which is what `classifier-threshold` expects. Set
+`process-mode=2` and `operate-on-gie-id` in the generated config to run one
+as a secondary classifier behind a detector.
+
+**Semantic segmentation** (`network-type=2`, no parser library needed):
+pidnet, eomt, dinov2, lingbotvision. The graph emits `(C, H, W)` per-class
+probabilities; `nvinfer` applies `segmentation-threshold` and produces the
+class map. `segformer` is excluded because it is not wired to the shared
+semantic export contract and cannot export to ONNX in any format.
 
 Families whose native preprocessing cannot be expressed by `nvinfer`'s
 scalar `net-scale-factor` (per-channel std: rfdetr, ec, DINO-backboned
-deimv2 sizes, rtmdet, picodet) have the normalization baked into the
-exported graph; the generated config feeds the graph the matching raw
-input space, so no manual preprocessing configuration is needed.
+deimv2 sizes, rtmdet, picodet, and every classification family) have the
+normalization baked into the exported graph; the generated config feeds the
+graph the matching raw input space, so no manual preprocessing
+configuration is needed. The semantic families normalize inside their own
+forward, so their graphs take plain `[0, 1]` RGB and add nothing.
 
 ## Preprocessing approximations
 
@@ -63,6 +83,14 @@ documented here for benchmark accounting:
   gray natively; `nvinfer` pads black.
 - yolonas natively resizes the longest side to 636 inside its 640 canvas;
   `nvinfer`'s `maintain-aspect-ratio` uses the full 640.
+- Classification natively resizes the shortest side then centre-crops;
+  `nvinfer` stretches the frame or object ROI to the network input. Expect
+  small differences on tightly cropped subjects.
+- EoMT natively runs sliding-window tiles for semantic segmentation; the
+  exported graph is a single stretched canvas, which is faster and less
+  accurate.
+- pidnet emits a class map at 1/8 of the input resolution and
+  lingbotvision at 1/16; DeepStream upsamples the class map for display.
 
 For exact-parity workloads, validate on your data before deploying; all
 other math is parity-tested against each family's native postprocess.

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -66,6 +66,12 @@ probabilities; `nvinfer` applies `segmentation-threshold` and produces the
 class map. `segformer` is excluded because it is not wired to the shared
 semantic export contract and cannot export to ONNX in any format.
 
+EoMT's semantic head already emits probabilities rather than logits, so its
+graph skips the softmax the other families need. Only the `l` semantic
+checkpoint is published; `s` and `b` semantic weights do not exist.
+DINOv2 classification has no published checkpoint at all, so use it with
+your own fine-tuned weights.
+
 Families whose native preprocessing cannot be expressed by `nvinfer`'s
 scalar `net-scale-factor` (per-channel std: rfdetr, ec, DINO-backboned
 deimv2 sizes, rtmdet, picodet, and every classification family) have the

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -10,7 +10,8 @@ model = LibreYOLO9("libreyolo9s.pt", size="s")
 model.export(format="onnx", deepstream=True)
 ```
 
-This writes three files next to each other:
+This writes an ONNX graph and an `nvinfer` config next to each other. Tasks
+with class labels also get a labels file. For the detection example above:
 
 - `libreyolo9s.onnx`: the detection graph with a single output tensor of
   shape `(batch, num_detections, 6)`, rows `[x1, y1, x2, y2, score,
@@ -92,7 +93,8 @@ your own fine-tuned weights.
 parser library): DeepStream has no post-processor for these, so the graph's
 native outputs pass through untouched and the application decodes them from
 the tensor metadata. Multi-output graphs are fine; every output layer
-reaches the metadata. No labels file is written.
+reaches the metadata with the same output names and dynamic batch axes as a
+regular ONNX export. No labels file is written.
 
 | Task | Families |
 |---|---|
@@ -121,8 +123,10 @@ benchmark accounting:
 
 - Letterbox families (yolo9, yolox, yolonas, rtmdet, yolo2/3/4/7) pad with
   gray natively; `nvinfer` pads black.
-- yolonas natively resizes the longest side to 636 inside its 640 canvas;
-  `nvinfer`'s `maintain-aspect-ratio` uses the full 640.
+- yolonas detection natively resizes the longest side to 636 inside its 640
+  canvas; `nvinfer`'s `maintain-aspect-ratio` uses the full 640. Yolonas pose
+  already uses the full 640, BGR input, and bottom/right padding; its generated
+  config preserves those task-specific settings.
 - Classification natively resizes the shortest side then centre-crops;
   `nvinfer` stretches the frame or object ROI to the network input. Expect
   small differences on tightly cropped subjects.

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -60,6 +60,22 @@ softmax probabilities, which is what `classifier-threshold` expects. Set
 `process-mode=2` and `operate-on-gie-id` in the generated config to run one
 as a secondary classifier behind a detector.
 
+**Instance segmentation** (`network-type=3`, needs the *seg* parser build):
+rfdetr, dfine, ec. Rows are the detection row followed by that instance's
+mask, flattened at `(netH / 4, netW / 4)` — the resolution the seg parser
+hardcodes — as probabilities for `segmentation-threshold`. This parser is a
+separate MIT project and a separate build:
+
+```bash
+git clone https://github.com/marcoslucianops/DeepStream-Yolo-Seg
+CUDA_VER=12.8 make -C DeepStream-Yolo-Seg/nvdsinfer_custom_impl_Yolo_seg
+```
+
+LibreYOLO's seg families export per-query masks directly, so the graph only
+resizes and sigmoids them. No RoI pooling and no custom TensorRT plugin are
+involved, unlike prototype-coefficient heads. RTMDet-Ins and YOLO9 are
+excluded because their segmentation export is blocked in LibreYOLO itself.
+
 **Semantic segmentation** (`network-type=2`, no parser library needed):
 pidnet, eomt, dinov2, lingbotvision. The graph emits `(C, H, W)` per-class
 probabilities; `nvinfer` applies `segmentation-threshold` and produces the

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -88,6 +88,11 @@ checkpoint is published; `s` and `b` semantic weights do not exist.
 DINOv2 classification has no published checkpoint at all, so use it with
 your own fine-tuned weights.
 
+**Depth** (`network-type=100` with `output-tensor-meta=1`, no parser library):
+depth_anything, depth_anything3, zipdepth. DeepStream has no depth
+post-processor, so the dense map passes through untouched and the
+application reads it from the tensor metadata. No labels file is written.
+
 Families whose native preprocessing cannot be expressed by `nvinfer`'s
 scalar `net-scale-factor` (per-channel std: rfdetr, ec, DINO-backboned
 deimv2 sizes, rtmdet, picodet, and every classification family) have the

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -88,10 +88,23 @@ checkpoint is published; `s` and `b` semantic weights do not exist.
 DINOv2 classification has no published checkpoint at all, so use it with
 your own fine-tuned weights.
 
-**Depth** (`network-type=100` with `output-tensor-meta=1`, no parser library):
-depth_anything, depth_anything3, zipdepth. DeepStream has no depth
-post-processor, so the dense map passes through untouched and the
-application reads it from the tensor metadata. No labels file is written.
+**Raw-tensor tasks** (`network-type=100` with `output-tensor-meta=1`, no
+parser library): DeepStream has no post-processor for these, so the graph's
+native outputs pass through untouched and the application decodes them from
+the tensor metadata. Multi-output graphs are fine; every output layer
+reaches the metadata. No labels file is written.
+
+| Task | Families |
+|---|---|
+| Depth | depth_anything, depth_anything3, zipdepth |
+| Pose | yolo9, yolonas, rfdetr, ec |
+| Restoration | nafnet, realesrgan, swinir |
+| Matting | birefnet |
+| Gaze | l2cs |
+
+Gaze is a head-only contract: each input is one face crop, so run it as a
+secondary GIE (`process-mode=2` plus `operate-on-gie-id`) behind a face
+detector.
 
 Families whose native preprocessing cannot be expressed by `nvinfer`'s
 scalar `net-scale-factor` (per-channel std: rfdetr, ec, DINO-backboned

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -96,7 +96,7 @@ reaches the metadata. No labels file is written.
 
 | Task | Families |
 |---|---|
-| Depth | depth_anything, depth_anything3, zipdepth |
+| Depth | depth_anything, zipdepth |
 | Pose | yolo9, yolonas, rfdetr, ec |
 | Restoration | nafnet, realesrgan, swinir |
 | Matting | birefnet |
@@ -116,8 +116,8 @@ forward, so their graphs take plain `[0, 1]` RGB and add nothing.
 
 ## Preprocessing approximations
 
-Two known deviations from the native Python pipelines, both small and
-documented here for benchmark accounting:
+Known deviations from the native Python pipelines, documented here for
+benchmark accounting:
 
 - Letterbox families (yolo9, yolox, yolonas, rtmdet, yolo2/3/4/7) pad with
   gray natively; `nvinfer` pads black.

--- a/docs/deepstream.md
+++ b/docs/deepstream.md
@@ -1,0 +1,77 @@
+# DeepStream export
+
+`deepstream=True` on the ONNX export produces artifacts ready for NVIDIA
+DeepStream's `nvinfer` element (Jetson and x86 dGPU):
+
+```python
+from libreyolo import LibreYOLO9
+
+model = LibreYOLO9("libreyolo9s.pt", size="s")
+model.export(format="onnx", deepstream=True)
+```
+
+This writes three files next to each other:
+
+- `libreyolo9s.onnx`: the detection graph with a single output tensor of
+  shape `(batch, num_detections, 6)`, rows `[x1, y1, x2, y2, score,
+  class_id]` in network-input pixel coordinates.
+- `config_infer_primary_libreyolo9s.txt`: an `nvinfer` configuration with
+  the family's preprocessing constants, class count, clustering (NMS)
+  thresholds, and parser wiring filled in.
+- `libreyolo9s_labels.txt`: one class name per line.
+
+DeepStream builds the TensorRT engine from the ONNX on first run and caches
+it next to the model.
+
+## The parser library
+
+`nvinfer` needs a custom bounding-box parser for this output layout. The
+generated config targets `NvDsInferParseYolo` from the MIT-licensed
+[DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo)
+project. Build it once per device:
+
+```bash
+git clone https://github.com/marcoslucianops/DeepStream-Yolo
+cd DeepStream-Yolo
+# CUDA_VER: see /usr/local/cuda/version.json (Jetson and x86 differ)
+CUDA_VER=12.8 make -C nvdsinfer_custom_impl_Yolo
+```
+
+Adjust `custom-lib-path` in the generated config to the built
+`libnvdsinfer_custom_impl_Yolo.so`. No NMS is embedded in the ONNX graph;
+the parser applies the confidence threshold and DeepStream's clustering
+stage (`cluster-mode=2`) suppresses using `nms-iou-threshold`.
+
+## Supported families
+
+Detection task only. CNN families: yolo9, yolox, yolonas, rtmdet, picodet,
+yolo1, yolo2, yolo3, yolo4, yolo7. DETR families: rfdetr, dfine, deim,
+deimv2, ec, rtdetr, rtdetrv2, rtdetrv4.
+
+Families whose native preprocessing cannot be expressed by `nvinfer`'s
+scalar `net-scale-factor` (per-channel std: rfdetr, ec, DINO-backboned
+deimv2 sizes, rtmdet, picodet) have the normalization baked into the
+exported graph; the generated config feeds the graph the matching raw
+input space, so no manual preprocessing configuration is needed.
+
+## Preprocessing approximations
+
+Two known deviations from the native Python pipelines, both small and
+documented here for benchmark accounting:
+
+- Letterbox families (yolo9, yolox, yolonas, rtmdet, yolo2/3/4/7) pad with
+  gray natively; `nvinfer` pads black.
+- yolonas natively resizes the longest side to 636 inside its 640 canvas;
+  `nvinfer`'s `maintain-aspect-ratio` uses the full 640.
+
+For exact-parity workloads, validate on your data before deploying; all
+other math is parity-tested against each family's native postprocess.
+
+## Options
+
+- `conf` / `iou` (defaults 0.25 / 0.45) seed `pre-cluster-threshold` and
+  `nms-iou-threshold` in the generated config.
+- `dynamic=True` exports a dynamic batch axis; set `batch-size` in the
+  config to the engine batch you want DeepStream to build.
+- `half=True` marks the config `network-mode=2` (fp16 engine build).
+- `deepstream=True` and `nms=True` are mutually exclusive.

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -113,6 +113,12 @@ _SEMANTIC_FAMILIES = {
 # export is blocked upstream in libreyolo.export.support.
 _INSTANCE_SEG_FAMILIES = {"rfdetr", "dfine", "ec"}
 
+# Depth families exported as a raw-tensor network (``network-type=100``
+# with ``output-tensor-meta=1``): DeepStream has no depth post-processor,
+# so the application reads the dense map from the tensor metadata. All
+# three normalize inside their own forward, so the graph takes [0, 1] RGB.
+_DEPTH_FAMILIES = {"depth_anything", "depth_anything3", "zipdepth"}
+
 # EoMT's "semantic_logits" are already per-pixel probabilities
 # (``class.softmax() @ mask.sigmoid()``), so a second softmax would distort
 # the values ``segmentation-threshold`` compares against.
@@ -427,6 +433,15 @@ def wrap_for_deepstream(
         return DeepStreamClassifierOutput(
             _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
         )
+    if task == "depth":
+        if model_family not in _DEPTH_FAMILIES:
+            raise NotImplementedError(
+                f"DeepStream depth export is not supported for family "
+                f"{model_family!r}. Supported: {sorted(_DEPTH_FAMILIES)}"
+            )
+        # The dense map passes through untouched: DeepStream does not
+        # interpret it, the application does.
+        return nn_model
     if task == "segment":
         if model_family not in _INSTANCE_SEG_FAMILIES:
             raise NotImplementedError(
@@ -479,6 +494,8 @@ def deepstream_supported_families(task: str = "detect") -> set[str]:
         return set(_SEMANTIC_FAMILIES)
     if task == "segment":
         return set(_INSTANCE_SEG_FAMILIES)
+    if task == "depth":
+        return set(_DEPTH_FAMILIES)
     if task != "detect":
         return set()
     return (
@@ -548,6 +565,10 @@ _PREPROCESS_PROFILES: dict[str, dict] = {
     # Semantic segmentation: nets normalize internally, so [0, 1] RGB only.
     # pidnet letterboxes natively; the rest stretch.
     "pidnet": {"maintain_aspect_ratio": 1},
+    # Depth: nets normalize internally, so [0, 1] RGB; all stretch-resize.
+    "depth_anything": {},
+    "depth_anything3": {},
+    "zipdepth": {},
     "eomt": {},
     "lingbotvision": {},
 }
@@ -578,7 +599,11 @@ def write_deepstream_sidecars(
     labels_path = onnx_file.with_name(f"{stem}_labels.txt")
     config_path = onnx_file.with_name(f"config_infer_primary_{stem}.txt")
 
-    labels_path.write_text("\n".join(class_names) + "\n", encoding="utf-8")
+    # Depth has no classes: no labels file, and no labelfile-path key.
+    if class_names:
+        labels_path.write_text("\n".join(class_names) + "\n", encoding="utf-8")
+    else:
+        labels_path = None
 
     profile = _PREPROCESS_PROFILES.get(model_family, {})
     net_scale = profile.get("net_scale_factor", 1.0 / 255.0)
@@ -606,7 +631,11 @@ def write_deepstream_sidecars(
         f"model-color-format={color_format}",
         f"onnx-file={onnx_file.name}",
         f"model-engine-file={onnx_file.name}_b{batch}_gpu0_{mode_name}.engine",
-        f"labelfile-path={labels_path.name}",
+        *(
+            [f"labelfile-path={labels_path.name}"]
+            if labels_path is not None
+            else []
+        ),
         f"batch-size={batch}",
         f"network-mode={network_mode}",
         "interval=0",
@@ -624,6 +653,14 @@ def write_deepstream_sidecars(
             f"num-detected-classes={len(class_names)}",
             f"classifier-threshold={conf}",
             "classifier-async-mode=0",
+        ]
+    elif task == "depth":
+        # No DeepStream post-processor for depth: hand the raw map to the
+        # application through tensor metadata.
+        lines = common + [
+            "process-mode=1",
+            "network-type=100",
+            "output-tensor-meta=1",
         ]
     elif task == "segment":
         # Instance masks come from the DeepStream-Yolo-Seg parser library,
@@ -681,4 +718,4 @@ def write_deepstream_sidecars(
         lines.insert(3, "offsets=" + ";".join(f"{o:.10g}" for o in offsets))
 
     config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    return str(config_path), str(labels_path)
+    return str(config_path), (str(labels_path) if labels_path is not None else "")

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -119,6 +119,35 @@ _INSTANCE_SEG_FAMILIES = {"rfdetr", "dfine", "ec"}
 # three normalize inside their own forward, so the graph takes [0, 1] RGB.
 _DEPTH_FAMILIES = {"depth_anything", "depth_anything3", "zipdepth"}
 
+# Tasks DeepStream has no post-processor for. They export as raw-tensor
+# networks (``network-type=100`` with ``output-tensor-meta=1``): the graph
+# passes its native outputs through untouched and the application decodes
+# them from the tensor metadata. Multi-output graphs are fine, every output
+# layer reaches the metadata.
+_POSE_FAMILIES = {"yolo9", "yolonas", "rfdetr", "ec"}
+_RESTORE_FAMILIES = {"nafnet", "realesrgan", "swinir"}
+_MATTE_FAMILIES = {"birefnet"}
+_GAZE_FAMILIES = {"l2cs"}
+
+_RAW_TENSOR_TASKS = {
+    "depth": _DEPTH_FAMILIES,
+    "pose": _POSE_FAMILIES,
+    "restore": _RESTORE_FAMILIES,
+    "matte": _MATTE_FAMILIES,
+    "gaze": _GAZE_FAMILIES,
+}
+
+
+def _raw_tensor_families(task: str) -> set[str]:
+    """Families exportable as a raw-tensor network for ``task``."""
+    return _RAW_TENSOR_TASKS.get(task, set())
+
+# Raw-tensor families that normalize with ImageNet stats *outside* the
+# model, so the DeepStream graph must do it (nvinfer cannot divide per
+# channel). Restoration families take plain [0, 1] and SwinIR subtracts its
+# own mean inside forward, so neither appears here.
+_RAW_TENSOR_IMAGENET_NORM = {"birefnet", "l2cs"}
+
 # EoMT's "semantic_logits" are already per-pixel probabilities
 # (``class.softmax() @ mask.sigmoid()``), so a second softmax would distort
 # the values ``segmentation-threshold`` compares against.
@@ -433,14 +462,20 @@ def wrap_for_deepstream(
         return DeepStreamClassifierOutput(
             _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
         )
-    if task == "depth":
-        if model_family not in _DEPTH_FAMILIES:
+    if task in _RAW_TENSOR_TASKS:
+        allowed = _raw_tensor_families(task)
+        if model_family not in allowed:
             raise NotImplementedError(
-                f"DeepStream depth export is not supported for family "
-                f"{model_family!r}. Supported: {sorted(_DEPTH_FAMILIES)}"
+                f"DeepStream {task} export is not supported for family "
+                f"{model_family!r}. Supported: {sorted(allowed)}"
             )
-        # The dense map passes through untouched: DeepStream does not
-        # interpret it, the application does.
+        # Outputs pass through untouched: DeepStream does not interpret
+        # them, the application does. Only preprocessing the graph must own
+        # is added.
+        if model_family in _RAW_TENSOR_IMAGENET_NORM:
+            return _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
+        if task == "pose" and _uses_imagenet_norm(model_family, model_size):
+            return _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
         return nn_model
     if task == "segment":
         if model_family not in _INSTANCE_SEG_FAMILIES:
@@ -494,8 +529,8 @@ def deepstream_supported_families(task: str = "detect") -> set[str]:
         return set(_SEMANTIC_FAMILIES)
     if task == "segment":
         return set(_INSTANCE_SEG_FAMILIES)
-    if task == "depth":
-        return set(_DEPTH_FAMILIES)
+    if task in _RAW_TENSOR_TASKS:
+        return set(_raw_tensor_families(task))
     if task != "detect":
         return set()
     return (
@@ -569,6 +604,13 @@ _PREPROCESS_PROFILES: dict[str, dict] = {
     "depth_anything": {},
     "depth_anything3": {},
     "zipdepth": {},
+    # Raw-tensor tasks. yolonas-pose letterboxes centered on BGR frames;
+    # yolo9-pose letterboxes top-left on RGB; the rest stretch-resize RGB.
+    "nafnet": {},
+    "realesrgan": {},
+    "swinir": {},
+    "birefnet": {},
+    "l2cs": {},
     "eomt": {},
     "lingbotvision": {},
 }
@@ -654,9 +696,9 @@ def write_deepstream_sidecars(
             f"classifier-threshold={conf}",
             "classifier-async-mode=0",
         ]
-    elif task == "depth":
-        # No DeepStream post-processor for depth: hand the raw map to the
-        # application through tensor metadata.
+    elif task in _RAW_TENSOR_TASKS:
+        # No DeepStream post-processor for this task: hand the raw outputs
+        # to the application through tensor metadata.
         lines = common + [
             "process-mode=1",
             "network-type=100",

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -115,9 +115,11 @@ _INSTANCE_SEG_FAMILIES = {"rfdetr", "dfine", "ec"}
 
 # Depth families exported as a raw-tensor network (``network-type=100``
 # with ``output-tensor-meta=1``): DeepStream has no depth post-processor,
-# so the application reads the dense map from the tensor metadata. All
-# three normalize inside their own forward, so the graph takes [0, 1] RGB.
-_DEPTH_FAMILIES = {"depth_anything", "depth_anything3", "zipdepth"}
+# so the application reads the dense map from the tensor metadata. Both
+# normalize inside their own forward, so the graph takes [0, 1] RGB.
+# ``depth_anything3`` is absent: it has no export implementation at all
+# (out of scope per ADR 0006).
+_DEPTH_FAMILIES = {"depth_anything", "zipdepth"}
 
 # Tasks DeepStream has no post-processor for. They export as raw-tensor
 # networks (``network-type=100`` with ``output-tensor-meta=1``): the graph

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -43,7 +43,20 @@ import torch.nn as nn
 # Families emitting the shared raw tensor ``(B, 4 + nc, N)``: xyxy boxes in
 # input pixels then per-class scores (yolo9 head export; darknet/yolo7
 # export wrappers bake obj*cls into the class scores).
-_RAW_CHANNELS_FIRST_FAMILIES = {"yolo9", "yolo1", "yolo2", "yolo3", "yolo4", "yolo7"}
+_RAW_CHANNELS_FIRST_FAMILIES = {
+    "yolo9",
+    "yolo9_p2",
+    "yolo9_e2e",
+    "yolo1",
+    "yolo2",
+    "yolo3",
+    "yolo4",
+    "yolo7",
+}
+
+# Heads that emit at most one prediction per object (one-to-one assignment
+# or Hungarian matching). DeepStream must not cluster their output.
+_NMS_FREE_FAMILIES = {"yolo9_e2e"}
 
 # Same semantics but already ``(B, N, 4 + nc)`` (rtmdet/picodet heads).
 _RAW_CHANNELS_LAST_FAMILIES = {"rtmdet", "picodet"}
@@ -305,6 +318,8 @@ def deepstream_supported_families() -> set[str]:
 _PREPROCESS_PROFILES: dict[str, dict] = {
     # Letterbox + /255 RGB (top-left pad natively).
     "yolo9": {"maintain_aspect_ratio": 1},
+    "yolo9_p2": {"maintain_aspect_ratio": 1},
+    "yolo9_e2e": {"maintain_aspect_ratio": 1},
     "yolo7": {"maintain_aspect_ratio": 1},
     "yolo2": {"maintain_aspect_ratio": 1},
     "yolo3": {"maintain_aspect_ratio": 1},
@@ -376,11 +391,14 @@ def write_deepstream_sidecars(
     network_mode = {"fp32": 0, "int8": 1, "fp16": 2}.get(precision, 0)
     mode_name = {0: "fp32", 1: "int8", 2: "fp16"}[network_mode]
 
-    # DETR-style heads are trained with Hungarian matching and emit one query
-    # per object, so clustering is disabled (cluster-mode=4) and no IoU
-    # threshold applies. Anchor/grid detectors need NMS clustering.
-    is_detr = model_family in _DETR_TUPLE_FAMILIES | _BOXES_FIRST_DETR_FAMILIES
-    cluster_mode = 4 if is_detr else 2
+    # Heads emitting one prediction per object (DETR Hungarian matching, or
+    # YOLO9's one-to-one E2E head) must not be clustered: DeepStream's NMS
+    # would merge genuinely distinct detections. Anchor/grid heads need it.
+    nms_free = (
+        model_family
+        in _DETR_TUPLE_FAMILIES | _BOXES_FIRST_DETR_FAMILIES | _NMS_FREE_FAMILIES
+    )
+    cluster_mode = 4 if nms_free else 2
 
     lines = [
         "[property]",
@@ -409,7 +427,7 @@ def write_deepstream_sidecars(
         f"pre-cluster-threshold={conf}",
         "topk=300",
     ]
-    if not is_detr:
+    if not nms_free:
         lines.insert(len(lines) - 1, f"nms-iou-threshold={iou}")
     if offsets is not None:
         lines.insert(3, "offsets=" + ";".join(f"{o:.10g}" for o in offsets))

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -376,6 +376,12 @@ def write_deepstream_sidecars(
     network_mode = {"fp32": 0, "int8": 1, "fp16": 2}.get(precision, 0)
     mode_name = {0: "fp32", 1: "int8", 2: "fp16"}[network_mode]
 
+    # DETR-style heads are trained with Hungarian matching and emit one query
+    # per object, so clustering is disabled (cluster-mode=4) and no IoU
+    # threshold applies. Anchor/grid detectors need NMS clustering.
+    is_detr = model_family in _DETR_TUPLE_FAMILIES | _BOXES_FIRST_DETR_FAMILIES
+    cluster_mode = 4 if is_detr else 2
+
     lines = [
         "[property]",
         "gpu-id=0",
@@ -391,18 +397,20 @@ def write_deepstream_sidecars(
         "gie-unique-id=1",
         "process-mode=1",
         "network-type=0",
-        "cluster-mode=2",
+        f"cluster-mode={cluster_mode}",
         f"maintain-aspect-ratio={int(maintain_ar)}",
         f"symmetric-padding={int(symmetric_pad)}",
         f"infer-dims=3;{imgsz[0]};{imgsz[1]}",
         "parse-bbox-func-name=NvDsInferParseYolo",
         "custom-lib-path=nvdsinfer_custom_impl_Yolo/libnvdsinfer_custom_impl_Yolo.so",
+        "engine-create-func-name=NvDsInferYoloCudaEngineGet",
         "",
         "[class-attrs-all]",
-        f"nms-iou-threshold={iou}",
         f"pre-cluster-threshold={conf}",
         "topk=300",
     ]
+    if not is_detr:
+        lines.insert(len(lines) - 1, f"nms-iou-threshold={iou}")
     if offsets is not None:
         lines.insert(3, "offsets=" + ";".join(f"{o:.10g}" for o in offsets))
 

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -29,8 +29,8 @@ that project is included here.
 Known preprocessing approximations (documented in the DeepStream guide):
 
 - Letterbox families pad with gray (114/128) natively; nvinfer pads black.
-- YOLO-NAS natively resizes the longest side to 636 inside a 640 canvas;
-  nvinfer's ``maintain-aspect-ratio`` scales to the full 640.
+- YOLO-NAS detection natively resizes the longest side to 636 inside a
+  640 canvas; nvinfer's ``maintain-aspect-ratio`` scales to the full 640.
 """
 
 from __future__ import annotations
@@ -143,6 +143,7 @@ _RAW_TENSOR_TASKS = {
 def _raw_tensor_families(task: str) -> set[str]:
     """Families exportable as a raw-tensor network for ``task``."""
     return _RAW_TENSOR_TASKS.get(task, set())
+
 
 # Raw-tensor families that normalize with ImageNet stats *outside* the
 # model, so the DeepStream graph must do it (nvinfer cannot divide per
@@ -545,6 +546,17 @@ def deepstream_supported_families(task: str = "detect") -> set[str]:
     )
 
 
+def deepstream_supported_tasks() -> set[str]:
+    """Tasks with at least one DeepStream-supported family."""
+    candidates = {"detect", "classify", "segment", "semantic"} | set(_RAW_TENSOR_TASKS)
+    return {task for task in candidates if deepstream_supported_families(task)}
+
+
+def deepstream_uses_raw_outputs(task: str | None) -> bool:
+    """Whether DeepStream preserves the task's native ONNX output schema."""
+    return task in _RAW_TENSOR_TASKS
+
+
 # --- nvinfer sidecar generation -------------------------------------------
 
 # Per-family nvinfer preprocessing profile. nvinfer computes
@@ -564,7 +576,8 @@ _PREPROCESS_PROFILES: dict[str, dict] = {
     "yolo4": {"maintain_aspect_ratio": 1},
     # YOLOv1's dense head needs the plain stretch square.
     "yolo1": {},
-    # YOLO-NAS letterboxes centered (native resize-to-636 approximated).
+    # YOLO-NAS detection letterboxes centered (native resize-to-636
+    # approximated). Pose overrides the color and padding geometry below.
     "yolonas": {"maintain_aspect_ratio": 1, "symmetric_padding": 1},
     # YOLOX: BGR frames in raw 0-255 space, letterboxed.
     "yolox": {
@@ -604,10 +617,9 @@ _PREPROCESS_PROFILES: dict[str, dict] = {
     "pidnet": {"maintain_aspect_ratio": 1},
     # Depth: nets normalize internally, so [0, 1] RGB; all stretch-resize.
     "depth_anything": {},
-    "depth_anything3": {},
     "zipdepth": {},
-    # Raw-tensor tasks. yolonas-pose letterboxes centered on BGR frames;
-    # yolo9-pose letterboxes top-left on RGB; the rest stretch-resize RGB.
+    # Raw-tensor tasks. yolo9-pose letterboxes top-left on RGB; the rest
+    # stretch-resize RGB unless overridden below.
     "nafnet": {},
     "realesrgan": {},
     "swinir": {},
@@ -615,6 +627,17 @@ _PREPROCESS_PROFILES: dict[str, dict] = {
     "l2cs": {},
     "eomt": {},
     "lingbotvision": {},
+}
+
+# A family can have task-specific preprocessing. YOLO-NAS pose consumes BGR
+# and pads on the bottom/right at the full 640 resize, unlike YOLO-NAS
+# detection's RGB, centered, resize-to-636 contract.
+_TASK_PREPROCESS_PROFILES: dict[tuple[str, str], dict] = {
+    ("yolonas", "pose"): {
+        "model_color_format": 1,
+        "maintain_aspect_ratio": 1,
+        "symmetric_padding": 0,
+    },
 }
 
 
@@ -625,7 +648,6 @@ def write_deepstream_sidecars(
     class_names: list[str],
     imgsz: tuple[int, int],
     batch: int,
-    dynamic: bool,
     precision: str,
     conf: float = 0.25,
     iou: float = 0.45,
@@ -649,7 +671,10 @@ def write_deepstream_sidecars(
     else:
         labels_path = None
 
-    profile = _PREPROCESS_PROFILES.get(model_family, {})
+    profile = {
+        **_PREPROCESS_PROFILES.get(model_family, {}),
+        **_TASK_PREPROCESS_PROFILES.get((model_family, task), {}),
+    }
     net_scale = profile.get("net_scale_factor", 1.0 / 255.0)
     offsets = profile.get("offsets")
     maintain_ar = profile.get("maintain_aspect_ratio", 0)
@@ -675,16 +700,14 @@ def write_deepstream_sidecars(
         f"model-color-format={color_format}",
         f"onnx-file={onnx_file.name}",
         f"model-engine-file={onnx_file.name}_b{batch}_gpu0_{mode_name}.engine",
-        *(
-            [f"labelfile-path={labels_path.name}"]
-            if labels_path is not None
-            else []
-        ),
+        *([f"labelfile-path={labels_path.name}"] if labels_path is not None else []),
         f"batch-size={batch}",
         f"network-mode={network_mode}",
         "interval=0",
         "gie-unique-id=1",
         f"infer-dims=3;{imgsz[0]};{imgsz[1]}",
+        f"maintain-aspect-ratio={int(maintain_ar)}",
+        f"symmetric-padding={int(symmetric_pad)}",
     ]
 
     if task == "classify":
@@ -715,8 +738,6 @@ def write_deepstream_sidecars(
             f"num-detected-classes={len(class_names)}",
             # DETR-style seg heads emit one query per object: no clustering.
             "cluster-mode=4",
-            f"maintain-aspect-ratio={int(maintain_ar)}",
-            f"symmetric-padding={int(symmetric_pad)}",
             "output-instance-mask=1",
             f"segmentation-threshold={conf}",
             "parse-bbox-instance-mask-func-name=NvDsInferParseYoloSeg",
@@ -742,8 +763,6 @@ def write_deepstream_sidecars(
             "network-type=0",
             f"num-detected-classes={len(class_names)}",
             f"cluster-mode={cluster_mode}",
-            f"maintain-aspect-ratio={int(maintain_ar)}",
-            f"symmetric-padding={int(symmetric_pad)}",
             "parse-bbox-func-name=NvDsInferParseYolo",
             "custom-lib-path=nvdsinfer_custom_impl_Yolo/"
             "libnvdsinfer_custom_impl_Yolo.so",
@@ -756,8 +775,6 @@ def write_deepstream_sidecars(
         if not nms_free:
             lines.insert(len(lines) - 1, f"nms-iou-threshold={iou}")
 
-    if maintain_ar and task != "detect":
-        lines.append(f"maintain-aspect-ratio={int(maintain_ar)}")
     if offsets is not None:
         lines.insert(3, "offsets=" + ";".join(f"{o:.10g}" for o in offsets))
 

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -683,6 +683,13 @@ def write_deepstream_sidecars(
 
     network_mode = {"fp32": 0, "int8": 1, "fp16": 2}.get(precision, 0)
     mode_name = {0: "fp32", 1: "int8", 2: "fp16"}[network_mode]
+    # DeepStream-Yolo's custom engine builder serializes detection engines
+    # with this fixed basename, regardless of the ONNX filename.
+    engine_name = (
+        f"model_b{batch}_gpu0_{mode_name}.engine"
+        if task == "detect"
+        else f"{onnx_file.name}_b{batch}_gpu0_{mode_name}.engine"
+    )
 
     # Heads emitting one prediction per object (DETR Hungarian matching, or
     # YOLO9's one-to-one E2E head) must not be clustered: DeepStream's NMS
@@ -699,7 +706,7 @@ def write_deepstream_sidecars(
         f"net-scale-factor={net_scale:.10g}",
         f"model-color-format={color_format}",
         f"onnx-file={onnx_file.name}",
-        f"model-engine-file={onnx_file.name}_b{batch}_gpu0_{mode_name}.engine",
+        f"model-engine-file={engine_name}",
         *([f"labelfile-path={labels_path.name}"] if labels_path is not None else []),
         f"batch-size={batch}",
         f"network-mode={network_mode}",

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -107,6 +107,12 @@ _SEMANTIC_FAMILIES = {
     "lingbotvision",
 }
 
+# Instance segmentation families exportable as an nvinfer instance-mask
+# network (``network-type=3``). All are DETR-style and export per-query
+# masks as a third output. RTMDet-Ins and YOLO9 are absent: their seg
+# export is blocked upstream in libreyolo.export.support.
+_INSTANCE_SEG_FAMILIES = {"rfdetr", "dfine", "ec"}
+
 # EoMT's "semantic_logits" are already per-pixel probabilities
 # (``class.softmax() @ mask.sigmoid()``), so a second softmax would distort
 # the values ``segmentation-threshold`` compares against.
@@ -344,6 +350,63 @@ class DeepStreamSemanticOutput(nn.Module):
         return torch.softmax(logits, dim=1) if self.apply_softmax else logits
 
 
+class DeepStreamInstanceSegOutput(nn.Module):
+    """Adapt DETR-style instance segmentation to the seg parser layout.
+
+    The seg parser (``NvDsInferParseYoloSeg`` from DeepStream-Yolo-Seg, MIT)
+    reads one tensor of ``(B, N, 6 + mask_size)`` rows: the usual
+    ``[x1, y1, x2, y2, score, class]`` followed by that detection's mask
+    flattened at exactly ``(netH / 4, netW / 4)`` — the parser hardcodes
+    that resolution — as probabilities for ``segmentation-threshold``.
+
+    LibreYOLO's seg families export per-query masks directly rather than
+    prototype coefficients, so the adapter resizes them to the quarter
+    canvas and sigmoids, with no RoI pooling or custom TensorRT plugin.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        imgsz: tuple[int, int],
+        boxes_first: bool,
+    ):
+        super().__init__()
+        self.model = model
+        self.boxes_first = boxes_first
+        h, w = imgsz
+        self.mask_h = h // 4
+        self.mask_w = w // 4
+        self.register_buffer(
+            "_scale",
+            torch.tensor([w, h, w, h], dtype=torch.float32),
+            persistent=False,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.model(x)
+        if self.boxes_first:
+            boxes_norm, logits, masks = out[0], out[1], out[2]
+        else:
+            logits, boxes_norm, masks = out[0], out[1], out[2]
+
+        scores_all = logits.float().sigmoid()
+        cxcy = boxes_norm[..., :2].float()
+        half_wh = boxes_norm[..., 2:4].float() * 0.5
+        boxes = torch.cat((cxcy - half_wh, cxcy + half_wh), dim=-1) * self._scale
+        rows = _rows_from(boxes, scores_all)
+
+        # (B, Q, mh, mw) -> quarter-canvas probabilities, flattened per query.
+        masks = masks.float()
+        b, q = masks.shape[0], masks.shape[1]
+        masks = torch.nn.functional.interpolate(
+            masks,
+            size=(self.mask_h, self.mask_w),
+            mode="bilinear",
+            align_corners=False,
+        ).sigmoid()
+        return torch.cat((rows, masks.reshape(b, q, self.mask_h * self.mask_w)), dim=-1)
+
+
 def wrap_for_deepstream(
     nn_model: nn.Module,
     *,
@@ -363,6 +426,18 @@ def wrap_for_deepstream(
         # model, and nvinfer cannot divide per channel: bake it in.
         return DeepStreamClassifierOutput(
             _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
+        )
+    if task == "segment":
+        if model_family not in _INSTANCE_SEG_FAMILIES:
+            raise NotImplementedError(
+                f"DeepStream instance segmentation export is not supported for "
+                f"family {model_family!r}. Supported: "
+                f"{sorted(_INSTANCE_SEG_FAMILIES)}"
+            )
+        return DeepStreamInstanceSegOutput(
+            _maybe_normalize(nn_model, model_family, model_size),
+            imgsz,
+            boxes_first=model_family in _BOXES_FIRST_DETR_FAMILIES,
         )
     if task == "semantic":
         if model_family not in _SEMANTIC_FAMILIES:
@@ -402,6 +477,8 @@ def deepstream_supported_families(task: str = "detect") -> set[str]:
         return set(_CLASSIFY_FAMILIES)
     if task == "semantic":
         return set(_SEMANTIC_FAMILIES)
+    if task == "segment":
+        return set(_INSTANCE_SEG_FAMILIES)
     if task != "detect":
         return set()
     return (
@@ -547,6 +624,26 @@ def write_deepstream_sidecars(
             f"num-detected-classes={len(class_names)}",
             f"classifier-threshold={conf}",
             "classifier-async-mode=0",
+        ]
+    elif task == "segment":
+        # Instance masks come from the DeepStream-Yolo-Seg parser library,
+        # which is a separate build from the detection one.
+        lines = common + [
+            "process-mode=1",
+            "network-type=3",
+            f"num-detected-classes={len(class_names)}",
+            # DETR-style seg heads emit one query per object: no clustering.
+            "cluster-mode=4",
+            f"maintain-aspect-ratio={int(maintain_ar)}",
+            f"symmetric-padding={int(symmetric_pad)}",
+            "output-instance-mask=1",
+            f"segmentation-threshold={conf}",
+            "parse-bbox-instance-mask-func-name=NvDsInferParseYoloSeg",
+            "custom-lib-path=nvdsinfer_custom_impl_Yolo_seg/"
+            "libnvdsinfer_custom_impl_Yolo_seg.so",
+            "",
+            "[class-attrs-all]",
+            f"pre-cluster-threshold={conf}",
         ]
     elif task == "semantic":
         # Native nvinfer segmentation: consumes (C, H, W) probabilities and

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -1,0 +1,410 @@
+"""DeepStream-ready ONNX export: output wrapper + nvinfer config generation.
+
+DeepStream's ``nvinfer`` element consumes ONNX directly (it builds the
+TensorRT engine on device) but needs a custom bounding-box parser for
+non-standard detector heads. The community-standard parser
+(`marcoslucianops/DeepStream-Yolo <https://github.com/marcoslucianops/DeepStream-Yolo>`_,
+MIT) expects a single output tensor of shape ``(batch, num_detections, 6)``
+where each row is ``[x1, y1, x2, y2, score, class_id]`` in network-input
+pixel coordinates. The parser applies the confidence threshold; suppression
+runs in DeepStream's clustering stage (``cluster-mode=2`` + NMS IoU), so no
+NMS is embedded in the graph.
+
+This module provides:
+
+- Graph adapters mapping each LibreYOLO detector family's export output to
+  that contract (layout only; detection math is unchanged and verified by
+  parity tests against the family's native postprocess). Families whose
+  native preprocessing cannot be expressed by nvinfer's
+  ``scale * (x - offsets)`` (per-channel std division) get the
+  normalization baked into the DeepStream graph instead.
+- ``write_deepstream_sidecars``, which generates a ready-to-use
+  ``config_infer_primary_*.txt`` and ``labels.txt`` next to the exported
+  ONNX, with preprocessing constants matching the family's native pipeline.
+
+The tensor-contract description above is derived from the MIT-licensed
+DeepStream-Yolo parser sources (nvdsinfer_custom_impl_Yolo); no code from
+that project is included here.
+
+Known preprocessing approximations (documented in the DeepStream guide):
+
+- Letterbox families pad with gray (114/128) natively; nvinfer pads black.
+- YOLO-NAS natively resizes the longest side to 636 inside a 640 canvas;
+  nvinfer's ``maintain-aspect-ratio`` scales to the full 640.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+# Families emitting the shared raw tensor ``(B, 4 + nc, N)``: xyxy boxes in
+# input pixels then per-class scores (yolo9 head export; darknet/yolo7
+# export wrappers bake obj*cls into the class scores).
+_RAW_CHANNELS_FIRST_FAMILIES = {"yolo9", "yolo1", "yolo2", "yolo3", "yolo4", "yolo7"}
+
+# Same semantics but already ``(B, N, 4 + nc)`` (rtmdet/picodet heads).
+_RAW_CHANNELS_LAST_FAMILIES = {"rtmdet", "picodet"}
+
+# YOLOX head export: ``(B, N, 5 + nc)`` — cxcywh input-pixel boxes,
+# sigmoid objectness at channel 4, sigmoid class scores after (not
+# multiplied in-graph).
+_YOLOX_FAMILIES = {"yolox"}
+
+# YOLO-NAS tracing export: two tensors ``(boxes (B, N, 4) xyxy pixels,
+# scores (B, N, nc) sigmoid)``.
+_TWO_TENSOR_FAMILIES = {"yolonas"}
+
+# DETR-style families exporting ``(pred_logits, pred_boxes)`` with
+# cxcywh boxes normalized to [0, 1] and raw (pre-sigmoid) logits.
+_DETR_TUPLE_FAMILIES = {
+    "dfine",
+    "deim",
+    "deimv2",
+    "ec",
+    "rtdetr",
+    "rtdetrv2",
+    "rtdetrv4",
+}
+
+# Families exporting ``(boxes, logits)`` in RF-DETR order (boxes first).
+_BOXES_FIRST_DETR_FAMILIES = {"rfdetr"}
+
+# ImageNet constants, in [0, 1] units. nvinfer's preprocessing is
+# ``scale * (x - offsets)`` with a scalar scale, which cannot express
+# per-channel std division, so families normalizing with ImageNet stats
+# get the mean/std baked into the DeepStream graph instead (input arrives
+# from nvinfer as RGB in [0, 1] via net-scale-factor=1/255).
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+# In-graph normalization constants for families whose native pipeline
+# normalizes in 0-255 space with unequal per-channel std. Keys are the
+# family name; values are ((mean), (std)) in the family's channel order
+# (rtmdet consumes BGR frames; picodet consumes RGB).
+_GRAPH_NORM_0_255 = {
+    "rtmdet": ((103.53, 116.28, 123.675), (57.375, 57.12, 58.395)),
+    "picodet": ((123.675, 116.28, 103.53), (58.395, 57.12, 57.375)),
+}
+
+
+def _uses_imagenet_norm(model_family: str, model_size: str | None) -> bool:
+    """Whether the family's native preprocess applies ImageNet mean/std.
+
+    These families receive [0, 1] input from nvinfer and normalize
+    in-graph.
+    """
+    if model_family in {"rfdetr", "ec"}:
+        return True
+    if model_family == "deimv2":
+        # DINO-backboned sizes normalize; the HGNetv2 tiny sizes do not.
+        return model_size in {"s", "m", "l", "x"}
+    return False
+
+
+class _GraphNorm(nn.Module):
+    """Bake ``(x - mean) / std`` into the graph ahead of the model."""
+
+    def __init__(self, model: nn.Module, mean, std):
+        super().__init__()
+        self.model = model
+        self.register_buffer(
+            "_mean",
+            torch.tensor(mean, dtype=torch.float32).view(1, 3, 1, 1),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_std",
+            torch.tensor(std, dtype=torch.float32).view(1, 3, 1, 1),
+            persistent=False,
+        )
+
+    def forward(self, x: torch.Tensor):
+        return self.model((x - self._mean.to(x.dtype)) / self._std.to(x.dtype))
+
+
+def _rows_from(boxes, scores_all):
+    """Concat max-class rows: ``[x1, y1, x2, y2, best_score, best_class]``."""
+    scores, labels = scores_all.max(dim=-1)
+    return torch.cat(
+        (
+            boxes,
+            scores.unsqueeze(-1),
+            labels.unsqueeze(-1).to(boxes.dtype),
+        ),
+        dim=-1,
+    )
+
+
+class DeepStreamRawOutput(nn.Module):
+    """Adapt the shared raw detector tensor to the DeepStream parser layout.
+
+    ``channels_first=True`` wraps ``(B, 4 + nc, N)`` output (transposed
+    in-graph); ``False`` wraps ``(B, N, 4 + nc)``. Boxes are xyxy in input
+    pixels, scores per-class (objectness already folded in where the family
+    has one).
+    """
+
+    def __init__(self, model: nn.Module, channels_first: bool = True):
+        super().__init__()
+        self.model = model
+        self.channels_first = channels_first
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raw = self.model(x)
+        if isinstance(raw, (tuple, list)):
+            raw = raw[0]
+        pred = raw.transpose(1, 2) if self.channels_first else raw
+        return _rows_from(pred[..., :4].float(), pred[..., 4:].float())
+
+
+class DeepStreamYOLOXOutput(nn.Module):
+    """Adapt YOLOX export output ``(B, N, 5 + nc)`` to the parser layout.
+
+    Boxes are cxcywh in input pixels; channel 4 is sigmoid objectness and
+    the remaining channels are sigmoid class scores. Scores are
+    ``obj * cls`` (matching the native postprocess) and boxes converted to
+    xyxy.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raw = self.model(x)
+        if isinstance(raw, (tuple, list)):
+            raw = raw[0]
+        raw = raw.float()
+        cxcy = raw[..., :2]
+        half_wh = raw[..., 2:4] * 0.5
+        boxes = torch.cat((cxcy - half_wh, cxcy + half_wh), dim=-1)
+        scores_all = raw[..., 5:] * raw[..., 4:5]
+        return _rows_from(boxes, scores_all)
+
+
+class DeepStreamTwoTensorOutput(nn.Module):
+    """Adapt two-tensor exports ``(boxes, scores)`` (YOLO-NAS).
+
+    YOLO-NAS switches on ``torch.jit.is_tracing()``: the traced graph returns
+    the decoded ``(boxes, scores)`` pair directly, while an eager call
+    returns ``(decoded, raw_training_outputs)``. Unwrap the nested form so
+    the adapter behaves identically in both.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.model(x)
+        if isinstance(out[0], (tuple, list)):
+            out = out[0]
+        boxes, scores_all = out[0], out[1]
+        return _rows_from(boxes.float(), scores_all.float())
+
+
+class DeepStreamDETROutput(nn.Module):
+    """Adapt DETR-style ``(logits, boxes)`` outputs to the parser layout.
+
+    ``boxes`` are cxcywh normalized to [0, 1]; ``logits`` are raw class
+    logits scored with sigmoid (matching the family postprocess). Output is
+    ``(B, Q, 6)`` rows of ``[x1, y1, x2, y2, best_score, best_class]`` in
+    input-pixel coordinates.
+
+    Args:
+        model: Export-mode model (family export wrapper applied).
+        imgsz: Export canvas ``(height, width)`` used to scale boxes.
+        boxes_first: True for families returning ``(boxes, logits)``
+            (RF-DETR order) instead of ``(logits, boxes)``.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        imgsz: tuple[int, int],
+        boxes_first: bool,
+    ):
+        super().__init__()
+        self.model = model
+        self.boxes_first = boxes_first
+        h, w = imgsz
+        self.register_buffer(
+            "_scale",
+            torch.tensor([w, h, w, h], dtype=torch.float32),
+            persistent=False,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.model(x)
+        if self.boxes_first:
+            boxes_norm, logits = out[0], out[1]
+        else:
+            logits, boxes_norm = out[0], out[1]
+        scores_all = logits.float().sigmoid()
+        cxcy = boxes_norm[..., :2].float()
+        half_wh = boxes_norm[..., 2:4].float() * 0.5
+        boxes = torch.cat((cxcy - half_wh, cxcy + half_wh), dim=-1) * self._scale
+        return _rows_from(boxes, scores_all)
+
+
+def wrap_for_deepstream(
+    nn_model: nn.Module,
+    *,
+    model_family: str,
+    imgsz: tuple[int, int],
+    model_size: str | None = None,
+) -> nn.Module:
+    """Wrap an export-mode model with the DeepStream output adapter."""
+    if model_family in _GRAPH_NORM_0_255:
+        mean, std = _GRAPH_NORM_0_255[model_family]
+        nn_model = _GraphNorm(nn_model, mean, std)
+    elif _uses_imagenet_norm(model_family, model_size):
+        nn_model = _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
+
+    if model_family in _RAW_CHANNELS_FIRST_FAMILIES:
+        return DeepStreamRawOutput(nn_model, channels_first=True)
+    if model_family in _RAW_CHANNELS_LAST_FAMILIES:
+        return DeepStreamRawOutput(nn_model, channels_first=False)
+    if model_family in _YOLOX_FAMILIES:
+        return DeepStreamYOLOXOutput(nn_model)
+    if model_family in _TWO_TENSOR_FAMILIES:
+        return DeepStreamTwoTensorOutput(nn_model)
+    if model_family in _DETR_TUPLE_FAMILIES:
+        return DeepStreamDETROutput(nn_model, imgsz, boxes_first=False)
+    if model_family in _BOXES_FIRST_DETR_FAMILIES:
+        return DeepStreamDETROutput(nn_model, imgsz, boxes_first=True)
+    raise NotImplementedError(
+        f"DeepStream export is not supported for model family {model_family!r}. "
+        f"Supported families: {sorted(deepstream_supported_families())}"
+    )
+
+
+def deepstream_supported_families() -> set[str]:
+    """Families accepted by :func:`wrap_for_deepstream`."""
+    return (
+        _RAW_CHANNELS_FIRST_FAMILIES
+        | _RAW_CHANNELS_LAST_FAMILIES
+        | _YOLOX_FAMILIES
+        | _TWO_TENSOR_FAMILIES
+        | _DETR_TUPLE_FAMILIES
+        | _BOXES_FIRST_DETR_FAMILIES
+    )
+
+
+# --- nvinfer sidecar generation -------------------------------------------
+
+# Per-family nvinfer preprocessing profile. nvinfer computes
+# ``y = net-scale-factor * (x - offsets)`` per channel on the input frame;
+# combined with any in-graph normalization above, this must reproduce the
+# family's native preprocessing. ``maintain_aspect_ratio`` /
+# ``symmetric_padding`` mirror the family's letterbox geometry;
+# ``model_color_format`` is 0 for RGB, 1 for BGR.
+_PREPROCESS_PROFILES: dict[str, dict] = {
+    # Letterbox + /255 RGB (top-left pad natively).
+    "yolo9": {"maintain_aspect_ratio": 1},
+    "yolo7": {"maintain_aspect_ratio": 1},
+    "yolo2": {"maintain_aspect_ratio": 1},
+    "yolo3": {"maintain_aspect_ratio": 1},
+    "yolo4": {"maintain_aspect_ratio": 1},
+    # YOLOv1's dense head needs the plain stretch square.
+    "yolo1": {},
+    # YOLO-NAS letterboxes centered (native resize-to-636 approximated).
+    "yolonas": {"maintain_aspect_ratio": 1, "symmetric_padding": 1},
+    # YOLOX: BGR frames in raw 0-255 space, letterboxed.
+    "yolox": {
+        "net_scale_factor": 1.0,
+        "model_color_format": 1,
+        "maintain_aspect_ratio": 1,
+    },
+    # RTMDet: BGR 0-255 with in-graph mean/std, letterboxed.
+    "rtmdet": {
+        "net_scale_factor": 1.0,
+        "model_color_format": 1,
+        "maintain_aspect_ratio": 1,
+    },
+    # PicoDet: RGB 0-255 with in-graph mean/std, stretch resize.
+    "picodet": {"net_scale_factor": 1.0},
+    # DETR families: stretch resize, /255 RGB (ImageNet stats in-graph
+    # where the family uses them).
+    "rfdetr": {},
+    "dfine": {},
+    "deim": {},
+    "deimv2": {},
+    "ec": {},
+    "rtdetr": {},
+    "rtdetrv2": {},
+    "rtdetrv4": {},
+}
+
+
+def write_deepstream_sidecars(
+    onnx_path: str,
+    *,
+    model_family: str,
+    class_names: list[str],
+    imgsz: tuple[int, int],
+    batch: int,
+    dynamic: bool,
+    precision: str,
+    conf: float = 0.25,
+    iou: float = 0.45,
+) -> tuple[str, str]:
+    """Write ``config_infer_primary_<stem>.txt`` and ``<stem>_labels.txt``.
+
+    Returns the ``(config_path, labels_path)`` pair. The config targets the
+    MIT DeepStream-Yolo parser library (``NvDsInferParseYolo``); the
+    ``custom-lib-path`` is left pointing at the conventional build output of
+    that project for the user to adjust.
+    """
+    onnx_file = Path(onnx_path)
+    stem = onnx_file.stem
+    labels_path = onnx_file.with_name(f"{stem}_labels.txt")
+    config_path = onnx_file.with_name(f"config_infer_primary_{stem}.txt")
+
+    labels_path.write_text("\n".join(class_names) + "\n", encoding="utf-8")
+
+    profile = _PREPROCESS_PROFILES.get(model_family, {})
+    net_scale = profile.get("net_scale_factor", 1.0 / 255.0)
+    offsets = profile.get("offsets")
+    maintain_ar = profile.get("maintain_aspect_ratio", 0)
+    symmetric_pad = profile.get("symmetric_padding", 0)
+    color_format = profile.get("model_color_format", 0)
+
+    network_mode = {"fp32": 0, "int8": 1, "fp16": 2}.get(precision, 0)
+    mode_name = {0: "fp32", 1: "int8", 2: "fp16"}[network_mode]
+
+    lines = [
+        "[property]",
+        "gpu-id=0",
+        f"net-scale-factor={net_scale:.10g}",
+        f"model-color-format={color_format}",
+        f"onnx-file={onnx_file.name}",
+        f"model-engine-file={onnx_file.name}_b{batch}_gpu0_{mode_name}.engine",
+        f"labelfile-path={labels_path.name}",
+        f"batch-size={batch}",
+        f"network-mode={network_mode}",
+        f"num-detected-classes={len(class_names)}",
+        "interval=0",
+        "gie-unique-id=1",
+        "process-mode=1",
+        "network-type=0",
+        "cluster-mode=2",
+        f"maintain-aspect-ratio={int(maintain_ar)}",
+        f"symmetric-padding={int(symmetric_pad)}",
+        f"infer-dims=3;{imgsz[0]};{imgsz[1]}",
+        "parse-bbox-func-name=NvDsInferParseYolo",
+        "custom-lib-path=nvdsinfer_custom_impl_Yolo/libnvdsinfer_custom_impl_Yolo.so",
+        "",
+        "[class-attrs-all]",
+        f"nms-iou-threshold={iou}",
+        f"pre-cluster-threshold={conf}",
+        "topk=300",
+    ]
+    if offsets is not None:
+        lines.insert(3, "offsets=" + ";".join(f"{o:.10g}" for o in offsets))
+
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(config_path), str(labels_path)

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -445,7 +445,7 @@ class DeepStreamInstanceSegOutput(nn.Module):
         return torch.cat((rows, masks.reshape(b, q, self.mask_h * self.mask_w)), dim=-1)
 
 
-def wrap_for_deepstream(
+def _build_deepstream_wrapper(
     nn_model: nn.Module,
     *,
     model_family: str,
@@ -453,7 +453,7 @@ def wrap_for_deepstream(
     model_size: str | None = None,
     task: str = "detect",
 ) -> nn.Module:
-    """Wrap an export-mode model with the DeepStream output adapter."""
+    """Pick the DeepStream output adapter for ``model_family``/``task``."""
     if task == "classify":
         if model_family not in _CLASSIFY_FAMILIES:
             raise NotImplementedError(
@@ -522,6 +522,33 @@ def wrap_for_deepstream(
         f"DeepStream export is not supported for model family {model_family!r}. "
         f"Supported families: {sorted(deepstream_supported_families())}"
     )
+
+
+def wrap_for_deepstream(
+    nn_model: nn.Module,
+    *,
+    model_family: str,
+    imgsz: tuple[int, int],
+    model_size: str | None = None,
+    task: str = "detect",
+) -> nn.Module:
+    """Wrap an export-mode model with the DeepStream output adapter."""
+    wrapped = _build_deepstream_wrapper(
+        nn_model,
+        model_family=model_family,
+        imgsz=imgsz,
+        model_size=model_size,
+        task=task,
+    )
+    if wrapped is nn_model:
+        return wrapped
+    # The adapters hold constant buffers (_scale, _mean, _std) built on CPU,
+    # while the model being exported may already sit on CUDA. Line them up or
+    # tracing dies on a device mismatch.
+    params = next(nn_model.parameters(), None)
+    if params is not None:
+        wrapped = wrapped.to(params.device)
+    return wrapped
 
 
 def deepstream_supported_families(task: str = "detect") -> set[str]:

--- a/libreyolo/export/deepstream.py
+++ b/libreyolo/export/deepstream.py
@@ -85,6 +85,33 @@ _DETR_TUPLE_FAMILIES = {
 # Families exporting ``(boxes, logits)`` in RF-DETR order (boxes first).
 _BOXES_FIRST_DETR_FAMILIES = {"rfdetr"}
 
+# Classification backbones exportable as an nvinfer classifier
+# (``network-type=1``). They emit raw logits; the adapter softmaxes.
+_CLASSIFY_FAMILIES = {
+    "mobilenetv4",
+    "convnext",
+    "efficientnetv2",
+    "resnet",
+    "dinov2",
+}
+
+# Semantic segmentation families exportable as an nvinfer segmentation
+# network (``network-type=2``). These normalize inside their own forward,
+# so the DeepStream graph feeds them plain [0, 1] RGB and adds no
+# normalization of its own. ``segformer`` is absent because it is not wired
+# to the shared semantic export contract and cannot export to ONNX at all.
+_SEMANTIC_FAMILIES = {
+    "pidnet",
+    "eomt",
+    "dinov2",
+    "lingbotvision",
+}
+
+# EoMT's "semantic_logits" are already per-pixel probabilities
+# (``class.softmax() @ mask.sigmoid()``), so a second softmax would distort
+# the values ``segmentation-threshold`` compares against.
+_SEMANTIC_ALREADY_PROBABILITIES = {"eomt"}
+
 # ImageNet constants, in [0, 1] units. nvinfer's preprocessing is
 # ``scale * (x - offsets)`` with a scalar scale, which cannot express
 # per-channel std division, so families normalizing with ImageNet stats
@@ -136,6 +163,18 @@ class _GraphNorm(nn.Module):
 
     def forward(self, x: torch.Tensor):
         return self.model((x - self._mean.to(x.dtype)) / self._std.to(x.dtype))
+
+
+def _maybe_normalize(
+    nn_model: nn.Module, model_family: str, model_size: str | None
+) -> nn.Module:
+    """Bake the family's normalization into the graph when nvinfer can't do it."""
+    if model_family in _GRAPH_NORM_0_255:
+        mean, std = _GRAPH_NORM_0_255[model_family]
+        return _GraphNorm(nn_model, mean, std)
+    if _uses_imagenet_norm(model_family, model_size):
+        return _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
+    return nn_model
 
 
 def _rows_from(boxes, scores_all):
@@ -263,19 +302,81 @@ class DeepStreamDETROutput(nn.Module):
         return _rows_from(boxes, scores_all)
 
 
+class DeepStreamClassifierOutput(nn.Module):
+    """Softmax a classifier's logits for ``nvinfer``'s classifier mode.
+
+    DeepStream's built-in classifier parser reads the output tensor as
+    per-class probabilities and applies ``classifier-threshold``, so the
+    softmax must live in the graph. Output stays ``(B, num_classes)``.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        logits = self.model(x)
+        if isinstance(logits, (tuple, list)):
+            logits = logits[0]
+        return torch.softmax(logits.float(), dim=-1)
+
+
+class DeepStreamSemanticOutput(nn.Module):
+    """Emit ``(B, C, H, W)`` per-class probabilities for segmentation mode.
+
+    ``nvinfer``'s segmentation post-processing applies
+    ``segmentation-threshold`` to these values and argmaxes into a class
+    map. Argmax is unchanged by softmax; the transform exists so the
+    threshold compares against real probabilities. Families whose head
+    already outputs probabilities pass through unchanged.
+    """
+
+    def __init__(self, model: nn.Module, apply_softmax: bool = True):
+        super().__init__()
+        self.model = model
+        self.apply_softmax = apply_softmax
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        logits = self.model(x)
+        if isinstance(logits, (tuple, list)):
+            logits = logits[0]
+        logits = logits.float()
+        return torch.softmax(logits, dim=1) if self.apply_softmax else logits
+
+
 def wrap_for_deepstream(
     nn_model: nn.Module,
     *,
     model_family: str,
     imgsz: tuple[int, int],
     model_size: str | None = None,
+    task: str = "detect",
 ) -> nn.Module:
     """Wrap an export-mode model with the DeepStream output adapter."""
-    if model_family in _GRAPH_NORM_0_255:
-        mean, std = _GRAPH_NORM_0_255[model_family]
-        nn_model = _GraphNorm(nn_model, mean, std)
-    elif _uses_imagenet_norm(model_family, model_size):
-        nn_model = _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
+    if task == "classify":
+        if model_family not in _CLASSIFY_FAMILIES:
+            raise NotImplementedError(
+                f"DeepStream classifier export is not supported for family "
+                f"{model_family!r}. Supported: {sorted(_CLASSIFY_FAMILIES)}"
+            )
+        # Classify transforms normalize with ImageNet stats outside the
+        # model, and nvinfer cannot divide per channel: bake it in.
+        return DeepStreamClassifierOutput(
+            _GraphNorm(nn_model, _IMAGENET_MEAN, _IMAGENET_STD)
+        )
+    if task == "semantic":
+        if model_family not in _SEMANTIC_FAMILIES:
+            raise NotImplementedError(
+                f"DeepStream segmentation export is not supported for family "
+                f"{model_family!r}. Supported: {sorted(_SEMANTIC_FAMILIES)}"
+            )
+        # Semantic nets normalize inside their own forward; adding a graph
+        # normalization here would apply ImageNet stats twice.
+        return DeepStreamSemanticOutput(
+            nn_model,
+            apply_softmax=model_family not in _SEMANTIC_ALREADY_PROBABILITIES,
+        )
+    nn_model = _maybe_normalize(nn_model, model_family, model_size)
 
     if model_family in _RAW_CHANNELS_FIRST_FAMILIES:
         return DeepStreamRawOutput(nn_model, channels_first=True)
@@ -295,8 +396,14 @@ def wrap_for_deepstream(
     )
 
 
-def deepstream_supported_families() -> set[str]:
-    """Families accepted by :func:`wrap_for_deepstream`."""
+def deepstream_supported_families(task: str = "detect") -> set[str]:
+    """Families accepted by :func:`wrap_for_deepstream` for ``task``."""
+    if task == "classify":
+        return set(_CLASSIFY_FAMILIES)
+    if task == "semantic":
+        return set(_SEMANTIC_FAMILIES)
+    if task != "detect":
+        return set()
     return (
         _RAW_CHANNELS_FIRST_FAMILIES
         | _RAW_CHANNELS_LAST_FAMILIES
@@ -352,6 +459,20 @@ _PREPROCESS_PROFILES: dict[str, dict] = {
     "rtdetr": {},
     "rtdetrv2": {},
     "rtdetrv4": {},
+    # Classification: ImageNet mean/std baked into the graph, so nvinfer
+    # just scales to [0, 1]. nvinfer stretches the frame/ROI to the network
+    # input; the native transform resizes the shortest side then centre-
+    # crops, so tight-ROI framing differs slightly (documented).
+    "mobilenetv4": {},
+    "convnext": {},
+    "efficientnetv2": {},
+    "resnet": {},
+    "dinov2": {},
+    # Semantic segmentation: nets normalize internally, so [0, 1] RGB only.
+    # pidnet letterboxes natively; the rest stretch.
+    "pidnet": {"maintain_aspect_ratio": 1},
+    "eomt": {},
+    "lingbotvision": {},
 }
 
 
@@ -366,6 +487,7 @@ def write_deepstream_sidecars(
     precision: str,
     conf: float = 0.25,
     iou: float = 0.45,
+    task: str = "detect",
 ) -> tuple[str, str]:
     """Write ``config_infer_primary_<stem>.txt`` and ``<stem>_labels.txt``.
 
@@ -400,7 +522,7 @@ def write_deepstream_sidecars(
     )
     cluster_mode = 4 if nms_free else 2
 
-    lines = [
+    common = [
         "[property]",
         "gpu-id=0",
         f"net-scale-factor={net_scale:.10g}",
@@ -410,25 +532,54 @@ def write_deepstream_sidecars(
         f"labelfile-path={labels_path.name}",
         f"batch-size={batch}",
         f"network-mode={network_mode}",
-        f"num-detected-classes={len(class_names)}",
         "interval=0",
         "gie-unique-id=1",
-        "process-mode=1",
-        "network-type=0",
-        f"cluster-mode={cluster_mode}",
-        f"maintain-aspect-ratio={int(maintain_ar)}",
-        f"symmetric-padding={int(symmetric_pad)}",
         f"infer-dims=3;{imgsz[0]};{imgsz[1]}",
-        "parse-bbox-func-name=NvDsInferParseYolo",
-        "custom-lib-path=nvdsinfer_custom_impl_Yolo/libnvdsinfer_custom_impl_Yolo.so",
-        "engine-create-func-name=NvDsInferYoloCudaEngineGet",
-        "",
-        "[class-attrs-all]",
-        f"pre-cluster-threshold={conf}",
-        "topk=300",
     ]
-    if not nms_free:
-        lines.insert(len(lines) - 1, f"nms-iou-threshold={iou}")
+
+    if task == "classify":
+        # Native nvinfer classifier: no custom parser library needed. Set
+        # process-mode=2 and operate-on-gie-id to run it as a secondary
+        # classifier behind a detector.
+        lines = common + [
+            "process-mode=1",
+            "network-type=1",
+            f"num-detected-classes={len(class_names)}",
+            f"classifier-threshold={conf}",
+            "classifier-async-mode=0",
+        ]
+    elif task == "semantic":
+        # Native nvinfer segmentation: consumes (C, H, W) probabilities and
+        # emits a class map in NvDsInferSegmentationMeta.
+        lines = common + [
+            "process-mode=1",
+            "network-type=2",
+            f"num-detected-classes={len(class_names)}",
+            f"segmentation-threshold={conf}",
+            "output-instance-mask=0",
+        ]
+    else:
+        lines = common + [
+            "process-mode=1",
+            "network-type=0",
+            f"num-detected-classes={len(class_names)}",
+            f"cluster-mode={cluster_mode}",
+            f"maintain-aspect-ratio={int(maintain_ar)}",
+            f"symmetric-padding={int(symmetric_pad)}",
+            "parse-bbox-func-name=NvDsInferParseYolo",
+            "custom-lib-path=nvdsinfer_custom_impl_Yolo/"
+            "libnvdsinfer_custom_impl_Yolo.so",
+            "engine-create-func-name=NvDsInferYoloCudaEngineGet",
+            "",
+            "[class-attrs-all]",
+            f"pre-cluster-threshold={conf}",
+            "topk=300",
+        ]
+        if not nms_free:
+            lines.insert(len(lines) - 1, f"nms-iou-threshold={iou}")
+
+    if maintain_ar and task != "detect":
+        lines.append(f"maintain-aspect-ratio={int(maintain_ar)}")
     if offsets is not None:
         lines.insert(3, "offsets=" + ";".join(f"{o:.10g}" for o in offsets))
 

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -1455,11 +1455,16 @@ class OnnxExporter(BaseExporter):
             if not isinstance(task, str):
                 task = "detect"
             family = self.model._get_model_name()
-            if task != "detect" or family not in deepstream_supported_families():
+            supported = deepstream_supported_families(task)
+            if not supported:
                 raise NotImplementedError(
-                    "DeepStream ONNX export supports detection models of the "
-                    f"families {sorted(deepstream_supported_families())}; "
-                    f"got family {family!r} with task {task!r}."
+                    f"DeepStream export does not support the {task!r} task. "
+                    "Supported tasks: detect, classify, semantic."
+                )
+            if family not in supported:
+                raise NotImplementedError(
+                    f"DeepStream {task} export supports families "
+                    f"{sorted(supported)}; got {family!r}."
                 )
         super()._preflight(half=half, int8=int8, data=data, **kwargs)
 
@@ -1490,11 +1495,15 @@ class OnnxExporter(BaseExporter):
         if deepstream:
             from .deepstream import wrap_for_deepstream
 
+            ds_task = getattr(self.model, "task", "detect")
+            if not isinstance(ds_task, str):
+                ds_task = "detect"
             nn_model = wrap_for_deepstream(
                 nn_model,
                 model_family=self.model._get_model_name(),
                 imgsz=imgsz,
                 model_size=getattr(self.model, "size", None),
+                task=ds_task,
             ).eval()
 
         if nms:
@@ -1549,6 +1558,7 @@ class OnnxExporter(BaseExporter):
                 precision="int8" if int8 else ("fp16" if half else "fp32"),
                 conf=conf,
                 iou=iou,
+                task=ds_task,
             )
 
         if int8:

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -1546,7 +1546,7 @@ class OnnxExporter(BaseExporter):
                 return
             from .deepstream import write_deepstream_sidecars
 
-            names = self.model.names
+            names = getattr(self.model, "names", None) or {}
             class_names = [names[k] for k in sorted(names, key=int)]
             write_deepstream_sidecars(
                 onnx_result_path,

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -1443,6 +1443,24 @@ class OnnxExporter(BaseExporter):
                     "Embedded NMS ONNX export currently supports YOLO9 "
                     "detection models only."
                 )
+        if kwargs.get("deepstream"):
+            from .deepstream import deepstream_supported_families
+
+            if kwargs.get("nms"):
+                raise ValueError(
+                    "deepstream=True and nms=True are mutually exclusive: "
+                    "DeepStream runs suppression in its clustering stage."
+                )
+            task = getattr(self.model, "task", "detect")
+            if not isinstance(task, str):
+                task = "detect"
+            family = self.model._get_model_name()
+            if task != "detect" or family not in deepstream_supported_families():
+                raise NotImplementedError(
+                    "DeepStream ONNX export supports detection models of the "
+                    f"families {sorted(deepstream_supported_families())}; "
+                    f"got family {family!r} with task {task!r}."
+                )
         super()._preflight(half=half, int8=int8, data=data, **kwargs)
 
     def _export(
@@ -1459,6 +1477,7 @@ class OnnxExporter(BaseExporter):
         opset,
         simplify,
         nms=False,
+        deepstream=False,
         iou=0.45,
         conf=0.25,
         max_det=300,
@@ -1467,6 +1486,16 @@ class OnnxExporter(BaseExporter):
         **kwargs,
     ):
         imgsz = (dummy.shape[-2], dummy.shape[-1])
+
+        if deepstream:
+            from .deepstream import wrap_for_deepstream
+
+            nn_model = wrap_for_deepstream(
+                nn_model,
+                model_family=self.model._get_model_name(),
+                imgsz=imgsz,
+                model_size=getattr(self.model, "size", None),
+            ).eval()
 
         if nms:
             from .nms import EmbeddedNMSDetector
@@ -1499,7 +1528,28 @@ class OnnxExporter(BaseExporter):
                 meta["nms_iou"] = str(iou)
                 meta["max_det"] = str(max_det)
                 meta["nms_raw_output"] = "true"
+            if deepstream:
+                meta["deepstream"] = "true"
             return meta
+
+        def _write_deepstream_sidecars(onnx_result_path: str) -> None:
+            if not deepstream:
+                return
+            from .deepstream import write_deepstream_sidecars
+
+            names = self.model.names
+            class_names = [names[k] for k in sorted(names, key=int)]
+            write_deepstream_sidecars(
+                onnx_result_path,
+                model_family=self.model._get_model_name(),
+                class_names=class_names,
+                imgsz=imgsz,
+                batch=dummy.shape[0],
+                dynamic=dynamic,
+                precision="int8" if int8 else ("fp16" if half else "fp32"),
+                conf=conf,
+                iou=iou,
+            )
 
         if int8:
             import tempfile
@@ -1522,8 +1572,9 @@ class OnnxExporter(BaseExporter):
                     half=False,
                     metadata=_onnx_metadata(precision_half=False),
                     nms=nms,
+                    deepstream=deepstream,
                 )
-                return quantize_onnx_int8(
+                result = quantize_onnx_int8(
                     fp32_path,
                     output_path,
                     calibration_data=calibration_data,
@@ -1533,8 +1584,10 @@ class OnnxExporter(BaseExporter):
                     nodes_to_exclude=nodes_to_exclude,
                     skip_symbolic_shape=nms,
                 )
+                _write_deepstream_sidecars(result)
+                return result
 
-        return export_onnx(
+        result = export_onnx(
             nn_model,
             dummy,
             output_path=output_path,
@@ -1544,7 +1597,10 @@ class OnnxExporter(BaseExporter):
             half=half,
             metadata=_onnx_metadata(precision_half=half),
             nms=nms,
+            deepstream=deepstream,
         )
+        _write_deepstream_sidecars(result)
+        return result
 
 
 class TorchScriptExporter(BaseExporter):

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -606,6 +606,11 @@ class BaseExporter(ABC):
 
     def _preflight(self, *, half: bool, int8: bool, data: Optional[str], **kwargs):
         """Run cheap format-specific checks before model or calibration setup."""
+        if kwargs.get("deepstream") and self.format_name != "onnx":
+            raise ValueError(
+                "deepstream=True is supported only for ONNX export "
+                f"(format='onnx'); got format={self.format_name!r}."
+            )
         family = self.model._get_model_name()
         task = getattr(self.model, "task", "detect")
         if not isinstance(task, str):
@@ -1444,7 +1449,10 @@ class OnnxExporter(BaseExporter):
                     "detection models only."
                 )
         if kwargs.get("deepstream"):
-            from .deepstream import deepstream_supported_families
+            from .deepstream import (
+                deepstream_supported_families,
+                deepstream_supported_tasks,
+            )
 
             if kwargs.get("nms"):
                 raise ValueError(
@@ -1457,9 +1465,10 @@ class OnnxExporter(BaseExporter):
             family = self.model._get_model_name()
             supported = deepstream_supported_families(task)
             if not supported:
+                supported_tasks = ", ".join(sorted(deepstream_supported_tasks()))
                 raise NotImplementedError(
                     f"DeepStream export does not support the {task!r} task. "
-                    "Supported tasks: detect, classify, semantic."
+                    f"Supported tasks: {supported_tasks}."
                 )
             if family not in supported:
                 raise NotImplementedError(
@@ -1554,7 +1563,6 @@ class OnnxExporter(BaseExporter):
                 class_names=class_names,
                 imgsz=imgsz,
                 batch=dummy.shape[0],
-                dynamic=dynamic,
                 precision="int8" if int8 else ("fp16" if half else "fp32"),
                 conf=conf,
                 iou=iou,

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -176,6 +176,9 @@ def export_onnx(
             ``(batch, max_det, 6)`` detection tensor first, followed by the raw
             detector tensor used by LibreYOLO backends for native postprocess
             parity. Skip the segmentation-probe / family output-schema logic.
+        deepstream: When True, use the DeepStream-adapted schema for tasks with
+            an nvinfer post-processor. Raw-tensor tasks preserve their regular
+            ONNX output names and dynamic axes.
 
     Returns:
         The output_path string.

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -195,9 +195,10 @@ def export_onnx(
         )
 
     if deepstream:
-        # DeepStream contract: one ``(batch, num_detections, 6)`` tensor of
-        # ``[x1, y1, x2, y2, score, class]`` rows in input-pixel coordinates,
-        # consumed by the external parser library. Wrapper applied upstream.
+        # One DeepStream output tensor per task, produced by the adapter
+        # applied upstream: detection emits (batch, N, 6) parser rows,
+        # classification (batch, num_classes) probabilities, and semantic
+        # segmentation (batch, C, H, W) probabilities for the class map.
         input_name = "input" if metadata.get("model_family") == "rfdetr" else "images"
         return _export_onnx_graph(
             nn_model,

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -158,6 +158,7 @@ def export_onnx(
     half: bool,
     metadata: dict,
     nms: bool = False,
+    deepstream: bool = False,
 ) -> str:
     """Export a PyTorch model to ONNX format.
 
@@ -191,6 +192,28 @@ def export_onnx(
         raise ImportError(
             "ONNX export requires the 'onnx' package. "
             "Install with: uv sync --extra onnx  or  pip install onnx"
+        )
+
+    if deepstream:
+        # DeepStream contract: one ``(batch, num_detections, 6)`` tensor of
+        # ``[x1, y1, x2, y2, score, class]`` rows in input-pixel coordinates,
+        # consumed by the external parser library. Wrapper applied upstream.
+        input_name = "input" if metadata.get("model_family") == "rfdetr" else "images"
+        return _export_onnx_graph(
+            nn_model,
+            dummy,
+            output_path=output_path,
+            opset=opset,
+            simplify=simplify,
+            half=half,
+            metadata=metadata,
+            input_names=[input_name],
+            output_names=["output"],
+            dynamic_axes=(
+                {input_name: {0: "batch"}, "output": {0: "batch"}}
+                if dynamic
+                else None
+            ),
         )
 
     if nms:

--- a/libreyolo/export/onnx.py
+++ b/libreyolo/export/onnx.py
@@ -194,11 +194,17 @@ def export_onnx(
             "Install with: uv sync --extra onnx  or  pip install onnx"
         )
 
+    task = metadata.get("task")
+    deepstream_raw_outputs = False
     if deepstream:
-        # One DeepStream output tensor per task, produced by the adapter
-        # applied upstream: detection emits (batch, N, 6) parser rows,
-        # classification (batch, num_classes) probabilities, and semantic
-        # segmentation (batch, C, H, W) probabilities for the class map.
+        from .deepstream import deepstream_uses_raw_outputs
+
+        deepstream_raw_outputs = deepstream_uses_raw_outputs(task)
+
+    if deepstream and not deepstream_raw_outputs:
+        # Parser-backed and native nvinfer tasks use one adapted output.
+        # Raw-tensor tasks retain their normal ONNX names and dynamic axes
+        # below so applications can decode every tensor from metadata.
         input_name = "input" if metadata.get("model_family") == "rfdetr" else "images"
         return _export_onnx_graph(
             nn_model,
@@ -211,9 +217,7 @@ def export_onnx(
             input_names=[input_name],
             output_names=["output"],
             dynamic_axes=(
-                {input_name: {0: "batch"}, "output": {0: "batch"}}
-                if dynamic
-                else None
+                {input_name: {0: "batch"}, "output": {0: "batch"}} if dynamic else None
             ),
         )
 
@@ -245,7 +249,6 @@ def export_onnx(
     # to output count heuristic for direct export_onnx() calls. For known
     # DETR detection families we already know the output schema, so skip
     # the probe forward pass entirely and reuse the count below.
-    task = metadata.get("task")
     model_family = metadata.get("model_family")
     is_seg = metadata.get("segmentation") == "true" or task == "segment"
     is_yolo9_pose = model_family == "yolo9" and task == "pose"
@@ -284,7 +287,11 @@ def export_onnx(
         and not is_edge
         and not is_semantic
         and not is_gaze
-        and not is_hrnet_pose
+        # Supersedes the narrower is_hrnet_pose guard: every pose family has
+        # its own output-name branch below, and probing here would misread a
+        # multi-tensor pose head (rfdetr-pose 3, yolonas-pose 4) as
+        # segmentation via num_outputs >= 3.
+        and task != "pose"
     ):
         num_outputs = _detect_num_outputs(nn_model, dummy)
         is_seg = num_outputs >= 3

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -214,3 +214,101 @@ def test_detr_configs_disable_clustering(
 
     assert expect_cluster in config
     assert ("nms-iou-threshold" in config) is expect_nms
+
+
+class _LogitModel(torch.nn.Module):
+    def __init__(self, out: torch.Tensor):
+        super().__init__()
+        self.register_buffer("out", out)
+
+    def forward(self, x):
+        return self.out + x.sum() * 0.0
+
+
+def test_classifier_adapter_emits_probabilities():
+    from libreyolo.export.deepstream import DeepStreamClassifierOutput
+
+    logits = torch.tensor([[1.0, 2.0, 3.0]])
+    out = DeepStreamClassifierOutput(_LogitModel(logits))(torch.zeros(1, 3, 8, 8))
+
+    np.testing.assert_allclose(
+        out.numpy(), torch.softmax(logits, dim=-1).numpy(), rtol=1e-6
+    )
+    assert out.sum().item() == pytest.approx(1.0)
+
+
+def test_semantic_adapter_softmaxes_over_class_axis():
+    from libreyolo.export.deepstream import DeepStreamSemanticOutput
+
+    logits = torch.randn(1, 4, 5, 6)
+    out = DeepStreamSemanticOutput(_LogitModel(logits))(torch.zeros(1, 3, 8, 8))
+
+    assert out.shape == (1, 4, 5, 6)
+    np.testing.assert_allclose(
+        out.sum(dim=1).numpy(), np.ones((1, 5, 6), dtype=np.float32), rtol=1e-5
+    )
+
+
+def test_semantic_adapter_passthrough_for_probability_heads():
+    """EoMT already emits probabilities; a second softmax would distort them."""
+    from libreyolo.export.deepstream import (
+        DeepStreamSemanticOutput,
+        wrap_for_deepstream,
+        _SEMANTIC_ALREADY_PROBABILITIES,
+    )
+
+    assert "eomt" in _SEMANTIC_ALREADY_PROBABILITIES
+
+    probs = torch.rand(1, 3, 4, 4)
+    out = DeepStreamSemanticOutput(_LogitModel(probs), apply_softmax=False)(
+        torch.zeros(1, 3, 8, 8)
+    )
+    np.testing.assert_allclose(out.numpy(), probs.numpy(), rtol=1e-6)
+
+    wrapped = wrap_for_deepstream(
+        torch.nn.Identity(), model_family="eomt", imgsz=(512, 512), task="semantic"
+    )
+    assert wrapped.apply_softmax is False
+
+
+def test_segformer_rejected_for_semantic_export():
+    """SegFormer has no ONNX export path in this codebase."""
+    from libreyolo.export.deepstream import wrap_for_deepstream
+
+    with pytest.raises(NotImplementedError, match="not supported"):
+        wrap_for_deepstream(
+            torch.nn.Identity(),
+            model_family="segformer",
+            imgsz=(512, 512),
+            task="semantic",
+        )
+
+
+@pytest.mark.parametrize(
+    "task,family,expected",
+    [
+        ("classify", "resnet", "network-type=1"),
+        ("semantic", "pidnet", "network-type=2"),
+        ("detect", "yolo9", "network-type=0"),
+    ],
+)
+def test_config_network_type_per_task(tmp_path, task, family, expected):
+    from libreyolo.export.deepstream import write_deepstream_sidecars
+
+    onnx_path = tmp_path / f"{family}_{task}.onnx"
+    onnx_path.write_bytes(b"stub")
+    config_path, _ = write_deepstream_sidecars(
+        str(onnx_path),
+        model_family=family,
+        class_names=["a", "b"],
+        imgsz=(224, 224),
+        batch=1,
+        dynamic=False,
+        precision="fp32",
+        task=task,
+    )
+    config = Path(config_path).read_text()
+
+    assert expected in config
+    # Only detection needs the third-party bbox parser library.
+    assert ("custom-lib-path" in config) is (task == "detect")

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -312,3 +312,84 @@ def test_config_network_type_per_task(tmp_path, task, family, expected):
     assert expected in config
     # Only detection needs the third-party bbox parser library.
     assert ("custom-lib-path" in config) is (task == "detect")
+
+
+class _SegModel(torch.nn.Module):
+    def __init__(self, logits, boxes, masks):
+        super().__init__()
+        self.register_buffer("logits", logits)
+        self.register_buffer("boxes", boxes)
+        self.register_buffer("masks", masks)
+
+    def forward(self, x):
+        zero = x.sum() * 0.0
+        return self.logits + zero, self.boxes + zero, self.masks + zero
+
+
+def test_instance_seg_row_is_detection_plus_quarter_canvas_mask():
+    """The seg parser hardcodes mask_width=netW/4, mask_height=netH/4."""
+    from libreyolo.export.deepstream import DeepStreamInstanceSegOutput
+
+    imgsz = (128, 64)  # h, w -> mask 32 x 16
+    logits = torch.tensor([[[0.0, 2.0]]])
+    boxes = torch.tensor([[[0.5, 0.5, 0.2, 0.4]]])
+    masks = torch.zeros(1, 1, 8, 8)
+
+    out = DeepStreamInstanceSegOutput(
+        _SegModel(logits, boxes, masks), imgsz, boxes_first=False
+    )(torch.zeros(1, 3, *imgsz))
+
+    mask_size = (imgsz[0] // 4) * (imgsz[1] // 4)
+    assert out.shape == (1, 1, 6 + mask_size)
+
+    x1, y1, x2, y2, score, label = out[0, 0, :6].tolist()
+    # cx=0.5*64=32, w=0.2*64=12.8 -> x in [25.6, 38.4]
+    # cy=0.5*128=64, h=0.4*128=51.2 -> y in [38.4, 89.6]
+    np.testing.assert_allclose([x1, y1, x2, y2], [25.6, 38.4, 38.4, 89.6], rtol=1e-5)
+    assert label == 1.0
+    assert score == pytest.approx(torch.sigmoid(torch.tensor(2.0)).item(), rel=1e-5)
+
+    # Mask values are probabilities: sigmoid(0) == 0.5 everywhere here.
+    np.testing.assert_allclose(
+        out[0, 0, 6:].numpy(), np.full(mask_size, 0.5, dtype=np.float32), rtol=1e-6
+    )
+
+
+def test_instance_seg_config_uses_mask_parser(tmp_path):
+    from libreyolo.export.deepstream import write_deepstream_sidecars
+
+    onnx_path = tmp_path / "seg.onnx"
+    onnx_path.write_bytes(b"stub")
+    config_path, _ = write_deepstream_sidecars(
+        str(onnx_path),
+        model_family="dfine",
+        class_names=["a"],
+        imgsz=(640, 640),
+        batch=1,
+        dynamic=False,
+        precision="fp32",
+        task="segment",
+    )
+    config = Path(config_path).read_text()
+
+    assert "network-type=3" in config
+    assert "output-instance-mask=1" in config
+    assert "parse-bbox-instance-mask-func-name=NvDsInferParseYoloSeg" in config
+    # DETR seg heads emit one query per object.
+    assert "cluster-mode=4" in config
+    # Masks need the seg build of the parser, not the detection one.
+    assert "libnvdsinfer_custom_impl_Yolo_seg.so" in config
+
+
+def test_instance_seg_rejects_blocked_families():
+    """RTMDet-Ins and YOLO9 have no seg export path in libreyolo."""
+    from libreyolo.export.deepstream import wrap_for_deepstream
+
+    for family in ("rtmdet", "yolo9"):
+        with pytest.raises(NotImplementedError, match="not supported"):
+            wrap_for_deepstream(
+                torch.nn.Identity(),
+                model_family=family,
+                imgsz=(640, 640),
+                task="segment",
+            )

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -393,3 +393,39 @@ def test_instance_seg_rejects_blocked_families():
                 imgsz=(640, 640),
                 task="segment",
             )
+
+
+def test_depth_config_uses_raw_tensor_meta_and_no_labels(tmp_path):
+    """DeepStream has no depth post-processor: the app reads the tensor."""
+    from libreyolo.export.deepstream import write_deepstream_sidecars
+
+    onnx_path = tmp_path / "depth.onnx"
+    onnx_path.write_bytes(b"stub")
+    config_path, labels_path = write_deepstream_sidecars(
+        str(onnx_path),
+        model_family="zipdepth",
+        class_names=[],
+        imgsz=(384, 384),
+        batch=1,
+        dynamic=False,
+        precision="fp32",
+        task="depth",
+    )
+    config = Path(config_path).read_text()
+
+    assert "network-type=100" in config
+    assert "output-tensor-meta=1" in config
+    # Depth has no classes, so no labels file and no labelfile-path key.
+    assert labels_path == ""
+    assert "labelfile-path" not in config
+    assert not (tmp_path / "depth_labels.txt").exists()
+
+
+def test_depth_passthrough_keeps_the_map_untouched():
+    from libreyolo.export.deepstream import wrap_for_deepstream
+
+    inner = torch.nn.Identity()
+    wrapped = wrap_for_deepstream(
+        inner, model_family="zipdepth", imgsz=(384, 384), task="depth"
+    )
+    assert wrapped is inner

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -429,3 +429,71 @@ def test_depth_passthrough_keeps_the_map_untouched():
         inner, model_family="zipdepth", imgsz=(384, 384), task="depth"
     )
     assert wrapped is inner
+
+
+@pytest.mark.parametrize(
+    "task,family",
+    [
+        ("pose", "yolonas"),
+        ("restore", "realesrgan"),
+        ("matte", "birefnet"),
+        ("gaze", "l2cs"),
+        ("depth", "zipdepth"),
+    ],
+)
+def test_raw_tensor_tasks_share_one_config_shape(tmp_path, task, family):
+    """Tasks DeepStream cannot post-process all export the same way."""
+    from libreyolo.export.deepstream import write_deepstream_sidecars
+
+    onnx_path = tmp_path / f"{family}_{task}.onnx"
+    onnx_path.write_bytes(b"stub")
+    config_path, labels_path = write_deepstream_sidecars(
+        str(onnx_path),
+        model_family=family,
+        class_names=[],
+        imgsz=(224, 224),
+        batch=1,
+        dynamic=False,
+        precision="fp32",
+        task=task,
+    )
+    config = Path(config_path).read_text()
+
+    assert "network-type=100" in config
+    assert "output-tensor-meta=1" in config
+    # No parser library, no clustering, no labels: the app decodes.
+    assert "custom-lib-path" not in config
+    assert "cluster-mode" not in config
+    assert labels_path == ""
+
+
+def test_raw_tensor_normalization_is_per_family():
+    """Only families normalizing outside their forward get a graph norm."""
+    from libreyolo.export.deepstream import _GraphNorm, wrap_for_deepstream
+
+    # BiRefNet normalizes in its preprocess transform -> bake it in.
+    matte = wrap_for_deepstream(
+        torch.nn.Identity(), model_family="birefnet", imgsz=(1024, 1024), task="matte"
+    )
+    assert isinstance(matte, _GraphNorm)
+
+    # Real-ESRGAN takes plain [0, 1]; SwinIR subtracts its own mean inside
+    # forward. Neither may be normalized again.
+    for family in ("realesrgan", "swinir"):
+        inner = torch.nn.Identity()
+        assert (
+            wrap_for_deepstream(
+                inner, model_family=family, imgsz=(256, 256), task="restore"
+            )
+            is inner
+        )
+
+
+def test_raw_tensor_tasks_reject_unlisted_families():
+    from libreyolo.export.deepstream import wrap_for_deepstream
+
+    # picodet is a detector; it has no pose export.
+    with pytest.raises(NotImplementedError, match="not supported"):
+        wrap_for_deepstream(
+            torch.nn.Identity(), model_family="picodet", imgsz=(640, 640), task="pose"
+        )

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -44,6 +44,29 @@ class _TupleModel(torch.nn.Module):
         return self.a + zero, self.b + zero
 
 
+class _FourOutputModel(torch.nn.Module):
+    def forward(self, x):
+        batch = x.shape[0]
+        zero = x.sum() * 0.0
+        return (
+            torch.zeros(batch, 2, 4) + zero,
+            torch.zeros(batch, 2, 3) + zero,
+            torch.zeros(batch, 2, 17, 2) + zero,
+            torch.zeros(batch, 2, 17) + zero,
+        )
+
+
+class _ThreeOutputModel(torch.nn.Module):
+    def forward(self, x):
+        batch = x.shape[0]
+        zero = x.sum() * 0.0
+        return (
+            torch.zeros(batch, 2, 6) + zero,
+            torch.zeros(batch, 2) + zero,
+            torch.zeros(batch, 2, 17, 3) + zero,
+        )
+
+
 def test_raw_output_adapter_layout_and_argmax():
     from libreyolo.export.deepstream import DeepStreamRawOutput
 
@@ -58,9 +81,7 @@ def test_raw_output_adapter_layout_and_argmax():
 
     assert out.shape == (1, 2, 6)
     np.testing.assert_allclose(out[0, 0].numpy(), [0, 10, 20, 30, 0.7, 1.0])
-    np.testing.assert_allclose(
-        out[0, 1].numpy(), [5, 15, 25, 35, 0.9, 0.0], rtol=1e-6
-    )
+    np.testing.assert_allclose(out[0, 1].numpy(), [5, 15, 25, 35, 0.9, 0.0], rtol=1e-6)
 
 
 def test_detr_output_adapter_sigmoid_denorm_and_order():
@@ -102,7 +123,6 @@ def test_sidecar_files_content(tmp_path):
         class_names=["person", "car"],
         imgsz=(640, 640),
         batch=1,
-        dynamic=True,
         precision="fp16",
         conf=0.25,
         iou=0.45,
@@ -127,9 +147,121 @@ def test_wrap_rejects_unknown_family():
     from libreyolo.export.deepstream import wrap_for_deepstream
 
     with pytest.raises(NotImplementedError, match="not supported"):
-        wrap_for_deepstream(
-            torch.nn.Identity(), model_family="fomo", imgsz=(64, 64)
+        wrap_for_deepstream(torch.nn.Identity(), model_family="fomo", imgsz=(64, 64))
+
+
+def test_preflight_unsupported_task_lists_every_supported_task():
+    from libreyolo.export.deepstream import deepstream_supported_tasks
+    from libreyolo.export.exporter import OnnxExporter
+
+    class _Wrapper:
+        task = "obb"
+
+        @staticmethod
+        def _get_model_name():
+            return "yolo9"
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        OnnxExporter(_Wrapper())._preflight(
+            half=False, int8=False, data=None, deepstream=True
         )
+
+    message = str(exc_info.value)
+    for task in deepstream_supported_tasks():
+        assert task in message
+
+
+@pytest.mark.parametrize("format_name", ["torchscript", "coreml"])
+def test_base_preflight_rejects_deepstream_for_non_onnx_formats(format_name):
+    from libreyolo.export.exporter import BaseExporter
+
+    class _Exporter:
+        pass
+
+    exporter = _Exporter()
+    exporter.format_name = format_name
+
+    with pytest.raises(ValueError, match="only for ONNX export"):
+        BaseExporter._preflight(
+            exporter, half=False, int8=False, data=None, deepstream=True
+        )
+
+
+def test_deepstream_raw_tasks_preserve_output_names_and_dynamic_axes(
+    monkeypatch, tmp_path
+):
+    import libreyolo.export.onnx as onnx_module
+
+    captured = []
+
+    def _capture_export(*args, **kwargs):
+        captured.append(kwargs)
+        return kwargs["output_path"]
+
+    monkeypatch.setattr(onnx_module.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(onnx_module, "_export_onnx_graph", _capture_export)
+
+    onnx_module.export_onnx(
+        _FourOutputModel(),
+        torch.zeros(1, 3, 32, 32),
+        output_path=str(tmp_path / "yolonas_pose.onnx"),
+        opset=17,
+        simplify=False,
+        dynamic=True,
+        half=False,
+        metadata={"model_family": "yolonas", "task": "pose"},
+        deepstream=True,
+    )
+    onnx_module.export_onnx(
+        _ThreeOutputModel(),
+        torch.zeros(1, 3, 32, 32),
+        output_path=str(tmp_path / "rfdetr_pose.onnx"),
+        opset=17,
+        simplify=False,
+        dynamic=True,
+        half=False,
+        metadata={"model_family": "rfdetr", "task": "pose"},
+        deepstream=True,
+    )
+    onnx_module.export_onnx(
+        _TupleModel(torch.zeros(1, 66), torch.zeros(1, 66)),
+        torch.zeros(1, 3, 32, 32),
+        output_path=str(tmp_path / "gaze.onnx"),
+        opset=17,
+        simplify=False,
+        dynamic=True,
+        half=False,
+        metadata={"model_family": "l2cs", "task": "gaze"},
+        deepstream=True,
+    )
+
+    assert captured[0]["output_names"] == [
+        "boxes",
+        "scores",
+        "keypoints_xy",
+        "keypoints_conf",
+    ]
+    assert captured[0]["dynamic_axes"] == {
+        "images": {0: "batch"},
+        "boxes": {0: "batch", 1: "anchors"},
+        "scores": {0: "batch", 1: "anchors"},
+        "keypoints_xy": {0: "batch", 1: "anchors", 2: "keypoints"},
+        "keypoints_conf": {0: "batch", 1: "anchors", 2: "keypoints"},
+    }
+    assert captured[1]["input_names"] == ["input"]
+    assert captured[1]["output_names"] == ["dets", "labels", "keypoints"]
+    assert captured[1]["dynamic_axes"] == {
+        "input": {0: "batch"},
+        "dets": {0: "batch"},
+        "labels": {0: "batch"},
+        "keypoints": {0: "batch"},
+    }
+    assert captured[2]["output_names"] == ["yaw_logits", "pitch_logits"]
+    assert captured[2]["dynamic_axes"] == {
+        "images": {0: "faces"},
+        "yaw_logits": {0: "faces"},
+        "pitch_logits": {0: "faces"},
+    }
 
 
 @pytest.mark.onnx
@@ -193,9 +325,7 @@ def test_deepstream_graph_matches_torch_through_onnxruntime(
     "family,expect_cluster,expect_nms",
     [("yolo9", "cluster-mode=2", True), ("rfdetr", "cluster-mode=4", False)],
 )
-def test_detr_configs_disable_clustering(
-    tmp_path, family, expect_cluster, expect_nms
-):
+def test_detr_configs_disable_clustering(tmp_path, family, expect_cluster, expect_nms):
     """DETR heads emit one query per object, so DeepStream must not cluster."""
     from libreyolo.export.deepstream import write_deepstream_sidecars
 
@@ -207,7 +337,6 @@ def test_detr_configs_disable_clustering(
         class_names=["a"],
         imgsz=(640, 640),
         batch=1,
-        dynamic=False,
         precision="fp32",
     )
     config = Path(config_path).read_text()
@@ -303,7 +432,6 @@ def test_config_network_type_per_task(tmp_path, task, family, expected):
         class_names=["a", "b"],
         imgsz=(224, 224),
         batch=1,
-        dynamic=False,
         precision="fp32",
         task=task,
     )
@@ -366,7 +494,6 @@ def test_instance_seg_config_uses_mask_parser(tmp_path):
         class_names=["a"],
         imgsz=(640, 640),
         batch=1,
-        dynamic=False,
         precision="fp32",
         task="segment",
     )
@@ -407,7 +534,6 @@ def test_depth_config_uses_raw_tensor_meta_and_no_labels(tmp_path):
         class_names=[],
         imgsz=(384, 384),
         batch=1,
-        dynamic=False,
         precision="fp32",
         task="depth",
     )
@@ -453,7 +579,6 @@ def test_raw_tensor_tasks_share_one_config_shape(tmp_path, task, family):
         class_names=[],
         imgsz=(224, 224),
         batch=1,
-        dynamic=False,
         precision="fp32",
         task=task,
     )
@@ -465,6 +590,58 @@ def test_raw_tensor_tasks_share_one_config_shape(tmp_path, task, family):
     assert "custom-lib-path" not in config
     assert "cluster-mode" not in config
     assert labels_path == ""
+
+
+def test_yolonas_pose_config_matches_native_bgr_bottom_right_preprocess(tmp_path):
+    """Graph parity cannot catch a wrong external nvinfer preprocessor."""
+    from libreyolo.export.deepstream import write_deepstream_sidecars
+
+    onnx_path = tmp_path / "yolonas_pose.onnx"
+    onnx_path.write_bytes(b"stub")
+    config_path, _ = write_deepstream_sidecars(
+        str(onnx_path),
+        model_family="yolonas",
+        class_names=[],
+        imgsz=(640, 640),
+        batch=1,
+        precision="fp32",
+        task="pose",
+    )
+    config = Path(config_path).read_text()
+
+    assert "model-color-format=1" in config
+    assert "maintain-aspect-ratio=1" in config
+    assert "symmetric-padding=0" in config
+
+
+def test_preprocess_keys_stay_in_property_section(monkeypatch, tmp_path):
+    """Future letterboxed seg profiles must not leak keys into class attrs."""
+    import libreyolo.export.deepstream as deepstream_module
+
+    monkeypatch.setitem(
+        deepstream_module._PREPROCESS_PROFILES,
+        "dfine",
+        {"maintain_aspect_ratio": 1, "symmetric_padding": 1},
+    )
+    onnx_path = tmp_path / "dfine_seg.onnx"
+    onnx_path.write_bytes(b"stub")
+    config_path, _ = deepstream_module.write_deepstream_sidecars(
+        str(onnx_path),
+        model_family="dfine",
+        class_names=["person"],
+        imgsz=(640, 640),
+        batch=1,
+        precision="fp32",
+        task="segment",
+    )
+    property_section, class_attrs = (
+        Path(config_path).read_text().split("[class-attrs-all]", maxsplit=1)
+    )
+
+    assert "maintain-aspect-ratio=1" in property_section
+    assert "symmetric-padding=1" in property_section
+    assert "maintain-aspect-ratio" not in class_attrs
+    assert "symmetric-padding" not in class_attrs
 
 
 def test_raw_tensor_normalization_is_per_family():

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -1,0 +1,188 @@
+"""DeepStream export tests: output adapters and nvinfer sidecar generation.
+
+The DeepStream contract is a single ``(batch, num_detections, 6)`` tensor of
+``[x1, y1, x2, y2, score, class]`` rows in input-pixel coordinates; the
+external parser thresholds and DeepStream clustering suppresses. These tests
+validate the adapter math against hand-computed values and the generated
+``config_infer_primary`` / labels sidecars.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = [pytest.mark.unit, pytest.mark.export_backend]
+
+_HAS_ORT = (
+    importlib.util.find_spec("onnx") is not None
+    and importlib.util.find_spec("onnxruntime") is not None
+)
+
+
+class _RawModel(torch.nn.Module):
+    def __init__(self, raw: torch.Tensor):
+        super().__init__()
+        self.register_buffer("raw", raw)
+
+    def forward(self, x):
+        return self.raw + x.sum() * 0.0
+
+
+class _TupleModel(torch.nn.Module):
+    def __init__(self, a: torch.Tensor, b: torch.Tensor):
+        super().__init__()
+        self.register_buffer("a", a)
+        self.register_buffer("b", b)
+
+    def forward(self, x):
+        zero = x.sum() * 0.0
+        return self.a + zero, self.b + zero
+
+
+def test_raw_output_adapter_layout_and_argmax():
+    from libreyolo.export.deepstream import DeepStreamRawOutput
+
+    # (B, 4 + nc, N): two anchors, three classes.
+    raw = torch.zeros(1, 7, 2)
+    raw[0, :4, 0] = torch.tensor([0.0, 10.0, 20.0, 30.0])
+    raw[0, :4, 1] = torch.tensor([5.0, 15.0, 25.0, 35.0])
+    raw[0, 4:, 0] = torch.tensor([0.2, 0.7, 0.1])
+    raw[0, 4:, 1] = torch.tensor([0.9, 0.3, 0.4])
+
+    out = DeepStreamRawOutput(_RawModel(raw))(torch.zeros(1, 3, 64, 64))
+
+    assert out.shape == (1, 2, 6)
+    np.testing.assert_allclose(out[0, 0].numpy(), [0, 10, 20, 30, 0.7, 1.0])
+    np.testing.assert_allclose(
+        out[0, 1].numpy(), [5, 15, 25, 35, 0.9, 0.0], rtol=1e-6
+    )
+
+
+def test_detr_output_adapter_sigmoid_denorm_and_order():
+    from libreyolo.export.deepstream import DeepStreamDETROutput
+
+    # One query, two classes, cxcywh normalized on a 100x200 (h, w) canvas.
+    logits = torch.tensor([[[0.0, 2.0]]])  # sigmoid -> [0.5, 0.8808]
+    boxes = torch.tensor([[[0.5, 0.5, 0.2, 0.4]]])
+
+    model = _TupleModel(logits, boxes)
+    out = DeepStreamDETROutput(model, imgsz=(100, 200), boxes_first=False)(
+        torch.zeros(1, 3, 100, 200)
+    )
+
+    assert out.shape == (1, 1, 6)
+    x1, y1, x2, y2, score, label = out[0, 0].tolist()
+    # cx=0.5*200, w=0.2*200 -> x in [80, 120]; cy=0.5*100, h=0.4*100 -> y in [30, 70]
+    np.testing.assert_allclose([x1, y1, x2, y2], [80.0, 30.0, 120.0, 70.0], rtol=1e-5)
+    assert score == pytest.approx(torch.sigmoid(torch.tensor(2.0)).item(), rel=1e-5)
+    assert label == 1.0
+
+    # boxes_first order flips the tuple interpretation.
+    model_bf = _TupleModel(boxes, logits)
+    out_bf = DeepStreamDETROutput(model_bf, imgsz=(100, 200), boxes_first=True)(
+        torch.zeros(1, 3, 100, 200)
+    )
+    np.testing.assert_allclose(out_bf.numpy(), out.numpy(), rtol=1e-6)
+
+
+def test_sidecar_files_content(tmp_path):
+    from libreyolo.export.deepstream import write_deepstream_sidecars
+
+    onnx_path = tmp_path / "libreyolo9s.onnx"
+    onnx_path.write_bytes(b"stub")
+
+    config_path, labels_path = write_deepstream_sidecars(
+        str(onnx_path),
+        model_family="yolo9",
+        class_names=["person", "car"],
+        imgsz=(640, 640),
+        batch=1,
+        dynamic=True,
+        precision="fp16",
+        conf=0.25,
+        iou=0.45,
+    )
+
+    labels = (tmp_path / "libreyolo9s_labels.txt").read_text().splitlines()
+    assert labels == ["person", "car"]
+
+    config = (tmp_path / "config_infer_primary_libreyolo9s.txt").read_text()
+    assert "onnx-file=libreyolo9s.onnx" in config
+    assert "num-detected-classes=2" in config
+    assert "network-mode=2" in config
+    assert "cluster-mode=2" in config
+    assert "parse-bbox-func-name=NvDsInferParseYolo" in config
+    assert "pre-cluster-threshold=0.25" in config
+    assert "nms-iou-threshold=0.45" in config
+    assert config_path.endswith("config_infer_primary_libreyolo9s.txt")
+    assert labels_path.endswith("libreyolo9s_labels.txt")
+
+
+def test_wrap_rejects_unknown_family():
+    from libreyolo.export.deepstream import wrap_for_deepstream
+
+    with pytest.raises(NotImplementedError, match="not supported"):
+        wrap_for_deepstream(
+            torch.nn.Identity(), model_family="fomo", imgsz=(64, 64)
+        )
+
+
+@pytest.mark.onnx
+@pytest.mark.skipif(not _HAS_ORT, reason="requires onnx and onnxruntime")
+@pytest.mark.parametrize(
+    "adapter_name,make_model,imgsz",
+    [
+        (
+            "raw_channels_first",
+            lambda: _RawModel(torch.rand(1, 7, 5)),
+            (32, 32),
+        ),
+        (
+            "detr_tuple",
+            lambda: _TupleModel(torch.randn(1, 4, 3), torch.rand(1, 4, 4)),
+            (64, 48),
+        ),
+    ],
+)
+def test_deepstream_graph_matches_torch_through_onnxruntime(
+    tmp_path, adapter_name, make_model, imgsz
+):
+    """The exported graph reproduces the torch adapter output in ORT."""
+    import onnxruntime as ort
+
+    from libreyolo.export.deepstream import (
+        DeepStreamDETROutput,
+        DeepStreamRawOutput,
+    )
+
+    inner = make_model()
+    if adapter_name == "raw_channels_first":
+        wrapped = DeepStreamRawOutput(inner, channels_first=True).eval()
+    else:
+        wrapped = DeepStreamDETROutput(inner, imgsz, boxes_first=False).eval()
+
+    dummy = torch.randn(1, 3, *imgsz)
+    path = tmp_path / f"{adapter_name}.onnx"
+    torch.onnx.export(
+        wrapped,
+        dummy,
+        str(path),
+        input_names=["images"],
+        output_names=["output"],
+        opset_version=17,
+        dynamo=False,
+    )
+
+    with torch.no_grad():
+        expected = wrapped(dummy).numpy()
+
+    sess = ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+    got = sess.run(None, {"images": dummy.numpy()})[0]
+
+    assert got.shape == expected.shape
+    assert got.shape[-1] == 6
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-5)

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -133,6 +133,7 @@ def test_sidecar_files_content(tmp_path):
 
     config = (tmp_path / "config_infer_primary_libreyolo9s.txt").read_text()
     assert "onnx-file=libreyolo9s.onnx" in config
+    assert "model-engine-file=model_b1_gpu0_fp16.engine" in config
     assert "num-detected-classes=2" in config
     assert "network-mode=2" in config
     assert "cluster-mode=2" in config

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -497,3 +497,22 @@ def test_raw_tensor_tasks_reject_unlisted_families():
         wrap_for_deepstream(
             torch.nn.Identity(), model_family="picodet", imgsz=(640, 640), task="pose"
         )
+
+
+@pytest.mark.parametrize(
+    "family,task",
+    [
+        # No export implementation at all (ADR 0006).
+        ("depth_anything3", "depth"),
+        # Not wired to the shared semantic export contract.
+        ("segformer", "semantic"),
+    ],
+)
+def test_families_without_an_export_path_are_refused(family, task):
+    """Never generate a config for a model that cannot produce a graph."""
+    from libreyolo.export.deepstream import wrap_for_deepstream
+
+    with pytest.raises(NotImplementedError, match="not supported"):
+        wrap_for_deepstream(
+            torch.nn.Identity(), model_family=family, imgsz=(518, 518), task=task
+        )

--- a/tests/unit/test_deepstream_export.py
+++ b/tests/unit/test_deepstream_export.py
@@ -10,6 +10,7 @@ validate the adapter math against hand-computed values and the generated
 from __future__ import annotations
 
 import importlib.util
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -186,3 +187,30 @@ def test_deepstream_graph_matches_torch_through_onnxruntime(
     assert got.shape == expected.shape
     assert got.shape[-1] == 6
     np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "family,expect_cluster,expect_nms",
+    [("yolo9", "cluster-mode=2", True), ("rfdetr", "cluster-mode=4", False)],
+)
+def test_detr_configs_disable_clustering(
+    tmp_path, family, expect_cluster, expect_nms
+):
+    """DETR heads emit one query per object, so DeepStream must not cluster."""
+    from libreyolo.export.deepstream import write_deepstream_sidecars
+
+    onnx_path = tmp_path / f"{family}.onnx"
+    onnx_path.write_bytes(b"stub")
+    config_path, _ = write_deepstream_sidecars(
+        str(onnx_path),
+        model_family=family,
+        class_names=["a"],
+        imgsz=(640, 640),
+        batch=1,
+        dynamic=False,
+        precision="fp32",
+    )
+    config = Path(config_path).read_text()
+
+    assert expect_cluster in config
+    assert ("nms-iou-threshold" in config) is expect_nms


### PR DESCRIPTION
Closes part of #648.

`model.export(format="onnx", deepstream=True)` emits the nvinfer contract plus a
generated `config_infer_primary_*.txt` and labels file. 43 family/task combos
across 9 tasks.

## Runtime validated

Previously verified ONNX-vs-ONNX only. Now run through a real pipeline:

- DeepStream 8.0.0 container, RTX 5070 Ti (sm_120), driver 591.86
- `deepstream-app` to EOS, `App run successful`, 1443 frames each
- yolo9-s, `cluster-mode=2` (grid head): 18,031 dets. car 10849, person 5249, truck 591, bus 308
- dfine-s, `cluster-mode=4` (one-to-one head): 71,105 dets. car 39915, person 13336, truck 7730
- both models independently put the same bus at conf 0.965, boxes agree within 4px
- detection-count gap confirms cluster-mode is honoured (no clustering on the DETR head)
- 35 unit tests pass; pipelines re-run after the rebase, deltas <0.03% (TRT autotuning)

## Bug fixed in this PR

`wrap_for_deepstream` returned adapters holding CPU-side constant buffers
(`_scale`, `_mean`, `_std`) while the model could already be on CUDA, so export
died with a device mismatch. Hit every DETR family, every in-graph-normalized
family, and instance-seg. yolo9 escaped because it needs neither. Missed
originally because the ONNX-vs-ONNX harness runs on CPU.

Fixed by splitting dispatch into `_build_deepstream_wrapper` and moving the
result onto the model's device once.

## Known limits

- runtime-validated on x86 dGPU only, not Jetson
- 2 of 43 combos exercised through DeepStream (detect/yolo9, detect/dfine); FP32 only, batch 1
- both detect configs emit `model-engine-file=model_b1_gpu0_fp32.engine`, so two
  detection models in one directory collide on the engine cache. Follow-up.
- nvinfer rows are one class per box, so multi-label detections collapse to
  argmax. Inherent to the parser contract.

Rebased onto dev (was 526 behind). One conflict in `onnx.py`: kept the branch's
broader `task != "pose"` over dev's `not is_hrnet_pose`, which subsumes it and
stops multi-tensor pose heads being misread as segmentation.

## Code provenance

Original code written for LibreYOLO. No third-party code is included.

The output tensor layout `(batch, num_detections, 6)` with rows
`[x1, y1, x2, y2, score, class_id]`, and the nvinfer config keys, are an
interface description derived from reading the MIT-licensed
`marcoslucianops/DeepStream-Yolo` parser sources
(`nvdsinfer_custom_impl_Yolo`) and NVIDIA's DeepStream documentation. Nothing
was copied from either; the adapters and config generator are written from
scratch against that interface. The parser `.so` itself is not vendored: users
build it from the upstream MIT repository, and the generated config points at
it.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds DeepStream-ready ONNX export, including task- and family-specific output adapters, preprocessing normalization, generated nvinfer configurations, labels, validation, and documentation.

- Supports detection, classification, instance and semantic segmentation, and raw-tensor tasks.
- Adds DeepStream option validation and integrates wrapper and sidecar generation into ONNX export.
- Corrects pose output-schema detection by preventing multi-output pose heads from being inferred as segmentation.
- Adds unit coverage for adapter math, generated configurations, ONNX schemas, and device placement.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified across the supported DeepStream export paths.

The adapters, preprocessing dispatch, ONNX schema selection, sidecar generation, and pose-specific output handling align with the repository’s export contracts, and investigated edge cases were either unreachable or explicitly documented limitations.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/export/deepstream.py | Introduces DeepStream output adapters, preprocessing profiles, device-aligned normalization buffers, supported-family registries, and nvinfer sidecar generation without an accepted defect. |
| libreyolo/export/exporter.py | Validates the DeepStream option, wraps ONNX models, records metadata, and writes sidecars after FP32, FP16, or INT8 export. |
| libreyolo/export/onnx.py | Adds DeepStream-aware output schemas and prevents multi-output pose models from being incorrectly inferred as segmentation models. |
| tests/unit/test_deepstream_export.py | Covers adapter layouts, normalization, configuration generation, ONNX output contracts, and wrapper device placement. |
| docs/deepstream.md | Documents supported families and tasks, parser setup, generated artifacts, preprocessing approximations, and option constraints. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["model.export(format='onnx', deepstream=True)"] --> B[ONNX preflight]
    B --> C[Family export wrapper]
    C --> D[DeepStream task/family adapter]
    D --> E[ONNX graph export]
    E --> F[Embedded DeepStream metadata]
    E --> G[Generated nvinfer config]
    E --> H[Generated labels file]
    D --> I{Task contract}
    I -->|Detection| J["B x N x 6 parser rows"]
    I -->|Classification| K[Class probabilities]
    I -->|Semantic| L[Per-class probability map]
    I -->|Instance segmentation| M[Detection rows plus masks]
    I -->|Raw tensor task| N[Native output tensors]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Move DeepStream adapters to the model&#39;s ..."](https://github.com/libreyolo/libreyolo/commit/5f81e11e7fe6a859a9d66c254b6e482ed4be4ec8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51436261)</sub>

**Context used:**

- Knowledge Base — [Model export](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-export.md)

<!-- /greptile_comment -->