### PR TITLE
Support train from scratch in G0 and G1

### DIFF
--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -20,6 +20,7 @@ from ..config import (
     apply_family_defaults,
     build_family_train_kwargs,
     detect_family_from_model_ref,
+    get_model_class,
     get_unsupported_train_params,
 )
 from ..output import OutputHandler
@@ -53,17 +54,40 @@ def _create_explicit_task_train_model(
     task: str | None,
     resume: bool | str,
     device: str,
+    pretrained: bool = True,
+    seed: int = 0,
 ):
-    """Instantiate task-specific train models that should start from architecture.
+    """Build a known architecture when training must not load a checkpoint.
 
-    Cross-task training can use detect checkpoints only as transfer weights.
-    Create the requested architecture first so task-specific heads exist before
-    training.
+    Scratch training covers every G0/G1 family. The older transfer path below
+    remains limited to families that need a task-specific architecture before
+    loading their published checkpoint.
     """
+    from libreyolo.tasks import normalize_task
+
+    if pretrained is False and not resume:
+        from libreyolo.models.registry import group_of
+
+        model_cls = get_model_class(family)
+        if model_cls is not None and group_of(family) in {"g0", "g1"}:
+            size = model_cls.detect_size_from_filename(Path(model_path).name)
+            if size is None:
+                return None
+            train_task = (
+                normalize_task(task)
+                if task is not None
+                else model_cls.detect_task_from_filename(Path(model_path).name)
+                or model_cls.DEFAULT_TASK
+            )
+            return model_cls._from_scratch(
+                size=size,
+                task=train_task,
+                device=device,
+                seed=seed,
+            )
+
     if family not in {"yolo9", "rfdetr", "dfine"} or resume:
         return None
-
-    from libreyolo.tasks import normalize_task
 
     if family == "yolo9":
         from libreyolo.models.yolo9.model import LibreYOLO9 as model_cls
@@ -438,6 +462,15 @@ def train_cmd(
             out, model=model, model_path=model_path, device=device
         )
         family = get_loaded_model_family(loaded_model)
+    if train_pretrained is False and resume_val:
+        from libreyolo.models.registry import group_of
+
+        if group_of(family) in {"g0", "g1"}:
+            exit_with_error(
+                out,
+                "config_unsupported",
+                "pretrained=false cannot be combined with resume.",
+            )
     if loaded_model is None:
         loaded_model = _create_explicit_task_train_model(
             family=family,
@@ -445,7 +478,13 @@ def train_cmd(
             task=normalized_task,
             resume=resume_val,
             device=device,
+            pretrained=train_pretrained,
+            seed=seed,
         )
+        if loaded_model is not None and train_pretrained is False:
+            # The architecture was seeded and built through _from_scratch().
+            # Do not rebuild it a second time in the public train wrapper.
+            train_pretrained = None
         if (
             loaded_model is not None
             and family == "yolo9"
@@ -674,9 +713,11 @@ def train_cmd(
     train_kwargs = build_family_train_kwargs(
         params, family, model_path=model_path, user_provided=user_provided
     )
-    train_kwargs["pretrained"] = train_pretrained  # Not in TrainConfig
+    if train_pretrained is not None:
+        train_kwargs["pretrained"] = train_pretrained  # Not in TrainConfig
     if family == "rfdetr":
-        train_kwargs.pop("pretrained", None)
+        if train_pretrained is not False:
+            train_kwargs.pop("pretrained", None)
         if not val and "val" in user_provided:
             out.progress(
                 "Warning: RF-DETR does not support disabling validation via val=false. Ignoring."

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -19,7 +19,7 @@ def get_unsupported_train_params(family: str | None) -> set[str]:
     (``libreyolo.data.augment.spec``), which covers every trainable family.
     Families may declare additional non-augmentation ignores via an
     ``UNSUPPORTED_TRAIN_PARAMS`` class attribute (RF-DETR: optimizer/momentum/
-    nesterov/pretrained), which is unioned in.
+    nesterov), which is unioned in.
     """
     from libreyolo.data.augment.spec import ignored_aug_params
 
@@ -172,6 +172,11 @@ def _iter_model_classes():
     rfcls = try_ensure_rfdetr()
     if rfcls is not None and rfcls not in seen:
         yield rfcls
+
+
+def get_model_class(family: str | None):
+    """Return the registered wrapper for *family*, including lazy families."""
+    return next((cls for cls in _iter_model_classes() if cls.FAMILY == family), None)
 
 
 def detect_family_from_weight_filename(model: str) -> Optional[str]:

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -68,7 +68,7 @@ _WRAPPER_OWNED_CFG_KEYS = frozenset({"size", "num_classes"})
 
 
 def _wrap_train_with_cfg(train_fn: Callable) -> Callable:
-    """Decorate a family ``train()`` method to accept ``cfg='path/to/yaml'``.
+    """Add shared config-file and scratch-initialization handling to ``train()``.
 
     Loads the yaml as a dict and merges it into kwargs with user-provided
     kwargs winning. Keys consumed by positional args (and a small set of
@@ -86,12 +86,35 @@ def _wrap_train_with_cfg(train_fn: Callable) -> Callable:
 
     @functools.wraps(train_fn)
     def wrapper(self, *args, cfg=None, **user_kwargs):
-        if cfg is None:
-            return train_fn(self, *args, **user_kwargs)
-        cfg_kwargs = load_train_cfg(cfg)
-        consumed = set(pos_names[: len(args)]) | _WRAPPER_OWNED_CFG_KEYS
-        merged = {k: v for k, v in cfg_kwargs.items() if k not in consumed}
-        merged.update(user_kwargs)
+        merged = dict(user_kwargs)
+        if cfg is not None:
+            cfg_kwargs = load_train_cfg(cfg)
+            consumed = set(pos_names[: len(args)]) | _WRAPPER_OWNED_CFG_KEYS
+            merged = {k: v for k, v in cfg_kwargs.items() if k not in consumed}
+            merged.update(user_kwargs)
+
+        if merged.get("pretrained") is False:
+            from ..registry import group_of
+
+            if group_of(self.FAMILY) in {"g0", "g1"}:
+                bound = sig.bind_partial(self, *args, **merged)
+                bound.apply_defaults()
+                extras = next(
+                    (
+                        bound.arguments.get(param.name, {})
+                        for param in sig.parameters.values()
+                        if param.kind == inspect.Parameter.VAR_KEYWORD
+                    ),
+                    {},
+                )
+                if bound.arguments.get("resume", extras.get("resume", False)):
+                    raise ValueError("pretrained=False cannot be combined with resume.")
+                self._reset_for_scratch(
+                    seed=bound.arguments.get("seed", extras.get("seed", 0))
+                )
+                if "pretrained" not in sig.parameters:
+                    merged.pop("pretrained")
+
         return train_fn(self, *args, **merged)
 
     wrapper._libreyolo_cfg_wrapped = True  # type: ignore[attr-defined]
@@ -191,6 +214,7 @@ class BaseModel(ABC):
         **kwargs,
     ):
         ensure_default_logging()
+        scratch_init = bool(kwargs.pop("_scratch_init", False))
         self.family = self.FAMILY
         self.task = self._resolve_task(task)
         valid_sizes = self._get_valid_sizes()
@@ -237,10 +261,13 @@ class BaseModel(ABC):
         # Signal _init_model that weights will be loaded immediately after, so
         # subclasses can skip pretrained backbone downloads that would be wasted.
         self._loading_from_weights = isinstance(model_path, (str, Path, dict))
+        self._initializing_from_scratch = scratch_init
         try:
             self.model = self._init_model()
         finally:
             self._loading_from_weights = False
+            self._initializing_from_scratch = False
+        self._training_from_scratch = scratch_init
 
         if model_path is None:
             self.model_path = None
@@ -257,6 +284,44 @@ class BaseModel(ABC):
         else:
             self.model.eval()
         self.model.to(self.device)
+
+    @classmethod
+    def _from_scratch(
+        cls,
+        *,
+        size: str,
+        nb_classes: int = 80,
+        device: str = "auto",
+        task: str | None = None,
+        seed: int = 0,
+        **kwargs,
+    ) -> "BaseModel":
+        """Construct an architecture without loading model or backbone weights."""
+        cls._seed_scratch_initialization(seed)
+        return cls(
+            None,
+            size=size,
+            nb_classes=nb_classes,
+            device=device,
+            task=task,
+            _scratch_init=True,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _seed_scratch_initialization(seed: int) -> None:
+        if seed is None or int(seed) < 0:
+            return
+        import random
+
+        import numpy as np
+
+        seed = int(seed)
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
 
     @staticmethod
     def _resolve_weights_path(model_path: str) -> str:
@@ -515,6 +580,38 @@ class BaseModel(ABC):
         heads.
         """
         return state_dict
+
+    def _prepare_scratch_init(self) -> None:
+        """Let wrappers reset checkpoint-derived architecture state."""
+
+    def _is_scratch_build(self) -> bool:
+        """Return whether this build belongs to a scratch-training lifecycle."""
+        return bool(
+            getattr(self, "_initializing_from_scratch", False)
+            or getattr(self, "_training_from_scratch", False)
+        )
+
+    def _reset_for_scratch(self, *, seed: int = 0) -> None:
+        """Replace the loaded network with a freshly initialized architecture."""
+        self._seed_scratch_initialization(seed)
+        self._prepare_scratch_init()
+        self._graph_runner = None
+        self._cuda_graph_mode = None
+        self._initializing_from_scratch = True
+        try:
+            model = self._init_model()
+        finally:
+            self._initializing_from_scratch = False
+
+        self.model = model
+        self.model_path = None
+        self._training_from_scratch = True
+        self.names = (
+            {i: name for i, name in enumerate(COCO_CLASSES)}
+            if self.nb_classes == 80
+            else {i: f"class_{i}" for i in range(self.nb_classes)}
+        )
+        self.model.train().to(self.device)
 
     def _rebuild_for_new_classes(self, new_nb_classes: int):
         """Rebuild model with a new class count, preserving weights where shapes match."""

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -122,6 +122,7 @@ class LibreDEIM(BaseModel):
             config=self.size,
             nb_classes=self.nb_classes,
             eval_spatial_size=(self.input_size, self.input_size),
+            train_from_scratch=self._is_scratch_build(),
         )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:

--- a/libreyolo/models/deim/nn.py
+++ b/libreyolo/models/deim/nn.py
@@ -165,6 +165,7 @@ class LibreDEIMModel(nn.Module):
         config: str,
         nb_classes: int = 80,
         eval_spatial_size: tuple[int, int] | None = (640, 640),
+        train_from_scratch: bool = False,
     ):
         super().__init__()
         if config not in SIZE_CONFIGS:
@@ -176,9 +177,9 @@ class LibreDEIMModel(nn.Module):
             name=cfg["backbone"],
             use_lab=cfg["use_lab"],
             return_idx=cfg["return_idx"],
-            freeze_stem_only=cfg["freeze_stem_only"],
-            freeze_at=cfg["freeze_at"],
-            freeze_norm=cfg["freeze_norm"],
+            freeze_stem_only=False if train_from_scratch else cfg["freeze_stem_only"],
+            freeze_at=-1 if train_from_scratch else cfg["freeze_at"],
+            freeze_norm=False if train_from_scratch else cfg["freeze_norm"],
             pretrained=False,
         )
         self.encoder = HybridEncoder(

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -169,6 +169,7 @@ class LibreDFINE(BaseModel):
             nb_classes=self.nb_classes,
             eval_spatial_size=(self.input_size, self.input_size),
             enable_mask_head=self.task == "segment",
+            train_from_scratch=self._is_scratch_build(),
         )
 
     def _get_available_layers(self) -> Dict[str, nn.Module]:

--- a/libreyolo/models/dfine/nn.py
+++ b/libreyolo/models/dfine/nn.py
@@ -162,6 +162,7 @@ class LibreDFINEModel(nn.Module):
         eval_spatial_size: tuple[int, int] | None = (640, 640),
         activation: str = "relu",
         enable_mask_head: bool = False,
+        train_from_scratch: bool = False,
     ):
         super().__init__()
         if config not in SIZE_CONFIGS:
@@ -182,9 +183,9 @@ class LibreDFINEModel(nn.Module):
             name=cfg["backbone"],
             use_lab=cfg["use_lab"],
             return_idx=return_idx,
-            freeze_stem_only=cfg["freeze_stem_only"],
-            freeze_at=cfg["freeze_at"],
-            freeze_norm=cfg["freeze_norm"],
+            freeze_stem_only=False if train_from_scratch else cfg["freeze_stem_only"],
+            freeze_at=-1 if train_from_scratch else cfg["freeze_at"],
+            freeze_norm=False if train_from_scratch else cfg["freeze_norm"],
             pretrained=False,
         )
         self.encoder = HybridEncoder(

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -148,7 +148,6 @@ class LibreRFDETR(BaseModel):
         "nesterov",
         "hsv_prob",
         "translate",
-        "pretrained",
     }
 
     # =========================================================================
@@ -356,7 +355,10 @@ class LibreRFDETR(BaseModel):
             # detection/seg/etc. fall back to the small default.
             size = "x" if normalize_task(resolved_task) == "pose" else "s"
 
-        if isinstance(model_path, dict) and not model_path:
+        scratch_init = bool(kwargs.get("_scratch_init", False))
+        if (scratch_init and model_path is None) or (
+            isinstance(model_path, dict) and not model_path
+        ):
             weight_source = None
         elif normalize_task(resolved_task) == "pose" and model_path is None:
             weight_source = None
@@ -576,6 +578,10 @@ class LibreRFDETR(BaseModel):
             obb=self._is_obb,
             num_keypoints=self.num_keypoints,
         )
+
+    def _prepare_scratch_init(self) -> None:
+        self._weight_source = None
+        self._model_num_classes = self.nb_classes
 
     def _rebuild_for_new_classes(self, new_nc: int):
         """Rebuild the detector head for a new class count."""

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -336,8 +336,15 @@ class LibreRTDETR(BaseModel):
         # Skip pretrained download when weights will be loaded immediately after
         # (_loading_from_weights) or when called from _rebuild_for_new_classes
         # (_in_rebuild) — in both cases the backbone weights are overwritten anyway.
-        skip = getattr(self, "_in_rebuild", False) or getattr(self, "_loading_from_weights", False)
+        scratch = self._is_scratch_build()
+        skip = (
+            scratch
+            or getattr(self, "_in_rebuild", False)
+            or getattr(self, "_loading_from_weights", False)
+        )
         pretrained = cfg["backbone_pretrained"] and not skip
+        freeze_at = -1 if scratch else cfg["backbone_freeze_at"]
+        freeze_norm = False if scratch else cfg["backbone_freeze_norm"]
         backbone_kwargs: Dict[str, Any] = {}
         if cfg.get("backbone_type") == "hgnetv2":
             from .hgnetv2 import HGNetv2
@@ -345,15 +352,15 @@ class LibreRTDETR(BaseModel):
             backbone_kwargs["backbone"] = HGNetv2(
                 name=cfg["backbone_arch"],
                 return_idx=[1, 2, 3],
-                freeze_at=cfg["backbone_freeze_at"],
-                freeze_norm=cfg["backbone_freeze_norm"],
+                freeze_at=freeze_at,
+                freeze_norm=freeze_norm,
                 pretrained=pretrained,
             )
         else:
             backbone_kwargs.update(
                 backbone_depth=cfg["backbone_depth"],
-                backbone_freeze_at=cfg["backbone_freeze_at"],
-                backbone_freeze_norm=cfg["backbone_freeze_norm"],
+                backbone_freeze_at=freeze_at,
+                backbone_freeze_norm=freeze_norm,
                 backbone_pretrained=pretrained,
             )
         return RTDETRModel(

--- a/libreyolo/models/rtdetrv2/model.py
+++ b/libreyolo/models/rtdetrv2/model.py
@@ -86,11 +86,12 @@ class LibreRTDETRv2(LibreRTDETR):
                 f"LibreRTDETRv2 size {self.size!r} uses an HGNetv2 backbone; "
                 f"use LibreRTDETR for HGNetv2 variants."
             )
+        scratch = self._is_scratch_build()
         return RTDETRv2Model(
             num_classes=self.nb_classes,
             backbone_depth=cfg["backbone_depth"],
-            backbone_freeze_at=cfg["backbone_freeze_at"],
-            backbone_freeze_norm=cfg["backbone_freeze_norm"],
+            backbone_freeze_at=-1 if scratch else cfg["backbone_freeze_at"],
+            backbone_freeze_norm=False if scratch else cfg["backbone_freeze_norm"],
             backbone_pretrained=False,
             hidden_dim=cfg["encoder_hidden_dim"],
             dim_feedforward=cfg["encoder_dim_feedforward"],

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -72,6 +72,7 @@ class LibreRTDETRv4(LibreDFINE):
             nb_classes=self.nb_classes,
             eval_spatial_size=(self.input_size, self.input_size),
             activation="silu",
+            train_from_scratch=self._is_scratch_build(),
         )
 
     @ddp_aware()

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -114,6 +114,10 @@ def _build_init_kw(model_instance: Any) -> dict:
     for attr in ("size", "nb_classes", "reg_max", "task", "num_masks", "proto_channels", "num_keypoints"):
         if (attr in supported or supports_kwargs) and hasattr(model_instance, attr):
             kw[attr] = getattr(model_instance, attr)
+    if supports_kwargs and getattr(model_instance, "_training_from_scratch", False):
+        # Workers rebuild the architecture before loading the temporary state
+        # dict. Preserve scratch-only backbone trainability during that build.
+        kw["_scratch_init"] = True
     return kw
 
 

--- a/tests/e2e/test_profile_training_families.py
+++ b/tests/e2e/test_profile_training_families.py
@@ -333,6 +333,7 @@ def test_profile_emits_report(
     """profile=True + profile_then_stop=True must emit the analysis artifacts
     and truncate the run — for every trainable family, through the public API."""
     import libreyolo
+    from libreyolo.models.registry import group_of
 
     dataset = request.getfixturevalue(dataset_fixture)
     torch.manual_seed(0)
@@ -352,6 +353,7 @@ def test_profile_emits_report(
         profile_steps=2,
         profile_open=False,
         eval_interval=100,
+        **({"pretrained": False} if group_of(family) in {"g0", "g1"} else {}),
         **extra,
     )
 

--- a/tests/unit/test_augment_spec.py
+++ b/tests/unit/test_augment_spec.py
@@ -497,7 +497,8 @@ def test_get_unsupported_train_params_rfdetr_keeps_class_level_ignores():
     # Spec-derived augmentation ignores plus the class-declared extras.
     assert {"mosaic", "mixup", "hsv_prob", "degrees", "translate", "shear",
             "mosaic_scale", "mixup_scale", "optimizer", "momentum",
-            "nesterov", "pretrained"} <= rf
+            "nesterov"} <= rf
+    assert "pretrained" not in rf
     assert "flip_prob" not in rf
 
 

--- a/tests/unit/test_train_from_scratch.py
+++ b/tests/unit/test_train_from_scratch.py
@@ -1,0 +1,373 @@
+"""G0/G1 train-from-scratch contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+import torch.nn as nn
+import typer
+from typer.testing import CliRunner
+
+from libreyolo.cli.commands.train import train_cmd
+from libreyolo.cli.config import get_model_class
+from libreyolo.cli.parsing import KeyValueCommand
+from libreyolo.models.base.model import _wrap_train_with_cfg
+from libreyolo.models.registry import families_in
+
+pytestmark = pytest.mark.unit
+
+SCRATCH_FAMILIES = families_in("g0") + families_in("g1")
+CLI_CASES = (
+    ("yolo9-t", "yolo9", "t"),
+    ("rfdetr-n", "rfdetr", "n"),
+    ("yolo9_e2e-t", "yolo9_e2e", "t"),
+    ("yolo9_p2-t", "yolo9_p2", "t"),
+    ("ec-s", "ec", "s"),
+    ("rtdetr-r18", "rtdetr", "r18"),
+    ("rtdetrv2-r18", "rtdetrv2", "r18"),
+    ("rtdetrv4-s", "rtdetrv4", "s"),
+    ("dfine-n", "dfine", "n"),
+    ("deim-n", "deim", "n"),
+    ("deimv2-atto", "deimv2", "atto"),
+    ("yolonas-s", "yolonas", "s"),
+)
+
+
+class _ScratchReached(RuntimeError):
+    pass
+
+
+@pytest.mark.parametrize("family", SCRATCH_FAMILIES)
+def test_pretrained_false_reaches_scratch_reset_for_every_family(family):
+    """Intercept the flag before any family-specific training code runs."""
+    model_cls = get_model_class(family)
+    assert model_cls is not None
+    model = model_cls.__new__(model_cls)
+
+    def reset(*, seed):
+        assert seed == 37
+        raise _ScratchReached
+
+    model._reset_for_scratch = reset
+    with pytest.raises(_ScratchReached):
+        model.train("unused.yaml", pretrained=False, seed=37)
+
+
+@pytest.mark.parametrize("family", SCRATCH_FAMILIES)
+def test_pretrained_false_rejects_resume_before_reset(family):
+    model_cls = get_model_class(family)
+    assert model_cls is not None
+    model = model_cls.__new__(model_cls)
+    model._reset_for_scratch = lambda **_kwargs: pytest.fail(
+        "resume conflict must be rejected before rebuilding"
+    )
+
+    with pytest.raises(ValueError, match="cannot be combined with resume"):
+        model.train("unused.yaml", pretrained=False, resume=True)
+
+
+def test_scratch_handling_does_not_change_g2_behavior():
+    captured = {}
+
+    class Wrapper:
+        FAMILY = "yolox"
+
+        def _reset_for_scratch(self, **_kwargs):
+            pytest.fail("G2 behavior must remain unchanged")
+
+    def train(_self, data, **kwargs):
+        captured.update(data=data, kwargs=kwargs)
+
+    _wrap_train_with_cfg(train)(Wrapper(), "data.yaml", pretrained=False)
+    assert captured == {"data": "data.yaml", "kwargs": {"pretrained": False}}
+
+
+def test_explicit_pretrained_parameter_remains_false_after_reset():
+    captured = {}
+
+    class Wrapper:
+        FAMILY = "yolo9"
+
+        def _reset_for_scratch(self, *, seed):
+            captured["seed"] = seed
+
+    def train(_self, data, *, pretrained=True, seed=0):
+        captured.update(data=data, pretrained=pretrained)
+
+    _wrap_train_with_cfg(train)(
+        Wrapper(), "data.yaml", pretrained=False, seed=17
+    )
+    assert captured == {"seed": 17, "data": "data.yaml", "pretrained": False}
+
+
+def test_scratch_flag_and_seed_can_come_from_cfg(tmp_path):
+    captured = {}
+    cfg = tmp_path / "scratch.yaml"
+    cfg.write_text("pretrained: false\nseed: 19\n")
+
+    class Wrapper:
+        FAMILY = "dfine"
+
+        def _reset_for_scratch(self, *, seed):
+            captured["seed"] = seed
+
+    def train(_self, data, **kwargs):
+        captured.update(data=data, kwargs=kwargs)
+
+    _wrap_train_with_cfg(train)(Wrapper(), "data.yaml", cfg=cfg)
+    assert captured == {"seed": 19, "data": "data.yaml", "kwargs": {"seed": 19}}
+
+
+def test_ddp_workers_rebuild_with_the_scratch_policy():
+    from libreyolo.training.ddp_spawn import _build_init_kw
+
+    class Wrapper:
+        def __init__(self, size, **kwargs):
+            pass
+
+    model = Wrapper.__new__(Wrapper)
+    model.size = "s"
+    model._training_from_scratch = True
+
+    assert _build_init_kw(model)["_scratch_init"] is True
+
+
+def test_yolo9_scratch_reset_is_seeded_and_discards_loaded_state():
+    from libreyolo.models.yolo9.model import LibreYOLO9
+
+    model = LibreYOLO9._from_scratch(
+        size="t", nb_classes=3, device="cpu", seed=11
+    )
+    expected = next(model.model.parameters()).detach().clone()
+    with torch.no_grad():
+        next(model.model.parameters()).fill_(123)
+
+    model._reset_for_scratch(seed=11)
+
+    assert torch.equal(next(model.model.parameters()), expected)
+    assert model.model_path is None
+    assert model.model.training
+    assert model._training_from_scratch is True
+    assert model.names == {0: "class_0", 1: "class_1", 2: "class_2"}
+
+
+@pytest.mark.parametrize(
+    "module_name,class_name",
+    [
+        ("libreyolo.models.rtdetr.model", "LibreRTDETR"),
+        ("libreyolo.models.rtdetrv2.model", "LibreRTDETRv2"),
+    ],
+)
+def test_rtdetr_scratch_backbone_stays_trainable_after_rehead(
+    monkeypatch, module_name, class_name
+):
+    module = __import__(module_name, fromlist=[class_name])
+    model_cls = getattr(module, class_name)
+    monkeypatch.setattr(
+        torch.hub,
+        "load_state_dict_from_url",
+        lambda *_args, **_kwargs: pytest.fail("scratch build downloaded weights"),
+    )
+
+    wrapper = model_cls._from_scratch(
+        size="r18", nb_classes=2, device="cpu", seed=5
+    )
+    wrapper._rebuild_for_new_classes(3)
+
+    from libreyolo.models.rtdetr.backbone import FrozenBatchNorm2d
+
+    backbone = wrapper.model.backbone
+    assert all(parameter.requires_grad for parameter in backbone.parameters())
+    assert not any(isinstance(layer, FrozenBatchNorm2d) for layer in backbone.modules())
+
+
+def test_rfdetr_scratch_clears_checkpoint_derived_class_layout(monkeypatch):
+    import libreyolo.models.rfdetr.model as rfdetr_module
+
+    built_classes = []
+
+    def build_model(*, nb_classes, **_kwargs):
+        built_classes.append(nb_classes)
+        return nn.Identity()
+
+    monkeypatch.setattr(rfdetr_module, "LibreRFDETRModel", build_model)
+    model = rfdetr_module.LibreRFDETR._from_scratch(
+        size="n", nb_classes=5, device="cpu", seed=3
+    )
+    model._model_num_classes = 90
+    model._weight_source = "checkpoint.pt"
+
+    model._reset_for_scratch(seed=3)
+
+    assert built_classes == [5, 5]
+    assert model._model_num_classes == 5
+    assert model._weight_source is None
+
+
+def test_rfdetr_ddp_scratch_worker_loads_temporary_state(monkeypatch):
+    import libreyolo.models.rfdetr.model as rfdetr_module
+
+    loaded = []
+    monkeypatch.setattr(
+        rfdetr_module,
+        "LibreRFDETRModel",
+        lambda **_kwargs: nn.Identity(),
+    )
+    monkeypatch.setattr(
+        rfdetr_module.LibreRFDETR,
+        "_load_weights",
+        lambda _self, source: loaded.append(source),
+    )
+
+    model = rfdetr_module.LibreRFDETR(
+        "scratch-worker.pt",
+        size="n",
+        nb_classes=5,
+        device="cpu",
+        _scratch_init=True,
+    )
+
+    assert loaded and str(loaded[0]).endswith("scratch-worker.pt")
+    assert model._training_from_scratch is True
+
+
+@pytest.mark.parametrize(
+    "module_name,class_name,decoder_name",
+    [
+        ("libreyolo.models.dfine.nn", "LibreDFINEModel", "DFINETransformer"),
+        ("libreyolo.models.deim.nn", "LibreDEIMModel", "DEIMTransformer"),
+    ],
+)
+@pytest.mark.parametrize("scratch", [False, True], ids=["finetune", "scratch"])
+def test_hgnet_scratch_build_only_disables_finetune_freezes(
+    monkeypatch, module_name, class_name, decoder_name, scratch
+):
+    module = __import__(module_name, fromlist=[class_name])
+    captured = {}
+
+    def build_backbone(**kwargs):
+        captured.update(kwargs)
+        return nn.Identity()
+
+    monkeypatch.setattr(module, "HGNetv2", build_backbone)
+    monkeypatch.setattr(module, "HybridEncoder", lambda **_kwargs: nn.Identity())
+    monkeypatch.setattr(module, decoder_name, lambda **_kwargs: nn.Identity())
+
+    getattr(module, class_name)(config="l", train_from_scratch=scratch)
+
+    cfg = module.SIZE_CONFIGS["l"]
+    expected = (
+        (False, -1, False)
+        if scratch
+        else (cfg["freeze_stem_only"], cfg["freeze_at"], cfg["freeze_norm"])
+    )
+    assert (
+        captured["freeze_stem_only"],
+        captured["freeze_at"],
+        captured["freeze_norm"],
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    "module_name,class_name,model_name",
+    [
+        ("libreyolo.models.dfine.model", "LibreDFINE", "LibreDFINEModel"),
+        ("libreyolo.models.deim.model", "LibreDEIM", "LibreDEIMModel"),
+        ("libreyolo.models.rtdetrv4.model", "LibreRTDETRv4", "LibreDFINEModel"),
+    ],
+)
+def test_hgnet_wrappers_preserve_scratch_policy_on_rebuild(
+    monkeypatch, module_name, class_name, model_name
+):
+    module = __import__(module_name, fromlist=[class_name])
+    captured = {}
+    monkeypatch.setattr(
+        module,
+        model_name,
+        lambda **kwargs: captured.update(kwargs) or nn.Identity(),
+    )
+    wrapper_cls = getattr(module, class_name)
+    wrapper = wrapper_cls.__new__(wrapper_cls)
+    wrapper.size = "s"
+    wrapper.nb_classes = 3
+    wrapper.input_size = 640
+    wrapper.task = "detect"
+    wrapper._training_from_scratch = True
+
+    wrapper._init_model()
+
+    assert captured["train_from_scratch"] is True
+
+
+@pytest.mark.parametrize(
+    "alias,family,size",
+    CLI_CASES,
+    ids=[case[1] for case in CLI_CASES],
+)
+def test_cli_known_alias_builds_scratch_without_loading_weights(
+    monkeypatch, tmp_path, alias, family, size
+):
+    import libreyolo.cli.commands.train as train_module
+
+    captured = {}
+
+    class ScratchModel:
+        device = torch.device("cpu")
+
+        def train(self, data, **kwargs):
+            captured["train"] = {"data": data, "kwargs": kwargs}
+            return {"output_dir": str(tmp_path / "run")}
+
+    ScratchModel.FAMILY = family
+
+    class ScratchClass:
+        DEFAULT_TASK = "detect"
+
+        @classmethod
+        def detect_size_from_filename(cls, _filename):
+            return size
+
+        @classmethod
+        def detect_task_from_filename(cls, _filename):
+            return None
+
+        @classmethod
+        def _from_scratch(cls, **kwargs):
+            captured["init"] = kwargs
+            return ScratchModel()
+
+    monkeypatch.setattr(train_module, "get_model_class", lambda _family: ScratchClass)
+    monkeypatch.setattr(
+        train_module,
+        "load_model_or_exit",
+        lambda *_args, **_kwargs: pytest.fail("scratch aliases must not load weights"),
+    )
+
+    app = typer.Typer()
+    app.command("train", cls=KeyValueCommand)(train_cmd)
+    result = CliRunner().invoke(
+        app,
+        [
+            "data=unused.yaml",
+            f"model={alias}",
+            "pretrained=false",
+            "epochs=1",
+            "seed=29",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["model_family"] == family
+    assert captured["init"] == {
+        "size": size,
+        "task": "detect",
+        "device": "auto",
+        "seed": 29,
+    }
+    assert captured["train"]["data"] == "unused.yaml"
+    assert "pretrained" not in captured["train"]["kwargs"]


### PR DESCRIPTION
What: Make `pretrained=False` train randomly initialized architectures across G0/G1.
Why: Fixes #730 and removes silent no-op behavior.

- Centralize deterministic scratch rebuilding for API and config calls.
- Make known CLI aliases bypass checkpoint loading.
- Keep random transformer backbones trainable through reheads and DDP reconstruction.
- Cover all 12 families with unit and GPU smoke tests.

Check: scratch lifecycle, transformer freeze policy, and DDP propagation.
Not verified: physical multi-GPU DDP execution.
Opened by an agent.

## Code provenance
Original code written for this PR; bug fixes to LibreYOLO's first-party code only. No third-party code was ported, adapted, or introduced, and no GPL, AGPL, LGPL, non-commercial, proprietary, or unknown-license material was used.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR centralizes scratch initialization for G0/G1 models and propagates that lifecycle through CLI, configuration, transformer-backbone rebuilding, and DDP reconstruction.

- Rebuilds loaded API models deterministically when `pretrained=False` is requested and rejects incompatible resume requests.
- Constructs known CLI aliases directly from architecture rather than loading checkpoints.
- Preserves trainable transformer backbones during scratch reheading and DDP worker reconstruction.
- Adds unit and profiling coverage across the supported G0/G1 families.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

Scratch initialization is consistently routed through the API, configuration, CLI alias, transformer-rebuild, and DDP paths, and the investigated state-propagation concerns are contradicted by the implemented reset and reconstruction flow.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/base/model.py | Centralizes seeded scratch construction and reset handling while preserving the scratch lifecycle across subsequent architecture rebuilds. |
| libreyolo/cli/commands/train.py | Routes recognized G0/G1 aliases directly to scratch constructors, suppresses redundant resets, and rejects scratch training combined with resume. |
| libreyolo/training/ddp_spawn.py | Propagates scratch initialization policy into DDP worker reconstruction so transformer backbones retain the intended trainability. |
| libreyolo/models/rtdetr/model.py | Prevents pretrained backbone loading and disables fine-tuning freezes during scratch initialization and later scratch rebuilds. |
| libreyolo/models/rfdetr/model.py | Removes the prior pretrained-option ignore and clears checkpoint-derived weight and class-layout state when rebuilding from scratch. |
| tests/unit/test_train_from_scratch.py | Covers scratch dispatch, deterministic resetting, resume rejection, transformer freeze policy, RF-DETR state cleanup, and DDP propagation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request["API/config/CLI training request"] --> Scratch{"pretrained = false<br/>and G0/G1?"}
  Scratch -->|No| Existing["Existing pretrained or G2 lifecycle"]
  Scratch -->|Yes, API/config| Reset["_reset_for_scratch(seed)"]
  Scratch -->|Yes, known CLI alias| Build["_from_scratch(size, task, seed)"]
  Reset --> Rehead["Dataset-specific rehead if needed"]
  Build --> Rehead
  Rehead --> DDP{"Multi-device DDP?"}
  DDP -->|No| Train["Train scratch model"]
  DDP -->|Yes| Snapshot["Save temporary model state"]
  Snapshot --> Worker["Reconstruct worker with _scratch_init"]
  Worker --> Load["Load temporary state"]
  Load --> Train
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Support scratch training in G0 and G1"](https://github.com/libreyolo/libreyolo/commit/c1de0f24b8449dac9a35799f56870edb7f357e6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51445582)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [CLI entrypoint](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/cli-entrypoint.md)
- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Training Pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-pipeline.md)
</details>

<!-- /greptile_comment -->