### PR TITLE
Remove capability acknowledgement gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,5 +129,8 @@
   what it did not. It never implies review or approval it does not have.
 
 ## General library constraints
+- User-facing workflows must be directly callable. Document validation evidence
+  and known limits separately; do not make acknowledgement flags the public
+  capability contract.
 - Generally every user facing API (Python, yamls, etc) has to follow the de-facto YOLO CLI/API conventions
 - The Flagship models of LibreYOLO are YOLO9 (CNNs) and RF-DETR (transformers), and new features have to at least cover this two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,7 +233,7 @@ before 1.4.0 are documented in the
   official COCO checkpoint loads all 319 state entries strictly; raw heads,
   anchors, preprocessing, and native detections are exact against the pinned
   BSD-3-Clause source. ONNX and TorchScript have trained-checkpoint runtime
-  parity, OpenVINO is experimental due to low-confidence NMS ordering drift,
+  parity, OpenVINO has a low-confidence NMS ordering drift,
   and the published `LibreFCOSr50.pt` mirror carries the explicit
   pretrained-weight license caveat
 - LibreDeepLabv3, an inference-only semantic port of torchvision's three
@@ -345,11 +345,11 @@ LibreYOLO v1.4.0: 15 new model families, 3 new tasks (panoptic, matte, OCR), a q
   - LibrePicoSAM3, native 96px promptable ROI segmentation, ONNX-only export (#585)
   - LibreOMDetTurbo, open-vocabulary detection, size t, transformers-backed (#600)
   - LibreOVDEIM, open-vocabulary detection, sizes s/m/l, native NMS-free port via LibreOpenVocab("ov-deim"); code Apache-2.0, weights CC BY-NC 4.0, licensing confirmed by the upstream author (#607)
-  - LibreSenseNovaVision (experimental), 7B unified multimodal checkpoint serving 7 tasks; weights CC BY-NC 4.0 non-commercial; not yet in __all__, the model inventory, CLI or UI (#618)
+  - LibreSenseNovaVision, 7B unified multimodal checkpoint serving 7 tasks; weights CC BY-NC 4.0 non-commercial; not yet in __all__, the model inventory, CLI or UI (#618)
 - Three new tasks: panoptic, matte, ocr, with result types PanopticSegmentation, Matte, OCRRegions and validators PanopticValidator (+ PanopticQuality), MatteValidator, OCRValidator (#557, #560, #549, #575)
 - EoMT instance segmentation and panoptic: sizes s/b/l, 640px, new 1280 weight variant, panoptic checkpoints for s/b/l (#553, #557, #560)
 - RTMDet-Ins instance segmentation, inference and validation, sizes t/s/m/l/x (training not implemented) (#572)
-- D-FINE segmentation (experimental) with published seg weights and automatic detect-to-segment transfer in CLI train (#537)
+- D-FINE segmentation with published seg weights and automatic detect-to-segment transfer in CLI train (#537)
 - NAFNet SIDD denoise weight variant (LibreNAFNetl-restore-sidd, l size only) (#549)
 - Quantization subsystem: libreyolo quantize CLI and model.quantize()/quant_info()/dequantize()/save(); recipes fp16/bf16/fp8/int8/w4a16/w4a8/nvfp4/mxfp4/int2 (research); QAT/QAD via train() on quantized checkpoints; supported families yolo9 and rfdetr; in-tree Triton kernels with a pluggable registry and LIBREYOLO_QUANT_KERNELS override (#619, #623)
 - BoT-SORT tracker (model.track(tracker="botsort"), BoTSortTracker/BoTSortConfig exported top-level) (#621)
@@ -362,7 +362,7 @@ LibreYOLO v1.4.0: 15 new model families, 3 new tasks (panoptic, matte, OCR), a q
 - Augmentations: classification auto_augment/erasing/mixup/cutmix, copy-paste for segmentation, perspective and flipud, rot90 for OBB, vflip+rot90 for restore, HSV jitter for semantic (#532)
 - Declarative augmentation spec (libreyolo/data/augment/spec.py): a per-family used/mosaic-gated/ignored matrix for every TrainConfig augmentation knob, pinned to the real pipelines by tests; the CLI now warns for every family when an explicitly-set training parameter is ignored (previously RF-DETR only), and training warns when mixup_prob is set with mosaic_prob=0 in the mosaic-gated pipelines (#635)
 - Spawn-path multi-GPU training for ResNet, ConvNeXt, EfficientNetV2, MobileNetV4 and NAFNet (#567)
-- Canonical export-support matrix with validated/experimental/blocked tiers, docs page and ADR 0011 (#578, #587)
+- Canonical export-support matrix with validated/available/blocked tiers, docs page and ADR 0011 (#578, #587)
 - TFLite inference backend (LibreYOLO("model.tflite") via ai-edge-litert, Python >= 3.12) (#587)
 - "litert" export alias for tflite and libreyolo[litert] extra (#563)
 - Semantic, depth and point export unblocked (PIDNet, FOMO, ZipDepth, Depth Anything V2 under a fixed-resolution batch-1 depth contract) (#562, #578, #587)
@@ -385,7 +385,9 @@ LibreYOLO v1.4.0: 15 new model families, 3 new tasks (panoptic, matte, OCR), a q
 - model.train(profile=True) keeps training after the profiled window; profile_then_stop=True restores the old stop behavior (#590)
 - Semantic and panoptic val/predict accept augment=True (previously raised) (#601, #608)
 - YOLO-NAS multi-class pose checkpoints load with their real class count and return real class ids (previously forced to single-class person) (#530)
-- Export gated by the support matrix: blocked combos raise up front, experimental combos warn (#578, #587)
+- Export gated by the support matrix: blocked combinations raise up front;
+  callable combinations proceed without blanket warnings, with validation
+  context recorded in the generated support documentation (#578, #587)
 - RF-DETR imgsz validated early in predict/val/export with suggested valid sizes (#551)
 - EC training config augmentation defaults zeroed to match the trainer's actual pass-through path (executed training unchanged) (#551)
 - libreyolo models --json schema changed (task-suffixed cli_names, new keys); libreyolo formats/info JSON gained keys (#578)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ LibreYOLO is MIT. That only stays true if every contribution is clean:
 - Changes that add, remove, or reinterpret checkpoint metadata must update
   `docs/checkpoint_schema.md` and the shared helpers in
   `libreyolo/utils/serialization.py`.
+- Describe user-facing workflows in terms of the validation evidence they have;
+  keep known limits separate from the callable API contract.
 
 ## LLM policy
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  test_install_smoke            - Run clean install smoke (MODE=editable|wheel|sdist|pypi)"
 	@echo "  test_e2e                      - Run all e2e tests (needs GPU + model weights)"
 	@echo "  test_e2e FROM=<file>          - Resume from a test file (e.g. FROM=test_rf1_training.py or FROM=rf1_training)"
-	@echo "  test_e2e MARKERS='<expr>'     - Run only matching e2e markers (e.g. MARKERS='e2e and not experimental_backend')"
+	@echo "  test_e2e MARKERS='<expr>'     - Run only matching e2e markers (e.g. MARKERS='e2e and not extended_backend')"
 	@echo "  test_e2e MARKER='<expr>'      - Alias for MARKERS=..., also works with FROM=..."
 	@echo "  test_e2e E2E_TIMEOUT=<secs>   - Per-test timeout, default 900 (0 disables)"
 	@echo "  print_nightly_suite           - Print nightly suite version and contract"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ LibreYOLO 推荐以下模型系列，因为它们在性能上达到最佳平衡�
 
 ## 兼容性
 
-`✓` 表示支持，`exp` 表示实验性支持。空单元格表示当前不支持。
+`✓` 表示支持。空单元格表示当前不支持。
 
 <table>
   <thead>
@@ -81,25 +81,25 @@ LibreYOLO 推荐以下模型系列，因为它们在性能上达到最佳平衡�
   </thead>
   <tbody>
     <tr><td><strong>⭐ YOLOv9</strong></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
-    <tr><td><strong>⭐ RF-DETR</strong></td><td>✓</td><td>✓</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td>exp</td></tr>
-    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td></tr>
-    <tr><td>YOLOv9-E2E</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td><td></td></tr>
-    <tr><td>YOLOv9-P2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>exp</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>YOLO-NAS</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td></tr>
+    <tr><td><strong>⭐ RF-DETR</strong></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td>✓</td></tr>
+    <tr><td>YOLOX</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
+    <tr><td>YOLOv9-E2E</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td><td></td></tr>
+    <tr><td>YOLOv9-P2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>YOLO-NAS</td><td>✓</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td></tr>
     <tr><td>CenterNet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td></tr>
     <tr><td>HRNet</td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
-    <tr><td>D-FINE</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td></tr>
-    <tr><td>DEIM</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td></tr>
-    <tr><td>DEIMv2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td></tr>
-    <tr><td>RT-DETR</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td></tr>
-    <tr><td>RT-DETRv2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>RT-DETRv4</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>D-FINE</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
+    <tr><td>DEIM</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
+    <tr><td>DEIMv2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
+    <tr><td>RT-DETR</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
+    <tr><td>RT-DETRv2</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>RT-DETRv4</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>RetinaNet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>DINO-DETR</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td></tr>
-    <tr><td>PicoDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td>exp</td><td>exp</td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>RTMDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>DINO-DETR</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td></tr>
+    <tr><td>PicoDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>RTMDet</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>Mask R-CNN</td><td>✓</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
-    <tr><td>EC</td><td>✓</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td>exp</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+    <tr><td>EC</td><td>✓</td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>ViT</td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>SSD300</td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td></tr>
     <tr><td>L2CS</td><td></td><td></td><td></td><td></td><td></td><td></td><td>✓</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -64,6 +64,7 @@ evidence-based, and scoped to the PR under review.
 - Flag metadata behavior that bypasses `/docs`.
 - Flag filename heuristics replacing metadata contracts.
 - Flag API behavior that silently accepts ignored options.
+- Flag acknowledgement flags that replace a directly callable user workflow.
 - Flag changes that weaken normal single-GPU training.
 - Flag DDP fixes that regress non-DDP paths.
 - Flag CI marker changes that hide tests.

--- a/docs/adr/0011-export-support-tiers.md
+++ b/docs/adr/0011-export-support-tiers.md
@@ -13,15 +13,16 @@ from the model registry and `libreyolo.tasks.TASKS`.
 Each combination has one tier:
 
 - `validated`: numeric parity is covered in CI or a documented nightly run.
-- `experimental`: conversion is available, but numeric parity is not guaranteed.
+- `available`: conversion is implemented, but numeric runtime parity evidence is incomplete or has not been recorded.
 - `blocked`: preflight raises `NotImplementedError` with a reason before tracing.
 
-CoreML conversion without a macOS prediction run can be experimental, but it
-cannot be validated. Documentation is generated from the matrix and checked for
-drift.
+A CoreML conversion without a macOS prediction run is available but not
+validated. Documentation is generated from the matrix and checked for drift.
 
 ## Consequences
 
-Exporters warn for experimental combinations. Blocked combinations fail before
-dependency checks, calibration loading, tracing, or artifact creation. Adding a
-validated entry requires a parity test and updating the `since` field.
+Validated and available combinations proceed without an acknowledgement or
+blanket warning. Their recorded evidence and constraints remain visible in the
+generated documentation. Blocked combinations fail before dependency checks,
+calibration loading, tracing, or artifact creation. Adding a validated entry
+requires a parity test and updating the `since` field.

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -220,7 +220,7 @@ checkpoint.
 
 MNN exports write the flat metadata to a required `<model>.mnn.json` sidecar.
 The v1 contract is CPU, FP32, detection-only, and a fixed NCHW input shape for
-all G0 and G1 model families. It additionally requires:
+the detector families with explicit MNN support entries. It additionally requires:
 
 - `mnn_version`: installed MNN package version used to export.
 - `mnn_backend`: `"cpu"`.
@@ -230,12 +230,11 @@ all G0 and G1 model families. It additionally requires:
   order.
 - `mnn_batch`: fixed artifact batch, equal to `mnn_input_shape[0]`.
 
-The loader rejects dynamic, non-FP32, non-detection, non-G0/G1-family, or
+The loader rejects dynamic, non-FP32, non-detection, unsupported-family, or
 inconsistent shape metadata. A `.mnn` artifact is backend-specific and is not
-a native PyTorch checkpoint. DEIMv2 remains experimental because its shared
-ONNX intermediate has incomplete query-level score parity; its trained atto
-checkpoint nevertheless converts, reloads, runs, and preserves public
-post-NMS detections in the MNN end-to-end test.
+a native PyTorch checkpoint. DEIMv2 converts, reloads, runs, and preserves
+public post-NMS detections in the MNN end-to-end test, but its shared ONNX
+intermediate has incomplete query-level score parity.
 
 For ONNX YOLO9 detection exports with `nms=true`, output `0` / `output` is the
 standalone post-NMS tensor using the export-time `nms_conf`, `nms_iou`, and

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -3,45 +3,46 @@
 This document is generated from `libreyolo/export/support.py`.
 Do not edit the matrix by hand.
 
-`✓` means parity-validated, `exp` means conversion is available without a
-numeric parity guarantee, and an empty cell is blocked in preflight.
+`✓` means parity-validated, `available` means the converter path is callable
+with the validation context described below, and an empty cell is blocked
+in preflight.
 
 | Family | Task | onnx | torchscript | executorch | tensorrt | openvino | paddle | mnn | rknn | ncnn | tflite | coreml | coreai |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| alexnet | classify | ✓ | ✓ | exp | ✓ | ✓ |  |  |  | exp |  |  |  |
-| birefnet | matte | exp | ✓ |  |  |  |  |  |  |  |  |  |  |
-| centernet | detect | ✓ | ✓ | exp | exp | exp |  |  |  |  |  |  |  |
+| alexnet | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
+| birefnet | matte | available | ✓ |  |  |  |  |  |  |  |  |  |  |
+| centernet | detect | ✓ | ✓ | available | available | available |  |  |  |  |  |  |  |
 | clip | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  | ✓ |
 | clip | embed | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  |  |
 | convnext | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ | ✓ |  | ✓ |
 | deeplabv3 | semantic | ✓ | ✓ |  | ✓ | ✓ |  |  |  |  |  |  |  |
-| deformable_detr | detect | ✓ | exp | exp | exp | exp |  |  |  |  |  |  |  |
-| deim | detect | ✓ | ✓ |  | exp | exp | ✓ | ✓ |  |  |  |  | ✓ |
-| deimv2 | detect | exp | ✓ |  | exp | exp | ✓ | exp |  |  |  |  | ✓ |
-| deit | classify | ✓ | ✓ | exp | ✓ | ✓ |  |  |  | exp |  |  |  |
+| deformable_detr | detect | ✓ | available | available | available | available |  |  |  |  |  |  |  |
+| deim | detect | ✓ | ✓ |  | available | available | ✓ | ✓ |  |  |  |  | ✓ |
+| deimv2 | detect | available | ✓ |  | available | available | ✓ | available |  |  |  |  | ✓ |
+| deit | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | depth_anything | depth | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  | ✓ |
 | depth_anything3 | depth | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  |  |
-| detr | detect | ✓ | ✓ | exp | exp | exp |  |  |  |  |  |  |  |
+| detr | detect | ✓ | ✓ | available | available | available |  |  |  |  |  |  |  |
 | dexined | edge | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
-| dfine | detect | ✓ | ✓ |  | exp | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
-| dfine | segment | ✓ | ✓ |  | exp | ✓ |  |  |  |  |  |  |  |
-| dinodetr | detect | ✓ | exp | exp | exp | exp |  |  |  |  |  |  |  |
+| dfine | detect | ✓ | ✓ |  | available | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
+| dfine | segment | ✓ | ✓ |  | available | ✓ |  |  |  |  |  |  |  |
+| dinodetr | detect | ✓ | available | available | available | available |  |  |  |  |  |  |  |
 | dinov2 | semantic | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  |  |
-| dinov2 | classify | ✓ | ✓ | ✓ | exp | ✓ |  |  |  |  |  |  | exp |
-| dinov2 | embed | ✓ | ✓ | exp | exp | exp |  |  |  |  | ✓ |  |  |
-| ec | detect | ✓ | ✓ | ✓ | exp | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
-| ec | pose | ✓ | ✓ | ✓ | exp | exp | ✓ |  |  |  |  |  |  |
-| ec | segment | ✓ | ✓ | ✓ | exp | ✓ | ✓ |  |  |  |  |  |  |
+| dinov2 | classify | ✓ | ✓ | ✓ | available | ✓ |  |  |  |  |  |  | available |
+| dinov2 | embed | ✓ | ✓ | available | available | available |  |  |  |  | ✓ |  |  |
+| ec | detect | ✓ | ✓ | ✓ | available | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
+| ec | pose | ✓ | ✓ | ✓ | available | available | ✓ |  |  |  |  |  |  |
+| ec | segment | ✓ | ✓ | ✓ | available | ✓ | ✓ |  |  |  |  |  |  |
 | edgetam | segment |  |  |  |  |  |  |  |  |  |  |  |  |
-| efficientdet | detect | ✓ | ✓ | exp | ✓ | ✓ |  |  |  | exp |  |  |  |
+| efficientdet | detect | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | efficientnetv2 | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ | ✓ |  | ✓ |
 | eomt | semantic | ✓ | ✓ |  | ✓ | ✓ |  |  |  |  |  |  |  |
 | eomt | segment |  |  |  |  |  |  |  |  |  |  |  |  |
 | eomt | panoptic |  |  |  |  |  |  |  |  |  |  |  |  |
 | faster_rcnn | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
 | fcn | semantic | ✓ | ✓ |  | ✓ | ✓ |  |  |  |  |  |  |  |
-| fcos | detect | ✓ | ✓ |  |  | exp |  |  |  |  |  |  |  |
-| feynobg | matte | exp | ✓ | exp |  |  |  |  |  |  |  |  |  |
+| fcos | detect | ✓ | ✓ |  |  | available |  |  |  |  |  |  |  |
+| feynobg | matte | available | ✓ |  |  |  |  |  |  |  |  |  |  |
 | florence2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | fomo | point | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
 | grounding_dino | detect |  |  |  |  |  |  |  |  |  |  |  |  |
@@ -50,36 +51,36 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | kosmos2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | l2cs | gaze | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  |  |
 | lfm2vl | detect |  |  |  |  |  |  |  |  |  |  |  |  |
-| lingbotvision | semantic | ✓ | ✓ | ✓ | exp | ✓ |  |  |  |  |  |  | ✓ |
+| lingbotvision | semantic | ✓ | ✓ | ✓ | available | ✓ |  |  |  |  |  |  | ✓ |
 | locateanything | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | locateanything | point |  |  |  |  |  |  |  |  |  |  |  |  |
-| lwdetr | detect | ✓ | ✓ | exp | exp | exp |  |  |  |  |  |  |  |
+| lwdetr | detect | ✓ | ✓ | available | available | available |  |  |  |  |  |  |  |
 | mask_rcnn | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
 | mask_rcnn | segment | ✓ |  |  |  |  |  |  |  |  |  |  |  |
-| midas | depth | ✓ | ✓ | exp | ✓ | ✓ |  |  |  | exp |  |  |  |
+| midas | depth | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | mobilenetv4 | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ | ✓ |  | ✓ |
 | mobilesam | segment |  |  |  |  |  |  |  |  |  |  |  |  |
-| moge2 | normal | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | exp |  |  |  |
+| moge2 | normal | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | available |  |  |  |
 | nafnet | restore | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
 | omdet_turbo | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | ov_deim | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | owlv2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
-| picodet | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  | exp | ✓ |  |  | ✓ |
+| picodet | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  | available | ✓ |  |  | ✓ |
 | picosam3 | segment | ✓ |  |  |  |  |  |  |  |  |  |  |  |
-| pidnet | semantic | ✓ | ✓ | ✓ | exp | ✓ |  |  |  | ✓ | ✓ |  | ✓ |
+| pidnet | semantic | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ | ✓ |  | ✓ |
 | ppocr | ocr |  |  |  |  |  |  |  |  |  |  |  |  |
 | qwen3vl | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | realesrgan | restore | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ | ✓ |  | ✓ |
 | resnet | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ | ✓ |  | ✓ |
 | retinanet | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
-| rfdetr | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  | ✓ |  |  |  | exp | ✓ |
-| rfdetr | segment | ✓ | ✓ | ✓ | exp | exp |  |  |  |  |  |  |  |
-| rfdetr | pose | ✓ | ✓ | ✓ | exp | exp |  |  |  |  |  |  |  |
-| rfdetr | obb | ✓ | ✓ | ✓ | exp | exp |  |  |  |  |  |  |  |
-| rtdetr | detect | ✓ | ✓ | ✓ | exp | ✓ |  | ✓ |  |  |  | exp | ✓ |
-| rtdetrv2 | detect | ✓ | ✓ | ✓ | exp | exp |  | ✓ |  |  |  |  | ✓ |
-| rtdetrv4 | detect | ✓ | ✓ | ✓ | exp | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
-| rtmdet | detect | ✓ | ✓ | exp | ✓ | ✓ |  |  |  |  |  |  | ✓ |
+| rfdetr | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  | ✓ |  |  |  | available | ✓ |
+| rfdetr | segment | ✓ | ✓ | ✓ | available | available |  |  |  |  |  |  |  |
+| rfdetr | pose | ✓ | ✓ | ✓ | available | available |  |  |  |  |  |  |  |
+| rfdetr | obb | ✓ | ✓ | ✓ | available | available |  |  |  |  |  |  |  |
+| rtdetr | detect | ✓ | ✓ | ✓ | available | ✓ |  | ✓ |  |  |  | available | ✓ |
+| rtdetrv2 | detect | ✓ | ✓ | ✓ | available | available |  | ✓ |  |  |  |  | ✓ |
+| rtdetrv4 | detect | ✓ | ✓ | ✓ | available | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
+| rtmdet | detect | ✓ | ✓ | available | ✓ | ✓ |  |  |  |  |  |  | ✓ |
 | rtmdet | segment |  |  |  |  |  |  |  |  |  |  |  |  |
 | sam | segment |  |  |  |  |  |  |  |  |  |  |  |  |
 | sam2 | segment |  |  |  |  |  |  |  |  |  |  |  |  |
@@ -90,23 +91,23 @@ numeric parity guarantee, and an empty cell is blocked in preflight.
 | siglip2 | embed | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | ssd | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
-| swin | classify | ✓ | ✓ | exp | ✓ | ✓ |  |  |  | exp |  |  |  |
+| swin | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | swinir | restore | ✓ | ✓ |  | ✓ | ✓ |  |  |  |  | ✓ |  |  |
 | teed | edge | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
-| vgg | classify | ✓ | ✓ | exp | ✓ | ✓ |  |  |  | exp |  |  |  |
-| vit | classify | ✓ | exp | exp | exp | exp |  |  |  | exp |  |  |  |
+| vgg | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
+| vit | classify | ✓ | available | available | available | available |  |  |  | available |  |  |  |
 | yolo1 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
-| yolo2 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | exp |  |  | ✓ |
+| yolo2 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  | ✓ |
 | yolo3 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
 | yolo4 | detect | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
-| yolo7 | detect | ✓ | ✓ | ✓ | exp | ✓ |  |  |  | ✓ |  |  | ✓ |
-| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | exp | ✓ | ✓ | exp | ✓ |
-| yolo9_e2e | detect | ✓ | ✓ | ✓ | exp | ✓ | ✓ | ✓ | exp | ✓ |  |  | ✓ |
-| yolo9_p2 | detect | ✓ | ✓ | ✓ | exp | ✓ | ✓ | ✓ |  | exp |  |  | ✓ |
-| yolonas | detect | ✓ | ✓ | ✓ | exp | ✓ | ✓ | ✓ | exp | ✓ | ✓ |  | ✓ |
-| yolonas | pose | ✓ | ✓ | ✓ | exp | ✓ | ✓ |  |  | ✓ |  |  |  |
-| yolox | detect | ✓ | ✓ | ✓ | exp | ✓ |  |  |  | ✓ | ✓ | exp | ✓ |
-| zipdepth | depth | ✓ | ✓ | ✓ | exp | ✓ |  |  |  | ✓ |  |  | ✓ |
+| yolo7 | detect | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ |  |  | ✓ |
+| yolo9 | detect | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | available | ✓ | ✓ | available | ✓ |
+| yolo9_e2e | detect | ✓ | ✓ | ✓ | available | ✓ | ✓ | ✓ | available | ✓ |  |  | ✓ |
+| yolo9_p2 | detect | ✓ | ✓ | ✓ | available | ✓ | ✓ | ✓ |  | available |  |  | ✓ |
+| yolonas | detect | ✓ | ✓ | ✓ | available | ✓ | ✓ | ✓ | available | ✓ | ✓ |  | ✓ |
+| yolonas | pose | ✓ | ✓ | ✓ | available | ✓ | ✓ |  |  | ✓ |  |  |  |
+| yolox | detect | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ | ✓ | available | ✓ |
+| zipdepth | depth | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ |  |  | ✓ |
 
 ## Parity thresholds
 
@@ -425,10 +426,99 @@ A check mark applies only under any constraint listed here.
 - `zipdepth` / `depth` / `ncnn`: PNNX/NCNN 20260526 CPU FP32 with a fixed-resolution export canvas; two-input raw parity, factory reload, metadata, and public predict parity
 - `zipdepth` / `depth` / `coreai`: fixed export canvas; permissively licensed trained checkpoints are covered on Apple hardware by direct named-output parity with a 3e-04 tolerance and a 100x input-sensitivity margin
 
+## Available combinations
+
+These converter paths are callable with the recorded validation context.
+
+- `alexnet` / `classify` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `alexnet` / `classify` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `birefnet` / `matte` / `onnx`: The opset-19 DeformConv graph exports, but ONNX Runtime's CPU provider has no DeformConv implementation for runtime parity.
+- `centernet` / `detect` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `centernet` / `detect` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `centernet` / `detect` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `deformable_detr` / `detect` / `torchscript`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `deformable_detr` / `detect` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `deformable_detr` / `detect` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `deformable_detr` / `detect` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `deim` / `detect` / `tensorrt`: A published Apache-2.0 trained checkpoint exports, reloads, and passes public predict parity, but normalized raw output error is 0.41%, above the 0.1% promotion gate.
+- `deim` / `detect` / `openvino`: The trained artifact reaches the elementwise tolerance, but its input signal is only 17.9x the conversion error; validation requires more than 20x.
+- `deimv2` / `detect` / `onnx`: After Hungarian query alignment, only 43.7% of score values meet tolerance because ONNX top-k selects a different query set.
+- `deimv2` / `detect` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `deimv2` / `detect` / `openvino`: After Hungarian query alignment, only 42.3% of scores meet the converted-runtime tolerance.
+- `deimv2` / `detect` / `mnn`: The trained atto checkpoint converts, reloads, executes on MNN CPU, and preserves post-NMS detections, but the intermediate ONNX route has incomplete query-level score parity. Constraint: MNN 3.6.1, CPU, FP32, batch 1, fixed NCHW input shape
+- `deit` / `classify` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `deit` / `classify` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `detr` / `detect` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `detr` / `detect` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `detr` / `detect` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `dfine` / `detect` / `tensorrt`: A published Apache-2.0 trained checkpoint exports and reloads, but public top-k class membership changes after TensorRT 10.16 FP32 conversion.
+- `dfine` / `segment` / `tensorrt`: A published Apache-2.0 trained segmentation checkpoint exports and reloads, but public top-k class membership changes after TensorRT 10.16 FP32 conversion.
+- `dinodetr` / `detect` / `torchscript`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `dinodetr` / `detect` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `dinodetr` / `detect` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `dinodetr` / `detect` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `dinov2` / `classify` / `tensorrt`: A deterministic input-sensitive fixture exports, reloads, and runs, but changed-input logits carry only 2.2x more native signal than TensorRT 10.16 FP32 conversion error; validation requires more than 20x.
+- `dinov2` / `classify` / `coreai`: Conversion has been measured, but the LibreDINOv2 classification checkpoint is not publicly downloadable for a reproducible trained-weight Core AI parity gate.
+- `dinov2` / `embed` / `executorch`: The real pretrained DINOv2 backbone has full XNNPACK conversion, runtime execution, input sensitivity, embedding-vector parity, normalization, and result parsing coverage. Constraint: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed 224x224 input shape
+- `dinov2` / `embed` / `tensorrt`: TensorRT 10.16 exports, reloads, and predicts, but 0.52% of embedding elements miss strict tolerance with maximum error 0.00782.
+- `dinov2` / `embed` / `openvino`: OpenVINO 2026.2 exports, reloads, and predicts, but 11.2% of embedding elements miss strict tolerance with maximum error 0.0124.
+- `ec` / `detect` / `tensorrt`: A published Apache-2.0 trained checkpoint exports, reloads, and passes public predict parity, but normalized raw output error is 1.2%, above the 0.1% promotion gate.
+- `ec` / `pose` / `tensorrt`: A published Apache-2.0 trained pose checkpoint exports and reloads, but matched public boxes fall to 0.920 IoU with 1.43-pixel coordinate drift.
+- `ec` / `pose` / `openvino`: Raw parity passes after Hungarian query alignment, but trained public boxes fall to 0.916 matched IoU.
+- `ec` / `segment` / `tensorrt`: A published Apache-2.0 trained segmentation checkpoint exports and reloads, but public top-k class membership changes.
+- `efficientdet` / `detect` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `efficientdet` / `detect` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `fcos` / `detect` / `openvino`: FP32 dynamic-shape conversion and high-confidence public predictions pass, but small score/box drift can change low-confidence NMS ordering. Constraint: OpenVINO CPU, FP32, batch 1, dynamic padded H/W
+- `feynobg` / `matte` / `onnx`: The opset-19 DeformConv graph exports, but ONNX Runtime's CPU provider has no DeformConv implementation for runtime parity.
+- `lingbotvision` / `semantic` / `tensorrt`: TensorRT 10.16 FP32 exports, reloads, and predicts, but repeated builds produced raw-logit cosine as low as 0.9842, below the 0.999 promotion gate.
+- `lwdetr` / `detect` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `lwdetr` / `detect` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `lwdetr` / `detect` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `midas` / `depth` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `midas` / `depth` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `moge2` / `normal` / `ncnn`: PNNX/NCNN 20260526 exports, reloads, and runs, but the measured two-image raw signal is only 4.5x conversion error; validation requires more than 20x.
+- `picodet` / `detect` / `rknn`: Exact small variants passed RKNN Toolkit2 2.3.2 compilation, RK3588 PC-simulator raw-output gates, and matched post-NMS detections on a real image. Support is limited to YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s; on-device latency and parity have not been measured. Constraint: RKNN Toolkit2 2.3.2, RK3588 PC simulator, vendor floating build, batch 1, fixed square input
+- `pidnet` / `semantic` / `tensorrt`: TensorRT 10.16 FP32 exports and runs, but repeated builds produced raw-logit cosine as low as 0.9970, below the 0.999 promotion gate.
+- `rfdetr` / `detect` / `coreml`: Conversion is available, but runtime parity requires a macOS runner.
+- `rfdetr` / `segment` / `tensorrt`: A published Apache-2.0 trained segmentation checkpoint exports and reloads, but public top-k class membership changes.
+- `rfdetr` / `segment` / `openvino`: After Hungarian query alignment, measured converted-runtime element match rates remain below validation: trained segment 69.0%, trained pose 72.75%, and input-sensitive OBB 91.25%.
+- `rfdetr` / `pose` / `tensorrt`: A published Apache-2.0 trained pose checkpoint exports and reloads, but matched public boxes fall to 0.704 IoU with 41.4-pixel coordinate drift.
+- `rfdetr` / `pose` / `openvino`: After Hungarian query alignment, measured converted-runtime element match rates remain below validation: trained segment 69.0%, trained pose 72.75%, and input-sensitive OBB 91.25%.
+- `rfdetr` / `obb` / `tensorrt`: A deterministic synthetic OBB fixture exports and reloads, but public top-k class membership changes.
+- `rfdetr` / `obb` / `openvino`: After Hungarian query alignment, measured converted-runtime element match rates remain below validation: trained segment 69.0%, trained pose 72.75%, and input-sensitive OBB 91.25%.
+- `rtdetr` / `detect` / `tensorrt`: The permissively licensed trained checkpoint exports, reloads, and passes public predict parity, but normalized raw outputs drift by 17% to 38% after TensorRT 10.16 conversion.
+- `rtdetr` / `detect` / `coreml`: Conversion is available, but runtime parity requires a macOS runner.
+- `rtdetrv2` / `detect` / `tensorrt`: A deterministic synthetic fixture exports and reloads, but matched public boxes drift by at least 8 pixels and fall to 0.231 IoU.
+- `rtdetrv2` / `detect` / `openvino`: After Hungarian query alignment, only 93.94% of trained raw elements meet the converted-runtime tolerance.
+- `rtdetrv4` / `detect` / `tensorrt`: A deterministic synthetic fixture exports, reloads, and predicts, but repeated TensorRT 10.16 FP32 builds change public top-k class membership or box geometry; a measured reconstruction reached 0 IoU with 50.4-pixel coordinate drift.
+- `rtmdet` / `detect` / `executorch`: The export-only graph unshares RTMDet's cross-level head convolutions to avoid duplicate XNNPACK batch-norm fusion parameter names. Full conversion, runtime execution, input sensitivity, deterministic random-weight raw parity, and detection parsing are covered. Constraint: ExecuTorch 1.2, XNNPACK, CPU, FP32, batch 1, fixed input shape
+- `swin` / `classify` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `swin` / `classify` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vgg` / `classify` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vgg` / `classify` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vit` / `classify` / `torchscript`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vit` / `classify` / `executorch`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `vit` / `classify` / `tensorrt`: The converter path is available, but the project has not yet recorded TensorRT runtime parity for this family and task.
+- `vit` / `classify` / `openvino`: The converter path is available, but the project has not yet recorded OpenVINO runtime parity for this family and task.
+- `vit` / `classify` / `ncnn`: Conversion is implemented; numeric runtime parity has not been recorded for this combination.
+- `yolo7` / `detect` / `tensorrt`: TensorRT 10.16 FP32 exports and reloads, but the permissively licensed trained checkpoint changes the public top-k class membership.
+- `yolo9` / `detect` / `rknn`: Exact small variants passed RKNN Toolkit2 2.3.2 compilation, RK3588 PC-simulator raw-output gates, and matched post-NMS detections on a real image. Support is limited to YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s; on-device latency and parity have not been measured. Constraint: RKNN Toolkit2 2.3.2, RK3588 PC simulator, vendor floating build, batch 1, fixed square input
+- `yolo9` / `detect` / `coreml`: Conversion is available, but runtime parity requires a macOS runner.
+- `yolo9_e2e` / `detect` / `tensorrt`: Repeated TensorRT 10.16 FP32 engine builds with the permissively licensed trained checkpoint alternate between public top-k class drift and parity.
+- `yolo9_e2e` / `detect` / `rknn`: Exact small variants passed RKNN Toolkit2 2.3.2 compilation, RK3588 PC-simulator raw-output gates, and matched post-NMS detections on a real image. Support is limited to YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s; on-device latency and parity have not been measured. Constraint: RKNN Toolkit2 2.3.2, RK3588 PC simulator, vendor floating build, batch 1, fixed square input
+- `yolo9_p2` / `detect` / `tensorrt`: TensorRT 10.16 FP32 exports and reloads, but the pinned permissive YOLO9 transfer fixture changes the public top-k class membership.
+- `yolo9_p2` / `detect` / `ncnn`: The SHA-pinned MIT YOLO9 transfer fixture exports, reloads, and preserves raw NCNN parity, but changes near-noise public top-k classes and produces no detections above 0.05 on the bundled real image.
+- `yolonas` / `detect` / `tensorrt`: A deterministic synthetic trained fixture exports, reloads, and passes public predict parity, but image signal is only 4 to 5 times the TensorRT conversion error.
+- `yolonas` / `detect` / `rknn`: Exact small variants passed RKNN Toolkit2 2.3.2 compilation, RK3588 PC-simulator raw-output gates, and matched post-NMS detections on a real image. Support is limited to YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s; on-device latency and parity have not been measured. Constraint: RKNN Toolkit2 2.3.2, RK3588 PC simulator, vendor floating build, batch 1, fixed square input
+- `yolonas` / `pose` / `tensorrt`: A deterministic synthetic trained fixture exports, reloads, and passes public predict parity, but image signal is only 2 to 6 times the TensorRT conversion error.
+- `yolox` / `detect` / `tensorrt`: The permissively licensed trained checkpoint exports, reloads, and passes public predict parity, but normalized raw error is 1.6% and image signal is only 2.1 times the conversion error.
+- `yolox` / `detect` / `coreml`: Conversion is available, but runtime parity requires a macOS runner.
+- `zipdepth` / `depth` / `tensorrt`: TensorRT 10.16 FP32 exports, reloads, and predicts, but repeated builds produced raw depth PSNR as low as 30.27 dB, below the 40 dB promotion gate.
+
 ## Blocked combinations
 
 - `alexnet` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `alexnet` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `alexnet` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `alexnet` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `alexnet` / `classify` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `alexnet` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
@@ -437,34 +527,34 @@ A check mark applies only under any constraint listed here.
 - `birefnet` / `matte` / `tensorrt`: TensorRT 10.16 reaches the shared ONNX DeformConv node but cannot parse it because ModulatedDeformConv2d is absent from the plugin registry.
 - `birefnet` / `matte` / `openvino`: OpenVINO 2026.2 cannot lower the shared matte decoder's standard ONNX DeformConv-19 operation.
 - `birefnet` / `matte` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `birefnet` / `matte` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `birefnet` / `matte` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `birefnet` / `matte` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `birefnet` / `matte` / `ncnn`: BiRefNet's decoder requires torchvision deformable convolution, which PNNX/NCNN cannot lower to a runnable graph.
 - `birefnet` / `matte` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `birefnet` / `matte` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `birefnet` / `matte` / `coreai`: The decoder needs torchvision deform_conv2d, which the Core AI converter cannot lower ('unable to handle call function op: deform_conv2d.default'). The same operator already blocks the NCNN path. An encoder-only contract is the realistic route, matching the seam the CUDA graph work used.
 - `centernet` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `centernet` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `centernet` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `centernet` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `centernet` / `detect` / `ncnn`: NCNN cannot lower CenterNet's portable deformable sampling plus baked top-k decode contract. Use ONNX or TorchScript.
 - `centernet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `centernet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `centernet` / `detect` / `coreai`: This family and task have not been validated for Core AI export.
 - `clip` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `clip` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `clip` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `clip` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `clip` / `classify` / `ncnn`: No parity-valid frozen-class artifact is available for this runtime.
 - `clip` / `classify` / `tflite`: onnx2tf 2.6.7 emits a LiteRT graph whose TRANSPOSE receives a rank-5 permutation for a rank-4 tensor.
 - `clip` / `classify` / `coreml`: No parity-valid frozen-class artifact is available for this runtime.
 - `clip` / `embed` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `clip` / `embed` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `clip` / `embed` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `clip` / `embed` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `clip` / `embed` / `ncnn`: PNNX 20260526 leaves unsupported pnnx.Expression nodes in the CLIP attention graph, so the generated NCNN network has no runnable input.
 - `clip` / `embed` / `tflite`: onnx2tf 2.6.7 emits a LiteRT graph whose TRANSPOSE receives a rank-5 permutation for a rank-4 tensor.
 - `clip` / `embed` / `coreml`: No parity-valid embedding artifact is available for this runtime.
 - `clip` / `embed` / `coreai`: No parity-valid embedding artifact is available for this runtime.
 - `convnext` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `convnext` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `convnext` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `convnext` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `convnext` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `deeplabv3` / `semantic` / `executorch`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
@@ -476,7 +566,7 @@ A check mark applies only under any constraint listed here.
 - `deeplabv3` / `semantic` / `coreml`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `deeplabv3` / `semantic` / `coreai`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `deformable_detr` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `deformable_detr` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `deformable_detr` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `deformable_detr` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `deformable_detr` / `detect` / `ncnn`: NCNN export is not supported for Deformable DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `deformable_detr` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
@@ -493,13 +583,13 @@ A check mark applies only under any constraint listed here.
 - `deimv2` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `deimv2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `deit` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `deit` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `deit` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `deit` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `deit` / `classify` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `deit` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `deit` / `classify` / `coreai`: This family and task have not been validated for Core AI export.
 - `depth_anything` / `depth` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `depth_anything` / `depth` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `depth_anything` / `depth` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `depth_anything` / `depth` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `depth_anything` / `depth` / `ncnn`: PNNX 20260526 reports unsupported batch-index reshapes in the DINOv2 transformer graph; the produced NCNN artifact fails numeric parity.
 - `depth_anything` / `depth` / `tflite`: onnx2tf 2.6.7 converts the DINOv2 depth graph, but LiteRT 2.1.2 cannot broadcast [1,3,3,32] and [1,72,72,32] in a generated ADD.
@@ -512,14 +602,14 @@ A check mark applies only under any constraint listed here.
 - `depth_anything3` / `depth` / `coreml`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `coreai`: The model raises NotImplementedError for every format: depth export is out of scope per ADR 0006, the depth task contract. Depth Anything V2 exports and validates at 5.2e-06, so this is specific to the V3 family and not a Core AI limitation.
 - `detr` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `detr` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `detr` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `detr` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `detr` / `detect` / `ncnn`: NCNN export is not supported for DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `detr` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `detr` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `detr` / `detect` / `coreai`: This family and task have not been validated for Core AI export.
 - `dexined` / `edge` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `dexined` / `edge` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `dexined` / `edge` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `dexined` / `edge` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `dexined` / `edge` / `ncnn`: PNNX 20260526 leaves an unsupported Tensor.index channel-reversal node, so the generated NCNN network has no runnable input.
 - `dexined` / `edge` / `coreml`: This edge runtime has no parity-valid artifact for the requested format.
@@ -531,14 +621,14 @@ A check mark applies only under any constraint listed here.
 - `dfine` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `dfine` / `segment` / `executorch`: Strict capture reaches the same untraceable deformable-attention ContextVar read as detection. Forcing the manual capture path permits serialization, but ExecuTorch 1.2 runtime execution fails with an invalid delegated tensor dimension order.
 - `dfine` / `segment` / `paddle`: The trained LibreDFINEn segmentation graph converts and reloads, but mask-logit relative RMS error is 3.52% and minimum matched-mask IoU is only 0.582.
-- `dfine` / `segment` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `dfine` / `segment` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `dfine` / `segment` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `dfine` / `segment` / `ncnn`: NCNN export is not supported for D-FINE: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `dfine` / `segment` / `tflite`: onnx2tf flatbuffer-direct lowering crashes in GatherElements shape handling with an axis IndexError.
 - `dfine` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `dfine` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
 - `dinodetr` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `dinodetr` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `dinodetr` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `dinodetr` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `dinodetr` / `detect` / `ncnn`: NCNN export is not supported for DINO-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `dinodetr` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
@@ -552,13 +642,13 @@ A check mark applies only under any constraint listed here.
 - `dinov2` / `semantic` / `coreml`: The CoreML wrapper does not implement the dense semantic-logits contract.
 - `dinov2` / `semantic` / `coreai`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `dinov2` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `dinov2` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `dinov2` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `dinov2` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `dinov2` / `classify` / `ncnn`: LibreDINOv2 classify export is not implemented for this format.
 - `dinov2` / `classify` / `tflite`: LibreDINOv2 classify export is not implemented for this format.
 - `dinov2` / `classify` / `coreml`: LibreDINOv2 classify export is not implemented for this format.
 - `dinov2` / `embed` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `dinov2` / `embed` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `dinov2` / `embed` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `dinov2` / `embed` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `dinov2` / `embed` / `ncnn`: PNNX 20260526 cannot lower the DINOv2 attention graph's batch-axis broadcasts and leaves an unsupported pnnx.Expression node.
 - `dinov2` / `embed` / `coreml`: No parity-valid embedding artifact is available for this runtime.
@@ -567,13 +657,13 @@ A check mark applies only under any constraint listed here.
 - `ec` / `detect` / `ncnn`: NCNN export is not supported for EC: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `ec` / `detect` / `tflite`: onnx2tf 2.6.7 emits an ONNX_LAYERNORMALIZATION custom operation that LiteRT 2.1.2 cannot prepare.
 - `ec` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `ec` / `pose` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `ec` / `pose` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `ec` / `pose` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `ec` / `pose` / `ncnn`: NCNN export is not supported for EC: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `ec` / `pose` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `ec` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `ec` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
-- `ec` / `segment` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `ec` / `segment` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `ec` / `segment` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `ec` / `segment` / `ncnn`: NCNN export is not supported for EC: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `ec` / `segment` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
@@ -592,13 +682,13 @@ A check mark applies only under any constraint listed here.
 - `edgetam` / `segment` / `coreml`: Promptable model export is out of scope for the v1 runtime contract.
 - `edgetam` / `segment` / `coreai`: Promptable model export is out of scope for the v1 runtime contract.
 - `efficientdet` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `efficientdet` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `efficientdet` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `efficientdet` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `efficientdet` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `efficientdet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `efficientdet` / `detect` / `coreai`: This family and task have not been validated for Core AI export.
 - `efficientnetv2` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `efficientnetv2` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `efficientnetv2` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `efficientnetv2` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `efficientnetv2` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `eomt` / `semantic` / `executorch`: Strict torch.export capture fails on a data-dependent symbolic expression in the mask path before XNNPACK lowering.
@@ -638,7 +728,7 @@ A check mark applies only under any constraint listed here.
 - `faster_rcnn` / `detect` / `tensorrt`: This runtime has no parity evidence for Faster R-CNN's proposal, RoIAlign, variable-length output, and embedded-NMS graph.
 - `faster_rcnn` / `detect` / `openvino`: This runtime has no parity evidence for Faster R-CNN's proposal, RoIAlign, variable-length output, and embedded-NMS graph.
 - `faster_rcnn` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `faster_rcnn` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `faster_rcnn` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `faster_rcnn` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `faster_rcnn` / `detect` / `ncnn`: This runtime has no parity evidence for Faster R-CNN's proposal, RoIAlign, variable-length output, and embedded-NMS graph.
 - `faster_rcnn` / `detect` / `tflite`: This runtime has no parity evidence for Faster R-CNN's proposal, RoIAlign, variable-length output, and embedded-NMS graph.
@@ -655,16 +745,17 @@ A check mark applies only under any constraint listed here.
 - `fcos` / `detect` / `executorch`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
 - `fcos` / `detect` / `tensorrt`: FCOS requires dynamic padded H/W to preserve its 800/1333 aspect transform, while the current TensorRT runtime profiles dynamic batch only.
 - `fcos` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `fcos` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `fcos` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `fcos` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `fcos` / `detect` / `ncnn`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
 - `fcos` / `detect` / `tflite`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
 - `fcos` / `detect` / `coreml`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
 - `fcos` / `detect` / `coreai`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
+- `feynobg` / `matte` / `executorch`: The fixed 1024x1024 large graph exceeded the local conversion timebox while its working set grew past 4.7 GB; no .pte artifact was produced, so runtime parity remains untested.
 - `feynobg` / `matte` / `tensorrt`: TensorRT 10.16 reaches the shared ONNX DeformConv node but cannot parse it because ModulatedDeformConv2d is absent from the plugin registry.
 - `feynobg` / `matte` / `openvino`: OpenVINO 2026.2 cannot lower the shared matte decoder's standard ONNX DeformConv-19 operation.
 - `feynobg` / `matte` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `feynobg` / `matte` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `feynobg` / `matte` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `feynobg` / `matte` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `feynobg` / `matte` / `ncnn`: BiRefNet's decoder requires torchvision deformable convolution, which PNNX/NCNN cannot lower to a runnable graph.
 - `feynobg` / `matte` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
@@ -781,7 +872,7 @@ A check mark applies only under any constraint listed here.
 - `locateanything` / `point` / `coreml`: Generative VLM export is out of scope for v1.
 - `locateanything` / `point` / `coreai`: Generative VLM export is out of scope for v1.
 - `lwdetr` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `lwdetr` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `lwdetr` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `lwdetr` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `lwdetr` / `detect` / `ncnn`: NCNN export is not supported for LW-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `lwdetr` / `detect` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
@@ -810,13 +901,13 @@ A check mark applies only under any constraint listed here.
 - `mask_rcnn` / `segment` / `coreml`: Only ONNX Runtime has parity evidence for Mask R-CNN's proposal, RoIAlign, variable-length detection, and full-image mask graph.
 - `mask_rcnn` / `segment` / `coreai`: Only ONNX Runtime has parity evidence for Mask R-CNN's proposal, RoIAlign, variable-length detection, and full-image mask graph.
 - `midas` / `depth` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `midas` / `depth` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `midas` / `depth` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `midas` / `depth` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `midas` / `depth` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `midas` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `midas` / `depth` / `coreai`: This family and task have not been validated for Core AI export.
 - `mobilenetv4` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `mobilenetv4` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `mobilenetv4` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `mobilenetv4` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `mobilenetv4` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `mobilesam` / `segment` / `onnx`: Promptable model export is out of scope for the v1 runtime contract.
@@ -838,7 +929,7 @@ A check mark applies only under any constraint listed here.
 - `moge2` / `normal` / `coreml`: This family is not wired to the fixed-canvas dense unit-normal export and backend renormalization contract.
 - `moge2` / `normal` / `coreai`: This family is not wired to the fixed-canvas dense unit-normal export and backend renormalization contract.
 - `nafnet` / `restore` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `nafnet` / `restore` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `nafnet` / `restore` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `nafnet` / `restore` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `nafnet` / `restore` / `tflite`: onnx2tf 2.6.7 converts the fixed-canvas graph, but LiteRT 2.1.2 fails at invoke time because input tensor 4539 lacks data.
 - `nafnet` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
@@ -879,7 +970,7 @@ A check mark applies only under any constraint listed here.
 - `owlv2` / `detect` / `coreml`: Open-vocabulary runtime export is out of scope for v1.
 - `owlv2` / `detect` / `coreai`: Open-vocabulary runtime export is out of scope for v1.
 - `picodet` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `picodet` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `picodet` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `picodet` / `detect` / `tflite`: LiteRT 2.1.2 cannot prepare the onnx2tf 2.6.7 artifact because a RESHAPE maps 19,200 input elements to 9,600 output elements.
 - `picodet` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `picosam3` / `segment` / `torchscript`: PicoSAM3 currently exports its raw ROI CNN through ONNX only.
@@ -922,11 +1013,11 @@ A check mark applies only under any constraint listed here.
 - `qwen3vl` / `detect` / `coreml`: Generative VLM export is out of scope for v1.
 - `qwen3vl` / `detect` / `coreai`: Generative VLM export is out of scope for v1.
 - `realesrgan` / `restore` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `realesrgan` / `restore` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `realesrgan` / `restore` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `realesrgan` / `restore` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `realesrgan` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `resnet` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `resnet` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `resnet` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `resnet` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `resnet` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `retinanet` / `detect` / `torchscript`: RetinaNet's dynamic P3-P7 anchor graph and external class-aware postprocessing have parity evidence only through ONNX Runtime.
@@ -934,7 +1025,7 @@ A check mark applies only under any constraint listed here.
 - `retinanet` / `detect` / `tensorrt`: RetinaNet's dynamic P3-P7 anchor graph and external class-aware postprocessing have parity evidence only through ONNX Runtime.
 - `retinanet` / `detect` / `openvino`: RetinaNet's dynamic P3-P7 anchor graph and external class-aware postprocessing have parity evidence only through ONNX Runtime.
 - `retinanet` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `retinanet` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `retinanet` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `retinanet` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `retinanet` / `detect` / `ncnn`: RetinaNet's dynamic P3-P7 anchor graph and external class-aware postprocessing have parity evidence only through ONNX Runtime.
 - `retinanet` / `detect` / `tflite`: RetinaNet's dynamic P3-P7 anchor graph and external class-aware postprocessing have parity evidence only through ONNX Runtime.
@@ -945,21 +1036,21 @@ A check mark applies only under any constraint listed here.
 - `rfdetr` / `detect` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `detect` / `tflite`: onnx2tf emits a flatbuffer at the native 384x384 canvas, but LiteRT cannot allocate it because STRIDED_SLICE receives an input above its supported 5-D rank.
 - `rfdetr` / `segment` / `paddle`: RF-DETR requires ONNX opset 17 and GridSample, while X2Paddle 1.6.0 accepts opset 15 or lower and has no GridSample mapper.
-- `rfdetr` / `segment` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `rfdetr` / `segment` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `rfdetr` / `segment` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `rfdetr` / `segment` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `segment` / `tflite`: onnx2tf 2.4.x assigns an invalid NHWC layout to the segmentation-head Einsum (78 channels versus the required 256), so conversion fails.
 - `rfdetr` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `rfdetr` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
 - `rfdetr` / `pose` / `paddle`: RF-DETR requires ONNX opset 17 and GridSample, while X2Paddle 1.6.0 accepts opset 15 or lower and has no GridSample mapper.
-- `rfdetr` / `pose` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `rfdetr` / `pose` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `rfdetr` / `pose` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `rfdetr` / `pose` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `pose` / `tflite`: RF-DETR pose-x TFLite conversion exceeded the CPU timebox and 8 GB working memory without producing an artifact on this toolchain.
 - `rfdetr` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `rfdetr` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
 - `rfdetr` / `obb` / `paddle`: RF-DETR requires ONNX opset 17 and GridSample, while X2Paddle 1.6.0 accepts opset 15 or lower and has no GridSample mapper.
-- `rfdetr` / `obb` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `rfdetr` / `obb` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `rfdetr` / `obb` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `rfdetr` / `obb` / `ncnn`: NCNN export is not supported for RF-DETR: the model requires decoder or sampling operations unavailable in NCNN. Use ONNX, OpenVINO, TorchScript, or TensorRT instead.
 - `rfdetr` / `obb` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
@@ -979,7 +1070,7 @@ A check mark applies only under any constraint listed here.
 - `rtdetrv4` / `detect` / `tflite`: onnx2tf flatbuffer-direct lowering crashes in GatherElements shape handling with an axis IndexError at the native 640x640 canvas.
 - `rtdetrv4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `rtmdet` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `rtmdet` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `rtmdet` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `rtmdet` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `rtmdet` / `detect` / `ncnn`: PNNX 20260526 reports an unregistered nn.Conv2d layer and leaves the RTMDet NCNN graph without usable input blobs.
 - `rtmdet` / `detect` / `tflite`: onnx2tf 2.6.7 exports, reloads, and preserves raw output parity, but at the native 640x640 canvas public boxes fall to 0.911 IoU with 29.9 px coordinate drift.
@@ -1052,12 +1143,12 @@ A check mark applies only under any constraint listed here.
 - `segformer` / `semantic` / `coreml`: This family is not wired to the shared dense-logits and backend argmax semantic export contract.
 - `segformer` / `semantic` / `coreai`: The SegFormer Core AI capture path has not been assessed. Its published weights are non-commercial regardless of export format.
 - `siglip2` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `siglip2` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `siglip2` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `siglip2` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `siglip2` / `classify` / `ncnn`: No parity-valid frozen-class artifact is available for this runtime.
 - `siglip2` / `classify` / `coreml`: No parity-valid frozen-class artifact is available for this runtime.
 - `siglip2` / `embed` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `siglip2` / `embed` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `siglip2` / `embed` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `siglip2` / `embed` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `siglip2` / `embed` / `ncnn`: PNNX 20260526 leaves unsupported pnnx.Expression nodes in the SigLIP2 attention graph, so the generated NCNN network has no runnable input.
 - `siglip2` / `embed` / `coreml`: No parity-valid embedding artifact is available for this runtime.
@@ -1079,65 +1170,66 @@ A check mark applies only under any constraint listed here.
 - `ssd` / `detect` / `tensorrt`: SSD's decoded fixed-default-box head has only been parity-validated through the ONNX Runtime contract.
 - `ssd` / `detect` / `openvino`: SSD's decoded fixed-default-box head has only been parity-validated through the ONNX Runtime contract.
 - `ssd` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `ssd` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `ssd` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `ssd` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `ssd` / `detect` / `ncnn`: SSD's decoded fixed-default-box head has only been parity-validated through the ONNX Runtime contract.
 - `ssd` / `detect` / `tflite`: SSD's decoded fixed-default-box head has only been parity-validated through the ONNX Runtime contract.
 - `ssd` / `detect` / `coreml`: SSD's decoded fixed-default-box head has only been parity-validated through the ONNX Runtime contract.
 - `ssd` / `detect` / `coreai`: SSD's decoded fixed-default-box head has only been parity-validated through the ONNX Runtime contract.
 - `swin` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `swin` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `swin` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `swin` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `swin` / `classify` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `swin` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `swin` / `classify` / `coreai`: This family and task have not been validated for Core AI export.
 - `swinir` / `restore` / `executorch`: The fixed-canvas graph captures, lowers, serializes, and reloads, but ExecuTorch 1.2 runtime execution fails in aten::alias_copy.out because the source and destination tensors have different dimension orders.
 - `swinir` / `restore` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `swinir` / `restore` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `swinir` / `restore` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `swinir` / `restore` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `swinir` / `restore` / `ncnn`: PNNX writes NCNN artifacts after reporting unsupported 5-rank Permute operations, but the NCNN runtime process exits while loading or executing the resulting graph.
 - `swinir` / `restore` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `swinir` / `restore` / `coreai`: The export process DIES rather than hangs, and the kill point moves between runs, which is the signature of memory exhaustion rather than a stuck loop. One run reached 'Step 3/3: Optimizing and writing the asset' before stopping; a later run of the same graph at the same 128 canvas died inside to_coreai() before returning, in both cases with a leaked-semaphore warning and no traceback. Window attention unrolls into a very large number of small ops, so the converter's peak memory is the prime suspect on a 16 GB machine. Next steps: watch RSS during conversion, try the smallest available size at a 64 canvas, and check the system log for a memory kill. Do NOT assume optimize() is at fault; an earlier note said so on the strength of a single run and the second run contradicted it.
 - `teed` / `edge` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `teed` / `edge` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `teed` / `edge` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `teed` / `edge` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `teed` / `edge` / `ncnn`: PNNX 20260526 leaves an unsupported Tensor.index channel-reversal node, so the generated NCNN network has no runnable input.
 - `teed` / `edge` / `coreml`: This edge runtime has no parity-valid artifact for the requested format.
 - `teed` / `edge` / `coreai`: This edge runtime has no parity-valid artifact for the requested format.
 - `vgg` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `vgg` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `vgg` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `vgg` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `vgg` / `classify` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `vgg` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `vgg` / `classify` / `coreai`: This family and task have not been validated for Core AI export.
 - `vit` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `vit` / `classify` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `vit` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `vit` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `vit` / `classify` / `tflite`: This family and task have not been validated through the ONNX-to-TFLite path.
 - `vit` / `classify` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `vit` / `classify` / `coreai`: This family and task have not been validated for Core AI export.
 - `yolo1` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `yolo1` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `yolo1` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolo1` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `yolo1` / `detect` / `tflite`: onnx2tf 2.6.7 emits an ONNX_EINSUM custom operation that LiteRT 2.1.2 cannot prepare at the native 448x448 canvas.
 - `yolo1` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo2` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `yolo2` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `yolo2` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolo2` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
+- `yolo2` / `detect` / `ncnn`: The public-domain trained checkpoint exports through PNNX 20260526, but NCNN 20260526 on Windows terminates the runtime with a native integer divide-by-zero during output extraction.
 - `yolo2` / `detect` / `tflite`: LiteRT 2.1.2 cannot prepare the onnx2tf 2.6.7 artifact because a RESHAPE maps 4,225 input elements to one output element.
 - `yolo2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo3` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `yolo3` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `yolo3` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolo3` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `yolo3` / `detect` / `tflite`: A public-domain trained checkpoint exports, reloads, and preserves normalized raw parity, but public top-k class membership changes.
 - `yolo3` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo4` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `yolo4` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `yolo4` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolo4` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `yolo4` / `detect` / `tflite`: onnx2tf 2.6.7 exports and runs, but public boxes fall to 0 IoU with 176 px coordinate drift on the deterministic full model.
 - `yolo4` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolo7` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `yolo7` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `yolo7` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolo7` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `yolo7` / `detect` / `tflite`: The converted LiteRT graph changes decoded box coordinates beyond the detector parity tolerance.
 - `yolo7` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
@@ -1147,16 +1239,16 @@ A check mark applies only under any constraint listed here.
 - `yolo9_p2` / `detect` / `tflite`: onnx2tf 2.6.7 exports a runnable artifact, but public top-k class membership changes after LiteRT 2.1.2 conversion.
 - `yolo9_p2` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolonas` / `detect` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `yolonas` / `pose` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `yolonas` / `pose` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolonas` / `pose` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `yolonas` / `pose` / `tflite`: LiteRT rejects the converted pose graph because a CONCATENATION input has an unsupported/invalid tensor type.
 - `yolonas` / `pose` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `yolonas` / `pose` / `coreai`: This family and task have not been validated for Core AI export.
 - `yolox` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `yolox` / `detect` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `yolox` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `yolox` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `zipdepth` / `depth` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
-- `zipdepth` / `depth` / `mnn`: MNN v1 supports G0/G1 detection exports only.
+- `zipdepth` / `depth` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `zipdepth` / `depth` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `zipdepth` / `depth` / `tflite`: onnx2tf 2.6.7 flatbuffer-direct conversion does not support the edge-mode Pad operation in ZipDepth's convex upsampler.
 - `zipdepth` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -8,9 +8,10 @@ task-resolution rules in [`libreyolo/tasks.py`](../libreyolo/tasks.py).
 
 ## Model groups
 
-Families are enrolled in rollout groups that decide where a cross-cutting
-feature lands first and how hard it is validated. The single source of truth
-is `MODEL_GROUPS` in
+Families are enrolled in coverage groups used by cross-family tests and
+tooling. A group does not grant or restrict a user-facing capability; support
+comes from the family's implemented API and format-specific capability checks.
+The single source of truth is `MODEL_GROUPS` in
 [`libreyolo/models/registry.py`](../libreyolo/models/registry.py); the CLI
 inventory exposes each family's group, and
 `tests/unit/test_model_registry.py` fails when a registered family is not
@@ -18,18 +19,17 @@ enrolled.
 
 | Group | Meaning |
 |---|---|
-| `g0` | Flagship (`yolo9`, `rfdetr`). Features are designed and fully GPU-validated here first. |
-| `g1` | Core trainable detectors. Features follow `g0` in the same release wave, GPU-smoked per family. |
-| `g2` | Supporting trainables. Kept green in CI; features land opportunistically or on request. |
-| `g3` | Inference-only specialists. Predict/val/export surface only; training features do not apply. |
-| `g4` | Museum (`deit`, `yolo1`-`yolo4`). Frozen exhibits; bug fixes only. |
-| `s`  | Sibling tiers (SAM, open-vocab, VLM, zero-shot). Separate product surfaces, excluded from group rollouts. |
+| `g0` | Flagship anchors (`yolo9`, `rfdetr`) required in shared-feature coverage. |
+| `g1` | Trainable detector coverage set. |
+| `g2` | Additional trainable-family coverage set. |
+| `g3` | Families without a training implementation. |
+| `g4` | Historical families with inference coverage (`deit`, `yolo1`-`yolo4`). |
+| `s`  | Sibling APIs (SAM, open-vocab, VLM, zero-shot) covered separately. |
 
-Groups classify **families, not tasks**: "add validation loss to `g1`" means
-the `g1` families, and a task-scoped rollout says so explicitly ("`g1`
-detect"). A group states the default priority, not an obligation; a family
-may sit out a feature its architecture cannot support, documented at the
-feature.
+Groups classify **families, not tasks**. A task-scoped coverage run says so
+explicitly (for example, "`g1` detect"). Capability decisions must remain
+explicit at the family, task, and format surface rather than being inferred
+from group membership.
 
 ## Filename schema
 
@@ -466,7 +466,7 @@ Detector-factory family support follows:
 | `fcos`      | `("detect",)`                     | detect | detect-only; inference-only native dense graph; official 91-column COCO head maps sparse ids to contiguous COCO-80 |
 | `deeplabv3` | `("semantic",)`                    | semantic | background plus 20 VOC-named classes, trained on the matching COCO subset; fixed 520; inference + `val`; `train()` raises |
 | `efficientdet` | `("detect",)`                    | detect | EfficientDet D0-D4; inference-only; fixed native resolution per size; ONNX, TorchScript, OpenVINO, and TensorRT export parity validated |
-| `rtmdet`    | `("detect", "segment")` (default: detect) | detect | RTMDet-Ins uses `-seg`; detect training is gated experimental, segment training is not implemented |
+| `rtmdet`    | `("detect", "segment")` (default: detect) | detect | RTMDet-Ins uses `-seg`; detect training is implemented and directly callable, segment training is not implemented |
 | `picodet`   | `("detect",)` (default)             | detect | detect-only |
 | `rfdetr`    | `("detect", "segment", "pose", "obb")` | detect | seg uses smaller sizes; pose/OBB use detect sizes |
 | `dinov2`    | `("semantic", "classify", "embed")` | semantic | DINOv2 backbone + task head; embed bypasses heads and returns the 384-d final CLS token at 224 (all sizes share DINOv2-S); no text tower |

--- a/docs/paddle.md
+++ b/docs/paddle.md
@@ -1,7 +1,7 @@
 # PaddlePaddle export
 
 LibreYOLO supports a narrow PaddlePaddle export and CPU inference path for the
-parity-backed G0/G1 cells listed below. The graph is exported to static ONNX
+parity-backed family/task cells listed below. The graph is exported to static ONNX
 opset 15, converted with X2Paddle, and packaged with LibreYOLO metadata so the
 exported directory can be loaded through the same factory as other runtimes.
 

--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -42,9 +42,8 @@ point, classify, semantic, restore). That includes the DFINE/DEIM-family
 trainers, whose copied training loops carry the same hooks as the base loop.
 `tests/e2e/test_profile_training_families.py` runs a real profiled training
 per family and is kept in lockstep with the registry, so a family cannot join
-a trainable group without profiler coverage. Families whose training is gated
-behind `allow_experimental=True` (ec, yolo7, rtmdet, picodet, fomo) need that
-flag alongside `profile=True` — or `--allow-experimental` on the CLI.
+a trainable group without profiler coverage. Every trainable family uses the
+same direct `profile=True` call.
 
 **Inference** profiling (`libreyolo profile infer`) drives the shared
 predict-stage contract, verified per family for every g0/g1 family plus the
@@ -135,10 +134,8 @@ libreyolo profile compare <before.json> <after.json>   # did it help? img/s + ms
 Every command takes either the **self-contained `profile.json`** (recommended — copy
 it freely) or a raw `profile_trace.json`. `get <file>` with no field lists every
 metric. `run` follows normal training defaults, including AMP on supported CUDA
-devices; pass `--no-amp` to force fp32. For families whose training is gated as
-experimental (e.g. ec), pass **`--allow-experimental`**: a profile run trains a
-few steps and writes no checkpoint, so the unvalidated-convergence caveat
-behind the gate does not apply. Use **`run --repeat N`** for mean±stdev
+devices; pass `--no-amp` to force fp32. A profile run trains a few steps and
+writes no checkpoint. Use **`run --repeat N`** for mean±stdev
 img/s — a single run *lies* when the step is launch-bound (the bottleneck itself
 makes the step time noisy). Repeated runs emit an aggregate `profile_repeat.json`
 for `compare`, plus per-trial `prof_*/profile.json` files for drill-down.

--- a/docs/provenance/fcos.md
+++ b/docs/provenance/fcos.md
@@ -99,7 +99,8 @@ load with `strict=True` and no remapping.
   drift is `1.103e-6`. TorchScript is bit-exact for the same input.
 - OpenVINO CPU FP32 passes raw-output tolerances and high-confidence public
   prediction parity. Small numerical drift can reorder low-confidence NMS
-  survivors, so OpenVINO is recorded as experimental rather than validated.
+  survivors, so validation is limited to raw outputs and high-confidence
+  predictions.
 - TensorRT is blocked for this family because the current LibreYOLO TensorRT
   runtime profiles dynamic batch only, while FCOS requires dynamic padded
   height and width to preserve its aspect-resize contract.

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -84,8 +84,8 @@ know what you are doing.
 - `data=` (train/val): the labeled dataset. Purpose: gradients and metrics.
 
 Activation range estimation (`algorithm=`): the default `minmax` keeps the
-absolute extremes seen across calibration batches; `percentile`
-(experimental) uses the mean of per-batch 0.1/99.9 percentiles. Measured on
+absolute extremes seen across calibration batches; `percentile` uses the mean
+of per-batch 0.1/99.9 percentiles. Measured on
 coco128, minmax with a multi-batch calibration set wins for every tested
 model, and percentile clipping collapses DETR-family accuracy because
 transformer activation outliers are functionally load-bearing. What

--- a/docs/rfdetr_keypoints_port.md
+++ b/docs/rfdetr_keypoints_port.md
@@ -73,8 +73,8 @@ slot is still selected by the internal class. Keypoint coordinates and confidenc
 The converted checkpoint carries LibreYOLO metadata (`model_family="rfdetr"`, `task="pose"`, `nc`,
 `num_keypoints`, `keypoint_dim`, `oks_sigmas`, `names`, `num_keypoints_per_class`) and is published as
 `LibreYOLO/LibreRFDETRx-pose` on HuggingFace with explicit Roboflow Apache-2.0 attribution.
-`THIRD_PARTY_NOTICES.txt` records the provenance. The weight is flagged experimental (preview), matching
-upstream's early-access framing.
+`THIRD_PARTY_NOTICES.txt` records the provenance. The checkpoint was converted from
+upstream's early-access release.
 
 ## Licensing / hygiene
 

--- a/docs/rknn.md
+++ b/docs/rknn.md
@@ -1,6 +1,6 @@
 # Rockchip RKNN export
 
-Status: experimental F0 integration.
+Status: F0 integration with simulator validation.
 
 LibreYOLO can compile a fixed-shape ONNX export to Rockchip's `.rknn` format
 and run tensor-level parity checks in Toolkit2's x86 host simulator. A board is
@@ -30,10 +30,10 @@ raw-output checks, and real-image detection comparison:
 
 | Model variant | Task | Status |
 | --- | --- | --- |
-| YOLO9-t | detect | Experimental, simulator validated |
-| YOLO9-E2E-t | detect | Experimental, simulator validated |
-| PicoDet-s | detect | Experimental, simulator validated |
-| YOLO-NAS-s | detect | Experimental, simulator validated |
+| YOLO9-t | detect | Simulator validated |
+| YOLO9-E2E-t | detect | Simulator validated |
+| PicoDet-s | detect | Simulator validated |
+| YOLO-NAS-s | detect | Simulator validated |
 
 Other sizes, tasks, and Rockchip targets are rejected before compilation.
 The lower-level ONNX-to-RKNN helpers remain available for development probes,
@@ -188,7 +188,6 @@ families pass in a pinned Toolkit2 environment:
 4. RK3588 hardware: latency and memory measurements. This is the only gate that
    requires a board.
 
-Until those results are recorded, the four enabled variants remain an
-experimental simulator-validated surface rather than a generally supported
-backend. RF-DETR's failure also means this integration does not yet satisfy
-LibreYOLO's two-flagship coverage requirement for promotion.
+The four enabled variants are available with simulator validation; board
+performance has not been recorded. RF-DETR's failure also means this
+integration does not yet satisfy LibreYOLO's two-flagship coverage requirement.

--- a/docs/swinir.md
+++ b/docs/swinir.md
@@ -22,7 +22,7 @@ result.save("upscaled.png")
 Inputs run at native resolution and are reflect-padded to an 8-pixel window
 multiple. Tiling is optional and bounds peak memory for large images. Training
 and dynamic spatial export are outside the first release. Static ONNX export is
-available as an experimental path: backend prediction pads inputs that fit
+available: backend prediction pads inputs that fit
 within the exported canvas and crops the 4x result back to the expected output
 shape, but the window attention sees that padding, so sub-canvas inputs
 measurably diverge from native inference. Export at the resolution you intend

--- a/libreyolo/backends/mnn.py
+++ b/libreyolo/backends/mnn.py
@@ -111,7 +111,7 @@ class MNNBackend(BaseBackend):
         model_family = str(metadata.get("model_family", "")).lower()
         if model_family not in _SUPPORTED_FAMILIES:
             raise ValueError(
-                "MNN v1 supports G0/G1 detection exports only; "
+                "MNN v1 has no runtime contract for this model family; "
                 f"got model_family={model_family or 'missing'!r}."
             )
         model_size = metadata.get("model_size") or metadata.get("size")

--- a/libreyolo/cli/commands/profile.py
+++ b/libreyolo/cli/commands/profile.py
@@ -90,12 +90,6 @@ def run_cmd(
     warmup: int = typer.Option(5, "--warmup", help="Warmup steps before measuring"),
     repeat: int = typer.Option(1, "--repeat", help="Repeat N times for mean +/- stdev (a single run lies when launch-bound)"),
     device: str = typer.Option("0", "--device"),
-    allow_experimental: bool = typer.Option(
-        False, "--allow-experimental",
-        help="Acknowledge an experimental training path (e.g. ec) so gated "
-             "families can be profiled. A profile run trains for a few steps "
-             "and writes no checkpoint, so the unvalidated-convergence caveat "
-             "behind the gate does not apply."),
     project: str = typer.Option("runs/profile", "--project"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
@@ -113,14 +107,12 @@ def run_cmd(
     for i in range(max(1, repeat)):
         name = f"prof_{i}" if repeat > 1 else "prof"
         model = LibreYOLO(model_path=weights, size=size, device=device)
-        # Only forwarded when set: non-gated families don't accept the kwarg.
-        extra = {"allow_experimental": True} if allow_experimental else {}
         model.train(
             data=data, epochs=epochs, batch=batch, imgsz=imgsz, workers=workers,
             amp=amp, device=device, profile=True, profile_then_stop=True,
             profile_steps=steps,
             profile_warmup=warmup, profile_open=False, no_aug_epochs=0,
-            project=project, name=name, exist_ok=True, **extra,
+            project=project, name=name, exist_ok=True,
         )
         last_dir = Path(project) / name
         pj = last_dir / "profile.json"

--- a/libreyolo/cli/commands/quantize.py
+++ b/libreyolo/cli/commands/quantize.py
@@ -32,7 +32,7 @@ def quantize_cmd(
     algorithm: str = typer.Option(
         "auto",
         help="Activation range estimation: auto (minmax), minmax, "
-        "percentile (experimental)",
+        "percentile (can reduce transformer accuracy)",
     ),
     out: Optional[str] = typer.Option(
         None,

--- a/libreyolo/export/exporter.py
+++ b/libreyolo/export/exporter.py
@@ -627,13 +627,6 @@ class BaseExporter(ABC):
                 f"{family} {task} export to {self.format_name} is blocked: "
                 f"{support.reason}{alternatives_text}"
             )
-        if support.tier == "experimental":
-            warnings.warn(
-                f"{family} {task} export to {self.format_name} is experimental: "
-                f"{support.reason}",
-                RuntimeWarning,
-                stacklevel=3,
-            )
         if kwargs.get("nms") and not self.supports_embedded_nms:
             raise NotImplementedError(
                 f"{self.format_name.upper()} embedded NMS export is not supported."

--- a/libreyolo/export/rknn.py
+++ b/libreyolo/export/rknn.py
@@ -52,7 +52,7 @@ RKNN_SIMULATOR_VALIDATED_TARGETS = frozenset({DEFAULT_RKNN_TARGET})
 # Toolkit2's floating build commonly lowers internal tensors to float16, so
 # decoded detector tensors are not elementwise-allclose to ONNX Runtime even
 # when final boxes/classes remain stable. These output-scale-independent gates
-# separated every validated detector above from the failed G0/G1 candidates.
+# separated every validated detector above from the other measured candidates.
 DEFAULT_RKNN_MIN_COSINE = 0.9999
 DEFAULT_RKNN_MAX_NORMALIZED_RMSE = 0.02
 

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from ..tasks import TASKS
 
-Tier = Literal["validated", "experimental", "blocked"]
+Tier = Literal["validated", "available", "blocked"]
 EXPORT_FORMATS = (
     "onnx",
     "torchscript",
@@ -293,20 +293,20 @@ _add(
     constraint="MNN 3.6.1, CPU, FP32, batch 1, fixed NCHW input shape",
 )
 _add(
-    "experimental",
+    "available",
     ("deimv2",),
     ("detect",),
     ("mnn",),
     reason=(
         "The trained atto checkpoint converts, reloads, executes on MNN CPU, "
         "and preserves post-NMS detections, but the intermediate ONNX route "
-        "remains experimental because query-level score parity is incomplete."
+        "has incomplete query-level score parity."
     ),
     since="1.6",
     constraint="MNN 3.6.1, CPU, FP32, batch 1, fixed NCHW input shape",
 )
 _add(
-    "experimental",
+    "available",
     ("yolo9", "yolo9_e2e", "yolonas", "picodet"),
     ("detect",),
     ("rknn",),
@@ -386,7 +386,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rtmdet",),
     ("detect",),
     ("executorch",),
@@ -575,7 +575,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("dinov2",),
     ("embed",),
     ("executorch",),
@@ -666,7 +666,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("moge2",),
     ("normal",),
     ("ncnn",),
@@ -1114,7 +1114,7 @@ _add(
     constraint="OpenVINO 2026.2 CPU FP32, batch 1, fixed 224x224 input",
 )
 _add(
-    "experimental",
+    "available",
     ("dinov2",),
     ("classify",),
     ("tensorrt",),
@@ -1219,7 +1219,7 @@ _add(
     constraint="FP32, batch 1, fixed 224x224 input",
 )
 _add(
-    "experimental",
+    "available",
     ("dinov2",),
     ("embed",),
     ("openvino",),
@@ -1229,7 +1229,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("dinov2",),
     ("embed",),
     ("tensorrt",),
@@ -1289,7 +1289,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "blocked",
     ("feynobg",),
     ("matte",),
     ("executorch",),
@@ -1312,7 +1312,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("birefnet", "feynobg"),
     ("matte",),
     ("onnx",),
@@ -1359,7 +1359,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("yolox", "yolo9", "rtdetr", "rfdetr"),
     ("detect",),
     ("coreml",),
@@ -1382,7 +1382,7 @@ _add(
     constraint="FP32 with a fixed family-native export canvas",
 )
 _add(
-    "experimental",
+    "available",
     ("lingbotvision",),
     ("semantic",),
     ("tensorrt",),
@@ -1393,7 +1393,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("pidnet",),
     ("semantic",),
     ("tensorrt",),
@@ -1763,7 +1763,7 @@ _add(
     constraint="fixed-resolution export canvas",
 )
 _add(
-    "experimental",
+    "available",
     ("zipdepth",),
     ("depth",),
     ("tensorrt",),
@@ -1838,7 +1838,7 @@ _add(
     constraint="TensorRT 10.16 FP32 with a fixed canvas; YOLO1 requires 448x448",
 )
 _add(
-    "experimental",
+    "available",
     ("yolo7",),
     ("detect",),
     ("tensorrt",),
@@ -1848,7 +1848,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("yolo9_e2e",),
     ("detect",),
     ("tensorrt",),
@@ -1859,7 +1859,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("yolo9_p2",),
     ("detect",),
     ("tensorrt",),
@@ -1869,7 +1869,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("yolox",),
     ("detect",),
     ("tensorrt",),
@@ -1880,7 +1880,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rtdetr",),
     ("detect",),
     ("tensorrt",),
@@ -1891,7 +1891,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("yolonas",),
     ("detect",),
     ("tensorrt",),
@@ -1902,7 +1902,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("yolonas",),
     ("pose",),
     ("tensorrt",),
@@ -1913,7 +1913,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("dfine",),
     ("detect",),
     ("tensorrt",),
@@ -1924,7 +1924,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("dfine",),
     ("segment",),
     ("tensorrt",),
@@ -1935,7 +1935,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("deim",),
     ("detect",),
     ("tensorrt",),
@@ -1946,7 +1946,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rtdetrv2",),
     ("detect",),
     ("tensorrt",),
@@ -1956,7 +1956,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rtdetrv4",),
     ("detect",),
     ("tensorrt",),
@@ -1968,7 +1968,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("ec",),
     ("detect",),
     ("tensorrt",),
@@ -1979,7 +1979,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("ec",),
     ("pose",),
     ("tensorrt",),
@@ -1990,7 +1990,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("ec",),
     ("segment",),
     ("tensorrt",),
@@ -2000,7 +2000,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rfdetr",),
     ("segment",),
     ("tensorrt",),
@@ -2010,7 +2010,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rfdetr",),
     ("pose",),
     ("tensorrt",),
@@ -2021,7 +2021,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rfdetr",),
     ("obb",),
     ("tensorrt",),
@@ -2043,7 +2043,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "blocked",
     ("yolo2",),
     ("detect",),
     ("ncnn",),
@@ -2118,7 +2118,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("yolo9_p2",),
     ("detect",),
     ("ncnn",),
@@ -2501,7 +2501,7 @@ _add(
     constraint="FP32, batch 1, out-of-graph aspect resize, variable padded H/W",
 )
 _add(
-    "experimental",
+    "available",
     ("fcos",),
     ("detect",),
     ("openvino",),
@@ -2578,7 +2578,7 @@ _add(
     constraint="fixed export canvas",
 )
 _add(
-    "experimental",
+    "available",
     ("deim",),
     ("detect",),
     ("openvino",),
@@ -2589,7 +2589,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("deimv2",),
     ("detect",),
     ("openvino",),
@@ -2599,7 +2599,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("rtdetrv2",),
     ("detect",),
     ("openvino",),
@@ -2609,7 +2609,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("deimv2",),
     ("detect",),
     ("onnx",),
@@ -2662,7 +2662,7 @@ _add(
     constraint="fixed 640x640 input",
 )
 _add(
-    "experimental",
+    "available",
     ("ec",),
     ("pose",),
     ("openvino",),
@@ -2680,7 +2680,7 @@ _add(
     constraint="fixed task-native input resolution",
 )
 _add(
-    "experimental",
+    "available",
     ("rfdetr",),
     ("segment", "pose", "obb"),
     ("openvino",),
@@ -2983,7 +2983,7 @@ _add(
     ),
 )
 _add(
-    "experimental",
+    "available",
     ("dinov2",),
     ("classify",),
     ("coreai",),
@@ -3574,7 +3574,7 @@ def get_support(family: str, task: str, fmt: str) -> SupportEntry:
     if fmt == "mnn":
         return SupportEntry(
             "blocked",
-            "MNN v1 supports G0/G1 detection exports only.",
+            "MNN v1 has no implemented runtime contract for this family and task.",
         )
     if fmt == "rknn":
         return SupportEntry(
@@ -3585,7 +3585,7 @@ def get_support(family: str, task: str, fmt: str) -> SupportEntry:
     if fmt in {"tensorrt", "openvino"}:
         runtime = "TensorRT" if fmt == "tensorrt" else "OpenVINO"
         return SupportEntry(
-            "experimental",
+            "available",
             f"The converter path is available, but the project has not yet "
             f"recorded {runtime} runtime parity for this family and task.",
         )
@@ -3611,8 +3611,9 @@ def get_support(family: str, task: str, fmt: str) -> SupportEntry:
             "This family and task are not covered by the family-aware CoreML wrapper.",
         )
     return SupportEntry(
-        "experimental",
-        "This combination exports without a numeric parity guarantee.",
+        "available",
+        "Conversion is implemented; numeric runtime parity has not been recorded "
+        "for this combination.",
     )
 
 

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -51,7 +51,6 @@ from ...utils.serialization import (
 )
 from ...validation.preprocessors import StandardValPreprocessor
 from .cuda_graph import (
-    CudaGraphUnavailable,
     GraphRunner,
     forward_maybe_graphed,
     normalize_cuda_graph_mode,
@@ -132,7 +131,6 @@ class BaseModel(ABC):
     TRAIN_CONFIG: ClassVar[Optional[type[TrainConfig]]] = None
     val_preprocessor_class = StandardValPreprocessor
     validator_class: ClassVar[Optional[type]] = None
-    EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset[str]] = frozenset()
     # Dataset-variant weight suffixes (e.g. "visdrone" accepts
     # ``LibreYOLO9P2s-visdrone.pt``). Families that publish checkpoints
     # trained on a non-default dataset opt in; the variant stays part of the
@@ -653,13 +651,7 @@ class BaseModel(ABC):
     @classmethod
     def get_download_notice(cls, filename: str, url: str) -> Optional[str]:
         """Return an optional warning shown before auto-downloading weights."""
-        if Path(filename).name.lower() not in cls.EXPERIMENTAL_WEIGHT_FILENAMES:
-            return None
-        return (
-            f"{Path(filename).name} is an EXTREMELY experimental preview checkpoint. "
-            "It is provided for early pose-estimation testing and may change without "
-            "compatibility guarantees."
-        )
+        return None
 
     @classmethod
     def verify_downloaded_file(cls, local_path: str, source_url: str) -> None:
@@ -1607,8 +1599,8 @@ class BaseModel(ABC):
             batch: Calibration batch size.
             algorithm: Activation range estimation: "minmax" (absolute
                 extremes across batches; the measured best default),
-                "percentile" (experimental: mean of per-batch 0.1/99.9
-                percentiles; degrades transformer families), or "auto"
+                "percentile" (mean of per-batch 0.1/99.9 percentiles; measured
+                to degrade transformer families), or "auto"
                 (minmax).
             keep_high_precision: Substring patterns of module names kept in
                 float. Defaults to the family policy (first layer + heads).

--- a/libreyolo/models/birefnet/export.py
+++ b/libreyolo/models/birefnet/export.py
@@ -5,8 +5,8 @@ convolution), which neither ONNX exporter knows how to translate out of the box.
 ONNX opset 19 defines a standard ``DeformConv`` operator, and torchvision's
 offset/mask layout matches the ONNX spec, so we register a symbolic that maps
 the op to ``DeformConv`` and export at a fixed resolution. ONNX Runtime's CPU
-provider does not currently implement this node, so CPU runtime parity remains
-experimental even though graph creation succeeds.
+provider does not currently implement this node, so CPU runtime parity cannot
+be measured there even though graph creation succeeds.
 """
 
 from __future__ import annotations

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -30,7 +30,7 @@ class LibreDFINE(BaseModel):
     inference, fine-tuning (via ``DFINETrainer``), validation, and export
     (ONNX / TensorRT / OpenVINO).
 
-    ``task='segment'`` adds the D-FINE-seg mask head (experimental).
+    ``task='segment'`` adds the D-FINE-seg mask head.
     COCO-pretrained ``LibreDFINE{n,s,m,l,x}-seg.pt`` weights auto-download from
     the LibreYOLO Hugging Face org (converted from ArgoSA/D-FINE-seg,
     Apache-2.0). Fine-tuning from detect weights instead requires an explicit

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -260,8 +260,6 @@ class LibreDINOv2(BaseModel):
     semantic_resize_mode: ClassVar[str] = "stretch"
     semantic_imgsz_divisor: ClassVar[int] = 14
 
-    EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset] = frozenset()
-
     # =========================================================================
     # Registry classmethods
     # =========================================================================

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -278,12 +278,11 @@ class LibreEC(BaseModel):
         # forward time. Mirror the D-FINE policy.
         return False
 
-    @ddp_aware(experimental_key="allow_experimental")
+    @ddp_aware()
     def train(
         self,
         data: str,
         *,
-        allow_experimental: bool = False,
         epochs: int = 74,
         batch: int = 16,
         imgsz: int = 640,
@@ -310,11 +309,12 @@ class LibreEC(BaseModel):
         matcher + OKS/L1 criterion). Segmentation needs YOLO polygon labels;
         pose needs YOLO keypoint labels with ``kpt_shape`` in the dataset yaml.
 
-        **EXPERIMENTAL.** All three follow upstream EdgeCrafter's recipe (AdamW,
-        FlatCosine, EMA 0.9999, ImageNet-normalized inputs). Detect/seg add
-        MAL+L1+GIoU+FGL+DDF; loss + one-step train are validated on synthetic
-        input, but full-fine-tune convergence has not been run end-to-end. Pass
-        ``allow_experimental=True`` to acknowledge.
+        All three follow upstream EdgeCrafter's recipe (AdamW, FlatCosine,
+        EMA 0.9999, ImageNet-normalized inputs). Detect/seg add
+        MAL+L1+GIoU+FGL+DDF. Loss and one-step training are validated on
+        synthetic input. Full-fine-tune convergence, multi-GPU training, the
+        stop-augmentation best-reload behavior, and the Objects365-to-COCO
+        class remap have not been validated end to end.
 
         Args:
             callbacks: Optional training callback or iterable of callbacks.
@@ -324,7 +324,6 @@ class LibreEC(BaseModel):
         if self.task == "pose":
             return self._train_pose(
                 data=data,
-                allow_experimental=allow_experimental,
                 epochs=epochs,
                 batch=batch,
                 imgsz=imgsz,
@@ -342,16 +341,6 @@ class LibreEC(BaseModel):
                 loggers=loggers,
                 **kwargs,
             )
-        if not allow_experimental:
-            raise RuntimeError(
-                "EC training is experimental and has not been validated by a "
-                "full fine-tune. Pass allow_experimental=True to proceed.\n"
-                "What's been validated: inference parity (1e-5 vs upstream on all "
-                "4 sizes), ONNX export round-trip, COCO val2017 mAP. What's NOT "
-                "validated: full fine-tune convergence, multi-GPU, the "
-                "stop_aug_epoch best-reload trick, Obj365→COCO class remap."
-            )
-
         from pathlib import Path
 
         from libreyolo.data import load_data_config
@@ -440,7 +429,6 @@ class LibreEC(BaseModel):
         self,
         data: str,
         *,
-        allow_experimental: bool = False,
         epochs: int = 74,
         batch: int = 16,
         imgsz: int = 640,
@@ -460,22 +448,16 @@ class LibreEC(BaseModel):
     ) -> dict:
         """Fine-tune EdgeCrafter ECPose on a YOLO-format keypoint dataset.
 
-        **EXPERIMENTAL.** ECPose is a DETRPose keypoint transformer; this path
-        follows DETRPose's released recipe — Hungarian matcher (class + keypoint
+        ECPose is a DETRPose keypoint transformer; this path follows DETRPose's
+        released recipe — Hungarian matcher (class + keypoint
         L1 + OKS), VFL classification keyed on OKS, keypoint L1 + OKS losses,
         GO-LSD union matching, deep supervision over decoder/encoder/pre layers,
         and contrastive keypoint denoising — on a keypoint-aware (RGB +
-        ImageNet-normalized) data pipeline. Convergence has not been validated
-        end to end; pass ``allow_experimental=True`` to acknowledge. The dataset
-        ``data.yaml`` must declare ``kpt_shape: [num_keypoints, 2|3]``; only the
-        model's native keypoint count is supported (head fixed at construction).
+        ImageNet-normalized) data pipeline. Full-fine-tune convergence has not
+        been validated end to end. The dataset ``data.yaml`` must declare
+        ``kpt_shape: [num_keypoints, 2|3]``; only the model's native keypoint
+        count is supported because the head is fixed at construction.
         """
-        if not allow_experimental:
-            raise RuntimeError(
-                "EC pose training is experimental and has not been validated by "
-                "a full fine-tune. Pass allow_experimental=True to proceed."
-            )
-
         from pathlib import Path
 
         from libreyolo.data import load_data_config

--- a/libreyolo/models/ec/pose_trainer.py
+++ b/libreyolo/models/ec/pose_trainer.py
@@ -1,4 +1,4 @@
-"""ECPoseTrainer — native EdgeCrafter ECPose (DETR-style) fine-tuning (EXPERIMENTAL).
+"""ECPoseTrainer — native EdgeCrafter ECPose (DETR-style) fine-tuning.
 
 ECPose is a keypoint transformer, so this trainer owns its data pipeline
 (:class:`~libreyolo.data.YOLOPoseDataset` with keypoint-aware transforms, padded
@@ -59,7 +59,7 @@ def _set_bn_eval(module: torch.nn.Module) -> None:
 
 
 class ECPoseTrainer(BaseTrainer):
-    """Trainer for EdgeCrafter ECPose models (experimental)."""
+    """Trainer for EdgeCrafter ECPose models."""
 
     artifact_model_families = ("ec",)
     best_metric_key = "metrics/keypoints_mAP50-95"
@@ -189,7 +189,7 @@ class ECPoseTrainer(BaseTrainer):
     def _ddp_find_unused_parameters(self) -> bool:
         # Contrastive denoising exercises label_enc/pose_enc, but some auxiliary
         # heads can still go unused on batches with no GT, so keep this on for
-        # DDP safety (this is an experimental single-GPU-first path anyway).
+        # DDP to discover those unused parameters safely.
         return True
 
     def _build_dataset(self, img_files, label_files, preproc) -> YOLOPoseDataset:

--- a/libreyolo/models/ec/seg_trainer.py
+++ b/libreyolo/models/ec/seg_trainer.py
@@ -1,4 +1,4 @@
-"""ECSegTrainer — native EC instance-segmentation fine-tuning (EXPERIMENTAL).
+"""ECSegTrainer — native EC instance-segmentation fine-tuning.
 
 EC's seg model shares the detect backbone/encoder/decoder and adds a mask head.
 The training recipe therefore reuses the EC detect recipe (AdamW, FlatCosine,
@@ -27,7 +27,7 @@ from .seg_loss import ECSegCriterion, ECSegHungarianMatcher
 
 
 class ECSegTrainer(BaseTrainer):
-    """Trainer for EC segmentation models (experimental)."""
+    """Trainer for EC segmentation models."""
 
     artifact_model_families = ("ec",)
     # max GT instances per image carried as rasterized target masks.

--- a/libreyolo/models/ec/trainer.py
+++ b/libreyolo/models/ec/trainer.py
@@ -1,4 +1,4 @@
-"""ECTrainer — D-FINE-style trainer adapted for EC (EXPERIMENTAL).
+"""ECTrainer — D-FINE-style trainer adapted for EC.
 
 Subclasses ``DFINETrainer`` and overrides only the points where EC's recipe
 diverges from D-FINE's:
@@ -9,8 +9,7 @@ diverges from D-FINE's:
 * ``get_loss_components`` reports ``mal`` instead of ``vfl``.
 * ``get_model_family`` / ``get_model_tag`` / ``_config_class`` updated.
 
-Training has not been validated on a real fine-tune run; this is shipped
-behind an explicit ``allow_experimental`` gate on ``LibreEC.train()``.
+Training has not yet been validated on a full real-data fine-tune run.
 """
 
 from __future__ import annotations

--- a/libreyolo/models/fomo/model.py
+++ b/libreyolo/models/fomo/model.py
@@ -179,15 +179,14 @@ class LibreFOMO(BaseModel):
         return validator.parse_gt_points_from_boxes(gt_row, orig_h, orig_w)
 
     # -------------------------------------------------------------------------
-    # Training (experimental — requires allow_experimental=True)
+    # Training
     # -------------------------------------------------------------------------
 
-    @ddp_aware(experimental_key="allow_experimental")
+    @ddp_aware()
     def train(
         self,
         data: str,
         *,
-        allow_experimental: bool = False,
         callbacks: TrainCallbacks = None,
         loggers=None,
         **kwargs: Any,
@@ -199,12 +198,6 @@ class LibreFOMO(BaseModel):
             loggers: Optional built-in experiment loggers: a registered name,
                 a configured logger instance, or an iterable mixing both.
         """
-        if not allow_experimental:
-            raise NotImplementedError(
-                "LibreFOMO training is experimental in this version. "
-                "Pass allow_experimental=True to model.train() to enable it."
-            )
-
         from .trainer import FOMOTrainer
 
         if "imgsz" not in kwargs:

--- a/libreyolo/models/picodet/model.py
+++ b/libreyolo/models/picodet/model.py
@@ -165,12 +165,11 @@ class LibrePICODET(BaseModel):
 
     # ---- training --------------------------------------------------------
 
-    @ddp_aware(experimental_key="allow_experimental")
+    @ddp_aware()
     def train(
         self,
         data: str,
         *,
-        allow_experimental: bool = False,
         epochs: int = _TRAIN_DEFAULTS.epochs,
         batch: int = _TRAIN_DEFAULTS.batch,
         imgsz: int | None = None,
@@ -193,35 +192,19 @@ class LibrePICODET(BaseModel):
     ) -> dict:
         """Fine-tune PICODET on a YOLO-format dataset.
 
-        **EXPERIMENTAL.** Loss components and assigner mirror Bo's upstream
-        recipe (VFL + DFL + GIoU + SimOTA, with cls-quality weighting and
-        dynamic-IoU VFL targets). Inference is bit-equivalent to upstream
-        on the same checkpoint. Training has *not* been validated to clear
-        LibreYOLO's RF1 floor on small custom datasets — PICODET-s/320's
-        tiny 1.17M-param ESNet + 320 input is a poor fit for the
-        30-image/2-class fine-tunes RF1 stresses (see skill §6
-        "fine-tune parity, not paper parity"). Use it for full-COCO scale
-        training or accept that small-dataset transfer is rough.
-
-        Pass ``allow_experimental=True`` to acknowledge.
+        Loss components and the assigner follow Bo's upstream recipe (VFL +
+        DFL + GIoU + SimOTA, with classification-quality weighting and dynamic
+        IoU VFL targets). Inference is bit-equivalent to upstream on the same
+        checkpoint. PICODET-s/320 has not reliably cleared LibreYOLO's RF1
+        floor on the 30-image, two-class fine-tune fixture. Full-dataset
+        convergence, multi-GPU behavior, and augmentation beyond horizontal
+        flipping have not been validated.
 
         Args:
             callbacks: Optional training callback or iterable of callbacks.
             loggers: Optional built-in experiment loggers: a registered name,
                 a configured logger instance, or an iterable mixing both.
         """
-        if not allow_experimental:
-            raise RuntimeError(
-                "PICODET training is experimental. The loss + assigner match "
-                "Bo's upstream recipe and the trainer runs end-to-end, but "
-                "small-dataset fine-tunes (e.g. RF1's marbles) don't reliably "
-                "clear the 5%% mAP floor due to model capacity and the "
-                "no-aug upstream recipe. Pass allow_experimental=True to "
-                "proceed.\n"
-                "What's validated: inference, ONNX/TorchScript/NCNN/OpenVINO "
-                "export. What's NOT validated: small-dataset fine-tune "
-                "convergence, multi-GPU, augmentation policy beyond hflip."
-            )
         from libreyolo.data import load_data_config
 
         from .trainer import PICODETTrainer

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -1,22 +1,22 @@
-"""The model registry: every family enrolled in a rollout group.
+"""Model coverage groups used by cross-family tests and tooling.
 
-Groups decide where a cross-cutting feature lands first and how hard it is
-validated before release. They classify families, never tasks: a feature
-scoped to "g1 detect" combines a group with a task filter at the feature
-level. ``tests/unit/test_model_registry.py`` fails when a registered family
-is not enrolled here, so porting a new model requires adding exactly one
-line to ``MODEL_GROUPS``.
+Groups select representative coverage sets; they do not grant or restrict a
+user-facing capability. Support is determined by each family's implemented
+API and by format-specific capability checks. Groups classify families, never
+tasks. ``tests/unit/test_model_registry.py`` fails when a registered family is
+not enrolled here, so porting a new model requires adding exactly one line to
+``MODEL_GROUPS``.
 """
 
 from __future__ import annotations
 
 GROUPS: dict[str, str] = {
-    "g0": "Flagship: features are designed and fully GPU-validated here first.",
-    "g1": "Core trainable detectors: features follow g0 in the same release wave, GPU-smoked per family.",
-    "g2": "Supporting trainables: kept green in CI; features land opportunistically or on request.",
-    "g3": "Inference-only specialists: predict/val/export surface only; training features do not apply.",
-    "g4": "Museum: frozen exhibits; bug fixes only.",
-    "s": "Sibling tiers (SAM, open-vocab, VLM, zero-shot): separate product surfaces, excluded from group rollouts.",
+    "g0": "Flagship anchors required in shared-feature coverage.",
+    "g1": "Trainable detector coverage set.",
+    "g2": "Additional trainable-family coverage set.",
+    "g3": "Families without a training implementation.",
+    "g4": "Historical families with inference coverage.",
+    "s": "Sibling APIs (SAM, open-vocab, VLM, zero-shot) covered separately.",
 }
 
 MODEL_GROUPS: dict[str, str] = {
@@ -116,7 +116,7 @@ MODEL_GROUPS: dict[str, str] = {
 
 
 def group_of(family: str) -> str | None:
-    """Return the rollout group for ``family``, or ``None`` if unenrolled."""
+    """Return the coverage group for ``family``, or ``None`` if unenrolled."""
     return MODEL_GROUPS.get(family)
 
 

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -125,7 +125,6 @@ class LibreRFDETR(BaseModel):
         "pose": POSE_INPUT_SIZES,
         "obb": INPUT_SIZES,
     }
-    EXPERIMENTAL_WEIGHT_FILENAMES: ClassVar[frozenset[str]] = frozenset()
     TRAIN_CONFIG: ClassVar[type[RFDETRConfig]] = RFDETRConfig
     val_preprocessor_class: ClassVar[type[RFDETRValPreprocessor]] = RFDETRValPreprocessor
     TTA_FIXED_SIZE: ClassVar[bool] = True  # fixed square; multi-scale TTA is a no-op

--- a/libreyolo/models/rtmdet/model.py
+++ b/libreyolo/models/rtmdet/model.py
@@ -4,9 +4,8 @@ Port of RTMDet (Lyu et al., 2022) from open-mmlab/mmdetection
 (Apache-2.0). Sizes: t / s / m / l / x. Supports detection and RTMDet-Ins
 instance segmentation inference and validation.
 
-Detection training is wired but experimental via ``allow_experimental=True``.
-RTMDet-Ins training is not implemented. Inference is compatible with official
-mmdetection checkpoints.
+Detection training is implemented. RTMDet-Ins training is not implemented.
+Inference is compatible with official mmdetection checkpoints.
 """
 
 from __future__ import annotations
@@ -234,15 +233,14 @@ class LibreRTMDet(BaseModel):
         )
 
     # =========================================================================
-    # Training (experimental)
+    # Training
     # =========================================================================
 
-    @ddp_aware(experimental_key="allow_experimental")
+    @ddp_aware()
     def train(
         self,
         data: str,
         *,
-        allow_experimental: bool = False,
         epochs: int = _TRAIN_DEFAULTS.epochs,
         batch: int = _TRAIN_DEFAULTS.batch,
         imgsz: int | None = None,
@@ -265,9 +263,9 @@ class LibreRTMDet(BaseModel):
     ) -> dict:
         """Fine-tune LibreRTMDet on a YOLO-format dataset.
 
-        **EXPERIMENTAL.** The QualityFocalLoss + GIoU + DynamicSoftLabelAssigner
-        components are ported from mmdetection (Apache-2.0) and the trainer
-        runs end-to-end. What is NOT validated:
+        The QualityFocalLoss + GIoU + DynamicSoftLabelAssigner components are
+        ported from mmdetection (Apache-2.0) and the trainer runs end-to-end.
+        The following have not been validated:
 
         - small-dataset fine-tune convergence (RF1-floor parity)
         - paper-parity training-from-scratch (reproducing the 41.1 val mAP)
@@ -280,8 +278,6 @@ class LibreRTMDet(BaseModel):
         mmdet, postprocess matches mmdet's output to within 0.001 mAP on
         val2017 subsets. See the family docstring for the full contract.
 
-        Pass ``allow_experimental=True`` to acknowledge.
-
         Args:
             callbacks: Optional training callback or iterable of callbacks.
             loggers: Optional built-in experiment loggers: a registered name,
@@ -291,19 +287,6 @@ class LibreRTMDet(BaseModel):
             raise NotImplementedError(
                 "RTMDet-Ins training is not implemented yet. Instance "
                 "segmentation currently supports inference and validation."
-            )
-        if not allow_experimental:
-            raise RuntimeError(
-                "RTMDet training is experimental. The loss + assigner follow "
-                "mmdetection's DynamicSoftLabelAssigner + QualityFocalLoss + "
-                "GIoULoss recipe and the trainer runs end-to-end, but small-"
-                "dataset fine-tune convergence and from-scratch paper parity "
-                "have NOT been verified. Pass allow_experimental=True to "
-                "proceed.\n"
-                "Validated: inference, ONNX export, bit-equivalent to upstream "
-                "mmdet on val2017 subsets within 0.001 mAP. "
-                "Not validated: training convergence, multi-GPU, the strict "
-                "two-stage pipeline switch, cached Mosaic/MixUp throughput."
             )
         from libreyolo.data import load_data_config
 

--- a/libreyolo/models/rtmdet/trainer.py
+++ b/libreyolo/models/rtmdet/trainer.py
@@ -1,9 +1,9 @@
 """RTMDet trainer.
 
-Experimental trainer subclassing :class:`BaseTrainer`. Reuses the shared
-mosaic+mixup augmentation pipeline. Documented gaps vs upstream
-mmdet/mmyolo (these matter for full-paper-parity, not for the
-fine-tune-from-pretrained path that ``allow_experimental=True`` gates):
+This trainer subclasses :class:`BaseTrainer` and reuses the shared mosaic and
+mixup augmentation pipeline. Documented gaps versus upstream mmdet/mmyolo
+(these matter for full-paper parity, not for fine-tuning from pretrained
+weights):
 
 - mmdet uses ``CachedMosaic`` / ``CachedMixUp`` (FIFO of decoded images) for
   throughput; we use the standard non-cached pair.
@@ -59,7 +59,7 @@ class RTMDetTrainTransform(TrainTransform):
 
 
 class RTMDetTrainer(BaseTrainer):
-    """RTMDet detection trainer (experimental)."""
+    """RTMDet detection trainer."""
 
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -54,7 +54,6 @@ class LibreYOLO9(BaseModel):
     TASK_INPUT_SIZES = {
         "detect": INPUT_SIZES,
     }
-    EXPERIMENTAL_WEIGHT_FILENAMES: frozenset = frozenset()
     TRAIN_CONFIG = YOLO9Config
     val_preprocessor_class = YOLO9ValPreprocessor
     # The detection forward is pure tensor work with no host sync, so it

--- a/libreyolo/quant/api.py
+++ b/libreyolo/quant/api.py
@@ -452,7 +452,7 @@ def quantize_model(
         # Measured on coco128: multi-batch min/max beats percentile clipping
         # for every tested model, and percentile collapses transformer
         # activations (their outliers are load-bearing). minmax is the
-        # default; percentile stays available as an experimental estimator.
+        # default; percentile remains selectable for workloads where it helps.
         algorithm = "minmax"
     if algorithm == "percentile" and family == "rfdetr":
         logger.warning(

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -746,7 +746,7 @@ class DEIMv2Config(TrainConfig):
 
 @dataclass(kw_only=True)
 class ECConfig(TrainConfig):
-    """EC-specific training defaults (experimental).
+    """EC-specific training defaults.
 
     Fine-tune defaults keep the optimizer/scheduler/loss shape from
     EdgeCrafter's published recipe (S/M):
@@ -759,8 +759,7 @@ class ECConfig(TrainConfig):
     strong color/geometric knobs are disabled here so the public config matches
     the effective training path.
 
-    Training has NOT been validated on a real fine-tune run — ship as
-    experimental.
+    Full real-data fine-tune convergence has not yet been validated.
     """
 
     optimizer: str = "adamw"
@@ -802,7 +801,7 @@ class ECConfig(TrainConfig):
 
 @dataclass(kw_only=True)
 class ECSegConfig(ECConfig):
-    """EC segmentation fine-tune defaults (experimental).
+    """EC segmentation fine-tune defaults.
 
     Inherits the EC detect recipe and adds the instance-mask loss knobs. The
     seg data path reuses RF-DETR's square-resize + polygon-rasterization
@@ -839,7 +838,7 @@ class ECSegConfig(ECConfig):
 
 @dataclass(kw_only=True)
 class ECPoseConfig(ECConfig):
-    """EC (DETR-style) pose fine-tune defaults (experimental).
+    """EC (DETR-style) pose fine-tune defaults.
 
     EdgeCrafter's ECPose is a DETRPose-style keypoint transformer (Hungarian
     matching + OKS). This config carries the keypoint count / sigmas and the
@@ -1030,11 +1029,10 @@ class RTMDetConfig(TrainConfig):
     - DynamicSoftLabelAssigner (topk=13)
     - QualityFocalLoss (beta=2.0, weight=1.0) + GIoULoss (weight=2.0)
 
-    Status: training is implemented but experimental. ``LibreRTMDet.train()``
-    requires ``allow_experimental=True`` because small-dataset fine-tune
-    convergence, from-scratch paper parity, multi-GPU behavior, cached
-    Mosaic/MixUp throughput, and the strict upstream two-stage pipeline switch
-    are not validated yet.
+    Detection training is implemented. Small-dataset fine-tune convergence,
+    from-scratch paper parity, multi-GPU behavior, cached Mosaic/MixUp
+    throughput, and the strict upstream two-stage pipeline switch have not yet
+    been validated.
     """
 
     # BatchNorm-heavy pure CNN: sync BN stats across ranks under DDP (same

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -282,7 +282,7 @@ def spawn_for_model(
 # ---------------------------------------------------------------------------
 
 
-def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
+def ddp_aware(batch_key: str = "batch"):
     """Decorator that adds automatic DDP spawn to a model ``train()`` method.
 
     When the decorated method is called with a multi-GPU device spec from
@@ -293,12 +293,6 @@ def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
     Args:
         batch_key: Key in the captured kwargs that holds the batch size.
             Defaults to ``"batch"``; RF-DETR uses ``"batch_size"``.
-        experimental_key: If set, names a boolean kwarg (e.g.
-            ``"allow_experimental"``) that must be truthy before DDP spawn
-            is attempted. When it is falsy the decorator falls through to
-            the function body immediately, letting the body raise its own
-            validation error on the main process rather than inside a
-            spawned worker.
     """
     def decorator(train_fn):
         @functools.wraps(train_fn)
@@ -326,10 +320,6 @@ def ddp_aware(batch_key: str = "batch", experimental_key: str | None = None):
                         f"Multi-GPU DDP requires CUDA. Got device={device!r} but "
                         "CUDA is not available on this machine."
                     )
-                if experimental_key and not train_kw.get(experimental_key, True):
-                    # Guard not satisfied — fall through so the function body
-                    # raises its validation error cleanly on the main process.
-                    return train_fn(self, *args, **kwargs)
                 return spawn_for_model(self, train_kw, len(devices), devices=devices, batch_key=batch_key)
 
             return train_fn(self, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -436,7 +436,7 @@ markers = [
     "training_nightly: opt-in GPU checks for training-time CUDA graph capture",
     "export_backend: tests covering an export backend or serialized runtime format",
     "supported_backend: tests covering a release-blocking supported backend",
-    "experimental_backend: tests covering an experimental backend",
+    "extended_backend: tests covering an extended backend",
     "onnx: tests covering ONNX export or inference",
     "triton: tests covering NVIDIA Triton HTTP inference",
     "torchscript: tests covering TorchScript export or inference",

--- a/skills/libreyolo-export-formats/SKILL.md
+++ b/skills/libreyolo-export-formats/SKILL.md
@@ -39,8 +39,8 @@ re-specify imgsz/task/classes).
 
 Formats are not equally supported, and support is per (format, family,
 task), not per format. ONNX is the release-gated supported backend; the
-others are covered by e2e but several are marked experimental
-(`supported_backend` vs `experimental_backend` markers in `tests/e2e/`).
+others are covered by e2e but have extended runtime coverage
+(`supported_backend` vs `extended_backend` markers in `tests/e2e/`).
 `libreyolo formats` prints the format list with capabilities; the e2e files
 (`test_onnx.py`, `test_tensorrt.py`, ...) are the truth for which families
 each format actually covers. Before telling anyone "family X exports to Y",
@@ -117,8 +117,8 @@ Copy the twin structure: exporter subclass (declare `format_name`, deps via
 shared pre/postprocess helpers in `BaseBackend`, never fork them), a lazy
 export in `libreyolo/__init__.py`, an optional-dependency extra in
 `pyproject.toml` (never a core dep), `libreyolo formats` row, an
-`experimental_backend`-marked e2e file, and docs. A new format starts
-experimental and stays that way until family coverage and parity tests say
+`extended_backend`-marked e2e file, and docs. A new format uses the extended
+marker until family coverage and parity tests say
 otherwise. Note the precedent that not everything becomes a format: when the
 toolchain cannot be a pip dependency (Hailo's proprietary compiler), ship a
 skill/doc for the two-stage flow instead of a `format=` target.
@@ -128,4 +128,4 @@ skill/doc for the two-stage flow instead of a `format=` target.
 - `skills/use-libreyolo/`: the user-facing export + exported-inference API.
 - `skills/libreyolo-export-hailo/`: the no-format precedent, done right.
 - `skills/libreyolo-write-e2e-tests/`: markers for export coverage.
-- `docs/testing.md`: which backends gate releases vs run experimentally.
+- `docs/testing.md`: which backends gate releases vs run on the extended schedule.

--- a/skills/libreyolo-export-hailo/SKILL.md
+++ b/skills/libreyolo-export-hailo/SKILL.md
@@ -88,7 +88,7 @@ postprocess.
 **Status caveat:** no LibreYOLO family has been validated end-to-end through the DFC to a
 running HEF yet. The rules above predict compilability from architecture; parser,
 quantization, and accuracy remain unproven until a HEF is compiled and measured. Treat
-every "candidate" as experimental.
+every "candidate" as requiring recorded validation evidence.
 
 ## Step 1 — export static ONNX from LibreYOLO
 

--- a/skills/libreyolo-port-model/SKILL.md
+++ b/skills/libreyolo-port-model/SKILL.md
@@ -27,7 +27,7 @@ scaffold:
 3. **Tasks shipped**: detect / pose / segment (this skill's templates), or classify / semantic / depth / restore / point / gaze (clone the merged exemplar family — §10 lists them)?
 4. **Backbone source**: standard PyTorch, vendored separately-licensed (e.g. DINOv3), or loaded from an optional dependency (e.g. transformers — RF-DETR's DINOv2 backbone)?
 5. **License**: code (upstream `LICENSE` file) and weights (HF model card YAML). Both must be permissive (MIT / Apache-2.0 / BSD) for the family to live in core.
-6. **Maturity target**: inference-only, gated experimental training, or production training with e2e parity?
+6. **Implementation and evidence target**: inference-only, training with recorded validation evidence, or training with e2e parity?
 
 The answers route you through §1 (license gate) → §3 (pick scaffold) → §4
 (per-family ledger entry to clone) → §5 (commit sequence) → §6 (paste-ready
@@ -35,7 +35,7 @@ templates). Reference sections fill in the contract details.
 
 **Two concrete starts**:
 
-- **RTMO (one-stage pose)** → YOLO-grid pose, Apache-2.0 (MMPose-based). **Closest scaffolds: YOLOX** for the CSPDarknet backbone, **RTMDet** (`models/rtmdet/`) as the worked example of the mm-series route — mm-series upstream, key remap in `models/rtmdet/convert.py`, gated-experimental training. (RTMDet itself used to be the hypothetical example here; it has since shipped following exactly this skill.)
+- **RTMO (one-stage pose)** → YOLO-grid pose, Apache-2.0 (MMPose-based). **Closest scaffolds: YOLOX** for the CSPDarknet backbone, **RTMDet** (`models/rtmdet/`) as the worked example of the mm-series route — mm-series upstream and key remap in `models/rtmdet/convert.py`. (RTMDet itself used to be the hypothetical example here; it has since shipped following exactly this skill.)
 - **A random model on HF** → Run §1 (license check) first. If permissive, find architecture in §4 ledger; if no row matches, fall back to §3 decision tree.
 
 ## 1. License check — both code and weights
@@ -113,20 +113,20 @@ license), the family's own license isn't sufficient. Required:
 
 Don't quietly bundle a non-OSI sub-component without these three artifacts.
 
-## 2. Pick your maturity target
+## 2. Pick the implementation and evidence target
 
 Pick one and document scope explicitly:
 
-1. **Inference-only.** No trainer wired, or trainer rejects all tasks in `train()`. The user can `model.predict(...)` but not `model.train(...)`. YOLO-NAS pose, EC pose, EC seg, L2CS, CLIP are here.
-2. **Gated experimental training.** Trainer exists and `train()` accepts the task, but raises unless the user passes `allow_experimental=True`. Use when loss + assignment match upstream but small-dataset fine-tune convergence is unvalidated. **PicoDet detect** (`models/picodet/model.py:157-201`), **EC detect** (`models/ec/model.py:269-310`), and **RTMDet detect** (`allow_experimental` in `models/rtmdet/model.py`) are gated this way today.
-3. **Production-grade training.** `test_rf1_training` passes; row in `MODEL_CATALOG`; recipe gaps documented in family docstring. YOLOX, YOLOv9, YOLO-NAS detect, D-FINE, DEIM, DEIMv2, RT-DETR, RF-DETR sit here, plus the classify families (MobileNetV4 / ConvNeXt / EfficientNetV2 / ResNet) on the shared classify path.
+1. **Inference-only.** No trainer is wired, or `train()` rejects the task. The user can `model.predict(...)` but not `model.train(...)`. YOLO-NAS pose, L2CS, and CLIP are examples.
+2. **Training with limited evidence.** Trainer exists and `train()` accepts the task. Record the exact completed checks and the missing convergence evidence; do not turn a user acknowledgement into the capability contract.
+3. **Training with RF1 evidence.** `test_rf1_training` passes; row in `MODEL_CATALOG`; recipe gaps documented in the family docstring. YOLOX, YOLOv9, YOLO-NAS detect, D-FINE, DEIM, DEIMv2, RT-DETR, RF-DETR sit here, plus the classify families (MobileNetV4 / ConvNeXt / EfficientNetV2 / ResNet) on the shared classify path.
 
 **Inference-only is a legitimate ship state.** Don't gate the port on a working trainer.
 
 Which target to pick belongs to the PRD: `libreyolo-write-model-prd` section 4
-carries the three-gate trainer rule (task shape, upstream fine-tune recipe,
-audience/rollout tier). If the PRD is silent on maturity, apply the same gates
-and record the answer in the PR description.
+checks the task/data shape and the available fine-tuning recipe. If the PRD is
+silent on implementation scope or evidence, apply the same checks and record
+the answer in the PR description.
 
 ## 3. Pick your scaffold
 
@@ -137,7 +137,7 @@ Use this decision tree to pick the family you'll clone as your starting point.
 | Upstream looks like | Closest scaffold | What to keep | What to swap |
 |---|---|---|---|
 | YOLO-grid + SimOTA / TaskAlignedAssigner | **YOLOX** (`models/yolox/`, 6 files, ~288 LoC `model.py`) | mosaic+mixup pipeline, label assignment idiom, BGR preprocess if YOLOX-style | head architecture, backbone, optionally loss |
-| YOLO-grid + GFL/DFL + ESNet/light backbone | **PicoDet** (`models/picodet/`, 6 files, ~272 LoC `model.py`) | shared GFL head pattern, RGB+ImageNet norm, gated training pattern | backbone parser, neck, possibly DFL reg_max |
+| YOLO-grid + GFL/DFL + ESNet/light backbone | **PicoDet** (`models/picodet/`, 6 files, ~272 LoC `model.py`) | shared GFL head pattern, RGB+ImageNet norm, training implementation and evidence notes | backbone parser, neck, possibly DFL reg_max |
 | YOLO-grid + ELAN/RepNCSPELAN, complex conversion | **YOLOv9** (`models/yolo9/`, 7 files) | aux-head-skip pattern, heavy structural converter | head modules |
 | NMS-free YOLO-grid (one-to-one head, top-K) | **YOLOv9-E2E** (`models/yolo9_e2e/`, ~271 LoC `model.py`) | NMS-free postprocess pattern, parent-child sibling pattern | inherit from your detect parent rather than `BaseModel` |
 | DETR — light, mostly metadata-wrap conversion | **D-FINE** (`models/dfine/`, 16 files) | encoder/decoder/MS-deform-attn modules, FlatCosineScheduler, deploy() wrapper | matcher, loss weights |
@@ -172,19 +172,19 @@ Use this decision tree to pick the family you'll clone as your starting point.
 Dense reference. Find the family closest to your port and clone its directory
 as your starting scaffold. Each row tells you what's already solved.
 
-| Family | Pattern | Sizes | Tasks | Maturity (per task) | Files | Conversion tier | Notable |
+| Family | Pattern | Sizes | Tasks | Training state (per task) | Files | Weight conversion | Notable |
 |---|---|---|---|---|---|---|---|
-| **YOLOX** | YOLO-grid (NMS) | n/t/s/m/l/x | detect | production | 6 | none (in-process unwrap) | BGR 0–255 inference; mosaic+mixup; closest to upstream of any family |
-| **YOLOv9** | YOLO-grid (NMS) | t/s/m/c | detect | production | 7 | heavy structural | RGB 0–1; aux head dropped; `xyxy` normalized targets in loss; from-scratch recipe gap (3 param groups at same LR, no backbone-LR split) |
-| **YOLOv9-E2E** | NMS-free YOLO-grid | t/s/m/c | detect | production | 5 | reuses YOLOv9 converter (different `model_family` at wrap) | Inherits from `LibreYOLO9`. Postprocess does top-K only — `del iou_thres`. In the `_is_nms_free_family()` allowlist (was a miss for a while — since fixed) |
-| **YOLO-NAS** | YOLO-grid (NMS) | n*/s/m/l (n* pose-only) | detect, pose | detect = production, pose = inference-only | 7 | none (in-process EMA unwrap) | Weights from Deci CDN (license, not LibreYOLO HF). Only family with asymmetric-per-task `INPUT_SIZES` |
-| **PicoDet** | YOLO-grid (NMS) | s/m/l | detect | gated experimental (`allow_experimental=True`) | 6 | light structural (mmcv key remap + EMA drop) | GFL+DFL loss; ESNet backbone; per-size `INPUT_SIZES` (320/416/640) |
-| **D-FINE** | DETR | n/s/m/l/x | detect | production | 16 | metadata-wrap (~50 LoC) | Per-group LR via `lr_mult` in `_setup_optimizer` + `_train_epoch` override; `FlatCosineScheduler` (added by this family); `min_lr_ratio=0.05`; backbone-LR multiplier 0.5× |
-| **DEIM** | DETR (D-FINE sibling) | n/s/m/l/x | detect | production | small | metadata-wrap | Architecturally identical to D-FINE; `min_lr_ratio=0.5`; tie-break in factory (`models/__init__.py`, search "Ambiguous D-FINE/DEIM") |
-| **DEIMv2** | DETR | atto/femto/pico/n/s/m/l/x | detect | production | small | metadata-wrap + safetensors handling | s/m/l/x **vendor DINOv3** (separate license). Per-size `min_lr_ratio` overrides (`n` = 1.0, others 0.5). Documents `warmup_iters` epoch-override scaling |
-| **EC** | DETR | s/m/l/x | detect, pose, segment | detect = gated experimental, pose/segment = inference-only | many | metadata-wrap multi-task (`--task` flag) | 3-way `_init_model` dispatch; `is_pose_state_dict` / `is_seg_state_dict` discriminators; pose forces `nc=1, names={0:"person"}`; mask head DETR-style (transformer cross-attention, not YOLO proto) |
-| **RT-DETR** | DETR | r18/r34/r50/r50m/r101/l/x | detect | production | medium | light structural | Multi-char size codes (`r50m` vs `r50`) — overrides `detect_size_from_filename` with length-descending sort. **Per-group LR via `lr_ratio` + `_scale_lr` override** — better template than D-FINE for new DETR ports. Pretrained-backbone-download fix prototyped in `bf16a2b` but not in current code |
-| **RF-DETR** | DETR (native port) | n/s/m/l | detect, segment, pose, obb | detect/segment production; pose ported from official GroupPose (parity gate: `tests/e2e/test_rfdetr_keypoint_parity.py`) | 18 | bespoke autoconvert recognizer (needs the full checkpoint for size detection + COCO class remap) | **No longer a PyPI-package wrapper — full native port.** DINOv2 backbone loaded via transformers `AutoBackbone` with an explicit state-dict transfer (`models/rfdetr/backbone.py`) because `from_pretrained` silently no-ops on the windowed subclass (landmine #37). Lazy-registered behind the `transformers` dep (`_ensure_rfdetr`). Family-local config (`models/rfdetr/config.py`). Multi-task training via compile-time `RFDETR_TRAINERS` vs `RFDETR_SEG_TRAINERS` selection |
+| **YOLOX** | YOLO-grid (NMS) | n/t/s/m/l/x | detect | trainable; RF1 covered | 6 | none (in-process unwrap) | BGR 0–255 inference; mosaic+mixup; closest to upstream of any family |
+| **YOLOv9** | YOLO-grid (NMS) | t/s/m/c | detect | trainable; RF1 covered | 7 | heavy structural | RGB 0–1; aux head dropped; `xyxy` normalized targets in loss; from-scratch recipe gap (3 param groups at same LR, no backbone-LR split) |
+| **YOLOv9-E2E** | NMS-free YOLO-grid | t/s/m/c | detect | trainable; RF1 covered | 5 | reuses YOLOv9 converter (different `model_family` at wrap) | Inherits from `LibreYOLO9`. Postprocess does top-K only — `del iou_thres`. In the `_is_nms_free_family()` allowlist (was a miss for a while — since fixed) |
+| **YOLO-NAS** | YOLO-grid (NMS) | n*/s/m/l (n* pose-only) | detect, pose | detect trainable; pose has no trainer | 7 | none (in-process EMA unwrap) | Weights from Deci CDN (license, not LibreYOLO HF). Only family with asymmetric-per-task `INPUT_SIZES` |
+| **PicoDet** | YOLO-grid (NMS) | s/m/l | detect | trainable; RF1 gap documented | 6 | light structural (mmcv key remap + EMA drop) | GFL+DFL loss; ESNet backbone; per-size `INPUT_SIZES` (320/416/640) |
+| **D-FINE** | DETR | n/s/m/l/x | detect | trainable; RF1 covered | 16 | metadata-wrap (~50 LoC) | Per-group LR via `lr_mult` in `_setup_optimizer` + `_train_epoch` override; `FlatCosineScheduler` (added by this family); `min_lr_ratio=0.05`; backbone-LR multiplier 0.5× |
+| **DEIM** | DETR (D-FINE sibling) | n/s/m/l/x | detect | trainable; RF1 covered | small | metadata-wrap | Architecturally identical to D-FINE; `min_lr_ratio=0.5`; tie-break in factory (`models/__init__.py`, search "Ambiguous D-FINE/DEIM") |
+| **DEIMv2** | DETR | atto/femto/pico/n/s/m/l/x | detect | trainable; RF1 covered | small | metadata-wrap + safetensors handling | s/m/l/x **vendor DINOv3** (separate license). Per-size `min_lr_ratio` overrides (`n` = 1.0, others 0.5). Documents `warmup_iters` epoch-override scaling |
+| **EC** | DETR | s/m/l/x | detect, pose, segment | trainable; evidence recorded per task | many | metadata-wrap multi-task (`--task` flag) | 3-way `_init_model` dispatch; `is_pose_state_dict` / `is_seg_state_dict` discriminators; pose forces `nc=1, names={0:"person"}`; mask head DETR-style (transformer cross-attention, not YOLO proto) |
+| **RT-DETR** | DETR | r18/r34/r50/r50m/r101/l/x | detect | trainable; RF1 covered | medium | light structural | Multi-char size codes (`r50m` vs `r50`) — overrides `detect_size_from_filename` with length-descending sort. **Per-group LR via `lr_ratio` + `_scale_lr` override** — better template than D-FINE for new DETR ports. Pretrained-backbone-download fix prototyped in `bf16a2b` but not in current code |
+| **RF-DETR** | DETR (native port) | n/s/m/l | detect, segment, pose, obb | trainers implemented per task; evidence recorded separately | 18 | bespoke autoconvert recognizer (needs the full checkpoint for size detection + COCO class remap) | **No longer a PyPI-package wrapper — full native port.** DINOv2 backbone loaded via transformers `AutoBackbone` with an explicit state-dict transfer (`models/rfdetr/backbone.py`) because `from_pretrained` silently no-ops on the windowed subclass (landmine #37). Lazy-registered behind the `transformers` dep (`_ensure_rfdetr`). Family-local config (`models/rfdetr/config.py`). Multi-task training via compile-time `RFDETR_TRAINERS` vs `RFDETR_SEG_TRAINERS` selection |
 
 **File-count signal**: 6–7 files = single-task YOLO-grid scaffold.
 16+ = a DETR family with non-trivial loss + matcher + transforms.
@@ -195,27 +195,27 @@ Compact rows — clone these directly for the newer archetypes:
 
 | Family | Pattern | Tasks | Training | Notable |
 |---|---|---|---|---|
-| **RTMDet** (`models/rtmdet/`) | YOLO-grid (NMS) | detect | gated experimental | CSPNeXt; mm-series upstream; runtime auto-convert remap in `models/rtmdet/convert.py` |
+| **RTMDet** (`models/rtmdet/`) | YOLO-grid (NMS) | detect | trainable; evidence gaps documented | CSPNeXt; mm-series upstream; runtime auto-convert remap in `models/rtmdet/convert.py` |
 | **RT-DETRv2** | DETR (child of RT-DETR) | detect | inherits RT-DETR | registered **after** v1 so metadata-less checkpoints default to v1 |
-| **RT-DETRv4** | DETR (child of D-FINE) | detect | production | must register **before** D-FINE (more-specific `can_load`); own `models/rtdetrv4/convert.py` |
-| **FOMO** | boxless point head | point | production | `point` task; `PointValidator`; per-size `imgsz` from family `CONFIGS` |
+| **RT-DETRv4** | DETR (child of D-FINE) | detect | trainable | must register **before** D-FINE (more-specific `can_load`); own `models/rtdetrv4/convert.py` |
+| **FOMO** | boxless point head | point | trainable | `point` task; `PointValidator`; per-size `imgsz` from family `CONFIGS` |
 | **L2CS** | CNN gaze | gaze | inference-only | redistribution-restricted weights → autoconvert skiplist, no HF rehost |
 | **Depth Anything V2** | ViT dense | depth | inference-only | `DepthValidator`; check per-size weight licenses (upstream b/l are CC-BY-NC) |
 | **NAFNet** | encoder-decoder restore | restore | wired (see docstring) | native-resolution path (no letterbox); `RestoreValidator` |
 | **EoMT** | ViT semantic | semantic | see docstring | `SemanticValidator`; unique query/mask keys make `can_load` trivial |
 | **PIDNet** | CNN semantic | semantic | see docstring | 1024-px default input; fusion-key `can_load` |
-| **MobileNetV4 / ConvNeXt / EfficientNetV2 / ResNet** | classify backbone | classify | production | shared `BaseTrainer` classify path; parity vs timm is bit-identical (`max_abs_diff == 0`) |
+| **MobileNetV4 / ConvNeXt / EfficientNetV2 / ResNet** | classify backbone | classify | trainable | shared `BaseTrainer` classify path; parity vs timm is bit-identical (`max_abs_diff == 0`) |
 | **CLIP** | dual-tower zero-shot | classify | inference-only | pure-torch towers (no open_clip at runtime); `set_classes` API; `clip_validator.py` |
 | **DINOv2** | ViT | semantic, classify | via `RFDETRConfig` | lazy-registered together with RF-DETR (transformers dep) |
-| **YOLO9-P2** (`models/yolo9_p2/`) | YOLO-grid (child of YOLO9) | detect | production | stride-4 P2 head for small objects; sizes t/s; the `WEIGHT_VARIANTS = ("visdrone",)` precedent for dataset-variant weight suffixes |
+| **YOLO9-P2** (`models/yolo9_p2/`) | YOLO-grid (child of YOLO9) | detect | trainable | stride-4 P2 head for small objects; sizes t/s; the `WEIGHT_VARIANTS = ("visdrone",)` precedent for dataset-variant weight suffixes |
 | **Darknet lineage: YOLO2/3/4** (`models/darknet/` + thin `models/yolo{2,3,4}/`) | anchor-grid CNN | detect | inference-only | one shared `DarknetFamily` (cfg parser + blocks + anchor decode) serves all three; public-domain upstream; converter `weights/convert_darknet_weights.py`, parity via `weights/parity_darknet.py` |
 | **Darknet lineage: YOLO1** (`models/darknet/` + thin `models/yolo1/`) | dense FC-head CNN | detect | inference-only | shares the `DarknetFamily` engine but the FC head (`[connected]`/`[local]`/`[detection]`) does NOT fit the anchor decode: v1-specific `decode_detection` (7x7x30, VOC-20, fixed 448, square-stretch preprocess). OpenCV can't oracle it, so faithfulness = byte-exact reader + dog/bicycle/car golden. `b` weights on HF; tiny `t` weights lost upstream (code-ready, BYO `.weights`) |
-| **YOLO7** (`models/yolo7/`) | anchor-grid CNN | detect | experimental training (RF1 skip map) + infer | MIT upstream (same repo as the YOLO9 source); own `v7.yaml` + net; converter `weights/convert_yolo7_weights.py`, parity via `weights/parity_yolo7.py`; training via SimOTA loss (`loss.py`) adapted from Apache-2.0 YOLOX |
+| **YOLO7** (`models/yolo7/`) | anchor-grid CNN | detect | training evidence recorded in the RF1 skip map + infer | MIT upstream (same repo as the YOLO9 source); own `v7.yaml` + net; converter `weights/convert_yolo7_weights.py`, parity via `weights/parity_yolo7.py`; training via SimOTA loss (`loss.py`) adapted from Apache-2.0 YOLOX |
 | **BiRefNet** (`models/birefnet/`) | Swin v1 + bilateral-reference decoder | matte | inference-only (v1) | MIT upstream; `matte` task (ADR 0010); `MatteValidator` (MAE + S-measure); **family-local Swin v1** (original lineage, NOT the timm `models/swin/` tower, see NOTICE); ASPP deformable conv exports to ONNX `DeformConv` (opset 19) via a registered symbolic; converter `weights/convert_birefnet_weights.py`, parity via `weights/parity_birefnet.py` (max_abs_diff == 0) |
 | **Faster R-CNN** (`models/faster_rcnn/`) | two-stage RPN + RoIAlign + class-wise NMS | detect | inference-only | native port from torchvision v0.26.0 (BSD-3-Clause), sizes n/s/m/l; official state keys load strictly and all four variants have exact eager parity. COCO-91 sparse ids map to contiguous COCO-80. ONNX is batch-1/fixed-square and emits final already-NMSed boxes/scores/labels. Weight mirrors carry BSD-3-Clause on a disclosed implied basis plus torchvision's pretrained-model caveat; `weights/upload_faster_rcnn_hf.py` enforces the five-file contract |
 | **FCN** (`models/fcn/`) | dilated ResNet + primary/auxiliary FCN heads | semantic | inference-only | native port from torchvision v0.26.0 (BSD-3-Clause), sizes r50/r101 at 520; this is not the original VGG FCN-8s graph. Both heads have exact eager parity. Semantic predict/val and ONNX/TorchScript/OpenVINO/TensorRT are validated. Weight mirrors carry BSD-3-Clause on a disclosed implied basis plus torchvision's pretrained-model caveat; `weights/upload_fcn_hf.py` enforces the five-file contract |
 
-### 4.1 Sibling factory tiers (not `BaseModel` families)
+### 4.1 Sibling factories (not `BaseModel` families)
 
 Prompt-driven models do not join the checkpoint-driven `BaseModel` registry.
 They live in sibling factories with their own contracts:
@@ -229,8 +229,8 @@ They live in sibling factories with their own contracts:
   MobileSAM (`models/mobilesam/`).
 - **`LibreVLM`** (`models/vlm/`) — vision-language models.
 
-If your port is prompt-driven, clone one of these tiers instead of a factory
-family. The license gate (§1), parity discipline (§12), and HF-upload rules
+If your port is prompt-driven, clone one of these factories instead of a
+`BaseModel` family. The license gate (§1), parity discipline (§12), and HF-upload rules
 (commit 10) still apply in full; the `BaseModel` ABC contract (§8) does not.
 
 ## 5. Walking the port — commit sequence
@@ -253,10 +253,9 @@ Add `from .<family>.model import Libre<FAMILY>` to `libreyolo/models/__init__.py
 
 **Enroll the family in the model registry**: add one `"<family>": "<group>"`
 line to `MODEL_GROUPS` in `libreyolo/models/registry.py`. Group semantics are
-in `docs/nomenclature.md` ("Model groups"); new ports usually enter `g2`
-(trainable) or `g3` (inference-only) — `g0`/`g1` placement is a maintainer
-decision, take the group from the PRD. `tests/unit/test_model_registry.py`
-fails until the family is enrolled.
+in `docs/nomenclature.md` ("Model groups"). Take the coverage group from the
+PRD; it mirrors the implemented surface and never decides capability.
+`tests/unit/test_model_registry.py` fails until the family is enrolled.
 
 **Verify**: `python -c "from libreyolo import Libre<FAMILY>; m = Libre<FAMILY>(size='s'); print(m.task, m.family)"` runs.
 
@@ -382,7 +381,7 @@ doesn't work for DETR — block early with `NotImplementedError`.
 
 ### Commit 8 — Trainer (skip if shipping inference-only)
 
-Decide maturity (§2). Inference-only: `TRAIN_CONFIG = None`, override
+Decide implementation scope and evidence (§2). Inference-only: `TRAIN_CONFIG = None`, override
 `train()` to raise `NotImplementedError`, and **stop here**. Otherwise:
 
 Create `models/<family>/trainer.py` using template §6.6 (YOLO-grid) or §6.7
@@ -390,9 +389,8 @@ Create `models/<family>/trainer.py` using template §6.6 (YOLO-grid) or §6.7
 to `libreyolo/training/config.py` (or use a family-local config — RF-DETR /
 RT-DETR / YOLOv9-E2E do this).
 
-If gated experimental: override `train()` with an `allow_experimental=True`
-flag that raises a `RuntimeError` with a detailed rationale otherwise. See
-`models/picodet/model.py:157-201` for the pattern.
+For limited-evidence training, expose the same `train()` interface and document
+the completed checks and known limits separately from the callable API.
 
 For non-detect tasks: **override `best_metric_key`** explicitly. Default is
 `"metrics/mAP50-95"` (bbox). Set `"metrics/mAP50-95(M)"` for segment,
@@ -1111,11 +1109,11 @@ silent issue this skill calls out as landmine #23.
 
 ## 11. Training, per task
 
-### 11.1 Detection — production
+### 11.1 Detection training
 
-Every existing family ships a detection trainer that subclasses `BaseTrainer`
-(or `DFINETrainer` for DETR). E2E covered by `tests/e2e/test_val_coco128.py`
-+ `tests/e2e/test_rf1_training.py`.
+Families with detection training subclass `BaseTrainer` (or `DFINETrainer` for
+DETR). Recorded E2E coverage lives in `tests/e2e/test_val_coco128.py` and
+`tests/e2e/test_rf1_training.py`.
 
 ### 11.2 Segmentation — plumbing exists, native uptake limited
 
@@ -1128,14 +1126,16 @@ Every existing family ships a detection trainer that subclasses `BaseTrainer`
 
 To wire native segmentation training: proto/mask head + mask coefficients + polygon→mask rasterization + mask loss in family-local `nn.py` / `loss.py`. Override `best_metric_key = "metrics/mAP50-95(M)"`. Disable mosaic/mixup or use a family-local dataset wrapper (D-FINE pattern).
 
-### 11.3 Pose — inference-only territory
+### 11.3 Pose training
 
 - `PoseValidator` exists (`validation/pose_validator.py:35-270`), uses `COCOeval(iouType="keypoints")`.
 - `Results.keypoints` plumbing is complete; `_select` preserves alignment.
-- **Data pipeline does not yet have `load_keypoints=`.** No `YOLODataset` flag, no batch shape for keypoints. A pose trainer would have to add this first.
-- Mosaic/mixup don't transform keypoints either.
+- `YOLOPoseDataset` and the family-local EC/RF-DETR transforms carry keypoints.
+- Augmentation support is family-specific; do not assume detection mosaic or
+  mixup transforms keypoints correctly.
 
-If you ship a pose trainer, you're greenfield: land the `load_keypoints=` data path first, then keypoint loss, then the trainer. Document scope in your commit message.
+When shipping another pose trainer, reuse the closest keypoint-aware family and
+document its dataset, augmentation, loss, and validation evidence explicitly.
 
 ## 12. Inference parity proof
 
@@ -1174,7 +1174,7 @@ Always edited:
 | `libreyolo/training/config.py` | append `<Family>Config(TrainConfig)` if shared route. Family-local `models/<family>/config.py` is also fine — RF-DETR, RT-DETR, YOLOv9-E2E |
 | `libreyolo/validation/preprocessors.py` | append `<Family>ValPreprocessor` |
 | `tests/unit/test_<family>_*.py` | parity / shape / loss / smoke / sibling-rejection |
-| `tests/e2e/conftest.py` | task-appropriate registration: for detect, append rows to `MODEL_CATALOG` and `GENERAL_NIGHTLY_INFERENCE_MODELS` (and add the family to `_EXPERIMENTAL_TRAINING_SKIP` in `tests/e2e/test_rf1_training.py` when training is out of scope). `MODEL_CATALOG` is detect-only — its mAP gate fails classify / semantic / depth rows by construction; mirror the closest merged non-detect family instead |
+| `tests/e2e/conftest.py` | task-appropriate registration: for detect, append rows to `MODEL_CATALOG` and `GENERAL_NIGHTLY_INFERENCE_MODELS` (and record the family in `_RF1_NOT_APPLICABLE` when training is out of scope, or `_RF1_VALIDATION_GAPS` when a callable trainer has not cleared RF1). `MODEL_CATALOG` is detect-only — its mAP gate fails classify / semantic / depth rows by construction; mirror the closest merged non-detect family instead |
 | `CHANGELOG.md` | `Unreleased / Added` entry for the new family |
 | `README.md` | one row in the family support table — nothing else (README policy in `AGENTS.md`; tick only export columns you actually ran) |
 | `reports/export_inventory.json` | regenerate — `tests/unit` checks the committed snapshot matches the runtime inventory (including the family's `group`) |
@@ -1290,7 +1290,7 @@ In priority order. Each line: *[which family hit it]* — what to do.
   - Parent-child sibling: YOLOv9-E2E inheriting from YOLOv9
   - Same-architecture siblings (D-FINE / DEIM): tie-break in `libreyolo/models/__init__.py` (search "Ambiguous D-FINE/DEIM")
   - Lazy import for optional dep: `_ensure_rfdetr` in `libreyolo/models/__init__.py` (registers RF-DETR + DINOv2 behind the `transformers` dep)
-  - Gated experimental training: `libreyolo/models/picodet/model.py:157-201`, `libreyolo/models/ec/model.py:269-310`
+  - Training evidence: RF1 and family-specific trainer tests
   - Vendored sub-component license: `libreyolo/models/deimv2/engine/backbone/dinov3/`
   - Per-group LR via `lr_ratio` + `_scale_lr` (preferred): `libreyolo/models/rtdetr/trainer.py:185-260`
   - Per-group LR via `_train_epoch` fork (older): `libreyolo/models/dfine/trainer.py:148-212`

--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -171,9 +171,9 @@ attributed as "issue #N" or "commit `<sha>`", **not** "PR #N". Mark each
 fact `verified` or `struck (reason)`. Only verified facts may appear in the
 changelog.
 
-Also tag each surviving capability **GA** vs **experimental/gated** (check
-whether it is on the RF1 skip-list or otherwise fenced). The changelog must
-not present a gated-experimental feature as generally available.
+Also record each surviving capability's validation evidence, including any
+RF1 exclusion and its exact reason. The changelog must describe callable
+behavior and known limits separately.
 
 Out of scope for the changelog (do not spend the pass on these): raw
 performance/throughput deltas and docs/website prose content. Everything
@@ -406,7 +406,7 @@ the user to post by hand.
   internal backbone as a shipped user-facing family. Verify it's exported
   and reachable first.
 - Shipping the changelog without the false-positive fact-check pass.
-- Presenting a gated-experimental feature as generally available.
+- Replacing exact validation evidence with a blanket capability label.
 - Attributing a direct-commit change as "PR #N" when it has no merge-PR.
 - Inferring the version number from the diff size instead of asking; the
   label is the human's call.

--- a/skills/libreyolo-run-e2e-tests/SKILL.md
+++ b/skills/libreyolo-run-e2e-tests/SKILL.md
@@ -39,7 +39,7 @@ resource-heavy. Treat them as an integration gate, not a quick check.
 ```bash
 make test_e2e                                  # all e2e files, each own process, "e2e and not rf5"
 make test_e2e FROM=test_rf1_training.py        # resume from a file (skip earlier ones)
-make test_e2e MARKERS='e2e and not experimental_backend'   # custom marker expr
+make test_e2e MARKERS='e2e and not extended_backend'   # custom marker expr
 make test_e2e MARKER='onnx'                    # MARKER= is an alias for MARKERS=
 
 make test_nightly            # general + flagship nightly (what CI runs)
@@ -89,7 +89,7 @@ Every file carries `pytest.mark.e2e` plus more specific markers. Compose with
 
 | Group | Marker(s) | Files |
 |---|---|---|
-| **Export backends** | `export_backend` + `supported_backend`/`experimental_backend` + backend | `test_onnx` (onnx, *supported*), `test_torchscript`, `test_openvino`, `test_ncnn`, `test_tensorrt` (trt), `test_coreml_roundtrip` (macOS), `test_yolonas_pose_export` |
+| **Export backends** | `export_backend` + `supported_backend`/`extended_backend` + backend | `test_onnx` (onnx, *supported*), `test_torchscript`, `test_openvino`, `test_ncnn`, `test_tensorrt` (trt), `test_coreml_roundtrip` (macOS), `test_yolonas_pose_export` |
 | **Inference / parity** | `general_nightly`, plus family/task | `test_deterministic_inference`, `test_openvocab_inference`, `test_rfdetr_keypoint_parity`, `test_weight_requirements` |
 | **Training** | `rf1`, `rf5`, `slow`, `flagship_nightly` | `test_rf1_training` (rf1), `test_rf5_training` (rf5), `test_training_regression`, `test_rfdetr_lora`, `test_rfdetr_seg_training` |
 | **Task / family tiers** | `fomo`, `l2cs`, `sam`, `vlm`, `openvocab`, `yolonas` | `test_fomo`, `test_l2cs_gaze`, `test_sam_smoke`, `test_sam2_smoke`, `test_mobilesam_smoke`, `test_lfm2_vlm_smoke`, `test_yolonas`, `test_sam3dbody_contract` |
@@ -100,8 +100,8 @@ Common selections:
 ```bash
 # Only the ONNX backend, across all families
 make test_e2e MARKERS='onnx'
-# All export backends except the experimental ones (ONNX only, the release gate)
-make test_e2e MARKERS='export_backend and not experimental_backend'
+# All export backends except extended-runtime coverage (ONNX only, the release gate)
+make test_e2e MARKERS='export_backend and not extended_backend'
 # One model family end to end
 make test_e2e MARKERS='yolo9'
 # Everything except training and the slowest export backends

--- a/skills/libreyolo-update-readme/SKILL.md
+++ b/skills/libreyolo-update-readme/SKILL.md
@@ -23,7 +23,7 @@ favor.
 - The only unprompted reason to propose a README change is a **real error or
   inconsistency**: a command that no longer runs, a weight or class name that
   does not exist, a compatibility-table cell that contradicts
-  `SUPPORTED_TASKS` or a maturity gate, a dead link.
+  `SUPPORTED_TASKS` or the callable API, a dead link.
 - Even then, **propose first**: show the user the exact diff and the evidence
   (what you ran, what the code says), and land it only after their approval.
 - A new feature landing in the library is NOT by itself a reason to grow the
@@ -64,9 +64,9 @@ The README sells the project honestly and gets a developer to a working
 - Every command must run as pasted. Actually run it before proposing it.
 - Model classes and weight filenames come from `docs/nomenclature.md` and
   `libreyolo models`, never from memory.
-- Compatibility/maturity claims must match the code's gates: a family whose
-  training is experimental-gated or on the RF1 skip list must not be
-  presented as trainable GA (same discipline as the release process).
+- Compatibility claims must match the callable API. Mark training as supported
+  when an ordinary `train()` call reaches the trainer; keep RF1 evidence and
+  known limits in the detailed documentation.
 - Mind the version gap: the GitHub README is read by PyPI users of the
   released package, but it renders from `dev`. If a claim is true on dev and
   false on the released version, say so to the user and let them decide

--- a/skills/libreyolo-update-website-docs/SKILL.md
+++ b/skills/libreyolo-update-website-docs/SKILL.md
@@ -45,8 +45,8 @@ signpost rather than diverging.
 - A release: the release process (`skills/libreyolo-release/` Gate G) lists
   headline changelog items with no doc mention; each needs a site update or
   the user's explicit "ship without docs" per item.
-- Experimental features go on the experimental docs page with their gating
-  caveats stated, not presented as GA.
+- For features without full validation, state the exact completed checks and
+  known limits without changing whether the implemented API is shown as available.
 
 When a feature ships without its docs, say so in the PR/release handoff
 rather than letting it be discovered.

--- a/skills/libreyolo-verify-training/SKILL.md
+++ b/skills/libreyolo-verify-training/SKILL.md
@@ -5,10 +5,10 @@ description: >-
   train() runs without crashing. Use when adding or changing a trainer, loss,
   augmentation, scheduler, or DDP path; when someone asks "does training work
   for family X?", "is this model trainable?", or reports bad fine-tune
-  results; or before claiming a new family's training is production-ready.
+  results; or before making a validation claim about a new family's training.
   Covers the confidence ladder (overfit gate, RF1 marbles floor, regression
   and RF5 tiers, full-run spot checks), the objective definition of
-  "experimental training", the recurring silent-training-bug classes and how
+  training-evidence tiers, the recurring silent-training-bug classes and how
   to hunt each one, and how to watch a live run. Speed problems are
   libreyolo-profiling; running the suites is libreyolo-run-e2e-tests.
 ---
@@ -45,11 +45,11 @@ libreyolo val model=runs/train/exp/weights/best.pt data=coco8.yaml split=train
 **Rung 1: the RF1 floor (the repo's objective bar).**
 `tests/e2e/test_rf1_training.py` fine-tunes every trainable family on the
 marbles dataset and asserts `MIN_MAP = 0.05` plus a save/reload check.
-The `_EXPERIMENTAL_TRAINING_SKIP` map in that file **is** the objective
-definition of "experimental training": a family on that list has wired
-training but unvalidated convergence, and must not be advertised as trainable
-without that caveat. Getting a family off the list means making it pass RF1,
-not editing the list.
+The `_RF1_NOT_APPLICABLE` and `_RF1_VALIDATION_GAPS` maps distinguish families
+without a training implementation from trainable families that have not yet
+cleared RF1. Each entry must describe completed checks and known limits.
+Removing a validation-gap entry means making the family pass RF1, not hiding
+the evidence gap.
 
 ```bash
 PYTHONPATH=. .venv/Scripts/python.exe -m pytest tests/e2e/test_rf1_training.py \
@@ -127,7 +127,7 @@ number of runs, live or finished.
 State the rung reached, per family: "YOLO9-t passes rung 0 and RF1;
 regression suite green; no rung-4 claim made." Never say "training works"
 from a completed `train()` alone, and never present a family on the
-experimental skip list as trainable without saying so.
+RF1 skip list as having validated convergence without saying so.
 
 ## Related
 

--- a/skills/libreyolo-write-e2e-tests/SKILL.md
+++ b/skills/libreyolo-write-e2e-tests/SKILL.md
@@ -26,7 +26,7 @@ Writing one is mostly bookkeeping; this skill is the bookkeeping.
   dedicated `test_<family>*.py` file is for family-specific behavior
   (e.g. `test_yolonas.py`, `test_l2cs_gaze.py`, `test_openvocab_inference.py`).
 - **New export backend**: its own `test_<backend>.py`, modeled on
-  `test_onnx.py` (supported) or `test_ncnn.py` (experimental).
+  `test_onnx.py` (supported) or `test_ncnn.py` (extended coverage).
 - **Training behavior**: `test_rf1_training.py` (per-family train+reload on
   the marbles dataset) or `test_training_regression.py`.
 - **Smoke for a new optional tier**: pattern of `test_sam_smoke.py`,
@@ -47,7 +47,7 @@ marker-driven selections (and the nightly) will never pick it up, and
   unknown markers are a lint/CI failure.
 - tier marker for non-factory tiers: `vlm`, `sam`, `openvocab`, `clip`.
 - backend markers for export tests: `export_backend` + `supported_backend`
-  or `experimental_backend` + the backend name (`onnx`, `tensorrt`, ...).
+  or `extended_backend` + the backend name (`onnx`, `tensorrt`, ...).
 - `network` / `external_data` when it downloads or needs staged files.
 - nightly promotion markers: `general_nightly` / `flagship_nightly`
   (see below; do not sprinkle these casually).

--- a/skills/libreyolo-write-model-prd/SKILL.md
+++ b/skills/libreyolo-write-model-prd/SKILL.md
@@ -110,49 +110,44 @@ identifiers you are claiming do not collide, and list the families whose
 `can_load` could steal your checkpoints, so the PRD can require bidirectional
 rejection tests.
 
-## 4. Scope and maturity
+## 4. Scope and evidence
 
 Say which tasks are in scope and declare `SUPPORTED_TASKS` explicitly. Then pick
-a maturity target from `libreyolo-port-model` section 2, and remember that
+an implementation and evidence target from `libreyolo-port-model` section 2, and remember that
 **inference-only is a legitimate ship state**. A PRD that gates delivery on a
 working trainer will usually stall. Make the trainer a follow-up unless training
 is the point of the port.
 
-Whether the PRD requires a trainer is a three-gate test, not taste:
+Whether the PRD requires a trainer follows two implementation facts:
 
 1. **Task shape.** The task is closed-set and label-supervised: the user's
    dataset is images plus plain labels the existing pipeline already carries
    (boxes, masks, keypoints, class ids). Prompt-driven, text-conditioned,
    zero-shot and multimodal models (SAM, VLMs, CLIP, open-vocab detectors,
-   foundation backbones) fail this gate and never ship training code: their
+   foundation backbones) do not use the ordinary supervised trainer surface: their
    "training" is web-scale pretraining, not user fine-tuning.
 2. **Upstream recipe.** Upstream ships a permissively licensed *fine-tuning*
    implementation (loss, assignment, recipe) that converges on a small dataset
    on a single GPU. A pretraining pipeline needing multi-node or web-scale
    data does not count (Depth Anything V2's teacher-student distillation is
    the precedent: supervised task, no user-facing recipe, inference-only).
-3. **Audience.** The port is meant for practitioners to fine-tune (headed for
-   `g2` or better). Museum/historic ports and inference-only specialists
-   (`g3`/`g4` candidates: original DETR, Faster R-CNN) ship inference-only
-   even for classical detection; the trainer is an optional follow-up.
-
-All three pass: the PRD requires a trainer (production-grade when e2e
-convergence is validated, otherwise gated experimental behind
-`allow_experimental=True`). Any gate fails: inference-only, and the PRD names
-the failed gate. Genuinely unsure: write "maturity: maintainer call" in the
-PRD and ask, instead of guessing.
+Both facts support a normal fine-tuning path: the PRD requires a trainer and
+states the completed checks and remaining validation work. Otherwise the PRD
+states the concrete missing implementation or recipe. Genuinely unsure: write
+"implementation scope: maintainer call" in the PRD and ask, instead of
+guessing.
 
 The one-line intuition: ship a trainer when a real user could run
 `model.train(data="their_small_dataset.yaml")` on one GPU and expect a better
 model; ship inference-only when "training" really means "pretraining nobody
 can reproduce".
 
-Also name the **rollout group** the family enters (`MODEL_GROUPS` in
+Also name the **coverage group** the family enters (`MODEL_GROUPS` in
 `libreyolo/models/registry.py`; semantics in `docs/nomenclature.md`, "Model
-groups"). New ports normally enter `g2` (trainable) or `g3` (inference-only);
-`g0`/`g1` placement needs maintainer sign-off. The implementer copies this
-into the registry at commit 1, and `tests/unit/test_model_registry.py` blocks
-merge until they do.
+groups"). Group membership mirrors the implemented surface and selects
+cross-family tests; it never grants or removes a capability. The implementer
+copies the selected group into the registry at commit 1, and
+`tests/unit/test_model_registry.py` blocks merge until they do.
 
 ## 5. The PRD document
 
@@ -171,7 +166,7 @@ review, and a consistent shape is what lets an implementing agent trust it.
 ## 3. Why we did not add it before
 ## 4. Why we are adding it now
 ## 5. Head start already in-tree (closest scaffold, and its traps)
-## 6. Scope and maturity
+## 6. Scope and evidence
 ## 7. Implementation pointers  (family id, can_load, converter, export contract)
 ## 8. Definition of done       (checklist mirroring section 0)
 ```

--- a/skills/use-libreyolo/SKILL.md
+++ b/skills/use-libreyolo/SKILL.md
@@ -146,7 +146,7 @@ handles every run under the root (`?run=` in the URL selects one).
 `detect` (suffixless default), `segment`, `semantic`, `pose`, `classify`,
 `gaze`, `obb`, `point`, `depth`, `restore`, `matte`, `ocr`. Detection — plus
 **RF-DETR segmentation** — is the heavily-tested core; other task/family
-combinations vary in maturity, so check the README compatibility table before
+combinations vary in validation coverage, so check the README compatibility table before
 relying on one. Task outputs land on matching `Results` fields
 (`r.semantic_mask`, `r.depth_map`, `r.restored`, `r.points`, `r.matte`, …).
 Matte adds `r.cutout()` (RGBA) and a transparent-PNG `r.save()`.
@@ -170,7 +170,7 @@ as the source of truth. By tier:
 - **Other detectors:** YOLOX, YOLO9-E2E, YOLO9-P2 (stride-4 small-object),
   YOLO-NAS, D-FINE, DEIM, DEIMv2, RT-DETR / v2 / v4, PicoDet, RTMDet, EC,
   and the classic lineage: YOLO1/2/3/4 (inference-only; YOLO1 is the original
-  2016 VOC model, fixed 448) and YOLO7 (also trainable; experimental SimOTA
+  2016 VOC model, fixed 448) and YOLO7 (also trainable; SimOTA
   recipe).
 - **Specialized:** L2CS (gaze), DepthAnything3 (recommended depth quality
   default), DepthAnythingV2 and ZipDepth (depth alternatives), FOMO (point),

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,13 +58,13 @@ make test_e2e
 pytest tests/e2e/ -v -m "e2e and onnx"
 pytest tests/e2e/ -v -m "e2e and torchscript and yolonas"
 pytest tests/e2e/ -v -m "e2e and yolo9 and not ncnn"
-pytest tests/e2e/ -v -m "e2e and not experimental_backend"
+pytest tests/e2e/ -v -m "e2e and not extended_backend"
 
 # Same marker filtering through the Makefile runner
 make test_e2e MARKERS='e2e and onnx'
 make test_e2e MARKERS='e2e and (onnx or torchscript) and not ncnn'
-make test_e2e MARKERS='e2e and not experimental_backend'
-make test_e2e MARKER='e2e and not experimental_backend' FROM=rf1_training
+make test_e2e MARKERS='e2e and not extended_backend'
+make test_e2e MARKER='e2e and not extended_backend' FROM=rf1_training
 make test_e2e MARKERS='e2e and dfine' FROM=test_rf1_training.py
 
 # MARKER= and MARKERS= are equivalent
@@ -87,7 +87,7 @@ python -m tests.e2e.test_rf5_training --list-configs
 
 ### Useful Markers
 
-- Support tiers: `supported_backend`, `experimental_backend`, `export_backend`
+- Scheduling groups: `supported_backend`, `extended_backend`, `export_backend`
 - Backends: `onnx`, `torchscript`, `tensorrt`, `trt`, `openvino`, `mnn`, `ncnn`
 - Model families: `yolox`, `yolo9`, `yolonas`, `rfdetr`, `dfine`, `rtdetr`
 - Suites: `rf1`, `rf5`, `slow`
@@ -97,16 +97,16 @@ python -m tests.e2e.test_rf5_training --list-configs
 | Backend | Status | Marker | Release guidance |
 |---------|--------|--------|------------------|
 | ONNX | Supported | `supported_backend`, `onnx` | Keep in full release validation. |
-| TorchScript | Experimental | `experimental_backend`, `torchscript` | Optional release coverage. |
-| TensorRT | Experimental | `experimental_backend`, `tensorrt`, `trt` | Optional release coverage. |
-| OpenVINO | Experimental | `experimental_backend`, `openvino` | Optional release coverage. |
+| TorchScript | Extended schedule | `extended_backend`, `torchscript` | Optional release coverage. |
+| TensorRT | Extended schedule | `extended_backend`, `tensorrt`, `trt` | Optional release coverage. |
+| OpenVINO | Extended schedule | `extended_backend`, `openvino` | Optional release coverage. |
 | MNN | Supported | `supported_backend`, `mnn` | Flagship CPU parity coverage. |
-| NCNN | Experimental | `experimental_backend`, `ncnn` | Exclude by default if turnaround matters. |
+| NCNN | Extended schedule | `extended_backend`, `ncnn` | Exclude by default if turnaround matters. |
 
-If you want "everything except experimental export backends", run:
+If you want "everything except extended export backends", run:
 
 ```bash
-make test_e2e MARKERS='e2e and not rf5 and not experimental_backend'
+make test_e2e MARKERS='e2e and not rf5 and not extended_backend'
 ```
 
 That keeps training, validation, CLI, video, tracking, and ONNX coverage while dropping TorchScript, TensorRT, OpenVINO, and NCNN.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -455,7 +455,7 @@ def reset_gpu_state():
 #     gated on LIBREYOLO1B_CKPT). Its pretrained tiny weights are unrecoverable
 #     upstream, so there is no auto-download route to gate on at all.
 #   - yolo2/3/4 are inference-only conversions, and yolo7 (trainable via the
-#     experimental SimOTA recipe) has no HF auto-download route either; all are
+#     alternate SimOTA recipe) has no HF auto-download route either; all are
 #     covered by the offline synthetic-weight unit suites
 #     (tests/unit/test_darknet_families.py, tests/unit/test_yolo1.py,
 #     tests/unit/test_yolo7.py) plus the external numeric-parity scripts

--- a/tests/e2e/test_cuda_graph_training_families.py
+++ b/tests/e2e/test_cuda_graph_training_families.py
@@ -80,8 +80,8 @@ CASES = [
     ("yolo9_p2", "LibreYOLO9P2", "t", 320, "detect", 0.0, {}),
     ("yolo9_e2e", "LibreYOLO9E2E", "t", 320, "detect", 0.0, {}),
     ("yolox", "LibreYOLOX", "t", 320, "detect", 0.0, {}),
-    ("picodet", "LibrePICODET", "s", 320, "detect", 0.0, {"allow_experimental": True}),
-    ("yolo7", "LibreYOLO7", "b", 320, "detect", 0.0, {"allow_experimental": True}),
+    ("picodet", "LibrePICODET", "s", 320, "detect", 0.0, {}),
+    ("yolo7", "LibreYOLO7", "b", 320, "detect", 0.0, {}),
     # YOLO-NAS captures bit-identically on a fixed batch (the unit suite gates
     # that), but its affine/mixup pipeline draws from generators the training
     # seed does not reach, so two eager train() runs already differ.
@@ -92,7 +92,7 @@ CASES = [
     # autograd and the graphed backward sum them in a different order, which
     # under fp16 differs in the last bits — 137 of 139 gradients are still
     # bit-identical — and the dynamic assigner's discrete choices amplify it.
-    ("rtmdet", "LibreRTMDet", "t", 320, "detect", 0.05, {"allow_experimental": True}),
+    ("rtmdet", "LibreRTMDet", "t", 320, "detect", 0.05, {}),
     # Encoder-boundary capture. None of these reproduce their own eager run:
     # deformable attention accumulates its backward with atomics.
     # multi_scale=False because they resize every batch by default and a graph
@@ -111,7 +111,7 @@ CASES = [
         320,
         "detect",
         0.01,
-        {"allow_experimental": True, "multi_scale": False},
+        {"multi_scale": False},
     ),
 ]
 
@@ -378,8 +378,7 @@ NON_DETECT_CASES = [
     # unit suite gate that); its coupled crop/flip augmentation is what makes
     # two eager train() runs differ.
     ("nafnet", "LibreNAFNet", "s", 256, "restore", "restore_dataset", 0.01, {}),
-    ("fomo", "LibreFOMO", "s", 96, "point", "detect_dataset", 0.01,
-     {"allow_experimental": True}),
+    ("fomo", "LibreFOMO", "s", 96, "point", "detect_dataset", 0.01, {}),
     (
         "lingbotvision",
         "LibreLingBotVision",

--- a/tests/e2e/test_executorch.py
+++ b/tests/e2e/test_executorch.py
@@ -471,7 +471,7 @@ def test_detection_flagship_raw_parity_and_predict(
     assert result.boxes is not None
 
 
-@pytest.mark.experimental_backend
+@pytest.mark.extended_backend
 @pytest.mark.parametrize(
     ("family", "class_name", "size"),
     [
@@ -529,7 +529,7 @@ def test_edge_map_runtime_parity(
     assert runtime.imgsz == 64
 
 
-@pytest.mark.experimental_backend
+@pytest.mark.extended_backend
 @pytest.mark.network
 def test_dinov2_semantic_runtime_parity(tmp_path, monkeypatch):
     """Cover the real DINOv2 backbone and dense semantic output contract."""
@@ -591,7 +591,7 @@ def test_dinov2_semantic_runtime_parity(tmp_path, monkeypatch):
     assert float(np.mean(actual_mask == expected_mask)) > 0.95
 
 
-@pytest.mark.experimental_backend
+@pytest.mark.extended_backend
 @pytest.mark.network
 def test_dinov2_classification_runtime_parity(tmp_path, monkeypatch):
     """Cover the real DINOv2 backbone and classification logits contract."""
@@ -644,7 +644,7 @@ def test_dinov2_classification_runtime_parity(tmp_path, monkeypatch):
     assert runtime.predict(np.zeros((224, 224, 3), dtype=np.uint8)).probs is not None
 
 
-@pytest.mark.experimental_backend
+@pytest.mark.extended_backend
 @pytest.mark.network
 def test_dinov2_embedding_runtime_parity(tmp_path, monkeypatch):
     """Cover the real DINOv2 backbone and normalized embedding contract."""
@@ -695,7 +695,7 @@ def test_dinov2_embedding_runtime_parity(tmp_path, monkeypatch):
     )
 
 
-@pytest.mark.experimental_backend
+@pytest.mark.extended_backend
 @pytest.mark.parametrize("family", ["rtmdet", "yolonas", "yolo9_p2"])
 def test_additional_detection_raw_parity(tmp_path, monkeypatch, family):
     """Cover detector families lacking redistributable trained parity data."""
@@ -798,7 +798,7 @@ def test_additional_detection_raw_parity(tmp_path, monkeypatch, family):
     assert runtime.imgsz == 64
 
 
-@pytest.mark.experimental_backend
+@pytest.mark.extended_backend
 @pytest.mark.parametrize(
     ("case", "imgsz"),
     [

--- a/tests/e2e/test_export_round22.py
+++ b/tests/e2e/test_export_round22.py
@@ -11,7 +11,7 @@ import torch
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
 ]
 
 

--- a/tests/e2e/test_export_round23.py
+++ b/tests/e2e/test_export_round23.py
@@ -12,7 +12,7 @@ import torch
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
 ]
 
 

--- a/tests/e2e/test_export_round24.py
+++ b/tests/e2e/test_export_round24.py
@@ -15,7 +15,7 @@ from .test_tensorrt_round11 import _align_outputs
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
 ]
 
 
@@ -164,7 +164,7 @@ def test_round24_export_predict_parity(tmp_path, monkeypatch, case):
         monkeypatch.setitem(
             SUPPORT,
             (case.family, case.task, case.format),
-            SupportEntry("experimental", "Round 24 measured block probe."),
+            SupportEntry("available", "Round 24 measured block probe."),
         )
     torch.manual_seed(21 if case.family == "depth_anything3" else 24)
     device = torch.device("cuda" if case.format == "tensorrt" else "cpu")

--- a/tests/e2e/test_export_round25.py
+++ b/tests/e2e/test_export_round25.py
@@ -16,7 +16,7 @@ from .test_tensorrt_round11 import _align_outputs
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
 ]
 
 
@@ -168,7 +168,7 @@ def test_round25_export_predict_parity(tmp_path, monkeypatch, case):
     monkeypatch.setitem(
         SUPPORT,
         (case.family, "embed", case.format),
-        SupportEntry("experimental", "Round 25 measured embedding probe."),
+        SupportEntry("available", "Round 25 measured embedding probe."),
     )
     torch.manual_seed(25)
     device = torch.device("cuda" if case.format == "tensorrt" else "cpu")

--- a/tests/e2e/test_export_round26.py
+++ b/tests/e2e/test_export_round26.py
@@ -18,7 +18,7 @@ from .test_tensorrt_round11 import _align_outputs
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.slow,
 ]
 
@@ -163,7 +163,7 @@ def test_round26_export_predict_parity(tmp_path, monkeypatch, case):
     monkeypatch.setitem(
         SUPPORT,
         (case.family, case.task, case.format),
-        SupportEntry("experimental", "Round 26 measured edge-runtime probe."),
+        SupportEntry("available", "Round 26 measured edge-runtime probe."),
     )
     torch.manual_seed(26)
     model = _build_model(case, monkeypatch)

--- a/tests/e2e/test_export_round27.py
+++ b/tests/e2e/test_export_round27.py
@@ -18,7 +18,7 @@ from .test_tensorrt_round11 import _align_outputs
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
 ]
 
 
@@ -147,7 +147,7 @@ def test_round27_export_predict_parity(tmp_path, monkeypatch, case):
     monkeypatch.setitem(
         SUPPORT,
         (case.family, "classify", case.format),
-        SupportEntry("experimental", "Round 27 frozen-class classifier probe."),
+        SupportEntry("available", "Round 27 frozen-class classifier probe."),
     )
     torch.manual_seed(27)
     device = torch.device("cuda" if case.format == "tensorrt" else "cpu")

--- a/tests/e2e/test_fomo.py
+++ b/tests/e2e/test_fomo.py
@@ -88,7 +88,6 @@ def test_fomo_multiclass_training_e2e(tmp_path: Path) -> None:
     model = LibreFOMO(model_path=None, size="s", nb_classes=2, device="cpu")
 
     results = model.train(
-        allow_experimental=True,
         data=str(data_yaml),
         epochs=1,
         batch=2,
@@ -123,7 +122,6 @@ def test_training_configurations_parameterized(
     model = _make_random_fomo(size="s", nc=1)
 
     train_kwargs = {
-        "allow_experimental": True,
         "data": str(data_yaml),
         "epochs": 1,
         "batch": 2,

--- a/tests/e2e/test_mnn.py
+++ b/tests/e2e/test_mnn.py
@@ -41,7 +41,7 @@ _TRAINED_DETECTORS = [
     pytest.param(
         "deimv2",
         "atto",
-        marks=(pytest.mark.deimv2, pytest.mark.experimental_backend),
+        marks=(pytest.mark.deimv2, pytest.mark.extended_backend),
     ),
     pytest.param("yolonas", "s", marks=pytest.mark.yolonas),
 ]

--- a/tests/e2e/test_ncnn.py
+++ b/tests/e2e/test_ncnn.py
@@ -40,7 +40,7 @@ from .conftest import (
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.ncnn,
 ]
 OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")

--- a/tests/e2e/test_ncnn_round17.py
+++ b/tests/e2e/test_ncnn_round17.py
@@ -19,7 +19,7 @@ from scipy.optimize import linear_sum_assignment
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.ncnn,
     pytest.mark.slow,
     pytest.mark.skipif(

--- a/tests/e2e/test_ncnn_round18.py
+++ b/tests/e2e/test_ncnn_round18.py
@@ -26,7 +26,7 @@ from .test_ncnn_round17 import _native_outputs
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.ncnn,
     pytest.mark.slow,
     pytest.mark.skipif(

--- a/tests/e2e/test_onnx_round16.py
+++ b/tests/e2e/test_onnx_round16.py
@@ -19,7 +19,7 @@ from scipy.optimize import linear_sum_assignment
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.onnx,
     pytest.mark.network,
     pytest.mark.slow,

--- a/tests/e2e/test_openvino.py
+++ b/tests/e2e/test_openvino.py
@@ -32,7 +32,7 @@ from .conftest import (
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.openvino,
 ]
 

--- a/tests/e2e/test_openvino_round21.py
+++ b/tests/e2e/test_openvino_round21.py
@@ -12,7 +12,7 @@ from scipy.optimize import linear_sum_assignment
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.network,
     pytest.mark.slow,
 ]

--- a/tests/e2e/test_paddle.py
+++ b/tests/e2e/test_paddle.py
@@ -1,4 +1,4 @@
-"""End-to-end Paddle export and CPU inference parity for supported G0/G1 cells."""
+"""End-to-end Paddle export and CPU inference parity for supported cells."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ requires_paddle = pytest.mark.skipif(
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.external_data,
     pytest.mark.network,
     pytest.mark.paddle,

--- a/tests/e2e/test_profile_training_families.py
+++ b/tests/e2e/test_profile_training_families.py
@@ -59,7 +59,7 @@ CASES = [
         None,
         {},
         "detect_dataset",
-        {"imgsz": 320, "allow_experimental": True, "multi_scale": False},
+        {"imgsz": 320, "multi_scale": False},
     ),
     ("rtdetr", "LibreRTDETR", "r18", None, {}, "detect_dataset", {"imgsz": 320}),
     ("rtdetrv2", "LibreRTDETRv2", "r18", None, {}, "detect_dataset", {"imgsz": 320}),
@@ -109,7 +109,7 @@ CASES = [
         None,
         {},
         "detect_dataset",
-        {"imgsz": 320, "allow_experimental": True},
+        {"imgsz": 320},
     ),
     (
         "rtmdet",
@@ -118,7 +118,7 @@ CASES = [
         None,
         {},
         "detect_dataset",
-        {"imgsz": 320, "allow_experimental": True},
+        {"imgsz": 320},
     ),
     (
         "picodet",
@@ -127,7 +127,7 @@ CASES = [
         None,
         {},
         "detect_dataset",
-        {"imgsz": 320, "allow_experimental": True},
+        {"imgsz": 320},
     ),
     (
         "fomo",
@@ -136,7 +136,7 @@ CASES = [
         None,
         {"task": "point"},
         "detect_dataset",
-        {"imgsz": 96, "allow_experimental": True},
+        {"imgsz": 96},
     ),
     (
         "segformer",

--- a/tests/e2e/test_rf1_training.py
+++ b/tests/e2e/test_rf1_training.py
@@ -86,11 +86,10 @@ def dataset_data_yaml(dataset):
 MIN_MAP = 0.05
 DETR_RF1_FAMILIES = {"dfine", "deim", "deimv2", "rtdetr"}
 
-# Families excluded from the RF1 training contract. This includes
-# inference-only families and training paths whose small-dataset fine-tune
-# convergence has not been validated against the RF1 mAP floor. Every RF1
-# training test skips them — keep the two tests consistent via this map.
-_EXPERIMENTAL_TRAINING_SKIP = {
+# Families without a training implementation cannot participate in the RF1
+# contract. Keep their concrete missing capability separate from trainable
+# families that simply have not cleared this particular validation fixture.
+_RF1_NOT_APPLICABLE = {
     "vit": (
         "ViT ships inference-only: the AugReg fine-tuning recipe is outside "
         "this museum port, and train() raises. Pretrained and export parity "
@@ -146,17 +145,19 @@ _EXPERIMENTAL_TRAINING_SKIP = {
         "training recipe is not implemented, and train() raises. Exact raw "
         "inference parity is verified separately."
     ),
+}
+
+_RF1_VALIDATION_GAPS = {
     "picodet": (
-        "PICODET training is experimental and not expected to clear the "
-        "RF1 mAP floor on small datasets (skill section 6: fine-tune parity, "
-        "not paper parity). Inference parity is verified separately."
+        "PICODET-s/320 has not reliably cleared the RF1 mAP floor on this "
+        "30-image fixture. Training remains directly callable and is covered "
+        "by smoke and backward-pass tests."
     ),
     "yolo7": (
-        "YOLOv7 training is experimental: the loss is LibreYOLO's SimOTA "
-        "assignment (Apache-2.0 YOLOX lineage) driving the v7 anchor head, "
-        "not the upstream v7 OTA recipe, and its RF1 fine-tune floor has not "
-        "been validated yet. Inference parity vs MIT MultimediaTechLab/YOLO "
-        "is exact and verified separately."
+        "YOLOv7 uses LibreYOLO's SimOTA assignment (Apache-2.0 YOLOX lineage) "
+        "with the v7 anchor head, not the upstream v7 OTA recipe, and has not "
+        "yet cleared the RF1 fine-tune floor. Training remains directly "
+        "callable; inference parity is verified separately."
     ),
 }
 
@@ -167,9 +168,9 @@ RF1_MODEL_WEIGHT_PARAMS = model_cases(
 )
 
 
-def skip_if_experimental_training(family: str) -> None:
-    """Skip an RF1 training test for families with experimental training."""
-    reason = _EXPERIMENTAL_TRAINING_SKIP.get(family)
+def skip_if_outside_rf1_contract(family: str) -> None:
+    """Skip families for which the RF1 contract is inapplicable or unproven."""
+    reason = _RF1_NOT_APPLICABLE.get(family) or _RF1_VALIDATION_GAPS.get(family)
     if reason is not None:
         pytest.skip(reason)
 
@@ -225,8 +226,6 @@ def rf1_train_kwargs(family: str, size: str) -> dict:
             "mosaic_prob": 0.0,
             "hsv_prob": 0.0,
         }
-    if family == "ec":
-        return {"allow_experimental": True}
     return {}
 
 
@@ -236,7 +235,7 @@ def rf1_train_kwargs(family: str, size: str) -> dict:
 )
 def test_rf1_training(family, size, weights, dataset_data_yaml, tmp_path):
     """Train on marbles, verify the model learns and clears a basic mAP floor."""
-    skip_if_experimental_training(family)
+    skip_if_outside_rf1_contract(family)
     weights = require_test_weights(weights, expected_family=family)
     if size == "x" or size == "l":
         val_batch = 4
@@ -489,7 +488,7 @@ def test_load_finetuned_checkpoint(family, size, weights, dataset_data_yaml, tmp
     with correct nc, names, and architecture auto-rebuild.
     Also verifies loss decreased during training and mAP improved.
     """
-    skip_if_experimental_training(family)
+    skip_if_outside_rf1_contract(family)
     weights = require_test_weights(weights, expected_family=family)
 
     if size in ("x", "l"):

--- a/tests/e2e/test_tensorrt.py
+++ b/tests/e2e/test_tensorrt.py
@@ -30,7 +30,7 @@ from .conftest import (
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.tensorrt,
     pytest.mark.trt,
 ]

--- a/tests/e2e/test_tensorrt_round10.py
+++ b/tests/e2e/test_tensorrt_round10.py
@@ -21,7 +21,7 @@ from .conftest import requires_tensorrt
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.tensorrt,
     pytest.mark.trt,
 ]
@@ -41,7 +41,7 @@ ROUND10_VALIDATED_CASES = (
     TensorRTRound10Case("LibreYOLO4", "t", 416),
 )
 
-ROUND10_EXPERIMENTAL_CASES = (
+ROUND10_AVAILABLE_CASES = (
     TensorRTRound10Case("LibreYOLO1", "t", 448, 20),
     TensorRTRound10Case("LibreYOLO7", "b", 128),
     TensorRTRound10Case("LibreYOLO9E2E", "t", 128),
@@ -259,8 +259,8 @@ def test_tensorrt_round10_raw_and_predict_parity(tmp_path, case):
 )
 @pytest.mark.parametrize(
     "case",
-    ROUND10_EXPERIMENTAL_CASES,
+    ROUND10_AVAILABLE_CASES,
     ids=lambda case: case.class_name,
 )
-def test_tensorrt_round10_measured_experimental(tmp_path, case):
+def test_tensorrt_round10_measured_available(tmp_path, case):
     _run_tensorrt_case(tmp_path, case)

--- a/tests/e2e/test_tensorrt_round11.py
+++ b/tests/e2e/test_tensorrt_round11.py
@@ -26,7 +26,7 @@ from .test_tensorrt_round10 import _image, _pairwise_box_iou, _raw_outputs
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.tensorrt,
     pytest.mark.trt,
 ]
@@ -95,7 +95,7 @@ ROUND11_VALIDATED_CASES = (
     _RTMDET,
 )
 
-ROUND11_EXPERIMENTAL_CASES = (
+ROUND11_AVAILABLE_CASES = (
     pytest.param(
         _YOLO7,
         marks=pytest.mark.xfail(
@@ -478,8 +478,8 @@ def test_tensorrt_round11_raw_and_predict_parity(tmp_path, case):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "case",
-    ROUND11_EXPERIMENTAL_CASES,
+    ROUND11_AVAILABLE_CASES,
     ids=lambda case: f"{case.family}-{case.task}",
 )
-def test_tensorrt_round11_measured_experimental(tmp_path, case):
+def test_tensorrt_round11_measured_available(tmp_path, case):
     _run_tensorrt_case(tmp_path, case)

--- a/tests/e2e/test_tensorrt_round12.py
+++ b/tests/e2e/test_tensorrt_round12.py
@@ -23,7 +23,7 @@ from .test_tensorrt_round11 import _align_outputs, _match_detection_rows, _rms
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.tensorrt,
     pytest.mark.trt,
 ]
@@ -336,5 +336,5 @@ def _run_tensorrt_case(tmp_path, case: TensorRTRound12Case) -> None:
     ROUND12_CASES,
     ids=lambda case: f"{case.family}-{case.task}",
 )
-def test_tensorrt_round12_measured_experimental(tmp_path, case):
+def test_tensorrt_round12_measured_available(tmp_path, case):
     _run_tensorrt_case(tmp_path, case)

--- a/tests/e2e/test_tensorrt_round15.py
+++ b/tests/e2e/test_tensorrt_round15.py
@@ -18,7 +18,7 @@ from .test_tensorrt_round12 import TensorRTRound12Case, _run_tensorrt_case
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.tensorrt,
     pytest.mark.trt,
 ]
@@ -41,5 +41,5 @@ _RTDETRV4 = TensorRTRound12Case(
         "Repeated builds change public top-k class membership or box geometry."
     ),
 )
-def test_tensorrt_round15_rtdetrv4_measured_experimental(tmp_path):
+def test_tensorrt_round15_rtdetrv4_measured_available(tmp_path):
     _run_tensorrt_case(tmp_path, _RTDETRV4)

--- a/tests/e2e/test_tensorrt_round8.py
+++ b/tests/e2e/test_tensorrt_round8.py
@@ -8,7 +8,7 @@ The nine promoted cases cover the complete double-tick contract:
 4. reject constant/disconnected graphs with a second input; and
 5. compare the public ``predict()`` result using the task threshold.
 
-PIDNet is the tenth measured case. It gets an explicit experimental parity
+PIDNet is the tenth measured case. It gets an explicit available status because
 floor because repeated TensorRT builds can straddle the stricter promotion
 threshold. The models use deterministic random weights so this suite validates
 conversion and runtime behavior, not task accuracy.
@@ -27,7 +27,7 @@ from .conftest import requires_tensorrt
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.tensorrt,
     pytest.mark.trt,
 ]
@@ -54,7 +54,7 @@ ROUND8_VALIDATED_CASES = (
     TensorRTRound8Case("LibreDepthAnythingV2", "s", "depth", 70, 1),
 )
 
-ROUND8_EXPERIMENTAL_PIDNET = TensorRTRound8Case(
+ROUND8_AVAILABLE_PIDNET = TensorRTRound8Case(
     "LibrePIDNet",
     "s",
     "semantic",
@@ -323,11 +323,11 @@ def test_tensorrt_round8_raw_and_predict_parity(tmp_path, case):
 
 @requires_tensorrt
 @pytest.mark.slow
-def test_tensorrt_round8_pidnet_experimental_parity_floor(tmp_path):
+def test_tensorrt_round8_pidnet_available_parity_floor(tmp_path):
     """Keep PIDNet runnable while its build-to-build drift blocks promotion."""
     from libreyolo import LibreYOLO
 
-    case = ROUND8_EXPERIMENTAL_PIDNET
+    case = ROUND8_AVAILABLE_PIDNET
     torch.manual_seed(0)
     model = _build_model(case)
     model.model.eval()

--- a/tests/e2e/test_tensorrt_round9.py
+++ b/tests/e2e/test_tensorrt_round9.py
@@ -19,7 +19,7 @@ from .test_tensorrt_round8 import TensorRTRound8Case, _run_tensorrt_case
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.tensorrt,
     pytest.mark.trt,
 ]

--- a/tests/e2e/test_tflite_round13.py
+++ b/tests/e2e/test_tflite_round13.py
@@ -26,7 +26,7 @@ from .test_tensorrt_round12 import _assert_predict_parity
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.slow,
     pytest.mark.skipif(
         importlib.util.find_spec("onnx2tf") is None
@@ -161,7 +161,7 @@ def _run_tflite_case(tmp_path, monkeypatch, case: TFLiteRound13Case) -> None:
         SUPPORT,
         key,
         SupportEntry(
-            "experimental",
+            "available",
             "Round 13 measured probe bypasses the recorded conversion hold.",
         ),
     )

--- a/tests/e2e/test_tflite_round14.py
+++ b/tests/e2e/test_tflite_round14.py
@@ -35,7 +35,7 @@ from .test_tflite_round13 import _native_outputs
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.slow,
     pytest.mark.skipif(
         importlib.util.find_spec("onnx2tf") is None
@@ -175,7 +175,7 @@ def _run_tflite_case(tmp_path, monkeypatch, case: TFLiteRound14Case) -> None:
         SUPPORT,
         (case.family, case.task, "tflite"),
         SupportEntry(
-            "experimental",
+            "available",
             "Round 14 measured probe bypasses the recorded conversion hold.",
         ),
     )

--- a/tests/e2e/test_torchscript.py
+++ b/tests/e2e/test_torchscript.py
@@ -26,7 +26,7 @@ from .conftest import (
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.export_backend,
-    pytest.mark.experimental_backend,
+    pytest.mark.extended_backend,
     pytest.mark.torchscript,
 ]
 OFFICIAL_YOLONAS_S = Path("downloads/yolonas/yolo_nas_s_coco.pth")

--- a/tests/unit/cli/commands/test_profile.py
+++ b/tests/unit/cli/commands/test_profile.py
@@ -147,9 +147,8 @@ def test_compare_significance_note(tmp_path):
     assert "ms/image" in r.stdout
 
 
-def test_run_forwards_allow_experimental(tmp_path, monkeypatch):
-    """--allow-experimental reaches model.train(); without the flag the kwarg
-    is absent entirely (non-gated families don't accept it)."""
+def test_run_forwards_profile_settings(tmp_path, monkeypatch):
+    """The profile command reaches the ordinary public training path."""
     import libreyolo
 
     calls: list[dict] = []
@@ -164,17 +163,8 @@ def test_run_forwards_allow_experimental(tmp_path, monkeypatch):
     monkeypatch.setattr(libreyolo, "LibreYOLO", _StubModel)
 
     r = runner.invoke(_app(), ["profile", "run", "coco128",
-                               "--project", str(tmp_path),
-                               "--allow-experimental"])
+                               "--project", str(tmp_path)])
     assert r.exit_code == 3  # stub trains but produces no profile.json
     assert calls
-    assert calls[0]["allow_experimental"] is True
     assert calls[0]["profile"] is True
     assert calls[0]["profile_then_stop"] is True
-
-    calls.clear()
-    r = runner.invoke(_app(), ["profile", "run", "coco128",
-                               "--project", str(tmp_path)])
-    assert r.exit_code == 3
-    assert calls
-    assert "allow_experimental" not in calls[0]

--- a/tests/unit/test_ec_pose.py
+++ b/tests/unit/test_ec_pose.py
@@ -101,18 +101,12 @@ class TestPoseFamilyClassWiring:
         with pytest.raises(ValueError, match="not supported"):
             LibreEC(model_path=None, size="s", task="classify")
 
-    def test_train_pose_requires_allow_experimental(self):
-        # Pose training is implemented but gated behind the experimental flag.
-        m = LibreEC(model_path=None, size="s", task="pose")
-        with pytest.raises(RuntimeError, match="experimental"):
-            m.train(data="dummy.yaml")
-
-    def test_train_pose_selects_pose_trainer(self):
-        # With the flag set, the pose task dispatches to the pose path (it fails
-        # only later, on the missing dummy dataset — not with NotImplementedError).
+    def test_train_pose_selects_pose_path_without_opt_in(self):
+        # The ordinary call reaches pose dataset validation rather than an
+        # acknowledgement gate or an unavailable-task error.
         m = LibreEC(model_path=None, size="s", task="pose")
         with pytest.raises(FileNotFoundError):
-            m.train(data="definitely_missing.yaml", allow_experimental=True)
+            m.train(data="definitely_missing.yaml")
 
     def test_train_pose_rejects_multiclass_yaml(self, tmp_path):
         data_yaml = tmp_path / "pose.yaml"
@@ -131,12 +125,12 @@ class TestPoseFamilyClassWiring:
 
         m = LibreEC(model_path=None, size="s", task="pose")
         with pytest.raises(ValueError, match="single-class pose datasets"):
-            m.train(data=str(data_yaml), allow_experimental=True)
+            m.train(data=str(data_yaml))
 
     def test_train_pose_rejects_non_native_imgsz(self):
         m = LibreEC(model_path=None, size="s", task="pose")
         with pytest.raises(ValueError, match="imgsz=640"):
-            m.train(data="dummy.yaml", allow_experimental=True, imgsz=320)
+            m.train(data="dummy.yaml", imgsz=320)
 
     def test_train_pose_explicit_flip_idx_overrides_yaml(self, tmp_path, monkeypatch):
         data_yaml = tmp_path / "pose.yaml"
@@ -168,7 +162,6 @@ class TestPoseFamilyClassWiring:
         m = LibreEC(model_path=None, size="s", task="pose")
         m.train(
             data=str(data_yaml),
-            allow_experimental=True,
             workers=0,
             flip_idx=explicit_flip_idx,
         )

--- a/tests/unit/test_ec_seg.py
+++ b/tests/unit/test_ec_seg.py
@@ -59,23 +59,17 @@ class TestSegFamilyClassWiring:
         assert m.family == "ec"
         assert isinstance(m.model, LibreECSegModel)
 
-    def test_train_seg_requires_allow_experimental(self):
-        # Seg training is implemented but gated behind the experimental flag.
-        m = LibreEC(model_path=None, size="s", task="segment")
-        with pytest.raises(RuntimeError, match="experimental"):
-            m.train(data="dummy.yaml")
-
-    def test_train_seg_selects_seg_trainer(self):
-        # With the flag set, the seg task dispatches to ECSegTrainer (it fails
-        # only later, on the missing dummy dataset — not with NotImplementedError).
+    def test_train_seg_selects_seg_path_without_opt_in(self):
+        # The ordinary call reaches dataset validation rather than an
+        # acknowledgement gate or an unavailable-task error.
         m = LibreEC(model_path=None, size="s", task="segment")
         with pytest.raises(FileNotFoundError):
-            m.train(data="definitely_missing.yaml", allow_experimental=True)
+            m.train(data="definitely_missing.yaml")
 
     def test_train_seg_rejects_non_native_imgsz(self):
         m = LibreEC(model_path=None, size="s", task="segment")
         with pytest.raises(ValueError, match="imgsz=640"):
-            m.train(data="dummy.yaml", allow_experimental=True, imgsz=320)
+            m.train(data="dummy.yaml", imgsz=320)
 
 
 class TestSegForwardAndPostprocess:

--- a/tests/unit/test_ec_training_fixes.py
+++ b/tests/unit/test_ec_training_fixes.py
@@ -101,7 +101,7 @@ def test_ec_train_applies_dataset_class_names_before_trainer(monkeypatch, tmp_pa
     monkeypatch.setattr(trainer_module, "ECTrainer", FakeTrainer)
 
     model = LibreEC(model_path=None, size="s", nb_classes=80, device="cpu")
-    model.train(data=str(data_yaml), allow_experimental=True, seed=0)
+    model.train(data=str(data_yaml), seed=0)
 
     assert model.nb_classes == 2
     assert model.names == {0: "red", 1: "white"}

--- a/tests/unit/test_export_mnn.py
+++ b/tests/unit/test_export_mnn.py
@@ -14,7 +14,7 @@ import torch
 import libreyolo.export.mnn as mnn_export
 from libreyolo.export.exporter import BaseExporter, MNNExporter
 from libreyolo.export.support import EXPORT_FORMATS, get_support
-from libreyolo.models.registry import families_in
+from libreyolo.backends.mnn import _SUPPORTED_FAMILIES
 
 pytestmark = pytest.mark.unit
 
@@ -42,12 +42,12 @@ def test_mnn_registry_and_support_contract():
     assert MNNExporter.supports_int8 is False
     assert get_support("yolo9", "detect", "mnn").tier == "validated"
     assert get_support("rfdetr", "detect", "mnn").tier == "validated"
-    assert get_support("deimv2", "detect", "mnn").tier == "experimental"
+    assert get_support("deimv2", "detect", "mnn").tier == "available"
     assert get_support("yolox", "detect", "mnn").tier == "blocked"
 
 
-def test_mnn_covers_every_g0_g1_detection_family():
-    expected = set(families_in("g0") + families_in("g1"))
+def test_mnn_support_matches_the_runtime_family_contract():
+    expected = set(_SUPPORTED_FAMILIES)
     covered = {
         family
         for family in expected

--- a/tests/unit/test_export_rknn.py
+++ b/tests/unit/test_export_rknn.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 from typing import ClassVar
 
@@ -182,13 +183,15 @@ def test_rknn_preflight_checks_scope_before_vendor_sdk(monkeypatch):
         )
     assert sdk_checked is False
 
-    with pytest.warns(RuntimeWarning, match="experimental"):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         RknnExporter(_FakeModel())._preflight(
             half=False,
             int8=False,
             data=None,
             name="rk3588",
         )
+    assert not caught
     assert sdk_checked is True
 
 

--- a/tests/unit/test_export_support.py
+++ b/tests/unit/test_export_support.py
@@ -7,12 +7,13 @@ import json
 import os
 import subprocess
 import sys
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from libreyolo.export.exporter import NcnnExporter, OnnxExporter
+from libreyolo.export.exporter import ExecuTorchExporter, NcnnExporter, OnnxExporter
 from libreyolo.export.support import EXPORT_FORMATS, SUPPORT, get_support
 from libreyolo.models.inventory import collect_model_inventory
 from libreyolo.tasks import TASKS, task_to_suffix
@@ -39,6 +40,14 @@ def test_matrix_keys_use_canonical_registry_values():
         assert fmt in EXPORT_FORMATS
 
 
+def test_matrix_uses_capability_statuses_only():
+    assert {entry.tier for entry in SUPPORT.values()} == {
+        "validated",
+        "available",
+        "blocked",
+    }
+
+
 def test_matrix_rejects_duplicate_explicit_keys():
     from libreyolo.export import support
 
@@ -59,16 +68,38 @@ def test_ncnn_detr_families_fail_in_preflight(family):
         exporter._preflight(half=False, int8=False, data=None)
 
 
-def test_experimental_export_warns_in_preflight():
+def test_available_export_proceeds_without_blanket_warning():
     exporter = OnnxExporter(_wrapper("deimv2"))
-    with pytest.warns(RuntimeWarning, match="experimental"):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        exporter._preflight(half=False, int8=False, data=None)
+    assert not caught
+
+
+@pytest.mark.parametrize(
+    "exporter_cls,family,task,reason",
+    [
+        (
+            ExecuTorchExporter,
+            "feynobg",
+            "matte",
+            r"no \.pte artifact was produced",
+        ),
+        (NcnnExporter, "yolo2", "detect", "integer divide-by-zero"),
+    ],
+)
+def test_non_runnable_exports_are_blocked_in_preflight(
+    exporter_cls, family, task, reason
+):
+    exporter = exporter_cls(_wrapper(family, task))
+    with pytest.raises(NotImplementedError, match=reason):
         exporter._preflight(half=False, int8=False, data=None)
 
 
 @pytest.mark.parametrize("family", ["yolo9", "yolo9_e2e", "yolonas", "picodet"])
-def test_rknn_retained_families_are_experimental(family):
+def test_rknn_retained_families_are_available(family):
     entry = get_support(family, "detect", "rknn")
-    assert entry.tier == "experimental"
+    assert entry.tier == "available"
     assert "RK3588 PC-simulator" in entry.reason
 
 
@@ -139,15 +170,15 @@ def test_executorch_realtime_support_is_evidence_backed():
     for family, task in validated:
         assert get_support(family, task, "executorch").tier == "validated"
 
-    assert get_support("rtmdet", "detect", "executorch").tier == "experimental"
+    assert get_support("rtmdet", "detect", "executorch").tier == "available"
     assert get_support("dfine", "detect", "executorch").tier == "blocked"
     assert get_support("deim", "detect", "executorch").tier == "blocked"
     assert get_support("deimv2", "detect", "executorch").tier == "blocked"
     assert get_support("swinir", "restore", "executorch").tier == "blocked"
-    assert get_support("dinov2", "embed", "executorch").tier == "experimental"
+    assert get_support("dinov2", "embed", "executorch").tier == "available"
     assert get_support("eomt", "semantic", "executorch").tier == "blocked"
     assert get_support("birefnet", "matte", "executorch").tier == "blocked"
-    assert get_support("feynobg", "matte", "executorch").tier == "experimental"
+    assert get_support("feynobg", "matte", "executorch").tier == "blocked"
 
 
 def test_tflite_support_keys_use_canonical_tasks():
@@ -230,7 +261,7 @@ def test_yolonas_detect_tflite_is_validated():
     assert get_support("yolonas", "detect", "tflite").tier == "validated"
 
 
-def test_paddle_support_matches_measured_g0_g1_matrix():
+def test_paddle_support_matches_measured_family_task_matrix():
     validated = {
         ("yolo9", "detect"),
         ("yolo9_e2e", "detect"),
@@ -297,7 +328,7 @@ def test_round8_tensorrt_fp32_parity_promotes_nine_cells():
         assert "FP32" in entry.constraint
 
     pidnet = get_support("pidnet", "semantic", "tensorrt")
-    assert pidnet.tier == "experimental"
+    assert pidnet.tier == "available"
     assert "0.9970" in pidnet.reason
 
 
@@ -323,11 +354,11 @@ def test_round9_promotes_three_parity_cells_and_records_seven_gaps():
         assert "FP32" in entry.constraint
 
     lingbot = get_support("lingbotvision", "semantic", "tensorrt")
-    assert lingbot.tier == "experimental"
+    assert lingbot.tier == "available"
     assert "0.9842" in lingbot.reason
 
     zipdepth = get_support("zipdepth", "depth", "tensorrt")
-    assert zipdepth.tier == "experimental"
+    assert zipdepth.tier == "available"
     assert "30.27 dB" in zipdepth.reason
 
     expected_gaps = {
@@ -335,7 +366,7 @@ def test_round9_promotes_three_parity_cells_and_records_seven_gaps():
     }
     for family, measured in expected_gaps.items():
         entry = get_support(family, "detect", "onnx")
-        assert entry.tier == "experimental"
+        assert entry.tier == "available"
         assert measured in entry.reason
 
     for family in ("birefnet", "feynobg"):
@@ -391,11 +422,11 @@ def test_round18_records_nine_ncnn_parity_cells_and_two_holds():
         assert "public predict parity" in entry.constraint
 
     yolo2 = get_support("yolo2", "detect", "ncnn")
-    assert yolo2.tier == "experimental"
+    assert yolo2.tier == "blocked"
     assert "integer divide-by-zero" in yolo2.reason
 
     yolo9_p2 = get_support("yolo9_p2", "detect", "ncnn")
-    assert yolo9_p2.tier == "experimental"
+    assert yolo9_p2.tier == "available"
     assert "no detections above 0.05" in yolo9_p2.reason
 
 
@@ -423,7 +454,7 @@ def test_round11_promotes_three_trained_tensorrt_detectors_and_records_holds():
     }
     for (family, task), reason_fragment in measured_holds.items():
         entry = get_support(family, task, "tensorrt")
-        assert entry.tier == "experimental"
+        assert entry.tier == "available"
         assert reason_fragment in entry.reason
 
 
@@ -442,13 +473,13 @@ def test_round12_records_ten_measured_tensorrt_holds():
     }
     for (family, task), reason_fragment in measured_holds.items():
         entry = get_support(family, task, "tensorrt")
-        assert entry.tier == "experimental"
+        assert entry.tier == "available"
         assert reason_fragment in entry.reason
 
 
 def test_round15_records_rtdetrv4_tensorrt_hold():
     entry = get_support("rtdetrv4", "detect", "tensorrt")
-    assert entry.tier == "experimental"
+    assert entry.tier == "available"
     assert "50.4-pixel" in entry.reason
 
 
@@ -463,7 +494,7 @@ def test_round21_records_six_trained_openvino_holds():
     }
     for (family, task), reason_fragment in measured_holds.items():
         entry = get_support(family, task, "openvino")
-        assert entry.tier == "experimental"
+        assert entry.tier == "available"
         assert reason_fragment in entry.reason
 
 
@@ -485,7 +516,7 @@ def test_round22_promotes_nine_edge_gaze_and_classify_cells():
         assert "parity" in entry.reason
 
     hold = get_support("dinov2", "classify", "tensorrt")
-    assert hold.tier == "experimental"
+    assert hold.tier == "available"
     assert "2.2x" in hold.reason
 
 
@@ -507,7 +538,7 @@ def test_round23_promotes_nine_normal_semantic_depth_and_edge_cells():
         assert "parity" in entry.reason
 
     hold = get_support("rtmdet", "detect", "executorch")
-    assert hold.tier == "experimental"
+    assert hold.tier == "available"
     assert "detection parsing" in hold.reason
 
 
@@ -523,9 +554,9 @@ def test_round24_promotes_six_embedding_and_depth_cells():
     for family, task, format in validated:
         assert get_support(family, task, format).tier == "validated"
 
-    assert get_support("dinov2", "embed", "openvino").tier == "experimental"
-    assert get_support("dinov2", "embed", "tensorrt").tier == "experimental"
-    assert get_support("moge2", "normal", "ncnn").tier == "experimental"
+    assert get_support("dinov2", "embed", "openvino").tier == "available"
+    assert get_support("dinov2", "embed", "tensorrt").tier == "available"
+    assert get_support("moge2", "normal", "ncnn").tier == "available"
     assert get_support("moge2", "normal", "tflite").tier == "blocked"
 
 
@@ -718,10 +749,12 @@ def test_compat_table_paths_do_not_depend_on_working_directory(tmp_path, monkeyp
 
     monkeypatch.chdir(tmp_path)
     assert gen_compat_table.INVENTORY_PATH.exists()
-    rows, _, _ = gen_compat_table._rows()
+    rows, _, _, _ = gen_compat_table._rows()
     assert rows
     # The full matrix lives in docs/export_support.md; the README is curated.
-    assert gen_compat_table.render_docs().startswith("# Export support")
+    rendered = gen_compat_table.render_docs()
+    assert rendered.startswith("# Export support")
+    assert "## Available combinations" in rendered
 
 
 def test_dump_inventory_refuses_partial_overwrite(tmp_path):

--- a/tests/unit/test_fcos_export.py
+++ b/tests/unit/test_fcos_export.py
@@ -136,7 +136,7 @@ def test_export_support_is_explicit_for_every_format() -> None:
     entries = {fmt: get_support("fcos", "detect", fmt) for fmt in EXPORT_FORMATS}
     assert entries["onnx"].tier == "validated"
     assert entries["torchscript"].tier == "validated"
-    assert entries["openvino"].tier == "experimental"
+    assert entries["openvino"].tier == "available"
     assert all(
         entry.tier == "blocked"
         for fmt, entry in entries.items()

--- a/tests/unit/test_fomo_trainer_smoke.py
+++ b/tests/unit/test_fomo_trainer_smoke.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import torch
 
 pytestmark = [pytest.mark.unit, pytest.mark.fomo]
+
+if TYPE_CHECKING:
+    from libreyolo.models.fomo.model import LibreFOMO
 
 
 def _make_random_fomo(size: str = "s", nc: int = 1) -> "LibreFOMO":
@@ -54,13 +57,13 @@ class TestLibreFOMOTrainerSmoke:
             
         monkeypatch.setattr(model, "_load_weights", mock_load_weights)
         
-        results = model.train("dummy.yaml", allow_experimental=True)
+        model.train("dummy.yaml")
         assert loaded_path == str(dummy_ckpt)
 
     def test_train_resume_raises_when_no_checkpoint(self) -> None:
         model = _make_random_fomo(size="s", nc=1)
         with pytest.raises(ValueError, match="resume=True requires a checkpoint"):
-            model.train("dummy.yaml", allow_experimental=True, resume=True)
+            model.train("dummy.yaml", resume=True)
 
     def test_train_resume_calls_trainer_resume(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         model = _make_random_fomo(size="s", nc=1)
@@ -84,7 +87,7 @@ class TestLibreFOMOTrainerSmoke:
 
         monkeypatch.setattr("libreyolo.models.fomo.trainer.FOMOTrainer", DummyTrainer)
 
-        results = model.train("dummy.yaml", allow_experimental=True, resume=True)
+        model.train("dummy.yaml", resume=True)
         assert setup_called is True
         assert resume_called_with == str(dummy_ckpt)
 
@@ -110,15 +113,15 @@ class TestLibreFOMOTrainerSmoke:
 
         monkeypatch.setattr("libreyolo.models.fomo.trainer.FOMOTrainer", DummyTrainer)
 
-        model.train("dummy.yaml", allow_experimental=True, seed=0)
+        model.train("dummy.yaml", seed=0)
         state_0_first = seeds_recorded[0]
 
         seeds_recorded.clear()
-        model.train("dummy.yaml", allow_experimental=True, seed=0)
+        model.train("dummy.yaml", seed=0)
         state_0_second = seeds_recorded[0]
 
         seeds_recorded.clear()
-        model.train("dummy.yaml", allow_experimental=True, seed=100)
+        model.train("dummy.yaml", seed=100)
         state_100 = seeds_recorded[0]
 
         assert state_0_first == state_0_second
@@ -309,12 +312,7 @@ class TestLibreFOMOTrainerSmoke:
         with pytest.raises(ValueError, match="Augmented validation"):
             BaseModel.val(model, data="unused.yaml", imgsz=96, augment=True)
 
-    def test_train_without_flag_raises(self) -> None:
-        model = _make_random_fomo(size="s")
-        with pytest.raises(NotImplementedError, match="allow_experimental"):
-            model.train("dummy.yaml")
-
     def test_train_with_invalid_imgsz_raises(self) -> None:
         model = _make_random_fomo(size="s")
         with pytest.raises(ValueError, match="only supports imgsz=96"):
-            model.train("dummy.yaml", allow_experimental=True, imgsz=128)
+            model.train("dummy.yaml", imgsz=128)

--- a/tests/unit/test_mnn_backend.py
+++ b/tests/unit/test_mnn_backend.py
@@ -12,9 +12,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from libreyolo.backends.mnn import MNNBackend
+from libreyolo.backends.mnn import MNNBackend, _SUPPORTED_FAMILIES
 from libreyolo.models import LibreYOLO
-from libreyolo.models.registry import families_in
 
 pytestmark = pytest.mark.unit
 
@@ -170,8 +169,8 @@ def test_backend_routes_rfdetr_outputs_through_shared_parser(tmp_path, monkeypat
     assert masks is None
 
 
-@pytest.mark.parametrize("family", families_in("g0") + families_in("g1"))
-def test_backend_accepts_every_g0_g1_detection_family(tmp_path, monkeypatch, family):
+@pytest.mark.parametrize("family", sorted(_SUPPORTED_FAMILIES))
+def test_backend_accepts_every_implemented_detection_family(tmp_path, monkeypatch, family):
     _install_fake_mnn(monkeypatch, (np.zeros((1, 1, 6), dtype=np.float32),))
 
     backend = MNNBackend(str(_write_artifact(tmp_path, family=family, batch=1)))
@@ -209,7 +208,7 @@ def test_backend_reports_optional_dependency_install_hint(tmp_path, monkeypatch)
     [
         ("dynamic", True, "dynamic=false"),
         ("precision", "fp16", "precision='fp32'"),
-        ("model_family", "yolox", "G0/G1 detection"),
+        ("model_family", "yolox", "no runtime contract"),
         ("task", "segment", "Supported tasks: detect"),
         ("mnn_backend", "opencl", "mnn_backend='cpu'"),
         ("names", {"1": "a", "2": "b"}, "keys must cover the range"),

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -1,6 +1,6 @@
-"""The model-registry enrollment gate.
+"""The model-registry coverage enrollment contract.
 
-Every family the factory registers must be enrolled in a rollout group in
+Every family the factory registers must be enrolled in a coverage group in
 ``libreyolo/models/registry.py``. This is what keeps the registry maintained:
 a port that forgets to enroll fails here, not in review.
 """

--- a/tests/unit/test_moge2.py
+++ b/tests/unit/test_moge2.py
@@ -191,7 +191,7 @@ def test_moge2_export_support_matches_validated_runtimes():
     }
     for format_name in validated:
         assert get_support("moge2", "normal", format_name).tier == "validated"
-    assert get_support("moge2", "normal", "ncnn").tier == "experimental"
+    assert get_support("moge2", "normal", "ncnn").tier == "available"
     for format_name in set(EXPORT_FORMATS) - validated - {"ncnn"}:
         assert get_support("moge2", "normal", format_name).tier == "blocked"
 

--- a/tests/unit/test_onnx_parity_runner.py
+++ b/tests/unit/test_onnx_parity_runner.py
@@ -162,7 +162,7 @@ def test_ensure_case_weights_available_downloads_canonical_path(tmp_path):
             size="s",
             task="detect",
             weights="missing.pt",
-            onnx_claim="experimental",
+            onnx_claim="available",
         ),
         resolve_weights_path=lambda _name: str(weight_path),
         downloader=lambda path, size: seen.update({"path": path, "size": size}),
@@ -183,7 +183,7 @@ def test_ensure_case_weights_available_skips_existing_file(tmp_path):
             size="s",
             task="detect",
             weights="exists.pt",
-            onnx_claim="experimental",
+            onnx_claim="available",
         ),
         resolve_weights_path=lambda _name: str(weight_path),
         downloader=lambda _path, _size: pytest.fail("download should not run"),
@@ -199,7 +199,7 @@ def test_preflight_case_weights_raises_unavailable_for_weight_download_failure(m
         size="s",
         task="detect",
         weights="missing.pt",
-        onnx_claim="experimental",
+        onnx_claim="available",
     )
     monkeypatch.setattr(
         parity,
@@ -225,7 +225,7 @@ def test_preflight_case_weights_does_not_hide_unrelated_file_errors(monkeypatch)
         size="s",
         task="detect",
         weights="exists.pt",
-        onnx_claim="experimental",
+        onnx_claim="available",
     )
     monkeypatch.setattr(
         parity,
@@ -327,7 +327,7 @@ def test_write_summary_counts_unavailable_cases(tmp_path):
                 "family": "family",
                 "size": "s",
                 "task": "detect",
-                "onnx_claim": "experimental",
+                "onnx_claim": "available",
                 "notes": "",
             },
             "status": "unavailable",
@@ -356,7 +356,7 @@ def test_filter_cases_by_family_task_and_claim():
         DEFAULT_CASES,
         families=["ec"],
         tasks=["pose"],
-        claims=["experimental"],
+        claims=["available"],
     )
 
     assert {case.id for case in selected} == {

--- a/tests/unit/test_repository_capability_language.py
+++ b/tests/unit/test_repository_capability_language.py
@@ -1,0 +1,75 @@
+"""Repository-level checks for capability language and status markers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FORBIDDEN_WORDS = ("experi" + "mental", "\u5b9e\u9a8c" + "\u6027")
+_SHORT_STATUS = "ex" + "p"
+_FORBIDDEN_STATUS_MARKERS = (
+    f"`{_SHORT_STATUS}` means",
+    f"<td>{_SHORT_STATUS}</td>",
+    f"| {_SHORT_STATUS} |",
+)
+
+
+def _tracked_paths() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return [
+        Path(raw.decode("utf-8"))
+        for raw in result.stdout.split(b"\0")
+        if raw
+    ]
+
+
+def _tracked_text_matches(patterns: tuple[str, ...]) -> list[str]:
+    command = ["git", "grep", "-n", "-I", "-i", "-F"]
+    for pattern in patterns:
+        command.extend(("-e", pattern))
+    command.extend(("--", "."))
+    result = subprocess.run(
+        command,
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode not in (0, 1):
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            command,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+    return result.stdout.splitlines()
+
+
+def test_tracked_tree_has_no_deprecated_capability_vocabulary() -> None:
+    """Keep capability access separate from validation depth."""
+    forbidden_words = tuple(word.casefold() for word in _FORBIDDEN_WORDS)
+    violations = [
+        str(path)
+        for path in _tracked_paths()
+        if any(word in path.as_posix().casefold() for word in forbidden_words)
+    ]
+    violations.extend(
+        _tracked_text_matches(_FORBIDDEN_WORDS + _FORBIDDEN_STATUS_MARKERS)
+    )
+
+    assert not violations, "Forbidden capability labels found:\n" + "\n".join(
+        violations
+    )

--- a/tests/unit/test_rtmdet.py
+++ b/tests/unit/test_rtmdet.py
@@ -194,21 +194,14 @@ def test_export_mode_returns_flat_tensor():
     assert out.shape == (1, 8400, 84)  # 80*80 + 40*40 + 20*20 = 8400; 4 box + 80 cls
 
 
-def test_train_gated_without_allow_experimental():
-    """``model.train(...)`` raises a clear error unless allow_experimental=True."""
-    m = LibreRTMDet(size="t", nb_classes=80)
-    with pytest.raises(RuntimeError, match="experimental"):
-        m.train(data="coco128.yaml", epochs=1)
-
-
-def test_config_docstring_matches_experimental_training_status():
-    """RTMDet config docs should not claim training is unimplemented."""
+def test_config_docstring_records_training_evidence():
+    """RTMDet config docs distinguish implementation from missing evidence."""
     from libreyolo.training.config import RTMDetConfig
 
-    doc = RTMDetConfig.__doc__ or ""
-    assert "implemented but experimental" in doc
-    assert "NOT yet implemented" not in doc
-    assert "NotImplementedError" not in doc
+    doc = " ".join((RTMDetConfig.__doc__ or "").split())
+    assert "Detection training is implemented" in doc
+    assert "Small-dataset fine-tune convergence" in doc
+    assert "have not yet been validated" in doc
 
 
 def test_trainer_filters_targets_by_width_and_height():

--- a/tests/unit/test_rtmdet_ins.py
+++ b/tests/unit/test_rtmdet_ins.py
@@ -141,7 +141,7 @@ def test_rtmdet_ins_rejects_detect_checkpoint_for_segment_task(tmp_path):
 def test_rtmdet_ins_training_and_export_are_explicitly_unsupported():
     wrapper = LibreRTMDet(None, size="t", nb_classes=2, device="cpu", task="segment")
     with pytest.raises(NotImplementedError, match="training"):
-        wrapper.train(data="unused.yaml", allow_experimental=True)
+        wrapper.train(data="unused.yaml")
 
     wrapper.model.head.export = True
     with pytest.raises(NotImplementedError, match="export"):

--- a/tests/unit/test_ssd.py
+++ b/tests/unit/test_ssd.py
@@ -1,4 +1,4 @@
-"""SSD family shell, naming, and maturity tests."""
+"""SSD family shell, naming, and capability tests."""
 
 from __future__ import annotations
 

--- a/tests/unit/test_train_hook_surface.py
+++ b/tests/unit/test_train_hook_surface.py
@@ -24,6 +24,7 @@ from libreyolo.models.yolo9.model import LibreYOLO9
 from libreyolo.models.yolo9_e2e.model import LibreYOLO9E2E
 from libreyolo.models.yolonas.model import LibreYOLONAS
 from libreyolo.models.yolox.model import LibreYOLOX
+from libreyolo.training.ddp_spawn import ddp_aware
 
 pytestmark = pytest.mark.unit
 
@@ -62,6 +63,22 @@ def test_trainable_models_expose_callbacks_and_loggers(model_cls: type) -> None:
 
 
 @pytest.mark.parametrize(
+    "model_cls",
+    TRAINABLE_MODEL_CLASSES,
+    ids=lambda cls: cls.__name__,
+)
+def test_trainable_models_have_no_acknowledgement_parameter(model_cls: type) -> None:
+    signature = inspect.signature(model_cls.train)
+    legacy_parameter = "allow_" + "experi" + "mental"
+
+    assert legacy_parameter not in signature.parameters
+
+
+def test_ddp_decorator_only_configures_batch_key() -> None:
+    assert tuple(inspect.signature(ddp_aware).parameters) == ("batch_key",)
+
+
+@pytest.mark.parametrize(
     "module_path,class_name",
     [
         ("libreyolo.models.sam.model", "LibreSAM1"),
@@ -93,7 +110,6 @@ class _StopTraining(RuntimeError):
 class ForwardingCase:
     model_factory: Callable[[], Any]
     trainer_target: str
-    train_kwargs: dict[str, Any] | None = None
     data_config: dict[str, Any] | None = None
 
 
@@ -172,32 +188,26 @@ FORWARDING_CASES = {
     "rtmdet": ForwardingCase(
         lambda: LibreRTMDet(None, size="t", nb_classes=2, device="cpu"),
         "libreyolo.models.rtmdet.trainer.RTMDetTrainer",
-        train_kwargs={"allow_experimental": True},
     ),
     "picodet": ForwardingCase(
         lambda: LibrePICODET(None, size="s", nb_classes=2, device="cpu"),
         "libreyolo.models.picodet.trainer.PICODETTrainer",
-        train_kwargs={"allow_experimental": True},
     ),
     "fomo": ForwardingCase(
         lambda: LibreFOMO(None, size="s", nb_classes=2, device="cpu"),
         "libreyolo.models.fomo.trainer.FOMOTrainer",
-        train_kwargs={"allow_experimental": True},
     ),
     "ec_detect": ForwardingCase(
         lambda: LibreEC(None, size="s", nb_classes=2, device="cpu"),
         "libreyolo.models.ec.trainer.ECTrainer",
-        train_kwargs={"allow_experimental": True},
     ),
     "ec_segment": ForwardingCase(
         lambda: LibreEC(None, size="s", nb_classes=2, device="cpu", task="segment"),
         "libreyolo.models.ec.seg_trainer.ECSegTrainer",
-        train_kwargs={"allow_experimental": True},
     ),
     "ec_pose": ForwardingCase(
         lambda: LibreEC(None, size="s", device="cpu", task="pose"),
         "libreyolo.models.ec.pose_trainer.ECPoseTrainer",
-        train_kwargs={"allow_experimental": True},
         data_config=_pose_data_config(),
     ),
 }
@@ -235,8 +245,6 @@ def test_train_hooks_reach_family_trainer(
     )
 
     model = case.model_factory()
-    train_kwargs = dict(case.train_kwargs or {})
-
     with pytest.raises(_StopTraining):
         model.train(
             "dummy.yaml",
@@ -245,7 +253,6 @@ def test_train_hooks_reach_family_trainer(
             device="cpu",
             callbacks=callback,
             loggers="mlflow",
-            **train_kwargs,
         )
 
     assert captured["kwargs"]["callbacks"] is callback

--- a/tools/gen_compat_table.py
+++ b/tools/gen_compat_table.py
@@ -17,10 +17,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INVENTORY_PATH = REPO_ROOT / "reports" / "export_inventory.json"
 DOCS_PATH = REPO_ROOT / "docs" / "export_support.md"
-MARKERS = {"validated": "✓", "experimental": "exp", "blocked": ""}
+MARKERS = {"validated": "✓", "available": "available", "blocked": ""}
 
 
-def _rows() -> tuple[list[str], list[str], list[str]]:
+def _rows() -> tuple[list[str], list[str], list[str], list[str]]:
     from libreyolo.export.support import EXPORT_FORMATS, get_support
 
     if not INVENTORY_PATH.exists():
@@ -36,6 +36,7 @@ def _rows() -> tuple[list[str], list[str], list[str]]:
         "| " + " | ".join(["---", "---", *(["---:"] * len(EXPORT_FORMATS))]) + " |",
     ]
     validated_constraints = []
+    available_details = []
     blocked = []
     for family, metadata in inventory.items():
         for task in metadata["tasks"]:
@@ -52,13 +53,20 @@ def _rows() -> tuple[list[str], list[str], list[str]]:
                     validated_constraints.append(
                         f"- `{family}` / `{task}` / `{fmt}`: {entry.constraint}"
                     )
+                if entry.tier == "available":
+                    detail = entry.reason
+                    if entry.constraint:
+                        detail = f"{detail} Constraint: {entry.constraint}"
+                    available_details.append(
+                        f"- `{family}` / `{task}` / `{fmt}`: {detail}"
+                    )
                 if entry.tier == "blocked":
                     blocked.append(f"- `{family}` / `{task}` / `{fmt}`: {entry.reason}")
-    return rows, validated_constraints, blocked
+    return rows, validated_constraints, available_details, blocked
 
 
 def render_docs() -> str:
-    rows, validated_constraints, blocked = _rows()
+    rows, validated_constraints, available_details, blocked = _rows()
     return "\n".join(
         [
             "# Export support",
@@ -66,8 +74,9 @@ def render_docs() -> str:
             "This document is generated from `libreyolo/export/support.py`.",
             "Do not edit the matrix by hand.",
             "",
-            "`✓` means parity-validated, `exp` means conversion is available without a",
-            "numeric parity guarantee, and an empty cell is blocked in preflight.",
+            "`✓` means parity-validated, `available` means the converter path is callable",
+            "with the validation context described below, and an empty cell is blocked",
+            "in preflight.",
             "",
             *rows,
             "",
@@ -86,6 +95,12 @@ def render_docs() -> str:
             "A check mark applies only under any constraint listed here.",
             "",
             *validated_constraints,
+            "",
+            "## Available combinations",
+            "",
+            "These converter paths are callable with the recorded validation context.",
+            "",
+            *available_details,
             "",
             "## Blocked combinations",
             "",

--- a/vision_analysis_benchmark/onnx_parity.py
+++ b/vision_analysis_benchmark/onnx_parity.py
@@ -318,7 +318,7 @@ def build_default_cases() -> list[ParityCase]:
         ("s",),
         "pose",
         "complete",
-        "experimental preview checkpoint",
+        "checkpoint converted from upstream early-access release",
     )
 
     add_many("rfdetr", "LibreRFDETR", ("n", "s", "m", "l"), "detect", "complete")
@@ -335,7 +335,7 @@ def build_default_cases() -> list[ParityCase]:
         ("n", "s", "m", "l", "x"),
         "pose",
         "complete",
-        "experimental preview checkpoint",
+        "checkpoint converted from upstream early-access release",
     )
 
     add_many(
@@ -343,53 +343,53 @@ def build_default_cases() -> list[ParityCase]:
         "LibreYOLOX",
         ("n", "t", "s", "m", "l", "x"),
         "detect",
-        "experimental",
+        "available",
     )
     add_many(
         "yolo9_e2e",
         "LibreYOLO9E2E",
         ("t", "s", "m", "c"),
         "detect",
-        "experimental",
+        "available",
     )
-    add_many("yolonas", "LibreYOLONAS", ("s", "m", "l"), "detect", "experimental")
+    add_many("yolonas", "LibreYOLONAS", ("s", "m", "l"), "detect", "available")
     add_many(
         "yolonas",
         "LibreYOLONAS",
         ("n", "s", "m", "l"),
         "pose",
-        "experimental",
+        "available",
         "pose weights download from Deci CDN with pinned checksums",
     )
-    add_many("dfine", "LibreDFINE", ("n", "s", "m", "l", "x"), "detect", "experimental")
-    add_many("deim", "LibreDEIM", ("n", "s", "m", "l", "x"), "detect", "experimental")
+    add_many("dfine", "LibreDFINE", ("n", "s", "m", "l", "x"), "detect", "available")
+    add_many("deim", "LibreDEIM", ("n", "s", "m", "l", "x"), "detect", "available")
     add_many(
         "deimv2",
         "LibreDEIMv2",
         ("atto", "femto", "pico", "n", "s", "m", "l", "x"),
         "detect",
-        "experimental",
+        "available",
     )
     add_many(
         "rtdetr",
         "LibreRTDETR",
         ("r18", "r34", "r50", "r50m", "r101", "l", "x"),
         "detect",
-        "experimental",
+        "available",
     )
     add_many(
         "rtdetrv2",
         "LibreRTDETRv2",
         ("r18", "r34", "r50", "r50m", "r101"),
         "detect",
-        "experimental",
+        "available",
     )
-    add_many("rtdetrv4", "LibreRTDETRv4", ("s", "m", "l", "x"), "detect", "experimental")
-    add_many("picodet", "LibrePICODET", ("s", "m", "l"), "detect", "experimental")
-    add_many("rtmdet", "LibreRTMDet", ("t", "s", "m", "l", "x"), "detect", "experimental")
-    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "detect", "experimental")
-    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "segment", "experimental")
-    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "pose", "experimental")
+    add_many("rtdetrv4", "LibreRTDETRv4", ("s", "m", "l", "x"), "detect", "available")
+    add_many("picodet", "LibrePICODET", ("s", "m", "l"), "detect", "available")
+    add_many("rtmdet", "LibreRTMDet", ("t", "s", "m", "l", "x"), "detect", "available")
+    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "detect", "available")
+    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "segment", "available")
+    add_many("ec", "LibreEC", ("s", "m", "l", "x"), "pose", "available")
     return cases
 
 
@@ -1144,7 +1144,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--case", dest="cases", nargs="*", default=None)
     parser.add_argument("--families", nargs="*", default=None)
     parser.add_argument("--tasks", nargs="*", choices=["detect", "segment", "pose"], default=None)
-    parser.add_argument("--claims", nargs="*", choices=["complete", "experimental"], default=None)
+    parser.add_argument("--claims", nargs="*", choices=["complete", "available"], default=None)
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--list-cases", action="store_true")
     parser.add_argument("--device", default="auto", help="Device for PyTorch model load.")


### PR DESCRIPTION
<!--
Write your PR description however you like. Structure it your own way.
Only the "Code provenance" section below is required (CI checks it exists and
is filled). Everything else is up to you.
-->

## Code provenance

<!--
Required. Replace this comment with a statement of where the code in this PR
comes from. Use whatever wording and structure you prefer, as long as the
provenance is clear. Cover, as applicable:
  - original code written for this PR, and/or
  - code ported, adapted, or derived from a third party: the upstream
    repository, the commit or version, and its license.
Only permissively licensed sources are acceptable (MIT, Apache-2.0, BSD, or
similar). GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license
code is not accepted, in any form (including rewrites or renamed adaptations).
-->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes experimental-capability acknowledgement gates and replaces the experimental export tier with an available tier while retaining blocked-combination checks. It also updates training, profiling, export-support documentation, tests, and generated compatibility material to use the directly callable capability contract.

- Removes `allow_experimental` parameters, CLI options, and DDP forwarding behavior.
- Reclassifies callable export combinations as available and removes blanket runtime warnings.
- Retains blocked export checks and RKNN-specific model and image-size validation.
- Rewrites capability terminology across documentation and tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, but the Chinese README edits should first follow the repository's explicit approval process.

The executable changes remove acknowledgement-only gates while retaining blocked-combination and format-specific validation; the remaining accepted concern is a non-blocking repository-policy violation in README.zh-CN.md.

**Files Needing Attention:** README.zh-CN.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/export/support.py | Replaces the experimental support tier with available while preserving blocked entries and support metadata. |
| libreyolo/export/exporter.py | Removes blanket warnings for formerly experimental exports while retaining blocked, NMS, and dependency preflight checks. |
| libreyolo/training/ddp_spawn.py | Removes acknowledgement-specific decorator forwarding so supported training workflows dispatch directly. |
| libreyolo/cli/commands/profile.py | Removes the profile command's experimental acknowledgement option and invokes training directly. |
| README.zh-CN.md | Broadly updates the compatibility legend and support cells despite the repository requirement for prior approval of README edits. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[User workflow request] --> Support[Resolve capability support]
  Support -->|blocked| Reject[Raise unsupported-combination error]
  Support -->|validated or available| Preflight[Run format and dependency preflight]
  Preflight --> Execute[Execute training, profiling, or export]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0AREADME.zh-CN.md%3A56%0A**README%20compatibility%20edits%20lack%20approval**%0A%0AThis%20changes%20the%20compatibility%20legend%20and%20rewrites%20numerous%20existing%20support%20cells%20without%20the%20explicit%20approval%20required%20for%20README%20edits%2C%20bypassing%20the%20repository's%20review%20process%20for%20this%20high-stakes%20documentation%20surface.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=732&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22fix%2Fremove-capability-gates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fremove-capability-gates%22.%0A%0A%23%23%23%20Issue%201%0AREADME.zh-CN.md%3A56%0A**README%20compatibility%20edits%20lack%20approval**%0A%0AThis%20changes%20the%20compatibility%20legend%20and%20rewrites%20numerous%20existing%20support%20cells%20without%20the%20explicit%20approval%20required%20for%20README%20edits%2C%20bypassing%20the%20repository's%20review%20process%20for%20this%20high-stakes%20documentation%20surface.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=732&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Remove capability acknowledgement gates"](https://github.com/libreyolo/libreyolo/commit/a788eb907eaabc84206db0a6d2d6f2d6cb8c3c0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51443871)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/libreyolo/libreyolo/blob/dev/CLAUDE.md))

<!-- /greptile_comment -->