### PR TITLE
Make skipped nightly runs distinguishable from passes

### DIFF
--- a/.github/workflows/e2e-nightly-dev.yml
+++ b/.github/workflows/e2e-nightly-dev.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       should_run: ${{ steps.diff.outputs.should_run }}
       target_sha: ${{ steps.resolve.outputs.target_sha }}
+      cache_key: ${{ steps.resolve.outputs.cache_key }}
       cache_hit: ${{ steps.cache-target.outputs.cache-hit }}
     steps:
       - id: resolve
@@ -34,31 +35,82 @@ jobs:
         run: |
           set -euo pipefail
           TARGET_SHA=$(git ls-remote https://github.com/LibreYOLO/libreyolo refs/heads/dev | cut -f1)
+          # The cache key carries an ISO week so a frozen target is still
+          # retested once a week. A SHA-only key means a quiet dev branch is
+          # never re-run, and the environment underneath it (Modal image,
+          # published weights, transitive deps) drifts untested.
+          WINDOW=$(date -u +%G-W%V)
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
-          echo "Resolved: dev=$TARGET_SHA"
+          echo "window=$WINDOW" >> "$GITHUB_OUTPUT"
+          echo "cache_key=last-tested-nightly-dev-$TARGET_SHA-$WINDOW" >> "$GITHUB_OUTPUT"
+          echo "Resolved: dev=$TARGET_SHA window=$WINDOW"
 
+      # restore, not cache: this job never creates the marker file, so the
+      # save-on-post of actions/cache would warn every run and could claim the
+      # key with nothing in it.
       - id: cache-target
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .last-dev
-          key: last-tested-nightly-dev-${{ steps.resolve.outputs.target_sha }}
+          key: ${{ steps.resolve.outputs.cache_key }}
 
       - id: diff
         name: Decide whether dev needs testing
         env:
           FORCE: ${{ inputs.force }}
           HIT_TARGET: ${{ steps.cache-target.outputs.cache-hit }}
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+          WINDOW: ${{ steps.resolve.outputs.window }}
         run: |
           set -euo pipefail
           if [ "${FORCE:-false}" = "true" ]; then
             SHOULD_RUN=true
+            REASON="forced by workflow_dispatch input"
           elif [ "${HIT_TARGET:-}" = "true" ]; then
             SHOULD_RUN=false
+            REASON="dev@${TARGET_SHA} already passed a nightly in week ${WINDOW}"
           else
             SHOULD_RUN=true
+            REASON="no passing nightly recorded for dev@${TARGET_SHA} in week ${WINDOW}"
           fi
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-          echo "Should run dev: $SHOULD_RUN"
+          echo "Should run dev: $SHOULD_RUN ($REASON)"
+
+          # Every run says, in its own summary, which SHA it covers and whether
+          # it actually tested it. A skipped run is green; without this line it
+          # is indistinguishable from a pass in the run list.
+          if [ "$SHOULD_RUN" = "true" ]; then
+            VERDICT="RUNNING the GPU suite"
+          else
+            VERDICT="SKIPPED, no GPU suite ran in this run"
+          fi
+          {
+            echo "### Nightly guard: $VERDICT"
+            echo
+            echo "- Target: \`dev@${TARGET_SHA}\`"
+            echo "- Week window: \`${WINDOW}\`"
+            echo "- Reason: ${REASON}"
+            echo
+            if [ "$SHOULD_RUN" != "true" ]; then
+              echo "This run did **not** execute the GPU suite. The green tick"
+              echo "means the guard resolved cleanly, not that this commit was"
+              echo "tested in this run. The pass it is standing on is an earlier"
+              echo "run against the same SHA."
+              echo
+              echo "To test it anyway: re-dispatch with \`force=true\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  skipped:
+    name: Skipped (dev already tested)
+    needs: guard
+    if: needs.guard.outputs.should_run == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain the skip
+        run: |
+          echo "No GPU suite ran. dev@${{ needs.guard.outputs.target_sha }} already"
+          echo "passed a nightly this week. Re-dispatch with force=true to retest."
 
   e2e:
     name: e2e (dev)
@@ -67,10 +119,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 195
     steps:
-      - name: Checkout dev
+      # The resolved SHA, not the branch: dev can move between the guard
+      # resolving it and this checkout, which would run the harness from one
+      # commit against a different one.
+      - name: Checkout the resolved dev SHA
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: ${{ needs.guard.outputs.target_sha }}
 
       - uses: astral-sh/setup-uv@v4
 
@@ -155,4 +210,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .last-dev
-          key: last-tested-nightly-dev-${{ needs.guard.outputs.target_sha }}
+          key: ${{ needs.guard.outputs.cache_key }}

--- a/.github/workflows/e2e-nightly-pypi.yml
+++ b/.github/workflows/e2e-nightly-pypi.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       should_run: ${{ steps.diff.outputs.should_run }}
       pypi_ver: ${{ steps.resolve.outputs.pypi_ver }}
+      cache_key: ${{ steps.resolve.outputs.cache_key }}
       cache_hit: ${{ steps.cache-target.outputs.cache-hit }}
     steps:
       - id: resolve
@@ -28,31 +29,83 @@ jobs:
         run: |
           set -euo pipefail
           PYPI_VER=$(curl -fsSL https://pypi.org/pypi/libreyolo/json | jq -r .info.version)
+          # The cache key carries an ISO week so a published version is still
+          # retested once a week. A version-only key means the released wheel
+          # is tested exactly once ever, and the environment underneath it
+          # (published weights, transitive deps, driver stack) drifts untested.
+          # This is the target where that matters most: it is what users get.
+          WINDOW=$(date -u +%G-W%V)
           echo "pypi_ver=$PYPI_VER" >> "$GITHUB_OUTPUT"
-          echo "Resolved: pypi=$PYPI_VER"
+          echo "window=$WINDOW" >> "$GITHUB_OUTPUT"
+          echo "cache_key=last-tested-nightly-pypi-$PYPI_VER-$WINDOW" >> "$GITHUB_OUTPUT"
+          echo "Resolved: pypi=$PYPI_VER window=$WINDOW"
 
+      # restore, not cache: this job never creates the marker file, so the
+      # save-on-post of actions/cache would warn every run and could claim the
+      # key with nothing in it.
       - id: cache-target
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .last-pypi
-          key: last-tested-nightly-pypi-${{ steps.resolve.outputs.pypi_ver }}
+          key: ${{ steps.resolve.outputs.cache_key }}
 
       - id: diff
         name: Decide whether PyPI needs testing
         env:
           FORCE: ${{ inputs.force }}
           HIT_TARGET: ${{ steps.cache-target.outputs.cache-hit }}
+          PYPI_VER: ${{ steps.resolve.outputs.pypi_ver }}
+          WINDOW: ${{ steps.resolve.outputs.window }}
         run: |
           set -euo pipefail
           if [ "${FORCE:-false}" = "true" ]; then
             SHOULD_RUN=true
+            REASON="forced by workflow_dispatch input"
           elif [ "${HIT_TARGET:-}" = "true" ]; then
             SHOULD_RUN=false
+            REASON="libreyolo==${PYPI_VER} already passed a nightly in week ${WINDOW}"
           else
             SHOULD_RUN=true
+            REASON="no passing nightly recorded for libreyolo==${PYPI_VER} in week ${WINDOW}"
           fi
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-          echo "Should run PyPI: $SHOULD_RUN"
+          echo "Should run PyPI: $SHOULD_RUN ($REASON)"
+
+          # Every run says, in its own summary, which version it covers and
+          # whether it actually tested it. A skipped run is green; without this
+          # line it is indistinguishable from a pass in the run list.
+          if [ "$SHOULD_RUN" = "true" ]; then
+            VERDICT="RUNNING the GPU suite"
+          else
+            VERDICT="SKIPPED, no GPU suite ran in this run"
+          fi
+          {
+            echo "### Nightly guard: $VERDICT"
+            echo
+            echo "- Target: \`libreyolo==${PYPI_VER}\`"
+            echo "- Week window: \`${WINDOW}\`"
+            echo "- Reason: ${REASON}"
+            echo
+            if [ "$SHOULD_RUN" != "true" ]; then
+              echo "This run did **not** execute the GPU suite. The green tick"
+              echo "means the guard resolved cleanly, not that this version was"
+              echo "tested in this run. The pass it is standing on is an earlier"
+              echo "run against the same version."
+              echo
+              echo "To test it anyway: re-dispatch with \`force=true\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  skipped:
+    name: Skipped (PyPI version already tested)
+    needs: guard
+    if: needs.guard.outputs.should_run == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain the skip
+        run: |
+          echo "No GPU suite ran. libreyolo==${{ needs.guard.outputs.pypi_ver }} already"
+          echo "passed a nightly this week. Re-dispatch with force=true to retest."
 
   e2e:
     name: e2e (pypi)
@@ -133,4 +186,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .last-pypi
-          key: last-tested-nightly-pypi-${{ needs.guard.outputs.pypi_ver }}
+          key: ${{ needs.guard.outputs.cache_key }}

--- a/.github/workflows/e2e-nightly-release.yml
+++ b/.github/workflows/e2e-nightly-release.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       should_run: ${{ steps.diff.outputs.should_run }}
       target_sha: ${{ steps.resolve.outputs.target_sha }}
+      cache_key: ${{ steps.resolve.outputs.cache_key }}
       cache_hit: ${{ steps.cache-target.outputs.cache-hit }}
     steps:
       - id: resolve
@@ -28,31 +29,81 @@ jobs:
         run: |
           set -euo pipefail
           TARGET_SHA=$(git ls-remote https://github.com/LibreYOLO/libreyolo refs/heads/release | cut -f1)
+          # The cache key carries an ISO week so a frozen target is still
+          # retested once a week. A SHA-only key means a quiet branch is never
+          # re-run, and the environment underneath it drifts untested.
+          WINDOW=$(date -u +%G-W%V)
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
-          echo "Resolved: release=$TARGET_SHA"
+          echo "window=$WINDOW" >> "$GITHUB_OUTPUT"
+          echo "cache_key=last-tested-nightly-release-$TARGET_SHA-$WINDOW" >> "$GITHUB_OUTPUT"
+          echo "Resolved: release=$TARGET_SHA window=$WINDOW"
 
+      # restore, not cache: this job never creates the marker file, so the
+      # save-on-post of actions/cache would warn every run and could claim the
+      # key with nothing in it.
       - id: cache-target
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .last-release
-          key: last-tested-nightly-release-${{ steps.resolve.outputs.target_sha }}
+          key: ${{ steps.resolve.outputs.cache_key }}
 
       - id: diff
         name: Decide whether release needs testing
         env:
           FORCE: ${{ inputs.force }}
           HIT_TARGET: ${{ steps.cache-target.outputs.cache-hit }}
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+          WINDOW: ${{ steps.resolve.outputs.window }}
         run: |
           set -euo pipefail
           if [ "${FORCE:-false}" = "true" ]; then
             SHOULD_RUN=true
+            REASON="forced by workflow_dispatch input"
           elif [ "${HIT_TARGET:-}" = "true" ]; then
             SHOULD_RUN=false
+            REASON="release@${TARGET_SHA} already passed a nightly in week ${WINDOW}"
           else
             SHOULD_RUN=true
+            REASON="no passing nightly recorded for release@${TARGET_SHA} in week ${WINDOW}"
           fi
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-          echo "Should run release: $SHOULD_RUN"
+          echo "Should run release: $SHOULD_RUN ($REASON)"
+
+          # Every run says, in its own summary, which SHA it covers and whether
+          # it actually tested it. A skipped run is green; without this line it
+          # is indistinguishable from a pass in the run list.
+          if [ "$SHOULD_RUN" = "true" ]; then
+            VERDICT="RUNNING the GPU suite"
+          else
+            VERDICT="SKIPPED, no GPU suite ran in this run"
+          fi
+          {
+            echo "### Nightly guard: $VERDICT"
+            echo
+            echo "- Target: \`release@${TARGET_SHA}\`"
+            echo "- Week window: \`${WINDOW}\`"
+            echo "- Reason: ${REASON}"
+            echo
+            if [ "$SHOULD_RUN" != "true" ]; then
+              echo "This run did **not** execute the GPU suite. The green tick"
+              echo "means the guard resolved cleanly, not that this commit was"
+              echo "tested in this run. The pass it is standing on is an earlier"
+              echo "run against the same SHA."
+              echo
+              echo "To test it anyway: re-dispatch with \`force=true\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  skipped:
+    name: Skipped (release already tested)
+    needs: guard
+    if: needs.guard.outputs.should_run == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain the skip
+        run: |
+          echo "No GPU suite ran. release@${{ needs.guard.outputs.target_sha }} already"
+          echo "passed a nightly this week. Re-dispatch with force=true to retest."
 
   e2e:
     name: e2e (release)
@@ -61,10 +112,13 @@ jobs:
     runs-on: [self-hosted, gpu, libreyolo-e2e]
     timeout-minutes: 180
     steps:
-      - name: Checkout release
+      # The resolved SHA, not the branch. This job tests whatever it checks
+      # out, so a branch ref would let release move between the guard and the
+      # checkout and mark one SHA as tested while having tested another.
+      - name: Checkout the resolved release SHA
         uses: actions/checkout@v4
         with:
-          ref: release
+          ref: ${{ needs.guard.outputs.target_sha }}
 
       - uses: astral-sh/setup-uv@v4
 
@@ -130,4 +184,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .last-release
-          key: last-tested-nightly-release-${{ needs.guard.outputs.target_sha }}
+          key: ${{ needs.guard.outputs.cache_key }}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -209,9 +209,15 @@ Reading the cache correctly matters, because a skipped run is still green:
   not that the target was tested in that run. Every run states which it was in
   its step summary, and a skipping run shows a `Skipped (...)` job instead of
   the `e2e` job.
-- To answer "was this exact commit tested?", look for the run whose artifact is
-  named `modal-nightly-<sha>`. Only a run that really executed the suite
-  produces one. The run list alone cannot answer the question.
+- To answer "was this exact commit tested, and did it pass?", read the `e2e`
+  job's conclusion, not the run's. A skipped run still lists the `e2e` job with
+  conclusion `skipped`, while the overall run reports success. Only
+  `e2e` concluding `success` means the suite ran and passed.
+- The `dev` workflow additionally uploads `modal-nightly-<sha>`, but that upload
+  is `if: always()`, so the artifact exists for failed and timed-out runs too.
+  Its name proves the suite executed on that SHA, not that it passed; the pass
+  is `"status": "passed"` inside `modal-nightly-result.json`. The release and
+  PyPI workflows upload no artifact at all.
 
 The Modal-backed `dev` run is serialized with a GitHub Actions concurrency group
 because it writes a shared Modal volume. The remote GPU function has a 180 minute

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -199,6 +199,20 @@ SHA/version cache skips unchanged targets; manual `force=true` runs the selected
 target. The scheduled `dev` run starts at `04:00` UTC. Do not add a
 `pull_request` trigger.
 
+Reading the cache correctly matters, because a skipped run is still green:
+
+- The cache key is the target SHA (or PyPI version) plus the ISO week, so an
+  unchanged target is retested once a week rather than never. Without the week
+  component a quiet branch is tested once and the environment underneath it
+  (Modal image, published weights, transitive dependencies) drifts untested.
+- A run that skips reports success. The green tick means the guard resolved,
+  not that the target was tested in that run. Every run states which it was in
+  its step summary, and a skipping run shows a `Skipped (...)` job instead of
+  the `e2e` job.
+- To answer "was this exact commit tested?", look for the run whose artifact is
+  named `modal-nightly-<sha>`. Only a run that really executed the suite
+  produces one. The run list alone cannot answer the question.
+
 The Modal-backed `dev` run is serialized with a GitHub Actions concurrency group
 because it writes a shared Modal volume. The remote GPU function has a 180 minute
 timeout and the GitHub controller leaves timeout headroom so logs and result

--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -236,10 +236,24 @@ uvx modal run tools/ci/modal_nightly.py --ref <candidate-sha> --target test_nigh
 ```
 
 Both print a `MODAL_NIGHTLY_RESULT {json}` line with `status`, runtime, and
-estimated GPU cost; record status **and cost** on the scoreboard. If the
-last successful nightly already ran on the candidate SHA (check the run's
-step summary for the ref), count it and skip the re-run; that is the whole
-point of reusing the nightly.
+estimated GPU cost; record status **and cost** on the scoreboard.
+
+**A green nightly in the run list does not mean the candidate was tested.**
+The workflow skips when the target already passed this week, and a skipped run
+still reports success. Establish what was actually covered before deciding:
+
+```bash
+# Which runs really executed the suite? Only those have this artifact.
+gh api repos/LibreYOLO/libreyolo/actions/runs/<run-id>/artifacts \
+  --jq '.artifacts[].name'      # -> modal-nightly-<sha> on a real run, empty on a skip
+```
+
+A run whose artifact is `modal-nightly-<candidate-sha>` is a genuine pass on
+the candidate: count it and skip the re-run, that is the point of reusing the
+nightly. Anything else, including three consecutive green runs, is not
+evidence about the candidate. Two quick tells for a skip: the run finished in
+seconds rather than tens of minutes, and its job list shows
+`Skipped (dev already tested)` instead of `e2e (dev)`.
 
 For gates beyond the nightly contract (RF5 training benchmark, a heavier
 suite, a specific GPU), use the `launch-serverless-gpu-job` skill
@@ -413,6 +427,9 @@ the user to post by hand.
 - Treating the empty checks list on the `dev -> release` PR as green.
 - Re-running a 3-hour Modal nightly when the last green run already tested
   the candidate SHA.
+- Reading a green nightly as a pass on the candidate without checking that the
+  run produced a `modal-nightly-<candidate-sha>` artifact. Skipped runs are
+  green too.
 - Squash-merging the release PR.
 - Bumping the version on dev instead of on the release-PR branch.
 - Skipping Phase 4 because "publish.yml was green" (green publish and a

--- a/skills/libreyolo-release/SKILL.md
+++ b/skills/libreyolo-release/SKILL.md
@@ -240,20 +240,40 @@ estimated GPU cost; record status **and cost** on the scoreboard.
 
 **A green nightly in the run list does not mean the candidate was tested.**
 The workflow skips when the target already passed this week, and a skipped run
-still reports success. Establish what was actually covered before deciding:
+still reports success. Counting a skip as a pass is how an untested commit
+ships. Two questions, in order, and both must be answered from the run itself:
+
+**1. Did the suite run at all, on this SHA?** Read the `e2e` job's
+**conclusion**, not whether the job is listed: a skipped run still lists
+`e2e (dev)`, with conclusion `skipped`. The guard's step summary on every run
+names the target it resolved.
 
 ```bash
-# Which runs really executed the suite? Only those have this artifact.
-gh api repos/LibreYOLO/libreyolo/actions/runs/<run-id>/artifacts \
-  --jq '.artifacts[].name'      # -> modal-nightly-<sha> on a real run, empty on a skip
+gh api repos/LibreYOLO/libreyolo/actions/runs/<run-id>/jobs \
+  --jq '.jobs[] | "\(.name) \(.conclusion)"'
+# e2e (dev) success  -> the suite ran and the job passed
+# e2e (dev) skipped  -> it never ran; this run is not evidence about any SHA
+#                       (a companion "Skipped (dev already tested)" job says so)
 ```
 
-A run whose artifact is `modal-nightly-<candidate-sha>` is a genuine pass on
-the candidate: count it and skip the re-run, that is the point of reusing the
-nightly. Anything else, including three consecutive green runs, is not
-evidence about the candidate. Two quick tells for a skip: the run finished in
-seconds rather than tens of minutes, and its job list shows
-`Skipped (dev already tested)` instead of `e2e (dev)`.
+**2. Did it pass?** For the dev workflow, do not stop at the artifact name.
+The upload is `if: always()`, so `modal-nightly-<sha>` also exists for failed,
+timed-out, and unknown-status runs. Read the status out of it:
+
+```bash
+gh run download <run-id> -R LibreYOLO/libreyolo \
+  -n modal-nightly-<candidate-sha> -D /tmp/nightly
+jq -r '.status, .ref, .estimated_gpu_cost_usd' /tmp/nightly/modal-nightly-result.json
+# status must be exactly "passed", and ref must be the candidate SHA
+```
+
+Only `status == "passed"` on the candidate SHA counts; then skip the re-run,
+that is the point of reusing the nightly. Anything else, including three
+consecutive green runs, is not evidence about the candidate.
+
+Note the artifact exists **only** for the dev workflow. The release and PyPI
+workflows run on the self-hosted runner and upload nothing, so for those the
+evidence is the job list plus the run conclusion from question 1.
 
 For gates beyond the nightly contract (RF5 training benchmark, a heavier
 suite, a specific GPU), use the `launch-serverless-gpu-job` skill
@@ -427,9 +447,11 @@ the user to post by hand.
 - Treating the empty checks list on the `dev -> release` PR as green.
 - Re-running a 3-hour Modal nightly when the last green run already tested
   the candidate SHA.
-- Reading a green nightly as a pass on the candidate without checking that the
-  run produced a `modal-nightly-<candidate-sha>` artifact. Skipped runs are
-  green too.
+- Reading a green nightly as a pass on the candidate. Skipped runs are green
+  too, and the dev artifact is uploaded on failure as well, so neither the tick
+  nor the artifact name is the evidence. The evidence is an `e2e` job that
+  concluded `success`, plus `status == "passed"` inside
+  `modal-nightly-result.json`.
 - Squash-merging the release PR.
 - Bumping the version on dev instead of on the release-PR branch.
 - Skipping Phase 4 because "publish.yml was green" (green publish and a


### PR DESCRIPTION
Three nightly workflows (`dev`, `release`, `pypi`) share a guard that skips the
GPU suite when the target already passed. A skipped run reports success, so the
run list shows green ticks that are not passes on the current commit. This came
up while checking whether dev HEAD was tested for the v1.5.0 cut: the 08-06,
08-07 and 08-08 runs are green and ran in 8 to 12 seconds.

What changed:

- Guard writes a step summary on every run: which SHA or version it covers, and
  whether the GPU suite actually ran.
- A skipping run now shows a `Skipped (...)` job instead of just omitting `e2e`.
- Cache key gains an ISO week (`last-tested-...-<sha>-<year>-W<week>`), so an
  unchanged target is retested weekly instead of never. A SHA-only key means a
  quiet branch is tested once and the environment underneath it (Modal image,
  published weights, transitive deps) drifts untested. Cost is one extra L4 run
  per frozen week, about $0.48 at the last measured nightly.
- Guard uses `actions/cache/restore` instead of `actions/cache`. It never
  creates the marker file, so save-on-post warned on every run and could claim
  the key with an empty entry.
- `e2e` jobs check out the resolved SHA, not the branch. The release workflow
  tests whatever it checks out, so a branch ref could mark one SHA as tested
  while having tested another.
- `docs/testing.md` and the release skill's Gate B document how to tell a real
  pass from a skip: only a run that executed the suite produces a
  `modal-nightly-<sha>` artifact.

Reviewer should check: the weekly retest cadence is wanted, and the ISO week
boundary (a Sunday run followed by a Monday rerun) is acceptable.

Verified: all three files parse as YAML; `bash -n` over all 23 `run` steps;
guard decision logic executed locally for force / cache-hit / cache-miss on all
three workflows, asserting `should_run` and the summary text.

Not verified: no workflow run has executed with these changes. The dev nightly
next fires at 04:00 UTC, or dispatch with `force=true`.

## Code provenance

All changes are original code written for this PR. No third-party code was
copied, adapted, or derived. The files touched are GitHub Actions workflow
YAML, a docs page, and a skill markdown file, all pre-existing in this repo.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes skipped nightly runs visibly distinct from genuine GPU-suite passes and updates release verification to require explicit passing evidence.

- Adds weekly target-specific cache windows and explicit skipped jobs to the dev, release, and PyPI nightly workflows.
- Pins dev and release checkouts to the SHA resolved by each workflow guard.
- Documents that release Gate B must verify both a successful `e2e` job and a `modal-nightly-result.json` whose status is `passed` and ref matches the candidate SHA.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previous artifact-presence issue is resolved because Gate B now requires the dev nightly result status to be exactly passed, verifies its ref against the candidate SHA, and separately confirms that the e2e job actually succeeded; no blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/e2e-nightly-dev.yml | Adds weekly cache keys, explicit skip reporting, resolved-SHA checkout, and consistent restoration and saving of the passing marker. |
| .github/workflows/e2e-nightly-pypi.yml | Adds weekly version-scoped retesting and an explicit skipped job for already-tested PyPI releases. |
| .github/workflows/e2e-nightly-release.yml | Adds weekly SHA-scoped retesting, explicit skip reporting, and checkout of the exact release SHA resolved by the guard. |
| docs/testing.md | Explains how to distinguish a skipped workflow from an executed and passing nightly suite. |
| skills/libreyolo-release/SKILL.md | Corrects Gate B by requiring successful job execution plus a passing result status and matching candidate ref. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Nightly guard resolves target and ISO week] --> B{Passing cache marker exists?}
    B -->|Yes| C[Skipped job reports no GPU suite ran]
    B -->|No or force=true| D[e2e checks out resolved target]
    D --> E[GPU suite executes]
    E --> F{e2e conclusion is success?}
    F -->|No| G[Do not count as a pass]
    F -->|Yes| H{Dev result status passed and ref matches?}
    H -->|No| G
    H -->|Yes| I[Accept as passing nightly evidence]
    E --> J[Save weekly passing cache marker only after success]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Correct Gate B evidence rules for the ni..."](https://github.com/libreyolo/libreyolo/commit/9ce66b3d784443e5ef05a4496200d3c92e82abb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51446812)</sub>

<!-- /greptile_comment -->